### PR TITLE
docs: add Python installer tabs

### DIFF
--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -14,11 +14,31 @@ Before using OpenViking, ensure your environment meets the following requirement
 
 OpenViking can be installed via a Python Package to be used as a local library, or you can quickly launch it as an independent service using Docker.
 
-### Option 1: Install via pip (As a local library)
+### Option 1: Install as a Python package (local commands and library)
 
-```bash
+Choose your preferred Python package manager to install OpenViking:
+
+::: code-group
+
+```bash [uv (recommended)]
+uv tool install openviking --upgrade
+```
+
+```bash [pip]
 pip install openviking --upgrade --force-reinstall
 ```
+
+```bash [pipx]
+# Install
+pipx install openviking
+
+# Update
+pipx upgrade openviking
+```
+
+:::
+
+After installation, the `ov`, `openviking`, and `openviking-server` commands are available.
 
 ### Option 2: Start via Docker (As an independent service)
 

--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -38,7 +38,7 @@ pipx upgrade openviking
 
 :::
 
-After installation, the `ov`, `openviking`, and `openviking-server` commands are available.
+After installation, use `ov` as the client command (`openviking` is an alias) and `openviking-server` as the server command.
 
 ### Option 2: Start via Docker (As an independent service)
 

--- a/docs/en/guides/17-vikingbot.md
+++ b/docs/en/guides/17-vikingbot.md
@@ -10,9 +10,27 @@ Python 3.11 or later is recommended for VikingBot.
 
 ### Install from PyPI
 
-```bash
-pip install "openviking[bot]"
+Choose your preferred Python package manager to install VikingBot:
+
+::: code-group
+
+```bash [uv (recommended)]
+uv tool install "openviking[bot]" --upgrade
 ```
+
+```bash [pip]
+pip install "openviking[bot]" --upgrade --force-reinstall
+```
+
+```bash [pipx]
+# Install
+pipx install "openviking[bot]"
+
+# Update
+pipx upgrade openviking
+```
+
+:::
 
 Verify the installation:
 

--- a/docs/zh/getting-started/02-quickstart.md
+++ b/docs/zh/getting-started/02-quickstart.md
@@ -38,7 +38,7 @@ pipx upgrade openviking
 
 :::
 
-安装完成后，可以使用 `ov`、`openviking` 和 `openviking-server` 命令。
+安装完成后，可以使用客户端命令 `ov`（`openviking` 是其别名）和服务端命令 `openviking-server`。
 
 ### 方式二：通过 Docker 启动 (作为独立服务)
 

--- a/docs/zh/getting-started/02-quickstart.md
+++ b/docs/zh/getting-started/02-quickstart.md
@@ -14,11 +14,31 @@
 
 OpenViking 支持通过 Python Package 安装作为本地库使用，也支持通过 Docker 快速启动独立服务。
 
-### 方式一：通过 pip 安装 (作为本地库)
+### 方式一：通过 Python 包安装（作为本地命令和库）
 
-```bash
+选择你常用的 Python 包管理工具安装 OpenViking：
+
+::: code-group
+
+```bash [uv（推荐）]
+uv tool install openviking --upgrade
+```
+
+```bash [pip]
 pip install openviking --upgrade --force-reinstall
 ```
+
+```bash [pipx]
+# 安装
+pipx install openviking
+
+# 更新
+pipx upgrade openviking
+```
+
+:::
+
+安装完成后，可以使用 `ov`、`openviking` 和 `openviking-server` 命令。
 
 ### 方式二：通过 Docker 启动 (作为独立服务)
 

--- a/docs/zh/guides/17-vikingbot.md
+++ b/docs/zh/guides/17-vikingbot.md
@@ -10,9 +10,27 @@ VikingBot 建议使用 Python 3.11 或更高版本。
 
 ### 从 PyPI 安装
 
-```bash
-pip install "openviking[bot]"
+选择你常用的 Python 包管理工具安装 VikingBot：
+
+::: code-group
+
+```bash [uv（推荐）]
+uv tool install "openviking[bot]" --upgrade
 ```
+
+```bash [pip]
+pip install "openviking[bot]" --upgrade --force-reinstall
+```
+
+```bash [pipx]
+# 安装
+pipx install "openviking[bot]"
+
+# 更新
+pipx upgrade openviking
+```
+
+:::
 
 安装后检查版本：
 


### PR DESCRIPTION
## Description

Add Python package manager tabs to the OpenViking quickstart and VikingBot installation guides so users can choose uv, pip, or pipx.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add uv, pip, and pipx installation tabs to the English and Chinese quickstart pages.
- Document the commands exposed by the base OpenViking package.
- Add matching installation tabs for the optional `openviking[bot]` package in the VikingBot guides.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation: `npm --prefix docs run docs:build` and `git diff --check`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="1169" height="784" alt="OpenViking Python installer tabs" src="https://github.com/user-attachments/assets/8bc626d8-ad32-4a69-baa7-af77b0477879" />

## Additional Notes

The base `openviking` installation exposes `ov`, `openviking`, and `openviking-server`. VikingBot requires the optional `openviking[bot]` dependencies.
