### PR TITLE
refactor(feishu): share block markdown conversion

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, NoReturn, Optional, Tuple, Union
 from urllib.parse import urlparse
 
+from openviking.parse.feishu_markdown import FeishuBlockMarkdownMixin
 from openviking.utils.exceptions import error_code_from_http_status
 from openviking_cli.exceptions import OpenVikingError
 from openviking_cli.utils.logger import get_logger
@@ -30,13 +31,6 @@ logger = get_logger(__name__)
 
 _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
-
-
-def _getattr_safe(obj, key: str, default=None):
-    """Get attribute from SDK object or dict, with safe fallback."""
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
 
 
 def _response_http_status(response: Any) -> int | None:
@@ -91,7 +85,7 @@ class FeishuDocument:
     meta: Dict[str, Any]
 
 
-class FeishuAccessor(DataAccessor):
+class FeishuAccessor(FeishuBlockMarkdownMixin, DataAccessor):
     """
     Accessor for Feishu/Lark cloud documents.
 
@@ -553,114 +547,7 @@ class FeishuAccessor(DataAccessor):
 
         return all_blocks
 
-    # ========== Block -> Markdown Conversion ==========
-
-    def _detect_block_attr(self, block) -> Optional[str]:
-        """Detect which content attribute is populated on a block object.
-
-        Uses block_type integer as the primary dispatch (reliable), falling
-        back to attribute inspection over a known whitelist for unknown types.
-        """
-        # Primary: lookup by block_type integer
-        block_type = getattr(block, "block_type", None)
-        if block_type is not None:
-            attr = self._BLOCK_TYPE_TO_ATTR.get(block_type)
-            if attr:
-                return attr
-
-        # Fallback: scan known content attributes for unknown block types
-        for attr in self._KNOWN_CONTENT_ATTRS:
-            if getattr(block, attr, None) is not None:
-                return attr
-        return None
-
-    def _block_to_markdown(
-        self, block, block_map: Dict, ordered_counter: Dict[str, int], document_id: str = ""
-    ) -> Optional[str]:
-        """Convert a single SDK block object to markdown string.
-
-        Uses block_type integer for primary dispatch, with attribute whitelist
-        fallback for unknown types. Formatting is data-driven via _TEXT_FORMAT
-        and _SPECIAL_BLOCK_HANDLERS tables.
-        """
-        attr = self._detect_block_attr(block)
-
-        if attr is None:
-            return None
-
-        # Skip structural containers (processed via their children)
-        if attr in self._SKIP_ATTRS:
-            return None
-
-        # Reset ordered list counter when any non-ordered block appears
-        if attr != "ordered":
-            parent_id = block.parent_id or ""
-            if parent_id in ordered_counter:
-                del ordered_counter[parent_id]
-
-        # Special blocks (non-text: divider, image, table)
-        special_handler = self._SPECIAL_BLOCK_HANDLERS.get(attr)
-        if special_handler:
-            return getattr(self, special_handler)(block, block_map, document_id=document_id)
-
-        # --- Text-bearing blocks: extract elements, apply formatting ---
-        content_obj = getattr(block, attr, None)
-        if not content_obj or not hasattr(content_obj, "elements") or not content_obj.elements:
-            return None
-
-        text = self._extract_text_from_elements(content_obj.elements)
-        if not text:
-            return None
-
-        # Headings: heading1 -> #, heading2 -> ##, ...
-        if attr.startswith("heading"):
-            level = int(attr.replace("heading", "") or "1")
-            return f"{'#' * level} {text}"
-
-        # Ordered list (needs counter state)
-        if attr == "ordered":
-            parent_id = block.parent_id or ""
-            counter = ordered_counter.get(parent_id, 0) + 1
-            ordered_counter[parent_id] = counter
-            return f"{counter}. {text}"
-
-        # Code block (needs language from style)
-        if attr == "code":
-            lang = ""
-            if hasattr(content_obj, "style") and content_obj.style:
-                lang = str(getattr(content_obj.style, "language", "") or "")
-            return f"```{lang}\n{text}\n```"
-
-        # Todo (needs done state from style)
-        if attr == "todo":
-            done = False
-            if hasattr(content_obj, "style") and content_obj.style:
-                done = getattr(content_obj.style, "done", False)
-            checkbox = "[x]" if done else "[ ]"
-            return f"- {checkbox} {text}"
-
-        # Simple template formatting (bullet, quote, etc.)
-        fmt = self._TEXT_FORMAT.get(attr)
-        if fmt:
-            return fmt.format(text=text)
-
-        # Default: return plain text (covers callout, equation, task, unknown, etc.)
-        return text
-
-    @staticmethod
-    def _handle_divider(block, block_map: Dict = None, **_) -> str:
-        """Convert divider block to markdown."""
-        return "---"
-
-    @staticmethod
-    def _handle_image(block, block_map: Dict = None, **_) -> Optional[str]:
-        """Convert image block to markdown."""
-        image = block.image
-        if not image:
-            return None
-        file_token = image.token or ""
-        alt_text = getattr(image, "alt", "") or "image"
-        return f"![{alt_text}](feishu://image/{file_token})"
+    # Block-to-Markdown conversion is inherited from FeishuBlockMarkdownMixin.
 
     # Image byte-magic signatures → file extension. Sniffed from the raw bytes
     # first, since the actual content is authoritative over a (possibly generic
@@ -822,120 +709,3 @@ class FeishuAccessor(DataAccessor):
             return f"![{alt_text}]({rel_path})"
 
         return _FEISHU_IMAGE_RE.sub(_replace, markdown), downloaded_images
-
-    def _extract_block_text(self, block, attr_name: str) -> str:
-        """Extract text from a block's named attribute (e.g. block.text, block.heading2)."""
-        content_obj = getattr(block, attr_name, None)
-        if content_obj and hasattr(content_obj, "elements") and content_obj.elements:
-            return self._extract_text_from_elements(content_obj.elements)
-        return ""
-
-    def _extract_text_from_elements(self, elements) -> str:
-        """Convert Feishu TextElement SDK objects to formatted text."""
-        if not elements:
-            return ""
-        parts = []
-        for element in elements:
-            # TextRun
-            text_run = element.text_run
-            if text_run:
-                content = text_run.content or ""
-                style = text_run.text_element_style
-                content = self._apply_text_style(content, style)
-                parts.append(content)
-                continue
-
-            # MentionUser
-            mention_user = element.mention_user
-            if mention_user:
-                user_id = _getattr_safe(mention_user, "user_id", "user")
-                parts.append(f"@{user_id}")
-                continue
-
-            # MentionDoc
-            mention_doc = element.mention_doc
-            if mention_doc:
-                title = _getattr_safe(mention_doc, "title", "document")
-                url = _getattr_safe(mention_doc, "url", "")
-                parts.append(f"[{title}]({url})" if url else str(title))
-                continue
-
-            # Equation
-            equation = element.equation
-            if equation:
-                parts.append(f"${_getattr_safe(equation, 'content', '')}$")
-                continue
-
-        return "".join(parts)
-
-    @staticmethod
-    def _apply_text_style(text: str, style) -> str:
-        """Apply markdown formatting based on TextElementStyle SDK object."""
-        if not text or not style:
-            return text
-        # inline_code (SDK uses 'inline_code', not 'code_inline')
-        if getattr(style, "inline_code", False):
-            return f"`{text}`"
-        # link
-        link = getattr(style, "link", None)
-        if link:
-            url = _getattr_safe(link, "url", "")
-            if url:
-                text = f"[{text}]({url})"
-        if getattr(style, "bold", False):
-            text = f"**{text}**"
-        if getattr(style, "italic", False):
-            text = f"*{text}*"
-        if getattr(style, "strikethrough", False):
-            text = f"~~{text}~~"
-        return text
-
-    def _table_block_to_markdown(self, block, block_map: Dict, **_) -> Optional[str]:
-        """Convert table block to markdown table."""
-        table = block.table
-        children = block.children
-        if not table or not children:
-            return None
-
-        prop = table.property
-        if not prop:
-            return None
-        row_size = prop.row_size or 0
-        col_size = prop.column_size or 0
-        if not row_size or not col_size:
-            return None
-
-        rows = []
-        for row_idx in range(row_size):
-            row = []
-            for col_idx in range(col_size):
-                cell_idx = row_idx * col_size + col_idx
-                if cell_idx < len(children):
-                    cell_block_id = children[cell_idx]
-                    cell_block = block_map.get(cell_block_id)
-                    cell_text = self._extract_cell_text(cell_block, block_map)
-                    row.append(cell_text)
-                else:
-                    row.append("")
-            rows.append(row)
-
-        from openviking.parse.base import format_table_to_markdown
-
-        return format_table_to_markdown(rows, has_header=True) if rows else None
-
-    def _extract_cell_text(self, cell_block, block_map: Dict) -> str:
-        """Extract text from a table cell block by reading its children."""
-        if not cell_block or not cell_block.children:
-            return ""
-        texts = []
-        for child_id in cell_block.children:
-            child = block_map.get(child_id)
-            if not child:
-                continue
-            # Use attribute-driven detection to find text in any block type
-            attr = self._detect_block_attr(child)
-            if attr:
-                text = self._extract_block_text(child, attr)
-                if text:
-                    texts.append(text)
-        return " ".join(texts)

