### PR TITLE
fix: allow file resources as relation sources

### DIFF
--- a/docs/en/concepts/05-storage.md
+++ b/docs/en/concepts/05-storage.md
@@ -62,7 +62,7 @@ viking://user/skills          →  /local/{account_id}/user/{user_id}/skills
 
 ### Relation Management
 
-VikingFS manages resource relations through `.relations.json`:
+VikingFS manages resource relations through a `.relations.json` sidecar next to a file or directory source:
 
 ```python
 # Create relation

--- a/docs/zh/concepts/05-storage.md
+++ b/docs/zh/concepts/05-storage.md
@@ -60,7 +60,7 @@ viking://user/skills          →  /local/{account_id}/user/{user_id}/skills
 
 ### 关联管理
 
-VikingFS 通过 `.relations.json` 管理资源间的关联：
+VikingFS 通过文件或目录资源旁边的 `.relations.json` 伴随文件管理资源间的关联：
 
 ```python
 # 创建关联

--- a/openviking/server/routers/webdav.py
+++ b/openviking/server/routers/webdav.py
@@ -18,7 +18,7 @@ from fastapi.responses import Response as FastAPIResponse
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
-from openviking.storage.internal_names import WEBDAV_RESERVED_FILENAMES
+from openviking.storage.internal_names import is_webdav_reserved_filename
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 from openviking_cli.utils.uri import VikingURI
@@ -65,7 +65,7 @@ def _ensure_exposed_path(resource_path: str) -> None:
     if not resource_path:
         return
     parts = resource_path.split("/")
-    if any(part in WEBDAV_RESERVED_FILENAMES for part in parts):
+    if any(is_webdav_reserved_filename(part) for part in parts):
         raise NotFoundError(resource_path, "resource")
 
 
@@ -199,7 +199,7 @@ def _exposed_child_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]
         name = str(entry.get("name", "") or "")
         if not name or name in {".", ".."}:
             continue
-        if name in WEBDAV_RESERVED_FILENAMES:
+        if is_webdav_reserved_filename(name):
             continue
         exposed.append(entry)
     return exposed

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -19,6 +19,7 @@ from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
 from openviking.session.memory.memory_updater import MemoryUpdater
 from openviking.storage.content_write import ContentWriteCoordinator
+from openviking.storage.internal_names import is_relation_sidecar_name
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.viking_fs import VikingFS
@@ -26,7 +27,11 @@ from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
 from openviking.utils.embedding_utils import vectorize_directory_meta
-from openviking_cli.exceptions import DeadlineExceededError, NotInitializedError
+from openviking_cli.exceptions import (
+    DeadlineExceededError,
+    InvalidArgumentError,
+    NotInitializedError,
+)
 from openviking_cli.utils import VikingURI, get_logger
 
 logger = get_logger(__name__)
@@ -75,6 +80,12 @@ class FSService:
         if not self._viking_fs:
             raise NotInitializedError("VikingFS")
         return self._viking_fs
+
+    @staticmethod
+    def _reject_relation_sidecar_uri(uri: str, *, operation: str) -> None:
+        name = uri.rstrip("/").rsplit("/", 1)[-1]
+        if is_relation_sidecar_name(name):
+            raise InvalidArgumentError(f"cannot {operation} relation sidecar directly: {uri}")
 
     def _get_watch_manager(self) -> Optional["WatchManager"]:
         if not self._watch_scheduler:
@@ -165,6 +176,7 @@ class FSService:
     ) -> None:
         """Create directory."""
         uri = validate_viking_uri(uri)
+        self._reject_relation_sidecar_uri(uri, operation="create")
         viking_fs = self._ensure_initialized()
         await viking_fs.mkdir(uri, ctx=ctx)
         abstract = self._normalize_directory_description(description)
@@ -205,6 +217,7 @@ class FSService:
     ) -> Optional[Dict[str, Any]]:
         """Remove resource."""
         uri = validate_viking_uri(uri)
+        self._reject_relation_sidecar_uri(uri, operation="remove")
         viking_fs = self._ensure_initialized()
         cleanup_result: Optional[Dict[str, Any]] = None
         context_type = context_type_for_uri(uri)
@@ -298,7 +311,7 @@ class FSService:
         if context_type != "memory":
             return None
         leaf = uri.rstrip("/").rsplit("/", 1)[-1]
-        if leaf in {".abstract.md", ".overview.md", ".relations.json"}:
+        if leaf in {".abstract.md", ".overview.md"} or is_relation_sidecar_name(leaf):
             return None
         parent = VikingURI(uri).parent
         if parent is None:
@@ -393,6 +406,8 @@ class FSService:
         """Move resource."""
         from_uri = validate_viking_uri(from_uri, field_name="from_uri")
         to_uri = validate_viking_uri(to_uri, field_name="to_uri")
+        self._reject_relation_sidecar_uri(from_uri, operation="move")
+        self._reject_relation_sidecar_uri(to_uri, operation="move")
         viking_fs = self._ensure_initialized()
         watch_manager = self._get_watch_manager()
         if not watch_manager or context_type_for_uri(from_uri) != "resource":

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -17,6 +17,7 @@ from openviking.session.memory.utils.resource_refs import (
     sync_memory_resource_refs,
 )
 from openviking.storage.errors import ResourceBusyError
+from openviking.storage.internal_names import is_relation_sidecar_name
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
 from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.transaction import get_lock_manager
@@ -39,7 +40,7 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     from openviking.storage.transaction.lock_handle import LockHandle
 
