### PR TITLE
fix(auth): refresh API keys across instances

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1432,6 +1432,7 @@ When running OpenViking as an HTTP service, add a `server` section to `ov.conf`:
     "port": 1933,
     "auth_mode": "api_key",
     "root_api_key": "your-secret-root-key",
+    "api_key_cache_ttl_seconds": 30,
     "profile_enabled": false,
     "cors_origins": ["*"],
     "public_base_url": "https://ov.example.com",
@@ -1457,6 +1458,7 @@ When running OpenViking as an HTTP service, add a `server` section to `ov.conf`:
 | `port` | int | Bind port | `1933` |
 | `auth_mode` | str | Authentication mode: `"api_key"` or `"trusted"`. Default is `"api_key"` | `"api_key"` |
 | `root_api_key` | str | Root API key for multi-tenant auth in `api_key` mode. In `trusted` mode it is optional on localhost, but required for any non-localhost deployment; it does not become the source of user identity | `null` |
+| `api_key_cache_ttl_seconds` | float | Maximum age of the in-process account and API-key cache. The next authenticated request reloads shared account state after this interval; values must be greater than zero. | `30` |
 | `profile_enabled` | bool | Whether to allow request-scoped cProfile via `profile=1` on HTTP requests. When disabled, the server ignores that query parameter. When enabled, the CLI can display the returned `profile`, while the Python HTTP client currently triggers profiling but does not automatically attach the top-level `profile` field to most SDK return values. | `false` |
 | `cors_origins` | list | Allowed CORS origins | `["*"]` |
 | `public_base_url` | str | Public-facing base URL emitted in MCP-issued upload instructions. Resolution order: env var `OPENVIKING_PUBLIC_BASE_URL` → this field → `X-Forwarded-Host`/`X-Forwarded-Proto` request headers → `Host` request header → listen-address fallback. Set this (or the env var) when the server runs behind a reverse proxy that does not forward `X-Forwarded-*` headers. | `null` |
@@ -1692,6 +1694,7 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     "host": "127.0.0.1",
     "port": 1933,
     "root_api_key": "string",
+    "api_key_cache_ttl_seconds": 30,
     "cors_origins": ["*"]
   }
 }

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1399,6 +1399,7 @@ openviking add-resource ./docs --exclude "*.tmp"
     "port": 1933,
     "auth_mode": "api_key",
     "root_api_key": "your-secret-root-key",
+    "api_key_cache_ttl_seconds": 30,
     "profile_enabled": false,
     "cors_origins": ["*"],
     "public_base_url": "https://ov.example.com",
@@ -1424,6 +1425,7 @@ openviking add-resource ./docs --exclude "*.tmp"
 | `port` | int | 绑定端口 | `1933` |
 | `auth_mode` | str | 认证模式：`"api_key"` 或 `"trusted"`。默认值为 `"api_key"` | `"api_key"` |
 | `root_api_key` | str | Root API Key。在 `api_key` 模式下启用多租户认证；在 `trusted` 模式下它只是可选附加保护，不负责解析普通用户身份 | `null` |
+| `api_key_cache_ttl_seconds` | float | 进程内账户与 API Key 缓存的最长存活时间。超过该时间后，下一次认证请求会重新读取共享账户状态；必须大于 0。 | `30` |
 | `profile_enabled` | bool | 是否允许 HTTP 请求通过 `profile=1` 开启请求级 cProfile。关闭时服务端会忽略该请求参数；开启后，CLI 可以显示返回的 `profile`，而 Python HTTP client 默认只触发服务端 profile，不会把顶层 `profile` 字段自动附着到大多数 SDK 返回值上。 | `false` |
 | `cors_origins` | list | CORS 允许的来源 | `["*"]` |
 | `public_base_url` | str | MCP `add_resource` 工具向客户端返回的上传指令里使用的对外可见 base URL。解析顺序：环境变量 `OPENVIKING_PUBLIC_BASE_URL` → 本字段 → 请求头 `X-Forwarded-Host` / `X-Forwarded-Proto` → 请求头 `Host` → 监听地址兜底。当 server 部署在反向代理后且代理不转发 `X-Forwarded-*` 时，请显式设置本字段（或环境变量）。 | `null` |
