### PR TITLE
fix(lock): extend default lock expiration to 30 minutes

### DIFF
--- a/openviking_cli/utils/config/transaction_config.py
+++ b/openviking_cli/utils/config/transaction_config.py
@@ -22,7 +22,7 @@ class TransactionConfig(BaseModel):
     )
 
     lock_expire: float = Field(
-        default=300.0,
+        default=1800.0,
         description=(
             "Lock inactivity threshold (seconds). "
             "Locks not refreshed within this window are treated as stale and reclaimed."

--- a/tests/unit/config/test_transaction_config.py
+++ b/tests/unit/config/test_transaction_config.py
@@ -1,0 +1,5 @@
+from openviking_cli.utils.config.transaction_config import TransactionConfig
+
+
+def test_lock_expire_defaults_to_thirty_minutes():
+    assert TransactionConfig().lock_expire == 30 * 60


### PR DESCRIPTION
## Summary
- change the default transaction lock expiration from 5 minutes to 30 minutes
- keep explicitly configured lock expiration values unchanged
- add regression coverage for the configuration default

## Testing
- python -m pytest tests/unit/config/test_transaction_config.py tests/transaction/test_path_lock.py -q (42 passed)