### PR TITLE
fix(server): preserve graceful SIGTERM shutdown

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -94,6 +94,7 @@ class OpenVikingService:
         self._encryptor: Optional[Any] = None
         self._privacy_config_service: Optional[UserPrivacyConfigService] = None
         self._data_dir_lock_acquired = False
+        self._data_dir_lock_path: Optional[str] = None
 
         # Sub-services
         self._fs_service = FSService()
@@ -198,13 +199,23 @@ class OpenVikingService:
         if not self._config.storage.skip_process_lock:
             from openviking.utils.process_lock import acquire_data_dir_lock
 
-            acquire_data_dir_lock(self._config.storage.workspace)
+            self._data_dir_lock_path = acquire_data_dir_lock(self._config.storage.workspace)
         else:
             logger.warning(
                 "Skipping workspace process lock for '%s'; multi-process access may corrupt data",
                 self._config.storage.workspace,
             )
         self._data_dir_lock_acquired = True
+
+    def _release_data_dir_lock(self) -> None:
+        """Release the process-level workspace lock after service shutdown."""
+        lock_path = getattr(self, "_data_dir_lock_path", None)
+        if lock_path is not None:
+            from openviking.utils.process_lock import release_data_dir_lock
+
+            release_data_dir_lock(lock_path)
+            self._data_dir_lock_path = None
+        self._data_dir_lock_acquired = False
 
     @property
     def _agfs(self) -> Any:
@@ -487,6 +498,7 @@ class OpenVikingService:
         if get_service_or_none() is self:
             set_service(None)
 
