### PR TITLE
fix(cli): preserve server config sections and restrict ov.conf permissions in setup wizard

### DIFF
--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -1828,8 +1828,8 @@ def _update_existing_config(config_path: Path, section: str) -> int:
             _summarize_server(server_dict),
         )
         updated_server = {**current_server, **server_dict}
-        updated_server.pop("auth_mode", None)
         if server_dict.get("host") == "127.0.0.1":
+            updated_server.pop("auth_mode", None)
             updated_server.pop("root_api_key", None)
         data["server"] = updated_server
 

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -15,6 +15,7 @@ import select
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -397,7 +398,6 @@ def _prompt_confirm(prompt: str, default: bool = True) -> bool:
     if not raw:
         return default
     return raw in ("y", "yes")
-
 
 
 def _rule(title: str) -> None:
@@ -879,8 +879,6 @@ def _ollama_vlm_config(vlm: VLMPreset) -> dict[str, Any]:
     }
 
 
-
-
 def _build_query_planner_config(preset: QueryPlannerPreset) -> dict[str, Any]:
     """Build the ``query_planner`` config block for an Ollama-served model.
 
@@ -934,19 +932,32 @@ def _next_backup_path(config_path: Path) -> Path:
 
 def _write_config(config_dict: dict[str, Any], config_path: Path) -> bool:
     """Write config dict as JSON. Backs up existing file as .bak (rotates on conflict)."""
+    temp_path: Path | None = None
     try:
         config_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, raw_temp_path = tempfile.mkstemp(prefix=f".{config_path.name}.", dir=config_path.parent)
+        temp_path = Path(raw_temp_path)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(config_dict, indent=2, ensure_ascii=False) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_path, 0o600)
         if config_path.exists():
             backup = _next_backup_path(config_path)
-            config_path.rename(backup)
+            os.chmod(config_path, 0o600)
+            shutil.copy2(config_path, backup)
+            os.chmod(backup, 0o600)
             print(f"  {_dim('Existing config backed up to ' + str(backup))}")
-        config_path.write_text(
-            json.dumps(config_dict, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-        )
+        os.replace(temp_path, config_path)
+        temp_path = None
+        os.chmod(config_path, 0o600)
         return True
     except OSError as exc:
         print(f"  {_red(f'Failed to write config: {exc}')}")
         return False
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -1528,7 +1539,6 @@ def _wizard_two_step() -> tuple[dict[str, Any] | None | object, bool | None]:
         return config, ollama_running
 
 
-
 def _wizard_server(current: dict[str, Any] | None = None) -> dict[str, Any] | None:
     """Prompt for server binding, port, and auth (root API key when remote).
 
@@ -1802,7 +1812,10 @@ def _update_existing_config(config_path: Path, section: str) -> int:
             _summarize_server(current_server),
             _summarize_server(server_dict),
         )
-        data["server"] = server_dict
+        updated_server = {**current_server, **server_dict}
+        if server_dict.get("host") == "127.0.0.1":
+            updated_server.pop("root_api_key", None)
+        data["server"] = updated_server
 
     print(f"\n  {_bold('Change:')} {old_summary}")
     print(f"      {_cyan('→')}    {new_summary}")

--- a/openviking_cli/setup_wizard.py
+++ b/openviking_cli/setup_wizard.py
@@ -930,6 +930,22 @@ def _next_backup_path(config_path: Path) -> Path:
         i += 1
 
 
+def _write_secure_backup(config_path: Path, backup: Path) -> None:
+    fd, raw_temp_path = tempfile.mkstemp(prefix=f".{backup.name}.", dir=backup.parent)
+    temp_path = Path(raw_temp_path)
+    try:
+        with os.fdopen(fd, "wb") as target, config_path.open("rb") as source:
+            shutil.copyfileobj(source, target)
+            target.flush()
+            os.fsync(target.fileno())
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, backup)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
 def _write_config(config_dict: dict[str, Any], config_path: Path) -> bool:
     """Write config dict as JSON. Backs up existing file as .bak (rotates on conflict)."""
     temp_path: Path | None = None
