### PR TITLE
fix(resource): isolate external parsing queue

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -416,15 +416,19 @@ class OpenVikingService:
         )
 
         if self._queue_manager:
-            external_parse_processor = AddResourceProcessor(
-                self._resource_service,
-                asyncio.get_running_loop(),
-            )
-            self._queue_manager.get_queue(
+            for queue_name in (
+                self._queue_manager.EXTERNAL_PARSE,
                 self._queue_manager.ADD_RESOURCE,
-                dequeue_handler=external_parse_processor,
-                allow_create=True,
-            )
+            ):
+                self._queue_manager.get_queue(
+                    queue_name,
+                    dequeue_handler=AddResourceProcessor(
+                        self._resource_service,
+                        asyncio.get_running_loop(),
+                        queue_name,
+                    ),
+                    allow_create=True,
+                )
             self._queue_manager.get_queue(
                 self._queue_manager.SESSION_COMMIT,
                 dequeue_handler=SessionCommitProcessor(

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -38,7 +38,7 @@ from openviking.server.user_config import (
     effective_skill_add_target,
 )
 from openviking.storage import VikingDBManager
-from openviking.storage.queuefs import get_queue_manager
+from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.transaction import NO_LOCK, LockLease
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
@@ -340,14 +340,15 @@ class ResourceService:
         self,
         msg: Any,
         *,
+        queue_name: str,
         resource_lock: LockLease = NO_LOCK,
     ) -> Any:
         """Persist a job before its TaskRecord so a crash cannot orphan the task."""
         from openviking.service.task_tracker import get_task_tracker
-        from openviking.storage.queuefs import QueueManager, get_queue_manager
+        from openviking.storage.queuefs import get_queue_manager
 
         try:
-            await get_queue_manager().enqueue(QueueManager.ADD_RESOURCE, msg.to_dict())
+            await get_queue_manager().enqueue(queue_name, msg.to_dict())
             await resource_lock.handoff()
         except BaseException:
             await resource_lock.close()
@@ -560,7 +561,11 @@ class ResourceService:
                 source_name=source_name,
                 args=self._sanitize_watch_processor_kwargs(processor_args),
             )
-            task = await self._enqueue_add_resource_job(msg, resource_lock=resource_lock)
+            task = await self._enqueue_add_resource_job(
+                msg,
+                queue_name=QueueManager.ADD_RESOURCE,
+                resource_lock=resource_lock,
+            )
             resource_lock = NO_LOCK
             return {
                 "status": "success",
@@ -936,7 +941,11 @@ class ResourceService:
                         understanding_response_id=understanding_response_id,
                     )
                     enqueue_started = True
-                    task = await self._enqueue_add_resource_job(msg, resource_lock=lock_lease)
+                    task = await self._enqueue_add_resource_job(
+                        msg,
+                        queue_name=QueueManager.EXTERNAL_PARSE,
+                        resource_lock=lock_lease,
+                    )
                 except BaseException:
                     if not enqueue_started:
                         await lock_lease.close()
@@ -1074,6 +1083,7 @@ class ResourceService:
                 )
                 task = await self._enqueue_add_resource_job(
                     msg,
+                    queue_name=QueueManager.ADD_RESOURCE,
                     resource_lock=deferred_lock,
                 )
                 deferred_lock = NO_LOCK

