### PR TITLE
fix(memory): route tool memories through execution context

### DIFF
--- a/openviking/prompts/templates/memory/skills.yaml
+++ b/openviking/prompts/templates/memory/skills.yaml
@@ -4,6 +4,7 @@ description: |
 directory: "viking://user/{{ user_space }}/memories/skills"
 filename_template: "{{ skill_name }}.md"
 enabled: true
+stage: agent
 content_template: |
   Skill: {{ skill_name }}
   

--- a/openviking/prompts/templates/memory/tools.yaml
+++ b/openviking/prompts/templates/memory/tools.yaml
@@ -15,6 +15,7 @@ description: |
 directory: "viking://user/{{ user_space }}/memories/tools"
 filename_template: "{{ tool_name }}.md"
 enabled: true
+stage: agent
 content_template: |
   Tool: {{ tool_name }}
 

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -16,7 +16,12 @@ from openviking.core.context import Context
 from openviking.message import Message
 from openviking.server.identity import RequestContext
 from openviking.session.memory import ExtractLoop, MemoryUpdater
-from openviking.session.memory.constants import EXECUTION_MEMORY_TYPES
+from openviking.session.memory.constants import (
+    DIRECT_EXECUTION_MEMORY_TYPES,
+    EXECUTION_MEMORY_TYPES,
+    EXPERIENCE_MEMORY_TYPE,
+    TRAJECTORY_MEMORY_TYPE,
+)
 from openviking.session.memory.dataclass import MemoryFile, ResolvedOperations, StoredLink
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import (
@@ -28,8 +33,8 @@ from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.memory.utils.uri import render_template
 from openviking.session.skill import SkillOperationUpdater, dedup_session_skill_operations
 from openviking.session.skill.session_skill_context_provider import SESSION_SKILL_MEMORY_TYPE
-from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.viking_fs import VikingFS, get_viking_fs
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.session.user_id import UserIdentifier
@@ -505,21 +510,22 @@ class SessionCompressorV2:
         allowed_memory_types: Optional[set[str]] = None,
         include_session_skills: Optional[bool] = None,
     ) -> Dict[str, List[Any]]:
-        """Extract trajectory, experience, and session-skill memories from execution context."""
+        """Extract memories that are grounded in execution context."""
         config = get_openviking_config()
         allowed_execution_types = (
             set(EXECUTION_MEMORY_TYPES)
             if allowed_memory_types is None
             else set(allowed_memory_types) & EXECUTION_MEMORY_TYPES
         )
-        include_trajectories = "trajectories" in allowed_execution_types
-        include_experiences = "experiences" in allowed_execution_types
+        direct_execution_types = allowed_execution_types & DIRECT_EXECUTION_MEMORY_TYPES
+        include_trajectories = TRAJECTORY_MEMORY_TYPE in direct_execution_types
+        include_experiences = EXPERIENCE_MEMORY_TYPE in allowed_execution_types
         if include_session_skills is None:
             include_session_skills = bool(
                 getattr(config.memory, "session_skill_extraction_enabled", False)
             )
         empty_result: Dict[str, List[Any]] = {"contexts": [], "session_skills": []}
-        if not include_trajectories:
+        if not direct_execution_types:
             return empty_result
         if not messages or not ctx:
             return empty_result
@@ -540,6 +546,7 @@ class SessionCompressorV2:
             latest_archive_overview=latest_archive_overview,
             include_trajectories=include_trajectories,
             include_session_skills=include_session_skills,
+            allowed_memory_types=direct_execution_types,
         )
         traj_result = await self._run_extract_phase(
             provider=traj_provider,
@@ -547,13 +554,13 @@ class SessionCompressorV2:
             ctx=ctx,
             strict_extract_errors=strict_extract_errors,
             phase_label="trajectory",
-            allowed_memory_types=allowed_execution_types,
+            allowed_memory_types=direct_execution_types,
             thinking=True,
         )
         if traj_result is None:
             return empty_result
 
-        written_trajectory_uris, _, traj_contexts, _, traj_skill_results = traj_result
+        written_phase_uris, _, traj_contexts, _, traj_skill_results = traj_result
         contexts.extend(traj_contexts)
         if archive_uri:
             for item in traj_skill_results:
@@ -563,11 +570,17 @@ class SessionCompressorV2:
         # Deduplicate: LLM may output the same trajectory_name twice in one call,
         # producing identical URIs. Without this, experience extraction would run
         # once per duplicate and generate near-identical experiences.
-        written_trajectory_uris = list(dict.fromkeys(written_trajectory_uris))
+        written_trajectory_uris = list(
+            dict.fromkeys(uri for uri in written_phase_uris if "/memories/trajectories/" in uri)
+        )
 
