### PR TITLE
fix(parse): honor optional parser registration

### DIFF
--- a/openviking/parse/registry.py
+++ b/openviking/parse/registry.py
@@ -75,9 +75,11 @@ class ParserRegistry:
         self.register("zip", ZipParser())
         self.register("directory", DirectoryParser())
 
-        self.register("image", ImageParser(config=self._parser_configs.get("image")))
-        self.register("audio", AudioParser())
-        self.register("video", VideoParser())
+        # Register optional media parsers
+        if register_optional:
+            self.register("image", ImageParser(config=self._parser_configs.get("image")))
+            self.register("audio", AudioParser())
+            self.register("video", VideoParser())
 
     def register(self, name: str, parser: BaseParser) -> None:
         """

--- a/tests/parse/test_directory_parser_routing.py
+++ b/tests/parse/test_directory_parser_routing.py
@@ -49,6 +49,24 @@ def registry() -> ParserRegistry:
     return ParserRegistry(register_optional=False)
 
 
+@pytest.mark.parametrize(
+    ("filename", "parser_name"),
+    [
+        ("photo.png", "image"),
+        ("recording.mp3", "audio"),
+        ("clip.mp4", "video"),
+    ],
+)
+def test_optional_media_parsers_respect_registration_flag(filename: str, parser_name: str) -> None:
+    """Optional media parsers are only available when explicitly enabled."""
+    disabled_registry = ParserRegistry(register_optional=False)
+    enabled_registry = ParserRegistry()
+
+    assert parser_name not in disabled_registry.list_parsers()
+    assert disabled_registry.get_parser_for_file(Path(filename)) is None
+    assert parser_name in enabled_registry.list_parsers()
+
+
 # -- directory tree that covers every parser type ----------------------------
 
 


### PR DESCRIPTION
## Description

Restore the documented behavior of `ParserRegistry(register_optional=False)`.
The registry currently registers image, audio, and video parsers even when the
caller explicitly disables optional parsers.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None. This is a discovery-backed regression with no matching open issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Gate the existing image, audio, and video parser registrations behind `register_optional`.
- Add routing regressions for `.png`, `.mp3`, and `.mp4` with optional parsers disabled.
- Verify that the default registry continues to include each media parser.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Passed locally:

- `python -m pytest -q -o addopts='' tests/parse/test_directory_parser_routing.py --disable-warnings --no-header -p no:cacheprovider` (41 passed)
- `ruff check openviking/parse/registry.py tests/parse/test_directory_parser_routing.py`
- `ruff format --check openviking/parse/registry.py tests/parse/test_directory_parser_routing.py`
- `python -m py_compile openviking/parse/registry.py`
- `git diff --check`

`tests/parse` completed with 548 passed, 31 skipped, and 9 existing failures unchanged from the pre-change baseline. Full-suite collection is blocked locally by a missing `pytest-html` plugin, and the CI quick-start script requires the unavailable native Rust binding.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No documentation change is needed because this restores the existing constructor contract.

Duplicate-work check: searched the current 325 open PRs by changed file and relevant terms. The only other open PRs touching `openviking/parse/registry.py` are #1552 (provider layer), #3283 (ambiguous media suffix detection), and draft #3295 (resource-routing refactor); none restores the `register_optional` behavior.
