### PR TITLE
fix(parse): recognize mixed-case resource URL schemes

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -225,7 +225,7 @@ class FeishuAccessor(DataAccessor):
         source_str = str(source)
 
         # Only handle http/https URLs
-        if not source_str.startswith(("http://", "https://")):
+        if not source_str.lower().startswith(("http://", "https://")):
             return False
 
         return self._is_feishu_url(source_str)

--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -34,6 +34,10 @@ from .base import DataAccessor, LocalResource, SourceType
 logger = get_logger(__name__)
 
 
+def _has_url_scheme(source: str) -> bool:
+    return source.lower().startswith(("http://", "https://", "git://", "ssh://"))
+
+
 class GitAccessor(DataAccessor):
     """
     Accessor for Git repositories and code archives.
@@ -64,7 +68,7 @@ class GitAccessor(DataAccessor):
         source_str = str(source)
 
         # Git protocol URLs
-        if source_str.startswith(("git@", "git://", "ssh://")):
+        if source_str.startswith("git@") or source_str.lower().startswith(("git://", "ssh://")):
             try:
                 if source_str.startswith("git@"):
                     validate_git_ssh_uri(source_str)
@@ -73,7 +77,7 @@ class GitAccessor(DataAccessor):
                 return False
 
         # HTTP/HTTPS URLs to code hosting repos
-        if source_str.startswith(("http://", "https://")):
+        if source_str.lower().startswith(("http://", "https://")):
             return is_git_repo_url(source_str)
 
         # Local .git files (NOT .zip - .zip goes to ZipParser via LocalAccessor)
@@ -118,7 +122,7 @@ class GitAccessor(DataAccessor):
                     branch=branch,
                     commit=commit,
                 )
-            elif source_str.startswith(("http://", "https://", "git://", "ssh://")):
+            elif _has_url_scheme(source_str):
                 repo_url, branch, commit = self._parse_repo_source(source_str, **kwargs)
                 if self._is_github_url(repo_url):
                     # Try GitHub ZIP API first, fall back to git clone
@@ -217,7 +221,7 @@ class GitAccessor(DataAccessor):
         branch = kwargs.get("branch") or kwargs.get("ref")
         commit = kwargs.get("commit")
         repo_url = source
-        if source.startswith(("http://", "https://", "git://", "ssh://")):
+        if _has_url_scheme(source):
             parsed = urlparse(source)
             repo_url = parsed._replace(query="", fragment="").geturl()
             if commit is None or branch is None:
@@ -268,7 +272,7 @@ class GitAccessor(DataAccessor):
 
     def _normalize_repo_url(self, url: str) -> str:
         """Normalize repository URL to base form."""
-        if url.startswith(("http://", "https://", "git://", "ssh://")):
+        if _has_url_scheme(url):
             parsed = urlparse(url)
             path_parts = [p for p in parsed.path.split("/") if p]
             base_parts = path_parts
@@ -305,7 +309,7 @@ class GitAccessor(DataAccessor):
 
         # Fallback for other URLs
         name_source = url
-        if url.startswith(("http://", "https://", "git://", "ssh://")):
+        if _has_url_scheme(url):
             name_source = urlparse(url).path.rstrip("/")
         elif ":" in url and not url.startswith("file://"):
             name_source = url.split(":", 1)[1]

--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -429,7 +429,7 @@ class HTTPAccessor(DataAccessor):
         and will be checked first for their specific URL types.
         """
         source_str = str(source)
-        return source_str.startswith(("http://", "https://"))
+        return source_str.lower().startswith(("http://", "https://"))
 
     async def access(self, source: Union[str, Path], **kwargs) -> LocalResource:
         """

--- a/openviking/parse/accessors/web_feed_accessor.py
+++ b/openviking/parse/accessors/web_feed_accessor.py
@@ -100,6 +100,10 @@ def _localname(tag: str) -> str:
     return tag.rsplit("}", 1)[-1].lower()
 
 
+def _is_http_url(source: Union[str, Path]) -> bool:
+    return str(source).lower().startswith(("http://", "https://"))
+
+
 def looks_like_feed_url(source: Union[str, Path]) -> bool:
     """Heuristic: does this URL path look like a sitemap / RSS / Atom feed?
 
@@ -107,7 +111,7 @@ def looks_like_feed_url(source: Union[str, Path]) -> bool:
     HTTPAccessor for single-page ingestion.
     """
     source_str = str(source)
-    if not source_str.startswith(("http://", "https://")):
+    if not _is_http_url(source_str):
         return False
     basename = urlparse(source_str).path.lower().rstrip("/").rsplit("/", 1)[-1]
     if not basename:
@@ -273,7 +277,7 @@ class WebFeedAccessor(DataAccessor):
         ``args={"site": False}`` opts a feed-looking URL back out to HTTPAccessor.
         """
         source_str = str(source)
