### PR TITLE
fix(bot): reject unschedulable cron jobs and honest manual runs

### DIFF
--- a/bot/tests/test_channel_delivery_metadata.py
+++ b/bot/tests/test_channel_delivery_metadata.py
@@ -205,6 +205,40 @@ def test_cron_service_accepts_missing_channel_metadata(tmp_path):
     assert job.payload.channel_metadata == {}
 
 
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        CronSchedule(kind="every", every_ms=0),
+        CronSchedule(kind="at", at_ms=1),
+        CronSchedule(kind="cron", expr="not a cron expression"),
+    ],
+)
+def test_cron_service_rejects_unschedulable_jobs(tmp_path, schedule):
+    path = tmp_path / "jobs.json"
+    key = SessionKey(type="cli", channel_id="default", chat_id="default")
+    with pytest.raises(ValueError, match="future run time"):
+        CronService(path).add_job("invalid", schedule, "hello", key)
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cron_service_without_callback_preserves_one_shot(tmp_path):
+    path = tmp_path / "jobs.json"
+    service = CronService(path)
+    job = service.add_job(
+        "one-shot",
+        CronSchedule(kind="at", at_ms=9999999999999),
+        "hello",
+        SessionKey(type="cli", channel_id="default", chat_id="default"),
+        delete_after_run=True,
+    )
+    original = path.read_bytes()
+
+    with pytest.raises(RuntimeError, match="no job execution callback"):
+        await service.run_job(job.id)
+    assert path.read_bytes() == original
+
+
 def test_feishu_uses_thread_root_for_scheduled_delivery():
     assert (
         FeishuChannel._reply_to_message_id_from_metadata(

--- a/bot/vikingbot/agent/tools/cron.py
+++ b/bot/vikingbot/agent/tools/cron.py
@@ -113,15 +113,18 @@ class CronTool(Tool):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
 
-        job = self._cron.add_job(
-            name=name,
-            schedule=schedule,
-            message=message,
-            deliver=True,
-            session_key=session_key,
-            channel_metadata=channel_metadata,
-            delete_after_run=delete_after,
-        )
+        try:
+            job = self._cron.add_job(
+                name=name,
+                schedule=schedule,
+                message=message,
+                deliver=True,
+                session_key=session_key,
+                channel_metadata=channel_metadata,
+                delete_after_run=delete_after,
+            )
+        except ValueError as e:
+            return f"Error: {e}"
         return f"Created job '{job.name}' (id: {job.id})"
 
     def _delivery_metadata(self, metadata: dict[str, Any] | None) -> dict[str, Any]:

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -1061,13 +1061,17 @@ def cron_add(
 
     session_key = SessionKey(type="cli", channel_id="default", chat_id="default")
 
-    job = service.add_job(
-        name=name,
-        schedule=schedule,
-        message=message,
-        deliver=deliver,
-        session_key=session_key,
-    )
+    try:
+        job = service.add_job(
+            name=name,
+            schedule=schedule,
+            message=message,
+            deliver=deliver,
+            session_key=session_key,
+        )
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1) from e
 
     console.print(f"[green]✓[/green] Added job '{job.name}' ({job.id})")
 
@@ -1124,10 +1128,16 @@ def cron_run(
     async def run():
         return await service.run_job(job_id, force=force)
 
-    if asyncio.run(run()):
-        console.print("[green]✓[/green] Job executed")
-    else:
+    try:
+        executed = asyncio.run(run())
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1) from e
+
+    if not executed:
         console.print(f"[red]Failed to run job {job_id}[/red]")
+        raise typer.Exit(1)
+    console.print("[green]✓[/green] Job executed")
 
 
 # ============================================================================

--- a/bot/vikingbot/cron/service.py
+++ b/bot/vikingbot/cron/service.py
@@ -229,12 +229,14 @@ class CronService:
 
     async def _execute_job(self, job: CronJob) -> None:
         """Execute a single job."""
+        if self.on_job is None:
+            raise RuntimeError("Cron service has no job execution callback")
+
         start_ms = _now_ms()
         logger.info(f"Cron: executing job '{job.name}' ({job.id})")
 
         try:
-            if self.on_job:
-                await self.on_job(job)
+            await self.on_job(job)
 
             job.state.last_status = "ok"
             job.state.last_error = None
@@ -278,8 +280,11 @@ class CronService:
         delete_after_run: bool = False,
     ) -> CronJob:
         """Add a new job."""
-        store = self._load_store()
         now = _now_ms()
+        next_run_at_ms = _compute_next_run(schedule, now)
+        if next_run_at_ms is None:
+            raise ValueError("Schedule does not have a future run time")
+        store = self._load_store()
 
         job = CronJob(
             id=str(uuid.uuid4())[:8],
@@ -293,7 +298,7 @@ class CronService:
                 session_key_str=session_key.model_dump_json(),
                 channel_metadata=dict(_dict_or_empty(channel_metadata)),
             ),
-            state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
+            state=CronJobState(next_run_at_ms=next_run_at_ms),
             created_at_ms=now,
             updated_at_ms=now,
             delete_after_run=delete_after_run,


### PR DESCRIPTION
## 概述
cron 有两处「假成功」：`add_job` 会把永远算不出下次执行时间的任务当作已启用持久化（用户以为定了提醒，实际永不触发）；独立 CLI 的 `cron run` 在没有执行回调的进程里跳过 agent 执行却打印 ✓，还会顺手禁用或删除一次性任务。本 PR 在持久化前校验调度、在无回调时于任何状态改动之前抛错，并把两类错误透传到 CLI（exit 1）和 agent tool（Error 文本）。

## 为什么必要（可达性/严重性）
两条路径都是第一道防线，上游没有任何调度校验：
- C-07 三个入口均可触发：CLI `cron add`（非法 cron 表达式 / `--at` 已过期 / every=0）和 agent cron tool（模型传入过期 ISO 时间或坏表达式）。旧行为返回 "Created job"，任务落盘 enabled=true 且 nextRunAtMs=null；`_get_next_wake_ms` 和 `_on_timer` 都会过滤掉它——永不执行、无任何报错。
- C-08 在网关进程之外执行 `cron run <id>` 即触发：该 CLI 构造的 CronService 没有 on_job，旧 `_execute_job` 静默跳过回调、标记 last_status=ok；一次性任务被禁用（delete_after_run 时直接删除）——本该由网关执行的一次性提醒被白白消费。
诚实定级 P1：静默丢自动化 + 消费一次性任务，属真实正确性缺陷；但无安全面、无批量数据损失，不到 P0。

## 关键设计与取舍
- 校验放在 `add_job`（CLI、agent tool 及未来入口的共同汇聚点），而非逐入口做参数检查，一处覆盖所有调用方；next_run 计算提前到 `_load_store()` 之前，失败时零副作用。
- `_execute_job` 在 try 块之前抛 RuntimeError（而非在 `run_job` 里预判），确保抛错发生在任何 job 状态改动之前，落盘文件字节不变（测试断言了这一点）。
- 不会伤及调度循环：网关在 `prepare_cron`（`bot/vikingbot/cli/commands.py:568` 附近）同步设置 on_job 之后才 `start()`；裸 CronService 的 `_arm_timer` 因 `_running=False` 直接返回，定时器不可能跑在 on_job=None 的实例上——新 RuntimeError 无法杀死网关 timer task。

## 作用域与已知限制
- `cron run` / `cron add` 失败时 exit code 从 0 变为 1，依赖旧行为的脚本会感知（这正是修复意图，但属可见行为变化）。
- `enable_job`（CLI `cron enable`）仍可把过期一次性任务重新置为 enabled=true + next_run=null——C-07 同类症状的另一入口，不在本 diff 内，建议另开 issue 跟进。
- 环境缺 croniter（未装 `bot` extra）时，合法 cron 表达式也会在 add 时被拒，文案是 "no future run time" 而非 "croniter missing"——比旧的静默接受更诚实，但文案略含混；生产 bot 安装始终带 croniter。
- 纯 bot/cron 本地逻辑，与存储后端（S3/远程 vs 本地）无关。

## 修复的问题
- C-07 next-run 为 None 的任务仍持久化为 enabled（`bot/vikingbot/cron/service.py:286`）
- C-08 无回调的手动执行报成功并消费一次性任务（`bot/vikingbot/cron/service.py:233`、`bot/vikingbot/cli/commands.py:1133`）

## 合入价值
**P1** · 三个入口的假成功变为即时报错；一次性任务不再被空跑消费。

## 验证
- 在 PR commit 的独立 worktree 复跑 `pytest bot/tests/test_channel_delivery_metadata.py`：13 passed，1 failed（`test_system_message_response_preserves_channel_metadata`，config 依赖）；该失败在 base 分支同样复现，与本改动无关。
- 新增用例覆盖 every=0 / 过期 at / 坏表达式（参数化）及无回调 run 保持 store 字节不变（async）。
- 单独验证 croniter：非法表达式抛 CroniterBadCronError → `_compute_next_run` 返回 None → ValueError；合法表达式返回未来时间戳，正常入库。

---
自动化全仓清扫(2026-07)· draft 待 review
