### PR TITLE
fix(bot): supervise Feishu WebSocket connection to recover from silent SDK failures

### DIFF
--- a/bot/tests/test_feishu_ws_lifecycle.py
+++ b/bot/tests/test_feishu_ws_lifecycle.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for the Feishu channel WebSocket lifecycle supervision.
+
+The lark-oapi ws client can end up with a permanently dead connection while its
+blocking start() call keeps running (its internal reconnect task dies silently).
+These tests verify that the channel-level watchdog detects the dead connection
+and rebuilds the client, that the ws thread survives start() crashes, and that
+handler failures do not break subsequent message processing.
+
+The tests use fake ws clients so they run without the lark-oapi SDK installed.
+"""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+from vikingbot.bus.events import InboundMessage
+from vikingbot.channels import feishu as feishu_module
+from vikingbot.channels.feishu import FeishuChannel
+from vikingbot.config.schema import FeishuChannelConfig
+
+
+class FakeBus:
+    """Minimal message bus capturing published inbound messages."""
+
+    def __init__(self):
+        self.inbound: list[InboundMessage] = []
+
+    async def publish_inbound(self, msg: InboundMessage) -> None:
+        self.inbound.append(msg)
+
+
+class FakeConn:
+    """Stands in for a websockets connection with an OPEN/CLOSED state."""
+
+    def __init__(self, open_: bool = True):
+        self.state = SimpleNamespace(name="OPEN" if open_ else "CLOSED")
+        self.close_called = False
+
+    async def close(self):
+        self.close_called = True
+        self.state = SimpleNamespace(name="CLOSED")
+
+
+class FakeWsClient:
+    """
+    Mimics lark's ws Client.start(): blocks on the thread's event loop until the
+    loop is stopped from outside (like run_until_complete of a sleep-forever
+    task), or raises if configured to.
+    """
+
+    def __init__(self, conn=None, start_error: Exception | None = None):
+        self._conn = conn
+        self._auto_reconnect = True
+        self._start_error = start_error
+        self.started = threading.Event()
+
+    def start(self) -> None:
+        self.started.set()
+        if self._start_error is not None:
+            raise self._start_error
+        loop = asyncio.get_event_loop()
+        loop.run_forever()
+
+
+def make_channel(monkeypatch, ws_client_factory) -> FeishuChannel:
+    """Build a FeishuChannel wired to fake clients with fast supervision timings."""
+    monkeypatch.setattr(feishu_module, "FEISHU_AVAILABLE", True)
+    config = FeishuChannelConfig(app_id="cli_test", app_secret="secret", bot_name="TestBot")
+    channel = FeishuChannel(config, FakeBus())
+    channel._WS_HEALTH_CHECK_INTERVAL_SEC = 0.05
+    channel._WS_UNHEALTHY_RESTART_SEC = 0.15
+    channel._WS_RESTART_DELAY_SEC = 0.05
+    channel._WS_THREAD_JOIN_TIMEOUT_SEC = 2
+    monkeypatch.setattr(channel, "_build_rest_client", lambda: object())
+    monkeypatch.setattr(channel, "_build_ws_client", ws_client_factory)
+    return channel
+
+
+async def wait_for(predicate, timeout: float = 5.0):
+    """Poll predicate until true or fail the test on timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    pytest.fail("condition not met within timeout")
+
+
+async def run_channel(channel: FeishuChannel):
+    task = asyncio.create_task(channel.start())
+    # Give start() a chance to fail fast if wiring is broken
+    await asyncio.sleep(0)
+    assert not task.done(), "channel.start() exited immediately"
+    return task
+
+
+class TestConnAliveDetection:
+    def test_no_client(self):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b"), FakeBus()
+        )
+        assert channel._ws_conn_alive() is False
+
+    def test_client_without_conn(self):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b"), FakeBus()
+        )
+        channel._ws_client = FakeWsClient(conn=None)
+        assert channel._ws_conn_alive() is False
+
+    def test_open_and_closed_state(self):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b"), FakeBus()
+        )
+        channel._ws_client = FakeWsClient(conn=FakeConn(open_=True))
+        assert channel._ws_conn_alive() is True
+        channel._ws_client = FakeWsClient(conn=FakeConn(open_=False))
+        assert channel._ws_conn_alive() is False
+
+    def test_legacy_closed_property(self):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b"), FakeBus()
+        )
+        channel._ws_client = FakeWsClient(conn=SimpleNamespace(closed=False))
+        assert channel._ws_conn_alive() is True
+        channel._ws_client = FakeWsClient(conn=SimpleNamespace(closed=True))
+        assert channel._ws_conn_alive() is False
+
+
+class TestConnectionFailureRecovery:
+    async def test_watchdog_rebuilds_client_when_connection_stays_dead(self, monkeypatch):
+        """A client whose connection is dead (SDK reconnect silently gave up)
+        must be replaced by a fresh client after the grace period."""
+        clients: list[FakeWsClient] = []
+
+        def factory():
+            # First generation: permanently dead connection. Later: healthy.
+            client = FakeWsClient(conn=None if not clients else FakeConn())
+            clients.append(client)
+            return client
+
+        channel = make_channel(monkeypatch, factory)
+        task = await run_channel(channel)
+        try:
+            await wait_for(lambda: len(clients) >= 2)
+            # The dead generation must be neutralized so it cannot reconnect
+            assert clients[0]._auto_reconnect is False
+            # The replacement generation is considered healthy and is kept
+            await asyncio.sleep(0.3)
+            assert channel._ws_conn_alive() is True
+        finally:
+            await channel.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+    async def test_watchdog_keeps_healthy_client(self, monkeypatch):
+        """A healthy connection must never be restarted."""
+        clients: list[FakeWsClient] = []
+
+        def factory():
+            client = FakeWsClient(conn=FakeConn())
+            clients.append(client)
+            return client
+
+        channel = make_channel(monkeypatch, factory)
+        task = await run_channel(channel)
+        try:
+            await wait_for(lambda: len(clients) == 1)
+            # Wait well past the unhealthy-restart threshold
+            await asyncio.sleep(0.5)
+            assert len(clients) == 1
+            assert clients[0]._auto_reconnect is True
+        finally:
+            await channel.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+    async def test_ws_thread_retries_when_start_raises(self, monkeypatch):
+        """If the SDK start() call raises (e.g. connect failure), the ws thread
+        must keep rebuilding clients until one succeeds."""
+        clients: list[FakeWsClient] = []
+
+        def factory():
+            error = RuntimeError("connect failed") if len(clients) < 2 else None
+            client = FakeWsClient(
+                conn=FakeConn() if error is None else None, start_error=error
+            )
+            clients.append(client)
+            return client
+
+        channel = make_channel(monkeypatch, factory)
+        task = await run_channel(channel)
+        try:
+            await wait_for(lambda: len(clients) >= 3 and clients[2].started.is_set())
+            await wait_for(channel._ws_conn_alive)
+        finally:
+            await channel.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+    async def test_watchdog_respawns_dead_thread(self, monkeypatch):
+        """If the ws thread itself dies, the watchdog must respawn it."""
+        clients: list[FakeWsClient] = []
+
+        def factory():
+            client = FakeWsClient(conn=FakeConn())
+            clients.append(client)
+            return client
+
+        channel = make_channel(monkeypatch, factory)
+        task = await run_channel(channel)
+        try:
+            await wait_for(lambda: len(clients) == 1)
+            # Kill the current generation's thread by superseding it directly
+            with channel._ws_state_lock:
+                channel._ws_generation += 1
+                client, ws_loop = channel._ws_client, channel._ws_loop
+            channel._neutralize_ws_client(client, ws_loop)
+            await wait_for(lambda: not channel._ws_thread.is_alive())
+            # Watchdog notices the dead thread and spawns a new generation
+            await wait_for(lambda: len(clients) >= 2)
+            await wait_for(channel._ws_conn_alive)
+        finally:
+            await channel.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+
+class TestGatewayLifecycle:
+    async def test_stop_terminates_thread_and_watchdog(self, monkeypatch):
+        clients: list[FakeWsClient] = []
+
+        def factory():
+            client = FakeWsClient(conn=FakeConn())
+            clients.append(client)
+            return client
+
+        channel = make_channel(monkeypatch, factory)
+        task = await run_channel(channel)
+        await wait_for(lambda: len(clients) == 1 and clients[0].started.is_set())
+        thread = channel._ws_thread
+
+        await channel.stop()
+        await asyncio.wait_for(task, timeout=5)
+
+        assert not thread.is_alive()
+        assert channel._ws_client is None
+        assert clients[0]._auto_reconnect is False
+
+
+def _make_feishu_event(message_id: str, text: str):
+    """Build the minimal object shape _on_message reads from a Feishu event."""
+    message = SimpleNamespace(
+        message_id=message_id,
+        chat_id="oc_chat",
+        chat_type="p2p",
+        message_type="text",
+        content=f'{{"text": "{text}"}}',
+        mentions=None,
+        root_id=None,
+    )
+    sender = SimpleNamespace(
+        sender_type="user",
+        sender_id=SimpleNamespace(open_id="ou_sender"),
+    )
+    return SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+
+class TestHandlerFailureRecovery:
+    async def test_handler_exception_does_not_break_later_messages(self, monkeypatch):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b", bot_name="TestBot"),
+            FakeBus(),
+        )
+
+        async def no_reaction(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(channel, "_add_reaction", no_reaction)
+        monkeypatch.setattr(
+            feishu_module, "load_config", lambda: SimpleNamespace(mode="debug")
+        )
+
+        # First event is malformed and raises inside the handler
+        broken = SimpleNamespace(event=None)
+        await channel._on_message(broken)
+
+        # A well-formed event must still be processed and reach the bus
+        await channel._on_message(_make_feishu_event("om_1", "hello"))
+        assert len(channel.bus.inbound) == 1
+        assert channel.bus.inbound[0].content == "hello"
+
+    async def test_duplicate_messages_are_ignored(self, monkeypatch):
+        channel = FeishuChannel(
+            FeishuChannelConfig(app_id="a", app_secret="b", bot_name="TestBot"),
+            FakeBus(),
+        )
+
+        async def no_reaction(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(channel, "_add_reaction", no_reaction)
+        monkeypatch.setattr(
+            feishu_module, "load_config", lambda: SimpleNamespace(mode="debug")
+        )
+
+        await channel._on_message(_make_feishu_event("om_dup", "hello"))
+        await channel._on_message(_make_feishu_event("om_dup", "hello"))
+        assert len(channel.bus.inbound) == 1

--- a/bot/vikingbot/channels/feishu.py
+++ b/bot/vikingbot/channels/feishu.py
@@ -56,10 +56,15 @@ try:
         ReplyMessageRequestBody,
     )
 
+    # The ws client schedules all of its internal tasks on this module-level
+    # event loop; we rebind it per connection generation (see _ws_thread_main).
+    from lark_oapi.ws import client as lark_ws_client_module
+
     FEISHU_AVAILABLE = True
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None
+    lark_ws_client_module = None
     Emoji = None
     GetImageRequest = None
     GetUserRequest = None
@@ -103,12 +108,25 @@ class FeishuChannel(BaseChannel):
         "EatingFood",
     ]
 
+    # WebSocket supervision tuning. The lark-oapi ws client can end up with a
+    # permanently dead connection while its blocking start() call keeps running
+    # (its reconnect task dies silently), so we watch connection health from the
+    # outside and force a full client rebuild when it stays down too long.
+    _WS_HEALTH_CHECK_INTERVAL_SEC = 15
+    _WS_UNHEALTHY_RESTART_SEC = 60
+    _WS_RESTART_DELAY_SEC = 5
+    _WS_THREAD_JOIN_TIMEOUT_SEC = 10
+
     def __init__(self, config: FeishuChannelConfig, bus: MessageBus, **kwargs):
         super().__init__(config, bus, **kwargs)
         self.config: FeishuChannelConfig = config
         self._client: Any = None
         self._ws_client: Any = None
         self._ws_thread: threading.Thread | None = None
+        self._ws_loop: asyncio.AbstractEventLoop | None = None
+        self._ws_generation: int = 0
+        self._ws_state_lock = threading.Lock()
+        self._ws_unhealthy_since: float | None = None
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()  # Ordered dedup cache
         self._loop: asyncio.AbstractEventLoop | None = None
         self._tenant_access_token: str | None = None
