### PR TITLE
fix(feishu): preserve title prefixes in resource names

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -32,6 +32,16 @@ _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
 
 
+def _title_as_filename(title: str) -> str:
+    """Keep a Feishu display title intact while making it one filename segment.
+
+    Feishu titles may contain path separators.  ``original_filename`` is passed
+    through filename-oriented helpers downstream, so leaving separators in that
+    field makes ``Path(...).name`` silently discard the title prefix.
+    """
+    return title.replace("/", "_").replace("\\", "_")
+
+
 def _getattr_safe(obj, key: str, default=None):
     """Get attribute from SDK object or dict, with safe fallback."""
     if isinstance(obj, dict):
@@ -247,7 +257,7 @@ class FeishuAccessor(DataAccessor):
                 "feishu_doc_type": doc.doc_type,
                 "feishu_token": doc.token,
                 "feishu_title": doc.title,
-                "original_filename": doc.title,
+                "original_filename": _title_as_filename(doc.title),
                 **doc.meta,
             }
 

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -7,7 +7,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
-from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+from openviking.parse.accessors.feishu_accessor import FeishuAccessor, _title_as_filename
 
 
 class _SuccessResponse:
@@ -249,6 +249,10 @@ def test_guess_image_ext_defaults_to_png_when_unknown():
     assert accessor._guess_image_ext(b"anything", "image/gif") == ".gif"
 
 
+def test_title_as_filename_preserves_prefix_around_path_separators():
+    assert _title_as_filename("API Docs/Overview\\v2") == "API Docs_Overview_v2"
+
+
 def test_access_offloads_synchronous_download_to_thread(monkeypatch):
     """access() must not run the synchronous _resolve_image_refs on the event loop."""
     import threading
@@ -332,3 +336,28 @@ def test_access_writes_downloaded_images_next_to_markdown(monkeypatch):
         resource.cleanup()
 
     assert not resource.path.parent.exists()
+
+
+def test_access_keeps_raw_title_but_exposes_safe_original_filename(monkeypatch):
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+
+    async def fake_fetch_document(*_args, **_kwargs):
+        from openviking.parse.accessors.feishu_accessor import FeishuDocument
+
+        return FeishuDocument(
+            doc_type="docx",
+            token="doc_token",
+            markdown_content="# API Docs/Overview",
+            title="API Docs/Overview",
+            meta={},
+        )
+
+    monkeypatch.setattr(accessor, "_fetch_document", fake_fetch_document)
+
+    resource = asyncio.run(accessor.access("https://example.feishu.cn/docx/doc_token"))
+    try:
+        assert resource.meta["feishu_title"] == "API Docs/Overview"
+        assert resource.meta["original_filename"] == "API Docs_Overview"
+    finally:
+        resource.cleanup()


### PR DESCRIPTION
## Summary

- normalize Feishu title path separators before exposing the title as `original_filename`
- preserve the raw display title in `feishu_title`
- cover both slash styles and the accessor metadata contract

Fixes #3025

## Validation

- `uv run --extra test pytest tests/parse/test_feishu_accessor.py -q` (12 passed)
- `uvx ruff check openviking/parse/accessors/feishu_accessor.py tests/parse/test_feishu_accessor.py`
- `git diff --check`

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop