### PR TITLE
fix(bot): enable logs for config-started gateway

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -256,7 +256,12 @@ def main():
         # Determine if bot logging should be enabled
         enable_bot_logging = args.enable_bot_logging
         if enable_bot_logging is None:
-            enable_bot_logging = args.with_bot
+            # Reaching this block means bot integration is enabled, either by
+            # ``--with-bot`` or by ``server.with_bot`` in ov.conf.  Default
+            # logging must not depend only on which activation surface was
+            # used, otherwise config-enabled gateways silently lose their
+            # child-process diagnostics.
+            enable_bot_logging = True
         bot_log_dir = args.bot_log_dir or _resolve_default_bot_log_dir(args.config)
         # Start vikingbot gateway if --with-bot is set
         bot_process = _start_vikingbot_gateway(

--- a/tests/server/test_bootstrap.py
+++ b/tests/server/test_bootstrap.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import openviking.server.bootstrap as bootstrap
 from openviking.server.config import ServerConfig
 from openviking.utils.agfs_utils import resolve_queuefs_mount_point
+from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
 from openviking_cli.utils.config.storage_config import StorageConfig
 
 
@@ -118,6 +119,59 @@ def test_main_coerces_cli_host_all_to_none(monkeypatch):
 
     assert captured["host"] is None
     assert captured["port"] == 1933
+
+
+def test_main_enables_bot_logging_when_with_bot_comes_from_config(monkeypatch):
+    config = ServerConfig(host="127.0.0.1", port=1933, with_bot=True)
+    captured: dict[str, object] = {}
+    bot_process = object()
+
+    monkeypatch.setattr(bootstrap, "load_server_config", lambda config_path: config)
+    monkeypatch.setattr(bootstrap, "create_app", lambda config: "app")
+    monkeypatch.setattr(bootstrap, "configure_uvicorn_logging", lambda: None)
+    monkeypatch.setattr(
+        OpenVikingConfigSingleton,
+        "initialize",
+        classmethod(lambda cls, config_path: None),
+    )
+    monkeypatch.setattr(
+        bootstrap.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            host=None,
+            port=None,
+            config=None,
+            workers=None,
+            bot=False,
+            with_bot=False,
+            bot_port=bootstrap.VIKINGBOT_DEFAULT_PORT,
+            enable_bot_logging=None,
+            bot_log_dir="/tmp/bot-logs",
+        ),
+    )
+    monkeypatch.setattr(bootstrap, "_abort_if_port_in_use", lambda port, label: None)
+
+    def _fake_start(enable_logging, log_dir, port, **kwargs):
+        captured.update(
+            {
+                "enable_logging": enable_logging,
+                "log_dir": log_dir,
+                "port": port,
+            }
+        )
+        return bot_process
+
+    monkeypatch.setattr(bootstrap, "_start_vikingbot_gateway", _fake_start)
+    monkeypatch.setattr(bootstrap, "_stop_vikingbot_gateway", lambda process: None)
+    monkeypatch.setattr(bootstrap.uvicorn, "run", lambda *args, **kwargs: None)
+
+    bootstrap.main()
+
+    assert captured == {
+        "enable_logging": True,
+        "log_dir": "/tmp/bot-logs",
+        "port": bootstrap.VIKINGBOT_DEFAULT_PORT,
+    }
 
 
 def test_resolve_queuefs_mount_point_defaults_to_shared():


### PR DESCRIPTION
## Description

Enable VikingBot child-process logging by default when bot integration is activated through `server.with_bot` in `ov.conf`, matching the existing `--with-bot` behavior.

This removes a deterministic diagnostics blind spot reported in #3293. It does **not** claim to fix the longer-lived Feishu channel silence itself; the resulting gateway log is needed to distinguish connection, channel, and process failures.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #3293

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Default bot logging to enabled whenever the resolved server configuration enables bot integration.
- Preserve the explicit `--disable-bot-logging` override.
- Add a regression proving config-only activation starts the gateway with logging enabled.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation:

- `pytest -q tests/server/test_bootstrap.py::test_main_enables_bot_logging_when_with_bot_comes_from_config tests/unit/test_server_bootstrap_bot_gateway.py` → 7 passed
- `ruff check openviking/server/bootstrap.py tests/server/test_bootstrap.py`
- `ruff format --check openviking/server/bootstrap.py tests/server/test_bootstrap.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

A full `tests/server/test_bootstrap.py` run in the reused workspace environment also encounters two pre-existing config-loader failures because that file's older tests patch a module attribute that `main()` re-imports. The new regression and all gateway bootstrap tests pass when run directly, and this PR does not modify that unrelated fixture behavior.
