### PR TITLE
fix(models): route multimodal inputs to DashScope embed_content

### DIFF
--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -150,7 +150,7 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        return True
+        return self._input_type == "multimodal"
 
     @staticmethod
     def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:
@@ -164,6 +164,13 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 if url:
                     contents.append({"image": str(url)})
         return contents
+
+    def _standard_input_fusion(self, contents: List[Dict[str, str]]) -> Optional[bool]:
+        if len(contents) <= 1:
+            return None
+        if self.model_name.startswith(("qwen3-vl-embedding", "qwen2.5-vl-embedding")):
+            return True
+        raise ValueError(f"{self.model_name} cannot fuse multiple multimodal input parts")
 
     def _multimodal_params(self) -> Dict[str, Any]:
         """Build parameters dict for multimodal requests, excluding None values."""
@@ -214,7 +221,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     def embed(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
         if isinstance(text, list):
-            return self.embed_content(self._to_dashscope_contents(text))
+            contents = self._to_dashscope_contents(text)
+            return self.embed_content(contents, enable_fusion=self._standard_input_fusion(contents))
 
         def _call() -> EmbedResult:
             if self._input_type == "text":
@@ -244,7 +252,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     async def embed_async(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
         if isinstance(text, list):
-            return await self.embed_content_async(self._to_dashscope_contents(text))
+            contents = self._to_dashscope_contents(text)
+            return await self.embed_content_async(
+                contents, enable_fusion=self._standard_input_fusion(contents)
+            )
 
         async def _call() -> EmbedResult:
             if self._input_type == "text":
@@ -274,7 +285,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed_content — multimodal content (text + image URLs)
     # ------------------------------------------------------------------
 
-    def embed_content(self, contents: List[Dict[str, str]]) -> EmbedResult:
+    def embed_content(
+        self, contents: List[Dict[str, str]], *, enable_fusion: Optional[bool] = None
+    ) -> EmbedResult:
         """Embed multimodal content (text + image URLs) via native DashScope API.
 
         Args:
@@ -290,6 +303,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 "input": {"contents": contents},
             }
             params = self._multimodal_params()
+            if enable_fusion is not None:
+                params["enable_fusion"] = enable_fusion
             if params:
                 body["parameters"] = params
             resp = self._httpx_client.post(self._multimodal_url, json=body)
@@ -305,7 +320,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
         except Exception as e:
             raise RuntimeError(f"DashScope content embedding failed: {e}") from e
 
-    async def embed_content_async(self, contents: List[Dict[str, str]]) -> EmbedResult:
+    async def embed_content_async(
+        self, contents: List[Dict[str, str]], *, enable_fusion: Optional[bool] = None
+    ) -> EmbedResult:
         """Async version of embed_content."""
 
         client = self._get_async_httpx_client()
@@ -316,6 +333,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 "input": {"contents": contents},
             }
             params = self._multimodal_params()
+            if enable_fusion is not None:
+                params["enable_fusion"] = enable_fusion
             if params:
                 body["parameters"] = params
             resp = await client.post(self._multimodal_url, json=body)

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -150,7 +150,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        return self._input_type == "multimodal"
+        return self._input_type == "multimodal" and self.model_name.startswith(
+            ("qwen3-vl-embedding", "qwen2.5-vl-embedding")
+        )
 
     @staticmethod
     def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -14,6 +14,7 @@ import openai
 from openviking.models.embedder.base import (
     DenseEmbedderBase,
     EmbedResult,
+    EmbeddingInput,
     truncate_and_normalize,
 )
 from openviking.telemetry import get_current_telemetry
@@ -147,6 +148,23 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # Multimodal helpers
     # ------------------------------------------------------------------
 
+    @property
+    def supports_multimodal(self) -> bool:
+        return True
+
+    @staticmethod
+    def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        contents = []
+        for part in content:
+            if part.get("type") == "text":
+                contents.append({"text": str(part.get("text", ""))})
+            elif part.get("type") == "image_url":
+                image_url = part.get("image_url")
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+                if url:
+                    contents.append({"image": str(url)})
+        return contents
+
     def _multimodal_params(self) -> Dict[str, Any]:
         """Build parameters dict for multimodal requests, excluding None values."""
         return {
@@ -194,7 +212,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed
     # ------------------------------------------------------------------
 
-    def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+    def embed(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
+        if isinstance(text, list):
+            return self.embed_content(self._to_dashscope_contents(text))
+
         def _call() -> EmbedResult:
             if self._input_type == "text":
                 response = self._openai_client.embeddings.create(
@@ -221,7 +242,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed_async
     # ------------------------------------------------------------------
 
-    async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+    async def embed_async(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
+        if isinstance(text, list):
+            return await self.embed_content_async(self._to_dashscope_contents(text))
+
         async def _call() -> EmbedResult:
             if self._input_type == "text":
                 client = self._get_async_openai_client()

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -168,8 +168,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     def _standard_input_fusion(self, contents: List[Dict[str, str]]) -> Optional[bool]:
         if len(contents) <= 1:
             return None
-        if self.model_name.startswith(("qwen3-vl-embedding", "qwen2.5-vl-embedding")):
+        if self.model_name.startswith("qwen3-vl-embedding"):
             return True
+        if self.model_name.startswith("qwen2.5-vl-embedding"):
+            return None
         raise ValueError(f"{self.model_name} cannot fuse multiple multimodal input parts")
 
     def _multimodal_params(self) -> Dict[str, Any]:

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -443,6 +443,33 @@ class TestDashScopeAsync:
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    @pytest.mark.anyio
+    async def test_embed_compat_downgrades_non_fusing_multimodal_model(
+        self, mock_httpx, mock_openai
+    ):
+        response = MagicMock()
+        response.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.2] * 768}]}
+        }
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        embedder = DashScopeDenseEmbedder(
+            "tongyi-embedding-vision-flash", api_key="sk-test"
+        )
+        embedder._get_async_httpx_client = MagicMock(return_value=client)
+        parts = [
+            {"type": "text", "text": "cat"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+
+        await embed_compat(embedder, parts, is_query=False)
+
+        assert embedder.supports_multimodal is False
+        body = client.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [{"text": "cat"}]
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
     @patch("openviking.models.embedder.dashscope_embedders.openai.AsyncOpenAI")
     @pytest.mark.anyio
     async def test_embed_async_text_error_raises_runtime_error(

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -13,6 +13,7 @@ from openviking.models.embedder.dashscope_embedders import (
     DashScopeDenseEmbedder,
     get_dashscope_model_default_dimension,
 )
+from openviking.models.embedder.base import embed_compat
 
 # ---------------------------------------------------------------------------
 # Dimension helper
@@ -236,6 +237,29 @@ class TestDashScopeMultimodalEmbed:
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    def test_embed_routes_standard_multimodal_parts(self, mock_httpx_class, mock_openai):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.1] * 2560}]}
+        }
+        mock_httpx_class.return_value.post.return_value = mock_response
+        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+
+        embedder.embed(
+            [
+                {"type": "text", "text": "cat"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ]
+        )
+
+        body = mock_httpx_class.return_value.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [
+            {"text": "cat"},
+            {"image": "https://example.com/cat.png"},
+        ]
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
     def test_embed_sends_multimodal_params(self, mock_httpx_class, mock_openai):
         mock_client = MagicMock()
         mock_httpx_class.return_value = mock_client
@@ -388,6 +412,25 @@ class TestDashScopeAsync:
         )
         result = await embedder.embed_async("hello multimodal async")
         assert result.dense_vector == [0.4] * 768
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    @pytest.mark.anyio
+    async def test_embed_compat_preserves_image(self, mock_httpx, mock_openai):
+        response = MagicMock()
+        response.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.2] * 2560}]}
+        }
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+        embedder._get_async_httpx_client = MagicMock(return_value=client)
+        parts = [{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}]
+
+        await embed_compat(embedder, parts, is_query=True)
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [{"image": "https://example.com/cat.png"}]
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -239,13 +239,19 @@ class TestDashScopeMultimodalEmbed:
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
-    def test_embed_routes_standard_multimodal_parts(self, mock_httpx_class, mock_openai):
+    @pytest.mark.parametrize(
+        ("model_name", "expected_fusion"),
+        [("qwen3-vl-embedding", True), ("qwen2.5-vl-embedding", None)],
+    )
+    def test_embed_routes_standard_multimodal_parts(
+        self, mock_httpx_class, mock_openai, model_name, expected_fusion
+    ):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "output": {"embeddings": [{"embedding": [0.1] * 2560}]}
         }
         mock_httpx_class.return_value.post.return_value = mock_response
-        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+        embedder = DashScopeDenseEmbedder(model_name, api_key="sk-test")
 
         embedder.embed(
             [
@@ -259,7 +265,7 @@ class TestDashScopeMultimodalEmbed:
             {"text": "cat"},
             {"image": "https://example.com/cat.png"},
         ]
-        assert body["parameters"]["enable_fusion"] is True
+        assert body["parameters"].get("enable_fusion") is expected_fusion
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -80,6 +80,8 @@ class TestDashScopeInit:
         assert embedder.api_key == "sk-test"
         assert embedder.api_base == "https://dashscope.aliyuncs.com"
         assert embedder.provider == "dashscope"
+        assert embedder.supports_multimodal is False
+        assert embedder.prepare_embedding_input([{"type": "text", "text": "cat"}]) == "cat"
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
@@ -257,6 +259,7 @@ class TestDashScopeMultimodalEmbed:
             {"text": "cat"},
             {"image": "https://example.com/cat.png"},
         ]
+        assert body["parameters"]["enable_fusion"] is True
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")


### PR DESCRIPTION
## 概述
根因:`DashScopeDenseEmbedder` 从未覆写 `supports_multimodal`(基类默认 False),`embed/embed_async` 只接受 `str`,原生 `embed_content` 全仓没有调用方。公共入口 `embed_compat` 的 `prepare_embedding_input` 因此把标准多部件输入(text + image_url parts)降级成纯文本——图片在发请求之前就被丢掉。本 PR 让 qwen VL 模型在多模态模式下声明多模态能力,把 parts 转换成 DashScope contents 格式,同步/异步列表输入统一路由到 `embed_content(_async)`,并按模型控制 `enable_fusion`。

## 为什么必要(可达性/严重性)
第一道防线,无上游守卫覆盖,两条真实链路都可达:
- 摄取:`EmbeddingMsgConverter.from_context`(`openviking/storage/queuefs/embedding_msg_converter.py:77-88`)对带图资源生成 parts 列表 → 嵌入队列 → `collection_schemas.py:618` `embed_compat` → 因 `supports_multimodal=False` 静默丢图。带图资源只得到文本向量,全程无报错,属静默质量损失。
- 检索:`viking_fs.py:2137` 用 `build_multimodal_embedding_input` 构造图搜输入,`hierarchical_retriever.py:151` 检查 `supports_multimodal` 后直接抛 `InvalidArgumentError`——即使配置了 qwen3-vl-embedding 也无法图搜(硬失败)。

诚实定级:P1。功能缺陷,仅影响 DashScope 后端(volcengine 多模态路径本来就有同款机制且正常);非安全问题,不是 P0。

## 关键设计与取舍
- 复用 volcengine embedder 的既有模式(`supports_multimodal` 属性 + `embed` 接受 parts 列表),不引入新抽象。
- `supports_multimodal` 限定 `qwen3-vl-embedding` / `qwen2.5-vl-embedding` 前缀。tongyi-embedding-vision-* 等模型对多部件输入逐条返回向量、不支持融合,代码只取 `embeddings[0]`,会静默只嵌第一部件;因此评审后决定这些模型保留文本回退——宁可明确降级,不做错误融合。
- `enable_fusion`:qwen3-vl 多部件强制 `true`(契约是一次调用返回一个向量);qwen2.5-vl 不传该参数,沿用服务端默认;单部件不干预,用户配置的 `enable_fusion` 照常生效。
- 列表分支直接委托 `embed_content(_async)`,复用其中的 `_run_with_retry` 重试和 token 遥测,不重复实现。

## 作用域与已知限制
- 只改 `openviking/models/embedder/dashscope_embedders.py` + 单测;其他 provider、摄取/检索管线零改动。
- tongyi-embedding-vision-*、multimodal-embedding-v1 经标准 parts 输入时仍降级为纯文本(含单图部件),属本次刻意收窄;要支持需另行处理其逐条返回的语义。
- `str` 输入的既有路径逐字节不变(list 分支在函数最前面短路);`_input_type="text"` 的纯文本模型 `supports_multimodal` 仍为 False,不会被误路由到多模态端点。回归风险低。
- 修复只影响修复后的写入;历史已摄取的带图资源需重嵌才能获得视觉向量。

## 修复的问题
- A-09 经 embed_compat 使用 qwen3-vl-embedding 等 DashScope 多模态模型时,image_url parts 在请求前被丢弃,视觉向量退化为纯文本;图搜请求则被 supports_multimodal 守卫直接拒绝(`openviking/models/embedder/dashscope_embedders.py`)。

## 合入价值
**P1** · 打通 DashScope qwen VL 的图片摄取与图搜两条链路:摄取不再静默丢图,图搜不再硬失败;不误伤纯文本模型,tongyi 系列保持确定的文本回退。

## 验证
- `python -m pytest -q tests/unit/test_dashscope_embedder.py --no-cov` — 40 passed(含新增用例:标准 parts 路由与 fusion 参数断言、embed_compat 保图、tongyi 文本回退)。评审时在干净 worktree 复跑确认。
- 复核了摄取(`collection_schemas.py:618`)与图搜(`hierarchical_retriever.py:151-157`)调用点,确认 `embed_compat` 是唯一多模态入口,无其他调用方需同步修改。

---
自动化全仓清扫(2026-07)· draft 待 review
