### PR TITLE
fix(bot): make one-click Docker deployment generate a working config and port mapping

### DIFF
--- a/bot/deploy/docker/README.md
+++ b/bot/deploy/docker/README.md
@@ -212,30 +212,28 @@ REMOVE_IMAGE=true REMOVE_VOLUME=true ./deploy/docker/stop.sh
 
 ## 配置文件
 
-首次部署时，脚本会自动创建配置文件：`~/.vikingbot/config.json`
+首次部署时，脚本会自动创建配置文件：`~/.vikingbot/ov.conf`。脚本同时生成随机 Gateway Token；在非本机请求中通过 `X-Gateway-Token` 请求头传入该值。
 
 编辑该文件填入你的 API keys：
 
 ```json
 {
-  "providers": {
-    "openrouter": {
-      "apiKey": "sk-or-xxx"
+  "bot": {
+    "agents": {
+      "provider": "openrouter",
+      "model": "openrouter/anthropic/claude-3.5-sonnet",
+      "api_key": "sk-or-xxx"
+    },
+    "gateway": {
+      "host": "0.0.0.0",
+      "port": 18791,
+      "token": "脚本生成的随机值"
     }
-  },
-  "agents": {
-    "defaults": {
-      "model": "openrouter/anthropic/claude-3.5-sonnet"
-    }
-  },
-  "gateway": {
-    "host": "0.0.0.0",
-    "port": 18791
   }
 }
 ```
 
-**重要：** Console Web UI 端口是 **18791**，不是 18790！
+**重要：** `bot.gateway.port` 必须与 `CONTAINER_PORT` 一致；脚本默认都使用 **18791**。
 
 ## 访问控制台
 

--- a/bot/deploy/docker/deploy.sh
+++ b/bot/deploy/docker/deploy.sh
@@ -2,7 +2,7 @@
 # Vikingbot 本地一键部署脚本
 # ~/.vikingbot 会挂载到容器的 /root/.vikingbot（bridge 首次启动时自动初始化）
 # 用法: ./deploy/docker/deploy.sh
-# 变量: CONTAINER_NAME, IMAGE_NAME, IMAGE_TAG, HOST_PORT, COMMAND, AUTO_BUILD, PLATFORM
+# 变量: CONTAINER_NAME, IMAGE_NAME, IMAGE_TAG, HOST_PORT, CONTAINER_PORT, COMMAND, AUTO_BUILD, PLATFORM
 
 set -e
 
@@ -19,11 +19,12 @@ CONTAINER_NAME=${CONTAINER_NAME:-vikingbot}
 IMAGE_NAME=${IMAGE_NAME:-vikingbot}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 HOST_PORT=${HOST_PORT:-18791}
+CONTAINER_PORT=${CONTAINER_PORT:-18791}
 COMMAND=${COMMAND:-gateway}
 AUTO_BUILD=${AUTO_BUILD:-true}
 # openviking 只有 linux/amd64 wheel，固定使用 amd64（Apple Silicon 由 Docker Desktop Rosetta 模拟）
 PLATFORM=${PLATFORM:-linux/amd64}
-VIKINGBOT_DIR="$HOME/.vikingbot"
+VIKINGBOT_DIR=${VIKINGBOT_DIR:-"$HOME/.vikingbot"}
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}  Vikingbot 本地部署${NC}"
@@ -57,30 +58,31 @@ fi
 # 3. 初始化 ~/.vikingbot 目录
 echo -e "${GREEN}[3/6]${NC} 初始化 ${VIKINGBOT_DIR}..."
 mkdir -p "$VIKINGBOT_DIR/workspace" "$VIKINGBOT_DIR/sessions" "$VIKINGBOT_DIR/sandboxes" "$VIKINGBOT_DIR/bridge"
-# 创建 OpenViking 配置文件占位符
-touch "$VIKINGBOT_DIR/ov.conf"
 echo -e "  ${GREEN}✓${NC} 目录已就绪"
 
 # 4. 检查配置文件
 echo -e "${GREEN}[4/6]${NC} 检查配置文件..."
