### PR TITLE
fix(parse): preserve text file parser metadata

### DIFF
--- a/openviking/parse/parsers/text.py
+++ b/openviking/parse/parsers/text.py
@@ -29,7 +29,10 @@ class TextParser(BaseParser):
 
     async def parse(self, source: Union[str, Path], instruction: str = "", **kwargs) -> ParseResult:
         """Parse from file path or content string."""
-        return await self._md_parser.parse(source, **kwargs)
+        result = await self._md_parser.parse(source, instruction=instruction, **kwargs)
+        result.source_format = "text"
+        result.parser_name = "TextParser"
+        return result
 
     async def parse_content(
         self, content: str, source_path: Optional[str] = None, instruction: str = "", **kwargs

--- a/tests/parse/parsers/test_text.py
+++ b/tests/parse/parsers/test_text.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from openviking.parse.base import NodeType, ResourceNode, create_parse_result
+from openviking.parse.parsers.text import TextParser
+
+
+async def test_file_parse_preserves_text_parser_metadata_and_instruction(tmp_path):
+    source = tmp_path / "notes.txt"
+    source.write_text("Plain text content", encoding="utf-8")
+    delegate_parse = AsyncMock(
+        return_value=create_parse_result(
+            root=ResourceNode(type=NodeType.ROOT),
+            source_format="markdown",
+            parser_name="MarkdownParser",
+        )
+    )
+    parser = TextParser.__new__(TextParser)
+    parser._md_parser = SimpleNamespace(parse=delegate_parse)
+
+    result = await parser.parse(source, instruction="preserve this", marker=True)
+
+    delegate_parse.assert_awaited_once_with(source, instruction="preserve this", marker=True)
+    assert result.source_format == "text"
+    assert result.parser_name == "TextParser"


### PR DESCRIPTION
## Description

Preserve `TextParser` provenance when it delegates file parsing to `MarkdownParser`. File-based `.txt` and `.text` parsing now reports `source_format=text` and `parser_name=TextParser`, matching the existing content-based entry point. The caller-provided `instruction` is also forwarded to the delegated parser.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue. This is a discovery-backed parser-contract fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Forward `instruction` through `TextParser.parse()` to `MarkdownParser.parse()`.
- Mark delegated file results as `text` and `TextParser`, consistent with `TextParser.parse_content()`.
- Add a focused regression test that verifies the delegated call and returned provenance metadata.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

- New regression: `1 passed, 4 existing warnings`.
- With the existing text encoding tests: `24 passed, 1 existing failure`; the unchanged failure is `test_markdown_file_read_preserves_detector_first_non_cjk_text`.
- Ruff lint and format checks, `py_compile`, target Mypy, and `git diff --check` pass.
- The full pytest suite cannot collect locally because the environment lacks `volcengine`; no dependencies or lockfiles were changed to work around that limit.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No public API, dependency, schema, or configuration change is introduced. Duplicate-work searches used `TextParser`, `source metadata`, and `plain text`; the only related open PR, #3283, does not modify `openviking/parse/parsers/text.py`.