### PR TITLE
fix(ov): allow --help before first-run language selection

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -2552,10 +2552,22 @@ fn language_command_can_run_picker(has_language_value: bool, is_interactive: boo
     has_language_value || is_interactive
 }
 
+fn render_help_request(args: &[OsString]) -> Option<String> {
+    if help_ui::is_top_level_help_request(args) {
+        Some(help_ui::render_top_level_help())
+    } else {
+        help_ui::render_command_help_request(args)
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args = preprocess_cli_args(std::env::args_os().collect());
     let command_display = error_ui::display_command(&args);
+    if let Some(help) = render_help_request(&args) {
+        print!("{help}");
+        return;
+    }
     let (pre_parse_output_format, pre_parse_compact) = pre_parse_output_options(&args);
     match ensure_language_selected_before_command(&args).await {
         Ok(true) => {}
@@ -2572,14 +2584,6 @@ async fn main() {
         }
     }
 
-    if help_ui::is_top_level_help_request(&args) {
-        print!("{}", help_ui::render_top_level_help());
-        return;
-    }
-    if let Some(help) = help_ui::render_command_help_request(&args) {
-        print!("{help}");
-        return;
-    }
     if let Some(misuse) = plain_help_misuse(&args) {
         let report = error_ui::report_for_plain_help_error(&command_display, misuse.help_command);
         error_ui::print_report(&report, false);
@@ -3276,7 +3280,7 @@ mod tests {
         first_command_token, is_language_command_request, language_command_can_run_picker,
         language_gate_action, language_required_message, legacy_upload_option_error,
         plain_help_misuse, pre_parse_output_options, pre_parse_requires_cli_config_file,
-        preprocess_cli_args, preprocess_privacy_args,
+        preprocess_cli_args, preprocess_privacy_args, render_help_request,
     };
     use crate::config::{Config, DEFAULT_CUSTOM_URL};
     use crate::output::OutputFormat;
@@ -4206,6 +4210,13 @@ mod tests {
             language_gate_action(&os_args(&["ov", "status"]), false, false),
             LanguageGateAction::ExitNonInteractive
         );
+    }
+
+    #[test]
+    fn canonical_help_renders_before_language_gating() {
+        assert!(render_help_request(&os_args(&["ov", "--help"])).is_some());
+        assert!(render_help_request(&os_args(&["ov", "status", "--help"])).is_some());
+        assert!(render_help_request(&os_args(&["ov", "status"])).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 概述
全新安装（尚未保存显示语言）时，`main()` 里的首跑语言闸门排在 help 渲染之前。非交互场景（CI、脚本、管道，即 stdin/stdout 任一非 TTY）下闸门直接 `exit(2)`，导致 `ov --help` / `ov <command> --help` 连用法都看不到。此 PR 把 help 渲染整体移到语言闸门之前：新增 `render_help_request()` 合并原有的顶层与子命令 help 两个检查，在 `ensure_language_selected_before_command()` 之前执行；命令真正执行仍全部受闸门约束。

## 为什么必要（可达性/严重性）
- 根因：`ensure_language_selected_before_command()` 对非交互 + 无已存语言的组合走 `ExitNonInteractive` 分支（`main.rs:2445`），而 help 检查原本排在它之后。help 请求本身不需要已存语言——`Language::current()` 会按 env（`OPENVIKING_LANG`/`LC_*`/`LANG`）回退到 En，渲染只依赖 clap 元数据，不读 config。
- 可达性：第一道防线，无上游覆盖。任何 fresh install 在 CI/脚本里跑 `ov --help` 必现 exit 2；甚至交互终端里 `ov --help | less` 也会触发（stdout 非 TTY）。
- 诚实定级：P1。真实可达且影响新用户首触/CI，但仅限「未保存语言」窗口期，`ov language en` 一次即可永久绕过，无数据/安全影响。

## 关键设计与取舍
- 选择「把 help 渲染前移」而不是「在 `language_gate_action()` 里给 help 加豁免」：前者是纯顺序调整，help 路径保证零副作用（不弹 picker、不 exit）；后者要在闸门里复刻 help 匹配逻辑，且 help 仍会经过闸门的其余分支，面更大。
- 顺带把两个 help 检查收进 `render_help_request()` 一个函数，行为不变，可单测。
- 行为变化（预期内）：fresh install 的交互终端里 `ov --help` 不再先弹语言选择，直接按 env 语言渲染 help。看用法不应强制完成 setup。

## 作用域与已知限制
- 仅前移「规范 help 形式」：`ov --help/-h/-help` 和 curated 命令的 `ov <cmd> --help`。以下形式仍被闸门拦截（与改动前一致，非本 PR 引入）：`ov help`（plain-misuse 提示在闸门后）、`ov <未知命令> --help`（无 curated spec，落回 clap 路径）。闸门报错信息本身含 `ov language en` 指引，用户仍可自救。
- 无回归面：help 匹配是严格前缀/白名单式，普通命令（如 `ov status`）不受影响，闸门照常生效（已实测 exit 2）。

## 修复的问题
- E-08 首次运行的语言闸门在非交互 shell 中拦截了顶层与子命令 help（`crates/ov_cli/src/main.rs:2541`）

## 合入价值
**P1** · 新用户与 CI/脚本无需先设置语言或进入交互终端即可查看 CLI 用法；语言闸门对实际命令执行的约束不变。

## 验证
- `cargo test -p ov_cli canonical_help_renders_before_language_gating` — 1 passed
- 用 PR head 构建的二进制 + 空 `HOME`（无已存语言）+ stdin/stdout 均重定向实测：
  - `ov --help` → 渲染顶层 help，exit 0（改动前为闸门报错 exit 2）
  - `ov status --help` → 渲染 curated help，exit 0
  - `ov status` → 仍输出 "needs a display language"，exit 2（闸门未回归）
  - `ov help`、`ov unknowncmd --help` → 仍被闸门拦截，exit 2（见已知限制）

---
自动化全仓清扫(2026-07)· draft 待 review
