### PR TITLE
build: ship VikingBot workspace and bridge assets in wheels

### DIFF
--- a/bot/vikingbot/agent/skills.py
+++ b/bot/vikingbot/agent/skills.py
@@ -7,8 +7,10 @@ import re
 import shutil
 from pathlib import Path
 
+from vikingbot.utils.helpers import get_source_workspace_path
+
 # Default builtin skills directory (relative to this file)
-BUILTIN_SKILLS_DIR = Path(__file__).parent.parent.parent / "workspace" / "skills"
+BUILTIN_SKILLS_DIR = get_source_workspace_path() / "skills"
 
 
 class SkillsLoader:

--- a/bot/vikingbot/utils/helpers.py
+++ b/bot/vikingbot/utils/helpers.py
@@ -97,6 +97,9 @@ def get_mounts_path() -> Path:
 
 def get_source_workspace_path() -> Path:
     """Get the source workspace path from the codebase."""
+    package_workspace = Path(__file__).parent.parent / "workspace"
+    if package_workspace.is_dir():
+        return package_workspace
     return Path(__file__).parent.parent.parent / "workspace"
 
 
@@ -117,7 +120,7 @@ def ensure_workspace_templates(workspace: Path) -> None:
 
     if not has_any_file:
         # Workspace is empty, copy templates from source
-        source_dir = Path(__file__).parent.parent.parent / "workspace"
+        source_dir = get_source_workspace_path()
 
         if not source_dir.exists():
             # Fallback: create minimal templates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ vikingbot = [
     "**/*.mjs",
     "skills/**/*.md",
     "skills/**/*.sh",
+    "workspace/**/*",
     "bridge/**/*",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -512,6 +512,23 @@ class OpenVikingBuildPy(build_py):
     def run(self):
         _build_web_studio()
         super().run()
+        package_root = Path(self.build_lib) / "vikingbot"
+        for asset_name in ("workspace", "bridge"):
+            source = SETUP_DIR / "bot" / asset_name
+            if not source.is_dir():
+                raise FileNotFoundError(
+                    f"required VikingBot asset directory not found: {source}"
+                )
+            destination = package_root / asset_name
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(
+                source,
+                destination,
+                ignore=shutil.ignore_patterns(
+                    "node_modules", "dist", "__pycache__", "*.pyc"
+                ),
+            )
 
 
 if bdist_wheel is not None:
@@ -551,6 +568,10 @@ setup(
             "web_studio/dist/**/*",
             "storage/vectordb/engine/*.abi3.so",
             "storage/vectordb/engine/*.pyd",
+        ],
+        "vikingbot": [
+            "workspace/**/*",
+            "bridge/**/*",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
## 概述
VikingBot 的 workspace 模板（SOUL.md、内置 skills 等）和 WhatsApp bridge 源码放在 `bot/workspace`、`bot/bridge`，是 `bot/vikingbot` 包目录的兄弟目录。`[tool.setuptools.packages.find] where = [".", "bot"]` 只收 `vikingbot*` 包，已有的 package-data glob（`skills/**/*.md`、`bridge/**/*`）相对包目录解析，从来没匹配到任何文件——wheel 里这两棵资产树整体缺失。本 PR 在 `build_py` 阶段把两棵目录树复制进 `build_lib/vikingbot/`，并让 workspace 路径解析优先读包内资产、再回退源码检出。

## 根因与可达性
- 根因:资产目录在包外,setuptools 的包发现和 package-data 都够不到;此前 wheel 从未包含它们,只是运行时静默降级,没人报错。
- 可达性:所有 wheel/PyPI 安装用户,首次运行即触发,是第一道防线,不是 defense-in-depth:
  - `ensure_workspace_templates`(bot/vikingbot/utils/helpers.py:120)找不到源目录 → 退化成最小内联模板,丢掉全部内置 skills(cron/github/tmux/weather 等 8 个);
  - `vikingbot channels login` → `_get_bridge_dir`(bot/vikingbot/cli/commands.py:905)两个候选路径都不存在 → "Bridge source not found" 直接 exit 1,WhatsApp 接入完全不可用。
- 诚实定级:**P1**。功能缺失,无安全/数据丢失影响;源码检出和 editable 安装不受影响。

## 关键设计与取舍
- `_get_bridge_dir` 早就实现了"先查 `vikingbot/bridge` 包内路径"的逻辑,只是该路径从未被打包过——所以 bridge 侧只需把资产运进去,零运行时改动。workspace 侧对称地在 `get_source_workspace_path` 加包内优先,`skills.py` 和 `ensure_workspace_templates` 统一走这一个解析器(消掉三处重复的 `parent.parent.parent` 硬编码)。
- 用 build_py 复制而非只靠 package-data glob:目录在包树外,glob 无法引用;复制进 `build_lib` 后 wheel 收录与 glob 语义无关,pyproject/setup.py 里新增的 `workspace/**/*` 条目属于兜底声明。复制还顺带带上了旧 glob 漏掉的 skill 脚本(`.py`/`.json`)。
- 考虑过把目录直接移进包内:改动面大(dev 路径、文档、bot/README 全要跟着动),收益相同,不选。
- 资产缺失时 build_py 抛 `FileNotFoundError` 硬失败,而不是静默继续:宁可构建失败也不再产出残缺 wheel。

## 作用域与已知限制
- 只影响构建产物和路径解析;运行时行为在源码检出下不变(包内目录不存在时走原路径,已实测)。
- sdist→wheel 构建不会触发新的硬失败:setuptools_scm 的 git file-finder 会把全部 26 个 git 跟踪的资产文件收进 sdist(已对照 `openviking.egg-info/SOURCES.txt` 逐一核对),CI `_build.yml` 的 sdist 任务先 `git clean -fd`,发布产物干净。
- 已知限制:从脏工作树本地构建 wheel 时,copytree 会带上 `bot/workspace`/`bot/bridge` 下的未跟踪文件(ignore 只挡 node_modules/dist/__pycache__/*.pyc);CI 构建不受影响。
- 体积增量约 140KB(workspace 112K + bridge 28K,均为文本)。

## 修复的问题
- F-07 wheel 缺少运行时所需的 VikingBot workspace 和 bridge 资产(setup.py:511; bot/vikingbot/utils/helpers.py:98)

## 合入价值
**P1** · PyPI/wheel 安装的用户拿到完整 workspace 引导、8 个内置 skills 和 WhatsApp bridge,不再退化成最小模板或 "Bridge source not found" 退出。

## 验证
- setuptools 80.9.0 跑 `python3 setup.py ... build_py`,确认 `workspace/SOUL.md`、weather skill、`bridge/package.json` 及 bridge TS 源码进入 `build_lib/vikingbot`。
- 仅用构建产物放入 `PYTHONPATH`,两个 workspace 解析器均指向包内资产;源码检出布局下回退路径同样通过(review 时用 PR head 代码在 wheel/源码两种布局各跑了一次断言,均 PASS)。
- 无循环导入:`skills.py` → `utils.helpers` 单向,helpers 仅依赖 stdlib+loguru。
- `python -m py_compile` 与 `git diff --check` 通过。

---
自动化全仓清扫(2026-07)· draft 待 review
