### PR TITLE
fix(storage): support file resources as relation sources

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2999,11 +2999,37 @@ class VikingFS:
 
     # ========== Relation Table Internal Methods ==========
 
+    async def _resolve_relation_table_path(
+        self, resource_path: str, ctx: Optional[RequestContext] = None
+    ) -> str:
+        """Resolve the path to the relation table file for a resource.
+
+        For directories: ``{resource_path}/.relations.json``
+        For files: ``{parent_dir}/.{filename}.relations.json`` (sidecar file)
+
+        If stat fails (e.g. new resource not yet committed), falls back to
+        the directory convention for backward compatibility.
+        """
+        try:
+            stat_result = await self._async_agfs.stat(resource_path)
+            is_dir = stat_result.get("isDir", False) if isinstance(stat_result, dict) else False
+        except Exception:
+            is_dir = True  # backward compatible fallback
+
+        if is_dir:
+            return f"{resource_path}/.relations.json"
+
+        # File resource: store relation table as a sidecar in the parent directory
+        parts = resource_path.rstrip("/").split("/")
+        filename = parts[-1]
+        parent = "/".join(parts[:-1]) or "/"
+        return f"{parent}/.{filename}.relations.json"
+
     async def _read_relation_table(
-        self, dir_path: str, ctx: Optional[RequestContext] = None
+        self, resource_path: str, ctx: Optional[RequestContext] = None
     ) -> List[RelationEntry]:
-        """Read .relations.json."""
-        table_path = f"{dir_path}/.relations.json"
+        """Read relation table for a resource (file or directory)."""
+        table_path = await self._resolve_relation_table_path(resource_path, ctx=ctx)
         try:
             content = self._handle_agfs_read(await self._async_agfs.read(table_path))
             data = json.loads(content.decode("utf-8"))
@@ -3028,14 +3054,14 @@ class VikingFS:
         return entries
 
     async def _write_relation_table(
-        self, dir_path: str, entries: List[RelationEntry], ctx: Optional[RequestContext] = None
+        self, resource_path: str, entries: List[RelationEntry], ctx: Optional[RequestContext] = None
     ) -> None:
-        """Write .relations.json."""
+        """Write relation table for a resource (file or directory)."""
+        table_path = await self._resolve_relation_table_path(resource_path, ctx=ctx)
         # Use flat list format
         data = [entry.to_dict() for entry in entries]
 
         content = json.dumps(data, ensure_ascii=False, indent=2)
-        table_path = f"{dir_path}/.relations.json"
         if isinstance(content, str):
             content = content.encode("utf-8")
 

--- a/tests/server/test_api_relations.py
+++ b/tests/server/test_api_relations.py
@@ -92,3 +92,73 @@ async def test_link_multiple_targets(client_with_resource, upload_temp_dir):
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+async def test_link_from_file_uri(client_with_resource, upload_temp_dir):
+    """Link from a file URI (not a directory) should not fail with ENOTDIR.
+
+    Regression test for #3067: ``ov link`` from a file resource was failing
+    with "Not a directory (os error 20)" because the relation table was
+    stored at ``{file_path}/.relations.json``.
+    """
+    client, uri = client_with_resource
+    from tests.server.conftest import SAMPLE_MD_CONTENT
+
+    # List the resource directory to find a file URI
+    ls_resp = await client.get("/api/v1/fs/ls", params={"uri": uri, "simple": True})
+    assert ls_resp.status_code == 200
+    ls_data = ls_resp.json()
+    file_list = ls_data.get("result", [])
+    # Find a file entry (not a directory)
+    file_uri = None
+    for entry in file_list:
+        if isinstance(entry, str):
+            file_uri = entry if entry.startswith("viking://") else f"{uri}/{entry}"
+            break
+        elif isinstance(entry, dict):
+            name = entry.get("name", "")
+            if name and not entry.get("isDir", False) and not name.startswith("."):
+                file_uri = entry.get("uri") or f"{uri}/{name}"
+                break
+    assert file_uri is not None, f"No file found in resource {uri}, ls result: {file_list}"
+
+    # Create a second resource as link target
+    f2 = upload_temp_dir / "file_link_target.md"
+    f2.write_text(SAMPLE_MD_CONTENT)
+    add_resp = await client.post(
+        "/api/v1/resources",
+        json={"temp_file_id": f2.name, "reason": "file link target", "wait": True},
+    )
+    target_uri = add_resp.json()["result"]["root_uri"]
+
+    # Create link from file URI — this used to fail with ENOTDIR
+    resp = await client.post(
+        "/api/v1/relations/link",
+        json={
+            "from_uri": file_uri,
+            "to_uris": target_uri,
+            "reason": "file source link",
+        },
+    )
+    assert resp.status_code == 200, (
+        f"Link from file URI should succeed, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["status"] == "ok"
+
+    # Verify link exists
+    resp = await client.get("/api/v1/relations", params={"uri": file_uri})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert len(body["result"]) > 0, "Relation should exist after linking from file URI"
+
+    # Unlink should also work
+    resp = await client.request(
+        "DELETE",
+        "/api/v1/relations/link",
+        json={"from_uri": file_uri, "to_uri": target_uri},
+    )
+    assert resp.status_code == 200, (
+        f"Unlink from file URI should succeed, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Description

`VikingFS.link()` unconditionally appended `/.relations.json` to the source path, which fails with `ENOTDIR` (os error 20) when the source is a file rather than a directory. The same issue affected `unlink()` and `get_relation_table()`.

### Root Cause

`_read_relation_table()` and `_write_relation_table()` both constructed the table path as `{dir_path}/.relations.json`. When the source URI points to a file (e.g. `viking://space/myfile.txt`), this produces an invalid path like `…/myfile.txt/.relations.json`. The OS `open()` syscall fails with `ENOTDIR` because `myfile.txt` is a file, not a directory.

### Changes

- Add `_resolve_relation_table_path()` that stats the resource to determine if it is a file or directory:
  - **Directories**: table stored at `{path}/.relations.json` (unchanged)
  - **Files**: table stored as a sidecar file at `{parent}/.{filename}.relations.json` in the parent directory
- Update `_read_relation_table()` and `_write_relation_table()` to use the new resolver instead of hardcoding `{dir_path}/.relations.json`
- If stat fails (e.g. resource not yet committed), fall back to the directory convention for backward compatibility

### Sidecar File Convention

The sidecar file `.{filename}.relations.json` is:
- Hidden (starts with `."`)
- Unique per file (includes the filename)
- Clearly identifiable as a relations file (ends with `.relations.json`)

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

Fixes #3067

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

Integration test in `tests/server/test_api_relations.py` verifies that link, get relations, and unlink all work when the source URI points to a file resource. The test lists the resource directory to obtain a file URI, creates a link from it, verifies the relation exists, and then unlinks it.