### PR TITLE
fix(crawler): normalize same-host default ports

### DIFF
--- a/openviking/parse/accessors/web_crawler/scrapy_spider.py
+++ b/openviking/parse/accessors/web_crawler/scrapy_spider.py
@@ -4,7 +4,7 @@
 
 import os
 from collections.abc import Iterator
-from urllib.parse import urljoin, urlparse
+from urllib.parse import ParseResult, urljoin, urlparse
 
 import scrapy
 from parsel import Selector
@@ -13,7 +13,6 @@ from scrapy.exceptions import CloseSpider
 from openviking.parse.accessors.http_accessor import URLType, URLTypeDetector
 from openviking.parse.accessors.web_crawler.config import CrawlConfig
 from openviking.parse.accessors.web_crawler.models import CrawledDownload, CrawledPage
-
 
 _DOWNLOAD_URL_TYPES = frozenset(
     {
@@ -28,6 +27,24 @@ _DOWNLOAD_EXTENSIONS = frozenset(
     for ext, url_type in URLTypeDetector.EXTENSION_MAP.items()
     if url_type in _DOWNLOAD_URL_TYPES
 )
+
+
+def _normalized_host_port(parsed: ParseResult) -> tuple[str, int | None]:
+    """Return a comparable host key with default HTTP(S) ports elided."""
+    hostname = parsed.hostname
+    if not hostname:
+        return parsed.netloc.lower(), None
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return parsed.netloc.lower(), None
+
+    if (parsed.scheme.lower() == "http" and port == 80) or (
+        parsed.scheme.lower() == "https" and port == 443
+    ):
+        port = None
+    return hostname.rstrip(".").lower(), port
 
 
 class OpenVikingWebSpider(scrapy.Spider):
@@ -71,7 +88,7 @@ class OpenVikingWebSpider(scrapy.Spider):
         self.config = config
         self.collector = collector
         self.download_collector = download_collector
-        self.root_host = urlparse(root_url).netloc.lower()
+        self.root_host_key = _normalized_host_port(urlparse(root_url))
         self._success_count = 0
         self._seen_download_urls: set[str] = set()
 
@@ -199,7 +216,10 @@ class OpenVikingWebSpider(scrapy.Spider):
     def _passes_url_filters(self, url: str, parsed) -> bool:
         if parsed.scheme not in ("http", "https"):
             return False
-        if not self.config.allow_external_links and parsed.netloc.lower() != self.root_host:
+        if (
+            not self.config.allow_external_links
+            and _normalized_host_port(parsed) != self.root_host_key
+        ):
             return False
         if self.config.include_paths and not self._matches_any(
             parsed.path, self.config.include_paths

--- a/tests/parse/accessors/web_crawler/test_scrapy_spider.py
+++ b/tests/parse/accessors/web_crawler/test_scrapy_spider.py
@@ -40,6 +40,31 @@ class TestAcceptChildUrl:
         spider = _make_spider()
         assert spider._accept_child_url("http://example.com/foo") is True
 
+    @pytest.mark.parametrize(
+        ("root_url", "child_url"),
+        [
+            ("https://example.com:443/", "https://example.com/docs"),
+            ("https://example.com/", "https://example.com:443/docs"),
+            ("http://example.com:80/", "http://example.com/docs"),
+            ("http://example.com/", "http://example.com:80/docs"),
+            ("https://example.com./", "http://EXAMPLE.com/docs"),
+        ],
+    )
+    def test_accepts_equivalent_same_host_urls(self, root_url, child_url):
+        spider = _make_spider(root_url=root_url)
+        assert spider._accept_child_url(child_url) is True
+
+    @pytest.mark.parametrize(
+        ("root_url", "child_url"),
+        [
+            ("https://example.com:8443/", "https://example.com/docs"),
+            ("https://example.com/", "https://example.com:8443/docs"),
+        ],
+    )
+    def test_rejects_non_default_port_as_external(self, root_url, child_url):
+        spider = _make_spider(root_url=root_url)
+        assert spider._accept_child_url(child_url) is False
+
     def test_rejects_external_when_disallowed(self):
         spider = _make_spider()
         assert spider._accept_child_url("http://other.com/x") is False


### PR DESCRIPTION
## Description

Normalize recursive crawler same-host comparisons so explicit default HTTP(S) ports and DNS trailing dots are treated as their equivalent canonical hosts. Previously, a root URL such as `https://example.com:443/` rejected `https://example.com/docs` as external, which silently prevented expected same-site traversal.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. This is a discovery-backed regression fix; no related open issue was found.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Compare crawler hosts using a normalized hostname and port key.
- Elide only HTTP port 80 and HTTPS port 443, while retaining non-default ports as distinct origins.
- Add regression coverage for both directions of default-port equivalence, trailing-dot/case normalization, and non-default port isolation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Executed locally:

- `uv run --no-sync python -m pytest --noconftest -o addopts= tests/parse/accessors/web_crawler/test_scrapy_spider.py tests/parse/accessors/web_crawler/test_middlewares.py tests/parse/accessors/web_crawler/test_config.py tests/unit/test_web_importer.py -q --disable-warnings --no-header -p no:cacheprovider` (83 passed)
- `uv run --no-sync ruff check openviking/parse/accessors/web_crawler/scrapy_spider.py`
- `uv run --no-sync ruff format --check openviking/parse/accessors/web_crawler/scrapy_spider.py`
- `uv run --no-sync mypy --follow-imports=skip openviking/parse/accessors/web_crawler/scrapy_spider.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Documentation already defines recursive crawling as same-host traversal; this change aligns the implementation with that behavior.
- Full `pytest` was not claimed as passing because the local source-build environment lacks Cargo and several optional service test dependencies.
- Duplicate-work search keywords: `crawler default port same host recursive crawl scrapy spider`.
