### PR TITLE
fix(openclaw): search predecessor archives after reset

### DIFF
--- a/examples/openclaw-plugin/docs/workmemory-v2-design.md
+++ b/examples/openclaw-plugin/docs/workmemory-v2-design.md
@@ -313,7 +313,10 @@ OpenViking 在插件侧暴露两个独立的 archive 回查工具。
   - 默认遍历所有 archive（新到旧）
   - 默认永远不返回完整 archive 原文
   - case-insensitive；正则元字符自动转义为字面量匹配
-- **工具 description 文本**：`"Keyword-grep across all archived original conversation messages of the current session. Use this whenever the [Session History Summary] does not contain the specific detail the user is asking about. Extract 2-3 concrete entity words from the question (names, places, objects, dates) and search each separately. Only conclude information is unavailable after trying at least 2 different keyword variations."`
+  - 当前 session 无 archive 或无命中时，可回退到同一 `sessionKey` 的最近两个
+    `daily` / `idle` / `reset` 前序 session；只保留 48 小时内的进程内 lineage，
+    不接受跨 key 或用户指定的全局 scope
+- **工具 description 文本**：`"Keyword-grep across archived original conversation messages of the current session and recent reset predecessors. Use this whenever the [Session History Summary] does not contain the specific detail the user is asking about. Extract 2-3 concrete entity words from the question (names, places, objects, dates) and search each separately. Only conclude information is unavailable after trying at least 2 different keyword variations."`
 
 ---
 

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -22,6 +22,7 @@ import { registerOpenVikingArchiveTools } from "./plugin/openviking-archive-tool
 import { createOpenVikingImportRuntime } from "./plugin/openviking-import-runtime.js";
 import { registerOpenVikingImportTools } from "./plugin/openviking-import-tools.js";
 import { registerOpenVikingLifecycleHooks } from "./plugin/openviking-lifecycle-hooks.js";
+import { OpenVikingSessionLineageStore } from "./plugin/openviking-session-lineage.js";
 import { registerOpenVikingMemoryRecallTools } from "./plugin/openviking-memory-recall-tools.js";
 import { registerOpenVikingMemoryTools } from "./plugin/openviking-memory-tools.js";
 import { registerOpenVikingQueryTools } from "./plugin/openviking-query-tools.js";
@@ -205,6 +206,7 @@ const contextEnginePlugin = {
       cfg,
       logger: api.logger,
     });
+    const sessionLineageStore = new OpenVikingSessionLineageStore();
 
     const {
       rememberSessionAgentId,
@@ -354,6 +356,8 @@ const contextEnginePlugin = {
       traceRecallMaxResultsPerSearch: cfg.traceRecallMaxResultsPerSearch,
       traceRecallPreviewChars: cfg.traceRecallPreviewChars,
       createTraceId,
+      getPredecessorSessionIds: (sessionKey, currentSessionId) =>
+        sessionLineageStore.getPredecessorSessionIds(sessionKey, currentSessionId),
       logger: api.logger,
     });
 
@@ -374,6 +378,7 @@ const contextEnginePlugin = {
       isBypassedSession,
       verboseRoutingInfo,
       getContextEngine,
+      recordSessionTransition: (event) => sessionLineageStore.record(event),
       logger: api.logger,
     });
 