-        if not source_str.startswith(("http://", "https://")):
+        if not _is_http_url(source_str):
             return False
         override = _resolve_override(kwargs)
         if override is not None:
@@ -571,7 +575,7 @@ class WebFeedAccessor(DataAccessor):
         out: List[FeedEntry] = []
         for entry in entries:
             url = entry.url
-            if not url.startswith(("http://", "https://")):
+            if not _is_http_url(url):
                 continue
             if url in seen:
                 continue
@@ -771,7 +775,7 @@ async def _gather_feed_candidates(client, page_url: str, page_content: bytes) ->
 
 async def _discover_feed_hint(url: str, request_validator) -> Optional[str]:
     url = str(url)
-    if not url.startswith(("http://", "https://")):
+    if not _is_http_url(url):
         return None
     try:
         from openviking.utils.code_hosting_utils import is_git_repo_url

--- a/openviking/server/local_input_guard.py
+++ b/openviking/server/local_input_guard.py
@@ -12,9 +12,8 @@ from openviking.utils.network_guard import ensure_public_remote_target
 from openviking_cli.exceptions import PermissionDeniedError
 
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
-_NETWORK_SOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
+_NETWORK_URL_PREFIXES = ("http://", "https://", "ssh://", "git://")
 _PRIVATE_SOURCE_PREFIXES = ("tos://",)
-_REMOTE_SOURCE_PREFIXES = _NETWORK_SOURCE_PREFIXES + _PRIVATE_SOURCE_PREFIXES
 
 # Shape of temp_file_ids minted by TempUploadStore. Used by MCP add_resource to
 # detect when an agent has passed a tfid as the `path` argument by mistake and
@@ -37,9 +36,17 @@ def _is_configured_connector_source(source: str) -> bool:
     return source.startswith(allowed_schemes)
 
 
+def _is_network_source(source: str) -> bool:
+    return source.startswith("git@") or source.lower().startswith(_NETWORK_URL_PREFIXES)
+
+
 def is_remote_resource_source(source: str) -> bool:
     """Return True if *source* is a remotely fetchable resource location."""
-    return source.startswith(_REMOTE_SOURCE_PREFIXES) or _is_configured_connector_source(source)
+    return (
+        _is_network_source(source)
+        or source.startswith(_PRIVATE_SOURCE_PREFIXES)
+        or _is_configured_connector_source(source)
+    )
 
 
 def looks_like_local_path(value: str) -> bool:
@@ -61,7 +68,7 @@ def require_remote_resource_source(source: str) -> str:
             "HTTP server only accepts remote resource URLs or temp-uploaded files; "
             "direct host filesystem paths are not allowed."
         )
-    if source.startswith(_NETWORK_SOURCE_PREFIXES):
+    if _is_network_source(source):
         ensure_public_remote_target(source)
     return source
 

--- a/openviking/utils/code_hosting_utils.py
+++ b/openviking/utils/code_hosting_utils.py
@@ -142,7 +142,7 @@ def parse_code_hosting_url(url: str) -> Optional[str]:
         repo = _sanitize_segment(repo)
         return f"{org}/{repo}"
 
-    if not url.startswith(("http://", "https://", "git://", "ssh://")):
+    if not url.lower().startswith(("http://", "https://", "git://", "ssh://")):
         return None
 
     parsed = urlparse(url)
@@ -229,7 +229,7 @@ def is_code_hosting_blob_url(url: str) -> bool:
     historically go through HTTPAccessor (with optional blob->raw rewriting),
     not the recursive web crawler.
     """
-    if not url.startswith(("http://", "https://")):
+    if not url.lower().startswith(("http://", "https://")):
         return False
 
     config = get_openviking_config()
@@ -279,11 +279,12 @@ def is_git_repo_url(url: str) -> bool:
         True if the URL points to a cloneable git repository
     """
     # git@/ssh://git:// protocols: always a repo if the domain matches
-    if url.startswith(("git@", "ssh://", "git://")):
+    lower_url = url.lower()
+    if url.startswith("git@") or lower_url.startswith(("ssh://", "git://")):
         return is_code_hosting_url(url)
 
     # http/https: check domain AND require exactly 2 path parts (owner/repo)
-    if url.startswith(("http://", "https://")):
+    if lower_url.startswith(("http://", "https://")):
         config = get_openviking_config()
         all_domains = _get_all_domains()
         parsed = urlparse(url)

--- a/tests/server/test_api_local_input_security.py
+++ b/tests/server/test_api_local_input_security.py
@@ -11,6 +11,10 @@ import httpx
 import pytest
 
 from openviking.parse.accessors.http_accessor import URLTypeDetector
+from openviking.server.local_input_guard import (
+    is_remote_resource_source,
+    require_remote_resource_source,
+)
 from openviking.utils.network_guard import ensure_public_remote_target
 from openviking_cli.exceptions import PermissionDeniedError
 from tests.server.ovpack_test_helpers import build_ovpack_bytes
@@ -19,6 +23,19 @@ from tests.server.ovpack_test_helpers import build_ovpack_bytes
 def _allow_admin_api_in_dev_mode(client: httpx.AsyncClient) -> None:
     # Admin routes require the app to have an API key manager, even in dev-mode tests.
     client._transport.app.state.api_key_manager = object()
+
+
+def test_remote_resource_scheme_is_case_insensitive(monkeypatch):
+    source = "HTTPS://example.com/resource.md"
+    validated = []
+    monkeypatch.setattr(
+        "openviking.server.local_input_guard.ensure_public_remote_target", validated.append
+    )
+
+    assert is_remote_resource_source(source) is True
+    assert require_remote_resource_source(source) == source
+    assert validated == [source]
+    assert is_remote_resource_source("GIT@github.com:org/repo.git") is False
 
 
 async def test_add_skill_accepts_temp_uploaded_file(

--- a/tests/test_code_hosting_utils.py
+++ b/tests/test_code_hosting_utils.py
@@ -51,6 +51,7 @@ parse_code_hosting_url = _module.parse_code_hosting_url
 is_github_url = _module.is_github_url
 is_gitlab_url = _module.is_gitlab_url
 is_code_hosting_url = _module.is_code_hosting_url
+is_code_hosting_blob_url = _module.is_code_hosting_blob_url
 is_git_repo_url = _module.is_git_repo_url
 validate_git_ssh_uri = _module.validate_git_ssh_uri
 
@@ -82,6 +83,10 @@ def test_parse_code_hosting_url_git_ssh_single_segment():
 
 def test_parse_code_hosting_url_https():
     assert parse_code_hosting_url("https://github.com/org/repo") == "org/repo"
+
+
+def test_parse_code_hosting_url_uppercase_https_scheme():
+    assert parse_code_hosting_url("HTTPS://github.com/org/repo") == "org/repo"
 
 
 def test_parse_code_hosting_url_https_dotgit():
@@ -190,6 +195,10 @@ def test_is_code_hosting_url_https():
     assert is_code_hosting_url("https://github.com/org/repo") is True
 
 
+def test_is_code_hosting_blob_url_uppercase_https_scheme():
+    assert is_code_hosting_blob_url("HTTPS://github.com/org/repo/blob/main/README.md") is True
+
+
 def test_is_code_hosting_url_ssh_url_with_userinfo():
     assert is_code_hosting_url("ssh://git@github.com/org/repo.git") is True
 
@@ -222,6 +231,10 @@ def test_is_git_repo_url_git_ssh():
 
 def test_is_git_repo_url_https_repo():
     assert is_git_repo_url("https://github.com/org/repo") is True
+
+
+def test_is_git_repo_url_uppercase_https_scheme():
+    assert is_git_repo_url("HTTPS://github.com/org/repo") is True
 
 
 def test_is_git_repo_url_ssh_url_with_userinfo():

--- a/tests/unit/test_accessors_git.py
+++ b/tests/unit/test_accessors_git.py
@@ -84,6 +84,7 @@ class TestGitAccessor:
             "https://github.com/volcengine/OpenViking.git",
             "https://gitlab.com/org/repo",
             "http://github.com/org/repo",
+            "HTTPS://github.com/volcengine/OpenViking",
         ],
     )
     def test_can_handle_github_http_url(self, accessor: GitAccessor, source: str) -> None:
@@ -115,6 +116,15 @@ class TestGitAccessor:
     def test_can_handle_git_protocol_url(self, accessor: GitAccessor) -> None:
         """GitAccessor should handle git:// URLs."""
         assert accessor.can_handle("git://github.com/volcengine/OpenViking.git") is True
+
+    def test_parse_repo_source_with_uppercase_http_scheme(self, accessor: GitAccessor) -> None:
+        repo_url, branch, commit = accessor._parse_repo_source(
+            "HTTPS://github.com/volcengine/OpenViking/tree/main?raw=1#readme"
+        )
+
+        assert repo_url == "https://github.com/volcengine/OpenViking"
+        assert branch == "main"
+        assert commit is None
 
     def test_normalize_repo_url_ssh_with_userinfo_and_ref(self, accessor: GitAccessor) -> None:
         """GitAccessor should normalize ssh URLs with userinfo using the shared host matcher."""

