### PR TITLE
docs: fix stale commands, paths, and provider claims

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -97,7 +97,7 @@ curl -X GET "http://localhost:1933/api/v1/fs/ls?uri=viking://resources/&recursiv
 **CLI**
 
 ```bash
-openviking ls viking://resources/ [--simple] [--recursive]
+openviking ls viking://resources/
 ```
 
 
@@ -552,7 +552,7 @@ curl -X DELETE "http://localhost:1933/api/v1/fs?uri=viking://resources/old-proje
 **CLI**
 
 ```bash
-openviking rm viking://resources/old.md [--recursive]
+openviking rm viking://resources/old.md
 ```
 
 

--- a/docs/en/api/99-api-doc-writing-guide.md
+++ b/docs/en/api/99-api-doc-writing-guide.md
@@ -180,10 +180,11 @@ Add resources to the knowledge base, supporting various sources such as local fi
 5. Build vector index
 
 **Code Entry**:
-- `openviking/core/client.py:OpenViking.add_resource()` - SDK entry
-- `openviking/resource/importer.py:ResourceImporter.import_resource()` - Core implementation
-- `openviking/server/routers/resources.py` - HTTP router
-- `openviking_cli/commands/resources.py` - CLI command
+- `openviking/async_client.py:AsyncOpenViking.add_resource()` - Async SDK entry
+- `openviking/sync_client.py:SyncOpenViking.add_resource()` - Sync SDK entry
+- `openviking/service/resource_service.py:ResourceService.add_resource()` - Core implementation
+- `openviking/server/routers/resources.py:add_resource()` - HTTP router
+- `crates/ov_cli/src/handlers.rs:handle_add_resource()` - CLI handler
 
 #### 2. Interface and Parameter Description
 

--- a/docs/en/concepts/04-viking-uri.md
+++ b/docs/en/concepts/04-viking-uri.md
@@ -204,7 +204,7 @@ ov add-resource --parent-auto-create "viking://resources/emails/{calendar:today}
 ov read "viking://resources/logs/{calendar:yesterday}/app.log"
 
 # Prep tomorrow's tasks
-ov write --uri "viking://resources/tasks/{calendar:tomorrow}/todo.md" --content "Plan the day"
+ov write "viking://resources/tasks/{calendar:tomorrow}/todo.md" --content "Plan the day"
 
 # Upload monthly report, --parent-auto-create can be shortened to -p
 ov add-resource --parent-auto-create "viking://resources/reports/{calendar:ym}" ./report.pdf

--- a/docs/en/concepts/10-encryption.md
+++ b/docs/en/concepts/10-encryption.md
@@ -85,7 +85,7 @@ Suitable for development and single-node deployments:
 
 **Initialization command**:
 ```bash
-ov system crypto init-key --output ~/.openviking/master.key
+ov system crypto init-key --output-file ~/.openviking/master.key
 ```
 
 ### Vault (HashiCorp Vault)

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -13,7 +13,7 @@ openviking-server doctor
 
 ## Configuration File
 
-Create `~/.openviking/ov.conf` in your project directory:
+Create `~/.openviking/ov.conf` in your home configuration directory:
 
 ```json
 {

--- a/docs/en/guides/03-deployment.md
+++ b/docs/en/guides/03-deployment.md
@@ -170,7 +170,7 @@ export OPENVIKING_CLI_CONFIG_FILE=/path/to/ovcli.conf
 Then use the CLI:
 
 ```bash
-python -m openviking ls viking://resources/
+ov ls viking://resources/
 ```
 
 ### curl

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -98,7 +98,7 @@ curl -X GET "http://localhost:1933/api/v1/fs/ls?uri=viking://resources/&recursiv
 **CLI**
 
 ```bash
-openviking ls viking://resources/ [--simple] [--recursive]
+openviking ls viking://resources/
 ```
 
 
@@ -553,7 +553,7 @@ curl -X DELETE "http://localhost:1933/api/v1/fs?uri=viking://resources/old-proje
 **CLI**
 
 ```bash
