### PR TITLE
fix(parse): honor HTML metadata extraction setting

### DIFF
--- a/openviking/parse/parsers/html.py
+++ b/openviking/parse/parsers/html.py
@@ -123,7 +123,7 @@ class HTMLParser(BaseParser):
         """Convert HTML to Markdown using trafilatura."""
         html = self._preprocess_html(html)
         content = self._extract_markdown(html, base_url or "")
-        title = self._extract_title(html, base_url or "")
+        title = self._extract_title(html, base_url or "") if self.config.extract_metadata else ""
         content = self._clean_markdown(content)
         if not content:
             content = self._extract_noscript_notice(html)

--- a/tests/parse/parsers/test_html.py
+++ b/tests/parse/parsers/test_html.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from openviking.parse.parsers.html import HTMLParser
+from openviking_cli.utils.config.parser_config import HTMLConfig
 
 
 class TestHTMLParserMarkdownCleaning:
@@ -76,3 +79,25 @@ class TestHTMLParserTitleExtraction:
     def test_returns_empty_on_no_title(self):
         html = "<html><body>no title</body></html>"
         assert self.parser._extract_title(html, "http://example.com/") == ""
+
+    def test_metadata_enabled_injects_title(self):
+        parser = HTMLParser(config=HTMLConfig(extract_metadata=True))
+        with (
+            patch.object(parser, "_extract_markdown", return_value="Visible body"),
+            patch.object(parser, "_extract_title", return_value="Document title") as extract_title,
+        ):
+            markdown = parser._html_to_markdown("<html></html>")
+
+        assert markdown == "# Document title\n\nVisible body"
+        extract_title.assert_called_once()
+
+    def test_metadata_disabled_does_not_inject_title(self):
+        parser = HTMLParser(config=HTMLConfig(extract_metadata=False))
+        with (
+            patch.object(parser, "_extract_markdown", return_value="Visible body"),
+            patch.object(parser, "_extract_title", return_value="Private title") as extract_title,
+        ):
+            markdown = parser._html_to_markdown("<html></html>")
+
+        assert markdown == "Visible body"
+        extract_title.assert_not_called()


### PR DESCRIPTION
## Description

Honor `HTMLConfig.extract_metadata` when converting HTML to Markdown. Disabling metadata extraction now prevents title extraction and title injection into indexed body content; the default enabled behavior is unchanged.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. This is a discovery-backed configuration-contract fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Gate HTML title extraction on `HTMLConfig.extract_metadata`.
- Preserve default title injection when metadata extraction is enabled.
- Add isolated tests for both enabled and disabled configuration states without depending on `trafilatura`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

The new enabled/disabled metadata tests pass locally (2 passed, 4 existing warnings). The full `test_html.py` module is unchanged relative to baseline failures: it now reports 11 passed and 3 existing failures caused by local `trafilatura` extraction/title behavior (baseline: 9 passed, 3 failed). Ruff lint, Python syntax compilation, target Mypy, and `git diff --check` pass. The local Ruff version would reformat one unrelated existing line in each changed file, so no broad formatting change was committed.

The full pytest suite cannot collect locally because the existing environment lacks `volcengine`; no dependencies or lockfiles were changed to work around that environment limit.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No public API or schema changes are introduced. Duplicate-work searches used `HTMLConfig` and `extract_metadata`; no equivalent open PR was found.