### PR TITLE
fix(bot): make SRT sandbox constructible and surface startup failures

### DIFF
--- a/bot/tests/test_sandbox_startup.py
+++ b/bot/tests/test_sandbox_startup.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for sandbox construction and startup failures."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.config.schema import Config, SessionKey  # noqa: E402
+from vikingbot.sandbox.backends.srt import SrtBackend  # noqa: E402
+from vikingbot.sandbox.manager import SandboxManager  # noqa: E402
+
+
+def test_srt_backend_uses_workspace_id_and_nested_config(tmp_path):
+    config = Config().sandbox
+    config.backends.srt.network.allowed_domains = ["example.com"]
+
+    backend = SrtBackend(config, "shared", tmp_path / "shared")
+
+    assert backend._settings_path.name == "shared-srt-settings.json"
+    settings = json.loads(backend._settings_path.read_text())
+    assert settings["network"]["allowedDomains"] == ["example.com"]
+    assert settings["filesystem"]["allowWrite"][0] == str((tmp_path / "shared").resolve())
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_is_not_cached_and_can_retry(tmp_path):
+    class FailingBackend:
+        instances = []
+
+        def __init__(self, config, workspace_id, workspace):
+            self.stopped = False
+            self.instances.append(self)
+
+        async def start(self):
+            raise RuntimeError("startup failed")
+
+        async def stop(self):
+            self.stopped = True
+
+    manager = SandboxManager(Config(), tmp_path / "sandboxes", tmp_path / "source")
+    manager._backend_cls = FailingBackend
+    session_key = SessionKey(type="cli", channel_id="default", chat_id="test")
+
+    for expected_attempts in (1, 2):
+        with pytest.raises(RuntimeError, match="startup failed"):
+            await manager.get_sandbox(session_key)
+        assert manager._sandboxes == {}
+        assert len(FailingBackend.instances) == expected_attempts
+        assert FailingBackend.instances[-1].stopped

--- a/bot/vikingbot/sandbox/backends/srt.py
+++ b/bot/vikingbot/sandbox/backends/srt.py
@@ -11,18 +11,18 @@ from vikingbot.sandbox.base import SandboxBackend, SandboxNotStartedError
 from vikingbot.sandbox.backends import register_backend
 
 
-from vikingbot.config.schema import SandboxConfig, SessionKey
+from vikingbot.config.schema import SandboxConfig
 
 
 @register_backend("srt")
 class SrtBackend(SandboxBackend):
     """SRT backend using @anthropic-ai/sandbox-runtime."""
 
-    def __init__(self, config, session_key: SessionKey, workspace: Path):
+    def __init__(self, config: SandboxConfig, workspace_id: str, workspace: Path):
         # SRT has built-in isolation, restrict_to_workspace is not needed
         super().__init__()
         self.config = config
-        self.session_key = session_key
+        self.workspace_id = workspace_id
         self._workspace = workspace
         self._process = None
         self._settings_path = self._generate_settings()
@@ -42,9 +42,7 @@ class SrtBackend(SandboxBackend):
         srt_config = self._load_config()
 
         # Place settings file in workspace/sandboxes/ directory
-        settings_path = (
-            self._workspace / "sandboxes" / f"{self.session_key.safe_name()}-srt-settings.json"
-        )
+        settings_path = self._workspace / "sandboxes" / f"{self.workspace_id}-srt-settings.json"
         settings_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(settings_path, "w") as f:
@@ -224,6 +222,7 @@ class SrtBackend(SandboxBackend):
     def _load_config(self) -> dict[str, Any]:
         sandbox_workspace_str = str(self._workspace.resolve())
         allow_write = [sandbox_workspace_str]
+        srt_config = self.config.backends.srt
 
         tmp_dir = "/tmp"
         if tmp_dir not in allow_write:
@@ -231,14 +230,14 @@ class SrtBackend(SandboxBackend):
 
         return {
             "network": {
-                "allowedDomains": self.config.network.allowed_domains,
-                "deniedDomains": self.config.network.denied_domains,
-                "allowLocalBinding": self.config.network.allow_local_binding,
+                "allowedDomains": srt_config.network.allowed_domains,
+                "deniedDomains": srt_config.network.denied_domains,
+                "allowLocalBinding": srt_config.network.allow_local_binding,
             },
             "filesystem": {
-                "denyRead": self.config.filesystem.deny_read,
+                "denyRead": srt_config.filesystem.deny_read,
                 "allowWrite": allow_write,
-                "denyWrite": self.config.filesystem.deny_write,
+                "denyWrite": srt_config.filesystem.deny_write,
             },
         }
 

--- a/bot/vikingbot/sandbox/manager.py
+++ b/bot/vikingbot/sandbox/manager.py
@@ -44,12 +44,15 @@ class SandboxManager:
         instance = self._backend_cls(self.config.sandbox, workspace_id, workspace)
         try:
             await instance.start()
-        except Exception as e:
-            import traceback
-
-            traceback.print_exc()
-        if not workspace.exists():
-            await self._copy_bootstrap_files(workspace)
+            if not workspace.exists():
+                await self._copy_bootstrap_files(workspace)
+        except Exception:
+            logger.exception(f"Failed to start sandbox for workspace {workspace_id}")
+            try:
+                await instance.stop()
+            except Exception:
+                logger.exception(f"Failed to clean up sandbox for workspace {workspace_id}")
+            raise
         return instance
 
     async def _copy_bootstrap_files(self, sandbox_workspace: Path) -> None:


### PR DESCRIPTION
## 概述
`sandbox.backend=srt` 目前完全不可用:SrtBackend 构造时就抛 `AttributeError`。同时 SandboxManager 会吞掉任意后端的启动异常,把没启动成功的实例塞进缓存,该 workspace 后续所有请求都拿到死实例,只能重启进程恢复。本 PR 让 SrtBackend 接受 manager 实际传入的参数、从正确的配置层级读设置,并让启动失败向上抛、坏实例不进缓存。

## 为什么必要(可达性/严重性)
**诚实定级:P1(功能性缺陷,非安全绕过)。**

- C-02 是第一道防线,无上游拦截:README.md:457 文档化了 `"backend": "srt"` 配置;一旦配置,首个到达 `get_sandbox` 的请求(shell/filesystem/image 工具、subagent、session manager 都走这条路)即触发构造失败,100% 复现。已在 main 上实测:`SrtBackend(Config().sandbox, "shared", ...)` → `AttributeError: 'SandboxConfig' object has no attribute 'network'`。
- C-04 与后端无关:任何 `start()` 可能失败的后端都受影响(opensandbox server 不可达、srt 的 node 不存在等)。失败被 `traceback.print_exc()` 吞掉后实例仍被缓存,后续 `execute()` 只报 `SandboxNotStartedError`,真实原因丢失,且永远不重试。
- 不升为 P0 的理由:默认后端是 `direct`,只有显式配 srt 才踩 C-02;启动失败不会静默降级为无沙箱执行(工具调用直接报错),所以是可用性问题而非隔离绕过。

## 根因
- C-02 有两处错位,都在 `SrtBackend.__init__` 内触发:
  1. manager 传的是 `(SandboxConfig, workspace_id: str, workspace)`(manager.py:44),SrtBackend 却按 `SessionKey` 用,对字符串调 `.safe_name()`;
  2. `_load_config` 读 `self.config.network/.filesystem`,但这两个字段在 schema 里只存在于 `backends.srt` 之下(schema.py:713-719、784-790),`SandboxConfig` 顶层没有。
- C-04:`_create_sandbox` 捕获 `start()` 异常后仅打印 traceback 并照常返回实例,`_get_or_create_sandbox` 按 workspace_id 缓存之。

## 关键设计与取舍
- **改 SrtBackend 签名为 `workspace_id: str`,而不是让 manager 改传 SessionKey**:workspace_id 由 mode 派生(shared/per-channel/per-session,manager.py:107-113),shared 模式下多个 session 共用一个沙箱,单个 SessionKey 对后端没有意义;其余三个后端从不调用 SessionKey 方法,字符串本就能穿透。设置文件名改为 `{workspace_id}-srt-settings.json`,各 mode 下仍唯一。
- **启动失败选择 re-raise 而不是返回降级实例或内置重试**:抛出让调用方看到真实错误,下一个请求自然重试;抛出前尽力 `stop()`,避免部分启动成功时泄漏 node 子进程(清理失败仅记日志,不掩盖原始异常)。
- bootstrap 文件拷贝移入 try:只为真正启动成功的沙箱做引导。行为变化:此前 start() 失败也会拷贝 bootstrap 文件,现在不会——这是有意的。

## 作用域与已知限制
- 其余三个后端(direct/opensandbox/aiosandbox)的 `session_key: SessionKey` 类型标注仍是错的(实际收到 str;direct.py:163 拿它当 dict key,字符串恰好可用)。纯注解问题,不在本 PR 修。
- `_get_or_create_sandbox` 无并发锁,两个并发首请求可能各建一个实例——先前就存在,本 PR 未改。
- 先前就存在的怪癖(本 PR 未改变):SRT 的 `__init__` 会创建 `workspace/sandboxes/`,导致 start 后 `workspace.exists()` 恒为 True,`_copy_bootstrap_files` 对 SRT 永远不执行。建议另开 issue。

## 修复的问题
- C-02 SRT 构造时对字符串调 `.safe_name()`,并从顶层不存在的字段读网络/文件系统配置(bot/vikingbot/sandbox/backends/srt.py:21,224)
- C-04 启动异常被吞,坏实例进缓存,阻塞该 workspace 重试(bot/vikingbot/sandbox/manager.py:41-53)

## 合入价值
**P1** · 文档记载的 SRT 后端从"必崩"恢复为可用;所有后端的启动失败带真实原因上抛,请求级可重试,无需重启进程。

## 验证
- PR head(0d379839)实际执行:`python -m pytest -q --no-cov bot/tests/test_sandbox_startup.py` — 2 passed(覆盖:SRT 用 workspace_id + 嵌套配置构造成功;启动失败抛出、不缓存、实例被 stop、可重试)。
- main 上复现原缺陷:按 manager 的实参构造 SrtBackend → `AttributeError: 'SandboxConfig' object has no attribute 'network'`。

---
自动化全仓清扫(2026-07)· draft 待 review