@@ -1659,6 +1661,7 @@ Task 记录文件位于所属账号的系统目录：
     "host": "string",
     "port": 1933,
     "root_api_key": "string",
+    "api_key_cache_ttl_seconds": 30,
     "cors_origins": ["string"]
   }
 }

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -69,6 +69,7 @@ class LegacyAPIKeyManager:
         root_key: str,
         viking_fs: VikingFS,
         api_key_hashing_enabled: bool = False,
+        accounts_cache_ttl_seconds: float = ACCOUNTS_CACHE_TTL_SECONDS,
     ):
         """Initialize APIKeyManager.
 
@@ -77,11 +78,14 @@ class LegacyAPIKeyManager:
             viking_fs: VikingFS client for persistent storage of user keys.
             api_key_hashing_enabled: Whether API key Argon2id hashing is enabled.
                 Default: false - rely on file-level AES encryption for protection.
+            accounts_cache_ttl_seconds: Maximum age of the in-process account
+                cache before the next authenticated request reloads it.
         """
         self._root_key = root_key
         self._viking_fs = viking_fs
         self._async_agfs = AsyncAGFSClient(viking_fs.agfs)
         self._api_key_hashing_enabled = api_key_hashing_enabled
+        self._accounts_cache_ttl_seconds = accounts_cache_ttl_seconds
         self._accounts: Dict[str, AccountInfo] = {}
         # Prefix index: key_prefix -> list[UserKeyEntry]
         self._prefix_index: Dict[str, list[UserKeyEntry]] = {}
@@ -246,7 +250,7 @@ class LegacyAPIKeyManager:
     def _cache_is_stale(self) -> bool:
         if self._loaded_at is None:
             return True
-        return time.monotonic() - self._loaded_at >= ACCOUNTS_CACHE_TTL_SECONDS
+        return time.monotonic() - self._loaded_at >= self._accounts_cache_ttl_seconds
 
     def _miss_refresh_is_due(self) -> bool:
         if self._last_miss_refresh_at is None:

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Legacy API Key management (original implementation)."""
 
+import asyncio
 import fnmatch
 import hashlib
 import hmac
 import json
 import secrets
+import time
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
@@ -44,6 +46,14 @@ LEGACY_ARGON2_MEMORY_COST = ARGON2_MEMORY_COST
 LEGACY_ARGON2_PARALLELISM = ARGON2_PARALLELISM
 LEGACY_ARGON2_HASH_LENGTH = ARGON2_HASH_LENGTH
 
+# Multi-instance deployments share AGFS state while keeping one in-process
+# account cache per server. Known entries are refreshed periodically, and a
+# cache miss may refresh sooner so a key created by a peer becomes usable
+# promptly. The shorter interval globally bounds attacker-controlled misses:
+# distinct invalid keys cannot each trigger a full AGFS reload.
+ACCOUNTS_CACHE_TTL_SECONDS = 30.0
+CACHE_MISS_REFRESH_MIN_INTERVAL_SECONDS = 1.0
+
 
 def derive_seeded_api_key_secret(user_id: str, seed: str) -> str:
     if not isinstance(seed, str) or seed == "":
@@ -75,6 +85,11 @@ class LegacyAPIKeyManager:
         self._accounts: Dict[str, AccountInfo] = {}
         # Prefix index: key_prefix -> list[UserKeyEntry]
         self._prefix_index: Dict[str, list[UserKeyEntry]] = {}
+        self._loaded_at: Optional[float] = None
+        self._last_miss_refresh_at: Optional[float] = None
+        # Construct lazily because managers may be created outside an event
+        # loop. All request-triggered reloads share this process-wide lock.
+        self._reload_lock: Optional[asyncio.Lock] = None
 
     def _discard_account_state(self, account_id: str) -> None:
         """Remove an account and its key index entries from in-memory state."""
@@ -111,68 +126,85 @@ class LegacyAPIKeyManager:
             logger.exception("Failed to persist rollback for account %s", account_id)
 
     async def load(self) -> None:
-        """Load accounts and user keys from VikingFS into memory."""
-        accounts_data = await self._read_json(ACCOUNTS_PATH)
-        if accounts_data is None:
-            # First run: create default account
-            now = datetime.now(timezone.utc).isoformat()
-            accounts_data = {"accounts": {"default": {"created_at": now}}}
-            await self._write_json(ACCOUNTS_PATH, accounts_data)
+        """Load accounts and user keys from VikingFS into memory.
 
