### PR TITLE
feat: support per-user workspace kinds

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1363,9 +1363,39 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 |-------|-------------|---------|
 | `version` | Deprecated and ignored. OpenViking always uses the v3 memory extraction pipeline; existing configs that set this field still load without error. | `"v3"` |
 | `custom_templates_dir` | Custom memory templates directory. If set, templates from this directory are loaded in addition to built-in templates. | `""` |
+| `workspace_kind` | Semantic meaning of the OpenViking `user` namespace for memory extraction. Built-in kinds: `personal`, `team`, `project`, and `organization`. | `"personal"` |
+| `workspace_kinds_dir` | Optional directory containing custom workspace-kind YAML definitions. | `""` |
 | `extraction_enabled` | Whether session commit runs long-term memory extraction. | `true` |
 | `session_skill_extraction_enabled` | Whether session commit also extracts reusable skills into the current user's skill directory. | `false` |
 | `link_enabled` | Whether memory extraction writes and resolves memory links. | `false` |
+
+#### Workspace kinds
+
+`workspace_kind` changes the extraction model's interpretation of the OpenViking
+`user` namespace. It does not change URI routing, permissions, or inheritance.
+Routing remains:
+
+- no `peer_id` → the shared `user` workspace;
+- `peer_id` → the actor-specific `user/peers/{peer_id}` workspace;
+- resources → canonical documents and knowledge in the applicable resource scope.
+
+Choose the kind according to what the configured `user` identifier represents:
+
+| Kind | The `user` namespace represents | Use it when | Resource relationship |
+|-------|--------------------------------|-------------|-----------------------|
+| `personal` | One human's personal workspace | A human owns the memory and peers are assistants, devices, or other actors | Personal memory may refer to resources; canonical documents remain resources |
+| `team` | A durable shared team workspace | Multiple agents collaborate on team facts, procedures, infrastructure, ownership, and decisions | Team resources contain team documents; account-level resources remain company-wide |
+| `project` | A bounded project workspace | A project needs shared memory across teams or agents without automatically mixing in a team's operational memory | Project resources contain project documents; there is no implicit inheritance from team or organization users |
+| `organization` | One shared organization workspace | The deployment intentionally uses one user namespace for organization-wide extracted facts | Usually redundant when the account's global resources already hold canonical organization knowledge |
+
+OpenViking users are sibling namespaces, not a hierarchy. A project user does
+not automatically inherit team memory, and a team user does not automatically
+inherit organization memory. Use resources, explicit links, or deliberate
+copying when knowledge must cross those boundaries.
+
+For a multi-agent DevOps deployment, `team` is usually the appropriate kind:
+the configured `user` identifies the team, while each agent gets its own
+`peer_id` for actor-private memory.
 
 ### ovcli.conf
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1393,6 +1393,30 @@ not automatically inherit team memory, and a team user does not automatically
 inherit organization memory. Use resources, explicit links, or deliberate
 copying when knowledge must cross those boundaries.
 
+For multi-tenant servers, `workspace_kind` can be fixed per user when the
+user is created by ROOT or an account ADMIN. Pass it in the administrative
+user configuration:
+
+```json
+{
+  "user_id": "devops",
+  "user_config": {"workspace_kind": "team"}
+}
+```
+
+```json
+{
+  "user_id": "migration-alpha",
+  "user_config": {"workspace_kind": "project"}
+}
+```
+
+Both users may belong to the same account and therefore use the same
+company-wide `viking://resources/...` namespace. The per-user setting affects
+the extraction prompt's interpretation of the user namespace; it does not
+change account boundaries, resource visibility, peer routing, or URI layout.
+The regular user-settings API does not expose `workspace_kind` for mutation.
+
 For a multi-agent DevOps deployment, `team` is usually the appropriate kind:
 the configured `user` identifies the team, while each agent gets its own
 `peer_id` for actor-private memory.

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -159,6 +159,8 @@
     "memory_decay_check_interval": 3600,
     "memory": {
         "version": "v2",
+        "workspace_kind": "personal",
+        "workspace_kinds_dir": "",
         "extraction_enabled": true,
         "session_skill_extraction_enabled": false,
     },

