### PR TITLE
fix(sdk/python): runnable quickstarts, correct migrate payload, explicit timeout precedence

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -86,6 +86,7 @@ client = SyncHTTPClient(
     url="http://127.0.0.1:1933",
     api_key="your-user-key",
 )
+client.initialize()
 
 healthy = client.health()
 print("health:", healthy)
@@ -96,6 +97,8 @@ print("session:", session)
 client.session("demo-session").add_message("user", "hello from sdk")
 context = client.session("demo-session").get_session_context(token_budget=4096)
 print("context:", context)
+
+client.close()
 ```
 
 ## Quick Start: Async Client
@@ -111,6 +114,7 @@ async def main() -> None:
         url="http://127.0.0.1:1933",
         api_key="your-user-key",
     )
+    await client.initialize()
 
     healthy = await client.health()
     print("health:", healthy)
@@ -137,6 +141,7 @@ asyncio.run(main())
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 result = client.create_session("demo-session")
 print(result)
 ```
@@ -149,6 +154,7 @@ print(result)
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 result = client.add_resource(
     "/path/to/notes.md",
@@ -165,6 +171,7 @@ print(result)
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 client.mkdir("viking://resources/demo-dir")
 print(client.ls("viking://resources"))
@@ -177,6 +184,7 @@ print(client.read("viking://resources/demo-dir/example.md"))
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 result = client.find("hello", limit=5)
 print(result)
@@ -209,6 +217,7 @@ root_client = SyncHTTPClient(
     url="http://127.0.0.1:1933",
     api_key="your-root-key",
 )
+root_client.initialize()
 
 result = root_client.admin_create_account(
     account_id="demo-account",
@@ -251,6 +260,7 @@ The SDK maps server-side error codes to Python exceptions.
 from openviking_sdk import OpenVikingError, SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 try:
     print(client.read("viking://resources/not-exists.md"))

--- a/sdk/python/README_CN.md
+++ b/sdk/python/README_CN.md
@@ -86,6 +86,7 @@ client = SyncHTTPClient(
     url="http://127.0.0.1:1933",
     api_key="your-user-key",
 )
+client.initialize()
 
 healthy = client.health()
 print("health:", healthy)
@@ -96,6 +97,8 @@ print("session:", session)
 client.session("demo-session").add_message("user", "hello from sdk")
 context = client.session("demo-session").get_session_context(token_budget=4096)
 print("context:", context)
+
+client.close()
 ```
 
 ## 快速开始：异步客户端
@@ -111,6 +114,7 @@ async def main() -> None:
         url="http://127.0.0.1:1933",
         api_key="your-user-key",
     )
+    await client.initialize()
 
     healthy = await client.health()
     print("health:", healthy)
@@ -137,6 +141,7 @@ asyncio.run(main())
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 result = client.create_session("demo-session")
 print(result)
 ```
@@ -149,6 +154,7 @@ print(result)
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 result = client.add_resource(
     "/path/to/notes.md",
@@ -165,6 +171,7 @@ print(result)
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 client.mkdir("viking://resources/demo-dir")
 print(client.ls("viking://resources"))
@@ -177,6 +184,7 @@ print(client.read("viking://resources/demo-dir/example.md"))
 from openviking_sdk import SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 result = client.find("hello", limit=5)
 print(result)
@@ -209,6 +217,7 @@ root_client = SyncHTTPClient(
     url="http://127.0.0.1:1933",
     api_key="your-root-key",
 )
+root_client.initialize()
 
 result = root_client.admin_create_account(
     account_id="demo-account",
@@ -248,6 +257,7 @@ SDK 会把服务端错误码映射为 Python 异常。
 from openviking_sdk import OpenVikingError, SyncHTTPClient
 
 client = SyncHTTPClient(url="http://127.0.0.1:1933", api_key="your-user-key")
+client.initialize()
 
 try:
     print(client.read("viking://resources/not-exists.md"))

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -264,7 +264,7 @@ class AsyncHTTPClient:
         user: Optional[str] = None,
         actor_peer_id: Optional[str] = None,
         agent_id: Optional[str] = None,
-        timeout: float = 60.0,
+        timeout: Optional[float] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         profile_enabled: Optional[bool] = None,
         upload_mode: Optional[str] = None,
@@ -1484,7 +1484,8 @@ class AsyncHTTPClient:
         return self._handle_response(response)
 
     async def admin_migrate(self, cleanup: bool = False) -> Dict[str, Any]:
-        response = await self._request("POST", "/api/v1/admin/migrate", json={"cleanup": cleanup})
+        action = "cleanup" if cleanup else "migrate"
+        response = await self._request("POST", "/api/v1/admin/migrate", json={"action": action})
         return self._handle_response(response)
 
     def get_status(self) -> Dict[str, Any]:

--- a/sdk/python/openviking_sdk/config.py
+++ b/sdk/python/openviking_sdk/config.py
@@ -186,7 +186,7 @@ def resolve_client_config(
     account: Optional[str] = None,
     user: Optional[str] = None,
     actor_peer_id: Optional[str] = None,
-    timeout: float = 60.0,
+    timeout: Optional[float] = None,
     extra_headers: Optional[dict[str, str]] = None,
     profile_enabled: Optional[bool] = None,
     upload_mode: Optional[str] = None,
@@ -211,13 +211,16 @@ def resolve_client_config(
     if resolved_actor_peer_id is None and cli_config is not None and cli_config.agent_id:
         resolved_actor_peer_id = cli_config.agent_id
 
-    resolved_timeout = timeout
-    if timeout == 60.0:
+    if timeout is not None:
+        resolved_timeout = timeout
+    else:
         env_timeout = os.getenv("OPENVIKING_TIMEOUT")
         if env_timeout:
             resolved_timeout = float(env_timeout)
         elif cli_config is not None:
             resolved_timeout = cli_config.timeout
+        else:
+            resolved_timeout = 60.0
 
     resolved_profile_enabled = bool(profile_enabled)
     if profile_enabled is None and cli_config is not None:

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -87,6 +87,19 @@ async def test_async_http_client_reindex_posts_content_reindex():
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("cleanup", "action"), [(False, "migrate"), (True, "cleanup")])
+async def test_async_http_client_admin_migrate_posts_action_payload(cleanup, action):
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    client._request = AsyncMock(return_value=object())
+    client._handle_response = lambda _response: {"status": "accepted"}
+
+    assert await client.admin_migrate(cleanup=cleanup) == {"status": "accepted"}
+    client._request.assert_awaited_once_with(
+        "POST", "/api/v1/admin/migrate", json={"action": action}
+    )
+
+
 def test_sync_http_client_reindex_forwards_to_async_client():
     client = SyncHTTPClient(url="http://localhost:1933")
     with patch.object(

--- a/sdk/python/tests/test_ovcli_config_compat.py
+++ b/sdk/python/tests/test_ovcli_config_compat.py
@@ -102,6 +102,19 @@ def test_async_http_client_explicit_arguments_override_ovcli_config(tmp_path, mo
     assert client._upload_mode == "local"
 
 
+def test_async_http_client_explicit_default_timeout_overrides_lower_priority_sources(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(json.dumps({"url": "http://config-host:1933", "timeout": 12.5}))
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("OPENVIKING_TIMEOUT", "20")
+
+    client = AsyncHTTPClient(timeout=60.0)
+
+    assert client._timeout == 60.0
+
+
 def test_async_http_client_reports_invalid_ovcli_config(tmp_path, monkeypatch):
     config_path = tmp_path / "ovcli.conf"
     config_path.write_text(json.dumps({"url": "http://localhost:1933", "timeout": "fast"}))


### PR DESCRIPTION
## 概述
修 Python SDK 三个独立缺陷：README 全部快速上手示例缺 `initialize()` 调用、`admin_migrate(cleanup=True)` 发的字段与服务端契约不符、显式传入的 `timeout=60.0` 被环境变量/配置文件覆盖。

## 为什么必要（可达性/严重性）
- F-01：`AsyncHTTPClient._request` 在 `self._http is None` 时直接抛 `RuntimeError("Client is not initialized")`（client.py:362），而 httpx 客户端只在 `initialize()` 里创建。README 中英文版所有带请求的示例都没调它——新用户照抄第一个示例必然失败。这是文档级 bug，可达性 100%。
- F-02：服务端 `MigrateLegacyDataRequest` 只认 `action: str = "migrate"`（openviking/server/routers/admin.py:64），pydantic 默认忽略未知字段，所以旧 SDK 发的 `{"cleanup": true}` 被静默解析成 `action="migrate"`——用户请求 cleanup，服务端却启动一次 legacy migration。Go SDK（sdk/go/admin.go:116）和 Rust CLI（crates/ov_cli/src/client.rs:1413）都已用 `action` 契约，Python SDK 是唯一掉队者。诚实定级：该端点 `@require_auth_root`，只有 ROOT 运维可达，且错误方向是"该删的没删、多跑了一次带 preflight 的迁移"，不产生数据丢失——是真实 bug 但不是 P0。
- F-14：旧代码用 `if timeout == 60.0` 猜测"用户没传"，显式传 60.0 的用户会被 `OPENVIKING_TIMEOUT` 或 ovcli.conf 静默覆盖。低频但违反显式参数最高优先的直觉。

## 关键设计与取舍
- F-02 改客户端对齐服务端契约，而不是让服务端兼容 `cleanup` 字段：服务端契约已被 Go/Rust 两端实现且有校验（action 必须是 migrate/cleanup），扩服务端只会固化错误字段。
- F-14 把默认值从魔数比较改成 `None` 哨兵：`timeout=None`（缺省）→ 环境变量 → ovcli 配置 → 60.0；显式传值永远最高优先。`OVCLIConfig.timeout` 加载时已兜底为 float，`ClientConfig.timeout: float` 类型不变。
- F-01 只在示例里加 `initialize()`/`close()`，不做构造时自动初始化——自动初始化会改变现有生命周期语义，超出本 PR 范围。

## 作用域与已知限制
- 仅 Python SDK + 两份 README，不碰服务端。SyncHTTPClient 透传 `*args/**kwargs`，无第二份默认值，同步侧无回归路径。
- 一处行为变化：旧签名 `timeout: float = 60.0` 下若有人越过类型注解传 `timeout=None`，None 会漏进 httpx 并禁用超时；现在 None 表示"走缺省链"，得到有限超时。全仓无调用方传 None（tests/integration、tests/parse 均传显式 float），属可接受的契约收紧。
- README 示例仍要求 127.0.0.1:1933 有运行中的服务，本 PR 不解决。

## 修复的问题
- F-01 带请求的同步/异步示例先 `initialize()` 再使用，快速上手示例补 `close()`（sdk/python/README.md、sdk/python/README_CN.md）
- F-02 `admin_migrate(cleanup=True)` 改发 `{"action": "cleanup"}`，与 Go SDK / Rust CLI / 服务端契约一致（sdk/python/openviking_sdk/client.py:1486）
- F-14 显式 timeout（含 60.0）优先于 `OPENVIKING_TIMEOUT` 与 ovcli 配置（sdk/python/openviking_sdk/config.py:214）

## 合入价值
**P1** · 新用户能跑通文档里的第一个示例；ROOT 的 cleanup 请求不再被静默执行成 migrate；timeout 优先级符合直觉。

## 验证
- reviewer 独立在 PR head（d9a64f56）worktree 复跑：`pytest tests/test_async_client_behaviors.py tests/test_ovcli_config_compat.py` → 44 passed, 1 failed
- 唯一失败 `test_glob_normalizes_scope_uri` 在不含本 PR 的基线上同样失败，属既有问题，与本改动无关
- 新增用例覆盖 migrate/cleanup 两种 payload 与"显式 60.0 压过 env=20、config=12.5"的优先级

---
自动化全仓清扫（2026-07）· draft 待 review