+        self._release_data_dir_lock()
         logger.info("OpenVikingService closed")
 
     async def reindex(

--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -8,7 +8,6 @@ directory, which causes silent failures in AGFS and VectorDB.
 
 import atexit
 import os
-import signal
 import sys
 
 from openviking_cli.utils import get_logger
@@ -69,6 +68,15 @@ def _is_pid_alive(pid: int) -> bool:
     return True
 
 
+def release_data_dir_lock(lock_path: str) -> None:
+    """Remove *lock_path* when it is still owned by the current process."""
+    try:
+        if _read_pid_file(lock_path) == os.getpid():
+            os.remove(lock_path)
+    except OSError:
+        pass
+
+
 def acquire_data_dir_lock(data_dir: str) -> str:
     """Acquire an advisory PID lock on *data_dir*.
 
@@ -105,21 +113,9 @@ def acquire_data_dir_lock(data_dir: str) -> str:
 
     # Schedule cleanup on exit.
     def _cleanup(*_args: object) -> None:
-        try:
-            if os.path.isfile(lock_path):
-                stored = _read_pid_file(lock_path)
-                if stored == my_pid:
-                    os.remove(lock_path)
-        except OSError:
-            pass
+        release_data_dir_lock(lock_path)
 
     atexit.register(_cleanup)
-    # Also try to clean up on SIGTERM (graceful shutdown).
-    try:
-        signal.signal(signal.SIGTERM, lambda sig, frame: (_cleanup(), sys.exit(0)))
-    except (OSError, ValueError):
-        # signal.signal() can fail in non-main threads.
-        pass
 
     logger.debug("Acquired data directory lock: %s (PID %d)", lock_path, my_pid)
     return lock_path

--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -9,12 +9,16 @@ directory, which causes silent failures in AGFS and VectorDB.
 import atexit
 import os
 import sys
+import threading
 
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
 LOCK_FILENAME = ".openviking.pid"
+
+_lock_refcounts: dict[str, int] = {}
+_lock_refcounts_guard = threading.Lock()
 
 
 class DataDirectoryLocked(RuntimeError):
@@ -69,12 +73,21 @@ def _is_pid_alive(pid: int) -> bool:
 
 
 def release_data_dir_lock(lock_path: str) -> None:
-    """Remove *lock_path* when it is still owned by the current process."""
-    try:
-        if _read_pid_file(lock_path) == os.getpid():
-            os.remove(lock_path)
-    except OSError:
-        pass
+    """Release one local owner and remove its PID file after the last release."""
+    lock_key = os.path.realpath(os.path.abspath(lock_path))
+    with _lock_refcounts_guard:
+        refcount = _lock_refcounts.get(lock_key, 0)
+        if refcount > 1:
+            _lock_refcounts[lock_key] = refcount - 1
+            return
+        if refcount == 1:
+            del _lock_refcounts[lock_key]
+
+        try:
+            if _read_pid_file(lock_path) == os.getpid():
+                os.remove(lock_path)
+        except OSError:
+            pass
 
 
 def acquire_data_dir_lock(data_dir: str) -> str:
@@ -110,6 +123,10 @@ def acquire_data_dir_lock(data_dir: str) -> str:
     except OSError as exc:
         logger.warning("Could not write PID lock %s: %s", lock_path, exc)
         return lock_path
+
+    lock_key = os.path.realpath(os.path.abspath(lock_path))
+    with _lock_refcounts_guard:
+        _lock_refcounts[lock_key] = _lock_refcounts.get(lock_key, 0) + 1
 
     # Schedule cleanup on exit.
     def _cleanup(*_args: object) -> None:

--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -97,35 +97,38 @@ def acquire_data_dir_lock(data_dir: str) -> str:
 
     Raises ``DataDirectoryLocked`` if another live process already holds the
     lock, with a message that explains the situation and suggests HTTP mode.
+    Raises ``OSError`` if the PID file cannot be created or updated.
     """
     lock_path = os.path.join(data_dir, LOCK_FILENAME)
+    lock_key = os.path.realpath(os.path.abspath(lock_path))
     my_pid = os.getpid()
 
-    existing_pid = _read_pid_file(lock_path)
-    if existing_pid and existing_pid != my_pid and _is_pid_alive(existing_pid):
-        raise DataDirectoryLocked(
-            f"Another OpenViking process (PID {existing_pid}) is already using "
-            f"the data directory '{data_dir}'. Running multiple OpenViking "
-            f"instances on the same data directory causes silent storage "
-            f"contention and data corruption.\n\n"
-            f"To fix this, use one of these approaches:\n"
-            f"  1. Use HTTP mode: start a single openviking-server and connect "
-            f"via --transport http (recommended for multi-session hosts)\n"
-            f"  2. Use separate data directories for each instance\n"
-            f"  3. Stop the other process (PID {existing_pid}) first"
-        )
-
-    # Write our PID (overwrites stale lock from a dead process).
-    try:
-        os.makedirs(data_dir, exist_ok=True)
-        with open(lock_path, "w") as f:
-            f.write(str(my_pid))
-    except OSError as exc:
-        logger.warning("Could not write PID lock %s: %s", lock_path, exc)
-        return lock_path
-
-    lock_key = os.path.realpath(os.path.abspath(lock_path))
     with _lock_refcounts_guard:
+        existing_pid = _read_pid_file(lock_path)
+        if existing_pid and existing_pid != my_pid and _is_pid_alive(existing_pid):
+            raise DataDirectoryLocked(
+                f"Another OpenViking process (PID {existing_pid}) is already using "
+                f"the data directory '{data_dir}'. Running multiple OpenViking "
+                f"instances on the same data directory causes silent storage "
+                f"contention and data corruption.\n\n"
+                f"To fix this, use one of these approaches:\n"
+                f"  1. Use HTTP mode: start a single openviking-server and connect "
+                f"via --transport http (recommended for multi-session hosts)\n"
+                f"  2. Use separate data directories for each instance\n"
+                f"  3. Stop the other process (PID {existing_pid}) first"
+            )
+
+        # A same-process reentrant acquire already owns a valid PID file. Avoid
+        # rewriting it so every successful acquire maps to exactly one local ref.
+        if existing_pid != my_pid:
+            try:
+                os.makedirs(data_dir, exist_ok=True)
+                with open(lock_path, "w") as f:
+                    f.write(str(my_pid))
+            except OSError as exc:
+                logger.warning("Could not write PID lock %s: %s", lock_path, exc)
+                raise
+
         _lock_refcounts[lock_key] = _lock_refcounts.get(lock_key, 0) + 1
 
     # Schedule cleanup on exit.

--- a/tests/unit/service/test_core_encryption_startup.py
+++ b/tests/unit/service/test_core_encryption_startup.py
@@ -95,11 +95,13 @@ def test_ensure_data_dir_lock_acquired_once(monkeypatch, tmp_path):
         storage=SimpleNamespace(workspace=str(tmp_path), skip_process_lock=False)
     )
     service._data_dir_lock_acquired = False
