### PR TITLE
[WIP] [Bug]: not confirm empty message.jsonl state before commit return

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -37,7 +37,7 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens
-from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config import get_openviking_config
@@ -1162,6 +1162,13 @@ class Session:
                 messages_to_archive = self._messages.copy()
                 retained_messages = []
 
+            original_live_messages = list(self._messages)
+            original_live_content = ""
+            if self._viking_fs:
+                original_live_content = await self._viking_fs.read_file(
+                    f"{self._session_uri}/messages.jsonl", ctx=self.ctx
+                )
+            live_rewrite_started = False
             try:
                 # Persist archive raw messages before trimming live messages so
                 # an archive write failure cannot drop live conversation history.
@@ -1173,11 +1180,26 @@ class Session:
                         ctx=self.ctx,
                     )
                 self._messages = retained_messages
+                live_rewrite_started = True
                 await self._write_to_agfs_async(messages=self._messages)
+                await self._verify_live_messages_persisted(self._messages)
             except Exception as e:
                 logger.error(f"[commit] Failed to persist archive/live messages: {e}")
-                self._messages = list(messages_to_archive) + list(retained_messages)
+                self._messages = original_live_messages
                 self._compression.compression_index -= 1
+                if live_rewrite_started and self._viking_fs:
+                    try:
+                        await self._viking_fs.write_file(
+                            uri=f"{self._session_uri}/messages.jsonl",
+                            content=original_live_content,
+                            ctx=self.ctx,
+                        )
+                    except Exception as rollback_error:
+                        raise RuntimeError(
+                            "Failed to persist archive/live messages and restore the "
+                            f"original live messages: persist error: {e}; "
+                            f"rollback error: {rollback_error}"
+                        ) from rollback_error
                 raise
         # Lock released; live session now contains only the retained tail.
 
@@ -3172,6 +3194,33 @@ class Session:
             content=overview,
             ctx=self.ctx,
         )
+
+    async def _verify_live_messages_persisted(self, messages: List[Message]) -> None:
+        """Confirm the Phase 1 live-message rewrite reached persistent storage."""
+        if not self._viking_fs:
+            return
+
+        uri = f"{self._session_uri}/messages.jsonl"
+        try:
+            content = await self._viking_fs.read_file(uri, ctx=self.ctx)
+        except NotFoundError:
+            if not messages:
+                return
+            raise RuntimeError("Live messages persistence verification failed: file is missing")
+
+        try:
+            persisted = [json.loads(line) for line in content.splitlines() if line.strip()]
+            expected = [json.loads(message.to_jsonl()) for message in messages]
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                "Live messages persistence verification failed: invalid JSONL"
+            ) from exc
+
+        if persisted != expected:
+            raise RuntimeError(
+                "Live messages persistence verification failed: stored messages "
+                "do not match the committed live-message state"
+            )
 
     def _append_messages_to_jsonl_batch(self, messages: List[Message]) -> None:
         """Append multiple messages to messages.jsonl in a single write."""

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -48,6 +48,66 @@ class _MemoryVikingFS:
         self.files[uri] = content
 
 
