### PR TITLE
feat: add OpenClaw plugin icon

### DIFF
--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -3,6 +3,7 @@
   "name": "OpenViking",
   "kind": "context-engine",
   "description": "OpenClaw context-engine plugin for memory management — powered by OpenViking",
+  "icon": "https://raw.githubusercontent.com/volcengine/OpenViking/main/docs/images/ov-logo.png",
   "activation": {
     "onStartup": true,
     "onCapabilities": [


### PR DESCRIPTION
## Summary

Add OpenViking's existing project logo to `openclaw.plugin.json` so ClawHub and other OpenClaw catalog surfaces can render branded artwork instead of the generic fallback.

## Validation

- Parsed `openclaw.plugin.json` with `jq`
- Verified the HTTPS icon URL returns `image/png`

## Release

After merging, please run the **OpenViking OpenClaw plugin release** workflow (`clawhub-dev-release.yml`) against `main`. The workflow can auto-generate the next version when the version input is left blank and publish the plugin to ClawHub and npm.