-openviking rm viking://resources/old.md [--recursive]
+openviking rm viking://resources/old.md
 ```
 
 

--- a/docs/zh/api/99-api-doc-writing-guide.md
+++ b/docs/zh/api/99-api-doc-writing-guide.md
@@ -174,10 +174,11 @@ API 文档应按 API 模块和具体接口组织，而不是按客户端语言�
 5. 建立向量索引
 
 **代码入口**：
-- `openviking/core/client.py:OpenViking.add_resource()` - SDK 入口
-- `openviking/resource/importer.py:ResourceImporter.import_resource()` - 核心实现
-- `openviking/server/routers/resources.py` - HTTP 路由
-- `openviking_cli/commands/resources.py` - CLI 命令
+- `openviking/async_client.py:AsyncOpenViking.add_resource()` - 异步 SDK 入口
+- `openviking/sync_client.py:SyncOpenViking.add_resource()` - 同步 SDK 入口
+- `openviking/service/resource_service.py:ResourceService.add_resource()` - 核心实现
+- `openviking/server/routers/resources.py:add_resource()` - HTTP 路由
+- `crates/ov_cli/src/handlers.rs:handle_add_resource()` - CLI 处理函数
 
 #### 2. 接口和参数说明
 

--- a/docs/zh/concepts/04-viking-uri.md
+++ b/docs/zh/concepts/04-viking-uri.md
@@ -201,7 +201,7 @@ ov add-resource --parent-auto-create "viking://resources/emails/{calendar:today}
 ov read "viking://resources/logs/{calendar:yesterday}/app.log"
 
 # 准备明天的任务
-ov write --uri "viking://resources/tasks/{calendar:tomorrow}/todo.md" --content "规划一天"
+ov write "viking://resources/tasks/{calendar:tomorrow}/todo.md" --content "规划一天"
 
 # 上传月度报告 --parent-auto-create 可以简写为 -p
 ov add-resource --parent-auto-create "viking://resources/reports/{calendar:ym}" ./report.pdf

--- a/docs/zh/concepts/10-encryption.md
+++ b/docs/zh/concepts/10-encryption.md
@@ -85,7 +85,7 @@ OpenViking 支持三种密钥提供程序，适应不同的部署场景：
 
 **初始化命令**：
 ```bash
-ov system crypto init-key --output ~/.openviking/master.key
+ov system crypto init-key --output-file ~/.openviking/master.key
 ```
 
 ### Vault（HashiCorp Vault）

--- a/docs/zh/concepts/10-encryption.md
+++ b/docs/zh/concepts/10-encryption.md
@@ -85,7 +85,7 @@ OpenViking 支持三种密钥提供程序，适应不同的部署场景：
 
 **初始化命令**：
 ```bash