-        for account_id, info in accounts_data.get("accounts", {}).items():
-            users_path = USERS_PATH_TEMPLATE.format(account_id=account_id)
-            users_data = await self._read_json(users_path)
-            users = users_data.get("users", {}) if users_data else {}
+        Repeated loads replace the cache so peer-instance deletions and key
+        rotations are reflected. If a storage read fails, the last complete
+        cache remains available instead of exposing partial state.
+        """
+        previous_accounts = self._accounts
+        previous_prefix_index = self._prefix_index
+        self._accounts = {}
+        self._prefix_index = {}
+        try:
+            accounts_data = await self._read_json(ACCOUNTS_PATH)
+            if accounts_data is None:
+                # First run: create default account
+                now = datetime.now(timezone.utc).isoformat()
+                accounts_data = {"accounts": {"default": {"created_at": now}}}
+                await self._write_json(ACCOUNTS_PATH, accounts_data)
 
-            self._accounts[account_id] = AccountInfo(
-                created_at=info.get("created_at", ""),
-                users=users,
-            )
+            for account_id, info in accounts_data.get("accounts", {}).items():
+                users_path = USERS_PATH_TEMPLATE.format(account_id=account_id)
+                users_data = await self._read_json(users_path)
+                users = users_data.get("users", {}) if users_data else {}
 
-            for user_id, user_info in users.items():
-                key_or_hash = user_info.get("key", "")
-                if key_or_hash:
-                    # Check if it's a hashed key
-                    if key_or_hash.startswith("$argon2"):
-                        # Already hashed
-                        stored_key = key_or_hash
-                        is_hashed = True
-                        key_prefix = user_info.get("key_prefix", "")
-                    else:
-                        # Plaintext key
-                        if self._api_key_hashing_enabled:
-                            # If API key hashing enabled, migrate to hashed
-                            stored_key = self._hash_api_key(key_or_hash)
-                            is_hashed = True
-                            key_prefix = self._get_key_prefix(key_or_hash)
-                            # Update storage
-                            user_info["key"] = stored_key
-                            user_info["key_prefix"] = key_prefix
-                            await self._save_users_json(account_id)
-                            logger.info(
-                                "Migrated API key for user %s in account %s", user_id, account_id
-                            )
-                        else:
-                            # If API key hashing not enabled, keep as plaintext
+                self._accounts[account_id] = AccountInfo(
+                    created_at=info.get("created_at", ""),
+                    users=users,
+                )
+
+                for user_id, user_info in users.items():
+                    key_or_hash = user_info.get("key", "")
+                    if key_or_hash:
+                        # Check if it's a hashed key
+                        if key_or_hash.startswith("$argon2"):
+                            # Already hashed
                             stored_key = key_or_hash
-                            is_hashed = False
-                            # For plaintext keys, compute prefix on the fly for indexing
-                            key_prefix = self._get_key_prefix(key_or_hash)
+                            is_hashed = True
+                            key_prefix = user_info.get("key_prefix", "")
+                        else:
+                            # Plaintext key
+                            if self._api_key_hashing_enabled:
+                                # If API key hashing enabled, migrate to hashed
+                                stored_key = self._hash_api_key(key_or_hash)
+                                is_hashed = True
+                                key_prefix = self._get_key_prefix(key_or_hash)
+                                # Update storage
+                                user_info["key"] = stored_key
+                                user_info["key_prefix"] = key_prefix
+                                await self._save_users_json(account_id)
+                                logger.info(
+                                    "Migrated API key for user %s in account %s",
+                                    user_id,
+                                    account_id,
+                                )
+                            else:
+                                # If API key hashing not enabled, keep as plaintext
+                                stored_key = key_or_hash
+                                is_hashed = False
+                                # For plaintext keys, compute prefix on the fly for indexing
+                                key_prefix = self._get_key_prefix(key_or_hash)
 
-                    entry = UserKeyEntry(
-                        account_id=account_id,
-                        user_id=user_id,
-                        role=Role(user_info.get("role", "user")),
-                        key_or_hash=stored_key,
-                        is_hashed=is_hashed,
-                    )
+                        entry = UserKeyEntry(
+                            account_id=account_id,
+                            user_id=user_id,
+                            role=Role(user_info.get("role", "user")),
+                            key_or_hash=stored_key,
+                            is_hashed=is_hashed,
+                        )
 
-                    # Add to prefix index
-                    if key_prefix:
-                        if key_prefix not in self._prefix_index:
-                            self._prefix_index[key_prefix] = []
-                        self._prefix_index[key_prefix].append(entry)
+                        # Add to prefix index
+                        if key_prefix:
+                            if key_prefix not in self._prefix_index:
+                                self._prefix_index[key_prefix] = []
+                            self._prefix_index[key_prefix].append(entry)
+        except Exception:
+            self._accounts = previous_accounts
+            self._prefix_index = previous_prefix_index
+            raise
 
+        self._loaded_at = time.monotonic()
         logger.info(
             "LegacyAPIKeyManager loaded: %d accounts, %d user keys",
             len(self._accounts),
@@ -210,6 +242,80 @@ class LegacyAPIKeyManager:
                     )
 
         raise UnauthenticatedError("Invalid API Key")
+
+    def _cache_is_stale(self) -> bool:
+        if self._loaded_at is None:
+            return True
+        return time.monotonic() - self._loaded_at >= ACCOUNTS_CACHE_TTL_SECONDS
+
+    def _miss_refresh_is_due(self) -> bool:
+        if self._last_miss_refresh_at is None:
+            return True
+        return (
+            time.monotonic() - self._last_miss_refresh_at >= CACHE_MISS_REFRESH_MIN_INTERVAL_SECONDS
+        )
+
+    def _get_reload_lock(self) -> asyncio.Lock:
+        if self._reload_lock is None:
+            self._reload_lock = asyncio.Lock()
+        return self._reload_lock
+
+    async def _refresh_if_stale(self) -> None:
+        if not self._cache_is_stale():
+            return
+        async with self._get_reload_lock():
+            if self._cache_is_stale():
+                await self.load()
+
+    async def _refresh_on_miss(self) -> None:
+        """Reload at most once per process-wide miss interval.
+
+        The bound is intentionally independent of the presented key. A
+        per-key negative cache still lets a stream of distinct invalid keys
+        amplify unauthenticated traffic into one full AGFS reload per key.
+        """
+        reload_lock = self._get_reload_lock()
+        if not self._miss_refresh_is_due():
+            # A peer request may have reserved the global interval before its
+            # load completes. Wait for that in-flight refresh so callers do
+            # not retry against the old cache.
+            if reload_lock.locked():
+                async with reload_lock:
+                    pass
+            return
+        async with reload_lock:
+            if self._miss_refresh_is_due():
+                # Stamp before I/O so a failing storage backend is still
+                # protected from request-driven retry amplification.
+                self._last_miss_refresh_at = time.monotonic()
+                await self.load()
+
+    async def resolve_with_refresh(
+        self,
+        api_key: str,
+        *,
+        resolve_callable: Optional[Callable[[str], ResolvedIdentity]] = None,
+    ) -> ResolvedIdentity:
+        """Resolve with bounded cross-instance cache freshness.
+
+        Known keys refresh on the normal TTL. A missing key may trigger one
+        earlier reload, globally rate-limited across all key values, before
+        authentication fails. ``resolve_callable`` lets the new-format
+        manager reuse the same refresh contract without private duplication.
+        """
+        resolver = resolve_callable or self.resolve
+        # Root authentication is process-local and does not depend on the
+        # shared account cache. Keep this recovery path available even when
+        # AGFS is unavailable or the user-key cache has expired.
+        if api_key and hmac.compare_digest(api_key, self._root_key):
+            return resolver(api_key)
+
+        await self._refresh_if_stale()
+        try:
+            return resolver(api_key)
+        except UnauthenticatedError:
+            await self._refresh_on_miss()
+            return resolver(api_key)
 
     async def create_account(
         self,
@@ -381,7 +487,9 @@ class LegacyAPIKeyManager:
 
         await self._save_users_json(account_id)
 
-    async def regenerate_key(self, account_id: str, user_id: str, seed: Optional[str] = None) -> str:
+    async def regenerate_key(
+        self, account_id: str, user_id: str, seed: Optional[str] = None
+    ) -> str:
         """Regenerate a user's API key. Old key is immediately invalidated."""
         account = self._accounts.get(account_id)
         if account is None:

