### PR TITLE
fix(kernel): stop conflating storage failures with not-found

### DIFF
--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from openviking.storage import VikingDBManager
     from openviking.storage.viking_fs import VikingFS
 
+from openviking_cli.exceptions import NotFoundError
+
 
 @dataclass
 class DirectoryDefinition:
@@ -308,7 +310,7 @@ class DirectoryInitializer:
             viking_fs = self._get_viking_fs()
             await viking_fs.abstract(uri, ctx=ctx)
             return True
-        except Exception:
+        except (FileNotFoundError, NotFoundError):
             return False
 
     async def _initialize_children(

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Protocol
 
 from openviking.pyagfs import AsyncAGFSClient
-from openviking.pyagfs.exceptions import AGFSAlreadyExistsError
+from openviking.pyagfs.exceptions import AGFSAlreadyExistsError, AGFSNotFoundError
 
 SYSTEM_TASK_ACCOUNT_ID = "_system"
 SYSTEM_TASK_USER_ID = "root"
@@ -65,7 +65,7 @@ class PersistentTaskStore:
         path = self._task_path(account_id, user_id, task_id)
         try:
             raw = await self._agfs.read(path)
-        except Exception:
+        except (AGFSNotFoundError, FileNotFoundError):
             return None
         return json.loads(_decode_bytes(raw))
 
@@ -75,7 +75,7 @@ class PersistentTaskStore:
         directory = self._task_dir(account_id, user_id)
         try:
             items = await self._agfs.ls(directory)
-        except Exception:
+        except (AGFSNotFoundError, FileNotFoundError):
             return []
         tasks: List[Dict[str, Any]] = []
         for item in items:
@@ -84,9 +84,9 @@ class PersistentTaskStore:
                 continue
             try:
                 raw = await self._agfs.read(path)
-                tasks.append(json.loads(_decode_bytes(raw)))
-            except Exception:
+            except (AGFSNotFoundError, FileNotFoundError):
                 continue
+            tasks.append(json.loads(_decode_bytes(raw)))
         return tasks
 
     async def delete(self, task_id: str, *, account_id: str, user_id: Optional[str] = None) -> None:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -69,6 +69,10 @@ _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS = 30.0
 _MEMORY_STEP_NAMES = ("long_term", "execution")
 
 
+class _ArchiveMessagesCorruptError(ValueError):
+    """Raised when an archive messages file cannot be deserialized."""
+
+
 def _is_storage_not_found(exc: BaseException) -> bool:
     if isinstance(exc, AGFSClientError):
         return isinstance(exc, AGFSNotFoundError) or (
@@ -1977,9 +1981,9 @@ class Session:
         archive_error = ""
         try:
             archive_messages = await self._read_archive_messages(msg.archive_uri)
-        except json.JSONDecodeError as exc:
+        except _ArchiveMessagesCorruptError as exc:
             archive_messages = []
-            archive_error = f"session commit archive has invalid JSON: {exc}"
+            archive_error = f"session commit archive has invalid messages: {exc}"
         except Exception as exc:
             if not _is_storage_not_found(exc):
                 raise
@@ -3002,7 +3006,10 @@ class Session:
         for line in content.strip().split("\n"):
             if not line.strip():
                 continue
-            messages.append(Message.from_dict(json.loads(line)))
+            try:
+                messages.append(Message.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError) as exc:
+                raise _ArchiveMessagesCorruptError("invalid message record") from exc
 
         return messages
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -17,6 +17,7 @@ from openviking.core.namespace import canonical_session_uri
 from openviking.core.peer_id import normalize_peer_id, safe_peer_id
 from openviking.message import Message, Part
 from openviking.message.part import ContextPart, TextPart, ToolPart
+from openviking.pyagfs.exceptions import AGFSClientError, AGFSHTTPError, AGFSNotFoundError
 from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.constants import EXECUTION_MEMORY_TYPES
@@ -45,7 +46,7 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens, truncate_text_to_token_budget
-from openviking_cli.exceptions import FailedPreconditionError
+from openviking_cli.exceptions import FailedPreconditionError, NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config import get_openviking_config
@@ -66,6 +67,17 @@ _MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS = 1.0
 _MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS = 8.0
 _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS = 30.0
 _MEMORY_STEP_NAMES = ("long_term", "execution")
+
+
+def _is_storage_not_found(exc: BaseException) -> bool:
+    if isinstance(exc, AGFSClientError):
+        return isinstance(exc, AGFSNotFoundError) or (
+            isinstance(exc, AGFSHTTPError) and exc.status_code == 404
+        )
+    if isinstance(exc, (FileNotFoundError, NotFoundError)):
+        nested = exc.__cause__ or exc.__context__
+        return nested is None or _is_storage_not_found(nested)
+    return False
 
 
 def _wm_debug(msg: str) -> None:
@@ -529,7 +541,9 @@ class Session:
                 if line.strip()
             ]
             logger.info(f"Session loaded: {self.session_id} ({len(self._messages)} messages)")
-        except (FileNotFoundError, Exception):
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
             logger.debug(f"Session {self.session_id} not found, starting fresh")
 
         # Restore compression_index (scan history directory)
@@ -543,8 +557,9 @@ class Session:
                 self._compression.compression_index = max_index
                 self._stats.compression_count = len(archives)
                 logger.debug(f"Restored compression_index: {max_index}")
-        except Exception:
-            pass
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
 
         # Load .meta.json
         try:
@@ -552,7 +567,9 @@ class Session:
                 f"{self._session_uri}/.meta.json", ctx=self.ctx
             )
             self._meta = SessionMeta.from_dict(json.loads(meta_content))
