### PR TITLE
fix(storage): preserve user-managed files during watched resource re-sync

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -401,6 +401,7 @@ class SemanticProcessor(DequeueHandlerBase):
                                         msg.target_uri,
                                         ctx=current_ctx,
                                         lock=semantic_lock.lock,
+                                        preserve_target_only=bool(msg.target_preexisting),
                                     )
                                     logger.info(
                                         "[SyncDiff] Diff computed: "
@@ -746,7 +747,16 @@ class SemanticProcessor(DequeueHandlerBase):
         ctx: Optional[RequestContext] = None,
         file_change_status: Optional[Dict[str, bool]] = None,
         lock: LockLease = NO_LOCK,
+        preserve_target_only: bool = False,
     ) -> DiffResult:
+        """Recursively sync root_uri into target_uri (top-down).
+
+        When ``preserve_target_only`` is True, files and directories that exist
+        only in the target (not in the source) are preserved instead of being
+        deleted. This protects user-managed files during re-syncs of watched
+        resources (e.g. Feishu documents). Files that exist in both are still
+        updated, and new files from the source are still added.
+        """
         viking_fs = get_viking_fs()
         if not await viking_fs.exists(root_uri, ctx=ctx):
             raise FileNotFoundError(
@@ -813,6 +823,11 @@ class SemanticProcessor(DequeueHandlerBase):
                     continue
 
                 if target_file and not root_file:
+                    if preserve_target_only:
+                        logger.debug(
+                            f"[SyncDiff] Preserving target-only file (preserve_target_only=True): {target_file}"
+                        )
+                        continue
                     try:
                         await viking_fs.rm(target_file, ctx=ctx, lock_handle=lock_handle)
                         diff.deleted_files.append(target_file)
@@ -892,6 +907,11 @@ class SemanticProcessor(DequeueHandlerBase):
                     target_subdir = None
 
                 if target_subdir and not root_subdir:
+                    if preserve_target_only:
+                        logger.debug(
+                            f"[SyncDiff] Preserving target-only directory (preserve_target_only=True): {target_subdir}"
+                        )
+                        continue
                     try:
                         await viking_fs.rm(
                             target_subdir,

--- a/tests/storage/test_semantic_processor_target_preexisting.py
+++ b/tests/storage/test_semantic_processor_target_preexisting.py
@@ -169,3 +169,132 @@ async def test_sync_missing_source_never_touches_target(monkeypatch):
 
     fake_fs.ls.assert_not_awaited()
     fake_fs.rm.assert_not_awaited()
+
+
+class _PreserveTestFS:
+    """Fake FS with source (temp) and target (resources/root) directories.
+
+    Source has: a.md (changed), b.md (same), new_file.md (new)
+    Target has: a.md (old), b.md (same), user_notes.md (user-managed),
+                user_dir/ (user-managed directory)
+    """
+
+    def __init__(self):
+        self.contents = {
+            # Source (temp)
+            "viking://temp/import/a.md": "new content",
+            "viking://temp/import/b.md": "same",
+            "viking://temp/import/new_file.md": "brand new",
+            # Target
+            "viking://resources/root/a.md": "old content",
+            "viking://resources/root/b.md": "same",
+            "viking://resources/root/user_notes.md": "user-managed notes",
+            "viking://resources/root/user_dir/inner.md": "user-managed inner",
+        }
+        self.entries = {
+            "viking://temp/import": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+                {"name": "new_file.md", "isDir": False},
+            ],
+            "viking://resources/root": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+                {"name": "user_notes.md", "isDir": False},
+                {"name": "user_dir", "isDir": True},
+            ],
+            "viking://resources/root/user_dir": [
+                {"name": "inner.md", "isDir": False},
+            ],
+        }
+        self.deleted = []
+        self.deleted_temp = []
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.entries or uri in self.contents
+
+    async def ls(self, uri, show_all_hidden=False, node_limit=None, ctx=None):
+        return self.entries.get(uri, [])
+
+    async def stat(self, uri, ctx=None):
+        return {"size": len(self.contents.get(uri, ""))}
+
+    async def read_file(self, uri, ctx=None):
+        return self.contents.get(uri, "")
+
+    async def rm(self, uri, recursive=False, ctx=None, lock_handle=None):
+        self.deleted.append(uri)
+        self.contents.pop(uri, None)
+        self.entries.pop(uri, None)
+
+    async def mv(self, src, dst, ctx=None, lock_handle=None):
+        self.contents[dst] = self.contents.pop(src, "")
+
+    async def mkdir(self, uri, exist_ok=False, ctx=None):
+        self.entries.setdefault(uri, [])
+
+    async def delete_temp(self, uri, ctx=None):
+        self.deleted_temp.append(uri)
+
+
+@pytest.mark.asyncio
+async def test_preserve_target_only_protects_user_files(monkeypatch):
+    """When preserve_target_only=True, user-managed files are not deleted."""
+    fake_fs = _PreserveTestFS()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    diff = await SemanticProcessor()._sync_topdown_recursive(
+        "viking://temp/import",
+        "viking://resources/root",
+        lock=NO_LOCK,
+        preserve_target_only=True,
+    )
+
+    # a.md should be updated (exists in both, content changed)
+    assert fake_fs.contents["viking://resources/root/a.md"] == "new content"
+    assert "viking://resources/root/a.md" in diff.updated_files
+
+    # new_file.md should be added (exists only in source)
+    assert "viking://resources/root/new_file.md" in diff.added_files
+
+    # user_notes.md should NOT be deleted (user-managed)
+    assert "viking://resources/root/user_notes.md" not in fake_fs.deleted
+    assert "viking://resources/root/user_notes.md" in fake_fs.contents
+
+    # user_dir/ should NOT be deleted (user-managed)
+    assert "viking://resources/root/user_dir" not in fake_fs.deleted
+    assert "viking://resources/root/user_dir" in fake_fs.entries
+
+    # Nothing should be in deleted_files or deleted_dirs
+    assert len(diff.deleted_files) == 0
+    assert len(diff.deleted_dirs) == 0
+
+
+@pytest.mark.asyncio
+async def test_default_sync_deletes_target_only_files(monkeypatch):
+    """When preserve_target_only=False (default), target-only files ARE deleted.
+
+    This confirms the flag actually controls deletion behavior.
+    """
+    fake_fs = _PreserveTestFS()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+
+    diff = await SemanticProcessor()._sync_topdown_recursive(
+        "viking://temp/import",
+        "viking://resources/root",
+        lock=NO_LOCK,
+    )
+
+    # user_notes.md should be deleted (default behavior)
+    assert "viking://resources/root/user_notes.md" in fake_fs.deleted
+    assert "viking://resources/root/user_notes.md" not in fake_fs.contents
+
+    # user_dir/ should be deleted
+    assert "viking://resources/root/user_dir" in fake_fs.deleted
+    assert "viking://resources/root/user_dir" not in fake_fs.entries


