### PR TITLE
fix(scripts): surface backfill enumeration failures and remove no-op flags

### DIFF
--- a/scripts/maintenance/vikingdb_content_backfill/README.md
+++ b/scripts/maintenance/vikingdb_content_backfill/README.md
@@ -96,15 +96,6 @@ Then execute the update:
   --execute
 ```
 
-Optional throttling:
-
-```bash
-./venv/bin/python scripts/maintenance/vikingdb_content_backfill/backfill_vikingdb_content.py \
-  --execute \
-  --batch-size 100 \
-  --limit 10000
-```
-
 ## Output Files
 
 Each run writes to a timestamped directory under `result/`.

--- a/scripts/maintenance/vikingdb_content_backfill/backfill_vikingdb_content.py
+++ b/scripts/maintenance/vikingdb_content_backfill/backfill_vikingdb_content.py
@@ -212,8 +212,8 @@ class ContentBackfillEnumerator:
     def _list_dir_names(self, path: str) -> list[str]:
         try:
             entries = self._raw_agfs.ls(path)
-        except Exception:
-            return []
+        except Exception as exc:
+            raise RuntimeError(f"failed to list AGFS directory {path}") from exc
         names: list[str] = []
         for entry in entries or []:
             if entry.get("isDir", entry.get("is_dir", False)) and entry.get("name"):
@@ -236,8 +236,10 @@ class ContentBackfillEnumerator:
                 node_limit=node_limit,
                 level_limit=None,
             )
-        except Exception:
-            return
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to enumerate account {account_id} tree at {root_uri}"
+            ) from exc
 
         for entry in entries:
             uri = entry.get("uri")
@@ -330,7 +332,6 @@ class BackfillOptions:
     run_dir: Path
     execute: bool = False
     rewrite_non_empty: bool = False
-    batch_size: int = 100
     limit: int | None = None
     cutoff: datetime | None = None
     fail_fast: bool = False
@@ -551,7 +552,6 @@ def build_options(args: argparse.Namespace) -> BackfillOptions:
         run_dir=Path(args.run_dir),
         execute=bool(args.execute),
         rewrite_non_empty=bool(getattr(args, "rewrite_non_empty", False)),
-        batch_size=int(args.batch_size),
         limit=getattr(args, "limit", None),
         cutoff=datetime.now(),
         fail_fast=bool(getattr(args, "fail_fast", False)),
@@ -563,10 +563,6 @@ def build_options(args: argparse.Namespace) -> BackfillOptions:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-dir", type=Path, default=default_run_dir())
-    parser.add_argument("--batch-size", type=int, default=100)
-    parser.add_argument("--page-size", type=int, default=500)
-    parser.add_argument("--read-concurrency", type=int, default=8)
-    parser.add_argument("--update-sleep-ms", type=int, default=0)
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--execute", action="store_true")
     parser.add_argument("--rewrite-non-empty", action="store_true")


### PR DESCRIPTION
## 概述
backfill 脚本的两处枚举失败(`ls /local`、按账号 `tree`)被 `except Exception` 吞掉后返回空,存储故障就被上报成 candidate_count=0 的"成功空跑";CLI 还暴露四个 runner 从不消费的调优 flag。本 PR 让枚举失败带上下文抛出,并删除四个假旋钮及其 README 示例。

## 为什么必要(可达性/严重性)
- 根因:`_list_dir_names` 对 `ls` 失败 `return []`、`_iter_tree_candidates` 对 `tree` 失败 `return`,把"枚举不了"和"确实没有候选"折叠成同一个结果。`run()` 的计数与处理两趟都走这条路,所以 AGFS 挂载失败/权限错误/后端不可用时,summary.json 全零、退出码为 0,连 `--execute` 也一样——运维会误判 backfill 已完成。
- 严重性:诚实定级 **P1**。这是 `scripts/maintenance/` 下运维手动运行的一次性脚本,不在服务链路上;后果是静默漏跑(误判完成),不是数据损坏。没有上游守卫覆盖——脚本本身就是唯一入口,所以这是第一道防线而非 defense-in-depth。
- 空目录不会误报:脚本自行挂载本地后端后,`ls /local` 在零账号部署下返回空列表,走 `entries or []` 正常空跑;只有 `ls`/`tree` 真正抛异常才会 RuntimeError。

## 关键设计与取舍
- 抛 `RuntimeError(...) from exc` 而不是打日志继续:枚举失败意味着候选全集不可知,继续跑只会产出一份不可信的 summary。异常沿 async 生成器传到 `main()`,非零退出码 + 完整 traceback(`from exc` 保留原始原因)。
- 枚举失败不受 `--fail-fast` 控制、总是致命:`--fail-fast` 只管单条 `update_data` 失败(可跳过继续),而枚举失败没有"跳过一条"的语义。有意区分,不是遗漏。
- 四个 flag(`--batch-size`/`--page-size`/`--read-concurrency`/`--update-sleep-ms`)直接删除而非接线:main 上 `batch_size` 只存进 dataclass 从未读取,另外三个连存都没存(仅 argparse 定义)。串行 runner 目前不需要这些控制;等真正实现并发/限速时再加回,比留着骗人的旋钮好。

## 作用域与已知限制
- 仅影响该维护脚本;全仓 grep 确认无 CI/helm/其他脚本调用它或传这四个 flag,README 是唯一引用且已同步删除示例(`--limit` 在 README 其他位置仍有文档)。
- 旧命令行里带已删 flag 会得到 argparse "unrecognized arguments" 报错——这是有意的显式失败,不是静默忽略。
- 中途枚举失败时 summary.json 不落盘(每条候选后写的 progress 文件保留最后状态),单个账号树坏了会中止整轮而非跳过该账号;需要"跳过坏账号继续"时可后续加显式 flag,默认仍应 loud。

## 修复的问题
- F-05 AGFS 列举与账号树失败被静默当成零候选成功,含 `--execute`(scripts/maintenance/vikingdb_content_backfill/backfill_vikingdb_content.py:212,236)
- F-15 四个宣传的调优 flag 对 runner 行为毫无影响(scripts/maintenance/vikingdb_content_backfill/backfill_vikingdb_content.py:563)

## 合入价值
**P1(维护脚本运维正确性,非服务链路)** · 存储故障与真实空跑可区分,不再暴露不存在的控制面。

## 验证
- `python -m py_compile backfill_vikingdb_content.py` 通过
- `--help` 确认保留 `--limit`,四个已删 flag 全部消失
- 注入 AGFS 列举与账号树失败,确认抛错含 source path、account、root URI 且退出码非零;`git diff --check` 通过
- 全仓 grep 确认无自动化(CI/helm/yaml/脚本)引用已删 flag

---
自动化全仓清扫(2026-07)· draft 待 review
