### PR TITLE
fix(models): honor configured stream mode in OpenAI VLM backend

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -215,6 +215,66 @@ class OpenAIVLM(VLMBase):
             )
         return message.content or ""
 
+    def _extract_from_chunk(self, chunk):
+        """Extract content and usage from a single streaming chunk."""
+        content = None
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        if chunk.choices and chunk.choices[0].delta:
+            content = getattr(chunk.choices[0].delta, "content", None)
+        if hasattr(chunk, "usage") and chunk.usage:
+            prompt_tokens = chunk.usage.prompt_tokens or 0
+            completion_tokens = chunk.usage.completion_tokens or 0
+
+        return content, prompt_tokens, completion_tokens
+
+    def _process_streaming_response(self, response):
+        """Aggregate a synchronous stream and record its final usage."""
+        content_parts = []
+        prompt_tokens = 0
+        completion_tokens = 0
+        for chunk in response:
+            content, pt, ct = self._extract_from_chunk(chunk)
+            if content:
+                content_parts.append(content)
+            if pt > 0:
+                prompt_tokens = pt
+            if ct > 0:
+                completion_tokens = ct
+
+        if prompt_tokens > 0 or completion_tokens > 0:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+        return "".join(content_parts)
+
+    async def _process_streaming_response_async(self, response):
+        """Aggregate an asynchronous stream and record its final usage."""
+        content_parts = []
+        prompt_tokens = 0
+        completion_tokens = 0
+        async for chunk in response:
+            content, pt, ct = self._extract_from_chunk(chunk)
+            if content:
+                content_parts.append(content)
+            if pt > 0:
+                prompt_tokens = pt
+            if ct > 0:
+                completion_tokens = ct
+
+        if prompt_tokens > 0 or completion_tokens > 0:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+        return "".join(content_parts)
+
     def _build_text_kwargs(
         self,
         prompt: str = "",
@@ -230,6 +290,7 @@ class OpenAIVLM(VLMBase):
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
+            "stream": self.stream,
         }
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
@@ -268,6 +329,7 @@ class OpenAIVLM(VLMBase):
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
+            "stream": self.stream,
         }
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
@@ -282,13 +344,19 @@ class OpenAIVLM(VLMBase):
         return kwargs
 
     def _extract_completion_content(self, response, elapsed: float) -> str:
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        content = self._extract_content_from_response(response)
+        if self.stream:
+            content = self._process_streaming_response(response)
+        else:
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
     async def _extract_completion_content_async(self, response, elapsed: float) -> str:
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        content = self._extract_content_from_response(response)
+        if self.stream:
+            content = await self._process_streaming_response_async(response)
+        else:
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
     def get_completion(

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -223,7 +223,7 @@ class OpenAIVLM(VLMBase):
             content = getattr(chunk.choices[0].delta, "content", None)
         return content, chunk if getattr(chunk, "usage", None) else None
 
-    def _process_streaming_response(self, response, duration_seconds: float = 0.0):
+    def _process_streaming_response(self, response, started_at: Optional[float] = None):
         """Aggregate a synchronous stream and record its final usage."""
         content_parts = []
         usage_response = None
@@ -233,10 +233,11 @@ class OpenAIVLM(VLMBase):
                 content_parts.append(content)
             usage_response = chunk_usage or usage_response
         if usage_response:
+            duration_seconds = time.perf_counter() - started_at if started_at is not None else 0.0
             self._update_token_usage_from_response(usage_response, duration_seconds)
         return "".join(content_parts)
 
-    async def _process_streaming_response_async(self, response, duration_seconds: float = 0.0):
+    async def _process_streaming_response_async(self, response, started_at: Optional[float] = None):
         """Aggregate an asynchronous stream and record its final usage."""
         content_parts = []
         usage_response = None
@@ -246,6 +247,7 @@ class OpenAIVLM(VLMBase):
                 content_parts.append(content)
             usage_response = chunk_usage or usage_response
         if usage_response:
+            duration_seconds = time.perf_counter() - started_at if started_at is not None else 0.0
             self._update_token_usage_from_response(usage_response, duration_seconds)
         return "".join(content_parts)
 
@@ -323,18 +325,20 @@ class OpenAIVLM(VLMBase):
             kwargs["tool_choice"] = tool_choice or "auto"
         return kwargs
 
-    def _extract_completion_content(self, response, elapsed: float) -> str:
+    def _extract_completion_content(self, response, started_at: float) -> str:
         if self.stream:
-            content = self._process_streaming_response(response, elapsed)
+            content = self._process_streaming_response(response, started_at)
         else:
+            elapsed = time.perf_counter() - started_at
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
-    async def _extract_completion_content_async(self, response, elapsed: float) -> str:
+    async def _extract_completion_content_async(self, response, started_at: float) -> str:
         if self.stream:
-            content = await self._process_streaming_response_async(response, elapsed)
+            content = await self._process_streaming_response_async(response, started_at)
         else:
+            elapsed = time.perf_counter() - started_at
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             content = self._extract_content_from_response(response)
         return self._clean_response(content)
@@ -355,11 +359,11 @@ class OpenAIVLM(VLMBase):
         def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
             if tools:
+                elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
-            return self._extract_completion_content(response, elapsed)
+            return self._extract_completion_content(response, t0)
 
         return retry_sync(
             _call,
@@ -385,11 +389,11 @@ class OpenAIVLM(VLMBase):
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
             if tools:
+                elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
-            return await self._extract_completion_content_async(response, elapsed)
+            return await self._extract_completion_content_async(response, t0)
 
         # 用 tracer.info 打印请求
         tracer.info(f"messages={json.dumps(kwargs, ensure_ascii=False, indent=2)}")
@@ -471,11 +475,11 @@ class OpenAIVLM(VLMBase):
         def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
             if tools:
+                elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
-            return self._extract_completion_content(response, elapsed)
+            return self._extract_completion_content(response, t0)
 
         return retry_sync(
             _call,
@@ -503,11 +507,11 @@ class OpenAIVLM(VLMBase):
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
-            elapsed = time.perf_counter() - t0
             if tools:
+                elapsed = time.perf_counter() - t0
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
-            return await self._extract_completion_content_async(response, elapsed)
+            return await self._extract_completion_content_async(response, t0)
 
         return await retry_async(
             _call,

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -218,61 +218,35 @@ class OpenAIVLM(VLMBase):
     def _extract_from_chunk(self, chunk):
         """Extract content and usage from a single streaming chunk."""
         content = None
-        prompt_tokens = 0
-        completion_tokens = 0
 
         if chunk.choices and chunk.choices[0].delta:
             content = getattr(chunk.choices[0].delta, "content", None)
-        if hasattr(chunk, "usage") and chunk.usage:
-            prompt_tokens = chunk.usage.prompt_tokens or 0
-            completion_tokens = chunk.usage.completion_tokens or 0
+        return content, chunk if getattr(chunk, "usage", None) else None
 
-        return content, prompt_tokens, completion_tokens
-
-    def _process_streaming_response(self, response):
+    def _process_streaming_response(self, response, duration_seconds: float = 0.0):
         """Aggregate a synchronous stream and record its final usage."""
         content_parts = []
-        prompt_tokens = 0
-        completion_tokens = 0
+        usage_response = None
         for chunk in response:
-            content, pt, ct = self._extract_from_chunk(chunk)
+            content, chunk_usage = self._extract_from_chunk(chunk)
             if content:
                 content_parts.append(content)
-            if pt > 0:
-                prompt_tokens = pt
-            if ct > 0:
-                completion_tokens = ct
-
-        if prompt_tokens > 0 or completion_tokens > 0:
-            self.update_token_usage(
-                model_name=self.model or "gpt-4o-mini",
-                provider=self.provider,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-            )
+            usage_response = chunk_usage or usage_response
+        if usage_response:
+            self._update_token_usage_from_response(usage_response, duration_seconds)
         return "".join(content_parts)
 
-    async def _process_streaming_response_async(self, response):
+    async def _process_streaming_response_async(self, response, duration_seconds: float = 0.0):
         """Aggregate an asynchronous stream and record its final usage."""
         content_parts = []
-        prompt_tokens = 0
-        completion_tokens = 0
+        usage_response = None
         async for chunk in response:
-            content, pt, ct = self._extract_from_chunk(chunk)
+            content, chunk_usage = self._extract_from_chunk(chunk)
             if content:
                 content_parts.append(content)
-            if pt > 0:
-                prompt_tokens = pt
-            if ct > 0:
-                completion_tokens = ct
-
-        if prompt_tokens > 0 or completion_tokens > 0:
-            self.update_token_usage(
-                model_name=self.model or "gpt-4o-mini",
-                provider=self.provider,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-            )
+            usage_response = chunk_usage or usage_response
+        if usage_response:
+            self._update_token_usage_from_response(usage_response, duration_seconds)
         return "".join(content_parts)
 
     def _build_text_kwargs(
@@ -287,11 +261,14 @@ class OpenAIVLM(VLMBase):
         kwargs_messages = messages or [{"role": "user", "content": prompt}]
         model = self.model or "gpt-4o-mini"
         is_reasoning = _is_reasoning_model(model)
+        effective_stream = self.stream and not tools
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
-            "stream": self.stream,
+            "stream": effective_stream,
         }
+        if effective_stream:
+            kwargs["stream_options"] = {"include_usage": True}
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
         else:
@@ -326,11 +303,14 @@ class OpenAIVLM(VLMBase):
 
         model = self.model or "gpt-4o-mini"
         is_reasoning = _is_reasoning_model(model)
+        effective_stream = self.stream and not tools
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
-            "stream": self.stream,
+            "stream": effective_stream,
         }
+        if effective_stream:
+            kwargs["stream_options"] = {"include_usage": True}
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
         else:
@@ -345,7 +325,7 @@ class OpenAIVLM(VLMBase):
 
     def _extract_completion_content(self, response, elapsed: float) -> str:
         if self.stream:
-            content = self._process_streaming_response(response)
+            content = self._process_streaming_response(response, elapsed)
         else:
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             content = self._extract_content_from_response(response)
@@ -353,7 +333,7 @@ class OpenAIVLM(VLMBase):
 
     async def _extract_completion_content_async(self, response, elapsed: float) -> str:
         if self.stream:
-            content = await self._process_streaming_response_async(response)
+            content = await self._process_streaming_response_async(response, elapsed)
         else:
             self._update_token_usage_from_response(response, duration_seconds=elapsed)
             content = self._extract_content_from_response(response)

--- a/tests/unit/test_stream_config_vlm.py
+++ b/tests/unit/test_stream_config_vlm.py
@@ -90,7 +90,15 @@ class TestVLMStreamConfig:
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs.get("stream") is True
+        assert call_kwargs.get("stream_options") == {"include_usage": True}
         assert result == "Hello world!"
+
+    def test_tool_calls_keep_non_streaming_response_contract(self):
+        vlm = OpenAIVLM({"api_key": "sk-test", "stream": True})
+        tools = [{"type": "function", "function": {"name": "lookup"}}]
+
+        assert vlm._build_text_kwargs(tools=tools)["stream"] is False
+        assert vlm._build_vision_kwargs(tools=tools)["stream"] is False
 
     @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
     def test_stream_false_uses_non_streaming_path(self, mock_openai_class):
@@ -425,15 +433,10 @@ class TestStreamingResponseProcessing:
             MockChunk(content="Hello", usage=MockUsage(prompt_tokens=10, completion_tokens=5)),
         ]
 
-        with patch.object(vlm, "update_token_usage") as mock_update:
+        with patch.object(vlm, "_update_token_usage_from_response") as mock_update:
             vlm._process_streaming_response(iter(chunks))
 
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=10,
-                completion_tokens=5,
-            )
+            mock_update.assert_called_once_with(chunks[0], 0.0)
 
     def test_process_streaming_response_empty_chunks(self):
         """_process_streaming_response should handle empty chunks."""
@@ -464,12 +467,8 @@ class TestStreamingResponseProcessing:
             yield MockChunk(content="Test")
             yield MockChunk(content="", usage=MockUsage(prompt_tokens=15, completion_tokens=8))
 
-        with patch.object(vlm, "update_token_usage") as mock_update:
+        with patch.object(vlm, "_update_token_usage_from_response") as mock_update:
             await vlm._process_streaming_response_async(async_chunks())
 
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=15,
-                completion_tokens=8,
-            )
+            assert mock_update.call_args.args[1] == 0.0
+            assert mock_update.call_args.args[0].usage.prompt_tokens == 15

