### PR TITLE
build: fail Makefile recipes on real errors and align CMake minimum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OV_CLI_DIR := crates/ov_cli
 
 # Dependency Versions
 MIN_PYTHON_VERSION := 3.10
-MIN_CMAKE_VERSION := 3.12
+MIN_CMAKE_VERSION := 3.15
 MIN_RUST_VERSION := 1.91.1
 MIN_GCC_VERSION := 9
 MIN_CLANG_VERSION := 11
@@ -63,7 +63,9 @@ check-deps:
 	@# CMake check
 	@command -v cmake > /dev/null 2>&1 || (echo "Error: CMake is not installed."; exit 1)
 	@CMAKE_VER=$$(cmake --version | head -n1 | awk '{print $$3}'); \
-	$(PYTHON) -c "v='$$CMAKE_VER'.split('.'); exit(0 if int(v[0]) > 3 or (int(v[0]) == 3 and int(v[1]) >= 12) else 1)" || (echo "Error: CMake >= $(MIN_CMAKE_VERSION) is required. Found $$CMAKE_VER"; exit 1); \
+	if ! $(PYTHON) -c "import sys; parse=lambda v: tuple(int(x) for x in v.split('.')); raise SystemExit(0 if parse(sys.argv[1]) >= parse(sys.argv[2]) else 1)" "$$CMAKE_VER" "$(MIN_CMAKE_VERSION)"; then \
+		echo "Error: CMake >= $(MIN_CMAKE_VERSION) is required. Found $$CMAKE_VER"; exit 1; \
+	fi; \
 	echo "  [OK] CMake $$CMAKE_VER"
 	@# Rust check
 	@command -v rustc > /dev/null 2>&1 || (echo "Error: Rust is not installed."; exit 1)
@@ -96,35 +98,38 @@ build: check-deps check-pip build-studio
 		$(PYTHON) -m pip install -e .; \
 	fi
 	@echo "Building ragfs-python (Rust RAGFS binding) into openviking/lib/..."
-	@MATURIN_CMD=""; \
+	@set -e; \
+	MATURIN_CMD=""; \
 	if command -v maturin > /dev/null 2>&1; then \
 		MATURIN_CMD=maturin; \
 	elif command -v uv > /dev/null 2>&1 && uv pip --help > /dev/null 2>&1; then \
 		uv pip install maturin && MATURIN_CMD=maturin; \
 	fi; \
 	if [ -n "$$MATURIN_CMD" ]; then \
-		TMPDIR=$$(mktemp -d); \
-		cd crates/ragfs-python && $$MATURIN_CMD build --release --out "$$TMPDIR" 2>&1; \
-		cd ../..; \
+		RAGFS_TMPDIR=$$(mktemp -d); \
+		EXTRACT_SCRIPT=$$(mktemp); \
+		trap 'rm -f "$$EXTRACT_SCRIPT"; rm -rf "$$RAGFS_TMPDIR"' 0; \
+		(cd crates/ragfs-python && $$MATURIN_CMD build --release --out "$$RAGFS_TMPDIR" 2>&1); \
 		mkdir -p openviking/lib; \
 		rm -f openviking/lib/ragfs_python*.so openviking/lib/ragfs_python*.pyd openviking/lib/ragfs_python*.dylib; \
