### PR TITLE
fix(bot): OpenAPI channel concurrency, session deletion, and context handling

### DIFF
--- a/bot/tests/test_openapi_auth.py
+++ b/bot/tests/test_openapi_auth.py
@@ -15,8 +15,9 @@ from fastapi.testclient import TestClient
 from vikingbot.bus.events import OutboundEventType, OutboundMessage
 from vikingbot.bus.queue import MessageBus
 from vikingbot.channels.openapi import OpenAPIChannel, OpenAPIChannelConfig, PendingResponse
-from vikingbot.channels.openapi_models import ChatResponse
+from vikingbot.channels.openapi_models import ChatRequest, ChatResponse
 from vikingbot.config.schema import BotChannelConfig, SessionKey
+from vikingbot.session.manager import Session
 
 
 @pytest.fixture
@@ -50,6 +51,41 @@ class _AsyncBytesStream(httpx.AsyncByteStream):
 
 
 class TestOpenAPIAuth:
+    def test_chat_request_rejects_unsupported_context(self):
+        with pytest.raises(ValueError, match="context is not supported"):
+            ChatRequest(message="hello", context=[{"role": "user", "content": "prior"}])
+        assert ChatRequest(message="hello", context=[]).context == []
+
+    def test_chat_rejects_second_in_flight_request(self, message_bus, temp_workspace):
+        channel = OpenAPIChannel(OpenAPIChannelConfig(), message_bus, temp_workspace)
+        scope = channel._principal_scope("standalone")
+        storage_key = channel._scoped_session_id(scope, "same-session")
+        channel._pending[storage_key] = PendingResponse()
+
+        response = _make_client(channel).post(
+            "/bot/v1/chat", json={"message": "hello", "session_id": "same-session"}
+        )
+
+        assert response.status_code == 409
+        assert message_bus.inbound_size == 0
+
+    def test_delete_removes_history_and_rotates_storage_key(
+        self, message_bus, temp_workspace
+    ):
+        channel = OpenAPIChannel(OpenAPIChannelConfig(), message_bus, temp_workspace)
+        client = _make_client(channel)
+        session_id = client.post("/bot/v1/sessions", json={}).json()["session_id"]
+        scope = channel._principal_scope("standalone")
+        storage_key = channel._scoped_session_id(scope, session_id)
+        key = SessionKey(type="cli", channel_id="default", chat_id=storage_key)
+        channel._session_manager._save_unlocked(Session(key=key))
+
+        response = client.delete(f"/bot/v1/sessions/{session_id}")
+
+        assert response.status_code == 200
+        assert not channel._session_manager.has_persisted(key)
+        assert channel._scoped_session_id(scope, session_id) != storage_key
+
     def test_health_remains_available_without_api_key(self, message_bus, temp_workspace):
         channel = OpenAPIChannel(
             OpenAPIChannelConfig(),

--- a/bot/vikingbot/channels/openapi.py
+++ b/bot/vikingbot/channels/openapi.py
@@ -148,6 +148,7 @@ class OpenAPIChannel(BaseChannel):
         # Regular OpenAPI pending and sessions
         self._pending: Dict[str, PendingResponse] = {}
         self._sessions: Dict[str, Dict[str, Any]] = {}
+        self._session_generations: Dict[str, int] = {}
         # BotChannel pending and sessions - key is channel_id
         self._bot_pending: Dict[str, Dict[str, PendingResponse]] = {}
         self._bot_sessions: Dict[str, Dict[str, Dict[str, Any]]] = {}
@@ -470,7 +471,15 @@ class OpenAPIChannel(BaseChannel):
             if storage_key not in channel._sessions:
                 raise HTTPException(status_code=404, detail="Session not found")
 
+            channel._ensure_no_pending(channel._pending, storage_key)
+            session_key = SessionKey(
+                type="cli",
+                channel_id=channel.config.channel_id(),
+                chat_id=storage_key,
+            )
+            channel._session_manager.delete(session_key)
             del channel._sessions[storage_key]
+            channel._advance_session_generation(scope, session_id)
             return {"deleted": True}
 
         # ========== Bot Channel Routes ==========
@@ -1014,9 +1023,23 @@ class OpenAPIChannel(BaseChannel):
             )
         return self._principal_scope(f"openviking:{account_id}:{user_id}")
 
+    def _scoped_session_id(self, principal_scope: str, session_id: str) -> str:
+        base = f"{principal_scope}:{session_id}"
+        generation = self._session_generations.get(base, 0)
+        return base if generation == 0 else f"{base}:{generation}"
+
+    def _advance_session_generation(self, principal_scope: str, session_id: str) -> None:
+        base = f"{principal_scope}:{session_id}"
+        self._session_generations[base] = self._session_generations.get(base, 0) + 1
+
     @staticmethod
