### PR TITLE
fix(parse): preserve optional titles on local Markdown images

### DIFF
--- a/openviking/parse/image_rewrite.py
+++ b/openviking/parse/image_rewrite.py
@@ -36,6 +36,106 @@ _FENCE_PATTERN = re.compile(r"^(\s{0,3})(`{3,}|~{3,})")
 _LIST_ITEM_PATTERN = re.compile(r"^(\s{0,3})([-*+]|\d{1,9}[.)])(\s+)")
 
 
+def _split_markdown_image_target(payload: str) -> tuple[str, str]:
+    """Return ``(destination, exact_title_suffix)`` for one image payload.
+
+    This scans once from the end instead of making the image regex choose an
+    ambiguous whitespace boundary. Callers can still prefer the full payload
+    when it names an existing file or sidecar key.
+    """
+    content_end = len(payload)
+    while content_end > 0 and payload[content_end - 1].isspace():
+        content_end -= 1
+    if content_end == 0:
+        return payload, ""
+
+    closing = payload[content_end - 1]
+    if closing not in {'"', "'", ")"}:
+        return payload, ""
+
+    slash = content_end - 2
+    while slash >= 0 and payload[slash] == "\\":
+        slash -= 1
+    if (content_end - slash - 2) % 2:
+        return payload, ""
+
+    opening = -1
+    if closing in {'"', "'"}:
+        index = content_end - 2
+        while index >= 0:
+            if payload[index] != closing:
+                index -= 1
+                continue
+            slash = index - 1
+            while slash >= 0 and payload[slash] == "\\":
+                slash -= 1
+            if (index - slash - 1) % 2 == 0:
+                opening = index
+                break
+            index = slash
+    else:
+        depth = 1
+        index = content_end - 2
+        while index >= 0:
+            char = payload[index]
+            if char not in "()":
+                index -= 1
+                continue
+            slash = index - 1
+            while slash >= 0 and payload[slash] == "\\":
+                slash -= 1
+            if (index - slash - 1) % 2:
+                index = slash
+                continue
+            if char == ")":
+                depth += 1
+            else:
+                depth -= 1
+                if depth == 0:
+                    opening = index
+                    break
+            index = slash
+
+    if opening <= 0:
+        return payload, ""
+
+    separator_start = opening
+    while separator_start > 0 and payload[separator_start - 1].isspace():
+        separator_start -= 1
+    if separator_start == opening or not payload[:separator_start].strip():
+        return payload, ""
+
+    return payload[:separator_start], payload[separator_start:]
+
+
+def _artifact_image_candidate(
+    image_ref: str,
+    md_dir: Path,
+    root: Path,
+    *,
+    strip_suffix: bool = True,
+) -> Optional[Path]:
+    # Query/fragment suffixes are reference syntax, not literal filenames. The
+    # title-ambiguity caller opts out for its compatibility-first exact probe.
+    ref = image_ref.strip()
+    if not ref or _is_remote_uri(ref):
+        return None
+
+    path_part = re.split(r"[?#]", ref, maxsplit=1)[0] if strip_suffix else ref
+    ref_path = Path(path_part)
+    if not path_part or ref_path.is_absolute():
+        return None
+
+    try:
+        candidate = (md_dir / ref_path).resolve()
+        candidate.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if candidate.parent != md_dir or not candidate.is_file():
+        return None
+    return candidate
+
+
 def build_artifact_image_mappings(root_dir: Path) -> Dict[str, Dict[str, str]]:
     """Build the sidecar mapping for an already-materialized parser artifact.
 
@@ -58,38 +158,44 @@ def build_artifact_image_mappings(root_dir: Path) -> Dict[str, Dict[str, str]]:
 
         protected = _protected_ranges(content)
 
-        refs = [(match.start(), match.group(2)) for match in _IMAGE_PATTERN.finditer(content)]
-        refs.extend((match.start(), match.group(2)) for match in HTML_IMG_PATTERN.finditer(content))
+        refs = [
+            (match.start(), match.end(), match.group(2), True)
+            for match in _IMAGE_PATTERN.finditer(content)
+        ]
+        refs.extend(
+            (match.start(), match.end(), match.group(2), False)
+            for match in HTML_IMG_PATTERN.finditer(content)
+        )
 
         file_mappings: Dict[str, str] = {}
         md_dir = md_path.parent.resolve()
-        for pos, original_ref in refs:
-            if any(start <= pos < end for start, end in protected):
+
+        for start, end, original_ref, is_markdown in refs:
+            if _span_intersects_protected_ranges(start, end, protected):
                 continue
 
-            ref = original_ref.strip()
-            if not ref or _is_remote_uri(ref):
-                continue
-
-            # Queries/fragments are not part of the local filesystem path, but
-            # the exact original reference remains the mapping key used later.
-            path_part = re.split(r"[?#]", ref, maxsplit=1)[0]
-            ref_path = Path(path_part)
-            if not path_part or ref_path.is_absolute():
-                continue
-
-            try:
-                candidate = (md_dir / ref_path).resolve()
-                candidate.relative_to(root)
-            except (OSError, ValueError):
+            destination, title = (
+                _split_markdown_image_target(original_ref) if is_markdown else (original_ref, "")
+            )
+            mapping_ref = original_ref
+            if title:
+                # Compatibility first: an existing literal filename such as
+                # ``photo.png (copy)`` remains a path, not a title-bearing ref.
+                candidate = _artifact_image_candidate(
+                    original_ref, md_dir, root, strip_suffix=False
+                )
+                if candidate is None:
+                    candidate = _artifact_image_candidate(destination, md_dir, root)
+                    if candidate is not None:
+                        mapping_ref = destination
+            else:
+                candidate = _artifact_image_candidate(original_ref, md_dir, root)
+            if candidate is None:
                 continue
 
             # The existing sidecar contract stores only the final filename and
             # rewrite_image_uris resolves it beside the markdown file.
-            if candidate.parent != md_dir or not candidate.is_file():
-                continue
-
-            file_mappings[original_ref] = candidate.name
+            file_mappings[mapping_ref] = candidate.name
 
         if file_mappings:
             mappings[md_path.relative_to(root).as_posix()] = file_mappings
@@ -217,7 +323,33 @@ def _protected_ranges(content: str):
 
         prev_blank = is_blank
 
-    return ranges
+    if not ranges:
+        return []
+
+    merged = []
+    for start, end in sorted(ranges):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _span_intersects_protected_ranges(
+    start: int,
+    end: int,
+    ranges: list[tuple[int, int]],
+) -> bool:
+    """Return whether ``[start, end)`` overlaps sorted, disjoint ``ranges``."""
+    low = 0
+    high = len(ranges)
+    while low < high:
+        middle = (low + high) // 2
+        if ranges[middle][1] <= start:
+            low = middle + 1
+        else:
+            high = middle
+    return low < len(ranges) and ranges[low][0] < end
 
 
 async def _discover_mappings(
@@ -384,11 +516,8 @@ def _rewrite_content(
 
     protected = _protected_ranges(content)
 
-    def _in_protected(pos: int) -> bool:
-        for s, e in protected:
-            if s <= pos < e:
-                return True
-        return False
+    def _in_protected(start: int, end: int) -> bool:
+        return _span_intersects_protected_ranges(start, end, protected)
 
     def _mapped_uri(path: str) -> Optional[str]:
         """viking:// URI for *path* if the mapping covers it, else None."""
