### PR TITLE
fix: normalize watch scheduler timestamps to UTC

### DIFF
--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -10,7 +10,7 @@ import asyncio
 import inspect
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -20,6 +20,7 @@ from openviking.resource.watch_storage import (
     WATCH_TASK_STORAGE_TMP_URI,
     WATCH_TASK_STORAGE_URI,
 )
+from openviking.utils.time_utils import parse_iso_datetime, to_utc
 from openviking_cli.exceptions import ConflictError, NotFoundError
 from openviking_cli.utils.logger import get_logger
 
@@ -73,7 +74,9 @@ class WatchTask(BaseModel):
     auth_state: Optional[Dict[str, Any]] = Field(
         default=None, description="Private authentication state for scheduled re-processing"
     )
-    created_at: datetime = Field(default_factory=datetime.now, description="Task creation time")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), description="Task creation time"
+    )
     last_execution_time: Optional[datetime] = Field(None, description="Last execution time")
     next_execution_time: Optional[datetime] = Field(None, description="Next execution time")
     is_active: bool = Field(default=True, description="Whether the task is active")
@@ -123,11 +126,11 @@ class WatchTask(BaseModel):
         """Create task from dictionary."""
         data = dict(data)
         if isinstance(data.get("created_at"), str):
-            data["created_at"] = datetime.fromisoformat(data["created_at"])
+            data["created_at"] = to_utc(parse_iso_datetime(data["created_at"]))
         if isinstance(data.get("last_execution_time"), str):
-            data["last_execution_time"] = datetime.fromisoformat(data["last_execution_time"])
+            data["last_execution_time"] = to_utc(parse_iso_datetime(data["last_execution_time"]))
         if isinstance(data.get("next_execution_time"), str):
-            data["next_execution_time"] = datetime.fromisoformat(data["next_execution_time"])
+            data["next_execution_time"] = to_utc(parse_iso_datetime(data["next_execution_time"]))
         if data.get("processor_kwargs") is None:
             data["processor_kwargs"] = {}
         if data.get("auth_state") is not None and not isinstance(data.get("auth_state"), dict):
@@ -228,6 +231,19 @@ class WatchManager:
             normalized = False
             for task_data in data.get("tasks", []):
                 try:
+                    for field_name in (
+                        "created_at",
+                        "last_execution_time",
+                        "next_execution_time",
+                    ):
+                        raw_timestamp = task_data.get(field_name)
+                        if isinstance(raw_timestamp, str):
+                            parsed_timestamp = parse_iso_datetime(raw_timestamp)
+                            if (
+                                parsed_timestamp.tzinfo is None
+                                or parsed_timestamp.utcoffset() != timedelta(0)
+                            ):
+                                normalized = True
                     task = WatchTask.from_dict(task_data)
                     if not task.is_active:
                         if task.next_execution_time is not None:
@@ -273,7 +289,7 @@ class WatchManager:
 
             data = {
                 "tasks": [task.to_storage_dict() for task in self._tasks.values()],
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
             }
 
             content = json.dumps(data, ensure_ascii=False, indent=2)
@@ -865,7 +881,7 @@ class WatchManager:
                 await self._save_tasks()
                 return
 
-            task.last_execution_time = datetime.now()
+            task.last_execution_time = datetime.now(timezone.utc)
             task.next_execution_time = task.calculate_next_execution_time()
 
             await self._save_tasks()
