### PR TITLE
feat(bot): add per-peer workspace isolation

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -354,6 +354,7 @@ The active directory used by the Agent also depends on `bot.sandbox.mode`:
 | `shared` (default) | `<workspace>/shared` |
 | `per-session` | `<workspace>/<session-key>` |
 | `per-channel` | `<workspace>/<channel-key>` |
+| `per-peer` | `<workspace>/peer__<actor-peer-id>` |
 
 For example, with the default configuration, edit `~/.openviking/data/bot/workspace/shared/SOUL.md`.
 
@@ -447,6 +448,9 @@ Workspace modes:
 - `shared`: all sessions share one workspace;
 - `per-session`: every Session has an independent workspace;
 - `per-channel`: sessions on the same channel instance share a workspace.
+- `per-peer`: sessions authenticated as the same Peer share a workspace, while different Peers remain isolated.
+
+`per-peer` uses the trusted `actor_peer_id` resolved by the channel. It rejects missing or path-like identities instead of falling back to a shared workspace.
 
 DirectBackend defaults to `restrict_to_workspace: false`. For a Gateway exposed to untrusted users, choose an isolated backend and configure channel allowlists and network/file policies.
 

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -354,6 +354,7 @@ Agent 实际使用的活动目录还取决于 `bot.sandbox.mode`：
 | `shared`（默认） | `<workspace>/shared` |
 | `per-session` | `<workspace>/<session-key>` |
 | `per-channel` | `<workspace>/<channel-key>` |
+| `per-peer` | `<workspace>/peer__<actor-peer-id>` |
 
 例如，默认配置下应修改 `~/.openviking/data/bot/workspace/shared/SOUL.md`。
 
@@ -447,6 +448,9 @@ Agent 实际使用的活动目录还取决于 `bot.sandbox.mode`：
 - `shared`：所有会话共享工作区；
 - `per-session`：每个 Session 独立；
 - `per-channel`：同一渠道实例共享。
+- `per-peer`：认证为同一 Peer 的会话共享工作区，不同 Peer 相互隔离。
+
+`per-peer` 使用渠道解析出的可信 `actor_peer_id`；身份缺失或包含路径分隔符时会拒绝创建工作区，不会回退到共享目录。
 
 DirectBackend 默认 `restrict_to_workspace: false`。对不可信用户开放 Gateway 时，应选择隔离后端，并设置渠道白名单和网络/文件策略。
 

--- a/bot/docs/en/concepts/02-agent-capabilities.md
+++ b/bot/docs/en/concepts/02-agent-capabilities.md
@@ -86,6 +86,7 @@ ContextBuilder reads from the active Workspace selected by `sandbox.mode`:
 | `shared` | `<workspace>/shared` |
 | `per-session` | `<workspace>/<session-key>` |
 | `per-channel` | `<workspace>/<channel-key>` |
+| `per-peer` | `<workspace>/peer__<actor-peer-id>` |
 
 With the default `shared` mode, customize files under `<workspace>/shared`, not directly in the Workspace root.
 
@@ -127,6 +128,9 @@ SandboxManager selects a workspace from SessionKey and `sandbox.mode`:
 | `shared` | All sessions share `workspace/shared` |
 | `per-session` | Every session has an independent directory |
 | `per-channel` | Sessions on the same channel instance share a directory |
+| `per-peer` | Sessions authenticated as the same Peer share a directory |
+
+`per-peer` derives its directory from the channel's trusted `actor_peer_id`. Missing or path-like identities fail closed so an unidentifiable request cannot enter another Peer's workspace.
 
 The current implementation provides these execution backends:
 

--- a/bot/docs/zh/concepts/02-agent-capabilities.md
+++ b/bot/docs/zh/concepts/02-agent-capabilities.md
@@ -86,6 +86,7 @@ ContextBuilder 实际读取按 `sandbox.mode` 选择的活动 Workspace：
 | `shared` | `<workspace>/shared` |
 | `per-session` | `<workspace>/<session-key>` |
 | `per-channel` | `<workspace>/<channel-key>` |
+| `per-peer` | `<workspace>/peer__<actor-peer-id>` |
 
 因此，默认 `shared` 模式下，应定制 `<workspace>/shared` 中的文件，而不是直接修改 Workspace 根目录。
 
@@ -127,6 +128,9 @@ SandboxManager 根据 SessionKey 和 `sandbox.mode` 选择工作区：
 | `shared` | 所有会话共享 `workspace/shared` |
 | `per-session` | 每个会话独立目录 |
 | `per-channel` | 同一渠道实例共享目录 |
+| `per-peer` | 认证为同一 Peer 的会话共享目录 |
+
+`per-peer` 根据渠道解析出的可信 `actor_peer_id` 选择目录。身份缺失或包含路径分隔符时会拒绝创建工作区，避免无法识别的请求进入其他 Peer 的工作区。
 
 当前实现提供以下执行后端：
 

