### PR TITLE
fix(kernel): atomic PID lock acquisition and lock release on error

### DIFF
--- a/openviking/storage/transaction/lock_context.py
+++ b/openviking/storage/transaction/lock_context.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """LockContext — async context manager for acquiring/releasing path locks."""
 
+import asyncio
 from typing import Any, Optional
 
 from openviking.storage.errors import LockAcquisitionError
@@ -47,25 +48,32 @@ class LockContext:
 
         if self._lock_mode == "tree":
             for path in self._paths:
-                success = await self._manager.acquire_tree(
-                    self._handle, path, timeout=self._timeout
+                success = await self._await_acquisition(
+                    self._manager.acquire_tree(self._handle, path, timeout=self._timeout)
                 )
                 if not success:
                     break
         elif self._lock_mode == "exact":
-            success = await self._manager.acquire_exact_path_batch(
-                self._handle, self._paths, timeout=self._timeout
+            success = await self._await_acquisition(
+                self._manager.acquire_exact_path_batch(
+                    self._handle, self._paths, timeout=self._timeout
+                )
             )
         elif self._lock_mode == "mv":
             if self._mv_dst_path is None:
                 raise LockAcquisitionError("mv lock mode requires mv_dst_path")
-            success = await self._manager.acquire_mv(
-                self._handle,
-                self._paths[0],
-                self._mv_dst_path,
-                src_is_dir=self._src_is_dir,
-                timeout=self._timeout,
+            acquire_src = (
+                self._manager.acquire_tree if self._src_is_dir else self._manager.acquire_exact_path
             )
+            success = await self._await_acquisition(
+                acquire_src(self._handle, self._paths[0], timeout=self._timeout)
+            )
+            if success:
+                success = await self._await_acquisition(
+                    self._manager.acquire_exact_path(
+                        self._handle, self._mv_dst_path, timeout=self._timeout
+                    )
+                )
         else:
             raise LockAcquisitionError(f"Unsupported lock mode: {self._lock_mode}")
 
@@ -74,16 +82,39 @@ class LockContext:
         ]
 
         if not success:
-            if self._owns_handle:
-                await self._manager.release(self._handle)
-            else:
-                await self._manager.release_selected(self._handle, self._acquired_lock_paths)
+            await self._release_acquired(self._acquired_lock_paths)
             raise LockAcquisitionError(
                 f"Failed to acquire {self._lock_mode} lock for {self._paths}"
             )
         if self._owns_handle and self._handle.locks:
             self._owned_lease = OwnedLockLease.from_handle(self._manager, self._handle)
         return self._handle
+
+    async def _await_acquisition(self, acquisition: Any) -> bool:
+        try:
+            return await acquisition
+        except BaseException:
+            acquired = [path for path in self._handle.locks if path not in self._locks_before]
+            await self._release_acquired(acquired)
+            raise
+
+    async def _release_acquired(self, acquired: list[str]) -> None:
+        cleanup = asyncio.create_task(
+            self._manager.release(self._handle)
+            if self._owns_handle
+            else self._manager.release_selected(self._handle, acquired)
+        )
+        cancelled = False
+        try:
+            while not cleanup.done():
+                try:
+                    await asyncio.shield(cleanup)
+                except asyncio.CancelledError:
+                    cancelled = True
+        except Exception:
+            pass
+        if cancelled:
+            raise asyncio.CancelledError
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._handle:

--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -10,12 +10,17 @@ import atexit
 import os
 import signal
 import sys
+import threading
 
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
 LOCK_FILENAME = ".openviking.pid"
+_LOCK_FILES: dict[str, object] = {}
+_LOCK_GUARD = threading.RLock()
+getattr(os, "register_at_fork", lambda **_: None)(after_in_child=_LOCK_GUARD._at_fork_reinit)
+getattr(os, "register_at_fork", lambda **_: None)(after_in_child=_LOCK_FILES.clear)
 
 
 class DataDirectoryLocked(RuntimeError):
@@ -69,6 +74,19 @@ def _is_pid_alive(pid: int) -> bool:
     return True
 
 
+def _lock_file(lock_file) -> None:
+    if os.name == "nt":
+        import msvcrt
+        if os.fstat(lock_file.fileno()).st_size == 0:
+            lock_file.write("0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
 def acquire_data_dir_lock(data_dir: str) -> str:
     """Acquire an advisory PID lock on *data_dir*.
 
@@ -78,6 +96,7 @@ def acquire_data_dir_lock(data_dir: str) -> str:
     lock, with a message that explains the situation and suggests HTTP mode.
     """
     lock_path = os.path.join(data_dir, LOCK_FILENAME)
+    lock_key = os.path.normcase(os.path.realpath(lock_path))
     my_pid = os.getpid()
 
     existing_pid = _read_pid_file(lock_path)
@@ -94,24 +113,33 @@ def acquire_data_dir_lock(data_dir: str) -> str:
             f"  3. Stop the other process (PID {existing_pid}) first"
         )
 
-    # Write our PID (overwrites stale lock from a dead process).
-    try:
-        os.makedirs(data_dir, exist_ok=True)
-        with open(lock_path, "w") as f:
-            f.write(str(my_pid))
-    except OSError as exc:
-        logger.warning("Could not write PID lock %s: %s", lock_path, exc)
-        return lock_path
+    os.makedirs(data_dir, exist_ok=True)
+    with _LOCK_GUARD:
+        if lock_key in _LOCK_FILES:
+            return lock_path
+
+        lock_file = open(lock_path, "a+")
+        try:
+            _lock_file(lock_file)
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.write(str(my_pid))
+            lock_file.flush()
+        except OSError as exc:
+            lock_file.close()
+            raise DataDirectoryLocked(f"Could not lock data directory: '{data_dir}'") from exc
+        _LOCK_FILES[lock_key] = lock_file
 
     # Schedule cleanup on exit.
     def _cleanup(*_args: object) -> None:
-        try:
-            if os.path.isfile(lock_path):
-                stored = _read_pid_file(lock_path)
-                if stored == my_pid:
-                    os.remove(lock_path)
-        except OSError:
-            pass
+        with _LOCK_GUARD:
+            locked = _LOCK_FILES.pop(lock_key, None)
+            if locked is not None:
+                try:
+                    locked.truncate(0)
+                except OSError:
+                    pass
+                locked.close()
 
     atexit.register(_cleanup)
     # Also try to clean up on SIGTERM (graceful shutdown).

--- a/tests/transaction/test_lock_context.py
+++ b/tests/transaction/test_lock_context.py
@@ -3,6 +3,7 @@
 """Tests for LockContext async context manager."""
 
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -84,6 +85,16 @@ class TestLockContextFailure:
                 pass
 
         assert len(await lm.get_active_handles_async()) == 0
+
+    async def test_mv_failure_preserves_external_handle_locks(self, lm):
+        h = lm.create_handle()
+        h.add_lock("/outer/.lock")
+        lm.acquire_tree = AsyncMock(side_effect=lambda *_a, **_kw: not h.add_lock("/src/.lock"))
+        lm.acquire_exact_path = AsyncMock(return_value=False)
+        lm.release_selected = AsyncMock()
+        with pytest.raises(LockAcquisitionError):
+            await LockContext(lm, ["/src"], "mv", "/dst", handle=h).__aenter__()
+        lm.release_selected.assert_awaited_once_with(h, ["/src/.lock"])
 
 
 class TestLockContextExternalHandle:


### PR DESCRIPTION
## 概述
Workspace 的 PID 锁此前是「读文件 → 检查存活 → 覆盖写」三步,检查与写入之间没有独占语义:并发启动的多个进程可以同时通过检查、各自写入自己的 PID,全部自认加锁成功;写入遇到权限/磁盘错误时还会仅告警后继续裸跑。本 PR 改为进程存活期间持有内核级非阻塞文件锁(POSIX `fcntl.flock` / Windows `msvcrt.locking`),并让 LockContext 的多步加锁在中途异常(含 asyncio 取消)时只回收本上下文新增的锁。

## 为什么必要(可达性/严重性)
- PID 锁是防止多进程共享同一 workspace 的第一道也是唯一一道防线(openviking/service/core.py `_ensure_data_dir_lock_acquired`),上游没有其它守卫;绕过它意味着 AGFS/VectorDB 静默写冲突(issue #473)。
- 真实可达:任意两个 embedded 模式进程在留有 stale pid 文件(前一进程崩溃)后并发启动即触发。实测 main 分支 6 进程并发抢锁,5 个同时「成功」;本 PR 后恰好 1 个成功、其余收到 DataDirectoryLocked。
- B-06(路径锁)是可用性问题:后端异常或任务取消发生在多路径加锁中途时,已加的锁残留到租约过期,阻塞同路径后续请求;租约会兜底回收,不涉及数据损坏。
- 诚实定级 P1:常见场景(第二个进程在第一个存活期间启动)旧的 pid 检查已能拒绝,损坏窗口在「并发启动竞态」和「写入出错裸跑」两条边上,不到 P0。

## 关键设计与取舍
- 选 OS 原生 flock 而非 `O_EXCL` 创建或 mkdir 锁:内核锁随进程消亡自动释放,天然无 stale 问题;`O_EXCL`/mkdir 方案在进程崩溃后仍需活性判定,等于重回旧逻辑。保留 pid 读取 + 存活检查只为给出带 PID 的友好报错,独占性不再依赖它。
- 清理时 truncate 而非 unlink pid 文件:unlink + 重开有经典 split-brain 竞态(旧 inode 与新文件各被一个进程 flock 成功),代价是退出后留下一个空 `.openviking.pid`。
- `os.register_at_fork` 在子进程清空锁注册表:fork 出的子进程既不自认持锁,也不会在退出时清掉父进程的 pid 文件。用到 `RLock._at_fork_reinit`(CPython 私有 API,3.9+ 存在,仓库要求 >=3.10)。
- LockContext:每次 acquire 包一层 `_await_acquisition`,BaseException(含 CancelledError)时只释放 `_locks_before` 之后新增的锁;释放动作放进 `asyncio.shield` 保护的独立 task,取消不会把清理打断一半,清理完成后再重新抛出取消。
- mv 模式从 `manager.acquire_mv` 拆成 src(tree/exact)+ dst(exact)两步,顺序不变:原 `path_lock.acquire_mv` 在 dst 失败时 `release(owner)` 释放整个 handle,外部传入 handle 时会连调用方先前持有的锁一起清掉;拆开后失败路径只回收本上下文新增的锁(新增测试 test_mv_failure_preserves_external_handle_locks 覆盖)。`manager.acquire_mv` 本身保留,仍有测试与外部调用可用。

## 作用域与已知限制
- 行为变化:权限/磁盘错误时从「告警后裸跑」改为抛 DataDirectoryLocked 拒绝启动;确需绕过的场景走既有 `storage.skip_process_lock` 逃生门。`os.makedirs`/`open` 本身失败时抛原生 OSError 而非 DataDirectoryLocked,仅报错类型不一致,不影响独占性。
- flock 是建议锁,NFS 等网络文件系统上的可靠性取决于挂载配置;workspace 在本地盘时语义完整。手工删除 `.openviking.pid` 仍可绕过锁(任何 pidfile 方案的固有限制,非本 PR 引入)。
- `_release_acquired` 吞掉释放阶段的后端异常(锁交由租约过期兜底,与旧行为同一终态),未加日志。
- 不改变 exact/tree 正常路径的加锁顺序、公平性与超时语义。

## 修复的问题
- A-04 并发启动或写入出错时,多个进程可同时自认持有 workspace PID 锁(openviking/utils/process_lock.py:77)
- B-06 多路径加锁中途异常/取消,已加入 handle 的锁残留到租约过期(openviking/storage/transaction/lock_context.py:49)
- 附带:mv 加锁 dst 失败时,外部 handle 上调用方先前持有的锁被整体释放(openviking/storage/transaction/path_lock.py:811)

## 合入价值
**P1** · 多个 OpenViking 进程不再静默共享同一 workspace(防 AGFS/VectorDB 写冲突损坏);存储瞬时故障或任务取消不再留下阻塞性残留锁。

## 验证
- `pytest tests/unit/test_process_lock.py tests/misc/test_process_lock.py tests/transaction/test_lock_context.py tests/transaction/test_lock_reentrancy_unit.py` — 48 passed(review 时独立复跑确认)
- 6 进程并发抢 stale pid 锁复现脚本:main 上 5 个进程同时成功,本 PR 上恰好 1 成功 5 拒绝
- CI 全绿:API & CLI Integration Tests (ubuntu-24.04)、check-deps、plugin-tests pass

---
自动化全仓清扫(2026-07)· draft 待 review
