### PR TITLE
fix(parse): normalize code hosting blob URL hosts

### DIFF
--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -30,6 +30,7 @@ from openviking.parse.parsers.media.constants import (
     VIDEO_EXTENSIONS,
 )
 from openviking.utils import is_code_hosting_blob_url
+from openviking.utils.code_hosting_utils import _domain_matches
 from openviking.utils.network_guard import build_httpx_request_validation_hooks
 from openviking_cli.exceptions import PermissionDeniedError
 from openviking_cli.utils.logger import get_logger
@@ -843,14 +844,14 @@ class HTTPAccessor(DataAccessor):
             gitlab_domains = config.code.gitlab_domains
             github_raw_domain = config.code.github_raw_domain
 
-            if parsed.netloc in github_domains:
+            if _domain_matches(parsed, github_domains):
                 path_parts = parsed.path.strip("/").split("/")
                 if len(path_parts) >= 4 and path_parts[2] == "blob":
                     # Remove 'blob'
                     new_path = "/".join(path_parts[:2] + path_parts[3:])
                     return f"https://{github_raw_domain}/{new_path}"
 
-            if parsed.netloc in gitlab_domains and "/blob/" in parsed.path:
+            if _domain_matches(parsed, gitlab_domains) and "/blob/" in parsed.path:
                 return url.replace("/blob/", "/raw/")
 
         except Exception as e:

--- a/tests/unit/test_accessors_http.py
+++ b/tests/unit/test_accessors_http.py
@@ -273,6 +273,7 @@ class TestHTTPAccessorPriorityRouting:
         assert accessor is not None
         assert accessor.__class__.__name__ == "HTTPAccessor"
 
+
 class TestHTTPAccessorRawUrlConversion:
     """Tests for HTTPAccessor._convert_to_raw_url (GitHub/GitLab blob -> raw)."""
 
@@ -298,6 +299,32 @@ class TestHTTPAccessorRawUrlConversion:
             "https://raw.githubusercontent.com/user/repo/feature/branch/src/components/Button.tsx"
         )
         assert accessor._convert_to_raw_url(blob_deep) == expected_deep
+
+    @pytest.mark.parametrize(
+        ("blob_url", "expected"),
+        [
+            (
+                "https://github.com:443/owner/repo/blob/main/readme.md",
+                "https://raw.githubusercontent.com/owner/repo/main/readme.md",
+            ),
+            (
+                "https://GitHub.com/owner/repo/blob/main/readme.md",
+                "https://raw.githubusercontent.com/owner/repo/main/readme.md",
+            ),
+            (
+                "https://gitlab.com:443/group/repo/-/blob/main/readme.md",
+                "https://gitlab.com:443/group/repo/-/raw/main/readme.md",
+            ),
+            (
+                "https://GitLab.com/group/repo/-/blob/main/readme.md",
+                "https://GitLab.com/group/repo/-/raw/main/readme.md",
+            ),
+        ],
+    )
+    def test_blob_conversion_normalizes_host(
+        self, accessor: HTTPAccessor, blob_url: str, expected: str
+    ) -> None:
+        assert accessor._convert_to_raw_url(blob_url) == expected
 
     def test_github_non_blob_urls(self, accessor: HTTPAccessor) -> None:
         repo_root = "https://github.com/volcengine/OpenViking"


### PR DESCRIPTION
## Description

Normalize GitHub/GitLab blob URL host matching before raw URL conversion. `urlparse().netloc` retains a port, userinfo, and host casing, so otherwise valid URLs such as `https://github.com:443/.../blob/...` were left pointing at the HTML page instead of raw content.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. This is a Discovery-backed regression fix; no related open issue was found.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Use the existing shared host-matching helper for GitHub and GitLab blob URL conversion.
- Convert explicit-port and mixed-case GitHub/GitLab blob URLs to their expected raw URLs.
- Add focused regression coverage for both hosting providers.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Executed locally:

- `uv run --no-sync python -m pytest --noconftest -o addopts= tests/unit/test_accessors_http.py tests/test_code_hosting_utils.py -q --disable-warnings --no-header -p no:cacheprovider` (79 passed)
- `uv run --no-sync python -m pytest --noconftest -o addopts= tests/parse/test_url_filename_preservation.py -q --disable-warnings --no-header -p no:cacheprovider` (44 passed)
- `uv run --no-sync ruff check openviking/parse/accessors/http_accessor.py tests/unit/test_accessors_http.py`
- `uv run --no-sync ruff format --check openviking/parse/accessors/http_accessor.py tests/unit/test_accessors_http.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- No documentation or dependent change is needed: this is an internal normalization fix that preserves existing URL behavior while handling ports and host casing correctly.
- Full `pytest` is not claimed as passing: local collection is blocked by unavailable optional test dependencies and service-specific packages. The focused parser/accessor suites above passed.
- `mypy --follow-imports=skip openviking/parse/accessors/http_accessor.py` retains three pre-existing diagnostics at lines 591 and 778; none are in this diff.
- Duplicate-work search keywords: `code hosting blob raw URL parsed.netloc hostname port GitHub GitLab`. Open PRs #3315 and #3347 were reviewed and do not overlap semantically with this change.
