### PR TITLE
fix(sdk): preserve zero deadline timeouts

### DIFF
--- a/sdk/python/openviking_sdk/errors.py
+++ b/sdk/python/openviking_sdk/errors.py
@@ -97,7 +97,7 @@ class InternalError(OpenVikingError):
 class DeadlineExceededError(OpenVikingError):
     def __init__(self, operation: str = "operation", timeout: Optional[float] = None):
         message = f"{operation.capitalize()} timed out"
-        if timeout:
+        if timeout is not None:
             message += f" after {timeout}s"
         super().__init__(
             message,

--- a/sdk/python/tests/test_error_mapping.py
+++ b/sdk/python/tests/test_error_mapping.py
@@ -3,6 +3,7 @@ from openviking_sdk import AsyncHTTPClient
 from openviking_sdk.errors import (
     AbortedError,
     ConflictError,
+    DeadlineExceededError,
     OpenVikingError,
     ResourceExhaustedError,
     UnimplementedError,
@@ -41,3 +42,10 @@ def test_client_preserves_unknown_error_code():
 
     assert exc_info.value.code == "PROVIDER_SPECIFIC"
     assert exc_info.value.details == {"x": 1}
+
+
+def test_deadline_exceeded_includes_zero_timeout():
+    error = DeadlineExceededError("wait", 0)
+
+    assert str(error) == "Wait timed out after 0s"
+    assert error.details == {"operation": "wait", "timeout": 0}


### PR DESCRIPTION
## Summary
- Treat timeout=0 as an explicit value in DeadlineExceededError messages
- Keep message text aligned with structured error details

## Tests
- PYTHONPATH=sdk/python:. python -m pytest sdk/python/tests/test_error_mapping.py -q