### PR TITLE
feat(connector): Add git remote connector

### DIFF
--- a/openviking/connector/client.py
+++ b/openviking/connector/client.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -60,11 +60,18 @@ class ConnectorClient:
         api_key: str,
         *,
         tos_path: Optional[str] = None,
-        path_prefix: Optional[List[str]] = None,
+        to: Optional[str] = None,
         include_child: bool = True,
+        param_config: Optional[Dict[str, Any]] = None,
+        auth_config: Optional[Dict[str, Any]] = None,
         extra_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Submit a document import job via the configured doc/add endpoint.
+
+        ``to`` is the exact OpenViking file or directory target. Source-specific
+        settings stay inside ``param_config``; source credentials stay inside
+        ``auth_config``, the only body field redacted from request logs on
+        every hop, and must never be merged into ``param_config``.
 
         Returns the Connector response dict (contains task key / id on success).
         """
@@ -75,8 +82,12 @@ class ConnectorClient:
         }
         if tos_path is not None:
             payload["tos_path"] = tos_path
-        if path_prefix is not None:
-            payload["path_prefix"] = path_prefix
+        if to is not None:
+            payload["to"] = to
+        if param_config:
+            payload["param_config"] = param_config
+        if auth_config:
+            payload["auth_config"] = auth_config
         if extra_params:
             # Authentication belongs exclusively in the Authorization header.
             payload.update({key: value for key, value in extra_params.items() if key != "api_key"})

--- a/openviking/connector/routing.py
+++ b/openviking/connector/routing.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Connector source-type detection shared by routing and input guards.
+
+Detection mirrors the standard pipeline's own routing (accessor
+``can_handle`` predicates) instead of raw URL schemes, so a Connector
+add_type matches exactly the sources its plugin can import: ``tos`` by the
+``tos://`` prefix, ``git`` by the same repository-URL predicate the
+standard ``GitAccessor`` uses (``git@``/``ssh://``/``git://`` and code
+hosting ``http(s)`` URLs).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, FrozenSet, Optional, Tuple
+
+from openviking.utils import is_git_repo_url
+
+# add_resource ``args`` keys each Connector type forwards to its plugin via
+# param_config. A key's meaning must match what the standard pipeline's
+# accessor gives it (git: branch/ref select the branch to sync). Keys outside
+# the set flow into the unsupported-parameter framework: connector-only
+# sources reject them, shared sources degrade to the standard pipeline.
+CONNECTOR_SUPPORTED_ARGS: Dict[str, FrozenSet[str]] = {
+    "tos": frozenset(),
+    "git": frozenset({"branch", "ref"}),
+}
+
+# add_resource ``args`` keys carrying source credentials (git: HTTPS PAT as
+# the Basic-Auth password, username defaults to "oauth2" plugin-side). They
+# are stripped out of args and transported in the top-level ``auth_config``
+# request field -- never ``param_config`` -- because only the auth channel
+# is excluded from request logging on every hop (Connector and plugin log
+# param_config verbatim). One-shot use: credentials are never persisted.
+CONNECTOR_CREDENTIAL_ARGS: Dict[str, FrozenSet[str]] = {
+    "tos": frozenset(),
+    "git": frozenset({"token", "username"}),
+}
+
+
+def detect_connector_add_type(path: str) -> Optional[Tuple[str, bool]]:
+    """Map *path* to ``(add_type, connector_only)``; None when no type matches.
+
+    connector_only types have no standard-pipeline accessor, so requests
+    that cannot be delegated raise instead of degrading.
+    """
+    if not isinstance(path, str):
+        return None
+    if path.startswith("tos://"):
+        return ("tos", True)
+    if is_git_repo_url(path):
+        return ("git", False)
+    return None

--- a/openviking/connector/routing.py
+++ b/openviking/connector/routing.py
@@ -18,12 +18,13 @@ from openviking.utils import is_git_repo_url
 
 # add_resource ``args`` keys each Connector type forwards to its plugin via
 # param_config. A key's meaning must match what the standard pipeline's
-# accessor gives it (git: branch/ref select the branch to sync). Keys outside
+# accessor gives it (git: branch/ref select the branch to sync, commit pins
+# an exact snapshot and takes precedence when both are supplied). Keys outside
 # the set flow into the unsupported-parameter framework: connector-only
 # sources reject them, shared sources degrade to the standard pipeline.
 CONNECTOR_SUPPORTED_ARGS: Dict[str, FrozenSet[str]] = {
     "tos": frozenset(),
-    "git": frozenset({"branch", "ref"}),
+    "git": frozenset({"branch", "ref", "commit"}),
 }
 
 # add_resource ``args`` keys carrying source credentials (git: HTTPS PAT as
@@ -31,11 +32,23 @@ CONNECTOR_SUPPORTED_ARGS: Dict[str, FrozenSet[str]] = {
 # are stripped out of args and transported in the top-level ``auth_config``
 # request field -- never ``param_config`` -- because only the auth channel
 # is excluded from request logging on every hop (Connector and plugin log
-# param_config verbatim). One-shot use: credentials are never persisted.
+# param_config verbatim). One-shot use: credentials are never persisted, and
+# requests carrying them must not fall back to a durable native import job.
 CONNECTOR_CREDENTIAL_ARGS: Dict[str, FrozenSet[str]] = {
     "tos": frozenset(),
     "git": frozenset({"token", "username"}),
 }
+
+
+def is_full_commit_sha(ref: str) -> bool:
+    """True when *ref* is a full 40-hex commit SHA.
+
+    The Connector git plugin fetches pinned commits by SHA over the wire,
+    which cannot resolve abbreviated forms; only the full form may be
+    delegated, shorter SHAs stay on the standard pipeline where a local
+    clone resolves them.
+    """
+    return len(ref) == 40 and all(c in "0123456789abcdefABCDEF" for c in ref)
 
 
 def detect_connector_add_type(path: str) -> Optional[Tuple[str, bool]]:

--- a/openviking/server/local_input_guard.py
+++ b/openviking/server/local_input_guard.py
@@ -23,18 +23,19 @@ TEMP_FILE_ID_RE = re.compile(r"^(upload_|shared_)[a-zA-Z0-9]+(\.[^/\\]+)?$")
 
 
 def _is_configured_connector_source(source: str) -> bool:
-    """Return whether Connector is enabled for the source URL scheme."""
+    """Return whether Connector is enabled for the detected source type."""
     try:
+        from openviking.connector.routing import detect_connector_add_type
         from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
         config = get_openviking_config().connector
+        if not config.enable:
+            return False
+        detected = detect_connector_add_type(source)
     except Exception:
         return False
 
-    if not config.enable:
-        return False
-    allowed_schemes = tuple(f"{add_type}://" for add_type in config.allowed_add_types)
-    return source.startswith(allowed_schemes)
+    return detected is not None and detected[0] in config.allowed_add_types
 
 
 def is_remote_resource_source(source: str) -> bool:

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -206,8 +206,12 @@ async def add_resource(
         "exclude": request.exclude,
         "directly_upload_media": request.directly_upload_media,
         "watch_interval": request.watch_interval,
-        "create_parent": request.create_parent,
     }
+    # Connector routing needs to distinguish an omitted create_parent from an
+    # explicit false.  Standard imports still observe false when the field is
+    # omitted because ResourceService reads it with kwargs.get(..., False).
+    if "create_parent" in request.model_fields_set:
+        kwargs["create_parent"] = request.create_parent
     if request.temp_file_id:
         kwargs["temp_file_id"] = request.temp_file_id
     if request.preserve_structure is not None:

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -769,7 +769,6 @@ class ResourceService:
             to=to,
             parent=parent,
             wait=wait,
-            reason=reason,
             instruction=instruction,
             build_index=build_index,
             summarize=summarize,
@@ -780,7 +779,9 @@ class ResourceService:
             return await self._add_resource_via_connector(
                 path=path,
                 ctx=ctx,
-                parent=parent,
+                to=to,
+                reason=reason,
+                connector_args=args or {},
                 **kwargs,
             )
 
@@ -1198,11 +1199,6 @@ class ResourceService:
 
     # ── Connector routing ──
 
-    # Schemes only the external Connector can import; the standard pipeline
-    # has no accessor for them, so degrading to it would only fail later with
-    # a misleading parse error.
-    _CONNECTOR_ONLY_SCHEMES = ("tos://",)
-
     def _should_use_connector(
         self,
         path: str,
@@ -1211,7 +1207,6 @@ class ResourceService:
         to: Optional[str] = None,
         parent: Optional[str] = None,
         wait: bool = False,
-        reason: str = "",
         instruction: str = "",
         build_index: bool = True,
         summarize: bool = False,
@@ -1222,24 +1217,25 @@ class ResourceService:
         """Decide whether a top-level resource path belongs to Connector.
 
         Returns True to delegate to the Connector, False to route to the
