### PR TITLE
fix(observability): count recall retrieval usage

### DIFF
--- a/openviking/observability/usage_audit/README.md
+++ b/openviking/observability/usage_audit/README.md
@@ -117,6 +117,7 @@ store backend，而不是让多个实例各写各的本地 SQLite。
 | --- | --- |
 | `POST /api/v1/search/find` | `find` |
 | `POST /api/v1/search/search` | `search` |
+| `POST /api/v1/search/recall` | `recall` |
 
 `2xx` 和 `3xx` 记为 `success`，`4xx/5xx` 记为 `error`。Dashboard 今日检索只展示成功请求数。
 
@@ -230,7 +231,8 @@ GET /api/v1/console/dashboard/summary
     "today_retrievals": {
       "find": 10,
       "search": 4,
-      "total": 14
+      "recall": 6,
+      "total": 20
     }
   }
 }

--- a/openviking/observability/usage_audit/projection.py
+++ b/openviking/observability/usage_audit/projection.py
@@ -278,6 +278,8 @@ def retrieval_operation_for_http(method: str, route: str) -> str | None:
         return "find"
     if route == "/api/v1/search/search":
         return "search"
+    if route == "/api/v1/search/recall":
+        return "recall"
     return None
 
 
@@ -302,6 +304,8 @@ def derive_api_type(route: str) -> str:
         return "search.find"
     if route == "/api/v1/search/search":
         return "search.search"
+    if route == "/api/v1/search/recall":
+        return "search.recall"
     prefix_map = {
         "/api/v1/resources": "resources",
         "/api/v1/skills": "skills",

--- a/openviking/observability/usage_audit/sqlite_store.py
+++ b/openviking/observability/usage_audit/sqlite_store.py
@@ -355,7 +355,7 @@ class SQLiteUsageAuditStore:
         assert self._conn is not None
         day = date.fromisoformat(user_date)
         utc_start, utc_end = _user_day_window_utc(day, tz)
-        result = {"find": 0, "search": 0}
+        result = {"find": 0, "search": 0, "recall": 0}
         for operation, total in self._fetch_hourly_retrieval_rows(
             account_id, utc_start, utc_end, user_id=user_id
         ):

--- a/tests/observability/test_usage_audit_runtime.py
+++ b/tests/observability/test_usage_audit_runtime.py
@@ -38,7 +38,7 @@ async def test_usage_audit_runtime_subscribes_to_shared_event_bus(tmp_path):
                 "account_id": "acct-runtime",
                 "user_id": "user-runtime",
                 "method": "POST",
-                "route": "/api/v1/search/find",
+                "route": "/api/v1/search/recall",
                 "status": "200",
                 "duration_seconds": 0.01,
             },
@@ -57,6 +57,7 @@ async def test_usage_audit_runtime_subscribes_to_shared_event_bus(tmp_path):
         await shutdown_usage_audit(app=app)
         _GLOBAL_EVENT_BUS.clear()
 
-    assert retrievals["find"] == 1
+    assert retrievals["recall"] == 1
+    assert retrievals["total"] == 1
     assert audit["total"] == 1
     assert audit["items"][0]["request_id"] == "req-runtime"

--- a/tests/observability/test_usage_audit_store.py
+++ b/tests/observability/test_usage_audit_store.py
@@ -159,6 +159,16 @@ async def test_sqlite_usage_audit_store_aggregates_dashboard_data(tmp_path):
                 _event(
                     "http.request",
                     {
+                        "request_id": "req-recall",
+                        "method": "POST",
+                        "route": "/api/v1/search/recall",
+                        "status": "200",
+                        "duration_seconds": 0.1,
+                    },
+                ),
+                _event(
+                    "http.request",
+                    {
                         "request_id": "req-message",
                         "method": "POST",
                         "route": "/api/v1/sessions/{session_id}/messages",
@@ -231,14 +241,16 @@ async def test_sqlite_usage_audit_store_aggregates_dashboard_data(tmp_path):
         ) == {
             "find": 1,
             "search": 1,
-            "total": 2,
+            "recall": 1,
+            "total": 3,
         }
         assert await store.get_today_retrievals(
             account_id="acct-1", user_id="user-1", user_date="2026-05-12", tz=UTC
         ) == {
             "find": 1,
             "search": 0,
-            "total": 1,
+            "recall": 1,
+            "total": 2,
         }
         commits = await store.get_context_commit_heatmap(
             account_id="acct-1",
@@ -261,17 +273,22 @@ async def test_sqlite_usage_audit_store_aggregates_dashboard_data(tmp_path):
         )
         assert any(row["hour"] == 1 and row["session_add_message"] == 1 for row in commits)
         audit = await store.query_audit_logs(account_id="acct-1")
-        assert audit["total"] == 4
+        assert audit["total"] == 5
         assert audit["success_rate"] == 1.0
         assert {item["api_type"] for item in audit["items"]} == {
             "search.find",
             "search.search",
+            "search.recall",
             "sessions",
         }
         audit = await store.query_audit_logs(account_id="acct-1", user_id="user-1")
-        assert audit["total"] == 2
+        assert audit["total"] == 3
         assert audit["success_rate"] == 1.0
-        assert {item["request_id"] for item in audit["items"]} == {"req-find", "req-message"}
+        assert {item["request_id"] for item in audit["items"]} == {
+            "req-find",
+            "req-message",
+            "req-recall",
+        }
     finally:
         await store.close()
 

--- a/web-studio/src/i18n/locales/en.ts
+++ b/web-studio/src/i18n/locales/en.ts
@@ -286,8 +286,9 @@ const en = {
     requestFailed: 'Request failed',
     todayRetrievals: {
       description:
-        'Shows successful semantic retrieval calls for find() and search() today. Resets at midnight.',
+        'Shows successful semantic retrieval calls for find(), search(), and recall() today. Resets at midnight.',
       find: 'find',
+      recall: 'recall',
       search: 'search',
       title: 'Retrievals Today',
     },

--- a/web-studio/src/i18n/locales/zh-CN.ts
+++ b/web-studio/src/i18n/locales/zh-CN.ts
@@ -284,8 +284,9 @@ const zhCN = {
     requestFailed: '请求失败',
     todayRetrievals: {
       description:
-        '展示用户或 Agent 今日使用语义检索 find() 和 search() 的成功调用次数，每天零点刷新。',
+        '展示用户或 Agent 今日使用语义检索 find()、search() 和 recall() 的成功调用次数，每天零点刷新。',
       find: 'find',
+      recall: 'recall',
       search: 'search',
       title: '今日检索次数',
     },

--- a/web-studio/src/routes/home/-components/metric-panels.tsx
+++ b/web-studio/src/routes/home/-components/metric-panels.tsx
@@ -262,6 +262,10 @@ export function TodayRetrievalsPanel({
             label={t('todayRetrievals.search')}
             value={formatNumber(data?.search)}
           />
+          <DetailRow
+            label={t('todayRetrievals.recall')}
+            value={formatNumber(data?.recall)}
+          />
         </>
       )}
     </MetricPanel>

--- a/web-studio/types/ov-server/api/v1/console.ts
+++ b/web-studio/types/ov-server/api/v1/console.ts
@@ -20,6 +20,7 @@ export type ConsoleTokenCounts = {
 
 export type ConsoleRetrievalCounts = {
   find?: number
+  recall?: number
   search?: number
   total?: number
 }
@@ -58,7 +59,8 @@ export type ConsoleTokenSeriesItem = {
   vlm_output?: number
 }
 
-export type ConsoleTokenSeriesResult = ConsoleSeriesResult<ConsoleTokenSeriesItem>
+export type ConsoleTokenSeriesResult =
+  ConsoleSeriesResult<ConsoleTokenSeriesItem>
 
 export type ConsoleContextCommitItem = {
   add_resource?: number
@@ -70,7 +72,8 @@ export type ConsoleContextCommitItem = {
   total?: number
 }
 
-export type ConsoleContextCommitsResult = ConsoleSeriesResult<ConsoleContextCommitItem>
+export type ConsoleContextCommitsResult =
+  ConsoleSeriesResult<ConsoleContextCommitItem>
 
 export type ConsoleAuditLogItem = {
   account_id?: string | null
@@ -84,9 +87,10 @@ export type ConsoleAuditLogItem = {
   user_id?: string | null
 }
 
-export type ConsoleAuditResult = OvMaybeDisabled & PaginatedResult<ConsoleAuditLogItem> & {
-  success_rate?: number
-}
+export type ConsoleAuditResult = OvMaybeDisabled &
+  PaginatedResult<ConsoleAuditLogItem> & {
+    success_rate?: number
+  }
 
 export type ConsoleAuditQuery = {
   api_type?: string[] | null


### PR DESCRIPTION
## Summary

Fixes the recall retrieval-count half of #3443.

Successful `POST /api/v1/search/recall` requests are currently written to request audit, but they are not projected into `usage_retrieval_hourly`, so Web Studio's "Retrievals Today" panel can stay at zero for agent integrations that use recall.

This PR:
- maps `POST /api/v1/search/recall` to the `recall` retrieval operation
- derives `search.recall` for request-audit API type display
- includes `recall` in `today_retrievals` totals returned by the SQLite usage-audit store
- shows the recall count in the Web Studio retrieval panel and generated console API type
- updates the usage-audit README shape

Out of scope: the separate `__unknown__` VLM token attribution half of #3443, and historical backfill.

## Tests

- `python -m pytest tests/observability/test_usage_audit_store.py tests/observability/test_usage_audit_runtime.py -q --noconftest -o addopts="" -p no:cacheprovider`
- `python -m ruff check openviking/observability/usage_audit/projection.py openviking/observability/usage_audit/sqlite_store.py tests/observability/test_usage_audit_store.py tests/observability/test_usage_audit_runtime.py`
- `npm exec -- prettier --check src/i18n/locales/en.ts src/i18n/locales/zh-CN.ts src/routes/home/-components/metric-panels.tsx types/ov-server/api/v1/console.ts`
- `npm run build`