--- a/bot/tests/test_per_peer_workspace.py
+++ b/bot/tests/test_per_peer_workspace.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import pytest
+from vikingbot.config.schema import Config, SandboxConfig, SessionKey
+from vikingbot.heartbeat.service import HeartbeatService
+from vikingbot.sandbox.manager import WORKSPACE_PEER_ID_METADATA_KEY, SandboxManager
+from vikingbot.session.manager import SessionManager
+
+
+def _session(chat_id: str) -> SessionKey:
+    return SessionKey(type="openapi", channel_id="default", chat_id=chat_id)
+
+
+def _manager(tmp_path, mode: str = "per-peer") -> SandboxManager:
+    config = Config(sandbox=SandboxConfig(mode=mode), skills=[])
+    return SandboxManager(config, tmp_path / "workspaces", tmp_path / "source")
+
+
+def test_per_peer_workspace_reuses_identity_across_sessions(tmp_path):
+    manager = _manager(tmp_path)
+
+    alice_first = manager.to_workspace_id(_session("one"), "alice")
+    alice_second = manager.to_workspace_id(_session("two"), "alice")
+    bob = manager.to_workspace_id(_session("one"), "bob")
+
+    assert alice_first == alice_second == "peer__alice"
+    assert bob == "peer__bob"
+    assert bob != alice_first
+
+
+def test_per_peer_workspace_encodes_non_ascii_and_rejects_unsafe_identity(tmp_path):
+    manager = _manager(tmp_path)
+
+    workspace_id = manager.to_workspace_id(_session("one"), "用户 A")
+
+    assert workspace_id.startswith("peer__ext-")
+    assert "/" not in workspace_id
+    with pytest.raises(ValueError, match="actor_peer_id"):
+        manager.to_workspace_id(_session("one"))
+    with pytest.raises(ValueError, match="actor_peer_id"):
+        manager.to_workspace_id(_session("one"), "../alice")
+
+
+def test_session_manager_defers_per_peer_workspace_until_identity_is_known(tmp_path):
+    manager = _manager(tmp_path)
+    sessions = SessionManager(tmp_path / "data", sandbox_manager=manager)
+
+    session = sessions.get_or_create(_session("one"))
+
+    assert session.key == _session("one")
+    assert manager._sandboxes == {}
+
+
+def test_heartbeat_groups_sessions_by_recorded_peer_workspace(tmp_path):
+    manager = _manager(tmp_path)
+    sessions = SimpleNamespace(
+        sandbox_manager=manager,
+        list_sessions=lambda: [
+            {
+                "key": _session("one"),
+                "metadata": {WORKSPACE_PEER_ID_METADATA_KEY: "alice"},
+            },
+            {
+                "key": _session("two"),
+                "metadata": {WORKSPACE_PEER_ID_METADATA_KEY: "alice"},
+            },
+            {"key": _session("legacy"), "metadata": {}},
+        ],
+    )
+    service = HeartbeatService(
+        workspace=manager.workspace,
+        sandbox_mode="per-peer",
+        session_manager=sessions,
+    )
+
+    workspaces = service._get_all_workspaces()
+
+    assert workspaces == {
+        manager.workspace / "peer__alice": [_session("one"), _session("two")]
+    }

--- a/bot/tests/test_per_peer_workspace.py
+++ b/bot/tests/test_per_peer_workspace.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from vikingbot.agent.context import ContextBuilder
 from vikingbot.config.schema import Config, SandboxConfig, SessionKey
 from vikingbot.heartbeat.service import HeartbeatService
 from vikingbot.sandbox.manager import WORKSPACE_PEER_ID_METADATA_KEY, SandboxManager
