### PR TITLE
fix(openclaw-plugin): commit sessions on lifecycle end

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -18,6 +18,7 @@ import {
   afterTurnOpenVikingSession,
   compactOpenVikingSession,
   commitOpenVikingSession,
+  type CommitOpenVikingSessionOptions,
 } from "./services/context-lifecycle-service.js";
 
 type ContextEngineInfo = {
@@ -100,7 +101,7 @@ export type ContextEngineWithCommit = ContextEngine & {
     sessionId: string;
     sessionKey?: string;
     runtimeContext?: Record<string, unknown>;
-  }) => Promise<boolean>;
+  }, options?: CommitOpenVikingSessionOptions) => Promise<boolean>;
 };
 
 type Logger = {
@@ -274,12 +275,13 @@ export function createMemoryOpenVikingContextEngine(params: {
     sessionId: string;
     sessionKey?: string;
     runtimeContext?: Record<string, unknown>;
-  }): Promise<boolean> {
+  }, commitOptions?: CommitOpenVikingSessionOptions): Promise<boolean> {
     const { sessionId } = params;
     const { sessionKey } = resolveSessionIdentity(params);
     return commitOpenVikingSession({
       sessionId,
       sessionKey,
+      commitOptions,
       getClient,
       logger,
       rememberSessionAgentId,

--- a/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
+++ b/examples/openclaw-plugin/docs/openviking-openclaw-plugin-guide.md
@@ -140,9 +140,11 @@ transformContext auto recall 流程：
 5. 如果归档成功，再回读 `getSessionContext`，获取最新 `latest_archive_overview` 作为 summary：`context-engine.ts:1605`。
 6. 返回 tokensBefore/tokensAfter、latest archive id 和 summary。
 
-### 4.6 `before_reset`：重置前保护性提交
+### 4.6 `session_end` / `before_reset`：会话结束保护性提交
 
-插件监听 `before_reset`，在 reset 前尽量 commit 当前 OpenViking session，避免对话被重置时未归档内容丢失：`index.ts:1919`。
+插件在 `session_end` 和 `before_reset` 时调用 `commitSession(wait=false, keepRecentCount=0)`：Phase 1 会先归档全部剩余消息，Phase 2 记忆抽取在服务端异步继续，因此 `/new`、Webchat 新建会话、reset 和 gateway 关闭不需要等待抽取完成。
+
+若 OpenClaw 同时触发 `before_reset` 和 `session_end`，插件按解析后的 OpenViking session id 去重正在执行的 commit，避免同一批消息被并发重复归档；失败的 commit 会释放去重状态，允许后续生命周期事件重试。实现位置：`plugin/openviking-lifecycle-hooks.ts`、`services/context-lifecycle-service.ts`。
 
 ---
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -371,6 +371,7 @@ const contextEnginePlugin = {
     registerOpenVikingLifecycleHooks({
       api,
       rememberSessionAgentId,
+      toOVSessionId: openClawSessionToOvStorageId,
       isBypassedSession,
       verboseRoutingInfo,
       getContextEngine,

--- a/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
+++ b/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
@@ -6,7 +6,10 @@ export type OpenVikingHookContext = {
 };
 
 export type ContextEngineCommitPort = {
-  commitOVSession: (ctx: { sessionId: string; sessionKey?: string }) => Promise<boolean>;
+  commitOVSession: (
+    ctx: { sessionId: string; sessionKey?: string },
+    options?: { wait: boolean; keepRecentCount: number },
+  ) => Promise<boolean>;
 };
 
 export type OpenVikingLifecycleHookApi = {
@@ -20,6 +23,7 @@ export type OpenVikingLifecycleHookApi = {
 export type OpenVikingLifecycleHooksDeps = {
   api: OpenVikingLifecycleHookApi;
   rememberSessionAgentId: (ctx: OpenVikingHookContext) => void;
+  toOVSessionId: (sessionId: string, sessionKey?: string) => string;
   isBypassedSession: (ctx?: OpenVikingHookContext) => boolean;
   verboseRoutingInfo: (message: string) => void;
   getContextEngine: () => ContextEngineCommitPort | null;
@@ -30,34 +34,76 @@ export type OpenVikingLifecycleHooksDeps = {
 };
 
 export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksDeps): void {
+  const inFlightFinalCommits = new Map<string, Promise<boolean>>();
+
+  const finalizeSession = async (
+    ctx: OpenVikingHookContext | undefined,
+    trigger: "session_end" | "before_reset",
+  ): Promise<boolean> => {
+    if (deps.isBypassedSession(ctx)) {
+      deps.verboseRoutingInfo(
+        `openviking: bypassing ${trigger} due to session pattern match (sessionKey=${ctx?.sessionKey ?? "none"}, sessionId=${ctx?.sessionId ?? "none"})`,
+      );
+      return false;
+    }
+
+    const sessionId = ctx?.sessionId;
+    const contextEngine = deps.getContextEngine();
+    if (!sessionId || !contextEngine) {
+      return false;
+    }
+
+    const ovSessionId = deps.toOVSessionId(sessionId, ctx?.sessionKey);
+    const existingCommit = inFlightFinalCommits.get(ovSessionId);
+    if (existingCommit) {
+      deps.verboseRoutingInfo(
+        `openviking: reusing in-flight final commit for session=${sessionId} trigger=${trigger}`,
+      );
+      const ok = await existingCommit;
+      if (ok) {
+        return true;
+      }
+      deps.verboseRoutingInfo(
+        `openviking: retrying failed shared final commit for session=${sessionId} trigger=${trigger}`,
+      );
+      return finalizeSession(ctx, trigger);
+    }
+
+    const commitContext = { sessionId, sessionKey: ctx?.sessionKey };
+    let handledCommit: Promise<boolean>;
+    handledCommit = Promise.resolve()
+      .then(() => contextEngine.commitOVSession(
+        commitContext,
+        { wait: false, keepRecentCount: 0 },
+      ))
+      .then((ok) => {
+        if (ok) {
+          deps.logger.info(`openviking: committed OV session on ${trigger} for session=${sessionId}`);
+        }
+        return ok;
+      })
+      .catch((err) => {
+        deps.logger.warn(`openviking: failed to commit OV session on ${trigger}: ${String(err)}`);
+        return false;
+      })
+      .finally(() => {
+        if (inFlightFinalCommits.get(ovSessionId) === handledCommit) {
+          inFlightFinalCommits.delete(ovSessionId);
+        }
+      });
+    inFlightFinalCommits.set(ovSessionId, handledCommit);
+    return handledCommit;
+  };
+
   deps.api.on("session_start", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
   });
   deps.api.on("session_end", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
+    await finalizeSession(ctx, "session_end");
   });
   deps.api.on("before_reset", async (_event: unknown, ctx?: OpenVikingHookContext) => {
-    if (deps.isBypassedSession(ctx)) {
-      deps.verboseRoutingInfo(
-        `openviking: bypassing before_reset due to session pattern match (sessionKey=${ctx?.sessionKey ?? "none"}, sessionId=${ctx?.sessionId ?? "none"})`,
-      );
-      return;
-    }
-    const sessionId = ctx?.sessionId;
-    const contextEngine = deps.getContextEngine();
-    if (sessionId && contextEngine) {
-      try {
-        const ok = await contextEngine.commitOVSession({
-          sessionId,
-          sessionKey: ctx?.sessionKey,
-        });
-        if (ok) {
-          deps.logger.info(`openviking: committed OV session on reset for session=${sessionId}`);
-        }
-      } catch (err) {
-        deps.logger.warn(`openviking: failed to commit OV session on reset: ${String(err)}`);
-      }
-    }
+    await finalizeSession(ctx, "before_reset");
   });
   deps.api.on("after_compaction", async (_event: unknown, _ctx?: OpenVikingHookContext) => {
     // Reserved hook registration for future post-compaction memory integration.

--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -27,9 +27,15 @@ export type ContextEngineLifecycleLogger = {
   warn?: (msg: string) => void;
 };
 
+export type CommitOpenVikingSessionOptions = {
+  wait?: boolean;
+  keepRecentCount?: number;
+};
+
 export type CommitOpenVikingSessionParams = {
   sessionId: string;
   sessionKey?: string;
+  commitOptions?: CommitOpenVikingSessionOptions;
   getClient: () => Promise<Pick<OpenVikingClient, "commitSession">>;
   logger: ContextEngineLifecycleLogger;
   rememberSessionAgentId?: (ctx: {
@@ -343,6 +349,7 @@ function buildAssembledContext(
 export async function commitOpenVikingSession({
   sessionId,
   sessionKey,
+  commitOptions,
   getClient,
   logger,
   rememberSessionAgentId,
@@ -363,8 +370,8 @@ export async function commitOpenVikingSession({
       ovSessionId: ovId,
     });
     const commitResult = await client.commitSession(ovId, {
-      wait: true,
-      keepRecentCount: 0,
+      wait: commitOptions?.wait ?? true,
+      keepRecentCount: commitOptions?.keepRecentCount ?? 0,
     });
     const memCount = totalExtractedMemories(commitResult.memories_extracted);
     if (commitResult.status === "failed") {

--- a/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
@@ -174,6 +174,31 @@ describe("context-engine lifecycle service seam", () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("memories=5"));
   });
 
+  it("forwards non-blocking full-archive options for lifecycle finalization", async () => {
+    const client = {
+      commitSession: vi.fn().mockResolvedValue({
+        status: "accepted",
+        archived: true,
+        task_id: "task-finalize",
+      }),
+    };
+
+    const ok = await commitOpenVikingSession({
+      sessionId: "session-finalize",
+      sessionKey: "agent:main:main",
+      getClient: vi.fn().mockResolvedValue(client),
+      logger: { info: vi.fn(), warn: vi.fn() },
+      isBypassedSession: () => false,
+      commitOptions: { wait: false, keepRecentCount: 0 },
+    });
+
+    expect(ok).toBe(true);
+    expect(client.commitSession).toHaveBeenCalledWith(
+      openClawSessionToOvStorageId("session-finalize", "agent:main:main"),
+      { wait: false, keepRecentCount: 0 },
+    );
+  });
+
   it("compacts an OpenViking session behind the lifecycle service seam", async () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const client = {

--- a/examples/openclaw-plugin/tests/ut/openviking-lifecycle-hooks.test.ts
+++ b/examples/openclaw-plugin/tests/ut/openviking-lifecycle-hooks.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenVikingClient } from "../../client.js";
+import { memoryOpenVikingConfigSchema } from "../../config.js";
+import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
+import { registerOpenVikingLifecycleHooks } from "../../plugin/openviking-lifecycle-hooks.js";
+import { openClawSessionToOvStorageId } from "../../routing/identity-routing.js";
+
+describe("OpenViking lifecycle hooks", () => {
+  it("finalizes session_end with a non-blocking full commit", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitOVSession = vi.fn().mockResolvedValue(true);
+    const rememberSessionAgentId = vi.fn();
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId,
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    const context = {
+      agentId: "main",
+      sessionId: "session-old",
+      sessionKey: "agent:main:main",
+    };
+    await handlers.get("session_end")?.({}, context);
+
+    expect(rememberSessionAgentId).toHaveBeenCalledWith(context);
+    expect(commitOVSession).toHaveBeenCalledWith(
+      { sessionId: "session-old", sessionKey: "agent:main:main" },
+      { wait: false, keepRecentCount: 0 },
+    );
+  });
+
+  it("forwards final commit options through the real context engine", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitSession = vi.fn().mockResolvedValue({
+      status: "accepted",
+      archived: true,
+      task_id: "task-finalize",
+    });
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      mode: "remote",
+      baseUrl: "http://127.0.0.1:1933",
+      autoCapture: false,
+      autoRecall: false,
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const contextEngine = createMemoryOpenVikingContextEngine({
+      id: "openviking",
+      name: "Test Engine",
+      version: "test",
+      cfg,
+      logger,
+      getClient: vi.fn().mockResolvedValue({ commitSession } as unknown as OpenVikingClient),
+      resolveAgentId: () => "main",
+    });
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: openClawSessionToOvStorageId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => contextEngine,
+      logger,
+    });
+
+    const context = { sessionId: "plain-session", sessionKey: "agent:main:main" };
+    await handlers.get("session_end")?.({}, context);
+
+    expect(commitSession).toHaveBeenCalledWith(
+      openClawSessionToOvStorageId(context.sessionId, context.sessionKey),
+      { wait: false, keepRecentCount: 0 },
+    );
+  });
+
+  it.each([
+    ["missing session ID", {}, () => ({ commitOVSession: vi.fn() })],
+    ["missing context engine", { sessionId: "session-without-engine" }, () => null],
+  ])("skips finalization with %s", async (_label, context, getContextEngine) => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const toOVSessionId = vi.fn((sessionId: string) => sessionId);
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine,
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await handlers.get("session_end")?.({}, context);
+
+    expect(toOVSessionId).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates overlapping reset and session_end finalization", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    let finishCommit: ((value: boolean) => void) | undefined;
+    const commitOVSession = vi.fn(() => new Promise<boolean>((resolve) => {
+      finishCommit = resolve;
+    }));
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    const resetCommit = handlers.get("before_reset")?.({}, {
+      sessionId: "session-old-a",
+      sessionKey: "agent:main:main",
+    });
+    const endCommit = handlers.get("session_end")?.({}, {
+      sessionId: "session-old-b",
+      sessionKey: "agent:main:main",
+    });
+    await vi.waitFor(() => expect(commitOVSession).toHaveBeenCalledTimes(1));
+    finishCommit?.(true);
+    await Promise.all([resetCommit, endCommit]);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(1);
+    expect(commitOVSession).toHaveBeenCalledWith(
+      { sessionId: "session-old-a", sessionKey: "agent:main:main" },
+      { wait: false, keepRecentCount: 0 },
+    );
+  });
+
+  it("does not finalize bypassed session_end events", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitOVSession = vi.fn();
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: (ctx) => ctx?.sessionId === "session-bypassed",
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await handlers.get("session_end")?.({}, {
+      sessionId: "session-normal",
+      sessionKey: "agent:main:main",
+    });
+    await handlers.get("session_end")?.({}, {
+      sessionId: "session-bypassed",
+      sessionKey: "agent:main:cron:job",
+    });
+
+    expect(commitOVSession).toHaveBeenCalledTimes(1);
+    expect(commitOVSession).toHaveBeenCalledWith(
+      { sessionId: "session-normal", sessionKey: "agent:main:main" },
+      { wait: false, keepRecentCount: 0 },
+    );
+  });
+
+  it("retries a shared rejection from the waiting lifecycle event", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    let rejectCommit: ((reason: Error) => void) | undefined;
+    const commitOVSession = vi.fn()
+      .mockImplementationOnce(() => new Promise<boolean>((_resolve, reject) => {
+        rejectCommit = reject;
+      }))
+      .mockResolvedValueOnce(true);
+    const logger = { info: vi.fn(), warn: vi.fn() };
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger,
+    });
+
+    const context = { sessionId: "session-retry", sessionKey: "agent:main:main" };
+    const resetCommit = handlers.get("before_reset")?.({}, context);
+    const endCommit = handlers.get("session_end")?.({}, context);
+    await vi.waitFor(() => expect(commitOVSession).toHaveBeenCalledTimes(1));
+    rejectCommit?.(new Error("commit unavailable"));
+    await expect(Promise.all([resetCommit, endCommit])).resolves.toEqual([undefined, undefined]);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "openviking: failed to commit OV session on before_reset: Error: commit unavailable",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "openviking: committed OV session on session_end for session=session-retry",
+    );
+  });
+
+  it("does not deduplicate distinct OV sessions that share a raw session ID", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const pendingCommits: Array<(value: boolean) => void> = [];
+    const commitOVSession = vi.fn(() => new Promise<boolean>((resolve) => {
+      pendingCommits.push(resolve);
+    }));
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    const first = handlers.get("session_end")?.({}, {
+      sessionId: "shared-raw-id",
+      sessionKey: "agent:main:first",
+    });
+    const second = handlers.get("session_end")?.({}, {
+      sessionId: "shared-raw-id",
+      sessionKey: "agent:main:second",
+    });
+    await vi.waitFor(() => expect(commitOVSession).toHaveBeenCalledTimes(2));
+    for (const resolve of pendingCommits) resolve(true);
+    await Promise.all([first, second]);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears successful finalization so a later event can commit new messages", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitOVSession = vi.fn().mockResolvedValue(true);
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    const context = { sessionId: "session-reused", sessionKey: "agent:main:main" };
+    await handlers.get("before_reset")?.({}, context);
+    await handlers.get("session_end")?.({}, context);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a resolved failure so a later event can retry", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitOVSession = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    const context = { sessionId: "session-false", sessionKey: "agent:main:main" };
+    await handlers.get("session_end")?.({}, context);
+    await handlers.get("session_end")?.({}, context);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles a synchronous commit throw and allows retry", async () => {
+    const handlers = new Map<string, (event: unknown, ctx?: Record<string, string>) => unknown>();
+    const commitOVSession = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error("synchronous failure");
+      })
+      .mockResolvedValueOnce(true);
+    const logger = { info: vi.fn(), warn: vi.fn() };
+
+    registerOpenVikingLifecycleHooks({
+      api: {
+        on: vi.fn((hookName, handler) => {
+          handlers.set(hookName, handler);
+        }),
+      },
+      rememberSessionAgentId: vi.fn(),
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
+      isBypassedSession: () => false,
+      verboseRoutingInfo: vi.fn(),
+      getContextEngine: () => ({ commitOVSession }),
+      logger,
+    });
+
+    const context = { sessionId: "session-sync-throw", sessionKey: "agent:main:main" };
+    await handlers.get("session_end")?.({}, context);
+    await handlers.get("session_end")?.({}, context);
+
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "openviking: failed to commit OV session on session_end: Error: synchronous failure",
+    );
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -439,6 +439,7 @@ describe("plugin module seams", () => {
     registerOpenVikingLifecycleHooks({
       api,
       rememberSessionAgentId,
+      toOVSessionId: (sessionId, sessionKey) => sessionKey ?? sessionId,
       isBypassedSession: (ctx) => ctx?.sessionKey === "bypass",
       verboseRoutingInfo,
       getContextEngine: () => ({ commitOVSession }),
@@ -456,14 +457,26 @@ describe("plugin module seams", () => {
     await handlers.get("session_end")?.({}, { sessionId: "session-2", agentId: "agent-main" });
     expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-1", agentId: "agent-main" });
     expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-2", agentId: "agent-main" });
+    expect(commitOVSession).toHaveBeenCalledWith(
+      { sessionId: "session-2", sessionKey: undefined },
+      { wait: false, keepRecentCount: 0 },
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "openviking: committed OV session on session_end for session=session-2",
+    );
 
     await handlers.get("before_reset")?.({}, { sessionId: "session-3", sessionKey: "key-3" });
-    expect(commitOVSession).toHaveBeenCalledWith({ sessionId: "session-3", sessionKey: "key-3" });
-    expect(logger.info).toHaveBeenCalledWith("openviking: committed OV session on reset for session=session-3");
+    expect(commitOVSession).toHaveBeenCalledWith(
+      { sessionId: "session-3", sessionKey: "key-3" },
+      { wait: false, keepRecentCount: 0 },
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "openviking: committed OV session on before_reset for session=session-3",
+    );
 
     await handlers.get("before_reset")?.({}, { sessionId: "session-4", sessionKey: "bypass" });
     expect(verboseRoutingInfo).toHaveBeenCalledWith(expect.stringContaining("bypassing before_reset"));
-    expect(commitOVSession).toHaveBeenCalledTimes(1);
+    expect(commitOVSession).toHaveBeenCalledTimes(2);
   });
 
   it("registers the context engine through a dedicated plugin module", () => {


### PR DESCRIPTION
## Summary

OpenClaw terminal session lifecycle events now archive all remaining OpenViking messages before the session is replaced or the gateway exits. This prevents short sessions below the automatic token threshold from remaining indefinitely in the live `messages.jsonl` file.

## Changes

- Handle both `before_reset` and `session_end` with `commit(wait=false, keepRecentCount=0)`.
- Wait for server-side Phase 1 archive creation while leaving Phase 2 extraction asynchronous.
- Deduplicate overlapping lifecycle hooks by the resolved OpenViking session ID.
- Handle synchronous failures, rejected commits, and `false` results without leaking in-flight state; a waiting terminal hook retries after a shared failure.
- Forward commit options through the context engine and lifecycle service.
- Document the terminal final-commit behavior and add lifecycle regression coverage.

## Verification

- `npx vitest run tests/ut/openviking-lifecycle-hooks.test.ts tests/ut/context-engine-modules.test.ts tests/ut/context-engine-compact.test.ts tests/ut/plugin-bypass-session-patterns.test.ts tests/ut/plugin-modules.test.ts` — 65 passed.
- `npx vitest run --exclude tests/ut/architecture-boundaries.test.ts` — 671 passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- Full suite — 743 passed, 4 failed in `architecture-boundaries.test.ts`; the untouched upstream baseline has the same 4 failures (72 passed, 4 failed in that file).
- Codex uncommitted review — no findings, patch marked correct.

The fixed build was also installed through OpenClaw's native plugin manager and exercised against a real local OpenClaw + OpenViking runtime. `/new`, `/reset`, the Webchat `sessions.reset` gateway operation, and gateway restart each changed the probe session from 2 live messages / `commit_count=0` / `pending_tokens>0` to 0 live messages / `commit_count=1` / `pending_tokens=0`. Each Phase 2 task completed, `archive_001` contained the original user and assistant messages, and the root `messages.jsonl` was empty.
