### PR TITLE
fix(ragfs): propagate S3 delete failures instead of reporting success

### DIFF
--- a/crates/ragfs/src/plugins/s3fs/client.rs
+++ b/crates/ragfs/src/plugins/s3fs/client.rs
@@ -18,6 +18,28 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const ENCODED_SEGMENT_PREFIX: char = '!';
 const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
+fn partial_delete_error(bucket: &str, errors: &[aws_sdk_s3::types::Error]) -> Option<Error> {
+    if errors.is_empty() {
+        return None;
+    }
+
+    let details = errors
+        .iter()
+        .map(|error| {
+            format!(
+                "key={} code={} message={}",
+                error.key().unwrap_or("<unknown>"),
+                error.code().unwrap_or("<unknown>"),
+                error.message().unwrap_or("<unknown>")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    Some(Error::internal(format!(
+        "S3 DeleteObjects partial failure: bucket={bucket} errors=[{details}]"
+    )))
+}
+
 fn build_s3_error_message(
     op: &str,
     scope: &str,
@@ -615,7 +637,8 @@ impl S3Client {
                     .build()
                     .map_err(|e| format_bucket_s3_error("BuildDelete", &self.bucket, e))?;
 
-                self.client
+                let response = self
+                    .client
                     .delete_objects()
                     .bucket(&self.bucket)
                     .delete(delete)
@@ -624,6 +647,9 @@ impl S3Client {
                     .map_err(|e| {
                         format_sdk_s3_error("DeleteObjects", &format!("bucket={}", self.bucket), &e)
                     })?;
+                if let Some(error) = partial_delete_error(&self.bucket, response.errors()) {
+                    return Err(error);
+                }
             }
         }
 
@@ -1111,6 +1137,19 @@ mod tests {
     #[test]
     fn test_build_key_preserves_segments_when_normalization_disabled() {
         assert_eq!(test_client("", "").build_key("/a b"), "a b");
+    }
+
+    #[test]
+    fn test_partial_delete_error_reports_each_failed_key() {
+        let errors = [aws_sdk_s3::types::Error::builder()
+            .key("denied.txt")
+            .code("AccessDenied")
+            .message("denied")
+            .build()];
+
+        let error = partial_delete_error("bucket", &errors).unwrap();
+        assert!(error.to_string().contains("key=denied.txt"));
+        assert!(error.to_string().contains("code=AccessDenied"));
     }
 
     #[test]

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -540,7 +540,7 @@ impl FileSystem for S3FileSystem {
 
         // Delete the file itself (if it exists as a file)
         let key = self.client.build_key(&normalized);
-        let _ = self.client.delete_object(&key).await;
+        self.client.delete_object(&key).await?;
 
         // Delete directory and all children
         self.client.delete_directory(&normalized).await?;


### PR DESCRIPTION
## 概述
S3 后端的删除操作在两处把失败当成成功:`remove_all` 丢弃精确 key 删除的结果(`let _ =`),`delete_objects` 批量删除只检查了传输层错误,忽略了 S3 `DeleteObjects` 返回 HTTP 200 但响应体内携带逐 key 错误(`AccessDenied`/`InternalError` 等)的情况——这是 S3 批量删除 API 的固有语义,不是异常路径。结果是对象仍在桶里,调用方却拿到 `Ok`,随后 dir/stat 缓存被失效,上层(redis/mooncake 缓存包装、multibackend 同步)全部按"已删除"处理。

本 PR 让两处失败如实传播:批量删除逐 chunk 检查 `response.errors()`,失败时返回带 key/code/message 明细的错误;精确 key 删除改为 `?` 传播。两处都发生在缓存失效之前,失败时缓存保持原状。

## 为什么必要(可达性/严重性)
第一道防线,非 defense-in-depth:`remove_all` 从 ragfs-python 绑定(`crates/ragfs-python/src/lib.rs:1297`)直通 s3fs 插件,上游没有任何环节校验对象是否真的删掉。触发条件是 S3 侧的部分失败(逐 key 权限拒绝、服务端内部错误)或精确 key 删除时的网络/鉴权失败——仅 S3/S3 兼容后端受影响,本地后端无此路径。诚实定级 **P1**:是真实可达的数据一致性问题(用户以为删了、数据还在,涉及删除类合规场景),但只在 S3 出错时显现,属于错误上报失真而非主动损坏数据。

## 关键设计与取舍
- 失败即返回错误,不做原地重试:删除是幂等操作,重试策略归上层调用方所有;失败时不失效缓存,重试会重新 list 再删,语义自洽。
- 批量删除首个失败 chunk 即中断,不继续后续 chunk:剩余对象留待重试,避免在已知失败后继续盲删并掩盖首个错误。
- 不改 `Result<()>` 签名去返回"已删除的 key 列表":当前没有消费方需要部分成功账目,改签名是为不存在的需求加复杂度。
- 精确 key 删除的 `?` 传播不会破坏"路径仅为目录"的场景:S3 `DeleteObject` 对不存在的 key 返回 204 成功(MinIO/OSS 同),因此能传播出来的都是真实故障。

## 作用域与已知限制
- 仅影响 s3fs 插件的删除路径;`disable_batch_delete`(OSS 兼容)顺序删除路径本就逐个传播错误,未改动。
- `mod.rs:769` rename 路径仍有一处 `let _ = delete_object(&old_dir_key)`:那是改名后清理旧目录 marker,失败只留下冗余 marker,不产生"假删除",不属于 E-05,故不动。
- 逐 key 错误聚合为单个 `Error::internal` 字符串,未引入结构化错误类型;上层目前只消费错误文本,够用。
- 回归风险:此前被吞掉的精确 key 删除错误现在会让 `remove_all` 失败——这正是预期行为变化;唯一理论边界是"桶策略对精确 key 拒绝 DeleteObject 但允许其子对象"的畸形配置,此时报错也是正确的。

## 修复的问题
- E-05 递归/批量 S3 删除在对象仍存在时报成功,缓存被错误失效(`crates/ragfs/src/plugins/s3fs/mod.rs:543`、`crates/ragfs/src/plugins/s3fs/client.rs:640`)

## 合入价值
**P1** · 删除结果如实反馈:S3 部分删除失败不再伪装成功,不再错误失效缓存,残留对象可被重试正确处理。

## 验证
- `cargo test -p ragfs --features s3 test_partial_delete_error_reports_each_failed_key --lib` — 通过(1 项)
- `cargo check -p ragfs --features s3` / `cargo check -p ragfs` — 通过(仅告警)
- PR CI 全绿(全平台 build、API & CLI 集成测试通过)

---
自动化全仓清扫(2026-07)· draft 待 review
