### PR TITLE
fix(mcp): advertise plain-typed tool schemas for strict function-calling APIs

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -323,7 +323,7 @@ async def recall(
     max_chars: int = DEFAULT_MAX_CHARS,
     min_score: float = DEFAULT_MIN_SCORE,
     peer_scope: str = "all",
-    other_peer_penalty: Optional[Any] = None,
+    other_peer_penalty: Optional[Union[float, Dict[str, float]]] = None,
 ) -> str:
     """Type-quota memory recall. Searches events, entities, preferences, and experiences separately, then returns a bounded memory_group block."""
     service = get_service()
@@ -970,6 +970,94 @@ async def health() -> str:
         return f"OpenViking is healthy (service initialized, storage: {type(service.viking_fs).__name__})"
     except Exception as e:
         return f"OpenViking is unhealthy: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Portable tool schemas
+# ---------------------------------------------------------------------------
+#
+# FastMCP derives tool input schemas from Python type hints, so Optional/Union
+# parameters become `anyOf` nodes with no top-level `type`, and nested models
+# become `$ref`/`$defs`. That is valid JSON Schema, but several LLM function
+# calling APIs (notably Gemini's OpenAPI 3.0 subset) require an explicit
+# `type` on every schema node and reject `anyOf`/`$ref`, so MCP clients that
+# forward our schemas verbatim get the whole request rejected. Rewrite the
+# advertised schemas into a plain-typed form: drop null branches, collapse
+# unions to their most general branch, and inline $refs. Runtime argument
+# validation still uses the original function signatures, so union parameters
+# keep accepting every branch (e.g. `read` still takes a bare URI string even
+# though the schema advertises an array).
+
+_PORTABLE_TYPE_PREFERENCE = ("array", "object", "string", "number", "integer", "boolean")
+
+
+def _portable_schema(schema: Any, defs: Optional[Dict[str, Any]] = None) -> Any:
+    if not isinstance(schema, dict):
+        return schema
+    if defs is None:
+        defs = schema.get("$defs") or {}
+    node = {k: v for k, v in schema.items() if k != "$defs"}
+
+    ref = node.pop("$ref", None)
+    if isinstance(ref, str) and ref.startswith("#/$defs/"):
+        target = defs.get(ref.rsplit("/", 1)[-1])
+        if isinstance(target, dict):
+            return _portable_schema({**target, **node}, defs)
+
+    any_of = node.pop("anyOf", None)
+    if isinstance(any_of, list):
+        branches = [
+            b
+            for b in (_portable_schema(b, defs) for b in any_of)
+            if isinstance(b, dict) and b.get("type") != "null"
+        ]
+        if branches:
+
+            def _rank(branch: Dict[str, Any]) -> int:
+                branch_type = branch.get("type")
+                if branch_type in _PORTABLE_TYPE_PREFERENCE:
+                    return _PORTABLE_TYPE_PREFERENCE.index(branch_type)
+                return len(_PORTABLE_TYPE_PREFERENCE)
+
+            node = {**min(branches, key=_rank), **node}
+        # A null default contradicts the collapsed non-null type; omission
+        # already means "not provided", so drop it.
+        if node.get("default", "") is None:
+            node.pop("default")
+
+    if isinstance(node.get("properties"), dict):
+        node["properties"] = {
+            key: _portable_schema(value, defs) for key, value in node["properties"].items()
+        }
+    for key in ("items", "additionalProperties"):
+        if isinstance(node.get(key), dict):
+            node[key] = _portable_schema(node[key], defs)
+
+    if "type" not in node:
+        if "properties" in node:
+            node["type"] = "object"
+        elif "items" in node:
+            node["type"] = "array"
+        else:
+            enum_values = node.get("enum") or ([node["const"]] if "const" in node else [])
+            sample = enum_values[0] if enum_values else ""
+            if isinstance(sample, bool):
+                node["type"] = "boolean"
+            elif isinstance(sample, int):
+                node["type"] = "integer"
+            elif isinstance(sample, float):
+                node["type"] = "number"
+            else:
+                node["type"] = "string"
+    return node
+
+
+def _apply_portable_schemas() -> None:
+    for tool in mcp._tool_manager.list_tools():
+        tool.parameters = _portable_schema(tool.parameters)
+
+
+_apply_portable_schemas()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -129,6 +129,64 @@ async def test_search_tools_expose_only_context_type_parameter():
         assert "filter" not in properties
 
 
