### PR TITLE
fix(parse): normalize skipped directory paths

### DIFF
--- a/openviking/parse/directory_scan.py
+++ b/openviking/parse/directory_scan.py
@@ -270,17 +270,17 @@ def scan_directory(
 
             skip, reason = _should_skip_file(file_path)
             if skip:
-                result.skipped.append(f"{rel_path} ({reason})")
+                result.skipped.append(f"{rel_path_norm} ({reason})")
                 continue
             if gitignore_matcher.is_ignored_file(file_path, dir_spec):
-                result.skipped.append(f"{rel_path} (gitignore)")
+                result.skipped.append(f"{rel_path_norm} (gitignore)")
                 continue
 
             if include_patterns and not _matches_include(name, include_patterns):
-                result.skipped.append(f"{rel_path} (excluded by include filter)")
+                result.skipped.append(f"{rel_path_norm} (excluded by include filter)")
                 continue
             if exclude_patterns and _matches_exclude(rel_path_norm, name, exclude_patterns):
-                result.skipped.append(f"{rel_path} (excluded by exclude filter)")
+                result.skipped.append(f"{rel_path_norm} (excluded by exclude filter)")
                 continue
 
             classification = _classify_file(file_path, effective_registry)

--- a/tests/parse/test_directory_scan.py
+++ b/tests/parse/test_directory_scan.py
@@ -54,6 +54,7 @@ def tmp_tree(tmp_path: Path) -> Path:
     # subdir with mixed
     sub = tmp_path / "src"
     sub.mkdir()
+    (sub / ".nested").write_text("hidden", encoding="utf-8")
     (sub / "app.py").write_text("code", encoding="utf-8")
     (sub / "custom.bin").write_bytes(b"\x00\x01")
 
@@ -112,6 +113,7 @@ class TestScanDirectoryTraversal:
         assert ".hidden" not in all_rel
         assert "empty.txt" not in all_rel
         assert any("empty" in s or "dot" in s for s in result.skipped)
+        assert "src/.nested (dot file)" in result.skipped
 
 
 class TestScanDirectoryClassification:
@@ -301,6 +303,7 @@ class TestIncludeExclude:
         assert "drafts/skip.py" not in rel_paths
         skipped_reasons = " ".join(result.skipped)
         assert "excluded by include" in skipped_reasons
+        assert "drafts/skip.py (excluded by include filter)" in result.skipped
 
     def test_exclude_path_prefix(self, tmp_with_drafts: Path, registry: ParserRegistry) -> None:
         result: DirectoryScanResult = scan_directory(
@@ -318,6 +321,7 @@ class TestIncludeExclude:
         assert "drafts/skip.py" not in rel_paths
         skipped_reasons = " ".join(result.skipped)
         assert "excluded by exclude" in skipped_reasons
+        assert "drafts/draft.pdf (excluded by exclude filter)" in result.skipped
 
     def test_include_and_exclude_combined(
         self, tmp_with_drafts: Path, registry: ParserRegistry
@@ -437,9 +441,9 @@ class TestGitignoreHandling:
         assert "src/sub/skip.tmp" not in rel_paths
         # .tmp is no longer accepted in src/sub/ due to nested gitignore
         assert "src/sub/skip.log" not in rel_paths
-        assert any("src/skip.log (gitignore)" in s for s in result.skipped)
-        assert any("src/sub/skip.tmp (gitignore)" in s for s in result.skipped)
-        assert any("src/sub/skip.log (gitignore)" in s for s in result.skipped)
+        assert "src/skip.log (gitignore)" in result.skipped
+        assert "src/sub/skip.tmp (gitignore)" in result.skipped
+        assert "src/sub/skip.log (gitignore)" in result.skipped
 
     def test_respects_negation(self, tmp_path: Path, registry: ParserRegistry) -> None:
         (tmp_path / ".gitignore").write_text("*.tmp\n!important.tmp\n", encoding="utf-8")


### PR DESCRIPTION
## Description

Normalize file-level entries in `DirectoryScanResult.skipped` to use forward-slash relative paths on Windows. `scan_directory()` already normalizes processable and unsupported entries, as well as skipped directories, but four file-level skip branches still emitted native `Path` separators. That made diagnostics inconsistent and broke cross-platform assertions.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. Discovery-backed cross-platform consistency fix.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Use the existing `rel_path_norm` value for dot/empty-file, `.gitignore`, include-filter, and exclude-filter skipped entries.
- Add exact-path regression coverage for nested dot files, gitignore, include, and exclude handling.
- Preserve matching, classification, and skip-reason semantics.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

- `tests/parse/test_directory_scan.py`: 27 passed, 4 existing warnings.
- `tests/parse/test_directory_parser_routing.py`: 38 passed, 4 existing warnings.
- Ruff lint and format checks passed for both changed files.
- Targeted Mypy check passed for `openviking/parse/directory_scan.py`.
- `git diff --check` passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- This changes only the formatting of file-level `skipped` diagnostics; filtering, classification, and skip-reason behavior are unchanged.
- Duplicate-work search used `directory scan skipped path Windows gitignore include exclude` and exact open-PR file matching. Open PR #3295 changes only the `ParserRegistry` fixture in the same test file; it does not modify `directory_scan.py` or skipped-path behavior.