+    service._data_dir_lock_path = None
 
     service._ensure_data_dir_lock_acquired()
     service._ensure_data_dir_lock_acquired()
 
     assert calls == [str(tmp_path)]
+    assert service._data_dir_lock_path == str(tmp_path / ".openviking.pid")
 
 
 def test_ensure_data_dir_lock_respects_skip_process_lock(monkeypatch, tmp_path):
@@ -117,8 +119,28 @@ def test_ensure_data_dir_lock_respects_skip_process_lock(monkeypatch, tmp_path):
         storage=SimpleNamespace(workspace=str(tmp_path), skip_process_lock=True)
     )
     service._data_dir_lock_acquired = False
+    service._data_dir_lock_path = None
 
     service._ensure_data_dir_lock_acquired()
 
     assert calls == []
     assert service._data_dir_lock_acquired is True
+    assert service._data_dir_lock_path is None
+
+
+def test_release_data_dir_lock_clears_service_state(monkeypatch, tmp_path):
+    calls = []
+    lock_path = str(tmp_path / ".openviking.pid")
+    monkeypatch.setattr(
+        "openviking.utils.process_lock.release_data_dir_lock",
+        calls.append,
+    )
+    service = OpenVikingService.__new__(OpenVikingService)
+    service._data_dir_lock_acquired = True
+    service._data_dir_lock_path = lock_path
+
+    service._release_data_dir_lock()
+
+    assert calls == [lock_path]
+    assert service._data_dir_lock_acquired is False
+    assert service._data_dir_lock_path is None

--- a/tests/utils/test_process_lock.py
+++ b/tests/utils/test_process_lock.py
@@ -3,8 +3,12 @@
 
 """Regression tests for process-lock shutdown behavior."""
 
+import os
 import signal
+import threading
 from pathlib import Path