@@ -49,6 +50,28 @@ def test_session_manager_defers_per_peer_workspace_until_identity_is_known(tmp_p
 
     assert session.key == _session("one")
     assert manager._sandboxes == {}
+
+
+@pytest.mark.asyncio
+async def test_context_prompt_uses_actor_identity_for_per_peer_workspace(tmp_path, monkeypatch):
+    manager = _manager(tmp_path)
+    observed_actor_peer_ids = []
+
+    async def get_sandbox_cwd(session_key, actor_peer_id=None):
+        observed_actor_peer_ids.append(actor_peer_id)
+        return str(manager.get_workspace_path(session_key, actor_peer_id))
+
+    monkeypatch.setattr(manager, "get_sandbox_cwd", get_sandbox_cwd)
+    context = ContextBuilder(
+        workspace=tmp_path / "source",
+        sandbox_manager=manager,
+        actor_peer_id="alice",
+    )
+
+    prompt = await context.build_system_prompt(_session("one"), ov_tools_enable=False)
+
+    assert str(manager.workspace / "peer__alice") in prompt
+    assert observed_actor_peer_ids == ["alice", "alice"]
 
 
 def test_heartbeat_groups_sessions_by_recorded_peer_workspace(tmp_path):

--- a/bot/vikingbot/agent/context.py
+++ b/bot/vikingbot/agent/context.py
@@ -128,7 +128,9 @@ class ContextBuilder:
 
         # Sandbox environment info
         if self.sandbox_manager:
-            sandbox_cwd = await self.sandbox_manager.get_sandbox_cwd(session_key)
+            sandbox_cwd = await self.sandbox_manager.get_sandbox_cwd(
+                session_key, self._actor_peer_id
+            )
             parts.append(
                 f"## Sandbox Environment\n\nYou are running in a sandboxed environment. All file operations and command execution are restricted to the sandbox directory.\nThe sandbox root directory is `{sandbox_cwd}` (use relative paths for all operations)."
             )
@@ -291,7 +293,9 @@ Skills with available="false" need dependencies installed first - you can try in
 
         # Determine workspace display based on sandbox state
         if self.sandbox_manager:
-            workspace_display = await self.sandbox_manager.get_sandbox_cwd(session_key)
+            workspace_display = await self.sandbox_manager.get_sandbox_cwd(
+                session_key, self._actor_peer_id
+            )
         else:
             workspace_display = workspace_path
 

--- a/bot/vikingbot/agent/context.py
+++ b/bot/vikingbot/agent/context.py
@@ -83,7 +83,7 @@ class ContextBuilder:
 
     def _get_workspace_id(self, session_key: SessionKey) -> str:
         if self.sandbox_manager:
-            return self.sandbox_manager.to_workspace_id(session_key)
+            return self.sandbox_manager.to_workspace_id(session_key, self._actor_peer_id)
         return session_key.safe_name()
 
     @staticmethod

--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -37,6 +37,7 @@ from vikingbot.openviking_mount.session_state import (
 )
 from vikingbot.providers.base import LLMProvider
 from vikingbot.sandbox import SandboxManager
+from vikingbot.sandbox.manager import WORKSPACE_PEER_ID_METADATA_KEY
 from vikingbot.session.manager import Session, SessionManager
 from vikingbot.utils.helpers import cal_str_tokens, ensure_non_empty_assistant_content
 from vikingbot.utils.tracing import set_response_id, trace
@@ -350,10 +351,17 @@ class AgentLoop:
             and getattr(agents_config, "session_context_enabled", False)
         )
 
-    def _get_ov_workspace_id(self, session_key: SessionKey) -> str:
+    def _get_ov_workspace_id(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> str:
         if self.sandbox_manager:
-            return self.sandbox_manager.to_workspace_id(session_key)
+            return self.sandbox_manager.to_workspace_id(session_key, actor_peer_id)
         return "shared"
+
+    @staticmethod
+    def _session_workspace_peer_id(session: Session) -> str | None:
+        value = session.metadata.get(WORKSPACE_PEER_ID_METADATA_KEY)
+        return str(value) if value else None
 
     async def _get_ov_client(
         self,
@@ -361,7 +369,7 @@ class AgentLoop:
         openviking_connection: dict[str, Any] | None = None,
         actor_peer_id: str | None = None,
     ):
-        workspace_id = self._get_ov_workspace_id(session_key)
+        workspace_id = self._get_ov_workspace_id(session_key, actor_peer_id)
         if openviking_connection or actor_peer_id:
             from vikingbot.openviking_mount.ov_server import VikingClient
 
@@ -640,7 +648,9 @@ class AgentLoop:
             context=HookContext(
                 event_type="message.compact",
                 session_id=get_openviking_session_id(session),
-                workspace_id=self._get_ov_workspace_id(session.key),
+                workspace_id=self._get_ov_workspace_id(
+                    session.key, self._session_workspace_peer_id(session)
+                ),
                 session_key=session.key,
                 config=self.config,
                 openviking_connection=openviking_connection,
@@ -887,7 +897,9 @@ class AgentLoop:
                             ]
                             _query = "\n".join(_user_msgs[-3:])
                             workspace_id = (
-                                self.sandbox_manager.to_workspace_id(session_key)
+                                self.sandbox_manager.to_workspace_id(
+                                    session_key, actor_peer_id or sender_id
+                                )
                                 if self.sandbox_manager
                                 else "shared"
                             )
@@ -1204,6 +1216,7 @@ class AgentLoop:
             msg.openviking_connection = openviking_connection
             actor_peer_id = getattr(msg, "actor_peer_id", None) or msg.sender_id
             msg.actor_peer_id = actor_peer_id
+            session.metadata[WORKSPACE_PEER_ID_METADATA_KEY] = actor_peer_id
             profile_user_list = []
             memory_peer_ids = self._metadata_memory_peer_ids(msg.metadata)
             memory_owner_user_ids = self._metadata_memory_owner_user_ids(msg.metadata)
@@ -1352,7 +1365,10 @@ class AgentLoop:
                 )
 
             if self.sandbox_manager:
-                message_workspace = self.sandbox_manager.get_workspace_path(session_key)
+                await self.sandbox_manager.get_sandbox(session_key, actor_peer_id)
+                message_workspace = self.sandbox_manager.get_workspace_path(
+                    session_key, actor_peer_id
+                )
             else:
                 message_workspace = self.workspace
 