+async def test_tool_schemas_are_portable():
+    """Every advertised schema node must carry an explicit type, with no
+    anyOf/$ref/$defs — strict function-calling APIs (e.g. Gemini's OpenAPI
+    subset) reject schemas that lack these guarantees."""
+
+    def assert_portable(node, path):
+        if not isinstance(node, dict):
+            return
+        assert "anyOf" not in node, f"{path}: anyOf not portable"
+        assert "$ref" not in node, f"{path}: $ref not portable"
+        assert "$defs" not in node, f"{path}: $defs not portable"
+        assert "type" in node, f"{path}: missing explicit type"
+        assert node.get("default", "") is not None, f"{path}: null default"
+        for key, sub in node.get("properties", {}).items():
+            assert_portable(sub, f"{path}.{key}")
+        for key in ("items", "additionalProperties"):
+            if isinstance(node.get(key), dict):
+                assert_portable(node[key], f"{path}.{key}")
+
+    tools = await mcp_endpoint.mcp.list_tools()
+    assert tools
+    for tool in tools:
+        assert_portable(tool.inputSchema, tool.name)
+
+
+def test_portable_schema_collapses_unions():
+    collapsed = mcp_endpoint._portable_schema(
+        {
+            "anyOf": [
+                {"type": "string"},
+                {"items": {"type": "string"}, "type": "array"},
+                {"type": "null"},
+            ],
+            "default": None,
+            "description": "one or many",
+        }
+    )
+    assert collapsed == {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "one or many",
+    }
+
+
+def test_portable_schema_inlines_refs():
+    inlined = mcp_endpoint._portable_schema(
+        {
+            "$defs": {"Item": {"properties": {"name": {"type": "string"}}, "type": "object"}},
+            "items": {"$ref": "#/$defs/Item"},
+            "type": "array",
+        }
+    )
+    assert inlined == {
+        "items": {"properties": {"name": {"type": "string"}}, "type": "object"},
+        "type": "array",
+    }
+
+
 async def test_find_tool_calls_lightweight_find(service, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Description

The MCP endpoint's tool input schemas are auto-generated by FastMCP from Python type hints, so `Optional`/`Union` parameters become `anyOf` nodes with no top-level `type`, and nested models become `$ref`/`$defs`. That is valid JSON Schema, but MCP clients that forward these schemas verbatim to strict function-calling APIs break in practice:

- **Gemini** (reported via an astrbot + Gemini setup): Gemini's function-calling schema is an OpenAPI 3.0 subset that requires an explicit `type` on every schema node, so tool registration fails with `400: find functionDeclaration *.level schema didn't specify the schema type field` and the whole request is rejected.
- **n8n** (reported via an n8n MCP Client Tool setup): n8n converts MCP `inputSchema` to Zod via `convertJsonSchemaToZod`, which silently falls back on complex schemas ([n8n-io/n8n#15603](https://github.com/n8n-io/n8n/issues/15603)); the LLM produced `{"query": "Vikingbot"}` but the server received `{}`, failing with `Error executing tool search: 1 validation error for searchArguments query Field required`.

A scan of the 16 MCP tools found 12 such nodes across 8 tools (`find`/`search` `level`, `context_type`, `session_id`; `recall` `quotas`, `other_peer_penalty`; `read.uris`; `grep.pattern`; `add_resource.args`; `remember`'s `$ref`).

This PR rewrites the advertised schemas into a maximally portable plain-typed form after tool registration: null branches are dropped, unions collapse to their most general branch (array > object > scalar, so `str | list[str]` advertises as an array), `$ref`/`$defs` are inlined, every node carries an explicit `type`, and contradictory `default: null` entries are removed.

**No behavior change for existing clients**: FastMCP validates call arguments against the original function signatures (`fn_metadata.arg_model`), which are untouched — `read` still accepts a bare URI string, `context_type` still accepts a single string, even though the schema now advertises arrays.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No upstream issue filed; both failures were reported by downstream integrators (n8n and astrbot + Gemini users).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `_portable_schema()` in `openviking/server/mcp_endpoint.py`, applied to all registered tools at import time: drops null branches, collapses `anyOf` unions to the most general branch, inlines `$ref`/`$defs`, ensures every schema node has an explicit `type`, and removes `default: null` when it contradicts the collapsed type.
- Fix `recall`'s `other_peer_penalty` parameter type from `Optional[Any]` (which generated an empty `{}` schema node) to `Optional[Union[float, Dict[str, float]]]`, matching what `normalize_penalties` actually accepts.
- Add regression tests: a portability assertion over every advertised tool schema (guards future tools), plus unit tests for union collapsing and `$ref` inlining.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`pytest tests/server/test_mcp_endpoint.py` — 57 passed. Verified by dumping all 16 tool schemas via `mcp.list_tools()`: 0 nodes without an explicit `type`, no `anyOf`/`$ref`/`$defs` remain. `ruff format --check`, `ruff check`, and `mypy` are clean on the touched files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Example of the rewrite for `find.level` (the exact node Gemini rejected):

Before:

```json
"level": {"anyOf": [{"items": {"type": "integer"}, "type": "array"}, {"type": "null"}], "default": null, "title": "Level"}
```

After:

```json
"level": {"items": {"type": "integer"}, "type": "array", "title": "Level"}
```

vikingbot's own tool schemas (`bot/vikingbot/agent/tools/ov_file.py`) are hand-written with explicit types and are not affected.