@@ -249,6 +267,35 @@ class FeishuChannel(BaseChannel):
 
         return "group"  # 失败默认普通群
 
+    def _build_rest_client(self) -> Any:
+        """Build the Lark REST client used for sending messages."""
+        return (
+            lark.Client.builder()
+            .app_id(self.config.app_id)
+            .app_secret(self.config.app_secret)
+            .log_level(lark.LogLevel.INFO)
+            .build()
+        )
+
+    def _build_ws_client(self) -> Any:
+        """Build a fresh Lark WebSocket client with the event handler registered."""
+        # Create event handler (only register message receive, ignore other events)
+        event_handler = (
+            lark.EventDispatcherHandler.builder(
+                self.config.encrypt_key or "",
+                self.config.verification_token or "",
+            )
+            .register_p2_im_message_receive_v1(self._on_message_sync)
+            .build()
+        )
+
+        return lark.ws.Client(
+            self.config.app_id,
+            self.config.app_secret,
+            event_handler=event_handler,
+            log_level=lark.LogLevel.INFO,
+        )
+
     async def start(self) -> None:
         """Start the Feishu bot with WebSocket long connection."""
         if not FEISHU_AVAILABLE:
@@ -265,65 +312,226 @@ class FeishuChannel(BaseChannel):
         self._loop = asyncio.get_running_loop()
 
         # Create Lark client for sending messages
-        self._client = (
-            lark.Client.builder()
-            .app_id(self.config.app_id)
-            .app_secret(self.config.app_secret)
-            .log_level(lark.LogLevel.INFO)
-            .build()
-        )
+        self._client = self._build_rest_client()
 
-        # Create event handler (only register message receive, ignore other events)
-        event_handler = (
-            lark.EventDispatcherHandler.builder(
-                self.config.encrypt_key or "",
-                self.config.verification_token or "",
-            )
-            .register_p2_im_message_receive_v1(self._on_message_sync)
-            .build()
-        )
-
-        # Create WebSocket client for long connection
-        self._ws_client = lark.ws.Client(
-            self.config.app_id,
-            self.config.app_secret,
-            event_handler=event_handler,
-            log_level=lark.LogLevel.INFO,
-        )
-
-        # Start WebSocket client in a separate thread with reconnect loop
-        def run_ws():
-            while self._running:
-                try:
-                    self._ws_client.start()
-                except Exception as e:
-                    logger.exception(f"Feishu WebSocket error: {e}")
-                if self._running:
-                    import time
-
-                    time.sleep(5)
-
-        self._ws_thread = threading.Thread(target=run_ws, daemon=True)
-        self._ws_thread.start()
+        with self._ws_state_lock:
+            self._ws_generation += 1
+        self._spawn_ws_thread()
 
         logger.info("Feishu bot started with WebSocket long connection")
         logger.info("No public IP required - using WebSocket to receive events")
 
-        # Keep running until stopped
-        while self._running:
-            await asyncio.sleep(1)
+        # Supervise the connection until stopped; the SDK's own reconnect can
+        # die silently while its start() call keeps blocking, so an external
+        # watchdog is required to keep the bot responsive indefinitely.
+        await self._ws_watchdog()
 
     async def stop(self) -> None:
         """Stop the Feishu bot."""
         self._running = False
-        if self._ws_client:
+        with self._ws_state_lock:
+            self._ws_generation += 1  # tells the ws thread to exit its retry loop
+            client, ws_loop, thread = self._ws_client, self._ws_loop, self._ws_thread
+            self._ws_client = None
+            self._ws_loop = None
+            self._ws_thread = None
+        self._neutralize_ws_client(client, ws_loop)
+        if thread is not None and thread.is_alive():
             try:
-                # Try to close the WebSocket connection gracefully
-                if hasattr(self._ws_client, "close"):
-                    self._ws_client.close()
-            except Exception as e:
-                logger.debug(f"Error closing WebSocket client: {e}")
+                await asyncio.get_running_loop().run_in_executor(
+                    None, thread.join, self._WS_THREAD_JOIN_TIMEOUT_SEC
+                )
+            except RuntimeError:
+                thread.join(self._WS_THREAD_JOIN_TIMEOUT_SEC)
         logger.info("Feishu bot stopped")
