### PR TITLE
docs(ov): fix session/observer/snapshot examples and add fs alias

### DIFF
--- a/crates/ov_cli/README.md
+++ b/crates/ov_cli/README.md
@@ -175,7 +175,7 @@ Run `ov --help` and `ov <command> --help` for the exact command surface of your 
 - `observer vikingdb` - VikingDB status.
 - `observer models` - VLM, embedding, and rerank model status.
 - `observer retrieval` - Retrieval quality metrics.
-- `observer fs` - Filesystem operation metrics.
+- `observer filesystem` - Filesystem operation metrics.
 - `observer system` - Overall system status.
 
 ### Configuration
@@ -269,8 +269,8 @@ ov glob "**/*.md" --uri viking://resources
 
 # Session workflow
 SESSION=$(ov -o json session new | jq -r '.result.session_id')
-ov session add-message --session-id "$SESSION" --role user --content "Hello"
-ov session commit --session-id "$SESSION"
+ov session add-message "$SESSION" --role user --content "Hello"
+ov session commit "$SESSION"
 
 # Watch task management
 ov add-resource https://example.com/docs --to viking://resources/docs --watch-interval 60

--- a/crates/ov_cli/README_CN.md
+++ b/crates/ov_cli/README_CN.md
@@ -175,7 +175,7 @@ ov grep "openviking" --uri viking://resources
 - `observer vikingdb` - VikingDB 状态。
 - `observer models` - VLM、embedding 和 rerank 模型状态。
 - `observer retrieval` - 检索质量指标。
-- `observer fs` - 文件系统操作指标。
+- `observer filesystem` - 文件系统操作指标。
 - `observer system` - 整体系统状态。
 
 ### 配置
@@ -269,8 +269,8 @@ ov glob "**/*.md" --uri viking://resources
 
 # Session 工作流
 SESSION=$(ov -o json session new | jq -r '.result.session_id')
-ov session add-message --session-id "$SESSION" --role user --content "Hello"
-ov session commit --session-id "$SESSION"
+ov session add-message "$SESSION" --role user --content "Hello"
+ov session commit "$SESSION"
 
 # Watch 任务管理
 ov add-resource https://example.com/docs --to viking://resources/docs --watch-interval 60

--- a/crates/ov_cli/src/help_ui.rs
+++ b/crates/ov_cli/src/help_ui.rs
@@ -542,7 +542,7 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
                 description: "Compare one file between two snapshots.",
             },
             HelpItem {
-                label: "ov snapshot restore viking://projects/acme <commit> --dry-run",
+                label: "ov snapshot restore <commit> viking://projects/acme --dry-run",
                 description: "Preview restoring a directory to a past snapshot.",
             },
         ],
