### PR TITLE
fix(parse): normalize MIME aliases with parameters

### DIFF
--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -295,9 +295,12 @@ class URLTypeDetector:
         media_type_str = content_type.lower().strip()
 
         # Handle common aliases
-        if media_type_str in MEDIA_TYPE_ALIASES:
-            meta["media_type_alias"] = media_type_str
-            media_type_str = MEDIA_TYPE_ALIASES[media_type_str]
+        media_type_token = media_type_str.split(";", 1)[0].strip()
+        if media_type_token in MEDIA_TYPE_ALIASES:
+            meta["media_type_alias"] = media_type_token
+            media_type_str = (
+                MEDIA_TYPE_ALIASES[media_type_token] + media_type_str[len(media_type_token) :]
+            )
 
         # Parse into structured IANAMediaType
         try:

--- a/openviking/parse/accessors/mime_types.py
+++ b/openviking/parse/accessors/mime_types.py
@@ -183,6 +183,12 @@ MEDIA_TYPE_ALIASES: Dict[str, str] = {
     "video/mp4": "video/mp4",  # Keep as is (standard)
 }
 
+
+def _normalize_media_type(media_type: str) -> str:
+    """Return the media type token without parameters."""
+    return media_type.lower().strip().split(";", 1)[0].strip()
+
+
 # Comprehensive IANA media type to file extension mapping
 # Based on IANA registry and common usage
 IANA_MEDIA_TYPE_TO_EXTENSION: Dict[str, List[str]] = {
@@ -317,15 +323,11 @@ def get_preferred_extension(media_type: str) -> Optional[str]:
         return None
 
     # Normalize and parse
-    media_type = media_type.lower().strip()
+    media_type = _normalize_media_type(media_type)
 
     # Handle aliases first
     if media_type in MEDIA_TYPE_ALIASES:
         media_type = MEDIA_TYPE_ALIASES[media_type]
-
-    # Strip parameters
-    if ";" in media_type:
-        media_type = media_type.split(";", 1)[0].strip()
 
     # Exact match
     if media_type in IANA_MEDIA_TYPE_TO_EXTENSION:
@@ -379,14 +381,10 @@ def get_all_extensions(media_type: str) -> List[str]:
     if not media_type:
         return []
 
-    media_type = media_type.lower().strip()
+    media_type = _normalize_media_type(media_type)
 
     # Handle aliases first
     if media_type in MEDIA_TYPE_ALIASES:
         media_type = MEDIA_TYPE_ALIASES[media_type]
-
-    # Strip parameters
-    if ";" in media_type:
-        media_type = media_type.split(";", 1)[0].strip()
 
     return IANA_MEDIA_TYPE_TO_EXTENSION.get(media_type, [])

--- a/tests/parse/test_url_filename_preservation.py
+++ b/tests/parse/test_url_filename_preservation.py
@@ -10,7 +10,7 @@ Verifies fix for https://github.com/volcengine/OpenViking/issues/251:
 import pytest
 
 from openviking.parse.accessors.http_accessor import HTTPAccessor, URLType, URLTypeDetector
-from openviking.parse.accessors.mime_types import get_preferred_extension
+from openviking.parse.accessors.mime_types import get_all_extensions, get_preferred_extension
 
 
 class TestExtractFilenameFromUrl:
@@ -172,6 +172,19 @@ class TestHTTPAccessorGetFallback:
 
     def test_audio_ac3_mime_type_preserves_extension(self):
         assert get_preferred_extension("audio/ac3") == ".ac3"
+
+    def test_content_type_alias_with_parameters_preserves_extension(self):
+        assert get_preferred_extension("image/jpg; profile=display-p3") == ".jpg"
+        assert get_all_extensions("image/jpg; profile=display-p3") == [".jpg", ".jpeg"]
+
+    def test_content_type_alias_with_parameters_routes_to_pdf(self):
+        detector = URLTypeDetector()
+        metadata = {}
+
+        url_type = detector._detect_from_media_type("application/x-pdf; charset=binary", metadata)
+
+        assert url_type == URLType.DOWNLOAD_PDF
+        assert metadata["media_type_alias"] == "application/x-pdf"
 
     @pytest.mark.asyncio
     async def test_ac3_url_with_generic_content_type_stays_audio(self, monkeypatch):


### PR DESCRIPTION
## Description

Normalize Content-Type tokens before resolving MIME aliases so parameterized aliases keep their correct file type and extension during HTTP and Feishu imports.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A. No matching open or closed upstream Issue/PR was found during duplicate-work checks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Strip Content-Type parameters before MIME alias lookup in the shared extension helpers.
- Resolve parameterized aliases before URL type detection while preserving their parameters for parsing.
- Add regressions for parameterized `image/jpg` extensions and `application/x-pdf` routing.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Executed:

```text
python -m pytest --noconftest -o addopts= tests\\parse\\test_url_filename_preservation.py -q
# 44 passed

python -m ruff format --check openviking\\parse\\accessors\\mime_types.py openviking\\parse\\accessors\\http_accessor.py tests\\parse\\test_url_filename_preservation.py
python -m ruff check openviking\\parse\\accessors\\mime_types.py openviking\\parse\\accessors\\http_accessor.py tests\\parse\\test_url_filename_preservation.py
```

The repository's root test fixture was not run because this local environment lacks unrelated Volcengine service dependencies; the focused test was run without that fixture and imports the affected HTTP/MIME modules directly.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A.

## Additional Notes

The change is deliberately limited to MIME alias normalization and its URL-import regressions.