-        standard pipeline. A source type only the Connector can import
-        (tos://) raises InvalidArgumentError when the Connector is disabled,
-        does not allow the type, or cannot honor the request parameters —
+        standard pipeline. Source types are detected the same way the
+        standard pipeline routes them (see connector.routing), not by raw
+        URL scheme. A source type only the Connector can import (tos)
+        raises InvalidArgumentError when the Connector is disabled, does
+        not allow the type, or cannot honor the request parameters —
         degrading such a request would only fail later with a misleading
         parse error. Source types the standard pipeline can also handle
         degrade to it instead when parameters are unsupported.
         """
+        from openviking.connector.routing import detect_connector_add_type
         from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
-        if not isinstance(path, str):
+        detected = detect_connector_add_type(path)
+        if detected is None:
             return False
-        connector_only = path.startswith(self._CONNECTOR_ONLY_SCHEMES)
+        add_type, connector_only = detected
 
         config = get_openviking_config().connector
-        # Match full URL schemes, not bare prefixes: "tos" must not capture
-        # paths like "tostring://..." or a local file named "tos_notes.md".
-        allowed_schemes = tuple(f"{add_type}://" for add_type in config.allowed_add_types)
-        if not config.enable or not path.startswith(allowed_schemes):
+        if not config.enable or add_type not in config.allowed_add_types:
             if connector_only:
                 raise InvalidArgumentError(
                     f"'{path}' can only be imported through the Connector integration, "
@@ -1259,8 +1255,8 @@ class ResourceService:
             parent = target.parent
 
         unsupported = self._unsupported_connector_params(
+            add_type=add_type,
             wait=wait,
-            reason=reason,
             instruction=instruction,
             build_index=build_index,
             summarize=summarize,
@@ -1284,8 +1280,8 @@ class ResourceService:
     @staticmethod
     def _unsupported_connector_params(
         *,
+        add_type: str,
         wait: bool,
-        reason: str,
         instruction: str,
         build_index: bool,
         summarize: bool,
@@ -1299,27 +1295,22 @@ class ResourceService:
 
         Returns an empty list when the request is fully supported.
         """
+        from openviking.connector.routing import (
+            CONNECTOR_CREDENTIAL_ARGS,
+            CONNECTOR_SUPPORTED_ARGS,
+        )
+
         unsupported: List[str] = []
-        if to:
-            unsupported.append(
-                "exact 'to' targets (Connector imports require a parent destination)"
-            )
-        if (
-            parent
-            and parent != "viking://resources"
-            and not parent.startswith("viking://resources/")
-        ):
-            unsupported.append("parent outside the public resources root (viking://resources/...)")
+        if wait:
+            unsupported.append("wait=true (Connector imports run asynchronously)")
+        if parent:
+            unsupported.append("parent targets (Connector imports require an exact 'to' target)")
+        if not to:
+            unsupported.append("missing exact 'to' target")
+        elif to != "viking://resources" and not to.startswith("viking://resources/"):
+            unsupported.append("to outside the public resources root (viking://resources/...)")
         if watch_interval > 0:
             unsupported.append("watch_interval>0 (Connector imports cannot be watched yet)")
-        if wait:
-            unsupported.append(
-                "wait=true (Connector imports run asynchronously; poll the returned task_id)"
-            )
-        if reason:
-            unsupported.append(
-                "reason (Connector imports cannot preserve resource-reason semantics)"
-            )
         if instruction:
             unsupported.append("instruction")
         if not build_index:
@@ -1330,7 +1321,7 @@ class ResourceService:
             unsupported.append("strict=true (Connector imports fail per file, not all-or-nothing)")
         for field in ("ignore_dirs", "include", "exclude"):
             if kwargs.get(field):
-                unsupported.append(f"{field} (scope TOS imports with the tos:// path prefix)")
+                unsupported.append(f"{field} (Connector imports cannot filter the source tree)")
         if kwargs.get("preserve_structure") is False:
             unsupported.append(
                 "preserve_structure=false (Connector always mirrors the source directory tree)"
@@ -1339,42 +1330,32 @@ class ResourceService:
             unsupported.append("directly_upload_media=false")
         if kwargs.get("source_name"):
             unsupported.append("source_name")
-        if connector_args:
-            unsupported.append(
-                "args (Connector imports derive path_prefix from parent; "
-                "args keys are not forwarded)"
+        supported_args = CONNECTOR_SUPPORTED_ARGS.get(
+            add_type, frozenset()
+        ) | CONNECTOR_CREDENTIAL_ARGS.get(add_type, frozenset())
+        unknown_args = sorted(set(connector_args) - supported_args)
+        if unknown_args:
+            supported_hint = (
+                f"supported: {sorted(supported_args)}" if supported_args else "no args supported"
             )
+            unsupported.append(f"args keys {unknown_args} ({supported_hint} for '{add_type}')")
         return unsupported
-
-    @staticmethod
-    def _connector_path_prefix(target_uri: Optional[str]) -> Optional[List[str]]:
-        """Map the resolved parent target onto the Connector's path_prefix.
-
-        The TOS plugin composes final URIs as
-        viking://resources/<path_prefix>/<source path>/<doc name>, so only
-        parent targets under the public resources root can be honored.
-        """
-        if not target_uri:
-            return None
-        root = "viking://resources"
-        if target_uri == root:
-            return None
-        if not target_uri.startswith(root + "/"):
-            raise InvalidArgumentError(
-                "Connector imports can only target the public resources root "
-                f"(viking://resources/...), got '{target_uri}'."
-            )
-        segments = [seg for seg in target_uri[len(root) + 1 :].split("/") if seg]
-        return segments or None
 
     async def _add_resource_via_connector(
         self,
         path: str,
         ctx: RequestContext,
-        parent: Optional[str],
+        to: Optional[str],
+        reason: str = "",
+        connector_args: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Route add_resource to the external Connector service."""
+        from openviking.connector.routing import (
+            CONNECTOR_CREDENTIAL_ARGS,
+            CONNECTOR_SUPPORTED_ARGS,
+            detect_connector_add_type,
+        )
         from openviking.service.task_tracker import get_task_tracker
         from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
@@ -1382,27 +1363,71 @@ class ResourceService:
         if not ctx.api_key:
             raise InvalidArgumentError("Connector import requires an API key in the request.")
 
+        detected = detect_connector_add_type(path)
+        if detected is None:
+            raise InvalidArgumentError(f"'{path}' does not match any Connector source type.")
+        add_type, _ = detected
+
         target = ContentTargetSpec.from_fields(
             ctx=ctx,
             kind="resource",
-            parent=parent,
+            to=to,
             create_parent=bool(kwargs.get("create_parent", False)),
         )
-        task_resource_id = target.parent or None
-        path_prefix = self._connector_path_prefix(task_resource_id)
+        if not target.to:
+            raise InvalidArgumentError("Connector import requires an exact 'to' target.")
+        task_resource_id = target.to
+
+        if not kwargs.get("create_parent", False):
+            # Match the native pipeline default: unless create_parent=true is
+            # given, the parent of the exact target must pre-exist.
+            parent_uri, _, _ = task_resource_id.rpartition("/")
+            if parent_uri.startswith("viking://") and not await self._viking_fs.exists(
+                parent_uri, ctx
+            ):
+                raise InvalidArgumentError(
+                    f"Parent directory '{parent_uri}' does not exist; "
+                    "pass create_parent=true to create it."
+                )
+
+        forwarded_args = {
+            key: value
+            for key, value in (connector_args or {}).items()
+            if key in CONNECTOR_SUPPORTED_ARGS.get(add_type, frozenset()) and value
+        }
+        # Credentials travel exclusively in the dedicated auth_config field:
+        # param_config is logged verbatim by the Connector and the plugin,
+        # auth_config is redacted on every hop.
+        auth_config = {
+            key: str(value)
+            for key, value in (connector_args or {}).items()
+            if key in CONNECTOR_CREDENTIAL_ARGS.get(add_type, frozenset()) and value
+        }
+
+        tos_path: Optional[str] = None
+        param_config: Optional[Dict[str, Any]] = None
+        if add_type == "tos":
+            source_path = path[len("tos://") :].strip()
+            if not source_path:
+                raise InvalidArgumentError(
+                    "Connector TOS import requires path='tos://<bucket>/<path>'."
+                )
+            tos_path = source_path
+        elif add_type == "git":
+            # Source-specific settings stay in param_config. The exact target
+            # is transported separately as the top-level ``to`` field.
+            param_config = {"repo_url": path.strip()}
+            branch = forwarded_args.get("branch") or forwarded_args.get("ref")
+            if branch:
+                param_config["branch"] = str(branch)
+        else:  # pragma: no cover - detection only yields tos/git today
+            raise InvalidArgumentError(f"Connector add_type '{add_type}' is not supported.")
 
         client = ConnectorClient(
             doc_add_url=config.connector,
             task_info_url=config.tracker,
             account_id=ctx.account_id,
         )
-
-        add_type, separator, source_path = path.partition("://")
-        source_path = source_path.strip()
-        if not separator or not add_type or not source_path:
-            raise InvalidArgumentError(
-                "Connector import requires path='<add_type>://<source path>'."
-            )
 
         task_tracker = get_task_tracker()
         task = await task_tracker.create(
@@ -1415,9 +1440,11 @@ class ResourceService:
             result = await client.submit_doc_add(
                 add_type=add_type,
                 api_key=ctx.api_key,
-                tos_path=source_path,
-                path_prefix=path_prefix,
+                tos_path=tos_path,
+                to=task_resource_id,
                 include_child=True,
+                param_config=param_config,
+                auth_config=auth_config or None,
                 extra_params=None,
             )
 
@@ -1443,16 +1470,18 @@ class ResourceService:
             )
             raise
 
-        background = asyncio.create_task(
-            self._monitor_connector_task(
-                client=client,
-                connector_task_key=connector_task_key,
-                ov_task_id=task.task_id,
-                poll_interval_ms=config.poll_interval_ms,
-                timeout_seconds=config.timeout_seconds,
-                ctx=ctx,
-            )
+        monitor = self._monitor_connector_task(
+            client=client,
+            connector_task_key=connector_task_key,
+            ov_task_id=task.task_id,
+            poll_interval_ms=config.poll_interval_ms,
+            timeout_seconds=config.timeout_seconds,
+            ctx=ctx,
+            reason=reason,
+            link_root_uri=task_resource_id or "viking://resources",
         )
+
+        background = asyncio.create_task(monitor)
         self._background_tasks.add(background)
         background.add_done_callback(self._background_tasks.discard)
 
@@ -1473,8 +1502,17 @@ class ResourceService:
         poll_interval_ms: int,
         timeout_seconds: int,
         ctx: RequestContext,
-    ) -> None:
-        """Poll the Connector task until terminal state, then update OV TaskRecord."""
+        reason: str = "",
+        link_root_uri: str = "",
+    ) -> Dict[str, Any]:
+        """Poll the Connector task until terminal state, then update OV TaskRecord.
+
+        Returns a terminal payload: ``{"status": "completed", ...}`` on
+        success, ``{"status": "failed", "error": ...}`` otherwise. When
+        *reason* is set, a successful import links one reason memory to
+        *link_root_uri* (the import root), matching the native add_resource
+        reason semantics of one reason entry referencing the resource root.
+        """
         from openviking.service.task_tracker import get_task_tracker
 
         task_tracker = get_task_tracker()
@@ -1519,28 +1557,47 @@ class ResourceService:
 
                 if status in terminal_statuses:
                     if status == "succeeded":
+                        completion: Dict[str, Any] = {
+                            "connector_status": status,
+                            "connector_task_key": connector_task_key,
+                        }
+                        if (reason or "").strip() and link_root_uri:
+                            link_result: Dict[str, Any] = {"root_uri": link_root_uri}
+                            await self._link_resource_reason_memory(
+                                result=link_result,
+                                ctx=ctx,
+                                reason=reason,
+                                source_name=None,
+                                timeout=None,
+                            )
+                            for key in ("memory_linking", "warnings"):
+                                if key in link_result:
+                                    completion[key] = link_result[key]
                         await task_tracker.complete(
                             ov_task_id,
-                            {"connector_status": status, "connector_task_key": connector_task_key},
+                            completion,
                             account_id=ctx.account_id,
                             user_id=ctx.user.user_id,
                         )
-                    else:
-                        error_msg = info.get("ErrorMessage") or info.get("error_message") or status
-                        await task_tracker.fail(
-                            ov_task_id,
-                            f"connector task {status}: {error_msg}",
-                            account_id=ctx.account_id,
-                            user_id=ctx.user.user_id,
-                        )
-                    return
+                        return {"status": "completed", **completion}
+                    error_msg = info.get("ErrorMessage") or info.get("error_message") or status
+                    failure = f"connector task {status}: {error_msg}"
+                    await task_tracker.fail(
+                        ov_task_id,
+                        failure,
+                        account_id=ctx.account_id,
+                        user_id=ctx.user.user_id,
+                    )
+                    return {"status": "failed", "error": failure}
 
+            timeout_msg = f"connector task timed out after {timeout_seconds}s"
             await task_tracker.fail(
                 ov_task_id,
-                f"connector task timed out after {timeout_seconds}s",
+                timeout_msg,
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
             )
+            return {"status": "failed", "error": timeout_msg}
         except asyncio.CancelledError:
             await task_tracker.fail(
                 ov_task_id,
@@ -1557,6 +1614,7 @@ class ResourceService:
                 account_id=ctx.account_id,
                 user_id=ctx.user.user_id,
             )
+            return {"status": "failed", "error": str(exc)}
 
     async def _handle_watch_task_creation(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -496,6 +496,18 @@ class ResourceService:
         self._ensure_initialized()
         normalized_args = self._normalize_add_resource_args(args, watch_interval=watch_interval)
         kwargs.update(normalized_args.processor_kwargs)
+        from openviking.connector.routing import CONNECTOR_CREDENTIAL_ARGS
+
+        credential_args = sorted(
+            set(kwargs).intersection(CONNECTOR_CREDENTIAL_ARGS.get("git", frozenset()))
+        )
+        if credential_args:
+            raise InvalidArgumentError(
+                "Git credential args "
+                f"{credential_args} cannot be used with the native asynchronous import "
+                "pipeline because it persists job parameters. Use a Connector-compatible "
+                "request instead."
+            )
 
         target = ContentTargetSpec.from_fields(
             ctx=ctx,
@@ -1224,24 +1236,59 @@ class ResourceService:
         not allow the type, or cannot honor the request parameters —
         degrading such a request would only fail later with a misleading
         parse error. Source types the standard pipeline can also handle
-        degrade to it instead when parameters are unsupported.
+        degrade to it instead when parameters are unsupported, unless the
+        request carries Connector-only credentials; credentialed requests
+        fail closed so secrets never enter a durable native job.
         """
-        from openviking.connector.routing import detect_connector_add_type
+        from openviking.connector.routing import (
+            CONNECTOR_CREDENTIAL_ARGS,
+            detect_connector_add_type,
+            is_full_commit_sha,
+        )
         from openviking_cli.utils.config.open_viking_config import get_openviking_config
 
         detected = detect_connector_add_type(path)
         if detected is None:
             return False
         add_type, connector_only = detected
+        connector_args = connector_args or {}
+        credential_args = sorted(
+            set(connector_args).intersection(CONNECTOR_CREDENTIAL_ARGS.get(add_type, frozenset()))
+        )
 
         config = get_openviking_config().connector
         if not config.enable or add_type not in config.allowed_add_types:
+            if credential_args:
+                raise InvalidArgumentError(
+                    f"Credential args {credential_args} for '{add_type}' require Connector "
+                    "import, but the Connector is disabled or does not allow this source type."
+                )
             if connector_only:
                 raise InvalidArgumentError(
                     f"'{path}' can only be imported through the Connector integration, "
                     "which is disabled or does not allow this source type."
                 )
             return False
+
+        if add_type == "git":
+            from openviking.parse.accessors.git_accessor import GitAccessor
+
+            _, _, commit = GitAccessor()._parse_repo_source(path, **connector_args)
+            if commit and not is_full_commit_sha(str(commit)):
+                # The plugin fetches pinned commits by SHA over the wire and
+                # cannot resolve abbreviated forms; the standard pipeline
+                # resolves them locally after a full clone.
+                if credential_args:
+                    raise InvalidArgumentError(
+                        f"Credential args {credential_args} for 'git' cannot fall back to the "
+                        "standard import pipeline; pass a full 40-character commit SHA."
+                    )
+                logger.info(
+                    "Connector git import degrades to the standard pipeline: "
+                    "abbreviated commit SHA %r needs a local clone to resolve.",
+                    commit,
+                )
+                return False
 
         if ctx is not None and (to or parent):
             target = ContentTargetSpec.from_fields(
@@ -1261,7 +1308,7 @@ class ResourceService:
             build_index=build_index,
             summarize=summarize,
             watch_interval=watch_interval,
-            connector_args=connector_args or {},
+            connector_args=connector_args,
             kwargs=kwargs or {},
             to=to,
             parent=parent,
@@ -1271,6 +1318,11 @@ class ResourceService:
         detail = "; ".join(unsupported)
         if connector_only:
             raise InvalidArgumentError(f"Connector import does not support: {detail}")
+        if credential_args:
+            raise InvalidArgumentError(
+                f"Credential args {credential_args} for '{add_type}' cannot fall back to the "
+                f"standard import pipeline. Connector import does not support: {detail}"
+            )
         logger.info(
             f"[ResourceService] Connector does not support {detail} for path {path}; "
             "falling back to the standard import pipeline"
@@ -1414,11 +1466,21 @@ class ResourceService:
                 )
             tos_path = source_path
         elif add_type == "git":
+            from openviking.parse.accessors.git_accessor import GitAccessor
+
             # Source-specific settings stay in param_config. The exact target
             # is transported separately as the top-level ``to`` field.
-            param_config = {"repo_url": path.strip()}
-            branch = forwarded_args.get("branch") or forwarded_args.get("ref")
-            if branch:
+            repo_url, branch, commit = GitAccessor()._parse_repo_source(
+                path.strip(), **forwarded_args
+            )
+            param_config = {"repo_url": repo_url}
+            if commit:
+                # Routing already degraded abbreviated SHAs to the standard
+                # pipeline. Preserve the native accessor's historical precedence:
+                # when both commit and branch/ref are present, send only the full
+                # commit SHA so the plugin receives an unambiguous pinned request.
+                param_config["commit"] = str(commit)
+            elif branch:
                 param_config["branch"] = str(branch)
         else:  # pragma: no cover - detection only yields tos/git today
             raise InvalidArgumentError(f"Connector add_type '{add_type}' is not supported.")

--- a/tests/connector/test_client.py
+++ b/tests/connector/test_client.py
@@ -48,7 +48,7 @@ async def test_submit_doc_add_sends_controlled_payload_and_auth_headers():
         add_type="tos",
         api_key="secret",
         tos_path="bucket/prefix",
-        path_prefix=["docs"],
+        to="viking://resources/docs/report.pdf",
         include_child=False,
         extra_params={"parser": "pdf", "api_key": "must-not-leak"},
     )
@@ -62,7 +62,7 @@ async def test_submit_doc_add_sends_controlled_payload_and_auth_headers():
                 "backend": "ov",
                 "include_child": False,
                 "tos_path": "bucket/prefix",
-                "path_prefix": ["docs"],
+                "to": "viking://resources/docs/report.pdf",
                 "parser": "pdf",
             },
             "headers": {
@@ -72,6 +72,53 @@ async def test_submit_doc_add_sends_controlled_payload_and_auth_headers():
             "timeout": 30.0,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_submit_doc_add_carries_non_tos_source_in_param_config():
+    _FakeAsyncClient.response_payload = {"code": 0, "data": {"task_key": "connector-1"}}
+    client = ConnectorClient("https://connector/doc/add", "https://tracker/task/info", "acct")
+
+    await client.submit_doc_add(
+        add_type="git",
+        api_key="secret",
+        to="viking://resources/imports/repo",
+        param_config={
+            "repo_url": "https://git.example/org/repo.git",
+            "branch": "release",
+        },
+    )
+
+    payload = _FakeAsyncClient.calls[0]["json"]
+    assert payload == {
+        "add_type": "git",
+        "backend": "ov",
+        "include_child": True,
+        "to": "viking://resources/imports/repo",
+        "param_config": {
+            "repo_url": "https://git.example/org/repo.git",
+            "branch": "release",
+        },
+    }
+    assert "tos_path" not in payload
+
+
+@pytest.mark.asyncio
+async def test_submit_doc_add_keeps_credentials_out_of_param_config():
+    _FakeAsyncClient.response_payload = {"code": 0, "data": {"task_key": "connector-1"}}
+    client = ConnectorClient("https://connector/doc/add", "https://tracker/task/info", "acct")
+
+    await client.submit_doc_add(
+        add_type="git",
+        api_key="secret",
+        to="viking://resources/imports/repo",
+        param_config={"repo_url": "https://git.example/org/private.git"},
+        auth_config={"token": "ghp-secret", "username": "oauth2"},
+    )
+
+    payload = _FakeAsyncClient.calls[0]["json"]
+    assert payload["auth_config"] == {"token": "ghp-secret", "username": "oauth2"}
+    assert payload["param_config"] == {"repo_url": "https://git.example/org/private.git"}
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -97,6 +97,38 @@ async def test_add_resource_forwards_args_to_service(
     assert seen["args"] == {"feishu_access_token": "u-test"}
 
 
+async def test_add_resource_preserves_create_parent_field_presence(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    calls = []
+
+    async def fake_add_resource(**kwargs):
+        calls.append(kwargs)
+        return {"status": "success", "root_uri": "viking://resources/demo"}
+
+    monkeypatch.setattr(service.resources, "add_resource", fake_add_resource)
+
+    omitted = await client.post(
+        "/api/v1/resources",
+        json={"path": "https://example.com/demo.md", "to": "viking://resources/demo.md"},
+    )
+    explicit_false = await client.post(
+        "/api/v1/resources",
+        json={
+            "path": "https://example.com/demo.md",
+            "to": "viking://resources/demo.md",
+            "create_parent": False,
+        },
+    )
+
+    assert omitted.status_code == 200
+    assert explicit_false.status_code == 200
+    assert "create_parent" not in calls[0]
+    assert calls[1]["create_parent"] is False
+
+
 async def test_add_resource_with_telemetry_wait(
     client: httpx.AsyncClient,
     sample_markdown_file,

--- a/tests/service/test_resource_service_connector.py
+++ b/tests/service/test_resource_service_connector.py
@@ -44,7 +44,19 @@ def connector_config(monkeypatch):
     )
     monkeypatch.setattr(
         "openviking.connector.routing.is_git_repo_url",
-        lambda path: isinstance(path, str) and path.startswith(_GIT_REPO_PREFIX),
+        lambda path: (
+            isinstance(path, str) and path.startswith((_GIT_REPO_PREFIX, "https://github.com/"))
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.parse.accessors.git_accessor.get_openviking_config",
+        lambda: SimpleNamespace(
+            code=SimpleNamespace(
+                github_domains=["github.com", "git.example"],
+                gitlab_domains=[],
+                azure_devops_domains=[],
+            )
+        ),
     )
     return config
 
@@ -202,6 +214,162 @@ async def test_git_connector_maps_ref_arg_to_branch(
     assert submitted["add_type"] == "git"
     assert submitted["param_config"]["branch"] == "v1.2"
     assert submitted["param_config"]["repo_url"] == "https://git.example/org/repo"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("args", "expected_branch"),
+    [
+        (None, "release"),
+        ({"branch": "override"}, "override"),
+    ],
+    ids=["url-branch", "explicit-branch"],
+)
+async def test_git_connector_preserves_native_tree_url_semantics(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+    args,
+    expected_branch,
+):
+    connector_config.allowed_add_types = ["git"]
+    tracker = _task_tracker()
+    connector_client = SimpleNamespace(
+        submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
+    )
+    _install_connector_dependencies(monkeypatch, tracker, connector_client)
+
+    await service.add_resource(
+        path="https://github.com/acme/repo/tree/release",
+        ctx=ctx,
+        to="viking://resources/imports",
+        args=args,
+    )
+
+    submitted = connector_client.submit_doc_add.await_args.kwargs
+    assert submitted["param_config"] == {
+        "repo_url": "https://github.com/acme/repo",
+        "branch": expected_branch,
+    }
+
+
+def test_git_commit_tree_url_falls_back_to_native(connector_config, service):
+    connector_config.allowed_add_types = ["git"]
+
+    assert (
+        service._should_use_connector(
+            "https://github.com/acme/repo/tree/deadbee",
+            to="viking://resources/imports",
+        )
+        is False
+    )
+
+
+def test_git_commit_tree_url_with_credentials_fails_closed(connector_config, service):
+    connector_config.allowed_add_types = ["git"]
+
+    with pytest.raises(InvalidArgumentError, match="cannot fall back") as exc_info:
+        service._should_use_connector(
+            "https://github.com/acme/repo/tree/deadbee",
+            to="viking://resources/imports",
+            connector_args={"token": "ghp-secret"},
+        )
+
+    assert "ghp-secret" not in str(exc_info.value)
+
+
+_FULL_COMMIT_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def test_git_full_commit_arg_routes_to_connector(connector_config, service):
+    connector_config.allowed_add_types = ["git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/imports",
+            connector_args={"commit": _FULL_COMMIT_SHA},
+        )
+        is True
+    )
+
+
+def test_git_full_commit_with_credentials_routes_to_connector(connector_config, service):
+    connector_config.allowed_add_types = ["git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/imports",
+            connector_args={"commit": _FULL_COMMIT_SHA, "token": "ghp-secret"},
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize("branch_arg", ["branch", "ref"])
+def test_git_commit_with_branch_falls_back_to_native_for_wait(
+    connector_config,
+    service,
+    branch_arg,
+):
+    connector_config.allowed_add_types = ["git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/imports",
+            wait=True,
+            connector_args={"commit": _FULL_COMMIT_SHA, branch_arg: "main"},
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "args"),
+    [
+        (f"https://github.com/acme/repo/tree/{_FULL_COMMIT_SHA}", None),
+        (
+            "https://github.com/acme/repo",
+            {"commit": _FULL_COMMIT_SHA, "branch": "main"},
+        ),
+        (
+            "https://github.com/acme/repo",
+            {"commit": _FULL_COMMIT_SHA, "ref": "release"},
+        ),
+    ],
+    ids=["tree-url", "commit-over-branch", "commit-over-ref"],
+)
+async def test_git_connector_pins_full_commit_in_param_config(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+    path,
+    args,
+):
+    connector_config.allowed_add_types = ["git"]
+    tracker = _task_tracker()
+    connector_client = SimpleNamespace(
+        submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
+    )
+    _install_connector_dependencies(monkeypatch, tracker, connector_client)
+
+    await service.add_resource(
+        path=path,
+        ctx=ctx,
+        to="viking://resources/imports",
+        args=args,
+    )
+
+    submitted = connector_client.submit_doc_add.await_args.kwargs
+    assert submitted["param_config"] == {
+        "repo_url": "https://github.com/acme/repo",
+        "commit": _FULL_COMMIT_SHA,
+    }
 
 
 @pytest.mark.asyncio
@@ -366,7 +534,7 @@ def test_git_source_falls_back_for_unsupported_args(connector_config, service):
     assert (
         service._should_use_connector(
             "https://git.example/org/repo.git",
-            connector_args={"commit": "abc123"},
+            connector_args={"depth": "1"},
         )
         is False
     )
@@ -383,6 +551,44 @@ def test_git_route_accepts_credential_args(connector_config, service):
         )
         is True
     )
+
+
+@pytest.mark.parametrize(
+    "routing_kwargs",
+    [
+        {"to": "viking://resources/repo", "kwargs": {"include": "docs/**"}},
+        {"to": "viking://resources/repo", "wait": True},
+        {},
+        {"parent": "viking://resources/imports"},
+    ],
+    ids=["include", "wait", "missing_to", "parent"],
+)
+def test_git_credentials_fail_closed_when_connector_request_would_fallback(
+    connector_config,
+    service,
+    routing_kwargs,
+):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    with pytest.raises(InvalidArgumentError, match="cannot fall back") as exc_info:
+        service._should_use_connector(
+            "https://git.example/org/private.git",
+            connector_args={"token": "ghp-secret", "username": "oauth2"},
+            **routing_kwargs,
+        )
+
+    assert "ghp-secret" not in str(exc_info.value)
+
+
+def test_git_credentials_require_enabled_allowed_connector(connector_config, service):
+    with pytest.raises(InvalidArgumentError, match="require Connector import") as exc_info:
+        service._should_use_connector(
+            "https://git.example/org/private.git",
+            to="viking://resources/private",
+            connector_args={"token": "ghp-secret"},
+        )
+
+    assert "ghp-secret" not in str(exc_info.value)
 
 
 def test_tos_route_rejects_credential_args(connector_config, service):
@@ -420,6 +626,61 @@ async def test_git_credential_args_travel_in_auth_config_only(
         "repo_url": "https://git.example/org/private.git",
         "branch": "main",
     }
+
+
+@pytest.mark.asyncio
+async def test_git_credentials_with_include_never_enqueue_native_job(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    connector_config.allowed_add_types = ["tos", "git"]
+    monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: True)
+    service._add_resource_via_connector = AsyncMock()
+    service.enqueue_git_add_resource = AsyncMock()
+
+    with pytest.raises(InvalidArgumentError, match="cannot fall back") as exc_info:
+        await service.add_resource(
+            path="https://git.example/org/private.git",
+            ctx=ctx,
+            to="viking://resources/private",
+            wait=False,
+            include="docs/**",
+            args={"token": "ghp-secret", "username": "oauth2"},
+        )
+
+    assert "ghp-secret" not in str(exc_info.value)
+    service._add_resource_via_connector.assert_not_awaited()
+    service.enqueue_git_add_resource.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "credential_args",
+    [
+        {"token": "ghp-secret"},
+        {"username": "oauth2"},
+    ],
+    ids=["token", "username"],
+)
+async def test_native_git_enqueue_rejects_credentials_before_durable_job(
+    ctx,
+    service,
+    credential_args,
+):
+    service._enqueue_add_resource_job = AsyncMock()
+
+    with pytest.raises(InvalidArgumentError, match="persists job parameters") as exc_info:
+        await service.enqueue_git_add_resource(
+            path="https://git.example/org/private.git",
+            ctx=ctx,
+            to="viking://resources/private",
+            args=credential_args,
+        )
+
+    assert all(value not in str(exc_info.value) for value in credential_args.values())
+    service._enqueue_add_resource_job.assert_not_awaited()
 
 
 @pytest.mark.parametrize("to", ["viking://resources/manuals", "resources/manuals"])

--- a/tests/service/test_resource_service_connector.py
+++ b/tests/service/test_resource_service_connector.py
@@ -15,6 +15,10 @@ from openviking.service.resource_service import ResourceService
 from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
 
+# Deterministic stand-in for the code-hosting predicate: routing tests must
+# not depend on the real hosting-domain configuration.
+_GIT_REPO_PREFIX = "https://git.example/"
+
 
 class _BackgroundTask:
     def add_done_callback(self, _callback):
@@ -38,6 +42,10 @@ def connector_config(monkeypatch):
         "get_openviking_config",
         lambda: SimpleNamespace(connector=config),
     )
+    monkeypatch.setattr(
+        "openviking.connector.routing.is_git_repo_url",
+        lambda path: isinstance(path, str) and path.startswith(_GIT_REPO_PREFIX),
+    )
     return config
 
 
@@ -52,9 +60,11 @@ def ctx():
 
 @pytest.fixture
 def service():
+    # Parent of the import target exists by default; the create_parent
+    # pre-check tests build their own service with a missing parent.
     return ResourceService(
         vikingdb=object(),
-        viking_fs=object(),
+        viking_fs=SimpleNamespace(exists=AsyncMock(return_value=True)),
         resource_processor=object(),
         skill_processor=object(),
     )
@@ -104,7 +114,7 @@ async def test_add_resource_routes_tos_to_connector(
     result = await service.add_resource(
         path="tos://bucket/a/b/c",
         ctx=ctx,
-        parent="viking://resources/x/y",
+        to="viking://resources/x/y",
     )
 
     assert result == {
@@ -117,8 +127,10 @@ async def test_add_resource_routes_tos_to_connector(
         add_type="tos",
         api_key="secret",
         tos_path="bucket/a/b/c",
-        path_prefix=["x", "y"],
+        to="viking://resources/x/y",
         include_child=True,
+        param_config=None,
+        auth_config=None,
         extra_params=None,
     )
     tracker.create.assert_awaited_once_with(
@@ -130,13 +142,13 @@ async def test_add_resource_routes_tos_to_connector(
 
 
 @pytest.mark.asyncio
-async def test_add_resource_uses_source_scheme_as_connector_add_type(
+async def test_add_resource_routes_git_repo_to_connector(
     monkeypatch,
     connector_config,
     ctx,
     service,
 ):
-    connector_config.allowed_add_types = ["s3", "tos"]
+    connector_config.allowed_add_types = ["tos", "git"]
     tracker = _task_tracker()
     connector_client = SimpleNamespace(
         submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
@@ -144,19 +156,52 @@ async def test_add_resource_uses_source_scheme_as_connector_add_type(
     _install_connector_dependencies(monkeypatch, tracker, connector_client)
 
     await service.add_resource(
-        path="s3://bucket/prefix",
+        path="https://git.example/org/repo.git",
         ctx=ctx,
-        parent="viking://resources/imports",
+        to="viking://resources/imports",
+        args={"branch": "release"},
     )
 
     connector_client.submit_doc_add.assert_awaited_once_with(
-        add_type="s3",
+        add_type="git",
         api_key="secret",
-        tos_path="bucket/prefix",
-        path_prefix=["imports"],
+        tos_path=None,
+        to="viking://resources/imports",
         include_child=True,
+        param_config={
+            "repo_url": "https://git.example/org/repo.git",
+            "branch": "release",
+        },
+        auth_config=None,
         extra_params=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_git_connector_maps_ref_arg_to_branch(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    connector_config.allowed_add_types = ["git"]
+    tracker = _task_tracker()
+    connector_client = SimpleNamespace(
+        submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
+    )
+    _install_connector_dependencies(monkeypatch, tracker, connector_client)
+
+    await service.add_resource(
+        path="https://git.example/org/repo",
+        ctx=ctx,
+        to="viking://resources/imports",
+        args={"ref": "v1.2"},
+    )
+
+    submitted = connector_client.submit_doc_add.await_args.kwargs
+    assert submitted["add_type"] == "git"
+    assert submitted["param_config"]["branch"] == "v1.2"
+    assert submitted["param_config"]["repo_url"] == "https://git.example/org/repo"
 
 
 @pytest.mark.asyncio
@@ -172,16 +217,14 @@ async def test_connector_import_persists_task_before_remote_submission(
         tracker.create.assert_awaited_once()
         raise RuntimeError("submission failed")
 
-    connector_client = SimpleNamespace(
-        submit_doc_add=AsyncMock(side_effect=fail_submission)
-    )
+    connector_client = SimpleNamespace(submit_doc_add=AsyncMock(side_effect=fail_submission))
     _install_connector_dependencies(monkeypatch, tracker, connector_client)
 
     with pytest.raises(RuntimeError, match="submission failed"):
         await service.add_resource(
             path="tos://bucket/prefix",
             ctx=ctx,
-            parent="viking://resources/imports",
+            to="viking://resources/imports",
         )
 
     tracker.fail.assert_awaited_once_with(
@@ -193,17 +236,77 @@ async def test_connector_import_persists_task_before_remote_submission(
 
 
 @pytest.mark.asyncio
-async def test_connector_import_rejects_exact_to_target(
+async def test_connector_import_rejects_parent_target(
     connector_config,
     ctx,
     service,
 ):
-    with pytest.raises(InvalidArgumentError, match="exact 'to' targets"):
+    with pytest.raises(InvalidArgumentError, match="parent targets"):
+        await service.add_resource(
+            path="tos://bucket/a/b/c",
+            ctx=ctx,
+            parent="viking://resources/x/y",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [{}, {"create_parent": False}],
+    ids=["omitted", "explicit_false"],
+)
+async def test_connector_requires_existing_parent_unless_create_parent(
+    connector_config,
+    ctx,
+    request_kwargs,
+):
+    viking_fs = SimpleNamespace(exists=AsyncMock(return_value=False))
+    service = ResourceService(
+        vikingdb=object(),
+        viking_fs=viking_fs,
+        resource_processor=object(),
+        skill_processor=object(),
+    )
+
+    with pytest.raises(InvalidArgumentError, match="does not exist"):
         await service.add_resource(
             path="tos://bucket/a/b/c",
             ctx=ctx,
             to="viking://resources/x/y",
+            **request_kwargs,
         )
+
+    viking_fs.exists.assert_awaited_once_with("viking://resources/x", ctx)
+
+
+@pytest.mark.asyncio
+async def test_connector_create_parent_false_accepts_existing_parent(
+    monkeypatch,
+    connector_config,
+    ctx,
+):
+    viking_fs = SimpleNamespace(exists=AsyncMock(return_value=True))
+    service = ResourceService(
+        vikingdb=object(),
+        viking_fs=viking_fs,
+        resource_processor=object(),
+        skill_processor=object(),
+    )
+    tracker = _task_tracker()
+    connector_client = SimpleNamespace(
+        submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
+    )
+    _install_connector_dependencies(monkeypatch, tracker, connector_client)
+
+    result = await service.add_resource(
+        path="tos://bucket/a/b/c",
+        ctx=ctx,
+        to="viking://resources/x/y",
+        create_parent=False,
+    )
+
+    assert result["status"] == "accepted"
+    connector_client.submit_doc_add.assert_awaited_once()
 
 
 def test_connector_only_route_rejects_disabled_or_unsupported_requests(
@@ -212,78 +315,143 @@ def test_connector_only_route_rejects_disabled_or_unsupported_requests(
 ):
     assert service._should_use_connector("https://example.com/doc") is False
 
-    with pytest.raises(InvalidArgumentError, match="wait=true"):
-        service._should_use_connector("tos://bucket/prefix", wait=True)
-
-    with pytest.raises(InvalidArgumentError, match="reason"):
-        service._should_use_connector("tos://bucket/prefix", reason="needed for Q3 planning")
+    with pytest.raises(InvalidArgumentError, match="args keys"):
+        service._should_use_connector("tos://bucket/prefix", connector_args={"parser": "pdf"})
 
     connector_config.enable = False
     with pytest.raises(InvalidArgumentError, match="Connector integration"):
         service._should_use_connector("tos://bucket/prefix")
 
 
-@pytest.mark.parametrize(
-    ("path", "target"),
-    [
-        (
-            "https://example.com/manual.pdf",
-            {"to": "viking://resources/manual.pdf"},
-        ),
-        (
-            "http://example.com/manual.pdf",
-            {"parent": "viking://user/alice/resources/manuals"},
-        ),
-        (
-            "git://example.com/repository.git",
-            {"parent": "viking://user/alice/peers/bob/resources/manuals"},
-        ),
-    ],
-)
-def test_shared_connector_sources_fall_back_for_unsupported_targets(
+def test_git_route_degrades_when_disabled_or_type_not_allowed(connector_config, service):
+    # "git" not in allowed_add_types: standard pipeline handles the repo.
+    assert service._should_use_connector("https://git.example/org/repo.git") is False
+
+    connector_config.allowed_add_types = ["tos", "git"]
+    connector_config.enable = False
+    assert service._should_use_connector("https://git.example/org/repo.git") is False
+
+
+def test_git_source_falls_back_for_parent_target(
     connector_config,
     service,
-    path,
-    target,
 ):
-    connector_config.allowed_add_types = ["https", "http", "git"]
-
-    assert service._should_use_connector(path, **target) is False
-
-
-@pytest.mark.parametrize(
-    "parent",
-    ["viking://resources/manuals", "resources/manuals"],
-)
-def test_connector_route_accepts_public_parent(connector_config, ctx, service, parent):
-    connector_config.allowed_add_types = ["https"]
+    connector_config.allowed_add_types = ["tos", "git"]
 
     assert (
         service._should_use_connector(
-            "https://example.com/manual.pdf",
+            "https://git.example/org/repo.git",
+            parent="viking://resources/manuals",
+        )
+        is False
+    )
+
+
+def test_git_route_accepts_explicit_create_parent_false(connector_config, service):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/repo",
+            kwargs={"create_parent": False},
+        )
+        is True
+    )
+
+
+def test_git_source_falls_back_for_unsupported_args(connector_config, service):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            connector_args={"commit": "abc123"},
+        )
+        is False
+    )
+
+
+def test_git_route_accepts_credential_args(connector_config, service):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/repo",
+            connector_args={"token": "ghp-secret", "username": "oauth2"},
+        )
+        is True
+    )
+
+
+def test_tos_route_rejects_credential_args(connector_config, service):
+    with pytest.raises(InvalidArgumentError, match="args keys"):
+        service._should_use_connector(
+            "tos://bucket/prefix",
+            connector_args={"token": "ghp-secret"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_git_credential_args_travel_in_auth_config_only(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    connector_config.allowed_add_types = ["tos", "git"]
+    tracker = _task_tracker()
+    connector_client = SimpleNamespace(
+        submit_doc_add=AsyncMock(return_value={"task_key": "connector-1"})
+    )
+    _install_connector_dependencies(monkeypatch, tracker, connector_client)
+
+    await service.add_resource(
+        path="https://git.example/org/private.git",
+        ctx=ctx,
+        to="viking://resources/private",
+        args={"branch": "main", "token": "ghp-secret", "username": "oauth2"},
+    )
+
+    submitted = connector_client.submit_doc_add.await_args.kwargs
+    assert submitted["auth_config"] == {"token": "ghp-secret", "username": "oauth2"}
+    assert submitted["param_config"] == {
+        "repo_url": "https://git.example/org/private.git",
+        "branch": "main",
+    }
+
+
+@pytest.mark.parametrize("to", ["viking://resources/manuals", "resources/manuals"])
+def test_connector_route_accepts_public_exact_to(connector_config, ctx, service, to):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
             ctx=ctx,
-            parent=parent,
+            to=to,
         )
         is True
     )
 
 
 @pytest.mark.asyncio
-async def test_add_resource_falls_back_for_shared_source_with_exact_to(
+async def test_add_resource_falls_back_for_shared_source_with_parent(
     monkeypatch,
     connector_config,
     ctx,
     service,
 ):
-    connector_config.allowed_add_types = ["https"]
+    connector_config.allowed_add_types = ["tos", "git"]
     monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: True)
     service._add_resource_via_connector = AsyncMock()
     service.enqueue_git_add_resource = AsyncMock(return_value={"root_uri": "standard-pipeline"})
 
     result = await service.add_resource(
-        path="https://example.com/manual.pdf",
+        path="https://git.example/org/repo.git",
         ctx=ctx,
-        to="viking://resources/manual.pdf",
+        parent="viking://resources/repo",
     )
 
     assert result == {"root_uri": "standard-pipeline"}
@@ -292,7 +460,31 @@ async def test_add_resource_falls_back_for_shared_source_with_exact_to(
 
 
 @pytest.mark.asyncio
-async def test_connector_import_without_target_keeps_resource_id_unset(
+async def test_shared_source_create_parent_false_routes_to_connector(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    connector_config.allowed_add_types = ["tos", "git"]
+    monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: True)
+    service._add_resource_via_connector = AsyncMock(return_value={"status": "accepted"})
+    service.enqueue_git_add_resource = AsyncMock()
+
+    result = await service.add_resource(
+        path="https://git.example/org/repo.git",
+        ctx=ctx,
+        to="viking://resources/repo",
+        create_parent=False,
+    )
+
+    assert result == {"status": "accepted"}
+    service.enqueue_git_add_resource.assert_not_awaited()
+    service._add_resource_via_connector.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connector_import_without_target_is_rejected(
     monkeypatch,
     connector_config,
     ctx,
@@ -304,14 +496,14 @@ async def test_connector_import_without_target_keeps_resource_id_unset(
     )
     _install_connector_dependencies(monkeypatch, tracker, connector_client)
 
-    result = await service._add_resource_via_connector(
-        path="tos://bucket/prefix",
-        ctx=ctx,
-        parent=None,
-    )
+    with pytest.raises(InvalidArgumentError, match="exact 'to' target"):
+        await service._add_resource_via_connector(
+            path="tos://bucket/prefix",
+            ctx=ctx,
+            to=None,
+        )
 
-    assert "resource_id" not in result
-    assert tracker.create.await_args.kwargs["resource_id"] is None
+    tracker.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -324,23 +516,105 @@ async def test_connector_import_rejects_target_outside_public_resources_root(
         await service.add_resource(
             path="tos://bucket/prefix",
             ctx=ctx,
-            parent="viking://user/alice/resources/spec",
+            to="viking://user/alice/resources/spec",
         )
 
 
 @pytest.mark.asyncio
-async def test_connector_import_rejects_nonempty_args(
+async def test_connector_import_rejects_unsupported_args(
     connector_config,
     ctx,
     service,
 ):
-    with pytest.raises(InvalidArgumentError, match="args"):
+    with pytest.raises(InvalidArgumentError, match="args keys"):
         await service.add_resource(
             path="tos://bucket/prefix",
             ctx=ctx,
-            parent="viking://resources/spec",
+            to="viking://resources/spec",
             args={"parser": "pdf"},
         )
+
+
+def test_git_source_falls_back_for_wait(connector_config, service):
+    connector_config.allowed_add_types = ["tos", "git"]
+
+    assert (
+        service._should_use_connector(
+            "https://git.example/org/repo.git",
+            to="viking://resources/repo",
+            wait=True,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_tos_connector_rejects_wait(connector_config, ctx, service):
+    with pytest.raises(InvalidArgumentError, match="wait=true"):
+        await service.add_resource(
+            path="tos://bucket/prefix",
+            ctx=ctx,
+            to="viking://resources/imports",
+            wait=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_monitor_links_reason_memory_on_success(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    tracker = _task_tracker()
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: tracker,
+    )
+    client = SimpleNamespace(get_task_info=AsyncMock(return_value={"Status": "succeeded"}))
+    service._link_resource_reason_memory = AsyncMock()
+
+    outcome = await service._monitor_connector_task(
+        client=client,
+        connector_task_key="connector-1",
+        ov_task_id="task-1",
+        poll_interval_ms=10,
+        timeout_seconds=5,
+        ctx=ctx,
+        reason="track quarterly reports",
+        link_root_uri="viking://resources/imports",
+    )
+
+    assert outcome["status"] == "completed"
+    tracker.complete.assert_awaited_once()
+    link_kwargs = service._link_resource_reason_memory.await_args.kwargs
+    assert link_kwargs["reason"] == "track quarterly reports"
+    assert link_kwargs["result"] == {"root_uri": "viking://resources/imports"}
+
+
+@pytest.mark.asyncio
+async def test_git_reason_routes_to_connector(
+    monkeypatch,
+    connector_config,
+    ctx,
+    service,
+):
+    connector_config.allowed_add_types = ["tos", "git"]
+    monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: True)
+    service._add_resource_via_connector = AsyncMock(return_value={"status": "accepted"})
+    service.enqueue_git_add_resource = AsyncMock()
+
+    result = await service.add_resource(
+        path="https://git.example/org/repo.git",
+        ctx=ctx,
+        to="viking://resources/imports",
+        reason="track quarterly reports",
+    )
+
+    assert result == {"status": "accepted"}
+    service.enqueue_git_add_resource.assert_not_awaited()
+    connector_kwargs = service._add_resource_via_connector.await_args.kwargs
+    assert connector_kwargs["reason"] == "track quarterly reports"
 
 
 @pytest.mark.asyncio
@@ -375,7 +649,7 @@ async def test_monitor_connector_task_maps_terminal_status(
     monkeypatch.setattr(resource_service_module.asyncio, "sleep", no_sleep)
     client = SimpleNamespace(get_task_info=AsyncMock(return_value=task_info))
 
-    await ResourceService()._monitor_connector_task(
+    outcome = await ResourceService()._monitor_connector_task(
         client=client,
         connector_task_key="connector-1",
         ov_task_id="task-1",
@@ -386,9 +660,11 @@ async def test_monitor_connector_task_maps_terminal_status(
 
     assert tracker.update_stage.await_args.args[1] == expected_stage
     if expected_error is None:
+        assert outcome["status"] == "completed"
         tracker.complete.assert_awaited_once()
         tracker.fail.assert_not_awaited()
     else:
+        assert outcome == {"status": "failed", "error": expected_error}
         assert tracker.fail.await_args.args[1] == expected_error
         tracker.complete.assert_not_awaited()
 

--- a/tests/unit/test_connector_config.py
+++ b/tests/unit/test_connector_config.py
@@ -14,6 +14,12 @@ def test_connector_config_is_opt_in_and_tos_only_by_default():
     assert config.allowed_add_types == ["tos"]
 
 
+def test_connector_config_accepts_arbitrary_add_types():
+    config = ConnectorConfig(allowed_add_types=["tos", "git", "custom"])
+
+    assert config.allowed_add_types == ["tos", "git", "custom"]
+
+
 def test_openviking_config_parses_connector_section():
     config = OpenVikingConfig.from_dict(
         {


### PR DESCRIPTION
## Description

Adds Connector-backed Git repository imports to `add_resource`. Git sources are detected with the same repository-URL predicate used by the native `GitAccessor` (`is_git_repo_url`), covering `git@`, `ssh://`, and `git://` URLs as well as supported HTTP(S) code-hosting URLs.

When the Connector is enabled and `git` is in `allowed_add_types`, OpenViking submits the repository with `add_type="git"`. The exact OpenViking destination is transported as the top-level `to` field; source-specific settings (`repo_url`, optional `branch`) travel in `param_config`; source credentials (`args.token` / `args.username`) travel exclusively in the dedicated top-level `auth_config` field, which is redacted from request logs on every hop and never merged into `param_config`.

Connector imports are strictly asynchronous: `wait=True` is not delegated. Because `git` is a shared source type, a Git request the Connector cannot honor (e.g. `wait=True`, `include`, or a missing `to`) falls back to the existing native pipeline; `tos` remains Connector-only and rejects such requests early. `reason` is supported by linking one reason memory to the import root after the Connector task succeeds, and an explicit `create_parent=false` is enforced by verifying the parent of `to` exists before submission.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

**Breaking change details:** Connector imports now require an exact `to` target and no longer accept `parent`. Existing `tos://` imports that passed `parent="viking://resources/x"` (or relied on a default target) must switch to `to="viking://resources/x/<name>"`. The Connector request payload replaces `path_prefix` with the top-level `to` field; the external Connector deployment must be upgraded in lockstep (it rejects `path_prefix` for `backend=ov`).

## Changes Made

- Added shared Connector source routing in `connector/routing.py`: per-type detection (`tos` by scheme, `git` via `is_git_repo_url`), `CONNECTOR_SUPPORTED_ARGS` (git: `branch`/`ref`), and `CONNECTOR_CREDENTIAL_ARGS` (git: `token`/`username`).
- Extended `ConnectorClient.submit_doc_add()` with top-level `to`, `param_config`, and `auth_config`; removed `path_prefix`.
- Git payload generation: `param_config.repo_url` from the request path; `args.branch`/`args.ref` select the branch (`branch` wins); credentials go to `auth_config` only.
- Per-source argument validation: whitelisted args pass through; anything else degrades shared sources to the native pipeline and rejects Connector-only sources early. `wait=True` is treated as unsupported for Connector delegation.
- `create_parent=false` is honored by checking that the parent of `to` pre-exists; the HTTP router now distinguishes an omitted `create_parent` from an explicit `false` via `model_fields_set`.
- `reason` support: the background task monitor links one reason memory to the import root after the Connector task reaches `succeeded`.
- Reworked the Connector task monitor to return structured terminal outcomes and propagate memory-linking results and warnings.
- Updated the local input guard to identify configured Connector sources by detected source type.
- Unit coverage for routing/fallback, branch/ref handling, credential isolation (never in `param_config`), `to` validation, `create_parent` semantics, wait rejection/fallback, reason linking, and terminal task-state mapping.

## Testing

- [x] I have added tests that prove the feature works
- [x] Relevant new and existing Connector unit tests pass locally
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

`pytest -q tests/connector/test_client.py tests/service/test_resource_service_connector.py`

Result: `35 passed`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Relevant tests pass
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Git imports use the Connector only when the integration is enabled and `git` is in `allowed_add_types`; otherwise they retain the existing native Git
- Deployment ordering: the external Connector service must be upgraded **before** this change ships. An older Connector ignores the unknown `to` field and would silently place `tos` imports at the resources root.
- Credentials are one-shot: they are never persisted by OpenViking and never appear in `param_config` or request logs. Known trade-off: `token` has no , so a Git request carrying `token` that falls back to the native pipeline (e.g. `wait=True` or a missing `to`) will clone without authentication andfail on private repositories.
- Connector source routing currently recognizes the official `tos` and `git` types. Future source types should extend the shared detection, supported-agument definitions.