### PR TITLE
fix(sdk/python): support sync client inside a running event loop

### DIFF
--- a/sdk/python/openviking_sdk/_utils.py
+++ b/sdk/python/openviking_sdk/_utils.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import os
 import threading
-from contextvars import copy_context
 from typing import Any, Coroutine
 
 _worker_lock = threading.Lock()
@@ -11,17 +11,21 @@ _worker_loop: asyncio.AbstractEventLoop | None = None
 _worker_thread: threading.Thread | None = None
 
 
+async def _capture_result(coro: Coroutine[Any, Any, Any]) -> tuple[bool, Any]:
+    try:
+        return True, await coro
+    except BaseException as exc:
+        return False, exc
+
+
 def _get_worker_loop() -> asyncio.AbstractEventLoop:
     global _worker_loop, _worker_thread
-    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
-        return _worker_loop
     with _worker_lock:
-        if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
-            return _worker_loop
-        _worker_loop = asyncio.new_event_loop()
-        _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
-        _worker_thread.start()
-        atexit.register(_shutdown_worker_loop)
+        if _worker_loop is None or _worker_thread is None or not _worker_thread.is_alive():
+            _worker_loop = asyncio.new_event_loop()
+            _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
+            _worker_thread.start()
+            atexit.register(_shutdown_worker_loop)
         return _worker_loop
 
 
@@ -36,6 +40,16 @@ def _shutdown_worker_loop() -> None:
     _worker_thread = None
 
 
+def _reset_worker_after_fork() -> None:
+    global _worker_lock, _worker_loop, _worker_thread
+    _worker_lock = threading.Lock()
+    _worker_loop = _worker_thread = None
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_worker_after_fork)
+
+
 def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     try:
         running_loop = asyncio.get_running_loop()
@@ -46,5 +60,8 @@ def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     if running_loop is worker_loop:
         coro.close()
         raise RuntimeError("run_async cannot be called from its worker event loop")
-    future = copy_context().run(asyncio.run_coroutine_threadsafe, coro, worker_loop)
-    return future.result()
+    future = asyncio.run_coroutine_threadsafe(_capture_result(coro), worker_loop)
+    succeeded, value = future.result()
+    if succeeded:
+        return value
+    raise value

--- a/sdk/python/openviking_sdk/_utils.py
+++ b/sdk/python/openviking_sdk/_utils.py
@@ -1,20 +1,50 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
+import threading
+from contextvars import copy_context
 from typing import Any, Coroutine
+
+_worker_lock = threading.Lock()
+_worker_loop: asyncio.AbstractEventLoop | None = None
+_worker_thread: threading.Thread | None = None
+
+
+def _get_worker_loop() -> asyncio.AbstractEventLoop:
+    global _worker_loop, _worker_thread
+    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+        return _worker_loop
+    with _worker_lock:
+        if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+            return _worker_loop
+        _worker_loop = asyncio.new_event_loop()
+        _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
+        _worker_thread.start()
+        atexit.register(_shutdown_worker_loop)
+        return _worker_loop
+
+
+def _shutdown_worker_loop() -> None:
+    global _worker_loop, _worker_thread
+    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+        _worker_loop.call_soon_threadsafe(_worker_loop.stop)
+        _worker_thread.join(timeout=5)
+    if _worker_loop is not None and not _worker_loop.is_running():
+        _worker_loop.close()
+    _worker_loop = None
+    _worker_thread = None
 
 
 def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     try:
-        loop = asyncio.get_event_loop()
+        running_loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        running_loop = None
 
-    if loop.is_running():
-        new_loop = asyncio.new_event_loop()
-        try:
-            return new_loop.run_until_complete(coro)
-        finally:
-            new_loop.close()
-    return loop.run_until_complete(coro)
+    worker_loop = _get_worker_loop()
+    if running_loop is worker_loop:
+        coro.close()
+        raise RuntimeError("run_async cannot be called from its worker event loop")
+    future = copy_context().run(asyncio.run_coroutine_threadsafe, coro, worker_loop)
+    return future.result()

