### PR TITLE
fix(memory): preserve delete_ids through structured operation parsing

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -177,19 +177,14 @@ class ExtractLoop:
             if tool.name in allowed_tools
         ]
 
-        # 预计算 expected_fields
+        # Resolve global link support before generating the operations model.
         config = get_openviking_config()
         self._link_enabled = config.memory.link_enabled if config.memory else False
-        self._expected_fields = []
-        if self._link_enabled:
-            self._expected_fields.append("links")
 
         # 获取 ExtractContext（整个流程复用）
         self._extract_context = self.context_provider.get_extract_context()
         if self._extract_context is None:
             raise ValueError("Failed to get ExtractContext from provider")
-        for schema in schemas:
-            self._expected_fields.append(f"{schema.memory_type}")
 
         # 预计算 operations_model
         role_scope = self._isolation_handler.get_read_scope() if self._isolation_handler else None
@@ -197,6 +192,9 @@ class ExtractLoop:
         self._operations_model = self.schema_model_generator.create_structured_operations_model(
             role_scope
         )
+        # Keep the stability parser's allowlist aligned with the generated
+        # contract, including conditional fields such as delete_ids and links.
+        self._expected_fields = list(self._operations_model.model_fields)
 
         json_schema = self._operations_model.model_json_schema()
 

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -7,10 +7,12 @@ Tests for memory ExtractLoop orchestrator.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from openviking.session.memory.dataclass import (
     MemoryTypeSchema,
+    ResolvedOperations,
 )
+from openviking.session.memory.schema_model_generator import SchemaModelGenerator
+
 from openviking.session.memory.extract_loop import (
     ExtractLoop,
 )
@@ -152,7 +154,80 @@ class TestAllowedDirectoriesList:
         """Create a mock VikingFS."""
         return MagicMock()
 
+
 class TestExtractLoopFinalJsonRetry:
+    @pytest.mark.asyncio
+    async def test_structured_parser_preserves_delete_ids(self):
+        class FakeContextProvider:
+            read_file_contents = {}
+
+            def get_memory_schemas(self, ctx):
+                return [
+                    MemoryTypeSchema(
+                        memory_type="preferences",
+                        description="Preferences",
+                        directory="viking://user/{user_space}/memories/preferences",
+                        filename_template="{topic}.md",
+                        fields=[],
+                    )
+                ]
+
+            def get_tools(self):
+                return []
+
+            def get_extract_context(self):
+                return MagicMock()
+
+            def get_output_language(self):
+                return "en"
+
+            def instruction(self):
+                return "Extract memory operations."
+
+            async def prefetch(self):
+                return []
+
+        vlm = MagicMock()
+        vlm.model = "test-model"
+        vlm.get_completion_async = AsyncMock(
+            return_value=('{"delete_ids": [{"delete_page_id": 7, "replacement_page_id": 11}]}')
+        )
+        extract_loop = ExtractLoop(
+            vlm=vlm,
+            viking_fs=MagicMock(),
+            context_provider=FakeContextProvider(),
+            max_iterations=1,
+        )
+        resolved = ResolvedOperations(
+            upsert_operations=[],
+            delete_file_contents=[],
+            errors=[],
+        )
+        extract_loop.resolve_operations = AsyncMock(return_value=(resolved, []))
+        extract_loop._check_unread_existing_files = AsyncMock(return_value={})
+        extract_loop._validate_patch_operations = MagicMock(return_value=[])
+        extract_loop.finalize_operations = AsyncMock()
+
+        await extract_loop.run()
+
+        parsed_operations = extract_loop.resolve_operations.await_args.args[0]
+        assert len(parsed_operations.delete_ids) == 1
+        assert parsed_operations.delete_ids[0].delete_page_id == 7
+        assert parsed_operations.delete_ids[0].replacement_page_id == 11
+
+    def test_add_only_contract_does_not_allow_delete_ids(self):
+        schema = MemoryTypeSchema(
+            memory_type="trajectories",
+            description="Trajectories",
+            directory="viking://agent/{agent_space}/memories/trajectories",
+            filename_template="{task}.md",
+            fields=[],
+            operation_mode="add_only",
+        )
+        generator = SchemaModelGenerator([schema], template_context={"language": "en"})
+
+        assert "delete_ids" not in generator.create_structured_operations_model().model_fields
+
     def test_final_instruction_includes_schema_aware_empty_json(self):
         extract_loop = object.__new__(ExtractLoop)
         extract_loop._expected_fields = ["preferences", "tools"]


### PR DESCRIPTION
## Summary

- derive the stability parser's allowlist from the generated operations model
- preserve conditional fields such as `delete_ids` and `links` without maintaining a second schema list
- add an `ExtractLoop.run()` regression for deletion/replacement operations and retain the add-only schema boundary

## Rationale

The structured schema asks the model for `delete_ids`, and
`resolve_operations()` consumes those IDs, but `_expected_fields` currently
contains only memory-type names and optional links. The stability parser filters
against that list before Pydantic validation, so a valid deletion is silently
turned into an empty operation.

Using the generated model's own fields keeps the filter aligned with the
conditional contract: deletable schemas retain `delete_ids`, while add-only
schemas still do not expose it.

## Testing

- Ruff check on both touched files and format check on the regression
- `python -m py_compile` on both touched files
- full pytest not run locally because this large-repository change used the required API-only workflow; CI will exercise the integrated dependency stack
