### PR TITLE
fix(web-studio): preserve identity probe credential

### DIFF
--- a/web-studio/src/lib/ov-client/client.test.ts
+++ b/web-studio/src/lib/ov-client/client.test.ts
@@ -96,4 +96,22 @@ describe('createOvClient API key selection', () => {
     expect(readRequestHeader(requests[0], 'X-API-Key')).toBe('admin-key')
     expect(readRequestHeader(requests[1], 'X-API-Key')).toBe('admin-key')
   })
+
+  it('preserves an explicit API key used to probe a candidate identity', async () => {
+    const { client, requests } = createRecordingClient()
+    client.setConnection({
+      adminApiKey: 'root-key',
+      apiKey: 'current-user-key',
+    })
+
+    await client.instance.get('/health', {
+      headers: {
+        'X-API-Key': 'candidate-user-key',
+      },
+    })
+
+    expect(readRequestHeader(requests[0], 'X-API-Key')).toBe(
+      'candidate-user-key',
+    )
+  })
 })

--- a/web-studio/src/lib/ov-client/client.ts
+++ b/web-studio/src/lib/ov-client/client.ts
@@ -184,10 +184,12 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
       headers.set(key, value)
     }
 
-    const apiKey = shouldUseAdminApiKey(config)
-      ? connection.adminApiKey || connection.apiKey
-      : connection.apiKey || connection.adminApiKey
-    setOptionalHeader(headers, 'X-API-Key', apiKey)
+    if (!readHeader(headers, 'X-API-Key')?.trim()) {
+      const apiKey = shouldUseAdminApiKey(config)
+        ? connection.adminApiKey || connection.apiKey
+        : connection.apiKey || connection.adminApiKey
+      setOptionalHeader(headers, 'X-API-Key', apiKey)
+    }
     if (connection.identityHeaders) {
       setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
       setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)


### PR DESCRIPTION
## Description

Fix Studio identity and account switching when probing a target user's API key. The shared Axios request interceptor previously replaced an explicitly supplied candidate `X-API-Key` with the currently active connection key, causing valid target credentials to fail identity validation and triggering an unnecessary manual API key prompt.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve a non-empty request-level `X-API-Key` in the shared OpenViking Axios interceptor.
- Keep the existing admin/data credential selection when a request does not provide an API key.
- Add a regression test for candidate identity probing.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `npm test -- --run src/lib/ov-client/client.test.ts src/hooks/use-app-connection.test.ts src/components/account-switcher.test.ts` (28 tests passed)
- `npm run lint`
- `npm run build`
- Verified in Chrome against the local Vite Studio that user identity switching succeeds and account switching no longer opens the manual User API Key dialog for valid managed credentials.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Documentation changes are not required for this internal request credential precedence fix.

## Screenshots (if applicable)

N/A

## Additional Notes

The configured Root API Key was valid and continued to authorize account/user management APIs. The manual prompt was a secondary symptom of the candidate User API Key being overwritten during the `/health` identity probe.
