### PR TITLE
fix(web-studio): preserve target identity headers in trusted-mode probes

### DIFF
--- a/web-studio/src/lib/ov-client/client.test.ts
+++ b/web-studio/src/lib/ov-client/client.test.ts
@@ -115,3 +115,102 @@ describe('createOvClient API key selection', () => {
     )
   })
 })
+
+describe('createOvClient trusted identity selection', () => {
+  it('preserves explicit identity headers used to probe a target identity', async () => {
+    const { client, requests } = createRecordingClient()
+    client.setConnection({
+      accountId: 'active-account',
+      identityHeaders: true,
+      userId: 'active-user',
+    })
+
+    await client.instance.get('/health', {
+      headers: {
+        'X-OpenViking-Account': 'target-account',
+        'X-OpenViking-User': 'target-user',
+      },
+    })
+
+    expect(readRequestHeader(requests[0], 'X-OpenViking-Account')).toBe(
+      'target-account',
+    )
+    expect(readRequestHeader(requests[0], 'X-OpenViking-User')).toBe(
+      'target-user',
+    )
+  })
+
+  it('keeps the active identity on ordinary trusted requests', async () => {
+    const { client, requests } = createRecordingClient()
+    client.setConnection({
+      accountId: 'active-account',
+      identityHeaders: true,
+      userId: 'active-user',
+    })
+
+    await client.instance.get('/api/v1/resources', {
+      headers: {
+        'X-OpenViking-Account': 'target-account',
+        'X-OpenViking-User': 'target-user',
+      },
+    })
+
+    expect(readRequestHeader(requests[0], 'X-OpenViking-Account')).toBe(
+      'active-account',
+    )
+    expect(readRequestHeader(requests[0], 'X-OpenViking-User')).toBe(
+      'active-user',
+    )
+  })
+
+  it('falls back atomically when a health probe identity is incomplete', async () => {
+    const { client, requests } = createRecordingClient()
+    client.setConnection({
+      accountId: 'active-account',
+      identityHeaders: true,
+      userId: 'active-user',
+    })
+
+    await client.instance.get('/health', {
+      headers: {
+        'X-OpenViking-Account': 'target-account',
+        'X-OpenViking-User': ' ',
+      },
+    })
+    await client.instance.get('/health', {
+      headers: {
+        'X-OpenViking-Account': ' ',
+        'X-OpenViking-User': 'target-user',
+      },
+    })
+    await client.instance.get('/health')
+
+    for (const request of requests) {
+      expect(readRequestHeader(request, 'X-OpenViking-Account')).toBe(
+        'active-account',
+      )
+      expect(readRequestHeader(request, 'X-OpenViking-User')).toBe(
+        'active-user',
+      )
+    }
+  })
+
+  it('strips explicit identity headers outside trusted mode', async () => {
+    const { client, requests } = createRecordingClient()
+    client.setConnection({
+      accountId: 'active-account',
+      identityHeaders: false,
+      userId: 'active-user',
+    })
+
+    await client.instance.get('/health', {
+      headers: {
+        'X-OpenViking-Account': 'target-account',
+        'X-OpenViking-User': 'target-user',
+      },
+    })
+
+    expect(readRequestHeader(requests[0], 'X-OpenViking-Account')).toBe('')
+    expect(readRequestHeader(requests[0], 'X-OpenViking-User')).toBe('')
+  })
+})

--- a/web-studio/src/lib/ov-client/client.ts
+++ b/web-studio/src/lib/ov-client/client.ts
@@ -191,8 +191,14 @@ export function createOvClient(options: OvClientOptions = {}): OvClientAdapter {
       setOptionalHeader(headers, 'X-API-Key', apiKey)
     }
     if (connection.identityHeaders) {
-      setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
-      setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
+      const preservesRequestedIdentity =
+        resolvePathname(config.url) === '/health' &&
+        Boolean(readHeader(headers, 'X-OpenViking-Account')?.trim()) &&
+        Boolean(readHeader(headers, 'X-OpenViking-User')?.trim())
+      if (!preservesRequestedIdentity) {
+        setOptionalHeader(headers, 'X-OpenViking-Account', connection.accountId)
+        setOptionalHeader(headers, 'X-OpenViking-User', connection.userId)
+      }
     } else {
       headers.delete('X-OpenViking-Account')
       headers.delete('X-OpenViking-User')


### PR DESCRIPTION
## Summary

- preserve a complete request-level account/user pair only for trusted-mode `/health` probes
- keep the active connection identity authoritative for ordinary requests and incomplete probes
- retain identity-header stripping outside trusted mode and cover each boundary with adapter tests

## Context

`switchIdentity` probes the requested account and user before committing them to
the shared client. The request therefore carries the target identity while the
interceptor still holds the previous active identity. The interceptor replaced
those target headers, `/health` echoed the old identity, and the Studio rejected
an otherwise valid switch as an identity mismatch.

#3509 preserved the explicit probe API key. This completes the adjacent
account/user precedence rule, but deliberately limits it to `/health` and
requires both identity headers so regular API calls cannot override the active
identity or construct a mixed principal.

## Validation

- `npm test` (17 files, 67 tests)
- `npm run lint`
- `npm run build -- --logLevel error`
- `npx prettier --check src/lib/ov-client/client.ts src/lib/ov-client/client.test.ts`
