### PR TITLE
fix(integrations): batch LangGraph history writes to avoid duplicates and lost context

### DIFF
--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -197,8 +197,8 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             start = len(previous_signatures)
 
         client = ensure_client(self._connection)
-        added = 0
-        pending_context_parts = list(self._pending_context_parts.pop(capture_key, []))
+        batch = []
+        pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
         for message in messages[start:]:
             if OPENVIKING_CONTEXT_MARKER in _message_content(message):
                 continue
@@ -207,17 +207,19 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 if pending_context_parts and payload["role"] == "assistant":
                     payload["parts"].extend(pending_context_parts)
                     pending_context_parts = []
-                call_openviking(
-                    client,
-                    "add_message",
-                    session_id=session_id,
-                    role=payload["role"],
-                    parts=payload["parts"],
-                    peer_id=peer_id,
-                )
-                added += 1
+                if peer_id is not None:
+                    payload["peer_id"] = peer_id
+                batch.append(payload)
+        if batch:
+            call_openviking(
+                client,
+                "batch_add_messages",
+                session_id=session_id,
+                messages=batch,
+            )
+        self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures
-        if added:
+        if batch:
             apply_commit_policy(client, session_id, self.commit_policy)
         return None
 

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -41,6 +41,7 @@ from openviking.integrations.langchain.retrievers import OpenVikingRetriever
 
 logger = logging.getLogger(__name__)
 
+_BATCH_ADD_MESSAGES_LIMIT = 100
 _SESSION_ID_ERROR = (
     "OpenVikingContextMiddleware requires a LangGraph session id. Pass "
     'config={"configurable": {"thread_id": "..."}}, set state["session_id"], '
@@ -210,12 +211,12 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 if peer_id is not None:
                     payload["peer_id"] = peer_id
                 batch.append(payload)
-        if batch:
+        for start in range(0, len(batch), _BATCH_ADD_MESSAGES_LIMIT):
             call_openviking(
                 client,
                 "batch_add_messages",
                 session_id=session_id,
-                messages=batch,
+                messages=batch[start : start + _BATCH_ADD_MESSAGES_LIMIT],
             )
         self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -199,25 +199,37 @@ class OpenVikingContextMiddleware(AgentMiddleware):
 
         client = ensure_client(self._connection)
         batch = []
+        chunks = []
+        batch_has_context = False
         pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
-        for message in messages[start:]:
+        for message_index, message in enumerate(messages[start:], start=start):
             if OPENVIKING_CONTEXT_MARKER in _message_content(message):
                 continue
             payloads = langchain_message_to_openviking(message)
+            if batch and len(batch) + len(payloads) > _BATCH_ADD_MESSAGES_LIMIT:
+                chunks.append((batch, message_index, batch_has_context))
+                batch = []
+                batch_has_context = False
             for payload in payloads:
                 if pending_context_parts and payload["role"] == "assistant":
                     payload["parts"].extend(pending_context_parts)
                     pending_context_parts = []
+                    batch_has_context = True
                 if peer_id is not None:
                     payload["peer_id"] = peer_id
                 batch.append(payload)
-        for start in range(0, len(batch), _BATCH_ADD_MESSAGES_LIMIT):
+        if batch:
+            chunks.append((batch, len(messages), batch_has_context))
+        for chunk, signature_end, has_context in chunks:
             call_openviking(
                 client,
                 "batch_add_messages",
                 session_id=session_id,
-                messages=batch[start : start + _BATCH_ADD_MESSAGES_LIMIT],
+                messages=chunk,
             )
+            self._captured_signatures[capture_key] = current_signatures[:signature_end]
+            if has_context:
+                self._pending_context_parts.pop(capture_key, None)
         self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures
         if batch:

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1750,3 +1750,39 @@ def test_langgraph_middleware_chunks_batches_at_server_limit():
 
     assert client.batch_sizes == [100, 1]
     assert len(client.sessions["middleware-large-batch"]) == 101
+
+
+def test_langgraph_middleware_retries_only_failed_batch_chunk():
+    class FailSecondBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes = []
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            self.batch_sizes.append(len(messages))
+            if len(self.batch_sizes) == 2:
+                raise RuntimeError("second batch failed")
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = FailSecondBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        session_id_resolver=lambda state, runtime: "middleware-chunk-retry",
+    )
+    middleware._pending_context_parts[("middleware-chunk-retry", "")] = [
+        {"type": "context", "uri": "viking://resources/retry.md"}
+    ]
+    messages = [HumanMessage(content="First"), AIMessage(content="Context holder")]
+    messages.extend(HumanMessage(content=f"Message {index}") for index in range(98))
+    messages.append(AIMessage(content="Retry only this message"))
+    state = {"messages": messages}
+
+    with pytest.raises(RuntimeError, match="second batch failed"):
+        middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_sizes == [100, 1, 1]
+    stored = client.sessions["middleware-chunk-retry"]
+    assert len(stored) == 101
+    assert sum(part["type"] == "context" for message in stored for part in message["parts"]) == 1

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1724,3 +1724,29 @@ def test_langgraph_middleware_retries_failed_batch_with_pending_context():
     assert len(client.sessions["middleware-batch-retry"]) == 2
     assistant_parts = client.sessions["middleware-batch-retry"][1]["parts"]
     assert sum(part["type"] == "context" for part in assistant_parts) == 1