-    def _scoped_session_id(principal_scope: str, session_id: str) -> str:
-        return f"{principal_scope}:{session_id}"
+    def _ensure_no_pending(
+        pending: Dict[str, PendingResponse], storage_key: str
+    ) -> None:
+        if storage_key in pending:
+            raise HTTPException(
+                status_code=409, detail="Session already has a request in progress"
+            )
 
     async def _gateway_health(self, request: Request) -> dict[str, Any]:
         from vikingbot import __version__
@@ -1176,6 +1199,7 @@ class OpenAPIChannel(BaseChannel):
         session_id = request.session_id or str(uuid.uuid4())
         storage_key = self._scoped_session_id(request._principal_scope, session_id)
         user_id = self._request_user_id(request)
+        self._ensure_no_pending(self._pending, storage_key)
 
         # Create session if new
         if storage_key not in self._sessions:
@@ -1205,11 +1229,7 @@ class OpenAPIChannel(BaseChannel):
                 chat_id=storage_key,
             )
 
-            # Build content with context if provided
             content = request.message
-            if request.context:
-                # Context is handled separately by session manager
-                pass
 
             # Create and publish inbound message
             msg = InboundMessage(
@@ -1255,6 +1275,7 @@ class OpenAPIChannel(BaseChannel):
         session_id = request.session_id or str(uuid.uuid4())
         storage_key = self._scoped_session_id(request._principal_scope, session_id)
         user_id = self._request_user_id(request)
+        self._ensure_no_pending(self._pending, storage_key)
 
         # Create session if new
         if storage_key not in self._sessions:
@@ -1327,6 +1348,7 @@ class OpenAPIChannel(BaseChannel):
         session_id = request.session_id or str(uuid.uuid4())
         storage_key = self._scoped_session_id(request._principal_scope, session_id)
         user_id = self._request_user_id(request)
+        self._ensure_no_pending(self._bot_pending[channel_id], storage_key)
 
         # Ensure channel has session storage
         if channel_id not in self._bot_sessions:
@@ -1360,11 +1382,7 @@ class OpenAPIChannel(BaseChannel):
                 chat_id=storage_key,
             )
 
-            # Build content with context if provided
             content = request.message
-            if request.context:
-                # Context is handled separately by session manager
-                pass
 
             # Create and publish inbound message
             msg = InboundMessage(
@@ -1414,6 +1432,7 @@ class OpenAPIChannel(BaseChannel):
         session_id = request.session_id or str(uuid.uuid4())
         storage_key = self._scoped_session_id(request._principal_scope, session_id)
         user_id = self._request_user_id(request)
+        self._ensure_no_pending(self._bot_pending[channel_id], storage_key)
 
         # Ensure channel has session storage
         if channel_id not in self._bot_sessions:

--- a/bot/vikingbot/channels/openapi_models.py
+++ b/bot/vikingbot/channels/openapi_models.py
@@ -89,6 +89,12 @@ class ChatRequest(BaseModel):
         description="Authenticated OpenViking connection forwarded by the server proxy",
     )
 
+    @model_validator(mode="after")
+    def reject_unsupported_context(self) -> "ChatRequest":
+        if self.context:
+            raise ValueError("context is not supported")
+        return self
+
 
 class ChatResponse(BaseModel):
     """Response from chat endpoint (non-streaming)."""


### PR DESCRIPTION
## 概述
OpenAPI 通道三处缺陷：并发请求互相覆盖同一会话的待响应 tracker，响应串给错误请求方且前一请求挂满 300s；DELETE 会话只清内存索引，磁盘 JSONL 与 agent 侧缓存会让"已删除"的历史随 ID 复用复活；公开的 `context` 字段被接收但从未送达 agent。本 PR 对同会话并发请求返回 409，删除时同步清除持久化文件并轮换存储代次，所有 chat 路径对非空 `context` 返回 422。

## 为什么必要(可达性/严重性)
三个问题都在第一道防线上，无上游拦截，但影响面按身份域(principal scope)收敛，诚实定级 P1 而非 P0：

- **C-09 并发串扰**：`_handle_chat` 无条件执行 `self._pending[storage_key] = pending`，第二个请求覆盖第一个的 tracker；agent 的第一条响应会填进第二个请求的 tracker(拿到别人的答案)，第一个请求等一个永不触发的 event 直到 300s 超时 504。且第一个请求的 `finally` 会 pop 掉第二个请求的 tracker，把错误级联下去。**可达性**：storage_key 含 principal scope 前缀(api_key 模式下为 `sha256(openviking:account:user)`)，串扰只发生在同一 account+user 的并发调用之间(如同一用户多端)；standalone 无鉴权部署下所有调用方共享 scope，串扰可跨调用方——但该模式本就无身份隔离。不构成跨租户泄露，是可靠性/正确性缺陷。
- **C-10 删除不彻底**：旧 delete_session 只 `del channel._sessions[storage_key]`(进程内字典)。会话真身是 SessionManager 写入的 `sessions/*.jsonl`，且 agent loop 持有**独立的** SessionManager 实例(loop.py:179)带独立 `_cache`。复用同一 session_id 时 agent 侧 `get_or_create`(loop.py:1195) 命中缓存或从磁盘重载，被"成功删除"(返回 200)的隐私敏感历史直接复活。假成功 + 数据残留，删除语义完全落空。
- **C-11 context 被静默丢弃**：`ChatRequest.context` 是公开 API 字段，四条 chat 路径全部 `if request.context: pass`，客户端以为注入了上下文实际什么都没发生。静默降级比报错更糟。

