### PR TITLE
feat(train): make baseline cache attributable and fail closed

### DIFF
--- a/openviking/session/train/batch_runner.py
+++ b/openviking/session/train/batch_runner.py
@@ -6,8 +6,9 @@ import inspect
 import json
 import os
 import shutil
+import subprocess
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
@@ -47,7 +48,14 @@ from openviking.session.train.domain import (
 from openviking.session.train.pipeline import OfflinePolicyOptimizationPipeline
 from openviking.telemetry import tracer
 from openviking_cli.client.http import AsyncHTTPClient
+from openviking_cli.utils.config.config_loader import load_json_config, resolve_config_path
+from openviking_cli.utils.config.consts import DEFAULT_OV_CONF, OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+_BASELINE_CACHE_VERSION = 2
+_BASELINE_CACHE_SCHEMA = "openviking.benchmark.baseline.v2"
+_BASELINE_CACHE_DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60
+_UNKNOWN_IDENTITY = "unknown"
 
 
 @dataclass(slots=True)
@@ -75,6 +83,7 @@ class BatchTrainEvalConfig:
     eval_index: int | str | list[int] | tuple[int, ...] | None = None
     benchmark_service_url: str | None = None
     baseline_force_recompute: bool = False
+    baseline_cache_ttl_seconds: int = _BASELINE_CACHE_DEFAULT_TTL_SECONDS
     skip_baseline_eval: bool = False
     eval_each_epoch: bool = False
     eval_split: str | None = "test"
@@ -123,6 +132,8 @@ class BatchTrainEvalConfig:
             raise ValueError("train_trials must be > 0")
         if self.benchmark_service_url is not None and not self.benchmark_service_url.strip():
             raise ValueError("benchmark_service_url must not be empty")
+        if self.baseline_cache_ttl_seconds <= 0:
+            raise ValueError("baseline_cache_ttl_seconds must be > 0")
         if self.keep_recent_results < 0:
             raise ValueError("keep_recent_results must be >= 0")
         if not str(self.result_dir_name or "").strip():
@@ -202,6 +213,9 @@ class BatchTrainEvalReport:
     baseline_cache_path: str | None = None
     baseline_cache_hit: bool = False
     baseline_force_recompute: bool = False
+    baseline_cache_schema: str = _BASELINE_CACHE_SCHEMA
+    baseline_cache_identity: dict[str, Any] | None = None
+    baseline_cache_ttl_seconds: int = _BASELINE_CACHE_DEFAULT_TTL_SECONDS
     skip_final_eval: bool = False
     final_eval_source: str | None = None
 
@@ -242,6 +256,9 @@ class BatchTrainEvalReport:
             "baseline_cache_path": self.baseline_cache_path,
             "baseline_cache_hit": self.baseline_cache_hit,
             "baseline_force_recompute": self.baseline_force_recompute,
+            "baseline_cache_schema": self.baseline_cache_schema,
+            "baseline_cache_identity": self.baseline_cache_identity,
+            "baseline_cache_ttl_seconds": self.baseline_cache_ttl_seconds,
             "skip_final_eval": self.skip_final_eval,
             "final_eval_source": self.final_eval_source,
         }
@@ -312,7 +329,9 @@ async def run_batch_train_eval(config: BatchTrainEvalConfig) -> BatchTrainEvalRe
             latest_pointer_path=_latest_rollouts_path(config),
         )
         remote_executor = getattr(pipeline, "rollout_executor", None)
-        if isinstance(remote_executor, (RemoteRolloutExecutor, CachedEpochZeroTrainRolloutExecutor)):
+        if isinstance(
+            remote_executor, (RemoteRolloutExecutor, CachedEpochZeroTrainRolloutExecutor)
+        ):
             remote_executor.on_rollout_complete = (
                 rollout_artifact_recorder.record_rollout_completion
             )
@@ -361,7 +380,7 @@ async def run_batch_train_eval(config: BatchTrainEvalConfig) -> BatchTrainEvalRe
                 baseline_eval = baseline_result.metadata["report"]
             else:
                 assert baseline_cache_path is not None
