### PR TITLE
docs: isolate OpenViking installs for Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,8 @@ Before starting with OpenViking, please ensure your environment meets the follow
 ##### Python Package
 
 ```bash
-python -m pip install --upgrade openviking
+pip install openviking --upgrade --force-reinstall
 ```
-
-Install OpenViking in a dedicated virtual environment or container. Avoid
-`--force-reinstall` in an environment shared with another application: pip can
-upgrade that application's pinned dependencies while resolving OpenViking.
 
 ##### Rust CLI (Optional)
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,12 @@ Before starting with OpenViking, please ensure your environment meets the follow
 ##### Python Package
 
 ```bash
-pip install openviking --upgrade --force-reinstall
+python -m pip install --upgrade openviking
 ```
+
+Install OpenViking in a dedicated virtual environment or container. Avoid
+`--force-reinstall` in an environment shared with another application: pip can
+upgrade that application's pinned dependencies while resolving OpenViking.
 
 ##### Rust CLI (Optional)
 

--- a/docs/en/agent-integrations/05-hermes.md
+++ b/docs/en/agent-integrations/05-hermes.md
@@ -2,6 +2,17 @@
 
 [Hermes Agent](https://hermes-agent.nousresearch.com/) by Nous Research has a first-class OpenViking memory provider built in. No plugin to install — just point Hermes at your OpenViking server and it handles memory storage, recall, and extraction natively.
 
+## Keep the Python environments separate
+
+Hermes connects to OpenViking over HTTP, so OpenViking does not need to be
+installed in the Hermes Python environment. Run the OpenViking server in its
+own virtual environment or container. Do not use `--force-reinstall` to add or
+upgrade OpenViking in an existing Hermes environment: a Hermes release may pin
+dependency versions that differ from OpenViking's supported, security-patched
+versions. If you intentionally combine both applications in one environment,
+resolve them together and run `python -m pip check` before starting either
+service.
+
 ## Setup
 
 Run the Hermes memory setup wizard:

--- a/docs/zh/agent-integrations/05-hermes.md
+++ b/docs/zh/agent-integrations/05-hermes.md
@@ -2,6 +2,15 @@
 
 [Hermes Agent](https://hermes-agent.nousresearch.com/) (Nous Research) 内置 OpenViking 记忆提供方。无需安装插件——把 Hermes 指向你的 OpenViking 服务即可，记忆存储、召回和抽取均原生支持。
 
+## 隔离 Python 环境
+
+Hermes 通过 HTTP 连接 OpenViking，因此无需把 OpenViking 安装到 Hermes 的
+Python 环境中。请在独立的虚拟环境或容器中运行 OpenViking 服务。不要在
+已有 Hermes 的环境中使用 `--force-reinstall` 安装或升级 OpenViking：Hermes
+版本可能会固定与 OpenViking 已支持、已修复安全问题的版本不同的依赖。如果确实要将
+两个应用放在同一环境中，请在同一次依赖求解中安装它们，并在启动任一服务前运行
+`python -m pip check`。
+
 ## 配置
 
 运行 Hermes 记忆配置向导：


### PR DESCRIPTION
## Description

The default README command recommended `--force-reinstall`, which can upgrade dependencies pinned by another application in a shared Python environment. Issue #3352 demonstrates this with Hermes Agent; its current `cryptography` pin is below OpenViking's security floor, so lowering OpenViking's constraint is not safe.

This focused documentation mitigation:

- changes the README default to a normal `python -m pip install --upgrade openviking`;
- recommends a dedicated virtual environment or container;
- explains in the English and Chinese Hermes guides that Hermes talks to OpenViking over HTTP and does not need a shared Python environment;
- recommends solving both packages together and running `python -m pip check` when users intentionally share an environment.

Related to #3352. This does not claim to resolve the upstream Hermes dependency constraint.

## Testing

- `git diff --check`
- `npm --prefix docs ci`
- `npm --prefix docs run docs:build` (passes; existing PromQL/Caddyfile syntax-highlighting fallback warnings only)

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop