### PR TITLE
fix(ragfs): enforce mount containment and write-flag semantics in LocalFS

### DIFF
--- a/crates/ragfs/src/core/filesystem.rs
+++ b/crates/ragfs/src/core/filesystem.rs
@@ -8,12 +8,22 @@ use async_trait::async_trait;
 use regex::Regex;
 use std::any::Any;
 use std::cmp::Ordering;
+use std::path::{Component, Path};
 
 use super::errors::{Error, Result};
-use super::glob::{
-    compare_rel_paths, decode_offset_token, encode_offset_token, PreparedGlob,
-};
+use super::glob::{compare_rel_paths, decode_offset_token, encode_offset_token, PreparedGlob};
 use super::types::{FileInfo, GlobEntry, GlobPage, GrepResult, TreeEntry, WriteFlag};
+
+/// Reject virtual paths that can escape a mounted backend lexically.
+pub(crate) fn validate_virtual_path(path: &str) -> Result<()> {
+    if Path::new(path)
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err(Error::invalid_path(path));
+    }
+    Ok(())
+}
 
 /// Normalize a path for prefix comparisons.
 ///

--- a/crates/ragfs/src/core/mountable.rs
+++ b/crates/ragfs/src/core/mountable.rs
@@ -21,7 +21,7 @@ const PATH_LOCK_FILE: &str = ".path.ovlock";
 
 use super::encryption_wrapper::EncryptionWrappedFS;
 use super::errors::{Error, Result};
-use super::filesystem::{sort_directory_entries, FileSystem};
+use super::filesystem::{sort_directory_entries, validate_virtual_path, FileSystem};
 use super::multibackend_wrapper::MultiWriteWrappedFS;
 use super::plugin::ServicePlugin;
 use super::stats::{FilesystemStats, StatsCollector};
@@ -611,6 +611,7 @@ impl MountableFS {
     /// # Errors
     /// * `Error::MountPointNotFound` - If no mount point matches the path
     async fn find_mount(&self, path: &str) -> Result<(MountInfo, String)> {
+        validate_virtual_path(path)?;
         let normalized_path = normalize_path(path);
         let mounts = self.mounts.read().await;
 

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -81,6 +81,9 @@ impl LocalFileSystem {
 
         // Remove leading slash to make it relative
         let relative = path.strip_prefix('/').unwrap_or(path);
+        if Path::new(relative).is_absolute() {
+            return Err(Error::invalid_path(path));
+        }
 
         // Join with base path
         if relative.is_empty() {
@@ -1152,7 +1155,8 @@ impl FileSystem for LocalFileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::FileSystem;
+    use crate::core::{ConfigValue, FileSystem, MountableFS};
+    use std::collections::HashMap;
     use std::path::Path;
     use tempfile::TempDir;
 
@@ -1205,6 +1209,28 @@ mod tests {
         let fs = LocalFileSystem::new(mount.to_str().unwrap()).unwrap();
 
         let err = fs.read("/../secret.txt", 0, 0).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidPath(_)));
+    }
+
+    #[tokio::test]
+    async fn test_localfs_mount_rejects_absolute_remainder() {
+        let dir = TempDir::new().unwrap();
+        let mount = dir.path().join("mount");
+        std::fs::create_dir(&mount).unwrap();
+        write_file(dir.path(), "secret.txt", "secret");
+
+        let fs = MountableFS::new();
+        fs.register_plugin(LocalFSPlugin::new()).await;
+        let params = HashMap::from([(
+            "local_dir".to_string(),
+            ConfigValue::String(mount.to_string_lossy().into_owned()),
+        )]);
+        fs.mount(PluginConfig::single_backend("localfs", "/local", params))
+            .await
+            .unwrap();
+
+        let escape_path = format!("/local/{}", dir.path().join("secret.txt").display());
+        let err = fs.read(&escape_path, 0, 0).await.unwrap_err();
         assert!(matches!(err, Error::InvalidPath(_)));
     }
 

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -17,7 +17,7 @@ use ignore::WalkBuilder;
 use serde::Deserialize;
 
 use crate::core::errors::{Error, Result};
-use crate::core::filesystem::FileSystem;
+use crate::core::filesystem::{validate_virtual_path, FileSystem};
 use crate::core::glob::{decode_offset_token, encode_offset_token, PreparedGlob};
 use crate::core::plugin::ServicePlugin;
 use crate::core::types::{ConfigParameter, FileInfo, GlobEntry, GlobPage, GrepResult, PluginConfig, WriteFlag};
@@ -76,15 +76,17 @@ impl LocalFileSystem {
     }
 
     /// Resolve a virtual path to actual local path
-    fn resolve_path(&self, path: &str) -> PathBuf {
+    fn resolve_path(&self, path: &str) -> Result<PathBuf> {
+        validate_virtual_path(path)?;
+
         // Remove leading slash to make it relative
         let relative = path.strip_prefix('/').unwrap_or(path);
 
         // Join with base path
         if relative.is_empty() {
-            self.base_path.clone()
+            Ok(self.base_path.clone())
         } else {
-            self.base_path.join(relative)
+            Ok(self.base_path.join(relative))
         }
     }
 
@@ -675,7 +677,7 @@ impl LocalFileSystem {
 #[async_trait]
 impl FileSystem for LocalFileSystem {
     async fn create(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if file already exists
         if local_path.exists() {
@@ -697,7 +699,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn mkdir(&self, path: &str, _mode: u32) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if directory already exists
         if local_path.exists() {
@@ -719,7 +721,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn remove(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -745,7 +747,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn remove_all(&self, path: &str) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -760,7 +762,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn read(&self, path: &str, offset: u64, size: u64) -> Result<Vec<u8>> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists and is not a directory
         let metadata = fs::metadata(&local_path).map_err(|_| Error::NotFound(path.to_string()))?;
@@ -790,7 +792,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn write(&self, path: &str, data: &[u8], offset: u64, flags: WriteFlag) -> Result<u64> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if it's a directory
         if local_path.exists() && local_path.is_dir() {
@@ -804,34 +806,41 @@ impl FileSystem for LocalFileSystem {
             }
         }
 
-        // Determine if we should truncate based on flags
-        let should_truncate = matches!(flags, WriteFlag::Create | WriteFlag::Truncate);
+        let mut options = fs::OpenOptions::new();
+        match flags {
+            WriteFlag::Create => {
+                options.write(true).create(true).truncate(true);
+            }
+            WriteFlag::Append => {
+                options.append(true);
+            }
+            WriteFlag::Truncate => {
+                options.write(true).truncate(true);
+            }
+            WriteFlag::None => {
+                options.write(true);
+            }
+        }
+        let mut file = options.open(&local_path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Error::NotFound(path.to_string())
+            } else {
+                Error::plugin(format!("failed to open file: {}", e))
+            }
+        })?;
 
-        // Open or create file with truncate support
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(should_truncate)
-            .open(&local_path)
-            .map_err(|e| Error::plugin(format!("failed to open file: {}", e)))?;
-
-        // Write data
         use std::io::{Seek, SeekFrom, Write};
-
-        if offset > 0 {
+        if matches!(flags, WriteFlag::None) && offset > 0 {
             file.seek(SeekFrom::Start(offset))
                 .map_err(|e| Error::plugin(format!("failed to seek: {}", e)))?;
         }
-
-        let written = file
-            .write(data)
+        file.write_all(data)
             .map_err(|e| Error::plugin(format!("failed to write: {}", e)))?;
-
-        Ok(written as u64)
+        Ok(data.len() as u64)
     }
 
     async fn read_dir(&self, path: &str) -> Result<Vec<FileInfo>> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
         let path = path.to_string();
 
         Self::run_blocking_fs(move || {
@@ -877,7 +886,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn stat(&self, path: &str) -> Result<FileInfo> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
         let path = path.to_string();
 
         Self::run_blocking_fs(move || {
@@ -906,8 +915,8 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn rename(&self, old_path: &str, new_path: &str) -> Result<()> {
-        let old_local = self.resolve_path(old_path);
-        let new_local = self.resolve_path(new_path);
+        let old_local = self.resolve_path(old_path)?;
+        let new_local = self.resolve_path(new_path)?;
 
         // Check if old path exists
         if !old_local.exists() {
@@ -929,8 +938,8 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn replace(&self, src_path: &str, dst_path: &str) -> Result<()> {
-        let src_local = self.resolve_path(src_path);
-        let dst_local = self.resolve_path(dst_path);
+        let src_local = self.resolve_path(src_path)?;
+        let dst_local = self.resolve_path(dst_path)?;
 
         if !src_local.exists() {
             return Err(Error::NotFound(src_path.to_string()));
@@ -1009,7 +1018,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn chmod(&self, path: &str, _mode: u32) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Check if exists
         if !local_path.exists() {
@@ -1022,7 +1031,7 @@ impl FileSystem for LocalFileSystem {
     }
 
     async fn ensure_parent_dirs(&self, path: &str, _mode: u32) -> Result<()> {
-        let local_path = self.resolve_path(path);
+        let local_path = self.resolve_path(path)?;
 
         // Get parent directory
         if let Some(parent) = local_path.parent() {
@@ -1050,7 +1059,7 @@ impl FileSystem for LocalFileSystem {
             return Ok(GrepResult::new());
         }
 
-        let local = self.resolve_path(path);
+        let local = self.resolve_path(path)?;
         if !local.exists() {
             return Err(Error::NotFound(path.to_string()));
         }
@@ -1120,6 +1129,7 @@ impl FileSystem for LocalFileSystem {
         level_limit: Option<usize>,
         continuation_token: Option<String>,
     ) -> Result<GlobPage> {
+        validate_virtual_path(path)?;
         let base_path = self.base_path.clone();
         let path_owned = path.to_string();
         let pattern_owned = pattern.to_string();
@@ -1184,6 +1194,35 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(path, content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_localfs_rejects_parent_path_components() {
+        let dir = TempDir::new().unwrap();
+        let mount = dir.path().join("mount");
+        std::fs::create_dir(&mount).unwrap();
+        write_file(dir.path(), "secret.txt", "secret");
+        let fs = LocalFileSystem::new(mount.to_str().unwrap()).unwrap();
+
+        let err = fs.read("/../secret.txt", 0, 0).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidPath(_)));
+    }
+
+    #[tokio::test]
+    async fn test_localfs_write_honors_flags() {
+        let (_dir, fs) = fallback_localfs();
+        fs.write("/file", b"old", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+        fs.write("/file", b"new", 0, WriteFlag::Append)
+            .await
+            .unwrap();
+        assert_eq!(fs.read("/file", 0, 0).await.unwrap(), b"oldnew");
+
+        for flag in [WriteFlag::Append, WriteFlag::Truncate, WriteFlag::None] {
+            let err = fs.write("/missing", b"data", 0, flag).await.unwrap_err();
+            assert!(matches!(err, Error::NotFound(_)));
+        }
     }
 
     /// Install a fake rg executable and prepend it to PATH for the current test.

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -1132,7 +1132,11 @@ impl FileSystem for LocalFileSystem {
         level_limit: Option<usize>,
         continuation_token: Option<String>,
     ) -> Result<GlobPage> {
-        validate_virtual_path(path)?;
+        // Use the same guard as every other op: `validate_virtual_path` alone lets an
+        // absolute remainder (e.g. `//etc` from a `//`-double-slash mount path) through,
+        // and `glob_via_walk`'s `resolve_virtual_path` would then join it over the base.
+        // `resolve_path` adds the is_absolute check; discard the PathBuf, keep the guard.
+        self.resolve_path(path)?;
         let base_path = self.base_path.clone();
         let path_owned = path.to_string();
         let pattern_owned = pattern.to_string();
@@ -1231,6 +1235,33 @@ mod tests {
 
         let escape_path = format!("/local/{}", dir.path().join("secret.txt").display());
         let err = fs.read(&escape_path, 0, 0).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidPath(_)));
+    }
+
+    #[tokio::test]
+    async fn test_localfs_glob_mount_rejects_absolute_remainder() {
+        let dir = TempDir::new().unwrap();
+        let mount = dir.path().join("mount");
+        std::fs::create_dir(&mount).unwrap();
+        write_file(dir.path(), "secret.txt", "secret");
+
+        let fs = MountableFS::new();
+        fs.register_plugin(LocalFSPlugin::new()).await;
+        let params = HashMap::from([(
+            "local_dir".to_string(),
+            ConfigValue::String(mount.to_string_lossy().into_owned()),
+        )]);
+        fs.mount(PluginConfig::single_backend("localfs", "/local", params))
+            .await
+            .unwrap();
+
+        // `/local/<abs dir>` -> remainder `//<abs dir>` would otherwise join over the mount
+        // base and let glob list a host directory outside the mount.
+        let escape_path = format!("/local/{}", dir.path().display());
+        let err = fs
+            .glob_directory(&escape_path, "**/*", false, None, None, None)
+            .await
+            .unwrap_err();
         assert!(matches!(err, Error::InvalidPath(_)));
     }
 


### PR DESCRIPTION
## 概述
LocalFS 的路径解析不拦截会越过挂载基目录的词法路径,写入实现也不遵守 `WriteFlag` 契约。本 PR 在两条必经路由——`MountableFS::find_mount` 与 `LocalFS::resolve_path`——前置词法校验:拒绝含 `..`/盘符前缀的分量,并拒绝“剩余路径本身是绝对路径”(`/mount//etc` 这类双斜杠会让 `join` 覆盖基目录);同时按 `WriteFlag` 精确选择文件打开方式,并用 `write_all` 保证整块写入。

## 为什么必要(可达性 / 严重性)
根因:`resolve_path` 用 `base_path.join(relative)`,而 `relative = path.strip_prefix('/')` 只剥掉一个前导斜杠。`/mount//etc/passwd` 经 MountableFS 路由后剩余路径是 `//etc/passwd`,剥一层后变成绝对路径 `/etc/passwd`;`PathBuf::join` 遇绝对路径直接丢弃基目录 → 逃逸到宿主机任意路径。`..` 同理,经 `join` 归一化后越界。

诚实定级:**这是 Rust 库边界的加固,属 defense-in-depth,而非产品主路径上正在被利用的活体 P0。** 产品主入口 `viking_fs`(agent/tool 的读写都走它)在 `_normalized_uri_parts` 已经拒绝 `.`/`..`/`\`/盘符段,并按段切分重组把多斜杠折叠成单斜杠(`openviking/storage/viking_fs.py:317`),`..` 与双斜杠都进不到 Rust 层。只有绕过 `viking_fs`、把原始路径直接喂给 `ragfs-python` 绑定 / `MountableFS` 的调用方才可能触发。
- 可达入口:直接调用 Rust `MountableFS`/`LocalFS`(或其 pyo3 绑定 `read/write/glob_directory`)且未做 `viking_fs` 归一化的代码;不是面向用户的默认 agent 路径。
- 后端相关性:仅 LocalFS(本地目录挂载)。S3/远程后端用对象 key、不做本地 `join`,不受影响。

## 关键设计与取舍
- 单点拦截:`validate_virtual_path`(拒 `ParentDir`/`Prefix`)放进 `find_mount` 与 `resolve_path` 两条必经路由,而非每个操作各写一遍——read/write/stat/rename/remove/grep 都经 `resolve_path`,一处生效。
- 为什么还要 `is_absolute(relative)`:`validate_virtual_path` 基于 `Path::components()`,而 `//etc` 的 components 是 `[RootDir, Normal("etc")]`,不含 `ParentDir`,单靠它拦不住双斜杠;必须在 `strip_prefix('/')` 之后再判一次剩余是否绝对路径。两道合起来才闭合 E-01。
- WriteFlag 精确化:`Create`=create+truncate、`Append`=append、`Truncate`=write+truncate(不 create)、`None`=write(不 create);文件缺失时 `None/Append/Truncate` 返回 `NotFound` 而非静默建文件。`write_all` 取代 `file.write()`,消除短写误报成功。
- 未选择的替代:不在本 PR 收窄/移除 `WriteFlag::Append`(改成“VFS 整对象、append 全上层模拟”)——那是跨后端契约决策;且若将来要治长会话整文件重写的 O(N²),反而需要一个语义正确的 Append 作升级基座。

## 作用域与已知限制
- **glob 仍有缺口,E-01 未完全闭合**:`LocalFS::glob_directory` 只加了 `validate_virtual_path`,但它取根走的是未改动的 `resolve_virtual_path`,缺 `is_absolute` 那道检查。`/mount//etc` 经路由得到剩余 `//etc`,glob 会把 `query_root` 解析成 `/etc` 并列出宿主机目录(信息泄露级,非内容读取)。建议:`glob_directory` 改用 `self.resolve_path(path)?` 复用同一套 guard(其内部已含 `validate_virtual_path`),并补一条 glob 逃逸回归测试。read/write/grep 已由 `resolve_path` 覆盖,不受此缺口影响。
- E-04 实际可达面:`WriteFlag::None + offset>0` 确有生产调用点(`mountable.rs:585` 与 `multibackend_wrapper.rs:327` 的分块 raw 拷贝)。旧 `file.write()` 可能短写并上报部分字节,`write_all` 修掉该隐患。`Append`/整块 `None/Truncate` 的静默建文件属契约正确性,当前无生产调用点(pyagfs `write` 只收整块 data、硬编码 `WriteFlag::Create`;应用层 `viking_fs.append_file` 是“读整文件→内存拼接→整写回”)。
- 回归面:`None` 不再 create,已核对所有生产拷贝路径都在 `offset==0` 先以 `Create` 建文件,后续 `None` chunk 打开的是已存在文件,无回归;`Truncate` 改为“不 create”,与 `encryption_wrapper`/`kvfs`/`memfs` 现有 `Create|Truncate` 分支一致。

## 修复的问题
- E-01 `..`/盘符/双斜杠绝对剩余路径可将 LocalFS 操作路由到挂载之外(`crates/ragfs/src/core/mountable.rs:614`、`crates/ragfs/src/plugins/localfs/mod.rs:79`);glob 路径尚未闭合(见上)
- E-04 LocalFS 无视 WriteFlag 且短写可能误报成功(`crates/ragfs/src/plugins/localfs/mod.rs:794`)

## 合入价值
**边界加固(defense-in-depth)· 收窄 LocalFS 挂载越界与静默建文件/短写**——不是产品主路径上的活体 P0(`viking_fs` 已在上游拦住 `..`/双斜杠),但显著收窄 Rust 库边界的容器逃逸面,并修正一个真实可达的分块拷贝短写隐患。合入前建议先补上 glob 的同款 guard,否则 E-01 只修了一半。

## 验证
PR 内新增测试(随 diff 一同提交):
- `cargo test -p ragfs test_localfs_rejects_parent_path_components --lib`
- `cargo test -p ragfs test_localfs_write_honors_flags --lib`
- `cargo test -p ragfs test_localfs_mount_rejects_absolute_remainder --lib`
- `cargo check -p ragfs`

独立复核(逃逸模拟,已实跑):按 PR 修改后的 `find_mount`+`resolve_path`+`resolve_virtual_path` 逻辑模拟,`/mount//etc` 经 `resolve_path` 被拒(InvalidPath),但经 `glob_directory`→`resolve_virtual_path` 仍解析为 `/etc`(逃逸)。glob 缺口据此确认;`test_localfs_mount_rejects_absolute_remainder` 只覆盖了 `read`,未覆盖 glob。

---
自动化全仓清扫(2026-07)· draft 待 review · 复核结论:fix-needed(glob 缺口待补)
