### PR TITLE
fix(ov): redact gateway secrets in config show and create root key with 0600

### DIFF
--- a/crates/ov_cli/src/commands/crypto.rs
+++ b/crates/ov_cli/src/commands/crypto.rs
@@ -8,6 +8,8 @@ use clap::Subcommand;
 use dirs::home_dir;
 use std::fs::OpenOptions;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
 /// Crypto subcommands.
@@ -63,9 +65,11 @@ async fn handle_init_key(output_file: Option<PathBuf>) -> Result<()> {
     let hex_key = hex::encode(&key);
 
     // Write to file
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
         .open(&key_path)
         .map_err(|e| Error::Client(format!("Failed to create key file: {}", e)))?;
 
@@ -106,5 +110,24 @@ fn get_key_path(output_file: Option<PathBuf>) -> Result<PathBuf> {
                 .ok_or_else(|| Error::Client("Failed to determine home directory".to_string()))?;
             Ok(home.join(".openviking").join("master.key"))
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[tokio::test]
+    async fn init_key_creates_owner_only_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+
+        handle_init_key(Some(path.clone())).await.unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/crates/ov_cli/src/commands/crypto.rs
+++ b/crates/ov_cli/src/commands/crypto.rs
@@ -112,22 +112,3 @@ fn get_key_path(output_file: Option<PathBuf>) -> Result<PathBuf> {
         }
     }
 }
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-    use std::os::unix::fs::PermissionsExt;
-
-    #[tokio::test]
-    async fn init_key_creates_owner_only_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("master.key");
-
-        handle_init_key(Some(path.clone())).await.unwrap();
-
-        assert_eq!(
-            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-    }
-}

--- a/crates/ov_cli/src/config_wizard/store.rs
+++ b/crates/ov_cli/src/config_wizard/store.rs
@@ -540,9 +540,17 @@ pub(crate) fn normalize_custom_url(url: &str) -> String {
 pub fn redacted_config_value(config: &Config) -> Result<Value> {
     let mut value = serde_json::to_value(config)?;
     if let Some(object) = value.as_object_mut() {
-        for key in ["api_key", "root_api_key"] {
+        for key in ["api_key", "root_api_key", "gateway_token"] {
             if object.get(key).is_some_and(|value| !value.is_null()) {
                 object.insert(key.to_string(), Value::String("********".to_string()));
+            }
+        }
+        if let Some(headers) = object
+            .get_mut("extra_headers")
+            .and_then(Value::as_object_mut)
+        {
+            for value in headers.values_mut() {
+                *value = Value::String("********".to_string());
             }
         }
     }
@@ -801,6 +809,21 @@ mod tests {
         config.url = url.to_string();
         config.api_key = api_key.map(ToString::to_string);
         config
+    }
+
+    #[test]
+    fn redacted_config_masks_gateway_and_header_secrets() {
+        let mut config = sample_config("http://local", Some("api-secret"));
+        config.gateway_token = Some("gateway-secret".to_string());
+        config.extra_headers = Some(std::collections::HashMap::from([
+            ("Authorization".to_string(), "Bearer secret".to_string()),
+            ("X-Gateway-Token".to_string(), "header-secret".to_string()),
+        ]));
+
+        let redacted = super::redacted_config_value(&config).unwrap();
+        assert_eq!(redacted["gateway_token"], "********");
+        assert_eq!(redacted["extra_headers"]["Authorization"], "********");
+        assert_eq!(redacted["extra_headers"]["X-Gateway-Token"], "********");
     }
 
     #[test]


### PR DESCRIPTION
## 概述
`ov config show` 一直在做脱敏(`api_key`/`root_api_key` 显示为 `********`),给用户"输出可以随便贴"的预期,但 `gateway_token` 和 `extra_headers` 的全部值仍按明文打印。根因是 `redacted_config_value` 的脱敏 key 列表是手写白名单,新增凭证字段时没有同步。另外 `ov crypto init-key` 先按 umask 默认权限(通常 0644)建文件、写入密钥后才 chmod 0600,存在一个短暂的宽权限窗口。

## 为什么必要(可达性/严重性)
- E-02 是真实可达的第一道防线:`config show` 是让用户贴进 issue/工单/CI 日志的标准支持路径,没有任何上游 guard。`gateway_token` 是网关直连凭证,`extra_headers` 常携带 `Authorization`/`X-Gateway-Token`(`Config::effective_gateway_token` 本身就会从 extra_headers 里取 token)。诚实定级 **P1** 而非清扫标注的 P0:泄露发生在本机 stdout,成害还需要输出被转贴或进 CI 日志,不是远程可利用。
- E-03 是 **P2 防御纵深**:窗口只有写盘到 chmod 之间的毫秒级,攻击者需与受害者同机且恰好竞态读取 `~/.openviking/master.key`。修了,但单独不值一个 PR。

## 关键设计与取舍
- `extra_headers` 采取整体掩码(值全部 `********`,key 保留可见),而不是维护"哪些 header 算敏感"的判别列表——判别列表会随自定义 header 命名腐化,漏一个就等于没修。代价是非敏感 header 的值在 `config show` 里也看不到,需要看原值时直接读 `~/.openviking/ovcli.conf`。
- init-key 改为 `OpenOptions::mode(0o600)`(`#[cfg(unix)]` 门控),文件在 open(2) 创建瞬间就是 0600,umask 只会更紧不会更宽;写后的 `set_permissions(0o600)` 保留作兜底。Windows 行为不变(本就不走 chmod)。

## 作用域与已知限制
- 只覆盖 `config show` 这一个输出口(它是 `redacted_config_value` 唯一调用方,已核对);`config validate` 与 wizard 渲染路径不打印 token/headers,配置文件落盘(`write_config_file`)必须保留原值,均不受影响。
- 根因(手写脱敏白名单)未根除:以后再往 `Config` 加凭证字段仍需记得同步这里,新增的单测能挡住 gateway/headers 回归,但挡不住未来的新字段。
- 无回归风险面:改动只影响 show 的展示值和密钥文件创建权限,不触碰任何读取/请求路径。

## 修复的问题
- E-02 `config show` 明文打印 `gateway_token` 与带凭证的 `extra_headers`(`crates/ov_cli/src/config_wizard/store.rs:540`)。
- E-03 root key 先写盘后 chmod,存在短暂宽权限窗口(`crates/ov_cli/src/commands/crypto.rs:65`)。

## 合入价值
**P1(E-02 凭证卫生,真实第一道防线)+ P2 防御纵深(E-03)** · 让"号称脱敏"的输出真正脱敏,密钥文件出生即 0600。

## 验证
- `cargo test -p ov_cli redacted_config_masks_gateway_and_header_secrets` — 通过(本 PR 新增的单测)。
- CI 全绿,含 `x86_64-pc-windows-msvc` 构建(确认 `#[cfg(unix)]` 门控跨平台可编译)与 API & CLI 集成测试。
- 勘误:旧描述里的 `init_key_creates_owner_only_file` 测试并不存在(该命令匹配 0 个测试,"通过"是空转)。E-03 无自动化覆盖,靠上面两处代码路径审阅 + Unix open(2) mode 语义保证。

---
自动化全仓清扫(2026-07)· 已于 2026-07-23 合入 main(#3411)
