### PR TITLE
fix(parse): report failed directory child parses

### DIFF
--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -389,17 +389,23 @@ class DirectoryParser(BaseParser):
                     # (e.g. ../images/x.gif) that still live inside the import.
                     allowed_media_dirs=[Path(import_root)] if import_root else None,
                 )
-                if sub_result.temp_dir_path:
-                    if preserve_structure:
-                        parent = str(PurePosixPath(rel_path).parent)
-                        dest = f"{target_uri}/{parent}" if parent != "." else target_uri
+                if not sub_result.temp_dir_path:
+                    if sub_result.warnings:
+                        warnings.extend(f"{rel_path}: {warning}" for warning in sub_result.warnings)
                     else:
-                        dest = target_uri
-                    await DirectoryParser._merge_temp(
-                        viking_fs,
-                        sub_result.temp_dir_path,
-                        dest,
-                    )
+                        warnings.append(f"Failed to parse {rel_path}: parser returned no output")
+                    return False
+
+                if preserve_structure:
+                    parent = str(PurePosixPath(rel_path).parent)
+                    dest = f"{target_uri}/{parent}" if parent != "." else target_uri
+                else:
+                    dest = target_uri
+                await DirectoryParser._merge_temp(
+                    viking_fs,
+                    sub_result.temp_dir_path,
+                    dest,
+                )
                 return True
             except Exception as exc:
                 warnings.append(f"Failed to parse {rel_path}: {exc}")

--- a/tests/parse/test_add_directory.py
+++ b/tests/parse/test_add_directory.py
@@ -688,6 +688,43 @@ class TestPDFConversion:
         # Should have a warning, not a crash
         assert any("bad.pdf" in w for w in result.warnings)
 
+    @pytest.mark.asyncio
+    async def test_pdf_without_temp_output_is_recorded_as_failed(
+        self, tmp_path: Path, parser, fake_fs
+    ) -> None:
+        pdf_file = tmp_path / "bad.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 broken")
+
+        failed_result = create_parse_result(
+            root=ResourceNode(type=NodeType.ROOT),
+            source_path=str(pdf_file),
+            source_format="pdf",
+            parser_name="PDFParser",
+            parse_time=0.1,
+            warnings=["Failed to parse PDF: broken input"],
+        )
+
+        with patch(
+            "openviking.parse.parsers.directory.DirectoryParser._assign_parser",
+        ) as mock_assign:
+            from openviking.parse.parsers.pdf import PDFParser as _PDF
+
+            mock_pdf = AsyncMock(spec=_PDF)
+            mock_pdf.parse = AsyncMock(return_value=failed_result)
+
+            def assign_side_effect(cf, registry):
+                if cf.path.suffix == ".pdf":
+                    return mock_pdf
+                return registry.get_parser_for_file(cf.path)
+
+            mock_assign.side_effect = assign_side_effect
+            result = await parser.parse(str(tmp_path))
+
+        assert result.meta["file_count"] == 0
+        assert result.meta["processed_files"] == []
+        assert result.meta["failed_files"][0]["path"] == "bad.pdf"
+        assert result.warnings == ["bad.pdf: Failed to parse PDF: broken input"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: ParseResult metadata


### PR DESCRIPTION
## Description

Fix directory ingestion so a delegated parser result without `temp_dir_path` is recorded as a failed file instead of a successful file. Existing parser warnings are propagated with the relative path, and a generic diagnostic is added when no warning is available.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. This is a discovery-backed reliability fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Treat a delegated parser result with no temporary output directory as a failed directory child parse.
- Preserve parser-supplied warnings with the child relative path, or add a generic no-output diagnostic.
- Add a regression test proving failed files no longer increase `file_count` or appear in `processed_files`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

`TestPDFConversion::test_pdf_parse_failure_adds_warning` and the new no-output regression both pass locally (2 passed, 4 existing warnings). The full `test_add_directory.py` module is unchanged relative to baseline: 8 existing failures caused by `FakeVikingFS` lacking `glob` or complete merge behavior; the branch adds one passing test (22 passed, 8 failed). Ruff lint, production-file Ruff format check, Python syntax compilation, and `git diff --check` pass. The test file has two unrelated pre-existing line-wrapping differences under the local Ruff version, so no broad formatting change was committed. Targeted Mypy reports the same pre-existing unused-ignore diagnostic as the unmodified baseline.

The full pytest suite cannot collect locally because the existing environment lacks `volcengine`; no dependencies or lockfiles were changed to work around that environment limit.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No public API or schema changes are introduced. Duplicate-work searches used `DirectoryParser`, `temp_dir_path`, and `failed_files`; no equivalent open PR was found. Open PR #3349 touches Markdown and PowerPoint parsing but does not modify `directory.py` or this test module.