### PR DESCRIPTION
## Description

When a watched resource (e.g. Feishu document) was re-synced, `_sync_topdown_recursive` treated the newly parsed output as a complete mirror of the target directory and deleted any file or directory not present in the new parse — including user-managed files the user had placed under the resource folder.

### Root Cause

The `target_preexisting` flag was already populated on `SemanticMsg` (set to `True` when the target directory already has content) but **never consumed** by `semantic_processor.py`. The sync logic unconditionally performed a full mirror sync, deleting any target-only files/directories.

### Changes

- Add `preserve_target_only` parameter to `_sync_topdown_recursive()`. When `True`:
  - Files/directories that exist **only in the target** are preserved (not deleted)
  - Files that exist in **both** source and target are still updated (content compared and replaced if changed)
  - Files that exist **only in the source** are still added (new content from the re-sync)
- Pass `preserve_target_only=bool(msg.target_preexisting)` in `on_dequeue()` so re-syncs of pre-existing targets switch to additive/update-only mode
- **First sync** (`target_preexisting=False`) retains the full mirror behavior — this is correct because the target is empty or only contains internal storage names

### Impact

| Scenario | Before | After |
|----------|--------|-------|
| First sync (empty target) | Full mirror (correct) | Full mirror (unchanged) |
| Re-sync (target has content) | Full mirror — **deletes user files** | Additive/update-only — **preserves user files** |
| Re-sync (file removed from source) | Deleted from target | **Preserved** in target (trade-off: stale files may remain) |

The trade-off of potentially retaining stale files is far less severe than deleting user-managed data.

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

Fixes #3029

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

Two new tests in `tests/storage/test_semantic_processor_target_preexisting.py`:
- `test_preserve_target_only_protects_user_files`: verifies user-managed files/dirs are preserved when `preserve_target_only=True`, while updates and additions still work
- `test_default_sync_deletes_target_only_files`: verifies the default behavior (deletion) is unchanged when `preserve_target_only=False`, confirming the flag actually controls behavior