### PR TITLE
docs(resources): add periodic report archive example

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -266,6 +266,12 @@ result = client.write(
 print(result["root_uri"])
 ```
 
+For a complete application example, see
+[Periodic report Resources](https://github.com/volcengine/OpenViking/tree/main/examples/periodic-report-resource).
+It writes a Markdown report followed by a small JSON manifest and verifies both
+with `read`. This is a caller-owned storage convention: OpenViking does not
+provide report scheduling, report generation, or an application extension ABI.
+
 **TypeScript SDK**
 
 ```typescript

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -266,6 +266,12 @@ result = client.write(
 print(result["root_uri"])
 ```
 
+完整的应用示例请参阅
+[周期报告 Resource](https://github.com/volcengine/OpenViking/tree/main/examples/periodic-report-resource)。
+该示例先写入 Markdown 正文，再写入小型 JSON manifest，并通过 `read` 精确
+校验两者。这是调用方负责的存储约定；OpenViking 不提供报告调度、报告生成
+或应用 extension ABI。
+
 **TypeScript SDK**
 
 ```typescript

--- a/examples/periodic-report-resource/README.md
+++ b/examples/periodic-report-resource/README.md
@@ -1,0 +1,25 @@
+# Periodic report Resources
+
+This example shows how an application can use the public `AsyncOpenViking`
+filesystem API to save one generated report as two project Resources:
+
+- `report.md` contains the readable report;
+- `manifest.json` is written last and points to the report plus its digest.
+
+The ordering is an application convention, not an OpenViking transaction or
+extension ABI. The application still owns scheduling, report generation,
+stable IDs, retries, and conflict policy. OpenViking provides the Resource
+write and exact readback surfaces.
+
+The manifest fields in this example are illustrative application metadata,
+not a registered OpenViking report schema.
+
+```bash
+python examples/periodic-report-resource/archive_report.py \
+  --path ./data \
+  --report-id 2026-W29
+```
+
+The example uses `mode="create"`, so reusing an existing report ID fails
+instead of overwriting history. A production retry handler can read the
+existing Resources, compare their digests, and accept only an exact match.

--- a/examples/periodic-report-resource/README_CN.md
+++ b/examples/periodic-report-resource/README_CN.md
@@ -1,0 +1,24 @@
+# 周期报告 Resource
+
+这个示例展示应用如何使用公开的 `AsyncOpenViking` 文件系统 API，将一份已
+生成的报告保存为两个项目 Resource：
+
+- `report.md` 保存可阅读的报告正文；
+- `manifest.json` 最后写入，并记录正文 URI 与摘要。
+
+该写入顺序是应用侧约定，不是 OpenViking 的事务或 extension ABI。调度、
+报告生成、稳定 ID、重试与冲突策略仍由应用负责；OpenViking 提供 Resource
+写入和精确回读能力。
+
+示例中的 manifest 字段只是应用元数据示意，并不是 OpenViking 注册的报告
+schema。
+
+```bash
+python examples/periodic-report-resource/archive_report.py \
+  --path ./data \
+  --report-id 2026-W29
+```
+
+示例使用 `mode="create"`，因此重复使用已有报告 ID 会失败，不会覆盖历史。
+生产环境的重试处理器可以读取已有 Resource、比较摘要，并且只接受完全一致
+的结果。

--- a/examples/periodic-report-resource/archive_report.py
+++ b/examples/periodic-report-resource/archive_report.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Store one generated periodic report as OpenViking Resources."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+
+import openviking as ov
+
+
+def _digest(content: str) -> str:
+    return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _safe_report_id(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value) is None:
+        raise ValueError(
+            "report ID must use only letters, digits, dot, dash, or underscore"
+        )
+    return value
+
+
+async def archive_report(*, path: str, report_id: str) -> dict[str, object]:
+    report_id = _safe_report_id(report_id)
+    client = ov.AsyncOpenViking(path=path)
+    await client.initialize()
+    try:
+        root = f"viking://resources/reports/{report_id}"
+        report_uri = f"{root}/report.md"
+        manifest_uri = f"{root}/manifest.json"
+        report = (
+            f"# Periodic report {report_id}\n\n"
+            "- Completed: published one verified outcome.\n"
+            "- Next: validate the next delivery milestone.\n"
+        )
+        manifest = {
+            "schema_version": "periodic_report_resource_example_v0",
+            "report_id": report_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "report_uri": report_uri,
+            "report_digest": _digest(report),
+        }
+        manifest_text = json.dumps(
+            manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ) + "\n"
+
+        # The caller chooses this ordering: the manifest is written last.
+        await client.write(report_uri, report, mode="create", wait=False)
+        if await client.read(report_uri) != report:
+            raise RuntimeError("report readback did not match")
+        await client.write(manifest_uri, manifest_text, mode="create", wait=False)
+        if await client.read(manifest_uri) != manifest_text:
+            raise RuntimeError("manifest readback did not match")
+
+        return {
+            "report_uri": report_uri,
+            "manifest_uri": manifest_uri,
+            "report_digest": manifest["report_digest"],
+            "manifest_digest": _digest(manifest_text),
+            "readback_verified": True,
+        }
+    finally:
+        await client.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", default="./data")
+    parser.add_argument("--report-id", required=True)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            asyncio.run(archive_report(path=args.path, report_id=args.report_id)),
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Document a caller-owned pattern for storing a generated periodic report through the public OpenViking filesystem SDK. The example writes `report.md`, then an illustrative `manifest.json`, and verifies both by exact readback.

This deliberately does not add `openviking/extensions`, a report provider, scheduling, query semantics, or any LoopX protocol to OpenViking core.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #3370. This documentation/example PR does not close the feature request: the proposed OpenViking-specific provider/query contract was superseded after architecture review, and #3371 was closed. The provider-specific implementation now lives behind the public SDK in https://github.com/huangruiteng/loopx/pull/2395.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature that would cause existing functionality to not work as expected
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a small `AsyncOpenViking` example that writes a Markdown report before its illustrative manifest and performs exact `read` verification.
- Explain that scheduling, generation, stable IDs, retries, conflict policy, and manifest shape remain caller-owned.
- Link the example from both English and Chinese filesystem write documentation.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `ruff check examples/periodic-report-resource/archive_report.py`
- `python -m py_compile examples/periodic-report-resource/archive_report.py`
- fake-client smoke for write ordering, exact readback, and unsafe report-ID rejection
- `node docs/scripts/check-api-reference.mjs`
- public-boundary scan for all five changed files
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

There is no runtime dependency on the LoopX PR. The link records the ownership decision: application adapters may use OpenViking's public Resource SDK without making OpenViking understand the application's capability or extension protocol.
