### PR TITLE
fix(client): align local/sync client surfaces with async client

### DIFF
--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -683,7 +683,7 @@ class AsyncOpenViking:
         simple = kwargs.get("simple", False)
         output = kwargs.get("output", "original")
         abs_limit = kwargs.get("abs_limit", 256)
-        show_all_hidden = kwargs.get("show_all_hidden", True)
+        show_all_hidden = kwargs.get("show_all_hidden", False)
         node_limit = kwargs.get("node_limit", 1000)
         sort_by = kwargs.get("sort_by")
         sort_order = kwargs.get("sort_order", "asc")
@@ -745,7 +745,7 @@ class AsyncOpenViking:
         await self._ensure_initialized()
         output = kwargs.get("output", "original")
         abs_limit = kwargs.get("abs_limit", 128)
-        show_all_hidden = kwargs.get("show_all_hidden", True)
+        show_all_hidden = kwargs.get("show_all_hidden", False)
         node_limit = kwargs.get("node_limit", 1000)
         return await self._client.tree(
             uri,

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -617,7 +617,10 @@ class LocalClient(BaseClient):
             offset: Starting line number (0-indexed). Default 0.
             limit: Number of lines to read. -1 means read to end. Default -1.
         """
-        return await self._service.fs.read(uri, ctx=self._ctx, offset=offset, limit=limit)
+        content = await self._service.fs.read(uri, ctx=self._ctx, offset=offset, limit=limit)
+        from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+        return MemoryFileUtils.read(content, uri=uri).content
 
     async def read_raw(self, uri: str, offset: int = 0, limit: int = -1) -> str:
         """Read raw file content, including hidden MEMORY_FIELDS metadata."""

--- a/openviking/sync_client.py
+++ b/openviking/sync_client.py
@@ -460,6 +460,10 @@ class SyncOpenViking:
         """Read file"""
         return run_async(self._async_client.read(uri, offset=offset, limit=limit))
 
+    def read_raw(self, uri: str, offset: int = 0, limit: int = -1) -> str:
+        """Read raw file content, including hidden MEMORY_FIELDS metadata."""
+        return run_async(self._async_client.read_raw(uri, offset=offset, limit=limit))
+
     def write(
         self,
         uri: str,
@@ -530,15 +534,22 @@ class SyncOpenViking:
     def import_ovpack(
         self,
         file_path: str,
-        target: str,
+        parent: Optional[str] = None,
         on_conflict: Optional[str] = None,
         vector_mode: Optional[str] = None,
+        *,
+        target: Optional[str] = None,
     ) -> str:
         """Import .ovpack file (triggers vectorization by default)"""
+        if parent is not None and target is not None:
+            raise ValueError("parent cannot be used with legacy target")
+        parent = parent if parent is not None else target
+        if parent is None:
+            raise TypeError("parent or legacy target is required")
         return run_async(
             self._async_client.import_ovpack(
                 file_path,
-                target,
+                parent,
                 on_conflict=on_conflict,
                 vector_mode=vector_mode,
             )
@@ -584,6 +595,14 @@ class SyncOpenViking:
     def wait_processed(self, timeout: float = None) -> Dict[str, Any]:
         """Wait for all async operations to complete"""
         return run_async(self._async_client.wait_processed(timeout))
+
+    def build_index(self, resource_uris: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
+        """Manually trigger index building for resources."""
+        return run_async(self._async_client.build_index(resource_uris, **kwargs))
+
+    def summarize(self, resource_uris: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
+        """Manually trigger summarization for resources."""
+        return run_async(self._async_client.summarize(resource_uris, **kwargs))
 
     def grep(
         self,

--- a/tests/client/test_ls_forwarding.py
+++ b/tests/client/test_ls_forwarding.py
@@ -27,8 +27,24 @@ async def test_async_openviking_ls_forwards_ordering_and_limit_options():
         simple=False,
         output="original",
         abs_limit=256,
-        show_all_hidden=True,
+        show_all_hidden=False,
         node_limit=200,
         sort_by="mtime",
         sort_order="desc",
+    )
+
+
+async def test_async_openviking_tree_hides_internal_files_by_default():
+    client = object.__new__(AsyncOpenViking)
+    client._ensure_initialized = AsyncMock()
+    client._client = SimpleNamespace(tree=AsyncMock(return_value={}))
+
+    await client.tree("viking://session")
+
+    client._client.tree.assert_awaited_once_with(
+        "viking://session",
+        output="original",
+        abs_limit=128,
+        show_all_hidden=False,
+        node_limit=1000,
     )

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -150,6 +150,46 @@ async def test_local_client_reindex_forwards_to_service():
     )
 
 
+async def test_local_client_read_strips_memory_fields():
+    client = object.__new__(LocalClient)
+    client._ctx = object()
+    raw = 'visible\n\n<!-- MEMORY_FIELDS\n{"memory_type":"notes"}\n-->'
+    client._service = SimpleNamespace(fs=SimpleNamespace(read=AsyncMock(return_value=raw)))
+
+    assert await client.read("viking://user/memories/notes/demo.md") == "visible"
+
+
+def test_sync_client_forwards_missing_async_surface():
+    client = object.__new__(SyncOpenViking)
+    client._async_client = SimpleNamespace(
+        build_index=Mock(return_value="index"),
+        summarize=Mock(return_value="summary"),
+        read_raw=Mock(return_value="raw"),
+    )
+    with patch("openviking.sync_client.run_async", side_effect=lambda result: result):
+        assert client.build_index(["uri"], wait=True) == "index"
+        assert client.summarize("uri", mode="fast") == "summary"
+        assert client.read_raw("uri", offset=1, limit=2) == "raw"
+
+    client._async_client.build_index.assert_called_once_with(["uri"], wait=True)
+    client._async_client.summarize.assert_called_once_with("uri", mode="fast")
+    client._async_client.read_raw.assert_called_once_with("uri", offset=1, limit=2)
+
+
+def test_sync_import_ovpack_accepts_parent_and_legacy_target():
+    client = object.__new__(SyncOpenViking)
+    import_ovpack = Mock(return_value="imported")
+    client._async_client = SimpleNamespace(import_ovpack=import_ovpack)
+    with patch("openviking.sync_client.run_async", side_effect=lambda result: result):
+        assert client.import_ovpack("pack", parent="parent") == "imported"
+        assert client.import_ovpack("pack", target="legacy") == "imported"
+        with pytest.raises(ValueError):
+            client.import_ovpack("pack", parent="parent", target="legacy")
+
+    assert import_ovpack.call_args_list[0].args == ("pack", "parent")
+    assert import_ovpack.call_args_list[1].args == ("pack", "legacy")
+
+
 async def test_local_client_batch_add_messages_forwards_to_session():
     class FakeSession:
         def __init__(self):


### PR DESCRIPTION
## 概述
嵌入式(local/async/sync)客户端与 HTTP 服务端的公开面漂移:同一份代码从 HTTP 切到嵌入式后,`read` 开始泄露 MEMORY_FIELDS 内部元数据、`ls`/`tree` 默认列出隐藏文件;sync 客户端缺 3 个 async 已有的方法、`import_ovpack(parent=...)` 直接 TypeError。本 PR 把嵌入式默认行为对齐到 HTTP 服务端语义,并补齐 sync 面。

## 根因
- A-14 有两处独立漂移,根因相同——清理逻辑只做在了 HTTP 入口,没做在嵌入式入口:
  - 服务端 `/api/v1/fs/read` 默认用 `MemoryFileUtils.read` 剥离 `<!-- MEMORY_FIELDS -->` 注释(openviking/server/routers/content.py:122-135),而 `LocalClient.read` 直接透传 `service.fs.read` 的原始内容;
  - 服务端 `/fs/ls`、`/fs/tree` 默认 `show_all_hidden=False`(openviking/server/routers/filesystem.py:65,108),`LocalClient.ls/tree`、`viking_fs.ls` 也都默认 False,唯独 `AsyncOpenViking.ls/tree` 这层 kwargs.get 默认写成了 True(async_client.py:686,748),覆盖了下层的正确默认。
- A-15:async 客户端先后加了 `build_index`/`summarize`/`read_raw`,且 `import_ovpack` 第二参数改名为 `parent`(async_client.py:836),sync 客户端没跟上,仍是必填的 `target`。

## 为什么必要(可达性/严重性)
嵌入式入口没有上游防线:服务端的 MEMORY_FIELDS 清理只覆盖 HTTP 路径,任何以 `SyncOpenViking(path=...)` / `AsyncOpenViking` 本地模式运行的用户(含 examples、bot 的 FUSE mount)调 `read`/`ls`/`tree` 都直接命中漂移行为——这是该入口的第一道防线,不是 defense-in-depth。影响是内部元数据污染 agent 上下文、跨客户端行为不一致、以及 sync 侧硬报错(AttributeError/TypeError),没有数据丢失或越权,诚实定级 **P1**,不是 P0。

## 关键设计与取舍
- 剥离做在 `LocalClient.read`(客户端出口),不做在 `fs_service.read`:服务内部消费者(reindex_executor、resource_memory_link_service)需要原始 MEMORY_FIELDS 自行解析,下沉到 service 层会破坏它们。
- 对所有 URI 剥离而非仅 memories 路径:与服务端 content.py 行为逐字对齐,避免再造一条按路径分叉的规则。
- sync `import_ovpack` 保留 `target` 为 keyword-only 旧别名:老的关键字调用不破坏,位置调用天然落到 `parent`;两者同传报 ValueError,都不传报 TypeError。备选方案是直接删 `target`,会无声破坏现存关键字调用方,不取。

## 作用域与已知限制
- 行为变化 1:嵌入式 `read` 不再字节保真——剥 MEMORY_FIELDS 注释并 strip 首尾空白(与 HTTP `/fs/read` 完全一致);需要保真用 `read_raw`。bot/vikingbot 的 FUSE mount 用嵌入式 `read` 取内容、用 `ls` 的 size 报 st_size,对含 MEMORY_FIELDS 的记忆文件会出现 size 与内容长度不一致,如需保真应改用 `read_raw`(建议后续单独处理)。
- 行为变化 2:`AsyncOpenViking.ls/tree`(及转发它的 sync)默认不再列隐藏文件;依赖旧默认的调用方需显式传 `show_all_hidden=True`。
- 已知边界:`read` 的 offset/limit 切片发生在剥离之前,切片切断 MEMORY_FIELDS 块时可能残留片段——与 HTTP 服务端行为相同,非本 PR 引入。

## 修复的问题
- A-14 嵌入式 read 泄露 MEMORY_FIELDS 元数据;ls/tree 默认列出隐藏文件(openviking/client/local.py:612-624, openviking/async_client.py:686,748)
- A-15 sync 客户端缺 `build_index`/`summarize`/`read_raw`;`import_ovpack` 的 `parent` 关键字 TypeError(openviking/sync_client.py:460-606)

## 合入价值
**P1(嵌入式入口第一道防线,API 面一致性)** · HTTP / 嵌入式 / async / sync 四个面行为一致,切换后端不再默认泄露记忆内部结构,也不再抛 AttributeError/TypeError。

## 验证
- `pytest tests/client/test_rebuild_clients.py tests/client/test_ls_forwarding.py`(PR 分支)— 14 passed, 4 failed
- 同样 4 个失败在不含本 PR 的 main 基线上复现(用户环境/已装 CLI 漂移导致),确认非本 PR 引入 — 2026-07-25 复核
- 逐一比对 async/sync/local 的 `build_index`/`summarize`/`read_raw`/`import_ovpack` 签名与服务端 filesystem/content 路由默认值 — 对齐

---
自动化全仓清扫(2026-07)· draft 待 review