+
+    def _spawn_ws_thread(self) -> None:
+        """Spawn the WebSocket thread for the current generation."""
+        generation = self._ws_generation
+        self._ws_thread = threading.Thread(
+            target=self._ws_thread_main,
+            args=(generation,),
+            name=f"feishu-ws-{generation}",
+            daemon=True,
+        )
+        self._ws_thread.start()
+
+    def _ws_thread_main(self, generation: int) -> None:
+        """
+        Run WebSocket client generations until stopped or superseded.
+
+        Each iteration builds a fresh event loop and a fresh ws client, so a
+        poisoned client (dead reconnect task, leaked internal lock, thread stuck
+        in a blocking call) can always be replaced with a clean one.
+        """
+        while self._running and generation == self._ws_generation:
+            ws_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(ws_loop)
+            try:
+                client = self._build_ws_client()
+            except Exception:
+                logger.exception("Failed to build Feishu WebSocket client")
+                ws_loop.close()
+                if self._running and generation == self._ws_generation:
+                    time.sleep(self._WS_RESTART_DELAY_SEC)
+                continue
+
+            with self._ws_state_lock:
+                if generation != self._ws_generation:
+                    ws_loop.close()
+                    return
+                self._ws_client = client
+                self._ws_loop = ws_loop
+
+            # The SDK schedules all its internal tasks on the module-level
+            # `loop` global; rebind it so this generation runs on its own loop
+            # even if a previous generation's loop is wedged in a blocked call.
+            if lark_ws_client_module is not None and hasattr(lark_ws_client_module, "loop"):
+                lark_ws_client_module.loop = ws_loop
+
+            try:
+                # Blocks until the loop is stopped (forced restart) or a
+                # connection error escapes the SDK.
+                client.start()
+            except Exception as e:
+                if self._running and generation == self._ws_generation:
+                    logger.warning(f"Feishu WebSocket exited: {e}")
+            finally:
+                self._cleanup_ws_loop(client, ws_loop)
+
+            if self._running and generation == self._ws_generation:
+                logger.info(
+                    f"Restarting Feishu WebSocket connection in {self._WS_RESTART_DELAY_SEC}s"
+                )
+                time.sleep(self._WS_RESTART_DELAY_SEC)
+
+    async def _shutdown_ws_client(self, client: Any) -> None:
+        """Close a ws client's underlying connection, bypassing its internal
+        lock (which can be left permanently held by SDK bugs)."""
+        conn = getattr(client, "_conn", None)
+        try:
+            client._conn = None
+        except Exception:
+            pass
+        if conn is not None:
+            try:
+                await asyncio.wait_for(conn.close(), timeout=5)
+            except Exception:
+                pass
+
+    def _cleanup_ws_loop(self, client: Any, ws_loop: asyncio.AbstractEventLoop) -> None:
+        """Best-effort close of the connection and event loop of a finished generation."""
+        try:
+            ws_loop.run_until_complete(self._shutdown_ws_client(client))
+        except Exception:
+            pass
+        try:
+            pending = asyncio.all_tasks(ws_loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                ws_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        except Exception:
+            pass
+        try:
+            ws_loop.close()
+        except Exception:
+            pass
+
+    def _neutralize_ws_client(
+        self, client: Any, ws_loop: asyncio.AbstractEventLoop | None
+    ) -> None:
+        """Disable a ws client generation so it cannot reconnect, and stop its loop
+        so the blocking start() call in its thread returns."""
+        if client is not None:
+            try:
+                client._auto_reconnect = False
+            except Exception:
+                pass
+        if ws_loop is not None and not ws_loop.is_closed():
+            if client is not None:
+                try:
+                    asyncio.run_coroutine_threadsafe(self._shutdown_ws_client(client), ws_loop)
+                except Exception:
+                    pass
+            try:
+                ws_loop.call_soon_threadsafe(ws_loop.stop)
+            except Exception:
+                pass
+
+    def _ws_conn_alive(self) -> bool:
+        """Check whether the current ws generation has a live connection."""
+        with self._ws_state_lock:
+            client = self._ws_client
+        conn = getattr(client, "_conn", None) if client is not None else None
+        if conn is None:
+            return False
+        # websockets legacy protocol exposes a bool `closed` property
+        closed = getattr(conn, "closed", None)
+        if isinstance(closed, bool):
+            return not closed
+        # websockets asyncio implementation exposes a `state` enum
+        state = getattr(conn, "state", None)
+        if state is not None:
+            return getattr(state, "name", "OPEN") == "OPEN"
+        return True
+
+    async def _restart_ws_client(self, reason: str) -> None:
+        """Force a full rebuild of the ws client in a fresh thread and event loop."""
+        logger.warning(f"Restarting Feishu WebSocket client: {reason}")
+        with self._ws_state_lock:
+            self._ws_generation += 1
+            client, ws_loop, old_thread = self._ws_client, self._ws_loop, self._ws_thread
+            self._ws_client = None
+            self._ws_loop = None
+        self._neutralize_ws_client(client, ws_loop)
+        if old_thread is not None and old_thread.is_alive():
+            await asyncio.get_running_loop().run_in_executor(
+                None, old_thread.join, self._WS_THREAD_JOIN_TIMEOUT_SEC
+            )
+            if old_thread.is_alive():
+                logger.warning(
+                    "Previous Feishu WebSocket thread did not exit in time; "
+                    "abandoning it (likely stuck in a blocking call)"
+                )
+        self._ws_unhealthy_since = None
+        if self._running:  # stop() may have raced with this restart
+            self._spawn_ws_thread()
+
+    async def _ws_watchdog(self) -> None:
+        """
+        Supervise the WebSocket connection until the channel stops.
+
+        Gives the SDK's own auto-reconnect a grace period, then forces a clean
+        client rebuild if the connection stays down (or the ws thread dies).
+        """
+        while self._running:
+            await asyncio.sleep(self._WS_HEALTH_CHECK_INTERVAL_SEC)
+            if not self._running:
+                break
+
+            thread = self._ws_thread
+            if thread is not None and not thread.is_alive():
+                await self._restart_ws_client("WebSocket thread exited unexpectedly")
+                continue
+
+            if self._ws_conn_alive():
+                if self._ws_unhealthy_since is not None:
+                    logger.info("Feishu WebSocket connection recovered")
+                    self._ws_unhealthy_since = None
+                continue
+
+            now = time.monotonic()
+            if self._ws_unhealthy_since is None:
+                self._ws_unhealthy_since = now
+                logger.warning(
+                    "Feishu WebSocket connection is down; waiting for SDK auto-reconnect"
+                )
+            elif now - self._ws_unhealthy_since >= self._WS_UNHEALTHY_RESTART_SEC:
+                await self._restart_ws_client(
+                    f"connection down for {int(now - self._ws_unhealthy_since)}s "
+                    "and SDK auto-reconnect did not recover"
+                )
 
     def _add_reaction_sync(self, message_id: str, emoji_type: str) -> None:
         """Sync helper for adding reaction (runs in thread pool)."""
@@ -675,6 +883,8 @@ class FeishuChannel(BaseChannel):
         """
         if self._loop and self._loop.is_running():
             asyncio.run_coroutine_threadsafe(self._on_message(data), self._loop)
+        else:
+            logger.warning("Dropping Feishu message: channel event loop is not running")
 
     async def _download_and_save_image(self, image_key: str, message_id: str) -> str | None:
         """Download single Feishu image and save to local, return file path or None if failed."""

--- a/docs/en/guides/11-local-embedding-for-codex.md
+++ b/docs/en/guides/11-local-embedding-for-codex.md
@@ -1,0 +1,170 @@
+# Local Embedding Setup for Codex Subscribers
+
+This guide is for ChatGPT Plus/Pro subscribers who use the Codex CLI and want OpenViking memory **without any extra API keys**:
+
+- **VLM (extraction / summarization)** → covered by your ChatGPT subscription via the `openai-codex` OAuth provider
+- **Embedding (vector search)** → a small model running entirely on your machine
+
+Nothing you index ever leaves your machine for search; only VLM calls go to your existing Codex backend.
+
+## What you end up with
+
+```
+Codex CLI ──MCP──► openviking-memory server (Node)
+                        │
+                        ▼
+                openviking-server :1933
+                ├── embedding: local (Ollama or llama.cpp GGUF)
+                └── vlm: openai-codex (OAuth, no API key)
+```
+
+## Prerequisites
+
+- Python 3.10+
+- Codex CLI installed and signed in (`~/.codex/auth.json` exists)
+- Node.js 22+ (for the Codex MCP plugin)
+- Disk: ~700 MB for the recommended embedding model
+- RAM guidance for the embedding model:
+
+| System RAM | Recommended embedding model | Size | Dimension |
+|---|---|---|---|
+| ≤ 16 GB | `qwen3-embedding:0.6b` | ~639 MB | 1024 |
+| 16–32 GB | `qwen3-embedding:8b` | ~4.7 GB | 1024 |
+| Any (lightest) | `embeddinggemma:300m` | ~622 MB | 768 |
+| Any (CPU-only, Chinese text) | `bge-small-zh-v1.5-f16` (GGUF) | ~24 MB | 512 |
+
+> **Language note:** the built-in GGUF preset (`bge-small-zh-v1.5`) is optimized for Chinese. If your memories are mostly English, use the Ollama path with `qwen3-embedding:0.6b` or `embeddinggemma:300m`.
+
+## Step 1 — Install OpenViking
+
+```bash
+pip install openviking
+```
+
+macOS users who prefer isolated installs:
+
+```bash
+brew install pipx && pipx ensurepath
+pipx install openviking
+```
+
+## Step 2 — Choose your local embedding runtime
+
+Two options:
+
+- **Path A: Ollama (recommended).** Best model selection for English, GPU-accelerated on Apple Silicon, one extra background service.
+- **Path B: llama.cpp GGUF (no daemon).** `pip install "openviking[local-embed]"`, model auto-downloads on first start. Currently only the Chinese-optimized `bge-small-zh-v1.5` preset ships.
+
+### Path A: Ollama
+
+```bash
+# Install from https://ollama.com/download, then:
+ollama pull qwen3-embedding:0.6b
+```
+
+### Path B: llama.cpp GGUF
+
+```bash
+pip install "openviking[local-embed]"
+```
+
+The model (~24 MB) downloads automatically to `~/.cache/openviking/models` on first server start. Note this path may compile `llama-cpp-python` from source if no wheel matches your platform (requires a C/C++ toolchain).
+
+## Step 3 — Configure `~/.openviking/ov.conf`
+
+> **Current wizard limitation:** `openviking-server init` offers Codex OAuth only in its *Cloud API* flow, and its two local flows only offer Ollama or API-key VLMs. The **local embedding + Codex VLM** combination this guide targets must be configured manually today. (This is the gap the planned installer profiles close.)
+
+First, import your Codex auth. The easiest way is to run `openviking-server init`, pick **Cloud API**, choose **OpenAI Codex** as VLM provider when prompted, and accept the offer to import auth from `~/.codex/auth.json` — then cancel before saving and write the config below manually. OpenViking stores its own token copy at `~/.openviking/codex_auth.json` and refreshes it independently.
+
+Then write `~/.openviking/ov.conf`:
+
+**Ollama embedding + Codex VLM:**
+
+```json
+{
+  "server": { "host": "127.0.0.1", "port": 1933 },
+  "storage": { "workspace": "~/.openviking/data" },
+  "embedding": {
+    "dense": {
+      "provider": "ollama",
+      "model": "qwen3-embedding:0.6b",
+      "api_base": "http://localhost:11434/v1",
+      "dimension": 1024,
+      "input": "text"
+    }
+  },
+  "vlm": {
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "api_base": "https://chatgpt.com/backend-api/codex",
+    "temperature": 0.0,
+    "max_retries": 2
+  }
+}
+```
+
+**GGUF embedding + Codex VLM** — replace the `embedding` block with:
+
+```json
+"embedding": {
+  "dense": {
+    "provider": "local",
+    "model": "bge-small-zh-v1.5-f16",
+    "dimension": 512
+  }
+}
+```
+
+Useful environment overrides for the Codex provider:
+
+| Variable | Purpose |
+|---|---|
+| `OPENVIKING_CODEX_AUTH_PATH` | Where OpenViking stores its Codex token (default `~/.openviking/codex_auth.json`) |
+| `OPENVIKING_CODEX_BOOTSTRAP_PATH` | Alternate Codex CLI `auth.json` to import from |
+| `OPENVIKING_CODEX_BASE_URL` | Override the Codex backend URL |
+
+> **Pick your embedding model once.** The vector dimension is baked into the index. Switching models (or dimensions) later means your existing memories must be re-embedded/re-imported.
+
+## Step 4 — Validate and start
+
+```bash
+openviking-server doctor
+openviking-server
+curl http://localhost:1933/health
+```
+
+## Step 5 — Wire up Codex
+
+Build the MCP memory server and register it:
+
+```bash
+cd examples/codex-memory-plugin
+npm install
+npm run build
+
+codex mcp add openviking-memory -- \
+  node /ABS/PATH/TO/OpenViking/examples/codex-memory-plugin/servers/memory-server.js
+```
+
+Codex gains four explicit tools: `openviking_recall`, `openviking_store`, `openviking_forget`, `openviking_health`. Note this integration is intentionally MCP-only — there is no automatic recall/capture on every turn (unlike the Claude Code plugin); the model calls the tools when it decides to.
+
+Connection settings are read from the same `~/.openviking/ov.conf`. Optional env overrides: `OPENVIKING_AGENT_ID` (default `codex`), `OPENVIKING_RECALL_LIMIT` (default 6), `OPENVIKING_SCORE_THRESHOLD` (default 0.01).
+
+## Step 6 — Smoke test
+
+In a Codex session:
+
+1. Ask it to run `openviking_health` — expect a reachable server.
+2. "Remember that I prefer tabs over spaces" → should invoke `openviking_store`.
+3. New session: "What are my formatting preferences?" → should invoke `openviking_recall` and find the memory.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `doctor` fails on embedding | Ollama not running (`ollama serve`), or model not pulled (`ollama pull qwen3-embedding:0.6b`) |
+| `llama-cpp-python is not installed` | `pip install "openviking[local-embed]"` |
+| llama-cpp-python build fails | Install a C/C++ toolchain (Xcode CLT on macOS; GCC 9+/Clang 11+ elsewhere) or switch to the Ollama path |
+| Codex VLM auth errors | Re-run the auth import; check `~/.openviking/codex_auth.json` exists and Codex CLI is still signed in |
+| Port 1933 in use | Change `server.port` in `ov.conf` (the MCP plugin picks up the new value from the same file) |
+| Recall returns nothing | Memory extraction is VLM-dependent — check server logs for `openai-codex` call failures |

--- a/docs/en/guides/12-local-embedding-for-claude-code.md
+++ b/docs/en/guides/12-local-embedding-for-claude-code.md
@@ -1,0 +1,145 @@
+# Local Embedding Setup for Claude Code Subscribers
+
+This guide is for Claude Pro/Max subscribers who use Claude Code and want OpenViking memory with a **small local embedding model** — no embedding API key, and vector search that never leaves your machine.
+
+**One thing to know up front:** unlike Codex (which has an OAuth VLM backend), OpenViking has **no Anthropic-subscription VLM backend** — your Claude subscription covers Claude Code itself, not OpenViking's internal extraction/summarization calls. So you pick one of two VLM strategies:
+
+- **Fully local (recommended here):** Ollama serves both the embedding model *and* a small VLM. Zero API keys, zero cloud calls.
+- **Hybrid:** local embedding + a cloud VLM API key (VolcEngine, OpenAI, Kimi, GLM, …) for higher-quality memory extraction.
+
+## What you end up with (fully local)
+
+```
+Claude Code
+├── UserPromptSubmit hook ── auto-recall (memories injected each turn)
+├── Stop hook ────────────── auto-capture (session extracted to memory)
+└── MCP tools ─────────────► openviking-server :1933
+                             ├── embedding: ollama/qwen3-embedding:0.6b
+                             └── vlm: ollama/qwen3.5:2b (via litellm)
+```
+
+## Prerequisites
+
+- Python 3.10+
+- Claude Code installed
+- Node.js (the plugin bootstraps its own runtime on first session start)
+- RAM sizing — the fully-local path runs *two* models, so size both together:
+
+| System RAM | Embedding | VLM | Total download |
+|---|---|---|---|
+| ≤ 8 GB | `qwen3-embedding:0.6b` (1024d) | `qwen3.5:2b` | ~3.3 GB |
+| 8–16 GB | `qwen3-embedding:0.6b` (1024d) | `qwen3.5:4b` | ~4.1 GB |
+| 16–32 GB | `qwen3-embedding:8b` (1024d) | `qwen3.5:9b` | ~11 GB |
+| 32–64 GB | `qwen3-embedding:8b` (1024d) | `gemma4:e4b` | ~14 GB |
+
+These are the same tiers `openviking-server init` auto-recommends from detected RAM.
+
+> **Language note:** for a lighter embedding option, `embeddinggemma:300m` (768d, ~622 MB) also works well for English. The tiny built-in GGUF preset (`bge-small-zh-v1.5`) is Chinese-optimized — prefer the Ollama models for English memories.
+
+## Step 1 — Install OpenViking
+
+```bash
+pip install openviking
+```
+
+macOS users who prefer isolated installs:
+
+```bash
+brew install pipx && pipx ensurepath
+pipx install openviking
+```
+
+## Step 2 — Run the setup wizard
+
+The fully-local path is a first-class wizard flow:
+
+```bash
+openviking-server init
+```
+
+1. Choose **Local models via Ollama** (option 3 — recommended for macOS / Apple Silicon).
+2. The wizard checks for Ollama, offers to install and start it if missing.
+3. It detects your RAM and pre-selects the recommended embedding + VLM presets from the table above (marked with `*`) — accept or override.
+4. It offers to `ollama pull` anything not yet downloaded.
+5. Choose **Local (127.0.0.1)** for server binding.
+6. Save. Config lands in `~/.openviking/ov.conf` (existing config is backed up as `.bak`).
+
+The generated config looks like:
+
+```json
+{
+  "server": { "host": "127.0.0.1" },
+  "storage": { "workspace": "~/.openviking/data" },
+  "embedding": {
+    "dense": {
+      "provider": "ollama",
+      "model": "qwen3-embedding:0.6b",
+      "api_base": "http://localhost:11434/v1",
+      "dimension": 1024,
+      "input": "text"
+    }
+  },
+  "vlm": {
+    "provider": "litellm",
+    "model": "ollama/qwen3.5:2b",
+    "api_key": "no-key",
+    "api_base": "http://localhost:11434",
+    "temperature": 0.0,
+    "max_retries": 2
+  }
+}
+```
+
+**Hybrid variant:** choose **Local embedding via llama.cpp** (option 2) instead, then pick **Use Cloud API for VLM** when prompted — you'll enter one VLM API key but embedding stays local. Or edit the `vlm` block of the config above to point at any supported cloud provider.
+
+> **Pick your embedding model once.** The vector dimension is baked into the index. Switching models (or dimensions) later means your existing memories must be re-embedded/re-imported.
+
+## Step 3 — Validate and start
+
+```bash
+openviking-server doctor
+openviking-server
+curl http://localhost:1933/health
+```
+
+Keep the server running while you use Claude Code (or register it as a login service — see the deployment guide).
+
+## Step 4 — Install the Claude Code plugin
+
+Inside Claude Code:
+
+```
+/plugin marketplace add Castor6/openviking-plugins
+/plugin install claude-code-memory-plugin@openviking-plugin
+```
+
+Then start a new session (`claude`). On first `SessionStart` the plugin bootstraps its own Node runtime (into `${CLAUDE_PLUGIN_DATA}/runtime`, falling back to `~/.openviking/claude-code-memory-plugin/runtime`) — no manual `npm install`.
+
+The plugin reads the same `~/.openviking/ov.conf`: it derives `baseUrl` from `server.host` + `server.port` and, if set, uses `server.root_api_key` as its API key.
+
+What you get automatically:
+
+- **Auto-recall** — every prompt triggers a semantic search over `viking://user/memories` and `viking://agent/memories`; relevant memories are injected as a system message.
+- **Auto-capture** — when a turn ends, the transcript is captured and the server extracts long-term memories from it (this is where the local VLM does its work).
+- **MCP tools** — explicit memory operations when you want them.
+
+Tune behavior in an optional `claude_code` section of `ov.conf` (`autoRecall`, `recallLimit`, `scoreThreshold`, `autoCapture`, `captureMode`, `agentId`, …).
+
+## Step 5 — Smoke test
+
+1. In a session: "Remember that my staging server is deploy@10.0.0.5."
+2. End the turn, start a **new** session.
+3. Ask "how do I reach staging?" — the answer should arrive with a recalled-memories system message.
+
+If recall is empty, give extraction a moment (capture runs on the `Stop` hook and extraction is asynchronous on the server), then check the logs below.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `doctor` fails on embedding or VLM | Ollama not running (`ollama serve`) or model not pulled (`ollama pull <model>`) |
+| Hooks seem to do nothing | Enable `claude_code.debug` or `OPENVIKING_DEBUG=1`, then check `~/.openviking/logs/cc-hooks.log` |
+| Recall slow / prompt submission lags | `UserPromptSubmit` hook has an 8s budget; lower `recallLimit` or use a smaller embedding model |
+| Capture times out | `Stop` hook allows 45s; keep `claude_code.captureTimeoutMs` below that, or use a smaller / faster VLM |
+| Memories extracted poorly | Small local VLMs trade quality for privacy — move up a VLM tier or switch to the hybrid variant |
+| Port 1933 in use | Change `server.port` in `ov.conf`; the plugin picks it up from the same file |

--- a/explaining/embedding-and-graph-system.md
+++ b/explaining/embedding-and-graph-system.md
@@ -1,0 +1,395 @@
+# OpenViking — Embedding System & Graph DB (Population + Retrieval)
+
+> A walkthrough of how OpenViking (OV) turns raw files into embeddings, how it
+> materializes a hierarchical knowledge **graph**, and how that graph is queried.
+> File paths are given so you can jump straight to the source.
+
+---
+
+## Part 1 — The Embedding System
+
+### 1.1 The big idea
+
+OV does **not** embed only flat documents. It builds a 3-level hierarchy per
+directory and embeds *each level separately*, so that semantic search can match
+at the right granularity (a whole topic vs. a single file).
+
+The three levels (`openviking/core/context.py` → `ContextLevel`):
+
+| Level | Enum value | What it represents | Canonical URI |
+|-------|-----------|--------------------|---------------|
+| **L0** | `ABSTRACT = 0` | A short *abstract* of a directory/topic | `{dir}/.abstract.md` |
+| **L1** | `OVERVIEW = 1` | A longer *overview* of a directory | `{dir}/.overview.md` |
+| **L2** | `DETAIL = 2`  | The actual leaf content (a file) | `{file_path}` |
+
+Every embedded record carries a `level` and a `parent_uri`. Those two fields are
+what turn a pile of vectors into a navigable tree (see Part 2).
+
+### 1.2 The embedder abstraction
+
+**The problem this solves.** OV supports a dozen embedding providers (OpenAI,
+Voyage, Cohere, Gemini, …) plus a local model. Each has its own SDK, request
+shape, and quirks. The rest of OV must *not* care which one is active — the
+indexing pipeline and the retriever just want to say "turn this text into a
+vector." So `base.py` defines one common interface, `EmbedderBase`, that every
+provider implements. Swap providers in config and nothing downstream changes.
+That interface is "the embedder abstraction."
+
+```
+   indexing pipeline / retriever
+              │  embed(text)            ← they only ever call this
+              ▼
+        EmbedderBase  (the contract)
+        ╱     │      ╲
+   OpenAI   Voyage   local …            ← concrete providers, hidden behind it
+```
+
+#### What you get back: `EmbedResult`
+
+Every `embed()` call returns one `EmbedResult` dataclass
+(`base.py:95`). It holds up to two representations of the same text:
+
+| Field | Type | What it is |
+|-------|------|-----------|
+| `dense_vector` | `List[float]` | The familiar "semantic" embedding — a fixed-length list of floats where closeness ≈ similar meaning. |
+| `sparse_vector` | `Dict[str, float]` | A `term → weight` map (e.g. `{"retrieval": 0.8, "system": 0.4}`). Lexical / BM25-style — good at exact keyword matches dense vectors miss. |
+
+Either may be `None`. Convenience properties (`is_dense`, `is_sparse`,
+`is_hybrid`) just check which fields are populated. Holding both in one object is
+what lets the vector store do **hybrid search** later (Part 1.6 / 2.3).
+
+#### The one method everyone implements: `embed(text, is_query)`
+
+This is the whole contract (`base.py:146`). The `is_query` flag is the one part
+that trips people up:
+
+- `is_query=False` → you're embedding a **document** being stored/indexed.
+- `is_query=True` → you're embedding a **search query** at retrieval time.
+
+The convenience wrappers `embed_query()` / `embed_document()` (`base.py:171`)
+just call `embed()` with the flag pre-set so call sites read clearly.
+
+> **Why `is_query` if both land in the same space?**
+>
+> Both *do* go into one shared vector space — that's exactly what makes
+> "find the document nearest the query" a valid distance comparison. The flag
+> isn't about *which space*; it's about *how the text enters it*.
+>
+> A query and the document that answers it rarely look alike — `"reset password"`
+> vs. *"To recover access to your account, navigate to Settings → Security…"*.
+> They share almost no words, so a naive model would place them far apart even
+> though one perfectly answers the other. To fix this, most modern retrieval
+> models are **asymmetric**: trained on (query, answer) pairs to pull the two
+> together *despite* the wording gap, usually by prepending a hidden instruction:
+>
+> ```
+> is_query=True   →  "query: reset password"
+> is_query=False  →  "passage: To recover access to your account..."
+> ```
+>
+> Think of it as **two on-ramps onto the same highway**: the highway (space) is
+> shared so distances are comparable, but queries and passages enter from
+> opposite sides and are deliberately routed to the *same neighborhood*. Pass the
+> wrong flag and you take the wrong on-ramp — nothing crashes, but you land in the
+> wrong neighborhood and retrieval quality silently degrades.
+>
+> Symmetric models (e.g. "find similar sentences") ignore the flag entirely. OV
+> passes it unconditionally because it's *correct* for asymmetric models and
+> *harmless* for symmetric ones. In OV: indexing embeds with `is_query=False`
+> (Part 1.4, step 2); retrieval embeds the query with `is_query=True`
+> (Part 2.3, step 1).
+
+#### The three "flavors" (why there are sub-base-classes)
+
+A provider might give you a dense model, a sparse model, or both. So `base.py`
+splits `EmbedderBase` into three abstract subclasses that just declare *what a
+correct `embed()` must return*:
+
+- `DenseEmbedderBase` (`base.py:385`) — `embed()` returns dense only; also must
+  implement `get_dimension()` (the vector length).
+- `SparseEmbedderBase` (`base.py:416`) — `embed()` returns sparse only.
+- `HybridEmbedderBase` (`base.py:445`) — `embed()` returns **both**.
+
+`CompositeHybridEmbedder` (`base.py:488`) is the clever bit: instead of needing a
+single model that does both, it **wraps one dense embedder + one sparse embedder
+and presents them as a single hybrid one**. Its `embed_async()` fires both at
+once with `asyncio.gather` (`base.py:523`) and stitches the two results into one
+`EmbedResult`. This is how you mix, say, OpenAI dense + Volcengine sparse.
+
+#### Sync vs async (and why async has guard rails)
+
+Every method comes in a sync form and an `_async` form. OV's pipeline is async,
+so it prefers `embed_async`. The default async impl just calls the sync `embed`
+(`base.py:187`), so a provider only *has* to implement one — but real providers
+override the async path to be genuinely non-blocking.
+
+Two production concerns are baked into the async retry wrapper
+`_run_with_async_retry` (`base.py:237`):
+
+- **Concurrency cap.** A per-event-loop `asyncio.Semaphore` keyed by
+  `max_concurrent` (default 10, `base.py:139`) limits how many embed calls hit
+  the provider at once — so a big indexing job can't trigger rate-limit
+  errors by firing thousands of requests simultaneously.
+- **Retry/backoff.** Failed calls retry up to `max_retries` (default 3) via
+  `retry_async`, with timing/wait telemetry recorded each attempt.
+
+#### Picking which embedder is live
+
+The active embedder is built from config —
+`config.embedding.{hybrid|dense|sparse}` resolved through `get_embedder()`.
+Providers live in `openviking/models/embedder/*_embedders.py`: OpenAI, Voyage,
+Cohere, Gemini, Jina, MiniMax, DashScope, Volcengine, VikingDB,
+LiteLLM (catch-all), and **local** (llama.cpp).
+
+#### Shared helpers in `base.py`
+
+- `truncate_and_normalize()` (`base.py:73`) — cut a dense vector to the target
+  dimension and L2-normalize it, so the store's inner-product distance behaves
+  like cosine similarity.
+- `update_token_usage()` (`base.py:307`) — emits per-call token + latency metrics
+  to `EmbeddingEventDataSource`. Wrapped in a `try/except` that swallows
+  everything: **metrics are never allowed to break the embed path.**
+
+### 1.3 What text actually gets embedded
+
+Decided in `openviking/utils/embedding_utils.py`:
+
+- **Directories** (`vectorize_directory_meta`): the `.abstract.md` content is
+  embedded as L0, the `.overview.md` content as L1.
+- **Files** (`vectorize_file`): strategy depends on `embedding.text_source`
+  config and file type (`get_resource_content_type`):
+  - Text files → embed **raw content** (default `content_only`), or the LLM
+    summary if `summary_first` / `summary_only`.
+  - Non-text (image/video/audio/unknown) → embed the **summary** instead.
+  - Raw input is guarded by `_truncate_embedding_input()` using a CJK-aware token
+    estimate against `embedding.max_input_tokens` (default 4096), appending a
+    `...(truncated for embedding)` marker.
+
+Each unit becomes a `Context` object (`openviking/core/context.py`) carrying
+`uri`, `parent_uri`, `is_leaf`, `level`, `abstract`, timestamps, and ownership
+(`account_id`, `owner_space`, user/agent). `context.set_vectorize(Vectorize(text=...))`
+attaches the exact string to embed.
+
+### 1.4 The async pipeline (queue-based, decoupled)
+
+OV never embeds inline on the request path. It enqueues work:
+
+```
+write/index a resource
+        │
+        ▼
+Context  ──EmbeddingMsgConverter.from_context──▶  EmbeddingMsg
+        │
+        ▼
+EmbeddingQueue.enqueue()      (openviking/storage/queuefs/embedding_queue.py)
+        │
+        ▼  (background worker dequeues)
+TextEmbeddingHandler.on_dequeue()   (openviking/storage/collection_schemas.py)
+        │  1. circuit-breaker check (CircuitBreaker)
+        │  2. embedder.embed(text, is_query=False)  → dense + sparse vectors
+        │  3. dimension validation (must == config.embedding.dimension)
+        │  4. compute deterministic id = md5(f"{account_id}:{seed_uri}")
+        │  5. vikingdb.upsert(record)
+        ▼
+Vector DB  (the "context collection")
+```
+
+Robustness details in `TextEmbeddingHandler`:
+- **Circuit breaker** opens after repeated failures; messages are re-enqueued
+  (with `retry_after` sleep) instead of being lost.
+- Errors are classified `permanent` vs `transient` (`classify_api_error`);
+  transient → re-enqueue, permanent → drop + record failure.
+- **Deterministic IDs**: `id = md5("{account_id}:{seed_uri}")` where `seed_uri`
+  appends `/.abstract.md` (L0) or `/.overview.md` (L1) so each semantic layer of
+  a URI maps to a stable row → upserts are idempotent.
+- An `EmbeddingTaskTracker` counts outstanding sub-tasks per `semantic_msg_id`
+  so callers can await "indexing complete".
+
+### 1.5 Where the abstracts/overviews come from
+
+L0/L1 text isn't authored by hand — it's generated **bottom-up** by the
+**Semantic** pipeline (`openviking/storage/queuefs/semantic_processor.py` +
+`semantic_dag.py`):
+
+1. Summarize each leaf file (LLM; image/video/audio summarizers for media).
+2. Roll child summaries up into the directory's `.abstract.md` (L0) and
+   `.overview.md` (L1).
+3. Hand those off to the embedding queue (Part 1.4).
+
+So there are **two cooperating queues**: a *semantic* queue (produces summaries
+bottom-up, a DAG over the directory tree) and an *embedding* queue (vectorizes
+the produced text). This is why OV ships `semantic_queue` + `embedding_queue`.
+
+### 1.6 The vector store schema
+
+Defined in `CollectionSchemas.context_collection`
+(`openviking/storage/collection_schemas.py`). One unified collection holds all
+levels. Notable fields:
+
+- `id` (string PK), `uri` (path), `context_type` (`resource|memory|skill`),
+- `vector` (dense, `Dim = config.embedding.dimension`) + `sparse_vector`,
+- `level` (0/1/2), `parent_uri` (implicitly via URI + PathScope), `abstract`,
+- `account_id`, `owner_user_id`, `owner_agent_id` (multi-tenant isolation),
+- `created_at`, `updated_at`, `active_count` (for hotness/recency boosting).
+
+Scalar indexes are built on `uri`, `level`, `context_type`, `account_id`,
+ownership and timestamps so filtered vector search stays fast.
+
+The engine itself (`openviking/storage/vectordb/`, C++ core with abi3 Python
+bindings) supports dense+sparse **hybrid** search, scalar filtering, TTL, and
+persistent multi-version snapshots — documented in
+`openviking/storage/vectordb/README.md`.
+
+---
+
+## Part 2 — The "Graph DB": Population & Retrieval
+
+### 2.1 What the graph actually is
+
+OV has **no separate graph database** (no Neo4j/Nebula). The "graph" is
+**materialized inside the vector store + filesystem** as two overlapping
+structures:
+
+1. **The hierarchy tree (primary edges).** Every vector row has a `uri` and a
+   `level`. Parent→child edges are implied by URI prefixes: a row at
+   `viking://.../topic/file.md` (L2) is a child of the directory
+   `viking://.../topic` whose L0/L1 rows are `.../topic/.abstract.md` and
+   `.../topic/.overview.md`. This is a **tree/DAG of contexts**.
+
+2. **Relations (cross-cutting edges).** Arbitrary, typed cross-links between
+   resources, stored per-directory in a sidecar `.relations.json` file
+   (`openviking/storage/viking_fs.py`). Each entry is `{uri, reason}`. These are
+   the "non-tree" edges that turn the tree into a genuine graph.
+
+The in-memory helper `BuildingTree` (`openviking/core/building_tree.py`) is the
+explicit tree abstraction used while building: it maintains `_uri_map`,
+parent/children lookups, `get_path_to_root`, and `to_directory_structure`.
+
+### 2.2 How the graph is populated
+
+**Tree edges** are populated automatically as part of indexing:
+
+- When a resource directory is indexed (`index_resource` in
+  `embedding_utils.py`), OV reads `.abstract.md`/`.overview.md` and the files,
+  builds `Context` objects with `parent_uri` set, and enqueues them.
+- The embedding worker writes each as a row with its `level` and `uri`. The
+  `parent_uri` relationship is preserved by the URI path itself + the `level`
+  field, and queried later via `PathScope` (prefix + depth).
+- The bottom-up Semantic DAG (`semantic_dag.py`, `semantic_processor.py`)
+  guarantees every directory gets L0/L1 rows so the tree has interior nodes, not
+  just leaves.
+
+**Relation (cross) edges** are populated explicitly via the API:
+
+- HTTP router: `openviking/server/routers/relations.py`
+  - `POST /api/v1/relations/link` `{from_uri, to_uris, reason}`
+  - `DELETE /api/v1/relations/link` `{from_uri, to_uri}`
+  - `GET  /api/v1/relations?uri=...`
+- Service layer: `openviking/service/relation_service.py` validates URIs and
+  delegates to `VikingFS.link / unlink / relations`.
+- Storage: `VikingFS` reads/writes `{dir}/.relations.json`
+  (`_read_relation_table` / `_write_relation_table`). `link` appends
+  `{uri, reason}` to the source's table; `unlink` removes it; `get_relations`
+  returns the linked URIs.
+
+So: **tree edges = emergent from indexing; relation edges = written on demand.**
+
+### 2.3 How the graph is retrieved
+
+Retrieval is **hierarchical graph traversal guided by vector similarity**,
+implemented in `openviking/retrieve/hierarchical_retriever.py`
+(`HierarchicalRetriever.retrieve`). It deliberately avoids a brute-force flat
+search; instead it walks the tree from the most promising entry points downward.
+
+The traversal primitives live in
+`openviking/storage/viking_vector_index_backend.py`:
+
+- `search_global_roots_in_tenant()` — vector search across all levels
+  (`In("level", [0,1,2])`) within the tenant scope. Finds promising *entry
+  points* anywhere in the graph.
+- `search_children_in_tenant(parent_uri, ...)` — vector search restricted to the
+  **direct children** of a node via `PathScope("uri", parent_uri, depth=1)`.
+  This is the "expand this node's edges" operation.
+- All searches are wrapped by `_build_scope_filter` / `_tenant_filter`, which AND
+  in `account_id` + visible-root `PathScope`s for **multi-tenant isolation**
+  (root role bypasses).
+
+The algorithm (best-first search over the tree):
+
+```
+1. Embed the query once (dense + sparse), is_query=True.
+
+2. Pick starting points:
+     - root URIs for the requested context_type
+       (_get_root_uris_for_type → memories / resources / skills), plus
+     - global vector hits (search_global_roots_in_tenant).
+   Level-2 global hits are seeded directly as terminal candidates;
+   non-L2 hits become directory entry points.
+
+3. Best-first expansion (a max-heap keyed by score) — _recursive_search:
+     pop highest-scoring node
+       → search_children_in_tenant(node)           # expand edges (depth=1)
+       → (optional) rerank children with RerankClient (THINKING mode)
+       → score-propagate to children:
+             final = α·child_score + (1−α)·parent_score   (score_propagation_alpha)
+       → keep children passing the threshold
+       → push directory children (level 0/1) back on the heap;
+         level-2 files are terminal hits (not expanded)
+     repeat until the top-k set stabilizes
+     (MAX_CONVERGENCE_ROUNDS = 3) or the queue drains.
+
+4. Convert to results — _convert_to_matched_contexts:
+     - optional hotness/recency boost:
+         final = (1−hotness_alpha)·semantic + hotness_alpha·hotness_score(active_count, updated_at)
+     - attach related contexts: get_viking_fs().get_relations(uri)
+       → read their L0 abstracts (capped at MAX_RELATIONS = 5)
+     - rebuild user-facing URI with the right level suffix
+       (.abstract.md / .overview.md).
+   Re-sort by blended score, return top-k.
+```
+
+Key tuning knobs (from `RetrievalConfig` / `RerankConfig`):
+
+- `score_propagation_alpha` — how much a child trusts its own score vs. its
+  parent's (controls how "directory relevance" flows down).
+- `hotness_alpha` — weight of recency/usage vs. pure semantic similarity.
+- `threshold` / `score_gte` — prune weak branches.
+- `mode = THINKING|QUICK` — THINKING enables the cross-encoder rerank pass at
+  every expansion; QUICK uses raw vector scores only.
+- `GLOBAL_SEARCH_TOPK = 10`, `DIRECTORY_DOMINANCE_RATIO = 1.2`,
+  `MAX_CONVERGENCE_ROUNDS = 3`.
+
+### 2.4 Why this design
+
+- **Hybrid vectors** (dense + sparse) give both semantic and lexical recall in
+  one store.
+- **Hierarchical traversal** means a query first lands on the right *topic*
+  (L0/L1) and only then drills into *files* (L2) — far cheaper and more precise
+  than flat top-k over every leaf, and it naturally returns context at the right
+  altitude.
+- **Score propagation** lets a strongly-matching directory lift its children,
+  and a weak directory prune entire subtrees early.
+- **Relations** overlay associative recall ("things linked to this") on top of
+  the hierarchy, and are surfaced alongside every hit.
+- Everything is **multi-tenant filtered** at the storage layer, so the same
+  collection safely serves many accounts/agents.
+
+---
+
+## Quick file map
+
+| Concern | File |
+|--------|------|
+| Embedder interfaces | `openviking/models/embedder/base.py` |
+| Provider impls | `openviking/models/embedder/*_embedders.py` |
+| What text to embed / indexing entry | `openviking/utils/embedding_utils.py` |
+| Levels & Context model | `openviking/core/context.py` |
+| Embedding queue worker | `openviking/storage/collection_schemas.py` (`TextEmbeddingHandler`) |
+| Queues | `openviking/storage/queuefs/{embedding,semantic}_queue.py` |
+| Bottom-up summary DAG | `openviking/storage/queuefs/semantic_{processor,dag}.py` |
+| Vector store schema | `openviking/storage/collection_schemas.py` (`CollectionSchemas`) |
+| Vector engine docs | `openviking/storage/vectordb/README.md` |
+| Tree abstraction | `openviking/core/building_tree.py` |
+| Graph traversal queries | `openviking/storage/viking_vector_index_backend.py` |
+| Hierarchical retrieval | `openviking/retrieve/hierarchical_retriever.py` |
+| Relations (cross edges) | `openviking/service/relation_service.py`, `openviking/server/routers/relations.py`, `openviking/storage/viking_fs.py` |

--- a/explaining/local-embedding-installer-spec.md
+++ b/explaining/local-embedding-installer-spec.md
@@ -1,0 +1,228 @@
+# Spec: One-Command Installer Profiles for Local-Embedding Setups
+
+Status: draft / proposal
+Companion docs: `docs/en/guides/11-local-embedding-for-codex.md`, `docs/en/guides/12-local-embedding-for-claude-code.md`
+
+## Problem
+
+Codex and Claude Code subscribers are the highest-volume "I want memory with zero extra API keys" audience, but getting them running today takes 6+ manual steps across three surfaces (pip, `ov.conf`, client plugin wiring), and the single most attractive configuration for Codex users — **local embedding + Codex-subscription VLM** — is not reachable through `openviking-server init` at all:
+
+- `_wizard_cloud()` is the only flow that offers the `openai-codex` OAuth VLM, but it forces a cloud embedding API key first (`setup_wizard.py:948`).
+- `_wizard_llamacpp()` offers Ollama / cloud-API-key / skip for VLM — no Codex option (`setup_wizard.py:864`).
+- `_wizard_ollama()` hardcodes Ollama for VLM (`setup_wizard.py:689`).
+
+Other friction points:
+
+1. The wizard is interactive-only — no flags, so nothing (bootstrap script, plugin hook, agent-led install) can drive it unattended.
+2. The wizard stops at `ov.conf`. Plugin wiring (`codex mcp add …`, `/plugin install …`) is a separate manual journey the user must discover in a different README.
+3. The server must be started (and kept running) by hand; there is no service registration.
+4. The GGUF path has exactly one preset, `bge-small-zh-v1.5-f16` (`setup_wizard.py:488`) — Chinese-optimized, wrong default for most English-speaking subscribers.
+5. Users must already have a working Python 3.10+ / pip before anything else.
+
+## Goal
+
+One command from zero to working memory in the user's coding agent:
+
+```bash
+curl -fsSL https://openviking.ai/install.sh | sh -s -- --profile codex
+```
+
+or, with Python already present:
+
+```bash
+openviking-server init --profile codex --yes
+```
+
+## Non-goals
+
+- Replacing the interactive wizard (it stays; profiles are a layer on top).
+- Docker / k8s / remote deployments (covered by existing deployment guide).
+- Windows service registration in v1 (doc the manual fallback; wheels-first install still applies).
+
+## Design
+
+### Profiles
+
+A profile = deterministic bundle of {embedding choice, VLM choice, client wiring, service setup}. Proposed set:
+
+| Profile | Embedding | VLM | Client wiring | Target user |
+|---|---|---|---|---|
+| `codex` | Ollama `qwen3-embedding:0.6b` (RAM-tiered) | `openai-codex` OAuth (import `~/.codex/auth.json`) | `codex mcp add openviking-memory …` | ChatGPT subscriber |
+| `codex-min` | GGUF via llama.cpp (no daemon) | `openai-codex` OAuth | same | ChatGPT subscriber, no Ollama wanted |
+| `claude-code` | Ollama (RAM-tiered) | Ollama VLM (RAM-tiered) | `/plugin` marketplace instructions or `claude plugin install` if CLI supports it | Claude subscriber, fully local |
+| `claude-code-hybrid` | Ollama (RAM-tiered) | cloud key (prompted once, or `--vlm-api-key`) | same | Claude subscriber wanting better extraction |
+
+Profiles reuse the existing preset tables (`EMBEDDING_PRESETS`, `VLM_PRESETS`, `_RAM_RECOMMENDATIONS`) and config builders (`_build_ollama_config`, `_build_local_config`) — a profile is essentially a pre-answered wizard run plus two new post-steps (wiring, service).
+
+### Global-by-default: one daemon, one model, blind projects (Claude-first)
+
+Installing OpenViking is a **machine-level** event, not a project-level one. The
+default outcome of any profile is: one global daemon, one embedding model shared
+by every project, and hard per-project data isolation — so that wherever Claude
+is used from a terminal on that machine, OpenViking is already running in the
+background with zero per-project setup. Claude Code users are the first target
+for this default; Codex follows.
+
+Three design consequences:
+
+**1. One daemon, always up.** The server is already a global singleton — config
+at `~/.openviking/ov.conf`, data under `storage.workspace` (default
+`~/.openviking`). What's missing is that nothing keeps it alive. Service
+registration (gap 5: launchd agent / systemd user unit) is therefore **promoted
+from M3 polish to a core requirement of the `claude-code` profiles** — it is
+what turns "the user must remember to start a server" into "OV is just there."
+Belt-and-suspenders: the Claude Code plugin's `SessionStart` hook health-checks
+`/health` and, if the daemon is down (fresh boot before service install, or
+service disabled), spawns `openviking-server` detached and waits for readiness —
+the openclaw plugin's `process-manager.ts` already implements this lazy-start
+pattern and should be ported to the claude-code-memory-plugin.
+
+*Idle footprint:* the always-on part is cheap. The daemon does nothing unless
+a hook fires — embedding is event-driven through the queue, not continuous —
+so steady state is one Python process + the local vector store (order of a
+few hundred MB RAM, ~0% CPU). The embedding model itself lives in Ollama,
+which unloads it after ~5 minutes idle by default, so its ~0.6–1 GB only
+occupies RAM around actual capture/recall bursts. `doctor` should measure and
+report the real numbers rather than us asserting them.
+
+**2. Shared embedding model, isolated data.** Sharing the embedding model
+across projects is safe and desirable: the model is stateless, so one Ollama
+model resident in RAM serves N projects with no cross-contamination — isolation
+never lives in the model, it lives in the store. And the store already has it:
+every vector row carries `account_id` / `owner_user_id` / `owner_agent_id`, and
+all searches are ANDed with tenant filters at the storage layer
+(`_tenant_filter` / `_build_scope_filter`, see
+`explaining/embedding-and-graph-system.md` §1.6, §2.3).
+
+The gap is on the client side: the claude-code plugin currently uses a single
+static agent identity for the whole machine (`agentId` defaults to
+`"claude-code"`, `examples/claude-code-memory-plugin/src/memory-server.ts:92`),
+so today **all projects land in one shared namespace**. Fix: **explicit
+per-project registration** — the user, not a heuristic, declares the project
+root.
+
+- On the first session in an unregistered directory, the `SessionStart` hook
+  injects a short notice: "This project isn't registered with OpenViking
+  memory — run `/ov-init` to give it an isolated memory namespace."
+- `/ov-init` (a plugin slash command) confirms the root with the user — "Is
+  `<cwd>` the project root?" — and writes a marker file `.ovproject` there:
+
+  ```json
+  { "projectId": "a1b2c3d4e5", "name": "my-app", "createdAt": "…" }
+  ```
+
+  `projectId` is randomly generated and stored, so it is stable across moves
+  and renames — which a derived path hash would not be. It is an opaque
+  namespace label, nothing more: `.ovproject` contains **only identity
+  metadata** — never memories, preferences, or embeddings. All actual data
+  lives in `~/.openviking` on the user's machine. Writing the marker is O(1):
+  one small file, **no repo scan, no indexing, no re-embedding** — `/ov-init`
+  costs nothing regardless of repo size. Monorepo users simply run `/ov-init`
+  inside the package folder they want as the memory boundary; nested markers
+  are allowed and **nearest marker wins** (walking up from cwd), so a repo
+  root and a sub-package can hold distinct namespaces.
+- **Not committed (decided).** `/ov-init` adds `.ovproject` to the clone's
+  `.git/info/exclude` — a per-clone ignore that is itself never committed —
+  so the marker stays local to the user and invisible to the repo and
+  teammates. Consequence: a fresh clone or a new machine re-runs `/ov-init`
+  once (fine — memories are per-machine and don't travel with the repo
+  anyway). Same applies to additional git worktrees.
+- Resolution: the MCP server and hooks walk up from their `cwd` to the nearest
+  `.ovproject` and compose `agentId = "cc-" + name + "-" + projectId`. No
+  marker found → fall back to the current shared `"claude-code"` namespace
+  (legacy behavior, zero breakage for existing users). The openclaw plugin's
+  agent-prefix mechanism (`openclaw.plugin.json`) is the precedent for
+  composed agent IDs.
+
+This maps cleanly onto OV's two memory scopes:
+
+| Scope | URI | Visibility |
+|---|---|---|
+| User | `viking://user/memories` | Global across projects — preferences, identity, "how I like to work" |
+| Agent | `viking://agent/memories` (agent = per-project ID) | Private to one project — codebase facts, decisions, project state |
+
+Auto-recall queries both scopes, so a session in project A gets the user's
+global preferences plus only A's project memories; project B's data is
+invisible to it by construction (server-side tenant filter, not client-side
+politeness).
+
+**3. Embedding model choice becomes a machine-level decision.** One shared
+collection has one vector dimension, so the embedding model is picked once per
+machine, not per project — switching later means re-embedding everything (this
+sharpens open question 3). Profiles should surface this at install time
+("model X will be used for all projects on this machine") and `doctor` should
+report the active model prominently.
+
+
+
+### CLI surface
+
+```
+openviking-server init
+  --profile codex|codex-min|claude-code|claude-code-hybrid
+  --embedding <preset>        # override profile default (e.g. embeddinggemma:300m)
+  --vlm <preset>              # override profile default
+  --yes / -y                  # non-interactive: accept defaults, fail hard instead of prompting
+  --no-wire                   # skip client plugin wiring
+  --no-service                # skip service registration
+  --dry-run                   # print planned actions + resulting ov.conf, change nothing
+```
+
+Rules for `--yes` mode: never prompt; if a required dependency is missing and not auto-installable (e.g. Codex CLI not signed in), exit non-zero with a single actionable message. Existing `ov.conf` is backed up via the existing `.bak` rotation, but `--yes` refuses to overwrite unless `--force` is passed (safer for scripted runs).
+
+### Execution plan per profile (example: `codex`)
+
+1. **Detect**: OS/arch, RAM (`_get_system_ram_gb`), Codex CLI auth (`~/.codex/auth.json` or `OPENVIKING_CODEX_BOOTSTRAP_PATH`), Ollama presence, existing `ov.conf`.
+2. **Provision embedding**: ensure Ollama installed + running (`_ensure_ollama`), pull the RAM-tiered embedding model.
+3. **Provision VLM auth**: import Codex auth into `~/.openviking/codex_auth.json` (`_ensure_codex_auth`); in `--yes` mode, import silently if the bootstrap file exists, else fail with "run `codex login` first".
+4. **Write config**: Ollama embedding block + `openai-codex` VLM block (`gpt-5.4`, `https://chatgpt.com/backend-api/codex`), local binding.
+5. **Wire client**: locate/build the codex-memory-plugin server bundle and run `codex mcp add openviking-memory -- node <path>`. Ship the built `memory-server.js` inside the wheel (new package data) so no Node build step happens on the user's machine — Node 22+ runtime is still required and should be preflighted.
+6. **Service**: register launchd agent (macOS) / systemd user unit (Linux) running `openviking-server`; `--no-service` prints the manual command instead.
+7. **Verify**: run `openviking-server doctor`, then hit `/health`, then one end-to-end embed round-trip; print a copy-pasteable smoke-test prompt for the user's agent.
+
+`claude-code` differs at step 3 (no Codex auth; VLM is a second Ollama pull) and step 5 (Claude Code plugin install is user-driven via `/plugin` today — the installer prints the exact two commands, and upgrades to automated install if/when a headless `claude plugin install` path is available).
+
+### Bootstrap script
+
+Thin `install.sh` that: checks for `uv` (installs if missing) → `uv tool install openviking` (isolated env, solves the "no Python" problem) → executes `openviking-server init --profile "$1" --yes`. Windows gets a `install.ps1` twin later; until then the guides' manual path applies.
+
+### Agent-led install path
+
+This repo already maintains agent-oriented install docs (`docs/en/getting-started/04-setup-for-agent.md`, openclaw `INSTALL-AGENT.md`). Profiles make those dramatically simpler and more reliable: the agent doc collapses to "confirm the user's subscription type, then run `init --profile … --yes --dry-run`, show the plan, run it for real." Non-interactive mode is what makes the agent path safe — no TTY prompts for the agent to fumble.
+
+## Code changes required (by gap)
+
+| # | Gap | Change | Where |
+|---|---|---|---|
+| 1 | No local-embed + Codex VLM path | Add `OpenAI Codex` to the VLM options of `_wizard_llamacpp` and `_wizard_ollama`, reusing `_ensure_codex_auth` and the `_DEFAULT_CODEX_MODEL`/`_DEFAULT_CODEX_BASE_URL` constants | `openviking_cli/setup_wizard.py` |
+| 2 | Interactive-only | Introduce a `Profile` dataclass + `run_init(args)` branching; prompts become the fallback when a value isn't supplied by profile/flag | `openviking_cli/setup_wizard.py` (or new `openviking_cli/profiles.py`) |
+| 3 | Single Chinese GGUF preset | Add an English/multilingual GGUF preset (e.g. `bge-small-en-v1.5` or an embeddinggemma GGUF) to `LOCAL_DENSE_MODEL_SPECS` + `LOCAL_GGUF_PRESETS`; make the English one the default for non-zh locales | `openviking/models/embedder/local_embedders.py`, `setup_wizard.py` |
+| 4 | No plugin wiring | New `_wire_codex()` / `_wire_claude_code()` post-steps; ship built `memory-server.js` as package data | new module + `pyproject.toml` package data |
+| 5 | No service management | `openviking-server service install|uninstall|status` (launchd/systemd user units) | new `openviking_cli/service.py` |
+| 6 | Python bootstrap | `install.sh` (uv-based) hosted at a stable URL | repo `scripts/` + website |
+| 7 | Single machine-wide agent ID → projects share one namespace | `/ov-init` command writes a `.ovproject` marker (stable random `projectId`); MCP server and hooks resolve the nearest marker upward from cwd; no marker → legacy shared namespace | `examples/claude-code-memory-plugin` (new command + `src/memory-server.ts` + hook scripts) |
+| 8 | Daemon not guaranteed alive when a session starts | `SessionStart` health-check + detached lazy start (port `process-manager.ts` from openclaw plugin) | `examples/claude-code-memory-plugin` |
+
+## Phasing
+
+Claude users first: the global-daemon + per-project-isolation default ships on
+the `claude-code` profiles before the Codex profile gets its installer polish.
+
+- **M1 (unblocks the docs + isolation):** gap 1 + gap 3, plus gap 7
+  (per-project `agentId`) — the isolation fix is client-side only, small, and
+  every day it waits, users accumulate cross-project data in one namespace
+  that is painful to migrate later.
+- **M2 (Claude installer core):** gap 2 (profiles + `--yes` + `--dry-run`),
+  gap 5 (service registration — required by `claude-code` profiles, not
+  polish), and gap 8 (lazy start). Codex side of gap 4 lands here too.
+- **M3 (polish):** gap 6, Windows story, and automated Claude Code plugin
+  install when the CLI supports it.
+
+## Open questions
+
+1. Ship the Codex MCP server inside the Python wheel (Node source as package data) vs. publish it to npm and `npx` it? npm publish avoids bundling Node artifacts in a Python package but adds a registry dependency at install time.
+2. Should `claude-code` profile default to hybrid instead of fully-local? Fully-local extraction quality on `qwen3.5:2b` may generate poor memories on 8 GB machines — needs a quality benchmark before choosing the default.
+3. Does re-embedding tooling exist for users who later change embedding models? If not, profiles should record the chosen model prominently and the docs' "pick once" warning stays load-bearing.
+4. Locale detection for GGUF default (zh vs en preset): env `LANG` sniffing, or just always ask/require a flag?
+5. ~~Should `.ovproject` be committed to the repo or gitignored?~~ **Decided: not committed.** Kept local via `.git/info/exclude` (see design section). Revisit only if a shared-server story ever lands.
+6. Migration for existing users: everyone on the current plugin has all projects under the shared `"claude-code"` agent. Ship a one-time split tool, or leave old data in the shared namespace (still recalled via user scope?) and only isolate going forward?

--- a/explaining/v1-agent-handoff.md
+++ b/explaining/v1-agent-handoff.md
@@ -1,0 +1,194 @@
+# Agent Handoff — V1: Per-Project Memory Isolation for Claude Code
+
+You are implementing V1 of OpenViking's "global daemon, isolated projects"
+feature for Claude Code users. This brief is self-contained; the full design
+rationale lives in `explaining/local-embedding-installer-spec.md` and
+`explaining/v1-implementation-plan.md` — read both before writing code.
+
+## Context (30 seconds)
+
+OpenViking (OV) is a local memory/context engine: a Python server
+(`openviking-server`) + local vector store under `~/.openviking`, with a
+Claude Code plugin at `examples/claude-code-memory-plugin/` that captures
+conversation memories (Stop hook), recalls them (UserPromptSubmit hook), and
+exposes MCP tools (`src/memory-server.ts`).
+
+**The bug/gap:** the plugin uses one static agent identity for the whole
+machine (`agentId` defaults to `"claude-code"` —
+`examples/claude-code-memory-plugin/src/memory-server.ts:92`), so every
+project on a machine shares one memory namespace. The server already enforces
+per-tenant isolation in the vector store (`account_id` / `owner_agent_id`
+filters); the client just never selects a per-project identity.
+
+**The fix (V1):** explicit per-project registration. The user runs `/ov-init`
+in a project; it writes a tiny `.ovproject` marker; the plugin resolves the
+nearest marker and scopes all captures/recalls to that project's namespace.
+
+## Locked decisions — do NOT relitigate or redesign these
+
+1. **Explicit registration only.** No path-hash or git-toplevel heuristics.
+   The user declares the root via `/ov-init`. Monorepo users run it in the
+   package folder they want; **nested markers are allowed, nearest marker
+   (walking up from cwd) wins**.
+2. **Marker file `.ovproject`** at the project root, JSON:
+   `{ "projectId": "<10 hex chars, crypto-random>", "name": "<slug>", "createdAt": "<ISO>" }`.
+   It is an opaque ID card ONLY — it must never contain memories, preferences,
+   embeddings, or config. All data stays in `~/.openviking`.
+3. **`agentId = "cc-" + slug(name) + "-" + projectId`** (slug: lowercase,
+   letters/digits/dash).
+4. **Resolution priority:** explicit `claude_code.agentId` in `ov.conf`
+   (machine-wide override / escape hatch) → nearest `.ovproject` → legacy
+   `"claude-code"`. **No marker = exactly today's behavior. Zero breakage for
+   existing users is a hard requirement.**
+5. **Not committed.** The init script adds `.ovproject` to the repo's
+   `.git/info/exclude` (per-clone ignore, itself never committed). Never touch
+   the team's `.gitignore`.
+6. **Nothing is ever re-embedded, re-indexed, or scanned.** `/ov-init` is
+   O(1): one file write + one exclude line + one registry append. After init,
+   the new namespace simply starts empty; legacy memories stay untouched under
+   the old namespace. The `/ov-init` user-facing output must state this
+   explicitly so it doesn't read as data loss ("previously captured project
+   memories won't appear here; user-scope memories still follow you; nothing
+   was deleted or recomputed").
+7. **Capture and recall must share one resolver.** The Stop-hook capture path
+   and the recall path must call the same identity-resolution function, or
+   memories get written to a namespace recall never searches. This must be
+   covered by a test.
+
+## Milestone 1 — Isolation (plugin only, do this first, ship as its own PR)
+
+All work in `examples/claude-code-memory-plugin/`. **No Python/server changes
+in this milestone.**
+
+1. **Resolver module** — new `scripts/project-marker.mjs`:
+   - `findNearestMarker(startDir)`: walk up to filesystem root, return first
+     directory containing `.ovproject`, else null.
+   - `readMarker(path)`: parse JSON; malformed/unreadable → treat as absent
+     and log one warning to the existing debug log (see `scripts/config.mjs`
+     for the debug-log pattern), never crash a hook.
+   - `resolveAgentId({ cwd, ovConfOverride })` implementing the priority
+     order in locked decision 4.
+   - Mirror the same logic in `src/memory-server.ts` (TypeScript, resolved
+     once at startup from `process.cwd()`). Keep the two implementations
+     trivially small so duplication is acceptable, or share via the built
+     bundle if the existing build setup allows it cleanly — follow whatever
+     the current build in `package.json` supports; do not restructure the
+     build.
+2. **`/ov-init` command** — new `commands/ov-init.md` (Claude Code plugin
+   slash command, markdown prompt). It must instruct Claude to:
+   - State the current directory and ask the user to confirm it is the
+     project root (mention: monorepo users should instead run this inside the
+     package folder they want as the memory boundary).
+   - Ask for an optional display name (default: directory basename).
+   - Run `node ${CLAUDE_PLUGIN_ROOT}/scripts/project-init.mjs --path <root> --name <name>`.
+   - Relay the script's output, including the "nothing was deleted or
+     recomputed" note from locked decision 6.
+3. **Init script** — new `scripts/project-init.mjs`:
+   - Generate `projectId` via `crypto.randomBytes(5).toString("hex")`.
+   - Write `.ovproject`; if inside a git repo, append `.ovproject` to
+     `.git/info/exclude` (idempotently).
+   - Append `{projectId, name, path, createdAt}` to
+     `~/.openviking/projects.json` (create if missing).
+   - Print the resulting `agentId`.
+   - Idempotent: existing marker → print existing identity, exit 0; refuse to
+     overwrite without `--force`.
+4. **Wire resolution into all surfaces:**
+   - MCP server: replace the static default at `src/memory-server.ts:92`.
+   - Hooks: `scripts/auto-recall.mjs` and `scripts/auto-capture.mjs` resolve
+     per invocation from the `cwd` field in the hook's stdin JSON, through
+     the shared resolver (`scripts/config.mjs` is the shared config loader —
+     extend it, don't fork it).
+5. **SessionStart nudge** — in `scripts/bootstrap-runtime.mjs`: when no
+   marker is found AND no `claude_code.agentId` override is set, emit a
+   one-line `additionalContext` suggesting `/ov-init`. Keep it to one line;
+   do not block or prompt.
+6. **Tests** (vitest is already configured — see `vitest.config.ts` /
+   `__tests__/`):
+   - nested markers → nearest wins; no marker → legacy id; malformed marker →
+     legacy id + warning; override beats marker.
+   - init script: idempotency, `--force`, exclude-file append idempotency.
+   - capture and recall resolve identical `agentId` for the same cwd (locked
+     decision 7).
+7. **Build + version:** rebuild the bundled server (see `package.json`
+   scripts → output `servers/memory-server.js`), bump plugin version to 0.2.0
+   in `package.json` and `.claude-plugin/plugin.json`.
+
+**M1 acceptance (automatable in sandbox):** unit tests above pass; plus an
+integration-style test that stubs the OV HTTP API (the plugin's client is
+plain `fetch` against `baseUrl`) and asserts that with markers in two temp
+dirs A and B, capture from A and recall from B use different
+`X-OpenViking-Agent` headers / agent identities, and recall from A matches
+A's capture identity.
+
+## Milestone 2 — Daemon lifecycle (second PR)
+
+1. **`openviking_cli/service.py`** — new subcommand
+   `openviking-server service install|uninstall|status`:
+   - macOS: launchd agent `~/Library/LaunchAgents/ai.openviking.server.plist`
+     (`RunAtLoad` + `KeepAlive`).
+   - Linux: systemd user unit
+     `~/.config/systemd/user/openviking-server.service`
+     (`Restart=on-failure`).
+   - Windows: print manual instructions, exit 0.
+   - Follow the CLI wiring conventions of the existing subcommands (see how
+     `doctor` is registered).
+2. **Lazy start** in `scripts/bootstrap-runtime.mjs`: `GET /health` with a
+   short timeout; if down, spawn `openviking-server` detached and poll
+   readiness (≤60s; the SessionStart hook timeout is 120s in
+   `hooks/hooks.json`). Use a lockfile under `~/.openviking/` to prevent
+   double-spawns from concurrent sessions. Port the pattern from
+   `examples/openclaw-plugin/process-manager.ts`.
+3. **`doctor` additions** (`openviking_cli/doctor.py`): service
+   registered/running; report the active embedding model prominently; report
+   daemon RSS/CPU at rest and note Ollama's `keep_alive` model-unload
+   behavior.
+
+**M2 verification note:** launchd/systemd registration cannot be fully
+exercised in a remote sandbox. Required instead: unit tests for plist/unit
+generation (golden-file compare), `service status` parsing, and lockfile
+logic; plus a `docs/` note with the manual verification steps (reboot →
+start claude → recall works).
+
+## Milestone 3 — Installer profile (third PR)
+
+1. `openviking-server init --profile claude-code|claude-code-hybrid --yes --dry-run`
+   in `openviking_cli/setup_wizard.py` (or a new `openviking_cli/profiles.py`):
+   a profile pre-answers the wizard using the existing `EMBEDDING_PRESETS`,
+   `_RAM_RECOMMENDATIONS`, `_build_ollama_config`. `--yes` never prompts and
+   fails hard with one actionable message; `--dry-run` prints planned actions
+   and the resulting `ov.conf` without writing.
+2. Post-steps: invoke `service install` (M2); print the `/plugin marketplace
+   add` + `/plugin install openviking-memory` commands.
+3. `scripts/install.sh`: ensure `uv` → `uv tool install openviking` →
+   `openviking-server init --profile "$1" --yes`.
+4. Docs: update `docs/en/guides/12-local-embedding-for-claude-code.md` and
+   the plugin README with the `/ov-init` flow, monorepo guidance, and the
+   machine-level "pick your embedding model once" warning.
+
+## Guardrails
+
+- One PR per milestone, in order; M1 must not depend on M2/M3.
+- Do not rename or repurpose existing `ov.conf` keys; `claude_code.agentId`
+  keeps working as before (it becomes the override).
+- Do not add heavy dependencies to the plugin (it currently uses node stdlib
+  + `@modelcontextprotocol/sdk`); the resolver and init script must be
+  stdlib-only.
+- Hook budgets are tight (`auto-recall` timeout is 8s): resolver work in the
+  hook path must be a few `stat` calls walking up, nothing more.
+- Match existing code style in each area (mjs scripts vs TS server vs Python
+  CLI). Do not reformat unrelated code.
+- If the OV server cannot run in your environment (Ollama models likely
+  unavailable), do NOT fake end-to-end results — stub the HTTP layer in tests
+  and say plainly in the PR description what was verified vs. what needs a
+  local machine.
+- Commit messages: conventional style used in this repo (see `git log`),
+  e.g. `feat(claude-code-plugin): per-project memory namespaces via /ov-init`.
+
+## Report back (per PR)
+
+- What was implemented, file by file.
+- Test results (paste the vitest/pytest output).
+- Anything verified only by stub/unit test that needs manual confirmation on
+  a real machine, as a checklist.
+- Any spot where reality contradicted this brief (file moved, API differs) —
+  flag it, don't silently improvise around a locked decision.

--- a/explaining/v1-implementation-plan.md
+++ b/explaining/v1-implementation-plan.md
@@ -1,0 +1,137 @@
+# V1 Implementation Plan — Global OpenViking for Claude Code
+
+Status: draft
+Parent spec: `explaining/local-embedding-installer-spec.md`
+Target: Claude Code subscribers, macOS + Linux. Codex, Windows, and migration
+tooling are explicitly out of V1.
+
+## What V1 delivers
+
+A Claude Code user goes from zero to isolated per-project memory like this:
+
+```bash
+curl -fsSL https://openviking.ai/install.sh | sh -s -- --profile claude-code
+# … one-time: /plugin install openviking-memory (printed by the installer)
+cd ~/code/my-app
+claude
+> /ov-init          # "Is ~/code/my-app the project root?" → yes
+```
+
+From then on: one global daemon (launchd/systemd user service) shares one
+embedding model across every project on the machine; each `/ov-init`-ed
+project has a private memory namespace; projects never see each other's data;
+user-scope memories (preferences) follow the user everywhere. If the user
+never runs `/ov-init`, everything behaves exactly as today (shared
+`"claude-code"` namespace) — zero breakage.
+
+## Design decisions locked for V1
+
+1. **Explicit registration, not heuristics.** The user confirms the project
+   root via `/ov-init`. Monorepo users run it inside the package folder they
+   want as the boundary. Nested `.ovproject` markers are allowed; nearest
+   marker (walking up from cwd) wins.
+2. **Stable random `projectId`** stored in `.ovproject` — an opaque namespace
+   label (no memories, preferences, or embeddings in the marker; all data
+   stays in `~/.openviking`). Survives moves and renames; never derived from
+   the path. Not committed to the repo (kept local via `.git/info/exclude`),
+   so fresh clones/worktrees re-run `/ov-init` once.
+3. **Identity resolution priority:** `claude_code.agentId` in `ov.conf`
+   (explicit machine-wide override, escape hatch that disables per-project
+   isolation) → nearest `.ovproject` → legacy `"claude-code"`.
+4. **Isolation is server-enforced.** The plugin only *selects* the namespace
+   (`agentId`); blindness between projects comes from the existing tenant
+   filters in the vector store (`_tenant_filter`, see
+   `embedding-and-graph-system.md` §2.3), not client politeness.
+
+---
+
+## Milestone 1 — Per-project isolation (plugin only)
+
+All changes in `examples/claude-code-memory-plugin`. No server changes.
+Estimated size: 2–4 days.
+
+| # | Task | Where |
+|---|------|-------|
+| 1.1 | Shared resolver module: `findNearestMarker(startDir)` (walk up to filesystem root), `readMarker` (tolerate malformed JSON → treat as absent, log once), `composeAgentId(name, projectId)` → `cc-<slug(name)>-<projectId>` | new `scripts/project-marker.mjs` + mirrored logic in `src/memory-server.ts` |
+| 1.2 | `/ov-init` slash command: prompt-driven — confirm `cwd` is the intended root (monorepo note in the prompt), ask for an optional display name, then run the init script | new `commands/ov-init.md` |
+| 1.3 | Init script: generate `projectId` (10 hex chars, `crypto.randomBytes`), write `.ovproject`, add `.ovproject` to `.git/info/exclude` if inside a git repo (per-clone ignore, never committed, doesn't touch the team's `.gitignore`), append `{projectId, name, path, createdAt}` to `~/.openviking/projects.json` registry, print the resulting `agentId`. Idempotent: existing marker → print it and exit 0 (no overwrite without `--force`). O(1) always: one file write, no repo scan, no indexing | new `scripts/project-init.mjs` |
+| 1.4 | Wire resolution into both surfaces: MCP server resolves once at startup from `process.cwd()` (`memory-server.ts:92` replaces the static default); hooks resolve per-invocation from the `cwd` field in hook stdin JSON (`auto-recall.mjs`, `auto-capture.mjs` via `config.mjs`) | `src/memory-server.ts`, `scripts/config.mjs` |
+| 1.5 | Unregistered-project notice: `bootstrap-runtime.mjs` (SessionStart) emits one-line `additionalContext` suggesting `/ov-init` when no marker is found and no `agentId` override is set | `scripts/bootstrap-runtime.mjs` |
+| 1.6 | Verify the server auto-creates an agent namespace on first write with a novel `agentId` (openclaw's agent-prefix flow implies it does; confirm and note in the plugin README) | manual check + README |
+| 1.7 | Tests (vitest): nested markers → nearest wins; no marker → legacy id; malformed marker → legacy id + warning; init idempotency; override precedence | `__tests__/` (new) |
+| 1.8 | Rebuild `servers/memory-server.js`, bump plugin to 0.2.0 | `package.json`, `.claude-plugin/plugin.json` |
+
+**Acceptance:** with two registered projects A and B — capture a memory in A;
+`auto-recall` in B does not surface it; recall in A does; a user-scope memory
+is visible in both; an unregistered third project still sees the legacy shared
+namespace and gets the `/ov-init` nudge.
+
+## Milestone 2 — Daemon always up
+
+Estimated size: 2–3 days.
+
+| # | Task | Where |
+|---|------|-------|
+| 2.1 | `openviking-server service install\|uninstall\|status`: macOS launchd agent (`~/Library/LaunchAgents/ai.openviking.server.plist`, `RunAtLoad` + `KeepAlive`), Linux systemd user unit (`~/.config/systemd/user/openviking-server.service`, `Restart=on-failure`). Windows: print manual instructions, exit 0 | new `openviking_cli/service.py` |
+| 2.2 | Lazy-start fallback in the SessionStart hook: `GET /health` with a short timeout; if down, spawn `openviking-server` detached and poll readiness (≤60s; hook timeout is already 120s). Use a lockfile in `~/.openviking/` so concurrent sessions don't double-spawn. Port the pattern from `examples/openclaw-plugin/process-manager.ts` | `scripts/bootstrap-runtime.mjs` |
+| 2.3 | `doctor` additions: service registered/running, and report the active embedding model prominently ("model X serves all projects on this machine") | `openviking_cli/doctor.py` |
+| 2.4 | Measure and report idle footprint: daemon RSS + CPU at rest, Ollama model residency (confirm the default ~5 min `keep_alive` unload; expose `keep_alive` tuning in `ov.conf` if users want faster unload on RAM-tight laptops). Surface in `doctor` output | `openviking_cli/doctor.py`, docs |
+
+**Acceptance:** reboot the machine, `cd` into a registered project, start
+`claude`, ask something that triggers recall — it works with no manual server
+start.
+
+## Milestone 3 — One-command install (claude-code profile)
+
+Estimated size: 3–5 days.
+
+| # | Task | Where |
+|---|------|-------|
+| 3.1 | Profile plumbing: `openviking-server init --profile claude-code|claude-code-hybrid --yes --dry-run`. A profile pre-answers the wizard (Ollama RAM-tiered embedding + VLM via existing `EMBEDDING_PRESETS` / `_RAM_RECOMMENDATIONS` / `_build_ollama_config`); `--yes` never prompts, fails hard with one actionable message; `--dry-run` prints planned actions + resulting `ov.conf` | `openviking_cli/setup_wizard.py` or new `openviking_cli/profiles.py` |
+| 3.2 | Profile post-steps: run `service install` (M2), then print the exact `/plugin marketplace add …` + `/plugin install openviking-memory` commands (automated install deferred until the CLI supports headless plugin install) | same |
+| 3.3 | `install.sh`: ensure `uv` (install if missing) → `uv tool install openviking` → `openviking-server init --profile "$1" --yes` | `scripts/install.sh` + hosting |
+| 3.4 | Docs: update `docs/en/guides/12-local-embedding-for-claude-code.md` and the plugin README with the `/ov-init` flow, the machine-level "pick your model once" warning, and the monorepo guidance | docs |
+
+**Acceptance:** on a clean macOS or Linux machine with Claude Code installed:
+`install.sh --profile claude-code`, one plugin install, `/ov-init`, and the
+M1/M2 acceptance scenarios pass end to end.
+
+---
+
+## Explicitly deferred (post-V1)
+
+- **Codex profile installer** (spec gaps 1, 3 — the English GGUF preset is not
+  blocking V1 because the claude-code profile defaults to Ollama).
+- **Migration/split tool** for data accumulated in the legacy shared
+  `"claude-code"` namespace (spec open question 6). V1 stance: legacy data
+  stays where it is and remains reachable in unregistered dirs; registered
+  projects start fresh.
+- **Windows** service + installer.
+- **Automated Claude Code plugin install** when a headless path exists.
+- **Re-embedding tooling** for model changes (spec open question 3).
+
+## Risks / watch items
+
+- **Hook cwd vs MCP-server cwd drift.** The MCP server resolves identity once
+  at startup; hooks resolve per call. A session that wanders across project
+  boundaries could disagree. V1 stance: a Claude Code session belongs to one
+  project; document it. If it bites, add re-resolution on the server side per
+  request.
+- **Auto-capture attribution.** The Stop-hook capture path must use the same
+  resolver as recall, or memories land in the wrong namespace — covered by
+  routing both through the shared module (task 1.1/1.4), guarded by a test.
+- **`.ovproject` in VCS — decided: not committed.** The init script adds it to
+  `.git/info/exclude` (per-clone, itself never committed), keeping the marker
+  local to the user and invisible to teammates. Cost: fresh clones, new
+  machines, and additional git worktrees re-run `/ov-init` once — acceptable,
+  since memories are per-machine and never travel with the repo.
+- **Empty namespace after `/ov-init`** in a project with prior legacy
+  memories: the new namespace starts *empty* — old memories were saved under
+  the shared legacy namespace name and are simply not matched by the new
+  filter. To be explicit: **nothing is recomputed, re-indexed, or re-embedded
+  — ever.** `/ov-init` writes one small file; memories are conversation-derived,
+  not a repo index, so there is no expensive "re-initialization" on any
+  hardware. The only user-visible effect is that previously captured
+  project memories stop appearing in recall (user-scope memories still
+  follow the user). The `/ov-init` output must say this explicitly so it
+  doesn't read as data loss.


### PR DESCRIPTION
## Summary

**Primary affected domain: Integration / Bot Runtime** (`bot/vikingbot`) — cc `@yeshion23333`

The Feishu bot stops responding after running for a while and only recovers on process restart. Root cause: the lark-oapi ws client's blocking `start()` never returns after startup — all receive/reconnect work runs in orphaned asyncio tasks whose failures are never observed. Four SDK defects (verified in lark-oapi 1.5.3 source, `lark_oapi/ws/client.py`) can leave the connection permanently dead while `start()` keeps sleeping:

1. Reconnect budget exhaustion raises `ServerUnreachableException` inside an orphaned task — reconnection silently stops forever.
2. `ClientException` during reconnect (transient auth failure, exceed-connection-limit) is re-raised by `_try_connect` — same silent task death.
3. `_connect()` returns while holding its internal lock when a connection already exists (early return before the `try/finally`) — later sends/ACKs/disconnects deadlock.
4. `_get_conn_url` uses sync `requests.post` with no timeout inside the event loop — a hang freezes the SDK's whole loop.

In all four cases the old `run_ws` retry loop in `feishu.py` never fires because `start()` neither returns nor raises, so the bot looks alive but is deaf.

This PR replaces the fire-and-forget ws thread with supervised connection generations:

- Each generation runs a **fresh `lark.ws.Client` on its own event loop**, so a poisoned client (dead reconnect task, leaked lock, wedged loop) can always be replaced with a clean one.
- A **watchdog** on the channel loop checks connection health every 15s, gives the SDK's own auto-reconnect a 60s grace period, then neutralizes the dead client (disables its reconnect, closes its connection bypassing the leak-prone internal lock, stops its loop so the blocked `start()` unwinds) and rebuilds a clean generation — even when the old thread is stuck in a blocking call (it is abandoned with a warning).
- Health transitions are logged (`connection is down` → `Restarting Feishu WebSocket client: <reason>` → `connection recovered`), and messages arriving with no running channel loop are no longer dropped silently.
- `stop()` performs a real teardown instead of calling a `close()` method the SDK client does not have.

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Unit tests pass
- [x] Manual testing completed

New regression suite `bot/tests/test_feishu_ws_lifecycle.py` (11 tests) uses fake ws clients so it runs with or without lark-oapi installed. It covers: watchdog rebuilds a dead-connection client and neutralizes the old generation; healthy connections are never churned; `start()` crashes are retried until success; a dead ws thread is respawned; `stop()` terminates thread and watchdog cleanly; a handler exception does not break later messages; duplicate deliveries are deduped.

Verified against the real SDK (lark-oapi 1.5.3): with invalid credentials the thread cycles real `ClientException` failures, the watchdog's forced rebuild fires, and shutdown is clean. To reproduce recovery end-to-end: run a connected bot, cut its network to Feishu for 5+ minutes (long enough to exhaust the SDK's reconnect budget), restore it — the bot recovers within ~60–75s without a restart, with the full log sequence above.

`ruff check` passes on both files.

## Related Issues

- Related to #3319 (that PR fixes missing bot logs for config-started gateways; this one fixes the unresponsiveness itself — together they make failures both recoverable and observable)

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [ ] Documentation updated (if needed)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)