### PR TITLE
fix(deps): restore openviking-sdk lock entry

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3633,6 +3633,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-asyncio" },
     { name = "opentelemetry-sdk" },
+    { name = "openviking-sdk" },
     { name = "pathspec" },
     { name = "pdfminer-six" },
     { name = "pdfplumber" },
@@ -3842,6 +3843,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.14" },
     { name = "opentelemetry-instrumentation-asyncio", specifier = ">=0.61b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.14" },
+    { name = "openviking-sdk", specifier = ">=0.1.1" },
     { name = "pandas", marker = "extra == 'benchmark'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0.0" },
@@ -3914,6 +3916,18 @@ provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+
+[[package]]
+name = "openviking-sdk"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/85/46464494cfa4a84d8355fb43edb455f08c6517629ecf81b50d63ad9ae525/openviking_sdk-0.1.4.tar.gz", hash = "sha256:cac236b8614f3471b294aa71c1e74b297cf72c6a7f286a94c3270e7ccc386de3", size = 33174, upload-time = "2026-07-13T11:38:40.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/af/4ca139b05f39c8ed04339d7c8aa56550df80f97d39768d2df9bd72fdbbb9/openviking_sdk-0.1.4-py3-none-any.whl", hash = "sha256:1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616", size = 22316, upload-time = "2026-07-13T11:38:39.541Z" },
+]
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
## Summary

- Regenerate `uv.lock` so it includes the required `openviking-sdk>=0.1.1` dependency.
- Resolve `openviking-sdk==0.1.4` and record its published artifact hashes.

## Why

`pyproject.toml` still requires `openviking-sdk`, but #3271 removed its lockfile records. As a result, `uv lock --check` and locked syncs fail on current `main` because `uv.lock` needs to be updated.

## Test coverage

No application code paths changed; this is a generated lockfile-only diff.

## Verification

- [x] `uv lock --check`
- [x] `uv sync --locked --dry-run`
- [x] Runtime import reports `openviking-sdk==0.1.4` and exposes `AsyncHTTPClient`
- [x] `uv run pytest -q --no-cov tests/client/test_sdk_import.py` (1 passed)
- [x] Negative-path check: the same `uv lock --check` exits 1 on `upstream/main` with "lockfile ... needs to be updated"

## Known upstream test issue

The full `uv run pytest` suite currently stops during collection because `tests/oc2ov_test/conftest.py` registers the unavailable `pytest_html_report_title` hook. The same error reproduces on an unmodified `upstream/main` detached worktree with the same environment, so this PR does not alter unrelated test dependencies.
