### PR TITLE
feat(sdk/go): add tags filter and relations API for parity

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -126,6 +126,7 @@ Implemented:
 | Watch management | `ListWatches`, `GetWatch`, `UpdateWatch`, `DeleteWatch`, `TriggerWatch` |
 | Filesystem and content | `List`, `Tree`, `Stat`, `Attrs`, `Mkdir`, `Remove`, `Move`, `Read`, `Abstract`, `Overview`, `Write`, `SetTags`, `Reindex` |
 | Retrieval | `Find`, `Search`, `Grep`, `Glob` |
+| Relations | `Relations`, `Link`, `Unlink` |
 | Sessions and tasks | `CreateSession`, `ListSessions`, `GetSession`, `SessionExists`, `GetSessionContext`, `GetSessionArchive`, `DeleteSession`, `AddMessage`, `BatchAddMessages`, `CommitSession`, `GetTask`, `ListTasks` |
 | Packs | `ExportOVPack`, `BackupOVPack`, `ImportOVPack`, `RestoreOVPack` |
 | System and observer | `Health`, `CheckConsistency`, `GetStatus`, `IsHealthy`, `QueueStatus`, `VikingDBStatus`, `ModelsStatus` |

--- a/sdk/go/README_CN.md
+++ b/sdk/go/README_CN.md
@@ -70,6 +70,7 @@ _, _, _ = imageResults, storedImageResults, similarPosters
 | Watch 管理 | `ListWatches`, `GetWatch`, `UpdateWatch`, `DeleteWatch`, `TriggerWatch` |
 | 文件系统和内容 | `List`, `Tree`, `Stat`, `Attrs`, `Mkdir`, `Remove`, `Move`, `Read`, `Abstract`, `Overview`, `Write`, `SetTags`, `Reindex` |
 | 检索 | `Find`, `Search`, `Grep`, `Glob` |
