### PR TITLE
fix(sdk-typescript): distinguish cancellation from timeout

### DIFF
--- a/sdk/typescript/src/transport.ts
+++ b/sdk/typescript/src/transport.ts
@@ -89,25 +89,35 @@ export class OpenVikingTransport {
       body = JSON.stringify(options.body);
     }
     const controller = new AbortController();
-    const abort = () => controller.abort(options.signal?.reason);
+    let abortSource: "caller" | "timeout" | undefined;
+    const abort = () => {
+      if (controller.signal.aborted) return;
+      abortSource = "caller";
+      controller.abort(options.signal?.reason);
+    };
     options.signal?.addEventListener("abort", abort, { once: true });
     if (options.signal?.aborted) abort();
-    const timer = setTimeout(
-      () =>
-        controller.abort(new DOMException("Request timed out", "TimeoutError")),
-      this.timeout,
-    );
+    const timer = setTimeout(() => {
+      if (controller.signal.aborted) return;
+      abortSource = "timeout";
+      controller.abort(new DOMException("Request timed out", "TimeoutError"));
+    }, this.timeout);
     try {
       const init: RequestInit = { method, headers, signal: controller.signal };
       if (body !== undefined) init.body = body;
       return await consume(await this.fetcher(url, init));
     } catch (error) {
-      if (error instanceof OpenVikingError) throw error;
-      if (controller.signal.aborted)
-        throw new OpenVikingError("Request timed out or was aborted", {
+      if (abortSource === "timeout")
+        throw new OpenVikingError("Request timed out", {
           code: "DEADLINE_EXCEEDED",
           cause: error,
         });
+      if (abortSource === "caller")
+        throw new OpenVikingError("Request was aborted by the caller", {
+          code: "ABORTED",
+          cause: error,
+        });
+      if (error instanceof OpenVikingError) throw error;
       throw new OpenVikingError(
         error instanceof Error ? error.message : "Network request failed",
         { code: "UNAVAILABLE", cause: error },

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -64,7 +64,9 @@ describe("OpenVikingClient", () => {
   });
 
   it("sends dry_run for prune_orphans reindex requests", async () => {
-    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok({ status: "completed" }));
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(ok({ status: "completed" }));
     const client = new OpenVikingClient({
       baseUrl: "https://example.com",
       fetch: fetcher,
@@ -484,7 +486,62 @@ describe("OpenVikingClient", () => {
 
     await expect(
       client.backupOVPack("backup", false, { signal: controller.signal }),
-    ).rejects.toMatchObject({ code: "DEADLINE_EXCEEDED" });
+    ).rejects.toMatchObject({
+      code: "ABORTED",
+      message: "Request was aborted by the caller",
+    });
+  });
+
+  it("maps OpenVikingError abort reasons to caller cancellation", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (_input, init) => {
+        if (init?.signal?.aborted) throw init.signal.reason;
+        return new Response(new Uint8Array([1]));
+      });
+    const client = new OpenVikingClient({
+      baseUrl: "https://example.com",
+      fetch: fetcher,
+    });
+    const controller = new AbortController();
+    controller.abort(new OpenVikingError("cancelled", { code: "UNAVAILABLE" }));
+
+    await expect(
+      client.backupOVPack("backup", false, { signal: controller.signal }),
+    ).rejects.toMatchObject({
+      code: "ABORTED",
+      message: "Request was aborted by the caller",
+    });
+  });
+
+  it("keeps in-flight caller cancellation distinct from timeouts", async () => {
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const fetcher = vi.fn<typeof fetch>().mockImplementation(
+      async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          markStarted?.();
+          init?.signal?.addEventListener("abort", () =>
+            reject(init.signal?.reason),
+          );
+        }),
+    );
+    const client = new OpenVikingClient({
+      baseUrl: "https://example.com",
+      fetch: fetcher,
+      timeout: 10_000,
+    });
+    const controller = new AbortController();
+
+    const request = client.backupOVPack("backup", false, {
+      signal: controller.signal,
+    });
+    await started;
+    controller.abort(new Error("cancelled"));
+
+    await expect(request).rejects.toMatchObject({ code: "ABORTED" });
   });
 
   it("rejects directories before importing or restoring OVPack files", async () => {


### PR DESCRIPTION
## Description

The TypeScript SDK currently maps two different events to the same error:

- the SDK's request timer expires;
- the caller explicitly aborts through `AbortSignal`.

Both become `DEADLINE_EXCEEDED`, so callers cannot tell whether a request timed out or was intentionally cancelled. Retry code may then retry work the application deliberately stopped.

This change records which source aborted the internal controller. Timer expiry remains `DEADLINE_EXCEEDED`; caller cancellation now returns the standard OpenViking `ABORTED` code.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Track whether the caller or the timeout aborted the internal request controller.
- Preserve `DEADLINE_EXCEEDED` and a timeout-specific message for timer expiry.
- Return `ABORTED` for both pre-aborted signals and cancellation while a request is in flight.
- Prevent a later timeout callback from overwriting an earlier caller cancellation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run from `sdk/typescript`:

- `npm test` — 30 passed
- `npm run typecheck` — passed
- `npm run format:check` — passed
- `git diff --check` — passed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code
- [x] I have commented the code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots

Not applicable.

## Additional Notes

No request API changes are required. Existing callers still pass an ordinary `AbortSignal`; only the resulting error code is corrected.
