### PR TITLE
fix(rerank): support Voyage via litellm (plain-string documents + dict results)

### DIFF
--- a/openviking/models/rerank/litellm_rerank.py
+++ b/openviking/models/rerank/litellm_rerank.py
@@ -6,12 +6,23 @@ LiteLLM Rerank API Client.
 
 # For logging, use Python's built-in logging
 import time
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from openviking.models.rerank.base import RerankBase
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
+
+
+def _result_field(item: Any, name: str, default: Any = None) -> Any:
+    """Read a field from a litellm rerank result item.
+
+    LiteLLM returns result items as objects for some providers (e.g. Cohere)
+    and as plain dicts for others (e.g. Voyage), so support both shapes.
+    """
+    if isinstance(item, dict):
+        return item.get(name, default)
+    return getattr(item, name, default)
 
 
 class LiteLLMRerankClient(RerankBase):
@@ -56,7 +67,7 @@ class LiteLLMRerankClient(RerankBase):
             response = litellm.rerank(
                 model=self.model_name,
                 query=query,
-                documents=[{"text": d} for d in documents],
+                documents=documents,
                 api_key=self.api_key,
                 api_base=self.api_base,
             )
@@ -86,7 +97,7 @@ class LiteLLMRerankClient(RerankBase):
                 return None
 
             for item in results:
-                idx = getattr(item, "index", None)
+                idx = _result_field(item, "index")
                 if idx is None or not (0 <= idx < len(documents)):
                     logger.warning(
                         "[LiteLLMRerankClient] Out-of-bounds or missing index in result: %s", item
@@ -94,8 +105,8 @@ class LiteLLMRerankClient(RerankBase):
                     return None
 
             # Results may not be in original order — sort by index
-            sorted_results = sorted(results, key=lambda x: x.index)
-            scores = [getattr(item, "relevance_score", 0.0) for item in sorted_results]
+            sorted_results = sorted(results, key=lambda x: _result_field(x, "index"))
+            scores = [_result_field(item, "relevance_score", 0.0) for item in sorted_results]
 
             logger.debug(f"[LiteLLMRerankClient] Reranked {len(documents)} documents")
             return scores

--- a/tests/unit/models/rerank/test_litellm_rerank.py
+++ b/tests/unit/models/rerank/test_litellm_rerank.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the LiteLLM rerank client (covers Voyage via litellm)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from openviking.models.rerank.litellm_rerank import LiteLLMRerankClient
+
+
+def _make_response(results):
+    response = MagicMock()
+    response.model_dump.return_value = {}
+    response.results = results
+    return response
+
+
+class TestLiteLLMRerankClient:
+    """Test cases for LiteLLMRerankClient."""
+
+    @patch("litellm.rerank")
+    def test_documents_passed_as_plain_strings(self, mock_rerank):
+        # Voyage's rerank API rejects [{"text": ...}] document wrappers; litellm
+        # expects a list of plain strings.
+        mock_rerank.return_value = _make_response(
+            [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.8},
+                {"index": 2, "relevance_score": 0.7},
+            ]
+        )
+
+        client = LiteLLMRerankClient(api_key="k", api_base=None, model_name="voyage/rerank-2.5")
+        client.rerank_batch("q", ["doc A", "doc B", "doc C"])
+
+        assert mock_rerank.call_args.kwargs["documents"] == ["doc A", "doc B", "doc C"]
+
+    @patch("litellm.rerank")
+    def test_parses_dict_results_and_preserves_order(self, mock_rerank):
+        # litellm returns dict result items for Voyage; scores must map back to
+        # the original document order.
+        mock_rerank.return_value = _make_response(
+            [
+                {"index": 2, "relevance_score": 0.99},
+                {"index": 0, "relevance_score": 0.50},
+                {"index": 1, "relevance_score": 0.01},
+            ]
+        )
+
+        client = LiteLLMRerankClient(api_key="k", api_base=None, model_name="voyage/rerank-2.5")
+        scores = client.rerank_batch("q", ["first", "second", "third"])
+
+        assert scores == [0.50, 0.01, 0.99]
+
+    @patch("litellm.rerank")
+    def test_parses_object_results(self, mock_rerank):
+        # Object-shaped result items (e.g. Cohere via litellm) must still work.
+        mock_rerank.return_value = _make_response(
+            [
+                SimpleNamespace(index=1, relevance_score=0.6),
+                SimpleNamespace(index=0, relevance_score=0.4),
+            ]
+        )
+
+        client = LiteLLMRerankClient(api_key="k", api_base=None, model_name="rerank-model")
+        scores = client.rerank_batch("q", ["a", "b"])
+
+        assert scores == [0.4, 0.6]
+
+    @patch("litellm.rerank")
+    def test_missing_index_falls_back_to_none(self, mock_rerank):
+        # A result item lacking an index must trigger the safe no-op fallback
+        # (caller then keeps the pre-rerank order) rather than mis-mapping.
+        mock_rerank.return_value = _make_response(
+            [
+                {"relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.8},
+            ]
+        )
+
+        client = LiteLLMRerankClient(api_key="k", api_base=None, model_name="voyage/rerank-2.5")
+        assert client.rerank_batch("q", ["a", "b"]) is None
+
+    @patch("litellm.rerank")
+    def test_empty_documents_short_circuits(self, mock_rerank):
+        client = LiteLLMRerankClient(api_key="k", api_base=None, model_name="voyage/rerank-2.5")
+        assert client.rerank_batch("q", []) == []
+        mock_rerank.assert_not_called()


### PR DESCRIPTION
## Summary

`LiteLLMRerankClient.rerank_batch` does not work with Voyage rerank models through litellm, due to two format mismatches:

1. **Request:** documents were wrapped as `[{"text": d} for d in documents]`. Voyage's rerank API rejects this with HTTP 400 (`'documents' is not a valid string`); litellm expects a plain `List[str]`.
2. **Response:** result items were read via `getattr(item, "index"/"relevance_score")`, but litellm returns Voyage results as plain `dict`s, so the lookups miss, the index-validation loop returns `None`, and reranking silently falls back to a no-op.

Net effect: configuring `rerank.provider = "litellm"` with a Voyage model (e.g. `voyage/rerank-2.5`) never actually reranks — it degrades to vector order without any error surfaced to the user.

## Changes

- Pass `documents` to `litellm.rerank` as plain strings.
- Add `_result_field(item, name, default)` to read `index` / `relevance_score` from either dict- or object-shaped result items, so both Voyage (dicts) and Cohere-style (objects) results are handled.

## Change type

- [x] Bug fix (non-breaking)

## Testing

- Added `tests/unit/models/rerank/test_litellm_rerank.py` (5 tests): plain-string documents contract, dict-shaped results with original-order preservation, object-shaped results (Cohere path unchanged), missing-index → safe `None` fallback, and empty-documents short-circuit. All pass locally with `pytest`.
- Verified end-to-end against `voyage/rerank-2.5`: relevance scores are now applied to search results (previously the client silently fell back to vector order).

Note: I could not run Ruff/Mypy in my local environment (not installed), but the change follows the repo style (<=100 cols, 4-space indent, double quotes, fully typed helper) and should pass CI.

## Related issues

None.

## Checklist

- [x] Non-breaking (Cohere / object-result path preserved and covered by a test)
- [x] Unit tests added and passing
- [x] Conventional Commit message
- [x] Follows code style (line width 100, double quotes, 4-space indent)