--- a/tests/unit/test_stream_config_vlm.py
+++ b/tests/unit/test_stream_config_vlm.py
@@ -433,10 +433,13 @@ class TestStreamingResponseProcessing:
             MockChunk(content="Hello", usage=MockUsage(prompt_tokens=10, completion_tokens=5)),
         ]
 
-        with patch.object(vlm, "_update_token_usage_from_response") as mock_update:
-            vlm._process_streaming_response(iter(chunks))
+        with (
+            patch.object(vlm, "_update_token_usage_from_response") as mock_update,
+            patch("openviking.models.vlm.backends.openai_vlm.time.perf_counter", return_value=2.0),
+        ):
+            vlm._process_streaming_response(iter(chunks), started_at=1.5)
 
-            mock_update.assert_called_once_with(chunks[0], 0.0)
+            mock_update.assert_called_once_with(chunks[0], 0.5)
 
     def test_process_streaming_response_empty_chunks(self):
         """_process_streaming_response should handle empty chunks."""
@@ -467,8 +470,11 @@ class TestStreamingResponseProcessing:
             yield MockChunk(content="Test")
             yield MockChunk(content="", usage=MockUsage(prompt_tokens=15, completion_tokens=8))
 
-        with patch.object(vlm, "_update_token_usage_from_response") as mock_update:
-            await vlm._process_streaming_response_async(async_chunks())
+        with (
+            patch.object(vlm, "_update_token_usage_from_response") as mock_update,
+            patch("openviking.models.vlm.backends.openai_vlm.time.perf_counter", return_value=3.0),
+        ):
+            await vlm._process_streaming_response_async(async_chunks(), started_at=1.0)
 