--- a/openviking/prompts/templates/memory/workspaces/organization.yaml
+++ b/openviking/prompts/templates/memory/workspaces/organization.yaml
@@ -1,0 +1,12 @@
+kind: organization
+display_name: Organization workspace
+shared_scope_label: shared organization workspace
+shared_scope_instruction: >
+  Store durable organization-wide facts, policies, ownership, procedures, and
+  operational constraints without peer_id.
+private_scope_instruction: >
+  Use peer_id for agent-specific execution knowledge, private working notes,
+  preferences, and temporary context.
+resource_scope_instruction: >
+  Keep canonical organization-wide documents in resources; use memory for
+  durable facts and decisions derived from them or from conversations.

--- a/openviking/prompts/templates/memory/workspaces/personal.yaml
+++ b/openviking/prompts/templates/memory/workspaces/personal.yaml
@@ -1,0 +1,12 @@
+kind: personal
+display_name: Personal workspace
+shared_scope_label: personal workspace
+shared_scope_instruction: >
+  Store durable facts, preferences, entities, events, and profile information
+  about the individual who owns this workspace without peer_id.
+private_scope_instruction: >
+  Use peer_id for memories specific to an assistant, device, or other actor
+  interacting with the workspace.
+resource_scope_instruction: >
+  Keep canonical documents and knowledge in resources; link to them from
+  memories when useful.

--- a/openviking/prompts/templates/memory/workspaces/project.yaml
+++ b/openviking/prompts/templates/memory/workspaces/project.yaml
@@ -1,0 +1,12 @@
+kind: project
+display_name: Project workspace
+shared_scope_label: shared project workspace
+shared_scope_instruction: >
+  Store durable project facts, architecture decisions, implementation
+  constraints, procedures, ownership, and project events without peer_id.
+private_scope_instruction: >
+  Use peer_id for agent-specific plans, working notes, preferences, and
+  temporary interpretations that are not project-wide knowledge.
+resource_scope_instruction: >
+  Keep canonical project documents in resources and link to them from memory
+  when useful.

--- a/openviking/prompts/templates/memory/workspaces/team.yaml
+++ b/openviking/prompts/templates/memory/workspaces/team.yaml
@@ -1,0 +1,15 @@
+kind: team
+display_name: Team workspace
+shared_scope_label: shared team workspace
+shared_scope_instruction: >
+  Store durable team facts, infrastructure knowledge, procedures, decisions,
+  service ownership, and operational constraints without peer_id. Treat the
+  configured user identifier as the team identity, not as a human preference
+  profile.
+private_scope_instruction: >
+  Use peer_id for agent-specific execution knowledge, private working notes,
+  actor-specific preferences, and temporary context that other team members
+  should not inherit automatically.
+resource_scope_instruction: >
+  Keep company-wide canonical documents and knowledge in resources. Team-
+  specific documents may remain in the team's resource area.

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -82,9 +82,27 @@ class AddTargetsConfig(BaseModel):
 
 
 class UserConfig(BaseModel):
-    """User configuration values that can be defaulted or initialized."""
+    """User configuration values that can be defaulted or initialized.
+
+    ``workspace_kind`` is administrator-owned semantic metadata. It tells
+    memory extraction what the account's ``user`` namespace represents; it
+    does not alter authentication or URI isolation.
+    """
 
     add_targets: AddTargetsConfig = Field(default_factory=AddTargetsConfig)
+    workspace_kind: Optional[str] = None
+
+    @field_validator("workspace_kind")
+    @classmethod
+    def validate_workspace_kind(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("workspace_kind must not be empty")
+        if not normalized.replace("_", "").isalnum():
+            raise ValueError("workspace_kind must contain only letters, numbers, or underscores")
+        return normalized
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -90,11 +90,27 @@ def _has_add_targets(user_config: UserConfig | None) -> bool:
     )
 
 
