### PR TITLE
fix(console): count shared agent skills in inventory

### DIFF
--- a/openviking/observability/usage_audit/inventory.py
+++ b/openviking/observability/usage_audit/inventory.py
@@ -45,11 +45,13 @@ class ContextInventoryProvider:
     async def _read_counts(self, ctx: RequestContext) -> dict[str, int]:
         user_root = canonical_user_root(ctx)
 
-        files, skills, memories = await asyncio.gather(
+        files, user_skills, agent_skills, memories = await asyncio.gather(
             self._stat_count("viking://resources", ctx=ctx),
             self._stat_count(f"{user_root}/skills", ctx=ctx),
+            self._stat_count("viking://agent/skills", ctx=ctx),
             self._stat_count(f"{user_root}/memories", ctx=ctx),
         )
+        skills = user_skills + agent_skills
         return {
             "files": files,
             "skills": skills,

--- a/tests/observability/test_usage_audit_inventory.py
+++ b/tests/observability/test_usage_audit_inventory.py
@@ -30,6 +30,7 @@ class FakeFSService:
         return {
             "viking://resources": {"count": 2},
             "viking://user/user-1/skills": {"count": 3},
+            "viking://agent/skills": {"count": 4},
             "viking://user/user-1/memories": {"count": 5},
         }[uri]
 
@@ -55,11 +56,12 @@ async def test_context_inventory_counts_from_stat():
 
     counts = await provider.get_counts(ctx)
 
-    assert counts == {"files": 2, "skills": 3, "memories": 5, "total": 10}
-    assert len(fs.calls) == 3
+    assert counts == {"files": 2, "skills": 7, "memories": 5, "total": 14}
+    assert len(fs.calls) == 4
     assert {uri for uri, call_ctx in fs.calls if call_ctx is ctx} == {
         "viking://resources",
         "viking://user/user-1/skills",
+        "viking://agent/skills",
         "viking://user/user-1/memories",
     }
 


### PR DESCRIPTION
## Root cause

`ContextInventoryProvider` counted only `viking://user/<user>/skills`. By contrast, when no `target_uri` is supplied, `GET /api/v1/skills` lists both that user-private root and `viking://agent/skills` by concatenating their results without deduplication. On a shared-only installation, the user-private count was therefore `0`, while the API still listed the usable shared skills.

## Fix
  - user skills = 0
  - agent skills = 4
  - 旧 inventory 只查 user root → Skills = 0
  - API 返回两个 root → total = 4
  - 修复后的 inventory → 0 + 4 = 4

The inventory provider now stats both visible skill roots concurrently and sums their counts. Existing per-root missing/error handling remains unchanged.

Closes #3523.

## Verification

- RED on `c67222c3`: the focused regression expected 3 user skills + 4 shared skills, but current `main` returned 3.
- GREEN on `6b3e168447b37e8410e69f1b1196c3d705ba2176`: `uv run pytest tests/observability -q --no-cov` — 24 passed.
- `uv run ruff check openviking/observability/usage_audit/inventory.py tests/observability/test_usage_audit_inventory.py`
- `uv run mypy --follow-imports=skip openviking/observability/usage_audit/inventory.py`
- `.venv/bin/openviking-server --help`

No external services, credentials, or persistent stores were used.