--- a/examples/openclaw-plugin/plugin/openviking-archive-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-archive-tools.ts
@@ -55,6 +55,10 @@ export type OpenVikingArchiveToolsDeps = {
   traceRecallMaxResultsPerSearch: number;
   traceRecallPreviewChars: number;
   createTraceId: (source: string) => string;
+  getPredecessorSessionIds: (
+    sessionKey: string,
+    currentSessionId: string,
+  ) => Promise<string[]>;
   logger?: {
     info?: (message: string) => void;
     warn?: (message: string) => void;
@@ -76,7 +80,8 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
       name: "ov_archive_search",
       label: "Archive Search (OpenViking)",
       description:
-        "Keyword-grep across all archived original conversation messages of the current session. " +
+        "Keyword-grep across archived original conversation messages of the current session " +
+        "and recent reset predecessors. " +
         "Use this whenever the [Session History Summary] does not contain the specific detail " +
         "the user is asking about. Extract 2-3 concrete entity words from the question " +
         "(names, places, objects, dates) and search each separately. " +
@@ -124,10 +129,46 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
           const client = await deps.getClient();
           const agentId = deps.resolveAgentId(ctx.sessionId, ctx.sessionKey);
           const started = Date.now();
-          const result = await client.grepSessionArchives(ovSessionId, escapedQuery, {
-            archiveId,
-            caseInsensitive: true,
-          });
+          const searchedSessionIds = [ovSessionId];
+          let matchedSessionId = ovSessionId;
+          let result: Awaited<ReturnType<OpenVikingArchiveClient["grepSessionArchives"]>>;
+          try {
+            result = await client.grepSessionArchives(ovSessionId, escapedQuery, {
+              archiveId,
+              caseInsensitive: true,
+            });
+          } catch (err) {
+            if (!(err instanceof Error) || !err.message.includes("[NOT_FOUND]")) throw err;
+            result = { count: 0, matches: [] };
+          }
+
+          if ((!result.matches || result.matches.length === 0) && sessionKey) {
+            const predecessorSessionIds = await deps.getPredecessorSessionIds(
+              sessionKey,
+              sessionId || ovSessionId,
+            );
+            for (const predecessorSessionId of predecessorSessionIds) {
+              const predecessorOvSessionId = deps.toOvSessionId(
+                predecessorSessionId,
+                sessionKey,
+              );
+              searchedSessionIds.push(predecessorOvSessionId);
+              try {
+                const predecessorResult = await client.grepSessionArchives(
+                  predecessorOvSessionId,
+                  escapedQuery,
+                  { archiveId, caseInsensitive: true },
+                );
+                if (predecessorResult.matches?.length) {
+                  result = predecessorResult;
+                  matchedSessionId = predecessorOvSessionId;
+                  break;
+                }
+              } catch (err) {
+                if (!(err instanceof Error) || !err.message.includes("[NOT_FOUND]")) throw err;
+              }
+            }
+          }
           const traceResults: RecallTraceResult[] = (result.matches ?? []).slice(0, deps.traceRecallMaxResultsPerSearch).map((match) => ({
             uri: match.uri,
             resourceType: "archive",
@@ -142,7 +183,7 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
               ts: Date.now(),
               sessionId: ctx.sessionId,
               sessionKey: ctx.sessionKey,
-              ovSessionId,
+              ovSessionId: matchedSessionId,
               agentId,
               source: "ov_archive_search",
               operationType: "archive_grep",
@@ -150,7 +191,7 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
               trigger: { query, derivedKeywords: [query] },
               searches: [{
                 resourceType: "archive",
-                targetUriResolved: archiveId ? `viking://session/${ovSessionId}/history/${archiveId}` : `viking://session/${ovSessionId}/history`,
+                targetUriResolved: archiveId ? `viking://session/${matchedSessionId}/history/${archiveId}` : `viking://session/${matchedSessionId}/history`,
                 limit: deps.traceRecallMaxResultsPerSearch,
                 durationMs: Date.now() - started,
                 total: result.matches?.length ?? result.count ?? 0,
@@ -182,7 +223,7 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
                   "the original conversation may use different wording than the question. " +
                   "Try synonyms, related terms, or shorter fragments.",
               }],
-              details: { query, matchCount: 0 },
+              details: { query, matchCount: 0, searchedSessionIds },
             };
           }
 
@@ -203,7 +244,13 @@ export function registerOpenVikingArchiveTools(deps: OpenVikingArchiveToolsDeps)
 
           return {
             content: [{ type: "text", text: header + "\n\n" + blocks.join("\n\n") }],
-            details: { query, matchCount: result.matches.length },
+            details: {
+              query,
+              matchCount: result.matches.length,
+              matchedSessionId,
+              predecessorFallback: matchedSessionId !== ovSessionId,
+              searchedSessionIds,
+            },
           };
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
+++ b/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
@@ -23,6 +23,14 @@ export type OpenVikingLifecycleHooksDeps = {
   isBypassedSession: (ctx?: OpenVikingHookContext) => boolean;
   verboseRoutingInfo: (message: string) => void;
   getContextEngine: () => ContextEngineCommitPort | null;
+  recordSessionTransition: (event: {
+    sessionId?: string;
+    sessionKey?: string;
+    nextSessionId?: string;
+    nextSessionKey?: string;
+    reason?: string;
+    transcriptArchived?: boolean;
+  }) => Promise<void>;
   logger: {
     info: (message: string) => void;
     warn: (message: string) => void;
@@ -33,8 +41,11 @@ export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksD
   deps.api.on("session_start", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
   });
-  deps.api.on("session_end", async (_event: unknown, ctx?: OpenVikingHookContext) => {
+  deps.api.on("session_end", async (event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
+    if (event && typeof event === "object") {
+      await deps.recordSessionTransition(event);
+    }
   });
   deps.api.on("before_reset", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     if (deps.isBypassedSession(ctx)) {

--- a/examples/openclaw-plugin/plugin/openviking-session-lineage.ts
+++ b/examples/openclaw-plugin/plugin/openviking-session-lineage.ts
@@ -1,0 +1,86 @@
+const DEFAULT_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+const DEFAULT_MAX_PREDECESSORS = 2;
+const SEARCHABLE_RESET_REASONS = new Set(["daily", "idle", "reset"]);
+
+export type OpenVikingSessionTransition = {
+  sessionId?: string;
+  sessionKey?: string;
+  nextSessionId?: string;
+  nextSessionKey?: string;
+  reason?: string;
+  transcriptArchived?: boolean;
+};
+
+type StoredTransition = {
+  previousSessionId: string;
+  nextSessionId: string;
+  resetAt: number;
+};
+
+export class OpenVikingSessionLineageStore {
+  private readonly transitionsBySessionKey = new Map<string, StoredTransition[]>();
+
+  constructor(
+    private readonly options: {
+      maxAgeMs?: number;
+      maxPredecessors?: number;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  async record(event: OpenVikingSessionTransition): Promise<void> {
+    const sessionKey = event.sessionKey?.trim();
+    const nextSessionKey = event.nextSessionKey?.trim() || sessionKey;
+    const previousSessionId = event.sessionId?.trim();
+    const nextSessionId = event.nextSessionId?.trim();
+    if (
+      !sessionKey ||
+      nextSessionKey !== sessionKey ||
+      !previousSessionId ||
+      !nextSessionId ||
+      previousSessionId === nextSessionId ||
+      event.transcriptArchived !== true ||
+      !SEARCHABLE_RESET_REASONS.has(event.reason ?? "")
+    ) {
+      return;
+    }
+
+    const resetAt = this.now();
+    const transitions = this.prune(this.transitionsBySessionKey.get(sessionKey) ?? [], resetAt)
+      .filter((transition) => transition.nextSessionId !== nextSessionId);
+    transitions.unshift({ previousSessionId, nextSessionId, resetAt });
+    this.transitionsBySessionKey.set(sessionKey, transitions.slice(0, this.maxPredecessors()));
+  }
+
+  async getPredecessorSessionIds(
+    sessionKey: string,
+    currentSessionId: string,
+  ): Promise<string[]> {
+    const now = this.now();
+    const transitions = this.prune(this.transitionsBySessionKey.get(sessionKey) ?? [], now);
+    this.transitionsBySessionKey.set(sessionKey, transitions);
+
+    const predecessors: string[] = [];
+    let nextSessionId = currentSessionId;
+    while (predecessors.length < this.maxPredecessors()) {
+      const transition = transitions.find((candidate) => candidate.nextSessionId === nextSessionId);
+      if (!transition || predecessors.includes(transition.previousSessionId)) break;
+      predecessors.push(transition.previousSessionId);
+      nextSessionId = transition.previousSessionId;
+    }
+    return predecessors;
+  }
+
+  private prune(transitions: StoredTransition[], now: number): StoredTransition[] {
+    const cutoff = now - (this.options.maxAgeMs ?? DEFAULT_MAX_AGE_MS);
+    return transitions.filter((transition) => transition.resetAt >= cutoff);
+  }
+
+  private maxPredecessors(): number {
+    return this.options.maxPredecessors ?? DEFAULT_MAX_PREDECESSORS;
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}

--- a/examples/openclaw-plugin/tests/ut/openviking-session-lineage.test.ts
+++ b/examples/openclaw-plugin/tests/ut/openviking-session-lineage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenVikingSessionLineageStore } from "../../plugin/openviking-session-lineage.js";
+
+describe("OpenVikingSessionLineageStore", () => {
+  it("returns at most two recent predecessors from the same session key", async () => {
+    let now = 1_000;
+    const store = new OpenVikingSessionLineageStore({ now: () => now });
+
+    for (const [previousSessionId, nextSessionId] of [
+      ["session-1", "session-2"],
+      ["session-2", "session-3"],
+      ["session-3", "session-4"],
+    ]) {
+      await store.record({
+        sessionId: previousSessionId,
+        sessionKey: "agent:main:dashboard:one",
+        nextSessionId,
+        nextSessionKey: "agent:main:dashboard:one",
+        reason: "daily",
+        transcriptArchived: true,
+      });
+      now += 1;
+    }
+
+    await expect(store.getPredecessorSessionIds(
+      "agent:main:dashboard:one",
+      "session-4",
+    )).resolves.toEqual(["session-3", "session-2"]);
+    await expect(store.getPredecessorSessionIds(
+      "agent:main:dashboard:other",
+      "session-4",
+    )).resolves.toEqual([]);
+  });
+
+  it("ignores expired, unarchived, cross-key, and explicit-new transitions", async () => {
+    let now = 1_000;
+    const store = new OpenVikingSessionLineageStore({
+      maxAgeMs: 100,
+      now: () => now,
+    });
+
+    await store.record({
+      sessionId: "expired",
+      sessionKey: "session-key",
+      nextSessionId: "current",
+      reason: "daily",
+      transcriptArchived: true,
+    });
+    now = 1_101;
+    await expect(store.getPredecessorSessionIds("session-key", "current")).resolves.toEqual([]);
+
+    for (const transition of [
+      { nextSessionKey: "other-key", reason: "daily", transcriptArchived: true },
+      { nextSessionKey: "session-key", reason: "daily", transcriptArchived: false },
+      { nextSessionKey: "session-key", reason: "new", transcriptArchived: true },
+    ]) {
+      await store.record({
+        sessionId: "previous",
+        sessionKey: "session-key",
+        nextSessionId: "current",
+        ...transition,
+      });
+    }
+    await expect(store.getPredecessorSessionIds("session-key", "current")).resolves.toEqual([]);
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -434,6 +434,7 @@ describe("plugin module seams", () => {
     const rememberSessionAgentId = vi.fn();
     const verboseRoutingInfo = vi.fn();
     const commitOVSession = vi.fn().mockResolvedValue(true);
+    const recordSessionTransition = vi.fn().mockResolvedValue(undefined);
     const logger = { info: vi.fn(), warn: vi.fn() };
 
     registerOpenVikingLifecycleHooks({
@@ -442,6 +443,7 @@ describe("plugin module seams", () => {
       isBypassedSession: (ctx) => ctx?.sessionKey === "bypass",
       verboseRoutingInfo,
       getContextEngine: () => ({ commitOVSession }),
+      recordSessionTransition,
       logger,
     });
 
@@ -453,9 +455,28 @@ describe("plugin module seams", () => {
     ]);
 
     await handlers.get("session_start")?.({}, { sessionId: "session-1", agentId: "agent-main" });
-    await handlers.get("session_end")?.({}, { sessionId: "session-2", agentId: "agent-main" });
+    await handlers.get("session_end")?.({
+      sessionId: "session-2",
+      sessionKey: "session-key",
+      nextSessionId: "session-3",
+      nextSessionKey: "session-key",
+      reason: "daily",
+      transcriptArchived: true,
+    }, { sessionId: "session-2", sessionKey: "session-key", agentId: "agent-main" });
     expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-1", agentId: "agent-main" });
-    expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-2", agentId: "agent-main" });
+    expect(rememberSessionAgentId).toHaveBeenCalledWith({
+      sessionId: "session-2",
+      sessionKey: "session-key",
+      agentId: "agent-main",
+    });
+    expect(recordSessionTransition).toHaveBeenCalledWith({
+      sessionId: "session-2",
+      sessionKey: "session-key",
+      nextSessionId: "session-3",
+      nextSessionKey: "session-key",
+      reason: "daily",
+      transcriptArchived: true,
+    });
 
     await handlers.get("before_reset")?.({}, { sessionId: "session-3", sessionKey: "key-3" });
     expect(commitOVSession).toHaveBeenCalledWith({ sessionId: "session-3", sessionKey: "key-3" });
@@ -613,6 +634,7 @@ describe("plugin module seams", () => {
       traceRecallPreviewChars: 20,
       createTraceId: () => "trace-archive-search",
       logger: { info: vi.fn(), warn: vi.fn() },
+      getPredecessorSessionIds: vi.fn().mockResolvedValue([]),
     };
 
     registerOpenVikingArchiveTools(deps);
@@ -632,6 +654,7 @@ describe("plugin module seams", () => {
     expect(searchResult.content[0].text).toContain("Found 1 match(es)");
     expect(searchResult.content[0].text).toContain("important command output");
     expect(searchResult.details).toMatchObject({ query: "command", matchCount: 1 });
+    expect(deps.getPredecessorSessionIds).not.toHaveBeenCalled();
     expect(recordAndFlush).toHaveBeenCalledWith(expect.objectContaining({
       traceId: "trace-archive-search",
       source: "ov_archive_search",
@@ -652,6 +675,112 @@ describe("plugin module seams", () => {
       sessionId: "session-1",
       ovSessionId: "ov-session-1",
     });
+  });
+
+  it("searches a recent predecessor archive after the current session has no archive", async () => {
+    const registerTool = vi.fn();
+    const grepSessionArchives = vi.fn()
+      .mockRejectedValueOnce(new Error("OpenViking request failed [NOT_FOUND]: File not found"))
+      .mockResolvedValueOnce({
+        count: 1,
+        matches: [{
+          uri: "viking://session/session-before-reset/history/archive_002#L8",
+          line: 8,
+          content: "the original story",
+        }],
+      });
+    const getPredecessorSessionIds = vi.fn().mockResolvedValue(["session-before-reset"]);
+
+    registerOpenVikingArchiveTools({
+      registerTool,
+      getClient: async () => ({
+        grepSessionArchives,
+        getSessionArchive: vi.fn(),
+      }),
+      rememberSessionAgentId: vi.fn(),
+      toOvSessionId: (sessionId) => sessionId ?? "",
+      resolveAgentId: () => "agent-main",
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-after-reset",
+        ovSessionId: "session-after-reset",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: vi.fn(),
+      formatMessage: vi.fn(),
+      traceRecallMaxResultsPerSearch: 10,
+      traceRecallPreviewChars: 20,
+      createTraceId: () => "trace-predecessor-search",
+      getPredecessorSessionIds,
+    });
+
+    const searchFactory = registerTool.mock.calls[0]?.[0];
+    const searchTool = searchFactory({
+      sessionId: "session-after-reset",
+      sessionKey: "agent:main:dashboard:one",
+    });
+    const result = await searchTool.execute("call-1", { query: "story" });
+
+    expect(getPredecessorSessionIds).toHaveBeenCalledWith(
+      "agent:main:dashboard:one",
+      "session-after-reset",
+    );
+    expect(grepSessionArchives.mock.calls.map(([sessionId]) => sessionId)).toEqual([
+      "session-after-reset",
+      "session-before-reset",
+    ]);
+    expect(result.content[0].text).toContain("the original story");
+    expect(result.details).toMatchObject({
+      matchedSessionId: "session-before-reset",
+      predecessorFallback: true,
+    });
+  });
+
+  it("searches a recent predecessor after the current archive has no match", async () => {
+    const registerTool = vi.fn();
+    const grepSessionArchives = vi.fn()
+      .mockResolvedValueOnce({ count: 0, matches: [] })
+      .mockResolvedValueOnce({
+        count: 1,
+        matches: [{
+          uri: "viking://session/session-before-reset/history/archive_002#L8",
+          line: 8,
+          content: "the original story",
+        }],
+      });
+
+    registerOpenVikingArchiveTools({
+      registerTool,
+      getClient: async () => ({
+        grepSessionArchives,
+        getSessionArchive: vi.fn(),
+      }),
+      rememberSessionAgentId: vi.fn(),
+      toOvSessionId: (sessionId) => sessionId ?? "",
+      resolveAgentId: () => "agent-main",
+      resolvePluginSessionRouting: () => ({
+        agentId: "agent-main",
+        sessionId: "session-after-reset",
+        ovSessionId: "session-after-reset",
+      }),
+      isBypassedSession: () => false,
+      makeBypassedToolResult: vi.fn(),
+      formatMessage: vi.fn(),
+      traceRecallMaxResultsPerSearch: 10,
+      traceRecallPreviewChars: 20,
+      createTraceId: () => "trace-predecessor-search",
+      getPredecessorSessionIds: vi.fn().mockResolvedValue(["session-before-reset"]),
+    });
+
+    const searchFactory = registerTool.mock.calls[0]?.[0];
+    const searchTool = searchFactory({
+      sessionId: "session-after-reset",
+      sessionKey: "agent:main:dashboard:one",
+    });
+    const result = await searchTool.execute("call-1", { query: "story" });
+
+    expect(grepSessionArchives).toHaveBeenCalledTimes(2);
+    expect(result.content[0].text).toContain("the original story");
   });
 
   it("registers import tools through a dedicated plugin module", async () => {


### PR DESCRIPTION
> TL;DR: `ov_archive_search` now falls back to recent same-key predecessor sessions after a reset, capped at two transitions and 48 hours.

## Why

A real daily-reset reproduction showed that the archived transcript still existed, but the new session UUID made current-only archive search miss it. This is a narrower fix than #2750: no `scope=all`, no arbitrary session IDs, and no cross-key search.

OpenClaw reset context: openclaw/openclaw#35481 and openclaw/openclaw#35493.

## Safety

Fallback runs only after the current session has no archive or no match. It follows trusted `session_end` lineage for the same `sessionKey`, accepts only archived `daily` / `idle` / `reset` transitions, and ignores `/new`.

## Verification

Typecheck, build, and 24 focused tests pass. The full plugin suite reports 735 passing tests; its four unrelated architecture-boundary failures reproduce unchanged on `upstream/main`.