### PR TITLE
fix(parse): normalize WebFeed entry URLs

### DIFF
--- a/openviking/parse/accessors/web_feed_accessor.py
+++ b/openviking/parse/accessors/web_feed_accessor.py
@@ -33,7 +33,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple, Union
-from urllib.parse import unquote, urljoin, urlparse
+from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunsplit
 from urllib.robotparser import RobotFileParser
 
 from openviking.parse.base import lazy_import
@@ -223,6 +223,21 @@ def _match_filters(url: str, include: Optional[str], exclude: Optional[str]) -> 
     if includes:
         return any(fnmatch.fnmatch(url, pat) or pat in url for pat in includes)
     return True
+
+
+def _normalize_feed_url(url: str) -> str:
+    """Return a comparison key for feed entries without changing the original URL."""
+    parts = urlsplit(url or "")
+    scheme = parts.scheme.lower()
+    hostname = (parts.hostname or "").lower().rstrip(".")
+    try:
+        port = parts.port
+    except ValueError:
+        return urlunsplit((scheme, parts.netloc, parts.path or "/", parts.query, ""))
+    if (scheme == "http" and port == 80) or (scheme == "https" and port == 443):
+        port = None
+    netloc = hostname if port is None else f"{hostname}:{port}"
+    return urlunsplit((scheme, netloc, parts.path or "/", parts.query, ""))
 
 
 def _build_httpx_client_kwargs(request_validator, timeout: float) -> Dict[str, Any]:
@@ -566,20 +581,21 @@ class WebFeedAccessor(DataAccessor):
         include: Optional[str],
         exclude: Optional[str],
     ) -> List[FeedEntry]:
-        base_host = urlparse(feed_url).netloc
+        base_host = urlsplit(_normalize_feed_url(feed_url)).netloc
         seen: set = set()
         out: List[FeedEntry] = []
         for entry in entries:
             url = entry.url
             if not url.startswith(("http://", "https://")):
                 continue
-            if url in seen:
+            normalized_url = _normalize_feed_url(url)
+            if normalized_url in seen:
                 continue
-            if cfg["same_host_only"] and urlparse(url).netloc != base_host:
+            if cfg["same_host_only"] and urlsplit(normalized_url).netloc != base_host:
                 continue
             if not _match_filters(url, include, exclude):
                 continue
-            seen.add(url)
+            seen.add(normalized_url)
             out.append(entry)
         return out
 

--- a/tests/unit/test_accessors_web_feed.py
+++ b/tests/unit/test_accessors_web_feed.py
@@ -350,6 +350,52 @@ class TestAccessSitemap:
         finally:
             resource.cleanup()
 
+    def test_filter_entries_normalizes_equivalent_hosts_and_fragments(self):
+        feed_url = "https://EXAMPLE.com.:443/sitemap.xml"
+        first_fragment = "https://example.com/page#overview"
+        entries = [
+            FeedEntry(url=first_fragment),
+            FeedEntry(url="https://example.com/page#details"),
+            FeedEntry(url="https://example.com/page?view=one"),
+            FeedEntry(url="https://example.com/page?view=two"),
+            FeedEntry(url="https://example.com:8443/private"),
+            FeedEntry(url="https://example.com:not-a-port/bad"),
+            FeedEntry(url="https://other.example/page"),
+        ]
+
+        filtered = WebFeedAccessor()._filter_entries(
+            entries, feed_url, {"same_host_only": True}, None, None
+        )
+
+        assert [entry.url for entry in filtered] == [
+            first_fragment,
+            "https://example.com/page?view=one",
+            "https://example.com/page?view=two",
+        ]
+
+    async def test_fragment_variants_are_mirrored_once(self, patch_httpx):
+        base = "https://example.com"
+        first_fragment = f"{base}/page#overview"
+        second_fragment = f"{base}/page#details"
+        routes = {
+            f"{base}/sitemap.xml": _FakeResponse(
+                content=_urlset([(first_fragment, None), (second_fragment, None)])
+            ),
+            first_fragment: _FakeResponse(content=_page("first")),
+            second_fragment: _FakeResponse(content=_page("second")),
+        }
+        patch_httpx(routes)
+
+        resource = await WebFeedAccessor().access(
+            f"{base}/sitemap.xml", respect_robots=False, politeness_delay=0
+        )
+        try:
+            assert resource.meta["page_count"] == 1
+            assert list(resource.meta["pages"]) == [first_fragment]
+            assert len(list(resource.path.rglob("*.html"))) == 1
+        finally:
+            resource.cleanup()
+
 
 # --------------------------------------------------------------------------- #
 # access() — auto-discovery from a bare domain / HTML page (args={"site": True})


### PR DESCRIPTION
## Description

Normalize WebFeed entry comparison keys so equivalent site URLs are not filtered or mirrored inconsistently. `same_host_only` previously compared raw `netloc` values, and deduplication used the full URL string. A feed URL with a default port, hostname case variation, or DNS trailing dot could therefore drop valid same-host entries, while fragment-only variants of one page were mirrored more than once.

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. Discovery-backed URL consistency fix.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add a private URL comparison key that normalizes scheme and hostname case, DNS trailing dots, and HTTP/HTTPS default ports while preserving path and query and removing fragments.
- Use the key for same-host filtering and entry deduplication while preserving the first original entry URL for filtering, fetching, and metadata.
- Keep malformed-port entries from raising during filtering; they retain their previous non-match behavior.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

- New regression tests fail on the old code: default-port/case/trailing-dot entries are filtered out and fragment variants mirror as two pages.
- `tests/unit/test_accessors_web_feed.py -k "not RegistryRouting"`: 50 passed, 4 deselected, 4 existing warnings.
- `tests/unit/test_web_importer.py`: 22 passed, 4 existing warnings.
- Full `tests/unit/test_accessors_web_feed.py` has the same four pre-existing `RegistryRouting` failures on both `upstream/main` and this branch because this machine has no `ov.conf`; the branch result is 50 passed and 4 failed versus the baseline's 48 passed and 4 failed.
- Ruff lint and format checks passed for both changed files; `git diff --check` passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- The existing project Mypy invocation reports one unchanged `set.add()` return-value error in WebFeed auto-discovery on both `upstream/main` and this branch; this PR does not claim a full Mypy pass.
- Duplicate-work search used `web feed webfeed same host default port fragment` and exact open-PR file matching; no open PR modifies the accessor or this test file.