+class _VerifyFailureVikingFS(_MemoryVikingFS):
+    def __init__(self, files, live_uri):
+        super().__init__(files)
+        self.live_uri = live_uri
+        self.live_reads = 0
+
+    async def read_file(self, uri, ctx=None):
+        if uri == self.live_uri:
+            self.live_reads += 1
+            if self.live_reads == 2:
+                raise OSError("transient verification read failure")
+        return await super().read_file(uri, ctx=ctx)
+
+
+@pytest.mark.asyncio
+async def test_live_message_verification_rejects_silently_ignored_empty_write():
+    session_uri = "viking://user/sessions/session-1"
+    stale = Message(id="stale", role="user", parts=[TextPart("old active message")])
+    files = {f"{session_uri}/messages.jsonl": f"{stale.to_jsonl()}\n"}
+    session = Session(
+        viking_fs=_MemoryVikingFS(files), session_id="session-1", session_uri=session_uri
+    )
+
+    with pytest.raises(RuntimeError, match="persistence verification failed"):
+        await session._verify_live_messages_persisted([])
+
+
+@pytest.mark.asyncio
+async def test_commit_restores_disk_live_messages_when_verification_fails(
+    monkeypatch, tmp_path
+):
+    session_uri = "viking://user/sessions/session-1"
+    live_uri = f"{session_uri}/messages.jsonl"
+    original = Message(id="original", role="user", parts=[TextPart("keep me")])
+    original_content = f"{original.to_jsonl()}\n"
+    files = {live_uri: original_content}
+    viking_fs = _VerifyFailureVikingFS(files, live_uri)
+    session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
+    session._messages = [original]
+
+    class _LockContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(
+        "openviking.storage.transaction.LockContext", lambda *args, **kwargs: _LockContext()
+    )
+    monkeypatch.setattr("openviking.storage.transaction.get_lock_manager", lambda: object())
+
+    with pytest.raises(OSError, match="transient verification read failure"):
+        await session.commit_async()
+
+    assert session._messages == [original]
+    assert session._compression.compression_index == 0
+    assert files[live_uri] == original_content
+
+
 @pytest.mark.asyncio
 async def test_resume_queued_commit_continues_phase2(monkeypatch):
     session_uri = "viking://user/sessions/session-1"


### PR DESCRIPTION
Resolves #1487

## Coderus 执行结果
开发 Agent 已完成分析、修复和测试，双 Reviewer 已各检视一次；本 PR 等待人工审核。

## 开发与测试报告
### 1. 问题描述
Issue #1487 的实际问题是 commit Phase 1 清空或裁剪根 messages.jsonl 后未确认结果已经持久化，Phase 2 仍可能完成归档并写入 .done，导致后续 /context 将旧消息再次视为活跃消息。影响范围为 Session 提交、归档恢复及活跃上下文加载。验收条件是提交继续前根 messages.jsonl 必须与 retained messages 一致；校验失败时不得损坏原有 live 消息，并须恢复内存状态和 compression_index。

### 2. 问题复现
代码探索确认集中检视意见成立。复现方式为：准备包含一条原始消息的根 messages.jsonl，执行 commit，使 live 重写成功，再令校验回读抛出瞬时 OSError。修改前异常分支只恢复 self._messages 和 compression_index，磁盘仍保持空或截断状态。新增测试覆盖了该场景，并验证原始文件内容需要逐字节恢复。

### 3. 修改方案
在 session 路径锁内、任何 Phase 1 写入前保存原始消息列表和根 messages.jsonl 完整内容；记录 live 重写是否已经开始。持久化或校验失败时恢复内存消息与 compression_index，并在 live 已开始重写时直接写回原始文件内容。若磁盘回滚也失败，抛出同时包含原持久化错误和回滚错误的 RuntimeError。保留了已有的成功路径校验，并新增静默忽略空写及校验失败后磁盘回滚测试。

### 4. 修改验证
已检查完整 diff，仅修改 openviking/session/session.py 和 tests/unit/session/test_session_commit_resume.py，共增加 111 行、删除 2 行，无无关文件变化。复现场景中异常仍会返回给调用方，同时内存消息、compression_index 和根 messages.jsonl 均恢复。git diff --check 与 Ruff 检查均通过。未提交、未推送，也未读取凭据。

### 5. 测试回归
实际运行 .venv/bin/python -m pytest -s -q -o addopts='' tests/unit/session/test_session_commit_resume.py，结果 3 passed、4 条既有 Pydantic 弃用警告。额外运行 tests/test_session_async_commit.py::test_commit_async_returns_accepted_with_task_id，但因环境缺少 OpenViking 配置文件而在 fixture 初始化阶段报错，未执行到测试主体。首次全局 pytest 不存在；使用虚拟环境后默认捕获曾遇到临时捕获文件异常，禁用捕获后受影响测试成功。

### 6. 遗留问题
必要的受影响单元测试已通过；完整异步提交回归测试因运行环境缺少 OpenViking 配置文件而未验证，这是当前唯一未验证项。代码层面无已知遗留问题。


Issue: https://github.com/volcengine/OpenViking/issues/1487
