### PR TITLE
docs: list all AST extraction languages

### DIFF
--- a/docs/en/concepts/06-extraction.md
+++ b/docs/en/concepts/06-extraction.md
@@ -161,10 +161,13 @@ The following languages have dedicated extractors built on tree-sitter:
 |----------|--------|
 | Python | Supported |
 | JavaScript / TypeScript | Supported |
-| Rust | Supported |
-| Go | Supported |
 | Java | Supported |
 | C / C++ | Supported |
+| Rust | Supported |
+| Go | Supported |
+| C# | Supported |
+| PHP | Supported |
+| Lua | Supported |
 
 Other languages automatically fall back to LLM.
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -794,7 +794,9 @@ Set `code_summary_mode` to one of:
 | `"llm"` | Always use LLM for summarization (higher cost) | |
 | `"ast_llm"` | Extract AST skeleton (with full docstrings) first, then pass it as context to LLM (highest quality, moderate cost) | |
 
-AST extraction supports: Python, JavaScript/TypeScript, Rust, Go, Java, C/C++. Other languages, extraction failures, or empty skeletons automatically fall back to LLM.
+AST extraction supports: Python, JavaScript/TypeScript, Java, C/C++, Rust, Go, C#, PHP,
+and Lua. Other languages, extraction failures, or empty skeletons automatically fall back
+to LLM.
 
 See [Code Skeleton Extraction](../concepts/06-extraction.md#code-skeleton-extraction-ast-mode) for details.
 

--- a/docs/zh/concepts/06-extraction.md
+++ b/docs/zh/concepts/06-extraction.md
@@ -160,10 +160,13 @@ SemanticMsg(
 |------|------|
 | Python | 完整支持 |
 | JavaScript / TypeScript | 完整支持 |
-| Rust | 完整支持 |
-| Go | 完整支持 |
 | Java | 完整支持 |
 | C / C++ | 完整支持 |
+| Rust | 完整支持 |
+| Go | 完整支持 |
+| C# | 完整支持 |
+| PHP | 完整支持 |
+| Lua | 完整支持 |
 
 其他语言不在支持列表内，自动 fallback 到 LLM。
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -763,7 +763,8 @@ ollama pull guoxuter/ov_intent_analysis_sft:v7_q8
 | `"llm"` | 全部走 LLM 生成摘要（成本较高） | |
 | `"ast_llm"` | 先提取 AST 骨架（含完整注释），再将骨架作为上下文辅助 LLM 生成摘要（质量最高，成本居中） | |
 
-AST 提取支持：Python、JavaScript/TypeScript、Rust、Go、Java、C/C++。其他语言、提取失败或骨架为空时自动 fallback 到 LLM。
+AST 提取支持：Python、JavaScript/TypeScript、Java、C/C++、Rust、Go、C#、PHP 和 Lua。
+其他语言、提取失败或骨架为空时自动 fallback 到 LLM。
 
 详见 [代码骨架提取](../concepts/06-extraction.md#代码骨架提取ast-模式)。
 


### PR DESCRIPTION
## Summary

- Document C#, PHP, and Lua as supported Code Skeleton Extraction (AST Mode) languages.
- Keep the English and Chinese concept and configuration guides consistent.

## Test Coverage

Documentation-only change; no executable code paths changed.

## Pre-Landing Review

No issues found.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

No relevant plan file detected.

## Test plan

- [x] Runtime smoke tests extracted imports, classes, and method/function signatures for C#, PHP, and Lua.
- [x] Unsupported `.rb` negative control returned `None`.
- [x] `.venv/bin/pytest -q tests/parse/test_ast_extractor.py` — 112 passed, 4 warnings.
- [x] Documentation consistency checks confirmed all four pages list C#, PHP, and Lua and contain no stale six-language statement.
- [x] `git diff --check` passed.
