### PR TITLE
docs(bot): correct channel setup config paths and license metadata

### DIFF
--- a/bot/docs/en/concepts/05-channel.md
+++ b/bot/docs/en/concepts/05-channel.md
@@ -14,6 +14,8 @@ Talk to your vikingbot through Telegram, Discord, WhatsApp, Feishu, Mochat, Ding
 | **Email** | Medium (IMAP/SMTP credentials) |
 | **QQ** | Easy (app credentials) |
 
+Channel configuration lives at `bot.channels` in `~/.openviking/ov.conf`. The complete Telegram example below shows the wrapper; later snippets show the `channels` field to merge into the same `bot` object.
+
 <details>
 <summary><b>Telegram</b> (recommended)</summary>
 
@@ -27,14 +29,16 @@ Talk to your vikingbot through Telegram, Discord, WhatsApp, Feishu, Mochat, Ding
 
 ```json
 {
-  "channels": [
-    {
-      "type": "telegram",
-      "enabled": true,
-      "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
-    }
-  ]
+  "bot": {
+    "channels": [
+      {
+        "type": "telegram",
+        "enabled": true,
+        "token": "YOUR_BOT_TOKEN",
+        "allowFrom": ["YOUR_USER_ID"]
+      }
+    ]
+  }
 }
 ```
 
@@ -62,7 +66,7 @@ Send the following message to vikingbot, replacing `xxx@xxx` with your actual em
 Read https://raw.githubusercontent.com/HKUDS/MoChat/refs/heads/main/skills/vikingbot/skill.md and register on MoChat. My Email account is xxx@xxx Bind me as your owner and DM me on MoChat.
 ```
 
-vikingbot automatically registers, updates `~/.vikingbot/config.json`, and connects to Mochat.
+After registration, add the returned channel settings to `bot.channels` in `~/.openviking/ov.conf` and connect to Mochat.
 
 **2. Restart the gateway**
 
@@ -77,7 +81,7 @@ That is all—vikingbot handles the rest.
 <details>
 <summary>Manual configuration (advanced)</summary>
 
-If you prefer to configure Mochat manually, add the following to `~/.vikingbot/config.json`:
+If you prefer to configure Mochat manually, merge the following `channels` field into the `bot` object in `~/.openviking/ov.conf`:
 
 > Keep `claw_token` secret. It should only be sent to your Mochat API endpoint in the `X-Claw-Token` header.
 

--- a/bot/docs/zh/concepts/05-channel.md
+++ b/bot/docs/zh/concepts/05-channel.md
@@ -14,6 +14,8 @@
 | **邮件** | 中等（IMAP/SMTP 凭证） |
 | **QQ** | 简单（应用凭证） |
 
+渠道配置位于 `~/.openviking/ov.conf` 的 `bot.channels`。下面的 Telegram 示例展示完整外层结构；后续片段中的 `channels` 字段都应合并到同一个 `bot` 对象中。
+
 <details>
 <summary><b>Telegram</b>（推荐）</summary>
 
@@ -26,14 +28,16 @@
 
 ```json
 {
-  "channels": [
-    {
-      "type": "telegram",
-      "enabled": true,
-      "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
-    }
-  ]
+  "bot": {
+    "channels": [
+      {
+        "type": "telegram",
+        "enabled": true,
+        "token": "YOUR_BOT_TOKEN",
+        "allowFrom": ["YOUR_USER_ID"]
+      }
+    ]
+  }
 }
 ```
 
@@ -62,7 +66,7 @@ vikingbot gateway
 Read https://raw.githubusercontent.com/HKUDS/MoChat/refs/heads/main/skills/vikingbot/skill.md and register on MoChat. My Email account is xxx@xxx Bind me as your owner and DM me on MoChat.
 ```
 
-vikingbot 将自动注册、配置 `~/.vikingbot/config.json` 并连接到 Mochat。
+注册后，请将返回的渠道设置添加到 `~/.openviking/ov.conf` 的 `bot.channels`，然后连接 Mochat。
 
 **2. 重启网关**
 
@@ -77,7 +81,7 @@ vikingbot gateway
 <details>
 <summary>手动配置（高级）</summary>
 