--- a/openviking/server/api_keys/new.py
+++ b/openviking/server/api_keys/new.py
@@ -12,6 +12,7 @@ import secrets
 from typing import Optional, Tuple
 
 from openviking.server.api_keys.legacy import (
+    ACCOUNTS_CACHE_TTL_SECONDS,
     LegacyAPIKeyManager,
     derive_seeded_api_key_secret,
 )
@@ -84,6 +85,7 @@ class NewAPIKeyManager:
         root_key: str,
         viking_fs: VikingFS,
         api_key_hashing_enabled: bool = False,
+        accounts_cache_ttl_seconds: float = ACCOUNTS_CACHE_TTL_SECONDS,
     ):
         """Initialize NewAPIKeyManager.
 
@@ -92,10 +94,15 @@ class NewAPIKeyManager:
             viking_fs: VikingFS client for persistent storage of user keys.
             api_key_hashing_enabled: Whether API key Argon2id hashing is enabled.
                 Default: false - rely on file-level AES encryption for protection.
+            accounts_cache_ttl_seconds: Maximum age of the in-process account
+                cache before the next authenticated request reloads it.
         """
         # Delegate to legacy manager for all core functionality
         self._legacy = LegacyAPIKeyManager(
-            root_key, viking_fs, api_key_hashing_enabled=api_key_hashing_enabled
+            root_key,
+            viking_fs,
+            api_key_hashing_enabled=api_key_hashing_enabled,
+            accounts_cache_ttl_seconds=accounts_cache_ttl_seconds,
         )
 
     async def load(self) -> None:

--- a/openviking/server/api_keys/new.py
+++ b/openviking/server/api_keys/new.py
@@ -64,9 +64,7 @@ def generate_api_key(account_id: str, user_id: str, seed: Optional[str] = None) 
     account_segment = _encode_segment(account_id)
     user_segment = _encode_segment(user_id)
     secret = (
-        derive_seeded_api_key_secret(user_id, seed)
-        if seed is not None
-        else secrets.token_hex(32)
+        derive_seeded_api_key_secret(user_id, seed) if seed is not None else secrets.token_hex(32)
     )
     secret_segment = _encode_segment(secret)
     return f"{account_segment}.{user_segment}.{secret_segment}"
@@ -160,6 +158,13 @@ class NewAPIKeyManager:
 
         # Fall back to legacy resolver for legacy keys
         return self._legacy.resolve(api_key)
+
+    async def resolve_with_refresh(self, api_key: str) -> ResolvedIdentity:
+        """Resolve using the legacy manager's bounded refresh contract."""
+        return await self._legacy.resolve_with_refresh(
+            api_key,
+            resolve_callable=self.resolve,
+        )
 
     async def create_account(
         self,

--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -82,7 +82,7 @@ class ApiKeyAuthPlugin(AuthPlugin):
         if oauth_identity is not None:
             return oauth_identity
 
-        identity = api_key_manager.resolve(api_key)
+        identity = await api_key_manager.resolve_with_refresh(api_key)
         identity.account_id = identity.account_id or "default"
         identity.user_id = identity.user_id or "default"
 

--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -200,6 +200,7 @@ class ApiKeyAuthPlugin(AuthPlugin):
             root_key=config.root_api_key,
             viking_fs=service.viking_fs,
             api_key_hashing_enabled=config.api_key_hashing_enabled,
+            accounts_cache_ttl_seconds=config.api_key_cache_ttl_seconds,
         )
         await api_key_manager.load()
         app.state.api_key_manager = api_key_manager

