### PR TITLE
fix(sdk): validate and normalize base URLs

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -28,9 +28,9 @@ func NewClient(cfg Config) (*Client, error) {
 	if strings.TrimSpace(cfg.BaseURL) == "" {
 		return nil, fmt.Errorf("openviking: BaseURL is required")
 	}
-	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
 	parsed, err := url.Parse(baseURL)
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, fmt.Errorf("openviking: invalid BaseURL %q", cfg.BaseURL)
 	}
 

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -78,6 +78,31 @@ func requireBodyKeysAbsent(t *testing.T, body map[string]any, keys ...string) {
 	}
 }
 
+func TestNewClientNormalizesAndValidatesBaseURL(t *testing.T) {
+	client, err := NewClient(Config{BaseURL: "  https://example.com/openviking///  "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.baseURL != "https://example.com/openviking" {
+		t.Fatalf("baseURL = %q", client.baseURL)
+	}
+
+	invalid := []string{
+		"ftp://example.com",
+		"localhost:1933",
+		"http:///missing-host",
+		"https://example.com?profile=1",
+		"https://example.com#fragment",
+	}
+	for _, baseURL := range invalid {
+		t.Run(baseURL, func(t *testing.T) {
+			if _, err := NewClient(Config{BaseURL: baseURL}); err == nil {
+				t.Fatalf("NewClient(%q) succeeded", baseURL)
+			}
+		})
+	}
+}
+
 func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/search/find" {

--- a/sdk/python/openviking_sdk/config.py
+++ b/sdk/python/openviking_sdk/config.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from difflib import get_close_matches
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlsplit
 
 OPENVIKING_CLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
 DEFAULT_OVCLI_CONF = Path.home() / ".openviking" / "ovcli.conf"
@@ -94,6 +95,19 @@ def _parse_extra_headers(value: object, *, path: str) -> dict[str, str]:
             raise ValueError(f"Invalid value for '{path}.{key}': expected string")
         parsed[key] = header_value
     return parsed
+
+
+def _normalize_base_url(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    try:
+        parsed = urlsplit(normalized)
+    except ValueError as exc:
+        raise ValueError(f"invalid OpenViking URL: {value!r}") from exc
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"OpenViking URL must be an absolute HTTP(S) URL: {value!r}")
+    if parsed.query or parsed.fragment:
+        raise ValueError(f"OpenViking URL must not include a query or fragment: {value!r}")
+    return normalized
 
 
 def _unknown_field_error(path: str, key: str, allowed_keys: set[str]) -> ValueError:
@@ -223,6 +237,12 @@ def resolve_client_config(
     if profile_enabled is None and cli_config is not None:
         resolved_profile_enabled = cli_config.profile
 
+    if not resolved_url:
+        raise ValueError(
+            "url is required. Pass it explicitly, set OPENVIKING_URL, or configure ovcli.conf."
+        )
+    resolved_url = _normalize_base_url(resolved_url)
+
     resolved_extra_headers = dict(extra_headers) if extra_headers is not None else {}
     if extra_headers is None and cli_config is not None:
         resolved_extra_headers = dict(cli_config.extra_headers)
@@ -231,7 +251,7 @@ def resolve_client_config(
         cli_config is not None
         and cli_config.url
         and resolved_url
-        and cli_config.url.rstrip("/") == resolved_url.rstrip("/")
+        and cli_config.url.strip().rstrip("/") == resolved_url
     ):
         resolved_gateway_token = cli_config.gateway_token
 
@@ -239,13 +259,8 @@ def resolve_client_config(
     if resolved_upload_mode is None and cli_config is not None:
         resolved_upload_mode = cli_config.upload_mode
 
-    if not resolved_url:
-        raise ValueError(
-            "url is required. Pass it explicitly, set OPENVIKING_URL, or configure ovcli.conf."
-        )
-
     return ClientConfig(
-        url=resolved_url.rstrip("/"),
+        url=resolved_url,
         api_key=resolved_api_key,
         account=resolved_account,
         user=resolved_user,

--- a/sdk/python/tests/test_client_config.py
+++ b/sdk/python/tests/test_client_config.py
@@ -50,3 +50,24 @@ def test_url_is_required_when_missing_everywhere(monkeypatch):
 
     with pytest.raises(ValueError, match="url is required"):
         AsyncHTTPClient()
+
+
+def test_url_is_trimmed_before_client_initialization():
+    client = AsyncHTTPClient(url="  https://example.com/openviking///  ")
+
+    assert client._url == "https://example.com/openviking"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com",
+        "localhost:1933",
+        "http:///missing-host",
+        "https://example.com?profile=1",
+        "https://example.com#fragment",
+    ],
+)
+def test_url_rejects_invalid_base_urls(url):
+    with pytest.raises(ValueError, match="OpenViking URL"):
+        AsyncHTTPClient(url=url)

--- a/sdk/typescript/src/transport.ts
+++ b/sdk/typescript/src/transport.ts
@@ -30,12 +30,25 @@ export class OpenVikingTransport {
   private readonly profile: boolean;
 
   constructor(config: ClientConfig) {
-    if (!config.baseUrl?.trim())
-      throw new TypeError("OpenViking: baseUrl is required");
-    const url = new URL(config.baseUrl);
+    const baseUrl = config.baseUrl?.trim();
+    if (!baseUrl) throw new TypeError("OpenViking: baseUrl is required");
+    if (!/^https?:\/\/[^/]/i.test(baseUrl))
+      throw new TypeError(
+        "OpenViking: baseUrl must be an absolute HTTP(S) URL",
+      );
+    let url: URL;
+    try {
+      url = new URL(baseUrl);
+    } catch {
+      throw new TypeError("OpenViking: baseUrl must be an absolute URL");
+    }
     if (!/^https?:$/.test(url.protocol))
       throw new TypeError("OpenViking: baseUrl must use http or https");
-    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    if (url.search || url.hash)
+      throw new TypeError(
+        "OpenViking: baseUrl must not include a query or fragment",
+      );
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.fetcher = config.fetch ?? globalThis.fetch;
     if (!this.fetcher)
       throw new TypeError("OpenViking: fetch is not available");

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -15,6 +15,26 @@ const ok = (result: unknown) =>
   });
 
 describe("OpenVikingClient", () => {
+  it("normalizes and validates base URLs", () => {
+    const client = new OpenVikingClient({
+      baseUrl: "  https://example.com/openviking///  ",
+      fetch: vi.fn<typeof fetch>(),
+    });
+    expect(client.baseUrl).toBe("https://example.com/openviking");
+
+    for (const baseUrl of [
+      "ftp://example.com",
+      "localhost:1933",
+      "http:///missing-host",
+      "https://example.com?profile=1",
+      "https://example.com#fragment",
+    ]) {
+      expect(
+        () => new OpenVikingClient({ baseUrl, fetch: vi.fn<typeof fetch>() }),
+      ).toThrow(TypeError);
+    }
+  });
+
   it("normalizes URIs", () => {
     expect(normalizeURI("resources/docs")).toBe("viking://resources/docs");
     expect(normalizeURI("viking://resources/docs")).toBe(
@@ -64,7 +84,9 @@ describe("OpenVikingClient", () => {
   });
 
   it("sends dry_run for prune_orphans reindex requests", async () => {
-    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok({ status: "completed" }));
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(ok({ status: "completed" }));
     const client = new OpenVikingClient({
       baseUrl: "https://example.com",
       fetch: fetcher,


### PR DESCRIPTION
## Description

The three standalone SDKs currently disagree on Base URL handling. Python accepts any non-empty string, Go accepts schemes such as `ftp://`, and TypeScript validates the scheme but keeps surrounding whitespace in the URL used for requests. Invalid values therefore fail late, often as a misleading network error on the first API call.

This change gives Python, Go, and TypeScript the same constructor-time contract: trim surrounding whitespace, remove trailing slashes, require an absolute HTTP(S) URL with a host, and reject query strings or fragments in the base address.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Normalize surrounding whitespace and trailing slashes before storing the Base URL.
- Reject non-HTTP(S), hostless, query-bearing, and fragment-bearing Base URLs during client construction.
- Keep URL validation behavior aligned across the Python, Go, and TypeScript SDKs.
- Add the same valid and invalid URL cases to each SDK's tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `PYTHONPATH=sdk/python .venv/bin/pytest -q -o addopts='' sdk/python/tests/test_client_config.py sdk/python/tests/test_ovcli_config_compat.py` — 17 passed
- `go test ./...` from `sdk/go` — passed
- `npm test` from `sdk/typescript` — 30 passed
- `npm run typecheck` — passed
- `npm run format:check` — passed
- Ruff and `git diff --check` — passed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code
- [x] I have commented the code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots

Not applicable.

## Additional Notes

Path prefixes remain supported, for example `https://example.com/openviking`. The restriction only removes URL components that cannot safely act as a request base.
