### PR TITLE
feat(sdk-typescript): expose retrieval provenance

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -347,6 +347,7 @@ export class OpenVikingClient {
         time_field: options.timeField,
         level: options.level,
         tags: options.tags,
+        include_provenance: options.includeProvenance || undefined,
       }),
     });
   }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -101,6 +101,7 @@ export interface SearchOptions {
   timeField?: string;
   level?: number[];
   tags?: string[];
+  includeProvenance?: boolean;
 }
 /** Content grep options. */
 export interface GrepOptions {
@@ -169,6 +170,7 @@ export interface FindResult {
   memories?: unknown[];
   resources?: unknown[];
   skills?: unknown[];
+  provenance?: JsonObject[];
   [key: string]: unknown;
 }
 /** Error payload returned by OpenViking. */

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -40,12 +40,38 @@ describe("OpenVikingClient", () => {
     expect(new Headers(init?.headers).get("X-OpenViking-Actor-Peer")).toBe(
       "peer",
     );
-    expect(JSON.parse(String(init?.body))).toMatchObject({
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
       query: "hello",
       target_uri: "viking://resources",
       limit: 5,
     });
+    expect(body).not.toHaveProperty("include_provenance");
   });
+
+  it.each(["find", "search"] as const)(
+    "forwards includeProvenance through %s",
+    async (method) => {
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(ok({ resources: [], provenance: [] }));
+      const client = new OpenVikingClient({
+        baseUrl: "https://example.com",
+        fetch: fetcher,
+      });
+
+      const result = await client[method]("hello", {
+        includeProvenance: true,
+      });
+
+      expect(JSON.parse(String(fetcher.mock.calls[0]![1]?.body))).toMatchObject(
+        {
+          include_provenance: true,
+        },
+      );
+      expect(result.provenance).toEqual([]);
+    },
+  );
 
   it("uses the Python/Go empty default retrieval target", async () => {
     const fetcher = vi
@@ -64,7 +90,9 @@ describe("OpenVikingClient", () => {
   });
 
   it("sends dry_run for prune_orphans reindex requests", async () => {
-    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok({ status: "completed" }));
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(ok({ status: "completed" }));
     const client = new OpenVikingClient({
       baseUrl: "https://example.com",
       fetch: fetcher,


### PR DESCRIPTION
## Description

The search API already supports `include_provenance`, but the TypeScript SDK had no public option for sending it. This adds an opt-in `includeProvenance` field to `SearchOptions` for both `find()` and `search()` and types the returned `provenance` array on `FindResult`.

Default requests still omit `include_provenance`, so callers that do not use the option keep the existing request shape, including against older servers that reject unknown fields.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. This closes a TypeScript SDK gap for the existing, documented retrieval API field.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `includeProvenance?: boolean` to TypeScript retrieval options.
- Send `include_provenance: true` from both `find()` and `search()` when requested, while omitting it by default.
- Type `FindResult.provenance` and cover request forwarding, response parsing, and default omission.

## Testing

- [x] I have added tests that prove the feature works
- [x] New and existing TypeScript SDK tests pass locally
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run from `sdk/typescript`:

- `npm test` — 31 passed
- `npm run typecheck`
- `npm run format:check`
- `npm run build`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code
- [x] I have commented the code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots

Not applicable.

## Additional Notes

The server request models and API reference already define `include_provenance`; this PR only makes that existing capability reachable from the TypeScript SDK.