--- a/openviking/server/auth/plugins/trusted.py
+++ b/openviking/server/auth/plugins/trusted.py
@@ -213,6 +213,7 @@ class TrustedAuthPlugin(AuthPlugin):
                 root_key=config.root_api_key,
                 viking_fs=service.viking_fs,
                 api_key_hashing_enabled=config.api_key_hashing_enabled,
+                accounts_cache_ttl_seconds=config.api_key_cache_ttl_seconds,
             )
             await api_key_manager.load()
             app.state.api_key_manager = api_key_manager

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -256,6 +256,7 @@ class ServerConfig(BaseModel):
     bot_api_url: str = "http://localhost:18790"  # Vikingbot OpenAPIChannel URL (default port)
     encryption_enabled: bool = False  # Whether file-level AES encryption is enabled
     api_key_hashing_enabled: bool = False  # Whether API key Argon2id hashing is enabled (default: false, rely on file encryption)
+    api_key_cache_ttl_seconds: float = Field(default=30.0, gt=0)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     usage_reporter: UsageReporterConfig = Field(default_factory=UsageReporterConfig)
     # Public-facing base URL emitted in MCP-issued upload instructions. See

--- a/tests/server/test_api_key_cache_freshness.py
+++ b/tests/server/test_api_key_cache_freshness.py
@@ -11,6 +11,7 @@ import pytest
 
 from openviking.server.api_keys import APIKeyManager
 from openviking.server.api_keys.legacy import ACCOUNTS_CACHE_TTL_SECONDS
+from openviking.server.config import ServerConfig
 from openviking.server.identity import Role
 from openviking_cli.exceptions import UnauthenticatedError
 
@@ -31,13 +32,40 @@ class FakeSharedStorage:
         self.values[path] = deepcopy(value)
 
 
-def _manager(storage: FakeSharedStorage) -> APIKeyManager:
+def _manager(
+    storage: FakeSharedStorage,
+    *,
+    accounts_cache_ttl_seconds: float = ACCOUNTS_CACHE_TTL_SECONDS,
+) -> APIKeyManager:
     viking_fs = MagicMock()
     viking_fs.agfs = MagicMock()
-    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    manager = APIKeyManager(
+        root_key=ROOT_KEY,
+        viking_fs=viking_fs,
+        accounts_cache_ttl_seconds=accounts_cache_ttl_seconds,
+    )
     manager._legacy._read_json = storage.read_json
     manager._legacy._write_json = storage.write_json
     return manager
+
+
+def test_server_cache_ttl_configuration_is_positive():
+    assert ServerConfig().api_key_cache_ttl_seconds == ACCOUNTS_CACHE_TTL_SECONDS
+
+    with pytest.raises(ValueError):
+        ServerConfig(api_key_cache_ttl_seconds=0)
+
+
+async def test_configured_cache_ttl_controls_staleness():
+    manager = _manager(FakeSharedStorage(), accounts_cache_ttl_seconds=120.0)
+    await manager.load()
+
+    assert manager._legacy._loaded_at is not None
+    manager._legacy._loaded_at -= 119.0
+    assert manager._legacy._cache_is_stale() is False
+
+    manager._legacy._loaded_at -= 2.0
+    assert manager._legacy._cache_is_stale() is True
 
 
 async def test_peer_created_key_refreshes_on_first_cache_miss():