-            assert mock_update.call_args.args[1] == 0.0
+            assert mock_update.call_args.args[1] == 2.0
             assert mock_update.call_args.args[0].usage.prompt_tokens == 15


### PR DESCRIPTION
## 概述
恢复 OpenAI VLM 后端对 `stream` 配置的支持。这是一次回归修复:#756 曾实现过完整的流式处理,后来 #1711(2026-05,群聊内存隔离的大型改动)在改动 `openai_vlm.py` 时把流式代码整体回退,只留下了配置字段和测试文件。此后 `stream: true` 被静默忽略,配套的 11 个单测在 main 上一直失败——没被发现是因为 CI 目前不跑 `tests/unit/`(lite 只跑 cuvs 回归 + 集成 quick start,full 套件处于 TODO 关闭状态)。

## 为什么必要(可达性/严重性)
- 可达性:`stream` 是 `VLMConfig` 的一等字段(`openviking_cli/utils/config/vlm_config.py:116`,文档写明 "Enable streaming mode for OpenAI-compatible providers"),会随 provider 配置下发到 openai/azure 后端。任何配了 `stream: true` 的部署都命中此路径。
- 实际后果:main 上 `stream=True` 只是静默降级为非流式请求,请求本身成功、内容不丢。原始 finding 里"开启后解析报错"的说法不成立——因为 stream 根本没传给 provider,不会返回流对象。
- 诚实定级:**P2**(清扫定级 P1 偏高)。无崩溃、无数据丢失,属于"配置承诺了但不生效"的功能回归;附带价值是把 main 上 11 个失败单测修回绿色。

