### PR TITLE
fix(server): make --bot work and propagate bot flags to workers

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -61,6 +61,20 @@ from openviking_cli.utils.logger import init_otel_log_handler_from_server_config
 
 logger = get_logger(__name__)
 
+WORKER_WITH_BOT_ENV = "OPENVIKING_WORKER_WITH_BOT"
+WORKER_BOT_API_URL_ENV = "OPENVIKING_WORKER_BOT_API_URL"
+
+
+def create_worker_app() -> FastAPI:
+    """Load file config and replay parent-process Bot CLI overrides."""
+    config = load_server_config()
+    with_bot = os.environ.get(WORKER_WITH_BOT_ENV)
+    if with_bot is not None:
+        config.with_bot = with_bot == "1"
+    bot_api_url = os.environ.get(WORKER_BOT_API_URL_ENV)
+    if bot_api_url is not None:
+        config.bot_api_url = bot_api_url
+    return create_app(config)
 
 
 async def _initialize_auth_plugin(

--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -16,7 +16,11 @@ from typing import Optional
 
 import uvicorn
 
-from openviking.server.app import create_app
+from openviking.server.app import (
+    WORKER_BOT_API_URL_ENV,
+    WORKER_WITH_BOT_ENV,
+    create_app,
+)
 from openviking.server.config import get_server_url_from_server_data, load_server_config
 from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.config.config_loader import resolve_config_path
@@ -160,10 +164,6 @@ def main():
     )
     parser.add_argument(
         "--bot",
-        action="store_true",
-        help="Also start vikingbot gateway after server starts",
-    )
-    parser.add_argument(
         "--with-bot",
         action="store_true",
         dest="with_bot",
@@ -290,8 +290,10 @@ def main():
             # can independently import the application.  We stash the
             # resolved config path in an env-var so that the factory can
             # pick it up (ServerConfig already reads OPENVIKING_CONFIG_FILE).
+            os.environ[WORKER_WITH_BOT_ENV] = "1" if config.with_bot else "0"
+            os.environ[WORKER_BOT_API_URL_ENV] = config.bot_api_url
             uvicorn.run(
-                "openviking.server.app:create_app",
+                "openviking.server.app:create_worker_app",
                 factory=True,
                 host=config.host,
                 port=config.port,

--- a/tests/server/test_bootstrap.py
+++ b/tests/server/test_bootstrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from types import SimpleNamespace
 
+import openviking.server.app as app_module
 import openviking.server.bootstrap as bootstrap
 from openviking.server.config import ServerConfig
 from openviking.utils.agfs_utils import resolve_queuefs_mount_point
@@ -172,6 +173,61 @@ def test_main_enables_bot_logging_when_with_bot_comes_from_config(monkeypatch):
         "log_dir": "/tmp/bot-logs",
         "port": bootstrap.VIKINGBOT_DEFAULT_PORT,
     }
+
+
+def test_bot_alias_propagates_resolved_config_to_workers(monkeypatch):
+    config = ServerConfig(host="127.0.0.1", port=1933)
+    captured = {}
+    original_parse_args = bootstrap.argparse.ArgumentParser.parse_args
+
+    def parse_bot_alias(parser):
+        args = original_parse_args(parser, ["--bot", "--workers", "2", "--bot-port", "19000"])
+        captured["with_bot"] = args.with_bot
+        return args
+
+    monkeypatch.delenv(app_module.WORKER_WITH_BOT_ENV, raising=False)
+    monkeypatch.delenv(app_module.WORKER_BOT_API_URL_ENV, raising=False)
+    monkeypatch.setattr(bootstrap.argparse.ArgumentParser, "parse_args", parse_bot_alias)
+    monkeypatch.setattr(bootstrap, "load_server_config", lambda config_path: config)
+    monkeypatch.setattr(bootstrap, "create_app", lambda config: "parent-app")
+    monkeypatch.setattr(bootstrap, "configure_uvicorn_logging", lambda: None)
+    monkeypatch.setattr(bootstrap, "_abort_if_port_in_use", lambda port, label: None)
+    monkeypatch.setattr(bootstrap, "_start_vikingbot_gateway", lambda *args, **kwargs: object())
+    monkeypatch.setattr(bootstrap, "_stop_vikingbot_gateway", lambda process: None)
+    monkeypatch.setattr(
+        OpenVikingConfigSingleton,
+        "initialize",
+        classmethod(lambda cls, config_path: None),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.ollama.detect_ollama_in_config",
+        lambda config: (False, "127.0.0.1", 11434),
+    )
+    monkeypatch.setattr(
+        bootstrap.uvicorn,
+        "run",
+        lambda app, **kwargs: captured.update({"app": app, **kwargs}),
+    )
+
+    bootstrap.main()
+
+    assert captured["with_bot"] is True
+    assert captured["app"] == "openviking.server.app:create_worker_app"
+    assert os.environ[app_module.WORKER_WITH_BOT_ENV] == "1"
+    assert os.environ[app_module.WORKER_BOT_API_URL_ENV] == "http://127.0.0.1:19000"
+
+
+def test_worker_factory_replays_bot_overrides(monkeypatch):
+    config = ServerConfig(with_bot=False, bot_api_url="http://from-config")
+    monkeypatch.setenv(app_module.WORKER_WITH_BOT_ENV, "1")
+    monkeypatch.setenv(app_module.WORKER_BOT_API_URL_ENV, "http://127.0.0.1:19000")
+    monkeypatch.setattr(app_module, "load_server_config", lambda: config)
+    monkeypatch.setattr(app_module, "create_app", lambda worker_config: worker_config)
+
+    worker_config = app_module.create_worker_app()
+
+    assert worker_config.with_bot is True
+    assert worker_config.bot_api_url == "http://127.0.0.1:19000"
 
 
 def test_resolve_queuefs_mount_point_defaults_to_shared():


### PR DESCRIPTION
## 概述
`ov serve`(console script `openviking-server`,入口 `openviking/server/bootstrap.py:main`)有两个 Bot 相关缺陷:`--bot` 解析到无人读取的 `args.bot`,是纯空操作;`--workers >1` 时 uvicorn 以 factory 模式在子进程里调用 `create_app()` 重新加载文件配置,丢掉父进程解析出的 CLI Bot 覆盖值。本 PR 把 `--bot` 合并为 `--with-bot` 的别名(同一 `add_argument`、同一 dest),并新增 `create_worker_app` 工厂:父进程通过 `OPENVIKING_WORKER_WITH_BOT` / `OPENVIKING_WORKER_BOT_API_URL` 两个环境变量把已解析的 Bot 配置传给 worker,worker 加载文件配置后重放这两项覆盖。

## 为什么必要(可达性/严重性)
- B-15:`ov serve --bot` 直接命中。argparse 接受该 flag,help 写着 "Also start vikingbot gateway",但 `main()` 只读 `args.with_bot`(bootstrap.py:244),gateway 不启动、代理不开。第一道防线,无上游兜底。
- B-09:`--with-bot --workers 2` 时,父进程启动 vikingbot gateway 并打印 "Bot API proxy enabled",但每个 worker 重读文件配置(`with_bot` 默认 false),bot 路由挂载了却未配置,所有 `/bot/v1/*` 请求返回 503 "Bot service not enabled"(`openviking/server/routers/bot.py:60`)。若文件里 `with_bot=true` 而 CLI 用 `--bot-port` 改端口,worker 会转发到文件/默认端口 18790 而非 CLI 指定端口。
- 诚实定级 **P1**:功能性 CLI/运维缺陷,不涉及安全或数据丢失。B-15 影响所有用 `--bot` 的用户;B-09 仅在多 worker 部署触发。与 sweep 定级一致。

## 关键设计与取舍
- `--bot` 做成 `--with-bot` 的 alias 而非删除:保留兼容,两种写法行为一致(开代理 + 起 gateway)。全仓除 bootstrap.py:162 外无其它 `--bot` 引用,无冲突。
- worker 传参走专用环境变量,而非复用 `OPENVIKING_CONFIG_FILE`:后者只能传文件路径,带不动 CLI-only 的覆盖值(`with_bot`、由 `--bot-port` 计算的 `bot_api_url` 从不落盘)。备选方案是把 resolved config 序列化到临时文件让 worker 读,机制更重还要管理临时文件生命周期;两个标量用 env 传是最小方案。
- 环境变量在 `workers > 1` 分支内、`_start_vikingbot_gateway` 之后才设置,且带 `OPENVIKING_WORKER_` 前缀,不会泄漏进 gateway 子进程,也不影响单 worker 路径。
- `bot_api_url` 是 pydantic 非 Optional `str`(config.py:256,`model_validate` 拒绝 null),`os.environ[...] = config.bot_api_url` 无 None 崩溃风险。

## 作用域与已知限制
- 只修 Bot 两个字段的 worker 传播。其它 CLI 覆盖(`--host`/`--port`)在 worker 的 config 对象里仍是文件值——监听地址由 `uvicorn.run` 参数决定,无已知功能影响,属既有行为,未扩大改动面。
- 既有小疣(非本 PR 引入,未动):多 worker 分支里 bootstrap.py:282 仍先 `create_app(config)` 构造一个不被使用的 app。
- 单 worker 路径完全不变(直接传 in-memory app 对象)。

## 修复的问题
- B-09 多 worker 下子进程丢弃 CLI 解析出的 `with_bot` / `bot_api_url`,`/bot/v1/*` 返回 503 或转发错误端口(openviking/server/bootstrap.py:293)
- B-15 `--bot` 被接受但从不读取,help 文案误导(openviking/server/bootstrap.py:162)

## 合入价值
**P1(功能缺陷,非安全)** · 两种文档化的 Bot 开关行为一致;多 worker 部署下 Bot 代理配置与父进程一致,不再出现 worker 503 或转发错误端口。

## 验证
- `python -m pytest -q tests/server/test_bootstrap.py::test_bot_alias_propagates_resolved_config_to_workers tests/server/test_bootstrap.py::test_worker_factory_replays_bot_overrides` — 2 passed(review 时在 PR head 32a898ca 复跑确认)
- 全文件 `pytest tests/server/test_bootstrap.py`:PR 分支 6 passed / 2 failed;两个失败(`test_main_keeps_config_host_*`)在 base 上同样失败,原因是本机 `~/.openviking/ov.conf` 含 schema 外字段 `codex`,属本地环境问题,与本 PR 无关。
- `python -m py_compile openviking/server/app.py openviking/server/bootstrap.py tests/server/test_bootstrap.py` — 通过

---
自动化全仓清扫(2026-07)· draft 待 review