@@ -945,8 +961,7 @@ def _write_config(config_dict: dict[str, Any], config_path: Path) -> bool:
         if config_path.exists():
             backup = _next_backup_path(config_path)
             os.chmod(config_path, 0o600)
-            shutil.copy2(config_path, backup)
-            os.chmod(backup, 0o600)
+            _write_secure_backup(config_path, backup)
             print(f"  {_dim('Existing config backed up to ' + str(backup))}")
         os.replace(temp_path, config_path)
         temp_path = None
@@ -1813,6 +1828,7 @@ def _update_existing_config(config_path: Path, section: str) -> int:
             _summarize_server(server_dict),
         )
         updated_server = {**current_server, **server_dict}
+        updated_server.pop("auth_mode", None)
         if server_dict.get("host") == "127.0.0.1":
             updated_server.pop("root_api_key", None)
         data["server"] = updated_server

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -976,7 +976,7 @@ class TestPartialUpdate:
         config_path = tmp_path / "ov.conf"
         original = _existing_config()
         original["server"].update(
-            {"auth_mode": "dev", "workers": 4, "temp_upload": {"default_mode": "shared"}}
+            {"auth_mode": "trusted", "workers": 4, "temp_upload": {"default_mode": "shared"}}
         )
         config_path.write_text(json.dumps(original), encoding="utf-8")
 
@@ -995,6 +995,7 @@ class TestPartialUpdate:
         assert data["server"] == {
             "host": "0.0.0.0",
             "root_api_key": "rk",
+            "auth_mode": "trusted",
             "workers": 4,
             "temp_upload": {"default_mode": "shared"},
         }

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -364,6 +364,21 @@ class TestConfigWriting:
         assert json.loads(config_path.read_text()) == {"old": True}
         assert not list(tmp_path.glob(".ov.conf.*"))
 