## 关键设计与取舍
- 流式仅作用于传输层:内部聚合分片后仍返回完整字符串,`VLMBase` 的 str/VLMResponse 调用方契约不变。备选方案是向调用方透出生成器,但那会破坏所有现有调用方,不在本 PR 范围。
- tool call 强制非流式(`effective_stream = self.stream and not tools`):结构化 tool_call delta 聚合暂未实现,保持原有非流式契约,避免半成品解析。
- 流式请求带 `stream_options={"include_usage": true}`,并在流完全消费后按整段耗时记录 token 用量(`started_at` 传入,替代原来只测 create() 调用的 `elapsed`)。
- 流的消费发生在 `_call` 内部,因此 retry_sync/retry_async 能覆盖流中断——中断即整次重试,不做断点续传。

## 作用域与已知限制
- 只改 `OpenAIVLM`(openai/azure provider);codex 后端自带流式逻辑,不受影响。默认 `stream=False` 路径行为不变。
- 个别 OpenAI 兼容网关可能不支持 `stream_options` 参数;此前 `stream: true` 在这类网关上"看似正常"(实为静默非流式),合入后可能显式报错。这是配置开始真实生效的代价,只影响主动开启流式的部署。
- provider 不回传 usage 分片时,该次调用跳过 token 计量(不报错);reasoning 模型(o1 系)服务器端是否支持流式由 provider 决定。

## 修复的问题
- A-13 `stream` 配置从未传给 provider,`stream=True` 静默失效(`openviking/models/vlm/backends/openai_vlm.py`,回归自 #1711,原实现见 #756)

## 合入价值
**P2(回归修复,原清扫定级 P1 偏高)** · `stream` 配置恢复生效,流式调用补回 usage 计量与真实耗时;main 上 11 个失败单测回绿;默认路径与 tool call 行为完全兼容。

## 验证
- `pytest -q tests/unit/test_stream_config_vlm.py tests/unit/test_vlm_response_formats.py --no-cov` — 本分支 27 passed
- 同一命令在 main 版本文件上复跑 — 11 failed, 9 passed(复核了"修复前失败"的说法)
- reviewer 独立复核:确认 #1711 的 diff 删除了 `_process_streaming_response`/`"stream"` kwargs;确认 CI workflow 不含 tests/unit,解释了失败单测长期未被发现

---
自动化全仓清扫(2026-07)· draft 待 review
