### PR TITLE
fix(integrations): batch LangGraph history writes to avoid duplicates and lost context

### DIFF
--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -197,8 +197,8 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             start = len(previous_signatures)
 
         client = ensure_client(self._connection)
-        added = 0
-        pending_context_parts = list(self._pending_context_parts.pop(capture_key, []))
+        batch = []
+        pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
         for message in messages[start:]:
             if OPENVIKING_CONTEXT_MARKER in _message_content(message):
                 continue
@@ -207,17 +207,19 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 if pending_context_parts and payload["role"] == "assistant":
                     payload["parts"].extend(pending_context_parts)
                     pending_context_parts = []
-                call_openviking(
-                    client,
-                    "add_message",
-                    session_id=session_id,
-                    role=payload["role"],
-                    parts=payload["parts"],
-                    peer_id=peer_id,
-                )
-                added += 1
+                if peer_id is not None:
+                    payload["peer_id"] = peer_id
+                batch.append(payload)
+        if batch:
+            call_openviking(
+                client,
+                "batch_add_messages",
+                session_id=session_id,
+                messages=batch,
+            )
+        self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures
-        if added:
+        if batch:
             apply_commit_policy(client, session_id, self.commit_policy)
         return None
 

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -41,6 +41,7 @@ from openviking.integrations.langchain.retrievers import OpenVikingRetriever
 
 logger = logging.getLogger(__name__)
 
+_BATCH_ADD_MESSAGES_LIMIT = 100
 _SESSION_ID_ERROR = (
     "OpenVikingContextMiddleware requires a LangGraph session id. Pass "
     'config={"configurable": {"thread_id": "..."}}, set state["session_id"], '
@@ -210,12 +211,12 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 if peer_id is not None:
                     payload["peer_id"] = peer_id
                 batch.append(payload)
-        if batch:
+        for start in range(0, len(batch), _BATCH_ADD_MESSAGES_LIMIT):
             call_openviking(
                 client,
                 "batch_add_messages",
                 session_id=session_id,
-                messages=batch,
+                messages=batch[start : start + _BATCH_ADD_MESSAGES_LIMIT],
             )
         self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -199,25 +199,37 @@ class OpenVikingContextMiddleware(AgentMiddleware):
 
         client = ensure_client(self._connection)
         batch = []
+        chunks = []
+        batch_has_context = False
         pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
-        for message in messages[start:]:
+        for message_index, message in enumerate(messages[start:], start=start):
             if OPENVIKING_CONTEXT_MARKER in _message_content(message):
                 continue
             payloads = langchain_message_to_openviking(message)
+            if batch and len(batch) + len(payloads) > _BATCH_ADD_MESSAGES_LIMIT:
+                chunks.append((batch, message_index, batch_has_context))
+                batch = []
+                batch_has_context = False
             for payload in payloads:
                 if pending_context_parts and payload["role"] == "assistant":
                     payload["parts"].extend(pending_context_parts)
                     pending_context_parts = []
+                    batch_has_context = True
                 if peer_id is not None:
                     payload["peer_id"] = peer_id
                 batch.append(payload)
-        for start in range(0, len(batch), _BATCH_ADD_MESSAGES_LIMIT):
+        if batch:
+            chunks.append((batch, len(messages), batch_has_context))
+        for chunk, signature_end, has_context in chunks:
             call_openviking(
                 client,
                 "batch_add_messages",
                 session_id=session_id,
-                messages=batch[start : start + _BATCH_ADD_MESSAGES_LIMIT],
+                messages=chunk,
             )
+            self._captured_signatures[capture_key] = current_signatures[:signature_end]
+            if has_context:
+                self._pending_context_parts.pop(capture_key, None)
         self._pending_context_parts.pop(capture_key, None)
         self._captured_signatures[capture_key] = current_signatures
         if batch:

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -198,8 +198,8 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             start = len(previous_signatures)
 
         client = ensure_client(self._connection)
-        batch = []
-        chunks = []
+        batch: list[dict[str, Any]] = []
+        chunks: list[tuple[list[dict[str, Any]], int, bool]] = []
         batch_has_context = False
         pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
         for message_index, message in enumerate(messages[start:], start=start):

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1750,3 +1750,39 @@ def test_langgraph_middleware_chunks_batches_at_server_limit():
 
     assert client.batch_sizes == [100, 1]
     assert len(client.sessions["middleware-large-batch"]) == 101
+
+
+def test_langgraph_middleware_retries_only_failed_batch_chunk():
+    class FailSecondBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes = []
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            self.batch_sizes.append(len(messages))
+            if len(self.batch_sizes) == 2:
+                raise RuntimeError("second batch failed")
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = FailSecondBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        session_id_resolver=lambda state, runtime: "middleware-chunk-retry",
+    )
+    middleware._pending_context_parts[("middleware-chunk-retry", "")] = [
+        {"type": "context", "uri": "viking://resources/retry.md"}
+    ]
+    messages = [HumanMessage(content="First"), AIMessage(content="Context holder")]
+    messages.extend(HumanMessage(content=f"Message {index}") for index in range(98))
+    messages.append(AIMessage(content="Retry only this message"))
+    state = {"messages": messages}
+
+    with pytest.raises(RuntimeError, match="second batch failed"):
+        middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_sizes == [100, 1, 1]
+    stored = client.sessions["middleware-chunk-retry"]
+    assert len(stored) == 101
+    assert sum(part["type"] == "context" for message in stored for part in message["parts"]) == 1

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1724,3 +1724,29 @@ def test_langgraph_middleware_retries_failed_batch_with_pending_context():
     assert len(client.sessions["middleware-batch-retry"]) == 2
     assistant_parts = client.sessions["middleware-batch-retry"][1]["parts"]
     assert sum(part["type"] == "context" for part in assistant_parts) == 1