-ov crypto init-key --output ~/.openviking/master.key
+ov system crypto init-key --output ~/.openviking/master.key
 ```
 
 ### Vault（HashiCorp Vault）

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -13,7 +13,7 @@ openviking-server doctor
 
 ## 快速开始
 
-在项目目录创建 `~/.openviking/ov.conf`：
+在用户配置目录 `~/.openviking/` 下创建 `ov.conf`：
 
 ```json
 {


### PR DESCRIPTION
## 概述
文档中多处命令、路径、代码入口与实现不符,照抄即报错。本 PR 逐条对照 `crates/ov_cli/src/main.rs`、`pyproject.toml` 和 Python 包结构修正,让示例可直接复制运行。根因是 CLI 从 Python 迁到 Rust(clap)后文档没有跟进:入口、子命令层级、flag 名、代码路径全部变了。

## ⚠️ 合入前需 rebase:README 两个文件已冲突
main 上 #3395(94827db8)已把 README.md / README_JA.md 整体重写为"sell first"结构,本 PR 的 D-09 hunk 所修补的 JSON 配置块和 VLM provider 表在 main 上已不存在,`git merge-tree` 确认这两个文件冲突。且新版 README 已写明正确的 provider 集合(Volcengine、OpenAI、Codex OAuth、Kimi、GLM、Ollama),**D-09 已被上游覆盖**。处理方式:rebase 到 main 并丢弃 README.md、README_JA.md 两个文件的改动,其余 11 个 docs/ 文件可干净自动合并(已验证)。

## 修复的问题(均已对照代码逐条核验)
- D-03 配置指南自相矛盾:"在项目目录创建 `~/.openviking/ov.conf`"。实际路径就是家目录,代码多处以 `~/.openviking/ov.conf` 为准(docs/en/guides/01-configuration.md:16; docs/zh/guides/01-configuration.md:16)
- D-04 `python -m openviking` 不存在:包内无 `__main__.py`;`ov` / `openviking` 均为 console script 指向 Rust CLI(pyproject.toml:204-205)。改用 `ov ls`,且上下文里的 `OPENVIKING_CLI_CONFIG_FILE` 确认被 Rust CLI 读取(crates/ov_cli/src/config.rs:7)(docs/en/guides/03-deployment.md:173)
- D-05 `ov write --uri` 无此 flag:uri 是位置参数,`--content` 存在(main.rs:523 Write 定义)(docs/en/concepts/04-viking-uri.md:207; docs/zh/concepts/04-viking-uri.md:204)
- D-06 init-key 命令两处错误:zh 缺 `system` 命名空间,en/zh 的 `--output` 应为 `--output-file`(crates/ov_cli/src/commands/crypto.rs:24 `long = "output-file"`)。中英文已对齐(docs/en/concepts/10-encryption.md:88; docs/zh/concepts/10-encryption.md:88)
- D-07 文件系统 CLI 示例带字面方括号 `[--simple]`,粘贴即 clap 报错。四条命令(ls/rm/grep/glob)的改写形式均已对照 clap 定义验证可运行(docs/en/api/03-filesystem.md; docs/zh/api/03-filesystem.md)
- D-08 API 写作指南的"代码入口"引用四个已删除路径(core/client.py、resource/importer.py 等)。新列的 5 个入口全部核验存在:async_client.py:291、sync_client.py:199、resource_service.py:676、routers/resources.py:172、handlers.rs:16(docs/en/api/99-api-doc-writing-guide.md:170; docs/zh/api/99-api-doc-writing-guide.md:167)
- D-09 README provider 声明与 max_concurrent 默认值(64,见 semantic_processor.py:104)——**已被 main 的 README 重写覆盖,rebase 时丢弃**

## 关键设计与取舍
- D-07 选择删掉可选 flag 而非去括号保留:`--simple`/`--recursive`/`--ignore-case`/`--uri` 都是真实 flag,但示例的职责是可粘贴运行,flag 说明由同页 API 参数表和 `--help` 承担。替代方案(去括号保留 flag)会改变示例行为,不取。
- D-04 选 `ov` 而非 `openviking`:两者等价(同一 Rust 入口),`ov` 是全文档主用形式。

## 作用域与已知限制
- 纯文档改动,无运行时影响。
- 残留:99-api-doc-writing-guide.md 两语言的第 33 行模板段仍引用已删除的 `openviking_cli/commands/<command-file>.py`,本 PR 未改(与 D-08 同源,可顺手带上或另开小 PR)。
- D-07 删除 flag 示例牺牲了一点可发现性,见上文取舍。

## 合入价值
**P2(纯文档)** · 修掉新用户照抄即报错的 7 处命令/路径,维护者按写作指南能找到真实代码入口。无安全/数据面,严重性不高于 P2。

## 验证
- 全部 CLI 形式对照 `crates/ov_cli/src/main.rs` clap 定义与 `pyproject.toml` scripts 核验
- D-08 五个代码入口逐一 grep 确认存在
- `git merge-tree origin/main origin/sweep/docs-stale-commands`:仅 README.md、README_JA.md 冲突,11 个 docs/ 文件干净合并
- `git diff --check` 通过

---
自动化全仓清扫(2026-07)· draft 待 review