+def _has_user_config(user_config: UserConfig | None) -> bool:
+    return bool(
+        user_config
+        and (_has_add_targets(user_config) or user_config.workspace_kind is not None)
+    )
+
+
 def _validate_initial_user_config(
     service,
     user_ctx: RequestContext,
     user_config: UserConfig | None,
 ) -> None:
+    if user_config and user_config.workspace_kind:
+        from openviking.session.memory.workspace_kind import load_workspace_kind
+        from openviking_cli.utils.config import get_openviking_config
+
+        config = get_openviking_config()
+        load_workspace_kind(
+            user_config.workspace_kind,
+            config.memory.workspace_kinds_dir if config.memory else "",
+        )
     if not _has_add_targets(user_config):
         return
     if service.viking_fs is None:
@@ -111,7 +127,7 @@ async def _write_initial_user_config(
     user_ctx: RequestContext,
     user_config: UserConfig | None,
 ) -> None:
-    if not _has_add_targets(user_config):
+    if not _has_user_config(user_config):
         return
     await write_user_config(service.viking_fs, user_ctx, user_config)
 

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -158,6 +158,10 @@ class ExtractLoop:
         self._format_retry_count = 0
         patch_repair_count = 0
 
+        # Providers may need request-scoped configuration from AGFS before
+        # their synchronous prompt is rendered.
+        await self.context_provider.prepare_extraction_messages()
+
         # 从 provider 获取 schemas（内部自动加载 registry）
         schemas = self.context_provider.get_memory_schemas(self.ctx)
 

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from openviking.message.part import TextPart, ToolPart
 from openviking.prompts.manager import PromptManager
 from openviking.server.identity import RequestContext, ToolContext
