### PR TITLE
fix(ingest): enforce local-path rejection before parse in media processor

### DIFF
--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -121,6 +121,20 @@ class UnifiedResourceProcessor:
         - Directories needed for TreeBuilder are preserved via ParseResult.temp_dir_path
         """
 
+        # Block local paths in HTTP server mode before raw-content fallback.
+        if (
+            not allow_local_path_resolution
+            and not is_remote_resource_source(source)
+            and (
+                looks_like_local_path(source)
+                or (len(source) <= 1024 and "\n" not in source and Path(source).exists())
+            )
+        ):
+            raise PermissionDeniedError(
+                "HTTP server only accepts remote resource URLs or temp-uploaded files; "
+                "direct host filesystem paths are not allowed."
+            )
+
         # First check if source is raw content (not URL/path)
         is_potential_path = (
             allow_local_path_resolution and len(source) <= 1024 and "\n" not in source
@@ -128,17 +142,6 @@ class UnifiedResourceProcessor:
         if not is_potential_path and not self._is_url(source):
             # Treat as raw content
             return await parse(source, instruction=instruction)
-
-        # Block local paths in HTTP server mode, but allow remote URLs
-        if (
-            not allow_local_path_resolution
-            and not is_remote_resource_source(source)
-            and looks_like_local_path(source)
-        ):
-            raise PermissionDeniedError(
-                "HTTP server only accepts remote resource URLs or temp-uploaded files; "
-                "direct host filesystem paths are not allowed."
-            )
 
         if self._should_bypass_feishu_accessor(source, kwargs):
             parse_kwargs = dict(kwargs)

--- a/tests/misc/test_media_processor_path_guard.py
+++ b/tests/misc/test_media_processor_path_guard.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.utils.media_processor import UnifiedResourceProcessor
+from openviking_cli.exceptions import PermissionDeniedError
+
+
+@pytest.mark.asyncio
+async def test_process_rejects_local_path_before_raw_content_fallback(monkeypatch, tmp_path):
+    parse = AsyncMock()
+    monkeypatch.setattr("openviking.utils.media_processor.parse", parse)
+    local_file = tmp_path / "secret.txt"
+    local_file.write_text("secret")
+    monkeypatch.chdir(tmp_path)
+
+    for source in (str(local_file), local_file.name):
+        with pytest.raises(PermissionDeniedError, match="direct host filesystem paths"):
+            await UnifiedResourceProcessor().process(
+                source,
+                allow_local_path_resolution=False,
+            )
+
+    parse.assert_not_awaited()


### PR DESCRIPTION
## 概述
HTTP 导入模式下，短路径或裸文件名（如 `/etc/passwd`）会先落到 raw-content parser 才被拒绝，绕过入口隔离。本 PR 把 local-path 拒绝逻辑挪到 parse 之前，并拦截裸文件名，同时保留显式受信的上传路径。

## 修复的问题
- A-02 HTTP 路径声称拒绝宿主机文件，但短路径会先交给 parser 绕过入口隔离（openviking/utils/media_processor.py:124-130）

## 合入价值
**P0** · 堵住 HTTP 资源导入经 raw-content 回退读取宿主机任意文件的信任边界漏洞。

## 验证
- `python -m py_compile openviking/utils/media_processor.py tests/misc/test_media_processor_path_guard.py` — 通过
- `python -m pytest -q --no-cov tests/misc/test_media_processor_path_guard.py` — 1 passed

---
自动化全仓清扫（2026-07-22）· 独立 <100 行改动 · draft 待 review