+| 关系 | `Relations`, `Link`, `Unlink` |
 | 会话和任务 | `CreateSession`, `ListSessions`, `GetSession`, `SessionExists`, `GetSessionContext`, `GetSessionArchive`, `DeleteSession`, `AddMessage`, `BatchAddMessages`, `CommitSession`, `GetTask`, `ListTasks` |
 | OVPack | `ExportOVPack`, `BackupOVPack`, `ImportOVPack`, `RestoreOVPack` |
 | 系统和 observer | `Health`, `CheckConsistency`, `GetStatus`, `IsHealthy`, `QueueStatus`, `VikingDBStatus`, `ModelsStatus` |

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -124,6 +124,9 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		if !ok || len(levels) != 2 || levels[0] != float64(0) || levels[1] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if tags, ok := body["tags"].([]any); !ok || len(tags) != 2 || tags[0] != "topic=docs" || tags[1] != "kind=api" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		requireBodyKeysAbsent(t, body, "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{
 			"resources": []map[string]any{
@@ -141,6 +144,7 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		Until:       "2026-06-18",
 		TimeField:   "created_at",
 		Level:       []int{0, 2},
+		Tags:        []string{"topic=docs", "kind=api"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +160,7 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -406,6 +410,9 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		if !ok || len(levels) != 1 || levels[0] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if tags, ok := body["tags"].([]any); !ok || len(tags) != 1 || tags[0] != "topic=docs" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		requireBodyKeysAbsent(t, body, "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
@@ -418,6 +425,7 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		Until:     "2026-06-18",
 		TimeField: "updated_at",
 		Level:     []int{2},
+		Tags:      []string{"topic=docs"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +437,7 @@ func TestSearchOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -456,6 +464,46 @@ func TestSearchSendsImageURI(t *testing.T) {
 		TargetURI: "viking://resources/images",
 		Image:     "viking://resources/images/cat.png",
 	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRelationRequests(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/relations":
+			if got := r.URL.Query().Get("uri"); got != "viking://resources/from" {
+				t.Fatalf("uri = %q", got)
+			}
+			writeOK(t, w, []map[string]any{{"uri": "viking://resources/to"}})
+		case "POST /api/v1/relations/link":
+			body := readJSONBody(t, r)
+			targets, ok := body["to_uris"].([]any)
+			if body["from_uri"] != "viking://resources/from" || body["reason"] != "related" ||
+				!ok || len(targets) != 1 || targets[0] != "viking://resources/to" {
+				t.Fatalf("link body = %#v", body)
+			}
+			writeOK(t, w, map[string]any{"linked": true})
+		case "DELETE /api/v1/relations/link":
+			body := readJSONBody(t, r)
+			if body["from_uri"] != "viking://resources/from" || body["to_uri"] != "viking://resources/to" {
+				t.Fatalf("unlink body = %#v", body)
+			}
+			writeOK(t, w, map[string]any{"unlinked": true})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer closeServer()
+
+	relations, err := client.Relations(context.Background(), "resources/from")
+	if err != nil || len(relations) != 1 {
+		t.Fatalf("relations = %#v, err = %v", relations, err)
+	}
+	if err := client.Link(context.Background(), "resources/from", []string{"resources/to"}, "related"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Unlink(context.Background(), "resources/from", "resources/to"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/sdk/go/relations.go
+++ b/sdk/go/relations.go
@@ -1,0 +1,34 @@
+package openviking
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Relations returns the relations associated with a resource.
+func (c *Client) Relations(ctx context.Context, uri string) ([]map[string]any, error) {
+	query := url.Values{"uri": []string{NormalizeURI(uri)}}
+	var result []map[string]any
+	err := c.doJSON(ctx, http.MethodGet, "/api/v1/relations", query, nil, &result)
+	return result, err
+}
+
+// Link creates relations from one resource to a string or []string target.
+func (c *Client) Link(ctx context.Context, fromURI string, toURIs any, reason string) error {
+	payload := map[string]any{
+		"from_uri": NormalizeURI(fromURI),
+		"to_uris":  normalizeTarget(toURIs),
+		"reason":   reason,
+	}
+	return c.doJSON(ctx, http.MethodPost, "/api/v1/relations/link", nil, payload, nil)
+}
+
+// Unlink removes a resource relation.
+func (c *Client) Unlink(ctx context.Context, fromURI, toURI string) error {
+	payload := map[string]any{
+		"from_uri": NormalizeURI(fromURI),
+		"to_uri":   NormalizeURI(toURI),
+	}
+	return c.doJSON(ctx, http.MethodDelete, "/api/v1/relations/link", nil, payload, nil)
+}

--- a/sdk/go/retrieval.go
+++ b/sdk/go/retrieval.go
@@ -37,6 +37,9 @@ func (c *Client) Find(ctx context.Context, queryText string, opts *FindOptions) 
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
 	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
+	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult
 	err = c.doJSON(ctx, http.MethodPost, "/api/v1/search/find", nil, payload, &result)
@@ -75,6 +78,9 @@ func (c *Client) Search(ctx context.Context, queryText string, opts *SearchOptio
 	setString(payload, "time_field", opts.TimeField)
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
+	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
 	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -203,6 +203,7 @@ type FindOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // SearchOptions controls Search.
@@ -220,6 +221,7 @@ type SearchOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // GrepOptions controls Grep.


### PR DESCRIPTION
## 概述
Go SDK README 声称 "intentionally follows the Python HTTP client surface"，但 main 上的 Go 客户端缺两块 Python/TS SDK 均已有的能力：Find/Search 传不了 tags 过滤，relations（列出/关联/解除）完全没有封装。本 PR 给 FindOptions/SearchOptions 加 Tags 字段，新增 relations.go 实现 Relations/Link/Unlink，并同步两份 README 的覆盖表。

## 根因
Go SDK v1 按早期的 Python 客户端表面生成，此后 server 在 #2706 给 /api/v1/search/find、/api/v1/search/search 加了顶层 tags 字段，Python/TS 客户端跟进而 Go 没有；relations 三个路由（openviking/server/routers/relations.py）自始未在 Go 侧封装，且 README 的 Implemented/Not implemented 两张表都没列它——对等清单漏项，不是设计取舍。

## 为什么必要（可达性/严重性）
纯 SDK 功能缺口，非安全问题，诚实定级 P1（不是 P0）：Go 调用方今天要按标签检索或管理资源关联，只能绕开 SDK 手写 HTTP。服务端能力已存在且对所有后端一致（search.py、relations.py 路由层），与 S3/本地无关。这不是 defense-in-depth——没有上游能替客户端补出缺失的方法，它就是缺失的第一层能力。

## 关键设计与取舍
- 与服务端契约逐字段对齐：GET /api/v1/relations?uri=、POST /api/v1/relations/link {from_uri, to_uris, reason}、DELETE /api/v1/relations/link {from_uri, to_uri}，对应 LinkRequest/UnlinkRequest（relations.py:27-39）；DELETE 带 JSON body 与 Python SDK 行为一致。
- Link 的 toURIs 用 any 接 string 或 []string，复用已有 normalizeTarget（helpers.go:90，与 Find/Search 的 TargetURI any 同一模式），不新造联合类型或双方法；URI 统一过 NormalizeURI。
- tags 仅在 len>0 时写入请求体，与 Python 客户端 _compact_request_body 的兼容策略一致：服务端模型 extra="forbid"，无条件带 tags 会在 pre-#2706 老服务器上直接 422。
- Relations 返回 []map[string]any，对应 service 层 List[Dict]（relation_service.py:36）；服务端未定义稳定 schema，不建强类型 struct。

## 作用域与已知限制
- 仅动 sdk/go（retrieval.go、types.go、新增 relations.go）+ 两份 README 覆盖表；不碰服务端与其他 SDK。新字段零值即旧行为，对现有调用零回归。
- 显式设置 Tags 请求 pre-#2706 旧服务器仍会 422，这是服务端 extra="forbid" 的固有行为，Python 客户端同样如此。
- 未封装 /api/v1/relations/build_graph——Python/TS 客户端也没有它，不在对等范围内。

## 修复的问题
- F-11 Find/Search 缺 tags 选项与请求字段，无法按标签检索（sdk/go/types.go、sdk/go/retrieval.go）
- F-12 Go 客户端缺 relations 列出/关联/解除方法（sdk/go/relations.go 新增）

## 合入价值
**P1（SDK 功能缺口，非安全）** · Go 调用方无需退回裸 HTTP 即可按标签检索、管理资源关联；README 的对等声明恢复真实。

## 验证
- PR head（8af0c2cb）worktree 实跑：`cd sdk/go && go build ./... && go vet ./... && go test ./...` — 全部通过（含新增 TestRelationRequests 与 Find/Search 的 tags 断言）
- 与 origin/main 比对：main 无 sdk/go/relations.go、types.go 无 Tags 字段，确认非重复修复
- 服务端契约核对：routers/search.py 的 FindRequest/SearchRequest 均有 tags: Optional[List[str]]；routers/relations.py 三个路由的方法、路径、字段与本实现逐一匹配

---
自动化全仓清扫(2026-07)· draft 待 review