+
+
+def test_langgraph_middleware_chunks_batches_at_server_limit():
+    class CappedBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes = []
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            if len(messages) > 100:
+                raise RuntimeError("server batch limit exceeded")
+            self.batch_sizes.append(len(messages))
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = CappedBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        session_id_resolver=lambda state, runtime: "middleware-large-batch",
+    )
+    state = {"messages": [HumanMessage(content=f"Message {index}") for index in range(101)]}
+
+    middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_sizes == [100, 1]
+    assert len(client.sessions["middleware-large-batch"]) == 101

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1677,3 +1677,50 @@ def test_langgraph_middleware_clears_pending_context_on_duplicate_retry():
 
     unrelated_assistant_parts = client.sessions["middleware-pending-cleanup"][-1]["parts"]
     assert unrelated_assistant_parts == [{"type": "text", "text": "Unrelated turn stored."}]
+
+
+def test_langgraph_middleware_retries_failed_batch_with_pending_context():
+    class FailFirstBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__({"viking://user/memories/profile.md": "Retained retry context."})
+            self.batch_attempts = 0
+
+        def batch_add_messages(self, session_id, messages, **kwargs):
+            self.batch_attempts += 1
+            if self.batch_attempts == 1:
+                raise RuntimeError("batch write failed")
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    client = FailFirstBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        client=client,
+        target_uri="viking://user/memories",
+        session_id_resolver=lambda state, runtime: "middleware-batch-retry",
+    )
+
+    class Request:
+        messages = [HumanMessage(content="What retry context?")]
+        system_message = None
+
+        def override(self, **overrides):
+            new_request = Request()
+            new_request.messages = overrides.get("messages", self.messages)
+            new_request.system_message = overrides.get("system_message", self.system_message)
+            return new_request
+
+    middleware.wrap_model_call(Request(), lambda request: AIMessage(content="ok"))
+    state = {
+        "messages": [
+            HumanMessage(content="What retry context?"),
+            AIMessage(content="Retry context stored."),
+        ]
+    }
+
+    with pytest.raises(RuntimeError, match="batch write failed"):
+        middleware.after_agent(state, runtime=None)
+    middleware.after_agent(state, runtime=None)
+
+    assert client.batch_attempts == 2
+    assert len(client.sessions["middleware-batch-retry"]) == 2
+    assistant_parts = client.sessions["middleware-batch-retry"][1]["parts"]
+    assert sum(part["type"] == "context" for part in assistant_parts) == 1


### PR DESCRIPTION
## Summary

- batch LangGraph history capture through `batch_add_messages`
- cap each request at the server limit of 100 messages
- advance capture progress after every successful chunk so retries resume at the unwritten suffix
- retain pending retrieval context until the chunk carrying it is persisted
- preserve per-message peer attribution
- add explicit batch types required by mypy

## Root cause

The middleware previously wrote new history one message at a time, removed pending retrieval context before persistence completed, and updated capture signatures only after the entire loop. If a later write failed, retrying replayed messages that had already been stored and the retrieval context could be lost permanently.

## Validation

- `python -m pytest --no-cov -q tests/unit/test_langchain_integration.py` — 65 passed
- `python -m mypy --follow-imports=skip --ignore-missing-imports openviking/integrations/langchain/middleware.py`
- `ruff check` and `ruff format --check` on the changed files
- `python -m py_compile` on the changed Python files
- `make check-deps PYTHON=.venv/bin/python`
- full unit comparison against current `upstream/main`: the branch adds three passing tests and introduces no additional failures

Supersedes #3405. Its three commits are cherry-picked with original authorship preserved.