--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Durable add-resource consumer on the legacy ExternalParse queue."""
+"""Durable add-resource queue consumer."""
 
 import asyncio
 import concurrent.futures
@@ -28,9 +28,11 @@ class AddResourceProcessor(DequeueHandlerBase):
         self,
         resource_service: Any,
         service_loop: asyncio.AbstractEventLoop,
+        queue_name: str,
     ):
         self._resource_service = resource_service
         self._service_loop = service_loop
+        self._queue_name = queue_name
 
     async def _load_lock(self, msg: AddResourceMsg, ctx: RequestContext) -> Any:
         if msg.lock_handoff is None:
@@ -55,11 +57,11 @@ class AddResourceProcessor(DequeueHandlerBase):
         if msg.lock_handoff_retry >= 2:
             return False
 
-        from openviking.storage.queuefs import QueueManager, get_queue_manager
+        from openviking.storage.queuefs import get_queue_manager
 
         payload = msg.to_dict()
         payload["lock_handoff_retry"] = msg.lock_handoff_retry + 1
-        await get_queue_manager().enqueue(QueueManager.ADD_RESOURCE, payload)
+        await get_queue_manager().enqueue(self._queue_name, payload)
         logger.warning(
             "[AddResource] Requeued task %s after lock handoff failure: %s",
             msg.task_id,

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -69,8 +69,9 @@ class QueueManager:
     # Standard queue names
     EMBEDDING = "Embedding"
     SEMANTIC = "Semantic"
-    # Keep the on-disk queue name stable so pre-upgrade jobs remain recoverable.
-    ADD_RESOURCE = "ExternalParse"
+    # Keep the on-disk name stable so pre-upgrade jobs remain recoverable.
+    EXTERNAL_PARSE = "ExternalParse"
+    ADD_RESOURCE = "AddResource"
     SESSION_COMMIT = "SessionCommit"
 
     def __init__(
@@ -158,7 +159,7 @@ class QueueManager:
 
         if queue.name == self.EMBEDDING:
             max_concurrent = self._max_concurrent_embedding
-        elif queue.name in {self.ADD_RESOURCE, self.SESSION_COMMIT}:
+        elif queue.name in {self.EXTERNAL_PARSE, self.SESSION_COMMIT}:
             max_concurrent = self._max_concurrent_external_parse
         else:
             max_concurrent = self._max_concurrent_semantic

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -13,6 +13,7 @@ from openviking.service.resource_service import ResourceService
 from openviking.service.task_tracker import TaskStatus
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
 from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor
+from openviking.storage.queuefs.queue_manager import QueueManager
 from openviking.utils.media_processor import UnifiedResourceProcessor
 from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
@@ -377,6 +378,11 @@ async def test_uat_producer_payload_reaches_worker_without_persisting_token(monk
         skill_processor=SimpleNamespace(),
     )
     service._parser_router = parser_router
+    monkeypatch.setattr(service, "_should_use_connector", Mock(return_value=False))
+    monkeypatch.setattr(
+        "openviking.service.resource_service.is_git_repo_url",
+        Mock(return_value=False),
+    )
     monkeypatch.setattr("openviking.service.resource_service.uuid4", Mock(return_value="task-1"))
     monkeypatch.setattr(service, "_is_feishu_url", Mock(return_value=True))
     ctx = RequestContext(
@@ -400,6 +406,7 @@ async def test_uat_producer_payload_reaches_worker_without_persisting_token(monk
         feishu_access_token="u-secret",
     )
     payload = queue_manager.enqueue.await_args.args[1]
+    assert queue_manager.enqueue.await_args.args[0] == QueueManager.EXTERNAL_PARSE
     assert "u-secret" not in json.dumps(payload)
     assert payload["understanding_response_id"] == "response-1"
     assert payload["args"] == {"custom_option": "forwarded"}
@@ -421,6 +428,53 @@ async def test_uat_producer_payload_reaches_worker_without_persisting_token(monk
     call = service.add_resource.await_args
     assert call.kwargs[PREPARED_RESPONSE_ID_ARG] == "response-1"
     assert call.kwargs["args"] == {"custom_option": "forwarded"}
+
+
+@pytest.mark.asyncio
+async def test_local_prepared_job_uses_add_resource_queue(monkeypatch):
+    root_uri = "viking://resources/script"
+    resource_lock = SimpleNamespace(to_handoff=Mock(return_value=None))
+    resource_processor = SimpleNamespace(
+        process_resource=AsyncMock(
+            return_value={
+                "status": "success",
+                "root_uri": root_uri,
+                "_post_process": {"root_uri": root_uri},
+                "_resource_lock": resource_lock,
+            }
+        )
+    )
+
+    service = ResourceService(
+        viking_fs=SimpleNamespace(),
+        resource_processor=resource_processor,
+        skill_processor=SimpleNamespace(),
+    )
+    service._enqueue_add_resource_job = AsyncMock(
+        return_value=SimpleNamespace(task_id="task-1")
+    )
+    monkeypatch.setattr(service, "_should_use_connector", Mock(return_value=False))
+    monkeypatch.setattr(service, "_should_use_understanding_api", Mock(return_value=False))
+    monkeypatch.setattr(
+        "openviking.service.resource_service.is_git_repo_url",
+        Mock(return_value=False),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier("account-1", "user-1"),
+        role=Role.USER,
+    )
+
+    result = await service.add_resource(
+        path="/tmp/script.md",
+        ctx=ctx,
+        to=root_uri,
+        wait=False,
+    )
+
+    assert result["task_id"] == "task-1"
+    call = service._enqueue_add_resource_job.await_args
+    assert call.kwargs["queue_name"] == QueueManager.ADD_RESOURCE
+    assert call.args[0].prepared == {"root_uri": root_uri}
 
 
 @pytest.mark.asyncio
@@ -493,6 +547,11 @@ async def test_uat_producer_cancellation_respects_queue_ownership(
         skill_processor=SimpleNamespace(),
     )
     service._parser_router = parser_router
+    monkeypatch.setattr(service, "_should_use_connector", Mock(return_value=False))
+    monkeypatch.setattr(
+        "openviking.service.resource_service.is_git_repo_url",
+        Mock(return_value=False),
+    )
     monkeypatch.setattr(service, "_is_feishu_url", Mock(return_value=True))
     ctx = RequestContext(
         user=UserIdentifier("account-1", "user-1"),
@@ -622,7 +681,16 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
         "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
         Mock(return_value=task_tracker),
     )
-    processor = AddResourceProcessor(service, asyncio.get_running_loop())
+    queue_manager = SimpleNamespace(enqueue=AsyncMock())
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        Mock(return_value=queue_manager),
+    )
+    processor = AddResourceProcessor(
+        service,
+        asyncio.get_running_loop(),
+        QueueManager.ADD_RESOURCE,
+    )
     msg = AddResourceMsg(
         task_id="task-1",
         path="https://example.larkoffice.com/docx/doxcnToken",
@@ -650,6 +718,8 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
         user_id="user-1",
         resource_id=final_uri,
     )
+    assert await processor._requeue_lock_handoff(msg, RuntimeError("stale lock"))
+    assert queue_manager.enqueue.await_args.args[0] == QueueManager.ADD_RESOURCE
 
 
 def test_feishu_bypass_requires_configured_auth(monkeypatch):


### PR DESCRIPTION
## Description

Separate durable local resource ingestion from UnderstandingAPI parsing so local jobs do not wait behind the external parser's concurrency limit.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Keep UnderstandingAPI jobs on the existing `ExternalParse` queue with its concurrency limit.
- Route local prepared-resource and Git ingestion jobs to a separate durable `AddResource` queue.
- Register independent consumers and preserve the source queue when retrying lock handoffs.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The on-disk `ExternalParse` queue name remains registered so jobs persisted before this change can still be recovered and processed.