+
+
+def test_langgraph_middleware_chunks_batches_at_server_limit():
+    class CappedBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes = []
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            if len(messages) > 100:
+                raise RuntimeError("server batch limit exceeded")
+            self.batch_sizes.append(len(messages))
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = CappedBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        session_id_resolver=lambda state, runtime: "middleware-large-batch",
+    )
+    state = {"messages": [HumanMessage(content=f"Message {index}") for index in range(101)]}
+
+    middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_sizes == [100, 1]
+    assert len(client.sessions["middleware-large-batch"]) == 101

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1677,3 +1677,50 @@ def test_langgraph_middleware_clears_pending_context_on_duplicate_retry():
 
     unrelated_assistant_parts = client.sessions["middleware-pending-cleanup"][-1]["parts"]
     assert unrelated_assistant_parts == [{"type": "text", "text": "Unrelated turn stored."}]
+
+
+def test_langgraph_middleware_retries_failed_batch_with_pending_context():
+    class FailFirstBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__({"viking://user/memories/profile.md": "Retained retry context."})
+            self.batch_attempts = 0
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            self.batch_attempts += 1
+            if self.batch_attempts == 1:
+                raise RuntimeError("batch write failed")
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = FailFirstBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        target_uri="viking://user/memories",
+        session_id_resolver=lambda state, runtime: "middleware-batch-retry",
+    )
+
+    class Request:
+        messages = [HumanMessage(content="What retry context?")]
+        system_message = None
+
+        def override(self, **overrides):
+            new_request = Request()
+            new_request.messages = overrides.get("messages", self.messages)
+            new_request.system_message = overrides.get("system_message", self.system_message)
+            return new_request
+
+    middleware.wrap_model_call(Request(), lambda request: AIMessage(content="ok"))
+    state = {
+        "messages": [
+            HumanMessage(content="What retry context?"),
+            AIMessage(content="Retry context stored."),
+        ]
+    }
+
+    with pytest.raises(RuntimeError, match="batch write failed"):
+        middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_attempts == 2
+    assert len(client.sessions["middleware-batch-retry"]) == 2
+    assistant_parts = client.sessions["middleware-batch-retry"][1]["parts"]
+    assert sum(part["type"] == "context" for part in assistant_parts) == 1


### PR DESCRIPTION
## 概述
`OpenVikingContextMiddleware.after_agent` 原实现先无条件弹出待写入的检索上下文（`_pending_context_parts.pop`），再对新消息逐条 `add_message`；`_captured_signatures` 只在整个循环成功后才推进。根因是进度推进和上下文消费都不与实际写入成功绑定：中途任何一条写失败，下一轮 after_agent（下个 turn 或显式重试）会从旧 start 重放整段消息——之前已成功的消息被重复写入，而检索上下文已被弹出、永久丢失。

