### PR TITLE
feat(accessors): add sync standard types and EmailAccessor pilot

### DIFF
--- a/openviking/parse/accessors/__init__.py
+++ b/openviking/parse/accessors/__init__.py
@@ -8,7 +8,14 @@ This module provides the two-layer architecture for resource processing:
 - DataParser: Parses local files/directories (existing Parser system)
 """
 
-from .base import DataAccessor, LocalResource
+from .base import (
+    AccessError,
+    AccessResult,
+    ConnectionStatus,
+    DataAccessor,
+    LocalResource,
+)
+from .email_accessor import EmailAccessor
 from .feishu_accessor import FeishuAccessor
 from .git_accessor import GitAccessor
 from .http_accessor import HTTPAccessor
@@ -24,6 +31,10 @@ __all__ = [
     # Base classes
     "DataAccessor",
     "LocalResource",
+    # Standard sync types
+    "AccessError",
+    "AccessResult",
+    "ConnectionStatus",
     # Registry
     "AccessorRegistry",
     "get_accessor_registry",
@@ -32,6 +43,7 @@ __all__ = [
     "GitAccessor",
     "HTTPAccessor",
     "FeishuAccessor",
+    "EmailAccessor",
     "LocalAccessor",
     "WebFeedAccessor",
     # Helpers

--- a/openviking/parse/accessors/base.py
+++ b/openviking/parse/accessors/base.py
@@ -11,7 +11,7 @@ import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 
 class SourceType:
@@ -32,6 +32,9 @@ class SourceType:
 
     FEISHU = "feishu"
     """Feishu/Lark document (from FeishuAccessor)."""
+
+    EMAIL = "email"
+    """Email mailbox over IMAP (from EmailAccessor)."""
 
 
 @dataclass
@@ -93,6 +96,54 @@ class LocalResource:
         self.cleanup()
 
 
+@dataclass
+class ConnectionStatus:
+    """Result of a credential/connection check. Never raised, always returned."""
+
+    success: bool
+    message: str = ""
+
+
+@dataclass
+class AccessError:
+    """A non-fatal error captured during an access run.
+
+    ``transient`` errors are safe to retry by the framework; ``permanent``
+    errors should be isolated (logged and skipped) without retry.
+    """
+
+    doc_id: Optional[str]
+    """Related document id, or None for a source-level error."""
+
+    kind: Literal["transient", "permanent"] = "permanent"
+    message: str = ""
+
+
+@dataclass
+class AccessResult:
+    """Extended result of an access run for standard-capable accessors.
+
+    Wraps the classic :class:`LocalResource` and carries the optional sync
+    metadata defined by the accessor standard. Accessors that don't need
+    incremental sync or mirror semantics keep returning ``LocalResource``.
+    """
+
+    resource: LocalResource
+    """Local directory/file with the fetched data (same as the classic return)."""
+
+    cursor: Optional[Dict[str, Any]] = None
+    """Incremental cursor. Opaque to the framework: persisted as-is and passed
+    back unchanged on the next run. None means the run has no cursor to save."""
+
+    doc_ids: Optional[Set[str]] = None
+    """Complete set of doc ids seen in a *full* sync, used for orphan cleanup.
+    Must be None on incremental (or otherwise partial) runs — the framework
+    never deletes based on a partial view."""
+
+    errors: List[AccessError] = field(default_factory=list)
+    """Per-document errors that did not abort the run."""
+
+
 class DataAccessor(ABC):
     """
     Abstract base class for data accessors.
@@ -102,6 +153,12 @@ class DataAccessor(ABC):
     - Fetching the data from the source to a local path
     - Providing metadata about the source
     - Cleaning up temporary resources when done
+
+    Standard optional capabilities (all opt-in, see ``auth_spec``/``check``):
+    accessors that support them declare auth via JSON Schema, accept a
+    ``cursor`` kwarg in ``access()`` for incremental sync, report progress via
+    a ``progress`` callback kwarg, and return :class:`AccessResult` instead of
+    :class:`LocalResource`.
     """
 
     @abstractmethod
@@ -121,18 +178,43 @@ class DataAccessor(ABC):
         pass
 
     @abstractmethod
-    async def access(self, source: Union[str, Path], **kwargs) -> LocalResource:
+    async def access(self, source: Union[str, Path], **kwargs) -> Union[LocalResource, AccessResult]:
         """
         Fetch the source and make it available locally.
 
         Args:
             source: Source string (URL, path, etc.) or Path object
-            **kwargs: Additional accessor-specific arguments
+            **kwargs: Additional accessor-specific arguments. Standard-capable
+                accessors also accept ``cursor`` (dict from the previous run,
+                None on first/full sync) and ``progress`` (callable taking
+                ``done``/``total`` keyword arguments).
 
         Returns:
-            LocalResource pointing to the locally available data
+            LocalResource pointing to the locally available data, or an
+            AccessResult wrapping it for accessors that implement the
+            standard sync capabilities (cursor / doc_ids / errors)
         """
         pass
+
+    def auth_spec(self) -> Optional[Dict[str, Any]]:
+        """
+        Declare the credentials this accessor needs as a JSON Schema.
+
+        Returns None (default) when the source needs no authentication. When a
+        schema is returned, the framework takes over credential storage and
+        passes the resolved credentials to ``access()`` via the ``auth`` kwarg.
+        """
+        return None
+
+    def check(self, auth: Dict[str, Any]) -> ConnectionStatus:
+        """
+        Validate credentials against the source without syncing.
+
+        Must not raise: failures are wrapped into the returned
+        ConnectionStatus. The default accepts anything, matching accessors
+        that declare no auth.
+        """
+        return ConnectionStatus(success=True)
 
     @property
     @abstractmethod

--- a/openviking/parse/accessors/email_accessor.py
+++ b/openviking/parse/accessors/email_accessor.py
@@ -1,0 +1,469 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Email Accessor (IMAP).
+
+Pilot implementation of the accessor sync standard (RFC discussion #3354):
+auth declaration via ``auth_spec()``/``check()``, incremental sync via an
+opaque ``sync_checkpoint`` cursor, full-sync ``doc_ids`` for orphan cleanup,
+and per-document error isolation.
+
+Source form: ``imap://user@host/INBOX`` or ``imaps://user@host:993/INBOX``.
+Emails are converted to markdown files (one directory per mailbox) so the
+existing markdown parser handles them — no dedicated eml parser.
+"""
+
+import asyncio
+import email
+import hashlib
+import imaplib
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.header import decode_header
+from email.message import Message
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Union
+from urllib.parse import unquote, urlparse
+
+from openviking_cli.exceptions import OpenVikingError
+from openviking_cli.utils.logger import get_logger
+
+from .base import AccessError, AccessResult, ConnectionStatus, DataAccessor, LocalResource, SourceType
+
+logger = get_logger(__name__)
+
+DEFAULT_IMAP_PORT = 993
+DEFAULT_IMAP_PORT_PLAIN = 143
+SYNC_CHECKPOINT_KEY = "sync_checkpoint"
+
+# IMAP SINCE requires DD-Mon-YYYY with English month names; strftime("%b") is
+# locale-dependent, so build the token explicitly.
+_IMAP_MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+_FILENAME_SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+@dataclass
+class _EmailParams:
+    """Resolved connection parameters for one access run."""
+
+    host: str
+    port: int
+    use_ssl: bool
+    username: str
+    password: str
+    mailboxes: List[str]
+
+
+def _imap_date(dt: datetime) -> str:
+    return f"{dt.day:02d}-{_IMAP_MONTHS[dt.month - 1]}-{dt.year}"
+
+
+def _to_utc_iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_checkpoint(cursor: Optional[Dict[str, Any]]) -> Optional[datetime]:
+    if not cursor:
+        return None
+    raw = cursor.get(SYNC_CHECKPOINT_KEY)
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        logger.warning(f"[EmailAccessor] Invalid {SYNC_CHECKPOINT_KEY} in cursor, ignoring: {raw!r}")
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _is_before_checkpoint(item_time: Optional[datetime], checkpoint: Optional[datetime]) -> bool:
+    """Strict ``<`` incremental filter.
+
+    cursor=T means "every email dated < T is already synced"; an email dated
+    exactly T is re-pulled next round so a crash on the boundary never loses
+    it (downstream dedup absorbs the repeat). Either side None means we can't
+    prove the item was handled, so it is kept.
+    """
+    return checkpoint is not None and item_time is not None and item_time < checkpoint
+
+
+def _mailbox_hash(mailbox: str) -> str:
+    return hashlib.sha256(mailbox.encode("utf-8")).hexdigest()[:8]
+
+
+def _decode_header_value(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    parts = []
+    for chunk, charset in decode_header(value):
+        if isinstance(chunk, bytes):
+            parts.append(chunk.decode(charset or "utf-8", errors="replace"))
+        else:
+            parts.append(chunk)
+    return "".join(parts).strip()
+
+
+def _message_date(msg: Message) -> Optional[datetime]:
+    raw = msg.get("Date")
+    if not raw:
+        return None
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _extract_body(msg: Message) -> str:
+    """Prefer text/plain; fall back to tag-stripped text/html."""
+    plain: Optional[str] = None
+    html: Optional[str] = None
+    parts = msg.walk() if msg.is_multipart() else [msg]
+    for part in parts:
+        if part.is_multipart() or part.get_filename():
+            continue
+        content_type = part.get_content_type()
+        if content_type not in ("text/plain", "text/html"):
+            continue
+        payload = part.get_payload(decode=True)
+        if payload is None:
+            continue
+        charset = part.get_content_charset() or "utf-8"
+        text = payload.decode(charset, errors="replace")
+        if content_type == "text/plain" and plain is None:
+            plain = text
+        elif content_type == "text/html" and html is None:
+            html = text
+    if plain is not None:
+        return plain.strip()
+    if html is not None:
+        return _HTML_TAG_RE.sub("", html).strip()
+    return ""
+
+
+def _attachment_names(msg: Message) -> List[str]:
+    names = []
+    if msg.is_multipart():
+        for part in msg.walk():
+            filename = part.get_filename()
+            if filename:
+                names.append(_decode_header_value(filename))
+    return names
+
+
+def _doc_filename(doc_id: str) -> str:
+    sanitized = _FILENAME_SANITIZE_RE.sub("_", doc_id).strip("_")
+    return f"{sanitized[:100] or 'email'}.md"
+
+
+def _build_markdown(msg: Message, mailbox: str, doc_id: str) -> str:
+    subject = _decode_header_value(msg.get("Subject")) or "(no subject)"
+    lines = [
+        f"# {subject}",
+        "",
+        f"- **From**: {_decode_header_value(msg.get('From'))}",
+        f"- **To**: {_decode_header_value(msg.get('To'))}",
+        f"- **Date**: {_decode_header_value(msg.get('Date'))}",
+        f"- **Mailbox**: {mailbox}",
+        f"- **Message-ID**: {doc_id}",
+    ]
+    attachments = _attachment_names(msg)
+    if attachments:
+        lines.append(f"- **Attachments**: {', '.join(attachments)}")
+    lines += ["", "---", "", _extract_body(msg), ""]
+    return "\n".join(lines)
+
+
+class EmailAccessor(DataAccessor):
+    """Fetches emails from an IMAP mailbox and converts them to markdown."""
+
+    def __init__(self, imap_factory: Optional[Callable[[str, int, bool, float], Any]] = None):
+        """
+        Args:
+            imap_factory: Optional factory ``(host, port, use_ssl, timeout) ->
+                IMAP4-like connection``, injectable for tests. Defaults to
+                stdlib ``imaplib``.
+        """
+        self._imap_factory = imap_factory or self._default_imap_factory
+
+    @property
+    def priority(self) -> int:
+        return 100  # Specific service, same tier as FeishuAccessor
+
+    def can_handle(self, source: Union[str, Path], **kwargs) -> bool:
+        return str(source).lower().startswith(("imap://", "imaps://"))
+
+    def auth_spec(self) -> Optional[Dict[str, Any]]:
+        return {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string", "description": "IMAP server hostname"},
+                "port": {"type": "integer", "default": DEFAULT_IMAP_PORT, "exclusiveMinimum": 0},
+                "use_ssl": {"type": "boolean", "default": True},
+                "username": {"type": "string", "description": "IMAP login, usually the email address"},
+                "password": {"type": "string", "description": "Password or app-specific password"},
+            },
+            "required": ["host", "username", "password"],
+        }
+
+    def check(self, auth: Dict[str, Any]) -> ConnectionStatus:
+        try:
+            conn = self._connect(self._params_from_auth(auth))
+            try:
+                conn.logout()
+            except Exception:
+                pass
+            return ConnectionStatus(success=True)
+        except Exception as e:
+            return ConnectionStatus(success=False, message=str(e))
+
+    async def access(
+        self,
+        source: Union[str, Path],
+        cursor: Optional[Dict[str, Any]] = None,
+        progress: Optional[Callable[..., None]] = None,
+        auth: Optional[Dict[str, Any]] = None,
+        mailboxes: Optional[List[str]] = None,
+        since_days: Optional[int] = None,
+        timeout: float = 30.0,
+        **kwargs,
+    ) -> AccessResult:
+        """
+        Sync emails to a local markdown directory tree.
+
+        Args:
+            source: ``imap[s]://user@host[:port]/mailbox`` URL. The mailbox
+                path segment is optional (defaults to INBOX).
+            cursor: Cursor returned by the previous run, replayed as-is by the
+                framework. None triggers a full sync.
+            progress: Optional ``progress(done=..., total=...)`` callback.
+            auth: Credentials matching ``auth_spec()``. URL parts win for
+                host/port/username; the password always comes from ``auth``.
+            mailboxes: Explicit mailbox list; overrides the URL path segment.
+            since_days: Cap history depth on first sync. Implies a partial
+                view, so ``doc_ids`` is not returned when set.
+            timeout: IMAP socket timeout in seconds.
+        """
+        params = self._resolve_params(str(source), auth or {}, mailboxes)
+        return await asyncio.to_thread(
+            self._sync, params, str(source), cursor, progress, since_days, timeout
+        )
+
+    # ── parameter resolution ─────────────────────────────────────────
+
+    def _resolve_params(
+        self,
+        source: str,
+        auth: Dict[str, Any],
+        mailboxes: Optional[List[str]],
+    ) -> _EmailParams:
+        parsed = urlparse(source)
+        use_ssl = auth.get("use_ssl")
+        if use_ssl is None:
+            use_ssl = parsed.scheme.lower() != "imap"
+        host = parsed.hostname or auth.get("host") or ""
+        if not host:
+            raise OpenVikingError(
+                "Email source needs a host: imap[s]://user@host/mailbox",
+                code="INVALID_ARGUMENT",
+            )
+        default_port = DEFAULT_IMAP_PORT if use_ssl else DEFAULT_IMAP_PORT_PLAIN
+        username = unquote(parsed.username) if parsed.username else auth.get("username") or ""
+        password = auth.get("password") or ""
+        if not username or not password:
+            raise OpenVikingError(
+                "Email access requires username and password credentials",
+                code="UNAUTHENTICATED",
+            )
+        url_mailbox = unquote(parsed.path).strip("/")
+        resolved_mailboxes = list(mailboxes) if mailboxes else ([url_mailbox] if url_mailbox else ["INBOX"])
+        return _EmailParams(
+            host=host,
+            port=parsed.port or int(auth.get("port") or default_port),
+            use_ssl=bool(use_ssl),
+            username=username,
+            password=password,
+            mailboxes=resolved_mailboxes,
+        )
+
+    def _params_from_auth(self, auth: Dict[str, Any]) -> _EmailParams:
+        use_ssl = bool(auth.get("use_ssl", True))
+        return _EmailParams(
+            host=auth.get("host") or "",
+            port=int(auth.get("port") or (DEFAULT_IMAP_PORT if use_ssl else DEFAULT_IMAP_PORT_PLAIN)),
+            use_ssl=use_ssl,
+            username=auth.get("username") or "",
+            password=auth.get("password") or "",
+            mailboxes=["INBOX"],
+        )
+
+    # ── IMAP plumbing ────────────────────────────────────────────────
+
+    @staticmethod
+    def _default_imap_factory(host: str, port: int, use_ssl: bool, timeout: float) -> Any:
+        if use_ssl:
+            return imaplib.IMAP4_SSL(host, port, timeout=timeout)
+        return imaplib.IMAP4(host, port, timeout=timeout)
+
+    def _connect(self, params: _EmailParams, timeout: float = 30.0) -> Any:
+        conn = self._imap_factory(params.host, params.port, params.use_ssl, timeout)
+        typ, _ = conn.login(params.username, params.password)
+        if typ != "OK":
+            raise OpenVikingError(
+                f"IMAP login failed for {params.username}@{params.host}",
+                code="UNAUTHENTICATED",
+            )
+        return conn
+
+    # ── sync core (runs in a worker thread) ──────────────────────────
+
+    def _sync(
+        self,
+        params: _EmailParams,
+        source: str,
+        cursor: Optional[Dict[str, Any]],
+        progress: Optional[Callable[..., None]],
+        since_days: Optional[int],
+        timeout: float,
+    ) -> AccessResult:
+        checkpoint = _parse_checkpoint(cursor)
+        watermark = datetime.now(timezone.utc)
+
+        # since_days caps history depth; combined with the checkpoint the
+        # later bound wins so a stale cursor never re-pulls capped history.
+        effective_since = checkpoint
+        if since_days is not None:
+            floor = watermark - timedelta(days=since_days)
+            if effective_since is None or floor > effective_since:
+                effective_since = floor
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="ov_email_"))
+        seen_ids: Set[str] = set()
+        errors: List[AccessError] = []
+        failed: List[str] = []
+        done = 0
+
+        conn = self._connect(params, timeout=timeout)
+        try:
+            for mailbox in params.mailboxes:
+                try:
+                    done = self._sync_mailbox(
+                        conn=conn,
+                        mailbox=mailbox,
+                        target_dir=temp_dir / _FILENAME_SANITIZE_RE.sub("_", mailbox),
+                        since=effective_since,
+                        checkpoint=checkpoint,
+                        seen_ids=seen_ids,
+                        errors=errors,
+                        progress=progress,
+                        done=done,
+                    )
+                except Exception as e:
+                    logger.exception(f"[EmailAccessor] Mailbox failed (continuing with the rest): {mailbox}")
+                    failed.append(mailbox)
+                    errors.append(AccessError(doc_id=None, kind="transient", message=f"{mailbox}: {e}"))
+        finally:
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
+        if failed:
+            # Never advance the cursor on a partial run: re-pulling beats losing mail.
+            raise OpenVikingError(
+                f"Email sync failed for {len(failed)} mailbox(es): {', '.join(failed)}",
+                code="UNAVAILABLE",
+                details={"failed_mailboxes": failed, "errors": [e.message for e in errors]},
+            )
+
+        # doc_ids drives orphan deletion, so it is only safe when this run saw
+        # the complete mailbox view: no cursor and no since_days cap.
+        full_view = checkpoint is None and since_days is None
+        logger.info(
+            f"[EmailAccessor] Synced {done} email(s) from {len(params.mailboxes)} mailbox(es), "
+            f"watermark={_to_utc_iso(watermark)}, full_view={full_view}"
+        )
+        return AccessResult(
+            resource=LocalResource(
+                path=temp_dir,
+                source_type=SourceType.EMAIL,
+                original_source=source,
+                meta={
+                    "host": params.host,
+                    "username": params.username,
+                    "mailboxes": params.mailboxes,
+                    "email_count": done,
+                },
+            ),
+            cursor={SYNC_CHECKPOINT_KEY: _to_utc_iso(watermark)},
+            doc_ids=seen_ids if full_view else None,
+            errors=errors,
+        )
+
+    def _sync_mailbox(
+        self,
+        *,
+        conn: Any,
+        mailbox: str,
+        target_dir: Path,
+        since: Optional[datetime],
+        checkpoint: Optional[datetime],
+        seen_ids: Set[str],
+        errors: List[AccessError],
+        progress: Optional[Callable[..., None]],
+        done: int,
+    ) -> int:
+        typ, _ = conn.select(f'"{mailbox}"', readonly=True)
+        if typ != "OK":
+            raise OpenVikingError(f"Cannot select mailbox: {mailbox}", code="NOT_FOUND")
+
+        criteria = f"SINCE {_imap_date(since)}" if since else "ALL"
+        typ, data = conn.uid("SEARCH", None, criteria)
+        if typ != "OK":
+            raise OpenVikingError(f"IMAP SEARCH failed in mailbox: {mailbox}", code="UNAVAILABLE")
+        uids = data[0].split() if data and data[0] else []
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for uid in uids:
+            uid_str = uid.decode() if isinstance(uid, bytes) else str(uid)
+            try:
+                typ, fetched = conn.uid("FETCH", uid_str, "(RFC822)")
+                if typ != "OK" or not fetched or fetched[0] is None:
+                    raise OpenVikingError(f"IMAP FETCH failed for uid {uid_str}", code="UNAVAILABLE")
+                raw = fetched[0][1] if isinstance(fetched[0], tuple) else fetched[0]
+                msg = email.message_from_bytes(raw)
+
+                # SINCE is day-granular; the strict `<` client-side filter is
+                # what actually enforces the checkpoint semantics.
+                if _is_before_checkpoint(_message_date(msg), checkpoint):
+                    continue
+
+                doc_id = _decode_header_value(msg.get("Message-ID")) or f"{_mailbox_hash(mailbox)}_{uid_str}"
+                (target_dir / _doc_filename(doc_id)).write_text(
+                    _build_markdown(msg, mailbox, doc_id), encoding="utf-8"
+                )
+                seen_ids.add(doc_id)
+                done += 1
+                if progress:
+                    progress(done=done, total=None)
+            except Exception as e:
+                logger.warning(f"[EmailAccessor] Skipping email uid={uid_str} in {mailbox}: {e}")
+                errors.append(
+                    AccessError(
+                        doc_id=f"{_mailbox_hash(mailbox)}_{uid_str}",
+                        kind="permanent",
+                        message=str(e),
+                    )
+                )
+        return done

