### PR TITLE
docs(openclaw): document manual plugin configuration

### DIFF
--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -203,6 +203,37 @@ openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --forc
 openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer-role assistant --peer-prefix <PREFIX> --json
 ```
 
+#### 无法执行 CLI 时直接配置文件
+
+如果容器内无法执行 `openclaw` CLI，可以把以下字段合并到 `$OPENCLAW_STATE_DIR/openclaw.json`（默认 `~/.openclaw/openclaw.json`）：
+
+```json
+{
+  "plugins": {
+    "allow": ["openviking"],
+    "entries": {
+      "openviking": {
+        "enabled": true,
+        "config": {
+          "mode": "remote",
+          "baseUrl": "http://openviking:1933",
+          "apiKey": "<API_KEY>",
+          "peer_role": "assistant"
+        }
+      }
+    },
+    "slots": {
+      "contextEngine": "openviking"
+    }
+  }
+}
+```
+
+- 插件必须已经安装；编辑前请备份配置，并把以上字段合并到现有 `plugins` 配置、将 `openviking` 追加到现有 `plugins.allow`。
+- `contextEngine` 是独占 slot；若已有其他 context engine，只有确认替换后再修改该字段。使用 root API key 时，还需在 `config` 中设置 `accountId` 和 `userId`。
+- 容器连接其他服务时，`baseUrl` 应使用容器内可访问的服务地址，而不是 `127.0.0.1`。
+- `apiKey` 会以明文保存；请限制文件权限或使用受控的 Secret 卷。修改后重启 Gateway、容器或 Pod。
+
 ### 3. 重启 OpenClaw Gateway
 
 ```bash

--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -205,12 +205,11 @@ openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer
 
 #### 无法执行 CLI 时直接配置文件
 
-如果容器内无法执行 `openclaw` CLI，可以把以下字段合并到 `$OPENCLAW_STATE_DIR/openclaw.json`（默认 `~/.openclaw/openclaw.json`）：
+如果容器内无法执行 `openclaw` CLI，可以把以下字段合并到 OpenClaw 实际读取的配置文件。设置了 `OPENCLAW_CONFIG_PATH` 时使用该路径；否则通常是 `$OPENCLAW_STATE_DIR/openclaw.json`（默认 `~/.openclaw/openclaw.json`）。
 
 ```json
 {
   "plugins": {
-    "allow": ["openviking"],
     "entries": {
       "openviking": {
         "enabled": true,
@@ -229,7 +228,8 @@ openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer
 }
 ```
 
-- 插件必须已经安装；编辑前请备份配置，并把以上字段合并到现有 `plugins` 配置、将 `openviking` 追加到现有 `plugins.allow`。
+- 插件必须已经安装；编辑前请备份配置，并把以上字段合并到现有 `plugins` 配置。
+- 如果配置中已有 `plugins.allow`，把 `openviking` 追加进去；如果没有，不要仅为本插件新建 allowlist。
 - `contextEngine` 是独占 slot；若已有其他 context engine，只有确认替换后再修改该字段。使用 root API key 时，还需在 `config` 中设置 `accountId` 和 `userId`。
 - 容器连接其他服务时，`baseUrl` 应使用容器内可访问的服务地址，而不是 `127.0.0.1`。
 - `apiKey` 会以明文保存；请限制文件权限或使用受控的 Secret 卷。修改后重启 Gateway、容器或 Pod。

--- a/examples/openclaw-plugin/INSTALL.md
+++ b/examples/openclaw-plugin/INSTALL.md
@@ -147,6 +147,37 @@ If you want assistant messages to carry a prefixed `peer_id` and data-plane reca
 openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer-role assistant --peer-prefix <PREFIX> --json
 ```
 
+#### Configure The File Directly When The CLI Is Unavailable
+
+If the `openclaw` CLI cannot run inside the container, merge the following fields into the config file that OpenClaw actually reads. Use `OPENCLAW_CONFIG_PATH` when it is set; otherwise the file is usually `$OPENCLAW_STATE_DIR/openclaw.json` (default: `~/.openclaw/openclaw.json`).
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openviking": {
+        "enabled": true,
+        "config": {
+          "mode": "remote",
+          "baseUrl": "http://openviking:1933",
+          "apiKey": "<API_KEY>",
+          "peer_role": "assistant"
+        }
+      }
+    },
+    "slots": {
+      "contextEngine": "openviking"
+    }
+  }
+}
+```
+
+- The plugin must already be installed. Back up the file and merge these fields into the existing `plugins` config.
+- If `plugins.allow` already exists, append `openviking`; otherwise, do not create an allowlist only for this plugin.
+- `contextEngine` is an exclusive slot. If another context engine is configured, change it only after confirming the replacement. Root API keys also require `accountId` and `userId` in `config`.
+- When connecting to another service from a container, use a `baseUrl` that is reachable from the container rather than `127.0.0.1`.
+- `apiKey` is stored as plaintext. Restrict file permissions or provide the file through a managed Secret volume, then restart the Gateway, container, or Pod.
+
 ### 3. Restart OpenClaw Gateway
 
 ```bash


### PR DESCRIPTION
## Why

- 容器内无法执行 OpenClaw CLI 时，中英文安装文档都缺少直接配置 `openclaw.json` 的可执行说明。
- 为两种语言补充最小配置示例，并明确插件安装、独占 slot、容器网络和密钥存储注意事项。

## Tested

- `git diff --check`
- `sed -n '155,172p' examples/openclaw-plugin/INSTALL.md | jq empty`
- `sed -n '211,228p' examples/openclaw-plugin/INSTALL-ZH.md | jq empty`