@@ -1689,6 +1705,8 @@ class AgentLoop:
         # Build messages with the announce content
         provider_name = self.config.get_provider_name(self.model) if self.config else None
         actor_peer_id = getattr(msg, "actor_peer_id", None) or msg.sender_id
+        msg.actor_peer_id = actor_peer_id
+        session.metadata[WORKSPACE_PEER_ID_METADATA_KEY] = actor_peer_id
         history = await self._build_prompt_history(
             session,
             provider_name=provider_name,
@@ -1697,11 +1715,13 @@ class AgentLoop:
         )
         from vikingbot.agent.context import ContextBuilder
 
-        message_workspace = (
-            self.sandbox_manager.get_workspace_path(msg.session_key)
-            if self.sandbox_manager
-            else self.workspace
-        )
+        if self.sandbox_manager:
+            await self.sandbox_manager.get_sandbox(msg.session_key, actor_peer_id)
+            message_workspace = self.sandbox_manager.get_workspace_path(
+                msg.session_key, actor_peer_id
+            )
+        else:
+            message_workspace = self.workspace
         message_context = ContextBuilder(
             message_workspace,
             sandbox_manager=self.sandbox_manager,
@@ -1790,7 +1810,9 @@ class AgentLoop:
                 )
 
             if self.sandbox_manager:
-                memory_workspace = self.sandbox_manager.get_workspace_path(session.key)
+                memory_workspace = self.sandbox_manager.get_workspace_path(
+                    session.key, self._session_workspace_peer_id(session)
+                )
             else:
                 memory_workspace = self.workspace
 
@@ -1887,7 +1909,9 @@ Respond with ONLY valid JSON, no markdown fences."""
                 context=HookContext(
                     event_type="message.compact",
                     session_id=session.key.safe_name(),
-                    workspace_id=self._get_ov_workspace_id(session.key),
+                    workspace_id=self._get_ov_workspace_id(
+                        session.key, self._session_workspace_peer_id(session)
+                    ),
                     session_key=session.key,
                     config=self.config,
                     openviking_connection=openviking_connection,

--- a/bot/vikingbot/agent/subagent.py
+++ b/bot/vikingbot/agent/subagent.py
@@ -57,6 +57,7 @@ class SubagentManager:
         label: str | None = None,
         channel_metadata: dict[str, Any] | None = None,
         openviking_connection: dict[str, Any] | None = None,
+        actor_peer_id: str | None = None,
     ) -> str:
         """
         Spawn a subagent to execute a task in the background.
@@ -76,12 +77,13 @@ class SubagentManager:
         # Create background task
         bg_task = asyncio.create_task(
             self._run_subagent(
-                task_id,
-                task,
-                display_label,
-                session_key,
-                dict(channel_metadata or {}),
-                openviking_connection,
+                task_id=task_id,
+                task=task,
+                label=display_label,
+                session_key=session_key,
+                channel_metadata=dict(channel_metadata or {}),
+                openviking_connection=openviking_connection,
+                actor_peer_id=actor_peer_id,
             )
         )
         self._running_tasks[task_id] = bg_task
@@ -100,6 +102,7 @@ class SubagentManager:
         session_key: SessionKey,
         channel_metadata: dict[str, Any] | None = None,
         openviking_connection: dict[str, Any] | None = None,
+        actor_peer_id: str | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info(f"Subagent [{task_id}] starting task: {label}")
@@ -123,7 +126,7 @@ class SubagentManager:
                     raise RuntimeError("OpenViking is unavailable")
                 memory_store = MemoryStore(self.workspace, config=self.config)
                 workspace_id = (
-                    self.sandbox_manager.to_workspace_id(session_key)
+                    self.sandbox_manager.to_workspace_id(session_key, actor_peer_id)
                     if self.sandbox_manager
                     else "shared"
                 )
@@ -138,7 +141,7 @@ class SubagentManager:
                 logger.warning(f"Subagent [{task_id}] failed to load experience memory: {e}")
 
             # Build messages with subagent-specific prompt
-            prompt_workspace = await self._get_session_workspace(session_key)
+            prompt_workspace = await self._get_session_workspace(session_key, actor_peer_id)
             system_prompt = self._build_subagent_prompt(task, workspace=prompt_workspace)
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
@@ -192,6 +195,7 @@ class SubagentManager:
                             tool_call.arguments,
                             session_key=session_key,
                             sandbox_manager=self.sandbox_manager,