-        except Exception:
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
             # Old session without meta — derive from existing data
             self._meta.message_count = len(self._messages)
             self._meta.commit_count = self._compression.compression_index
@@ -613,7 +630,9 @@ class Session:
         try:
             await self._viking_fs.stat(self._session_uri, ctx=self.ctx)
             return True
-        except Exception:
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
             return False
 
     async def ensure_exists(self) -> None:
@@ -1906,8 +1925,9 @@ class Session:
 
         try:
             await self._viking_fs.read_file(f"{msg.archive_uri}/.done", ctx=self.ctx)
-        except Exception:
-            pass
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
         else:
             if task.status.value == "completed":
                 return
@@ -1923,8 +1943,9 @@ class Session:
             failed = json.loads(
                 await self._viking_fs.read_file(f"{msg.archive_uri}/.failed.json", ctx=self.ctx)
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
         else:
             await tracker.fail(
                 msg.task_id,
@@ -2966,19 +2987,13 @@ class Session:
 
     async def _read_archive_messages(self, archive_uri: str) -> List[Message]:
         """Read archived messages from one archive."""
-        try:
-            content = await self._viking_fs.read_file(f"{archive_uri}/messages.jsonl", ctx=self.ctx)
-        except Exception:
-            return []
+        content = await self._viking_fs.read_file(f"{archive_uri}/messages.jsonl", ctx=self.ctx)
 
         messages: List[Message] = []
         for line in content.strip().split("\n"):
             if not line.strip():
                 continue
-            try:
-                messages.append(Message.from_dict(json.loads(line)))
-            except Exception:
-                continue
+            messages.append(Message.from_dict(json.loads(line)))
 
         return messages
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1974,9 +1974,18 @@ class Session:
             )
             return
 
-        archive_messages = await self._read_archive_messages(msg.archive_uri)
+        archive_error = ""
+        try:
+            archive_messages = await self._read_archive_messages(msg.archive_uri)
+        except json.JSONDecodeError as exc:
+            archive_messages = []
+            archive_error = f"session commit archive has invalid JSON: {exc}"
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                raise
+            archive_messages = []
         if not archive_messages:
-            error = "session commit archive has no messages"
+            error = archive_error or "session commit archive has no messages"
             await self._write_failed_marker(
                 msg.archive_uri,
                 stage="archive_read",
@@ -3309,7 +3318,15 @@ class Session:
         for state in states:
             if state.archive_id in covered or state.state == "completed":
                 continue
-            messages.extend(await self._read_archive_messages(state.archive_uri))
+            try:
+                messages.extend(await self._read_archive_messages(state.archive_uri))
+            except Exception as exc:
+                if not _is_storage_not_found(exc):
+                    raise
+                logger.warning(
+                    "Skipping pending archive %s because messages.jsonl is missing",
+                    state.archive_uri,
+                )
         return self._stable_deduplicate_messages(messages)
 
     async def _get_pending_archive_messages(self) -> List[Message]:

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from openviking.pyagfs import AGFSSyncClientProtocol, AsyncAGFSClient
+from openviking.pyagfs.exceptions import AGFSAlreadyExistsError, AGFSNotFoundError
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -195,9 +196,8 @@ class NamedQueue:
         if not self._initialized:
             try:
                 await self._async_agfs.mkdir(self.path)
-            except Exception as e:
-                if "exist" not in str(e).lower():
-                    logger.warning(f"[NamedQueue] Failed to ensure queue {self.name}: {e}")
+            except (AGFSAlreadyExistsError, FileExistsError):
+                pass
             self._initialized = True
 
     async def enqueue(self, data: Union[str, Dict[str, Any]]) -> str:
@@ -323,16 +323,17 @@ class NamedQueue:
 
         try:
             content = await self._async_agfs.read(size_file)
-            if not content:
+            if content is None:
                 return 0
             if isinstance(content, bytes):
-                return int(content.decode("utf-8").strip())
+                text = content.decode("utf-8")
             elif isinstance(content, str):
-                return int(content.strip())
+                text = content
             else:
-                return 0
-        except Exception as e:
-            logger.debug(f"[NamedQueue] Get size failed for {self.name}: {e}")
+                raise TypeError(f"Unexpected queue size response: {type(content).__name__}")
+            text = text.strip()
+            return int(text) if text else 0
+        except (AGFSNotFoundError, FileNotFoundError):
             return 0
 
     async def clear(self) -> bool:

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from openviking.message import Message, TextPart
-from openviking.service.task_tracker import TaskTracker, set_task_tracker
+from openviking.service.task_tracker import TaskStatus, TaskTracker, set_task_tracker
 from openviking.session.session import Session
 from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
 
@@ -84,3 +84,58 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     assert [
         item.id for item in session._run_memory_extraction.await_args.kwargs["messages"]
     ] == ["archived"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("archive_content", [None, "{invalid json"])
+async def test_resume_queued_commit_fails_terminally_for_unreadable_archive(
+    monkeypatch, archive_content
+):
+    session_uri = "viking://user/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    files = {}
+    if archive_content is not None:
+        files[f"{archive_uri}/messages.jsonl"] = archive_content
+    viking_fs = _MemoryVikingFS(files)
+    session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+    message = SessionCommitMsg(
+        task_id="task-1",
+        session_id="session-1",
+        session_uri=session_uri,
+        archive_uri=archive_uri,
+        user={"account_id": "default", "user_id": "default"},
+    )
+
+    try:
+        await session.resume_queued_commit(message)
+        task = await tracker.get("task-1")
+    finally:
+        set_task_tracker(None)
+
+    assert task.status == TaskStatus.FAILED
+    failed = json.loads(files[f"{archive_uri}/.failed.json"])
+    assert failed["stage"] == "archive_read"
+    session._run_memory_extraction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_context_skips_pending_archive_with_missing_messages(monkeypatch):
+    session_uri = "viking://user/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    session = Session(
+        viking_fs=_MemoryVikingFS({}),
+        session_id="session-1",
+        session_uri=session_uri,
+    )
+    monkeypatch.setattr(
+        session,
+        "_list_archive_refs",
+        AsyncMock(return_value=[{"archive_uri": archive_uri, "index": 1}]),
+    )
+
+    context = await session.get_context_for_search(query="test")
+
+    assert context == {"latest_archive_overview": "", "current_messages": []}

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -133,7 +133,11 @@ async def test_session_context_skips_pending_archive_with_missing_messages(monke
     monkeypatch.setattr(
         session,
         "_list_archive_refs",
-        AsyncMock(return_value=[{"archive_uri": archive_uri, "index": 1}]),
+        AsyncMock(
+            return_value=[
+                {"archive_id": "archive_001", "archive_uri": archive_uri, "index": 1}
+            ]
+        ),
     )
 
     context = await session.get_context_for_search(query="test")

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -87,7 +87,7 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("archive_content", [None, "{invalid json"])
+@pytest.mark.parametrize("archive_content", [None, "{invalid json", "{}"])
 async def test_resume_queued_commit_fails_terminally_for_unreadable_archive(
     monkeypatch, archive_content
 ):


### PR DESCRIPTION
## 概述
session、task、目录、队列的存储读取路径把一切异常(后端故障、网络错误、JSON 损坏)统一当作"数据不存在",随后走覆盖重建/假完成分支。本 PR 把"缺失"判定收窄为明确的 not-found(`AGFSNotFoundError` / `FileNotFoundError` / `NotFoundError`(cause 链上无非 not-found 异常)/ HTTP 404),其余异常保留原始异常链向上抛;损坏记录与非法 size 内容改为显式失败。

## 为什么必要(可达性/严重性)
这是真实可达的第一道防线,不是 defense-in-depth——上游没有任何 guard 区分 not-found 与存储故障:

- 数据损毁链路(A-03,已核实代码):`Session.load()` 吞掉读失败 → `self._messages=[]` → 后续 `_write_to_agfs_async` 用内存态整写 `messages.jsonl` → 会话历史被清空。`exists()` 吞异常返回 False → `ensure_exists` 重建覆盖。`load()` 在每次会话打开(mcp_endpoint、search router、session_service、commit processor、local client)都执行。
- 后端相关性:远程 AGFS(S3/网络后端)下瞬时故障是常态,该场景为真 P0;纯本地 FS 后端瞬时读失败罕见,暴露面主要是损坏文件,严重性相应为 P1。
- 误伤风险已排除:Rust binding(`crates/ragfs-python/src/lib.rs` `to_py_err`)只把 `NotFound` 映射为 `AGFSNotFoundError`,网络/超时映射为 `AGFSNetworkError`/`AGFSTimeoutError`;`VikingFS` 统一包装为 `openviking_cli.NotFoundError` 且带 cause 链。`directories.py` 只 catch `NotFoundError`/`FileNotFoundError`、`task_store` 只 catch `AGFSNotFoundError`/`FileNotFoundError`,与各自实际依赖的层一致。

## 关键设计与取舍
- 用显式异常类型收窄,`_is_storage_not_found` 对 `NotFoundError` 递归检查 cause 链:由非 not-found 异常引起的 NotFoundError 按故障处理。方向保守——宁可 fail loud,不可误判缺失后覆盖数据。
- 损坏选择显式失败而非静默跳过:`task_store.get` 对损坏任务抛错(API 500)而不是伪装 404;`named_queue.size` 对非法内容抛 `ValueError` 而不是 0。否掉的替代方案是"跳过坏行继续"——它正是本组 bug 的成因模式。
- `resume_queued_commit` 对缺失/损坏 archive 走 `.failed.json` + `tracker.fail` 终态化而非无限重试(评审修复轮加入):消息数据已不可恢复,重试无意义;真实存储故障仍上抛以便队列重试。
- 队列 worker 循环(`queue_manager.py`)本身 catch 异常并退避重试,`size()` 改为抛错后不会造成 worker 崩溃循环。

## 作用域与已知限制
- **已知回归,需 follow-up(已复现确认)**:`_prepare_phase2_archive_messages`(`openviking/session/session.py`,replay 早期 failed archive 处)没有加上与 `_get_uncovered_archive_messages` 相同的容错。终态失败且 `messages.jsonl` 缺失/损坏的 archive——旧版 "no messages" 终态路径留下的存量数据,以及本 PR archive_read 终态路径新产生的——会让之后每次 commit 的 Phase 2 在 replay 时抛 `FileNotFoundError`/`_ArchiveMessagesCorruptError` → 当前 commit 被终态 fail 且永远无法 cover 该 archive → 该会话的记忆提取永久失败(原始消息不丢,各 archive 自身仍保留)。复现:merge commit `2c80d443` 上对缺失 `messages.jsonl` 的 failed archive 调用 `_prepare_phase2_archive_messages` 抛 `FileNotFoundError`;父提交 `0ea58157` 同输入正常返回。最小修复:该 replay 调用套用 `_get_uncovered_archive_messages` 的 try/skip,并把 `_ArchiveMessagesCorruptError` 一并跳过告警(archive 已终态、数据不可恢复,跳过是唯一前进路径;真实存储故障仍上抛)。
- "损坏即失败"的副作用(既定取舍,非遗漏):pending archive 中一行损坏会让上下文读取整体抛错;`task_store.list` 中一个损坏任务文件会让整个列表失败;损坏的 `.done`/`.failed.json` 标记会让 `resume_queued_commit` 持续抛错重试(不 ack),表现为可见卡死而非静默错误。
- `vikingdb_manager.get_embedding_queue_size` 外层仍 `except Exception: return 0`,该包装层的故障→0 conflation 不在本 PR 范围内。
- 不覆盖:写路径原子性(部分写入仍可能产生损坏文件)、任务/队列的并发一致性。

## 修复的问题
- A-03 session 加载与存在性检查吞掉存储和 JSON 失败,已有会话被当空并整写覆盖(openviking/session/session.py)
- A-07 durable commit 的 `.done`/`.failed.json` 标记读取忽略失败,导致重复提取或误判(openviking/session/session.py)
- A-11 持久化任务读取静默隐藏后端和 JSON 失败,API 无法区分真 404 和存储故障(openviking/service/task_store.py)
- A-12 预设初始化把一切抽象层失败当目录缺失,误触发创建/重写(openviking/core/directories.py)
- B-07 NamedQueue 初始化与 size 读取把后端失败转成成功或 0(openviking/storage/queuefs/named_queue.py)

## 合入价值
**P0(远程/S3 后端)· P1(纯本地后端)** · 存储抖动或数据损坏期间,不再静默清空会话历史、重建目录、误报任务不存在或队列为空。附带一处已确认的 P1 回归(上文 replay 毒丸),需小改 follow-up。

## 验证
- `pytest tests/unit/session/test_session_commit_resume.py tests/test_task_tracker.py tests/unit/test_directory_initializer.py`(merge 后主干)— 50 passed
- 回归复现脚本:merge commit 上构造 failed archive(有 `.failed.json`、无 `messages.jsonl`),`_prepare_phase2_archive_messages` 抛 `FileNotFoundError`;父提交同输入返回正常(1 条消息保留)
- 异常映射链人工核对:`crates/ragfs-python/src/lib.rs` `to_py_err`、`openviking/storage/viking_fs.py` 的 `NotFoundError` 包装、queue worker 的异常退避
- 对 `5527cbcf` 的独立评审 — CLEAN(评审修复轮已并入)

---
自动化全仓清扫(2026-07)· 已于 2026-07-24 合入(2c80d443)· 合入后深评审确认一处 P1 回归待 follow-up
