### PR TITLE
perf(vectordb): avoid hydrating unrequested vectors

### DIFF
--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -533,46 +533,64 @@ class LocalCollection(ICollection):
 
         pk_list = label_list
         fields_list = []
-        if not output_fields:
-            output_fields = list(self.meta.fields_dict.keys())
-        if self.meta.primary_key or output_fields:
+        projected_fields = (
+            list(self.meta.fields_dict.keys()) if not output_fields else list(output_fields)
+        )
+        include_vector = bool(self.meta.vector_key) and self.meta.vector_key in projected_fields
+        if self.meta.primary_key or projected_fields:
             if not self.store_mgr:
                 raise RuntimeError("Store manager is not initialized")
-            cands_list = self.store_mgr.fetch_cands_data(label_list)
+
+            cands_vectors: Optional[List[List[float]]] = None
+            if include_vector:
+                cands_list = self.store_mgr.fetch_cands_data(label_list)
+                cands_fields_payloads = [
+                    cand.fields if cand is not None else None for cand in cands_list
+                ]
+                cands_vectors = [cand.vector if cand is not None else [] for cand in cands_list]
+            else:
+                cands_fields_payloads = self.store_mgr.fetch_cands_fields(label_list)
 
             valid_indices = []
-            for i, cand in enumerate(cands_list):
-                if cand is not None:
+            for i, fields_payload in enumerate(cands_fields_payloads):
+                if fields_payload is not None:
                     valid_indices.append(i)
                 else:
                     logger.warning(
                         f"Candidate data is None for label index {i} (label: {label_list[i] if i < len(label_list) else 'unknown'}), skipping."
                     )
 
-            if len(valid_indices) < len(cands_list):
-                cands_list = [cands_list[i] for i in valid_indices]
+            if len(valid_indices) < len(cands_fields_payloads):
+                cands_fields_payloads = [cands_fields_payloads[i] for i in valid_indices]
+                if cands_vectors is not None:
+                    cands_vectors = [cands_vectors[i] for i in valid_indices]
                 pk_list = [pk_list[i] for i in valid_indices]
                 scores_list = [scores_list[i] for i in valid_indices]
 
             # Parse each candidate's fields defensively: a single corrupted JSON
             # string (e.g. truncated by the storage layer's uint16 length prefix)
-            # must not fail the whole query. Skip the bad ones and keep cands_list,
-            # pk_list and scores_list aligned, mirroring the None-skip above.
+            # must not fail the whole query. Skip the bad ones and keep payloads,
+            # vectors, pk_list and scores_list aligned, mirroring the None-skip above.
             cands_fields = []
             json_valid_indices = []
-            for i, cand in enumerate(cands_list):
+            for i, fields_payload in enumerate(cands_fields_payloads):
                 try:
-                    cands_fields.append(json.loads(cand.fields))
+                    parsed_fields = json.loads(fields_payload)
+                    if not isinstance(parsed_fields, dict):
+                        raise TypeError("candidate fields JSON must be an object")
+                    cands_fields.append(parsed_fields)
                     json_valid_indices.append(i)
                 except (json.JSONDecodeError, TypeError) as e:
                     logger.warning(
-                        f"Failed to parse candidate fields as JSON (label={cand.label}, "
-                        f"fields_len={len(cand.fields) if cand.fields else 0}), skipping. "
+                        f"Failed to parse candidate fields as JSON (label={pk_list[i]}, "
+                        f"fields_len={len(fields_payload) if fields_payload else 0}), skipping. "
                         f"Error: {e}"
                     )
 
-            if len(json_valid_indices) < len(cands_list):
-                cands_list = [cands_list[i] for i in json_valid_indices]
+            if len(json_valid_indices) < len(cands_fields_payloads):
+                cands_fields_payloads = [cands_fields_payloads[i] for i in json_valid_indices]
+                if cands_vectors is not None:
+                    cands_vectors = [cands_vectors[i] for i in json_valid_indices]
                 pk_list = [pk_list[i] for i in json_valid_indices]
                 scores_list = [scores_list[i] for i in json_valid_indices]
 
@@ -581,12 +599,12 @@ class LocalCollection(ICollection):
                     cands_field.get(self.meta.primary_key, "") for cands_field in cands_fields
                 ]
             fields_list = [
-                {field: cands_field.get(field, None) for field in output_fields}
+                {field: cands_field.get(field, None) for field in projected_fields}
                 for cands_field in cands_fields
             ]
-            if self.meta.vector_key:
-                for i, cands in enumerate(cands_list):
-                    fields_list[i][self.meta.vector_key] = cands.vector
+            if include_vector and self.meta.vector_key and cands_vectors is not None:
+                for i, vector in enumerate(cands_vectors):
+                    fields_list[i][self.meta.vector_key] = vector
 
         search_result.data = [
             SearchItemResult(id=pk, fields=fields, score=score)

--- a/openviking/storage/vectordb/store/store_manager.py
+++ b/openviking/storage/vectordb/store/store_manager.py
@@ -198,6 +198,27 @@ class StoreManager:
         ]
         return cands_list
 
+    def fetch_cands_fields(self, label_list: List[int]) -> List[Optional[str]]:
+        """Fetch only the serialized scalar fields for candidate labels.
+
+        This avoids materializing dense and sparse vectors when a caller only
+        needs projected scalar fields. The returned list preserves the input
+        order and uses ``None`` for missing candidates, matching
+        :meth:`fetch_cands_data`.
+        """
+        bytes_list = self.storage.read(
+            [str(label) for label in label_list],
+            StoreManager.CandsTable,
+        )
+        return [
+            (
+                CandidateData.bytes_row.deserialize_field(bytes_data, "fields")
+                if bytes_data
+                else None
+            )
+            for bytes_data in bytes_list
+        ]
+
     def get_all_cands_data(self) -> List[CandidateData]:
         """Get all candidate data from the store.
 

--- a/tests/vectordb/test_local_collection_projection.py
+++ b/tests/vectordb/test_local_collection_projection.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.storage.vectordb.collection.local_collection import LocalCollection
+from openviking.storage.vectordb.store.data import CandidateData
+from openviking.storage.vectordb.store.store_manager import StoreManager
+
+
+class _FakeIndex:
+    def __init__(self, labels, scores):
+        self.labels = labels
+        self.scores = scores
+
+    def search(self, *_args, **_kwargs):
+        return list(self.labels), list(self.scores)
+
+
+class _FakeIndexes:
+    def __init__(self, index):
+        self.index = index
+
+    def get(self, _name):
+        return self.index
+
+
+class _FakeStoreManager:
+    def __init__(self, candidates, fields_payloads=None):
+        self.candidates = candidates
+        self.fields_payloads = fields_payloads
+        self.calls = []
+
+    def fetch_cands_data(self, labels):
+        self.calls.append(("data", list(labels)))
+        return list(self.candidates)
+
+    def fetch_cands_fields(self, labels):
+        self.calls.append(("fields", list(labels)))
+        if self.fields_payloads is not None:
+            return list(self.fields_payloads)
+        return [
+            candidate.fields if candidate is not None else None for candidate in self.candidates
+        ]
+
+
+def _candidate(label, doc_id, uri, vector):
+    return CandidateData(
+        label=label,
+        vector=vector,
+        fields=json.dumps({"doc_id": doc_id, "uri": uri}),
+    )
+
+
+def _collection(store, labels=(11, 12), scores=(0.9, 0.8)):
+    collection = object.__new__(LocalCollection)
+    collection.indexes = _FakeIndexes(_FakeIndex(labels, scores))
+    collection.store_mgr = store
+    collection.meta = SimpleNamespace(
+        primary_key="doc_id",
+        vector_key="embedding",
+        fields_dict={"doc_id": {}, "embedding": {}, "uri": {}},
+    )
+    return collection
+
+
+def test_search_by_vector_projects_fields_without_decoding_vectors():
+    store = _FakeStoreManager(
+        [
+            _candidate(11, "first", "/docs/one", [1.0, 0.0]),
+            _candidate(12, "second", "/docs/two", [0.0, 1.0]),
+        ]
+    )
+
+    result = _collection(store).search_by_vector(
+        "default", dense_vector=[1.0, 0.0], output_fields=["uri"]
+    )
+
+    assert store.calls == [("fields", [11, 12])]
+    assert [(item.id, item.fields, item.score) for item in result.data] == [
+        ("first", {"uri": "/docs/one"}, 0.9),
+        ("second", {"uri": "/docs/two"}, 0.8),
+    ]
+
+
+@pytest.mark.parametrize("output_fields", [None, [], ["uri", "embedding"]])
+def test_search_by_vector_preserves_full_and_explicit_vector_hydration(output_fields):
+    store = _FakeStoreManager(
+        [
+            _candidate(11, "first", "/docs/one", [1.0, 0.0]),
+            _candidate(12, "second", "/docs/two", [0.0, 1.0]),
+        ]
+    )
+
+    result = _collection(store).search_by_vector(
+        "default", dense_vector=[1.0, 0.0], output_fields=output_fields
+    )
+
+    assert store.calls == [("data", [11, 12])]
+    assert [item.id for item in result.data] == ["first", "second"]
+    assert [item.fields["embedding"] for item in result.data] == [
+        [1.0, 0.0],
+        [0.0, 1.0],
+    ]
+    if output_fields:
+        assert result.data[0].fields == {
+            "uri": "/docs/one",
+            "embedding": [1.0, 0.0],
+        }
+    else:
+        assert result.data[0].fields == {
+            "doc_id": "first",
+            "embedding": [1.0, 0.0],
+            "uri": "/docs/one",
+        }
+
+
+def test_search_by_vector_supports_vector_only_projection():
+    store = _FakeStoreManager(
+        [
+            _candidate(11, "first", "/docs/one", [1.0, 0.0]),
+            _candidate(12, "second", "/docs/two", [0.0, 1.0]),
+        ]
+    )
+
+    result = _collection(store).search_by_vector(
+        "default",
+        dense_vector=[1.0, 0.0],
+        output_fields=["embedding"],
+    )
+
+    assert store.calls == [("data", [11, 12])]
+    assert [(item.id, item.fields) for item in result.data] == [
+        ("first", {"embedding": [1.0, 0.0]}),
+        ("second", {"embedding": [0.0, 1.0]}),
+    ]
+
+
+def test_projected_hydration_skips_missing_and_corrupt_rows_without_misalignment():
+    store = _FakeStoreManager(
+        candidates=[],
+        fields_payloads=[
+            json.dumps({"doc_id": "first", "uri": "/docs/one"}),
+            None,
+            '{"doc_id": "broken"',
+            "null",
+            json.dumps({"doc_id": "fourth", "uri": "/docs/four"}),
+        ],
+    )
+    collection = _collection(
+        store,
+        labels=(11, 12, 13, 14, 15),
+        scores=(0.9, 0.8, 0.7, 0.65, 0.6),
+    )
+
+    result = collection.search_by_vector("default", dense_vector=[1.0, 0.0], output_fields=["uri"])
+
+    assert [(item.id, item.fields, item.score) for item in result.data] == [
+        ("first", {"uri": "/docs/one"}, 0.9),
+        ("fourth", {"uri": "/docs/four"}, 0.6),
+    ]
+
+
+def test_store_manager_projects_fields_and_preserves_missing_positions(monkeypatch):
+    payloads = {
+        "11": _candidate(11, "first", "/docs/one", [1.0, 0.0]).serialize(),
+        "13": _candidate(13, "third", "/docs/three", [0.0, 1.0]).serialize(),
+    }
+
+    class _Storage:
+        def read(self, keys, table):
+            assert table == StoreManager.CandsTable
+            return [payloads.get(key, b"") for key in keys]
+
+    manager = StoreManager(_Storage())
+
+    def reject_full_decode(_payload):
+        raise AssertionError("projected fetch must not deserialize CandidateData")
+
+    monkeypatch.setattr(CandidateData, "from_bytes", staticmethod(reject_full_decode))
+
+    fields = manager.fetch_cands_fields([11, 12, 13, 11])
+
+    assert fields == [
+        json.dumps({"doc_id": "first", "uri": "/docs/one"}),
+        None,
+        json.dumps({"doc_id": "third", "uri": "/docs/three"}),
+        json.dumps({"doc_id": "first", "uri": "/docs/one"}),
+    ]


### PR DESCRIPTION
## Description

Local vector search currently deserializes each returned `CandidateData` in full, even when
`output_fields` requests scalar metadata only. For dense-vector collections this creates a
Python-float copy of every top-k vector and then discards it before the result reaches the caller.

This PR adds a projected hydration path that reads and decodes only the serialized scalar
`fields` member when the vector field was not requested. This is a general Local backend
optimization: it benefits Native CPU, explicit cuVS, and Auto without changing index selection or
search semantics.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Add ordered, missing-row-preserving `StoreManager.fetch_cands_fields()` access.
- Make `LocalCollection.search_by_vector()` avoid dense and sparse vector materialization for
  scalar-only projections.
- Preserve full hydration for `output_fields=None`, `output_fields=[]`, and explicit vector-field
  requests.
- Preserve primary-key extraction and result alignment while skipping missing, malformed, or
  non-object scalar payloads.
- Add focused coverage for scalar-only, all-fields, explicit-vector, vector-only, missing-row, and
  corrupt-row behavior.

## Compatibility

This corrects a Local backend projection inconsistency: an explicit projection such as
`output_fields=["uri"]` no longer includes the unrequested dense vector. This matches the
collection API contract and remote adapters. Callers that need the vector can request the
configured vector field explicitly; `None` and `[]` continue to return all fields, including the
vector.

## Performance validation

Strict paired query-only A/B on DGX Spark used the same immutable Full Wiki snapshot
(`1,941,679 x 1,024`), query order, parameters, quality checks, and routes for before/after. The
matrix contains 36 isolated runs: 3 modes x 2 scopes x before/after x 3 seeds. Recovery, index
build/readiness, and Base warmup are excluded from measured QPS. Values are median +/- unscaled
MAD; speedups are paired within each seed before aggregation.

| Mode | Scope | Event QPS before | Event QPS after | Paired after / before |
| --- | --- | ---: | ---: | ---: |
| Native CPU | Base | 18.735 +/- 0.180 | 18.681 +/- 0.111 | 0.9971 +/- 0.0170x |
| Native CPU | Directory | 65.149 +/- 0.135 | 67.960 +/- 0.111 | 1.0481 +/- 0.0009x |
| Explicit cuVS | Base | 22.282 +/- 0.050 | 26.554 +/- 0.023 | 1.1907 +/- 0.0078x |
| Explicit cuVS | Directory | 51.671 +/- 0.108 | 60.155 +/- 0.643 | 1.1642 +/- 0.0100x |
| Auto + background | Base | 22.202 +/- 0.017 | 26.433 +/- 0.076 | 1.1920 +/- 0.0011x |
| Auto + background | Directory | 52.174 +/- 0.321 | 63.484 +/- 0.366 | 1.2001 +/- 0.0084x |

Post-patch, Explicit cuVS and Auto reach `1.4263 +/- 0.0024x` and
`1.4177 +/- 0.0014x` Native Base throughput. Directory remains CPU-favored: Explicit cuVS is
`0.8784 +/- 0.0012x` Native and Auto is `0.9270 +/- 0.0106x`; Auto is
`1.0447 +/- 0.0070x` Explicit cuVS.

All 36 runs passed. Quality remained identical across both arms and all modes: Base `435/456`
Hit@100 and Directory `213/217` Hit@100. Auto routing remained `456` Base queries on cuVS and
`126 cuVS + 91 Native-threshold` Directory queries.

The diagnostic profile confirms the mechanism. Across the 456 Base queries, projected hydration
reduced materialized vector values from `46,694,400` to zero and reduced the measured hydration
envelope by about `85.7%`. The corresponding diagnostic QPS gains (`+19.7%` Base and `+15.4%`
Directory for Explicit cuVS) agree with the independent three-run A/B.

### Tail-latency note

Explicit cuVS and Auto P50/P95 improved, but their closed-loop Base P99 increased by about `11.4%`
and `9.7%`. Stage profiling shows that GPU search work did not regress: aggregate and maximum GPU
search time improved by about `7.9%` and `25.6%`. The tail moved into queueing at
`concurrency=8` with the existing single-search GPU gate because faster hydration lets workers
return to the gate sooner. This PR does not change the gate or concurrency policy; batching/gate
work is intentionally kept separate.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Focused projection tests pass (`7 passed`)
- [x] Ruff check, Ruff format check, `py_compile`, and `git diff --check` pass
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The performance experiment compares OpenViking product paths, not equal-dtype kernels: Native CPU
uses the default scaled-int8 exact backend while cuVS uses FP32 brute-force exact search. The patch
itself is backend-independent and does not modify either representation.

---

## 中文说明

Local vector search 在调用方只请求标量字段时，仍会完整反序列化每条 top-k
`CandidateData`，包括随后被丢弃的稠密/稀疏向量。本修改增加 fields-only hydration 路径；
`output_fields=None`、`[]` 以及显式请求向量时仍保持原有完整 hydration 行为，因此不会改变默认
CPU 行为、索引选择或检索语义。

严格 Full Wiki 三轮配对 A/B 中，Explicit cuVS 的 Base/Directory event QPS 分别提高约
`19.1%/16.4%`，Auto 分别提高约 `19.2%/20.0%`；Native Base 基本持平。优化后 Explicit cuVS
和 Auto 的 Base 吞吐分别达到 Native 的 `1.426x/1.418x`。全部 36 个 run 的质量、查询顺序和
路由校验均通过。

Base P99 的上升来自现有 `concurrency=8`、单并发 GPU gate 前的排队，而不是 GPU kernel 退化；
P50/P95 和整体吞吐均改善。后续 batching/gate 优化将作为独立工作推进，不在本 PR 中扩大范围。
