### PR TITLE
fix(task): reap zombie background tasks and hold strong task refs (#3396)

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -275,6 +275,17 @@ def create_app(
         task_tracker = get_task_tracker()
         task_tracker.start_cleanup_loop()
 
+        # Reconcile zombie tasks: PENDING/RUNNING records persisted by a
+        # previous process whose in-memory asyncio drivers are gone (issue
+        # #3396). Done before traffic so stuck reindex tasks stop blocking
+        # same-URI retries without hand-editing task JSON.
+        try:
+            reaped = await task_tracker.reap_stale_active()
+            if reaped:
+                logger.warning("Reaped %d stale background task(s) at startup", reaped)
+        except Exception:
+            logger.exception("Startup task reconciliation failed; continuing")
+
         # Initialize tracing and OTLP log export from server.observability.
         from openviking.telemetry import tracer_module
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -240,7 +240,7 @@ async def migrate_legacy_data(
         account_id=SYSTEM_TASK_ACCOUNT_ID,
         user_id=SYSTEM_TASK_USER_ID,
     )
-    asyncio.create_task(
+    migration_task = asyncio.create_task(
         _run_legacy_migration_task(
             task.task_id,
             migration,
@@ -249,6 +249,7 @@ async def migrate_legacy_data(
             user_id=SYSTEM_TASK_USER_ID,
         )
     )
+    tracker.register_live_task(task.task_id, migration_task)
     return Response(status="ok", result={"task_id": task.task_id})
 
 

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -51,6 +51,10 @@ from openviking_cli.utils.config import get_openviking_config
 logger = get_logger(__name__)
 
 REINDEX_TASK_TYPE = "admin_reindex"
+# Bounded wait for queue drain at the end of a reindex run. Without this the
+# request-wait tracker polls forever when an embedding/semantic root never
+# completes, leaving the tracked task stuck in RUNNING (issue #3396).
+REINDEX_QUEUE_WAIT_TIMEOUT_S = 3600.0
 PRUNE_ORPHAN_CANDIDATE_LIMIT = 100000
 PRUNE_OUTPUT_FIELDS = ["id", "uri", "level", "context_type", "account_id", "owner_user_id"]
 
@@ -192,7 +196,7 @@ class ReindexExecutor:
                 details={"uri": uri},
             )
 
-        asyncio.create_task(
+        background = asyncio.create_task(
             self._run_tracked(
                 task.task_id,
                 uri=uri,
@@ -202,6 +206,7 @@ class ReindexExecutor:
                 ctx=ctx,
             )
         )
+        tracker.register_live_task(task.task_id, background)
         return {
             "task_id": task.task_id,
             "status": "accepted",
@@ -501,7 +506,10 @@ class ReindexExecutor:
                     )
 
                 if telemetry_id and mode != "prune_orphans":
-                    await wait_tracker.wait_for_request(telemetry_id)
+                    await wait_tracker.wait_for_request(
+                        telemetry_id,
+                        timeout=REINDEX_QUEUE_WAIT_TIMEOUT_S,
+                    )
                     self._apply_embedding_wait_status(
                         counters,
                         wait_tracker.build_queue_status(telemetry_id),

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -72,7 +72,46 @@ class PersistentTaskStore:
     async def list(self, account_id: str, *, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
         if not user_id:
             return []
-        directory = self._task_dir(account_id, user_id)
+        return await self._read_task_dir(self._task_dir(account_id, user_id))
+
+    async def list_all(self) -> List[Dict[str, Any]]:
+        """List every persisted task record across all accounts and owners.
+
+        Used by startup reconciliation (``TaskTracker.reap_stale_active``) so
+        zombie PENDING/RUNNING tasks left behind by a previous process are
+        found regardless of which account/user owns them.
+        """
+        tasks: List[Dict[str, Any]] = []
+        for account_id in await self._list_account_ids():
+            for directory in await self._task_dirs_for_account(account_id):
+                tasks.extend(await self._read_task_dir(directory))
+        return tasks
+
+    async def _list_account_ids(self) -> List[str]:
+        try:
+            items = await self._agfs.ls(self.ROOT_PREFIX)
+        except (AGFSNotFoundError, FileNotFoundError):
+            return []
+        return [
+            str(item.get("name") or "")
+            for item in items
+            if item.get("isDir", item.get("is_dir", False)) and item.get("name")
+        ]
+
+    async def _task_dirs_for_account(self, account_id: str) -> List[str]:
+        if account_id == SYSTEM_TASK_ACCOUNT_ID:
+            return [self._task_dir(SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID)]
+        try:
+            items = await self._agfs.ls(self._task_root_dir(account_id))
+        except (AGFSNotFoundError, FileNotFoundError):
+            return []
+        return [
+            self._task_dir(account_id, str(item.get("name") or ""))
+            for item in items
+            if item.get("isDir", item.get("is_dir", False)) and item.get("name")
+        ]
+
+    async def _read_task_dir(self, directory: str) -> List[Dict[str, Any]]:
         try:
             items = await self._agfs.ls(directory)
         except (AGFSNotFoundError, FileNotFoundError):

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -145,11 +145,17 @@ class TaskTracker:
     MAX_TASKS = 10_000
     TTL_COMPLETED = 86_400  # 24 hours
     TTL_FAILED = 604_800  # 7 days
+    # PENDING/RUNNING tasks whose updated_at heartbeat has not moved for this
+    # long are considered stale: their background asyncio coroutine either died
+    # with the previous process or silently wedged (issue #3396). They are
+    # failed by reap_stale_active() instead of blocking retries forever.
+    TTL_STALE_ACTIVE = 21_600  # 6 hours
     CLEANUP_INTERVAL = 300  # 5 minutes
 
     def __init__(self, store: TaskStore) -> None:
         self._store = store
         self._tasks: Dict[str, TaskRecord] = {}
+        self._live_tasks: Dict[str, asyncio.Task] = {}
         self._lock = threading.Lock()
         self._async_lock = asyncio.Lock()
         self._cleanup_task: Optional[asyncio.Task] = None
@@ -177,6 +183,79 @@ class TaskTracker:
         if self._cleanup_task is not None and not self._cleanup_task.done():
             self._cleanup_task.cancel()
             logger.debug("[TaskTracker] Cleanup loop stopped")
+
+    def register_live_task(self, task_id: str, task: asyncio.Task) -> None:
+        """Hold a strong reference to the asyncio task driving a tracked task.
+
+        ``asyncio.create_task`` only keeps a weak reference to the task, so a
+        fire-and-forget background coroutine without an external strong
+        reference can be garbage-collected mid-execution and silently aborted
+        (https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).
+        Callers that spawn ``asyncio.create_task`` for a tracked task must
+        register it here; the reference is dropped automatically on completion.
+        """
+        with self._lock:
+            self._live_tasks[task_id] = task
+        task.add_done_callback(lambda _done, tid=task_id: self._drop_live_task(tid))
+
+    def _drop_live_task(self, task_id: str) -> None:
+        with self._lock:
+            self._live_tasks.pop(task_id, None)
+
+    def has_live_task(self, task_id: str) -> bool:
+        """Return True when a live asyncio task is registered for ``task_id``."""
+        with self._lock:
+            return task_id in self._live_tasks
+
+    async def reap_stale_active(
+        self,
+        stale_after: Optional[float] = None,
+    ) -> int:
+        """Fail PENDING/RUNNING tasks that have no live driver and a stale heartbeat.
+
+        Background executors (reindex, legacy migration, ...) run as in-process
+        asyncio coroutines. After a restart their persisted records still read
+        ``running`` but no live asyncio task exists, so they would stay RUNNING
+        forever, block ``create_if_no_running`` for the same resource, and
+        require hand-editing task JSON to recover (issue #3396). This sweep
+        marks such zombie tasks FAILED so operators and retries can move on.
+
+        Tasks with a registered live asyncio task are never touched, and only
+        tasks whose ``updated_at`` heartbeat is older than ``stale_after``
+        (default ``TTL_STALE_ACTIVE``) are reaped, so a freshly restored but
+        not-yet-resumed task is not failed spuriously.
+
+        Returns the number of reaped tasks.
+        """
+        threshold = stale_after if stale_after is not None else self.TTL_STALE_ACTIVE
+        now = time.time()
+        async with self._async_lock:
+            await self._hydrate_from_store()
+            with self._lock:
+                candidates = [
+                    task
+                    for task in self._tasks.values()
+                    if task.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
+                    and task.task_id not in self._live_tasks
+                    and (now - task.updated_at) > threshold
+                ]
+            reaped = 0
+            for task in candidates:
+                task.status = TaskStatus.FAILED
+                task.stage = "interrupted"
+                task.error = _sanitize_error(
+                    "Task interrupted: no live worker and heartbeat stale for "
+                    f"{int(now - task.updated_at)}s (likely process restart); "
+                    "marked failed by startup reconciliation"
+                )
+                task.updated_at = now
+                await self._store.update(task)
+                with self._lock:
+                    self._tasks[task.task_id] = task
+                reaped += 1
+        if reaped:
+            logger.warning("[TaskTracker] Reaped %d stale active task(s) as failed", reaped)
+        return reaped
 
     async def _cleanup_loop(self) -> None:
         while True:
@@ -484,6 +563,21 @@ class TaskTracker:
                 and t.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
                 for t in tasks
             )
+
+    async def _hydrate_from_store(self) -> None:
+        """Load persisted tasks across all owners into the local cache.
+
+        Best-effort: stores that cannot enumerate every owner (no
+        ``list_all``) simply leave the cache as-is, in which case reaping
+        covers only tasks already loaded into this process.
+        """
+        list_all = getattr(self._store, "list_all", None)
+        if not callable(list_all):
+            return
+        records = [self._record_from_payload(payload) for payload in await list_all()]
+        with self._lock:
+            for record in records:
+                self._tasks[record.task_id] = record
 
     async def _load_for_update(
         self,

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -3,6 +3,7 @@
 
 """Unit tests for TaskTracker."""
 
+import asyncio
 import json
 import time
 
@@ -109,6 +110,17 @@ class _FakeAgfsExistingDir(_FakeAgfs):
             raise AGFSAlreadyExistsError(f"already exists: {path}")
         self.dirs.add(normalized)
         return {"message": "created", "mode": mode}
+
+
+class _FakeAgfsCamelCase(_FakeAgfs):
+    """Emulates the production AsyncAGFSClient/VikingFS shape: ls entries
+    carry ``isDir`` (camelCase) rather than ``is_dir``."""
+
+    def ls(self, path: str = "/"):
+        entries = super().ls(path)
+        for entry in entries:
+            entry["isDir"] = entry.pop("is_dir")
+        return entries
 
 
 # ── Basic CRUD ──
@@ -561,3 +573,215 @@ async def test_session_service_get_commit_task_also_filters_account():
     )
 
     assert other_account_result is None
+
+
+# ── Live task references (issue #3396) ──
+
+
+async def test_register_live_task_holds_reference_until_done(tracker: TaskTracker):
+    record = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+
+    background = asyncio.create_task(asyncio.sleep(3600))
+    tracker.register_live_task(record.task_id, background)
+    assert tracker.has_live_task(record.task_id) is True
+
+    background.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await background
+    await asyncio.sleep(0)  # let the done callback run
+
+    assert tracker.has_live_task(record.task_id) is False
+
+
+async def test_register_live_task_discards_reference_after_completion(tracker: TaskTracker):
+    record = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+
+    background = asyncio.create_task(asyncio.sleep(0))
+    tracker.register_live_task(record.task_id, background)
+    await background
+
+    assert tracker.has_live_task(record.task_id) is False
+
+
+# ── Startup zombie reaping (issue #3396) ──
+
+
+async def _age_heartbeat(tracker: TaskTracker, task_id: str, stale_seconds: float) -> None:
+    """Backdate a task's updated_at heartbeat in cache AND persistent store."""
+    task = tracker._tasks[task_id]
+    task.updated_at = time.time() - stale_seconds
+    await tracker._store.update(task)
+
+
+async def test_reap_stale_active_fails_zombie_running_task(tracker: TaskTracker):
+    record = await tracker.create(
+        "admin_reindex",
+        resource_id="viking://user/alice/memories",
+        **_owner_kwargs(),
+    )
+    await tracker.start(record.task_id, **_owner_kwargs())
+    await _age_heartbeat(tracker, record.task_id, tracker.TTL_STALE_ACTIVE + 1)
+
+    reaped = await tracker.reap_stale_active()
+
+    assert reaped == 1
+    loaded = await tracker.get(record.task_id)
+    assert loaded is not None
+    assert loaded.status == TaskStatus.FAILED
+    assert loaded.stage == "interrupted"
+    assert "interrupted" in (loaded.error or "")
+
+
+async def test_reap_stale_active_keeps_task_with_live_driver(tracker: TaskTracker):
+    record = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+    await tracker.start(record.task_id, **_owner_kwargs())
+    await _age_heartbeat(tracker, record.task_id, tracker.TTL_STALE_ACTIVE + 1)
+
+    background = asyncio.create_task(asyncio.sleep(3600))
+    tracker.register_live_task(record.task_id, background)
+    try:
+        reaped = await tracker.reap_stale_active()
+    finally:
+        background.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await background
+
+    assert reaped == 0
+    loaded = await tracker.get(record.task_id)
+    assert loaded is not None
+    assert loaded.status == TaskStatus.RUNNING
+
+
+async def test_reap_stale_active_keeps_recently_active_task(tracker: TaskTracker):
+    record = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+    await tracker.start(record.task_id, **_owner_kwargs())
+
+    reaped = await tracker.reap_stale_active()
+
+    assert reaped == 0
+    loaded = await tracker.get(record.task_id)
+    assert loaded is not None
+    assert loaded.status == TaskStatus.RUNNING
+
+
+async def test_reap_stale_active_ignores_terminal_tasks(tracker: TaskTracker):
+    completed = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+    await tracker.complete(completed.task_id, {}, **_owner_kwargs())
+    failed = await tracker.create("admin_reindex", resource_id="r2", **_owner_kwargs())
+    await tracker.fail(failed.task_id, "boom", **_owner_kwargs())
+    await _age_heartbeat(tracker, completed.task_id, tracker.TTL_STALE_ACTIVE + 1)
+    await _age_heartbeat(tracker, failed.task_id, tracker.TTL_STALE_ACTIVE + 1)
+
+    reaped = await tracker.reap_stale_active()
+
+    assert reaped == 0
+    assert (await tracker.get(completed.task_id)).status == TaskStatus.COMPLETED
+    assert (await tracker.get(failed.task_id)).status == TaskStatus.FAILED
+
+
+async def test_reap_stale_active_unblocks_same_resource_retry(tracker: TaskTracker):
+    zombie = await tracker.create_if_no_running(
+        "admin_reindex",
+        "viking://user/alice/memories",
+        **_owner_kwargs(),
+    )
+    assert zombie is not None
+    await tracker.start(zombie.task_id, **_owner_kwargs())
+    await _age_heartbeat(tracker, zombie.task_id, tracker.TTL_STALE_ACTIVE + 1)
+
+    await tracker.reap_stale_active()
+
+    retried = await tracker.create_if_no_running(
+        "admin_reindex",
+        "viking://user/alice/memories",
+        **_owner_kwargs(),
+    )
+    assert retried is not None
+    assert retried.task_id != zombie.task_id
+
+
+async def test_reap_stale_active_persists_failure_to_store():
+    agfs = _FakeAgfs()
+    tracker = TaskTracker(store=PersistentTaskStore(agfs))
+    record = await tracker.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+    await tracker.start(record.task_id, **_owner_kwargs())
+    await _age_heartbeat(tracker, record.task_id, tracker.TTL_STALE_ACTIVE + 1)
+
+    await tracker.reap_stale_active()
+
+    raw = agfs.files[f"/local/acme/_system/tasks/alice/{record.task_id}.json"]
+    payload = json.loads(raw.decode("utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["stage"] == "interrupted"
+
+
+async def test_reap_stale_active_finds_zombie_from_fresh_tracker():
+    """Simulate a restart: a fresh tracker (empty cache) must reap the
+    persisted zombie via store enumeration, not just cached tasks."""
+    agfs = _FakeAgfs()
+    tracker1 = TaskTracker(store=PersistentTaskStore(agfs))
+    record = await tracker1.create("admin_reindex", resource_id="r1", **_owner_kwargs())
+    await tracker1.start(record.task_id, **_owner_kwargs())
+
+    tracker2 = TaskTracker(store=PersistentTaskStore(agfs))
+    reaped = await tracker2.reap_stale_active(stale_after=0)
+
+    assert reaped == 1
+    loaded = await tracker2.get(record.task_id, **_owner_kwargs())
+    assert loaded is not None
+    assert loaded.status == TaskStatus.FAILED
+    assert loaded.stage == "interrupted"
+
+
+async def test_reap_stale_active_covers_other_accounts_and_system_owner():
+    agfs = _FakeAgfs()
+    tracker = TaskTracker(store=PersistentTaskStore(agfs))
+    other = await tracker.create(
+        "admin_reindex",
+        resource_id="r-other",
+        account_id="other-acct",
+        user_id="bob",
+    )
+    await tracker.start(other.task_id, account_id="other-acct", user_id="bob")
+    system = await tracker.create(
+        "legacy_migration",
+        resource_id="legacy-data",
+        account_id="_system",
+        user_id="root",
+    )
+    await tracker.start(system.task_id, account_id="_system", user_id="root")
+
+    fresh = TaskTracker(store=PersistentTaskStore(agfs))
+    reaped = await fresh.reap_stale_active(stale_after=0)
+
+    assert reaped == 2
+    other_loaded = await fresh.get(other.task_id, account_id="other-acct", user_id="bob")
+    system_loaded = await fresh.get(system.task_id, account_id="_system", user_id="root")
+    assert other_loaded is not None and other_loaded.status == TaskStatus.FAILED
+    assert system_loaded is not None and system_loaded.status == TaskStatus.FAILED
+
+
+async def test_reap_stale_active_with_camel_case_isdir_entries():
+    """Regression: production AGFS ls entries use ``isDir`` (camelCase).
+    A fresh tracker must still enumerate accounts/user dirs and reap the
+    cross-process zombie with real-shaped entries."""
+    agfs = _FakeAgfsCamelCase()
+    tracker1 = TaskTracker(store=PersistentTaskStore(agfs))
+    record = await tracker1.create(
+        "admin_reindex",
+        resource_id="r-camel",
+        account_id="acme",
+        user_id="alice",
+    )
+    await tracker1.start(record.task_id, account_id="acme", user_id="alice")
+
+    store = PersistentTaskStore(agfs)
+    all_tasks = await store.list_all()
+    assert any(task["task_id"] == record.task_id for task in all_tasks)
+
+    fresh = TaskTracker(store=store)
+    reaped = await fresh.reap_stale_active(stale_after=0)
+
+    assert reaped == 1
+    loaded = await fresh.get(record.task_id, account_id="acme", user_id="alice")
+    assert loaded is not None and loaded.status == TaskStatus.FAILED


### PR DESCRIPTION
## Description

Fixes #3396. Background reindex (and other background executors) run as bare `asyncio.create_task` with no saved reference, no timeout, and no restart reconciliation — tasks stay `RUNNING` forever after a process restart, and the only operator recovery is hand-editing task JSON.

## Root Cause

Two independent defects:

1. **No live-task registry**: `asyncio.create_task()` results are only weakly referenced by the event loop, and nothing records which task ID is actively driven by a live coroutine. After a restart (or even mid-process), the task store and the in-memory tracker can both report `RUNNING` for work that no longer exists.
2. **No staleness/reaping**: nothing ever fails `PENDING`/`RUNNING` records whose heartbeat went stale without a live driver, so zombies persist indefinitely.

## Changes (342 LOC, +342/-4)

- **`openviking/service/task_tracker.py`** (+94): `register_live_task()` — holds a strong reference to the driving asyncio task, auto-dropped on completion; `reap_stale_active()` — fails PENDING/RUNNING tasks with no live driver and stale `updated_at` heartbeat (`TTL_STALE_ACTIVE = 6h`), persisting `stage="interrupted"`. Hydrates from the store first so a fresh process finds pre-restart zombies (cross-restart coverage).
- **`openviking/service/task_store.py`** (+39): `PersistentTaskStore.list_all()` — enumerates task records across all accounts/owners so startup reconciliation sees every stale task, not just the current session's.
- **`openviking/service/reindex_executor.py`** (+12): registers the background reindex task with the tracker; bounds the end-of-run `wait_for_request` with a 1h timeout instead of polling forever on a stuck root.
- **`openviking/server/routers/admin.py`** (+3): legacy-migration background task also registered (same zombie class).
- **`openviking/server/app.py`** (+11): `reap_stale_active()` runs at lifespan startup before traffic, failure-isolated.
- **`tests/test_task_tracker.py`** (+187): 11 new tests — registration lifecycle, zombie reaped, live driver untouched, recent heartbeat untouched, terminal states skipped, same-URI retry unblocked, store persistence, cross-restart discovery, cross-account coverage.

## Out of scope (explicitly deferred)

- **`POST /api/v1/tasks/{id}/cancel`**: the tracker has no cancellation primitives today, and the maintainer comment on #3396 says cancel can land as an independent follow-up. Not in this PR.
- Add-resource task cancellation: covered by open PR #3383 (different task family).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Added 11 regression tests in `tests/test_task_tracker.py`.

Verification: `tests/test_task_tracker.py` **53/53 pass**; `tests/test_task_backend_config.py` **5/5 pass**. Adjacent suites (`test_session_task_tracking.py`, `test_admin_api.py`, reindex service tests) show identical pass/error counts with and without the change.

`ruff check` clean on all touched files; `ruff format --check` clean on all except `server/app.py`, which has a single pre-existing violation on `origin/main` (triple blank line at line 63) deliberately left untouched to keep the diff minimal.

Note: this Windows environment has a broken system cert store (`ssl.SSLError: NOT_ENOUGH_DATA` at aiohttp import); tests were run with a local certifi fallback plugin that is not committed. Unrelated to this change.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
