### PR TITLE
fix(ov): honor ovcli.conf output and upload.mode settings

### DIFF
--- a/crates/ov_cli/src/config.rs
+++ b/crates/ov_cli/src/config.rs
@@ -247,6 +247,7 @@ impl Config {
         let config: Config = serde_json::from_str(&content)
             .map_err(|e| Error::Config(format!("Failed to parse config file: {}", e)))?;
         config.validate_identity_mode()?;
+        config.validate_output()?;
         Ok(config)
     }
 
@@ -304,6 +305,16 @@ impl Config {
             return Err(Error::Config(
                 "actor_peer_id cannot be used with agent_id".to_string(),
             ));
+        }
+        Ok(())
+    }
+
+    fn validate_output(&self) -> Result<()> {
+        if !matches!(self.output.as_str(), "table" | "json") {
+            return Err(Error::Config(format!(
+                "Invalid output value {:?}: expected table or json",
+                self.output
+            )));
         }
         Ok(())
     }
@@ -456,6 +467,18 @@ mod tests {
             .expect_err("mixed identity mode should fail");
 
         assert!(error.to_string().contains("actor_peer_id cannot be used"));
+    }
+
+    #[test]
+    fn config_file_rejects_invalid_output() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("ovcli.conf");
+        std::fs::write(&path, r#"{"output": "yaml"}"#)
+            .expect("config file should be written");
+
+        let error = Config::from_file(&path.to_string_lossy())
+            .expect_err("invalid output should fail");
+        assert!(error.to_string().contains("Invalid output value \"yaml\""));
     }
 
     #[test]

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -118,12 +118,11 @@ struct Cli {
         short,
         long,
         value_enum,
-        default_value = "table",
         global = true,
         hide = true,
         value_name = "table|json"
     )]
-    output: OutputFormat,
+    output: Option<OutputFormat>,
 
     /// Use compact table/JSON rendering
     #[arg(
@@ -2552,6 +2551,10 @@ fn language_command_can_run_picker(has_language_value: bool, is_interactive: boo
     has_language_value || is_interactive
 }
 
+fn resolve_output_format(cli_output: Option<OutputFormat>, config: &Config) -> OutputFormat {
+    cli_output.unwrap_or_else(|| OutputFormat::from(config.output.as_str()))
+}
+
 #[tokio::main]
 async fn main() {
     let args = preprocess_cli_args(std::env::args_os().collect());
@@ -2617,7 +2620,7 @@ async fn main() {
         }
     };
 
