### PR TITLE
[WIP] [Bug]: not confirm empty message.jsonl state before commit return

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1172,8 +1172,20 @@ class Session:
                     )
                 self._messages = retained_messages
                 await self._write_to_agfs_async(messages=self._messages)
+                await self._confirm_live_messages_persisted(self._messages)
             except Exception as e:
                 logger.error(f"[commit] Failed to persist archive/live messages: {e}")
+                try:
+                    await self._write_failed_marker(
+                        archive_uri,
+                        stage="phase1_live_persist",
+                        error=str(e),
+                    )
+                except Exception:
+                    logger.warning(
+                        "[commit] Failed to mark archive as failed after Phase 1 error",
+                        exc_info=True,
+                    )
                 self._messages = list(messages_to_archive) + list(retained_messages)
                 self._compression.compression_index -= 1
                 raise
@@ -2114,6 +2126,77 @@ class Session:
         except Exception:
             return len(self._messages)
         return len([line for line in content.strip().split("\n") if line.strip()])
+
+    async def _confirm_live_messages_persisted(self, expected_messages: List[Message]) -> None:
+        """Verify the persisted live messages match the retained in-memory tail."""
+        if not self._viking_fs:
+            return
+
+        ignore_created_at = [message.created_at is None for message in expected_messages]
+        expected_rows = [
+            self._message_row_for_confirm(
+                json.loads(message.to_jsonl()),
+                ignore_created_at=ignore,
+            )
+            for message, ignore in zip(expected_messages, ignore_created_at)
+        ]
+        try:
+            content = await self._viking_fs.read_file(
+                f"{self._session_uri}/messages.jsonl",
+                ctx=self.ctx,
+            )
+        except Exception as exc:
+            raise FailedPreconditionError(
+                "Session commit could not confirm persisted live messages",
+                details={
+                    "session_id": self.session_id,
+                    "expected_message_count": len(expected_rows),
+                    "error": str(exc),
+                },
+            ) from exc
+
+        try:
+            actual_rows = []
+            lines = [line for line in (content or "").splitlines() if line.strip()]
+            for index, line in enumerate(lines):
+                actual_rows.append(
+                    self._message_row_for_confirm(
+                        json.loads(line),
+                        ignore_created_at=(
+                            ignore_created_at[index] if index < len(ignore_created_at) else False
+                        ),
+                    )
+                )
+        except json.JSONDecodeError as exc:
+            raise FailedPreconditionError(
+                "Session commit could not parse persisted live messages",
+                details={
+                    "session_id": self.session_id,
+                    "expected_message_count": len(expected_rows),
+                    "error": str(exc),
+                },
+            ) from exc
+
+        if actual_rows != expected_rows:
+            raise FailedPreconditionError(
+                "Session commit live messages persistence check failed",
+                details={
+                    "session_id": self.session_id,
+                    "expected_message_count": len(expected_rows),
+                    "actual_message_count": len(actual_rows),
+                },
+            )
+
+    @staticmethod
+    def _message_row_for_confirm(
+        row: Dict[str, Any],
+        *,
+        ignore_created_at: bool,
+    ) -> Dict[str, Any]:
+        """Return the comparable persisted message row."""
+        if not ignore_created_at:
+            return row
+        return {key: value for key, value in row.items() if key != "created_at"}
 
     def _extract_abstract_from_summary(self, summary: str) -> str:
         """Extract one-sentence overview from structured summary."""

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -12,10 +12,11 @@ import pytest
 
 from openviking import AsyncOpenViking
 from openviking.client.session import Session as ClientSession
-from openviking.message import TextPart
+from openviking.message import Message, TextPart
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.storage.transaction import get_lock_manager
+from openviking_cli.exceptions import FailedPreconditionError
 
 
 async def _wait_for_task(task_id: str, timeout: float = 30.0) -> dict:
@@ -340,6 +341,68 @@ class TestCommit:
         assert result.get("archived") is True
         # Current message list should be cleared after commit
         assert len(session_with_messages.messages) == 0
