### PR TITLE
fix(memory): preserve assistant-only range events

### DIFF
--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -179,7 +179,12 @@ class MemoryIsolationHandler:
                 target_id = self._message_target_id(msg)
                 if target_id:
                     target_ids.append(target_id)
-        return list(dict.fromkeys(target_ids))
+        target_ids = list(dict.fromkeys(target_ids))
+        if target_ids:
+            return target_ids
+
+        peer_id = self._unique_peer_target_id_in_messages()
+        return [peer_id] if peer_id else []
 
     def _resolve_operation_target_id(self, raw_peer_id: Any) -> Optional[str]:
         peer_id = safe_peer_id(raw_peer_id)

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -6,6 +6,8 @@ Tests for MemoryIsolationHandler.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from openviking.message.message import Message
 from openviking.message.part import TextPart
 from openviking.server.identity import RequestContext, Role
@@ -46,6 +48,39 @@ def create_mock_extract_context(messages):
     mock_ctx = MagicMock()
     mock_ctx.messages = messages
     return mock_ctx
+
+
+def calculate_event_range_uris(messages, ranges, allowed_peer_ids):
+    """Resolve an event range with deterministic URI generation."""
+    from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+    from openviking.session.memory.memory_updater import ExtractContext
+
+    extract_ctx = ExtractContext(messages, split_long_text_messages=False)
+    handler = MemoryIsolationHandler(
+        create_ctx(user_id="support_bot"),
+        extract_ctx,
+        allow_self=True,
+        allowed_peer_ids=allowed_peer_ids,
+    )
+    schema = MemoryTypeSchema(
+        memory_type="events",
+        filename_template="demo.md",
+        directory="viking://user/{user_space}/memories/events",
+    )
+    operation = ResolvedOperation(
+        old_memory_file_content=None,
+        memory_fields={"event_name": "demo", "ranges": ranges},
+        memory_type="events",
+        uris=[],
+    )
+
+    with patch(
+        "openviking.session.memory.memory_isolation_handler.generate_uri",
+        side_effect=lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        ),
+    ):
+        return handler.calculate_memory_uris(schema, operation, extract_ctx)
 
 
 class TestGetReadScope:
@@ -519,6 +554,69 @@ class TestCalculateMemoryUris:
         assert uris == ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"]
         assert operation.memory_fields["user_id"] == "support_bot"
         assert "peer_id" not in operation.memory_fields
+
+    @pytest.mark.parametrize(
+        ("ranges", "include_second_peer", "expected_uris"),
+        [
+            (
+                "1",
+                False,
+                ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"],
+            ),
+            (
+                "0",
+                False,
+                ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"],
+            ),
+            (
+                "0-1",
+                False,
+                ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"],
+            ),
+            ("1,3", True, []),
+            (
+                "99",
+                False,
+                ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"],
+            ),
+            ("not-a-range", False, []),
+        ],
+        ids=[
+            "assistant-only-single-peer",
+            "user-only",
+            "mixed-role",
+            "assistant-only-multi-peer",
+            "out-of-range-single-peer",
+            "malformed-range",
+        ],
+    )
+    def test_calculate_memory_uris_ranges_route_conservatively(
+        self,
+        ranges,
+        include_second_peer,
+        expected_uris,
+    ):
+        messages = [
+            create_message("user", "request", peer_id="web-visitor-alice"),
+            create_message("assistant", "completed", peer_id="web-visitor-alice"),
+        ]
+        allowed_peer_ids = {"web-visitor-alice"}
+        if include_second_peer:
+            messages.extend(
+                [
+                    create_message("user", "second request", peer_id="web-visitor-bob"),
+                    create_message("assistant", "second result", peer_id="web-visitor-bob"),
+                ]
+            )
+            allowed_peer_ids.add("web-visitor-bob")
+
+        uris = calculate_event_range_uris(
+            messages,
+            ranges,
+            allowed_peer_ids,
+        )
+
+        assert uris == expected_uris
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_calculate_memory_uris_unallowed_peer_id_does_not_fallback(self, mock_generate_uri):


### PR DESCRIPTION
## Description

When an event memory range contains no user-owned message, use the session peer only when the full session has exactly one eligible peer. This preserves assistant-only event memories without guessing in multi-peer sessions.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3502

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Fall back to the unique eligible session peer when a valid range has no user-owned target.
- Keep multi-peer and malformed-range cases unresolved instead of guessing.
- Cover assistant-only, user-only, mixed, ambiguous, out-of-range, and malformed ranges.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands:

```text
PYTHONPATH=. uv run --no-sync pytest --confcutdir=tests/session/memory -o addopts='' tests/session/memory/test_memory_isolation_handler.py -q
uv run --no-sync ruff format --check openviking/session/memory/memory_isolation_handler.py tests/session/memory/test_memory_isolation_handler.py
uv run --no-sync ruff check openviking/session/memory/memory_isolation_handler.py tests/session/memory/test_memory_isolation_handler.py
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The focused suite reports existing Pydantic deprecation warnings; this change adds no new warnings.
