### PR TITLE
fix(resource): reject watch_interval on uploaded one-shot sources instead of silently watching a frozen snapshot

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -214,6 +214,19 @@ class ResourceService:
                         "watch_interval > 0 requires a stable target URI. "
                         "Pass 'to' explicitly, or add a resource type that returns root_uri."
                     )
+                if processor_kwargs.get("temp_file_id"):
+                    # An uploaded source is a one-time snapshot: the staged upload is
+                    # consumed at ingest, so a watch task recorded against it would
+                    # re-process the frozen snapshot every interval — silently ignoring
+                    # all edits to the client-side source — instead of watching anything
+                    # live. Reject at creation instead of pretending to watch.
+                    raise InvalidArgumentError(
+                        "watch_interval > 0 is not supported for uploaded content: an "
+                        "upload is consumed as a one-time snapshot at ingest, so the "
+                        "watch would re-process stale content forever. Watch a URL / "
+                        "sitemap / RSS source instead, or re-add the resource when the "
+                        "source changes."
+                    )
                 try:
                     sanitized = self._sanitize_watch_processor_kwargs(processor_kwargs)
                     if watch_auth_state is not None:
@@ -651,6 +664,18 @@ class ResourceService:
         self._ensure_initialized()
         normalized_args = self._normalize_add_resource_args(args, watch_interval=watch_interval)
         kwargs.update(normalized_args.processor_kwargs)
+        if watch_interval > 0 and kwargs.get("temp_file_id"):
+            # Fail fast, before any ingestion: an uploaded source is a one-time
+            # snapshot, so a watch on it can never observe the live source (see the
+            # matching guard in _manage_watch_if_needed, the watch-creation choke
+            # point that protects all other call paths).
+            raise InvalidArgumentError(
+                "watch_interval > 0 is not supported for uploaded content: an "
+                "upload is consumed as a one-time snapshot at ingest, so the "
+                "watch would re-process stale content forever. Watch a URL / "
+                "sitemap / RSS source instead, or re-add the resource when the "
+                "source changes."
+            )
         if not to and not parent:
             from openviking.server.dependencies import get_server_config
 

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -13,7 +13,7 @@ from openviking.resource.watch_manager import WatchManager
 from openviking.server.identity import RequestContext, Role
 from openviking.service import resource_service as resource_service_module
 from openviking.service.resource_service import ResourceService
-from openviking_cli.exceptions import ConflictError
+from openviking_cli.exceptions import ConflictError, InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -145,6 +145,26 @@ class TestWatchTaskCreation:
         assert task.instruction == "Monitor for changes"
         assert task.watch_interval == 30.0
         assert task.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_watch_interval_rejected_for_uploaded_snapshot_source(
+        self, resource_service: ResourceService, request_context: RequestContext
+    ):
+        """A temp-upload source is a one-time snapshot: watching it would silently
+        re-process stale content forever, so creation must fail loudly."""
+        to_uri = "viking://resources/uploaded_resource"
+
+        with pytest.raises(InvalidArgumentError, match="uploaded content"):
+            await resource_service.add_resource(
+                path="/app/.openviking/workspace/temp/upload/upload_abc123.zip",
+                ctx=request_context,
+                to=to_uri,
+                watch_interval=30.0,
+                args={"temp_file_id": "upload_abc123.zip"},
+            )
+
+        task = await get_task_by_uri(resource_service, to_uri, request_context)
+        assert task is None
 
     @pytest.mark.asyncio
     async def test_watch_interval_auto_binds_root_uri_when_to_omitted(


### PR DESCRIPTION
## Summary

`add_resource(..., watch_interval > 0)` on an uploaded source registers a watch whose stored `path` is the ingest-time upload staging location (e.g. `workspace/temp/upload/upload_<id>.zip`). The scheduler re-fires `add_resource` on that frozen snapshot every interval (`watch_scheduler.py` `_execute_task`), so edits and new files in the client's source are never observed — the watch looks healthy (tasks complete every interval) while silently re-processing stale content forever. Full analysis and repro: #3323.

This PR makes watch creation fail loudly for one-shot uploaded sources:

- **Fail-fast guard in `add_resource`** — rejects `watch_interval > 0` when the processing kwargs carry `temp_file_id` (the marker that the source came through the temp-upload flow), before any ingestion happens.
- **Choke-point guard in `_manage_watch_if_needed`** — same rejection at the single place watch tasks are created, protecting any other call path.

Both raise `InvalidArgumentError` with a message pointing users at URL/sitemap/RSS sources (which are re-fetchable and remain fully supported) or plain re-adds.

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Unit test added: `test_watch_interval_rejected_for_uploaded_snapshot_source` (asserts the error and that no watch task is created)
- [x] Manual testing completed: applied the equivalent patch to a v0.4.9 container; `ov add-resource <dir> -p viking://resources --watch-interval 1` now returns `INVALID_ARGUMENT` with the new message (previously: silent snapshot watch), and non-watch adds are unaffected.

## Related Issues

- Fixes #3323

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality