### PR TITLE
fix(resource): isolate watch URI index by account

### DIFF
--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -165,7 +165,7 @@ class WatchManager:
             viking_fs: VikingFS instance for persistence storage
         """
         self._tasks: Dict[str, WatchTask] = {}
-        self._uri_to_task: Dict[str, str] = {}
+        self._uri_to_task: Dict[tuple[str, str], str] = {}
         self._lock = asyncio.Lock()
         self._viking_fs = viking_fs
         self._initialized = False
@@ -243,7 +243,7 @@ class WatchManager:
                             normalized = True
                     self._tasks[task.task_id] = task
                     if task.to_uri:
-                        self._uri_to_task[task.to_uri] = task.task_id
+                        self._uri_to_task[(task.account_id, task.to_uri)] = task.task_id
                 except Exception as e:
                     logger.warning(
                         f"[WatchManager] Failed to load task {task_data.get('task_id')}: {e}"
@@ -345,7 +345,10 @@ class WatchManager:
         return task.user_id == user_id
 
     def _check_uri_conflict(
-        self, to_uri: Optional[str], exclude_task_id: Optional[str] = None
+        self,
+        to_uri: Optional[str],
+        account_id: str = "default",
+        exclude_task_id: Optional[str] = None,
     ) -> bool:
         """Check if target URI conflicts with existing tasks.
 
@@ -359,7 +362,7 @@ class WatchManager:
         if not to_uri:
             return False
 
-        existing_task_id = self._uri_to_task.get(to_uri)
+        existing_task_id = self._uri_to_task.get((account_id, to_uri))
         if not existing_task_id:
             return False
 
@@ -409,7 +412,7 @@ class WatchManager:
             raise ValueError("watch_interval must be > 0")
 
         async with self._lock:
-            if self._check_uri_conflict(to_uri):
+            if self._check_uri_conflict(to_uri, account_id=account_id):
                 raise ConflictError(
                     f"Target URI '{to_uri}' is already used by another task",
                     resource=to_uri,
@@ -435,7 +438,7 @@ class WatchManager:
 
             self._tasks[task.task_id] = task
             if to_uri:
-                self._uri_to_task[to_uri] = task.task_id
+                self._uri_to_task[(account_id, to_uri)] = task.task_id
 
             await self._save_tasks()
 
@@ -495,7 +498,9 @@ class WatchManager:
                     f"User {account_id}/{user_id} does not have permission to update task {task_id}"
                 )
 
-            if self._check_uri_conflict(to_uri, exclude_task_id=task_id):
+            if self._check_uri_conflict(
+                to_uri, account_id=task.account_id, exclude_task_id=task_id
+            ):
                 raise ConflictError(
                     f"Target URI '{to_uri}' is already used by another task",
                     resource=to_uri,
@@ -549,9 +554,9 @@ class WatchManager:
 
             if to_uri is not None:
                 if old_to_uri and old_to_uri != to_uri:
-                    self._uri_to_task.pop(old_to_uri, None)
+                    self._uri_to_task.pop((task.account_id, old_to_uri), None)
                 if to_uri:
-                    self._uri_to_task[to_uri] = task_id
+                    self._uri_to_task[(task.account_id, to_uri)] = task_id
 
             await self._save_tasks()
 
@@ -575,17 +580,18 @@ class WatchManager:
         self,
         old_uri: str,
         new_uri: str,
+        account_id: str = "default",
     ) -> Dict[str, str]:
         old_prefix = old_uri.rstrip("/")
         new_prefix = new_uri.rstrip("/")
         plan: Dict[str, str] = {}
         for task_id, task in self._tasks.items():
-            if _uri_matches_prefix(task.to_uri, old_prefix):
+            if task.account_id == account_id and _uri_matches_prefix(task.to_uri, old_prefix):
                 plan[task_id] = _rewrite_uri_prefix(task.to_uri or "", old_prefix, new_prefix)
 
         moving_task_ids = set(plan)
         for task_id, target_uri in plan.items():
-            existing_task_id = self._uri_to_task.get(target_uri)
+            existing_task_id = self._uri_to_task.get((account_id, target_uri))
             if existing_task_id and existing_task_id not in moving_task_ids:
                 raise ConflictError(
                     f"Target URI '{target_uri}' is already used by another task",
@@ -604,10 +610,11 @@ class WatchManager:
         new_uri: str,
         move_resource: Callable[[], Awaitable[None]],
         rollback_resource: Optional[Callable[[], Awaitable[None]]] = None,
+        account_id: str = "default",
     ) -> List[WatchTask]:
         """Move a resource and keep watch-task target URIs in sync under one lock."""
         async with self._lock:
-            plan = self._plan_move_tasks_under_uri_unlocked(old_uri, new_uri)
+            plan = self._plan_move_tasks_under_uri_unlocked(old_uri, new_uri, account_id)
             move_result = move_resource()
             if inspect.isawaitable(move_result):
                 await move_result
@@ -625,7 +632,7 @@ class WatchManager:
                 for task_id in plan:
                     task = self._tasks[task_id]
                     if task.to_uri:
-                        self._uri_to_task.pop(task.to_uri, None)
+                        self._uri_to_task.pop((account_id, task.to_uri), None)
 
                 updated: List[WatchTask] = []
                 for task_id, target_uri in plan.items():
@@ -634,7 +641,7 @@ class WatchManager:
                     task.to_uri = target_uri
                     if task.parent_uri is not None and task.parent_uri == old_parent:
                         task.parent_uri = _parent_uri(target_uri)
-                    self._uri_to_task[target_uri] = task_id
+                    self._uri_to_task[(account_id, target_uri)] = task_id
                     updated.append(task)
 
                 await self._save_tasks()
@@ -655,13 +662,15 @@ class WatchManager:
                         await rollback_result
                 raise
 
-    async def deactivate_tasks_under_uri_internal(self, uri: str) -> List[WatchTask]:
+    async def deactivate_tasks_under_uri_internal(
+        self, uri: str, account_id: str = "default"
+    ) -> List[WatchTask]:
         """Deactivate watch tasks whose target URI is deleted."""
         async with self._lock:
             matched = [
                 task
                 for task in self._tasks.values()
-                if _uri_matches_prefix(task.to_uri, uri)
+                if task.account_id == account_id and _uri_matches_prefix(task.to_uri, uri)
             ]
             if not matched:
                 return []
@@ -707,7 +716,7 @@ class WatchManager:
 
             self._tasks.pop(task_id, None)
             if task.to_uri:
-                self._uri_to_task.pop(task.to_uri, None)
+                self._uri_to_task.pop((task.account_id, task.to_uri), None)
 
             await self._save_tasks()
 
@@ -789,7 +798,7 @@ class WatchManager:
             WatchTask if found and accessible, None otherwise
         """
         async with self._lock:
-            task_id = self._uri_to_task.get(to_uri)
+            task_id = self._uri_to_task.get((account_id, to_uri))
             if not task_id:
                 return None
 

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -211,7 +211,7 @@ class FSService:
         refresh_parent_uri = self._semantic_refresh_parent_uri(uri, context_type)
         memory_overview_uri = self._memory_overview_parent_uri(uri, context_type)
         result = await viking_fs.rm(uri, recursive=recursive, ctx=ctx)
-        await self._sync_watch_after_rm(uri, context_type=context_type)
+        await self._sync_watch_after_rm(uri, account_id=ctx.account_id, context_type=context_type)
         queue_status = None
         request_registered = False
         telemetry_id = get_current_telemetry().telemetry_id
@@ -408,11 +408,14 @@ class FSService:
         await watch_manager.sync_tasks_with_resource_move_internal(
             from_uri,
             to_uri,
+            account_id=ctx.account_id,
             move_resource=lambda: viking_fs.mv(from_uri, to_uri, ctx=ctx),
             rollback_resource=lambda: viking_fs.mv(to_uri, from_uri, ctx=ctx),
         )
 
-    async def _sync_watch_after_rm(self, uri: str, *, context_type: str) -> None:
+    async def _sync_watch_after_rm(
+        self, uri: str, *, account_id: str, context_type: str
+    ) -> None:
         if context_type != "resource":
             return
         if is_watch_task_control_uri(uri):
@@ -420,7 +423,7 @@ class FSService:
         watch_manager = self._get_watch_manager()
         if not watch_manager:
             return
-        deactivated = await watch_manager.deactivate_tasks_under_uri_internal(uri)
+        deactivated = await watch_manager.deactivate_tasks_under_uri_internal(uri, account_id)
         if deactivated:
             logger.info(
                 "Deactivated %d watch task(s) after deleting %s",

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -233,7 +233,7 @@ class TestWatchManager:
         )
 
         deactivated = await watch_manager_no_fs.deactivate_tasks_under_uri_internal(
-            "viking://resources/codeask/wiki"
+            "viking://resources/codeask/wiki", TEST_ACCOUNT_ID
         )
 
         assert {task.task_id for task in deactivated} == {root.task_id, child.task_id}
@@ -261,6 +261,7 @@ class TestWatchManager:
                 "viking://resources/codeask/wiki-renamed",
                 move_resource=move_resource,
                 rollback_resource=rollback_resource,
+                account_id=TEST_ACCOUNT_ID,
             )
 
         move_resource.assert_awaited_once()
@@ -269,6 +270,38 @@ class TestWatchManager:
         assert restored is not None
         assert restored.to_uri == "viking://resources/codeask/wiki"
         assert restored.parent_uri is None
+
+    @pytest.mark.asyncio
+    async def test_uri_index_move_and_deactivate_are_account_scoped(self):
+        manager = WatchManager()
+        uri = "viking://resources/shared"
+        task_a = await manager.create_task(
+            path="/a", account_id="account-a", to_uri=uri
+        )
+        task_b = await manager.create_task(
+            path="/b", account_id="account-b", to_uri=uri
+        )
+        with pytest.raises(ConflictError):
+            await manager.create_task(path="/duplicate", account_id="account-a", to_uri=uri)
+
+        await manager.sync_tasks_with_resource_move_internal(
+            uri,
+            f"{uri}-moved",
+            move_resource=AsyncMock(),
+            account_id="account-a",
+        )
+        deactivated = await manager.deactivate_tasks_under_uri_internal(uri, "account-b")
+
+        assert task_a.to_uri == f"{uri}-moved"
+        assert task_a.is_active is True
+        assert task_b.to_uri == uri
+        assert task_b.is_active is False
+        assert deactivated == [task_b]
+        moved = await manager.get_task_by_uri(
+            f"{uri}-moved", "account-a", "default", "root"
+        )
+        assert moved is task_a
+        assert await manager.get_task_by_uri(uri, "account-b", "default", "root") is task_b
 
     @pytest.mark.asyncio
     async def test_auth_state_persisted_and_hidden_from_public_dict(

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -50,17 +50,20 @@ class _FakeWatchManager:
         self,
         from_uri,
         to_uri,
+        account_id,
         move_resource,
         rollback_resource=None,
     ):
-        self.sync_calls.append({"from_uri": from_uri, "to_uri": to_uri})
+        self.sync_calls.append(
+            {"from_uri": from_uri, "to_uri": to_uri, "account_id": account_id}
+        )
         if self.plan_error:
             raise self.plan_error
         await move_resource()
         return [SimpleNamespace(task_id="watch-1")]
 
-    async def deactivate_tasks_under_uri_internal(self, uri):
-        self.deactivate_calls.append(uri)
+    async def deactivate_tasks_under_uri_internal(self, uri, account_id):
+        self.deactivate_calls.append({"uri": uri, "account_id": account_id})
         return [SimpleNamespace(task_id="watch-1")]
 
 
@@ -220,7 +223,9 @@ async def test_resource_rm_deactivates_watch_tasks(request_context):
 
     await service.rm("viking://resources/codeask/wiki", ctx=request_context, recursive=True)
 
-    assert watch_manager.deactivate_calls == ["viking://resources/codeask/wiki"]
+    assert watch_manager.deactivate_calls == [
+        {"uri": "viking://resources/codeask/wiki", "account_id": "default"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -256,6 +261,7 @@ async def test_resource_mv_plans_then_moves_then_rewrites_watch_tasks(request_co
         {
             "from_uri": "viking://resources/codeask/wiki",
             "to_uri": "viking://resources/codeask/wiki-renamed",
+            "account_id": "default",
         }
     ]
     assert viking_fs.mv_calls == [


### PR DESCRIPTION
## 概述
watch 任务本身记录了 account_id,但 URI→task 索引(`_uri_to_task`)和子树前缀匹配是全局的。本 PR 将索引键从裸 URI 改为 `(account_id, to_uri)` 元组,并在 rm/mv 的 watch 同步流程中透传请求方 account_id,使移动/删除只影响本账户的任务。

## 为什么必要(可达性/严重性)
- 根因:viking:// URI 是账户内逻辑路径(viking_fs.py:2462 把 `viking://{rest}` 映射到 `/local/{account_id}/{rest}`),两个账户合法持有相同的 URI 字符串;而 WatchManager 是全进程单例(watch_scheduler.py:88),索引和前缀扫描却不带账户维度,把不同账户的同名 URI 混为一个。
- 可达性:这是第一道防线,无上游拦截。任一 USER 角色账户对自己命名空间做 rm/mv(HTTP fs 路由、MCP、CLI 均可达)本身完全合法,但 `fs_service._sync_watch_after_rm` / `mv` 的同步用全局前缀匹配,会停用或改写其他账户 to_uri 同名的任务。另外 create 时的全局冲突检查会因 A 已占用某 URI 而让 B 无法 watch 自己的同名 URI(ConflictError),兼作跨租户存在性探测。
- 严重性:多账户部署下是真实 P0——跨租户篡改他人持久任务(停用定时摄取、mv 改写 to_uri)。单账户部署(全部走 "default")行为完全不变。不涉及数据泄露:`get_task_by_uri` 原本就有 `_check_permission`,非 root 跨账户一直返回 None。

## 关键设计与取舍
- 索引键 `str` → `(account_id, str)`,13 处读写全部同步改;比为每个账户建独立 WatchManager + 独立存储文件小一个量级,调度器零改动。备选的字符串拼接键(`f"{account}:{uri}"`)与元组等价但更易错,不取。
- rm/mv 同步必须显式透传 `ctx.account_id`:前缀扫描需要知道操作发生在哪个账户的命名空间,单靠 task.account_id 无法区分"A 删了 A 的子树"与"B 的任务恰好同名"。
- `update_task` 的冲突检查用 task.account_id(任务归属账户)而非请求方账户,保证 root 跨账户更新任务时在正确的命名空间查冲突。

## 作用域与已知限制
- 只改 watch 索引与 rm/mv 同步路径;调度执行本来就按 task.account_id 运行,未动。与存储后端无关(索引在内存,持久化为单一 JSON 文件)。
- 行为变化:ROOT 按 to_uri 查询(GET /watches?to_uri=、MCP cancel_watch)现在只命中自己账户的任务;跨账户管理仍可走 get_all_tasks / task_id。旧全局索引在同 URI 多账户共存时本就是"最后写入者获胜"的不确定结果,谈不上可依赖的旧语义。
- 旧持久化数据兼容:缺 account_id 的任务加载为 "default";旧全局唯一性保证了 (account, uri) 不会重复,加载无键冲突。
- 内部方法保留 `account_id="default"` 缺省值以兼容既有调用方;新调用方漏传会静默落到 default 账户,是轻微隐患,后续调用方应显式传参。

## 修复的问题
- A-01 watch URI 索引未按租户隔离,子树移动/删除会改写/停用其他账户的任务(openviking/resource/watch_manager.py:168)

## 合入价值
**P0(多账户部署;单账户不受影响)** · 账户间 watch 任务完全隔离:同一逻辑 URI 可各自 watch,一个租户的 rm/mv 不再停用或改写另一租户的定时摄取任务,冲突检查不再跨租户误报。

## 验证
- `pytest tests/resource/test_watch_manager.py tests/service/test_fs_service.py` — 24 passed / 23 errors;23 个 error 为既有 fixture 缺失导致的 setup 报错,在 main 基线上同样出现(已实测对照),与本改动无关
- 新增用例 `test_uri_index_move_and_deactivate_are_account_scoped` 通过:两账户 watch 同一 URI、同账户重复 watch 仍报 ConflictError、A 的 move 只改 A 的任务、B 的删除只停用 B 的任务、按账户查询各自命中
- 全部 13 处 `_uri_to_task` 读写与 2 处 fs_service 调用点逐一核对,无遗漏的裸 URI 键

---
自动化全仓清扫(2026-07)· draft 待 review