-                baseline_eval = _load_baseline_cache(baseline_cache_path)
+                baseline_eval = _load_baseline_cache(baseline_cache_path, config=config)
                 if baseline_eval is not None:
                     _print_baseline_cache_hit(baseline_eval, baseline_cache_path)
 
@@ -481,6 +500,8 @@ async def run_batch_train_eval(config: BatchTrainEvalConfig) -> BatchTrainEvalRe
             ),
             baseline_cache_hit=baseline_cache_hit,
             baseline_force_recompute=config.baseline_force_recompute,
+            baseline_cache_identity=_baseline_cache_identity(config),
+            baseline_cache_ttl_seconds=config.baseline_cache_ttl_seconds,
             skip_final_eval=config.skip_final_eval,
             final_eval_source=final_eval_source,
         )
@@ -595,7 +616,7 @@ async def _load_or_run_baseline_eval(
 ) -> tuple[Any | None, bool]:
     cache_path = _baseline_cache_path(config)
     if not config.baseline_force_recompute:
-        cached_report = _load_baseline_cache(cache_path)
+        cached_report = _load_baseline_cache(cache_path, config=config)
         if cached_report is not None:
             await event_recorder.record(
                 "baseline_cache_hit",
@@ -642,8 +663,11 @@ def _write_baseline_cache(
     *,
     config: BatchTrainEvalConfig,
 ) -> None:
+    created_at = _utc_now()
+    expires_at = created_at + timedelta(seconds=config.baseline_cache_ttl_seconds)
     payload = {
-        "cache_version": 1,
+        "cache_version": _BASELINE_CACHE_VERSION,
+        "schema_version": _BASELINE_CACHE_SCHEMA,
         "cache_key": _baseline_cache_key(config),
         "dataset": config.dataset,
         "domain": config.domain,
@@ -652,22 +676,64 @@ def _write_baseline_cache(
         "trials": config.trials,
         "max_iterations": config.max_iterations,
         "keep_default_tools": config.keep_default_tools,
-        "created_at": datetime.now().isoformat(),
+        "manifest": {
+            **_baseline_cache_identity(config),
+            "created_at": _format_utc_timestamp(created_at),
+            "expires_at": _format_utc_timestamp(expires_at),
+            "reuse_scope": "baseline_reference_only",
+        },
         "report": report,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path = path.with_suffix(f"{path.suffix}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path.replace(path)
 
 
-def _load_baseline_cache(path: Path) -> dict[str, Any] | None:
+def _load_baseline_cache(
+    path: Path,
+    *,
+    config: BatchTrainEvalConfig,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
     if not path.exists():
         return None
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("cache_version") != 1:
-        raise ValueError(f"unsupported baseline cache version in {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("cache_version") != _BASELINE_CACHE_VERSION:
+        return None
+    if payload.get("schema_version") != _BASELINE_CACHE_SCHEMA:
+        return None
+    if payload.get("cache_key") != _baseline_cache_key(config):
+        return None
+    manifest = payload.get("manifest")
+    if not isinstance(manifest, dict):
+        return None
+    expected_identity = _baseline_cache_identity(config)
+    if not _baseline_cache_identity_is_usable(expected_identity):
+        return None
+    if any(manifest.get(key) != value for key, value in expected_identity.items()):
+        return None
+    created_at = _parse_utc_timestamp(manifest.get("created_at"))
+    expires_at = _parse_utc_timestamp(manifest.get("expires_at"))
+    observed_at = now or _utc_now()
+    if observed_at.tzinfo is None:
+        observed_at = observed_at.replace(tzinfo=timezone.utc)
+    else:
+        observed_at = observed_at.astimezone(timezone.utc)
+    if created_at is None or expires_at is None:
+        return None
+    if created_at > observed_at or expires_at <= created_at or expires_at <= observed_at:
+        return None
+    if manifest.get("reuse_scope") != "baseline_reference_only":
+        return None
     report = payload.get("report")
     if not isinstance(report, dict):
-        raise ValueError(f"baseline cache file has no report: {path}")
+        return None
     return {
         **report,
         "baseline_cache_hit": True,
@@ -1014,19 +1080,171 @@ def _train_rollout_cache_key_prefix(config: BatchTrainEvalConfig) -> str:
 
 def _baseline_cache_key(config: BatchTrainEvalConfig) -> str:
     payload = {
-        "dataset": config.dataset,
-        "domain": config.domain,
-        "split": config.eval_split,
-        "eval_index": _index_payload(config.eval_index),
-        "trials": config.trials,
-        "max_iterations": config.max_iterations,
-        "keep_default_tools": config.keep_default_tools,
+        "cache_version": _BASELINE_CACHE_VERSION,
+        **_baseline_cache_identity(config),
     }
     stable = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     digest = sha256(stable.encode("utf-8")).hexdigest()[:16]
     index = _index_label(config.eval_index)
     split = _cache_slug(str(config.eval_split or "none"))
     return f"{_cache_slug(config.domain)}_{split}_index-{index}_trials-{config.trials}_{digest}"
+
+
+def _baseline_cache_identity(config: BatchTrainEvalConfig) -> dict[str, Any]:
+    return {
+        "openviking_revision": _openviking_revision(),
+        "benchmark_runtime_identity": _benchmark_runtime_identity(config),
+        "effective_config_digest": _effective_config_digest(config),
+        "dataset_selection_digest": _dataset_selection_digest(config),
+    }
+
+
+def _baseline_cache_identity_is_usable(identity: dict[str, Any]) -> bool:
+    revision = identity.get("openviking_revision")
+    runtime = identity.get("benchmark_runtime_identity")
+    return bool(
+        revision
+        and revision != _UNKNOWN_IDENTITY
+        and isinstance(runtime, dict)
+        and runtime.get("provider")
+        and runtime.get("identity_digest")
+        and runtime.get("identity_digest") != _UNKNOWN_IDENTITY
+        and identity.get("effective_config_digest")
+        and identity.get("dataset_selection_digest")
+    )
+
+
+def _benchmark_runtime_identity(config: BatchTrainEvalConfig) -> dict[str, str]:
+    service_url = str(config.benchmark_service_url or "").strip().rstrip("/")
+    return {
+        "provider": "remote_benchmark_service",
+        "identity_digest": _stable_digest(service_url) if service_url else _UNKNOWN_IDENTITY,
+    }
+
+
+def _effective_config_digest(config: BatchTrainEvalConfig) -> str:
+    config_file_payload: Any = {"source": "none"}
+    should_resolve_config = bool(
+        config.config_path or config.server_url is None or config.api_key is None
+    )
+    if should_resolve_config:
+        path = resolve_config_path(config.config_path, OPENVIKING_CONFIG_ENV, DEFAULT_OV_CONF)
+        if path is None:
+            config_file_payload = {"source": "missing"}
+        else:
+            try:
+                config_file_payload = _redact_config_value(load_json_config(path))
+            except (OSError, UnicodeError, ValueError):
+                config_file_payload = {"source": "unreadable"}
+    payload = {
+        "batch": {
+            "trials": config.trials,
+            "max_iterations": config.max_iterations,
+            "keep_default_tools": config.keep_default_tools,
+            "baseline_cache_ttl_seconds": config.baseline_cache_ttl_seconds,
+        },
+        "openviking_server_identity_digest": (
+            _stable_digest(str(config.server_url).strip().rstrip("/"))
+            if config.server_url
+            else _UNKNOWN_IDENTITY
+        ),
+        "config": config_file_payload,
+    }
+    return _stable_digest(payload)
+
+
+def _dataset_selection_digest(config: BatchTrainEvalConfig) -> str:
+    return _stable_digest(
+        {
+            "dataset": config.dataset,
+            "domain": config.domain,
+            "split": config.eval_split,
+            "eval_index": _index_payload(config.eval_index),
+        }
+    )
+
+
+def _redact_config_value(value: Any, *, key: str = "") -> Any:
+    if _is_sensitive_config_key(key):
+        return "<redacted>"
+    if isinstance(value, dict):
+        return {
+            str(item_key): _redact_config_value(item_value, key=str(item_key))
+            for item_key, item_value in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, list):
+        return [_redact_config_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_config_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+def _is_sensitive_config_key(key: str) -> bool:
+    normalized = str(key).strip().lower().replace("-", "_")
+    tokens = {token for token in normalized.split("_") if token}
+    collapsed = normalized.replace("_", "")
+    return bool(
+        tokens.intersection({"password", "secret", "token", "credential", "authorization"})
+        or normalized in {"ak", "sk", "key"}
+        or normalized.endswith("_key")
+        or any(marker in collapsed for marker in ("apikey", "accesskey", "privatekey", "authtoken"))
+    )
+
+
+def _stable_digest(value: Any) -> str:
+    stable = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(stable.encode("utf-8")).hexdigest()
+
+
+def _openviking_revision() -> str:
+    explicit = str(os.environ.get("OPENVIKING_BENCHMARK_REVISION") or "").strip()
+    if explicit:
+        return explicit
+    try:
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_repo_root(),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        if not head:
+            return _UNKNOWN_IDENTITY
+        diff = subprocess.run(
+            ["git", "diff", "--binary", "HEAD"],
+            cwd=_repo_root(),
+            check=True,
+            capture_output=True,
+            timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return _UNKNOWN_IDENTITY
+    if diff:
+        return f"{head}+dirty.{sha256(diff).hexdigest()[:16]}"
+    return head
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _format_utc_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
 
 
 def _index_payload(indices: list[int] | None) -> int | list[int] | None:

--- a/openviking/session/train/run_batch_train_eval.py
+++ b/openviking/session/train/run_batch_train_eval.py
@@ -43,10 +43,18 @@ def parse_args() -> argparse.Namespace:
         help="Max seconds to wait for each OpenViking session.commit task. Default waits indefinitely.",
     )
     parser.add_argument("--config", default=None, help="ov.conf path (optional)")
-    parser.add_argument("--server-url", default=None, help="OpenViking server URL. Defaults to ov.conf/ovcli.conf")
-    parser.add_argument("--api-key", default=None, help="OpenViking API key. Defaults to ov.conf/ovcli.conf")
-    parser.add_argument("--account-id", default="default", help="OpenViking trusted account id. Default: default")
-    parser.add_argument("--user-id", default="default", help="OpenViking trusted user id. Default: default")
+    parser.add_argument(
+        "--server-url", default=None, help="OpenViking server URL. Defaults to ov.conf/ovcli.conf"
+    )
+    parser.add_argument(
+        "--api-key", default=None, help="OpenViking API key. Defaults to ov.conf/ovcli.conf"
+    )
+    parser.add_argument(
+        "--account-id", default="default", help="OpenViking trusted account id. Default: default"
+    )
+    parser.add_argument(
+        "--user-id", default="default", help="OpenViking trusted user id. Default: default"
+    )
     parser.add_argument("--output", default=None, help="JSON report output path")
     parser.add_argument(
         "--events-output",
@@ -89,9 +97,14 @@ def parse_args() -> argparse.Namespace:
         "--force-baseline-recompute",
         action="store_true",
         help=(
-            "Recompute the cached pre-training baseline instead of reusing an "
-            "existing cache file."
+            "Recompute the cached pre-training baseline instead of reusing an existing cache file."
         ),
+    )
+    parser.add_argument(
+        "--baseline-cache-ttl-seconds",
+        type=int,
+        default=7 * 24 * 60 * 60,
+        help="Maximum baseline cache age in seconds (default: 604800 / 7 days).",
     )
     parser.add_argument(
         "--skip-baseline-eval",
@@ -209,6 +222,7 @@ async def main_async() -> int:
             eval_index=_parse_indices_arg(args.eval_index),
             benchmark_service_url=args.benchmark_service_url,
             baseline_force_recompute=args.force_baseline_recompute,
+            baseline_cache_ttl_seconds=args.baseline_cache_ttl_seconds,
             eval_each_epoch=args.eval_each_epoch,
             skip_final_eval=args.skip_final_eval,
             skip_baseline_eval=args.skip_baseline_eval,

--- a/tests/session/train/test_batch_runner_cache.py
+++ b/tests/session/train/test_batch_runner_cache.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from openviking.session.train.batch_runner import (
     BatchTrainEvalConfig,
     CachedEpochZeroTrainRolloutExecutor,
+    _baseline_cache_identity,
     _baseline_cache_key,
     _clean_result_dir,
     _load_baseline_cache,
@@ -87,7 +90,10 @@ def test_baseline_cache_key_depends_on_trials_eval_index_and_split():
     )
 
 
-def test_baseline_cache_round_trips_report(tmp_path: Path):
+def test_baseline_cache_round_trips_report(tmp_path: Path, monkeypatch):
+    import openviking.session.train.batch_runner as batch_runner
+
+    monkeypatch.setattr(batch_runner, "_openviking_revision", lambda: "revision-a")
     cache_path = tmp_path / "baseline.json"
     config = BatchTrainEvalConfig(
         dataset="tau2",
@@ -106,12 +112,132 @@ def test_baseline_cache_round_trips_report(tmp_path: Path):
     }
 
     _write_baseline_cache(cache_path, report, config=config)
-    loaded = _load_baseline_cache(cache_path)
+    loaded = _load_baseline_cache(cache_path, config=config)
 
     assert loaded is not None
     assert loaded["baseline_cache_hit"] is True
     assert loaded["baseline_cache_path"] == str(cache_path)
     assert loaded["accuracy"] == 1.0
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["cache_version"] == 2
+    assert payload["schema_version"] == "openviking.benchmark.baseline.v2"
+    assert payload["manifest"]["openviking_revision"] == "revision-a"
+    assert payload["manifest"]["reuse_scope"] == "baseline_reference_only"
+    assert payload["manifest"]["benchmark_runtime_identity"]["provider"] == (
+        "remote_benchmark_service"
+    )
+
+
+def test_baseline_cache_redacts_config_secrets_before_digest(tmp_path: Path, monkeypatch):
+    import openviking.session.train.batch_runner as batch_runner
+
+    monkeypatch.setattr(batch_runner, "_openviking_revision", lambda: "revision-a")
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "vlm": {"model": "model-a", "api_key": "secret-value"},
+                "server": {"root_api_key": "root-secret", "port": 1933},
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = BatchTrainEvalConfig(
+        dataset="tau2",
+        domain="airline",
+        config_path=str(config_path),
+        benchmark_service_url="http://127.0.0.1:1944",
+    )
+    cache_path = tmp_path / "baseline.json"
+
+    _write_baseline_cache(cache_path, {"accuracy": 1.0}, config=config)
+
+    serialized = cache_path.read_text(encoding="utf-8")
+    assert "secret-value" not in serialized
+    assert "root-secret" not in serialized
+    assert _load_baseline_cache(cache_path, config=config) is not None
+
+    original_digest = _baseline_cache_identity(config)["effective_config_digest"]
+    config_path.write_text(
+        json.dumps(
+            {
+                "vlm": {"model": "model-a", "api_key": "new-secret"},
+                "server": {"root_api_key": "new-root-secret", "port": 1933},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert _baseline_cache_identity(config)["effective_config_digest"] == original_digest
+    assert _load_baseline_cache(cache_path, config=config) is not None
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "vlm": {"model": "model-b", "api_key": "new-secret"},
+                "server": {"root_api_key": "new-root-secret", "port": 1933},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert _load_baseline_cache(cache_path, config=config) is None
+
+
+def test_baseline_cache_fails_closed_on_revision_expiry_and_legacy_payload(
+    tmp_path: Path, monkeypatch
+):
+    import openviking.session.train.batch_runner as batch_runner
+
+    revision = {"value": "revision-a"}
+    monkeypatch.setattr(batch_runner, "_openviking_revision", lambda: revision["value"])
+    config = BatchTrainEvalConfig(
+        dataset="tau2",
+        domain="airline",
+        benchmark_service_url="http://127.0.0.1:1944",
+        baseline_cache_ttl_seconds=60,
+    )
+    cache_path = tmp_path / "baseline.json"
+    _write_baseline_cache(cache_path, {"accuracy": 1.0}, config=config)
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    created_at = datetime.fromisoformat(payload["manifest"]["created_at"].replace("Z", "+00:00"))
+
+    assert (
+        _load_baseline_cache(
+            cache_path,
+            config=config,
+            now=created_at + timedelta(seconds=59),
+        )
+        is not None
+    )
+    assert (
+        _load_baseline_cache(
+            cache_path,
+            config=config,
+            now=created_at + timedelta(seconds=60),
+        )
+        is None
+    )
+
+    revision["value"] = "revision-b"
+    assert _load_baseline_cache(cache_path, config=config) is None
+
+    cache_path.write_text(
+        json.dumps({"cache_version": 1, "report": {"accuracy": 1.0}}),
+        encoding="utf-8",
+    )
+    assert _load_baseline_cache(cache_path, config=config) is None
+    cache_path.write_text("{not-json", encoding="utf-8")
+    assert _load_baseline_cache(cache_path, config=config) is None
+
+
+def test_baseline_cache_identity_rejects_unknown_runtime(monkeypatch):
+    import openviking.session.train.batch_runner as batch_runner
+
+    monkeypatch.setattr(batch_runner, "_openviking_revision", lambda: "revision-a")
+    config = BatchTrainEvalConfig(dataset="tau2", domain="airline")
+    identity = _baseline_cache_identity(config)
+
+    assert identity["benchmark_runtime_identity"]["identity_digest"] == "unknown"
 
 
 def test_clean_result_preserves_baseline_cache(tmp_path: Path, monkeypatch):
@@ -217,6 +343,18 @@ def test_keep_recent_results_must_be_non_negative():
             domain="airline",
             benchmark_service_url="http://127.0.0.1:1944",
             keep_recent_results=-1,
+        )
+
+
+def test_baseline_cache_ttl_must_be_positive():
+    import pytest
+
+    with pytest.raises(ValueError, match="baseline_cache_ttl_seconds must be > 0"):
+        BatchTrainEvalConfig(
+            dataset="tau2",
+            domain="airline",
+            benchmark_service_url="http://127.0.0.1:1944",
+            baseline_cache_ttl_seconds=0,
         )
 
 


### PR DESCRIPTION
## Description

当前 batch benchmark 的 baseline cache v1 只按局部参数复用，未绑定 OpenViking revision、benchmark runtime、脱敏后的有效配置、数据选择与有效期；旧缓存或不可归因缓存可能被当作可比 baseline，影响训练前后比较。

本 PR 将缓存升级为 fail-closed 的 v2 manifest：

```text
expected = revision + runtime + redacted_config + dataset_selection
if identity_unknown or manifest != expected or expired:
    recompute_baseline()
else:
    reuse_as_reference_only()
```

缓存命中仍只提供 baseline reference；候选结果的最终评估继续按同一协议运行，不会被缓存跳过。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

- Refs #885：为可复现 benchmark 比较补充可归因缓存边界。
- Related to #1258：避免陈旧或不可归因 baseline 被误当作可比结果；本 PR 不声称解决该 issue 报告的准确率问题。

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 为 baseline cache 增加 canonical v2 manifest，绑定 OpenViking revision、benchmark runtime identity、脱敏有效配置 digest、dataset/split/index digest 与 TTL。
- 对 legacy、损坏、未知 identity、不匹配、未来时间或过期缓存统一 fail closed，原子写入新缓存，并通过 CLI 暴露 TTL 与报告中的 identity 元数据。
- 增加 focused regression，覆盖正常 round-trip、secret redaction、identity mismatch、损坏/旧版本/过期缓存与未知 identity。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `tests/session/train/test_batch_runner_cache.py`：21 passed。
- 变更文件 Ruff：passed。
- 两个运行时模块 `compileall`：passed。
- `tests/session/train` 扩大运行：93 passed；另有 12 个环境依赖失败，需要 live LLM credentials 或可选 VikingBot benchmark 环境，与本 diff 无关。
- GitHub PR checks：通过（跳过项由工作流条件决定）。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

- v1 cache 会在首次读取时失效并重新计算，这是预期兼容行为。
- 无法证明 revision 或 benchmark runtime identity 时不会复用缓存，优先保证结果可归因。
- 本 PR 未执行有成本的 benchmark；验证仅使用本地测试与已有 CI。