--- a/openviking/parse/feishu_markdown.py
+++ b/openviking/parse/feishu_markdown.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Shared Feishu block-to-Markdown conversion primitives.
+
+Fetching and authentication remain owned by the caller.  The accessor and
+legacy parser provide their own block policy tables so this mixin can share
+the conversion algorithm without changing either surface's supported blocks.
+"""
+
+from typing import Any, Dict, Optional
+
+from openviking.parse.base import format_table_to_markdown
+
+
+def getattr_safe(obj: Any, key: str, default=None):
+    """Get an attribute from an SDK object or mapping."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+class FeishuBlockMarkdownMixin:
+    """Convert Feishu SDK blocks using caller-provided policy tables."""
+
+    _BLOCK_TYPE_TO_ATTR: Dict[int, str]
+    _KNOWN_CONTENT_ATTRS: frozenset[str]
+    _SKIP_ATTRS: set[str]
+    _SPECIAL_BLOCK_HANDLERS: Dict[str, str]
+    _TEXT_FORMAT: Dict[str, str]
+
+    def _detect_block_attr(self, block) -> Optional[str]:
+        """Detect the populated content attribute on an SDK block."""
+        block_type = getattr(block, "block_type", None)
+        if block_type is not None:
+            attr = self._BLOCK_TYPE_TO_ATTR.get(block_type)
+            if attr:
+                return attr
+
+        for attr in self._KNOWN_CONTENT_ATTRS:
+            if getattr(block, attr, None) is not None:
+                return attr
+        return None
+
+    def _block_to_markdown(
+        self,
+        block,
+        block_map: Dict,
+        ordered_counter: Dict[str, int],
+        document_id: str = "",
+    ) -> Optional[str]:
+        """Convert one SDK block according to the caller's block policy."""
+        attr = self._detect_block_attr(block)
+        if attr is None or attr in self._SKIP_ATTRS:
+            return None
+
+        if attr != "ordered":
+            parent_id = block.parent_id or ""
+            ordered_counter.pop(parent_id, None)
+
+        special_handler = self._SPECIAL_BLOCK_HANDLERS.get(attr)
+        if special_handler:
+            return getattr(self, special_handler)(
+                block,
+                block_map,
+                document_id=document_id,
+            )
+
+        content_obj = getattr(block, attr, None)
+        if not content_obj or not getattr(content_obj, "elements", None):
+            return None
+
+        text = self._extract_text_from_elements(content_obj.elements)
+        if not text:
+            return None
+
+        if attr.startswith("heading"):
+            level = int(attr.replace("heading", "") or "1")
+            return f"{'#' * level} {text}"
+
+        if attr == "ordered":
+            parent_id = block.parent_id or ""
+            counter = ordered_counter.get(parent_id, 0) + 1
+            ordered_counter[parent_id] = counter
+            return f"{counter}. {text}"
+
+        if attr == "code":
+            style = getattr(content_obj, "style", None)
+            lang = str(getattr(style, "language", "") or "") if style else ""
+            return f"```{lang}\n{text}\n```"
+
+        if attr == "todo":
+            style = getattr(content_obj, "style", None)
+            checkbox = "[x]" if style and getattr(style, "done", False) else "[ ]"
+            return f"- {checkbox} {text}"
+
+        fmt = self._TEXT_FORMAT.get(attr)
+        if fmt:
+            return fmt.format(text=text)
+        return text
+
+    @staticmethod
+    def _handle_divider(block, block_map: Dict = None, **_) -> str:
+        """Convert a divider block to Markdown."""
+        return "---"
+
+    @staticmethod
+    def _handle_image(block, block_map: Dict = None, **_) -> Optional[str]:
+        """Convert an image block to a deferred Feishu media reference."""
+        image = block.image
+        if not image:
+            return None
+        file_token = image.token or ""
+        alt_text = getattr(image, "alt", "") or "image"
+        return f"![{alt_text}](feishu://image/{file_token})"
+
+    def _extract_block_text(self, block, attr_name: str) -> str:
+        """Extract formatted text from one named block attribute."""
+        content_obj = getattr(block, attr_name, None)
+        if content_obj and getattr(content_obj, "elements", None):
+            return self._extract_text_from_elements(content_obj.elements)
+        return ""
+
+    def _extract_text_from_elements(self, elements) -> str:
+        """Convert Feishu TextElement SDK objects to formatted text."""
+        if not elements:
+            return ""
+        parts = []
+        for element in elements:
+            text_run = element.text_run
+            if text_run:
+                content = self._apply_text_style(
+                    text_run.content or "",
+                    text_run.text_element_style,
+                )
+                parts.append(content)
+                continue
+
+            mention_user = element.mention_user
+            if mention_user:
+                parts.append(f"@{getattr_safe(mention_user, 'user_id', 'user')}")
+                continue
+
+            mention_doc = element.mention_doc
+            if mention_doc:
+                title = getattr_safe(mention_doc, "title", "document")
+                url = getattr_safe(mention_doc, "url", "")
+                parts.append(f"[{title}]({url})" if url else str(title))
+                continue
+
+            equation = element.equation
+            if equation:
+                parts.append(f"${getattr_safe(equation, 'content', '')}$")
+
+        return "".join(parts)
+
+    @staticmethod
+    def _apply_text_style(text: str, style) -> str:
+        """Apply Markdown formatting from a TextElementStyle object."""
+        if not text or not style:
+            return text
+        if getattr(style, "inline_code", False):
+            return f"`{text}`"
+        link = getattr(style, "link", None)
+        if link:
+            url = getattr_safe(link, "url", "")
+            if url:
+                text = f"[{text}]({url})"
+        if getattr(style, "bold", False):
+            text = f"**{text}**"
+        if getattr(style, "italic", False):
+            text = f"*{text}*"
+        if getattr(style, "strikethrough", False):
+            text = f"~~{text}~~"
+        return text
+
+    def _table_block_to_markdown(self, block, block_map: Dict, **_) -> Optional[str]:
+        """Convert a table block and its cell children to Markdown."""
+        table = block.table
+        children = block.children
+        if not table or not children or not table.property:
+            return None
+
+        row_size = table.property.row_size or 0
+        col_size = table.property.column_size or 0
+        if not row_size or not col_size:
+            return None
+
+        rows = []
+        for row_idx in range(row_size):
+            row = []
+            for col_idx in range(col_size):
+                cell_idx = row_idx * col_size + col_idx
+                if cell_idx < len(children):
+                    cell_block = block_map.get(children[cell_idx])
+                    row.append(self._extract_cell_text(cell_block, block_map))
+                else:
+                    row.append("")
+            rows.append(row)
+
+        return format_table_to_markdown(rows, has_header=True) if rows else None
+
+    def _extract_cell_text(self, cell_block, block_map: Dict) -> str:
+        """Extract text from a table cell's child blocks."""
+        if not cell_block or not cell_block.children:
+            return ""
+        texts = []
+        for child_id in cell_block.children:
+            child = block_map.get(child_id)
+            if not child:
+                continue
+            attr = self._detect_block_attr(child)
+            if attr:
+                text = self._extract_block_text(child, attr)
+                if text:
+                    texts.append(text)
+        return " ".join(texts)