--- a/openviking/parse/accessors/registry.py
+++ b/openviking/parse/accessors/registry.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional, Union
 
 from openviking_cli.utils import get_logger
 
-from .base import DataAccessor, LocalResource
+from .base import AccessResult, DataAccessor, LocalResource
 
 logger = get_logger(__name__)
 
@@ -83,6 +83,14 @@ class AccessorRegistry:
             self.register(FeishuAccessor())
         except Exception as e:
             logger.debug(f"[AccessorRegistry] Failed to register FeishuAccessor: {e}")
+
+        # EmailAccessor - handles IMAP mailboxes (imap:// / imaps:// URLs)
+        try:
+            from .email_accessor import EmailAccessor
+
+            self.register(EmailAccessor())
+        except Exception as e:
+            logger.debug(f"[AccessorRegistry] Failed to register EmailAccessor: {e}")
 
         # LocalAccessor - handles local files (lowest priority)
         try:
@@ -174,7 +182,14 @@ class AccessorRegistry:
             logger.debug(
                 f"[AccessorRegistry] Using accessor {accessor.__class__.__name__} for source: {source_str}"
             )
-            return await accessor.access(source, **kwargs)
+            result = await accessor.access(source, **kwargs)
+            # Standard-capable accessors return AccessResult; this convenience
+            # path keeps the classic LocalResource contract for existing
+            # callers. Sync metadata (cursor/doc_ids) consumers must call
+            # accessor.access() directly.
+            if isinstance(result, AccessResult):
+                return result.resource
+            return result
 
         # This should not happen if LocalAccessor is registered
         raise RuntimeError(

--- a/tests/unit/test_accessors_email.py
+++ b/tests/unit/test_accessors_email.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for EmailAccessor and the accessor sync standard types."""
+
+from datetime import datetime, timedelta, timezone
+from email.message import EmailMessage
+from email.utils import format_datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pytest
+
+from openviking.parse.accessors.base import (
+    AccessError,
+    AccessResult,
+    ConnectionStatus,
+    DataAccessor,
+    LocalResource,
+)
+from openviking.parse.accessors.email_accessor import (
+    SYNC_CHECKPOINT_KEY,
+    EmailAccessor,
+)
+from openviking_cli.exceptions import OpenVikingError
+
+UTC = timezone.utc
+
+
+def _raw_email(
+    subject: str,
+    message_id: Optional[str],
+    date: Optional[datetime],
+    body: str = "hello",
+    to: str = "rcpt@example.com",
+) -> bytes:
+    msg = EmailMessage()
+    msg["From"] = "sender@example.com"
+    msg["To"] = to
+    msg["Subject"] = subject
+    if message_id:
+        msg["Message-ID"] = message_id
+    if date:
+        msg["Date"] = format_datetime(date)
+    msg.set_content(body)
+    return bytes(msg)
+
+
+class FakeIMAP:
+    """Minimal IMAP4-like double: mailbox -> {uid: raw rfc822 bytes}."""
+
+    def __init__(self, mailboxes: Dict[str, Dict[bytes, bytes]]):
+        self.mailboxes = mailboxes
+        self.login_calls: List[tuple] = []
+        self.search_criteria: List[str] = []
+        self.logged_out = False
+        self._selected: Optional[str] = None
+        self.fail_fetch_uids: set = set()
+
+    def login(self, username: str, password: str):
+        self.login_calls.append((username, password))
+        return "OK", [b"Logged in"]
+
+    def select(self, mailbox: str, readonly: bool = False):
+        name = mailbox.strip('"')
+        if name not in self.mailboxes:
+            return "NO", [b"nonexistent mailbox"]
+        self._selected = name
+        return "OK", [str(len(self.mailboxes[name])).encode()]
+
+    def uid(self, command: str, *args):
+        assert self._selected is not None
+        box = self.mailboxes[self._selected]
+        if command == "SEARCH":
+            self.search_criteria.append(args[-1])
+            uids = b" ".join(box.keys())
+            return "OK", [uids]
+        if command == "FETCH":
+            uid = args[0].encode() if isinstance(args[0], str) else args[0]
+            if uid in self.fail_fetch_uids:
+                return "NO", [None]
+            raw = box.get(uid)
+            if raw is None:
+                return "NO", [None]
+            return "OK", [(b"1 (RFC822 {%d}" % len(raw), raw), b")"]
+        raise AssertionError(f"unexpected IMAP command: {command}")
+
+    def logout(self):
+        self.logged_out = True
+        return "BYE", [b"bye"]
+
+
+def _accessor(fake: FakeIMAP) -> EmailAccessor:
+    return EmailAccessor(imap_factory=lambda host, port, use_ssl, timeout: fake)
+
+
+AUTH = {"password": "app-secret"}
+SOURCE = "imaps://user%40example.com@mail.example.com/INBOX"
+
+
+class TestStandardTypes:
+    def test_access_result_defaults(self, tmp_path: Path) -> None:
+        resource = LocalResource(path=tmp_path, source_type="email", original_source="x")
+        result = AccessResult(resource=resource)
+        assert result.cursor is None
+        assert result.doc_ids is None
+        assert result.errors == []
+
+    def test_access_error_defaults(self) -> None:
+        err = AccessError(doc_id=None, message="boom")
+        assert err.kind == "permanent"
+
+    def test_data_accessor_defaults(self) -> None:
+        class Minimal(DataAccessor):
+            def can_handle(self, source, **kwargs):
+                return False
+
+            async def access(self, source, **kwargs):
+                raise NotImplementedError
+
+            @property
+            def priority(self):
+                return 10
+
+        accessor = Minimal()
+        assert accessor.auth_spec() is None
+        status = accessor.check({})
+        assert isinstance(status, ConnectionStatus)
+        assert status.success is True
+
+
+class TestEmailAccessorBasics:
+    def test_can_handle_imap_schemes(self) -> None:
+        accessor = EmailAccessor()
+        assert accessor.can_handle("imap://u@h/INBOX")
+        assert accessor.can_handle("imaps://u@h:993/INBOX")
+        assert not accessor.can_handle("https://example.com")
+        assert not accessor.can_handle("/local/path")
+
+    def test_auth_spec_required_fields(self) -> None:
+        spec = EmailAccessor().auth_spec()
+        assert spec is not None
+        assert set(spec["required"]) == {"host", "username", "password"}
+        assert set(spec["properties"]) == {"host", "port", "use_ssl", "username", "password"}
+
+    def test_check_success_and_failure(self) -> None:
+        fake = FakeIMAP({"INBOX": {}})
+        auth = {"host": "mail.example.com", "username": "u", "password": "p"}
+        assert _accessor(fake).check(auth).success is True
+
+        def broken_factory(host, port, use_ssl, timeout):
+            raise ConnectionRefusedError("no route")
+
+        status = EmailAccessor(imap_factory=broken_factory).check(auth)
+        assert status.success is False
+        assert "no route" in status.message
+
+    async def test_missing_credentials_rejected(self) -> None:
+        fake = FakeIMAP({"INBOX": {}})
+        with pytest.raises(OpenVikingError):
+            await _accessor(fake).access("imaps://mail.example.com/INBOX")
+
+
+class TestEmailAccessorSync:
+    async def test_full_sync_writes_markdown_and_doc_ids(self) -> None:
+        now = datetime.now(UTC)
+        fake = FakeIMAP(
+            {
+                "INBOX": {
+                    b"1": _raw_email("First", "<id-1@example.com>", now - timedelta(days=2)),
+                    b"2": _raw_email("Second", None, now - timedelta(days=1)),
+                }
+            }
+        )
+        result = await _accessor(fake).access(SOURCE, auth=AUTH)
+
+        assert isinstance(result, AccessResult)
+        assert result.resource.source_type == "email"
+        assert result.cursor is not None and SYNC_CHECKPOINT_KEY in result.cursor
+        # Full view: doc_ids returned; Message-ID used, uid fallback for the second
+        assert result.doc_ids is not None and len(result.doc_ids) == 2
+        assert "<id-1@example.com>" in result.doc_ids
+        assert any(doc_id.endswith("_2") for doc_id in result.doc_ids)
+        assert result.errors == []
+
+        inbox_dir = result.resource.path / "INBOX"
+        files = sorted(p.name for p in inbox_dir.glob("*.md"))
+        assert len(files) == 2
+        content = (inbox_dir / files[0]).read_text(encoding="utf-8")
+        assert content.startswith("# ")
+        assert "**Mailbox**: INBOX" in content
+        # URL userinfo decoded and used for login
+        assert fake.login_calls == [("user@example.com", "app-secret")]
+        assert fake.logged_out is True
+        result.resource.cleanup()
+
+    async def test_incremental_strict_filter_and_no_doc_ids(self) -> None:
+        checkpoint = datetime(2026, 7, 10, 12, 0, 0, tzinfo=UTC)
+        fake = FakeIMAP(
+            {
+                "INBOX": {
+                    b"1": _raw_email("Old", "<old@example.com>", checkpoint - timedelta(hours=1)),
+                    b"2": _raw_email("Boundary", "<boundary@example.com>", checkpoint),
+                    b"3": _raw_email("New", "<new@example.com>", checkpoint + timedelta(hours=1)),
+                }
+            }
+        )
+        cursor = {SYNC_CHECKPOINT_KEY: "2026-07-10T12:00:00Z"}
+        result = await _accessor(fake).access(SOURCE, auth=AUTH, cursor=cursor)
+
+        # Strict `<` filter: old skipped, boundary (== checkpoint) re-pulled
+        files = list((result.resource.path / "INBOX").glob("*.md"))
+        names = {p.name for p in files}
+        assert len(files) == 2
+        assert not any("old" in n for n in names)
+        # Incremental view never returns doc_ids
+        assert result.doc_ids is None
+        # Server-side coarse filter used the checkpoint date
+        assert fake.search_criteria == ["SINCE 10-Jul-2026"]
+        result.resource.cleanup()
+
+    async def test_since_days_disables_doc_ids(self) -> None:
+        fake = FakeIMAP({"INBOX": {b"1": _raw_email("Hi", "<a@b>", datetime.now(UTC))}})
+        result = await _accessor(fake).access(SOURCE, auth=AUTH, since_days=7)
+        assert result.doc_ids is None
+        assert result.cursor is not None
+        result.resource.cleanup()
+
+    async def test_single_message_failure_is_isolated(self) -> None:
+        now = datetime.now(UTC)
+        fake = FakeIMAP(
+            {
+                "INBOX": {
+                    b"1": _raw_email("Good", "<good@example.com>", now),
+                    b"2": _raw_email("Bad", "<bad@example.com>", now),
+                }
+            }
+        )
+        fake.fail_fetch_uids = {b"2"}
+        result = await _accessor(fake).access(SOURCE, auth=AUTH)
+
+        # Good message synced, bad one isolated as a permanent error
+        assert result.doc_ids == {"<good@example.com>"}
+        assert len(result.errors) == 1
+        assert result.errors[0].kind == "permanent"
+        assert result.errors[0].doc_id is not None and result.errors[0].doc_id.endswith("_2")
+        # Cursor still advances: the run itself completed
+        assert result.cursor is not None
+        result.resource.cleanup()
+
+    async def test_mailbox_failure_aborts_without_cursor(self) -> None:
+        now = datetime.now(UTC)
+        fake = FakeIMAP({"INBOX": {b"1": _raw_email("Hi", "<x@y>", now)}})
+        with pytest.raises(OpenVikingError) as exc_info:
+            await _accessor(fake).access(
+                SOURCE, auth=AUTH, mailboxes=["INBOX", "Archive"]
+            )
+        assert "Archive" in str(exc_info.value)
+
+    async def test_progress_callback_invoked(self) -> None:
+        now = datetime.now(UTC)
+        fake = FakeIMAP(
+            {
+                "INBOX": {
+                    b"1": _raw_email("A", "<a@example.com>", now),
+                    b"2": _raw_email("B", "<b@example.com>", now),
+                }
+            }
+        )
+        calls: List[Dict] = []
+        result = await _accessor(fake).access(
+            SOURCE, auth=AUTH, progress=lambda **kw: calls.append(kw)
+        )
+        assert [c["done"] for c in calls] == [1, 2]
+        result.resource.cleanup()
+
+    async def test_multiple_mailboxes_one_dir_each(self) -> None:
+        now = datetime.now(UTC)
+        fake = FakeIMAP(
+            {
+                "INBOX": {b"1": _raw_email("A", "<a@example.com>", now)},
+                "Sent": {b"1": _raw_email("B", "<b@example.com>", now)},
+            }
+        )
+        result = await _accessor(fake).access(
+            SOURCE, auth=AUTH, mailboxes=["INBOX", "Sent"]
+        )
+        assert (result.resource.path / "INBOX").is_dir()
+        assert (result.resource.path / "Sent").is_dir()
+        # Same uid in different mailboxes must not collide (mailbox-hash fallback)
+        assert result.doc_ids == {"<a@example.com>", "<b@example.com>"}
+        result.resource.cleanup()


### PR DESCRIPTION
## Description

Pilot implementation of the accessor sync standard proposed in RFC discussion #3354. Introduces the standard types (`ConnectionStatus` / `AccessError` / `AccessResult`) and optional capabilities (`auth_spec()` / `check()`, `cursor` / `progress` kwargs) on the accessor layer, and validates them end to end with a new `EmailAccessor` (IMAP) built purely against the standard interface.

Existing accessors are untouched: the classic three-method contract (`can_handle` / `access` / `priority`) and the `LocalResource` return stay fully compatible, and all new capabilities are opt-in.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

RFC: https://github.com/volcengine/OpenViking/discussions/3354

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Added standard sync types to `accessors/base.py`: `ConnectionStatus`, `AccessError` (transient/permanent), and `AccessResult` (resource + opaque cursor + full-view `doc_ids` + per-doc errors), plus optional `DataAccessor.auth_spec()` / `check()` with no-auth defaults.
- Added `EmailAccessor` (IMAP, stdlib `imaplib`, no new dependencies): handles `imap://` / `imaps://` sources, converts emails to markdown (one directory per mailbox) so the existing markdown parser ingests them — no dedicated eml parser.
- Incremental sync via a `sync_checkpoint` time-watermark cursor with a strict less-than filter: boundary emails are re-pulled next round so a crash on the boundary never loses mail (downstream dedup absorbs the repeat).
- `doc_id` uses Message-ID with a `<mailbox_hash>_<uid>` fallback so ids never collide across mailboxes.
- Reliability semantics: per-message failures are isolated into `AccessResult.errors`; if any mailbox fails, the whole run raises and the cursor does not advance (re-pull beats data loss).
- `doc_ids` is returned only on a genuinely full view (no cursor, no `since_days` cap), so orphan cleanup can never act on a partial listing.
- Registered `EmailAccessor` in the registry; the registry convenience path unwraps `AccessResult` back to `LocalResource` so existing callers are unaffected (sync-metadata consumers call `accessor.access()` directly).
- Added hermetic unit tests with an injectable fake IMAP client (no network): scheme routing, auth schema, full/incremental sync, boundary re-pull, error isolation, mailbox failure abort, progress callback, and multi-mailbox layout.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Framework-side capabilities from the RFC (credential store, cursor persistence/replay on watch tasks, orphan diff cleanup, transient retry) are intenthis PR and will follow separately; credentials are currently passed via the `auth` kwarg with the same shape the future credential store will use.
- OAuth2 is declared as a schema extension point only; the pilot supports password / app-password auth, matching the RFC scope.