-		echo "import zipfile, glob, shutil, os, sys" > /tmp/extract_ragfs.py; \
-		echo "whls = glob.glob(os.path.join('$$TMPDIR', 'ragfs_python-*.whl'))" >> /tmp/extract_ragfs.py; \
-		echo "assert whls, 'maturin produced no wheel'" >> /tmp/extract_ragfs.py; \
-		echo "with zipfile.ZipFile(whls[0]) as zf:" >> /tmp/extract_ragfs.py; \
-		echo "    for name in zf.namelist():" >> /tmp/extract_ragfs.py; \
-		echo "        bn = os.path.basename(name)" >> /tmp/extract_ragfs.py; \
-		echo "        if bn.startswith('ragfs_python.abi3.') and (bn.endswith('.so') or bn.endswith('.pyd')):" >> /tmp/extract_ragfs.py; \
-		echo "            dst = os.path.join('openviking', 'lib', bn)" >> /tmp/extract_ragfs.py; \
-		echo "            with zf.open(name) as src, open(dst, 'wb') as f: f.write(src.read())" >> /tmp/extract_ragfs.py; \
-		echo "            os.chmod(dst, 0o755)" >> /tmp/extract_ragfs.py; \
-		echo "            print(f'  [OK] ragfs-python: extracted {bn} -> {dst}')" >> /tmp/extract_ragfs.py; \
-		echo "            sys.exit(0)" >> /tmp/extract_ragfs.py; \
-		echo "print('[Warning] No ragfs_python abi3 .so/.pyd found in wheel')" >> /tmp/extract_ragfs.py; \
-		echo "sys.exit(1)" >> /tmp/extract_ragfs.py; \
-		$(PYTHON) /tmp/extract_ragfs.py; \
-		rm -f /tmp/extract_ragfs.py; \
-		rm -rf "$$TMPDIR"; \
+		echo "import zipfile, glob, shutil, os, sys" > "$$EXTRACT_SCRIPT"; \
+		echo "whls = glob.glob(os.path.join('$$RAGFS_TMPDIR', 'ragfs_python-*.whl'))" >> "$$EXTRACT_SCRIPT"; \
+		echo "assert whls, 'maturin produced no wheel'" >> "$$EXTRACT_SCRIPT"; \
+		echo "with zipfile.ZipFile(whls[0]) as zf:" >> "$$EXTRACT_SCRIPT"; \
+		echo "    for name in zf.namelist():" >> "$$EXTRACT_SCRIPT"; \
+		echo "        bn = os.path.basename(name)" >> "$$EXTRACT_SCRIPT"; \
+		echo "        if bn.startswith('ragfs_python.abi3.') and (bn.endswith('.so') or bn.endswith('.pyd')):" >> "$$EXTRACT_SCRIPT"; \
+		echo "            dst = os.path.join('openviking', 'lib', bn)" >> "$$EXTRACT_SCRIPT"; \
+		echo "            with zf.open(name) as src, open(dst, 'wb') as f: f.write(src.read())" >> "$$EXTRACT_SCRIPT"; \
+		echo "            os.chmod(dst, 0o755)" >> "$$EXTRACT_SCRIPT"; \
+		echo "            print(f'  [OK] ragfs-python: extracted {bn} -> {dst}')" >> "$$EXTRACT_SCRIPT"; \
+		echo "            sys.exit(0)" >> "$$EXTRACT_SCRIPT"; \
+		echo "print('[Warning] No ragfs_python abi3 .so/.pyd found in wheel')" >> "$$EXTRACT_SCRIPT"; \
+		echo "sys.exit(1)" >> "$$EXTRACT_SCRIPT"; \
+		$(PYTHON) "$$EXTRACT_SCRIPT"; \
+		rm -f "$$EXTRACT_SCRIPT"; \
+		rm -rf "$$RAGFS_TMPDIR"; \
+		trap - 0; \
 	else \
 		echo "  [SKIP] maturin not found, ragfs-python (Rust binding) will not be built."; \
 		echo "         Install maturin to enable: uv pip install maturin"; \
@@ -145,7 +150,8 @@ clean:
 
 # Web Studio target
 build-studio:
-	@if [ "$$OV_SKIP_STUDIO_BUILD" = "1" ]; then \
+	@set -e; \
+	if [ "$$OV_SKIP_STUDIO_BUILD" = "1" ]; then \
 		echo "  [SKIP] web-studio build disabled by OV_SKIP_STUDIO_BUILD=1"; \
 	elif [ -f openviking/web_studio/dist/index.html ]; then \
 		echo "  [OK] web-studio bundle already present"; \
@@ -155,7 +161,7 @@ build-studio:
 		echo "  [SKIP] web-studio source not found"; \
 	else \
 		echo "Building web-studio (Vite SPA)..."; \
-		cd web-studio && npm ci && npm run build -- --base="/studio/" && cd ..; \
+		(cd web-studio && npm ci && npm run build -- --base="/studio/"); \
 		mkdir -p openviking/web_studio; \
 		rm -rf openviking/web_studio/dist; \
 		cp -r web-studio/dist openviking/web_studio/dist; \


### PR DESCRIPTION
## 概述
Makefile 两个复合 recipe 在关键命令失败后仍返回 0 并打印成功信息;依赖预检的 CMake 门槛与实际构建要求不一致。本 PR 用 `set -e` + 子 shell 让错误真实传播,并把 CMake 检查改为由 `MIN_CMAKE_VERSION` 驱动、对齐到 3.15。

