### PR TITLE
fix(cli): support tree boundary navigation in TUI

### DIFF
--- a/crates/ov_cli/src/tui/event.rs
+++ b/crates/ov_cli/src/tui/event.rs
@@ -77,6 +77,14 @@ async fn handle_tree_key(app: &mut App, key: KeyEvent) {
             app.tree.move_cursor_up();
             app.load_content_for_selected().await;
         }
+        KeyCode::Char('g') => {
+            app.tree.move_cursor_top();
+            app.load_content_for_selected().await;
+        }
+        KeyCode::Char('G') => {
+            app.tree.move_cursor_bottom();
+            app.load_content_for_selected().await;
+        }
         KeyCode::Char('.') => {
             // First try to load pending image if any
             if !app.load_pending_image().await {
@@ -154,5 +162,65 @@ fn handle_content_key(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::{client::HttpClient, tui::tree::VisibleRow};
+
+    fn app_with_tree_rows() -> App {
+        let client = HttpClient::new(
+            "http://127.0.0.1:9",
+            None,
+            None,
+            None,
+            None,
+            0.1,
+            false,
+            None,
+        );
+        let mut app = App::new(client);
+        app.tree.visible = (0..3)
+            .map(|index| VisibleRow {
+                depth: 0,
+                name: format!("file-{index}.md"),
+                uri: format!("viking://resources/file-{index}.md"),
+                is_dir: false,
+                expanded: false,
+                node_index: vec![index],
+            })
+            .collect();
+        app
+    }
+
+    #[tokio::test]
+    async fn tree_g_moves_cursor_to_first_row() {
+        let mut app = app_with_tree_rows();
+        app.tree.cursor = 2;
+
+        handle_tree_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+        )
+        .await;
+
+        assert_eq!(app.tree.cursor, 0);
+    }
+
+    #[tokio::test]
+    async fn tree_capital_g_moves_cursor_to_last_row() {
+        let mut app = app_with_tree_rows();
+
+        handle_tree_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+        )
+        .await;
+
+        assert_eq!(app.tree.cursor, 2);
     }
 }

--- a/crates/ov_cli/src/tui/tree.rs
+++ b/crates/ov_cli/src/tui/tree.rs
@@ -271,6 +271,14 @@ impl TreeState {
         }
     }
 
+    pub fn move_cursor_top(&mut self) {
+        self.cursor = 0;
+    }
+
+    pub fn move_cursor_bottom(&mut self) {
+        self.cursor = self.visible.len().saturating_sub(1);
+    }
+
     pub fn selected_uri(&self) -> Option<&str> {
         self.visible.get(self.cursor).map(|r| r.uri.as_str())
     }


### PR DESCRIPTION
## Description

Make the TUI footer's documented `g/G:top/bottom` shortcuts work while the Explorer tree has focus. Previously those keys were only handled by the content panel.

## Human Involvement

- [x] A human participated in the implementation or review loop by reporting and reproducing the issue

## Changes Made

- route `g` and `G` through tree-focused key handling
- move the tree cursor to the first or last visible row and refresh selected content
- add regression tests for both shortcuts

## Testing

- `cargo test -p ov_cli` — 421 passed, 0 failed
- `cargo test -p ov_cli tui::event::tests -- --nocapture` — 2 passed, 0 failed
- `cargo build -p ov_cli` — passed
- `rustfmt --edition 2021 --check crates/ov_cli/src/tui/event.rs crates/ov_cli/src/tui/tree.rs` — passed
- Manual macOS PTY smoke test against `http://127.0.0.1:1933`: after expanding and scrolling the tree, `g` selected `/` and `G` selected the final visible root scope

## Additional Notes

`cargo clippy -p ov_cli --all-targets -- -D warnings` remains blocked by existing warnings outside this change. No warning points to the newly added lines.