## 关键设计与取舍
- **409 而非排队**(C-09)：`_ensure_no_pending` 在四个 chat 入口(chat / chat/stream / chat/channel / chat/channel/stream)检查后拒绝。检查与 `_pending[storage_key] = pending` 赋值之间全部是同步字典操作、无 await，asyncio 单线程下无 TOCTOU 窗口。备选方案是按 session 排队串行执行，但需要队列生命周期管理且客户端要面对不可预期的延迟——409 让客户端显式重试，语义更清晰、代码更少。
- **删文件 + 代次轮换双管齐下**(C-10)：仅删磁盘文件不够——agent 侧独立 SessionManager 的 `_cache` 仍持有完整历史，同 key 下一条消息会命中缓存并把历史重新写回磁盘。轮换后 `_scoped_session_id` 返回 `base:N`，新消息用全新 SessionKey，agent 缓存永不命中旧对象。`_session_generations` 只在内存：进程重启后代次归零回到 base key，但届时磁盘文件已删、agent 缓存也已消亡，语义自洽。删除前还检查 in-flight 请求(409)，避免删除与进行中对话竞争。
- **422 而非静默忽略或实现注入**(C-11)：model_validator 拒绝非空 context(空列表仍允许，保持 schema 兼容)。真正实现 context 注入需要打通 agent 会话装配，超出清扫修复范围；在支持之前给诚实错误。**行为变化**：此前发送 context 的客户端得到 200(内容被丢弃)，现在得到 422——仓内无任何调用方发送该字段，外部客户端若依赖"发了也没用"的行为会开始收到报错，这是有意的契约收紧。

## 作用域与已知限制
- 串扰修复覆盖全部四条 chat 路径(regular + bot channel、同步 + 流式)。`_scoped_session_id` 由 staticmethod 改为实例方法，全部 9 处调用点均为实例调用，无破坏。
- **删除仍以进程内 `_sessions` 索引为 404 闸门**(沿袭原逻辑)：进程重启后旧会话不在索引里，DELETE 返回 404、磁盘文件不动。区别于修复前的"假成功"，这是诚实失败，但跨重启删除仍不可用——如需支持应让 DELETE 回退检查 `has_persisted`，建议另开 issue。
- 前置身份作用域改造遗留的 legacy 无前缀会话文件(openapi.py:1595 附近的 legacy_key 回退)不在本次删除范围内，仅影响旧版本产生的存量数据。
- bot channel(`/chat/channel`)会话本就没有删除路由，C-10 修复只涉及 regular 路由，无遗漏。
- `_pending`/`_sessions`/`_session_generations` 均为进程内存，多 worker 部署下本就不成立，非本 PR 引入。

## 修复的问题
- C-09 第二个并发请求覆盖前一个 tracker，响应串给错误调用方、前者挂到 300s(bot/vikingbot/channels/openapi.py:1196-1198)
- C-10 delete_session 只清内存索引，磁盘 JSONL 与 agent 缓存令已删历史随 ID 复用复活(bot/vikingbot/channels/openapi.py:461-474)
- C-11 公开的 ChatRequest.context 字段被接收但从未送达 agent(bot/vikingbot/channels/openapi_models.py:66-78)

## 合入价值
**P1** · 同一身份并发调用不再串响应或吊死五分钟；DELETE 返回 200 即代表磁盘历史真正清除且不因 ID 复用复活(隐私语义)；context 从静默丢弃改为诚实 422。串扰限同 principal scope 之内、删除限进程存活期内的会话，无跨租户泄露面，故为 P1 而非 P0。

## 验证
- `python -m pytest bot/tests/test_openapi_auth.py -q` — **31 passed**(reviewer 复跑确认；含新增 3 个用例：非空 context 拒绝、同会话第二请求 409、删除清持久化并轮换 storage key)。
- 人工核对：`_ensure_no_pending` 检查点到 `_pending` 赋值之间无 await(四条路径)；`_bot_pending[channel_id]` 在路由层 `channel._bot_configs` 校验后必然存在，无 KeyError 路径；delete 构造的 SessionKey(type="cli", channel_id=config.channel_id(), chat_id=storage_key) 与 chat 写入路径完全一致。

---
自动化全仓清扫(2026-07)· draft 待 review