+from openviking.server.user_config import read_user_config
 from openviking.session.memory.core import ExtractContextProvider
 from openviking.session.memory.dataclass import MemoryFile
 from openviking.session.memory.memory_isolation_handler import (
@@ -92,6 +93,18 @@ class SessionExtractContextProvider(ExtractContextProvider):
         self._vision_messages_prepared = False
         self._vision_vlm = None
 
+    async def _resolve_workspace_kind(self) -> None:
+        """Apply the administrator-defined kind for the current user."""
+        if not self._ctx or not self._viking_fs:
+            return
+        user_config = await read_user_config(self._viking_fs, self._ctx)
+        if user_config.workspace_kind:
+            config = get_openviking_config()
+            self._workspace_kind = load_workspace_kind(
+                user_config.workspace_kind,
+                config.memory.workspace_kinds_dir if config.memory else "",
+            )
+
     @property
     def read_file_contents(self) -> Dict[str, MemoryFile]:
         return self._read_file_contents
@@ -122,6 +135,7 @@ class SessionExtractContextProvider(ExtractContextProvider):
 
     async def prepare_extraction_messages(self) -> None:
         """Prepare extraction-only messages before ranges and prompts are built."""
+        await self._resolve_workspace_kind()
         if self._vision_messages_prepared:
             return
         if isinstance(self.messages, list):

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -28,6 +28,7 @@ from openviking.session.memory.tools import (
     add_tool_call_pair_to_messages,
     get_tool,
 )
+from openviking.session.memory.workspace_kind import load_workspace_kind
 from openviking.session.memory.utils.resource_refs import contains_resource_uri
 from openviking.session.memory.utils.uri import render_template
 from openviking.session.memory.vision_message_normalizer import (
@@ -84,6 +85,10 @@ class SessionExtractContextProvider(ExtractContextProvider):
         self._viking_fs = viking_fs
         self._transaction_handle = transaction_handle
         self._link_enabled = config.memory.link_enabled if config.memory else False
+        self._workspace_kind = load_workspace_kind(
+            config.memory.workspace_kind if config.memory else "personal",
+            config.memory.workspace_kinds_dir if config.memory else "",
+        )
         self._vision_messages_prepared = False
         self._vision_vlm = None
 
@@ -229,10 +234,11 @@ All memory content MUST be written in {output_language}.
 The system automatically generates URIs based on memory_type and fields. Just provide correct memory_type and fields.
 {resource_uri_handling}
 
+## Workspace Semantics
+Workspace kind: {self._workspace_kind.display_name}
+{self._workspace_kind.extraction_instructions()}
+
 ## Self and Peer Memory
-When a memory item describes the current user, omit peer_id.
-When a memory item describes a peer, set peer_id to one of the peer_id values allowed by
-the output schema. Do not invent peer_id values.
 For events with ranges, the system derives self/peer targets from the message range.
 Message role is authoritative: user-role content is the source for profile/preferences/entities/events,
 and assistant-role content is the source for cases/patterns/tools/skills. Do not infer ownership

--- a/openviking/session/memory/workspace_kind.py
+++ b/openviking/session/memory/workspace_kind.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Semantic definitions for the memory user namespace.
+
+The storage model always uses the existing user and peer URI scopes.  A
+workspace kind only tells the extraction model what the user namespace means;
+it does not change URI routing or isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+@dataclass(frozen=True)
+class WorkspaceKindDefinition:
+    """Prompt-facing semantics for one user namespace kind."""
+
+    kind: str
+    display_name: str
+    shared_scope_label: str
+    shared_scope_instruction: str
+    private_scope_instruction: str
+    resource_scope_instruction: str
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any], *, source: Path) -> "WorkspaceKindDefinition":
+        required = (
+            "kind",
+            "display_name",
+            "shared_scope_label",
+            "shared_scope_instruction",
+            "private_scope_instruction",
+            "resource_scope_instruction",
+        )
+        missing = [
+            key
+            for key in required
+            if not isinstance(data.get(key), str) or not data[key].strip()
+        ]
+        if missing:
+            raise ValueError(
+                f"Workspace kind {source} is missing required fields: {', '.join(missing)}"
+            )
+
+        kind = data["kind"].strip().lower()
+        if not kind.replace("_", "").isalnum():
+            raise ValueError(f"Workspace kind {source} has invalid kind: {kind!r}")
+        if kind != source.stem:
+            raise ValueError(
+                f"Workspace kind {source} declares kind {kind!r}; expected {source.stem!r}"
+            )
+
+        return cls(
+            kind=kind,
+            display_name=data["display_name"].strip(),
+            shared_scope_label=data["shared_scope_label"].strip(),
+            shared_scope_instruction=data["shared_scope_instruction"].strip(),
+            private_scope_instruction=data["private_scope_instruction"].strip(),
+            resource_scope_instruction=data["resource_scope_instruction"].strip(),
+        )
+
+    def extraction_instructions(self) -> str:
+        """Render the semantic policy block inserted into the extractor prompt."""
+        return f"""The current OpenViking user namespace represents a {self.shared_scope_label},
+not necessarily an individual human.
+
+- Shared-scope memory: {self.shared_scope_instruction}
+- Private actor memory: {self.private_scope_instruction}
+- Resource memory: {self.resource_scope_instruction}
+
+When a memory belongs to the {self.shared_scope_label}, omit peer_id.
+When a memory is private to one actor, set peer_id to an allowed peer_id value.
+Do not invent peer_id values. The user namespace and peer namespaces are
+storage scopes; use the configured workspace semantics rather than assuming
+that "user" means a person.
+"""
+
+
+def _bundled_workspace_kinds_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "prompts" / "templates" / "memory" / "workspaces"
+
+
+def _workspace_kind_path(kind: str, custom_dir: Optional[str]) -> Path:
+    if custom_dir and (custom_path := Path(custom_dir).expanduser() / f"{kind}.yaml").exists():
+        return custom_path
+    if custom_dir and (
+        custom_path := Path(custom_dir).expanduser() / "workspaces" / f"{kind}.yaml"
+    ).exists():
+        return custom_path
+    return _bundled_workspace_kinds_dir() / f"{kind}.yaml"
+
+
+def load_workspace_kind(kind: str, custom_dir: str = "") -> WorkspaceKindDefinition:
+    """Load a built-in or custom workspace-kind definition."""
+    path = _workspace_kind_path(kind.strip().lower(), custom_dir)
+    if not path.exists():
+        available = sorted(p.stem for p in _bundled_workspace_kinds_dir().glob("*.yaml"))
+        raise ValueError(
+            f"Unknown memory.workspace_kind {kind!r}; expected one of: {', '.join(available)}"
+        )
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Workspace kind definition must be a YAML object: {path}")
+    return WorkspaceKindDefinition.from_dict(data, source=path)

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -20,6 +20,20 @@ class MemoryConfig(BaseModel):
         default="",
         description="Custom memory templates directory. If set, templates from this directory will be loaded in addition to built-in templates",
     )
