### PR TITLE
fix(eval): flush queued records on stop and adapt RAG pipeline to FindResult

### DIFF
--- a/openviking/eval/ragas/pipeline.py
+++ b/openviking/eval/ragas/pipeline.py
@@ -154,15 +154,19 @@ class RAGQueryPipeline:
         contexts = []
         retrieved_uris = []
 
-        if search_result and "results" in search_result:
-            for item in search_result["results"]:
+        items = search_result.get("results", []) if isinstance(search_result, dict) else search_result
+        for item in items or []:
+            if isinstance(item, dict):
                 uri = item.get("uri", "")
                 content = (
                     item.get("content", "") or item.get("overview", "") or item.get("abstract", "")
                 )
-                if content:
-                    contexts.append(content)
-                    retrieved_uris.append(uri)
+            else:
+                uri = getattr(item, "uri", "")
+                content = getattr(item, "overview", None) or getattr(item, "abstract", "")
+            if content:
+                contexts.append(content)
+                retrieved_uris.append(uri)
 
         result = {
             "question": question,

--- a/openviking/eval/recorder/async_writer.py
+++ b/openviking/eval/recorder/async_writer.py
@@ -91,7 +91,7 @@ class AsyncRecordWriter:
         batch: list[Dict[str, Any]] = []
         last_flush = time.time()
 
-        while not self._stop_event.is_set():
+        while True:
             try:
                 record = self._queue.get(timeout=0.1)
 

--- a/tests/eval/test_ragas_basic.py
+++ b/tests/eval/test_ragas_basic.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import json
+import queue
 import tempfile
+import threading
 from pathlib import Path
 
+from openviking.eval.recorder.async_writer import AsyncRecordWriter
 from openviking.eval.ragas.generator import DatasetGenerator
 from openviking.eval.ragas.pipeline import RAGQueryPipeline
 from openviking.eval.ragas.types import EvalDataset, EvalSample
+from openviking_cli.retrieve.types import ContextType, FindResult, MatchedContext
 
 
 def test_eval_types():
@@ -34,6 +38,63 @@ def test_pipeline_initialization():
     assert pipeline.config_path == "./test.conf"
     assert pipeline.data_path == "./test_data/test_ragas"
     assert pipeline._client is None
+
+
+def test_async_record_writer_drains_records_before_stop_sentinel():
+    writer = AsyncRecordWriter.__new__(AsyncRecordWriter)
+    writer._queue = queue.Queue()
+    writer._stop_event = threading.Event()
+    writer._stop_event.set()
+    writer.batch_size = 100
+    writer.flush_interval = 60
+    writer._queue.put({"id": 1})
+    writer._queue.put({"id": 2})
+    writer._queue.put(None)
+    flushed = []
+    writer._flush_batch = lambda batch: flushed.extend(batch)
+
+    writer._writer_loop()
+
+    assert flushed == [{"id": 1}, {"id": 2}]
+
+
+def test_pipeline_query_consumes_find_result_and_generates_answer():
+    class Client:
+        def search(self, **kwargs):
+            return FindResult(
+                memories=[
+                    MatchedContext(
+                        uri="viking://user/memories/profile.md",
+                        context_type=ContextType.MEMORY,
+                        overview="Profile overview",
+                    )
+                ],
+                resources=[
+                    MatchedContext(
+                        uri="viking://resources/guide.md",
+                        context_type=ContextType.RESOURCE,
+                        abstract="Guide abstract",
+                    )
+                ],
+                skills=[],
+            )
+
+    class LLM:
+        def get_completion(self, prompt):
+            return "Generated answer"
+
+    pipeline = RAGQueryPipeline()
+    pipeline._client = Client()
+    pipeline._llm = LLM()
+
+    result = pipeline.query("How does it work?")
+
+    assert result["contexts"] == ["Profile overview", "Guide abstract"]
+    assert result["retrieved_uris"] == [
+        "viking://user/memories/profile.md",
+        "viking://resources/guide.md",
+    ]
+    assert result["answer"] == "Generated answer"
 
 
 def test_question_loader():


### PR DESCRIPTION
## 概述
修两个评测链路的正确性 bug:recorder 停止时丢弃队列尾部记录(B-05),RAG 评测管线按旧字典结构解析 `FindResult` 导致 contexts 恒为空(B-12)。均为评测基础设施,不涉及生产 serving 路径。

## 为什么必要(可达性/严重性)
**B-05 根因**:`AsyncRecordWriter.stop()` 先 set `_stop_event` 再放 sentinel,而 `_writer_loop` 的循环条件是 `while not self._stop_event.is_set()`。stop 一旦被调用,写线程在下一次循环顶部检查时立即退出,只 flush 本地已 drain 的 batch——sentinel 之前仍在 `_queue` 里的记录全部静默丢失。只要停止前不久有写入(评测收尾恰是写入高峰),丢尾部几乎必现。该 recorder 服务于 IO 回放(`RecordingAGFSClient`,代码里写失败直接 `os._exit(1)` 就是为了回放正确性),尾部截断会让回放数据静默不完整。

**B-12 根因**:`client.search()` 的返回类型已是 `FindResult`(链路逐层核实:`SyncOpenViking.search → AsyncOpenViking.search → LocalClient.search → SearchService.search`,openviking/service/search_service.py:93 明确返回 FindResult)。`FindResult` 定义了 `__iter__`(依次 yield memories/resources/skills 的 `MatchedContext`),因此旧代码 `"results" in search_result` 走迭代比较、恒为 False → contexts 恒空 → 答案生成恒跳过。也就是说 RAGAS 评测管线此前在静默空转,指标全部失真。

**诚实定级:P1**。两条都是真实可达的第一道防线(无上游兜底),但影响面限于 `openviking/eval/` 评测工具链,不触及生产数据路径,故不是 P0。

## 关键设计与取舍
- B-05 改为 `while True` + 仅靠 sentinel(`None`)退出。sentinel 由 `stop()` 保证恰好投递一次(重复 stop 有幂等 early-return;stop 之后的 `write_record` 会 `os._exit(1)`,不存在 sentinel 之后的记录)。备选方案 `while not stop_event or not queue.empty()` 更绕且有 empty() 竞态,弃用。不调 stop 的场景行为与改前一致(线程本来就只在 stop 时退出,且是 daemon 线程),无回归面。
- B-12 保留旧字典分支(`content/overview/abstract` 键序)兼容历史 dict 形态,新增属性分支取 `overview → abstract`(`MatchedContext` 无 `content` 字段,取序正确)。备选方案是调用处 `to_dict()`,但其产物键为 `memories/resources/skills` 而非 `results`,仍需一套映射,不如直接迭代;且 rag_eval.py 的 `retrieve()` 已是同样的迭代+getattr 消费方式,本修法与之对齐。
- 已 grep 确认 `openviking/eval/` 下 `client.search` 仅有这两处消费点,rag_eval.py:175 原本就正确,无其他同型 bug 残留。

## 作用域与已知限制
- 仅改 `openviking/eval/` 两个文件 + 测试,与后端(S3/远程/本地)无关。
- B-05 残余窗口:`stop(timeout=5.0)` join 超时后 daemon 线程仍可能被进程退出截断——极大积压 + 立即退出时仍可能丢,但丢失窗口从"必丢队列全部尾部"缩到"仅超时未 drain 部分",与改前的 timeout 语义一致。
- B-12 的 contexts 顺序由 `FindResult.__iter__` 决定(memories → resources → skills),skills 命中也会计入 contexts,评测语义上合理。
- 测试用 `__new__` 绕过 `__init__` 以避免真实线程/文件,只针对 `_writer_loop` 单元行为。

## 修复的问题
- B-05 `stop()` 先置位事件导致写线程在消费 sentinel 前退出,丢弃队列中未 drain 的尾部记录(openviking/eval/recorder/async_writer.py:94)
- B-12 `"results" in FindResult` 恒为 False,检索成功却得到空 contexts、答案生成被跳过(openviking/eval/ragas/pipeline.py:157)

## 合入价值
**P1(评测链路正确性,eval-only)** · 评测记录文件关闭时不再丢尾部;RAGAS 管线从"静默空转"恢复为真实评测,指标不再失真。

## 验证
- `pytest tests/eval/test_ragas_basic.py -q` 于 PR head:7 passed(repo venv 与 worktree 独立 uv 环境各跑一遍)
- 回归性证明:把 async_writer.py / pipeline.py 还原为 origin/main 版本后重跑,新增 2 个测试如预期 FAILED——测试确实钉住了这两个 bug
- 返回类型核实:逐层读码确认 `client.search` 返回 `FindResult`(openviking/sync_client.py:377 → openviking/async_client.py:521 → openviking/client/local.py:728 → openviking/service/search_service.py:69)
- `git diff --check` 通过

---
自动化全仓清扫(2026-07)· draft 待 review
