### PR TITLE
feat(session): make generated IDs readable

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -368,7 +368,9 @@ class Session:
         self._session_compressor = session_compressor
         self.user = user or UserIdentifier.the_default_user()
         self.ctx = ctx or RequestContext(user=self.user, role=Role.ROOT)
-        self.session_id = session_id or str(uuid4())
+        self.session_id = (
+            session_id or f"{datetime.now(timezone.utc):%Y%m%d-%H%M%S}-{uuid4().hex[:16]}"
+        )
         self.created_at = int(datetime.now(timezone.utc).timestamp() * 1000)
         self._auto_commit_threshold = auto_commit_threshold
         self._session_uri = session_uri or canonical_session_uri(self.ctx, self.session_id)

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -3,6 +3,8 @@
 
 """Session lifecycle tests"""
 
+import re
+
 from openviking import AsyncOpenViking
 from openviking.session import Session
 
@@ -16,7 +18,7 @@ class TestSessionCreate:
 
         assert session is not None
         assert session.session_id is not None
-        assert len(session.session_id) > 0
+        assert re.fullmatch(r"\d{8}-\d{6}-[0-9a-f]{16}", session.session_id)
 
     async def test_create_with_id(self, client: AsyncOpenViking):
         """Test creating session with specified ID"""


### PR DESCRIPTION
## Description

Make auto-generated session IDs readable by including their UTC creation date and time while retaining a random suffix for uniqueness.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Change auto-generated session IDs from UUIDs to `YYYYMMDD-HHMMSS-<16 hex characters>`.
- Preserve caller-provided session IDs and existing stored sessions unchanged.
- Verify the generated ID format in the session lifecycle test.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Existing session IDs are not migrated. The readable timestamp uses UTC for consistency with existing session metadata.