-_DERIVED_FILENAMES = frozenset({".abstract.md", ".overview.md", ".relations.json"})
+_DERIVED_FILENAMES = frozenset({".abstract.md", ".overview.md"})
 _CREATE_ALLOWED_EXTENSIONS = frozenset(
     {".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".py", ".js", ".ts"}
 )
@@ -345,7 +346,7 @@ class ContentWriteCoordinator:
 
     def _validate_target_uri(self, uri: str) -> None:
         name = uri.rstrip("/").split("/")[-1]
-        if name in _DERIVED_FILENAMES:
+        if name in _DERIVED_FILENAMES or is_relation_sidecar_name(name):
             raise InvalidArgumentError(f"cannot write derived semantic file directly: {uri}")
         if is_watch_task_control_uri(uri):
             raise InvalidArgumentError(f"cannot write watch task control file directly: {uri}")

--- a/openviking/storage/internal_names.py
+++ b/openviking/storage/internal_names.py
@@ -6,6 +6,7 @@ MULTIWRITE_PATH_LOCK_FILE = ".path.ovlock"
 MULTIWRITE_EXACT_LOCK_FILE_PREFIX = ".exact.ovlock."
 MULTIWRITE_REDIRECT_FILE = ".redirect.json"
 MULTIWRITE_SYNC_LOG_FILE = ".sync_log.json"
+RELATION_TABLE_FILENAME = ".relations.json"
 
 MULTIWRITE_INTERNAL_FILE_NAMES = frozenset(
     {
@@ -27,7 +28,34 @@ WEBDAV_RESERVED_FILENAMES = frozenset(
     {
         ".abstract.md",
         ".overview.md",
-        ".relations.json",
+        RELATION_TABLE_FILENAME,
         *MULTIWRITE_INTERNAL_FILE_NAMES,
     }
 )
+
+
+def is_relation_sidecar_name(name: str) -> bool:
+    """Return whether a leaf name is a relation table sidecar."""
+    return bool(name) and name.endswith(RELATION_TABLE_FILENAME)
+
+
+def file_relation_sidecar_path(source_path: str) -> str:
+    """Return the sibling relation sidecar path for a file source."""
+    return f"{source_path.rstrip('/')}{RELATION_TABLE_FILENAME}"
+
+
+def relation_table_path(source_path: str, *, is_dir: bool) -> str:
+    """Return the relation table path for either a file or directory source."""
+    if is_dir:
+        return f"{source_path.rstrip('/')}/{RELATION_TABLE_FILENAME}"
+    return file_relation_sidecar_path(source_path)
+
+
+def is_storage_internal_entry_name(name: str) -> bool:
+    """Return whether a storage directory entry is internal metadata."""
+    return name in STORAGE_INTERNAL_ENTRY_NAMES or is_relation_sidecar_name(name)
+
+
+def is_webdav_reserved_filename(name: str) -> bool:
+    """Return whether a WebDAV path component must not be exposed."""
+    return name in WEBDAV_RESERVED_FILENAMES or is_relation_sidecar_name(name)

--- a/openviking/storage/ovpack/policy.py
+++ b/openviking/storage/ovpack/policy.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from openviking.core.namespace import uri_depth, uri_parts
 from openviking.resource.watch_storage import is_watch_task_control_uri
+from openviking.storage.internal_names import is_relation_sidecar_name
 from openviking.storage.ovpack.format import (
     OVPACK_BACKUP_TYPE,
     join_uri,
@@ -21,11 +22,10 @@ from openviking_cli.utils.uri import VikingURI
 PUBLIC_SCOPES = ("resources", "user")
 IMPORTABLE_SCOPES = frozenset(PUBLIC_SCOPES)
 STRUCTURED_IMPORT_SCOPES = frozenset({"user"})
-EXCLUDED_FILENAMES = frozenset({".relations.json"})
 
 
 def is_excluded_rel_path(rel_path: str) -> bool:
-    return leaf_name(rel_path) in EXCLUDED_FILENAMES
+    return is_relation_sidecar_name(leaf_name(rel_path))
 
 
 def validate_ovpack_user_rel_path(rel_path: str, *, operation: str) -> None:
@@ -60,7 +60,7 @@ def validate_import_target_uri(uri: str) -> None:
     validate_public_scope(uri, operation="import")
     validate_ovpack_user_rel_path(_scope_relative_path(uri), operation="import")
     name = leaf_name(uri)
-    if name in EXCLUDED_FILENAMES:
+    if is_relation_sidecar_name(name):
         raise InvalidArgumentError(f"cannot import internal ovpack file: {uri}")
     if is_watch_task_control_uri(uri):
         raise InvalidArgumentError(f"cannot import watch task control file: {uri}")
@@ -70,7 +70,7 @@ def validate_export_source_uri(uri: str) -> None:
     validate_public_scope(uri, operation="export")
     validate_ovpack_user_rel_path(_scope_relative_path(uri), operation="export")
     name = leaf_name(uri)
-    if name in EXCLUDED_FILENAMES:
+    if is_relation_sidecar_name(name):
         raise InvalidArgumentError(f"cannot export internal ovpack file: {uri}")
     if is_watch_task_control_uri(uri):
         raise InvalidArgumentError(f"cannot export watch task control file: {uri}")

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2235,16 +2235,14 @@ class VikingFS:
         for uri in uris:
             self._ensure_access(uri, ctx)
 
-        from_path = self._uri_to_path(from_uri, ctx=ctx)
-
-        entries = await self._read_relation_table(from_path, ctx=ctx)
+        entries = await self._read_relation_table(from_uri, ctx=ctx)
         existing_ids = {e.id for e in entries}
 
         link_id = next(f"link_{i}" for i in range(1, 10000) if f"link_{i}" not in existing_ids)
 
         entries.append(RelationEntry(id=link_id, uris=uris, reason=reason))
 
-        await self._write_relation_table(from_path, entries, ctx=ctx)
+        await self._write_relation_table(from_uri, entries, ctx=ctx)
         logger.debug(f"[VikingFS] Created link: {from_uri} -> {uris}")
 
     async def unlink(
@@ -2256,10 +2254,9 @@ class VikingFS:
         """Delete relation."""
         self._ensure_mutable_access(from_uri, ctx)
         self._ensure_access(uri, ctx)
-        from_path = self._uri_to_path(from_uri, ctx=ctx)
 
         try:
-            entries = await self._read_relation_table(from_path, ctx=ctx)
+            entries = await self._read_relation_table(from_uri, ctx=ctx)
 
             entry_to_modify = None
             for entry in entries:
@@ -2277,7 +2274,7 @@ class VikingFS:
                 entries.remove(entry_to_modify)
                 logger.debug(f"[VikingFS] Removed empty entry: {entry_to_modify.id}")
 
-            await self._write_relation_table(from_path, entries, ctx=ctx)
+            await self._write_relation_table(from_uri, entries, ctx=ctx)
             logger.debug(f"[VikingFS] Removed link: {from_uri} -> {uri}")
 
         except Exception as e:
@@ -2289,8 +2286,7 @@ class VikingFS:
     ) -> List[RelationEntry]:
         """Get relation table."""
         self._ensure_access(uri, ctx)
-        path = self._uri_to_path(uri, ctx=ctx)
-        return await self._read_relation_table(path, ctx=ctx)
+        return await self._read_relation_table(uri, ctx=ctx)
 
     # ========== Tree Traversal (Refactored) ==========
 
@@ -3000,10 +2996,10 @@ class VikingFS:
     # ========== Relation Table Internal Methods ==========
 
     async def _read_relation_table(
-        self, dir_path: str, ctx: Optional[RequestContext] = None
+        self, uri: str, ctx: Optional[RequestContext] = None
     ) -> List[RelationEntry]:
-        """Read .relations.json."""
-        table_path = f"{dir_path}/.relations.json"
+        """Read relation table for a file or directory source."""
+        table_path = await self._relation_table_path(uri, ctx=ctx)
         try:
             content = self._handle_agfs_read(await self._async_agfs.read(table_path))
             data = json.loads(content.decode("utf-8"))
@@ -3028,18 +3024,30 @@ class VikingFS:
         return entries
 
     async def _write_relation_table(
-        self, dir_path: str, entries: List[RelationEntry], ctx: Optional[RequestContext] = None
+        self, uri: str, entries: List[RelationEntry], ctx: Optional[RequestContext] = None
     ) -> None:
-        """Write .relations.json."""
+        """Write relation table for a file or directory source."""
         # Use flat list format
         data = [entry.to_dict() for entry in entries]
 
         content = json.dumps(data, ensure_ascii=False, indent=2)
-        table_path = f"{dir_path}/.relations.json"
+        table_path = await self._relation_table_path(uri, ctx=ctx)
         if isinstance(content, str):
             content = content.encode("utf-8")
 
         await self._async_agfs.write(table_path, content)
+
+    async def _relation_table_path(
+        self, uri: str, ctx: Optional[RequestContext] = None
+    ) -> str:
+        """Return the canonical relation table path for a source URI."""
+        path = self._uri_to_path(uri, ctx=ctx)
+        try:
+            stat = await self._async_agfs.stat(path)
+        except Exception:
+            stat = {}
+        is_dir = isinstance(stat, dict) and stat.get("isDir", False)
+        return f"{path}/.relations.json" if is_dir else f"{path}.relations.json"
 
     # ========== Batch Read (backward compatible) ==========
 
@@ -3669,7 +3677,7 @@ class VikingFS:
         (no parent directory to scope an L0/L1 vector to).
         """
         parent, _, name = tree_path.rpartition("/")
-        if name in self._NO_VECTOR_DERIVED:
+        if name in self._NO_VECTOR_DERIVED or name.endswith(".relations.json"):
             return None
         level = self._DIR_MARKER_LEVELS.get(name)
         if level is not None:

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -48,7 +48,10 @@ from openviking.server.identity import RequestContext, Role
 from openviking.storage.expr import And, PathScope, RawDSL
 from openviking.storage.internal_names import (
     MULTIWRITE_PATH_LOCK_FILE,
-    STORAGE_INTERNAL_ENTRY_NAMES,
+    file_relation_sidecar_path,
+    is_relation_sidecar_name,
+    is_storage_internal_entry_name,
+    relation_table_path,
 )
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.image_search import build_multimodal_embedding_input
@@ -580,6 +583,7 @@ class VikingFS:
         self._ensure_delete_access(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
         target_uri = self._path_to_uri(path, ctx=ctx)
+        relation_sidecar_path = file_relation_sidecar_path(path)
 
         async def _estimate_deleted_count(target_path: str, real_ctx: RequestContext) -> int:
             """Estimate number of nodes to be deleted using vector index."""
@@ -606,14 +610,25 @@ class VikingFS:
                 if mapped is not None:
                     raise mapped from exc
                 raise
-            # Path does not exist: clean up any orphan index records and return
-            uris_to_delete = await self._collect_uris(path, recursive, ctx=ctx)
-            uris_to_delete.append(target_uri)
-            real_ctx = self._ctx_or_default(ctx)
-            estimated_count = await _estimate_deleted_count(path, real_ctx)
-            await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
-            logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
-            return {"estimated_deleted_count": estimated_count}
+            # A missing file can still leave behind its sibling relation table.
+            # Treat it as part of the file's lifecycle while cleaning orphan index records.
+            try:
+                async with LockContext(
+                    get_lock_manager(),
+                    [path, relation_sidecar_path],
+                    lock_mode="exact",
+                    handle=lock_handle,
+                ):
+                    await self._remove_path_if_exists(relation_sidecar_path)
+                    uris_to_delete = await self._collect_uris(path, recursive, ctx=ctx)
+                    uris_to_delete.append(target_uri)
+                    real_ctx = self._ctx_or_default(ctx)
+                    estimated_count = await _estimate_deleted_count(path, real_ctx)
+                    await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
+                    logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
+                    return {"estimated_deleted_count": estimated_count}
+            except LockAcquisitionError:
+                raise ResourceBusyError(f"Resource is being processed: {uri}", uri=uri)
 
         if is_dir:
             if not recursive:
@@ -624,7 +639,7 @@ class VikingFS:
             lock_paths = [path]
             lock_mode = "tree"
         else:
-            lock_paths = [path]
+            lock_paths = [path, relation_sidecar_path]
             lock_mode = "exact"
 
         try:
@@ -652,6 +667,8 @@ class VikingFS:
                             f"Directory not empty: {uri}. Use recursive=True to delete non-empty directories."
                         )
                     raise
+                if not is_dir:
+                    await self._remove_path_if_exists(relation_sidecar_path)
                 # Add estimated_deleted_count to the result
                 if isinstance(result, dict):
                     result["estimated_deleted_count"] = estimated_count
@@ -723,6 +740,11 @@ class VikingFS:
         real_ctx = self._ctx_or_default(ctx)
         old_uri = canonicalize_uri(old_uri, real_ctx)
         new_uri = canonicalize_uri(new_uri, real_ctx)
+        file_relation_sidecar_paths = (
+            [file_relation_sidecar_path(old_path), file_relation_sidecar_path(new_path)]
+            if not is_dir
+            else []
+        )
 
         lock_context = (
             LockContext(
@@ -736,7 +758,7 @@ class VikingFS:
             if is_dir
             else LockContext(
                 get_lock_manager(),
-                [old_path, new_path],
+                [old_path, new_path, *file_relation_sidecar_paths],
                 lock_mode="exact",
                 handle=lock_handle,
             )
@@ -783,13 +805,16 @@ class VikingFS:
                     if is_dir:
                         await self._async_agfs.rm(new_path, recursive=True)
                     else:
-                        await self._async_agfs.rm(new_path)
+                        await self._remove_path_if_exists(new_path)
+                        await self._remove_path_if_exists(file_relation_sidecar_paths[1])
                 except Exception:
                     pass
                 raise
 
             # Delete source
             await self._async_agfs.rm(old_path, recursive=is_dir)
+            if not is_dir:
+                await self._remove_path_if_exists(file_relation_sidecar_paths[0])
             return {}
 
     async def system_sync_status(
@@ -835,9 +860,7 @@ class VikingFS:
                 recursive=is_dir,
                 fs_ctx={"account_id": self._ctx_or_default(ctx).account_id},
             )
-            return
-
-        if is_dir:
+        elif is_dir:
             await self._copy_dir_through_vikingfs(
                 old_uri, new_uri, ctx=ctx, lock_handle=lock_handle
             )
@@ -845,6 +868,14 @@ class VikingFS:
             await self._copy_file_through_vikingfs(
                 old_uri,
                 new_uri,
+                ctx=ctx,
+                lock_handle=lock_handle,
+            )
+
+        if not is_dir:
+            await self._copy_file_relation_sidecar(
+                old_path,
+                new_path,
                 ctx=ctx,
                 lock_handle=lock_handle,
             )
@@ -859,7 +890,8 @@ class VikingFS:
         """Recursively copy a directory through VikingFS read/write hooks."""
         await self.mkdir(new_uri, exist_ok=True, ctx=ctx)
 
-        entries = await self.ls(old_uri, show_all_hidden=True, ctx=ctx)
+        old_path = self._uri_to_path(old_uri, ctx=ctx)
+        entries = await self._ls_entries(old_path, ctx=ctx, include_relation_sidecars=True)
         for entry in entries:
             name = entry.get("name", "")
             if not name or name in (".", ".."):
@@ -891,6 +923,41 @@ class VikingFS:
         """Copy one file through VikingFS read/write hooks without deleting source."""
         content_bytes = await self.read_file_bytes(from_uri, ctx=ctx)
         await self.write_file_bytes(to_uri, content_bytes, ctx=ctx, lock_handle=lock_handle)
+
+    async def _remove_path_if_exists(self, path: str) -> None:
+        """Remove a file path while allowing an already-absent sidecar."""
+        try:
+            await self._async_agfs.rm(path)
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                raise
+
+    async def _copy_file_relation_sidecar(
+        self,
+        source_path: str,
+        destination_path: str,
+        *,
+        ctx: Optional[RequestContext] = None,
+        lock_handle: Optional["LockHandle"] = None,
+    ) -> None:
+        """Copy a file source's relation sidecar or clear stale destination metadata."""
+        source_sidecar_path = file_relation_sidecar_path(source_path)
+        destination_sidecar_path = file_relation_sidecar_path(destination_path)
+        try:
+            await self._async_agfs.stat(source_sidecar_path)
+        except Exception as exc:
+            if not is_not_found_error(exc):
+                raise
+            await self._remove_path_if_exists(destination_sidecar_path)
+            return
+
+        content = self._handle_agfs_read(await self._async_agfs.read(source_sidecar_path))
+        await self._ensure_parent_dirs(destination_sidecar_path, ctx=ctx)
+        await self._run_with_encrypted_write_lock(
+            destination_sidecar_path,
+            lambda: self._async_agfs.write(destination_sidecar_path, content),
+            lock_handle=lock_handle,
+        )
 
     async def grep(
         self,
@@ -1190,6 +1257,8 @@ class VikingFS:
         files_scanned = 0
 
         for file_uri in file_uris:
+            if is_storage_internal_entry_name(file_uri.rstrip("/").rsplit("/", 1)[-1]):
+                continue
             files_scanned += 1
             try:
                 content_bytes = await self.read(file_uri, ctx=ctx)
@@ -1281,6 +1350,8 @@ class VikingFS:
                 continue
 
             agfs_file_path = self._resolve_grep_match_agfs_path(path, match_file)
+            if is_storage_internal_entry_name(agfs_file_path.rsplit("/", 1)[-1]):
+                continue
 
             file_uri = self._path_to_uri(agfs_file_path, ctx=ctx)
             if not self._is_accessible(file_uri, real_ctx):
@@ -1419,6 +1490,8 @@ class VikingFS:
         except Exception:
             return file_uris
         if not root_stat.get("isDir", False):
+            if is_storage_internal_entry_name(normalized_uri.rstrip("/").rsplit("/", 1)[-1]):
+                return file_uris
             file_uris.append(normalized_uri)
             return file_uris
 
@@ -2299,7 +2372,7 @@ class VikingFS:
         parts = [p for p in parent_path.strip("/").split("/") if p]
         if len(parts) == 2 and parts[0] == "local":
             return name in VikingURI.LISTABLE_SCOPES
-        return name not in STORAGE_INTERNAL_ENTRY_NAMES
+        return not is_storage_internal_entry_name(name)
 
     def _ancestor_is_filtered(self, entry_path: str, base_path: str) -> bool:
         """Check if any ancestor directory of entry_path would be filtered by _ls_entries.
@@ -2770,7 +2843,11 @@ class VikingFS:
     _ROOT_PATH = "/local"
 
     async def _ls_entries(
-        self, path: str, ctx: Optional[RequestContext] = None
+        self,
+        path: str,
+        ctx: Optional[RequestContext] = None,
+        *,
+        include_relation_sidecars: bool = False,
     ) -> List[Dict[str, Any]]:
         """List directory entries, filtering out internal directories.
 
@@ -2781,7 +2858,12 @@ class VikingFS:
         parts = [p for p in path.strip("/").split("/") if p]
         if len(parts) == 2 and parts[0] == "local":
             return [e for e in entries if e.get("name") in VikingURI.LISTABLE_SCOPES]
-        return [e for e in entries if e.get("name") not in STORAGE_INTERNAL_ENTRY_NAMES]
+        return [
+            entry
+            for entry in entries
+            if not is_storage_internal_entry_name(entry.get("name", ""))
+            or (include_relation_sidecars and is_relation_sidecar_name(entry.get("name", "")))
+        ]
 
     def _path_to_uri(self, path: str, ctx: Optional[RequestContext] = None) -> str:
         """/local/{account}/... -> viking://...
@@ -3047,7 +3129,7 @@ class VikingFS:
         except Exception:
             stat = {}
         is_dir = isinstance(stat, dict) and stat.get("isDir", False)
-        return f"{path}/.relations.json" if is_dir else f"{path}.relations.json"
+        return relation_table_path(path, is_dir=is_dir)
 
     # ========== Batch Read (backward compatible) ==========
 
@@ -3453,9 +3535,12 @@ class VikingFS:
         self._ensure_mutable_access(from_uri, ctx)
         self._ensure_mutable_access(to_uri, ctx)
         from_path = self._uri_to_path(from_uri, ctx=ctx)
+        to_path = self._uri_to_path(to_uri, ctx=ctx)
 
         await self._copy_file_through_vikingfs(from_uri, to_uri, ctx=ctx)
+        await self._copy_file_relation_sidecar(from_path, to_path, ctx=ctx)
         await self._async_agfs.rm(from_path)
+        await self._remove_path_if_exists(file_relation_sidecar_path(from_path))
 
     # ========== Temp File Operations (backward compatible) ==========
 
@@ -3494,7 +3579,7 @@ class VikingFS:
         self._ensure_mutable_access(temp_uri, ctx)
         path = self._uri_to_path(temp_uri, ctx=ctx)
         try:
-            for entry in await self._ls_entries(path, ctx=ctx):
+            for entry in await self._ls_entries(path, ctx=ctx, include_relation_sidecars=True):
                 name = entry.get("name", "")
                 if name in [".", ".."]:
                     continue
@@ -3657,7 +3742,7 @@ class VikingFS:
         ".abstract.md": ContextLevel.ABSTRACT,
         ".overview.md": ContextLevel.OVERVIEW,
     }
-    _NO_VECTOR_DERIVED = frozenset({".relations.json", ".ovgitignore"})
+    _NO_VECTOR_DERIVED = frozenset({".ovgitignore"})
 
     def _classify_restore_path(self, tree_path: str, *, deleted: bool) -> Optional[tuple]:
         """Classify a restore-affected tree path into a vector maintenance task.
@@ -3677,7 +3762,7 @@ class VikingFS:
         (no parent directory to scope an L0/L1 vector to).
         """
         parent, _, name = tree_path.rpartition("/")
-        if name in self._NO_VECTOR_DERIVED or name.endswith(".relations.json"):
+        if name in self._NO_VECTOR_DERIVED or is_relation_sidecar_name(name):
             return None
         level = self._DIR_MARKER_LEVELS.get(name)
         if level is not None:

--- a/openviking/usage_reporter/extractors.py
+++ b/openviking/usage_reporter/extractors.py
@@ -9,11 +9,12 @@ from datetime import datetime
 from typing import Any, Iterable, Protocol
 
 from openviking.message import Message, ToolPart
+from openviking.storage.internal_names import is_relation_sidecar_name
 from openviking.utils.time_utils import format_iso8601, parse_iso_datetime
 
 from .models import UsageContext, UsageEvent, utc_now_iso
 
-_EXPERIENCE_SIDECAR_FILENAMES = {".abstract.md", ".overview.md", ".relations.json"}
+_EXPERIENCE_SIDECAR_FILENAMES = {".abstract.md", ".overview.md"}
 
 
 class UsageExtractor(Protocol):
@@ -47,7 +48,9 @@ def _is_experience_uri(uri: str, context: UsageContext) -> bool:
     segments = relative.split("/")
     if not relative or any(not segment or segment in {".", ".."} for segment in segments):
         return False
-    return segments[-1] not in _EXPERIENCE_SIDECAR_FILENAMES
+    return segments[-1] not in _EXPERIENCE_SIDECAR_FILENAMES and not is_relation_sidecar_name(
+        segments[-1]
+    )
 
 
 def _event_time(message: Message) -> str:

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -17,7 +17,7 @@ from openviking.parse.tree_builder import TreeBuilder
 from openviking.server.identity import RequestContext
 from openviking.storage import VikingDBManager
 from openviking.storage.errors import LockAcquisitionError
-from openviking.storage.internal_names import STORAGE_INTERNAL_ENTRY_NAMES
+from openviking.storage.internal_names import is_storage_internal_entry_name
 from openviking.storage.transaction import (
     LOCK_TIMEOUT_DEFAULT,
     NO_LOCK,
@@ -321,7 +321,7 @@ class ResourceProcessor:
                                         if not name or name in {".", ".."}:
                                             continue
                                         names.append(str(name))
-                                    if all(name in STORAGE_INTERNAL_ENTRY_NAMES for name in names):
+                                    if all(is_storage_internal_entry_name(name) for name in names):
                                         target_preexisting = False
                             except Exception:
                                 pass

--- a/tests/client/test_relations.py
+++ b/tests/client/test_relations.py
@@ -3,7 +3,10 @@
 
 """Relation tests"""
 
+import pytest
+
 from openviking import AsyncOpenViking
+from openviking_cli.exceptions import InvalidArgumentError
 
 
 class TestLink:
@@ -57,6 +60,80 @@ class TestLink:
         link = next((r for r in relations if r.get("uri") == target_uri), None)
         assert link is not None
         assert link.get("reason") == "File source test"
+
+
+class TestFileRelationSidecars:
+    """Regression coverage for file-source relation metadata."""
+
+    async def test_file_relation_sidecar_is_hidden_and_not_directly_writable(
+        self, client: AsyncOpenViking
+    ):
+        source_uri = "viking://resources/hidden-sidecar-source.md"
+        target_uri = "viking://resources/hidden-sidecar-target.md"
+        sidecar_uri = f"{source_uri}.relations.json"
+
+        await client.write(source_uri, "source", mode="create")
+        await client.write(target_uri, "target", mode="create")
+        await client.link(from_uri=source_uri, uris=target_uri, reason="hidden sidecar")
+
+        entries = await client.ls("viking://resources", show_all_hidden=True)
+        assert sidecar_uri not in {entry["uri"] for entry in entries}
+
+        tree = await client.tree("viking://resources", show_all_hidden=True)
+        assert sidecar_uri not in {entry["uri"] for entry in tree}
+
+        with pytest.raises(
+            InvalidArgumentError, match="cannot write derived semantic file directly"
+        ):
+            await client.write(sidecar_uri, "collision", mode="create")
+
+    async def test_file_relation_sidecar_follows_mv_and_rm(self, client: AsyncOpenViking):
+        source_uri = "viking://resources/move-sidecar-source.md"
+        target_uri = "viking://resources/move-sidecar-target.md"
+        moved_uri = "viking://resources/move-sidecar-destination.md"
+        source_sidecar_uri = f"{source_uri}.relations.json"
+        moved_sidecar_uri = f"{moved_uri}.relations.json"
+        viking_fs = client._service.viking_fs
+
+        await client.write(source_uri, "source", mode="create")
+        await client.write(target_uri, "target", mode="create")
+        await client.link(from_uri=source_uri, uris=target_uri, reason="move sidecar")
+        assert await viking_fs.exists(source_sidecar_uri, ctx=client._ctx)
+
+        await client.mv(source_uri, moved_uri)
+
+        relations = await client.relations(moved_uri)
+        assert any(relation.get("uri") == target_uri for relation in relations)
+        assert not await viking_fs.exists(source_sidecar_uri, ctx=client._ctx)
+        assert await viking_fs.exists(moved_sidecar_uri, ctx=client._ctx)
+
+        await client.rm(moved_uri)
+        assert not await viking_fs.exists(moved_sidecar_uri, ctx=client._ctx)
+
+        orphan_uri = "viking://resources/orphan-sidecar-source.md"
+        orphan_sidecar_uri = f"{orphan_uri}.relations.json"
+        await viking_fs.write_file(orphan_sidecar_uri, "[]", ctx=client._ctx)
+        assert await viking_fs.exists(orphan_sidecar_uri, ctx=client._ctx)
+
+        await client.rm(orphan_uri)
+        assert not await viking_fs.exists(orphan_sidecar_uri, ctx=client._ctx)
+
+    async def test_move_file_preserves_file_relation_sidecar(self, client: AsyncOpenViking):
+        source_uri = "viking://resources/direct-move-sidecar-source.md"
+        target_uri = "viking://resources/direct-move-sidecar-target.md"
+        moved_uri = "viking://resources/direct-move-sidecar-destination.md"
+        viking_fs = client._service.viking_fs
+
+        await client.write(source_uri, "source", mode="create")
+        await client.write(target_uri, "target", mode="create")
+        await client.link(from_uri=source_uri, uris=target_uri, reason="direct move sidecar")
+
+        await viking_fs.move_file(source_uri, moved_uri, ctx=client._ctx)
+
+        relations = await client.relations(moved_uri)
+        assert any(relation.get("uri") == target_uri for relation in relations)
+        assert not await viking_fs.exists(f"{source_uri}.relations.json", ctx=client._ctx)
+        assert await viking_fs.exists(f"{moved_uri}.relations.json", ctx=client._ctx)
 
 
 class TestUnlink:

--- a/tests/client/test_relations.py
+++ b/tests/client/test_relations.py
@@ -3,6 +3,8 @@
 
 """Relation tests"""
 
+from openviking import AsyncOpenViking
+
 
 class TestLink:
     """Test link creating relations"""
@@ -40,6 +42,21 @@ class TestLink:
         link = next((r for r in relations if r.get("uri") == target_uri), None)
         assert link is not None
         assert link.get("reason") == reason
+
+    async def test_link_from_file_resource(self, client: AsyncOpenViking):
+        """Test creating relation when the source is a file resource."""
+        source_uri = "viking://resources/file-source.md"
+        target_uri = "viking://resources/file-target.md"
+
+        await client.write(source_uri, "source", mode="create")
+        await client.write(target_uri, "target", mode="create")
+
+        await client.link(from_uri=source_uri, uris=target_uri, reason="File source test")
+
+        relations = await client.relations(source_uri)
+        link = next((r for r in relations if r.get("uri") == target_uri), None)
+        assert link is not None
+        assert link.get("reason") == "File source test"
 
 
 class TestUnlink:

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -117,6 +117,37 @@ class MissingSidecarExportVikingFS(FakeExportVikingFS):
         self.text_files = {}
 
 
+class FileRelationSidecarExportVikingFS(FakeExportVikingFS):
+    def __init__(self) -> None:
+        super().__init__()
+        self.binary_files["viking://resources/demo/source.md.relations.json"] = b"[]"
+
+    async def tree(
+        self,
+        uri: str,
+        show_all_hidden: bool = False,
+        node_limit=None,
+        level_limit=None,
+        ctx=None,
+    ):
+        entries = await super().tree(
+            uri,
+            show_all_hidden=show_all_hidden,
+            node_limit=node_limit,
+            level_limit=level_limit,
+            ctx=ctx,
+        )
+        return [
+            *entries,
+            {
+                "rel_path": "source.md.relations.json",
+                "uri": "viking://resources/demo/source.md.relations.json",
+                "isDir": False,
+                "size": 2,
+            },
+        ]
+
+
 class ReservedPathExportVikingFS(FakeExportVikingFS):
     def __init__(self) -> None:
         super().__init__()
@@ -585,6 +616,36 @@ async def test_export_ovpack_skips_missing_semantic_sidecars(
     assert "demo/files/notes.txt" in names
     assert "demo/files/.overview.md" not in names
     assert ".overview.md" not in manifest_paths
+
+
+@pytest.mark.asyncio
+async def test_ovpack_excludes_and_rejects_file_relation_sidecars(
+    temp_ovpack_path: Path,
+    request_ctx: RequestContext,
+):
+    await export_ovpack(
+        FileRelationSidecarExportVikingFS(),
+        "viking://resources/demo",
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    with zipfile.ZipFile(temp_ovpack_path, "r") as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("demo/_ovpack/manifest.json").decode("utf-8"))
+
+    assert "demo/files/source.md.relations.json" not in names
+    assert "source.md.relations.json" not in {entry["path"] for entry in manifest["entries"]}
+
+    _write_ovpack_with_manifest(
+        temp_ovpack_path,
+        "demo",
+        {"source.md.relations.json": "[]"},
+    )
+    with pytest.raises(InvalidArgumentError, match="cannot import internal ovpack file"):
+        await import_ovpack(
+            FakeVikingFS(), str(temp_ovpack_path), "viking://resources", request_ctx
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_api_webdav.py
+++ b/tests/server/test_api_webdav.py
@@ -6,6 +6,7 @@
 import xml.etree.ElementTree as ET
 
 import httpx
+import pytest
 
 from openviking.server.routers.webdav import _ensure_exposed_path, _exposed_child_entries
 from openviking_cli.exceptions import NotFoundError
@@ -68,6 +69,18 @@ async def test_webdav_rejects_direct_access_to_reserved_semantic_files(client_wi
     assert resp.status_code == 404
 
 
+async def test_webdav_rejects_direct_write_to_file_relation_sidecar(client_with_resource):
+    client, uri = client_with_resource
+    webdav_path = _webdav_path_from_uri(uri)
+
+    resp = await client.put(
+        f"/webdav/resources/{webdav_path}/source.md.relations.json",
+        content=b"[]",
+    )
+
+    assert resp.status_code == 404
+
+
 async def test_webdav_rejects_direct_access_to_multiwrite_internal_files(client_with_resource):
     client, uri = client_with_resource
     webdav_path = _webdav_path_from_uri(uri)
@@ -86,12 +99,19 @@ def test_webdav_unit_rejects_direct_access_to_multiwrite_internal_files():
         raise AssertionError(f"{hidden_name} should be rejected")
 
 
+def test_webdav_unit_rejects_file_relation_sidecars():
+    for hidden_name in (".relations.json", "source.md.relations.json"):
+        with pytest.raises(NotFoundError):
+            _ensure_exposed_path(f"workspace/{hidden_name}")
+
+
 def test_webdav_unit_filters_multiwrite_internal_files_from_children():
     entries = [
         {"name": ".obsidian"},
         {"name": ".path.ovlock"},
         {"name": ".sync_log.json"},
         {"name": ".redirect.json"},
+        {"name": "notes.md.relations.json"},
         {"name": "notes.md"},
     ]
     filtered = _exposed_child_entries(entries)

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -20,6 +20,19 @@ from openviking_cli.session.user_id import UserIdentifier
 
 
 @pytest.mark.asyncio
+async def test_write_rejects_file_relation_sidecar_suffix(service):
+    ctx = RequestContext(user=service.user, role=Role.USER)
+
+    with pytest.raises(InvalidArgumentError, match="cannot write derived semantic file directly"):
+        await service.fs.write(
+            "viking://resources/source.md.relations.json",
+            content="[]",
+            ctx=ctx,
+            mode="create",
+        )
+
+
+@pytest.mark.asyncio
 async def test_write_updates_memory_file_and_parent_overview(service):
     ctx = RequestContext(user=service.user, role=Role.USER)
     memory_dir = f"viking://user/{ctx.user.user_space_name()}/memories/preferences"

--- a/tests/storage/test_internal_names.py
+++ b/tests/storage/test_internal_names.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for shared internal storage entry-name policies."""
+
+from openviking.storage.internal_names import (
+    file_relation_sidecar_path,
+    is_relation_sidecar_name,
+    is_storage_internal_entry_name,
+    is_webdav_reserved_filename,
+    relation_table_path,
+)
+
+
+def test_relation_sidecar_name_covers_file_and_directory_relation_tables():
+    assert is_relation_sidecar_name(".relations.json")
+    assert is_relation_sidecar_name("source.md.relations.json")
+    assert not is_relation_sidecar_name("source.relations.json.bak")
+    assert not is_relation_sidecar_name("source.md")
+
+
+def test_relation_sidecar_paths_match_source_type():
+    assert file_relation_sidecar_path("/local/account/resources/source.md") == (
+        "/local/account/resources/source.md.relations.json"
+    )
+    assert relation_table_path("/local/account/resources/source.md", is_dir=False) == (
+        "/local/account/resources/source.md.relations.json"
+    )
+    assert relation_table_path("/local/account/resources/source", is_dir=True) == (
+        "/local/account/resources/source/.relations.json"
+    )
+
+
+def test_relation_sidecars_are_internal_and_reserved_for_webdav():
+    name = "source.md.relations.json"
+    assert is_storage_internal_entry_name(name)
+    assert is_webdav_reserved_filename(name)

--- a/tests/storage/test_viking_fs_glob.py
+++ b/tests/storage/test_viking_fs_glob.py
@@ -157,6 +157,34 @@ async def test_glob_trusts_backend_glob_matches(monkeypatch, fs):
 
 
 @pytest.mark.asyncio
+async def test_glob_filters_relation_sidecar_matches(monkeypatch, fs):
+    async def fake_glob_directory(path, pattern, **kwargs):
+        return {
+            "entries": [
+                {
+                    "path": "/local/test_account/resources/source.md",
+                    "rel_path": "source.md",
+                    "name": "source.md",
+                    "is_dir": False,
+                },
+                {
+                    "path": "/local/test_account/resources/source.md.relations.json",
+                    "rel_path": "source.md.relations.json",
+                    "name": "source.md.relations.json",
+                    "is_dir": False,
+                },
+            ],
+            "next_token": None,
+        }
+
+    monkeypatch.setattr(fs._async_agfs, "glob_directory", fake_glob_directory)
+
+    result = await fs.glob("**/*", uri="viking://resources", ctx=_default_ctx())
+
+    assert result == {"matches": ["viking://resources/source.md"], "count": 1}
+
+
+@pytest.mark.asyncio
 async def test_glob_rejects_empty_pattern(fs):
     with pytest.raises(InvalidArgumentError):
         await fs.glob("", uri="viking://resources", ctx=_default_ctx())

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -460,6 +460,36 @@ async def test_grep_maps_agfs_matches_to_viking_uris(monkeypatch, fs):
 
 
 @pytest.mark.asyncio
+async def test_grep_filters_relation_sidecar_matches_from_agfs(monkeypatch, fs):
+    async def fake_grep(**kwargs):
+        return {
+            "matches": [
+                {"file": "source.md", "line": 1, "content": "visible match"},
+                {
+                    "file": "source.md.relations.json",
+                    "line": 1,
+                    "content": "internal match",
+                },
+            ],
+            "files_scanned": 2,
+        }
+
+    monkeypatch.setattr(fs._async_agfs, "grep", fake_grep)
+
+    result = await fs.grep("viking://resources", pattern="match")
+
+    assert result["matches"] == [
+        {
+            "line": 1,
+            "uri": "viking://resources/source.md",
+            "content": "visible match",
+        }
+    ]
+    assert result["count"] == 1
+    assert result["match_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_grep_applies_node_limit_to_backend_results(monkeypatch, fs):
     async def fake_grep(**kwargs):
         return {

--- a/tests/storage/test_viking_fs_tree.py
+++ b/tests/storage/test_viking_fs_tree.py
@@ -153,6 +153,7 @@ def test_is_name_visible_at_account_root(fs, name, parent_path, expected):
     [
         ("my_dir", "/local/test_account/resources", True),
         ("normal_dir", "/local/test_account/resources/foo", True),
+        ("file.md.relations.json", "/local/test_account/resources", False),
         ("_system", "/local/test_account/resources", False),
         ("tasks", "/local/test_account/resources/bar", False),
         (".path.ovlock", "/local/test_account/resources", False),
@@ -222,6 +223,42 @@ def test_is_tree_entry_visible_multiwrite_meta_filtered(monkeypatch, fs):
             is_dir=False,
         )
         assert fs._is_tree_entry_visible(entry, "/local/test_account", _default_ctx()) is False
+
+
+def test_is_tree_entry_visible_file_relation_sidecar_filtered(monkeypatch, fs):
+    patch_visibility(monkeypatch, fs, is_accessible=True)
+    entry = make_entry(
+        "/local/test_account/resources/file.md.relations.json",
+        "file.md.relations.json",
+        is_dir=False,
+    )
+    assert fs._is_tree_entry_visible(entry, "/local/test_account", _default_ctx()) is False
+
+
+@pytest.mark.asyncio
+async def test_ls_entries_hides_file_relation_sidecars_unless_needed_for_copy(monkeypatch, fs):
+    async def fake_ls(_path):
+        return [
+            {"name": "notes.md"},
+            {"name": ".relations.json"},
+            {"name": "notes.md.relations.json"},
+            {"name": ".path.ovlock"},
+        ]
+
+    monkeypatch.setattr(fs._async_agfs, "ls", fake_ls)
+
+    visible = await fs._ls_entries("/local/test_account/resources")
+    assert [entry["name"] for entry in visible] == ["notes.md"]
+
+    copy_entries = await fs._ls_entries(
+        "/local/test_account/resources",
+        include_relation_sidecars=True,
+    )
+    assert [entry["name"] for entry in copy_entries] == [
+        "notes.md",
+        ".relations.json",
+        "notes.md.relations.json",
+    ]
 
 
 def test_is_tree_entry_visible_default_ctx(monkeypatch, fs):


### PR DESCRIPTION
## Description

Allow file resources to be used as relation sources without trying to write `.relations.json` under the file path.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3067

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Store relation tables for file sources as sibling `.relations.json` sidecar files instead of writing under the file path.
- Keep directory source relation tables under `dir/.relations.json`.
- Skip file relation sidecars during snapshot restore vector classification.
- Add a regression test for linking from a file resource.
- Update storage concept docs for file and directory relation sources.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Verification performed:

- `python -m py_compile openviking\storage\viking_fs.py tests\client\test_relations.py`
- `git diff --check`

Full pytest was not run locally because the current Python environment lacks test dependencies.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This keeps the existing directory relation table behavior unchanged while adding support for file resources as relation sources.