### PR TITLE
fix(docker): derive entrypoint/health port from configured server port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ ENV HOME="/app" \
 EXPOSE 1933
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:1933/health || exit 1
+    CMD ["openviking-entrypoint", "--healthcheck"]
 
 # All persistent state (ov.conf, ovcli.conf, workspace data) lives under
 # /app/.openviking, which mirrors the host's ~/.openviking layout. Mount one

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       OPENVIKING_PUBLIC_BASE_URL: ${OPENVIKING_PUBLIC_BASE_URL:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:1933/health || exit 1"]
+      test: ["CMD", "openviking-entrypoint", "--healthcheck"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker/openviking-entrypoint.sh
+++ b/docker/openviking-entrypoint.sh
@@ -1,14 +1,32 @@
 #!/bin/sh
 set -eu
 
-SERVER_URL="http://127.0.0.1:1933"
-SERVER_HEALTH_URL="${SERVER_URL}/health"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
 HEALTH_MAX_ATTEMPTS="${OPENVIKING_HEALTH_MAX_ATTEMPTS:-120}"
 CONFIG_FILE="${OPENVIKING_CONFIG_FILE:-/app/.openviking/ov.conf}"
 PENDING_HEALTH_SCRIPT="/usr/local/bin/openviking-pending-health"
 SERVER_PID=""
 PENDING_PID=""
+
+resolve_server_port() {
+    SERVER_PORT="$(python - "${CONFIG_FILE}" <<'PY'
+import json
+import os
+import sys
+
+port = os.environ.get("OPENVIKING_SERVER_PORT", "").strip()
+if not port and os.path.isfile(sys.argv[1]):
+    with open(sys.argv[1], encoding="utf-8-sig") as config_file:
+        config = json.loads(os.path.expandvars(config_file.read()))
+    port = str((config.get("server") or {}).get("port", 1933)).strip()
+port = port or "1933"
+if not port.isdigit() or not 1 <= int(port) <= 65535:
+    raise SystemExit(f"invalid OpenViking server port: {port}")
+print(port)
+PY
+    )"
+    SERVER_HEALTH_URL="http://127.0.0.1:${SERVER_PORT}/health"
+}
 
 stop_pending_health() {
     if [ -n "${PENDING_PID}" ] && kill -0 "${PENDING_PID}" 2>/dev/null; then
@@ -39,8 +57,9 @@ To start OpenViking, do one of:
 While waiting, every HTTP request to this container returns a 503 JSON
 describing the problem and the fix above.
 EOF
+    resolve_server_port
     OPENVIKING_CONFIG_FILE="${CONFIG_FILE}" \
-    OPENVIKING_PENDING_PORT="1933" \
+    OPENVIKING_PENDING_PORT="${SERVER_PORT}" \
         python "${PENDING_HEALTH_SCRIPT}" &
     PENDING_PID=$!
     trap 'stop_pending_health; exit 0' INT TERM
@@ -74,6 +93,11 @@ normalize_with_bot() {
     esac
 }
 
+if [ "$#" -eq 1 ] && [ "$1" = "--healthcheck" ]; then
+    resolve_server_port
+    exec curl -fsS "${SERVER_HEALTH_URL}"
+fi
+
 if [ "$#" -gt 0 ]; then
     for arg in "$@"; do
         case "${arg}" in
@@ -92,6 +116,7 @@ fi
 
 normalize_with_bot "${WITH_BOT}"
 ensure_config
+resolve_server_port
 
 forward_signal() {
     if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
@@ -104,9 +129,9 @@ trap 'forward_signal' INT TERM
 SERVER_HOST="${OPENVIKING_SERVER_HOST:-0.0.0.0}"
 
 if [ "${WITH_BOT}" = "1" ]; then
-    openviking-server --host "${SERVER_HOST}" --with-bot &
+    openviking-server --host "${SERVER_HOST}" --port "${SERVER_PORT}" --with-bot &
 else
-    openviking-server --host "${SERVER_HOST}" &
+    openviking-server --host "${SERVER_HOST}" --port "${SERVER_PORT}" &
 fi
 SERVER_PID=$!
 


### PR DESCRIPTION
## 概述
容器入口脚本把健康探测地址硬编码为 `http://127.0.0.1:1933/health`，而 server 自己会读 `ov.conf` 的 `server.port`（`openviking/server/config.py:249`，配置优先于默认值）。配置成 8080 时 server 在 8080 正常监听，入口却持续探测 1933，120 次(约 120s)超时后 `forward_signal` 主动 kill 掉健康的 server 并以非零码退出（旧 `docker/openviking-entrypoint.sh:121-125`）。本 PR 让入口用与 server 完全一致的语义解析出端口，显式 `--port` 传给 server，并让 Dockerfile/Compose 健康检查复用同一解析逻辑。

## 为什么必要(可达性/严重性)
- 真实第一道防线，无上游兜底：杀进程的就是入口脚本本身，没有任何 guard 能拦。
- 三条路径全部命中：`docker run`、`docker compose`、Helm（`deploy/helm/openviking/templates/deployment.yaml` 不覆盖 `command:`，Pod 跑的就是这个 entrypoint；K8s 虽忽略 Dockerfile HEALTHCHECK，但入口内部的探测-kill 循环照样生效）。
- 触发条件仅一个：`server.port != 1933`。默认端口用户不受影响，且无安全影响，故定级 P1（功能性破坏，非 P0）。

## 关键设计与取舍
- **解析语义与 server 完全对齐**：`resolve_server_port` 用 `utf-8-sig` 读文件 + `os.path.expandvars` + `json.loads`，逐项复制 `openviking_cli/utils/config/config_loader.py:83-92` 的行为（含 BOM 与 `${VAR}` 展开），避免入口和 server 对同一份 ov.conf 得出不同端口。
- **入口显式传 `--port` 而非依赖 server 自行读配置**：`bootstrap.py:240` 保证 CLI 参数覆盖配置，这样新增的 `OPENVIKING_SERVER_PORT` 环境变量（与既有 `OPENVIKING_SERVER_HOST` 对称，仅入口层识别）的优先级语义（env > 配置 > 1933）对 server 和健康检查同时成立。
- **健康检查改为 `openviking-entrypoint --healthcheck`**：exec 形式，同一份解析逻辑，不再维护第二份端口猜测。该分支放在参数透传循环之前，否则会被 `exec "$@"` 吞掉。
- 考虑过 sed/grep 从 JSON 抠端口——放弃，无法正确处理嵌套/env 展开；考虑过让 server 打印自身端口——需要改 server 且解决不了启动前的 pending 阶段。
- 非法端口（非数字或超出 1-65535）直接报错退出而非静默回落 1933：配置错了应该早失败。

## 作用域与已知限制
- `docker-compose.yml` 的 `ports: "1933:1933"` 与 Dockerfile `EXPOSE 1933` 仍是硬编码：自定义端口用户需自行调整宿主机映射（EXPOSE 仅元数据，不影响运行）。
- pending 模式（无 ov.conf 等待挂载）期间端口按 env/1933 解析；配置文件出现后主流程重新解析。若新配置用了自定义端口，健康检查有最多一个 5s 轮询周期的短暂错位，`retries: 3` 完全吸收，可自愈。
- 每次健康探测多起一个 python 进程解析配置，30s 一次，开销可忽略。
- 无回归面：默认 1933 用户行为完全不变（解析结果仍是 1933，`--port 1933` 与不传等价）。

## 修复的问题
- F-06 入口、镜像与 Compose 健康检查忽略已配置的 server 端口，自定义端口时健康进程约 120s 后被误杀（`docker/openviking-entrypoint.sh`、`Dockerfile:118-119`、`docker-compose.yml:28`）

## 合入价值
**P1** · docker run / compose / Helm 用户可在任意端口运行 OpenViking，不再被入口的误报健康检查杀掉 server。

## 验证
- `bash -n docker/openviking-entrypoint.sh`、`docker buildx build --check .`、`docker compose config --quiet` 通过。
- `helm template openviking deploy/helm/openviking --set config.server.port=8080` 渲染的 containerPort 断言通过。
- 功能验证：配置端口 18080、`OPENVIKING_SERVER_PORT=18081` 覆盖、非法端口报错、桩 server 下 `--healthcheck` 探测，均按预期。
- 代码走查确认解析语义与 `config_loader.py` 一致（utf-8-sig/expandvars/json）、`--port` 覆盖链路存在（`bootstrap.py:240-241`）、`openviking-entrypoint` 在镜像 PATH 上（`Dockerfile:107`）、pending 服务读取 `OPENVIKING_PENDING_PORT`（`docker/pending_health_server.py:91`）。

---
自动化全仓清扫(2026-07)· draft 待 review