@@ -404,10 +533,19 @@ def _rewrite_content(
     def replacer(match: re.Match) -> str:
         nonlocal rewrite_count
         alt_text = match.group(1)
-        path = match.group(2)
+        payload = match.group(2)
+        path = payload
+        title = ""
+        # The sidecar is the provenance boundary. ``available_images`` only
+        # validates mapped targets; it cannot safely infer an original ref.
+        if payload not in mappings:
+            destination, title_suffix = _split_markdown_image_target(payload)
+            if title_suffix:
+                path = destination
+                title = title_suffix
 
         # Skip image references that live inside code blocks / inline code.
-        if _in_protected(match.start()):
+        if _in_protected(*match.span()):
             return match.group(0)
 
         if _is_remote_uri(path):
@@ -417,13 +555,13 @@ def _rewrite_content(
         if uri is None:
             return match.group(0)
         rewrite_count += 1
-        return f"![{alt_text}]({uri})"
+        return f"![{alt_text}]({uri}{title})"
 
     def img_tag_replacer(match: re.Match) -> str:
         nonlocal rewrite_count
         path = match.group(2)
 
-        if _in_protected(match.start()):
+        if _in_protected(*match.span()):
             return match.group(0)
 
         if _is_remote_uri(path):

--- a/openviking/parse/image_rewrite.py
+++ b/openviking/parse/image_rewrite.py
@@ -11,7 +11,7 @@ images themselves are stored next to the markdown file referencing them).
 import json
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Set
+from typing import TYPE_CHECKING, Dict, Iterator, NamedTuple, Optional, Set
 
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import get_viking_fs
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(((?:[^()]|\([^()]*\))+)\)")
 _REMOTE_PREFIXES = ("http://", "https://", "viking://", "data:", "ftp://")
 
 # Sidecar written by MarkdownParser._ingest_local_images at each document root,
@@ -34,6 +33,81 @@ IMAGE_MAPPINGS_FILENAME = ".image_mappings.json"
 HTML_IMG_PATTERN = re.compile(r"""(<img\s[^>]*?src=["'])([^"']+)(["'][^>]*>)""", re.IGNORECASE)
 _FENCE_PATTERN = re.compile(r"^(\s{0,3})(`{3,}|~{3,})")
 _LIST_ITEM_PATTERN = re.compile(r"^(\s{0,3})([-*+]|\d{1,9}[.)])(\s+)")
+
+
+class _MarkdownImageMatch(NamedTuple):
+    start: int
+    end: int
+    alt_text: str
+    payload: str
+
+
+def _iter_markdown_images(content: str) -> Iterator[_MarkdownImageMatch]:
+    """Yield Markdown image spans with balanced destinations in one pass."""
+    cursor = 0
+    length = len(content)
+    while cursor < length:
+        start = content.find("![", cursor)
+        if start < 0:
+            return
+
+        alt_end = start + 2
+        bracket_depth = 0
+        while alt_end < length:
+            char = content[alt_end]
+            if char == "\\" and alt_end + 1 < length:
+                alt_end += 2
+                continue
+            if char == "[":
+                bracket_depth += 1
+            elif char == "]":
+                if bracket_depth == 0:
+                    break
+                bracket_depth -= 1
+            alt_end += 1
+
+        if alt_end >= length:
+            return
+        if alt_end + 1 >= length or content[alt_end + 1] != "(":
+            cursor = alt_end + 1
+            continue
+
+        payload_start = alt_end + 2
+        index = payload_start
+        depth = 0
+        quote = ""
+        while index < length:
+            char = content[index]
+            if char == "\\" and index + 1 < length:
+                index += 2
+                continue
+            if quote:
+                if char == quote:
+                    quote = ""
+            elif (
+                char in {'"', "'"}
+                and depth == 0
+                and index > payload_start
+                and content[index - 1].isspace()
+            ):
+                quote = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    if index > payload_start:
+                        yield _MarkdownImageMatch(
+                            start,
+                            index + 1,
+                            content[start + 2 : alt_end],
+                            content[payload_start:index],
+                        )
+                    cursor = index + 1
+                    break
+                depth -= 1
+            index += 1
+        else:
+            return
 
 
 def _split_markdown_image_target(payload: str) -> tuple[str, str]:
@@ -159,8 +233,8 @@ def build_artifact_image_mappings(root_dir: Path) -> Dict[str, Dict[str, str]]:
         protected = _protected_ranges(content)
 
         refs = [
-            (match.start(), match.end(), match.group(2), True)
-            for match in _IMAGE_PATTERN.finditer(content)
+            (match.start, match.end, match.payload, True)
+            for match in _iter_markdown_images(content)
         ]
         refs.extend(
             (match.start(), match.end(), match.group(2), False)
@@ -530,10 +604,10 @@ def _rewrite_content(
         )
         return None
 
-    def replacer(match: re.Match) -> str:
+    def replace_markdown_image(match: _MarkdownImageMatch) -> str:
         nonlocal rewrite_count
-        alt_text = match.group(1)
-        payload = match.group(2)
+        alt_text = match.alt_text
+        payload = match.payload
         path = payload
         title = ""
         # The sidecar is the provenance boundary. ``available_images`` only
@@ -545,15 +619,15 @@ def _rewrite_content(
                 title = title_suffix
 
         # Skip image references that live inside code blocks / inline code.
-        if _in_protected(*match.span()):
-            return match.group(0)
+        if _in_protected(match.start, match.end):
+            return content[match.start : match.end]
 
         if _is_remote_uri(path):
-            return match.group(0)
+            return content[match.start : match.end]
 
         uri = _mapped_uri(path)
         if uri is None:
-            return match.group(0)
+            return content[match.start : match.end]
         rewrite_count += 1
         return f"![{alt_text}]({uri}{title})"
 
@@ -573,7 +647,14 @@ def _rewrite_content(
         rewrite_count += 1
         return f"{match.group(1)}{uri}{match.group(3)}"
 
-    new_content = _IMAGE_PATTERN.sub(replacer, content)
+    parts = []
+    cursor = 0
+    for match in _iter_markdown_images(content):
+        parts.append(content[cursor : match.start])
+        parts.append(replace_markdown_image(match))
+        cursor = match.end
+    parts.append(content[cursor:])
+    new_content = "".join(parts)
     # The markdown pass may have shifted offsets; recompute protected ranges
     # against the updated text before rewriting <img> tags.
     protected = _protected_ranges(new_content)

--- a/openviking/parse/image_rewrite.py
+++ b/openviking/parse/image_rewrite.py
@@ -38,76 +38,323 @@ _LIST_ITEM_PATTERN = re.compile(r"^(\s{0,3})([-*+]|\d{1,9}[.)])(\s+)")
 class _MarkdownImageMatch(NamedTuple):
     start: int
     end: int
-    alt_text: str
-    payload: str
+    alt_start: int
+    alt_end: int
+    payload_start: int
+    payload_end: int
+    title_start: int
+    title_end: int
 
 
-def _iter_markdown_images(content: str) -> Iterator[_MarkdownImageMatch]:
-    """Yield Markdown image spans with balanced destinations in one pass."""
-    cursor = 0
+def _iter_unprotected_html_images(
+    content: str,
+    protected_ranges: Optional[list[tuple[int, int]]] = None,
+) -> Iterator[re.Match]:
+    """Yield HTML image matches outside sorted protected ranges in linear time."""
+    protected = protected_ranges or []
+    protected_index = 0
+    for match in HTML_IMG_PATTERN.finditer(content):
+        start = match.start()
+        end = match.end()
+        while protected_index < len(protected) and protected[protected_index][1] <= start:
+            protected_index += 1
+        if protected_index < len(protected) and protected[protected_index][0] < end:
+            continue
+        yield match
+
+
+def _merge_sorted_ranges(
+    first: list[tuple[int, int]],
+    second: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """Merge two source-ordered range streams in linear time."""
+    merged: list[tuple[int, int]] = []
+    first_index = 0
+    second_index = 0
+    while first_index < len(first) or second_index < len(second):
+        if second_index >= len(second) or (
+            first_index < len(first) and first[first_index][0] <= second[second_index][0]
+        ):
+            start, end = first[first_index]
+            first_index += 1
+        else:
+            start, end = second[second_index]
+            second_index += 1
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _next_position_by_level(
+    starts: list[int],
+    levels: Dict[int, int],
+    positions_by_level: Dict[int, list[int]],
+) -> Dict[int, int]:
+    """Map each sorted start to the next position at its parenthesis level."""
+    offsets: Dict[int, int] = {}
+    result: Dict[int, int] = {}
+    for start in starts:
+        level = levels[start]
+        positions = positions_by_level.get(level, [])
+        offset = offsets.get(level, 0)
+        while offset < len(positions) and positions[offset] < start:
+            offset += 1
+        offsets[level] = offset
+        result[start] = positions[offset] if offset < len(positions) else -1
+    return result
+
+
+def _iter_markdown_images(
+    content: str,
+    protected_ranges: Optional[list[tuple[int, int]]] = None,
+) -> Iterator[_MarkdownImageMatch]:
+    """Yield Markdown image spans with linear preprocessing and bounded recovery."""
     length = len(content)
-    while cursor < length:
-        start = content.find("![", cursor)
-        if start < 0:
-            return
+    protected = protected_ranges or []
+    protected_index = 0
+    candidate_starts: list[int] = []
+    bracket_stack: list[int] = []
+    bracket_matches: Dict[int, int] = {}
+    backslashes = 0
 
-        alt_end = start + 2
-        bracket_depth = 0
-        while alt_end < length:
-            char = content[alt_end]
-            if char == "\\" and alt_end + 1 < length:
-                alt_end += 2
-                continue
-            if char == "[":
-                bracket_depth += 1
-            elif char == "]":
-                if bracket_depth == 0:
-                    break
-                bracket_depth -= 1
-            alt_end += 1
+    # Pair every unescaped bracket once. An unmatched outer image therefore
+    # cannot consume a later independently balanced image candidate.
+    for index, char in enumerate(content):
+        while protected_index < len(protected) and protected[protected_index][1] <= index:
+            protected_index += 1
+        if (
+            protected_index < len(protected)
+            and protected[protected_index][0] <= index < protected[protected_index][1]
+        ):
+            backslashes = 0
+            continue
+        if char == "\\":
+            backslashes += 1
+            continue
+        escaped = backslashes % 2 == 1
+        backslashes = 0
+        if not escaped and char == "!" and index + 1 < length and content[index + 1] == "[":
+            candidate_starts.append(index)
+        if escaped:
+            continue
+        if char == "[":
+            bracket_stack.append(index)
+        elif char == "]" and bracket_stack:
+            bracket_matches[bracket_stack.pop()] = index
 
-        if alt_end >= length:
-            return
-        if alt_end + 1 >= length or content[alt_end + 1] != "(":
-            cursor = alt_end + 1
+    candidate_bounds: Dict[int, tuple[int, int]] = {}
+    payload_start_set: Set[int] = set()
+    for start in candidate_starts:
+        alt_end = bracket_matches.get(start + 1)
+        if alt_end is None or alt_end + 1 >= length or content[alt_end + 1] != "(":
+            continue
+        payload_start = alt_end + 2
+        candidate_bounds[start] = (alt_end, payload_start)
+        payload_start_set.add(payload_start)
+
+    # Images and titles cannot borrow delimiters across blank lines or protected
+    # block-code regions. Inline code remains part of the surrounding block.
+    block_boundaries: Set[int] = set()
+    protected_index = 0
+    offset = 0
+    for line in content.splitlines(keepends=True):
+        line_start = offset
+        line_end = line_start + len(line)
+        offset = line_end
+        while protected_index < len(protected) and protected[protected_index][1] <= line_start:
+            protected_index += 1
+        if not line.strip():
+            block_boundaries.add(line_end)
+        if (
+            protected_index < len(protected)
+            and protected[protected_index][0] <= line_start
+            and protected[protected_index][1] >= line_end
+        ):
+            block_boundaries.add(line_start)
+            block_boundaries.add(line_end)
+    block_ids = [0] * (length + 1)
+    block_id = 0
+    for position in range(length + 1):
+        block_id += position in block_boundaries
+        block_ids[position] = block_id
+
+    payload_starts: list[int] = []
+    payload_levels: Dict[int, int] = {}
+    closes_by_level: Dict[int, list[int]] = {}
+    title_openers: list[tuple[int, int, str]] = []
+    next_same_quote: Dict[int, int] = {}
+    quote_positions: list[int] = []
+    last_quote: Dict[str, int] = {}
+    parenthesis_stack: list[int] = []
+    matching_parenthesis: Dict[int, int] = {}
+    parenthesis_level = 0
+    backslashes = 0
+    protected_index = 0
+
+    for index, char in enumerate(content):
+        if index in payload_start_set:
+            payload_starts.append(index)
+            payload_levels[index] = parenthesis_level
+        while protected_index < len(protected) and protected[protected_index][1] <= index:
+            protected_index += 1
+        if (
+            protected_index < len(protected)
+            and protected[protected_index][0] <= index < protected[protected_index][1]
+        ):
+            backslashes = 0
+            continue
+        if char == "\\":
+            backslashes += 1
+            continue
+        escaped = backslashes % 2 == 1
+        backslashes = 0
+        if escaped:
             continue
 
-        payload_start = alt_end + 2
-        index = payload_start
-        depth = 0
-        quote = ""
-        while index < length:
-            char = content[index]
-            if char == "\\" and index + 1 < length:
-                index += 2
+        if char == "(":
+            if index > 0 and content[index - 1].isspace():
+                title_openers.append((index, parenthesis_level, char))
+            parenthesis_stack.append(index)
+            parenthesis_level += 1
+        elif char == ")":
+            closes_by_level.setdefault(parenthesis_level, []).append(index)
+            if parenthesis_stack:
+                matching_parenthesis[parenthesis_stack.pop()] = index
+            parenthesis_level -= 1
+
+        if char in {'"', "'"}:
+            previous = last_quote.get(char)
+            if previous is not None:
+                next_same_quote[previous] = index
+            last_quote[char] = index
+            quote_positions.append(index)
+            if index > 0 and content[index - 1].isspace():
+                title_openers.append((index, parenthesis_level, char))
+
+    if length in payload_start_set:
+        payload_starts.append(length)
+        payload_levels[length] = parenthesis_level
+
+    next_close = _next_position_by_level(payload_starts, payload_levels, closes_by_level)
+    terminal_marker_positions = set(quote_positions)
+    terminal_marker_positions.update(matching_parenthesis.values())
+    next_nonspace_after_marker: Dict[int, int] = {}
+    following_nonspace = length
+    for index in range(length - 1, -1, -1):
+        if index in terminal_marker_positions:
+            next_nonspace_after_marker[index] = following_nonspace
+        if not content[index].isspace():
+            following_nonspace = index
+
+    terminal_titles_by_level: Dict[int, list[int]] = {}
+    title_bounds: Dict[int, tuple[int, int]] = {}
+    for position, level, marker in title_openers:
+        title_end = (
+            matching_parenthesis.get(position, -1)
+            if marker == "("
+            else next_same_quote.get(position, -1)
+        )
+        if title_end < 0:
+            continue
+        close = next_nonspace_after_marker[title_end]
+        if close < length and content[close] == ")":
+            terminal_titles_by_level.setdefault(level, []).append(position)
+            title_bounds[position] = (position + 1, title_end)
+    next_title_opener = _next_position_by_level(
+        payload_starts,
+        payload_levels,
+        terminal_titles_by_level,
+    )
+
+    raw_matches: Dict[int, tuple[int, int, int, int]] = {}
+    for start in candidate_starts:
+        if start not in candidate_bounds:
+            continue
+        alt_end, payload_start = candidate_bounds[start]
+        close = next_close[payload_start]
+        title_opener = next_title_opener[payload_start]
+        title_start = -1
+        title_end = -1
+
+        if title_opener >= 0 and (close < 0 or title_opener < close):
+            title_start, title_end = title_bounds[title_opener]
+            close = next_nonspace_after_marker[title_end]
+            if close >= length or content[close] != ")":
                 continue
-            if quote:
-                if char == quote:
-                    quote = ""
-            elif (
-                char in {'"', "'"}
-                and depth == 0
-                and index > payload_start
-                and content[index - 1].isspace()
-            ):
-                quote = char
-            elif char == "(":
-                depth += 1
-            elif char == ")":
-                if depth == 0:
-                    if index > payload_start:
-                        yield _MarkdownImageMatch(
-                            start,
-                            index + 1,
-                            content[start + 2 : alt_end],
-                            content[payload_start:index],
-                        )
-                    cursor = index + 1
-                    break
-                depth -= 1
-            index += 1
-        else:
-            return
+        elif close <= payload_start:
+            continue
+
+        if block_ids[start] != block_ids[close]:
+            continue
+        raw_matches[start] = (alt_end, close, title_start, title_end)
+
+    suppressed: Set[int] = set()
+
+    # A syntactically confirmed title owns all text that starts in its interior.
+    # Never let mapping or filesystem success reinterpret title text as an image.
+    title_events_at: Dict[int, list[tuple[int, int]]] = {}
+    for owner, (_alt_end, _close, title_start, title_end) in raw_matches.items():
+        if title_start >= 0:
+            title_events_at.setdefault(title_start, []).append((title_end, owner))
+    title_events = [
+        (position, title_end, owner)
+        for position in range(length)
+        for title_end, owner in title_events_at.get(position, ())
+    ]
+    title_event_index = 0
+    furthest_title_end = -1
+    for start in candidate_starts:
+        raw_match = raw_matches.get(start)
+        if raw_match is None:
+            continue
+        while title_event_index < len(title_events) and title_events[title_event_index][0] <= start:
+            title_start, title_end, owner = title_events[title_event_index]
+            title_event_index += 1
+            if owner not in suppressed:
+                furthest_title_end = max(furthest_title_end, title_end)
+        if start < furthest_title_end:
+            suppressed.add(start)
+
+    selected_end = -1
+    for start in candidate_starts:
+        if start not in raw_matches or start in suppressed:
+            continue
+        alt_end, close, title_start, title_end = raw_matches[start]
+        if start < selected_end:
+            continue
+        selected_end = close + 1
+        payload_start = candidate_bounds[start][1]
+        yield _MarkdownImageMatch(
+            start,
+            close + 1,
+            start + 2,
+            alt_end,
+            payload_start,
+            close,
+            title_start,
+            title_end,
+        )
+
+
+def _owned_image_matches(
+    content: str,
+    protected: list[tuple[int, int]],
+) -> tuple[list[_MarkdownImageMatch], list[re.Match]]:
+    """Return non-overlapping Markdown and HTML images with outer syntax owning."""
+    html_candidates = list(_iter_unprotected_html_images(content, protected))
+    markdown_protected = _merge_sorted_ranges(
+        protected,
+        [(match.start(), match.end()) for match in html_candidates],
+    )
+    markdown_matches = list(_iter_markdown_images(content, markdown_protected))
+    html_excluded = _merge_sorted_ranges(
+        protected,
+        [(match.start, match.end) for match in markdown_matches],
+    )
+    html_matches = list(_iter_unprotected_html_images(content, html_excluded))
+    return markdown_matches, html_matches
 
 
 def _split_markdown_image_target(payload: str) -> tuple[str, str]:
@@ -232,22 +479,19 @@ def build_artifact_image_mappings(root_dir: Path) -> Dict[str, Dict[str, str]]:
 
         protected = _protected_ranges(content)
 
-        refs = [
-            (match.start, match.end, match.payload, True)
-            for match in _iter_markdown_images(content)
-        ]
-        refs.extend(
-            (match.start(), match.end(), match.group(2), False)
-            for match in HTML_IMG_PATTERN.finditer(content)
-        )
+        markdown_matches, html_matches = _owned_image_matches(content, protected)
+        refs = [(match.start, match.end, match, True) for match in markdown_matches]
+        refs.extend((match.start(), match.end(), match.group(2), False) for match in html_matches)
 
         file_mappings: Dict[str, str] = {}
         md_dir = md_path.parent.resolve()
 
-        for start, end, original_ref, is_markdown in refs:
-            if _span_intersects_protected_ranges(start, end, protected):
-                continue
-
+        for _start, _end, reference, is_markdown in refs:
+            original_ref = (
+                content[reference.payload_start : reference.payload_end]
+                if is_markdown
+                else reference
+            )
             destination, title = (
                 _split_markdown_image_target(original_ref) if is_markdown else (original_ref, "")
             )
@@ -401,7 +645,8 @@ def _protected_ranges(content: str):
         return []
 
     merged = []
-    for start, end in sorted(ranges):
+    # Fenced/indented lines and inline spans are appended in source order.
+    for start, end in ranges:
         if merged and start <= merged[-1][1]:
             merged[-1] = (merged[-1][0], max(merged[-1][1], end))
         else:
@@ -424,6 +669,14 @@ def _span_intersects_protected_ranges(
         else:
             high = middle
     return low < len(ranges) and ranges[low][0] < end
+
+
+def _position_in_protected_ranges(
+    position: int,
+    ranges: list[tuple[int, int]],
+) -> bool:
+    """Return whether one source position is inside a protected Markdown span."""
+    return _span_intersects_protected_ranges(position, position + 1, ranges)
 
 
 async def _discover_mappings(
@@ -590,13 +843,12 @@ def _rewrite_content(
 
     protected = _protected_ranges(content)
 
-    def _in_protected(start: int, end: int) -> bool:
-        return _span_intersects_protected_ranges(start, end, protected)
-
     def _mapped_uri(path: str) -> Optional[str]:
         """viking:// URI for *path* if the mapping covers it, else None."""
         image_name = mappings.get(path)
-        if image_name and image_name in available_images:
+        if image_name is None:
+            return None
+        if image_name in available_images:
             return f"{image_dir}/{image_name}"
         logger.warning(
             f"[image_rewrite] Image not found in VikingFS: path = {path}, "
@@ -604,10 +856,9 @@ def _rewrite_content(
         )
         return None
 
-    def replace_markdown_image(match: _MarkdownImageMatch) -> str:
+    def replace_markdown_image(match: _MarkdownImageMatch) -> Optional[str]:
         nonlocal rewrite_count
-        alt_text = match.alt_text
-        payload = match.payload
+        payload = content[match.payload_start : match.payload_end]
         path = payload
         title = ""
         # The sidecar is the provenance boundary. ``available_images`` only
@@ -618,45 +869,53 @@ def _rewrite_content(
                 path = destination
                 title = title_suffix
 
-        # Skip image references that live inside code blocks / inline code.
-        if _in_protected(match.start, match.end):
-            return content[match.start : match.end]
-
         if _is_remote_uri(path):
-            return content[match.start : match.end]
+            return None
 
         uri = _mapped_uri(path)
         if uri is None:
-            return content[match.start : match.end]
+            return None
+        alt_text = content[match.alt_start : match.alt_end]
         rewrite_count += 1
         return f"![{alt_text}]({uri}{title})"
 
-    def img_tag_replacer(match: re.Match) -> str:
+    def replace_html_image(match: re.Match) -> Optional[str]:
         nonlocal rewrite_count
         path = match.group(2)
 
-        if _in_protected(*match.span()):
-            return match.group(0)
-
         if _is_remote_uri(path):
-            return match.group(0)
+            return None
 
         uri = _mapped_uri(path)
         if uri is None:
-            return match.group(0)
+            return None
         rewrite_count += 1
         return f"{match.group(1)}{uri}{match.group(3)}"
 
     parts = []
     cursor = 0
-    for match in _iter_markdown_images(content):
+    markdown_matches, _ = _owned_image_matches(content, protected)
+    for match in markdown_matches:
+        replacement = replace_markdown_image(match)
+        if replacement is None:
+            continue
         parts.append(content[cursor : match.start])
-        parts.append(replace_markdown_image(match))
+        parts.append(replacement)
         cursor = match.end
     parts.append(content[cursor:])
     new_content = "".join(parts)
     # The markdown pass may have shifted offsets; recompute protected ranges
     # against the updated text before rewriting <img> tags.
     protected = _protected_ranges(new_content)
-    new_content = HTML_IMG_PATTERN.sub(img_tag_replacer, new_content)
-    return new_content, rewrite_count
+    _, html_matches = _owned_image_matches(new_content, protected)
+    parts = []
+    cursor = 0
+    for match in html_matches:
+        replacement = replace_html_image(match)
+        if replacement is None:
+            continue
+        parts.append(new_content[cursor : match.start()])
+        parts.append(replacement)
+        cursor = match.end()
+    parts.append(new_content[cursor:])
+    return "".join(parts), rewrite_count

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -588,10 +588,24 @@ class MarkdownParser(BaseParser):
 
             # Collect all image references in this markdown file: markdown
             # embeds (![...]) and HTML <img src="..."> tags alike.
-            from openviking.parse.image_rewrite import HTML_IMG_PATTERN
+            from openviking.parse.image_rewrite import (
+                HTML_IMG_PATTERN,
+                _protected_ranges,
+                _span_intersects_protected_ranges,
+                _split_markdown_image_target,
+            )
 
-            image_refs = [m.group(2) for m in self._image_pattern.finditer(content)]
-            image_refs += [m.group(2) for m in HTML_IMG_PATTERN.finditer(content)]
+            protected = _protected_ranges(content)
+            image_refs = [
+                (match.group(2), True)
+                for match in self._image_pattern.finditer(content)
+                if not _span_intersects_protected_ranges(*match.span(), protected)
+            ]
+            image_refs += [
+                (match.group(2), False)
+                for match in HTML_IMG_PATTERN.finditer(content)
+                if not _span_intersects_protected_ranges(*match.span(), protected)
+            ]
             if not image_refs:
                 continue
 
@@ -600,12 +614,32 @@ class MarkdownParser(BaseParser):
             origin_images_links = []
             seen_paths = set()
 
-            for path_str in image_refs:
+            for raw_path, is_markdown in image_refs:
+                path_str = raw_path
+                resolved_path = None
+                if is_markdown:
+                    destination, title = _split_markdown_image_target(raw_path)
+                    if title:
+                        if self._is_remote_uri(destination):
+                            path_str = destination
+                        else:
+                            # Preserve the pre-title behavior for an existing local
+                            # filename whose final component only looks like a title.
+                            resolved_path = self._resolve_image_path(
+                                raw_path,
+                                base_dir,
+                                allowed_media_dirs,
+                                strip_suffix=False,
+                            )
+                            if resolved_path is None:
+                                path_str = destination
+
                 # Skip remote URIs
                 if self._is_remote_uri(path_str):
                     continue
 
-                resolved_path = self._resolve_image_path(path_str, base_dir, allowed_media_dirs)
+                if resolved_path is None:
+                    resolved_path = self._resolve_image_path(path_str, base_dir, allowed_media_dirs)
                 if resolved_path is None:
                     logger.warning(f"[MarkdownParser] Image file not found: {path_str}")
                     continue
@@ -679,6 +713,8 @@ class MarkdownParser(BaseParser):
         path_str: str,
         base_dir: Optional[Path],
         allowed_media_dirs: Optional[List[Path]] = None,
+        *,
+        strip_suffix: bool = True,
     ) -> Optional[Path]:
         """
         Resolve a local image reference to an existing filesystem path.
@@ -695,6 +731,16 @@ class MarkdownParser(BaseParser):
             allowed root, otherwise None
         """
         try:
+            if strip_suffix:
+                path_without_suffix = re.split(r"[?#]", path_str, maxsplit=1)[0]
+                if path_without_suffix != path_str:
+                    return self._resolve_image_path(
+                        path_without_suffix,
+                        base_dir,
+                        allowed_media_dirs,
+                        strip_suffix=False,
+                    )
+
             path = Path(path_str)
 
             # Reject absolute paths: they can point anywhere on the host
@@ -849,7 +895,7 @@ class MarkdownParser(BaseParser):
 
     def _sanitize_for_path(self, text: str, max_length: int = 50) -> str:
         safe = re.sub(
-            r"[^\w\u0080-\u02af\u0400-\u052f\u0600-\u077f\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\u3400-\u4dbf\U00020000-\U0002a6df\s.-]",
+            r"[^\w^@-\u02af\u0400-\u052f\u0600-\u077f\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\u3400-\u4dbf\U00020000-\U0002a6df\s.-]",
             "",
             text,
         )

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -895,7 +895,7 @@ class MarkdownParser(BaseParser):
 
     def _sanitize_for_path(self, text: str, max_length: int = 50) -> str:
         safe = re.sub(
-            r"[^\w^@-\u02af\u0400-\u052f\u0600-\u077f\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\u3400-\u4dbf\U00020000-\U0002a6df\s.-]",
+            r"[^\w\u0080-\u02af\u0400-\u052f\u0600-\u077f\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\u3400-\u4dbf\U00020000-\U0002a6df\s.-]",
             "",
             text,
         )

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -175,7 +175,6 @@ class MarkdownParser(BaseParser):
         self._code_block_pattern = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
         self._inline_code_pattern = re.compile(r"`([^`]+)`")
         self._link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
-        self._image_pattern = re.compile(r"!\[([^\]]*)\]\(((?:[^()]|\([^()]*\))+)\)")
         self._list_pattern = re.compile(r"^(\s*)[-*+]\s+(.+)$", re.MULTILINE)
         self._numbered_list_pattern = re.compile(r"^(\s*)\d+\.\s+(.+)$", re.MULTILINE)
         self._frontmatter_pattern = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
@@ -589,32 +588,31 @@ class MarkdownParser(BaseParser):
             # Collect all image references in this markdown file: markdown
             # embeds (![...]) and HTML <img src="..."> tags alike.
             from openviking.parse.image_rewrite import (
-                HTML_IMG_PATTERN,
+                _owned_image_matches,
                 _protected_ranges,
-                _span_intersects_protected_ranges,
                 _split_markdown_image_target,
             )
 
             protected = _protected_ranges(content)
-            image_refs = [
-                (match.group(2), True)
-                for match in self._image_pattern.finditer(content)
-                if not _span_intersects_protected_ranges(*match.span(), protected)
-            ]
+            markdown_matches, html_matches = _owned_image_matches(content, protected)
+            image_refs = [(match.start, match.end, match, True) for match in markdown_matches]
             image_refs += [
-                (match.group(2), False)
-                for match in HTML_IMG_PATTERN.finditer(content)
-                if not _span_intersects_protected_ranges(*match.span(), protected)
+                (match.start(), match.end(), match.group(2), False) for match in html_matches
             ]
             if not image_refs:
                 continue
 
             # Resolve local image paths, skipping remote URIs and duplicates
             local_images = []
-            origin_images_links = []
+            origin_links_by_path: Dict[Path, list[str]] = {}
             seen_paths = set()
 
-            for raw_path, is_markdown in image_refs:
+            for _start, _end, reference, is_markdown in image_refs:
+                raw_path = (
+                    content[reference.payload_start : reference.payload_end]
+                    if is_markdown
+                    else reference
+                )
                 path_str = raw_path
                 resolved_path = None
                 if is_markdown:
@@ -646,9 +644,10 @@ class MarkdownParser(BaseParser):
 
                 # Skip duplicates within the same markdown file
                 if resolved_path in seen_paths:
+                    origin_links_by_path[resolved_path].append(path_str)
                     continue
                 seen_paths.add(resolved_path)
-                origin_images_links.append(path_str)
+                origin_links_by_path[resolved_path] = [path_str]
                 local_images.append(resolved_path)
 
             if not local_images:
@@ -660,7 +659,7 @@ class MarkdownParser(BaseParser):
             # Copy each local image next to the markdown file, deduplicating names
             used_names: set[str] = set()
             file_mappings: Dict[str, str] = {}  # original_path_str -> unique_filename
-            for origin_link, resolved_path in zip(origin_images_links, local_images, strict=False):
+            for resolved_path in local_images:
                 try:
                     if not await asyncio.to_thread(resolved_path.exists):
                         logger.warning(f"[MarkdownParser] Image file not found: {resolved_path}")
@@ -685,8 +684,10 @@ class MarkdownParser(BaseParser):
                     await viking_fs.write_file_bytes(viking_path, image_bytes)
                     logger.debug(f"[MarkdownParser] Copied image to VikingFS: {viking_path}")
 
-                    # Record mapping for post-commit rewrite
-                    file_mappings[origin_link] = unique_filename
+                    # One physical file may have multiple query/fragment-bearing
+                    # source references; all of them must retain provenance.
+                    for origin_link in origin_links_by_path[resolved_path]:
+                        file_mappings[origin_link] = unique_filename
 
                 except Exception as e:
                     logger.warning(f"[MarkdownParser] Failed to ingest image {resolved_path}: {e}")

--- a/tests/parse/test_markdown_link_rewrite.py
+++ b/tests/parse/test_markdown_link_rewrite.py
@@ -558,6 +558,68 @@ class TestImageLinkSplit:
         assert f"![p]({root}/guides/page/photo.png)" in page, page
         assert f'<img src="{root}/guides/page/photo.png" width="80%">' in page, page
 
+    async def test_image_titles_preserved_through_ingest_and_rewrite(self, tmp_path: Path):
+        from openviking.parse.image_rewrite import rewrite_image_uris
+
+        kb = tmp_path / "kb"
+        (kb / "assets").mkdir(parents=True)
+        _write_valid_png(kb / "assets" / "system.png")
+        _write_valid_png(kb / "assets" / "diagram (draft).png")
+        _write_valid_png(kb / "assets" / "query.png")
+        _write_valid_png(kb / "assets" / "fragment.png")
+        (kb / "index.md").write_text(
+            '![plain](./assets/system.png "System architecture")\n\n'
+            "![paren](./assets/diagram (draft).png 'Draft diagram')\n\n"
+            '![query](./assets/query.png?rev=1 "Query title")\n\n'
+            "![fragment](./assets/fragment.png#preview 'Fragment title')",
+            encoding="utf-8",
+        )
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            result = await DirectoryParser().parse(str(kb))
+
+            temp = result.temp_dir_path
+            entries = await fake.ls(temp)
+            doc_dirs = [entry for entry in entries if entry["isDir"]]
+            root = f"viking://resources/{doc_dirs[0]['name']}"
+            src_prefix = doc_dirs[0]["uri"].rstrip("/") + "/"
+            for uri in list(fake.files):
+                if uri.startswith(src_prefix):
+                    fake.files[f"{root}/{uri[len(src_prefix) :]}"] = fake.files[uri]
+
+            import openviking.parse.image_rewrite as image_rewrite_mod
+
+            with patch.object(image_rewrite_mod, "get_viking_fs", return_value=fake):
+                stats = await rewrite_image_uris(root, lock_handle=None)
+
+        assert stats["references_rewritten"] == 4, stats
+        page = _decode(fake.files[f"{root}/index/index.md"])
+        assert f'![plain]({root}/index/system.png "System architecture")' in page, page
+        assert f"![paren]({root}/index/diagram (draft).png 'Draft diagram')" in page, page
+        assert f'![query]({root}/index/query.png "Query title")' in page, page
+        assert f"![fragment]({root}/index/fragment.png 'Fragment title')" in page, page
+
+    async def test_titled_image_examples_in_code_are_not_ingested(self, tmp_path: Path):
+        kb = tmp_path / "kb"
+        (kb / "assets").mkdir(parents=True)
+        _write_valid_png(kb / "assets" / "secret.png")
+        _write_valid_png(kb / "assets" / "se`cret`.png")
+        (kb / "index.md").write_text(
+            '`![inline](./assets/secret.png "Inline example")`\n\n'
+            "```markdown\n![fenced](./assets/secret.png 'Fenced example')\n```\n\n"
+            '![crossing](./assets/se`cret`.png "Crossing example")',
+            encoding="utf-8",
+        )
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            await DirectoryParser().parse(str(kb))
+
+        assert not any(uri.endswith("/secret.png") for uri in fake.files), fake.files
+        assert not any(uri.endswith("/se`cret`.png") for uri in fake.files), fake.files
+        assert not any(uri.endswith(".image_mappings.json") for uri in fake.files), fake.files
+
     async def test_invalid_image_depth_adjusted(self, tmp_path: Path):
         # In base_dir but not a decodable image -> ingest skips it -> depth-adjust.
         kb = tmp_path / "kb"
@@ -586,6 +648,101 @@ class TestRewriteImageUris:
         import openviking.parse.image_rewrite as image_rewrite_mod
 
         return patch.object(image_rewrite_mod, "get_viking_fs", return_value=fake)
+
+    def test_terminal_parenthesized_filename_mapping_wins(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![p](photo.png (copy))"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"photo.png (copy)"},
+            {"photo.png (copy)": "photo.png (copy)"},
+        )
+
+        assert count == 1
+        assert rewritten == "![p](viking://resources/doc/photo.png (copy))"
+
+    def test_title_splitter_handles_long_non_title_payload(self):
+        from openviking.parse.image_rewrite import _split_markdown_image_target
+
+        cases = {
+            'assets/image.png "Double title"': ("assets/image.png", ' "Double title"'),
+            "assets/image.png 'Single title'": ("assets/image.png", " 'Single title'"),
+            "assets/image.png (Parenthesized title)": (
+                "assets/image.png",
+                " (Parenthesized title)",
+            ),
+            r'assets/image.png "Escaped \" quote"': (
+                "assets/image.png",
+                r' "Escaped \" quote"',
+            ),
+            r'assets/image.png "unterminated\"': (
+                r'assets/image.png "unterminated\"',
+                "",
+            ),
+        }
+        for payload, expected in cases.items():
+            assert _split_markdown_image_target(payload) == expected
+
+        payload = "assets/" + (" " * 100_000) + "image.png"
+        assert _split_markdown_image_target(payload) == (payload, "")
+
+    def test_artifact_query_and_fragment_titles_survive_rewrite(self, tmp_path: Path):
+        from openviking.parse.image_rewrite import (
+            _rewrite_content,
+            build_artifact_image_mappings,
+        )
+
+        (tmp_path / "image.png").write_bytes(b"image")
+        content = (
+            '![query](image.png?rev=1 "Query title")\n'
+            "![fragment](image.png#preview 'Fragment title')"
+        )
+        (tmp_path / "doc.md").write_text(content, encoding="utf-8")
+
+        mappings = build_artifact_image_mappings(tmp_path)["doc.md"]
+        assert mappings == {
+            "image.png?rev=1": "image.png",
+            "image.png#preview": "image.png",
+        }
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            mappings,
+        )
+
+        assert count == 2
+        assert '![query](viking://resources/doc/image.png "Query title")' in rewritten
+        assert "![fragment](viking://resources/doc/image.png 'Fragment title')" in rewritten
+
+    def test_protected_span_overlap_is_detected(self):
+        from openviking.parse.image_rewrite import (
+            _protected_ranges,
+            _rewrite_content,
+            _span_intersects_protected_ranges,
+        )
+
+        protected = [(10, 20), (30, 40)]
+        assert _span_intersects_protected_ranges(5, 15, protected)
+        assert _span_intersects_protected_ranges(15, 25, protected)
+        assert not _span_intersects_protected_ranges(5, 10, protected)
+        assert not _span_intersects_protected_ranges(20, 30, protected)
+
+        content = '![ok](image.png)\n![example](image.png "`code`")'
+        ranges = _protected_ranges(content)
+        assert all(left[1] < right[0] for left, right in zip(ranges, ranges[1:], strict=False))
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+        assert count == 1
+        assert rewritten == (
+            '![ok](viking://resources/doc/image.png)\n![example](image.png "`code`")'
+        )
 
     async def test_nested_mapping_consumed(self):
         from openviking.parse.image_rewrite import rewrite_image_uris

--- a/tests/parse/test_markdown_link_rewrite.py
+++ b/tests/parse/test_markdown_link_rewrite.py
@@ -600,7 +600,7 @@ class TestImageLinkSplit:
         assert f'![query]({root}/index/query.png "Query title")' in page, page
         assert f"![fragment]({root}/index/fragment.png 'Fragment title')" in page, page
 
-    async def test_titled_image_examples_in_code_are_not_ingested(self, tmp_path: Path):
+    async def test_titled_image_examples_in_code_are_not_mapped(self, tmp_path: Path):
         kb = tmp_path / "kb"
         (kb / "assets").mkdir(parents=True)
         _write_valid_png(kb / "assets" / "secret.png")
@@ -616,9 +616,15 @@ class TestImageLinkSplit:
         with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
             await DirectoryParser().parse(str(kb))
 
-        assert not any(uri.endswith("/secret.png") for uri in fake.files), fake.files
-        assert not any(uri.endswith("/se`cret`.png") for uri in fake.files), fake.files
+        assert any(uri.endswith("/secret.png") for uri in fake.files), fake.files
+        assert any(uri.endswith("/se`cret`.png") for uri in fake.files), fake.files
         assert not any(uri.endswith(".image_mappings.json") for uri in fake.files), fake.files
+        pages = [_decode(content) for uri, content in fake.files.items() if uri.endswith(".md")]
+        assert pages == [
+            '`![inline](./assets/secret.png "Inline example")`\n\n'
+            "```markdown\n![fenced](./assets/secret.png 'Fenced example')\n```\n\n"
+            '![crossing](./assets/se`cret`.png "Crossing example")'
+        ]
 
     async def test_invalid_image_depth_adjusted(self, tmp_path: Path):
         # In base_dir but not a decodable image -> ingest skips it -> depth-adjust.
@@ -662,6 +668,66 @@ class TestRewriteImageUris:
 
         assert count == 1
         assert rewritten == "![p](viking://resources/doc/photo.png (copy))"
+
+    def test_quoted_title_may_contain_right_parenthesis(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![x](image.png "right)paren")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == '![x](viking://resources/doc/image.png "right)paren")'
+
+    def test_escaped_and_nested_alt_brackets_are_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = r"![a \] b [nested]](image.png)"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == r"![a \] b [nested]](viking://resources/doc/image.png)"
+
+    def test_path_sanitizer_drops_ascii_separators_and_brackets(self):
+        parser = MarkdownParser()
+
+        assert parser._sanitize_for_path(r"abc\\def[ghi]") == "abcdefghi"
+
+    def test_malformed_quoted_target_is_left_unchanged(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![x](" * 20_000
+
+        assert _rewrite_content(content, "viking://resources/doc", set(), {}) == (content, 0)
+
+    def test_escaped_parenthesis_and_apostrophe_destinations_are_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = r"![escaped](foo\)bar.png) ![apostrophe](it's.png)"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"escaped.png", "apostrophe.png"},
+            {
+                r"foo\)bar.png": "escaped.png",
+                "it's.png": "apostrophe.png",
+            },
+        )
+
+        assert count == 2
+        assert rewritten == (
+            "![escaped](viking://resources/doc/escaped.png) "
+            "![apostrophe](viking://resources/doc/apostrophe.png)"
+        )
 
     def test_title_splitter_handles_long_non_title_payload(self):
         from openviking.parse.image_rewrite import _split_markdown_image_target

--- a/tests/parse/test_markdown_link_rewrite.py
+++ b/tests/parse/test_markdown_link_rewrite.py
@@ -567,11 +567,15 @@ class TestImageLinkSplit:
         _write_valid_png(kb / "assets" / "diagram (draft).png")
         _write_valid_png(kb / "assets" / "query.png")
         _write_valid_png(kb / "assets" / "fragment.png")
+        _write_valid_png(kb / "assets" / "right.png")
+        _write_valid_png(kb / 'assets/photo "draft".png')
         (kb / "index.md").write_text(
             '![plain](./assets/system.png "System architecture")\n\n'
             "![paren](./assets/diagram (draft).png 'Draft diagram')\n\n"
             '![query](./assets/query.png?rev=1 "Query title")\n\n'
-            "![fragment](./assets/fragment.png#preview 'Fragment title')",
+            "![fragment](./assets/fragment.png#preview 'Fragment title')\n\n"
+            '![quoted-paren](./assets/right.png "right)paren")\n\n'
+            '![quoted-path](./assets/photo "draft".png "Caption")',
             encoding="utf-8",
         )
 
@@ -593,14 +597,16 @@ class TestImageLinkSplit:
             with patch.object(image_rewrite_mod, "get_viking_fs", return_value=fake):
                 stats = await rewrite_image_uris(root, lock_handle=None)
 
-        assert stats["references_rewritten"] == 4, stats
+        assert stats["references_rewritten"] == 6, stats
         page = _decode(fake.files[f"{root}/index/index.md"])
         assert f'![plain]({root}/index/system.png "System architecture")' in page, page
         assert f"![paren]({root}/index/diagram (draft).png 'Draft diagram')" in page, page
         assert f'![query]({root}/index/query.png "Query title")' in page, page
         assert f"![fragment]({root}/index/fragment.png 'Fragment title')" in page, page
+        assert f'![quoted-paren]({root}/index/right.png "right)paren")' in page, page
+        assert f'![quoted-path]({root}/index/photo "draft".png "Caption")' in page, page
 
-    async def test_titled_image_examples_in_code_are_not_mapped(self, tmp_path: Path):
+    async def test_code_examples_are_not_mapped_but_backticks_in_a_path_are(self, tmp_path: Path):
         kb = tmp_path / "kb"
         (kb / "assets").mkdir(parents=True)
         _write_valid_png(kb / "assets" / "secret.png")
@@ -618,13 +624,96 @@ class TestImageLinkSplit:
 
         assert any(uri.endswith("/secret.png") for uri in fake.files), fake.files
         assert any(uri.endswith("/se`cret`.png") for uri in fake.files), fake.files
-        assert not any(uri.endswith(".image_mappings.json") for uri in fake.files), fake.files
+        mappings = [
+            _decode(content)
+            for uri, content in fake.files.items()
+            if uri.endswith(".image_mappings.json")
+        ]
+        assert mappings and "./assets/se`cret`.png" in mappings[0], fake.files
+        assert "./assets/secret.png" not in mappings[0], fake.files
         pages = [_decode(content) for uri, content in fake.files.items() if uri.endswith(".md")]
         assert pages == [
             '`![inline](./assets/secret.png "Inline example")`\n\n'
             "```markdown\n![fenced](./assets/secret.png 'Fenced example')\n```\n\n"
             '![crossing](./assets/se`cret`.png "Crossing example")'
         ]
+
+    async def test_escaped_image_marker_is_not_ingested(self, tmp_path: Path):
+        kb = tmp_path / "kb"
+        (kb / "assets").mkdir(parents=True)
+        _write_valid_png(kb / "assets" / "literal.png")
+        _write_valid_png(kb / "assets" / "real.png")
+        (kb / "index.md").write_text(
+            r"\![literal](./assets/literal.png)"
+            "\n"
+            r"\\![real](./assets/real.png)",
+            encoding="utf-8",
+        )
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            await DirectoryParser().parse(str(kb))
+
+        mappings = [
+            _decode(content)
+            for uri, content in fake.files.items()
+            if uri.endswith(".image_mappings.json")
+        ]
+        assert mappings and "./assets/real.png" in mappings[0], fake.files
+        assert "./assets/literal.png" not in mappings[0], fake.files
+
+    async def test_same_image_with_distinct_suffixes_keeps_each_mapping(self, tmp_path: Path):
+        from openviking.parse.image_rewrite import rewrite_image_uris
+
+        kb = tmp_path / "kb"
+        (kb / "assets").mkdir(parents=True)
+        _write_valid_png(kb / "assets" / "shared.png")
+        (kb / "index.md").write_text(
+            "![one](./assets/shared.png?v=1)\n![two](./assets/shared.png?v=2#preview)",
+            encoding="utf-8",
+        )
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            result = await DirectoryParser().parse(str(kb))
+
+            temp = result.temp_dir_path
+            entries = await fake.ls(temp)
+            doc_dirs = [entry for entry in entries if entry["isDir"]]
+            root = f"viking://resources/{doc_dirs[0]['name']}"
+            src_prefix = doc_dirs[0]["uri"].rstrip("/") + "/"
+            for uri in list(fake.files):
+                if uri.startswith(src_prefix):
+                    fake.files[f"{root}/{uri[len(src_prefix) :]}"] = fake.files[uri]
+
+            import openviking.parse.image_rewrite as image_rewrite_mod
+
+            with patch.object(image_rewrite_mod, "get_viking_fs", return_value=fake):
+                stats = await rewrite_image_uris(root, lock_handle=None)
+
+        assert stats["references_rewritten"] == 2, stats
+        page = _decode(fake.files[f"{root}/index/index.md"])
+        assert page.count(f"({root}/index/shared.png)") == 2, page
+
+    async def test_protected_malformed_image_does_not_consume_later_image(self, tmp_path: Path):
+        kb = tmp_path / "kb"
+        (kb / "assets").mkdir(parents=True)
+        _write_valid_png(kb / "assets" / "image.png")
+        (kb / "index.md").write_text(
+            "`![code](ignored(` ![ok](./assets/image.png))) `",
+            encoding="utf-8",
+        )
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            await DirectoryParser().parse(str(kb))
+
+        mappings = [
+            _decode(content)
+            for uri, content in fake.files.items()
+            if uri.endswith(".image_mappings.json")
+        ]
+        assert mappings and "./assets/image.png" in mappings[0], fake.files
 
     async def test_invalid_image_depth_adjusted(self, tmp_path: Path):
         # In base_dir but not a decodable image -> ingest skips it -> depth-adjust.
@@ -702,12 +791,423 @@ class TestRewriteImageUris:
 
         assert parser._sanitize_for_path(r"abc\\def[ghi]") == "abcdefghi"
 
-    def test_malformed_quoted_target_is_left_unchanged(self):
+    def test_malformed_image_scanner_makes_monotonic_progress(self):
         from openviking.parse.image_rewrite import _rewrite_content
 
-        content = "![x](" * 20_000
+        malformed_documents = [
+            "![x](" * 20_000,
+            "![x](\n" * 20_000,
+            "![unterminated\n" * 20_000,
+            "![x](unterminated " * 20_000,
+            "![unterminated " * 20_000,
+            "![bad](broken 'unterminated ![ok](foo')" * 20_000,
+        ]
+        for content in malformed_documents:
+            assert _rewrite_content(content, "viking://resources/doc", set(), {}) == (
+                content,
+                0,
+            )
 
-        assert _rewrite_content(content, "viking://resources/doc", set(), {}) == (content, 0)
+    def test_scanner_and_rewrite_growth_are_linear(self):
+        from time import perf_counter
+
+        from openviking.parse.image_rewrite import (
+            _iter_markdown_images,
+            _rewrite_content,
+        )
+
+        def measure_scanner(repetitions: int) -> float:
+            content = "![outer ![inner](x)](y) " * repetitions
+            started = perf_counter()
+            assert sum(1 for _ in _iter_markdown_images(content)) == repetitions
+            return perf_counter() - started
+
+        small = min(measure_scanner(5_000) for _ in range(2))
+        large = min(measure_scanner(20_000) for _ in range(2))
+        assert large < small * 6 + 0.05
+
+        def measure_rewrite(repetitions: int) -> float:
+            content = "`![code](ignored(` ![ok](image.png)\n" * repetitions
+            started = perf_counter()
+            _rewritten, count = _rewrite_content(
+                content,
+                "viking://resources/doc",
+                {"image.png"},
+                {"image.png": "image.png"},
+            )
+            assert count == repetitions
+            return perf_counter() - started
+
+        small = min(measure_rewrite(1_000) for _ in range(2))
+        large = min(measure_rewrite(4_000) for _ in range(2))
+        assert large < small * 6 + 0.05
+
+    def test_deeply_nested_candidates_do_not_copy_overlapping_payloads(self):
+        from openviking.parse.image_rewrite import (
+            _iter_markdown_images,
+            _rewrite_content,
+        )
+
+        depth = 20_000
+        content = "![x](" * depth + "image.png" + ")" * depth
+        matches = list(_iter_markdown_images(content))
+        assert len(matches) == 1
+        match = matches[0]
+        payload = content[match.payload_start : match.payload_end]
+        assert payload.startswith("![x](")
+        assert payload.endswith(")")
+
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        ) == (content, 0)
+
+    def test_nested_alt_mapping_misses_have_linear_growth(self):
+        from time import perf_counter
+
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        def measure(depth: int) -> float:
+            content = "![a " * depth + "leaf" + "](missing.png)" * depth
+            started = perf_counter()
+            assert _rewrite_content(content, "viking://resources/doc", set(), {}) == (
+                content,
+                0,
+            )
+            return perf_counter() - started
+
+        small = min(measure(1_000) for _ in range(2))
+        large = min(measure(4_000) for _ in range(2))
+        assert large < small * 6 + 0.05
+
+    def test_nested_alt_uses_outer_syntax_regardless_of_mappings(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![outer ![inner](inner.png)](outer.png)"
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"inner.png"},
+            {"inner.png": "inner.png"},
+        ) == (content, 0)
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"inner.png", "outer.png"},
+            {
+                "inner.png": "inner.png",
+                "outer.png": "outer.png",
+            },
+        ) == (
+            "![outer ![inner](inner.png)](viking://resources/doc/outer.png)",
+            1,
+        )
+
+    def test_nested_image_text_in_destination_keeps_outer_syntax(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![outer](assets/foo![bar](baz).png)"
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"baz.png"},
+            {"baz": "baz.png"},
+        ) == (content, 0)
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"outer.png"},
+            {"assets/foo![bar](baz).png": "outer.png"},
+        ) == ("![outer](viking://resources/doc/outer.png)", 1)
+
+    def test_valid_image_after_malformed_image_is_still_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        malformed_prefixes = [
+            "![bad alt\n",
+            '![bad](broken "unterminated)\n',
+            "![bad](broken((\n",
+            "![bad alt ",
+            '![bad](broken "unterminated) ',
+            "![bad](broken(( ",
+            "![bad](broken 'unterminated ",
+        ]
+        for malformed_prefix in malformed_prefixes:
+            content = malformed_prefix + "  ![ok](image.png)"
+            rewritten, count = _rewrite_content(
+                content,
+                "viking://resources/doc",
+                {"image.png"},
+                {"image.png": "image.png"},
+            )
+
+            assert count == 1
+            assert rewritten == (malformed_prefix + "  ![ok](viking://resources/doc/image.png)")
+
+    def test_confirmed_multiline_title_does_not_expose_nested_candidate(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer](image.png "line\n![inner](other.png")'
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png", 'other.png"'},
+            {
+                "image.png": "image.png",
+                'other.png"': 'other.png"',
+            },
+        ) == ('![outer](viking://resources/doc/image.png "line\n![inner](other.png")', 1)
+
+    def test_confirmed_title_precedence_does_not_depend_on_outer_mapping(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![bad](broken 'unterminated) ![ok](foo')"
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"foo'": "image.png"},
+        ) == (content, 0)
+
+    def test_malformed_title_cannot_borrow_across_blank_line_or_fence(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        documents = [
+            "![bad](broken 'unterminated\n\n![ok](foo')",
+            '![bad](broken "unterminated\n```markdown\n")\n```\n![ok](image.png)',
+        ]
+        mappings = [
+            ({"image.png"}, {"foo'": "image.png"}),
+            ({"image.png"}, {"image.png": "image.png"}),
+        ]
+        expected = [
+            "![bad](broken 'unterminated\n\n![ok](viking://resources/doc/image.png)",
+            '![bad](broken "unterminated\n```markdown\n")\n```\n'
+            "![ok](viking://resources/doc/image.png)",
+        ]
+        for content, (available, path_mappings), rewritten in zip(
+            documents, mappings, expected, strict=True
+        ):
+            assert _rewrite_content(
+                content,
+                "viking://resources/doc",
+                available,
+                path_mappings,
+            ) == (rewritten, 1)
+
+    def test_valid_multiline_title_after_malformed_image_is_rewritten_normally(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        malformed_prefix = "![bad alt\n"
+        content = malformed_prefix + '![outer](image.png "line one\n![literal] line two")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == (
+            malformed_prefix
+            + '![outer](viking://resources/doc/image.png "line one\n![literal] line two")'
+        )
+
+    def test_complete_image_text_inside_a_valid_title_stays_title_text(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer](image.png "see ![icon](other.png)")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png", "other.png"},
+            {
+                "image.png": "image.png",
+                "other.png": "other.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == ('![outer](viking://resources/doc/image.png "see ![icon](other.png)")')
+
+    def test_image_text_inside_an_unresolved_valid_title_is_not_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer](missing.png "see ![icon](other.png)")'
+        assert _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"other.png"},
+            {"other.png": "other.png"},
+        ) == (content, 0)
+
+    def test_incomplete_image_text_inside_a_valid_title_stays_title_text(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer](image.png "see ![icon](other.png")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png", 'other.png"'},
+            {
+                "image.png": "image.png",
+                'other.png"': 'other.png"',
+            },
+        )
+
+        assert count == 1
+        assert rewritten == ('![outer](viking://resources/doc/image.png "see ![icon](other.png")')
+
+    def test_quoted_filename_chunk_before_terminal_title_is_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![x](photo "draft".png "Caption")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {'photo "draft".png'},
+            {'photo "draft".png': 'photo "draft".png'},
+        )
+
+        assert count == 1
+        assert rewritten == ('![x](viking://resources/doc/photo "draft".png "Caption")')
+
+    def test_html_image_text_inside_a_markdown_title_is_not_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![outer](image.png 'see <img src=\"other.png\">')"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png", "other.png"},
+            {
+                "image.png": "image.png",
+                "other.png": "other.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == (
+            "![outer](viking://resources/doc/image.png 'see <img src=\"other.png\">')"
+        )
+
+    def test_html_image_text_inside_a_parenthesized_title_is_not_rewritten(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer](image.png (see <img src="other.png">))'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png", "other.png"},
+            {
+                "image.png": "image.png",
+                "other.png": "other.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == (
+            '![outer](viking://resources/doc/image.png (see <img src="other.png">))'
+        )
+
+    def test_html_image_text_inside_markdown_alt_is_not_rewritten_separately(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![outer <img src="inner.png">](outer.png)'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"outer.png", "inner.png"},
+            {
+                "outer.png": "outer.png",
+                "inner.png": "inner.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == ('![outer <img src="inner.png">](viking://resources/doc/outer.png)')
+
+    def test_html_tag_owns_markdown_shaped_text_inside_its_attributes(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '<img alt="![inner](inner.png)" src="outer.png">'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"outer.png", "inner.png"},
+            {
+                "outer.png": "outer.png",
+                "inner.png": "inner.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == (
+            '<img alt="![inner](inner.png)" src="viking://resources/doc/outer.png">'
+        )
+
+    def test_backticks_inside_an_image_do_not_make_the_opener_code(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = '![`alt`](image.png "use `code`")'
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == ('![`alt`](viking://resources/doc/image.png "use `code`")')
+
+    def test_code_span_brackets_inside_alt_text_are_opaque_to_pairing(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "![alt `[`](image.png)"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == "![alt `[`](viking://resources/doc/image.png)"
+
+    def test_protected_malformed_image_does_not_suppress_a_real_image(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = "`![code](ignored(` ![ok](image.png))) `"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"image.png"},
+            {"image.png": "image.png"},
+        )
+
+        assert count == 1
+        assert rewritten == ("`![code](ignored(` ![ok](viking://resources/doc/image.png))) `")
+
+    def test_escaped_image_marker_requires_an_even_backslash_run(self):
+        from openviking.parse.image_rewrite import _rewrite_content
+
+        content = r"\![literal](literal.png) \\![real](image.png)"
+        rewritten, count = _rewrite_content(
+            content,
+            "viking://resources/doc",
+            {"literal.png", "image.png"},
+            {
+                "literal.png": "literal.png",
+                "image.png": "image.png",
+            },
+        )
+
+        assert count == 1
+        assert rewritten == (
+            r"\![literal](literal.png) \\![real](viking://resources/doc/image.png)"
+        )
 
     def test_escaped_parenthesis_and_apostrophe_destinations_are_rewritten(self):
         from openviking.parse.image_rewrite import _rewrite_content
@@ -785,6 +1285,7 @@ class TestRewriteImageUris:
 
     def test_protected_span_overlap_is_detected(self):
         from openviking.parse.image_rewrite import (
+            _iter_unprotected_html_images,
             _protected_ranges,
             _rewrite_content,
             _span_intersects_protected_ranges,
@@ -796,6 +1297,9 @@ class TestRewriteImageUris:
         assert not _span_intersects_protected_ranges(5, 10, protected)
         assert not _span_intersects_protected_ranges(20, 30, protected)
 
+        html = '<img alt="example" src="image.png">'
+        assert not list(_iter_unprotected_html_images(html, [(5, 15)]))
+
         content = '![ok](image.png)\n![example](image.png "`code`")'
         ranges = _protected_ranges(content)
         assert all(left[1] < right[0] for left, right in zip(ranges, ranges[1:], strict=False))
@@ -805,9 +1309,10 @@ class TestRewriteImageUris:
             {"image.png"},
             {"image.png": "image.png"},
         )
-        assert count == 1
+        assert count == 2
         assert rewritten == (
-            '![ok](viking://resources/doc/image.png)\n![example](image.png "`code`")'
+            "![ok](viking://resources/doc/image.png)\n"
+            '![example](viking://resources/doc/image.png "`code`")'
         )
 
     async def test_nested_mapping_consumed(self):


### PR DESCRIPTION
## Summary

- parse optional Markdown image titles separately from local destinations
- preserve those titles when rewriting destinations to `viking://` URIs
- keep literal parenthesized filenames, remote images, HTML images, and code examples compatible

## Context

#3462 fixed local image paths containing parentheses, but valid optional-title syntax such as `![diagram](assets/system.png "Architecture")` still reaches path resolution as one synthetic filename. The image is then skipped during ingest and is absent from the stored resource even though parsing otherwise succeeds.

This change uses the same destination/title split across direct Markdown ingest and already-materialized parser artifacts. Sidecar mappings remain the provenance boundary for rewrites, and query/fragment suffixes remain URI syntax rather than filesystem filename characters.

For the ambiguous `photo.png (copy)` form, an existing exact local filename wins; otherwise the terminal parenthesized suffix is treated as a title. Image matches overlapping fenced or inline code are left untouched.

## Validation

- added end-to-end regressions for quoted titles, parenthesized destinations, query/fragment suffixes, literal parenthesized filenames, and code protection
- `ruff format --check` on all three changed files
- `ruff check` on both source files
- `ruff check --ignore I001 tests/parse/test_markdown_link_rewrite.py` (the file has one pre-existing import-order finding)
- Python 3.12 `py_compile` on all three changed files
- direct behavior probes for mapping provenance, confinement/symlink escape, code spans, and 200k-character inputs

The focused pytest module was not run locally because this API-only sparse workspace does not contain the project's dependency environment; the added tests are intended to run in repository CI.
