### PR TITLE
fix(ov): validate config timeout and node-limit, avoid overwrite race, fix output ordering

### DIFF
--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::output::OutputFormat;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
@@ -100,7 +99,17 @@ pub async fn get(client: &HttpClient, uri: &str, local_path: &str) -> Result<()>
     let bytes = client.get_bytes(uri).await?;
 
     // Write to local file
-    let mut file = File::create(path)?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                crate::error::Error::Client(format!("File already exists: {}", local_path))
+            } else {
+                crate::error::Error::Io(error)
+            }
+        })?;
     file.write_all(&bytes)?;
     file.flush()?;
 

--- a/crates/ov_cli/src/commands/snapshot.rs
+++ b/crates/ov_cli/src/commands/snapshot.rs
@@ -189,11 +189,11 @@ fn handle_show(
         SnapshotShowResult::Blob { oid, bytes, size } => {
             if matches!(output_format, OutputFormat::Json) {
                 let envelope = serde_json::json!({"oid": oid, "size": size});
-                output_success(&envelope, output_format, compact);
                 if let Some(path) = out_path {
                     let mut f = std::fs::File::create(&path)?;
                     f.write_all(&bytes)?;
                 }
+                output_success(&envelope, output_format, compact);
                 return Ok(());
             }
             match out_path {

--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -247,6 +247,7 @@ impl Config {
         let config: Config = serde_json::from_str(&content)
             .map_err(|e| Error::Config(format!("Failed to parse config file: {}", e)))?;
         config.validate_identity_mode()?;
+        config.validate_timeout()?;
         Ok(config)
     }
 
@@ -304,6 +305,16 @@ impl Config {
             return Err(Error::Config(
                 "actor_peer_id cannot be used with agent_id".to_string(),
             ));
+        }
+        Ok(())
+    }
+
+    fn validate_timeout(&self) -> Result<()> {
+        if self.timeout <= 0.0 || std::time::Duration::try_from_secs_f64(self.timeout).is_err() {
+            return Err(Error::Config(format!(
+                "Invalid timeout value {}: timeout must be a positive finite number of seconds",
+                self.timeout
+            )));
         }
         Ok(())
     }
@@ -456,6 +467,20 @@ mod tests {
             .expect_err("mixed identity mode should fail");
 
         assert!(error.to_string().contains("actor_peer_id cannot be used"));
+    }
+
+    #[test]
+    fn config_file_rejects_invalid_timeout() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("ovcli.conf");
+
+        for timeout in ["-1", "0", "1e300"] {
+            std::fs::write(&path, format!(r#"{{"timeout": {timeout}}}"#))
+                .expect("config file should be written");
+            let error = Config::from_file(&path.to_string_lossy())
+                .expect_err("invalid timeout should fail");
+            assert!(error.to_string().contains("Invalid timeout value"));
+        }
     }
 
     #[test]

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -37,6 +37,13 @@ pub async fn handle_add_resource(
     if !is_url {
         use std::path::Path;
 
+        if watch_interval > 0.0 {
+            return Err(Error::Client(
+                "A local path cannot be watched. Use a URL, sitemap, or RSS source, or re-import the local content when it changes."
+                    .to_string(),
+            ));
+        }
+
         // Unescape path: replace backslash followed by space with just space
         let unescaped_path = path.replace("\\ ", " ");
         let path_obj = Path::new(&unescaped_path);

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -780,6 +780,7 @@ enum Commands {
             long = "node-limit",
             alias = "limit",
             default_value = "256",
+            value_parser = clap::value_parser!(i32).range(1..),
             value_name = "n",
             help_heading = "Common options"
         )]
@@ -4450,6 +4451,16 @@ mod tests {
         );
         let client = ctx.get_client();
         assert_eq!(client.api_key(), Some("root-key"));
+    }
+
+    #[test]
+    fn cli_glob_rejects_non_positive_node_limit() {
+        for node_limit in ["0", "-1"] {
+            assert!(
+                Cli::try_parse_from(["ov", "glob", "**/*", "--node-limit", node_limit]).is_err()
+            );
+        }
+        assert!(Cli::try_parse_from(["ov", "glob", "**/*", "--node-limit", "1"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## 概述
ov CLI 五处健壮性修复:校验配置 timeout 与 glob node-limit,本地 watch 上传前先拒绝,`ov get` 原子创建下载目标,snapshot show 先写文件再打印 JSON 成功。全部改动限于 ov_cli 客户端,55 行新增。

## 为什么必要(可达性/严重性)
五处都是用户直接可达的 CLI 路径,但没有一处是安全边界,诚实定级 **P2**(sweep 标 P1 偏高):

- E-06 根因:配置文件的 `timeout` 是 f64 直接反序列化,`base_client.rs:183` 用 `Duration::from_secs_f64` 构造 HTTP client,负数/非有限/超大值直接 panic。只由用户自己的配置文件触发,影响体验不影响他人。
- E-07 不是第一道防线:服务端已在 `openviking/service/resource_service.py:226` 拒绝 temp_file_id + watch_interval>0(上传内容是一次性快照,watch 无意义)。本修复是 fail-fast,省掉"整树 zip+上传完才收到拒绝"的浪费,不合入也没有正确性漏洞。
- E-09 根因:`ov get` 一直是"目标已存在则拒绝"的契约(函数开头有 `path.exists()` 检查),但检查和 `File::create`(truncate 语义)之间隔着整个下载过程,期间新出现的同名文件会被截断。数据丢失类,窗口窄。
- E-10 根因:JSON 模式先 `output_success` 再写输出文件,写失败时脚本拿到 success 加缺失/半截文件;table 分支本来就是先写后报。
- E-11 根因:服务端 glob 的上限判断是 `node_limit > 0` 才生效(`openviking/storage/viking_fs.py:1613`),CLI 把 i32 直传,`--node-limit 0/-1` 会全树无限枚举。调用方是已认证用户,属自伤型资源放大,非越权。

## 关键设计与取舍
- E-06 校验放在 `Config::from_file`——load_required/load_default/env 路径三个加载入口的唯一汇合点;用 `Duration::try_from_secs_f64` 复用 std 的溢出/NaN 判定,不手写阈值。
- E-07 守卫放在 `handle_add_resource` 的 `!is_url` 分支最前。非 URL 路径本就必须本地存在才能继续,不会误伤 sitemap/RSS/飞书等 https 源;条件 `> 0.0` 与服务端语义一致(负数=取消 watch,照常放行)。
- E-09 用 `create_new` 原子创建而非再查一次存在性:契约不变(已存在仍拒绝、报错文案不变),只是关掉 TOCTOU 窗口。考虑过加 `--force` 覆盖开关,属新功能,不在本修复范围。
- E-10 只交换 JSON 分支两行顺序,对齐 table 分支已有行为,最小 diff。
- E-11 用 clap `value_parser!(i32).range(1..)` 在解析期拒绝,而不是 handler 里悄悄 clamp——文档说 256 是上限,不该留 0=无限的暗门。仓库内无脚本/文档依赖 `--node-limit 0`,无回归。

## 作用域与已知限制
- E-06 只覆盖配置文件路径。`ov add --wait --timeout 1e300`(或 inf)仍会经 `handlers.rs:79` 的 `timeout.unwrap_or(60.0).max(config.timeout)` 触达同一 panic(NaN 安全,f64::max 忽略 NaN)。建议后续单独修。
- E-11 只修了 glob 这一个旗标。ls/tree/find/search/grep/skill-list 等另外 7 处 `--node-limit` 同样 i32 直传,至少 grep 服务端也是 `if node_limit and ...`(viking_fs.py:1195/1291/1439),0 同样等于无限。建议后续 PR 统一加 `range(1..)`。
- 全部改动在 ov_cli 客户端,与后端类型(S3/本地)无关;服务端行为未动。

## 修复的问题
- E-06 非法 timeout 让 HTTP client 构造 panic,改为可操作的配置错误(`crates/ov_cli/src/config.rs:250`)
- E-07 本地 watch 资源在服务端必然拒绝前就被整树上传(`crates/ov_cli/src/handlers.rs:40`)
- E-09 `ov get` 截断下载期间新建的同名目标文件(`crates/ov_cli/src/commands/content.rs:102`)
- E-10 snapshot show(JSON)在写出文件前就打印成功(`crates/ov_cli/src/commands/snapshot.rs:189`)
- E-11 glob 接受非正数 node-limit,绕过文档承诺的 256 上限(`crates/ov_cli/src/main.rs:783`)

## 合入价值
**P2** · 五处 CLI 健壮性小修合集,非安全边界:用户提前拿到可操作报错,自动化拿到与事实一致的输出,并发下载不覆盖新建的本地文件,省掉必然失败的整树上传。

## 验证
- `cargo test -p ov_cli -- config_file_rejects_invalid_timeout cli_glob_rejects_non_positive_node_limit` — 2 passed(review 时本地复跑确认)
- `cargo test -p ov_cli` 全量单测 — 421 passed, 0 failed(review 时本地复跑确认)
- 服务端行为核对:`resource_service.py:226`(watch+上传内容必被拒)、`viking_fs.py:1613`(glob node_limit<=0 无限枚举)

---
自动化全仓清扫(2026-07)· draft 待 review