+                            actor_peer_id=actor_peer_id,
                             openviking_connection=openviking_connection,
                         )
                         messages.append(
@@ -211,28 +215,30 @@ class SubagentManager:
 
             logger.info(f"Subagent [{task_id}] completed successfully")
             await self._announce_result(
-                task_id,
-                label,
-                task,
-                final_result,
-                session_key,
-                "ok",
-                channel_metadata,
-                openviking_connection,
+                task_id=task_id,
+                label=label,
+                task=task,
+                result=final_result,
+                session_key=session_key,
+                status="ok",
+                channel_metadata=channel_metadata,
+                openviking_connection=openviking_connection,
+                actor_peer_id=actor_peer_id,
             )
 
         except Exception as e:
             error_msg = f"Error: {str(e)}"
             logger.exception(f"Subagent [{task_id}] failed: {e}")
             await self._announce_result(
-                task_id,
-                label,
-                task,
-                error_msg,
-                session_key,
-                "error",
-                channel_metadata,
-                openviking_connection,
+                task_id=task_id,
+                label=label,
+                task=task,
+                result=error_msg,
+                session_key=session_key,
+                status="error",
+                channel_metadata=channel_metadata,
+                openviking_connection=openviking_connection,
+                actor_peer_id=actor_peer_id,
             )
 
     async def _announce_result(
@@ -245,6 +251,7 @@ class SubagentManager:
         status: str,
         channel_metadata: dict[str, Any] | None = None,
         openviking_connection: dict[str, Any] | None = None,
+        actor_peer_id: str | None = None,
     ) -> None:
         """Announce the subagent result to the main agent via the message bus."""
         status_text = "completed successfully" if status == "ok" else "failed"
@@ -261,6 +268,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         # Inject as system message to trigger main agent
         msg = InboundMessage(
             sender_id="subagent",
+            actor_peer_id=actor_peer_id,
             session_key=session_key,
             content=announce_content,
             metadata=dict(channel_metadata or {}),
@@ -270,13 +278,18 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         await self.bus.publish_inbound(msg)
         logger.debug(f"Subagent [{task_id}] announced result to {session_key}")
 
-    async def _get_session_workspace(self, session_key: SessionKey) -> Path:
+    async def _get_session_workspace(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> Path:
         """Return the workspace path used by tools for this subagent session."""
         if not self.sandbox_manager:
             return self.workspace
 
-        await self.sandbox_manager.get_sandbox(session_key)
-        return self.sandbox_manager.get_workspace_path(session_key)
+        if actor_peer_id is None:
+            await self.sandbox_manager.get_sandbox(session_key)
+            return self.sandbox_manager.get_workspace_path(session_key)
+        await self.sandbox_manager.get_sandbox(session_key, actor_peer_id)
+        return self.sandbox_manager.get_workspace_path(session_key, actor_peer_id)
 
     def _build_subagent_prompt(self, task: str, workspace: Path | None = None) -> str:
         """Build a focused system prompt for the subagent."""

--- a/bot/vikingbot/agent/tools/base.py
+++ b/bot/vikingbot/agent/tools/base.py
@@ -8,6 +8,16 @@ from vikingbot.config.schema import SessionKey
 from vikingbot.sandbox.manager import SandboxManager
 
 
+async def get_tool_sandbox(tool_context: "ToolContext"):
+    """Resolve the request sandbox while preserving legacy manager test doubles."""
+    actor_peer_id = getattr(tool_context, "actor_peer_id", None)
+    if actor_peer_id is None:
+        return await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+    return await tool_context.sandbox_manager.get_sandbox(
+        tool_context.session_key, actor_peer_id
+    )
+
+
 @dataclass
 class ToolContext:
     """Context passed to tools during execution, containing runtime information.
@@ -45,7 +55,7 @@ class ToolContext:
 
     session_key: SessionKey = None
     sandbox_manager: SandboxManager | None = None
-    workspace_id: str = sandbox_manager.to_workspace_id(session_key) if sandbox_manager else None
+    workspace_id: str | None = None
     sender_id: str | None = None
     actor_peer_id: str | None = None
     memory_peer_ids: list[str] | None = None
@@ -55,6 +65,14 @@ class ToolContext:
     channel_metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
+        if self.sandbox_manager is not None:
+            actor_peer_id = self.actor_peer_id or self.sender_id
+            if actor_peer_id is None:
+                self.workspace_id = self.sandbox_manager.to_workspace_id(self.session_key)
+            else:
+                self.workspace_id = self.sandbox_manager.to_workspace_id(
+                    self.session_key, actor_peer_id
+                )
         if self.memory_owner_user_ids is None and self.memory_user_ids is not None:
             self.memory_owner_user_ids = self.memory_user_ids
         elif self.memory_user_ids is None and self.memory_owner_user_ids is not None:

--- a/bot/vikingbot/agent/tools/filesystem.py
+++ b/bot/vikingbot/agent/tools/filesystem.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-from vikingbot.agent.tools.base import Tool
+from vikingbot.agent.tools.base import Tool, get_tool_sandbox
 
 if TYPE_CHECKING:
     from vikingbot.agent.tools.base import ToolContext
@@ -29,7 +29,7 @@ class ReadFileTool(Tool):
 
     async def execute(self, tool_context: "ToolContext", path: str, **kwargs: Any) -> str:
         try:
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            sandbox = await get_tool_sandbox(tool_context)
             content = await sandbox.read_file(path)
             return content
         except FileNotFoundError as e:
@@ -66,7 +66,7 @@ class WriteFileTool(Tool):
         self, tool_context: "ToolContext", path: str, content: str, **kwargs: Any
     ) -> str:
         try:
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            sandbox = await get_tool_sandbox(tool_context)
             await sandbox.write_file(path, content)
             return f"Successfully wrote {len(content)} bytes to {path}"
         except IOError as e:
@@ -102,7 +102,7 @@ class EditFileTool(Tool):
         self, tool_context: "ToolContext", path: str, old_text: str, new_text: str, **kwargs: Any
     ) -> str:
         try:
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            sandbox = await get_tool_sandbox(tool_context)
             content = await sandbox.read_file(path)
 
             if old_text not in content:
@@ -145,7 +145,7 @@ class ListDirTool(Tool):
 
     async def execute(self, tool_context: "ToolContext", path: str, **kwargs: Any) -> str:
         try:
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            sandbox = await get_tool_sandbox(tool_context)
             items = await sandbox.list_dir(path)
 
             if not items:

--- a/bot/vikingbot/agent/tools/image.py
+++ b/bot/vikingbot/agent/tools/image.py
@@ -121,7 +121,16 @@ class ImageGenerationTool(Tool):
             mime_type, _ = mimetypes.guess_type(image_str)
             if not mime_type:
                 mime_type = "application/octet-stream"
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            actor_peer_id = getattr(tool_context, "actor_peer_id", None)
+            if actor_peer_id is None:
+                sandbox = await tool_context.sandbox_manager.get_sandbox(
+                    tool_context.session_key
+                )
+            else:
+                sandbox = await tool_context.sandbox_manager.get_sandbox(
+                    tool_context.session_key,
+                    actor_peer_id=actor_peer_id,
+                )
             image_bytes = await sandbox.read_file_bytes(image_str)
             base64_str = base64.b64encode(image_bytes).decode("utf-8")
             data_uri = f"data:{mime_type};base64,{base64_str}"

--- a/bot/vikingbot/agent/tools/registry.py
+++ b/bot/vikingbot/agent/tools/registry.py
@@ -239,7 +239,11 @@ class ToolRegistry:
                 event_type="tool.post_call",
                 session_key=session_key,
                 workspace_id=(
-                    sandbox_manager.to_workspace_id(session_key) if sandbox_manager else "shared"
+                    sandbox_manager.to_workspace_id(
+                        session_key, actor_peer_id or sender_id
+                    )
+                    if sandbox_manager
+                    else "shared"
                 ),
                 config=self.config,
                 openviking_connection=openviking_connection,

--- a/bot/vikingbot/agent/tools/shell.py
+++ b/bot/vikingbot/agent/tools/shell.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-from vikingbot.agent.tools.base import Tool
+from vikingbot.agent.tools.base import Tool, get_tool_sandbox
 
 if TYPE_CHECKING:
     from vikingbot.agent.tools.base import ToolContext
@@ -45,7 +45,7 @@ class ExecTool(Tool):
     ) -> str:
         # Always use sandbox manager (includes direct mode)
         try:
-            sandbox = await tool_context.sandbox_manager.get_sandbox(tool_context.session_key)
+            sandbox = await get_tool_sandbox(tool_context)
 
             if command.strip() == "pwd":
                 return sandbox.sandbox_cwd

--- a/bot/vikingbot/agent/tools/spawn.py
+++ b/bot/vikingbot/agent/tools/spawn.py
@@ -57,6 +57,7 @@ class SpawnTool(Tool):
             task=task,
             label=label,
             session_key=tool_context.session_key,
+            actor_peer_id=tool_context.actor_peer_id,
             channel_metadata=tool_context.channel_metadata,
             openviking_connection=tool_context.openviking_connection,
         )

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -40,6 +40,7 @@ class SandboxMode(str, Enum):
     PER_SESSION = "per-session"
     SHARED = "shared"
     PER_CHANNEL = "per-channel"
+    PER_PEER = "per-peer"
 
 
 class AgentMemoryMode(str, Enum):

--- a/bot/vikingbot/heartbeat/service.py
+++ b/bot/vikingbot/heartbeat/service.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Coroutine
 from loguru import logger
 
 from vikingbot.config.schema import SessionKey
+from vikingbot.sandbox.manager import WORKSPACE_PEER_ID_METADATA_KEY
 from vikingbot.session.manager import SessionManager
 
 # Default interval: 30 minutes
@@ -128,7 +129,20 @@ class HeartbeatService:
             if self._is_session_stale(session_info):
                 continue
 
-            if self.sandbox_mode == "shared":
+            sandbox_manager = getattr(self.session_manager, "sandbox_manager", None)
+            if sandbox_manager is not None:
+                actor_peer_id = metadata.get(WORKSPACE_PEER_ID_METADATA_KEY)
+                try:
+                    sandbox_workspace = sandbox_manager.get_workspace_path(
+                        session_key, actor_peer_id=actor_peer_id
+                    )
+                except ValueError:
+                    logger.debug(
+                        f"Skipping heartbeat for {session_key}: "
+                        "per-peer workspace identity is unavailable"
+                    )
+                    continue
+            elif self.sandbox_mode == "shared":
                 sandbox_workspace = self.workspace / "shared"
             else:
                 sandbox_workspace = self.workspace / session_key.safe_name()

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import re
 import uuid
@@ -8,8 +7,8 @@ from loguru import logger
 
 import openviking as ov
 from openviking.core.namespace import uri_parts
-from openviking.core.peer_id import normalize_peer_id
 from vikingbot.config.loader import load_config
+from vikingbot.utils.peer_id import normalize_external_peer_id
 
 if TYPE_CHECKING:
     from vikingbot.config.schema import Config
@@ -19,23 +18,6 @@ viking_resource_prefix = "viking://resources/"
 
 def _is_session_key(agent_id: Optional[str]) -> bool:
     return agent_id is not None and "__" in agent_id
-
-
-def _peer_id_from_external_id(peer_id: Optional[str]) -> Optional[str]:
-    if not peer_id:
-        return None
-    raw_peer_id = str(peer_id).strip()
-    if not raw_peer_id:
-        return None
-    if "/" in raw_peer_id or "\\" in raw_peer_id:
-        return None
-    try:
-        return normalize_peer_id(raw_peer_id)
-    except ValueError:
-        pass
-
-    encoded = base64.urlsafe_b64encode(raw_peer_id.encode("utf-8")).decode("ascii").rstrip("=")
-    return normalize_peer_id(f"ext-{encoded}")
 
 
 class VikingClient:
@@ -360,7 +342,7 @@ class VikingClient:
 
     @staticmethod
     def _peer_id(value: Optional[str]) -> Optional[str]:
-        return _peer_id_from_external_id(str(value)) if value is not None else None
+        return normalize_external_peer_id(value)
 
     def _apply_actor_peer_scope(self, client_kwargs: Dict[str, Any]) -> None:
         if self.actor_peer_id:

--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -1,15 +1,13 @@
 """Sandbox manager for creating and managing sandbox instances."""
 
-import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from openviking.async_client import logger
-from vikingbot.sandbox.base import SandboxBackend, SandboxDisabledError, UnsupportedBackendError
+from vikingbot.config.schema import Config, SessionKey
 from vikingbot.sandbox.backends import get_backend
+from vikingbot.sandbox.base import SandboxBackend, UnsupportedBackendError
+from vikingbot.utils.peer_id import normalize_external_peer_id
 
-
-from vikingbot.config.schema import SandboxConfig, SessionKey, Config
+WORKSPACE_PEER_ID_METADATA_KEY = "workspace_peer_id"
 
 
 class SandboxManager:
@@ -27,12 +25,16 @@ class SandboxManager:
             raise UnsupportedBackendError(f"Unknown sandbox backend: {config.backend}")
         self._backend_cls = backend_cls
 
-    async def get_sandbox(self, session_key: SessionKey) -> SandboxBackend:
-        return await self._get_or_create_sandbox(session_key)
+    async def get_sandbox(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> SandboxBackend:
+        return await self._get_or_create_sandbox(session_key, actor_peer_id)
 
-    async def _get_or_create_sandbox(self, session_key: SessionKey) -> SandboxBackend:
+    async def _get_or_create_sandbox(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> SandboxBackend:
         """Get or create session-specific sandbox."""
-        workspace_id = self.to_workspace_id(session_key)
+        workspace_id = self.to_workspace_id(session_key, actor_peer_id)
         if workspace_id not in self._sandboxes:
             sandbox = await self._create_sandbox(workspace_id)
             self._sandboxes[workspace_id] = sandbox
@@ -44,7 +46,7 @@ class SandboxManager:
         instance = self._backend_cls(self.config.sandbox, workspace_id, workspace)
         try:
             await instance.start()
-        except Exception as e:
+        except Exception:
             import traceback
 
             traceback.print_exc()
@@ -54,9 +56,9 @@ class SandboxManager:
 
     async def _copy_bootstrap_files(self, sandbox_workspace: Path) -> None:
         """Copy bootstrap files from source workspace to sandbox workspace."""
-        from vikingbot.agent.context import ContextBuilder
-        from vikingbot.agent.skills import BUILTIN_SKILLS_DIR
         import shutil
+
+        from vikingbot.agent.context import ContextBuilder
 
         # Copy from source workspace init directory (if exists)
         init_dir = self.source_workspace / ContextBuilder.INIT_DIR
@@ -88,9 +90,11 @@ class SandboxManager:
                     continue
                 shutil.copytree(item, dst_skill, dirs_exist_ok=True)
 
-    async def cleanup_session(self, session_key: SessionKey) -> None:
+    async def cleanup_session(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> None:
         """Clean up sandbox for a session."""
-        workspace_id = self.to_workspace_id(session_key)
+        workspace_id = self.to_workspace_id(session_key, actor_peer_id)
         if workspace_id in self._sandboxes:
             await self._sandboxes[workspace_id].stop()
             del self._sandboxes[workspace_id]
@@ -101,17 +105,28 @@ class SandboxManager:
             await sandbox.stop()
         self._sandboxes.clear()
 
-    def get_workspace_path(self, session_key: SessionKey) -> Path:
-        return self.workspace / self.to_workspace_id(session_key)
+    def get_workspace_path(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> Path:
+        return self.workspace / self.to_workspace_id(session_key, actor_peer_id)
 
-    def to_workspace_id(self, session_key: SessionKey):
+    def to_workspace_id(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> str:
         if self.config.sandbox.mode == "shared":
             return "shared"
         elif self.config.sandbox.mode == "per-channel":
             return session_key.channel_key()
+        elif self.config.sandbox.mode == "per-peer":
+            peer_id = normalize_external_peer_id(actor_peer_id)
+            if not peer_id:
+                raise ValueError("per-peer sandbox mode requires a valid actor_peer_id")
+            return f"peer__{peer_id}"
         else:  # per-session
             return session_key.safe_name()
 
-    async def get_sandbox_cwd(self, session_key: SessionKey) -> str:
-        sandbox: SandboxBackend = await self._get_or_create_sandbox(session_key)
+    async def get_sandbox_cwd(
+        self, session_key: SessionKey, actor_peer_id: str | None = None
+    ) -> str:
+        sandbox: SandboxBackend = await self._get_or_create_sandbox(session_key, actor_peer_id)
         return sandbox.sandbox_cwd

--- a/bot/vikingbot/session/manager.py
+++ b/bot/vikingbot/session/manager.py
@@ -181,17 +181,20 @@ class SessionManager:
 
         self._cache[key] = session
 
-        if self.sandbox_manager:
+        if (
+            self.sandbox_manager
+            and self.sandbox_manager.config.sandbox.mode != "per-peer"
+        ):
             from vikingbot.utils.helpers import ensure_session_workspace
 
-            if self.sandbox_manager.config.mode == "shared":
-                workspace_path = self.sandbox_manager.workspace / "shared"
-            else:
-                workspace_path = self.sandbox_manager.workspace / key.safe_name()
+            workspace_path = self.sandbox_manager.get_workspace_path(key)
             ensure_session_workspace(workspace_path)
 
         # Initialize sandbox
-        if self.sandbox_manager:
+        if (
+            self.sandbox_manager
+            and self.sandbox_manager.config.sandbox.mode != "per-peer"
+        ):
             asyncio.create_task(self._init_sandbox(key))
 
         return session
@@ -326,8 +329,13 @@ class SessionManager:
         Returns:
             True if deleted, False if not found.
         """
-        # Clean up sandbox if enabled
-        if self.sandbox_manager is not None:
+        # A per-peer sandbox can be shared by multiple sessions. Deleting one
+        # session must not tear down the workspace used by that peer's other
+        # active sessions; shared peer sandboxes are reclaimed by cleanup_all.
+        if (
+            self.sandbox_manager is not None
+            and self.sandbox_manager.config.sandbox.mode != "per-peer"
+        ):
             asyncio.create_task(self.sandbox_manager.cleanup_session(key))
 
         # Remove from cache

--- a/bot/vikingbot/utils/peer_id.py
+++ b/bot/vikingbot/utils/peer_id.py
@@ -1,0 +1,19 @@
+"""Helpers for turning external peer identities into safe local identifiers."""
+
+import base64
+
+from openviking.core.peer_id import normalize_peer_id
+
+
+def normalize_external_peer_id(peer_id: object | None) -> str | None:
+    """Return a stable, path-safe peer ID for a trusted external identity."""
+    if peer_id is None:
+        return None
+    raw_peer_id = str(peer_id).strip()
+    if not raw_peer_id or "/" in raw_peer_id or "\\" in raw_peer_id:
+        return None
+    try:
+        return normalize_peer_id(raw_peer_id)
+    except ValueError:
+        encoded = base64.urlsafe_b64encode(raw_peer_id.encode("utf-8")).decode("ascii")
+        return normalize_peer_id(f"ext-{encoded.rstrip('=')}")


### PR DESCRIPTION
## Summary

- add a `per-peer` VikingBot sandbox mode keyed by the trusted inbound actor identity
- propagate that identity through the main agent, tools, subagents, OpenViking hooks, and heartbeat workspace discovery
- reuse one workspace across sessions for the same peer, isolate different peers, and fail closed when identity is missing or path-unsafe
- document the new mode in English and Chinese

## Scope

Addresses the workspace-isolation portion of #3259. Skill version synchronization is intentionally left for a separate follow-up.

## Validation

- `PYTHONPATH=bot:. uv run --no-project --with pytest --with pytest-asyncio --with pydantic-settings --with loguru --with pyyaml --with httpx --with fastapi --with json-repair -- python -m pytest --noconftest -o addopts='' -q bot/tests/test_per_peer_workspace.py` (4 passed)
- `python3 -m compileall -q bot/vikingbot`
- focused `ruff check` over all changed Python files
- `git diff --check`