--- a/sdk/python/tests/test_utils.py
+++ b/sdk/python/tests/test_utils.py
@@ -1,0 +1,47 @@
+import asyncio
+import contextvars
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+from openviking_sdk import SyncHTTPClient
+from openviking_sdk._utils import run_async
+
+
+def test_run_async_reuses_worker_loop_across_contexts_and_copies_caller_context():
+    caller_thread = threading.get_ident()
+    marker = contextvars.ContextVar("marker", default="missing")
+    marker.set("caller")
+
+    async def identify_execution():
+        return threading.get_ident(), asyncio.get_running_loop(), marker.get()
+
+    first_thread, first_loop, first_context = run_async(identify_execution())
+    marker.set("updated")
+
+    async def call_from_running_loop():
+        return run_async(identify_execution())
+
+    second_thread, second_loop, second_context = asyncio.run(call_from_running_loop())
+
+    assert first_thread == second_thread != caller_thread
+    assert first_loop is second_loop
+    assert (first_context, second_context) == ("caller", "updated")
+
+
+@pytest.mark.asyncio
+async def test_sync_client_method_inside_running_loop():
+    client = SyncHTTPClient(url="http://localhost:1933")
+    client._async_client.list_sessions = AsyncMock(return_value=[{"session_id": "demo"}])
+
+    assert client.list_sessions() == [{"session_id": "demo"}]
+
+
+@pytest.mark.asyncio
+async def test_run_async_inside_running_loop_propagates_exceptions():
+    async def fail():
+        await asyncio.sleep(0)
+        raise ValueError("worker failed")
+
+    with pytest.raises(ValueError, match="worker failed"):
+        run_async(fail())

--- a/sdk/python/tests/test_utils.py
+++ b/sdk/python/tests/test_utils.py
@@ -1,47 +1,27 @@
 import asyncio
-import contextvars
-import threading
-from unittest.mock import AsyncMock
 
 import pytest
-from openviking_sdk import SyncHTTPClient
 from openviking_sdk._utils import run_async
 
 
-def test_run_async_reuses_worker_loop_across_contexts_and_copies_caller_context():
-    caller_thread = threading.get_ident()
-    marker = contextvars.ContextVar("marker", default="missing")
-    marker.set("caller")
-
+def test_run_async_reuses_worker_loop_across_sync_and_async_contexts():
     async def identify_execution():
-        return threading.get_ident(), asyncio.get_running_loop(), marker.get()
+        return asyncio.get_running_loop()
 
-    first_thread, first_loop, first_context = run_async(identify_execution())
-    marker.set("updated")
+    first_loop = run_async(identify_execution())
 
     async def call_from_running_loop():
         return run_async(identify_execution())
 
-    second_thread, second_loop, second_context = asyncio.run(call_from_running_loop())
+    second_loop = asyncio.run(call_from_running_loop())
 
-    assert first_thread == second_thread != caller_thread
     assert first_loop is second_loop
-    assert (first_context, second_context) == ("caller", "updated")
 
 
 @pytest.mark.asyncio
-async def test_sync_client_method_inside_running_loop():
-    client = SyncHTTPClient(url="http://localhost:1933")
-    client._async_client.list_sessions = AsyncMock(return_value=[{"session_id": "demo"}])
+async def test_run_async_preserves_cancelled_error():
+    async def cancel():
+        raise asyncio.CancelledError("cancelled by caller")
 
-    assert client.list_sessions() == [{"session_id": "demo"}]
-
-
-@pytest.mark.asyncio
-async def test_run_async_inside_running_loop_propagates_exceptions():
-    async def fail():
-        await asyncio.sleep(0)
-        raise ValueError("worker failed")
-
-    with pytest.raises(ValueError, match="worker failed"):
-        run_async(fail())
+    with pytest.raises(asyncio.CancelledError, match="cancelled by caller"):
+        run_async(cancel())


### PR DESCRIPTION
## 概述
sync Python SDK 的所有方法都经 `run_async` 桥接到 async 实现。旧实现在检测到当前线程已有运行中的事件循环时,新建一个循环并在同一线程上 `run_until_complete`——asyncio 直接拒绝(`RuntimeError: Cannot run the event loop while another loop is running`),即 sync 客户端在 Jupyter/async 宿主内全接口不可用。本 PR 改为把协程提交到一个常驻的后台 worker 事件循环执行,调用方阻塞等待结果,异常原样重抛,并处理 fork 与重入。

