### PR TITLE
fix(session): strict memory_policy booleans and lossless unicode peer ids

### DIFF
--- a/openviking/ingest/peer.py
+++ b/openviking/ingest/peer.py
@@ -43,12 +43,15 @@ def safe_external_peer(raw: Optional[str]) -> Optional[str]:
     text = str(raw).strip()
     if not text:
         return None
+    if not text.isascii():
+        encoded = base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+        return safe_peer_id(f"ext-{encoded}")
     sanitized = _sanitize_component(text)
     if sanitized:
         pid = safe_peer_id(sanitized)
         if pid:
             return pid
-    # Non-ASCII / unsanitizable -> stable, valid, unique fallback.
+    # Unsanitizable ASCII -> stable, valid, unique fallback.
     encoded = base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
     return safe_peer_id(f"ext-{encoded}")
 

--- a/openviking/session/memory_policy.py
+++ b/openviking/session/memory_policy.py
@@ -33,7 +33,12 @@ def _target_enabled(data: Any, *, default_enabled: bool, key: str = "target") ->
     extra_keys = set(data) - _TARGET_KEYS
     if extra_keys:
         raise InvalidArgumentError(_memory_policy_keys_error(key))
-    return bool(data.get("enabled", default_enabled))
+    if "enabled" not in data:
+        return default_enabled
+    enabled = data["enabled"]
+    if not isinstance(enabled, bool):
+        raise InvalidArgumentError(f"memory_policy.{key}.enabled must be a boolean")
+    return enabled
 
 
 def _parse_memory_types(data: Any) -> Optional[set[str]]:

--- a/tests/ingest/test_peer.py
+++ b/tests/ingest/test_peer.py
@@ -27,6 +27,15 @@ def test_external_peer_non_ascii_falls_back_to_ext():
     assert pid is not None and pid.startswith("ext-")
 
 
+def test_external_peer_mixed_unicode_encodes_full_value_without_collisions():
+    first = safe_external_peer("张三 Alice")
+    second = safe_external_peer("李四 Alice")
+
+    assert first != second
+    assert first is not None and first.startswith("ext-")
+    assert second is not None and second.startswith("ext-")
+
+
 def test_git_human_peer_falls_back_without_repo(tmp_path):
     # tmp_path is not a git repo -> configured fallback is used
     assert resolve_git_human_peer(str(tmp_path), "me") == "me"

--- a/tests/unit/session/test_memory_policy.py
+++ b/tests/unit/session/test_memory_policy.py
@@ -66,6 +66,12 @@ def test_memory_policy_rejects_invalid_working_memory_shape():
         MemoryPolicy.from_dict({"working_memory": {"enabled": True, "mode": "summary"}})
 
 
+@pytest.mark.parametrize("target", ["self", "peer", "working_memory"])
+def test_memory_policy_rejects_non_boolean_enabled(target):
+    with pytest.raises(InvalidArgumentError, match="enabled must be a boolean"):
+        MemoryPolicy.from_dict({target: {"enabled": "false"}})
+
+
 def test_memory_policy_rejects_invalid_memory_types():
     policy = MemoryPolicy.from_dict({"memory_types": ["profile", "missing"]})
 


### PR DESCRIPTION
## 概述
两个会把用户身份/隐私开关搞错的输入处理缺陷：memory_policy 的 `enabled` 按 truthiness 判断，字符串 `"false"` 反而当成开启；含 Unicode 的用户名清洗有损，不同用户折叠成同一 peer_id。改为严格布尔校验 + 非 ASCII 用户名整体 base64 编码。

## 为什么必要（可达性/严重性）
两处都是第一道防线，上游无任何拦截：

- A-05：HTTP API `CreateSessionRequest.memory_policy` 的类型是 `Optional[Dict[str, Any]]`（openviking/server/routers/sessions.py:125），pydantic 不校验内层值，SDK/CLI 也原样透传 dict。`{"peer": {"enabled": "false"}}` 一路到 `MemoryPolicy.from_dict`（session_service.py:157 创建路径、session.py:1367 commit 路径），`bool("false")` 为 True——调用方明确要求关闭 peer 记忆抽取，系统却继续抽取。在 main 上实测复现：`peer_enabled == True`。
- A-10：群聊 harness（hermes/openclaw）的 ingest 用日志里的原始用户名生成 peer_id（openviking/ingest/sources/base.py:86 → safe_external_peer）。`_sanitize_component` 把非 ASCII 字符全部剥掉，实测 `"张三 Alice"` 和 `"李四 Alice"` 都塌缩成 `Alice`——不同人的消息与记忆归到同一 peer，跨用户错误串联。

诚实定级 **P1** 而非 P0：A-05 需要调用方发非布尔值才触发（JSON 的 true/false 解析为 Python bool，不受影响）；A-10 需要群聊日志里出现混合文字用户名。都真实可达，但有输入条件。

## 关键设计与取舍
- **enabled 非布尔直接报 InvalidArgumentError，而不是解析 `"false"`/`"true"` 字符串**。隐私开关宁可 fail-loud：静默猜语义会让 `"no"`、`"0"` 这类值继续歧义。缺省 `enabled` 键仍走默认值，行为不变。
- **非 ASCII 用户名整体 base64（`ext-` 前缀），而不是"清洗 + hash 后缀"**。整体编码可逆、无碰撞，且与已有的 unsanitizable fallback 用同一编码公式——纯 CJK 用户名的 peer_id 完全不变（main 与本分支都是 `ext-5byg5LiJ`）。base64 urlsafe 字母表落在 peer_id 允许字符集内，`safe_peer_id` 恒通过。
- 纯 ASCII 用户名路径零改动，保持人类可读。

## 作用域与已知限制
- **行为变化仅限混合 Unicode 用户名**：此前 `"张三 Alice"` → `Alice`，现在 → `ext-…`。这正是修复本身，但意味着这批用户历史数据在旧 peer_id 下，新数据在新 id 下，本 PR 不做存量迁移；此前已被污染的 peer（真 Alice + 被塌缩进来的他人数据）也无法回溯拆分。
- **兼容性**：此前发 `"enabled": "true"` / `1` 的调用方（若存在）现在会收到 400 而不是静默开启。这是有意的收紧。
- 与存储后端无关（S3/本地均同），纯输入解析层。

## 修复的问题
- A-05 memory_policy.enabled 用 truthiness 而非严格布尔，字符串 `"false"` 也会开启记忆抽取（openviking/session/memory_policy.py:36）
- A-10 混合 Unicode 用户名有损清洗后塌缩成相同 peer_id，跨用户错误归因（openviking/ingest/peer.py:39）

## 合入价值
**P1** · 隐私开关行为可预测（fail-loud），不同用户的消息/记忆不再因用户名清洗合并到同一 peer。

## 验证
- `pytest -q --no-cov tests/unit/session/test_memory_policy.py tests/ingest/test_peer.py` — 15 passed
- main 复现：`from_dict({'peer': {'enabled': 'false'}}).peer_enabled` → True；`safe_external_peer('张三 Alice') == safe_external_peer('李四 Alice')` → 都是 `Alice`
- 本分支：前者抛 `memory_policy.peer.enabled must be a boolean`；后者 `ext-5byg5LiJIEFsaWNl` ≠ `ext-5p2O5ZubIEFsaWNl`
- 回归确认：纯 ASCII id 不变（`alice@corp.com`）、纯 CJK id 与 main 一致（`ext-5byg5LiJ`）、真布尔与缺省 `enabled` 行为不变

---
自动化全仓清扫（2026-07）· draft 待 review
