### PR TITLE
fix: allow opencode recall after session context

### DIFF
--- a/examples/opencode-plugin/lib/memory-recall.mjs
+++ b/examples/opencode-plugin/lib/memory-recall.mjs
@@ -35,12 +35,13 @@ export function createMemoryRecall({ config }) {
   return { injectRelevantMemories }
 }
 
-function extractCurrentUserText(parts) {
+export function extractCurrentUserText(parts) {
   const texts = []
   for (const part of parts) {
     if (part.type !== "text" || typeof part.text !== "string") continue
+    if (part.synthetic || part.ignored) continue
     if (part.text.includes("<openviking-context")) return null
-    if (!part.synthetic && !part.ignored) texts.push(part.text)
+    texts.push(part.text)
   }
   const joined = texts.join(" ").trim()
   return joined || null

--- a/examples/opencode-plugin/tests/memory-recall.test.mjs
+++ b/examples/opencode-plugin/tests/memory-recall.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { extractCurrentUserText } from "../lib/memory-recall.mjs"
+
+test("extractCurrentUserText skips synthetic session context before user text", () => {
+  const query = extractCurrentUserText([
+    {
+      type: "text",
+      text: "<openviking-context source=\"session-start\">Profile</openviking-context>",
+      synthetic: true,
+    },
+    {
+      type: "text",
+      text: "Find the deployment notes for the recall test",
+    },
+  ])
+
+  assert.equal(query, "Find the deployment notes for the recall test")
+})
+
+test("extractCurrentUserText still rejects non-synthetic OpenViking context text", () => {
+  const query = extractCurrentUserText([
+    {
+      type: "text",
+      text: "<openviking-context>Injected context</openviking-context>",
+    },
+    {
+      type: "text",
+      text: "Find the deployment notes for the recall test",
+    },
+  ])
+
+  assert.equal(query, null)
+})


### PR DESCRIPTION
## Description

Fixes #3456.

The OpenCode plugin skipped auto-recall on the first message of a new or reconnected session because `extractCurrentUserText()` returned `null` as soon as it saw the synthetic `<openviking-context>` part inserted by session-start context injection.

This change skips synthetic or ignored parts before checking for OpenViking context markers, so the real user text can still be extracted. The guard remains in place for non-synthetic text containing `<openviking-context>`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3456

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Skip synthetic or ignored OpenCode message parts before extracting recall query text.
- Keep rejecting non-synthetic user text that already contains an OpenViking context block.
- Add regression tests for first-message session context injection and the non-synthetic context guard.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands run:

```bash
node --check lib/memory-recall.mjs
node --test tests/memory-recall.test.mjs
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The local Git clone was unavailable due network resets, so the branch was created through the GitHub API after validating the focused change locally. The PR diff was checked against upstream `main` and only contains the OpenCode recall fix and regression test.