### PR TITLE
fix(server): stop exporting raw query strings and buffering zip responses in observability

### DIFF
--- a/openviking/observability/http_observability_middleware.py
+++ b/openviking/observability/http_observability_middleware.py
@@ -825,7 +825,6 @@ def create_http_observability_middleware() -> Callable[[Request, Callable], Resp
 
         # Extract request information
         raw_path = str(request.url.path)
-        raw_query = request.url.query or None
         route_template = _get_route_template(request)
         request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
 
@@ -835,7 +834,6 @@ def create_http_observability_middleware() -> Callable[[Request, Callable], Resp
             http_route=route_template,
             request_id=request_id,
             url_path=raw_path,
-            url_query=raw_query,
             url_scheme=request.url.scheme,
             http_host=request.url.netloc,
             source_type=request.headers.get("x-source-type"),

--- a/openviking/server/body_dump_middleware.py
+++ b/openviking/server/body_dump_middleware.py
@@ -25,6 +25,7 @@ except ImportError:  # pragma: no cover - OTel optional
 _SKIP_CONTENT_TYPE_PREFIXES = (
     "multipart/form-data",
     "application/octet-stream",
+    "application/zip",
     "text/event-stream",
     "audio/",
     "video/",

--- a/tests/telemetry/test_http_observability_middleware.py
+++ b/tests/telemetry/test_http_observability_middleware.py
@@ -67,9 +67,11 @@ def test_http_observability_middleware_updates_route_template_after_routing(monk
         return {"ok": True}
 
     with TestClient(app) as client:
-        resp = client.get("/hello")
+        resp = client.get("/hello?token=top-secret")
         assert resp.status_code == 200
 
     root_attrs = captured["root_attrs"]
     assert root_attrs.http_route == "/hello"
+    assert root_attrs.url_query is None
+    assert "url.query" not in root_attrs.to_otel_attributes()
     assert "GET /hello" in dummy_span.updated_names

--- a/tests/unit/test_body_dump_middleware.py
+++ b/tests/unit/test_body_dump_middleware.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.server.body_dump_middleware import _should_skip
+
+
+def test_zip_responses_skip_body_capture():
+    assert _should_skip("application/zip")
+    assert _should_skip("application/zip; charset=binary")


### PR DESCRIPTION
## 概述
可观测层此前无差别采集:HTTP observability 中间件把 `request.url.query` 原样写进 root span 属性(`span_models.py:81-82` 输出为 `url.query`),没有任何脱敏;body dump 中间件的二进制跳过列表漏了 `application/zip`,会把 zip 响应的 `body_iterator` 全量 join 进内存再重建为非流式响应。本 PR 在采集入口停止收集 query,并把 zip 加入跳过列表。

## 为什么必要(可达性/严重性)
两条路径在默认配置下都不可达:traces 导出默认关(`OTelExporterConfig.enabled=False`)、body dump 默认关(`TraceDumpBodyConfig.enabled=False`,均见 `openviking/server/config.py`)。因此诚实定级是 **P1,不是无条件 P0**。

但一旦运维开启 tracing(常规动作),这就是第一道防线——上游没有任何脱敏:

- observability 中间件是最外层,在 auth 消费 `?token=` 之前就记录了 query。`temp_upload` 的单次上传令牌(`mcp_endpoint.py:673` 铸造、`auth/__init__.py:176-188` 消费)会进入导出属性;若请求在消费前失败(限流、权限拒绝),trace 里留下的是仍然有效的令牌。`protocol=local` 也不豁免——令牌落进明文 `~/.openviking/logs/traces.jsonl`。
- `POST /api/v1/pack/export` 与 `/pack/backup`(`pack.py:113/152`)以 `FileResponse(media_type="application/zip")` 流式返回 .ovpack;dump_body 开启时整包被吞进内存,大导出/全量备份直接变成高内存缓冲响应。

## 关键设计与取舍
- **全量移除 query vs 按参数名脱敏**:选全量移除。`span_models.url_query` 默认 `None`,全仓唯一消费方是 `to_otel_attributes`,没有其他读取方,删除零破坏;denylist(token/code/signature)会随新参数漂移,OTel semconv 本身就要求对 `url.query` 做 sanitize。代价是 trace 丢失全部 query(如分页参数),`url.path` 和 route 模板保留,足够定位请求。
- **跳过列表加 `application/zip`**:前缀匹配同时保护请求侧(避免 `request.body()` 对 zip 上传的全量内存拷贝)与响应侧(保持 FileResponse 流式),覆盖 `application/zip; charset=binary` 这类带参数的 content-type。

## 作用域与已知限制
- 与存储后端无关(S3/本地皆同),只影响 trace 属性采集与 dump 中间件。
- 不改 metrics、访问日志路径;`http.url` 类完整 URL 未在别处导出(已核对)。
- dump_body 对其他大体积非二进制响应(如超大 JSON)仍会全量缓冲——4096 截断只作用于 span 属性,不作用于内存中的 join。这是该中间件的既有设计,不在本 PR 范围。
- 回归风险:仅丢失 trace 中的 query 可见性;`tests/telemetry/` 全套通过,无其他消费方。

## 修复的问题
- B-03 原始 query 字符串把认证材料(temp_upload `?token=` 等)导出到 trace 后端(`openviking/observability/http_observability_middleware.py:827`)
- B-13 `application/zip` 响应绕过二进制跳过列表,被 body 采集完整缓冲进内存(`openviking/server/body_dump_middleware.py:23`)

## 合入价值
**P1(需开启 observability 配置才可达,开启后为第一道防线)** · 开 tracing 不再泄露 query 凭证到外部后端或本地明文日志;zip 导出/备份在 dump_body 下保持流式、不再有 OOM 风险。

## 验证
在 PR 分支 worktree 实际执行:
- `pytest -q tests/telemetry/test_http_observability_middleware.py tests/unit/test_body_dump_middleware.py` — 2 passed
- `pytest -q tests/telemetry/` — 36 passed(确认移除 `url_query` 无回归)

> 状态说明:本 PR 已于 2026-07-22 被无评论关闭。review 结论是修复正确、无回归、上游无覆盖,建议按 P1 重开合入;若关闭另有原因(如另行统一处理脱敏),请在此补充记录。

---
自动化全仓清扫(2026-07)· draft 待 review