本 PR 改为按服务端上限（100 条/请求，`BatchAddMessageRequest.messages max_length=100`，openviking/server/routers/sessions.py:110）在消息边界分块，经既有 `batch_add_messages` 接口逐块写入；每块确认成功后立刻把 `_captured_signatures` 推进到该块末尾，携带检索上下文的块成功后才清空 pending context。每条消息的 peer_id 内嵌进 payload（LocalClient 与 HTTP 路由均逐条解析，行为不变）。

## 为什么必要（可达性/严重性）
- 第一道防线，无上游兜底：服务端 `add_message`/`batch_add_messages` 对会话历史只追加、不去重，重放的消息会真实落库。
- 默认开启：`capture_on_after_agent=True` 是构造默认值，所有使用该 middleware 的 LangGraph 应用都走这条路径。
- 触发不需要显式重试：写失败使 after_agent 抛异常、签名不推进，下一个正常 turn 的 after_agent 就会从旧位置重放，任一次瞬时故障（网络抖动、服务端 5xx）即可触发。
- 后端无关：本地嵌入（SyncOpenViking）与 HTTP（SyncHTTPClient）两条路径同样受影响、同样被修复。
- 定级 **P1**：会话历史重复 + 检索来源丢失是数据完整性问题，但作用域限于 langchain 集成、需要一次客户端可见的写失败才触发，不涉及安全或服务端数据损坏，不到 P0。

## 关键设计与取舍
- 复用既有 `batch_add_messages`，不新增 API、不引入幂等 token。批量把失败重放窗口从逐条 N 个缩小为每块 1 个，同时减少 RPC 次数（N → ceil(N/100)）。
- 分块严格在消息边界切：一条 LangChain 消息的全部 payload 落在同一块，保证签名前缀始终对齐完整消息。当前转换器每条消息最多产出 1 个 payload，单块不会超限。
- 每块成功即推进签名、上下文块成功才 pop pending——二者都与确认写入绑定，这是根因修复而非重试补丁。
- 备选方案：保留逐条 add_message、逐条推进签名。能修重复问题，但 RPC 数不变、失败模糊窗口是 N 个而非每块 1 个，故不取。

## 作用域与已知限制
- 仅改 openviking/integrations/langchain/middleware.py 的 after_agent 写入路径；wrap_model_call、检索、commit 策略逻辑不动。
- 残留模糊窗口：若某块 RPC 在服务端已落库后才在客户端表现为失败（如超时），重试会重复该块（≤100 条）。彻底消除需要服务端幂等键，超出本 PR 范围；相比旧实现的逐条模糊窗口已收敛。
- pending context 的存活边界：下一次 wrap_model_call 仍按既有设计弹出旧 pending 并写入新 context；本修复保证的是 after_agent 重试期间不丢。整图重试场景下 wrap_model_call 会重新组装同 query 的 context，最终行为仍正确。
- 新消息里没有 assistant payload 时，块全部成功后 pending 被丢弃，与旧行为一致，非回归。
- commit 策略触发条件从 `if added` 改为 `if batch`，语义等价（均为本轮确实写了消息）。

## 修复的问题
- B-08 中途写入失败后重试重放已确认消息、并永久丢失待写入的检索上下文（openviking/integrations/langchain/middleware.py:198-237）

## 合入价值
**P1** · 默认开启路径上的数据完整性修复：重试从已确认分块处续写而非重放前缀，检索来源在客户端可见的写失败下恰好只附着一次，避免会话历史重复与上下文丢失。

## 验证
评审侧在 PR 分支（176711c4）实际复跑：
- `pytest --no-cov -q tests/unit/test_langchain_integration.py` → 65 passed（含新增 3 个用例：首块失败重试保留 context、101 条按 [100,1] 分块、第二块失败仅重试 1 条且 context 恰好出现 1 次）
- 契约逐一核对：服务端 100 条上限真实存在（sessions.py:110）；`batch_add_messages` 在 LocalClient 与 HTTP 路由均逐条解析 peer_id；`session.add_messages` 先全量构造校验、后单次追加，客户端可见失败时不产生部分写入
- `git diff --check` 通过

---
自动化全仓清扫（2026-07）· draft 待 review
