### PR TITLE
fix(storage): atomic OVPack export and temp-tree cleanup on unpack failure

### DIFF
--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -591,40 +591,44 @@ class UnderstandingAPI(BaseParser):
     async def _unpack_zip_to_temp_dir(self, zip_path: Path, resource_name: str) -> str:
         viking_fs = get_viking_fs()
         temp_uri = viking_fs.create_temp_uri()
-        await viking_fs.mkdir(temp_uri)
+        try:
+            await viking_fs.mkdir(temp_uri)
 
-        temp_doc_uri = f"{temp_uri}/{resource_name}"
-        await viking_fs.mkdir(temp_doc_uri)
+            temp_doc_uri = f"{temp_uri}/{resource_name}"
+            await viking_fs.mkdir(temp_doc_uri)
 
-        with tempfile.TemporaryDirectory() as extract_dir:
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                safe_extract_zip(zf, extract_dir)
-            extract_path = Path(extract_dir)
-            items = [p for p in extract_path.iterdir() if p.name not in {".", ".."}]
-            if len(items) == 1 and items[0].is_dir():
-                root_dir = items[0]
-            else:
-                root_dir = extract_path
-
-            image_mappings = await asyncio.to_thread(build_artifact_image_mappings, root_dir)
-
-            for child in root_dir.iterdir():
-                if child.name in {".", "..", IMAGE_MAPPINGS_FILENAME}:
-                    continue
-                if child.is_dir():
-                    sub_uri = f"{temp_doc_uri}/{child.name}"
-                    await viking_fs.mkdir(sub_uri)
-                    await self._copy_dir_to_fs(child, sub_uri)
+            with tempfile.TemporaryDirectory() as extract_dir:
+                with zipfile.ZipFile(zip_path, "r") as zf:
+                    safe_extract_zip(zf, extract_dir)
+                extract_path = Path(extract_dir)
+                items = [p for p in extract_path.iterdir() if p.name not in {".", ".."}]
+                if len(items) == 1 and items[0].is_dir():
+                    root_dir = items[0]
                 else:
-                    await viking_fs.write_file_bytes(
-                        f"{temp_doc_uri}/{child.name}", child.read_bytes()
-                    )
+                    root_dir = extract_path
 
-            if image_mappings:
-                await viking_fs.write_file(
-                    f"{temp_doc_uri}/{IMAGE_MAPPINGS_FILENAME}",
-                    json.dumps(image_mappings, ensure_ascii=False),
-                )
+                image_mappings = await asyncio.to_thread(build_artifact_image_mappings, root_dir)
+
+                for child in root_dir.iterdir():
+                    if child.name in {".", "..", IMAGE_MAPPINGS_FILENAME}:
+                        continue
+                    if child.is_dir():
+                        sub_uri = f"{temp_doc_uri}/{child.name}"
+                        await viking_fs.mkdir(sub_uri)
+                        await self._copy_dir_to_fs(child, sub_uri)
+                    else:
+                        await viking_fs.write_file_bytes(
+                            f"{temp_doc_uri}/{child.name}", child.read_bytes()
+                        )
+
+                if image_mappings:
+                    await viking_fs.write_file(
+                        f"{temp_doc_uri}/{IMAGE_MAPPINGS_FILENAME}",
+                        json.dumps(image_mappings, ensure_ascii=False),
+                    )
+        except Exception:
+            await viking_fs.delete_temp(temp_uri)
+            raise
 
         return temp_uri
 

--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -626,8 +626,11 @@ class UnderstandingAPI(BaseParser):
                         f"{temp_doc_uri}/{IMAGE_MAPPINGS_FILENAME}",
                         json.dumps(image_mappings, ensure_ascii=False),
                     )
-        except Exception:
-            await viking_fs.delete_temp(temp_uri)
+        except BaseException:
+            try:
+                await asyncio.shield(viking_fs.delete_temp(temp_uri))
+            except BaseException:
+                logger.exception("Failed to clean up Understanding API temp tree %s", temp_uri)
             raise
 
         return temp_uri

--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -5,6 +5,8 @@
 import asyncio
 import json
 import os
+import secrets
+import stat
 import tempfile
 import zipfile
 from contextlib import ExitStack
@@ -70,6 +72,30 @@ from openviking_cli.utils.logger import get_logger
 from openviking_cli.utils.uri import VikingURI
 
 logger = get_logger(__name__)