-        if not include_trajectories or not include_experiences or not written_trajectory_uris:
-            if not written_trajectory_uris:
-                tracer.info("No trajectories extracted; skipping experience phase")
+        if not include_trajectories or not include_experiences:
+            return {
+                "contexts": contexts,
+                "session_skills": session_skill_results,
+            }
+        if not written_trajectory_uris:
+            tracer.info("No trajectories extracted; skipping experience phase")
             return {
                 "contexts": contexts,
                 "session_skills": session_skill_results,
@@ -623,7 +636,7 @@ class SessionCompressorV2:
                 strict_extract_errors=strict_extract_errors,
                 phase_label=f"experience({traj_uri})",
                 post_apply=_append_sources_before_unlock,
-                allowed_memory_types=allowed_execution_types,
+                allowed_memory_types={EXPERIENCE_MEMORY_TYPE},
                 thinking=True,
             )
             if exp_result is None:

--- a/openviking/session/memory/agent_trajectory_context_provider.py
+++ b/openviking/session/memory/agent_trajectory_context_provider.py
@@ -3,15 +3,21 @@
 """
 Agent Trajectory Context Provider - Phase 1 of agent-scope extraction.
 
-Extracts execution trajectories from the conversation and can optionally
-co-extract reusable executable skills in the same ReAct pass.
+Extracts memories that depend on execution evidence from the conversation and
+can optionally co-extract reusable executable session skills in the same pass.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from openviking.server.identity import RequestContext
+from openviking.session.memory.constants import (
+    DIRECT_EXECUTION_MEMORY_TYPES,
+    SKILL_MEMORY_TYPE,
+    TOOL_MEMORY_TYPE,
+    TRAJECTORY_MEMORY_TYPE,
+)
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.session_extract_context_provider import SessionExtractContextProvider
 from openviking.session.skill.session_skill_context_provider import (
@@ -23,11 +29,9 @@ from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
-TRAJECTORY_MEMORY_TYPE = "trajectories"
-
 
 class AgentTrajectoryContextProvider(SessionExtractContextProvider):
-    """Phase 1 provider: extract trajectories and optional session skills."""
+    """Phase 1 provider for memories grounded in execution evidence."""
 
     include_tool_parts_in_conversation = True
     split_long_text_messages_for_extraction = False
@@ -49,10 +53,16 @@ class AgentTrajectoryContextProvider(SessionExtractContextProvider):
         *args,
         include_trajectories: bool = True,
         include_session_skills: bool = False,
+        allowed_memory_types: Optional[set[str]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self._include_trajectories = include_trajectories
+        if allowed_memory_types is None:
+            direct_memory_types = {TRAJECTORY_MEMORY_TYPE} if include_trajectories else set()
+        else:
+            direct_memory_types = set(allowed_memory_types) & DIRECT_EXECUTION_MEMORY_TYPES
+        self._direct_memory_types = direct_memory_types
+        self._include_trajectories = TRAJECTORY_MEMORY_TYPE in direct_memory_types
         self._include_session_skills = include_session_skills
         self._skill_provider = SessionSkillContextProvider(*args, **kwargs)
         self._sync_skill_provider_state()
@@ -81,12 +91,18 @@ class AgentTrajectoryContextProvider(SessionExtractContextProvider):
         )
 
     def get_memory_schemas(self, ctx: RequestContext) -> List[Any]:
-        """Expose trajectory schema and optionally session skill schema."""
+        """Expose requested execution schemas and optional session skill schema."""
         del ctx
         registry = self._get_registry()
-        memory_types: List[str] = []
-        if self._include_trajectories:
-            memory_types.append(TRAJECTORY_MEMORY_TYPE)
+        memory_types = [
+            memory_type
+            for memory_type in (
+                TRAJECTORY_MEMORY_TYPE,
+                TOOL_MEMORY_TYPE,
+                SKILL_MEMORY_TYPE,
+            )
+            if memory_type in self._direct_memory_types
+        ]
         if self._include_session_skills:
             memory_types.append(SESSION_SKILL_MEMORY_TYPE)
 
@@ -118,7 +134,7 @@ class AgentTrajectoryContextProvider(SessionExtractContextProvider):
 
     def _get_registry(self) -> MemoryTypeRegistry:
         if self._registry is None:
-            registry = MemoryTypeRegistry(load_schemas=self._include_trajectories)
+            registry = MemoryTypeRegistry(load_schemas=bool(self._direct_memory_types))
             if self._include_session_skills:
                 loaded = registry.load_from_directory(str(resolve_skill_extract_templates_dir()))
                 if loaded == 0:

--- a/openviking/session/memory/constants.py
+++ b/openviking/session/memory/constants.py
@@ -4,5 +4,14 @@
 CASE_MEMORY_TYPE = "cases"
 TRAJECTORY_MEMORY_TYPE = "trajectories"
 EXPERIENCE_MEMORY_TYPE = "experiences"
-EXECUTION_MEMORY_TYPES = frozenset({TRAJECTORY_MEMORY_TYPE, EXPERIENCE_MEMORY_TYPE})
+TOOL_MEMORY_TYPE = "tools"
+SKILL_MEMORY_TYPE = "skills"
+
+# These schemas are extracted together from the archived conversation because
+# they all require ToolPart evidence. Experiences remain a second phase that is
+# derived from newly written trajectories.
+DIRECT_EXECUTION_MEMORY_TYPES = frozenset(
+    {TRAJECTORY_MEMORY_TYPE, TOOL_MEMORY_TYPE, SKILL_MEMORY_TYPE}
+)
+EXECUTION_MEMORY_TYPES = DIRECT_EXECUTION_MEMORY_TYPES | {EXPERIENCE_MEMORY_TYPE}
 AGENT_EVOLUTION_MEMORY_TYPES = frozenset({CASE_MEMORY_TYPE, *EXECUTION_MEMORY_TYPES})

--- a/tests/session/memory/test_agent_experience_context_provider.py
+++ b/tests/session/memory/test_agent_experience_context_provider.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from openviking.message import Message
+from openviking.message.part import TextPart, ToolPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.agent_experience_context_provider import (
     AgentExperienceContextProvider,
@@ -18,8 +20,6 @@ from openviking.session.memory.memory_updater import ExtractContext
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
-from openviking.message import Message
-from openviking.message.part import TextPart
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -77,6 +77,63 @@ def test_agent_only_schemas_are_excluded_from_peer_user_memory_extraction():
 
     assert "experiences" not in schema_types
     assert "trajectories" not in schema_types
+
+
+def test_tool_and_skill_schemas_are_execution_scoped_and_receive_tool_evidence():
+    messages = [
+        Message(
+            id="tool-memory",
+            role="assistant",
+            parts=[
+                TextPart(text="I will inspect the repository."),
+                ToolPart(
+                    tool_id="tool-1",
+                    tool_name="read_file",
+                    tool_input={"path": "README.md", "skill_name": "code-review"},
+                    tool_output="OpenViking",
+                    tool_status="completed",
+                ),
+            ],
+        )
+    ]
+    config = SimpleNamespace(
+        output_language_override="en",
+        memory=SimpleNamespace(
+            eager_prefetch=False,
+            prefetch_search_topn=5,
+            link_enabled=False,
+            custom_templates_dir="/nonexistent/openviking-memory-templates",
+            experimental_memory_switch=False,
+        ),
+    )
+    with (
+        patch(
+            "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+            return_value=config,
+        ),
+        patch(
+            "openviking.session.memory.utils.language.get_openviking_config",
+            return_value=config,
+        ),
+        patch("openviking_cli.utils.config.get_openviking_config", return_value=config),
+    ):
+        user_provider = SessionExtractContextProvider(messages=messages)
+        execution_provider = AgentTrajectoryContextProvider(
+            messages=messages,
+            allowed_memory_types={"tools", "skills"},
+        )
+        user_schema_types = {
+            schema.memory_type for schema in user_provider.get_memory_schemas(ctx=None)
+        }
+        execution_schema_types = {
+            schema.memory_type for schema in execution_provider.get_memory_schemas(ctx=None)
+        }
+        conversation = execution_provider._assemble_conversation(messages)
+
+    assert {"tools", "skills"}.isdisjoint(user_schema_types)
+    assert execution_schema_types == {"tools", "skills"}
+    assert "ToolCall: tool_name=read_file" in conversation
+    assert "skill_name" in conversation
 
 
 @pytest.mark.asyncio

--- a/tests/session/memory/test_compressor_v2.py
+++ b/tests/session/memory/test_compressor_v2.py
@@ -496,6 +496,123 @@ class TestCompressorV2:
         debug_mock.assert_any_call("AGFS unavailable, running memory extraction without locks")
 
     @pytest.mark.asyncio
+    async def test_execution_extract_runs_tool_and_skill_schemas_in_one_phase(self):
+        compressor = SessionCompressorV2(vikingdb=None)
+        compressor._run_extract_phase = AsyncMock(
+            return_value=(
+                [
+                    "viking://user/default/memories/tools/read_file.md",
+                    "viking://user/default/memories/skills/code-review.md",
+                ],
+                [],
+                [],
+                {},
+                [],
+            )
+        )
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+        messages = [Message(id="tool-memory", role="user", parts=[TextPart("inspect")])]
+        config = SimpleNamespace(
+            output_language_override="en",
+            memory=SimpleNamespace(
+                session_skill_extraction_enabled=False,
+                eager_prefetch=False,
+                prefetch_search_topn=5,
+                link_enabled=False,
+                custom_templates_dir="/nonexistent/openviking-memory-templates",
+                experimental_memory_switch=False,
+            ),
+        )
+
+        with (
+            patch(
+                "openviking.session.compressor_v2.get_openviking_config",
+                return_value=config,
+            ),
+            patch(
+                "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+                return_value=config,
+            ),
+            patch(
+                "openviking.session.memory.utils.language.get_openviking_config",
+                return_value=config,
+            ),
+            patch("openviking_cli.utils.config.get_openviking_config", return_value=config),
+        ):
+            result = await compressor.extract_execution_memories(
+                messages=messages,
+                ctx=ctx,
+                allowed_memory_types={"tools", "skills"},
+            )
+            compressor._run_extract_phase.assert_awaited_once()
+            call = compressor._run_extract_phase.await_args.kwargs
+            assert call["allowed_memory_types"] == {"tools", "skills"}
+            assert {schema.memory_type for schema in call["provider"].get_memory_schemas(ctx)} == {
+                "tools",
+                "skills",
+            }
+        assert result == {"contexts": [], "session_skills": []}
+
+    @pytest.mark.asyncio
+    async def test_execution_extract_only_consolidates_written_trajectories(self):
+        compressor = SessionCompressorV2(vikingdb=None)
+        tool_uri = "viking://user/default/memories/tools/read_file.md"
+        trajectory_uri = "viking://user/default/memories/trajectories/inspect_repo.md"
+        compressor._run_extract_phase = AsyncMock(
+            side_effect=[
+                ([tool_uri, trajectory_uri], [], [], {}, []),
+                ([], [], [], {}, []),
+            ]
+        )
+        viking_fs = SimpleNamespace(read_file=AsyncMock(return_value="trajectory memory"))
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+        messages = [Message(id="tool-memory", role="user", parts=[TextPart("inspect")])]
+        config = SimpleNamespace(
+            output_language_override="en",
+            memory=SimpleNamespace(
+                session_skill_extraction_enabled=False,
+                eager_prefetch=False,
+                prefetch_search_topn=5,
+                link_enabled=False,
+                custom_templates_dir="/nonexistent/openviking-memory-templates",
+                experimental_memory_switch=False,
+            ),
+        )
+
+        with (
+            patch(
+                "openviking.session.compressor_v2.get_openviking_config",
+                return_value=config,
+            ),
+            patch("openviking.session.compressor_v2.get_viking_fs", return_value=viking_fs),
+            patch(
+                "openviking.session.compressor_v2.MemoryFileUtils.read",
+                return_value=SimpleNamespace(content="trajectory memory"),
+            ),
+            patch(
+                "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+                return_value=config,
+            ),
+            patch(
+                "openviking.session.memory.utils.language.get_openviking_config",
+                return_value=config,
+            ),
+            patch("openviking_cli.utils.config.get_openviking_config", return_value=config),
+        ):
+            await compressor.extract_execution_memories(
+                messages=messages,
+                ctx=ctx,
+                allowed_memory_types={"trajectories", "tools", "experiences"},
+            )
+
+        assert compressor._run_extract_phase.await_count == 2
+        viking_fs.read_file.assert_awaited_once()
+        assert viking_fs.read_file.await_args.args[0] == trajectory_uri
+        assert compressor._run_extract_phase.await_args_list[1].kwargs[
+            "allowed_memory_types"
+        ] == {"experiences"}
+
+    @pytest.mark.asyncio
     async def test_extract_long_term_memories_skips_self_init_when_self_disabled(self):
         compressor = SessionCompressorV2(vikingdb=None)
         user = UserIdentifier.the_default_user()


### PR DESCRIPTION
## Description

Route `tools` and `skills` memories through the execution-memory provider that can see `ToolPart` evidence. Previously both schemas defaulted to the user stage, where tool calls are intentionally hidden, so their required exact tool/skill names could never be extracted.

The change reuses the existing trajectory extraction pass; it does not add another VLM call or expose tool outputs to user-memory extraction.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3292

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Mark the `tools` and `skills` schemas as execution-stage memories.
- Generalize the phase-one execution provider to extract requested trajectories, tools, and skills together from ToolPart-visible context.
- Keep experience consolidation limited to written trajectory URIs and preserve the existing single-pass/session-skill behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation:

```text
21 passed
ruff check: All checks passed
git diff --check: clean
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The user-memory provider still excludes `ToolPart` data. Moving these schemas to the existing execution pass fixes the contradiction without widening that privacy boundary or increasing extraction-pass count.
