### PR TITLE
fix(crypto): 禁止重写 Vault root key on 临时 (503) read failures

### DIFF
--- a/openviking/crypto/providers.py
+++ b/openviking/crypto/providers.py
@@ -437,9 +437,13 @@ class VaultProvider(BaseProvider):
 
             self._root_key = secrets.token_bytes(32)
 
-            # Encrypt and store root key in Vault kv
-            encrypted_root_key = await self._encrypt_with_vault(self._root_key)
+            # Encrypt and store root key in Vault kv. Any failure here (transit
+            # encrypt down, KV write outage) must clear the cached ephemeral key
+            # before raising: otherwise a retried get_root_key() hits the
+            # `self._root_key is not None` fast path and encrypts data with a key
+            # that was never persisted — the data-loss class this provider guards.
             try:
+                encrypted_root_key = await self._encrypt_with_vault(self._root_key)
                 if self.kv_version == 2:
                     await asyncio.to_thread(
                         client.secrets.kv.v2.create_or_update_secret,
@@ -464,6 +468,7 @@ class VaultProvider(BaseProvider):
                     )
                 logger.info("Created and stored new root key in Vault")
             except Exception as e:
+                self._root_key = None
                 raise ConfigError(
                     f"Failed to persist root key to Vault. "
                     f"Refusing to start with ephemeral key (data loss risk): {e}"

--- a/openviking/crypto/providers.py
+++ b/openviking/crypto/providers.py
@@ -415,6 +415,8 @@ class VaultProvider(BaseProvider):
         client = await self._get_client()
         import base64
 
+        from hvac.exceptions import InvalidPath
+
         try:
             # Try to read encrypted root key from Vault kv
             if self.kv_version == 2:
@@ -423,19 +425,13 @@ class VaultProvider(BaseProvider):
                     path=self.encrypted_root_key_key,
                     mount_point=self.kv_mount_path,
                 )
-                encrypted_root_key_b64 = response["data"]["data"]["encrypted_root_key"]
             else:
                 response = await asyncio.to_thread(
                     client.secrets.kv.v1.read_secret,
                     path=self.encrypted_root_key_key,
                     mount_point=self.kv_mount_path,
                 )
-                encrypted_root_key_b64 = response["data"]["encrypted_root_key"]
-
-            encrypted_root_key = base64.b64decode(encrypted_root_key_b64)
-            self._root_key = await self._decrypt_with_vault(encrypted_root_key)
-            logger.info("Loaded existing root key from Vault")
-        except Exception:
+        except InvalidPath:
             # Generate new root key
             import secrets
 
@@ -472,6 +468,15 @@ class VaultProvider(BaseProvider):
                     f"Failed to persist root key to Vault. "
                     f"Refusing to start with ephemeral key (data loss risk): {e}"
                 )
+            return self._root_key
+
+        if self.kv_version == 2:
+            encrypted_root_key_b64 = response["data"]["data"]["encrypted_root_key"]
+        else:
+            encrypted_root_key_b64 = response["data"]["encrypted_root_key"]
+        encrypted_root_key = base64.b64decode(encrypted_root_key_b64)
+        self._root_key = await self._decrypt_with_vault(encrypted_root_key)
+        logger.info("Loaded existing root key from Vault")
 
         return self._root_key
 

--- a/tests/unit/crypto/test_providers_mock.py
+++ b/tests/unit/crypto/test_providers_mock.py
@@ -15,7 +15,9 @@ import base64
 import os
 import secrets
 import struct
+import sys
 import tempfile
+from types import ModuleType
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -63,6 +65,20 @@ def vault_mock_provider():
     provider._ensure_root_key_exists = AsyncMock()
 
     yield provider
+
+
+@pytest.fixture
+def vault_invalid_path(monkeypatch):
+    class InvalidPath(Exception):
+        pass
+
+    hvac = ModuleType("hvac")
+    exceptions = ModuleType("hvac.exceptions")
+    exceptions.InvalidPath = InvalidPath
+    hvac.exceptions = exceptions
+    monkeypatch.setitem(sys.modules, "hvac", hvac)
+    monkeypatch.setitem(sys.modules, "hvac.exceptions", exceptions)
+    return InvalidPath
 
 
 @pytest.fixture
