### PR TITLE
fix(storage): add short timeout for encrypted dual-path write locks

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -382,6 +382,14 @@ class VikingFS:
             get_lock_manager(),
             self._encrypted_write_lock_paths(path),
             lock_mode="exact",
+            # Encrypted writes lock both the final path and the deterministic
+            # staging path under `.encrypt_stage`. Keeping the global default
+            # timeout at 0 is still desirable for ordinary path locks, but
+            # this specific dual-path write is much more exposed to short-lived
+            # contention between concurrent writers. A small 1-second wait here
+            # lets us ride out transient conflicts without broadening lock
+            # behavior for unrelated call sites.
+            timeout=1.0,
             handle=lock_handle,
         ):
             return await operation()
@@ -4054,9 +4062,7 @@ class VikingFS:
         real_ctx = self._ctx_or_default(ctx)
         account = real_ctx.account_id
         tree_paths = (
-            None
-            if not paths
-            else [self._uri_to_tree_path(path, ctx=real_ctx) for path in paths]
+            None if not paths else [self._uri_to_tree_path(path, ctx=real_ctx) for path in paths]
         )
         return await self._async_agfs.run(
             "git_log",

--- a/tests/storage/test_viking_fs_write_locking.py
+++ b/tests/storage/test_viking_fs_write_locking.py
@@ -78,7 +78,7 @@ async def test_encrypted_writes_lock_final_and_temp_paths(
                 "/local/default/temp/.encrypt_stage/571a25aab6e6bca05a60a6e4aec646389a9ac38237daf55ceda4f72f3d1b4afe.encrypt",
             ],
             "exact",
-            {"handle": None},
+            {"timeout": 1.0, "handle": None},
         )
     ]
     assert agfs.storage["/local/default/resources/note.md"] == expected_bytes


### PR DESCRIPTION
## Description

Add a short timeout for encrypted dual-path write locks so transient lock contention does not fail immediately.

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `timeout=1.0` when acquiring encrypted dual-path exact locks in `VikingFS`
- Document why encrypted writes use a small local timeout instead of the global default
- Update write-locking tests to cover the explicit encrypted lock timeout behavior

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

