### PR TITLE
feat(extensions): add periodic report archive provider

### DIFF
--- a/docs/en/guides/18-periodic-report-provider.md
+++ b/docs/en/guides/18-periodic-report-provider.md
@@ -1,0 +1,138 @@
+# Optional periodic-report archive provider
+
+OpenViking ships an optional Resource provider for reports that another product has
+already selected and rendered. It is designed for LoopX `periodic-report`, but the
+provider contract is domain-neutral: release summaries, research reports, operational
+reports, and issue-fix reports use the same archive surface.
+
+The extension is **disabled by default**. Importing it only makes the provider
+available; it does not activate reporting or the archive sink. The formal sink entry
+point requires a verified LoopX `periodic_report_activation_v0` whose profile is
+enabled and binds this exact provider.
+
+This keeps one product state: LoopX owns capability activation and the project profile;
+OpenViking does not create a second reporting switch that can drift from it.
+
+## Ownership boundary
+
+The provider owns only:
+
+- `report.archive.write`
+- `report.archive.readback`
+- `report.query`
+
+It does not decide when a report is due, what evidence belongs in it, how Markdown or
+HTML is rendered, or whether a Lark message is sent. An archive failure is local to the
+optional archive sink; the caller chooses whether its primary delivery can continue.
+
+## Archive layout and receipts
+
+Each report uses a stable identity under:
+
+```text
+viking://resources/periodic-reports/{project_key}/{period_start}/{report_id}/
+```
+
+The directory contains `report.md`, `report.html.txt`, and `manifest.json`. HTML remains
+UTF-8 text; the manifest declares `media_type=text/html`. This preserves the exact HTML
+without widening OpenViking's bounded `content/write` create-extension allowlist.
+
+`manifest.json` is the commit marker and is written last. Its deterministic
+`bundle_digest` and `result_id` bind the identity, metadata, Markdown, and HTML. An
+identical retry is a no-op, a retry after a partial write completes the missing files,
+and a different payload at the same identity fails closed. Every successful write ends
+with exact manifest and payload readback.
+
+## Python usage
+
+```python
+from openviking import AsyncOpenViking
+from openviking.extensions.periodic_report import (
+    PeriodicReportArchiveProvider,
+    PeriodicReportBundle,
+)
+
+client = AsyncOpenViking(path="./data")
+provider = PeriodicReportArchiveProvider(client)
+
+bundle = PeriodicReportBundle(
+    project_key="my-project",
+    profile_id="my_project_weekly",
+    profile_version="v1",
+    report_id="weekly-2026-07-20",
+    period_start="2026-07-13",
+    period_end="2026-07-19",
+    generated_at="2026-07-20T09:00:00+08:00",
+    markdown="# Weekly report\n\n- Shipped the provider",
+    html="<h1>Weekly report</h1><ul><li>Shipped the provider</li></ul>",
+    metadata={"trigger": "cadence"},
+)
+
+# Exact periodic_report_activation_v0 returned by LoopX inspect-profile.
+activation_receipt = load_loopx_activation_receipt()
+readiness = provider.readiness(
+    activation_receipt=activation_receipt,
+    sink_id="project_archive",
+    bundle=bundle,
+)
+assert readiness["status"] == "ready"
+
+result = await provider.archive_sink(
+    bundle,
+    sink_id="project_archive",
+    idempotency_key="report_sink_0123456789abcdef",
+    activation_receipt=activation_receipt,
+)
+assert result["readback_verified"]
+
+history = await provider.query(project_key="my-project", limit=8)
+```
+
+## Optional LoopX binding
+
+The extension manifest is available through `get_extension_manifest()`. Its
+`report.archive.write@v0` capability and `periodic_report_sink_v0` protocol match the
+version-pinned LoopX sink contract:
+
+```json
+{
+  "schema_version": "periodic_report_sink_binding_v0",
+  "sink_id": "project_archive",
+  "sink_kind": "project_resource",
+  "sink_role": "archive",
+  "dependency_policy": "optional",
+  "capability": {
+    "capability_id": "report.archive.write",
+    "capability_version": "v0"
+  },
+  "extension": {
+    "extension_id": "openviking.periodic-report.archive",
+    "extension_version": "0.1.0",
+    "protocol": "periodic_report_sink_v0"
+  }
+}
+```
+
+Pass the LoopX activation receipt to `provider.readiness(...)`, then pass that provider
+receipt to LoopX extension-readiness evaluation. After generation, call
+`provider.archive_sink(...)` with the same activation receipt, sink id, and LoopX-derived
+idempotency key. A disabled capability, missing binding, disabled dependency, or version
+mismatch fails closed before any Resource write.
+
+A LoopX project should add this optional binding only after explicitly enabling its
+periodic-report profile. If OpenViking is absent, provider-neutral generation remains
+usable and the optional sink degrades without taking over scheduling or chat delivery.
+
+## Experience modes
+
+| Configuration | Experience |
+| --- | --- |
+| Capability disabled, extension installed | No report run and no archive write |
+| Capability enabled | Triggering, normalized evidence, Markdown/HTML generation, and configured primary delivery |
+| Capability + optional OpenViking extension | Everything above plus durable history, exact retry/readback, and query/visualization input; archive absence degrades locally |
+| Capability + required OpenViking extension | Durable mode; formal completion fails closed until the archive is verified |
+
+For the fullest team experience, use one enabled profile with both the primary Lark
+delivery sink and this OpenViking archive sink. The same report identity then backs the
+group message and historical report view without giving either provider scheduling
+authority.

--- a/docs/zh/guides/18-periodic-report-provider.md
+++ b/docs/zh/guides/18-periodic-report-provider.md
@@ -1,0 +1,132 @@
+# 可选的周期报告归档 Provider
+
+OpenViking 提供一个可选 Resource provider，用来归档其他产品已经完成选材和渲染的
+报告。它可与 LoopX `periodic-report` 配合，但协议不绑定具体业务：研发周报、版本总结、
+研究报告、运维报告和 issue-fix 周报都使用同一归档接口。
+
+该 extension **默认关闭**。import 只表示 provider 可用，不会激活周报或归档 sink。
+正式 sink 入口必须收到已验证的 LoopX `periodic_report_activation_v0`，其中 profile
+必须已启用，并且绑定的正是这个 provider。
+
+这样产品只有一份状态：LoopX 拥有 capability 激活和项目 profile；OpenViking 不再
+另造一个可能与 LoopX 漂移的“周报开关”。
+
+## Ownership 边界
+
+Provider 只拥有三项能力：
+
+- `report.archive.write`
+- `report.archive.readback`
+- `report.query`
+
+它不决定何时触发报告、不负责选材、不生成 Markdown/HTML，也不发送飞书消息。归档失败
+只影响可选 archive sink；主投递是否继续由上游产品策略决定。
+
+## Resource 布局与回执
+
+每份报告使用稳定路径：
+
+```text
+viking://resources/periodic-reports/{project_key}/{period_start}/{report_id}/
+```
+
+目录包含 `report.md`、`report.html.txt` 和 `manifest.json`。HTML 仍以 UTF-8 原文保存，
+manifest 声明 `media_type=text/html`；这样无需放宽 OpenViking `content/write` 的安全扩展名
+白名单。
+
+`manifest.json` 是最后写入的 commit marker。确定性的 `bundle_digest` 和 `result_id`
+绑定报告身份、元数据、Markdown 与 HTML：完全相同的重试为 no-op；部分写入后的重试只
+补齐缺失文件；同一身份出现不同内容则 fail closed。每次成功归档都会精确回读 manifest
+和两份正文。
+
+## Python 用法
+
+```python
+from openviking import AsyncOpenViking
+from openviking.extensions.periodic_report import (
+    PeriodicReportArchiveProvider,
+    PeriodicReportBundle,
+)
+
+client = AsyncOpenViking(path="./data")
+provider = PeriodicReportArchiveProvider(client)
+
+bundle = PeriodicReportBundle(
+    project_key="my-project",
+    profile_id="my_project_weekly",
+    profile_version="v1",
+    report_id="weekly-2026-07-20",
+    period_start="2026-07-13",
+    period_end="2026-07-19",
+    generated_at="2026-07-20T09:00:00+08:00",
+    markdown="# 周报\n\n- 完成 provider",
+    html="<h1>周报</h1><ul><li>完成 provider</li></ul>",
+    metadata={"trigger": "cadence"},
+)
+
+# LoopX inspect-profile 返回的原始 periodic_report_activation_v0。
+activation_receipt = load_loopx_activation_receipt()
+readiness = provider.readiness(
+    activation_receipt=activation_receipt,
+    sink_id="project_archive",
+    bundle=bundle,
+)
+assert readiness["status"] == "ready"
+
+result = await provider.archive_sink(
+    bundle,
+    sink_id="project_archive",
+    idempotency_key="report_sink_0123456789abcdef",
+    activation_receipt=activation_receipt,
+)
+assert result["readback_verified"]
+
+history = await provider.query(project_key="my-project", limit=8)
+```
+
+## 可选 LoopX 绑定
+
+`get_extension_manifest()` 返回 extension manifest，其中
+`report.archive.write@v0` 与 `periodic_report_sink_v0` 对齐 LoopX 的版本锁定 sink
+协议：
+
+```json
+{
+  "schema_version": "periodic_report_sink_binding_v0",
+  "sink_id": "project_archive",
+  "sink_kind": "project_resource",
+  "sink_role": "archive",
+  "dependency_policy": "optional",
+  "capability": {
+    "capability_id": "report.archive.write",
+    "capability_version": "v0"
+  },
+  "extension": {
+    "extension_id": "openviking.periodic-report.archive",
+    "extension_version": "0.1.0",
+    "protocol": "periodic_report_sink_v0"
+  }
+}
+```
+
+把 LoopX activation receipt 传给 `provider.readiness(...)`，再将 provider receipt
+交给 LoopX extension-readiness 评估。报告生成后，用同一 activation receipt、sink id
+和 LoopX 派生的幂等键调用 `provider.archive_sink(...)`。capability 未启用、binding
+缺失或禁用、版本不兼容时，都会在任何 Resource 写入前 fail closed。
+
+LoopX 项目应先显式启用通用 periodic-report profile，再添加这个 optional binding。
+OpenViking 缺失时，provider-neutral 生成结果仍然可用；可选归档只降级，不接管调度或群
+消息投递。
+
+## 体验模式
+
+| 配置 | 体验 |
+| --- | --- |
+| capability 未启用、extension 已安装 | 不运行报告，也不允许归档写入 |
+| capability 已启用 | 触发、证据归一化、Markdown/HTML 生成及已配置的主投递 |
+| capability + optional OV extension | 在上述基础上增加历史归档、精确重试/回读和查询/可视化输入；OV 缺失只局部降级 |
+| capability + required OV extension | durable 模式；归档未验证前，正式完成 fail closed |
+
+最完整的团队体验，是在同一个 enabled profile 中同时配置飞书主投递 sink 和这个
+OpenViking archive sink。群消息和历史报告共享同一报告身份，但两个 provider 都不会
+获得调度权。

--- a/openviking/extensions/__init__.py
+++ b/openviking/extensions/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Optional OpenViking product extensions.
+
+Extensions in this package are disabled unless a caller explicitly imports and
+binds them. They may add storage or query behavior, but must not silently take
+ownership of an upstream product's scheduling or delivery policy.
+"""

--- a/openviking/extensions/periodic_report/__init__.py
+++ b/openviking/extensions/periodic_report/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Optional periodic-report archive/query provider."""
+
+from .manifest import EXTENSION_MANIFEST, get_extension_manifest
+from .provider import (
+    PeriodicReportActivationError,
+    PeriodicReportArchiveConflict,
+    PeriodicReportArchiveError,
+    PeriodicReportArchiveIntegrityError,
+    PeriodicReportArchiveProvider,
+    PeriodicReportArchiveReceipt,
+    PeriodicReportBundle,
+)
+
+__all__ = [
+    "EXTENSION_MANIFEST",
+    "PeriodicReportArchiveConflict",
+    "PeriodicReportArchiveError",
+    "PeriodicReportArchiveIntegrityError",
+    "PeriodicReportArchiveProvider",
+    "PeriodicReportArchiveReceipt",
+    "PeriodicReportActivationError",
+    "PeriodicReportBundle",
+    "get_extension_manifest",
+]

--- a/openviking/extensions/periodic_report/manifest.py
+++ b/openviking/extensions/periodic_report/manifest.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Manifest for the optional periodic-report archive provider."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+EXTENSION_MANIFEST: dict[str, Any] = {
+    "schema_version": "openviking_extension_manifest_v0",
+    "id": "openviking.periodic-report.archive",
+    "version": "0.1.0",
+    "protocol_version": "periodic_report_sink_v0",
+    "default_enabled": False,
+    "provider_kind": "optional",
+    "entrypoint": ("openviking.extensions.periodic_report:PeriodicReportArchiveProvider"),
+    "requires_capability": {
+        "capability_id": "periodic-report",
+        "activation_schema": "periodic_report_activation_v0",
+        "profile_enabled": True,
+        "sink_binding_schema": "periodic_report_sink_binding_v0",
+        "accepted_dependency_policies": ["optional", "required"],
+    },
+    "capabilities": {
+        "report.archive.write": {"version": "v0", "method": "archive_sink"},
+        "report.archive.readback": {"version": "v0", "method": "readback"},
+        "report.query": {"version": "v0", "method": "query"},
+    },
+    "boundary": {
+        "owns": ["archive_write", "archive_readback", "archive_query"],
+        "does_not_own": [
+            "trigger",
+            "cadence",
+            "source_selection",
+            "rendering",
+            "lark_delivery",
+        ],
+        "failure_scope": "archive_sink_only",
+    },
+}
+
+
+def get_extension_manifest() -> dict[str, Any]:
+    """Return an isolated manifest copy for an extension registry."""
+
+    return deepcopy(EXTENSION_MANIFEST)

--- a/openviking/extensions/periodic_report/provider.py
+++ b/openviking/extensions/periodic_report/provider.py
@@ -1,0 +1,736 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""OpenViking Resource provider for generated periodic reports.
+
+The provider deliberately starts after a report has been selected and rendered.
+It archives the same Markdown and HTML payload, verifies exact Resource
+readback, and exposes a structured query surface for a future reports UI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime
+from hashlib import sha256
+from typing import Any, Mapping, Protocol
+
+from openviking_cli.exceptions import AlreadyExistsError, NotFoundError
+from openviking_cli.utils import VikingURI
+
+from .manifest import EXTENSION_MANIFEST
+
+ARCHIVE_SCHEMA_VERSION = "openviking_periodic_report_archive_v0"
+ACTIVATION_SCHEMA_VERSION = "periodic_report_activation_v0"
+SINK_BINDING_SCHEMA_VERSION = "periodic_report_sink_binding_v0"
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_VERSION_TOKEN = re.compile(r"^[0-9A-Za-z][A-Za-z0-9._+-]{0,127}$")
+
+
+class PeriodicReportArchiveError(RuntimeError):
+    """Base error for periodic-report archive operations."""
+
+
+class PeriodicReportArchiveConflict(PeriodicReportArchiveError):
+    """The stable report identity already contains different content."""
+
+
+class PeriodicReportArchiveIntegrityError(PeriodicReportArchiveError):
+    """Stored archive content does not match its manifest or receipt."""
+
+
+class PeriodicReportActivationError(PeriodicReportArchiveError):
+    """The LoopX periodic-report capability is not active for this sink."""
+
+
+class PeriodicReportArchiveClient(Protocol):
+    """Small async OpenViking client surface required by the provider."""
+
+    async def read(self, uri: str, offset: int = 0, limit: int = -1) -> str: ...
+
+    async def write(
+        self,
+        uri: str,
+        content: str,
+        mode: str = "replace",
+        wait: bool = False,
+        timeout: float | None = None,
+        telemetry: bool = False,
+    ) -> dict[str, Any]: ...
+
+    async def glob(self, pattern: str, uri: str = "viking://") -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class PeriodicReportBundle:
+    """A report that has already been selected and rendered upstream."""
+
+    project_key: str
+    profile_id: str
+    profile_version: str
+    report_id: str
+    period_start: str
+    period_end: str
+    generated_at: str
+    markdown: str
+    html: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_segment("project_key", self.project_key)
+        _validate_segment("profile_id", self.profile_id)
+        _validate_version("profile_version", self.profile_version)
+        _validate_segment("report_id", self.report_id)
+        start = _parse_date("period_start", self.period_start)
+        end = _parse_date("period_end", self.period_end)
+        if end < start:
+            raise ValueError("period_end must be on or after period_start")
+        _parse_datetime("generated_at", self.generated_at)
+        if not isinstance(self.markdown, str) or not self.markdown.strip():
+            raise ValueError("markdown must be a non-empty string")
+        if not isinstance(self.html, str) or not self.html.strip():
+            raise ValueError("html must be a non-empty string")
+        if not all(isinstance(key, str) for key in self.metadata):
+            raise ValueError("metadata keys must be strings")
+        try:
+            normalized_metadata = json.loads(_canonical_json(dict(self.metadata)))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("metadata must be JSON-serializable") from exc
+        object.__setattr__(self, "metadata", normalized_metadata)
+
+
+@dataclass(frozen=True)
+class PeriodicReportArchiveReceipt:
+    """Exact readback receipt for one archived report."""
+
+    schema_version: str
+    extension_id: str
+    protocol_version: str
+    result_id: str
+    resource_uri: str
+    manifest_uri: str
+    markdown_uri: str
+    html_uri: str
+    bundle_digest: str
+    write_status: str
+    exact_readback_verified: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "extension_id": self.extension_id,
+            "protocol_version": self.protocol_version,
+            "result_id": self.result_id,
+            "resource_uri": self.resource_uri,
+            "manifest_uri": self.manifest_uri,
+            "markdown_uri": self.markdown_uri,
+            "html_uri": self.html_uri,
+            "bundle_digest": self.bundle_digest,
+            "write_status": self.write_status,
+            "exact_readback_verified": self.exact_readback_verified,
+        }
+
+
+class PeriodicReportArchiveProvider:
+    """Optional archive/query provider backed by OpenViking Resources."""
+
+    def __init__(
+        self,
+        client: PeriodicReportArchiveClient,
+        *,
+        root_uri: str = "viking://resources/periodic-reports",
+    ) -> None:
+        normalized_root = root_uri.rstrip("/")
+        if not normalized_root.startswith("viking://") or any(
+            marker in normalized_root for marker in ("?", "#", "\\")
+        ):
+            raise ValueError("root_uri must be a safe viking:// URI")
+        parsed_root = VikingURI(normalized_root)
+        path_segments = parsed_root.full_path.split("/")[1:]
+        if (
+            parsed_root.scope != "resources"
+            or not path_segments
+            or any(not _SAFE_SEGMENT.fullmatch(segment) for segment in path_segments)
+        ):
+            raise ValueError("root_uri must use a safe project Resource path")
+        self._client = client
+        self._root_uri = normalized_root
+
+    @property
+    def root_uri(self) -> str:
+        return self._root_uri
+
+    def readiness(
+        self,
+        *,
+        activation_receipt: Mapping[str, Any] | None = None,
+        sink_id: str | None = None,
+        bundle: PeriodicReportBundle | None = None,
+    ) -> dict[str, Any]:
+        """Describe provider readiness after capability/profile activation."""
+
+        activation_error: str | None = None
+        if activation_receipt is None or sink_id is None or bundle is None:
+            activation_error = "periodic_report_activation_required"
+        else:
+            try:
+                self._validate_activation(
+                    activation_receipt,
+                    bundle=bundle,
+                    sink_id=sink_id,
+                    sink_kind="project_resource",
+                )
+            except PeriodicReportActivationError as exc:
+                activation_error = str(exc)
+        ready = activation_error is None
+
+        return {
+            "extension_id": EXTENSION_MANIFEST["id"],
+            "extension_version": EXTENSION_MANIFEST["version"],
+            "protocol": EXTENSION_MANIFEST["protocol_version"],
+            "status": "ready" if ready else "unavailable",
+            "readback_verified": ready,
+            "capabilities": sorted(
+                [
+                    {
+                        "capability_id": capability_id,
+                        "capability_version": capability["version"],
+                    }
+                    for capability_id, capability in EXTENSION_MANIFEST["capabilities"].items()
+                ],
+                key=lambda item: (item["capability_id"], item["capability_version"]),
+            ),
+            "activation_verified": ready,
+            "activation_error": activation_error,
+        }
+
+    async def archive_sink(
+        self,
+        bundle: PeriodicReportBundle,
+        *,
+        sink_id: str,
+        idempotency_key: str,
+        activation_receipt: Mapping[str, Any],
+        sink_kind: str = "project_resource",
+    ) -> dict[str, Any]:
+        """Archive a bundle and return a LoopX periodic-report sink result."""
+
+        _validate_segment("sink_id", sink_id)
+        _validate_segment("sink_kind", sink_kind)
+        self._validate_activation(
+            activation_receipt,
+            bundle=bundle,
+            sink_id=sink_id,
+            sink_kind=sink_kind,
+        )
+        if not isinstance(idempotency_key, str) or not 1 <= len(idempotency_key) <= 128:
+            raise ValueError("idempotency_key must be a non-empty string up to 128 characters")
+        receipt = await self.archive(bundle)
+        return {
+            "schema_version": "periodic_report_sink_result_v0",
+            "sink_id": sink_id,
+            "sink_kind": sink_kind,
+            "sink_role": "archive",
+            "status": "sent",
+            "idempotency_key": idempotency_key,
+            "receipt_ref": receipt.manifest_uri,
+            "result_id": receipt.result_id,
+            "readback_verified": receipt.exact_readback_verified,
+            "retryable": False,
+            "schedule_policy_applied": False,
+            "business_evidence_judged": False,
+            "write_status": receipt.write_status,
+            "bundle_digest": receipt.bundle_digest,
+            "capability_activation_verified": True,
+        }
+
+    async def archive(self, bundle: PeriodicReportBundle) -> PeriodicReportArchiveReceipt:
+        """Archive a bundle and return a deterministic exact-readback receipt.
+
+        The manifest is written last. A retry after a partial failure reuses
+        byte-identical files, while any content mismatch fails closed.
+        """
+
+        manifest, payloads = self._build_archive(bundle)
+        writes = 0
+        for uri, content in payloads:
+            writes += int(await self._ensure_exact_content(uri, content))
+
+        manifest_uri = str(manifest["manifest_uri"])
+        manifest_content = _canonical_json(manifest) + "\n"
+        writes += int(await self._ensure_exact_content(manifest_uri, manifest_content))
+
+        receipt = await self.readback(
+            manifest_uri,
+            expected_result_id=str(manifest["result_id"]),
+            expected_bundle_digest=str(manifest["bundle_digest"]),
+        )
+        if writes == 0:
+            status = "already_present"
+        elif writes == len(payloads) + 1:
+            status = "created"
+        else:
+            status = "recovered"
+        return replace(receipt, write_status=status)
+
+    async def readback(
+        self,
+        manifest_uri: str,
+        *,
+        expected_result_id: str | None = None,
+        expected_bundle_digest: str | None = None,
+    ) -> PeriodicReportArchiveReceipt:
+        """Verify the manifest, result id, digests, and both report payloads."""
+
+        raw_manifest = await self._client.read(manifest_uri)
+        try:
+            manifest = json.loads(raw_manifest)
+        except json.JSONDecodeError as exc:
+            raise PeriodicReportArchiveIntegrityError(
+                f"invalid archive manifest JSON: {manifest_uri}"
+            ) from exc
+        if not isinstance(manifest, dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"archive manifest must be an object: {manifest_uri}"
+            )
+        self._verify_manifest(manifest, manifest_uri)
+
+        stored_bundle_digest = _required_string(manifest, "bundle_digest", manifest_uri)
+        stored_result_id = _required_string(manifest, "result_id", manifest_uri)
+        core = dict(manifest)
+        core.pop("bundle_digest", None)
+        core.pop("result_id", None)
+        calculated_bundle_digest = _digest(_canonical_json(core))
+        calculated_result_id = _digest(f"{manifest_uri}\n{calculated_bundle_digest}")
+        if stored_bundle_digest != calculated_bundle_digest:
+            raise PeriodicReportArchiveIntegrityError(f"bundle digest mismatch for {manifest_uri}")
+        if stored_result_id != calculated_result_id:
+            raise PeriodicReportArchiveIntegrityError(f"result id mismatch for {manifest_uri}")
+        if expected_bundle_digest and stored_bundle_digest != expected_bundle_digest:
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected bundle digest for {manifest_uri}"
+            )
+        if expected_result_id and stored_result_id != expected_result_id:
+            raise PeriodicReportArchiveIntegrityError(f"unexpected result id for {manifest_uri}")
+
+        content = manifest.get("content")
+        if not isinstance(content, dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"manifest content must be an object: {manifest_uri}"
+            )
+        resource_uri = _required_string(manifest, "resource_uri", manifest_uri)
+        markdown_uri = await self._verify_content_entry(
+            content,
+            "markdown",
+            manifest_uri,
+            expected_uri=f"{resource_uri}/report.md",
+            expected_media_type="text/markdown",
+        )
+        html_uri = await self._verify_content_entry(
+            content,
+            "html",
+            manifest_uri,
+            expected_uri=f"{resource_uri}/report.html.txt",
+            expected_media_type="text/html",
+        )
+
+        return PeriodicReportArchiveReceipt(
+            schema_version="openviking_periodic_report_delivery_receipt_v0",
+            extension_id=str(EXTENSION_MANIFEST["id"]),
+            protocol_version=str(EXTENSION_MANIFEST["protocol_version"]),
+            result_id=stored_result_id,
+            resource_uri=resource_uri,
+            manifest_uri=manifest_uri,
+            markdown_uri=markdown_uri,
+            html_uri=html_uri,
+            bundle_digest=stored_bundle_digest,
+            write_status="readback",
+            exact_readback_verified=True,
+        )
+
+    async def query(
+        self,
+        *,
+        project_key: str,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Return verified report manifests for a project, newest first."""
+
+        _validate_segment("project_key", project_key)
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        since_date = _parse_date("since", since) if since else None
+        until_date = _parse_date("until", until) if until else None
+        if since_date and until_date and until_date < since_date:
+            raise ValueError("until must be on or after since")
+
+        project_root = f"{self._root_uri}/{project_key}"
+        glob_result = await self._client.glob("**/manifest.json", uri=project_root)
+        matches = glob_result.get("matches", []) if isinstance(glob_result, dict) else []
+        if not isinstance(matches, list):
+            raise PeriodicReportArchiveIntegrityError("glob matches must be a list")
+
+        if not all(isinstance(match, str) for match in matches):
+            raise PeriodicReportArchiveIntegrityError("glob manifest URI must be a string")
+
+        records: list[dict[str, Any]] = []
+        for manifest_uri in sorted(set(matches)):
+            raw_manifest = await self._client.read(manifest_uri)
+            try:
+                manifest = json.loads(raw_manifest)
+            except json.JSONDecodeError as exc:
+                raise PeriodicReportArchiveIntegrityError(
+                    f"invalid archive manifest JSON: {manifest_uri}"
+                ) from exc
+            if not isinstance(manifest, dict):
+                raise PeriodicReportArchiveIntegrityError(
+                    f"archive manifest must be an object: {manifest_uri}"
+                )
+            receipt = await self.readback(
+                manifest_uri,
+                expected_result_id=_required_string(manifest, "result_id", manifest_uri),
+                expected_bundle_digest=_required_string(manifest, "bundle_digest", manifest_uri),
+            )
+            identity = manifest["report_identity"]
+            period_start = _parse_date("period_start", identity["period_start"])
+            period_end = _parse_date("period_end", identity["period_end"])
+            if since_date and period_end < since_date:
+                continue
+            if until_date and period_start > until_date:
+                continue
+            records.append(
+                {
+                    "report_identity": identity,
+                    "capability_activation": manifest["capability_activation"],
+                    "generated_at": manifest["generated_at"],
+                    "metadata": manifest["metadata"],
+                    "content": manifest["content"],
+                    "receipt": receipt.to_dict(),
+                }
+            )
+
+        records.sort(
+            key=lambda record: (
+                record["report_identity"]["period_end"],
+                record["generated_at"],
+                record["report_identity"]["report_id"],
+            ),
+            reverse=True,
+        )
+        return records[:limit]
+
+    def _build_archive(
+        self, bundle: PeriodicReportBundle
+    ) -> tuple[dict[str, Any], list[tuple[str, str]]]:
+        resource_uri = (
+            f"{self._root_uri}/{bundle.project_key}/{bundle.period_start}/{bundle.report_id}"
+        )
+        markdown_uri = f"{resource_uri}/report.md"
+        # OpenViking content/write intentionally creates a bounded text-extension
+        # set. Keep the HTML bytes in a text resource and declare its media type
+        # in the manifest instead of widening the core write API.
+        html_uri = f"{resource_uri}/report.html.txt"
+        manifest_uri = f"{resource_uri}/manifest.json"
+        core: dict[str, Any] = {
+            "schema_version": ARCHIVE_SCHEMA_VERSION,
+            "extension_id": EXTENSION_MANIFEST["id"],
+            "protocol_version": EXTENSION_MANIFEST["protocol_version"],
+            "resource_uri": resource_uri,
+            "manifest_uri": manifest_uri,
+            "report_identity": {
+                "project_key": bundle.project_key,
+                "report_id": bundle.report_id,
+                "period_start": bundle.period_start,
+                "period_end": bundle.period_end,
+            },
+            "capability_activation": {
+                "capability_id": "periodic-report",
+                "activation_schema": ACTIVATION_SCHEMA_VERSION,
+                "profile_id": bundle.profile_id,
+                "profile_version": bundle.profile_version,
+            },
+            "generated_at": bundle.generated_at,
+            "metadata": dict(bundle.metadata),
+            "content": {
+                "markdown": {
+                    "uri": markdown_uri,
+                    "media_type": "text/markdown",
+                    "sha256": _digest(bundle.markdown),
+                },
+                "html": {
+                    "uri": html_uri,
+                    "media_type": "text/html",
+                    "storage_encoding": "utf-8",
+                    "sha256": _digest(bundle.html),
+                },
+            },
+        }
+        bundle_digest = _digest(_canonical_json(core))
+        core["bundle_digest"] = bundle_digest
+        core["result_id"] = _digest(f"{manifest_uri}\n{bundle_digest}")
+        return core, [(markdown_uri, bundle.markdown), (html_uri, bundle.html)]
+
+    async def _ensure_exact_content(self, uri: str, expected: str) -> bool:
+        existing = await self._read_optional(uri)
+        if existing is not None:
+            if existing != expected:
+                raise PeriodicReportArchiveConflict(
+                    f"stable report URI already contains different content: {uri}"
+                )
+            return False
+        try:
+            await self._client.write(uri, expected, mode="create", wait=False)
+            return True
+        except AlreadyExistsError:
+            # A concurrent identical retry may win between read and create.
+            raced = await self._client.read(uri)
+            if raced != expected:
+                raise PeriodicReportArchiveConflict(
+                    f"concurrent report write produced different content: {uri}"
+                )
+            return False
+
+    async def _read_optional(self, uri: str) -> str | None:
+        try:
+            return await self._client.read(uri)
+        except (NotFoundError, FileNotFoundError):
+            return None
+
+    def _verify_manifest(self, manifest: dict[str, Any], manifest_uri: str) -> None:
+        if manifest.get("schema_version") != ARCHIVE_SCHEMA_VERSION:
+            raise PeriodicReportArchiveIntegrityError(
+                f"unsupported archive schema for {manifest_uri}"
+            )
+        if manifest.get("extension_id") != EXTENSION_MANIFEST["id"]:
+            raise PeriodicReportArchiveIntegrityError(f"unexpected extension id for {manifest_uri}")
+        if manifest.get("protocol_version") != EXTENSION_MANIFEST["protocol_version"]:
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected protocol version for {manifest_uri}"
+            )
+        if manifest.get("manifest_uri") != manifest_uri:
+            raise PeriodicReportArchiveIntegrityError(
+                f"manifest URI is not self-consistent: {manifest_uri}"
+            )
+        resource_uri = _required_string(manifest, "resource_uri", manifest_uri)
+        if manifest_uri != f"{resource_uri}/manifest.json":
+            raise PeriodicReportArchiveIntegrityError(
+                f"resource and manifest URIs are not structurally bound: {manifest_uri}"
+            )
+        identity = manifest.get("report_identity")
+        if not isinstance(identity, dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"report identity must be an object: {manifest_uri}"
+            )
+        for key in ("project_key", "report_id"):
+            value = _required_string(identity, key, manifest_uri)
+            try:
+                _validate_segment(key, value)
+            except ValueError as exc:
+                raise PeriodicReportArchiveIntegrityError(str(exc)) from exc
+        period_start = _parse_manifest_date(identity, "period_start", manifest_uri)
+        period_end = _parse_manifest_date(identity, "period_end", manifest_uri)
+        if period_end < period_start:
+            raise PeriodicReportArchiveIntegrityError(
+                f"period_end precedes period_start in {manifest_uri}"
+            )
+        expected_resource_uri = (
+            f"{self._root_uri}/{identity['project_key']}/{identity['period_start']}"
+            f"/{identity['report_id']}"
+        )
+        if resource_uri != expected_resource_uri:
+            raise PeriodicReportArchiveIntegrityError(
+                f"report identity and Resource URI are not structurally bound: {manifest_uri}"
+            )
+        if not isinstance(manifest.get("metadata"), dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"manifest metadata must be an object: {manifest_uri}"
+            )
+        activation = manifest.get("capability_activation")
+        if not isinstance(activation, dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"capability activation must be an object: {manifest_uri}"
+            )
+        if (
+            activation.get("capability_id") != "periodic-report"
+            or activation.get("activation_schema") != ACTIVATION_SCHEMA_VERSION
+        ):
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected capability activation in {manifest_uri}"
+            )
+        profile_id = _required_string(activation, "profile_id", manifest_uri)
+        profile_version = _required_string(activation, "profile_version", manifest_uri)
+        try:
+            _validate_segment("profile_id", profile_id)
+            _validate_version("profile_version", profile_version)
+        except ValueError as exc:
+            raise PeriodicReportArchiveIntegrityError(str(exc)) from exc
+        generated_at = _required_string(manifest, "generated_at", manifest_uri)
+        try:
+            _parse_datetime("generated_at", generated_at)
+        except ValueError as exc:
+            raise PeriodicReportArchiveIntegrityError(str(exc)) from exc
+
+    async def _verify_content_entry(
+        self,
+        content: dict[str, Any],
+        key: str,
+        manifest_uri: str,
+        *,
+        expected_uri: str,
+        expected_media_type: str,
+    ) -> str:
+        entry = content.get(key)
+        if not isinstance(entry, dict):
+            raise PeriodicReportArchiveIntegrityError(
+                f"missing {key} content entry in {manifest_uri}"
+            )
+        uri = _required_string(entry, "uri", manifest_uri)
+        if uri != expected_uri:
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected {key} Resource URI in {manifest_uri}"
+            )
+        if entry.get("media_type") != expected_media_type:
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected {key} media type in {manifest_uri}"
+            )
+        if key == "html" and entry.get("storage_encoding") != "utf-8":
+            raise PeriodicReportArchiveIntegrityError(
+                f"unexpected html storage encoding in {manifest_uri}"
+            )
+        expected_digest = _required_string(entry, "sha256", manifest_uri)
+        actual = await self._client.read(uri)
+        if _digest(actual) != expected_digest:
+            raise PeriodicReportArchiveIntegrityError(f"{key} digest mismatch for {uri}")
+        return uri
+
+    def _validate_activation(
+        self,
+        raw: Mapping[str, Any],
+        *,
+        bundle: PeriodicReportBundle,
+        sink_id: str,
+        sink_kind: str,
+    ) -> dict[str, Any]:
+        if not isinstance(raw, Mapping):
+            raise PeriodicReportActivationError("activation receipt must be an object")
+        activation = dict(raw)
+        if activation.get("schema_version") != ACTIVATION_SCHEMA_VERSION:
+            raise PeriodicReportActivationError(
+                f"activation receipt must use {ACTIVATION_SCHEMA_VERSION}"
+            )
+        if not (
+            activation.get("status") == "enabled"
+            and activation.get("active") is True
+            and activation.get("generation_allowed") is True
+        ):
+            raise PeriodicReportActivationError(
+                "periodic-report capability profile must be enabled"
+            )
+        profile = activation.get("profile")
+        if not isinstance(profile, Mapping) or profile.get("enabled") is not True:
+            raise PeriodicReportActivationError(
+                "activation receipt must contain an enabled profile"
+            )
+        if (
+            profile.get("profile_id") != bundle.profile_id
+            or profile.get("profile_version") != bundle.profile_version
+        ):
+            raise PeriodicReportActivationError(
+                "report bundle and activation receipt use different profiles"
+            )
+        try:
+            expected_digest = "sha256:" + _digest(_canonical_json(profile))
+        except (TypeError, ValueError) as exc:
+            raise PeriodicReportActivationError(
+                "activation receipt profile must be JSON-serializable"
+            ) from exc
+        if activation.get("profile_digest") != expected_digest:
+            raise PeriodicReportActivationError(
+                "activation receipt profile digest does not match the profile"
+            )
+        bindings = profile.get("sink_bindings")
+        if not isinstance(bindings, list):
+            raise PeriodicReportActivationError("activation profile must contain sink bindings")
+        for raw_binding in bindings:
+            if not isinstance(raw_binding, Mapping):
+                continue
+            binding = dict(raw_binding)
+            if binding.get("sink_id") != sink_id:
+                continue
+            capability = binding.get("capability")
+            extension = binding.get("extension")
+            valid = (
+                binding.get("schema_version") == SINK_BINDING_SCHEMA_VERSION
+                and binding.get("sink_kind") == sink_kind
+                and binding.get("sink_role") == "archive"
+                and binding.get("dependency_policy") in {"optional", "required"}
+                and isinstance(capability, Mapping)
+                and capability.get("capability_id") == "report.archive.write"
+                and capability.get("capability_version") == "v0"
+                and isinstance(extension, Mapping)
+                and extension.get("extension_id") == EXTENSION_MANIFEST["id"]
+                and extension.get("extension_version") == EXTENSION_MANIFEST["version"]
+                and extension.get("protocol") == EXTENSION_MANIFEST["protocol_version"]
+            )
+            if valid:
+                return binding
+            raise PeriodicReportActivationError(
+                "periodic-report archive sink binding is incompatible or disabled"
+            )
+        raise PeriodicReportActivationError(
+            "periodic-report profile does not bind this archive sink"
+        )
+
+
+def _required_string(payload: Mapping[str, Any], key: str, source: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise PeriodicReportArchiveIntegrityError(f"missing string {key} in {source}")
+    return value
+
+
+def _validate_segment(name: str, value: str) -> None:
+    if not isinstance(value, str) or not _SAFE_SEGMENT.fullmatch(value):
+        raise ValueError(f"{name} must match {_SAFE_SEGMENT.pattern}")
+
+
+def _validate_version(name: str, value: str) -> None:
+    if not isinstance(value, str) or not _VERSION_TOKEN.fullmatch(value):
+        raise ValueError(f"{name} must match {_VERSION_TOKEN.pattern}")
+
+
+def _parse_date(name: str, value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an ISO date") from exc
+
+
+def _parse_manifest_date(identity: Mapping[str, Any], key: str, source: str) -> date:
+    value = _required_string(identity, key, source)
+    try:
+        return _parse_date(key, value)
+    except ValueError as exc:
+        raise PeriodicReportArchiveIntegrityError(str(exc)) from exc
+
+
+def _parse_datetime(name: str, value: str) -> datetime:
+    try:
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an ISO datetime") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{name} must include a UTC offset")
+    return parsed
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()

--- a/tests/extensions/test_periodic_report.py
+++ b/tests/extensions/test_periodic_report.py
@@ -1,0 +1,406 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+import json
+from fnmatch import fnmatch
+from hashlib import sha256
+from typing import Any
+
+import pytest
+
+from openviking.extensions.periodic_report import (
+    PeriodicReportActivationError,
+    PeriodicReportArchiveConflict,
+    PeriodicReportArchiveIntegrityError,
+    PeriodicReportArchiveProvider,
+    PeriodicReportBundle,
+    get_extension_manifest,
+)
+from openviking_cli.exceptions import AlreadyExistsError, NotFoundError
+
+
+class FakeArchiveClient:
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.write_calls: list[str] = []
+
+    async def read(self, uri: str, offset: int = 0, limit: int = -1) -> str:
+        del offset, limit
+        if uri not in self.files:
+            raise NotFoundError(uri, "file")
+        return self.files[uri]
+
+    async def write(
+        self,
+        uri: str,
+        content: str,
+        mode: str = "replace",
+        wait: bool = False,
+        timeout: float | None = None,
+        telemetry: bool = False,
+    ) -> dict[str, Any]:
+        del wait, timeout, telemetry
+        if mode == "create" and uri in self.files:
+            raise AlreadyExistsError(uri, "file")
+        self.files[uri] = content
+        self.write_calls.append(uri)
+        return {"uri": uri}
+
+    async def glob(self, pattern: str, uri: str = "viking://") -> dict[str, Any]:
+        prefix = uri.rstrip("/") + "/"
+        matches = [
+            candidate
+            for candidate in self.files
+            if candidate.startswith(prefix) and fnmatch(candidate[len(prefix) :], pattern)
+        ]
+        return {"matches": sorted(matches), "count": len(matches)}
+
+
+def make_bundle(
+    *,
+    report_id: str = "weekly-2026-07-20",
+    period_start: str = "2026-07-13",
+    period_end: str = "2026-07-19",
+    markdown: str = "# Weekly report\n\n- shipped",
+) -> PeriodicReportBundle:
+    return PeriodicReportBundle(
+        project_key="openviking",
+        profile_id="openviking_weekly",
+        profile_version="v1",
+        report_id=report_id,
+        period_start=period_start,
+        period_end=period_end,
+        generated_at=f"{period_end}T09:00:00+08:00",
+        markdown=markdown,
+        html=f"<html><body>{markdown}</body></html>",
+        metadata={"trigger": "cadence", "renderer": "ov-weekly"},
+    )
+
+
+def make_activation(
+    *,
+    enabled: bool = True,
+    dependency_policy: str = "optional",
+    sink_id: str = "project_archive",
+) -> dict[str, Any]:
+    profile = {
+        "schema_version": "periodic_report_profile_v0",
+        "enabled": enabled,
+        "profile_id": "openviking_weekly",
+        "profile_version": "v1",
+        "trigger_policy": {},
+        "source_bindings": [],
+        "renderer_bindings": [],
+        "sink_bindings": [
+            {
+                "schema_version": "periodic_report_sink_binding_v0",
+                "sink_id": sink_id,
+                "sink_kind": "project_resource",
+                "sink_role": "archive",
+                "dependency_policy": dependency_policy,
+                "capability": {
+                    "capability_id": "report.archive.write",
+                    "capability_version": "v0",
+                },
+                "extension": {
+                    "extension_id": "openviking.periodic-report.archive",
+                    "extension_version": "0.1.0",
+                    "protocol": "periodic_report_sink_v0",
+                },
+            }
+        ],
+    }
+    profile_digest = sha256(
+        json.dumps(
+            profile,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schema_version": "periodic_report_activation_v0",
+        "status": "enabled" if enabled else "disabled",
+        "active": enabled,
+        "generation_allowed": enabled,
+        "profile_digest": f"sha256:{profile_digest}",
+        "profile": profile,
+    }
+
+
+def test_manifest_is_default_off_and_provider_scoped() -> None:
+    manifest = get_extension_manifest()
+
+    assert manifest["default_enabled"] is False
+    assert manifest["requires_capability"] == {
+        "capability_id": "periodic-report",
+        "activation_schema": "periodic_report_activation_v0",
+        "profile_enabled": True,
+        "sink_binding_schema": "periodic_report_sink_binding_v0",
+        "accepted_dependency_policies": ["optional", "required"],
+    }
+    assert manifest["protocol_version"] == "periodic_report_sink_v0"
+    assert set(manifest["capabilities"]) == {
+        "report.archive.write",
+        "report.archive.readback",
+        "report.query",
+    }
+    assert manifest["capabilities"]["report.archive.write"] == {
+        "version": "v0",
+        "method": "archive_sink",
+    }
+    assert "lark_delivery" in manifest["boundary"]["does_not_own"]
+    assert "trigger" in manifest["boundary"]["does_not_own"]
+
+
+def test_readiness_matches_loopx_extension_binding() -> None:
+    provider = PeriodicReportArchiveProvider(FakeArchiveClient())
+
+    assert provider.readiness(
+        activation_receipt=make_activation(),
+        sink_id="project_archive",
+        bundle=make_bundle(),
+    ) == {
+        "extension_id": "openviking.periodic-report.archive",
+        "extension_version": "0.1.0",
+        "protocol": "periodic_report_sink_v0",
+        "status": "ready",
+        "readback_verified": True,
+        "capabilities": [
+            {"capability_id": "report.archive.readback", "capability_version": "v0"},
+            {"capability_id": "report.archive.write", "capability_version": "v0"},
+            {"capability_id": "report.query", "capability_version": "v0"},
+        ],
+        "activation_verified": True,
+        "activation_error": None,
+    }
+
+
+def test_readiness_is_unavailable_without_capability_activation() -> None:
+    readiness = PeriodicReportArchiveProvider(FakeArchiveClient()).readiness()
+
+    assert readiness["status"] == "unavailable"
+    assert readiness["readback_verified"] is False
+    assert readiness["activation_verified"] is False
+    assert readiness["activation_error"] == "periodic_report_activation_required"
+
+
+@pytest.mark.asyncio
+async def test_archive_writes_bundle_and_exact_receipt() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+
+    receipt = await provider.archive(make_bundle())
+
+    assert receipt.write_status == "created"
+    assert receipt.exact_readback_verified is True
+    assert len(receipt.result_id) == 64
+    assert client.files[receipt.markdown_uri].startswith("# Weekly report")
+    assert client.files[receipt.html_uri].startswith("<html>")
+    assert receipt.html_uri.endswith("report.html.txt")
+    assert client.write_calls[-1] == receipt.manifest_uri
+
+
+@pytest.mark.asyncio
+async def test_archive_sink_returns_loopx_sink_result() -> None:
+    provider = PeriodicReportArchiveProvider(FakeArchiveClient())
+
+    result = await provider.archive_sink(
+        make_bundle(),
+        sink_id="project_archive",
+        idempotency_key="report_sink_0123456789abcdef",
+        activation_receipt=make_activation(),
+    )
+
+    assert result["schema_version"] == "periodic_report_sink_result_v0"
+    assert result["sink_role"] == "archive"
+    assert result["status"] == "sent"
+    assert result["receipt_ref"].endswith("/manifest.json")
+    assert result["readback_verified"] is True
+    assert result["schedule_policy_applied"] is False
+    assert result["business_evidence_judged"] is False
+    assert result["capability_activation_verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_archive_sink_rejects_disabled_or_missing_binding() -> None:
+    provider = PeriodicReportArchiveProvider(FakeArchiveClient())
+
+    with pytest.raises(PeriodicReportActivationError, match="must be enabled"):
+        await provider.archive_sink(
+            make_bundle(),
+            sink_id="project_archive",
+            idempotency_key="report_sink_disabled",
+            activation_receipt=make_activation(enabled=False),
+        )
+
+    with pytest.raises(PeriodicReportActivationError, match="does not bind"):
+        await provider.archive_sink(
+            make_bundle(),
+            sink_id="project_archive",
+            idempotency_key="report_sink_missing",
+            activation_receipt=make_activation(sink_id="different_archive"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identical_retry_is_noop_with_same_result_id() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    bundle = make_bundle()
+
+    first = await provider.archive(bundle)
+    write_count = len(client.write_calls)
+    second = await provider.archive(bundle)
+
+    assert second.write_status == "already_present"
+    assert second.result_id == first.result_id
+    assert second.bundle_digest == first.bundle_digest
+    assert len(client.write_calls) == write_count
+
+
+@pytest.mark.asyncio
+async def test_partial_retry_recovers_and_keeps_stable_identity() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    bundle = make_bundle()
+    resource_uri = "viking://resources/periodic-reports/openviking/2026-07-13/weekly-2026-07-20"
+    client.files[f"{resource_uri}/report.md"] = bundle.markdown
+
+    receipt = await provider.archive(bundle)
+
+    assert receipt.write_status == "recovered"
+    assert receipt.exact_readback_verified is True
+    assert f"{resource_uri}/report.md" not in client.write_calls
+    assert client.write_calls[-1] == receipt.manifest_uri
+
+
+@pytest.mark.asyncio
+async def test_same_identity_with_different_content_fails_closed() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    await provider.archive(make_bundle())
+
+    with pytest.raises(PeriodicReportArchiveConflict):
+        await provider.archive(make_bundle(markdown="# changed"))
+
+
+@pytest.mark.asyncio
+async def test_readback_detects_tampered_payload() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    receipt = await provider.archive(make_bundle())
+    client.files[receipt.html_uri] = "<html>tampered</html>"
+
+    with pytest.raises(PeriodicReportArchiveIntegrityError, match="html digest mismatch"):
+        await provider.readback(receipt.manifest_uri)
+
+
+@pytest.mark.asyncio
+async def test_query_returns_verified_newest_reports_and_filters_period() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    await provider.archive(make_bundle())
+    await provider.archive(
+        make_bundle(
+            report_id="weekly-2026-07-27",
+            period_start="2026-07-20",
+            period_end="2026-07-26",
+        )
+    )
+
+    all_records = await provider.query(project_key="openviking")
+    assert [record["report_identity"]["report_id"] for record in all_records] == [
+        "weekly-2026-07-27",
+        "weekly-2026-07-20",
+    ]
+
+    records = await provider.query(
+        project_key="openviking",
+        since="2026-07-20",
+        until="2026-07-31",
+    )
+
+    assert [record["report_identity"]["report_id"] for record in records] == ["weekly-2026-07-27"]
+    assert records[0]["receipt"]["exact_readback_verified"] is True
+
+
+def test_bundle_rejects_path_traversal_and_invalid_period() -> None:
+    with pytest.raises(ValueError, match="project_key"):
+        PeriodicReportBundle(
+            project_key="../openviking",
+            profile_id="openviking_weekly",
+            profile_version="v1",
+            report_id="weekly",
+            period_start="2026-07-13",
+            period_end="2026-07-19",
+            generated_at="2026-07-20T09:00:00+08:00",
+            markdown="# report",
+            html="<h1>report</h1>",
+        )
+
+    with pytest.raises(ValueError, match="period_end"):
+        make_bundle(period_start="2026-07-20", period_end="2026-07-19")
+
+
+def test_bundle_detaches_metadata_from_mutable_input() -> None:
+    metadata = {"trigger": "cadence", "labels": ["weekly"]}
+    bundle = PeriodicReportBundle(
+        project_key="openviking",
+        profile_id="openviking_weekly",
+        profile_version="v1",
+        report_id="weekly-2026-07-20",
+        period_start="2026-07-13",
+        period_end="2026-07-19",
+        generated_at="2026-07-19T09:00:00+08:00",
+        markdown="# report",
+        html="<h1>report</h1>",
+        metadata=metadata,
+    )
+
+    metadata["trigger"] = "manual"
+    metadata["labels"].append("changed")
+
+    assert bundle.metadata == {"labels": ["weekly"], "trigger": "cadence"}
+
+
+def test_provider_rejects_non_resource_roots() -> None:
+    with pytest.raises(ValueError, match="Resource path"):
+        PeriodicReportArchiveProvider(
+            FakeArchiveClient(), root_uri="viking://user/memories/periodic-reports"
+        )
+
+    with pytest.raises(ValueError, match="Resource path"):
+        PeriodicReportArchiveProvider(
+            FakeArchiveClient(), root_uri="viking://resources/periodic-reports/../escape"
+        )
+
+
+def test_bundle_requires_offset_aware_generation_time() -> None:
+    with pytest.raises(ValueError, match="UTC offset"):
+        PeriodicReportBundle(
+            project_key="openviking",
+            profile_id="openviking_weekly",
+            profile_version="v1",
+            report_id="weekly-2026-07-20",
+            period_start="2026-07-13",
+            period_end="2026-07-19",
+            generated_at="2026-07-19T09:00:00",
+            markdown="# report",
+            html="<h1>report</h1>",
+        )
+
+
+@pytest.mark.asyncio
+async def test_readback_rejects_manifest_uri_rebinding() -> None:
+    client = FakeArchiveClient()
+    provider = PeriodicReportArchiveProvider(client)
+    receipt = await provider.archive(make_bundle())
+    manifest = json.loads(client.files[receipt.manifest_uri])
+    manifest["resource_uri"] = "viking://resources/periodic-reports/other"
+    client.files[receipt.manifest_uri] = json.dumps(manifest)
+
+    with pytest.raises(PeriodicReportArchiveIntegrityError, match="structurally bound"):
+        await provider.readback(receipt.manifest_uri)

--- a/tests/server/test_periodic_report_extension.py
+++ b/tests/server/test_periodic_report_extension.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from openviking.extensions.periodic_report import (
+    PeriodicReportArchiveProvider,
+    PeriodicReportBundle,
+)
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
+from openviking.utils.agfs_utils import RagfsBindingConfig, create_agfs_client
+from openviking_cli.exceptions import AlreadyExistsError
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.config.agfs_config import AGFSConfig
+
+
+def _activation_receipt() -> dict[str, Any]:
+    profile = {
+        "schema_version": "periodic_report_profile_v0",
+        "enabled": True,
+        "profile_id": "openviking_weekly",
+        "profile_version": "v1",
+        "sink_bindings": [
+            {
+                "schema_version": "periodic_report_sink_binding_v0",
+                "sink_id": "project_archive",
+                "sink_kind": "project_resource",
+                "sink_role": "archive",
+                "dependency_policy": "optional",
+                "capability": {
+                    "capability_id": "report.archive.write",
+                    "capability_version": "v0",
+                },
+                "extension": {
+                    "extension_id": "openviking.periodic-report.archive",
+                    "extension_version": "0.1.0",
+                    "protocol": "periodic_report_sink_v0",
+                },
+            }
+        ],
+    }
+    profile_digest = sha256(
+        json.dumps(
+            profile,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schema_version": "periodic_report_activation_v0",
+        "status": "enabled",
+        "active": True,
+        "generation_allowed": True,
+        "profile_digest": f"sha256:{profile_digest}",
+        "profile": profile,
+    }
+
+
+class VikingFSArchiveClient:
+    """Bind the provider to the real embedded Resource filesystem."""
+
+    def __init__(self, viking_fs: VikingFS) -> None:
+        self._fs = viking_fs
+        self._ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+    async def read(self, uri: str, offset: int = 0, limit: int = -1) -> str:
+        return await self._fs.read_file(uri, ctx=self._ctx, offset=offset, limit=limit)
+
+    async def write(
+        self,
+        uri: str,
+        content: str,
+        mode: str = "replace",
+        wait: bool = False,
+        timeout: float | None = None,
+        telemetry: bool = False,
+    ) -> dict[str, Any]:
+        del wait, timeout, telemetry
+        if mode == "create" and await self._fs.exists(uri, ctx=self._ctx):
+            raise AlreadyExistsError(uri, "file")
+        await self._fs.write_file(uri, content, ctx=self._ctx)
+        return {"uri": uri}
+
+    async def glob(self, pattern: str, uri: str = "viking://") -> dict[str, Any]:
+        return await self._fs.glob(pattern, ctx=self._ctx, uri=uri)
+
+
+@pytest_asyncio.fixture
+async def report_viking_fs(temp_dir, monkeypatch):
+    """Create a real local RAGFS-backed VikingFS without vector/model services."""
+
+    config_path = temp_dir / "ov.conf"
+    config_path.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("OPENVIKING_CONFIG_FILE", str(config_path))
+    agfs_config = AGFSConfig(path=str(temp_dir / "data"), backend="local")
+    try:
+        agfs_client = create_agfs_client(RagfsBindingConfig(agfs=agfs_config))
+    except ImportError as exc:
+        pytest.skip(f"RAGFS native binding is unavailable: {exc}")
+    viking_fs = VikingFS(agfs=agfs_client)
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    await viking_fs.mkdir("viking://resources/", exist_ok=True, ctx=ctx)
+    yield viking_fs
+
+
+@pytest.mark.asyncio
+async def test_periodic_report_resource_canary(report_viking_fs) -> None:
+    client = VikingFSArchiveClient(report_viking_fs)
+    provider = PeriodicReportArchiveProvider(client)
+    bundle = PeriodicReportBundle(
+        project_key="openviking",
+        profile_id="openviking_weekly",
+        profile_version="v1",
+        report_id="weekly-2026-07-20",
+        period_start="2026-07-13",
+        period_end="2026-07-19",
+        generated_at="2026-07-19T09:00:00+08:00",
+        markdown="# OpenViking weekly report\n\n- Resource canary passed",
+        html="<h1>OpenViking weekly report</h1><p>Resource canary passed</p>",
+        metadata={"trigger": "cadence", "renderer": "ov-weekly"},
+    )
+
+    first_result = await provider.archive_sink(
+        bundle,
+        sink_id="project_archive",
+        idempotency_key="report_sink_canary",
+        activation_receipt=_activation_receipt(),
+    )
+    first = await provider.readback(first_result["receipt_ref"])
+    second_result = await provider.archive_sink(
+        bundle,
+        sink_id="project_archive",
+        idempotency_key="report_sink_canary",
+        activation_receipt=_activation_receipt(),
+    )
+    records = await provider.query(project_key="openviking")
+
+    assert first_result["write_status"] == "created"
+    assert first.exact_readback_verified is True
+    assert second_result["write_status"] == "already_present"
+    assert second_result["result_id"] == first.result_id
+    assert records[0]["receipt"]["result_id"] == first.result_id
+    assert await client.read(first.markdown_uri) == bundle.markdown


### PR DESCRIPTION
## Description

Add a default-off OpenViking Resource provider for domain-neutral periodic reports. The provider accepts already-rendered Markdown and HTML artifacts, archives them with deterministic identities, verifies exact readback, and exposes a bounded query surface for future history and visualization consumers.

The formal archive entry point requires a verified LoopX `periodic_report_activation_v0`: the capability profile must be enabled and must bind this exact sink/version/protocol. Trigger policy, source selection, rendering, and Lark delivery remain outside OpenViking.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3370

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- add the optional `openviking.periodic-report.archive` provider and versioned `periodic_report_sink_v0` manifest
- require an enabled LoopX periodic-report activation plus a compatible profile sink binding before any archive write
- archive Markdown, HTML, and a last-written manifest under a stable project Resource identity with exact readback
- make identical retries no-ops, recover partial writes, fail closed on conflicts, and provide verified date-bounded queries
- document portable, enhanced, and durable experience modes plus the optional LoopX binding in English and Chinese

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `16 passed, 1 skipped` without a locally built RAGFS native binding; the canary skip is explicit
- real local RAGFS-backed OpenViking Resource canary: `1 passed`
- installed LoopX activation → OpenViking readiness/archive → LoopX delivery-receipt handshake: succeeded with exact readback
- Ruff format/check, focused mypy, compileall, and `git diff --check` passed
- no model credentials, network delivery, or benchmark spend were used

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The provider is disabled by default and only owns archive write, exact readback, and query. An archive failure remains local to an optional sink; a project can instead configure it as required for durable mode. The generic LoopX periodic-report capability is already merged and published independently. This PR does not add scheduling, report generation, or chat delivery to OpenViking.