+    def test_backup_copy_failure_leaves_no_public_backup(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        config_path.write_text('{"secret": true}', encoding="utf-8")
+
+        def fail_after_partial_copy(source, target):
+            target.write(source.read(1))
+            raise OSError("copy")
+
+        with patch("openviking_cli.setup_wizard.shutil.copyfileobj", fail_after_partial_copy):
+            assert _write_config({"new": True}, config_path) is False
+
+        assert json.loads(config_path.read_text()) == {"secret": True}
+        assert not (tmp_path / "ov.conf.bak").exists()
+        assert not list(tmp_path.glob(".ov.conf*.*"))
+
     def test_run_init_redacts_summary_output(self, tmp_path):
         config_path = tmp_path / "ov.conf"
         config = {
@@ -960,7 +975,9 @@ class TestPartialUpdate:
     def test_update_server_only(self, tmp_path):
         config_path = tmp_path / "ov.conf"
         original = _existing_config()
-        original["server"].update({"workers": 4, "temp_upload": {"default_mode": "shared"}})
+        original["server"].update(
+            {"auth_mode": "dev", "workers": 4, "temp_upload": {"default_mode": "shared"}}
+        )
         config_path.write_text(json.dumps(original), encoding="utf-8")
 
         with (
@@ -986,7 +1003,7 @@ class TestPartialUpdate:
     def test_update_server_local_removes_root_key_only(self, tmp_path):
         config_path = tmp_path / "ov.conf"
         original = _existing_config()
-        original["server"].update({"root_api_key": "rk", "workers": 4})
+        original["server"].update({"auth_mode": "api_key", "root_api_key": "rk", "workers": 4})
         config_path.write_text(json.dumps(original), encoding="utf-8")
 
         with (

--- a/tests/cli/test_setup_wizard.py
+++ b/tests/cli/test_setup_wizard.py
@@ -330,6 +330,7 @@ class TestConfigWriting:
 
         assert _write_config(config, config_path) is True
         assert config_path.exists()
+        assert config_path.stat().st_mode & 0o777 == 0o600
 
         loaded = json.loads(config_path.read_text(encoding="utf-8"))
         assert loaded["embedding"]["dense"]["provider"] == "ollama"
@@ -343,6 +344,7 @@ class TestConfigWriting:
 
         backup = tmp_path / "ov.conf.bak"
         assert backup.exists()
+        assert backup.stat().st_mode & 0o777 == 0o600
         assert json.loads(backup.read_text())["old"] is True
 
     def test_creates_parent_dirs(self, tmp_path):
@@ -351,6 +353,16 @@ class TestConfigWriting:
 
         assert _write_config(config, config_path) is True
         assert config_path.exists()
+
+    def test_replace_failure_preserves_existing_config(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        config_path.write_text('{"old": true}', encoding="utf-8")
+
+        with patch("openviking_cli.setup_wizard.os.replace", side_effect=OSError("replace")):
+            assert _write_config({"new": True}, config_path) is False
+
+        assert json.loads(config_path.read_text()) == {"old": True}
+        assert not list(tmp_path.glob(".ov.conf.*"))
 
     def test_run_init_redacts_summary_output(self, tmp_path):
         config_path = tmp_path / "ov.conf"
@@ -947,7 +959,9 @@ class TestPartialUpdate:
 
     def test_update_server_only(self, tmp_path):
         config_path = tmp_path / "ov.conf"
-        config_path.write_text(json.dumps(_existing_config()), encoding="utf-8")
+        original = _existing_config()
+        original["server"].update({"workers": 4, "temp_upload": {"default_mode": "shared"}})
+        config_path.write_text(json.dumps(original), encoding="utf-8")
 
         with (
             patch(
@@ -961,8 +975,36 @@ class TestPartialUpdate:
             assert _update_existing_config(config_path, "server") == 0
 
         data = json.loads(config_path.read_text(encoding="utf-8"))
-        assert data["server"] == {"host": "0.0.0.0", "root_api_key": "rk"}
+        assert data["server"] == {
+            "host": "0.0.0.0",
+            "root_api_key": "rk",
+            "workers": 4,
+            "temp_upload": {"default_mode": "shared"},
+        }
         assert data["vlm"] == _existing_config()["vlm"]
+
+    def test_update_server_local_removes_root_key_only(self, tmp_path):
+        config_path = tmp_path / "ov.conf"
+        original = _existing_config()
+        original["server"].update({"root_api_key": "rk", "workers": 4})
+        config_path.write_text(json.dumps(original), encoding="utf-8")
+
+        with (
+            patch(
+                "openviking_cli.setup_wizard._wizard_server",
+                return_value={"host": "127.0.0.1", "port": 1933},
+            ),
+            patch("openviking_cli.setup_wizard._prompt_confirm", return_value=True),
+            patch("openviking_cli.setup_wizard._post_save_actions", return_value=None),
+            patch("builtins.print"),
+        ):
+            assert _update_existing_config(config_path, "server") == 0
+
+        assert json.loads(config_path.read_text())["server"] == {
+            "host": "127.0.0.1",
+            "port": 1933,
+            "workers": 4,
+        }
 
     def test_embedding_dimension_change_requires_confirmation(self, tmp_path):
         config_path = tmp_path / "ov.conf"


### PR DESCRIPTION
## 概述
`ov setup` 向导有两个落盘问题:更新 server 段时整段替换导致非向导字段全部丢失(B-02);`ov.conf` 及其 `.bak` 按进程 umask 落盘,常见 `022` 下含密钥的配置全局可读(B-10)。本 PR 改为按键合并 server 段,并通过 0600 临时文件原子写入配置与备份。

## 根因(不是症状)
- B-02:`_update_existing_config` 的 server 分支执行 `data["server"] = server_dict`,而 `_wizard_server` 只返回 `host`/`port`(远端另加 `root_api_key`)。`ServerConfig` 里向导不询问的所有字段——`workers`、`cors_origins`、`observability`、`temp_upload`、`with_bot`/`bot_api_url`、`public_base_url`、`encryption_enabled`、`api_key_hashing_enabled` 等——被静默丢弃、回退默认值。其中 `encryption_enabled`/`api_key_hashing_enabled` 静默回退为 false、`cors_origins` 回退为 `["*"]`,是带安全后果的回退。
- B-10:`_write_config` 用 `Path.write_text` 新建文件,权限跟随 umask(022 → 0644);旧文件 `rename` 成 `.bak` 同样保留原权限。`ov.conf` 含 `server.root_api_key` 与 VLM/embedding 的 provider API key。

## 可达性与诚实定级
- 入口:`ov setup` / `openviking-server init` 是写 `ov.conf` 的唯一第一方路径,没有任何上游 guard 兜底——这是真实第一道防线,不是 defense-in-depth。与存储后端无关(纯本地 CLI 行为)。
- 定级 **P1**,不按清扫标定的 P0 卖:B-02 丢失前旧文件已备份为 `.bak`,可手工恢复,且触发前提是用户手工加过高级字段再重跑向导;B-10 的攻击模型是同主机其他本地用户(共享开发机/多用户主机),非远程可利用。两个都值得修,但都不是远程失陷级别。

## 关键设计与取舍
- **合并而非替换**:`{**current_server, **server_dict}`,向导只覆盖它真正询问的键。评审轮修复:远端→远端更新保留用户手工设置的 `auth_mode`(如 `trusted`),因为 `_wizard_server` 按设计从不写 `auth_mode`(服务端由 `root_api_key` 自动判定),替换语义会把它丢掉。
- **显式切回本地时清除 `auth_mode`/`root_api_key`**:向导对 Local 选项的承诺就是 "no auth, dev mode";若保留残留 `root_api_key`,`get_effective_auth_mode()` 会继续走 api_key 模式,与向导展示行为矛盾,残留密钥也没必要留盘。
- **写盘方式**:`mkstemp`(天然 0600)+ fsync + `os.replace` 原子替换;备份从 `rename` 改为先 `chmod` 原文件 0600、复制到 0600 临时文件再 replace。顺带消除了 main 上 rename 之后 write 失败会把 `config_path` 留空的窗口——现在任何一步失败,原文件原样保留(有测试覆盖)。
- **考虑过的替代**:临时改 `os.umask`——进程级全局副作用,不如 mkstemp 干净;仅在存在 `root_api_key` 时才收紧权限——`ov.conf` 还含 provider key,统一 0600 更简单。

## 作用域与已知限制
- 只影响 setup wizard 的写盘路径(新建 + 分段更新两条路都过同一个 `_write_config`)。不迁移既有用户磁盘上已是 0644 的 `ov.conf`/`.bak`,doctor 也未加权限检查——如需回溯收紧属后续工作。
- 边角:用户手工写过 `auth_mode: "dev"` 又通过向导切到远端时,合并会保留该字段;服务端 `DevAuthPlugin.validate_config` 对非 localhost 绑定直接 `sys.exit(1)`,fail-safe 不会静默裸奔,但用户需手工删掉该字段才能启动。
- Windows 上 POSIX 权限位语义有限,与 main 相比无回归。

## 修复的问题
- B-02 改 server/auth 丢弃已有 workers、CORS、observability、temp_upload、bot、加密开关等配置(`openviking_cli/setup_wizard.py:1805`)。
- B-10 新建/更新的 `ov.conf` 与 `.bak` 在 umask 022 下全局可读,泄露 root/provider API key(`openviking_cli/setup_wizard.py:935`)。

## 合入价值
**P1** · 常规向导更新不再静默丢配置(含加密/CORS 等安全相关字段),密钥文件对同主机其他用户不可读;写盘全程原子,失败不再留下半写或丢失的配置。

## 验证
- `uv run pytest --noconftest -q tests/cli/test_setup_wizard.py` → 93 passed(含新增:权限断言 ×2、replace/备份复制失败保留原文件 ×2、server 段合并保留字段、本地切换清除 auth_mode/root_api_key)。注意:不加 `--noconftest` 时 `tests/cli/conftest.py` 的 autouse fixture 会连 CLI 走活服务器,无认证环境下整个文件 93 skipped——复现验证请带该参数。
- main 上红测:umask 022 下 `_write_config` 落盘 `ov.conf` 与 `.bak` 均为 0644,证实 B-10;PR 分支同断言为 0600。

---
自动化全仓清扫(2026-07)· draft 待 review
