### PR TITLE
fix(bot): pass sender_name in all channel adapters

### DIFF
--- a/bot/bridge/src/whatsapp.ts
+++ b/bot/bridge/src/whatsapp.ts
@@ -21,6 +21,7 @@ export interface InboundMessage {
   id: string;
   sender: string;
   pn: string;
+  pushName: string;
   content: string;
   timestamp: number;
   isGroup: boolean;
@@ -125,6 +126,7 @@ export class WhatsAppClient {
           id: msg.key.id || '',
           sender: msg.key.remoteJid || '',
           pn: msg.key.remoteJidAlt || '',
+          pushName: msg.pushName || '',
           content,
           timestamp: msg.messageTimestamp as number,
           isGroup,

--- a/bot/tests/test_channel_sender_name.py
+++ b/bot/tests/test_channel_sender_name.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for channel sender names."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.bus.queue import MessageBus  # noqa: E402
+from vikingbot.channels.whatsapp import WhatsAppChannel  # noqa: E402
+from vikingbot.config.schema import WhatsAppChannelConfig  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_sender_name_falls_back_to_sender_id():
+    bus = MessageBus()
+    channel = WhatsAppChannel(WhatsAppChannelConfig(), bus)
+
+    await channel._handle_bridge_message(
+        json.dumps(
+            {
+                "type": "message",
+                "sender": "123456789@s.whatsapp.net",
+                "content": "hello",
+            }
+        )
+    )
+
+    inbound = await bus.consume_inbound()
+    assert inbound.sender_name == "123456789"

--- a/bot/vikingbot/channels/base.py
+++ b/bot/vikingbot/channels/base.py
@@ -142,9 +142,9 @@ class BaseChannel(ABC):
     async def _handle_message(
         self,
         sender_id: str,
-        sender_name: str,
         chat_id: str,
         content: str,
+        sender_name: str | None = None,
         need_reply: bool = True,
         media: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -156,6 +156,8 @@ class BaseChannel(ABC):
 
         Args:
             sender_id: The sender's identifier.
+            sender_name: The sender's display name; falls back to sender_id
+                downstream when unavailable.
             chat_id: The chat/channel identifier.
             content: Message text content.
             media: Optional list of media URLs.

--- a/bot/vikingbot/channels/dingtalk.py
+++ b/bot/vikingbot/channels/dingtalk.py
@@ -238,6 +238,7 @@ class DingTalkChannel(BaseChannel):
             logger.info(f"DingTalk inbound: {content} from {sender_name}")
             await self._handle_message(
                 sender_id=sender_id,
+                sender_name=sender_name or sender_id,
                 chat_id=sender_id,  # For private chat, chat_id == sender_id
                 content=str(content),
                 metadata={

--- a/bot/vikingbot/channels/discord.py
+++ b/bot/vikingbot/channels/discord.py
@@ -240,6 +240,7 @@ class DiscordChannel(BaseChannel):
 
         await self._handle_message(
             sender_id=sender_id,
+            sender_name=author.get("global_name") or author.get("username") or sender_id,
             chat_id=channel_id,
             content="\n".join(p for p in content_parts if p) or "[empty message]",
             media=media_paths,

--- a/bot/vikingbot/channels/mochat.py
+++ b/bot/vikingbot/channels/mochat.py
@@ -847,6 +847,7 @@ class MochatChannel(BaseChannel):
         body = build_buffered_body(entries, is_group) or "[empty message]"
         await self._handle_message(
             sender_id=last.author,
+            sender_name=last.sender_name or last.sender_username or last.author,
             chat_id=target_id,
             content=body,
             metadata={

--- a/bot/vikingbot/channels/qq.py
+++ b/bot/vikingbot/channels/qq.py
@@ -131,6 +131,11 @@ class QQChannel(BaseChannel):
 
             await self._handle_message(
                 sender_id=user_id,
+                sender_name=str(
+                    getattr(author, "username", None)
+                    or getattr(author, "name", None)
+                    or user_id
+                ),
                 chat_id=user_id,
                 content=content,
                 metadata={"message_id": data.id},

--- a/bot/vikingbot/channels/telegram.py
+++ b/bot/vikingbot/channels/telegram.py
@@ -263,6 +263,7 @@ class TelegramChannel(BaseChannel):
             return
         await self._handle_message(
             sender_id=str(update.effective_user.id),
+            sender_name=update.effective_user.full_name or str(update.effective_user.id),
             chat_id=str(update.message.chat_id),
             content=update.message.text,
         )
@@ -363,6 +364,7 @@ class TelegramChannel(BaseChannel):
         # Forward to the message bus
         await self._handle_message(
             sender_id=sender_id,
+            sender_name=user.full_name or sender_id,
             chat_id=str_chat_id,
             content=content,
             media=media_paths,

--- a/bot/vikingbot/channels/whatsapp.py
+++ b/bot/vikingbot/channels/whatsapp.py
@@ -125,7 +125,7 @@ class WhatsAppChannel(BaseChannel):
 
             await self._handle_message(
                 sender_id=sender_id,
-                sender_name=data.get("senderName") or data.get("pushName") or sender_id,
+                sender_name=data.get("pushName") or sender_id,
                 chat_id=sender,  # Use full LID for replies
                 content=content,
                 metadata={

--- a/bot/vikingbot/channels/whatsapp.py
+++ b/bot/vikingbot/channels/whatsapp.py
@@ -125,6 +125,7 @@ class WhatsAppChannel(BaseChannel):
 
             await self._handle_message(
                 sender_id=sender_id,
+                sender_name=data.get("senderName") or data.get("pushName") or sender_id,
                 chat_id=sender,  # Use full LID for replies
                 content=content,
                 metadata={


### PR DESCRIPTION
## 概述
`BaseChannel._handle_message` 的必填参数 `sender_name` 在 6 个渠道适配器(telegram、discord、qq、dingtalk、whatsapp、mochat)的调用点从未传入,每条入站消息在进消息总线前就抛 `TypeError`,被各层 catch+log 静默吞掉。本 PR 修掉签名根因(`sender_name` 改为可选,下游本就有回退),并为 6 个平台补上真实展示名。

## 为什么必要(可达性/严重性)
- 根因:#1534(4d34025c,2026-04-17)给 `_handle_message` 增加必填位置参数 `sender_name`,只同步改了 feishu 调用点;telegram/discord/qq/dingtalk/whatsapp/mochat 6 处调用(全关键字传参)从未传它。此后这 6 个渠道每条入站消息都抛 `TypeError: missing 1 required positional argument: 'sender_name'`。佐证:dingtalk `_on_message` 手里本就有 `sender_name`(还塞进了 metadata),只是没作为参数传——改签名时漏改的直接证据。
- 可达性:第一道防线,无上游守卫。异常发生在 allow_from 检查与 `bus.publish_inbound` 之前,消息必丢。
- 静默性:dingtalk catch+log 且已向钉钉服务端 ACK OK(不触发重试);qq 同样 catch+log;telegram 异常被 PTB dispatcher 吞;whatsapp/mochat 异常留在接收协程内。用户侧零反馈。
- 诚实定级:对这 6 个渠道是真实 P0(入站全瘫)。但 feishu/email/slack 不受影响,且该 bug 在 main 上存在约 3 个月无用户上报,主力部署(feishu)不受波及——实际爆炸半径限于启用这 6 个渠道的部署。

## 关键设计与取舍
- **签名改可选,而非只补调用点**:`InboundMessage.sender_name` 本就是 `str | None = None`,`agent/context.py:239` 群聊 prompt 已在缺失时回退 sender_id,required 属签名与契约不一致。改为 `sender_name: str | None = None` 后,未来新适配器漏传只会缺展示名,不会再崩。备选方案(保持必填、仅补 6 处)修不掉复发路径,弃。
- **参数重排安全**:`sender_name` 移到 chat_id/content 之后。全仓 10 个调用点全部关键字传参,`_handle_message` 无子类 override,重排不破坏任何调用。
- **各平台取真实展示名,缺失回退 sender_id**:telegram `full_name`、discord `global_name/username`、qq `author.username/name`(getattr 防 SDK 字段差异)、dingtalk `senderNick`、mochat `sender_name/sender_username`。
- **WhatsApp 端到端补链**:bridge(TS)此前不下发任何展示名字段,本 PR 让其转发 baileys 的 `msg.pushName`,server.ts 以 `...msg` 透传,Python 侧 `data.get("pushName") or sender_id` 读取。

## 作用域与已知限制
- 只改 bot 渠道层 + whatsapp bridge 2 行加性字段;不涉及 agent loop、bus、存储,与 S3/本地后端无关。
- feishu/email/slack 调用点原本就传 sender_name,行为不变(slack 仍以 sender_id 作展示名,属既有行为,不在本 PR 范围)。
- bridge 与 Python 可独立升级:旧 bridge 不发 pushName → Python 回退 sender_id,不崩;新 bridge + 旧 Python → 多余字段被忽略。无需 lockstep 部署。
- whatsapp.ts 给 `InboundMessage` 接口加必填 `pushName: string`,构造处 `msg.pushName || ''` 保证类型成立。

## 修复的问题
- C-01 六个渠道适配器漏传必填 `sender_name`,入站消息进总线前抛 TypeError 被静默丢弃(`bot/vikingbot/channels/base.py` + 6 个适配器)

## 合入价值
**P0(限 6 渠道)** · Telegram、Discord、QQ、DingTalk、WhatsApp、MoChat 入站恢复可用;群聊显示真实用户名而非数字 ID。feishu/email/slack 不受影响。

## 验证
- 反证(main 的渠道代码 + 本 PR 新测试):失败于 `TypeError: BaseChannel._handle_message() missing 1 required positional argument: 'sender_name'`(whatsapp.py:126),精确复现原 bug。
- PR head:`pytest tests/test_channel_sender_name.py` — 1 passed(覆盖 pushName 缺失回退 sender_id 路径)。
- 回归:`pytest tests/test_channel_delivery_metadata.py` — 相对 main 无新增失败(`test_system_message_response_preserves_channel_metadata` 在 main 上即失败,与本 PR 无关)。

---
自动化全仓清扫(2026-07)· draft 待 review
