### PR TITLE
docs: fix broken links and anchors across READMEs and guides

### DIFF
--- a/docs/en/concepts/11-multi-tenant.md
+++ b/docs/en/concepts/11-multi-tenant.md
@@ -115,6 +115,8 @@ Filesystem operations and semantic retrieval are tenant-aware:
 
 This keeps "what you can search" aligned with "what you can read."
 
+<a id="peer-restricted-view"></a>
+
 ### Peer Collection Filter
 
 `peer_id` is a content scope inside the current user boundary. It never changes the

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1538,6 +1538,8 @@ Task record files are stored under the owning account's system directory:
 /local/{account_id}/_system/tasks/{user_id}/{task_id}.json
 ```
 
+<a id="encryption"></a>
+
 ## encryption Section
 
 Enable at-rest data encryption to ensure data security and isolation in multi-tenant environments. Encryption is completely transparent to users with no API changes.

--- a/docs/en/guides/12-public-access.md
+++ b/docs/en/guides/12-public-access.md
@@ -14,6 +14,8 @@ public HTTPS domain.
 Prerequisites: a public domain, ports 80 + 443 reachable, DNS pointing at
 your host.
 
+<a id="adding-https-for-public-access"></a>
+
 ## Option A: bundled Caddy with auto Let's Encrypt (recommended)
 
 `docker compose up` already brings up a Caddy reverse-proxy container. Add a

--- a/docs/zh/agent-integrations/06-mcp-clients.md
+++ b/docs/zh/agent-integrations/06-mcp-clients.md
@@ -75,7 +75,7 @@ HTTPS 配置、部署模板和完整授权流程详见 [OAuth 2.1 指南](../gui
 
 ## 可用工具
 
-连接后，OpenViking 会提供检索、记忆、资源、watch、文件系统和代码导航工具。完整工具清单、参数、渐进式文件上传和高级配置见 [MCP 集成指南](../guides/06-mcp-integration.md#可用-mcp-工具)。
+连接后，OpenViking 会提供检索、记忆、资源、watch、文件系统和代码导航工具。完整工具清单、参数、渐进式文件上传和高级配置见 [MCP 集成指南](../guides/06-mcp-integration.md#可用的-mcp-工具)。
 
 ## 故障排查
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1471,6 +1471,8 @@ openviking add-resource ./docs --exclude "*.tmp"
 
 启动方式和部署详情见 [服务部署](./03-deployment.md)，认证详情见 [认证](./04-authentication.md)。
 
+<a id="encryption"></a>
+
 ## encryption 段
 
 启用静态数据加密，确保多租户环境下的数据安全与隔离。加密功能对用户完全透明，API 无变化。

--- a/docs/zh/guides/12-public-access.md
+++ b/docs/zh/guides/12-public-access.md
@@ -11,6 +11,8 @@ OpenViking 默认在 1933 端口对外提供 REST API、MCP、OAuth、`.well-kno
 
 前提：有公网域名、80 + 443 端口可达、DNS 已指向。
 
+<a id="添加-https公网访问"></a>
+
 ## 方式 A：用自带 Caddy 自动签发 Let's Encrypt 证书（推荐）
 
 `docker compose up` 默认带一个 Caddy 反代容器。给它追加一个域名块即可让


### PR DESCRIPTION
## 概述
六处文档链接指向目标页面不存在的锚点或文件。根因分两类:一是写链接时按标题原文猜锚点,与 GitHub 的 slug 规则不符(小写、空格转连字符,如 "encryption Section" → `encryption-section`);二是链接端笔误(D-14 漏写"的"字)。修法:锚点已有多处入站引用的,在目标标题前加 `<a id>` 显式别名,沿用 docs/zh/concepts/11-multi-tenant.md 里已有的 `peer-restricted-view` 别名模式;纯笔误直接改链接端。

## 修复的问题
- D-12 en/zh OAuth 指南的生产部署步骤指向缺失的 HTTPS 锚点;为两个 12-public-access.md 补 `<a id>`,与 guides/11-oauth.md:158/141 的入站片段逐字一致(docs/en/guides/12-public-access.md、docs/zh/guides/12-public-access.md)
- D-13 en/zh api/06-retrieval.md 链接 `#peer-restricted-view`,中文概念页已有该别名而英文页缺失;补齐英文页(docs/en/concepts/11-multi-tenant.md)
- D-14 中文 MCP 客户端指南锚点 `#可用-mcp-工具` 改为 `#可用的-mcp-工具`,与目标标题"可用的 MCP 工具"的 slug 一致;全仓无其他链接仍用旧锚点(docs/zh/agent-integrations/06-mcp-clients.md)
- D-15 en/zh concepts/10-encryption.md:214 链接 `01-configuration.md#encryption`,而标题 slug 实为 `encryption-section` / `encryption-段`;补 `<a id="encryption">` 别名(docs/en/guides/01-configuration.md、docs/zh/guides/01-configuration.md)
- D-10 / D-11 已作废:main 在本 PR 基线(4295dfde)之后重写了各语言 README,README_JA 的 license 链接已是 `./crates/LICENSE`(D-10),README_CN 社区链接已改用 docs 站 URL 且锚点正确(D-11)

## 合入前需要处理
`git merge-tree` 验证:README_CN.md、README_JA.md 两个文件与当前 main 冲突(冲突 hunk 正是 D-10/D-11,上游已修),其余 6 个 docs 文件自动合并干净。rebase 到 main 时丢弃两个 README 的改动即可,docs 部分无需变更。

## 作用域与已知限制
只改文档链接与锚点,不动正文内容。`<a id>` 别名对 GitHub 渲染和 docs 站均为无害的稳定跳转点;不处理 main 新 README 引入的 docs 站外链(经核对 `#lark-group`/`#wechat-group` 对应 EN about-us 的 "Lark Group"/"WeChat Group" 标题,slug 正确,无需修)。

## 合入价值
**P2(6 项 finding 中 4 项仍真实)** · OAuth HTTPS 部署、peer 过滤、MCP 工具清单、加密配置四条 en/zh 跳转恢复可用。

## 验证
- 对当前 main 逐一 `git grep` 核对入站链接与目标锚点:11-oauth.md:158/141、api/06-retrieval.md:74/75、concepts/10-encryption.md:214 的锚点片段与本 PR 新增 `<a id>` 逐字一致;`可用的 MCP 工具` 标题存在于 zh guides/06-mcp-integration.md:122
- `crates/LICENSE` 存在、`crates/ov_cli/LICENSE` 不存在
- `git merge-tree --write-tree origin/main origin/sweep/docs-broken-anchors`:仅两个 README 冲突,6 个 docs 文件干净合并

---
自动化全仓清扫(2026-07)· draft 待 review
