### PR TITLE
fix(task): 修复 TaskTracker 跨事件循环共享锁问题

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -23,7 +23,7 @@ from openviking.service.resource_memory_link_service import ResourceMemoryLinkSe
 from openviking.service.resource_service import ResourceService
 from openviking.service.search_service import SearchService
 from openviking.service.session_service import SessionService
-from openviking.service.task_tracker import set_task_tracker
+from openviking.service.task_tracker import get_task_tracker, set_task_tracker
 from openviking.session import create_session_compressor
 from openviking.storage import VikingDBManager
 from openviking.storage.collection_schemas import init_context_collection
@@ -300,6 +300,8 @@ class OpenVikingService:
 
         if self._embedder is None:
             self._embedder = self._config.embedding.get_embedder()
+
+        get_task_tracker().bind_to_current_loop()
 
         config = get_openviking_config()
 

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -21,7 +21,8 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from functools import wraps
+from typing import Any, Callable, Coroutine, Dict, List, Optional, TypeVar, cast
 from uuid import uuid4
 
 from openviking.service.task_store import TaskStore
@@ -131,6 +132,21 @@ def _sanitize_task_result(result: Any) -> Any:
 
 # ── TaskTracker ──
 
+_AsyncTaskTrackerMethod = TypeVar(
+    "_AsyncTaskTrackerMethod",
+    bound=Callable[..., Coroutine[Any, Any, Any]],
+)
+
+
+def _on_owner_loop(method: _AsyncTaskTrackerMethod) -> _AsyncTaskTrackerMethod:
+    """Run an async TaskTracker method on the tracker's owner event loop."""
+
+    @wraps(method)
+    async def wrapper(self: "TaskTracker", *args: Any, **kwargs: Any) -> Any:
+        return await self._run_on_owner_loop(method, *args, **kwargs)
+
+    return cast(_AsyncTaskTrackerMethod, wrapper)
+
 
 class TaskTracker:
     """Async task tracker with persistent storage and a process-local cache.
@@ -148,6 +164,8 @@ class TaskTracker:
         self._store = store
         self._tasks: Dict[str, TaskRecord] = {}
         self._lock = threading.Lock()
+        self._owner_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._owner_loop_lock = threading.Lock()
         self._async_lock = asyncio.Lock()
         self._cleanup_task: Optional[asyncio.Task] = None
         logger.info(
@@ -158,12 +176,47 @@ class TaskTracker:
 
     # ── Lifecycle ──
 
+    def bind_to_current_loop(self) -> None:
+        """Bind async task operations to the current running event loop."""
+        current_loop = asyncio.get_running_loop()
+        with self._owner_loop_lock:
+            if self._owner_loop is None:
+                self._owner_loop = current_loop
+            elif self._owner_loop is not current_loop:
+                raise RuntimeError("TaskTracker is already bound to a different event loop")
+
+    async def _run_on_owner_loop(
+        self,
+        method: Callable[..., Coroutine[Any, Any, Any]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        current_loop = asyncio.get_running_loop()
+        with self._owner_loop_lock:
+            if self._owner_loop is None:
+                self._owner_loop = current_loop
+            owner_loop = self._owner_loop
+
+        if current_loop is owner_loop:
+            return await method(self, *args, **kwargs)
+        if owner_loop.is_closed() or not owner_loop.is_running():
+            raise RuntimeError("TaskTracker owner event loop is not running")
+
+        operation = method(self, *args, **kwargs)
+        try:
+            submitted = asyncio.run_coroutine_threadsafe(operation, owner_loop)
+        except BaseException:
+            operation.close()
+            raise
+        return await asyncio.wrap_future(submitted)
+
     def start_cleanup_loop(self) -> None:
         """Start the background TTL cleanup coroutine.
 
         Safe to call multiple times; subsequent calls are no-ops.
         Must be called from within a running event loop.
         """
+        self.bind_to_current_loop()
         if self._cleanup_task is not None and not self._cleanup_task.done():
             return
         self._cleanup_task = asyncio.create_task(self._cleanup_loop())
@@ -171,6 +224,7 @@ class TaskTracker:
 
     def stop_cleanup_loop(self) -> None:
         """Cancel the background cleanup task. Safe to call if not started."""
+        self.bind_to_current_loop()
         if self._cleanup_task is not None and not self._cleanup_task.done():
             self._cleanup_task.cancel()
             logger.debug("[TaskTracker] Cleanup loop stopped")
@@ -185,6 +239,7 @@ class TaskTracker:
             except Exception:
                 logger.exception("[TaskTracker] Cleanup error")
 
+    @_on_owner_loop
     async def _evict_expired(self) -> None:
         """Remove expired tasks and enforce MAX_TASKS."""
         now = time.time()
@@ -233,6 +288,7 @@ class TaskTracker:
 
     # ── CRUD ──
 
+    @_on_owner_loop
     async def create(
         self,
         task_type: str,
@@ -275,6 +331,7 @@ class TaskTracker:
         )
         return self._copy(task)
 
+    @_on_owner_loop
     async def create_if_no_running(
         self,
         task_type: str,
@@ -323,6 +380,7 @@ class TaskTracker:
         )
         return self._copy(task)
 
+    @_on_owner_loop
     async def start(
         self,
         task_id: str,
@@ -342,6 +400,7 @@ class TaskTracker:
                 with self._lock:
                     self._tasks[task.task_id] = task
 
+    @_on_owner_loop
     async def update_stage(
         self,
         task_id: str,
@@ -359,6 +418,7 @@ class TaskTracker:
                 with self._lock:
                     self._tasks[task.task_id] = task
 
+    @_on_owner_loop
     async def complete(
         self,
         task_id: str,
@@ -379,6 +439,7 @@ class TaskTracker:
                     self._tasks[task.task_id] = task
         logger.info("[TaskTracker] Task %s completed", task_id)
 
+    @_on_owner_loop
     async def fail(
         self,
         task_id: str,
@@ -399,6 +460,7 @@ class TaskTracker:
                     self._tasks[task.task_id] = task
         logger.warning("[TaskTracker] Task %s failed: %s", task_id, _sanitize_error(error))
 
+    @_on_owner_loop
     async def get(
         self,
         task_id: str,
@@ -418,6 +480,7 @@ class TaskTracker:
                 return None
             return self._copy(task)
 
+    @_on_owner_loop
     async def list_tasks(
         self,
         task_type: Optional[str] = None,
@@ -447,6 +510,7 @@ class TaskTracker:
         tasks.sort(key=lambda t: t.created_at, reverse=True)
         return tasks[:limit]
 
+    @_on_owner_loop
     async def has_running(
         self,
         task_type: str,

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -3,8 +3,11 @@
 
 """Unit tests for TaskTracker."""
 
+import asyncio
 import json
 import time
+from copy import deepcopy
+from dataclasses import asdict
 
 import pytest
 
@@ -111,6 +114,28 @@ class _FakeAgfsExistingDir(_FakeAgfs):
         return {"message": "created", "mode": mode}
 
 
+class _BlockingTaskStore:
+    def __init__(self):
+        self.tasks = {}
+        self.create_started = asyncio.Event()
+        self.release_create = asyncio.Event()
+
+    async def create(self, task):
+        self.create_started.set()
+        await self.release_create.wait()
+        self.tasks[task.task_id] = deepcopy(task)
+
+    async def update(self, task):
+        self.tasks[task.task_id] = deepcopy(task)
+
+    async def get(self, task_id, *, account_id=None, user_id=None):
+        task = self.tasks.get(task_id)
+        return asdict(task) if task is not None else None
+
+    async def list(self, account_id, *, user_id=None):
+        return [asdict(task) for task in self.tasks.values()]
+
+
 # ── Basic CRUD ──
 
 
@@ -184,6 +209,69 @@ async def test_fail_task(tracker: TaskTracker):
 
 async def test_get_nonexistent_returns_none(tracker: TaskTracker):
     assert await tracker.get("does-not-exist") is None
+
+
+async def test_operations_from_different_event_loops_are_serialized():
+    store = _BlockingTaskStore()
+    tracker = TaskTracker(store=store)
+    owner_loop = asyncio.get_running_loop()
+    create_call = asyncio.create_task(
+        tracker.create("add_resource", resource_id="resource-1", **_owner_kwargs())
+    )
+    await store.create_started.wait()
+
+    main_loop_waiter = asyncio.create_task(tracker.get("missing"))
+    await asyncio.sleep(0)
+
+    def get_from_worker_loop():
+        async def run():
+            worker_call = asyncio.create_task(tracker.get("missing"))
+            await asyncio.sleep(0)
+            owner_loop.call_soon_threadsafe(store.release_create.set)
+            return await worker_call
+
+        return asyncio.run(run())
+
+    worker_loop_call = asyncio.to_thread(get_from_worker_loop)
+
+    created, main_result, worker_result = await asyncio.gather(
+        create_call,
+        main_loop_waiter,
+        worker_loop_call,
+    )
+
+    assert created.resource_id == "resource-1"
+    assert main_result is None
+    assert worker_result is None
+
+
+async def test_call_fails_promptly_after_owner_loop_is_closed():
+    tracker = TaskTracker(store=PersistentTaskStore(_FakeAgfs()))
+
+    def bind_then_close_loop():
+        return asyncio.run(tracker.get("missing"))
+
+    assert await asyncio.to_thread(bind_then_close_loop) is None
+
+    with pytest.raises(RuntimeError, match="owner event loop is not running"):
+        await tracker.get("missing")
+
+
+async def test_cleanup_lifecycle_rejects_different_event_loop():
+    tracker = TaskTracker(store=PersistentTaskStore(_FakeAgfs()))
+    tracker.start_cleanup_loop()
+
+    def stop_from_worker_loop():
+        async def run():
+            tracker.stop_cleanup_loop()
+
+        asyncio.run(run())
+
+    try:
+        with pytest.raises(RuntimeError, match="already bound to a different event loop"):
+            await asyncio.to_thread(stop_from_worker_loop)
+    finally:
+        tracker.stop_cleanup_loop()
 
 
 # ── List / Filter ──


### PR DESCRIPTION
## 变更说明

修复进程级 `TaskTracker` 被 HTTP 主事件循环和 QueueManager 工作线程事件循环
共同调用时，因跨事件循环共享 `asyncio.Lock` 而触发
`is bound to a different event loop` 的问题。

所有异步任务状态与持久化操作统一在 `TaskTracker` 的所属事件循环上执行；
其他事件循环的调用通过线程安全调度返回所属事件循环，保持现有接口、任务状态机和
持久化格式不变。

## 人工参与

- [x] 有人工参与实现或评审
- [ ] 本 PR 完全由 AI 智能体生成，无人工参与

## 关联 Issue

无。

## 变更类型

- [x] 问题修复（不影响兼容性）
- [ ] 新功能（不影响兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（无功能变化）
- [ ] 性能优化
- [x] 测试更新

## 主要变更

- 为 `TaskTracker` 增加所属事件循环，跨事件循环调用通过
  `asyncio.run_coroutine_threadsafe` 调度回所属事件循环，并使用
  `asyncio.wrap_future` 异步等待结果。
- 在 `OpenVikingService.initialize()` 启动 QueueManager 工作线程前显式绑定
  TaskTracker 所属事件循环；清理任务启停也校验事件循环归属。
- 增加跨线程双事件循环、所属事件循环已关闭及清理任务跨事件循环调用的回归测试。

## 测试

- [x] 已新增测试验证修复有效
- [x] 新增及现有定向单元测试在本地通过（共 46 个用例）
- [x] 使用 API 密钥完成 HTTP 冒烟测试：创建会话、写入消息、提交任务和轮询任务均成功
- [x] Ruff 格式检查、Ruff 静态检查和定向 mypy 检查通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成代码自查和人工评审
- [x] 已为事件循环归属和调度边界添加必要说明
- [x] 本次不涉及用户接口或用户文档变更
- [x] 未引入新的警告
- [x] 不涉及依赖变更

## 截图（如适用）

不适用。

## 补充说明

本次修复不修改 TaskTracker 公开方法签名、任务数据结构、任务状态值或持久化路径，
QueueManager 调用方无需增加调用点级别的适配。