--- a/tests/unit/test_accessors_http.py
+++ b/tests/unit/test_accessors_http.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from openviking.parse.accessors import AccessorRegistry, GitAccessor, HTTPAccessor
+from openviking.parse.accessors import (
+    AccessorRegistry,
+    FeishuAccessor,
+    GitAccessor,
+    HTTPAccessor,
+    WebFeedAccessor,
+)
 from openviking.parse.accessors.http_accessor import URLType
 
 
@@ -53,6 +59,7 @@ class TestHTTPAccessor:
             "https://example.com/page.html",
             "http://example.com/document.pdf",
             "https://example.org/file.md",
+            "HTTPS://example.com/page.html",
         ],
     )
     def test_can_handle_http_urls(self, accessor: HTTPAccessor, source: str) -> None:
@@ -272,6 +279,29 @@ class TestHTTPAccessorPriorityRouting:
         accessor = registry.get_accessor(test_url)
         assert accessor is not None
         assert accessor.__class__.__name__ == "HTTPAccessor"
+
+    @pytest.mark.parametrize(
+        ("test_url", "expected_accessor"),
+        [
+            ("HTTPS://github.com/volcengine/OpenViking", "GitAccessor"),
+            ("HTTPS://example.com/page.html", "HTTPAccessor"),
+            ("HTTPS://example.com/sitemap.xml", "WebFeedAccessor"),
+            ("HTTPS://example.feishu.cn/docx/doc_token", "FeishuAccessor"),
+        ],
+    )
+    def test_uppercase_scheme_routes_to_expected_accessor(
+        self, test_url: str, expected_accessor: str
+    ) -> None:
+        registry = AccessorRegistry(register_default=False)
+        registry.register(HTTPAccessor())
+        registry.register(WebFeedAccessor())
+        registry.register(GitAccessor())
+        registry.register(FeishuAccessor())
+
+        accessor = registry.get_accessor(test_url)
+
+        assert accessor is not None
+        assert accessor.__class__.__name__ == expected_accessor
 
 class TestHTTPAccessorRawUrlConversion:
     """Tests for HTTPAccessor._convert_to_raw_url (GitHub/GitLab blob -> raw)."""

--- a/tests/unit/test_accessors_web_feed.py
+++ b/tests/unit/test_accessors_web_feed.py
@@ -122,6 +122,7 @@ class TestCanHandle:
             "https://example.com/index.xml",
             "https://example.com/feed",
             "https://example.com/blog/feed/",
+            "HTTPS://example.com/sitemap.xml",
         ],
     )
     def test_handles_feed_like(self, accessor, url):
@@ -558,6 +559,7 @@ class TestDiscoverHint:
 # --------------------------------------------------------------------------- #
 def test_looks_like_feed_url():
     assert looks_like_feed_url("https://h/sitemap.xml")
+    assert looks_like_feed_url("HTTPS://h/sitemap.xml")
     assert looks_like_feed_url("https://h/rss.xml")
     assert not looks_like_feed_url("https://h/post")
     assert not looks_like_feed_url("/tmp/sitemap.xml")


### PR DESCRIPTION
## Description

RFC 3986 defines URI schemes as case-insensitive. Mixed-case HTTP(S) resource URLs were treated as local paths or skipped by accessor routing, and a mixed-case Feishu URL could fall through to the generic HTTP accessor. This change normalizes scheme comparisons only, while preserving the original URL for client calls, metadata, and remote-target validation.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. This is a discovery-backed regression fix; no matching open issue was found.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Recognize mixed-case HTTP(S), Git, and SSH URI schemes in resource accessor and code-hosting routing checks.
- Route mixed-case Git, HTTP, WebFeed, and Feishu URLs to their intended accessors.
- Keep the original URL flowing into the existing SSRF guard and add regression coverage for routing and validation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Executed locally:

- Focused accessor, code-hosting, and Feishu tests: 174 passed, 4 deselected existing `RegistryRouting` cases that require a local `ov.conf`.
- `tests/server/test_api_local_input_security.py -k remote_resource_scheme_is_case_insensitive`: 1 passed.
- `tests/misc/test_network_guard.py`: 66 passed.
- Ruff lint, Python bytecode compilation, and `git diff --check` passed for all changed files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Full pytest is not claimed as passing: collection is blocked locally by the unavailable optional `google.genai` dependency. The MCP server fixture also requires a local `ov.conf`.
- Ruff format reports two pre-existing formatting differences outside this diff (`openviking/parse/accessors/feishu_accessor.py:83` and `tests/unit/test_accessors_http.py:274`). Restricted Mypy reports six pre-existing diagnostics outside this diff.
- Duplicate-work search keywords: `mixed-case URL scheme HTTP HTTPS accessor Feishu RFC 3986`. Adjacent open PRs #2749, #3347, #3472, and #3295 were reviewed; none implements case-insensitive URI scheme routing.