--- a/openviking/parse/parsers/feishu.py
+++ b/openviking/parse/parsers/feishu.py
@@ -27,6 +27,7 @@ from openviking.parse.base import (
     create_parse_result,
     format_table_to_markdown,
 )
+from openviking.parse.feishu_markdown import FeishuBlockMarkdownMixin
 from openviking.parse.parsers.base_parser import BaseParser
 from openviking_cli.utils.config.parser_config import FeishuConfig
 from openviking_cli.utils.logger import get_logger
@@ -34,13 +35,6 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 _ALLOWED_FEISHU_HOSTS = ("feishu.cn", "larksuite.com", "larkoffice.com")
-
-
-def _getattr_safe(obj, key: str, default=None):
-    """Get attribute from SDK object or dict, with safe fallback."""
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
 
 
 def _is_allowed_feishu_url(source_path: str) -> bool:
@@ -53,7 +47,7 @@ def _is_allowed_feishu_url(source_path: str) -> bool:
     )
 
 
-class FeishuParser(BaseParser):
+class FeishuParser(FeishuBlockMarkdownMixin, BaseParser):
     """Parser for Feishu/Lark cloud documents.
 
     Block type detection uses a two-tier strategy:
@@ -426,231 +420,7 @@ class FeishuParser(BaseParser):
 
         return all_blocks
 
-    # ========== Block -> Markdown Conversion ==========
-
-    def _detect_block_attr(self, block) -> Optional[str]:
-        """Detect which content attribute is populated on a block object.
-
-        Uses block_type integer as the primary dispatch (reliable), falling
-        back to attribute inspection over a known whitelist for unknown types.
-        """
-        # Primary: lookup by block_type integer
-        block_type = getattr(block, "block_type", None)
-        if block_type is not None:
-            attr = self._BLOCK_TYPE_TO_ATTR.get(block_type)
-            if attr:
-                return attr
-
-        # Fallback: scan known content attributes for unknown block types
-        for attr in self._KNOWN_CONTENT_ATTRS:
-            if getattr(block, attr, None) is not None:
-                return attr
-        return None
-
-    def _block_to_markdown(
-        self, block, block_map: Dict, ordered_counter: Dict[str, int], document_id: str = ""
-    ) -> Optional[str]:
-        """Convert a single SDK block object to markdown string.
-
-        Uses block_type integer for primary dispatch, with attribute whitelist
-        fallback for unknown types. Formatting is data-driven via _TEXT_FORMAT
-        and _SPECIAL_BLOCK_HANDLERS tables.
-        """
-        attr = self._detect_block_attr(block)
-
-        if attr is None:
-            return None
-
-        # Skip structural containers (processed via their children)
-        if attr in self._SKIP_ATTRS:
-            return None
-
-        # Reset ordered list counter when any non-ordered block appears
-        if attr != "ordered":
-            parent_id = block.parent_id or ""
-            if parent_id in ordered_counter:
-                del ordered_counter[parent_id]
-
-        # Special blocks (non-text: divider, image, table, sheet)
-        special_handler = self._SPECIAL_BLOCK_HANDLERS.get(attr)
-        if special_handler:
-            return getattr(self, special_handler)(block, block_map, document_id=document_id)
-
-        # --- Text-bearing blocks: extract elements, apply formatting ---
-        content_obj = getattr(block, attr, None)
-        if not content_obj or not hasattr(content_obj, "elements") or not content_obj.elements:
-            return None
-
-        text = self._extract_text_from_elements(content_obj.elements)
-        if not text:
-            return None
-
-        # Headings: heading1 -> #, heading2 -> ##, ...
-        if attr.startswith("heading"):
-            level = int(attr.replace("heading", "") or "1")
-            return f"{'#' * level} {text}"
-
-        # Ordered list (needs counter state)
-        if attr == "ordered":
-            parent_id = block.parent_id or ""
-            counter = ordered_counter.get(parent_id, 0) + 1
-            ordered_counter[parent_id] = counter
-            return f"{counter}. {text}"
-
-        # Code block (needs language from style)
-        if attr == "code":
-            lang = ""
-            if hasattr(content_obj, "style") and content_obj.style:
-                lang = str(getattr(content_obj.style, "language", "") or "")
-            return f"```{lang}\n{text}\n```"
-
-        # Todo (needs done state from style)
-        if attr == "todo":
-            done = False
-            if hasattr(content_obj, "style") and content_obj.style:
-                done = getattr(content_obj.style, "done", False)
-            checkbox = "[x]" if done else "[ ]"
-            return f"- {checkbox} {text}"
-
-        # Simple template formatting (bullet, quote, etc.)
-        fmt = self._TEXT_FORMAT.get(attr)
-        if fmt:
-            return fmt.format(text=text)
-
-        # Default: return plain text (covers callout, equation, task, unknown, etc.)
-        return text
-
-    @staticmethod
-    def _handle_divider(block, block_map: Dict = None, **_) -> str:
-        """Convert divider block to markdown."""
-        return "---"
-
-    @staticmethod
-    def _handle_image(block, block_map: Dict = None, **_) -> Optional[str]:
-        """Convert image block to markdown."""
-        image = block.image
-        if not image:
-            return None
-        file_token = image.token or ""
-        alt_text = getattr(image, "alt", "") or "image"
-        return f"![{alt_text}](feishu://image/{file_token})"
-
-    def _extract_block_text(self, block, attr_name: str) -> str:
-        """Extract text from a block's named attribute (e.g. block.text, block.heading2)."""
-        content_obj = getattr(block, attr_name, None)
-        if content_obj and hasattr(content_obj, "elements") and content_obj.elements:
-            return self._extract_text_from_elements(content_obj.elements)
-        return ""
-
-    def _extract_text_from_elements(self, elements) -> str:
-        """Convert Feishu TextElement SDK objects to formatted text."""
-        if not elements:
-            return ""
-        parts = []
-        for element in elements:
-            # TextRun
-            text_run = element.text_run
-            if text_run:
-                content = text_run.content or ""
-                style = text_run.text_element_style
-                content = self._apply_text_style(content, style)
-                parts.append(content)
-                continue
-
-            # MentionUser
-            mention_user = element.mention_user
-            if mention_user:
-                user_id = _getattr_safe(mention_user, "user_id", "user")
-                parts.append(f"@{user_id}")
-                continue
-
-            # MentionDoc
-            mention_doc = element.mention_doc
-            if mention_doc:
-                title = _getattr_safe(mention_doc, "title", "document")
-                url = _getattr_safe(mention_doc, "url", "")
-                parts.append(f"[{title}]({url})" if url else str(title))
-                continue
-
-            # Equation
-            equation = element.equation
-            if equation:
-                parts.append(f"${_getattr_safe(equation, 'content', '')}$")
-                continue
-
-        return "".join(parts)
-
-    @staticmethod
-    def _apply_text_style(text: str, style) -> str:
-        """Apply markdown formatting based on TextElementStyle SDK object."""
-        if not text or not style:
-            return text
-        # inline_code (SDK uses 'inline_code', not 'code_inline')
-        if getattr(style, "inline_code", False):
-            return f"`{text}`"
-        # link
-        link = getattr(style, "link", None)
-        if link:
-            url = _getattr_safe(link, "url", "")
-            if url:
-                text = f"[{text}]({url})"
-        if getattr(style, "bold", False):
-            text = f"**{text}**"
-        if getattr(style, "italic", False):
-            text = f"*{text}*"
-        if getattr(style, "strikethrough", False):
-            text = f"~~{text}~~"
-        return text
-
-    def _table_block_to_markdown(self, block, block_map: Dict, **_) -> Optional[str]:
-        """Convert table block to markdown table."""
-        table = block.table
-        children = block.children
-        if not table or not children:
-            return None
-
-        prop = table.property
-        if not prop:
-            return None
-        row_size = prop.row_size or 0
-        col_size = prop.column_size or 0
-        if not row_size or not col_size:
-            return None
-
-        rows = []
-        for row_idx in range(row_size):
-            row = []
-            for col_idx in range(col_size):
-                cell_idx = row_idx * col_size + col_idx
-                if cell_idx < len(children):
-                    cell_block_id = children[cell_idx]
-                    cell_block = block_map.get(cell_block_id)
-                    cell_text = self._extract_cell_text(cell_block, block_map)
-                    row.append(cell_text)
-                else:
-                    row.append("")
-            rows.append(row)
-
-        return format_table_to_markdown(rows, has_header=True) if rows else None
-
-    def _extract_cell_text(self, cell_block, block_map: Dict) -> str:
-        """Extract text from a table cell block by reading its children."""
-        if not cell_block or not cell_block.children:
-            return ""
-        texts = []
-        for child_id in cell_block.children:
-            child = block_map.get(child_id)
-            if not child:
-                continue
-            # Use attribute-driven detection to find text in any block type
-            attr = self._detect_block_attr(child)
-            if attr:
-                text = self._extract_block_text(child, attr)
-                if text:
-                    texts.append(text)
-        return " ".join(texts)
-
-    # ========== Embedded Sheet in Docx ==========
+    # Block-to-Markdown conversion is inherited from FeishuBlockMarkdownMixin.
 
     def _embedded_sheet_to_markdown(
         self, block, block_map: Dict = None, *, document_id: str = "", **_

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -8,6 +8,8 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+from openviking.parse.feishu_markdown import FeishuBlockMarkdownMixin
+from openviking.parse.parsers.feishu import FeishuParser
 
 
 class _SuccessResponse:
@@ -185,9 +187,7 @@ def test_resolve_image_refs_uses_content_type_extension(monkeypatch):
     accessor._config = SimpleNamespace(download_images=True)
     accessor._client = SimpleNamespace(request=request_media)
 
-    updated, images = accessor._resolve_image_refs(
-        "![j](feishu://image/img_token_jpeg)"
-    )
+    updated, images = accessor._resolve_image_refs("![j](feishu://image/img_token_jpeg)")
 
     assert updated == "![j](images/img_token_jpeg.jpg)"
     assert images == {"images/img_token_jpeg.jpg": b"\xff\xd8\xff\xe0jpeg-bytes"}
@@ -202,9 +202,7 @@ def test_resolve_image_refs_falls_back_to_byte_magic_extension(monkeypatch):
     accessor._config = SimpleNamespace(download_images=True)
     accessor._client = SimpleNamespace(request=request_media)
 
-    updated, images = accessor._resolve_image_refs(
-        "![w](feishu://image/img_token_webp)"
-    )
+    updated, images = accessor._resolve_image_refs("![w](feishu://image/img_token_webp)")
 
     assert updated == "![w](images/img_token_webp.webp)"
     assert images == {"images/img_token_webp.webp": webp_bytes}
@@ -332,3 +330,31 @@ def test_access_writes_downloaded_images_next_to_markdown(monkeypatch):
         resource.cleanup()
 
     assert not resource.path.parent.exists()
+
+
+def test_accessor_and_legacy_parser_share_docx_block_conversion():
+    """Both Feishu entry points must use one conversion implementation."""
+    assert FeishuAccessor._block_to_markdown is FeishuBlockMarkdownMixin._block_to_markdown
+    assert FeishuParser._block_to_markdown is FeishuBlockMarkdownMixin._block_to_markdown
+
+    style = SimpleNamespace(
+        bold=True,
+        italic=False,
+        inline_code=False,
+        strikethrough=False,
+        link=None,
+    )
+    element = SimpleNamespace(
+        text_run=SimpleNamespace(content="shared", text_element_style=style),
+        mention_user=None,
+        mention_doc=None,
+        equation=None,
+    )
+    block = SimpleNamespace(
+        block_type=2,
+        parent_id="root",
+        text=SimpleNamespace(elements=[element]),
+    )
+
+    assert FeishuAccessor()._block_to_markdown(block, {}, {}) == "**shared**"
+    assert FeishuParser()._block_to_markdown(block, {}, {}) == "**shared**"


### PR DESCRIPTION
## Description

Consolidates the duplicated Feishu docx block-to-Markdown algorithm used by the production accessor and legacy parser. Each entry point keeps its own supported-block policy, authentication, permission mapping, image handling, and embedded sheet/base behavior.

This is the first bounded step toward closing the conversion gaps in #3027. It does not claim to add sheets/base support to the production accessor yet.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Part of #3027

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a shared `FeishuBlockMarkdownMixin` for block dispatch, text styling, tables, and deferred image references.
- Make both Feishu entry points use the same conversion implementation while retaining their distinct policy tables.
- Add a regression test that proves both entry points resolve to the shared implementation and produce identical docx text conversion.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation:
- `uv run --extra test python -m pytest -q tests/parse/test_feishu_accessor.py tests/parse/test_feishu_parser.py` — 60 passed.
- `uvx ruff check ...` — passed.
- `uvx ruff format --check ...` — passed.
- Full `tests/parse` run: 525 passed, 31 skipped, 8 failed. The same 8 `test_add_directory.py` failures reproduce on pristine main with the identical missing `FakeVikingFS.glob` and stale temp-path expectations, so this change introduces no new parse-suite failures.

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Follow-up work for #3027 should add production sheets/base conversion behind the shared boundary with user-auth tests and a live canary. That behavior change is intentionally excluded from this PR.