### PR TITLE
fix(helm): keep PVC on uninstall, honor mountPath for workspace, create ServiceAccount

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -176,8 +176,8 @@ multiple pods accessing the same RocksDB volume simultaneously.
 helm uninstall openviking
 ```
 
-Note: The PersistentVolumeClaim is not deleted automatically. To remove stored
-data:
+Note: The PersistentVolumeClaim is retained by Helm and becomes orphaned after
+uninstall. Delete it explicitly to remove the stored data:
 
 ```bash
 kubectl delete pvc openviking-data

--- a/deploy/helm/openviking/templates/configmap.yaml
+++ b/deploy/helm/openviking/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- $config := deepCopy .Values.config }}
+{{- if empty $config.storage.workspace }}
+{{- $_ := set $config.storage "workspace" (printf "%s/openviking_workspace" (trimSuffix "/" .Values.persistence.mountPath)) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,4 +10,4 @@ metadata:
     {{- include "openviking.labels" . | nindent 4 }}
 data:
   ov.conf: |
-    {{- .Values.config | toPrettyJson | nindent 4 }}
+    {{- $config | toPrettyJson | nindent 4 }}

--- a/deploy/helm/openviking/templates/deployment.yaml
+++ b/deploy/helm/openviking/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "openviking.serviceAccountName" . }}
       {{- end }}
       {{- with .Values.podSecurityContext }}

--- a/deploy/helm/openviking/templates/pvc.yaml
+++ b/deploy/helm/openviking/templates/pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "openviking.fullname" . }}-data
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "openviking.labels" . | nindent 4 }}
 spec:

--- a/deploy/helm/openviking/templates/serviceaccount.yaml
+++ b/deploy/helm/openviking/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openviking.serviceAccountName" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/openviking/values.yaml
+++ b/deploy/helm/openviking/values.yaml
@@ -85,7 +85,8 @@ bot:
 # ${persistence.mountPath}/ov.conf.
 config:
   storage:
-    workspace: /app/.openviking/openviking_workspace
+    # Defaults to <persistence.mountPath>/openviking_workspace when empty.
+    workspace: ""
     vectordb:
       name: context
       backend: local


### PR DESCRIPTION
## 概述
`deploy/helm` chart 三处修复：PVC 加 `helm.sh/resource-policy: keep` 注解、workspace 默认路径改为从 `persistence.mountPath` 推导、补上缺失的 ServiceAccount 模板。只改 chart 模板与默认值，不碰服务端代码。

## 为什么必要（可达性/严重性）
- F-03 是第一道防线，无上游兜底。chart 用普通模板创建 PVC（不是 StatefulSet 的 volumeClaimTemplates），`helm uninstall` 会连带删除它，向量库与 workspace 数据不可恢复；而 README「Uninstall」一节明确承诺 PVC 不会被自动删除。任何照文档操作的 Helm 用户都会踩中。诚实定级：P0（不可逆数据丢失），但影响面限 Helm 部署方式。
- F-08 仅在自定义 `persistence.mountPath` 时触发（P1）。根因是 `config.storage.workspace` 默认值把 mountPath 的默认值硬编码成了字面量，两个必须联动的值各自独立：PVC 挂到新路径后 workspace 仍写 `/app/.openviking/...`，数据落在容器临时层，Pod 重建即静默丢失。
- F-10 在 `serviceAccount.create=true` 时触发（P1）。deployment 引用 `openviking.serviceAccountName`（helper 一直存在），但没有任何模板创建该 SA，ReplicaSet 直接拉不起 Pod；`create=false` 且指定 `name` 时该名字又被忽略。SA 是 IRSA/Workload Identity 挂云端 IAM 权限的落点（`serviceAccount.annotations`），缺了它 S3/KMS 只能塞静态密钥。

## 关键设计与取舍
- PVC 保留用标准 `helm.sh/resource-policy: keep` 注解，让行为对齐 README 的既有承诺，而不是反过来改文档承认会删数据：丢数据不可逆，孤儿 PVC 只是一条 `kubectl delete pvc` 的清理成本。同名 release 重装时 Helm 按 ownership 元数据重新接管该 PVC，不会冲突。
- workspace 推导放在 configmap.yaml（`deepCopy` + `set`），values.yaml 默认值改为 `""`：显式设置 `config.storage.workspace` 的用户不受影响，否则取 `<mountPath>/openviking_workspace`（`trimSuffix "/"` 处理尾斜杠）。备选方案是在 values 里写 `tpl` 模板串，弃用——values 不再是纯数据，对 `--set` 和外部工具都不友好。
- ServiceAccount 采用 helm create 脚手架的标准三态：`create=true` 建 SA；`create=false`+`name` 用现有 SA；都空则省略字段、用 namespace default。deployment 条件相应从 `if create` 改为 `or create name`。

## 作用域与已知限制
- 仅影响 `deploy/helm`；服务端与镜像零改动。
- 默认 values 下 configmap 渲染结果逐字节不变（推导值与原硬编码路径相同），升级不会因 checksum/config 变化触发 Pod 重启。
- keep 的 PVC 在 uninstall 后成为无主资源，需手动 `kubectl delete pvc` 清理，README 已同步改写该段说明。
- `persistence.enabled=false` 时 workspace 推导到 emptyDir 路径，与改前同样是临时的，无行为变化。
- 用户显式把 `config.storage` 整体置 null 会让模板渲染报错；默认 values 合并下不会出现，未做防御。

## 修复的问题
- F-03 helm uninstall 删除 README 承诺保留的 PVC（deploy/helm/openviking/templates/pvc.yaml）
- F-08 自定义 mountPath 时 workspace 落在容器临时层，Pod 重建丢数据（deploy/helm/openviking/templates/configmap.yaml、values.yaml）
- F-10 `serviceAccount.create=true` 引用不存在的 SA 导致 Pod 无法创建，指定 name 也被忽略（deploy/helm/openviking/templates/serviceaccount.yaml、deployment.yaml）

## 合入价值
**P0（F-03 数据丢失）+ P1×2** · Helm 用户卸载/Pod 重建后数据仍在；`create=true` 不再打挂 Pod 调度；IRSA 场景可经 SA 注解免静态密钥。

## 验证
在合入后的 chart 树实测（helm v4.0.0）：
- `helm template`：默认渲染 workspace=`/app/.openviking/openviking_workspace`（与旧硬编码一致），PVC 带 keep 注解
- `--set persistence.mountPath=/data/`：workspace=`/data/openviking_workspace`，尾斜杠正确处理
- `--set config.storage.workspace=/custom/ws`：显式值生效
- `--set serviceAccount.create=true`：渲染 SA 对象且 Pod 引用之；`--set serviceAccount.name=external`：不建 SA、Pod 用 external；两者都不设：省略字段
- `--set persistence.existingClaim=mypvc`：不渲染 PVC
- `helm lint`：0 failed

---
自动化全仓清扫（2026-07）· 已于 2026-07-24 合入 main（ea3ea105）