@@ -580,11 +580,11 @@ const COMMAND_HELP_SPECS: &[CommandHelpSpec] = &[
         purpose: "Restore a project directory to a past snapshot via a forward commit.",
         examples: &[
             HelpItem {
-                label: "ov snapshot restore viking://projects/acme <commit> --dry-run",
+                label: "ov snapshot restore <commit> viking://projects/acme --dry-run",
                 description: "Preview which files would change.",
             },
             HelpItem {
-                label: "ov snapshot restore viking://projects/acme <commit> -m \"rollback\"",
+                label: "ov snapshot restore <commit> viking://projects/acme -m \"rollback\"",
                 description: "Apply the restore as a new commit.",
             },
         ],

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1219,6 +1219,7 @@ enum ObserverCommands {
     /// Get retrieval quality metrics
     Retrieval,
     /// Get filesystem operation metrics
+    #[command(alias = "fs")]
     Filesystem,
     /// Get overall system status
     System,
@@ -3272,10 +3273,11 @@ async fn main() {
 mod tests {
     use super::{
         Cli, CliContext, Commands, ConfigAddTarget, ConfigCommands, LanguageGateAction,
-        PrivacyCommands, SkillCommands, SnapshotCmd, UploadCliOptions, find_command_index,
-        first_command_token, is_language_command_request, language_command_can_run_picker,
-        language_gate_action, language_required_message, legacy_upload_option_error,
-        plain_help_misuse, pre_parse_output_options, pre_parse_requires_cli_config_file,
+        ObserverCommands, PrivacyCommands, SkillCommands, SnapshotCmd, UploadCliOptions,
+        find_command_index, first_command_token, is_language_command_request,
+        language_command_can_run_picker, language_gate_action, language_required_message,
+        legacy_upload_option_error, plain_help_misuse, pre_parse_output_options,
+        pre_parse_requires_cli_config_file,
         preprocess_cli_args, preprocess_privacy_args,
     };
     use crate::config::{Config, DEFAULT_CUSTOM_URL};
@@ -4545,6 +4547,36 @@ mod tests {
         );
         let client = ctx.get_client();
         assert_eq!(client.api_key(), Some("root-key"));
+    }
+
+    #[test]
+    fn observer_alias_and_snapshot_restore_examples_parse() {
+        let observer = Cli::try_parse_from(["ov", "observer", "fs"]).unwrap();
+        assert!(matches!(
+            observer.command,
+            Commands::Observer {
+                action: ObserverCommands::Filesystem
+            }
+        ));
+
+        let snapshot = Cli::try_parse_from([
+            "ov",
+            "snapshot",
+            "restore",
+            "abc123",
+            "viking://projects/acme",
+        ])
+        .unwrap();
+        assert!(matches!(
+            snapshot.command,
+            Commands::Snapshot {
+                cmd: SnapshotCmd::Restore {
+                    source_commit,
+                    project_dir,
+                    ..
+                }
+            } if source_commit == "abc123" && project_dir.as_deref() == Some("viking://projects/acme")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 概述
`ov_cli` 的 README 和内置帮助文案是手写的，从未对照 clap 定义校验，与真实命令面漂移：session 示例用了不存在的 `--session-id` flag、observer 写了不存在的 `fs` 子命令、snapshot restore 帮助把两个位置参数写反。本 PR 把示例改回与 clap 一致，并给 `observer filesystem` 加 `fs` 别名。

其中 E-15 比普通笔误重一档：`restore` 的两个位置参数都是自由字符串且第二个可选（`main.rs:1101-1118`），写反的 `restore <dir> <commit>` 能正常通过解析——URI 被当成 commit ref、commit 被当成目录——用户照抄帮助后在运行期才报错，而这是一个改写数据的命令。修正后帮助示例与 `docs/en|zh` 站点文档的参数顺序一致。

## 关键设计与取舍
- `observer fs`：README 已公开写过这个用法，可能有人的脚本在用。docs-only 修法会让这些用法保持坏掉，所以一行 `#[command(alias = "fs")]` 保兼容，文档统一写规范名 `filesystem`。别名与 observer 其余子命令（queue/vikingdb/models/retrieval/system）无冲突。
- session id 改为位置参数写法而不是给 clap 加 `--session-id` flag：全部 session 子命令（get/delete/commit/add-message 等，`main.rs:1226-1284`）都是位置参数，文档就该跟代码走，不为文档改接口。

## 作用域与已知限制
只动 `crates/ov_cli` 的两份 README、`help_ui.rs` 帮助文案和一行别名；`docs/en|zh` 站点的 snapshot 示例本来就是正确顺序，未动。唯一行为变化是新增 `observer fs` 别名，纯增量，无回归面。

## 修复的问题
- E-13：session 示例用了不存在的 `--session-id`，session id 实为位置参数（`crates/ov_cli/README.md:272`、`README_CN.md:272`）。
- E-14：README 写 `observer fs` 但 clap 只有 `observer filesystem`；文档改为规范名，代码补 `fs` 别名（`crates/ov_cli/src/main.rs:1211`）。
- E-15：snapshot restore 帮助示例把 `<commit>` 和项目目录写反，且反序仍可解析、运行期才失败（`crates/ov_cli/src/help_ui.rs:541,579,583`）。

## 合入价值
**P2（文档正确性）** · README 主要示例可直接复制执行；帮助文案不再引导用户以反序参数调用 restore；旧 `observer fs` 用法保持可用。

## 验证
- 逐条对照 clap 定义确认：session 子命令 session id 均为位置参数（`main.rs:1226-1284`）、`ObserverCommands` 无 `fs` 变体、`Restore` 参数顺序为 `<commit> [dir]`。
- 新增测试 `observer_alias_and_snapshot_restore_examples_parse` 覆盖别名解析与 restore 参数顺序，`cargo test -p ov_cli observer_alias_and_snapshot_restore_examples_parse` 通过（1 个测试）。
- `cargo check -p ov_cli` 通过；`rg` 确认仓内无残留的 `--session-id` / `observer fs` 旧示例（`docs/.vitepress/dist` 内的 `--session-id` 属于另一个 CLI 的 search 参数，不在本 PR 范围）。

---
自动化全仓清扫(2026-07)· draft 待 review
