### PR TITLE
fix(parse): normalize BOM-less Unicode text

### DIFF
--- a/openviking/parse/parsers/text_encoding.py
+++ b/openviking/parse/parsers/text_encoding.py
@@ -22,6 +22,8 @@ _BOM_ENCODINGS = (
     (codecs.BOM_UTF8, "utf-8-sig"),
 )
 
+_BOMLESS_UNICODE_ENCODINGS = {"utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"}
+
 _DETECTION_ENCODINGS = (
     "gb18030",
     "gbk",
@@ -83,6 +85,10 @@ def _normalize_text_bytes(content: bytes, file_path: Union[str, Path] = "") -> b
     if bom_normalized is not None:
         return bom_normalized
 
+    bomless_unicode = _decode_bomless_unicode(content)
+    if bomless_unicode is not None:
+        return bomless_unicode
+
     try:
         content.decode("utf-8")
         return content
@@ -111,6 +117,36 @@ def _decode_known_bom(content: bytes) -> Optional[bytes]:
                 return content.decode(encoding).encode("utf-8")
             except UnicodeDecodeError:
                 return None
+    return None
+
+
+def _decode_bomless_unicode(content: bytes) -> Optional[bytes]:
+    """Decode a detector-identified UTF-16/UTF-32 file that has no BOM."""
+    if b"\x00" not in content:
+        return None
+
+    match = from_bytes(content).best()
+    if match is None or not match.encoding:
+        return None
+
+    try:
+        encoding = codecs.lookup(match.encoding).name
+    except LookupError:
+        return None
+
+    if encoding not in _BOMLESS_UNICODE_ENCODINGS:
+        return None
+
+    width = 4 if encoding.startswith("utf-32") else 2
+    if len(content) < width * 2 or len(content) % width:
+        return None
+
+    try:
+        decoded = content.decode(encoding)
+    except UnicodeDecodeError:
+        return None
+    if _is_valid_text(decoded):
+        return decoded.encode("utf-8")
     return None
 
 

--- a/tests/parse/test_text_file_encoding.py
+++ b/tests/parse/test_text_file_encoding.py
@@ -80,6 +80,38 @@ def test_markdown_file_read_normalizes_unicode_bom_text(tmp_path, encoding):
     assert MarkdownParser()._read_file(path) == content
 
 
+@pytest.mark.parametrize("encoding", ["utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"])
+def test_markdown_file_read_normalizes_bomless_unicode_text(tmp_path, encoding):
+    content = "# Heading\n\nBody\n"
+    path = tmp_path / f"unicode-bomless-{encoding}.md"
+    path.write_bytes(content.encode(encoding))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
+@pytest.mark.parametrize("encoding", ["utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"])
+def test_markdown_file_read_normalizes_bomless_unicode_cjk_text(tmp_path, encoding):
+    content = "中文标题\n这是正文。\n"
+    path = tmp_path / f"unicode-bomless-cjk-{encoding}.md"
+    path.write_bytes(content.encode(encoding))
+
+    assert MarkdownParser()._read_file(path) == content
+
+
+def test_encoding_detection_preserves_nul_binary_without_unicode_text_layout(tmp_path):
+    raw = b"\x00\x00\x00\x01" * 32
+    path = tmp_path / "control-binary.md"
+
+    assert detect_and_convert_encoding(raw, path) == raw
+
+
+def test_encoding_detection_preserves_utf8_text_with_nul(tmp_path):
+    raw = b"Hello\x00World"
+    path = tmp_path / "embedded-nul.md"
+
+    assert detect_and_convert_encoding(raw, path) == raw
+
+
 @pytest.mark.parametrize(
     ("encoding", "content"),
     [


### PR DESCRIPTION
## Description

Normalize detector-identified BOM-less UTF-16/UTF-32 text containing NUL bytes before the UTF-8 pass-through path. This prevents Markdown parsing from retaining UTF-16 code-unit NUL bytes.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue. This is a discovery-backed parsing fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Decode first-choice UTF-16/UTF-32 detector matches with NUL bytes before the UTF-8 fast path.
- Preserve BOM handling, legacy encoding ranking, binary rejection, and UTF-8 content with embedded NUL bytes.
- Add BOM-less ASCII and CJK regression coverage for both byte orders, plus binary and UTF-8 control cases.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Targeted encoding tests: 34 passed.

The full `tests/parse` suite finished with 555 passed, 31 skipped, and 9 pre-existing failures. The same 9 failures occur in the recorded baseline: eight use a `FakeVikingFS` missing `glob()`, and one is a Windows skipped-path separator assertion.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Inputs without a BOM and without any NUL byte retain the existing conservative fallback because they cannot be reliably distinguished from arbitrary binary or legacy-encoded bytes.
- Duplicate-work searches used `utf-16`, `bomless`, `text encoding`, and `unicode`; no open PR changes either affected file.