### PR TITLE
fix(parse): treat TypeScript .ts files as code, not video

### DIFF
--- a/openviking/parse/parsers/media/constants.py
+++ b/openviking/parse/parsers/media/constants.py
@@ -9,7 +9,10 @@ IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".
 AUDIO_EXTENSIONS = [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a", ".opus", ".ac3"]
 
 # Video extensions supported by VideoParser
-VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv", ".ts"]
+# Note: ".ts" (MPEG-2 Transport Stream) is intentionally excluded because it
+# collides with TypeScript source files (.ts in CODE_EXTENSIONS). Users who
+# need to import .ts video files can pass source_format="video" explicitly.
+VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"]
 
 # All media extensions combined
 MEDIA_EXTENSIONS = set(IMAGE_EXTENSIONS + AUDIO_EXTENSIONS + VIDEO_EXTENSIONS)

--- a/openviking/parse/parsers/media/utils.py
+++ b/openviking/parse/parsers/media/utils.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from openviking.server.identity import RequestContext
 
 from .constants import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from openviking.parse.parsers.constants import CODE_EXTENSIONS
 
 logger = get_logger(__name__)
 
@@ -68,6 +69,11 @@ def get_media_type(source_path: Optional[str], source_format: Optional[str]) -> 
 
     if source_path:
         ext = Path(source_path).suffix.lower()
+        # Code extensions take priority over media extensions to prevent
+        # collisions (e.g. .ts is both TypeScript and MPEG-2 Transport Stream).
+        # Users can override with source_format="video" for genuine video files.
+        if ext in CODE_EXTENSIONS:
+            return None
         if ext in IMAGE_EXTENSIONS:
             return "image"
         elif ext in AUDIO_EXTENSIONS:

--- a/tests/parse/test_ts_media_type.py
+++ b/tests/parse/test_ts_media_type.py
@@ -1,0 +1,45 @@
+"""Tests for .ts file media type detection — regression for #3266."""
+
+from openviking.parse.parsers.media.utils import get_media_type
+from openviking.parse.parsers.media.constants import VIDEO_EXTENSIONS, MEDIA_EXTENSIONS
+
+
+class TestTsFileMediaType:
+    """TypeScript .ts files must not be detected as video (issue #3266)."""
+
+    def test_ts_is_not_video(self):
+        """.ts files should not be detected as video."""
+        assert get_media_type("app.ts", None) is None
+
+    def test_tsx_is_not_video(self):
+        """.tsx files should not be detected as video."""
+        assert get_media_type("component.tsx", None) is None
+
+    def test_ts_not_in_video_extensions(self):
+        """.ts should not be in VIDEO_EXTENSIONS."""
+        assert ".ts" not in VIDEO_EXTENSIONS
+
+    def test_ts_not_in_media_extensions(self):
+        """.ts should not be in MEDIA_EXTENSIONS."""
+        assert ".ts" not in MEDIA_EXTENSIONS
+
+    def test_mp4_still_video(self):
+        """Genuine video extensions should still be detected as video."""
+        assert get_media_type("movie.mp4", None) == "video"
+
+    def test_ts_with_explicit_video_format(self):
+        """source_format='video' should override code extension check."""
+        assert get_media_type("transport.ts", "video") == "video"
+
+    def test_other_code_extensions_not_media(self):
+        """Other code extensions should not be detected as media."""
+        for ext in [".py", ".js", ".go", ".rs", ".java"]:
+            assert get_media_type(f"file{ext}", None) is None
+
+    def test_image_still_image(self):
+        """Image extensions should still be detected as image."""
+        assert get_media_type("photo.png", None) == "image"
+
+    def test_audio_still_audio(self):
+        """Audio extensions should still be detected as audio."""
+        assert get_media_type("song.mp3", None) == "audio"


### PR DESCRIPTION
## Description

PR #3209 added `.ts` to `VIDEO_EXTENSIONS`, but `.ts` is already in `CODE_EXTENSIONS` (TypeScript). Since `get_media_type()` checks media extensions before code extensions, TypeScript files were routed to the video processing path (a VLM stub returning "not yet implemented") instead of the code/AST parser.

### Changes

- Remove `.ts` from `VIDEO_EXTENSIONS` in `media/constants.py`. Users who genuinely need to import MPEG-2 Transport Stream `.ts` files can pass `source_format="video"` explicitly.
- Add a defensive `CODE_EXTENSIONS` check in `get_media_type()` so that any future extension collisions between code and media are resolved in favour of code. The `source_format` override still takes priority.
- Add focused tests verifying `.ts` is not video, `.mp4`/`.png`/`.mp3` still work, and explicit `source_format="video"` overrides the code check.

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

Fixes #3266

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

Focused unit tests in `tests/parse/test_ts_media_type.py` cover the regression and edge cases.