+    workspace_kind: str = Field(
+        default="personal",
+        description=(
+            "Semantic meaning of the user namespace for memory extraction. "
+            "Built-in kinds are personal, team, project, and organization."
+        ),
+    )
+    workspace_kinds_dir: str = Field(
+        default="",
+        description=(
+            "Optional directory containing custom workspace-kind YAML definitions. "
+            "Built-in definitions are used when this is empty."
+        ),
+    )
     v2_lock_retry_interval_seconds: float = Field(
         default=0.2,
         ge=0.0,
@@ -115,6 +129,14 @@ class MemoryConfig(BaseModel):
                 "memory.version is deprecated and ignored; memory extraction always uses v3"
             )
         return "v3"
+
+    @field_validator("workspace_kind")
+    @classmethod
+    def validate_workspace_kind(cls, value: str) -> str:
+        value = value.strip().lower()
+        if not value:
+            raise ValueError("memory.workspace_kind must not be empty")
+        return value
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]) -> "MemoryConfig":

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -22,7 +22,7 @@ from openviking.server.config import ServerConfig
 from openviking.server.dependencies import set_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
-from openviking.server.user_config import read_user_add_targets
+from openviking.server.user_config import read_user_add_targets, read_user_config
 from openviking.service.core import OpenVikingService
 from openviking.service.task_store import (
     SYSTEM_TASK_ACCOUNT_ID,
@@ -299,7 +299,10 @@ async def test_create_user_paths_accept_initial_user_config(
         json={
             "user_id": "bob",
             "role": "user",
-            "user_config": {"add_targets": {"resource_uri": "viking://user/resources/bob"}},
+            "user_config": {
+                "workspace_kind": "project",
+                "add_targets": {"resource_uri": "viking://user/resources/bob"},
+            },
         },
         headers=root_headers(),
     )
@@ -310,6 +313,11 @@ async def test_create_user_paths_accept_initial_user_config(
         RequestContext(user=UserIdentifier(acct, "bob"), role=Role.USER),
     )
     assert bob_settings.resource_uri == "viking://user/resources/bob"
+    bob_config = await read_user_config(
+        viking_fs,
+        RequestContext(user=UserIdentifier(acct, "bob"), role=Role.USER),
+    )
+    assert bob_config.workspace_kind == "project"
 
 
 async def test_list_accounts(admin_client: httpx.AsyncClient):

--- a/tests/unit/test_workspace_kind.py
+++ b/tests/unit/test_workspace_kind.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.session.memory.session_extract_context_provider import (
+    SessionExtractContextProvider,
+)
+from openviking.session.memory.workspace_kind import load_workspace_kind
+from openviking_cli.utils.config.memory_config import MemoryConfig
+
+
+def test_builtin_workspace_kinds_are_available():
+    for kind in ("personal", "team", "project", "organization"):
+        assert load_workspace_kind(kind).kind == kind
+
+    personal = load_workspace_kind("personal")
+    team = load_workspace_kind("team")
+
+    assert personal.shared_scope_label == "personal workspace"
+    assert team.shared_scope_label == "shared team workspace"
+    assert "team facts" in team.shared_scope_instruction
+
+
+def test_custom_workspace_kind_definition_overrides_builtin(tmp_path):
+    (tmp_path / "team.yaml").write_text(
+        """kind: team
+display_name: Custom team workspace
+shared_scope_label: custom shared team workspace
+shared_scope_instruction: Store custom shared team knowledge without peer_id.
+private_scope_instruction: Store custom private actor knowledge with peer_id.
+resource_scope_instruction: Keep custom canonical documents in resources.
+""",
+        encoding="utf-8",
+    )
+
+    definition = load_workspace_kind("team", str(tmp_path))
+
+    assert definition.display_name == "Custom team workspace"
+    assert definition.shared_scope_label == "custom shared team workspace"
+
+
+def test_memory_config_defaults_to_personal_workspace():
+    config = MemoryConfig()
+
+    assert config.workspace_kind == "personal"
+    assert config.workspace_kinds_dir == ""
+
+
+def test_memory_config_normalizes_workspace_kind():
+    assert MemoryConfig(workspace_kind=" Team ").workspace_kind == "team"
+
+
+def test_unknown_workspace_kind_has_actionable_error():
+    with pytest.raises(ValueError, match="Unknown memory.workspace_kind"):
+        load_workspace_kind("unknown")
+
+
+def test_team_workspace_semantics_are_added_to_extraction_instruction(monkeypatch):
+    memory = SimpleNamespace(
+        eager_prefetch=False,
+        prefetch_search_topn=5,
+        link_enabled=False,
+        workspace_kind="team",
+        workspace_kinds_dir="",
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: SimpleNamespace(memory=memory),
+    )
+
+    instruction = SessionExtractContextProvider(messages=[]).instruction()
+
+    assert "Workspace kind: Team workspace" in instruction
+    assert "shared team workspace" in instruction
+    assert "Treat the configured user identifier as the team identity" in instruction
+    assert "When a memory belongs to the shared team workspace, omit peer_id." in instruction
+    assert "When a memory is private to one actor, set peer_id" in instruction

--- a/tests/unit/test_workspace_kind.py
+++ b/tests/unit/test_workspace_kind.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,8 @@ from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
 from openviking.session.memory.workspace_kind import load_workspace_kind
+from openviking.server.identity import RequestContext, Role
+from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config.memory_config import MemoryConfig
 
 
@@ -78,3 +81,35 @@ def test_team_workspace_semantics_are_added_to_extraction_instruction(monkeypatc
     assert "Treat the configured user identifier as the team identity" in instruction
     assert "When a memory belongs to the shared team workspace, omit peer_id." in instruction
     assert "When a memory is private to one actor, set peer_id" in instruction
+
+
+@pytest.mark.asyncio
+async def test_user_workspace_kind_overrides_server_default(monkeypatch):
+    memory = SimpleNamespace(
+        eager_prefetch=False,
+        prefetch_search_topn=5,
+        link_enabled=False,
+        workspace_kind="team",
+        workspace_kinds_dir="",
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: SimpleNamespace(memory=memory),
+    )
+
+    class FakeVikingFS:
+        async def read_file(self, uri, **_kwargs):
+            assert uri.endswith("/settings/user_config.json")
+            return json.dumps({"workspace_kind": "project"})
+
+    ctx = RequestContext(
+        user=UserIdentifier("hikari", "migration-alpha"),
+        role=Role.USER,
+    )
+    provider = SessionExtractContextProvider(messages=[], ctx=ctx, viking_fs=FakeVikingFS())
+
+    await provider.prepare_extraction_messages()
+
+    instruction = provider.instruction()
+    assert "Workspace kind: Project workspace" in instruction
+    assert "shared project workspace" in instruction


### PR DESCRIPTION
## Summary

- add configurable workspace-kind YAML definitions and extraction prompts;
- resolve the memory extraction policy from per-user UserConfig with a global fallback;
- allow root/admin user creation to persist workspace_kind;
- document and test personal, team, project, and organization workspace policies.

Fixes #3267

## Why

A single OpenViking account can contain multiple users representing different collaboration scopes. A global extraction policy cannot distinguish personal users, fixed teams, and cross-team projects. Making workspace_kind user-specific preserves the existing account/user/peer/resource model while making the policy explicit.

## Validation

- workspace-kind unit tests;
- admin user-config persistence tests;
- focused session/memory tests.
