### PR TITLE
feat(studio): add safe file deletion

### DIFF
--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -546,6 +546,13 @@ const en = {
     },
     filePreview: {
       cancel: 'Cancel',
+      delete: 'Delete',
+      deleteConfirmDescription:
+        'Delete {{name}} permanently? This action cannot be undone.',
+      deleteConfirmTitle: 'Delete this file?',
+      deleteFailed: 'Could not delete the file: {{message}}',
+      deleteSuccess: 'Deleted {{name}}',
+      deleting: 'Deleting...',
       edit: 'Edit',
       emptyFile: '(empty file)',
       emptyPrompt: 'Select a file to preview it here',

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -533,6 +533,12 @@ const zhCN = {
     },
     filePreview: {
       cancel: '取消',
+      delete: '删除',
+      deleteConfirmDescription: '确定永久删除 {{name}} 吗？此操作无法撤销。',
+      deleteConfirmTitle: '删除这个文件？',
+      deleteFailed: '删除文件失败：{{message}}',
+      deleteSuccess: '已删除 {{name}}',
+      deleting: '正在删除...',
       edit: '编辑',
       emptyFile: '(空文件)',
       emptyPrompt: '选择文件后在这里预览',

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -4,9 +4,20 @@ import { useQuery } from '@tanstack/react-query'
 import hljs from 'highlight.js/lib/core'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { X, Pencil, Save, XCircle, Loader2 } from 'lucide-react'
+import { X, Pencil, Save, XCircle, Loader2, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#/components/ui/alert-dialog'
 import { Button } from '#/components/ui/button'
 import { ScrollArea } from '#/components/ui/scroll-area'
 import { client } from '#/gen/ov-client/client.gen'
@@ -16,7 +27,11 @@ import type { GetContentDownloadData } from '#/gen/ov-client/types.gen'
 import type { ContentDownloadQuery } from '@ov-server/api/v1/content'
 
 import { formatSize, normalizeReadContent } from '../-lib/normalize'
-import { fetchDirectoryLevelContent, saveFileContent } from '../-lib/api'
+import {
+  deleteFile,
+  fetchDirectoryLevelContent,
+  saveFileContent,
+} from '../-lib/api'
 import {
   useVikingFilePreview,
   useInvalidateVikingFs,
@@ -1048,8 +1063,11 @@ export function FilePreview({
   >(new Set(['abstract', 'overview']))
   const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const editorRef = useRef<CodeEditorHandle>(null)
-  const { invalidatePreview } = useInvalidateVikingFs()
+  const { invalidateList, invalidatePreview, invalidateTree, removePreview } =
+    useInvalidateVikingFs()
 
   const canEdit =
     !file?.isDir &&
@@ -1062,6 +1080,7 @@ export function FilePreview({
   useEffect(() => {
     setMarkdownMode('preview')
     setEditing(false)
+    setDeleteDialogOpen(false)
     setActiveDirectoryLevels(new Set(['abstract', 'overview']))
   }, [file?.uri])
 
@@ -1190,6 +1209,30 @@ export function FilePreview({
     }
   }
 
+  const handleDelete = async () => {
+    if (!file || file.isDir) return
+    setDeleting(true)
+    try {
+      await deleteFile(file.uri)
+      removePreview(file.uri)
+      await Promise.all([
+        invalidateList(dirnameVikingUri(file.uri)),
+        invalidateTree(),
+      ])
+      setDeleteDialogOpen(false)
+      toast.success(t('filePreview.deleteSuccess', { name: file.name }))
+      onClose()
+    } catch (error) {
+      const message =
+        error && typeof error === 'object' && 'message' in error
+          ? String(error.message)
+          : String(error)
+      toast.error(t('filePreview.deleteFailed', { message }))
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   if (!file) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -1251,16 +1294,29 @@ export function FilePreview({
                 </Button>
               </div>
             ) : (
-              canEdit && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setEditing(true)}
-                >
-                  <Pencil className="mr-1 size-3.5" />
-                  {t('filePreview.edit')}
-                </Button>
-              )
+              <div className="flex items-center gap-1">
+                {canEdit ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setEditing(true)}
+                  >
+                    <Pencil className="mr-1 size-3.5" />
+                    {t('filePreview.edit')}
+                  </Button>
+                ) : null}
+                {!file.isDir ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setDeleteDialogOpen(true)}
+                  >
+                    <Trash2 className="mr-1 size-3.5" />
+                    {t('filePreview.delete')}
+                  </Button>
+                ) : null}
+              </div>
             )}
           </div>
           {showCloseButton ? (
@@ -1547,6 +1603,40 @@ export function FilePreview({
           </div>
         </ScrollArea>
       )}
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!deleting) setDeleteDialogOpen(open)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('filePreview.deleteConfirmTitle')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('filePreview.deleteConfirmDescription', { name: file.name })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>
+              {t('filePreview.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={deleting}
+              onClick={() => void handleDelete()}
+            >
+              {deleting ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Trash2 className="size-4" />
+              )}
+              {deleting ? t('filePreview.deleting') : t('filePreview.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/web-studio/src/routes/resources/-hooks/viking-fm.ts
+++ b/web-studio/src/routes/resources/-hooks/viking-fm.ts
@@ -178,6 +178,8 @@ export function useInvalidateVikingFs() {
       queryClient.invalidateQueries({
         queryKey: uri ? ['viking-file-read', uri] : ['viking-file-read'],
       }),
+    removePreview: (uri: string) =>
+      queryClient.removeQueries({ queryKey: ['viking-file-read', uri] }),
   }
 }
 

--- a/web-studio/src/routes/resources/-lib/api.test.ts
+++ b/web-studio/src/routes/resources/-lib/api.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchFsList } from './api'
+import type * as OvClientModule from '#/lib/ov-client'
 
-const { getFsLsMock } = vi.hoisted(() => ({
+import { deleteFile, fetchFsList } from './api'
+
+const { deleteFsMock, getFsLsMock } = vi.hoisted(() => ({
+  deleteFsMock: vi.fn(),
   getFsLsMock: vi.fn(),
 }))
 
 vi.mock('#/lib/ov-client', async (importOriginal) => {
-  const original = await importOriginal()
+  const original = await importOriginal<typeof OvClientModule>()
   return {
     ...original,
+    deleteFs: deleteFsMock,
     getFsLs: getFsLsMock,
   }
 })
@@ -33,6 +37,28 @@ describe('fetchFsList', () => {
         sort_by: 'mtime',
         sort_order: 'desc',
       }),
+    })
+  })
+})
+
+describe('deleteFile', () => {
+  beforeEach(() => {
+    deleteFsMock.mockReset()
+    deleteFsMock.mockResolvedValue({
+      data: { status: 'ok', result: null },
+      headers: {},
+      status: 200,
+    })
+  })
+
+  it('deletes only the selected file and never enables recursive removal', async () => {
+    await deleteFile('viking://resources/notes.md')
+
+    expect(deleteFsMock).toHaveBeenCalledWith({
+      query: {
+        uri: 'viking://resources/notes.md',
+        recursive: false,
+      },
     })
   })
 })

--- a/web-studio/src/routes/resources/-lib/api.ts
+++ b/web-studio/src/routes/resources/-lib/api.ts
@@ -1,5 +1,6 @@
 import { fetchFind, fetchFindAllTypes, fetchSearch } from '#/lib/retrieval'
 import {
+  deleteFs,
   getContentRead,
   getContentAbstract,
   getContentOverview,
@@ -216,6 +217,21 @@ export async function saveFileContent(
           content,
           mode: 'replace',
           wait: false,
+        },
+      }),
+    )
+  } catch (error) {
+    throw toVikingApiError(error)
+  }
+}
+
+export async function deleteFile(uri: string): Promise<void> {
+  try {
+    await getOvResult(
+      deleteFs({
+        query: {
+          uri,
+          recursive: false,
         },
       }),
     )


### PR DESCRIPTION
## Summary

- add an explicit delete action for individual files in the Studio preview
- require destructive confirmation and keep the API call non-recursive
- clear the deleted preview cache and refresh the parent listing/search tree
- add English/Chinese copy and a focused API regression test

## Testing

- npm test -- src/routes/resources (5 passed)
- targeted Prettier check
- targeted ESLint check
- npm run build

Closes #2998