+
+import pytest
 
 import openviking.utils.process_lock as process_lock_module
 from openviking.utils.process_lock import (
@@ -67,10 +71,110 @@ def test_reentrant_lock_is_removed_only_after_last_release(tmp_path: Path):
     assert not Path(second_lock_path).exists()
 
 
+def test_acquire_and_refcount_update_are_atomic(tmp_path: Path, monkeypatch):
+    lock_path = tmp_path / LOCK_FILENAME
+    first_write_closed = threading.Event()
+    allow_first_acquire = threading.Event()
+    second_acquire_started = threading.Event()
+    second_acquire_done = threading.Event()
+    thread_errors = []
+    acquired_paths = []
+    real_open = open
+
+    class BlockingClose:
+        def __init__(self, file_obj):
+            self._file_obj = file_obj
+
+        def __enter__(self):
+            return self._file_obj.__enter__()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            result = self._file_obj.__exit__(exc_type, exc_value, traceback)
+            first_write_closed.set()
+            if not allow_first_acquire.wait(timeout=5):
+                raise TimeoutError("first acquire was not released")
+            return result
+
+    def blocking_open(path, mode="r", *args, **kwargs):
+        file_obj = real_open(path, mode, *args, **kwargs)
+        if os.fspath(path) == str(lock_path) and "w" in mode and not first_write_closed.is_set():
+            return BlockingClose(file_obj)
+        return file_obj
+
+    def acquire_first():
+        try:
+            acquired_paths.append(acquire_data_dir_lock(str(tmp_path)))
+        except BaseException as exc:  # pragma: no cover - surfaced by the assertion below
+            thread_errors.append(exc)
+
+    def acquire_second():
+        try:
+            second_acquire_started.set()
+            acquired_paths.append(acquire_data_dir_lock(str(tmp_path)))
+        except BaseException as exc:  # pragma: no cover - surfaced by the assertion below
+            thread_errors.append(exc)
+        finally:
+            second_acquire_done.set()
+
+    monkeypatch.setattr(process_lock_module, "open", blocking_open, raising=False)
+    first_thread = threading.Thread(target=acquire_first)
+    second_thread = threading.Thread(target=acquire_second)
+    first_thread.start()
+    assert first_write_closed.wait(timeout=5)
+    second_thread.start()
+    assert second_acquire_started.wait(timeout=5)
+    try:
+        assert not second_acquire_done.wait(timeout=0.2)
+    finally:
+        allow_first_acquire.set()
+        first_thread.join(timeout=5)
+        second_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not thread_errors
+    assert len(acquired_paths) == 2
+    release_data_dir_lock(acquired_paths[0])
+    assert lock_path.exists()
+    release_data_dir_lock(acquired_paths[1])
+    assert not lock_path.exists()
+
+
+def test_reentrant_acquire_does_not_rewrite_owned_pid_file(tmp_path: Path, monkeypatch):
+    first_lock_path = acquire_data_dir_lock(str(tmp_path))
+    real_open = open
+
+    def fail_writes(path, mode="r", *args, **kwargs):
+        if os.fspath(path) == first_lock_path and "w" in mode:
+            raise OSError("simulated write failure")
+        return real_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(process_lock_module, "open", fail_writes, raising=False)
+
+    second_lock_path = acquire_data_dir_lock(str(tmp_path))
+    release_data_dir_lock(second_lock_path)
+
+    assert Path(first_lock_path).exists()
+
+    release_data_dir_lock(first_lock_path)
+    assert not Path(first_lock_path).exists()
+
+
+def test_initial_write_failure_is_not_reported_as_acquired(tmp_path: Path, monkeypatch):
+    def fail_writes(_path, _mode="r", *_args, **_kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(process_lock_module, "open", fail_writes, raising=False)
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        acquire_data_dir_lock(str(tmp_path))
+
+
 def test_release_data_dir_lock_preserves_another_process_lock(tmp_path: Path):
     lock_path = tmp_path / LOCK_FILENAME
-    lock_path.write_text("1")
+    another_pid = os.getpid() + 1
+    lock_path.write_text(str(another_pid))
 
     release_data_dir_lock(str(lock_path))
 
-    assert lock_path.read_text() == "1"
+    assert lock_path.read_text() == str(another_pid)

--- a/tests/utils/test_process_lock.py
+++ b/tests/utils/test_process_lock.py
@@ -1,53 +1,63 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
-"""Tests for process_lock.py signal handling."""
+"""Regression tests for process-lock shutdown behavior."""
 
 import signal
+from pathlib import Path
+
+import openviking.utils.process_lock as process_lock_module
+from openviking.utils.process_lock import (
+    LOCK_FILENAME,
+    acquire_data_dir_lock,
+    release_data_dir_lock,
+)
 
 
-def test_sigterm_handler_calls_sys_exit():
-    """SIGTERM handler 应该调用 sys.exit(0) 干净退出。
+def test_acquire_data_dir_lock_preserves_sigterm_handler(tmp_path: Path):
+    """The lock must not replace the host process's shutdown handler."""
 
-    验证修复后的 lambda 调用 sys.exit(0) 而非 signal.default_int_handler。
-    signal.default_int_handler 会抛出 KeyboardInterrupt（SIGINT handler），
-    语义错误。sys.exit(0) 触发 atexit cleanup 并正常退出。
-    """
-    exit_calls = []
+    def host_sigterm_handler(_signum, _frame):
+        return None
 
-    def fake_exit(code=0):
-        exit_calls.append(code)
+    previous_handler = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGTERM, host_sigterm_handler)
+    try:
+        acquire_data_dir_lock(str(tmp_path))
 
-    # 模拟修复后的 handler（与 process_lock.py:119-120 一致）
-    def handler(sig, frame):
-        (None, fake_exit(0))
-
-    handler(signal.SIGTERM, None)
-
-    assert exit_calls == [0]
+        assert signal.getsignal(signal.SIGTERM) is host_sigterm_handler
+    finally:
+        signal.signal(signal.SIGTERM, previous_handler)
 
 
-def test_sigterm_handler_calls_cleanup_before_exit():
-    """SIGTERM handler 应该在退出前调用 _cleanup。
+def test_acquire_data_dir_lock_registers_atexit_cleanup(tmp_path: Path, monkeypatch):
+    """Normal interpreter shutdown still removes the PID file via atexit."""
+    callbacks = []
+    monkeypatch.setattr(process_lock_module.atexit, "register", callbacks.append)
 
-    _cleanup 负责移除 PID 锁文件，即使在 SIGTERM 强制关闭时也应执行，
-    避免残留锁文件阻止后续进程启动。lambda 中的元组按顺序执行：
-    先 _cleanup()，再 sys.exit(0)。
-    """
-    cleanup_called = []
-    exit_calls = []
+    acquire_data_dir_lock(str(tmp_path))
 
-    def fake_cleanup():
-        cleanup_called.append(True)
+    assert len(callbacks) == 1
+    lock_path = tmp_path / LOCK_FILENAME
+    assert lock_path.exists()
 
-    def fake_exit(code=0):
-        exit_calls.append(code)
+    callbacks[0]()
 
-    # 模拟修复后的 handler（与 process_lock.py:119-120 一致）
-    def handler(sig, frame):
-        (fake_cleanup(), fake_exit(0))
+    assert not lock_path.exists()
 
-    handler(signal.SIGTERM, None)
 
-    assert cleanup_called == [True], "_cleanup 应在 exit 前被调用"
-    assert exit_calls == [0]
+def test_release_data_dir_lock_removes_owned_lock(tmp_path: Path):
+    lock_path = acquire_data_dir_lock(str(tmp_path))
+
+    release_data_dir_lock(lock_path)
+
+    assert not Path(lock_path).exists()
+
+
+def test_release_data_dir_lock_preserves_another_process_lock(tmp_path: Path):
+    lock_path = tmp_path / LOCK_FILENAME
+    lock_path.write_text("1")
+
+    release_data_dir_lock(str(lock_path))
+
+    assert lock_path.read_text() == "1"

--- a/tests/utils/test_process_lock.py
+++ b/tests/utils/test_process_lock.py
@@ -54,6 +54,19 @@ def test_release_data_dir_lock_removes_owned_lock(tmp_path: Path):
     assert not Path(lock_path).exists()
 
 
+def test_reentrant_lock_is_removed_only_after_last_release(tmp_path: Path):
+    first_lock_path = acquire_data_dir_lock(str(tmp_path))
+    second_lock_path = acquire_data_dir_lock(str(tmp_path))
+
+    release_data_dir_lock(first_lock_path)
+
+    assert Path(first_lock_path).exists()
+
+    release_data_dir_lock(second_lock_path)
+
+    assert not Path(second_lock_path).exists()
+
+
 def test_release_data_dir_lock_preserves_another_process_lock(tmp_path: Path):
     lock_path = tmp_path / LOCK_FILENAME
     lock_path.write_text("1")


### PR DESCRIPTION
## 根因与修复

- workspace PID 锁在服务启动时覆盖了 Uvicorn 的 `SIGTERM` handler，并直接调用 `sys.exit(0)`，导致 lifespan cleanup 被取消，服务、队列和存储后端可能来不及关闭。
- PID 锁不再接管进程信号，关停信号继续由宿主服务器处理。
- `OpenVikingService.close()` 完成存储清理后显式释放 workspace 锁；保留 `atexit` 作为普通解释器退出时的兜底。
- 同一进程重入同一 workspace 时使用引用计数，只在最后一个 owner 关闭后删除 PID 文件；acquire/release 状态转换在同一临界区内完成，同 PID 重入不重写锁文件，首次写锁失败会直接报错。

## 范围与已知现状

- 这是针对信号所有权和 PID 锁生命周期的最小修复；没有调整 `app.py` 的清理顺序，也没有改动存储对象析构逻辑。
- 本地环境为 macOS / Python 3.10 / Uvicorn 0.40。Issue 中的 WSL2 / Python 3.12 环境仍需要 CI 或报告者复核。
- 额外执行 `tests/server/test_server_health.py` 时有 3 个现有失败；在未修改的 `origin/main` (`ef4d97eb`) 上逐项复核，结果相同，与本 PR 无关。

## 验证

- 修复前回归测试可稳定观察到 PID 锁覆盖宿主 `SIGTERM` handler；修复后通过。
- `pytest -q --no-cov tests/utils/test_process_lock.py tests/unit/test_process_lock.py tests/misc/test_process_lock.py tests/unit/service/test_core_encryption_startup.py`：48 passed。
- `ruff check` 与 `ruff format --check`：通过。
- 真实 HTTP 服务连续 20 轮启动、健康检查和 `SIGTERM`：20/20 完成 queue、vector backend 和 service cleanup；20/20 无锁残留；未出现 `SystemExit`、lifespan `CancelledError`、SEGV 或 ABRT。
- MCP initialize → session DELETE → health 连续 3 轮：服务 PID 保持不变，DELETE 后仍健康，排除会话断开误停服务的回归。
- 写入哨兵内容 → `SIGTERM` → 重启 → 读取：内容完整恢复；两次关停均完成服务和后端清理，且无 PID 锁残留。

Closes #3101