--- a/tests/server/test_api_key_cache_freshness.py
+++ b/tests/server/test_api_key_cache_freshness.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Multi-instance API-key cache freshness regressions for issue #2351."""
+
+import asyncio
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from openviking.server.api_keys import APIKeyManager
+from openviking.server.api_keys.legacy import ACCOUNTS_CACHE_TTL_SECONDS
+from openviking.server.identity import Role
+from openviking_cli.exceptions import UnauthenticatedError
+
+ROOT_KEY = "test-root-key-abcdef1234567890abcdef1234567890"
+
+
+class FakeSharedStorage:
+    """The JSON surface used by two managers sharing one AGFS backend."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, dict] = {}
+
+    async def read_json(self, path: str):
+        value = self.values.get(path)
+        return deepcopy(value) if value is not None else None
+
+    async def write_json(self, path: str, value: dict) -> None:
+        self.values[path] = deepcopy(value)
+
+
+def _manager(storage: FakeSharedStorage) -> APIKeyManager:
+    viking_fs = MagicMock()
+    viking_fs.agfs = MagicMock()
+    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    manager._legacy._read_json = storage.read_json
+    manager._legacy._write_json = storage.write_json
+    return manager
+
+
+async def test_peer_created_key_refreshes_on_first_cache_miss():
+    """A key created after a peer loaded becomes usable on its next request."""
+    storage = FakeSharedStorage()
+    writer = _manager(storage)
+    reader = _manager(storage)
+    await writer.load()
+    await reader.load()
+
+    account_id = "peer_created"
+    api_key = await writer.create_account(account_id, "alice")
+
+    with pytest.raises(UnauthenticatedError):
+        reader.resolve(api_key)
+
+    identity = await reader.resolve_with_refresh(api_key)
+    assert identity.account_id == account_id
+    assert identity.user_id == "alice"
+
+
+async def test_distinct_invalid_keys_share_global_miss_refresh_bound(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Attacker-controlled key cardinality cannot cause one reload per key."""
+    manager = _manager(FakeSharedStorage())
+    await manager.load()
+
+    real_load = manager._legacy.load
+    reload_count = 0
+
+    async def counted_load() -> None:
+        nonlocal reload_count
+        reload_count += 1
+        await real_load()
+
+    monkeypatch.setattr(manager._legacy, "load", counted_load)
+
+    for index in range(20):
+        with pytest.raises(UnauthenticatedError):
+            await manager.resolve_with_refresh(f"invalid-key-{index}")
+
+    assert reload_count == 1
+
+
+async def test_concurrent_peer_key_misses_deduplicate_reload(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    storage = FakeSharedStorage()
+    writer = _manager(storage)
+    reader = _manager(storage)
+    await writer.load()
+    await reader.load()
+
+    account_id = "concurrent_peer"
+    api_key = await writer.create_account(account_id, "alice")
+
+    real_load = reader._legacy.load
+    reload_count = 0
+
+    async def counted_load() -> None:
+        nonlocal reload_count
+        reload_count += 1
+        await asyncio.sleep(0.01)
+        await real_load()
+
+    monkeypatch.setattr(reader._legacy, "load", counted_load)
+
+    identities = await asyncio.gather(*(reader.resolve_with_refresh(api_key) for _ in range(10)))
+
+    assert reload_count == 1
+    assert {identity.account_id for identity in identities} == {account_id}
+    assert {identity.user_id for identity in identities} == {"alice"}
+
+
+async def test_ttl_refresh_observes_peer_key_rotation():
+    storage = FakeSharedStorage()
+    writer = _manager(storage)
+    await writer.load()
+    account_id = "rotated_peer"
+    old_key = await writer.create_account(account_id, "alice")
+
+    reader = _manager(storage)
+    await reader.load()
+    assert reader.resolve(old_key).account_id == account_id
+
+    new_key = await writer.regenerate_key(account_id, "alice")
+    assert reader._legacy._loaded_at is not None
+    reader._legacy._loaded_at -= ACCOUNTS_CACHE_TTL_SECONDS + 1
+
+    identity = await reader.resolve_with_refresh(new_key)
+    assert identity.account_id == account_id
+    with pytest.raises(UnauthenticatedError):
+        reader.resolve(old_key)
+
+
+async def test_failed_reload_keeps_last_complete_cache(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    manager = _manager(FakeSharedStorage())
+    await manager.load()
+    account_id = "cached_account"
+    api_key = await manager.create_account(account_id, "alice")
+
+    async def failed_read(_path: str):
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(manager._legacy, "_read_json", failed_read)
+
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await manager._legacy.load()
+
+    assert manager.resolve(api_key).account_id == account_id
+
+
+async def test_root_key_bypasses_stale_shared_storage(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Root access remains available when only shared account storage fails."""
+    manager = _manager(FakeSharedStorage())
+    await manager.load()
+    assert manager._legacy._loaded_at is not None
+    manager._legacy._loaded_at -= ACCOUNTS_CACHE_TTL_SECONDS + 1
+
+    async def failed_read(_path: str):
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(manager._legacy, "_read_json", failed_read)
+
+    identity = await manager.resolve_with_refresh(ROOT_KEY)
+    assert identity.role is Role.ROOT

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -277,6 +277,39 @@ async def user_key(auth_app):
 # ---- Basic auth tests ----
 
 
+async def test_api_key_plugin_uses_async_cache_refresh_path():
+    """The current auth plugin must await the multi-instance refresh API."""
+
+    class RefreshOnlyManager:
+        def __init__(self):
+            self.called = False
+
+        async def resolve_with_refresh(self, api_key: str) -> ResolvedIdentity:
+            self.called = True
+            assert api_key == "peer-created-key"
+            return ResolvedIdentity(
+                role=Role.USER,
+                account_id="peer-account",
+                user_id="peer-user",
+            )
+
+        def resolve(self, _api_key: str) -> ResolvedIdentity:
+            raise AssertionError("synchronous resolve bypasses cross-instance refresh")
+
+    manager = RefreshOnlyManager()
+    request = _make_request(
+        "/api/v1/resources",
+        auth_enabled=True,
+        api_key_manager=manager,
+    )
+
+    identity = await resolve_identity(request, x_api_key="peer-created-key")
+
+    assert manager.called is True
+    assert identity.account_id == "peer-account"
+    assert identity.user_id == "peer-user"
+
+
 async def test_health_no_auth_required(auth_client: httpx.AsyncClient):
     """/health should be accessible without any API key."""
     resp = await auth_client.get("/health")


### PR DESCRIPTION
## Description

Refresh the in-process API-key cache so accounts and keys written by one OpenViking instance become visible to peer instances without a restart. The refresh path is bounded globally to avoid turning distinct invalid keys into one AGFS reload per request.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #2351

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Rebuild the API-key cache transactionally on a 30-second TTL so peer rotation and deletion become visible while a failed reload preserves the last complete cache.
- Refresh once on a cache miss with a process-wide one-second bound and an async lock, including concurrent miss deduplication.
- Await the refresh-aware resolver in the current auth plugin while keeping root authentication independent from shared-storage availability.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

- `python -m pytest tests/server/test_api_key_cache_freshness.py tests/server/test_auth.py::test_api_key_plugin_uses_async_cache_refresh_path tests/server/test_api_key_manager.py::test_new_api_key_manager_public_api_parity_with_legacy -q --no-cov` (8 passed)
- `ruff format --check` and `ruff check` on all changed Python files
- `python -m py_compile` on changed implementation and the new regression module
- `git diff --check`

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This is the atomic successor to closed, unmerged PR #2681. It intentionally excludes the deleted legacy auth module and unrelated parser changes from that PR.