### PR TITLE
fix(memory): restore event content rendering

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -10,6 +10,7 @@ to the storage system.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
@@ -51,6 +52,25 @@ logger = get_logger(__name__)
 _MEMORY_ABSTRACT_MAX_BYTES = 50_000
 _EXTRACTION_CHUNK_MIN_CHARS = 100
 _EXTRACTION_CHUNK_BOUNDARY_RE = re.compile(r"(\n+|[。！？；!?;]+|(?<!\d)\.(?!\d))")
+_RESOURCE_ADDITION_FIELD_RE = re.compile(
+    r"^(Resource URI|Source name|Added at|Resource abstract|User reason):\s*(.*)$",
+    re.MULTILINE,
+)
+_RESOURCE_URI_MARKER_RE = re.compile(
+    r"[，,；;：:\s]*(?:资源\s*URI\s*为|资源\s*URI|Resource\s+URI)\s*[:：为]?\s*",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ChunkMeta:
+    """Metadata for a derived extraction chunk message."""
+
+    source_message_id: str
+    chunk_index: int
+    chunk_count: int
+
+
 async def write_stored_links(
     links: List[StoredLink],
     ctx: RequestContext,
@@ -143,17 +163,24 @@ class ExtractContext:
     def __init__(
         self,
         messages: List[Message],
+        chunk_meta: Optional[Dict[int, ChunkMeta]] = None,
         *,
         split_long_text_messages: bool = True,
     ):
-        if split_long_text_messages:
-            self.messages = self._build_extraction_messages(messages)
+        if chunk_meta is None:
+            if split_long_text_messages:
+                self.messages, self.chunk_meta = self._build_extraction_messages(messages)
+            else:
+                self.messages, self.chunk_meta = list(messages or []), {}
         else:
-            self.messages = list(messages or [])
+            self.messages = messages
+            self.chunk_meta = chunk_meta
         self.page_id_map = PageIdMap()
 
     @classmethod
-    def _build_extraction_messages(cls, messages: List[Message]) -> List[Message]:
+    def _build_extraction_messages(
+        cls, messages: List[Message]
+    ) -> Tuple[List[Message], Dict[int, ChunkMeta]]:
         """Build messages used by memory extraction.
 
         Long text-only messages are split into derived chunks so event `ranges`
@@ -161,20 +188,26 @@ class ExtractContext:
         matching. The original session messages are not modified.
         """
         extraction_messages: List[Message] = []
+        chunk_meta: Dict[int, ChunkMeta] = {}
         for message in messages:
-            extraction_messages.extend(cls._split_message_for_extraction(message))
-        return extraction_messages
+            for extraction_message, meta in cls._split_message_for_extraction(message):
+                extraction_messages.append(extraction_message)
+                if meta is not None:
+                    chunk_meta[id(extraction_message)] = meta
+        return extraction_messages, chunk_meta
 
     @classmethod
-    def _split_message_for_extraction(cls, message: Message) -> List[Message]:
+    def _split_message_for_extraction(
+        cls, message: Message
+    ) -> List[Tuple[Message, Optional[ChunkMeta]]]:
         parts = getattr(message, "parts", [])
         if not parts or not all(isinstance(part, TextPart) for part in parts):
-            return [message]
+            return [(message, None)]
 
         text = "".join(part.text for part in parts)
         chunks = cls._split_text_for_extraction(text)
         if len(chunks) <= 1:
-            return [message]
+            return [(message, None)]
 
         chunk_messages = []
         for idx, chunk in enumerate(chunks):
@@ -185,7 +218,16 @@ class ExtractContext:
                 parts=[TextPart(chunk)],
                 created_at=message.created_at,
             )
-            chunk_messages.append(chunk_message)
+            chunk_messages.append(
+                (
+                    chunk_message,
+                    ChunkMeta(
+                        source_message_id=message.id,
+                        chunk_index=idx,
+                        chunk_count=len(chunks),
+                    ),
+                )
+            )
         return chunk_messages
 
     @classmethod
@@ -309,6 +351,138 @@ class ExtractContext:
                     continue
         return datetime.now().strftime("%Y%m%d%H%M%S")
 
+    def get_event_content(
+        self, ranges_str: str, summary: str | None, ratio_threshold: float = 0.2
+    ) -> str:
+        """根据原始消息与 summary 的字符数比例，决定返回原始消息还是摘要。"""
+        if not ranges_str:
+            return summary or ""
+        msg_range = self.read_message_ranges(ranges_str)
+        original = msg_range.pretty_print()
+        if not summary or not summary.strip():
+            return original or ""
+        if not original:
+            return summary
+        if len(summary) / len(original) >= ratio_threshold:
+            return original
+        return summary
+
+    def get_resource_event_content(self, ranges_str: str, summary: str) -> str:
+        """Return a user-readable event body for add-resource derived events."""
+        if not ranges_str:
+            return ""
+        additions = self._resource_additions_from_ranges(ranges_str)
+        if not additions:
+            return ""
+        addition = additions[0]
+        resource_uri = addition.get("Resource URI", "")
+        if not resource_uri:
+            return ""
+        return self._link_resource_summary(summary or "", resource_uri, addition).strip()
+
+    def _resource_additions_from_ranges(self, ranges_str: str) -> List[Dict[str, str]]:
+        msg_range = self.read_message_ranges(ranges_str)
+        additions: List[Dict[str, str]] = []
+        for msg_group in msg_range.elements:
+            for msg in msg_group:
+                text = self._message_text(msg)
+                if "## Resource Addition" not in text:
+                    continue
+                fields = {
+                    match.group(1): match.group(2).strip()
+                    for match in _RESOURCE_ADDITION_FIELD_RE.finditer(text)
+                }
+                if fields.get("Resource URI"):
+                    additions.append(fields)
+        return additions
+
+    @staticmethod
+    def _message_text(message: Message) -> str:
+        parts = getattr(message, "parts", [])
+        texts = [part.text for part in parts if isinstance(part, TextPart) and part.text]
+        if texts:
+            return "\n".join(texts)
+        return message.content or ""
+
+    @classmethod
+    def _link_resource_summary(
+        cls,
+        summary: str,
+        resource_uri: str,
+        addition: Dict[str, str],
+    ) -> str:
+        text = (summary or "").strip()
+        if not text:
+            return cls._resource_addition_fallback_sentence(resource_uri, addition)
+        if f"]({resource_uri})" in text:
+            return text
+        if resource_uri in text:
+            return cls._replace_bare_resource_uri(text, resource_uri, addition)
+        label = cls._resource_label_from_addition(addition)
+        return cls._finish_sentence(f"{text.rstrip('。.!')}，关联资源为[{label}]({resource_uri})")
+
+    @classmethod
+    def _replace_bare_resource_uri(
+        cls,
+        text: str,
+        resource_uri: str,
+        addition: Dict[str, str],
+    ) -> str:
+        uri_start = text.find(resource_uri)
+        if uri_start < 0:
+            return text
+        prefix = text[:uri_start]
+        suffix = text[uri_start + len(resource_uri) :]
+        marker = _RESOURCE_URI_MARKER_RE.search(prefix)
+        if marker:
+            visible_prefix = prefix[: marker.start()].rstrip("，,；;：: ")
+            label = cls._resource_clause_from_summary_prefix(visible_prefix)
+            if not label:
+                label = cls._resource_label_from_addition(addition)
+            if label and visible_prefix.endswith(label):
+                visible_prefix = visible_prefix[: -len(label)] + f"[{label}]({resource_uri})"
+            else:
+                visible_prefix = f"{visible_prefix}[{label}]({resource_uri})"
+            return cls._finish_sentence(visible_prefix)
+
+        label = cls._resource_label_from_addition(addition)
+        return cls._finish_sentence(f"{prefix.rstrip()}[{label}]({resource_uri}){suffix.strip()}")
+
+    @staticmethod
+    def _resource_clause_from_summary_prefix(prefix: str) -> str:
+        text = prefix.strip("，,；;：: ")
+        tail = re.split(r"[，,；;。.!?？]", text)[-1].strip()
+        return tail if 0 < len(tail) <= 120 else ""
+
+    @classmethod
+    def _resource_label_from_addition(cls, addition: Dict[str, str]) -> str:
+        reason = addition.get("User reason", "").strip()
+        for prefix in ("这是一张", "这是一个", "该资源是", "这个是", "这是"):
+            if reason.startswith(prefix):
+                reason = reason[len(prefix) :].strip()
+                break
+        reason = reason.strip("。.!！ ")
+        if reason:
+            return reason[:80]
+        source_name = addition.get("Source name", "").strip()
+        return source_name or "相关资源"
+
+    @classmethod
+    def _resource_addition_fallback_sentence(
+        cls,
+        resource_uri: str,
+        addition: Dict[str, str],
+    ) -> str:
+        label = cls._resource_label_from_addition(addition)
+        return f"用户保存了[{label}]({resource_uri})。"
+
+    @staticmethod
+    def _finish_sentence(text: str) -> str:
+        text = text.strip("，,；;：: ")
+        if text.endswith(("。", ".", "！", "!", "？", "?")):
+            return text
+        return text + "。"
+
     def read_message_ranges(self, ranges_str: str) -> "MessageRange":
         """Parse ranges string like "0-10,50-60" or "7,9,11,13" and return combined MessageRange.
 
@@ -363,14 +537,92 @@ class ExtractContext:
             range_msgs = self.messages[start : end + 1]
             elements.append(range_msgs)
 
-        return MessageRange(elements)
+        return MessageRange(elements, chunk_meta=self.chunk_meta)
 
 
 class MessageRange:
     """Represents a range of messages for formatting."""
 
-    def __init__(self, elements: List[List[Message]]):
+    def __init__(
+        self,
+        elements: List[List[Message]],
+        chunk_meta: Optional[Dict[int, ChunkMeta]] = None,
+    ):
         self.elements = elements
+        self.chunk_meta = chunk_meta or {}
+
+    def pretty_print(self) -> str:
+        """Pretty print the message range with '...' separator between non-contiguous ranges."""
+        result = []
+        for i, msg_group in enumerate(self.elements):
+            result.extend(self._format_contiguous_group(msg_group))
+            if i < len(self.elements) - 1:
+                result.append("...")
+        return "\n".join(result)
+
+    def _format_contiguous_group(self, msg_group: List[Message]) -> List[str]:
+        formatted = []
+        current_messages: List[Message] = []
+
+        def flush_current() -> None:
+            nonlocal current_messages
+            if not current_messages:
+                return
+            content = self._format_merged_content(current_messages)
+            formatted.append(f"**{self._speaker_for(current_messages[0])}**: {content}")
+            current_messages = []
+
+        for msg in msg_group:
+            if current_messages and not self._can_merge_messages(current_messages[-1], msg):
+                flush_current()
+            current_messages.append(msg)
+
+        flush_current()
+        return formatted
+
+    @staticmethod
+    def _speaker_for(message: Message) -> str:
+        return getattr(message, "peer_id", None) or message.role
+
+    def _can_merge_messages(self, previous: Message, current: Message) -> bool:
+        previous_meta = self._chunk_meta_for(previous)
+        current_meta = self._chunk_meta_for(current)
+        if previous_meta is None or current_meta is None:
+            return False
+        if self._speaker_for(previous) != self._speaker_for(current):
+            return False
+        return (
+            previous_meta.source_message_id == current_meta.source_message_id
+            and current_meta.chunk_index == previous_meta.chunk_index + 1
+        )
+
+    def _format_merged_content(self, messages: List[Message]) -> str:
+        content = "".join((self._message_content(msg) or "") for msg in messages)
+        if not messages or not self._contains_chunk_message(messages):
+            return content
+
+        first_chunk = self._chunk_meta_for(messages[0])
+        if first_chunk is not None and first_chunk.chunk_index > 0:
+            content = "..." + content.lstrip()
+        last_chunk = self._chunk_meta_for(messages[-1])
+        if last_chunk is not None and last_chunk.chunk_index < last_chunk.chunk_count - 1:
+            content = content.rstrip() + "..."
+        return content
+
+    def _message_content(self, message: Message) -> str:
+        texts: List[str] = []
+        for part in getattr(message, "parts", []) or []:
+            if isinstance(part, TextPart):
+                texts.append(part.text or "")
+        if texts:
+            return "".join(texts)
+        return getattr(message, "content", "") or ""
+
+    def _contains_chunk_message(self, messages: List[Message]) -> bool:
+        return any(self._chunk_meta_for(msg) is not None for msg in messages)
+
+    def _chunk_meta_for(self, message: Message) -> Optional[ChunkMeta]:
+        return self.chunk_meta.get(id(message))
 
     def _first_message_time(self) -> str | None:
         """获取第一条消息的时间（内部方法）"""

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -10,6 +10,7 @@ import pytest
 
 from openviking.message import Message
 from openviking.message.part import TextPart
+from openviking.prompts.manager import PromptManager
 from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.dataclass import (
     MemoryField,
@@ -79,6 +80,82 @@ class TestMemoryUpdater:
         assert len(split_context.messages) > 1
         assert len(unsplit_context.messages) == 1
         assert unsplit_context.messages[0] is messages[0]
+        assert unsplit_context.chunk_meta == {}
+
+    def test_extract_context_resource_event_content_hides_add_resource_fields(self):
+        resource_uri = "viking://resources/images/2026/06/12/yueqian_jpeg"
+        extract_context = ExtractContext(
+            messages=[
+                Message(
+                    id="1",
+                    role="user",
+                    parts=[
+                        TextPart(
+                            text=(
+                                "## Resource Addition\n"
+                                f"Resource URI: {resource_uri}\n"
+                                "Source name: yueqian.jpeg\n"
+                                "Added at: 2026-06-12T03:43:36.343325+00:00\n"
+                                "Resource abstract: This directory contains an anime illustration.\n"
+                                "User reason: 这是越前龙马的照片"
+                            )
+                        )
+                    ],
+                    created_at="2026-06-12T03:43:36.343325+00:00",
+                )
+            ]
+        )
+
+        content = extract_context.get_resource_event_content(
+            "0",
+            f"2026-06-12，用户保存了粉丝创作的越前龙马动漫插画资源，资源URI为{resource_uri}。",
+        )
+
+        assert (
+            content == f"2026-06-12，[用户保存了粉丝创作的越前龙马动漫插画资源]({resource_uri})。"
+        )
+        assert "Resource URI" not in content
+        assert "Added at" not in content
+        assert "Resource abstract" not in content
+        assert "User reason" not in content
+
+        registry = MemoryTypeRegistry(load_schemas=False)
+        registry.load_from_yaml(
+            str(PromptManager._get_bundled_templates_dir() / "memory" / "events.yaml")
+        )
+        rendered = MemoryFileUtils.write(
+            MemoryFile(
+                extra_fields={
+                    "event_name": "resource_saved",
+                    "goal": "save resource",
+                    "summary": (
+                        "2026-06-12，用户保存了粉丝创作的越前龙马动漫插画资源，"
+                        f"资源URI为{resource_uri}。"
+                    ),
+                    "ranges": "0",
+                }
+            ),
+            content_template=registry.get("events").content_template,
+            extract_context=extract_context,
+        )
+
+        assert rendered.startswith(content)
+
+    def test_extract_context_event_content_falls_back_to_range_when_summary_empty(self):
+        extract_context = ExtractContext(
+            messages=[
+                Message(
+                    id="1",
+                    role="user",
+                    parts=[TextPart(text="Gina can expand her clothing store now.")],
+                    created_at="2023-02-01T00:48:00",
+                )
+            ]
+        )
+
+        content = extract_context.get_event_content("0", "")
+
+        assert "Gina can expand her clothing store now." in content
 
     def test_create(self):
         """Test creating a MemoryUpdater."""


### PR DESCRIPTION
## Description

Restore the event-memory rendering helpers removed by #3272. The bundled `events.yaml` template still calls these `ExtractContext` methods, so their removal caused template rendering to fall back to an empty event body.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Regression from #3272.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Restore `ExtractContext.get_resource_event_content()` and `get_event_content()` used by the bundled events prompt.
- Restore chunk metadata and `MessageRange.pretty_print()` so event chat-log ranges render as before.
- Restore focused behavior tests and verify the real `events.yaml` content template renders a non-empty body.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `.venv/bin/pytest -q --confcutdir=tests/session/memory tests/session/memory/test_memory_updater.py -k 'extract_context_can_disable_long_text_message_split or extract_context_resource_event_content_hides_add_resource_fields or extract_context_event_content_falls_back_to_range_when_summary_empty'` (3 passed)
- `.venv/bin/ruff check --select F,E9,I001 openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The broader audit of other APIs removed by #3272 is intentionally not included in this PR; this change is limited to the confirmed event-memory regression.
