### PR TITLE
fix(server): apply configured temp_upload.default_mode to uploads

### DIFF
--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -222,7 +222,7 @@ class ObservabilityConfig(BaseModel):
 class TempUploadConfig(BaseModel):
     """Temporary upload configuration."""
 
-    default_mode: str = "local"
+    default_mode: Literal["local", "shared"] = "local"
     shared_max_size_bytes: int = 512 * 1024 * 1024
     shared_prefix: str = "viking://upload"
 

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Resource endpoints for OpenViking HTTP Server."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -126,7 +126,7 @@ async def temp_upload(
     request: Request,
     file: UploadFile = File(...),
     telemetry: bool = Form(False),
-    upload_mode: str = Form("local"),
+    upload_mode: Optional[Literal["local", "shared"]] = Form(None),
     _ctx: RequestContext = Depends(get_upload_request_context),
 ):
     """Upload a temporary file for add_resource or import_ovpack.
@@ -140,10 +140,11 @@ async def temp_upload(
     dependency.
     """
     signed = getattr(request.state, "signed_upload", None)
+    effective_upload_mode = upload_mode or request.app.state.config.temp_upload.default_mode
 
     async def _upload() -> dict[str, Any]:
         store = TempUploadStore.build(request.app.state.config)
-        temp_file_id = await store.save_upload(file, upload_mode, _ctx)
+        temp_file_id = await store.save_upload(file, effective_upload_mode, _ctx)
         if signed is None:
             return {"temp_file_id": temp_file_id}
         return await ingest_temp_upload(

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -5,9 +5,11 @@
 
 import asyncio
 import zipfile
+from types import SimpleNamespace
 
 import httpx
 
+from openviking.server.routers import resources as resources_router
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 
@@ -594,6 +596,37 @@ async def test_temp_upload_success(client: httpx.AsyncClient, upload_temp_dir):
     assert "telemetry" not in body
     assert body["result"]["temp_file_id"].endswith(".md")
     assert "/" not in body["result"]["temp_file_id"]
+
+
+async def test_temp_upload_uses_configured_shared_default(monkeypatch):
+    saved_modes = []
+
+    class Store:
+        async def save_upload(self, file, upload_mode, ctx):
+            saved_modes.append(upload_mode)
+            return "shared_123"
+
+    async def run_immediately(*, fn, **kwargs):
+        return SimpleNamespace(result=await fn(), telemetry=None)
+
+    config = SimpleNamespace(temp_upload=SimpleNamespace(default_mode="shared"))
+    request = SimpleNamespace(
+        state=SimpleNamespace(signed_upload=None),
+        app=SimpleNamespace(state=SimpleNamespace(config=config)),
+    )
+    monkeypatch.setattr(resources_router.TempUploadStore, "build", lambda _: Store())
+    monkeypatch.setattr(resources_router, "run_operation", run_immediately)
+
+    response = await resources_router.temp_upload(
+        request=request,
+        file=object(),
+        telemetry=False,
+        upload_mode=None,
+        _ctx=object(),
+    )
+
+    assert saved_modes == ["shared"]
+    assert response["result"]["temp_file_id"] == "shared_123"
 
 
 async def test_temp_upload_with_telemetry_returns_summary(


### PR DESCRIPTION
## 概述
`POST /api/v1/resources/temp_upload` 的表单参数把默认值硬编码为 `Form("local")`，服务端因此无法区分"客户端显式要求 local"和"客户端没传"。配置项 `temp_upload.default_mode` 在 main 上除定义（openviking/server/config.py:225）外没有任何读取点，是纯死配置。本 PR 把表单值改为可选：缺省时回退服务端配置，显式传参仍按请求覆盖。

## 为什么必要（可达性/严重性）
真实第一道防线，无上游覆盖。三个 SDK 在未配置 `upload.mode` 时都不发送该字段，直接落到服务端默认：
- sdk/python/openviking_sdk/client.py:522（`if self._upload_mode` 才带）
- sdk/go/upload.go:97（`uploadMode != ""` 才写字段）
- sdk/typescript/src/client.ts:65（同上）

触发场景：多副本部署的运维者按部署文档（docs/en+zh/guides/03-deployment.md）设置 `default_mode: "shared"` → 配置被静默忽略，文件仍写单实例本地磁盘 → 后续 `add_resource(temp_file_id)` 落到另一副本时文件不存在，上传丢失。

诚实定级 **P1**，不是 P0：只影响依赖服务端默认值的多副本部署；每个客户端显式传 `upload_mode=shared` 可以绕过（该路径一直是通的）；单机部署（默认 local）完全不受影响。

## 关键设计与取舍
- 表单改 `Optional[Literal["local","shared"]] = Form(None)`：`None` 表示"未传"，回退 `request.app.state.config.temp_upload.default_mode`；显式值仍最高优先。替代方案是改三个 SDK 默认发送 shared 或拉服务端配置——要动 3 个仓内 SDK 且已发布的旧客户端不受益，不选。
- 修在端点而不是 `TempUploadStore.save_upload` 内部：该端点是全仓唯一 mint 新上传的入口（pack.py / skills.py / mcp_endpoint.py 只 consume），在唯一入口处理，store 接口保持显式传参。
- `config.default_mode` 同步收紧为 `Literal["local","shared"]`：配置写错在启动时报 pydantic 错，而不是等到上传时才炸。

## 作用域与已知限制
- 显式传 `upload_mode` 的请求行为不变；单机默认行为不变。
- 错误码变化：非法值（如 `upload_mode=s3`）现在被 FastAPI 校验挡下返回 422，此前会进 `save_upload` 抛 `InvalidArgumentError`（unsigned 路径映射 400）。属于收紧，仓内所有客户端只发送合法值（web-studio 生成客户端该字段可选），无已知调用方受影响。
- signed-upload（MCP `add_resource` 的 `?token=` 路径）在同一请求内完成 ingest，同样应用该默认；但多副本下 signed token 本身的跨副本可用性由 upload_token_store 负责，不在本 PR 范围。
- 新测试直接调用端点函数并 monkeypatch store/run_operation，覆盖"缺省回退配置"这一分支；HTTP 集成路径由既有 `test_temp_upload_success`（local 模式）覆盖。

## 修复的问题
- B-11 未带 `upload_mode` 的请求从不读取配置默认值，多副本部署跨副本丢文件（openviking/server/routers/resources.py:129-147）
- D-01 部署文档要求设置的 `default_mode: "shared"` 此前无任何代码读取，现在真正生效且取值受校验（openviking/server/config.py:222-229）

## 合入价值
**P1** · 多副本部署可按文档把临时上传默认设为 shared，无需每个客户端显式传参，消除跨副本上传丢失。

## 验证
- `python -m py_compile openviking/server/config.py openviking/server/routers/resources.py tests/server/test_api_resources.py` — 通过
- review 复跑（PR head a0dc2498 worktree）：`python -m pytest tests/server/test_api_resources.py -q -k temp_upload` — 新增 `test_temp_upload_uses_configured_shared_default` 通过；同文件 5 个集成用例因本机 `~/.openviking` 配置含未知字段在 fixture 阶段报错，与 PR 无关（同错误在无本 PR 的 main 检出上复现），以 CI 为准
- 复核 main：`git grep default_mode` 确认配置此前零读取点；三个 SDK 均确认缺省不发送该字段

---
自动化全仓清扫(2026-07)· draft 待 review
