### PR TITLE
fix(semantic): persist filename-keyed memory summary cache

### DIFF
--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -28,6 +28,7 @@ from openviking.session.memory.utils.resource_refs import (
     sync_memory_resource_refs,
 )
 from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+from openviking.storage.internal_names import MEMORY_SUMMARY_CACHE_FILENAME
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.viking_fs import VikingFS
@@ -50,7 +51,9 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_DERIVED_FILENAMES = frozenset({".abstract.md", ".overview.md", ".relations.json"})
+_DERIVED_FILENAMES = frozenset(
+    {".abstract.md", ".overview.md", ".relations.json", MEMORY_SUMMARY_CACHE_FILENAME}
+)
 _CREATE_ALLOWED_EXTENSIONS = frozenset(
     {
         ".md",

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -6,6 +6,7 @@ MULTIWRITE_PATH_LOCK_FILE = ".path.ovlock"
 MULTIWRITE_EXACT_LOCK_FILE_PREFIX = ".exact.ovlock."
 MULTIWRITE_REDIRECT_FILE = ".redirect.json"
 MULTIWRITE_SYNC_LOG_FILE = ".sync_log.json"
+MEMORY_SUMMARY_CACHE_FILENAME = ".summary_cache.json"
 
 MULTIWRITE_INTERNAL_FILE_NAMES = frozenset(
     {

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -3,6 +3,7 @@
 """SemanticProcessor: Processes messages from SemanticQueue, generates .abstract.md and .overview.md."""
 
 import asyncio
+import json
 import re
 import threading
 from contextlib import nullcontext
@@ -31,7 +32,6 @@ from openviking.parse.parsers.media.utils import (
     get_media_type,
 )
 from openviking.prompts import render_prompt
-from openviking.utils.ingest_options import IngestOptions
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.internal_names import MEMORY_SUMMARY_CACHE_FILENAME
@@ -50,6 +50,7 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI
@@ -596,15 +597,31 @@ class SemanticProcessor(DequeueHandlerBase):
 
             existing_summaries: Dict[str, str] = {}
             if msg.changes:
+                valid_summary_cache = False
                 try:
-                    old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
-                    if old_overview:
-                        existing_summaries = self._parse_overview_md(old_overview)
+                    raw_cache = await viking_fs.read_file(
+                        f"{dir_uri}/{MEMORY_SUMMARY_CACHE_FILENAME}", ctx=ctx
+                    )
+                    parsed_cache = self._parse_memory_summary_cache(raw_cache)
+                    if parsed_cache is not None:
+                        valid_summary_cache = True
+                        existing_summaries.update(parsed_cache)
                         logger.info(
-                            f"Parsed {len(existing_summaries)} existing summaries from overview.md"
+                            f"Loaded {len(existing_summaries)} summaries from memory sidecar cache"
                         )
                 except Exception as e:
-                    logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
+                    logger.debug(f"No memory summary sidecar found for {dir_uri}: {e}")
+
+                if not valid_summary_cache:
+                    try:
+                        old_overview = await viking_fs.read_file(f"{dir_uri}/.overview.md", ctx=ctx)
+                        if old_overview:
+                            existing_summaries.update(self._parse_overview_md(old_overview))
+                            logger.info(
+                                f"Parsed {len(existing_summaries)} existing summaries from overview.md"
+                            )
+                    except Exception as e:
+                        logger.debug(f"No existing overview.md found for {dir_uri}: {e}")
 
             changed_files: Set[str] = set()
             if msg.changes:
@@ -693,12 +710,14 @@ class SemanticProcessor(DequeueHandlerBase):
             overview, abstract = self._normalize_overview_generation(generated_content)
 
             try:
+                summary_cache = self._serialize_memory_summary_cache(completed_summaries)
                 wrote_semantics = await self._write_memory_directory_semantics(
                     msg=msg,
                     viking_fs=viking_fs,
                     dir_uri=dir_uri,
                     overview=overview,
                     abstract=abstract,
+                    summary_cache=summary_cache,
                     ctx=ctx,
                     lock=lock,
                 )
@@ -756,6 +775,7 @@ class SemanticProcessor(DequeueHandlerBase):
         dir_uri: str,
         overview: str,
         abstract: str,
+        summary_cache: str,
         ctx: Optional[RequestContext],
         lock: Optional[Dict[str, Any]] = None,
     ) -> bool:
@@ -764,6 +784,7 @@ class SemanticProcessor(DequeueHandlerBase):
             dir_uri=dir_uri,
             overview=overview,
             abstract=abstract,
+            summary_cache=summary_cache,
             ctx=ctx,
             is_stale=lambda: is_semantic_msg_stale(msg),
             lock=lock,
@@ -1299,6 +1320,40 @@ class SemanticProcessor(DequeueHandlerBase):
             summaries[current_file] = " ".join(current_summary_lines).strip()
 
         return summaries
+
+    def _parse_memory_summary_cache(self, cache_content: str) -> Optional[Dict[str, str]]:
+        """Parse the deterministic per-file cache, preserving invalid-vs-empty state."""
+        if not cache_content:
+            return None
+        try:
+            payload = json.loads(cache_content)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(payload, dict) or payload.get("version") != MEMORY_SUMMARY_CACHE_VERSION:
+            return None
+        entries = payload.get("entries")
+        if not isinstance(entries, dict):
+            return None
+        return {
+            name: summary
+            for name, summary in entries.items()
+            if isinstance(name, str) and isinstance(summary, str) and summary.strip()
+        }
+
+    def _serialize_memory_summary_cache(self, file_summaries: List[Dict[str, str]]) -> str:
+        """Serialize summaries by exact filename, independent of LLM headings."""
+        entries = {
+            item["name"]: item["summary"]
+            for item in file_summaries
+            if isinstance(item.get("name"), str)
+            and isinstance(item.get("summary"), str)
+            and item["summary"].strip()
+        }
+        return json.dumps(
+            {"version": MEMORY_SUMMARY_CACHE_VERSION, "entries": entries},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
 
     async def _generate_overview(
         self,

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -34,6 +34,7 @@ from openviking.prompts import render_prompt
 from openviking.utils.ingest_options import IngestOptions
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import LockAcquisitionError
+from openviking.storage.internal_names import MEMORY_SUMMARY_CACHE_FILENAME
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_lock import SemanticLockScope
@@ -56,6 +57,8 @@ from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+MEMORY_SUMMARY_CACHE_VERSION = 1
 
 
 @dataclass

--- a/openviking/storage/queuefs/semantic_sidecar.py
+++ b/openviking/storage/queuefs/semantic_sidecar.py
@@ -16,8 +16,9 @@ async def write_semantic_sidecars(
     dir_uri: str,
     overview: str,
     abstract: str,
-    ctx: Optional[RequestContext],
     is_stale: Callable[[], bool],
+    summary_cache: Optional[str] = None,
+    ctx: Optional[RequestContext] = None,
     lock: Optional[Dict[str, Any]] = None,
     log_prefix: str = "[Semantic]",
 ) -> bool:
@@ -26,9 +27,11 @@ async def write_semantic_sidecars(
         logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
         return False
 
+    sidecar_names = [".overview.md", ".abstract.md"]
+    if summary_cache is not None:
+        sidecar_names.append(".summary_cache.json")
     lock_paths = [
-        viking_fs._uri_to_path(f"{dir_uri}/.overview.md", ctx=ctx),
-        viking_fs._uri_to_path(f"{dir_uri}/.abstract.md", ctx=ctx),
+        viking_fs._uri_to_path(f"{dir_uri}/{name}", ctx=ctx) for name in sidecar_names
     ]
     sidecar_lease = lock
     owns_lease = sidecar_lease is None
@@ -38,7 +41,9 @@ async def write_semantic_sidecars(
         if is_stale():
             logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
             return False
-        await _write_sidecars(viking_fs, dir_uri, overview, abstract, ctx, sidecar_lease)
+        await _write_sidecars(
+            viking_fs, dir_uri, overview, abstract, summary_cache, ctx, sidecar_lease
+        )
         return True
     finally:
         if owns_lease:
@@ -50,6 +55,7 @@ async def _write_sidecars(
     dir_uri: str,
     overview: str,
     abstract: str,
+    summary_cache: Optional[str],
     ctx: Optional[RequestContext],
     lease_ref: Optional[Dict[str, Any]] = None,
 ) -> None:
@@ -66,3 +72,10 @@ async def _write_sidecars(
         ctx=ctx,
         lease_ref=lease_ref,
     )
+    if summary_cache is not None:
+        await viking_fs.write_file(
+            f"{dir_uri}/.summary_cache.json",
+            summary_cache,
+            ctx=ctx,
+            lease_ref=lease_ref,
+        )

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -49,7 +49,7 @@ from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.error_mapping import is_not_found_error, map_exception
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.expr import And, PathScope, RawDSL
-from openviking.storage.internal_names import STORAGE_INTERNAL_ENTRY_NAMES
+from openviking.storage.internal_names import MEMORY_SUMMARY_CACHE_FILENAME, STORAGE_INTERNAL_ENTRY_NAMES
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking.utils.time_utils import format_iso8601, get_current_timestamp, parse_iso_datetime
@@ -3787,7 +3787,9 @@ class VikingFS:
         ".abstract.md": ContextLevel.ABSTRACT,
         ".overview.md": ContextLevel.OVERVIEW,
     }
-    _NO_VECTOR_DERIVED = frozenset({".relations.json", ".ovgitignore"})
+    _NO_VECTOR_DERIVED = frozenset(
+        {".relations.json", ".ovgitignore", MEMORY_SUMMARY_CACHE_FILENAME}
+    )
 
     def _classify_restore_path(self, tree_path: str, *, deleted: bool) -> Optional[tuple]:
         """Classify a restore-affected tree path into a vector maintenance task.
@@ -3798,7 +3800,8 @@ class VikingFS:
         - ``dir/.abstract.md`` / ``dir/.overview.md`` → recompute (write) or
           delete (removal) ONLY that directory's L0/L1 vector:
           ``("reindex_marker"|"delete", dir_uri, ABSTRACT|OVERVIEW)``.
-        - ``.relations.json`` → ``None`` (not a vector text source).
+        - ``.relations.json`` / ``.summary_cache.json`` → ``None``
+          (not vector text sources).
         - anything else (a source file) → reindex (write) or delete (removal)
           its DETAIL vector:
           ``("reindex_file", file_uri, DETAIL)`` / ``("delete", file_uri, DETAIL)``.

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -49,7 +49,10 @@ from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.error_mapping import is_not_found_error, map_exception
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.expr import And, PathScope, RawDSL
-from openviking.storage.internal_names import MEMORY_SUMMARY_CACHE_FILENAME, STORAGE_INTERNAL_ENTRY_NAMES
+from openviking.storage.internal_names import (
+    MEMORY_SUMMARY_CACHE_FILENAME,
+    STORAGE_INTERNAL_ENTRY_NAMES,
+)
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking.utils.time_utils import format_iso8601, get_current_timestamp, parse_iso_datetime

--- a/tests/agfs/test_viking_fs_git.py
+++ b/tests/agfs/test_viking_fs_git.py
@@ -576,6 +576,18 @@ def test_classify_restore_path(vfs):
     # .relations.json has no vector side-effect
     assert vfs._classify_restore_path("resources/proj/.relations.json", deleted=False) is None
     assert vfs._classify_restore_path("resources/proj/.relations.json", deleted=True) is None
+    assert (
+        vfs._classify_restore_path(
+            "user/default/memories/preferences/.summary_cache.json", deleted=False
+        )
+        is None
+    )
+    assert (
+        vfs._classify_restore_path(
+            "user/default/memories/preferences/.summary_cache.json", deleted=True
+        )
+        is None
+    )
 
     # Per-file sidecars do NOT exist in production -> treated as ordinary source files
     assert vfs._classify_restore_path("resources/proj/x.md.abstract.md", deleted=False) == (

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -885,6 +885,21 @@ async def test_create_mode_invalid_extension_raises_400(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["create", "replace"])
+async def test_memory_summary_cache_rejects_direct_writes(mode):
+    coordinator = ContentWriteCoordinator(viking_fs=object())
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+
+    with pytest.raises(InvalidArgumentError, match="cannot write derived semantic file directly"):
+        await coordinator.write(
+            uri="viking://user/default/memories/preferences/.summary_cache.json",
+            content='{"version": 1, "entries": {"profile.md": "injected"}}',
+            mode=mode,
+            ctx=ctx,
+        )
+
+
+@pytest.mark.asyncio
 async def test_create_mode_parent_dirs_auto_created(monkeypatch):
     file_uri = "viking://user/default/memories/new_subdir/test.md"
     root_uri = "viking://user/default/memories"

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -173,7 +173,7 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         dir_uri=first.uri,
         overview="old overview",
         abstract="old abstract",
-        summary_cache=None,
+        summary_cache="old cache",
         ctx=None,
     )
     wrote_latest = await processor._write_memory_directory_semantics(
@@ -182,7 +182,7 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         dir_uri=latest.uri,
         overview="latest overview",
         abstract="latest abstract",
-        summary_cache=None,
+        summary_cache="latest cache",
         ctx=None,
     )
 
@@ -192,11 +192,13 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         [
             "/fake/viking/user/default/memories/preferences/.overview.md",
             "/fake/viking/user/default/memories/preferences/.abstract.md",
+            "/fake/viking/user/default/memories/preferences/.summary_cache.json",
         ]
     ]
     assert viking_fs.writes == [
         ("viking://user/default/memories/preferences/.overview.md", "latest overview"),
         ("viking://user/default/memories/preferences/.abstract.md", "latest abstract"),
+        ("viking://user/default/memories/preferences/.summary_cache.json", "latest cache"),
     ]
 
 

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for memory-context semantic enqueue deduplication (#769)."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -138,6 +139,10 @@ class _FakeMemoryDirFS:
             {"name": "second.md", "isDir": False},
         ]
 
+    async def read_file(self, uri, ctx=None):
+        del uri, ctx
+        return ""
+
 
 @pytest.mark.asyncio
 async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
@@ -167,6 +172,7 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         dir_uri=first.uri,
         overview="old overview",
         abstract="old abstract",
+        summary_cache=None,
         ctx=None,
     )
     wrote_latest = await processor._write_memory_directory_semantics(
@@ -175,6 +181,7 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         dir_uri=latest.uri,
         overview="latest overview",
         abstract="latest abstract",
+        summary_cache=None,
         ctx=None,
     )
 
@@ -233,6 +240,211 @@ async def test_memory_directory_summarizes_all_uncached_files(monkeypatch):
     )
 
     assert [item["name"] for item in summaries] == ["first.md", "second.md"]
+
+
+@pytest.mark.asyncio
+async def test_memory_directory_reuses_filename_keyed_summary_cache(monkeypatch):
+    processor = SemanticProcessor(max_concurrent_llm=4)
+    dir_uri = "viking://user/default/memories/preferences"
+    generated = []
+    overview_inputs = []
+    written = []
+
+    class CachedMemoryDirFS(_FakeMemoryDirFS):
+        async def read_file(self, uri, ctx=None):
+            del ctx
+            if uri.endswith("/.summary_cache.json"):
+                return json.dumps(
+                    {
+                        "version": 1,
+                        "entries": {
+                            "first.md": "cached:first.md",
+                            "second.md": "cached:second.md",
+                        },
+                    }
+                )
+            if uri.endswith("/.overview.md"):
+                return ""
+            raise FileNotFoundError(uri)
+
+    async def generate_file_summary(file_path, llm_sem=None, ctx=None):
+        del llm_sem, ctx
+        generated.append(file_path)
+        name = file_path.rsplit("/", 1)[-1]
+        return {"name": name, "summary": f"fresh:{name}"}
+
+    async def generate_overview(dir_uri, file_summaries, children_abstracts, llm_sem=None):
+        del dir_uri, children_abstracts, llm_sem
+        overview_inputs.extend(file_summaries)
+        return "overview"
+
+    async def write_semantics(**kwargs):
+        written.append(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: CachedMemoryDirFS(),
+    )
+    monkeypatch.setattr(processor, "_generate_single_file_summary", generate_file_summary)
+    monkeypatch.setattr(processor, "_generate_overview", generate_overview)
+    monkeypatch.setattr(
+        processor,
+        "_normalize_overview_generation",
+        lambda overview: (overview, "abstract"),
+    )
+    monkeypatch.setattr(processor, "_write_memory_directory_semantics", write_semantics)
+
+    await processor._process_memory_directory(
+        SemanticMsg(
+            uri=dir_uri,
+            context_type="memory",
+            changes={"modified": [f"{dir_uri}/first.md"]},
+            skip_vectorization=True,
+        )
+    )
+
+    assert generated == [f"{dir_uri}/first.md"]
+    assert overview_inputs == [
+        {"name": "first.md", "summary": "fresh:first.md"},
+        {"name": "second.md", "summary": "cached:second.md"},
+    ]
+    assert json.loads(written[0]["summary_cache"]) == {
+        "version": 1,
+        "entries": {
+            "first.md": "fresh:first.md",
+            "second.md": "cached:second.md",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_memory_directory_falls_back_to_overview_for_invalid_summary_cache(monkeypatch):
+    processor = SemanticProcessor(max_concurrent_llm=4)
+    dir_uri = "viking://user/default/memories/preferences"
+    generated = []
+    written = []
+
+    class InvalidCachedMemoryDirFS(_FakeMemoryDirFS):
+        async def read_file(self, uri, ctx=None):
+            del ctx
+            if uri.endswith("/.summary_cache.json"):
+                return '{"version": 2, "entries": {}}'
+            if uri.endswith("/.overview.md"):
+                return "### first.md\n\nold:first.md\n\n### second.md\n\nold:second.md"
+            raise FileNotFoundError(uri)
+
+    async def generate_file_summary(file_path, llm_sem=None, ctx=None):
+        del llm_sem, ctx
+        generated.append(file_path)
+        name = file_path.rsplit("/", 1)[-1]
+        return {"name": name, "summary": f"fresh:{name}"}
+
+    async def write_semantics(**kwargs):
+        written.append(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: InvalidCachedMemoryDirFS(),
+    )
+    monkeypatch.setattr(processor, "_generate_single_file_summary", generate_file_summary)
+    monkeypatch.setattr(processor, "_generate_overview", AsyncMock(return_value="overview"))
+    monkeypatch.setattr(
+        processor,
+        "_normalize_overview_generation",
+        lambda overview: (overview, "abstract"),
+    )
+    monkeypatch.setattr(processor, "_write_memory_directory_semantics", write_semantics)
+
+    await processor._process_memory_directory(
+        SemanticMsg(
+            uri=dir_uri,
+            context_type="memory",
+            changes={"modified": [f"{dir_uri}/first.md"]},
+            skip_vectorization=True,
+        )
+    )
+
+    assert generated == [f"{dir_uri}/first.md"]
+    assert json.loads(written[0]["summary_cache"])["entries"] == {
+        "first.md": "fresh:first.md",
+        "second.md": "old:second.md",
+    }
+
+
+@pytest.mark.asyncio
+async def test_memory_directory_retries_blank_cached_summary(monkeypatch):
+    processor = SemanticProcessor(max_concurrent_llm=4)
+    dir_uri = "viking://user/default/memories/preferences"
+    generated = []
+    written = []
+
+    class BlankCachedMemoryDirFS(_FakeMemoryDirFS):
+        async def read_file(self, uri, ctx=None):
+            del ctx
+            if uri.endswith("/.summary_cache.json"):
+                return json.dumps(
+                    {
+                        "version": 1,
+                        "entries": {
+                            "first.md": "cached:first.md",
+                            "second.md": "   ",
+                        },
+                    }
+                )
+            if uri.endswith("/.overview.md"):
+                return "### second.md\n\nstale:second.md"
+            raise FileNotFoundError(uri)
+
+    async def generate_file_summary(file_path, llm_sem=None, ctx=None):
+        del llm_sem, ctx
+        generated.append(file_path)
+        name = file_path.rsplit("/", 1)[-1]
+        return {"name": name, "summary": f"fresh:{name}"}
+
+    async def write_semantics(**kwargs):
+        written.append(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: BlankCachedMemoryDirFS(),
+    )
+    monkeypatch.setattr(processor, "_generate_single_file_summary", generate_file_summary)
+    monkeypatch.setattr(processor, "_generate_overview", AsyncMock(return_value="overview"))
+    monkeypatch.setattr(
+        processor,
+        "_normalize_overview_generation",
+        lambda overview: (overview, "abstract"),
+    )
+    monkeypatch.setattr(processor, "_write_memory_directory_semantics", write_semantics)
+
+    await processor._process_memory_directory(
+        SemanticMsg(
+            uri=dir_uri,
+            context_type="memory",
+            changes={"modified": []},
+            skip_vectorization=True,
+        )
+    )
+
+    assert generated == [f"{dir_uri}/second.md"]
+    assert json.loads(written[0]["summary_cache"]) == {
+        "version": 1,
+        "entries": {
+            "first.md": "cached:first.md",
+            "second.md": "fresh:second.md",
+        },
+    }
+
+
+def test_memory_summary_cache_distinguishes_valid_empty_from_invalid():
+    processor = SemanticProcessor()
+
+    assert processor._parse_memory_summary_cache('{"version": 1, "entries": {}}') == {}
+    assert processor._parse_memory_summary_cache("not-json") is None
+    assert processor._parse_memory_summary_cache('{"version": 2, "entries": {}}') is None
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -109,7 +109,8 @@ class _FakePathLock:
         self.acquired_batches = []
         self.release_calls = []
 
-    async def pathlock_acquire_exact_batch(self, paths):
+    async def pathlock_acquire_exact_batch(self, paths, timeout=None):
+        del timeout
         self.acquired_batches.append(paths)
         return {"id": "lock-1"}
 

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -126,8 +126,8 @@ class _FakeVikingFS:
         del ctx
         return f"/fake/{uri.replace('://', '/').strip('/')}"
 
-    async def write_file(self, uri, content, ctx=None):
-        del ctx
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        del ctx, lease_ref
         self.writes.append((uri, content))
 
 
@@ -394,7 +394,7 @@ async def test_memory_directory_retries_blank_cached_summary(monkeypatch):
                     }
                 )
             if uri.endswith("/.overview.md"):
-                return "### second.md\n\nstale:second.md"
+                return ""
             raise FileNotFoundError(uri)
 
     async def generate_file_summary(file_path, llm_sem=None, ctx=None):


### PR DESCRIPTION
## Summary

- persist per-file memory summaries in a deterministic `.summary_cache.json` keyed by the real filename
- read that cache before falling back to best-effort `.overview.md` parsing, so unchanged files avoid repeated LLM summarization
- write the cache together with `.overview.md` and `.abstract.md` under the same stale-message check and exact path-lock batch
- cover cache reuse and atomic stale-write behavior with focused tests

This is a current-main replacement for #2636, whose patch no longer applies and whose test plan was not implemented.

Closes #1261.

## Validation

- `pytest tests/storage/test_semantic_queue_memory_dedupe.py -q --no-cov` — 8 passed
- `ruff format --check` on the three changed files
- `ruff check` on the three changed files
- `python -m compileall` on the changed Python files
- `git diff --check`
