### PR TITLE
fix(storage): report restore reindex failures

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -4153,8 +4153,8 @@ class VikingFS:
 
         Runs all classified ``(op, uri, level)`` rebuild tasks concurrently and
         drives the task through start → complete/fail. Per-task failures are
-        swallowed (and logged) inside :py:meth:`_run_vector_rebuild`, preserving
-        the "failures do not block" semantics.
+        logged inside :py:meth:`_run_vector_rebuild` and make the tracked task
+        fail without blocking the restore response.
         """
         from openviking.service.task_tracker import get_task_tracker
 
@@ -4169,12 +4169,21 @@ class VikingFS:
             from openviking.service.reindex_executor import get_reindex_executor
 
             executor = get_reindex_executor()
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *[
                     self._run_vector_rebuild(executor, op, uri, level, ctx)
                     for (op, uri, level) in tasks
                 ]
             )
+            failed_count = sum(not result for result in results)
+            if failed_count:
+                await tracker.fail(
+                    task_id,
+                    f"{failed_count} of {len(tasks)} vector rebuild tasks failed",
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+                return
             await tracker.complete(
                 task_id,
                 {"status": "completed", "task_count": len(tasks)},
@@ -4196,8 +4205,8 @@ class VikingFS:
         uri: str,
         level: ContextLevel,
         ctx: RequestContext,
-    ) -> None:
-        """Wrapper coroutine: dispatch one vector task and swallow errors."""
+    ) -> bool:
+        """Dispatch one vector task and return whether it completed successfully."""
         try:
             if op == "reindex_marker":
                 await executor.reindex_directory_marker(dir_uri=uri, level=level, ctx=ctx)
@@ -4207,5 +4216,8 @@ class VikingFS:
                 await executor.delete_uri_level(uri=uri, level=level, ctx=ctx)
             else:  # pragma: no cover - defensive
                 logger.warning("[VikingFS] unknown vector rebuild op %r for %s", op, uri)
+                return False
+            return True
         except Exception:
             logger.exception("[VikingFS] git restore vector task %s failed for %s", op, uri)
+            return False

--- a/tests/agfs/test_viking_fs_git.py
+++ b/tests/agfs/test_viking_fs_git.py
@@ -636,6 +636,29 @@ class _SpyExecutor:
         return 0
 
 
+class _MemTaskStore:
+    async def create(self, task):
+        return None
+
+    async def update(self, task):
+        return None
+
+    async def get(self, task_id, *, account_id=None, user_id=None):
+        return None
+
+    async def list(self, account_id, *, user_id=None):
+        return []
+
+    async def delete(self, task_id, *, account_id, user_id=None):
+        return None
+
+
+class _FailingReindexExecutor(_SpyExecutor):
+    async def execute(self, *, uri, mode, wait, ctx):
+        self.calls.append(("reindex_file", uri))
+        raise RuntimeError("vector backend unavailable")
+
+
 @pytest.mark.asyncio
 async def test_restore_schedules_reindex_for_derived_only_change(vfs, monkeypatch):
     """When a restore only changes a directory `.abstract.md` (source file
@@ -854,22 +877,6 @@ async def test_restore_returns_pollable_task_id(vfs, monkeypatch):
         set_task_tracker,
     )
 
-    class _MemTaskStore:
-        async def create(self, task):
-            return None
-
-        async def update(self, task):
-            return None
-
-        async def get(self, task_id, *, account_id=None, user_id=None):
-            return None
-
-        async def list(self, account_id, *, user_id=None):
-            return []
-
-        async def delete(self, task_id, *, account_id, user_id=None):
-            return None
-
     set_task_tracker(TaskTracker(store=_MemTaskStore()))
     try:
         ctx = _make_ctx(account="acct_taskid")
@@ -899,6 +906,51 @@ async def test_restore_returns_pollable_task_id(vfs, monkeypatch):
         assert task.task_type == "snapshot_restore_reindex"
         assert task.status.value == "completed"
         assert ("reindex_file", "viking://resources/proj/x.md") in spy.calls
+    finally:
+        set_task_tracker(None)
+
+
+@pytest.mark.asyncio
+async def test_restore_reindex_task_fails_when_vector_rebuild_fails(vfs, monkeypatch):
+    """A failed vector rebuild must not make a restore task look complete."""
+    executor = _FailingReindexExecutor()
+
+    import openviking.service.reindex_executor as reindex_mod
+
+    monkeypatch.setattr(reindex_mod, "get_reindex_executor", lambda: executor)
+
+    from openviking.service.task_tracker import TaskTracker, set_task_tracker
+
+    set_task_tracker(TaskTracker(store=_MemTaskStore()))
+    try:
+        ctx = _make_ctx(account="acct_failed_rebuild")
+        await vfs.write_file("viking://resources/proj/x.md", b"v1", ctx=ctx)
+        c1 = await vfs.commit(message="v1", ctx=ctx)
+        await vfs.write_file("viking://resources/proj/x.md", b"v2", ctx=ctx)
+        await vfs.commit(message="v2", ctx=ctx)
+
+        result = await vfs.restore(
+            project_dir="viking://resources/proj",
+            source_commit=c1["commit_oid"],
+            ctx=ctx,
+        )
+        task_id = result.get("task_id")
+        assert task_id
+
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        from openviking.service.task_tracker import get_task_tracker
+
+        task = await get_task_tracker().get(
+            task_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+        )
+        assert task is not None
+        assert task.status.value == "failed"
+        assert task.error == "1 of 1 vector rebuild tasks failed"
+        assert "vector backend unavailable" not in task.error
     finally:
         set_task_tracker(None)
 


### PR DESCRIPTION
## Description

Fix the tracked snapshot-restore reindex task so it is marked `failed` when any vector rebuild operation fails. The restore writeback remains asynchronous; callers can now rely on `completed` to mean every scheduled vector operation succeeded.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. This is a discovery-backed reliability fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Return a success flag from each restore vector rebuild operation while retaining per-path failure logging.
- Mark the tracked restore reindex task as failed after all rebuild operations finish when any operation fails.
- Add an AGFS restore regression test using a failing reindex executor and assert that backend details are not exposed through the task error.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Validated on Windows with an exact-source async harness: the upstream implementation reports `completed` after a failed vector rebuild, while this branch reports `failed`; the success path still reports `completed`. Ruff lint, Ruff format check, Python syntax compilation, and `git diff --check` pass. Targeted Mypy reports the same 10 pre-existing diagnostics as the unmodified baseline.

The full pytest suite and AGFS regression module cannot collect locally because the existing environment lacks `volcengine`; the AGFS module is additionally skipped without `ragfs_python`. No dependencies or lockfiles were changed to work around those environment limits.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No public API or task schema changes are introduced. Duplicate-work searches used `snapshot restore reindex`, `vector rebuild`, and `reindex failed completed`; no equivalent open PR was found. Open PR #3451 touches `viking_fs.py` only for the independent snapshot diff API.