+
+    async def test_commit_rejects_when_live_clear_is_not_persisted(
+        self, client: AsyncOpenViking, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Commit must not return accepted if the live messages file still has archived rows."""
+        session = client.session(session_id="commit_live_clear_confirm_test")
+        session.add_message("user", [TextPart("old user")])
+        session.add_message("assistant", [TextPart("old assistant")])
+
+        root_messages_uri = f"{session.uri}/messages.jsonl"
+        original_write_file = session._viking_fs.write_file
+
+        async def drop_empty_root_messages_write(*args, **kwargs):
+            uri = args[0] if args else kwargs.get("uri")
+            content = args[1] if len(args) > 1 else kwargs.get("content")
+            if uri == root_messages_uri and content == "":
+                return None
+            return await original_write_file(*args, **kwargs)
+
+        monkeypatch.setattr(session._viking_fs, "write_file", drop_empty_root_messages_write)
+
+        with pytest.raises(FailedPreconditionError, match="persistence check failed"):
+            await session.commit_async()
+
+        assert [message.parts[0].text for message in session.messages] == [
+            "old user",
+            "old assistant",
+        ]
+
+        archive_uri = f"{session.uri}/history/archive_001"
+        assert not await _marker_exists(session, archive_uri, ".done")
+        failed = json.loads(
+            await session._viking_fs.read_file(f"{archive_uri}/.failed.json", ctx=session.ctx)
+        )
+        assert failed["stage"] == "phase1_live_persist"
+
+        reloaded = client.session(session_id="commit_live_clear_confirm_test", must_exist=True)
+        context = await reloaded.get_session_context()
+        assert [message.parts[0].text for message in context["messages"]] == [
+            "old user",
+            "old assistant",
+        ]
+
+    async def test_commit_keep_recent_accepts_legacy_retained_message_without_created_at(
+        self, client: AsyncOpenViking
+    ):
+        """Retained legacy messages without created_at should not fail live persistence confirm."""
+        session = client.session(session_id="commit_legacy_retained_created_at_test")
+        session.add_message("user", [TextPart("archive me")])
+        session._messages.append(
+            Message(
+                id="legacy-retained",
+                role="assistant",
+                parts=[TextPart("retain me")],
+                created_at=None,
+            )
+        )
+
+        result = await session.commit_async(keep_recent_count=1)
+
+        assert result.get("archived") is True
+        assert [message.parts[0].text for message in session.messages] == ["retain me"]
 
     async def test_commit_empty_session(self, session: Session):
         """Test committing empty session"""


### PR DESCRIPTION
Resolves #1487

## Coderus 执行结果
开发 Agent 已完成分析、修复和测试，双 Reviewer 已各检视一次；本 PR 等待人工审核。

## 开发与测试报告
已完成最小修复和回归测试补充。

**复现**
我从代码路径确认了可复现场景：`commit_async()` 先写 archive，再把 root `messages.jsonl` 清空/写 retained tail，但此前没有读回确认；如果 root 空写被底层服务吞掉，Phase 2 仍可能写 `.done`，后续 `load()` 会把旧 root `messages.jsonl` 重新作为 active messages 合入 `/context`。

**根因**
[openviking/session/session.py](/abs/path/D:/Codes/OpenViking/Coderus/data/workspaces/task-3/openviking/session/session.py:1175) 在 Phase 1 写完 live tail 后直接进入 enqueue/返回 accepted，缺少“root live 持久化状态 == 本次 retained messages”的确认。

**修改**
在 [session.py](/abs/path/D:/Codes/OpenViking/Coderus/data/workspaces/task-3/openviking/session/session.py:2130) 新增 `_confirm_live_messages_persisted()`：写完 root `messages.jsonl` 后读回逐行比对。

在 Phase 1 中调用该确认；若不一致，抛 `FailedPreconditionError`，回滚内存状态，并尽量给对应 archive 写 `.failed.json`，避免半成品 archive 之后被当 pending context 合入。

新增测试 [tests/session/test_session_commit.py](/abs/path/D:/Codes/OpenViking/Coderus/data/workspaces/task-3/tests/session/test_session_commit.py:345)，模拟 root 空写“返回成功但实际未落盘”，断言 commit 不返回 accepted，archive 不写 `.done`，并标记 `.failed.json`。

**测试结果**
通过：
- `python -c ast.parse(...)` 语法解析通过
- `git diff --check -- openviking/session/session.py tests/session/test_session_commit.py` 通过

未能运行：
- `pytest tests/session/test_session_commit.py::TestCommit::test_commit_rejects_when_live_clear_is_not_persisted -q` 未进入测试收集，Python `tempfile` 报 “No usable temporary directory”
- `uv venv .venv` / `uv --no-cache venv .venv` 均因 uv 写解释器缓存被拒绝而失败
- 直接脚本执行被缺失依赖 `loguru` 阻断；未向系统环境安装依赖

**未验证项**
动态 pytest 未跑通，原因是本机临时目录/uv 缓存写入权限异常。测试探测过程中还产生了一批未跟踪的 8 字符临时文件，删除同样被系统拒绝；代码 diff 本身只包含上述两个目标文件。

---

已完成本轮集中修正，未提交、未推送、未读取凭据。

**已处理意见**
- 意见 1/2 成立，已修复：[session.py](D:/Codes/OpenViking/Coderus/data/workspaces/task-3/openviking/session/session.py:1179) 将不存在的 `_write_failed_file(...)` 改为现有 `_write_failed_marker(...)`，失败阶段写入 `.failed.json`。
- 补充覆盖重载路径：[test_session_commit.py](D:/Codes/OpenViking/Coderus/data/workspaces/task-3/tests/session/test_session_commit.py:345) 验证 live clear 未落盘时 commit 抛错、`.failed.json` 存在、重载 session 后 context 不重复插入 pending archive 消息。
- 意见 3 成立，已修复：[session.py](D:/Codes/OpenViking/Coderus/data/workspaces/task-3/openviking/session/session.py:2130) live 持久化确认改为解析 JSON 比较；仅当预期消息本身缺失 `created_at` 时忽略该行动态生成的 `created_at`。
- 补充 legacy 回归：[test_session_commit.py](D:/Codes/OpenViking/Coderus/data/workspaces/task-3/tests/session/test_session_commit.py:387) 覆盖 `keep_recent_count=1` 保留缺失 `created_at` 的 legacy 消息不误失败。

**拒绝/未处理**
- 无拒绝项；三条检视意见均成立并已处理。

**测试结果**
- 通过：`python -c "compile(...)"` 语法检查，覆盖 `openviking/session/session.py` 和 `tests/session/test_session_commit.py`。
- 通过：`git diff --check`，仅有 Git 的 CRLF 提示，无 whitespace 错误。
- 未能完成 pytest：直接运行目标测试先被 Python `tempfile` 临时目录探测阻塞；禁用捕获后又因当前 Python 环境缺少 `loguru` 导入失败；尝试 `uv run` 时被沙箱拒绝访问 `uv` 缓存/临时持久化目录。

**未验证项**
- 目标 pytest 用例未在当前环境实际跑通，原因是测试环境依赖和临时文件权限阻塞，不是断言失败。完整 diff 已自检，改动仅限 `session.py` 和提交测试文件。

## 待人工确认
- [high] The new exception path calls `self._write_failed_file(...)`, but the class only defines `_write_failed_marker(...)`. The AttributeError is swallowed by the inner `except Exception`, so a live persistence mismatch leaves `history/archive_NNN/messages.jsonl` without either `.done` or `.failed.json`. After reload, that incomplete archive can still be treated as pending context, and the new test's `.failed.json` assertion will fail. Call the existing `_write_failed_marker` helper or add the intended helper.
- [high] The new exception path calls `self._write_failed_file(...)`, but this class only defines `_write_failed_marker(...)`. The AttributeError is swallowed by the surrounding `except Exception`, so `.failed.json` is not created. After a failed live-message confirmation, a restarted session scans the leftover `history/archive_001` directory, sees no `.done` and no `.failed.json`, and can treat the archived rows as pending context again, reintroducing the bug this patch is meant to prevent. Use the existing `_write_failed_marker` helper or add the intended helper, and cover the restart/load path in the regression test.
- [medium] `_confirm_live_messages_persisted()` recomputes `message.to_jsonl()` after `_write_to_agfs_async()` has already serialized the same retained messages. For messages loaded from older/legacy JSONL without `created_at`, `Message.to_dict()` fills `created_at` with `datetime.now()`, so the write and the confirmation can produce different JSON strings even though persistence succeeded. This breaks commits with `keep_recent_count > 0` on such sessions. Compare parsed message data on stable fields, normalize/fill `created_at` before writing, or pass the exact serialized lines used for the write into the confirmation.

Issue: https://github.com/volcengine/OpenViking/issues/1487