-如果您更喜欢手动配置，请将以下内容添加到 `~/.vikingbot/config.json`：
+如果您更喜欢手动配置，请将下面的 `channels` 字段合并到 `~/.openviking/ov.conf` 的 `bot` 对象：
 
 > 请保密 `claw_token`。它只应在 `X-Claw-Token` 头中发送到您的 Mochat API 端点。
 

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "bot",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.37"
       }

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "bot",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.37"
       }

--- a/bot/package.json
+++ b/bot/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.37"

--- a/bot/package.json
+++ b/bot/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.37"


### PR DESCRIPTION
## 概述
渠道文档仍沿用上游 nanobot 独立部署时代的 `~/.vikingbot/config.json` + 顶层 `channels` 布局；bot 并入 OpenViking 后 loader 只读 `~/.openviking/ov.conf` 并从 `bot` 字段取配置（`bot/vikingbot/config/loader.py`：`get_config_path()` 固定解析 `~/.openviking/ov.conf`，`load_config()` 只取 `full_data.get("bot", {})`），文档没跟上——这是根因。新用户照文档粘贴，配置落在 loader 从不读取的文件里，渠道静默禁用且无报错。同时 `bot/package.json` 声明 ISC，与仓库根 LICENSE（AGPL-3.0）不符。

本 PR 让中英文渠道文档全部指向 `ov.conf` 的 `bot.channels`，并把 npm 元数据对齐为 AGPL-3.0。纯文档 + 元数据改动，不触碰任何代码路径，无回归可能。

## 关键设计与取舍
- 只有第一个 Telegram 示例展示完整 `{"bot": {"channels": [...]}}` 外层结构，其余 8 个渠道片段保持 `channels` 字段原样，由新增的开头说明统一交代"合并进同一个 `bot` 对象"。备选方案是给每个片段都加外层包裹——拒绝：9 处重复噪音大，且与 ov.conf 实际用法（往已有 `bot` 对象里合并字段，而非整文件粘贴）不符。
- MoChat 一节原文声称"vikingbot 自动注册并更新 `~/.vikingbot/config.json`"——`bot/vikingbot/channels/mochat.py` 中不存在任何配置写入逻辑（只写游标文件），改为"注册后手动把返回的渠道设置加入 `bot.channels`"，与代码实际行为一致。
- license 取 `AGPL-3.0` 这个写法（而非 `AGPL-3.0-only`）是为了与根 `pyproject.toml` 的 `license = "AGPL-3.0"` 完全一致。sdk/typescript、npm/cli 等对外发布包刻意用 Apache-2.0，但 `bot/` 无独立 LICENSE，受根 AGPL-3.0 约束；该包不发布到 npm，改动仅影响协议扫描器读数。

## 作用域与已知限制
- `bot/deploy/docker/README.md` 与 `bot/docs/zh/design/rfc-openviking-cli-ov-chat.md` 仍提及 `~/.vikingbot/config.json`，不在本 PR 范围。前者面向用户，建议后续跟进；后者是历史设计文档，可保留原貌。

## 修复的问题
- C-13 渠道示例指向 loader 从不读取的配置文件与层级，渠道被静默禁用（`bot/docs/en/concepts/05-channel.md`、`bot/docs/zh/concepts/05-channel.md`）
- C-15 npm 包元数据声明 ISC，与随包分发的 AGPL-3.0 协议不一致（`bot/package.json`、`bot/package-lock.json`）

## 合入价值
**P2（文档正确性，定级与清扫一致）** · 新用户按文档配置渠道即可生效，消除"配了没反应"的静默失败陷阱；协议元数据与仓库权威声明一致。

## 验证
- `rg -n 'ov.conf|\.vikingbot' bot/vikingbot/config/loader.py` — 确认 loader 只读 `~/.openviking/ov.conf`，且从 `bot` 字段加载（第 45、100 行）。
- `rg -n 'channels' bot/vikingbot/config/schema.py` — 确认 `channels` 是 bot 配置的字段（第 797 行），即 `bot.channels` 层级正确。
- `sed -n '31,42p' bot/docs/en/concepts/05-channel.md | jq empty`、`sed -n '30,41p' bot/docs/zh/concepts/05-channel.md | jq empty` — 示例 JSON 合法。
- `jq -e '.license == "AGPL-3.0"' bot/package.json` 及 lockfile 根 package 同项 — 通过；与根 `pyproject.toml` 的 license 写法一致。

---
自动化全仓清扫(2026-07)· draft 待 review