-    let output_format = cli.output;
+    let output_override = cli.output;
     let compact = cli.compact;
     let legacy_upload_options = UploadCliOptions {
         progress: cli.progress,
@@ -2680,7 +2683,7 @@ async fn main() {
             error_ui::print_runtime_error(
                 &command_display,
                 &e,
-                output_format,
+                pre_parse_output_format,
                 compact,
                 cli.verbose,
             );
@@ -2703,13 +2706,14 @@ async fn main() {
             error_ui::print_runtime_error(
                 &command_display,
                 &e,
-                output_format,
+                pre_parse_output_format,
                 compact,
                 cli.verbose,
             );
             std::process::exit(2);
         }
     };
+    let output_format = resolve_output_format(output_override, &config);
     let ctx = CliContext::from_config(
         config,
         output_format,
@@ -3276,7 +3280,7 @@ mod tests {
         first_command_token, is_language_command_request, language_command_can_run_picker,
         language_gate_action, language_required_message, legacy_upload_option_error,
         plain_help_misuse, pre_parse_output_options, pre_parse_requires_cli_config_file,
-        preprocess_cli_args, preprocess_privacy_args,
+        preprocess_cli_args, preprocess_privacy_args, resolve_output_format,
     };
     use crate::config::{Config, DEFAULT_CUSTOM_URL};
     use crate::output::OutputFormat;
@@ -4010,7 +4014,7 @@ mod tests {
         let show_global_output =
             Cli::try_parse_from(["ov", "skills", "show", "code-review", "-o", "json"])
                 .expect("skills show should accept global -o after the subcommand");
-        assert_eq!(show_global_output.output, OutputFormat::Json);
+        assert_eq!(show_global_output.output, Some(OutputFormat::Json));
 
         let remove = Cli::try_parse_from(["ov", "skills", "remove", "foo", "bar", "--yes"])
             .expect("skills remove --yes should parse");
@@ -4412,6 +4416,20 @@ mod tests {
                 "{args:?} should treat help as an option value"
             );
         }
+    }
+
+    #[test]
+    fn configured_output_is_used_unless_cli_overrides_it() {
+        let mut config = Config::default();
+        config.output = "json".to_string();
+
+        assert_eq!(resolve_output_format(None, &config), OutputFormat::Json);
+        assert_eq!(
+            resolve_output_format(Some(OutputFormat::Table), &config),
+            OutputFormat::Table
+        );
+        let cli = Cli::try_parse_from(["ov", "status"]).unwrap();
+        assert_eq!(cli.output, None);
     }
 
     #[test]

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -191,7 +191,7 @@ client.initialize()
 #### HTTP Call Examples
 
 - CLI, `SyncHTTPClient`, and `AsyncHTTPClient` automatically upload local files or directories before calling the server API.
-- Python HTTP client and CLI can also opt into shared temporary uploads via client config (`ovcli.conf` -> `upload.mode = "shared"`).
+- Python HTTP clients can opt into shared temporary uploads through `ovcli.conf` (`upload.mode = "shared"`). The Rust `ov` CLI does not read that field; set `OPENVIKING_UPLOAD_MODE=shared` for `ov` instead.
 - Raw HTTP calls don't get this convenience layer. When using `curl` or other HTTP clients, you need to first call `POST /api/v1/resources/temp_upload`, then pass the returned `temp_file_id` to the target API.
 - `temp_upload` defaults to `upload_mode=local`. Use `upload_mode=shared` only when you explicitly want distributed shared temporary uploads.
 - For raw HTTP imports of local directories, you need to first zip them into a `.zip` file and upload using the above method; the server does not accept direct host directory paths.

--- a/docs/en/api/04-skills.md
+++ b/docs/en/api/04-skills.md
@@ -183,7 +183,7 @@ Skills are a special type of resource that define actions or tools agents can pe
     - Send structured skill data directly in `data`
     - Send raw `SKILL.md` content in `data`
     - First call `POST /api/v1/resources/temp_upload` to upload a local `SKILL.md` file/zip directory, then call `POST /api/v1/skills` with `temp_file_id`
-    - `temp_upload` defaults to local temporary storage; pass `upload_mode=shared` only when you explicitly need distributed shared temporary uploads. In Python HTTP client / CLI flows, this can also be driven by `ovcli.conf` via `upload.mode = "shared"`
+    - `temp_upload` defaults to local temporary storage; pass `upload_mode=shared` only when you explicitly need distributed shared temporary uploads. Python HTTP clients can set `upload.mode = "shared"` in `ovcli.conf`; the Rust `ov` CLI instead uses `OPENVIKING_UPLOAD_MODE=shared`
   - `POST /api/v1/skills` does not accept direct host filesystem paths in `data`.
 
 - **Targeting**:

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1427,7 +1427,7 @@ Config file for the HTTP client (`SyncHTTPClient` / `AsyncHTTPClient`) and CLI t
 | `upload.ignore_dirs` | Default directory ignore list for `add-resource` (CSV) | `null` |
 | `upload.include` | Default include patterns for `add-resource` (CSV) | `null` |
 | `upload.exclude` | Default exclude patterns for `add-resource` (CSV) | `null` |
-| `upload.mode` | Temporary upload backend: `"local"` (per-instance disk) or `"shared"` (distributed shared store, required when consumer requests can land on a different server instance than the upload). Per-call override via `OPENVIKING_UPLOAD_MODE`. | `null` (server's `temp_upload.default_mode`, which itself defaults to `"local"`) |
+| `upload.mode` | Python HTTP-client temporary upload backend: `"local"` (per-instance disk) or `"shared"` (distributed shared store). The Rust `ov` CLI does not read this field; set `OPENVIKING_UPLOAD_MODE=shared` for shared uploads. | `null` (server's `temp_upload.default_mode`, which itself defaults to `"local"`) |
 
 Local directory uploads respect `.gitignore` files (root and nested). `ignore_dirs/include/exclude` apply on top of that.
 

--- a/docs/en/guides/07-operation-telemetry.md
+++ b/docs/en/guides/07-operation-telemetry.md
@@ -120,7 +120,7 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
 ```
 
 This endpoint currently accepts the boolean form only.
-`upload_mode` is also a form field for this endpoint; it defaults to `local` and should only be set to `shared` when you explicitly need distributed shared temporary uploads. Python HTTP client / CLI users can alternatively drive the same behavior with `ovcli.conf` -> `upload.mode = "shared"`.
+`upload_mode` is also a form field for this endpoint; it defaults to `local` and should only be set to `shared` when you explicitly need distributed shared temporary uploads. Python HTTP clients can alternatively set `upload.mode = "shared"` in `ovcli.conf`; the Rust `ov` CLI uses `OPENVIKING_UPLOAD_MODE=shared` instead.
 
 ## Common summary groups
 

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -186,7 +186,7 @@ client.initialize()
 #### HTTP 调用示例
 
 - CLI、`SyncHTTPClient`、`AsyncHTTPClient` 遇到本地文件或目录时，会先自动上传，再调用服务端 API。
-- Python HTTP client 和 CLI 也可以通过客户端配置启用 shared 临时上传（`ovcli.conf` 中设置 `upload.mode = "shared"`）。
+- Python HTTP client 可以通过 `ovcli.conf` 启用 shared 临时上传（设置 `upload.mode = "shared"`）。Rust `ov` CLI 不读取这个字段；使用 `ov` 时请设置 `OPENVIKING_UPLOAD_MODE=shared`。
 - 裸 HTTP 调用没有这层封装。使用 `curl` 或其他 HTTP 客户端时，需要先调用 `POST /api/v1/resources/temp_upload`，再把返回的 `temp_file_id` 传给目标 API。
 - `temp_upload` 默认使用 `upload_mode=local`。只有在你显式需要分布式共享临时上传时，才应传 `upload_mode=shared`。
 - 裸 HTTP 如果导入本地目录，需要先自行打成 `.zip` 再通过上述方法上传；服务端不接受直接传宿主机目录路径。

--- a/docs/zh/api/04-skills.md
+++ b/docs/zh/api/04-skills.md
@@ -183,7 +183,7 @@ This tool wraps the MCP tool `search-web`. Call this when the user needs functio
     1. 在 `data` 中直接传结构化 skill 数据
     2. 在 `data` 中直接传原始 `SKILL.md` 内容
     3. 先调用 `POST /api/v1/resources/temp_upload` 上传本地 `SKILL.md` 文件/zip 目录，再调用 `POST /api/v1/skills` 并传入 `temp_file_id`
-    4. `temp_upload` 默认使用本地临时存储；只有在明确需要分布式共享临时上传时，才传 `upload_mode=shared`。在 Python HTTP client / CLI 流程里，也可以通过 `ovcli.conf` 的 `upload.mode = "shared"` 驱动这一行为
+    4. `temp_upload` 默认使用本地临时存储；只有在明确需要分布式共享临时上传时，才传 `upload_mode=shared`。Python HTTP client 可以在 `ovcli.conf` 中设置 `upload.mode = "shared"`；Rust `ov` CLI 则使用 `OPENVIKING_UPLOAD_MODE=shared`
   - `POST /api/v1/skills` 不接受在 `data` 中直接传宿主机本地路径。
 
 - **目标规则**：

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1393,7 +1393,7 @@ HTTP 客户端（`SyncHTTPClient` / `AsyncHTTPClient`）和 CLI 工具连接远�
 | `upload.ignore_dirs` | `add-resource` 默认忽略目录列表（CSV） | `null` |
 | `upload.include` | `add-resource` 默认包含模式（CSV） | `null` |
 | `upload.exclude` | `add-resource` 默认排除模式（CSV） | `null` |
-| `upload.mode` | 临时上传后端：`"local"`（仅当前实例本地磁盘）或 `"shared"`（分布式共享存储，当消费请求可能落到不同实例时必需）。可通过 `OPENVIKING_UPLOAD_MODE` 单次覆盖。 | `null`（使用服务端 `temp_upload.default_mode`，默认仍为 `"local"`） |
+| `upload.mode` | Python HTTP client 的临时上传后端：`"local"`（仅当前实例本地磁盘）或 `"shared"`（分布式共享存储）。Rust `ov` CLI 不读取这个字段；如需 shared 上传，请设置 `OPENVIKING_UPLOAD_MODE=shared`。 | `null`（使用服务端 `temp_upload.default_mode`，默认仍为 `"local"`） |
 
 本地目录上传会默认遵循 `.gitignore`（根目录和子目录，含 `!` 反向规则）。`ignore_dirs/include/exclude` 会在此基础上进一步过滤。
 

--- a/docs/zh/guides/07-operation-telemetry.md
+++ b/docs/zh/guides/07-operation-telemetry.md
@@ -120,7 +120,7 @@ curl -X POST http://localhost:1933/api/v1/resources/temp_upload \
 ```
 
 这个接口当前只支持布尔形态的表单参数。
-这个接口的 `upload_mode` 也是表单字段；默认值为 `local`，只有在明确需要分布式共享临时上传时，才应设置为 `shared`。Python HTTP client / CLI 用户也可以通过 `ovcli.conf` 的 `upload.mode = "shared"` 达到同样效果。
+这个接口的 `upload_mode` 也是表单字段；默认值为 `local`，只有在明确需要分布式共享临时上传时，才应设置为 `shared`。Python HTTP client 也可以在 `ovcli.conf` 中设置 `upload.mode = "shared"`；Rust `ov` CLI 则使用 `OPENVIKING_UPLOAD_MODE=shared`。
 
 ## 常见 summary 分组
 


### PR DESCRIPTION
## 概述
`ovcli.conf` 的 `output` 是死配置:clap 给 `--output` 注入了 `default_value = "table"`,CLI 层永远有值,配置文件里的 output 从未参与解析,非法值也被静默当成 table。本 PR 把 `--output` 改为 `Option<OutputFormat>`,按「CLI 显式覆盖 > 配置默认 > table」解析,并在配置加载时校验取值;同时修正 EN/ZH 四处文档——`ovcli.conf` 的 `upload.mode` 只对 Python HTTP client 生效,Rust `ov` 从不读取该字段。

## 根因
- E-12:`crates/ov_cli/src/main.rs` 中 `--output` 带 `default_value = "table"`,`main()` 直接取 `cli.output`,`Config.output` 字段(config.rs:63)从未被读。`OutputFormat::From<&str>` 又把一切非 "json" 的值映射为 Table,所以 `output = "yaml"` 这类错误配置也无声通过。
- D-02:Rust 侧 `UploadConfig`(config.rs)只有 `ignore_dirs/include/exclude` 三个字段,没有 `mode`;serde 默认忽略未知字段,`upload.mode` 被静默丢弃。文档却宣称「Python HTTP client 和 CLI」都支持,与实现不符。

## 严重性(诚实定级)
纯客户端行为,无安全或数据丢失风险。E-12 是 P2 级配置一致性缺陷(影响所有在 ovcli.conf 设置了 output 的用户)。D-02 的文档误导在多实例部署下有实际运维后果:运维照文档给 `ov` 配 `upload.mode = "shared"`,实际仍走 local 临时盘,消费请求落到其他实例时会找不到临时文件——这是本 PR 里最接近 P1 的部分。综合低于 sweep 给的 P1,按 P2+文档修正看待即可。

## 关键设计与取舍
- output 解析放在 config 加载之后、`CliContext` 构造之前(main.rs `resolve_output_format`)。加载 config 前的错误路径走 `error_ui`,不依赖 output_format,无窗口期问题。
- 校验放在 `Config::from_file`(fail-fast,报错信息含非法值),不改 `From<&str>` 的宽松语义——后者还被子命令级 `--format`(如 `skills show`)复用,其「flag > ctx.output_format」优先级保持不变。
- D-02 选择改文档而非让 Rust CLI 真正读取 `upload.mode`。理由:`OPENVIKING_UPLOAD_MODE` 已覆盖该需求(client.rs:151,校验 shared/local),文档对齐现实是零回归风险的最小修复;后续若要 wire 配置字段,与本 PR 不冲突。

## 作用域与已知限制
- 行为变化:已有配置文件中 output 为非法值的用户,以前静默按 table,现在所有命令启动即报 `Invalid output value ...: expected table or json`。改一行配置即恢复,属预期的 fail-fast。
- Rust CLI 依旧不读取 `upload.mode`,本 PR 只让文档如实陈述。Python SDK 侧行为不变(已核对:sdk/python/openviking_sdk/config.py:155 读取 `upload.mode`,client.py:522 随请求发送)。
- 生产代码仅 `Config::from_file` 一处反序列化 Config,校验无旁路;config wizard/agent 不写 output 字段。

## 修复的问题
- E-12 配置的 output 默认值是死配置且不校验,`output=json` 仍输出 table(crates/ov_cli/src/main.rs, crates/ov_cli/src/config.rs)
- D-02 文档误称 Rust `ov` 会读取 `ovcli.conf` 的 `upload.mode`,实际被静默丢弃(docs/en+zh: api/01-overview.md, api/04-skills.md, guides/01-configuration.md, guides/07-operation-telemetry.md)

## 合入价值
**P2(D-02 多实例场景接近 P1)** · 持久化 output 偏好按可预期优先级生效并 fail-fast;文档不再误导运维在 Rust CLI 上配置无效的 upload.mode。

## 验证
- `cargo test -p ov_cli output` — 35 passed,含新增 `config_file_rejects_invalid_output`、`configured_output_is_used_unless_cli_overrides_it`(review 时在 PR 分支实测复跑通过)
- `cargo check -p ov_cli` — 通过

---
自动化全仓清扫(2026-07)· draft 待 review