@@ -197,6 +213,47 @@ class TestVaultProviderMock:
             ciphertext = await encryptor.encrypt(account_id, plaintext)
             assert ciphertext.startswith(b"OVE1")
             assert ciphertext[5] == PROVIDER_VAULT
+
+    @pytest.mark.asyncio
+    async def test_root_key_read_failure_never_creates(
+        self, vault_mock_provider, vault_invalid_path
+    ):
+        client = Mock()
+        client.secrets.kv.v1.read_secret.side_effect = RuntimeError("Vault unavailable")
+        vault_mock_provider._get_client = AsyncMock(return_value=client)
+
+        with pytest.raises(RuntimeError, match="Vault unavailable"):
+            await vault_mock_provider._get_or_create_root_key()
+
+        client.secrets.kv.v1.create_or_update_secret.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_root_key_is_created(self, vault_mock_provider, vault_invalid_path):
+        client = Mock()
+        client.secrets.kv.v1.read_secret.side_effect = vault_invalid_path()
+        vault_mock_provider._get_client = AsyncMock(return_value=client)
+        vault_mock_provider._encrypt_with_vault = AsyncMock(return_value=b"vault:ciphertext")
+
+        root_key = await vault_mock_provider._get_or_create_root_key()
+
+        assert len(root_key) == 32
+        client.secrets.kv.v1.create_or_update_secret.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_root_key_decrypt_failure_never_creates(
+        self, vault_mock_provider, vault_invalid_path
+    ):
+        client = Mock()
+        client.secrets.kv.v1.read_secret.return_value = {
+            "data": {"encrypted_root_key": base64.b64encode(b"vault:ciphertext").decode()}
+        }
+        vault_mock_provider._get_client = AsyncMock(return_value=client)
+        vault_mock_provider._decrypt_with_vault = AsyncMock(side_effect=RuntimeError("bad key"))
+
+        with pytest.raises(RuntimeError, match="bad key"):
+            await vault_mock_provider._get_or_create_root_key()
+
+        client.secrets.kv.v1.create_or_update_secret.assert_not_called()
 
 
 class TestVolcengineKMSProviderMock:

--- a/tests/unit/crypto/test_providers_mock.py
+++ b/tests/unit/crypto/test_providers_mock.py
@@ -28,6 +28,7 @@ from openviking.crypto.providers import (
     PROVIDER_LOCAL,
     PROVIDER_VAULT,
     PROVIDER_VOLCENGINE,
+    ConfigError,
     LocalFileProvider,
     VaultProvider,
     VolcengineKMSProvider,
@@ -238,6 +239,27 @@ class TestVaultProviderMock:
 
         assert len(root_key) == 32
         client.secrets.kv.v1.create_or_update_secret.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_clears_cache_and_retries(
+        self, vault_mock_provider, vault_invalid_path
+    ):
+        """A failed persist must not leave an unpersisted ephemeral key cached."""
+        client = Mock()
+        client.secrets.kv.v1.read_secret.side_effect = vault_invalid_path()
+        client.secrets.kv.v1.create_or_update_secret.side_effect = RuntimeError("write outage")
+        vault_mock_provider._get_client = AsyncMock(return_value=client)
+        vault_mock_provider._encrypt_with_vault = AsyncMock(return_value=b"vault:ciphertext")
+
+        with pytest.raises(ConfigError, match="data loss risk"):
+            await vault_mock_provider.get_root_key()
+
+        # Cache must be cleared so a retry re-reads Vault instead of returning
+        # via the get_root_key fast path a key that was never persisted.
+        assert vault_mock_provider._root_key is None
+        with pytest.raises(ConfigError, match="data loss risk"):
+            await vault_mock_provider.get_root_key()
+        assert client.secrets.kv.v1.read_secret.call_count == 2
 
     @pytest.mark.asyncio
     async def test_root_key_decrypt_failure_never_creates(


### PR DESCRIPTION
## 概述
Vault provider 加载根密钥时,原代码用宽泛 `except Exception` 把一切读取失败当作"密钥不存在":Vault 瞬时 503、sealed 状态、token 过期、KV 响应损坏、transit 解密失败,都会触发生成新根密钥并用 `create_or_update_secret` 覆盖 KV 中已有的加密根密钥。本 PR 把"创建新密钥"收窄到 hvac 明确抛出 `InvalidPath`(读取 404,密钥确实不存在)的情况,其余异常一律上抛;同时修复持久化失败后内存缓存未清除的次生数据丢失路径。

## 为什么必要(可达性/严重性)
- 第一道防线,无上游兜底。链路:`encryption.enabled=true` + `provider=vault` → `bootstrap_encryption`(openviking/crypto/config.py:152)→ `VaultProvider._get_or_create_root_key`(openviking/crypto/providers.py:405)。每次进程冷启动后的首个加解密操作都会走到这里,中间没有任何 guard 区分"密钥不存在"与"Vault 暂时不可用"。
- 触发条件是日常运维事件:Vault 重启后处于 sealed 状态即返回 503;此时 OpenViking 进程一启动就覆盖根密钥,不需要攻击者参与。
- 后果:默认 `kv_version=1` 下旧加密根密钥被永久覆盖,所有存量加密数据不可解且无法恢复;`kv_version=2` 有版本历史可手工回滚,但数据面已切到新密钥,存量数据同样立即不可用。
- 诚实定级:P0 成立,作用域限定在启用 Vault provider 的部署。默认的 local provider 和 volcengine_kms provider 不受影响 —— 两者本就用显式存在性检查,读取/解密失败直接抛错,从不重建密钥。

## 关键设计与取舍
- 以 hvac 的 `InvalidPath`(kv v1/v2 读取 404 的标准异常)作为唯一"密钥不存在"信号。备选方案是先 list/预读再决定写入,但多一次往返且存在 TOCTOU 窗口,异常类型收窄更直接。
- 响应解析、base64 解码、transit 解密移出 try 块:这些步骤失败意味着"密钥存在但数据坏了",正确行为是报错停机,而不是覆盖重建。
- 持久化失败时先 `self._root_key = None` 再抛 `ConfigError`:原代码把临时密钥留在缓存里,调用方捕获异常后重试 `get_root_key()` 会命中快路径直接返回这把从未落盘的密钥,用它加密的数据在进程重启后永久不可解 —— 与主 bug 同类。transit encrypt 也移入同一 try,失败同样清缓存后抛 `ConfigError`。

## 作用域与已知限制
- 仅改 VaultProvider;LocalFileProvider / VolcengineKMSProvider 已是安全模式,未改动。
- `_ensure_root_key_exists`(providers.py:341,transit 引擎密钥)仍是宽泛 except,但 transit `create_key` 对已存在的 key 是幂等 no-op,不会轮换或覆盖,无数据丢失风险,不在本 PR 范围。
- kv v2 中 soft-delete 后读取同样抛 `InvalidPath`,会按"不存在"新建 —— 与删除语义一致。
- 行为变化(刻意):Vault 不可用时进程启动直接失败,而不是"自愈"成新密钥。fail-closed 优于静默毁数据;运维需知启动报错即代表 Vault 侧需先恢复。

## 修复的问题
- B-01 宽泛 except 使任何 Vault 读取/解码/解密失败都触发覆盖已有加密根密钥(openviking/crypto/providers.py:420)
- B-01 附带:根密钥持久化失败后内存缓存未清,重试经 `get_root_key()` 快路径拿到未落盘的临时密钥(openviking/crypto/providers.py:468)

## 合入价值
**P0(限 Vault provider 部署,第一道防线)** · 瞬时 Vault 故障不再触发不可逆的根密钥覆盖;持久化失败不再把临时密钥泄露给重试路径。

## 验证
- `python -m pytest -q tests/unit/crypto/test_providers_mock.py --no-cov` — 合入后的 origin/main 实测 17 passed
- 新增 4 个用例:读失败不创建、仅 `InvalidPath` 才创建、持久化失败清缓存且重试重新读 Vault、解密失败不创建

---
自动化全仓清扫(2026-07)· 已于 2026-07-24 合入 main