## 根因
- F-04:make 每行 recipe 的退出码取决于该 shell 链的**最后一条命令**。`build` 的 maturin 链以 `rm -rf "$TMPDIR"` 收尾,`build-studio` 以 `echo "[OK] ..."` 收尾——中间的 maturin/npm/解包失败被吞掉。`build-studio` 还有第二层问题:`cd web-studio && npm ci && ... && cd ..` 失败时 `cd ..` 不执行,后续命令在 web-studio/ 里运行,把 `web-studio/openviking/web_studio/` 垃圾目录写进源码树。
- F-13:check-deps 的 CMake 检查硬编码了 `>= 3.12`,完全没有用 `MIN_CMAKE_VERSION` 变量;而 `src/CMakeLists.txt:1` 要求 `cmake_minimum_required(VERSION 3.15)`,`pyproject.toml`(第 5、137 行)也声明 `cmake>=3.15`。持有 3.12–3.14 的用户通过预检后,会在 `setup.py build_ext` 深处收到晦涩的 CMake 报错。

## 可达性与严重性(诚实定级:P2)
- 触发入口:本地 `make build` / `make build-studio`(`make help` 列出的开发者构建路径),以及下游自行包装 Makefile 的自动化。
- **CI 与发布流水线不受此 bug 影响**:`.github/workflows/_build.yml` 等直接用 `python -m build` / uv 构建,不经 Makefile。因此「假绿」不可能污染已发布 artifact,严重性到不了 P1;后果限于本地开发者拿到缺 ragfs_python .so 或 studio bundle 的残缺环境、事后在运行期才暴露,外加源码树污染。清扫初评 P1(rank 37/42)偏高,按 P2 合入。

## 关键设计与取舍
- recipe 级 `set -e` 而非逐命令 `&&` 串联:diff 最小,覆盖整段。考虑过全局 `.SHELLFLAGS := -ec`,但它会改变 clean/help 等所有 recipe 的语义,风险面更大,不取。
- `(cd web-studio && ...)` 子 shell 替代 `cd ... && cd ..`:失败时 cwd 不泄漏,根除源码树污染。
- 硬编码 `/tmp/extract_ragfs.py` 改 `mktemp` + `trap ... 0`:并发构建不互踩,失败路径也能清理临时文件。
- CMake 版本比较复用本文件 Rust 检查(Makefile:71)已有的 tuple-parse 写法,由变量驱动,不再出现「变量写 3.15、代码查 3.12」的漂移。
- 有意保留的行为:maturin 装不上仍走 `[SKIP]` 分支、构建继续(`uv pip install maturin && MATURIN_CMD=...` 的失败不触发 set -e,已实测确认)。本 PR 只让「本应成功的命令」失败时报错,不改变可选依赖的降级策略。

## 作用域与已知限制
- 仅改 Makefile 的 `check-deps` / `build` / `build-studio`;`build-cli` 的单条 `&&` 链本就能正确失败,未动。
- tuple-parse 对带后缀的版本号(如 CMake `3.28.0-rc1`、Rust nightly)会解析失败并误报为版本过低——这是 Rust 检查已有的既存局限,本 PR 沿用而非引入;报错会带上实测版本号,可自行判断。stable 版本(发行版/brew/choco 均是)不受影响。
- `MIN_CMAKE_VERSION` 提到 3.15 不会误伤任何人:3.12–3.14 用户此前也无法完成构建,只是死得更晚更难懂。

## 修复的问题
- F-04 native 与 Studio 构建的必需命令失败后 recipe 仍返回成功,且 build-studio 失败时污染源码树(Makefile:98;Makefile:151)
- F-13 依赖预检放行构建实际拒绝的 CMake 3.12–3.14,检查逻辑与 `MIN_CMAKE_VERSION` 变量脱节(Makefile:10;Makefile:65)

## 合入价值
**P2(构建工具正确性)** · 本地构建不再「假绿」产出残缺环境;不受支持的 CMake 在预检即报可操作错误,而非深埋在 setup.py 构建日志里。

## 验证(review 时在沙箱中实测,新旧 Makefile 对照)
- 旧 Makefile + 伪造 `npm` 退出码 7:`build-studio` 打印 `[OK] web-studio bundle copied` 并**退出 0**,且生成 `web-studio/openviking/web_studio/` 垃圾目录 → bug 复现。
- 本 PR 同场景:make 以 `Error 7` 失败,无成功信息,无目录污染。
- 旧 Makefile + 伪造 CMake 3.14.9:`check-deps` 打印 `[OK] CMake 3.14.9` 放行 → bug 复现;本 PR 同场景:`Error: CMake >= 3.15 is required. Found 3.14.9` 并失败。
- `sh -c 'set -e; false && true; echo after'` 打印 after:确认 maturin 安装失败的降级路径行为不变。
- `make -n build build-studio check-deps` 语法均通过(Python 3.10.19 / CMake 4.1.0 / Rust 1.93.1)。

---
自动化全仓清扫(2026-07)· draft 待 review