+
+
+def _create_export_temp(to: str) -> tuple[int, str]:
+    """Create a sibling temp file with the permissions a direct write would retain."""
+    directory = os.path.dirname(os.path.abspath(to))
+    while True:
+        temp_to = os.path.join(
+            directory, f".{os.path.basename(to)}.{secrets.token_hex(8)}.tmp"
+        )
+        try:
+            fd = os.open(temp_to, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o666)
+            break
+        except FileExistsError:
+            continue
+    try:
+        os.fchmod(fd, stat.S_IMODE(os.stat(to).st_mode))
+    except FileNotFoundError:
+        pass
+    except BaseException:
+        os.close(fd)
+        Path(temp_to).unlink(missing_ok=True)
+        raise
+    return fd, temp_to
+
 
 OPTIONAL_SEMANTIC_SIDECARS = frozenset({".abstract.md", ".overview.md"})
 
@@ -426,11 +452,7 @@ async def _write_ovpack_archive(
     }
 
     with ExitStack() as cleanup:
-        fd, temp_to = tempfile.mkstemp(
-            prefix=f".{os.path.basename(to)}.",
-            suffix=".tmp",
-            dir=os.path.dirname(os.path.abspath(to)),
-        )
+        fd, temp_to = _create_export_temp(to)
         os.close(fd)
         cleanup.callback(Path(temp_to).unlink, missing_ok=True)
         zf = cleanup.enter_context(

--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -87,7 +87,7 @@ def _create_export_temp(to: str) -> tuple[int, str]:
         except FileExistsError:
             continue
     try:
-        os.fchmod(fd, stat.S_IMODE(os.stat(to).st_mode))
+        os.chmod(temp_to, stat.S_IMODE(os.stat(to).st_mode))
     except FileNotFoundError:
         pass
     except BaseException:

--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -5,7 +5,10 @@
 import asyncio
 import json
 import os
+import tempfile
 import zipfile
+from contextlib import ExitStack
+from pathlib import Path
 from typing import Any, Optional
 
 from openviking.core.namespace import context_type_for_uri, is_session_uri, relative_uri_path
@@ -422,7 +425,17 @@ async def _write_ovpack_archive(
         if entry.get("kind") == "file"
     }
 
-    with zipfile.ZipFile(to, "w", zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
+    with ExitStack() as cleanup:
+        fd, temp_to = tempfile.mkstemp(
+            prefix=f".{os.path.basename(to)}.",
+            suffix=".tmp",
+            dir=os.path.dirname(os.path.abspath(to)),
+        )
+        os.close(fd)
+        cleanup.callback(Path(temp_to).unlink, missing_ok=True)
+        zf = cleanup.enter_context(
+            zipfile.ZipFile(temp_to, "w", zipfile.ZIP_DEFLATED, allowZip64=True)
+        )
         zf.writestr(base_name + "/", "")
         zf.writestr(f"{base_name}/{OVPACK_FILES_DIR}/", "")
 
@@ -470,6 +483,8 @@ async def _write_ovpack_archive(
             f"{base_name}/{OVPACK_MANIFEST_ZIP_LEAF}",
             json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8"),
         )
+        zf.close()
+        os.replace(temp_to, to)
     return to
 
 

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -611,6 +611,22 @@ async def test_export_failure_preserves_existing_archive(
 
 
 @pytest.mark.asyncio
+async def test_export_preserves_existing_archive_permissions(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    temp_ovpack_path.chmod(0o640)
+
+    await export_ovpack(
+        FakeExportVikingFS(),
+        "viking://resources/demo",
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    assert temp_ovpack_path.stat().st_mode & 0o777 == 0o640
+
+
+@pytest.mark.asyncio
 async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: RequestContext):
     await backup_ovpack(
         FakeBackupVikingFS(),

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -612,8 +612,9 @@ async def test_export_failure_preserves_existing_archive(
 
 @pytest.mark.asyncio
 async def test_export_preserves_existing_archive_permissions(
-    temp_ovpack_path: Path, request_ctx: RequestContext
+    temp_ovpack_path: Path, request_ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
 ):
+    monkeypatch.delattr(os, "fchmod", raising=False)
     temp_ovpack_path.chmod(0o640)
 
     await export_ovpack(

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -588,6 +588,29 @@ async def test_export_ovpack_skips_missing_semantic_sidecars(
 
 
 @pytest.mark.asyncio
+async def test_export_failure_preserves_existing_archive(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    temp_ovpack_path.write_bytes(b"previous archive")
+    fake_fs = FakeExportVikingFS()
+    original_read = fake_fs.read_file_bytes
+
+    async def fail_on_content(uri: str, ctx=None):
+        if uri.endswith("notes.txt"):
+            raise OSError("storage read failed")
+        return await original_read(uri, ctx=ctx)
+
+    fake_fs.read_file_bytes = fail_on_content
+    with pytest.raises(OSError, match="storage read failed"):
+        await export_ovpack(
+            fake_fs, "viking://resources/demo", str(temp_ovpack_path), ctx=request_ctx
+        )
+
+    assert temp_ovpack_path.read_bytes() == b"previous archive"
+    assert not list(temp_ovpack_path.parent.glob(f".{temp_ovpack_path.name}.*.tmp"))
+
+
+@pytest.mark.asyncio
 async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: RequestContext):
     await backup_ovpack(
         FakeBackupVikingFS(),

--- a/tests/parse/test_understanding_api_artifact_images.py
+++ b/tests/parse/test_understanding_api_artifact_images.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import zipfile
 from pathlib import Path
@@ -100,3 +101,41 @@ async def test_unpack_failure_deletes_temp_tree(tmp_path: Path):
         await api._unpack_zip_to_temp_dir(zip_path, "resource")
 
     assert fake_fs.deleted == ["viking://temp/artifact"]
+
+
+@pytest.mark.asyncio
+async def test_unpack_cancellation_deletes_temp_tree(tmp_path: Path):
+    fake_fs = _FakeVikingFS()
+
+    async def cancel(_uri, exist_ok=False):
+        raise asyncio.CancelledError
+
+    fake_fs.mkdir = cancel
+    api = UnderstandingAPI.__new__(UnderstandingAPI)
+
+    with (
+        patch("openviking.parse.understanding_api.get_viking_fs", return_value=fake_fs),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await api._unpack_zip_to_temp_dir(tmp_path / "unused.zip", "resource")
+
+    assert fake_fs.deleted == ["viking://temp/artifact"]
+
+
+@pytest.mark.asyncio
+async def test_unpack_cleanup_failure_preserves_original_error(tmp_path: Path):
+    zip_path = tmp_path / "broken.zip"
+    zip_path.write_bytes(b"not a zip")
+    fake_fs = _FakeVikingFS()
+
+    async def fail_cleanup(_uri):
+        raise RuntimeError("cleanup failed")
+
+    fake_fs.delete_temp = fail_cleanup
+    api = UnderstandingAPI.__new__(UnderstandingAPI)
+
+    with (
+        patch("openviking.parse.understanding_api.get_viking_fs", return_value=fake_fs),
+        pytest.raises(zipfile.BadZipFile),
+    ):
+        await api._unpack_zip_to_temp_dir(zip_path, "resource")

--- a/tests/parse/test_understanding_api_artifact_images.py
+++ b/tests/parse/test_understanding_api_artifact_images.py
@@ -16,6 +16,7 @@ class _FakeVikingFS:
     def __init__(self):
         self.files = {}
         self.dirs = set()
+        self.deleted = []
 
     def create_temp_uri(self):
         return "viking://temp/artifact"
@@ -28,6 +29,9 @@ class _FakeVikingFS:
 
     async def write_file(self, uri, content):
         self.files[uri] = content.encode("utf-8")
+
+    async def delete_temp(self, uri):
+        self.deleted.append(uri)
 
 
 def test_build_artifact_image_mappings_uses_existing_sibling_images(tmp_path: Path):
@@ -80,3 +84,19 @@ async def test_unpack_artifact_writes_image_mapping_sidecar(tmp_path: Path):
         "Ov测试_1.md": {"Ov测试_1_img1.png": "Ov测试_1_img1.png"}
     }
     assert fake_fs.files[f"{temp_uri}/resource/Ov测试_1_img1.png"] == b"png"
+
+
+@pytest.mark.asyncio
+async def test_unpack_failure_deletes_temp_tree(tmp_path: Path):
+    zip_path = tmp_path / "broken.zip"
+    zip_path.write_bytes(b"not a zip")
+    fake_fs = _FakeVikingFS()
+    api = UnderstandingAPI.__new__(UnderstandingAPI)
+
+    with (
+        patch("openviking.parse.understanding_api.get_viking_fs", return_value=fake_fs),
+        pytest.raises(zipfile.BadZipFile),
+    ):
+        await api._unpack_zip_to_temp_dir(zip_path, "resource")
+
+    assert fake_fs.deleted == ["viking://temp/artifact"]


### PR DESCRIPTION
## 概述
OVPack 导出/备份此前直接以 `w` 模式打开目标文件（`zipfile.ZipFile(to, "w")`），打开即截断——后续任一存储读取或 ZIP 写入失败时，上一份有效归档已被清空，只剩半成品。Understanding 解包则先在 VikingFS 建临时树再写入，中途失败（坏 ZIP、写入错误、任务取消）直接抛出，已建的临时树无人清理。本 PR 改为：导出先写同目录随机命名临时文件，`zf.close()` 落盘后 `os.replace` 原子替换；解包失败/取消时删除临时树，清理失败只记日志、不掩盖原始异常。

## 为什么必要（可达性/严重性）
- B-04 是第一道防线，无上游保护。链路：CLI/SDK（`openviking/sync_client.py:524`、`async_client.py:817`）与 HTTP `/pack` 路由（`openviking/server/routers/pack.py:92,140`）→ `pack_service` → `_write_ovpack_archive`。归档内容逐条 `await viking_fs.read_file_bytes(...)` 拉取，远端后端读失败或本地磁盘满都发生在目标文件已被截断之后。备份场景通常复用同一路径，失败一次即毁掉上一份可用备份——失败路径数据丢失，定级 P1。
- B-14 单独看是 P2 资源泄漏：`openviking/utils/resource_processor.py` 只在 `_unpack_zip_to_temp_dir` 成功返回后才清理 `temp_dir_path`（其 error 分支注释确认 viking://temp 无 GC，见 #2478），解包自身失败的窗口没有任何兜底，反复解析失败会在用户 temp 空间持续堆积孤儿树。

## 关键设计与取舍
- 同目录临时文件 + `os.replace`，不用系统 tempdir：避免跨设备 rename 失败，保证替换原子。
- 临时文件 `O_CREAT|O_EXCL` + 随机后缀防碰撞；目标已存在时把其权限位复制到临时文件（`os.chmod`，不依赖 `fchmod`，Windows 可用），使替换后权限与原 `open(to, "w")` 覆写行为一致，有测试锁定。
- `ExitStack` 注册 `unlink(missing_ok=True)`：任何失败路径（含 `zf.close()` 刷中央目录失败）删掉临时文件，成功路径 replace 后为 no-op，不留 `.tmp` 残骸。
- 解包侧捕获 `BaseException`（覆盖 `asyncio.CancelledError`），清理包在 `asyncio.shield` 里防二次取消打断；真实 `VikingFS.delete_temp` 自身吞异常，外层 try/except 兜底其它 FS 实现，原始异常始终重新抛出。
- 考虑过让上游 `resource_processor` 统一清理：失败发生在 `ParseResult` 产生之前，上游拿不到 temp_uri，只能在创建点自清理，故不选。

## 作用域与已知限制
- 只保证进程内失败的原子性；`os.replace` 前未 fsync，极端断电下不保证新文件落盘完整（与"失败不毁旧档"的修复目标无关）。
- 原子替换要求目标目录可写；此前覆写已有文件只需文件本身可写，极端目录权限配置下行为有变。
- 不改变导出内容与格式；两处成功路径行为不变。

## 修复的问题
- B-04 导出/备份以 `w` 模式打开目标，失败即截断上一份有效归档（`openviking/storage/ovpack/operations.py:454`）
- B-14 解包失败/取消遗留 VikingFS 临时树，且无 GC 兜底（`openviking/parse/understanding_api.py:591`）

## 合入价值
**P1** · 备份/导出失败不再连带销毁上一份有效归档；解析失败不再在共享存储堆积孤儿临时树。

## 验证
- `python -m pytest -q tests/misc/test_ovpack_import_policy.py tests/parse/test_understanding_api_artifact_images.py --no-cov` — 25 passed（review 时在干净 worktree 复跑，结果一致）
- 新增 5 个测试：失败保留旧档且无 `.tmp` 残留、权限保留（无 fchmod 环境）、坏 ZIP 清理临时树、取消清理临时树、清理失败保留原始异常

---
自动化全仓清扫（2026-07）· draft 待 review