## 根因
两个叠加问题,都出在 `sdk/python/openviking_sdk/_utils.py` 的 `run_async`:
1. asyncio 禁止在已有运行循环的线程上再 `run_until_complete` 另一个循环——旧代码的 `loop.is_running()` 分支正是这么做的,在 notebook/async 回调里必然抛 RuntimeError。
2. 即使绕过报错,旧代码在该分支下每次调用新建并销毁一个循环,而 sync 客户端经 `run_async(initialize())` 持有跨调用复用的 httpx `AsyncClient`——httpx 连接绑定创建它的循环,跨循环使用会失败。所以修复必须让所有 sync 调用固定在同一个循环上,而不是"每次新建循环"。

## 为什么必要(可达性/严重性)
**P1,真实第一道防线。** `run_async` 是 `client.py` 中 sync 客户端约 50 个方法的唯一桥接点(`sdk/python/openviking_sdk/client.py:1631` 起),上游没有任何守卫。任何在 Jupyter、IPython、FastAPI/async 框架回调里使用 sync `OpenViking` 客户端的用户,第一个调用就崩。不是 P0:无数据丢失/安全面,纯 sync 脚本不受影响,且用户可改用 `AsyncOpenViking` 规避。

## 关键设计与取舍
- **常驻 daemon worker 线程 + 专属事件循环**:所有 `run_async` 调用经 `asyncio.run_coroutine_threadsafe` 提交到同一个循环。既消除嵌套循环报错,又保证 httpx 客户端的循环亲和性稳定。
- 否决"每次 `asyncio.run`/新建循环":修不了根因 2(跨循环复用 httpx 连接),且在运行中循环的线程上依然非法。
- 否决 `nest_asyncio`:新增依赖 + 全局 monkeypatch,对 uvloop 无效。
- `_capture_result` 在 worker 侧捕获 `BaseException` 打包返回,调用侧原样 `raise`——保留原始异常类型(含 `CancelledError`),不被 `run_coroutine_threadsafe` 的封装吞掉。
- 重入守卫:worker 循环上的协程再调 `run_async` 会死锁,现改为立即 `RuntimeError` 并 `coro.close()` 防泄漏警告。
- fork 安全:`os.register_at_fork` 在子进程重置锁与 worker 状态(父进程的 worker 线程不会被 fork 带过去),子进程首次调用时重建。

## 作用域与已知限制
- 仅改 `_utils.py`,`AsyncOpenViking` 路径不受影响;与后端(S3/本地)无关,纯客户端行为。
- 协程现在跑在 worker 线程上:调用方的 contextvars 不再传播到协程(旧纯 sync 路径会传播)。SDK 自身与 httpx 均不依赖调用方 contextvars,无实际影响,但属行为变化。
- 在运行中的循环里调 sync API 会阻塞该循环线程直到完成——sync API 的固有语义,notebook 场景符合预期。
- worker 循环经 atexit 关闭;若关停时有任务悬挂超 5s,循环不 close,泄漏至进程退出。worker 线程重建时 atexit 可能重复注册,处理函数幂等,无害。
- 旧代码在无循环分支有 `set_event_loop` 副作用,新代码不再设置;依赖该副作用的代码(极边缘,`get_event_loop` 已弃用)行为会变。

## 修复的问题
- F-09 sync 调用在已有运行循环内触发 RuntimeError,Python 禁止同线程嵌套运行循环(`sdk/python/openviking_sdk/_utils.py:21`)

## 合入价值
**P1** · sync 客户端在 Jupyter 与 async 宿主内从"全接口不可用"变为可直接使用,同时修掉跨循环 httpx 连接亲和的隐患。

## 验证
review 复核实测(隔离副本,系统 Python 3.10):
- 基线复现:`asyncio.run` 内调用旧 `run_async` → `RuntimeError: Cannot run the event loop while another loop is running`(F-09 确认真实)
- patched 探针:纯 sync 调用、运行中循环内嵌套调用、异常类型保真(ValueError 原样抛出)、重入守卫(worker 循环内再调 → RuntimeError 而非死锁)、fork 探针(子进程重建 worker 后返回 child-ok,exit 0)——全部通过
- `python -m pytest sdk/python/tests -q`:patched 58 passed / 6 failed,基线 56 passed / 6 failed;6 个失败两侧完全相同(`test_glob_normalizes_scope_uri` + 5 个依赖完整仓库树的 legacy shim/exports 用例,环境性失败)。即 PR 零测试回归,新增 2 个用例通过
- `python -m py_compile sdk/python/openviking_sdk/_utils.py sdk/python/tests/test_utils.py` 通过

---
自动化全仓清扫(2026-07)· draft 待 review
