### PR TITLE
fix(session): attribute Phase-2 extraction token usage to committing account

### DIFF
--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -7,10 +7,15 @@ import concurrent.futures
 import json
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from openviking.observability.context import (
+    bind_root_observability_context,
+    reset_root_observability_context,
+)
 from openviking.server.identity import RequestContext, Role
 from openviking.service.task_tracker import get_task_tracker
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+from openviking.telemetry.span_models import create_root_span_attributes
 from openviking_cli.session.user_id import UserIdentifier
 
 if TYPE_CHECKING:
@@ -27,34 +32,49 @@ class SessionCommitProcessor(DequeueHandlerBase):
         self._service_loop = service_loop
 
     async def _process(self, msg: SessionCommitMsg, ctx: RequestContext) -> None:
-        session = self._session_service.session(
-            ctx,
-            msg.session_id,
-            session_uri=msg.session_uri,
+        # Bind a root observability context so Phase-2 extraction VLM/embedding
+        # token events are attributed to the committing account/user rather than
+        # "__unknown__" (mirrors SemanticProcessor.on_dequeue). Must bind inside
+        # this coroutine: on_dequeue hops loops via run_coroutine_threadsafe, so
+        # a context bound there would not propagate here.
+        root_attrs = create_root_span_attributes(
+            http_method="QUEUE",
+            http_route="/queuefs/session_commit",
+            request_id=msg.task_id,
+            url_path=msg.session_uri,
         )
-        if not await session.exists():
-            error = f"Session '{msg.session_id}' no longer exists"
-            tracker = get_task_tracker()
-            await tracker.create(
-                "session_commit",
-                resource_id=msg.session_id,
-                account_id=ctx.account_id,
-                user_id=ctx.user.user_id,
-                task_id=msg.task_id,
+        root_attrs.account_id = ctx.account_id
+        root_attrs.user_id = ctx.user.user_id
+        root_context_token = bind_root_observability_context(root_attrs)
+        try:
+            session = self._session_service.session(
+                ctx,
+                msg.session_id,
+                session_uri=msg.session_uri,
             )
-            await tracker.fail(
-                msg.task_id,
-                error,
-                account_id=ctx.account_id,
-                user_id=ctx.user.user_id,
-            )
-            return
-        await session.load()
-        await session.resume_queued_commit(msg)
+            if not await session.exists():
+                error = f"Session '{msg.session_id}' no longer exists"
+                tracker = get_task_tracker()
+                await tracker.create(
+                    "session_commit",
+                    resource_id=msg.session_id,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                    task_id=msg.task_id,
+                )
+                await tracker.fail(
+                    msg.task_id,
+                    error,
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+                return
+            await session.load()
+            await session.resume_queued_commit(msg)
+        finally:
+            reset_root_observability_context(root_context_token)
 
-    async def on_dequeue(
-        self, data: Optional[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         if not data:
             return None
 

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SessionCommitProcessor observability identity binding.
+
+Phase-2 memory extraction runs in this queue worker; its VLM/embedding token
+events read identity from the root observability context. These tests assert the
+worker binds the committing account/user (so tokens are not attributed to
+"__unknown__") and resets the context afterwards.
+"""
+
+import asyncio
+
+from openviking.observability.context import get_root_observability_context
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+from openviking.storage.queuefs.session_commit_processor import SessionCommitProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeSession:
+    def __init__(self, captured: dict) -> None:
+        self._captured = captured
+
+    async def exists(self) -> bool:
+        return True
+
+    async def load(self) -> None:
+        return None
+
+    async def resume_queued_commit(self, msg) -> None:
+        root = get_root_observability_context()
+        self._captured["account_id"] = root.account_id if root else None
+        self._captured["user_id"] = root.user_id if root else None
+
+
+class _FakeSessionService:
+    def __init__(self, captured: dict) -> None:
+        self._captured = captured
+
+    def session(self, ctx, session_id, session_uri=None):
+        return _FakeSession(self._captured)
+
+
+def _make_msg() -> SessionCommitMsg:
+    return SessionCommitMsg(
+        task_id="task-1",
+        session_id="sess-1",
+        session_uri="viking://sessions/sess-1",
+        archive_uri="viking://sessions/sess-1/history/archive_001",
+        user={"account_id": "acme", "user_id": "alice"},
+    )
+
+
+async def test_process_binds_committing_identity_to_root_context():
+    captured: dict = {}
+    processor = SessionCommitProcessor(
+        _FakeSessionService(captured),
+        asyncio.get_running_loop(),
+    )
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+    await processor._process(_make_msg(), ctx)
+
+    assert captured["account_id"] == "acme"
+    assert captured["user_id"] == "alice"
+
+
+async def test_process_resets_root_context_after_completion():
+    processor = SessionCommitProcessor(
+        _FakeSessionService({}),
+        asyncio.get_running_loop(),
+    )
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+    await processor._process(_make_msg(), ctx)
+
+    assert get_root_observability_context() is None


### PR DESCRIPTION
## Description

The Studio "Today's Tokens" card shows **0 VLM tokens** even while memory extraction is actively producing memories, while Embedding tokens still show a real number. VLM token usage from session-commit Phase-2 extraction is being attributed to `account_id="__unknown__"` and is therefore invisible to the account-filtered usage dashboard.

### Root cause

Data flow of the dashboard card:

1. `GET /api/v1/console/dashboard/summary` (`server/routers/console.py`) -> `UsageAuditQueryService.dashboard_summary` -> `sqlite_store.get_today_tokens(...)`, which sums the `usage_token_hourly` table **filtered by `account_id`** (and `user_id` for USER-role viewers).
2. Rows in `usage_token_hourly` are projected from `vlm.call` / `embedding.call` events. Each event's `account_id`/`user_id` is taken from the **ambient observability root context at emit time** — `openviking/models/vlm/base.py::update_token_usage` reads `get_root_observability_context()` and passes `root_context.account_id` (or `None`) to `VLMEventDataSource.record_call`.
3. If no root context is bound, `account_id` is `None` -> normalized to `"__unknown__"` in the projection, which never matches the viewer's real `account_id` (`"default"`), so those tokens are dropped from the card.

Session-commit Phase-2 extraction (the VLM-heavy step) runs in the detached `SESSION_COMMIT` queue worker `SessionCommitProcessor` (`openviking/storage/queuefs/session_commit_processor.py`). This worker **never bound a root observability context**, so every VLM/embedding call it triggers (via `resume_queued_commit` -> `_run_memory_extraction` -> compressor v2/v3 -> streaming memory updater) emitted under `__unknown__`.

### Why embeddings show but VLM does not

The embedding **indexing** worker `SemanticProcessor.on_dequeue` (`openviking/storage/queuefs/semantic_processor.py`) already binds a root context with `root_attrs.account_id = msg.account_id` before doing work. So freshly-indexed content's embedding tokens land under the correct account. Only the session-commit worker was missing the equivalent binding — hence the asymmetry (Embedding non-zero, VLM zero).

### How it was introduced (chain)

- **#900** (async commit) moved Phase-2 extraction into the detached `SESSION_COMMIT` queue worker. From this point the extraction VLM calls run outside any request/observability scope — structurally introducing the gap.
- **#1666** (unify observability context) added the identity binding to `SemanticProcessor` (embedding path) but not to the session-commit worker, creating the Embedding-vs-VLM asymmetry.
- **#2016** (Usage/Audit Dashboard BFF) shipped the account-filtered `usage_token_hourly` dashboard, which made the `__unknown__` bucket effectively invisible.
- **#3039** (stdio MCP proxy + `/recall`) switched plugin auto-recall from `/search` to `/recall`. `/search` used to make an in-request VLM intent-analysis call that WAS correctly attributed; removing it made the dashboard VLM count drop to a visible 0, surfacing the long-latent gap.
- **#3494** fixed identity attribution for MCP **requests** (middleware), but did not reach the detached Phase-2 background worker, which is what this PR fixes.

### Fix

Bind a QUEUE root observability context with the committing account/user at the start of `SessionCommitProcessor._process` and reset it in `finally`, mirroring `SemanticProcessor.on_dequeue`. The binding must live inside `_process` (not `on_dequeue`) because `on_dequeue` hops event loops via `run_coroutine_threadsafe`, so a context bound there would not propagate. The extraction call chain inherits the contextvar, so a single bind covers all Phase-2 VLM/embedding calls.

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

<!-- none -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Bind a root observability context (`account_id`/`user_id` from the committing `ctx`) around `SessionCommitProcessor._process`, so Phase-2 extraction VLM/embedding token events are attributed to the committing account instead of `__unknown__`.
- Reset the context in `finally` so it does not leak to subsequent queue items.
- Add `tests/storage/test_session_commit_processor_identity.py` asserting the worker binds the committing identity onto the root context and resets it afterwards.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

New tests + the reference `test_semantic_processor_identity.py` pass. `ruff format --check` and `ruff check` clean on the changed files.

End-to-end (dashboard) verification requires a deployed server: after a session commit triggers extraction, `usage_token_hourly` should contain `source='vlm'` rows under the real `account_id` (not `__unknown__`), and the Studio "Today's Tokens" VLM count should be non-zero.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Scope is intentionally limited to the session-commit worker; the synchronous `/extract` endpoint already runs inside an HTTP request whose middleware binds identity, so it needs no change.
