### PR TITLE
build(ragfs): clean stale .venv ragfs_python artifacts to avoid site-packages override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ check-deps:
 	fi
 
 build: check-deps check-pip build-studio
+	@echo "Cleaning stale ragfs-python native artifacts from project .venv..."
+	@if [ -x .venv/bin/python ]; then \
+		.venv/bin/python -c 'import sysconfig; from pathlib import Path; roots = {Path(sysconfig.get_path("platlib")), Path(sysconfig.get_path("purelib"))}; removed = []; [removed.append(path) or path.unlink() for root in roots if root.exists() for path in root.rglob("*") if path.is_file() and path.name.startswith("ragfs_python") and path.suffix in {".so", ".pyd", ".dylib"}]; print("  [OK] removed stale ragfs artifacts from .venv" if removed else "  [OK] no stale ragfs artifacts found in .venv")'; \
+	else \
+		echo "  [SKIP] project .venv not found; skip ragfs native cleanup"; \
+	fi
 	@echo "Starting build process via setup.py..."
 	$(PYTHON) $(SETUP_PY) build_ext --inplace
 	@if command -v uv > /dev/null 2>&1 && uv pip --help > /dev/null 2>&1; then \


### PR DESCRIPTION
## Description

1. 保留原本cd crates/ragfs-python && maturin develop 更新ragfs crate 的开发场景能力
2. 当使用make build 时， 主动清理.venv 中ragfs的开发产物

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
