### PR TITLE
fix(memory): restore vectorization after redo recovery

### DIFF
--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -1826,6 +1826,12 @@ async def get_streaming_memory_updater(
     with _streaming_memory_updater_registry_lock:
         existing = _streaming_memory_updater_registry.get(key)
         if existing is not None:
+            # Redo recovery can create the process-global updater before the
+            # service compressor is available, using ``vikingdb=None``.  Do
+            # not let that degraded first caller permanently disable
+            # vectorization for later normal commits with the same user key.
+            if vikingdb is not None and existing.vikingdb is not vikingdb:
+                existing.vikingdb = vikingdb
             return existing
         updater = StreamingMemoryUpdater(
             registry=registry,

--- a/tests/session/memory/test_streaming_memory_updater.py
+++ b/tests/session/memory/test_streaming_memory_updater.py
@@ -30,6 +30,7 @@ from openviking.session.memory.streaming_memory_updater import (
     StreamingMemoryUpdateResult,
     classify_memory_merge_mode,
     enforce_merge_group_peer_id,
+    get_streaming_memory_updater,
     merge_one_memory_type_operations,
     operation_to_patch,
     render_operation_after_file_content,
@@ -316,6 +317,88 @@ async def test_streaming_memory_updater_submit_applies_fast_path(monkeypatch):
     written_uri, written_content, _ = fs.writes[0]
     assert written_uri.endswith("/memories/cases/重复预订处理.md")
     assert "重复预订处理" in written_content
+
+
+@pytest.mark.asyncio
+async def test_cached_updater_restores_vectorization_for_tool_and_skill_memories(monkeypatch):
+    fs = InMemoryVikingFS({})
+    fs.search = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "openviking.session.memory.streaming_memory_updater.get_viking_fs",
+        lambda: fs,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.memory_updater.get_viking_fs",
+        lambda: fs,
+    )
+
+    registry = _registry()
+    for memory_type, name_field in (("tools", "tool_name"), ("skills", "skill_name")):
+        registry.register(
+            MemoryTypeSchema(
+                memory_type=memory_type,
+                description=f"{memory_type} memory",
+                directory=f"viking://user/{{{{ user_space }}}}/memories/{memory_type}",
+                filename_template=f"{{{{ {name_field} }}}}.md",
+                operation_mode="add_only",
+                content_template=f"{memory_type}: {{{{ {name_field} }}}}",
+                fields=[
+                    MemoryField(
+                        name=name_field,
+                        field_type=FieldType.STRING,
+                        merge_op=MergeOp.IMMUTABLE,
+                    )
+                ],
+            )
+        )
+
+    key = ("cached-updater-vectorization", id(fs))
+    degraded = await get_streaming_memory_updater(
+        key=key,
+        registry=registry,
+        vikingdb=None,
+    )
+    vikingdb = AsyncMock()
+    vikingdb.enqueue_embedding_msg.return_value = True
+    restored = await get_streaming_memory_updater(
+        key=key,
+        registry=registry,
+        vikingdb=vikingdb,
+    )
+
+    assert restored is degraded
+    assert restored.vikingdb is vikingdb
+
+    operations = []
+    for memory_type, name_field, name in (
+        ("tools", "tool_name", "terminal"),
+        ("skills", "skill_name", "analyze_code"),
+    ):
+        operations.append(
+            ResolvedOperation(
+                old_memory_file_content=None,
+                memory_type=memory_type,
+                uris=[f"viking://user/u/memories/{memory_type}/{name}.md"],
+                memory_fields={name_field: name},
+            )
+        )
+
+    result = await restored.submit(
+        MemoryUpdateRequest(
+            operations=ResolvedOperations(
+                upsert_operations=operations,
+                delete_file_contents=[],
+                errors=[],
+            ),
+            messages=[Message(id="m1", role="user", parts=[TextPart("use tools and skills")])],
+            ctx=_ctx(),
+        )
+    )
+
+    assert sorted(result.apply_result.written_uris) == sorted(
+        operation.uris[0] for operation in operations
+    )
+    assert vikingdb.enqueue_embedding_msg.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Restore vectorization for streaming memory updates when redo recovery created the process-global updater before the normal service compressor was available.

Redo recovery intentionally constructs a compressor with `vikingdb=None`. If that path is the first caller for a user key, the cached updater previously kept the missing database forever: memory files were written successfully, but embedding messages for later normal tool/skill commits were never enqueued. A later caller with a real VikingDB manager now upgrades the cached updater without allowing a `None` caller to downgrade it.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3328

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Upgrade an existing per-user streaming updater when a real VikingDB manager becomes available.
- Preserve the existing no-downgrade behavior for redo callers that still pass `None`.
- Add a regression covering tool and skill memory writes plus embedding enqueue calls.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
OPENVIKING_CONFIG_FILE=/private/tmp/openviking-empty-config-3328.json python -m pytest --confcutdir=tests/session/memory -o addopts='' tests/session/memory/test_streaming_memory_updater.py -q --tb=short
# 23 passed

ruff check openviking/session/memory/streaming_memory_updater.py tests/session/memory/test_streaming_memory_updater.py
ruff format --check openviking/session/memory/streaming_memory_updater.py tests/session/memory/test_streaming_memory_updater.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The initial full-file run picked up a newer user-level `~/.openviking/ov.conf`; the final run used an empty isolated config so repository tests were evaluated against this checkout's schema.