-CONFIG_FILE="$VIKINGBOT_DIR/config.json"
-if [ ! -f "$CONFIG_FILE" ]; then
+CONFIG_FILE="$VIKINGBOT_DIR/ov.conf"
+if [ ! -s "$CONFIG_FILE" ]; then
     echo -e "  ${YELLOW}配置文件不存在，创建默认配置...${NC}"
-    cat > "$CONFIG_FILE" << 'EOF'
+    if command -v openssl &> /dev/null; then
+        GATEWAY_TOKEN=$(openssl rand -hex 32)
+    else
+        GATEWAY_TOKEN=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')
+    fi
+    cat > "$CONFIG_FILE" << EOF
 {
-  "providers": {
-    "openrouter": {
-      "apiKey": ""
+  "bot": {
+    "agents": {
+      "provider": "openrouter",
+      "model": "openrouter/anthropic/claude-3.5-sonnet",
+      "api_key": ""
+    },
+    "gateway": {
+      "host": "0.0.0.0",
+      "port": ${CONTAINER_PORT},
+      "token": "${GATEWAY_TOKEN}"
     }
-  },
-  "agents": {
-    "defaults": {
-      "model": "openrouter/anthropic/claude-3.5-sonnet"
-    }
-  },
-  "gateway": {
-    "host": "0.0.0.0",
-    "port": 18791
   }
 }
 EOF
@@ -107,7 +109,7 @@ echo -e "${GREEN}[6/6]${NC} 启动容器..."
 echo "  容器名: ${CONTAINER_NAME}"
 echo "  镜像:   ${IMAGE_NAME}:${IMAGE_TAG}"
 echo "  命令:   vikingbot ${COMMAND}"
-echo "  端口:   ${HOST_PORT} → 18791"
+echo "  端口:   ${HOST_PORT} → ${CONTAINER_PORT}"
 echo "  挂载:   ${VIKINGBOT_DIR} → /root/.vikingbot"
 echo ""
 
@@ -116,7 +118,7 @@ docker run -d \
     --restart unless-stopped \
     --platform "${PLATFORM}" \
     -v "${VIKINGBOT_DIR}:/root/.vikingbot" \
-    -p "${HOST_PORT}:18791" \
+    -p "${HOST_PORT}:${CONTAINER_PORT}" \
     -e OPENVIKING_CONFIG_FILE=/root/.vikingbot/ov.conf \
     "${IMAGE_NAME}:${IMAGE_TAG}" \
     "${COMMAND}"


### PR DESCRIPTION
## 概述
`bot/deploy/docker/deploy.sh` 宣称一键部署，实际部署出来的 gateway 100% 不可达。本 PR 让脚本生成真正被 vikingbot 读取的 `ov.conf`（含随机 gateway token），并把配置端口、输出提示、`docker run -p` 统一到 `CONTAINER_PORT`。

## 根因（不是症状）
旧脚本的失败链，已逐环节对照代码确认：

1. 脚本 `touch` 出一个空的 `~/.vikingbot/ov.conf`，并把真实配置写进 `~/.vikingbot/config.json`（`providers/agents.defaults/gateway` 顶层结构）。但 bot/ 下没有任何运行时代码读 `config.json`（全仓 grep 仅命中文档；`bot/docs/zh/design/rfc-openviking-cli-ov-chat.md:285` 明确写了"不再使用 config.json"）。vikingbot 只读 `OPENVIKING_CONFIG_FILE` 指向的 `ov.conf` 的 `bot` 段（bot/vikingbot/config/loader.py:27-45, 100）。
2. 容器内 `vikingbot gateway` 加载空 `ov.conf` → `json.loads("")` 抛 JSONDecodeError → 静默回退到 `Config()` 默认值（loader.py:142-146）：gateway 默认 `127.0.0.1:18790`（schema.py:525-526）。
3. Docker 发布的是 `HOST_PORT:18791`：容器内 18791 无人监听，且 127.0.0.1 绑定本身就无法从发布端口转发。两处都错，服务必然连不上。

另外 README 环境变量表在 main 上早已文档化 `CONTAINER_PORT`（bot/deploy/docker/README.md:180），但旧脚本硬编码 `-p "${HOST_PORT}:18791"`，从未读它——本 PR 同时补上这个文档与实现的缺口。

## 可达性/严重性
第一道防线，无上游兜底：deploy.sh 就是入口本身，按 `bot/deploy/docker/README.md` 操作即 100% 复现。功能性 bug（宣传的部署路径完全失效），非安全漏洞、无数据丢失，手工写 ov.conf 可绕过——诚实定级 **P1**，不是 P0。

## 关键设计与取舍
- **`host: 0.0.0.0` + 随机 token 是绑定的**：`vikingbot gateway` 对非 localhost 绑定强制要求 `bot.gateway.token`，缺失直接 `exit(1)`（cli/commands.py:403-409, schema.py:518-519）。容器内必须 0.0.0.0 才能从发布端口访问，所以 token 生成不是可选加固，是启动的前置条件。fail-closed：即使 openssl 和 dd 都缺失导致 token 为空，gateway 也会拒绝启动并给出明确 SECURITY 报错，不会裸奔。
- **`[ ! -s ]` 而非 `[ ! -f ]`**：旧脚本部署过的机器上留有 `touch` 出来的空 ov.conf，按 `-f` 判断会跳过生成、复现原 bug；按 `-s` 判断则自动迁移。已存在的非空 ov.conf 不动，token 跨重复部署持久（在宿主机卷上）。
- **替代方案**：沿用 `config.json` 并让 vikingbot 读它——需要改配置加载器且与 RFC 定下的"ov.conf 单一配置"方向相反，不取。保持 127.0.0.1 + `--network host`——macOS Docker Desktop 上 host 网络不可用，不取。

## 作用域与已知限制
- 只改部署脚本和其 README，不触碰 vikingbot 运行时代码，无回归面。
- 旧部署的 `config.json` 里的 API key 不迁移（该文件从来没被读过，不存在行为回退），文件原样留下被忽略，用户需把 key 填进新生成的 ov.conf。
- ov.conf 已存在时再改 `CONTAINER_PORT` 不会自动同步配置里的端口，README 已注明二者必须一致。
- 容器仍以 standalone 模式运行（无 `server` 段，OpenViking memory/文件工具不可用），与改动前一致，不属本 PR 范围。

## 修复的问题
- C-12 生成的配置从不被读取，且默认 gateway 监听地址/端口（127.0.0.1:18790）与 Docker 发布端口（18791）不一致，一键部署产物不可达（bot/deploy/docker/deploy.sh:60-91）

## 合入价值
**P1** · 让文档宣传的本地 Docker 一键部署真正产出可达且带 token 保护的 gateway，并补齐 README 已承诺的 `CONTAINER_PORT` 支持。

## 验证
以 stub docker 实跑分支版 deploy.sh（`VIKINGBOT_DIR` 指向临时目录）：
- 首次运行：生成 `ov.conf`，`bot.gateway = {host: "0.0.0.0", port: 18888(=CONTAINER_PORT), token: 64 位 hex}`，`bot.agents` 字段与 `AgentsConfig`（provider/model/api_key）逐一对上；脚本按预期 exit 1 提示填 API key。
- 二次运行：`docker run` 收到 `-p 19999:18888` 与 `-e OPENVIKING_CONFIG_FILE=/root/.vikingbot/ov.conf`，token 未被重新生成（持久化确认）。
- 迁移场景：把 ov.conf 置为空文件（模拟旧脚本残留），重跑后自动重新生成。
- `bash -n deploy.sh` 通过；`X-Gateway-Token` 头名与鉴权实现核对一致（channels/openapi.py:330, 880-911）。

---
自动化全仓清扫(2026-07)· draft 待 review
