### PR TITLE
fix(session): tolerate missing/corrupt archive in Phase-2 replay (follow-up to #3417)

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -3409,7 +3409,29 @@ class Session:
         combined: List[Message] = []
         completed_memory_steps: Dict[str, set[str]] = {}
         for state in replay_states:
-            combined.extend(await self._read_archive_messages(state.archive_uri))
+            # A terminally-failed earlier archive can have a missing or corrupt
+            # messages.jsonl (legacy "no messages" data, or #3417's own
+            # archive_read terminal path). Tolerate that exactly like
+            # _get_uncovered_archive_messages does, otherwise every subsequent
+            # commit's Phase 2 re-raises here and stays permanently poisoned.
+            # Real storage failures still propagate.
+            try:
+                replayed = await self._read_archive_messages(state.archive_uri)
+            except _ArchiveMessagesCorruptError:
+                logger.warning(
+                    "Skipping failed archive %s in Phase-2 replay: messages.jsonl is corrupt",
+                    state.archive_uri,
+                )
+                continue
+            except Exception as exc:
+                if not _is_storage_not_found(exc):
+                    raise
+                logger.warning(
+                    "Skipping failed archive %s in Phase-2 replay: messages.jsonl is missing",
+                    state.archive_uri,
+                )
+                continue
+            combined.extend(replayed)
             marker = state.failed
             self._merge_completed_memory_steps(
                 completed_memory_steps,

--- a/tests/unit/session/test_session_phase2_replay_tolerance.py
+++ b/tests/unit/session/test_session_phase2_replay_tolerance.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for Phase-2 archive replay tolerance (follow-up to #3417).
+
+#3417 made ``Session._read_archive_messages`` strict: it now raises on a
+missing/corrupt ``messages.jsonl`` instead of returning ``[]``. The read path
+(``_get_uncovered_archive_messages``) gained not-found tolerance, but the
+Phase-2 commit replay path (``_prepare_phase2_archive_messages``) did not.
+
+A terminally-failed earlier archive whose ``messages.jsonl`` is missing would
+therefore make every subsequent commit's Phase-2 replay raise, terminal-fail
+the current archive, and permanently poison the session's memory extraction.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.session.session import ArchiveState, Session
+
+
+class _MemoryVikingFS:
+    def __init__(self, files):
+        self.files = files
+
+    def _uri_to_path(self, uri, ctx=None):
+        return "/local/session-1"
+
+    async def read_file(self, uri, ctx=None):
+        if uri not in self.files:
+            raise FileNotFoundError(uri)
+        value = self.files[uri]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    async def write_file(self, uri, content, ctx=None):
+        self.files[uri] = content
+
+
+def _session(files, states, monkeypatch):
+    session_uri = "viking://user/sessions/session-1"
+    session = Session(
+        viking_fs=_MemoryVikingFS(files),
+        session_id="session-1",
+        session_uri=session_uri,
+    )
+    monkeypatch.setattr(session, "_scan_archive_states", AsyncMock(return_value=states))
+    return session, session_uri
+
+
+def _failed_then_pending(session_uri):
+    """archive_001 = terminally failed (missing messages), archive_002 = current pending."""
+    a1 = f"{session_uri}/history/archive_001"
+    a2 = f"{session_uri}/history/archive_002"
+    states = [
+        ArchiveState(
+            archive_id="archive_001",
+            archive_uri=a1,
+            index=1,
+            state="failed",
+            failed={"stage": "archive_read", "error": "no messages"},
+        ),
+        ArchiveState(
+            archive_id="archive_002",
+            archive_uri=a2,
+            index=2,
+            state="pending",
+        ),
+    ]
+    return a1, a2, states
+
+
+@pytest.mark.asyncio
+async def test_phase2_replay_skips_failed_archive_with_missing_messages(monkeypatch):
+    session_uri = "viking://user/sessions/session-1"
+    a1, a2, states = _failed_then_pending(session_uri)
+    # archive_001/messages.jsonl is absent -> not-found; archive_002 has no
+    # replay reads of its own (current messages are passed in directly).
+    session, _ = _session({}, states, monkeypatch)
+
+    from openviking.message import Message, TextPart
+
+    current = [Message(id="cur", role="user", parts=[TextPart("hi")])]
+
+    combined, _start, _end, covered_failed, _steps = (
+        await session._prepare_phase2_archive_messages(a2, current)
+    )
+
+    # The poisoned archive is skipped; the current commit still gets its own
+    # messages and can complete Phase 2 instead of being terminal-failed.
+    assert [m.id for m in combined] == ["cur"]
+    # The skipped archive is still reported as covered_failed so the current
+    # archive's .done marks it covered — clearing the poison permanently
+    # instead of re-reading (and skipping) it on every future commit.
+    assert covered_failed == ["archive_001"]
+
+    # Asymmetry check: the read path already tolerates the exact same scenario.
+    uncovered = await session._get_uncovered_archive_messages(states)
+    assert uncovered == []
+
+
+@pytest.mark.asyncio
+async def test_phase2_replay_reraises_real_storage_failure(monkeypatch):
+    session_uri = "viking://user/sessions/session-1"
+    a1, a2, states = _failed_then_pending(session_uri)
+    # A real storage failure (not a not-found) reading archive_001 must still
+    # propagate so it is not silently swallowed.
+    boom = RuntimeError("storage backend unavailable")
+    session, _ = _session({f"{a1}/messages.jsonl": boom}, states, monkeypatch)
+
+    from openviking.message import Message, TextPart
+
+    current = [Message(id="cur", role="user", parts=[TextPart("hi")])]
+
+    with pytest.raises(RuntimeError, match="storage backend unavailable"):
+        await session._prepare_phase2_archive_messages(a2, current)


### PR DESCRIPTION
## Root cause

#3417 ("stop conflating storage failures with not-found") made
`Session._read_archive_messages` **strict**: it now raises
`NotFoundError` / `_ArchiveMessagesCorruptError` on a missing or corrupt
archive `messages.jsonl` instead of returning `[]`.

#3417 added skip-on-missing tolerance to the callers it touched:
- `_get_uncovered_archive_messages` (the read/context-assembly path)
- `resume_queued_commit` (the Phase-2 entrypoint)

But it left one caller unguarded: **`_prepare_phase2_archive_messages`**, the
Phase-2 commit *replay* path that rolls earlier **failed** archives into the
current commit's memory extraction:

```python
for state in replay_states:
    combined.extend(await self._read_archive_messages(state.archive_uri))  # unguarded
```

## Impact (permanent poisoning)

An earlier archive can reach a terminal **failed** state with a missing or
corrupt `messages.jsonl` — either legacy "no messages" terminal data, or
produced by #3417's own `archive_read` terminal path in
`resume_queued_commit` (which now tolerantly writes a `.failed.json` for such
an archive).

On the *next* commit, `_run_memory_extraction` calls
`_prepare_phase2_archive_messages`, which finds that failed archive in
`replay_states` and reads it unguarded → raises → caught by
`_run_memory_extraction`'s bare `except Exception` → the **current** archive
is terminal-failed too.

Because a failed archive is only dropped from `replay_states` once it is
**covered**, and coverage only comes from a *completed* later archive — but
every later Phase 2 now crashes at this same replay read before it can write
`.done` — the session's memory extraction is **permanently poisoned**. Raw
conversation messages are safe; extraction is stuck.

## The asymmetry (the bug)

The *exact same* terminally-failed archive is handled gracefully on the read
path:

```python
# _get_uncovered_archive_messages
try:
    messages.extend(await self._read_archive_messages(state.archive_uri))
except Exception as exc:
    if not _is_storage_not_found(exc):
        raise
    logger.warning("Skipping pending archive %s because messages.jsonl is missing", ...)
```

…but poisons the write/extraction path. That asymmetry is the regression.

## Reproduction

Against current `main` (which contains #3417),
`_prepare_phase2_archive_messages(archive_002, [current])` with `archive_001`
in terminal `failed` state and a missing `messages.jsonl` raises
`FileNotFoundError` at the replay read. The same states passed to
`_get_uncovered_archive_messages` return `[]` without raising. See the added
regression test.

## Fix

Wrap the replay-loop `_read_archive_messages` call in the same tolerance the
sibling callers already use: **skip + warn** on not-found
(`_is_storage_not_found`) and on `_ArchiveMessagesCorruptError`, **re-raise**
real storage failures. The skipped archive stays in `covered_failed`, so the
current archive's `.done` marks it covered — clearing the poison permanently
rather than re-reading and skipping it on every future commit.

Minimal, consistent with `_get_uncovered_archive_messages` /
`resume_queued_commit`.

## Verification

- `py_compile openviking/session/session.py`: OK
- New regression test fails without the fix (raises `FileNotFoundError`),
  passes with it.
- `tests/unit/session/` (170 tests) + `test_session_commit_resume.py` pass.
  (Pre-existing, unrelated `client`-fixture config errors in
  `tests/session/test_session_retention_integration.py` are present with and
  without this change.)

Follow-up to #3417. Does not touch #3417.
