### PR TITLE
fix(bot): only require VKE credentials when the TOS storage path needs them

### DIFF
--- a/bot/deploy/vke/README.md
+++ b/bot/deploy/vke/README.md
@@ -121,9 +121,9 @@
 
 ---
 
-### 5. 获取访问密钥
+### 5. 获取访问凭证
 
-#### 5.1 创建 AccessKey
+#### 5.1 创建 AccessKey（仅 TOS 存储需要）
 
 1. 鼠标悬停在右上角头像，点击 **API 访问密钥**
 2. 点击 **新建密钥**
@@ -181,11 +181,7 @@ vim ~/.config/vikingbot/vke_deploy.yaml
 填入以下信息：
 
 ```yaml
-volcengine_access_key: AKLTxxxxxxxxxx      # 你的 AccessKey ID
-volcengine_secret_key: xxxxxxxxxx          # 你的 Secret Access Key
 volcengine_region: cn-beijing               # 地域
-
-vke_cluster_id: ccxxxxxxxxxx                # 集群 ID（从控制台获取）
 
 image_registry: vikingbot-cn-beijing.cr.volces.com  # 镜像仓库地址
 image_namespace: vikingbot
@@ -200,6 +196,8 @@ registry_password: "你的火山引擎密码"
 storage_type: tos
 
 # TOS 配置（仅 storage_type=tos 时需要）
+volcengine_access_key: AKLTxxxxxxxxxx
+volcengine_secret_key: xxxxxxxxxx
 tos_bucket: vikingbot_data
 tos_path: /.vikingbot/
 tos_region: cn-beijing
@@ -227,10 +225,9 @@ deploy/vke/deploy.sh
 
 | 配置项 | 说明 | 必填 | 示例 |
 |--------|------|------|------|
-| `volcengine_access_key` | 火山引擎 AccessKey ID | 是 | `AKLTxxxx` |
-| `volcengine_secret_key` | 火山引擎 Secret Access Key | 是 | `xxxx` |
+| `volcengine_access_key` | 火山引擎 AccessKey ID | 执行 TOS 部署时 | `AKLTxxxx` |
+| `volcengine_secret_key` | 火山引擎 Secret Access Key | 执行 TOS 部署时 | `xxxx` |
 | `volcengine_region` | 地域 | 是 | `cn-beijing` |
-| `vke_cluster_id` | VKE 集群 ID | 是 | `ccxxxx` |
 | `image_registry` | 镜像仓库地址 | 是 | `vikingbot-cn-beijing.cr.volces.com` |
 | `image_namespace` | 命名空间 | 是 | `vikingbot` |
 | `image_repository` | 仓库名称 | 是 | `vikingbot` |

--- a/bot/deploy/vke/deploy.sh
+++ b/bot/deploy/vke/deploy.sh
@@ -109,20 +109,23 @@ source "$TEMP_ENV"
 
 # ── 校验必要字段 ──────────────────────────────────────────────────────────────
 # 只拒绝明确的占位符值，不误伤真实 AK（Volcengine 真实 AK 本身就以 AKLT 开头）
-PLACEHOLDERS=("AKLTxxxxxxxxxx" "xxxxxxxxxx" "ccxxxxxxxxxx")
+storage_type="${storage_type:-local}"
+PLACEHOLDERS=("AKLTxxxxxxxxxx" "xxxxxxxxxx")
 missing=()
-for field in volcengine_access_key volcengine_secret_key vke_cluster_id; do
-    val="${!field:-}"
-    rejected=false
-    if [[ -z "$val" ]]; then
-        rejected=true
-    else
-        for ph in "${PLACEHOLDERS[@]}"; do
-            [[ "$val" == "$ph" ]] && rejected=true && break
-        done
-    fi
-    $rejected && missing+=("$field")
-done
+if [[ "$SKIP_DEPLOY" == false && "$storage_type" == "tos" ]]; then
+    for field in volcengine_access_key volcengine_secret_key; do
+        val="${!field:-}"
+        rejected=false
+        if [[ -z "$val" ]]; then
+            rejected=true
+        else
+            for ph in "${PLACEHOLDERS[@]}"; do
+                [[ "$val" == "$ph" ]] && rejected=true && break
+            done
+        fi
+        $rejected && missing+=("$field")
+    done
+fi
 
 if [[ ${#missing[@]} -gt 0 ]]; then
     log_error "Config validation failed! Missing or placeholder fields:"
@@ -145,7 +148,6 @@ k8s_deployment_name="${k8s_deployment_name:-vikingbot}"
 k8s_replicas="${k8s_replicas:-1}"
 k8s_manifest_path="${k8s_manifest_path:-deploy/vke/k8s/deployment.yaml}"
 kubeconfig_path="${kubeconfig_path:-}"
-storage_type="${storage_type:-local}"
 tos_bucket="${tos_bucket:-vikingbot_data}"
 tos_path="${tos_path:-/.vikingbot/}"
 tos_region="${tos_region:-cn-beijing}"
@@ -182,7 +184,6 @@ log_info "=================================================="
 cat <<EOF
 Config:        ${CONFIG_FILE}
 Region:        ${volcengine_region:-cn-beijing}
-Cluster ID:    ${vke_cluster_id}
 Image:         ${full_image_name}
 Timestamp tag: ${use_timestamp_tag}
 Dockerfile:    ${dockerfile_path}

--- a/bot/deploy/vke/vke_deploy.example.yaml
+++ b/bot/deploy/vke/vke_deploy.example.yaml
@@ -3,23 +3,15 @@
 #
 # 详细文档请参考: deploy/vke/README.md
 
-# ── 火山引擎凭证 ──────────────────────────────────────────────────────────────
+# ── 火山引擎配置 ──────────────────────────────────────────────────────────────
 #
-# 获取方式：
+# AK/SK 仅在 storage_type=tos 且实际执行部署时需要。获取方式：
 #   1. 登录火山引擎控制台 https://console.volcengine.com/
 #   2. 右上角头像 → API 访问密钥 → 新建密钥
 #
-volcengine_access_key: AKLTxxxxxxxxxx
-volcengine_secret_key: xxxxxxxxxx
+volcengine_access_key: ""
+volcengine_secret_key: ""
 volcengine_region: cn-beijing
-
-# ── VKE 集群信息 ────────────────────────────────────────────────────────────
-#
-# 获取方式：
-#   1. 进入容器服务 VKE → 集群
-#   2. 找到你的集群，集群 ID 形如 "ccxxxxxxxxxx"
-#
-vke_cluster_id: ccxxxxxxxxxx
 
 # ── 镜像仓库配置 ──────────────────────────────────────────────────────────────
 #


### PR DESCRIPTION
## 概述
`deploy.sh` 的 preflight 无条件要求 `volcengine_access_key`、`volcengine_secret_key`、`vke_cluster_id` 三个字段，但脚本里 AK/SK 只有一个消费点（步骤 3 TOS 分支生成 k8s Secret），`vke_cluster_id` 则从未被消费（只在摘要里 echo 一次，kubectl 的集群定位靠 kubeconfig）。本 PR 把 AK/SK 校验收敛到与消费点完全一致的条件（`SKIP_DEPLOY == false && storage_type == tos`），彻底删除 `vke_cluster_id`，并同步 README 与示例配置。

## 根因
校验逻辑是按"所有字段都必填"写的，从未对照过字段的实际使用位置。AK/SK 仅用于 TOS CSI Secret；镜像推送用的是独立的 `registry_username`/`registry_password`；`vke_cluster_id` 在整个脚本中没有任何消费者——纯死配置，却在 README 表格里标着"必填"，引导 local 用户去控制台创建用不到的云凭证。

## 严重性（诚实定级）
**P2 · 可用性**，非安全问题。可达性：走 `storage_type=local`（README 快速路径的默认推荐之一）或任何 `--skip-deploy` 流程的每个用户都会撞上；但存在平凡绕过——占位符黑名单只拒绝 3 个示例字面量，随便填 `dummy` 即可通过，所以不构成硬阻塞。sweep 定的 P1 偏高。

## 关键设计与取舍
- **门控条件直接照抄消费点**：AK/SK 的唯一使用处是"步骤 3 未跳过且 storage_type=tos"，校验条件逐字对应，不多不少。`--skip-deploy` 下即使是 tos 配置也放行（build/push 不用 AK/SK）。
- **`vke_cluster_id` 整字段删除而非改为可选**：它没有消费者，留着只会继续误导。同时删掉摘要里的 `Cluster ID:` echo——这一步是必须的，`set -u` 下新配置缺该字段会直接崩。
- **`storage_type:-local` 默认值上移到校验之前**（从原默认值区块移动，非新增），否则 `set -u` 下校验行本身就会因未定义变量退出。
- 考虑过的替代：在 tos 分支内(步骤 3)就地校验。不选——那时镜像已经 build+push 完，失败成本高；现在保持"kubectl 之前提前失败"的原有语义。

## 作用域与已知限制
- 只改 `bot/deploy/vke/` 下三个文件，不触碰 k8s manifest 与其他部署路径。
- tos 部署填了错误但非占位符的 AK/SK，依然要到集群内挂载时才暴露——与改动前一致，不在本 PR 范围。
- `storage_type: TOS`（大小写不符）会静默走 EBS 分支，这是改动前 `case local|*` 的既有行为，本 PR 未改变。

## 修复的问题
- C-14 local/EBS 及 skip-only 部署被用不到的 AK/SK 和从不生效的 cluster ID 卡在 preflight（`bot/deploy/vke/deploy.sh:112`、`bot/deploy/vke/README.md:228`、`bot/deploy/vke/vke_deploy.example.yaml:6`）

## 合入价值
**P2 · 可用性** · local 用户不再被引导去创建用不到的云凭证；README"必填"表与代码实际行为对齐；TOS 真部署仍在 kubectl 之前对缺失凭证提前失败，且逐项报出字段名。

## 验证
对 PR 分支脚本实际执行（非 dry 阅读）：
- `bash -n deploy.sh` — 语法通过
- local 配置 + `--skip-build --skip-push --skip-deploy`，无任何凭证 — exit 0
- local 配置 + 真实 deploy 路径，无凭证 — 通过 preflight，进入 Step 3（在 manifest 处按环境预期失败，非凭证拦截）
- tos 配置 + 真实 deploy 路径，无凭证 — exit 1，逐项打印 `volcengine_access_key`、`volcengine_secret_key`
- tos 配置 + `--skip-deploy`，无凭证 — exit 0
- tos 配置 + 占位符 `AKLTxxxxxxxxxx` — 被拒绝
- `git grep vke_cluster_id`（PR 分支）— 零残留

---
自动化全仓清扫（2026-07）· draft 待 review
