### PR TITLE
fix(index): propagate vectorization failures instead of reporting success

### DIFF
--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -369,6 +369,7 @@ async def vectorize_directory_meta(
                     f"Failed to enqueue directory L0 (abstract) for vectorization: {uri}: {e}",
                     exc_info=True,
                 )
+                raise
 
         if include_overview:
             # Vectorize L1: .overview.md (overview)
@@ -402,6 +403,7 @@ async def vectorize_directory_meta(
                         f"Failed to enqueue directory L1 (overview) for vectorization: {uri}: {e}",
                         exc_info=True,
                     )
+                    raise
     except Exception as e:
         logger.error(
             f"Failed to vectorize directory metadata for {uri}: {e}",
@@ -547,6 +549,7 @@ async def vectorize_file(
 
     except Exception as e:
         logger.error(f"Failed to vectorize file {file_path}: {e}", exc_info=True)
+        raise
     finally:
         if not enqueued:
             await _decrement_embedding_tracker(semantic_msg_id, 1)
@@ -619,3 +622,4 @@ async def index_resource(
 
     except Exception as e:
         logger.error(f"Failed to scan directory {uri} for indexing: {e}")
+        raise

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -14,6 +14,11 @@ class DummyQueue:
         self.items.append(msg)
 
 
+class FailingQueue:
+    async def enqueue(self, _msg):
+        raise RuntimeError("queue unavailable")
+
+
 class DummyQueueManager:
     EMBEDDING = "embedding"
 
@@ -117,6 +122,32 @@ async def test_vectorize_file_uses_summary_first(monkeypatch):
     assert len(queue.items) == 1
     assert isinstance(queue.items[0], Context)
     assert queue.items[0].get_vectorization_text() == "short summary"
+
+
+@pytest.mark.asyncio
+async def test_vectorize_file_propagates_enqueue_failure(monkeypatch):
+    monkeypatch.setattr(
+        embedding_utils, "get_queue_manager", lambda: DummyQueueManager(FailingQueue())
+    )
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS("content"))
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_openviking_config",
+        lambda: types.SimpleNamespace(
+            embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
+        ),
+    )
+    monkeypatch.setattr(
+        embedding_utils.EmbeddingMsgConverter, "from_context", lambda context: context
+    )
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await embedding_utils.vectorize_file(
+            "viking://user/default/resources/test.md",
+            {"name": "test.md", "summary": "summary"},
+            "viking://user/default/resources",
+            ctx=DummyReq(),
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概述
`embedding_utils.py` 里四处 `except` 只记日志就吞掉向量化失败:目录 L0/L1 enqueue、`vectorize_file` 外层、`index_resource` 目录扫描。结果是 `build_index` 无条件返回 `{"status": "success"}`,索引可能一条都没写。本 PR 在这四处补 `raise`,保留 finally 中的 tracker 扣减(先扣减再传播,tracker 不挂起),让失败到达真正能处理它的调用方。

## 为什么必要(可达性/严重性)
根因不是某个 enqueue 会失败,而是失败被在最底层消化掉,上层没有任何机会感知。逐条核对过调用链:

- **显式 `build_index` API**(第一道防线,真实可达):`sync_client`/`async_client` → `resource_service.build_index`(resource_service.py:1796)→ `resource_processor.build_index`(resource_processor.py:100)→ `index_resource`。中间零捕获,修复前必然假成功;修复后错误直达调用方。
- **memory 目录语义路径**:`semantic_processor._process_memory_directory`(semantic_processor.py:699/708)直接调用这两个函数。异常现在传播到 `process()` 的顶层分类器(semantic_processor.py:466-516):transient → 重新入队重试,permanent → `mark_semantic_failed`。修复前该消息被标记完成,向量静默缺失。
- **ovpack 导入/恢复**:operations.py:359/697 无本地捕获,失败现在使导入报错,而非静默产出无向量、搜不到的资源。
- **`fs_service.mkdir`**(fs_service.py:176):`vectorize_directory_meta` 外层 except 在 main 上本来就 log+raise,本 PR 只是把内层 enqueue 失败也纳入这一既有语义,不新增异常面。

**已知未覆盖**:主 add_resource DAG 路径 `SemanticDagExecutor._run_vectorize_work`(semantic_dag.py:388-393)仍然 catch+log 后继续,该路径的假成功不归本 PR 修。所以诚实定级是 **P1,限 build_index 与队列重试路径**,不是全链路修复,不按"所有 add_resource 都假成功"来卖。

## 关键设计与取舍
- 在共享底层函数抛错,而不是让每个调用方检查返回值:5 个调用点自动获得该行为,与 `vectorize_directory_meta` 外层已有的 log+raise 一致。替代方案(返回 bool/计数)需要改所有调用方签名,且已有调用方都不检查返回值,改动面更大。
- 保留 `_decrement_embedding_tracker` 的 finally 语义:异常路径先扣减再传播,`EmbeddingTaskTracker` 不会因失败挂起;消息重试时 `register` 覆盖旧记录(embedding_tracker.py:143-147 有 overwrite 分支),无泄漏。
- 不动 semantic_dag 的 catch:去掉它意味着单文件 enqueue 失败会 fail 整个资源 DAG,这是更大的行为决策(整体失败 vs 跳过),应单独开 issue 讨论,不夹带在本 PR。

## 作用域与已知限制
- 行为变化 1:`index_resource` 扫描循环中单文件失败现在中止余下文件并使 `build_index` 报错(此前继续处理剩余文件)。重跑 `build_index` 可重入补齐。
- 行为变化 2:`vectorize_directory_meta` 的 L0 enqueue 失败不再继续尝试 L1;重试时两者都重做。
- 行为变化 3:ovpack 导入在文件落盘之后才做向量化,失败时数据已写入、向量缺失,现在报错而非静默;重跑导入或 `build_index` 可补。
- 后端无关:失败源是 embedding 队列 enqueue,与 S3/本地存储后端无关。
- 主 add_resource DAG 路径(semantic_dag.py:388-393)仍吞失败,建议后续 issue 单独处理其失败语义。

## 修复的问题
- A-06 向量化 enqueue/处理失败被吞,`build_index` 对未写入的索引报 success(openviking/utils/embedding_utils.py,四处:L0/L1 enqueue、vectorize_file 外层、index_resource 扫描)

## 合入价值
**P1(build_index 与队列重试路径的第一道防线;add_resource DAG 路径未覆盖)** · 显式建索引与 memory 语义处理不再对缺失的索引报假成功;transient 错误进入队列重试而非静默丢失。

## 验证
- `pytest -q --no-cov tests/unit/test_vectorize_file_strategy.py` @ PR head 02387deb(review 时独立复跑)— 26 passed
- 人工追踪全部 5 个调用点的异常处理:resource_processor.py:100、semantic_processor.py:699/708、semantic_dag.py:388-393(仍吞,列为限制)、ovpack/operations.py:232/246、fs_service.py:176
- 对照 origin/main 确认 `vectorize_directory_meta` 外层 raise 为既有行为,本 PR 未扩大该函数的异常面

---
自动化全仓清扫(2026-07)· draft 待 review