@@ -880,7 +896,7 @@ class WatchManager:
             List of tasks that need to be executed
         """
         async with self._lock:
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             due_tasks = []
 
             for task in self._tasks.values():

--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -7,7 +7,7 @@ Provides scheduled task execution for watch tasks.
 """
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Set
 
 from openviking.resource.feishu_watch_auth import (
@@ -167,7 +167,7 @@ class WatchScheduler:
                 if self._watch_manager:
                     next_time = await self._watch_manager.get_next_execution_time()
                     if next_time is not None:
-                        now = datetime.now()
+                        now = datetime.now(timezone.utc)
                         sleep_seconds = min(
                             self._check_interval,
                             max(0.0, (next_time - now).total_seconds()),

--- a/openviking/utils/time_utils.py
+++ b/openviking/utils/time_utils.py
@@ -18,6 +18,19 @@ def parse_iso_datetime(value: str) -> datetime:
     return datetime.fromisoformat(normalized)
 
 
+def to_utc(dt: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime.
+
+    Historical OpenViking data may contain naive local timestamps. Interpret
+    those timestamps in the host's local timezone before converting them to
+    UTC; never compare naive and aware datetimes directly.
+    """
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        local_tz = datetime.now().astimezone().tzinfo or timezone.utc
+        dt = dt.replace(tzinfo=local_tz)
+    return dt.astimezone(timezone.utc)
+
+
 def format_iso8601(dt: datetime) -> str:
     """
     Format datetime object to ISO 8601 format compatible with VikingDB.

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock
@@ -154,7 +154,7 @@ class TestWatchTask:
 
     def test_from_dict(self):
         """Test creating task from dictionary."""
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         data = {
             "task_id": "test-id",
             "path": "/test/path",
@@ -178,6 +178,22 @@ class TestWatchTask:
         assert task.is_active is False
         assert task.created_at == now
         assert task.last_execution_time == now
+
+    def test_from_dict_normalizes_timezone_variants(self):
+        """Persisted aware and legacy naive timestamps become UTC-aware."""
+        data = {
+            "task_id": "timezone-task",
+            "path": "/test/path",
+            "created_at": "2026-07-15T12:00:00+08:00",
+            "last_execution_time": "2026-07-15T12:00:00",
+            "next_execution_time": "2026-07-15T13:00:00+08:00",
+        }
+
+        task = WatchTask.from_dict(data)
+
+        assert task.created_at == datetime(2026, 7, 15, 4, tzinfo=timezone.utc)
+        assert task.last_execution_time.tzinfo is not None
+        assert task.next_execution_time == datetime(2026, 7, 15, 5, tzinfo=timezone.utc)
 
     def test_calculate_next_execution_time(self):
         """Test calculating next execution time."""
@@ -675,6 +691,38 @@ class TestWatchManager:
 
 class TestWatchManagerPersistence:
     """Tests for WatchManager persistence."""
+
+    @pytest.mark.asyncio
+    async def test_persistence_normalizes_legacy_timestamps(
+        self, mock_viking_fs: MockVikingFS
+    ):
+        """Loading legacy timestamps rewrites the task storage canonically."""
+        data = {
+            "tasks": [
+                {
+                    "task_id": "legacy-timezone-task",
+                    "path": "/test/path",
+                    "watch_interval": 15.0,
+                    "created_at": "2026-07-15T12:00:00+08:00",
+                    "last_execution_time": "2026-07-15T12:00:00",
+                    "next_execution_time": "2026-07-15T12:15:00+08:00",
+                    "is_active": True,
+                }
+            ]
+        }
+        await mock_viking_fs.write_file(WatchManager.STORAGE_URI, json.dumps(data))
+
+        manager = WatchManager(viking_fs=mock_viking_fs)
+        await manager.initialize()
+
+        task = await manager.get_task("legacy-timezone-task")
+        assert task is not None
+        assert task.created_at == datetime(2026, 7, 15, 4, tzinfo=timezone.utc)
+
+        saved = json.loads(await mock_viking_fs.read_file(WatchManager.STORAGE_URI))
+        saved_task = saved["tasks"][0]
+        assert saved_task["created_at"].endswith("+00:00")
+        assert saved_task["next_execution_time"].endswith("+00:00")
 
     @pytest.mark.asyncio
     async def test_persistence_save_and_load(


### PR DESCRIPTION
## Summary

- use UTC-aware timestamps for new watch tasks and scheduler calculations;
- normalize legacy naive and offset-aware persisted timestamps when loading;
- persist repaired timestamps and add regression coverage.

Fixes #3268

## Root cause

Persisted watch tasks can contain timezone-aware timestamps such as +08:00, while the scheduler compared them with naive datetime.now() values. Python raises TypeError for that comparison, causing the scheduler loop to stop processing watches.

## Validation

- focused watch manager/scheduler/recovery tests: 59 passed;
- broader resource/watch run: 61 passed, with one unrelated existing teardown-test error.
