### PR TITLE
fix(memory): prevent StreamingBatcher.close from stranding in-flight batches

### DIFF
--- a/openviking/session/memory/utils/streaming_batcher.py
+++ b/openviking/session/memory/utils/streaming_batcher.py
@@ -179,7 +179,7 @@ class StreamingBatcher(Generic[T, R]):
             try:
                 await asyncio.sleep(self.config.timer_check_interval_seconds)
                 if await self._should_flush_by_time_or_count():
-                    await self.flush("time")
+                    await asyncio.shield(self.flush("time"))
             except asyncio.CancelledError:
                 raise
             except Exception as exc:

--- a/tests/unit/test_streaming_batcher.py
+++ b/tests/unit/test_streaming_batcher.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+
+import pytest
+
+from openviking.session.memory.utils.streaming_batcher import (
+    StreamingBatcher,
+    StreamingBatcherConfig,
+)
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_in_flight_timer_flush():
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def process_batch(items: list[str], _reason: str) -> str:
+        started.set()
+        await finish.wait()
+        return ",".join(items)
+
+    batcher = StreamingBatcher(
+        name="test",
+        process_batch=process_batch,
+        config=StreamingBatcherConfig(
+            max_items_per_batch=10,
+            max_wait_seconds=0.01,
+            timer_check_interval_seconds=0.001,
+        ),
+    )
+    submit = asyncio.create_task(batcher.submit("item"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    close = asyncio.create_task(batcher.close())
+    await asyncio.sleep(0)
+    finish.set()
+
+    assert await asyncio.wait_for(submit, timeout=1) == "item"
+    assert await asyncio.wait_for(close, timeout=1) is None


### PR DESCRIPTION
## 概述
`StreamingBatcher.close()` 与定时 flush 存在竞态:定时任务已把 buffer 里的 items 换走并正在 `await process_batch(...)`,此时 close 取消定时任务,这批 items 的 future 永远无人兑现,对应的 `submit()` 调用方永久挂起。改动一行:定时 flush 用 `asyncio.shield` 包裹,取消只打断定时循环、不打断进行中的 flush;close 随后的 `flush("close")` 会在共享 `_flush_lock` 上排队,天然等到在途批次完成。

## 根因
- flush 先在锁内做 `items = self._buffer; self._buffer = []`,再 `await process_batch(...)`。取消落在这个 await 上时抛 `CancelledError` —— 它是 `BaseException`,flush 里 `except Exception` 的兜底(给 future 设异常)不会触发,futures 保持 pending。
- items 已经离开 buffer,close 接下来的 `flush("close")` 看到空 buffer 直接返回 None。于是每个 `await future` 的 submitter 永久挂起,这批数据也丢了。这违反类文档承诺的契约("each submit awaits the Future attached to its own batch item")。

## 可达性/严重性(诚实定级:P2,潜在缺陷)
- 触发条件:在定时 flush 的 `process_batch` 进行中(记忆路径是 LLM 合并调用,秒级窗口,不算窄)调用 `close()`。
- 但当前生产代码没有任何 `close()` 调用方:`StreamingMemoryUpdater`(openviking/session/memory/streaming_memory_updater.py:160)与 `StreamingPolicyTrainer`(openviking/session/train/components/policy_trainer.py:196)都是进程级全局单例,存活到进程结束;`close()` 只被测试调用(tests/session/train/test_train_framework.py)。
- 因此清扫标注的 P1("生产提交请求永久挂起")偏高:这是共享工具类公开 API 的真实契约缺陷,今天是潜在的,一旦优雅关停被接入(close 存在的目的)就会立刻踩中。修复成本一行,值得现在合。

## 关键设计与取舍
- 选 `asyncio.shield`:取消语义只作用于定时循环,在途 flush 跑完并兑现全部 future;close 不需要新增等待机制,复用已有的 `_flush_lock` 排队。
- 弃选一:flush 里 `except BaseException` 也给 future 设异常 —— 能解挂起但批次仍被丢弃(submitter 收到 CancelledError,数据丢失),且吞取消语义容易引入新问题。
- 弃选二:close 先 `flush("close")` 再 cancel timer —— cancel 前定时任务仍可能刚换走 buffer,窗口只是变小没消除。
- count 触发的后台 flush(`_trigger_background_flush`)本就跑在独立 task 上、不被 close 取消,并由 `_flush_lock` 串行化,无需 shield。

## 作用域与已知限制
- 纯 asyncio 工具类修复,后端无关;影响两个使用方:记忆流式提交与训练 rollout 批处理。
- 不防护事件循环整体关闭(loop shutdown 会直接取消所有 task,包括被 shield 的内层任务),那属于进程退出语义。
- 残留一个先前就存在的极窄竞态(本 PR 不处理):`submit()` 通过 closed 检查后恰好在争用的 `_buffer_lock` 上让出,而 close 在此期间完整跑完 —— 该 item 入队后无人 flush。需要 buffer 锁恰好在那一刻被持有,实际难触发;若之后接入优雅关停可再评估。
- shield 每次定时 flush 多创建一个 task 对象,开销可忽略;不改变任何成功/异常路径的对外行为。

## 修复的问题
- A-08 close 取消进行中的定时 flush,buffer 已换走导致 submit 永久挂起(openviking/session/memory/utils/streaming_batcher.py:182)

## 合入价值
**P2(潜在契约缺陷,当前无生产 close 调用方)** · 修复共享批处理器公开 API 的关停竞态,消除未来接入优雅关停时的数据丢失与调用方永久挂起;一行改动 + 定向回归测试。

## 验证
- PR 树:`pytest tests/unit/test_streaming_batcher.py` — 1 passed。
- 反向验证:同一测试在去掉 shield 的代码上运行 — `TimeoutError` 失败(submit future 被搁置),证明测试确实覆盖该竞态而非恒真。
- 测试位置与仓库惯例一致(tests/unit/,pytest-asyncio auto mode)。

---
自动化全仓清扫(2026-07)· draft 待 review
