### PR TITLE
fix(memory): require distilled session memories

### DIFF
--- a/openviking/prompts/templates/memory/skills.yaml
+++ b/openviking/prompts/templates/memory/skills.yaml
@@ -85,7 +85,9 @@ fields:
   - name: guidelines
     type: string
     description: |
-      Skill usage guidelines, complete usage guide content.
+      Concise, synthesized skill usage guidance based on observed execution evidence.
+      Do not copy the original skill definition, source document, or raw tool payload.
+      Keep only distinct best practices and examples learned from this session.
       Must include exact English headings:
       - "## Guidelines" - best practices
       - "### Good Cases" - successful usage examples

--- a/openviking/prompts/templates/memory/tools.yaml
+++ b/openviking/prompts/templates/memory/tools.yaml
@@ -91,7 +91,9 @@ fields:
   - name: guidelines
     type: string
     description: |
-      Tool usage guidelines, complete usage guide content.
+      Concise, synthesized tool usage guidance based on observed execution evidence.
+      Do not copy the original tool definition, source document, or raw tool payload.
+      Keep only distinct best practices and examples learned from this session.
       Must include exact English headings:
       - "## Guidelines" - best practices
       - "### Good Cases" - successful usage examples

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -219,6 +219,12 @@ class SessionExtractContextProvider(ExtractContextProvider):
 - Before editing ANY existing memory file, you MUST first read its complete content
 - ONLY read URIs that are explicitly listed in ls/search tool results, returned by previous tool calls{resource_deletion_read_source}
 
+## Distillation
+- Store only durable, retrieval-useful facts supported by the conversation.
+- Synthesize facts in concise words. Do NOT copy source documents, skill definitions, templates, transcripts, or tool input/output verbatim.
+- Preserve exact literals only when correctness requires them, such as identifiers, versions, settings, or error text; omit the surrounding raw source.
+- Keep one coherent fact or reusable lesson per item. Prefer structured schema fields over narrative dumps, and split independent facts when the schema supports multiple items.
+
 ## Target Output Language
 All memory content MUST be written in {output_language}.
 

--- a/tests/session/memory/test_memory_react_system_prompt.py
+++ b/tests/session/memory/test_memory_react_system_prompt.py
@@ -41,6 +41,16 @@ class TestProviderInstruction:
         assert "Target Output Language" in instruction
         assert "All memory content MUST be written in" in instruction
 
+    def test_instruction_requires_source_distillation(self):
+        provider = SessionExtractContextProvider(messages=[])
+
+        instruction = provider.instruction()
+
+        assert "Store only durable, retrieval-useful facts" in instruction
+        assert "Do NOT copy source documents, skill definitions" in instruction
+        assert "Preserve exact literals only when correctness requires them" in instruction
+        assert "Prefer structured schema fields over narrative dumps" in instruction
+
     def test_instruction_explains_peer_memory_routing(self):
         provider = SessionExtractContextProvider(messages=[])
 
@@ -232,8 +242,6 @@ class TestSessionConversationToolFiltering:
 
         assert provider._detect_language() == "zh-CN"
 
-
-
     async def test_prepare_extraction_messages_replaces_image_part_with_vlm_description(self):
         class FakeVisionVLM:
             def __init__(self):
@@ -340,6 +348,7 @@ class TestSessionConversationToolFiltering:
         assert len(messages) == 1
         assert any(isinstance(part, ImagePart) for part in messages[0].parts)
         assert provider.messages is not messages
+
 
 def test_session_provider_empty_messages_still_uses_environment_fallback(monkeypatch):
     monkeypatch.setenv("TZ", "Asia/Shanghai")

--- a/tests/session/memory/test_schema_models.py
+++ b/tests/session/memory/test_schema_models.py
@@ -83,7 +83,6 @@ class TestSchemaModelGenerator:
         """Create a registry with real schemas."""
         return create_default_registry()
 
-
     def test_peer_enabled_false_omits_peer_id_field(self):
         memory_type = MemoryTypeSchema(
             memory_type="cases",
@@ -143,6 +142,17 @@ class TestSchemaModelGenerator:
 
         assert "First test field" in model.model_fields["field1"].description
 
+    @pytest.mark.parametrize("memory_type", ["skills", "tools"])
+    def test_usage_guidelines_require_synthesis(self, real_registry, memory_type):
+        schema = real_registry.get(memory_type)
+        model = SchemaModelGenerator([schema]).create_flat_data_model(schema)
+
+        description = model.model_fields["guidelines"].description
+        assert "Concise, synthesized" in description
+        assert "Do not copy the original" in description
+        assert "raw tool payload" in description
+        assert "complete usage guide content" not in description
+
     def test_render_description_template_conditional_branch(self):
         memory_type = MemoryTypeSchema(
             memory_type="conditional",
@@ -184,7 +194,6 @@ class TestSchemaModelGenerator:
         # Check business fields
         assert "field1" in model.model_fields
         assert "field2" in model.model_fields
-
 
     def test_page_id_field_is_emitted_before_mutable_content(self, registry_with_sample):
         """page_id should appear before mutable fields so the model anchors target page first."""
@@ -390,6 +399,7 @@ class TestWikiLink:
 
         assert link_type_schema["type"] == "string"
         assert "enum" not in link_type_schema
+
 
 class TestIntegration:
     """Integration tests for the complete schema system."""


### PR DESCRIPTION
## Description

Addresses the extraction-quality portion of #3006 with a small prompt/schema correction. Session extraction now asks for durable, retrieval-focused facts instead of raw source material, and the tool/skill schema no longer rewards complete usage-guide copies.

This deliberately does not add a character limit, output truncation, an extra LLM repair round, or operation rejection. Those mechanisms were rejected as too heavy in #3235 and can also lose useful facts.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Refs #3006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a shared session-extraction distillation contract: keep durable facts, avoid verbatim source artifacts, retain exact literals only when correctness needs them, and prefer structured atomic items.
- Replace contradictory `complete usage guide content` guidance in tool and skill schemas with concise, evidence-based synthesis.
- Add prompt and generated-schema regression tests.

## Testing

- [x] Added tests for the new extraction and schema contracts
- [x] 38 targeted tests pass locally
- [x] Ruff check and format check pass for changed Python files
- [x] Both changed YAML templates parse successfully
- [x] Tested on macOS

Commands:

```bash
OPENVIKING_CONFIG_FILE=/private/tmp/openviking-test-empty.json pytest -p no:cacheprovider --confcutdir=tests/session/memory -o addopts="" tests/session/memory/test_memory_react_system_prompt.py tests/session/memory/test_schema_models.py -q
ruff check openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_react_system_prompt.py tests/session/memory/test_schema_models.py
ruff format --check openviking/session/memory/session_extract_context_provider.py tests/session/memory/test_memory_react_system_prompt.py tests/session/memory/test_schema_models.py
```

## Checklist

- [x] My code follows the project style
- [x] I performed a self-review
- [x] No new runtime warnings are introduced
- [x] No dependencies are added

## Additional Notes

The embedding input guard remains the last-resort provider safety mechanism. This PR only improves extraction semantics and does not claim to rewrite existing oversized memories.