### PR TITLE
docs: use localized absolute links in agent docs

### DIFF
--- a/docs/images/agents/en/cursor.md
+++ b/docs/images/agents/en/cursor.md
@@ -14,7 +14,7 @@ When asked where to connect, select **Volcengine OpenViking Cloud** and enter yo
 2. In **Cursor Settings → Hooks**, confirm that the lifecycle Hooks ran `cursor-hook.mjs`, the URI protection Hooks ran `uri-guard.mjs`, and the prompt Hook returned `additional_context`.
 3. In **Cursor Settings → Tools & MCPs**, confirm that `openviking` is connected.
 
-See the complete [Cursor integration guide](../../../en/agent-integrations/12-cursor.md).
+See the complete [Cursor integration guide](https://docs.openviking.ai/en/agent-integrations/12-cursor).
 
 ## Troubleshooting
 

--- a/docs/images/agents/en/opencode.md
+++ b/docs/images/agents/en/opencode.md
@@ -53,4 +53,4 @@ Behavior knobs (recall limits, commit thresholds) live in `~/.config/opencode/op
 ## Reference docs
 
 - [Plugin README](https://github.com/volcengine/OpenViking/tree/main/examples/opencode-plugin) - full tool list, configuration fields, and runtime details
-- [Deployment Guide](https://www.openviking.ai/en/guides/03-deployment) - setting up OpenViking server and CLI config
+- [Deployment Guide](https://docs.openviking.ai/en/guides/03-deployment) - setting up OpenViking server and CLI config

--- a/docs/images/agents/en/trae.md
+++ b/docs/images/agents/en/trae.md
@@ -22,7 +22,7 @@ When asked where to connect, select **Volcengine OpenViking Cloud** and enter yo
 3. Start a new session and ask about a previous project or preference.
 4. Share a temporary preference and ask for it in the next session to verify capture and commit.
 
-See the complete [TRAE integration guide](../../../en/agent-integrations/13-trae.md).
+See the complete [TRAE integration guide](https://docs.openviking.ai/en/agent-integrations/13-trae).
 
 ## Troubleshooting
 

--- a/docs/images/agents/zh/claude-code.md
+++ b/docs/images/agents/zh/claude-code.md
@@ -78,7 +78,7 @@ Claude Code 和 Codex 共用这一个安装脚本。它会依次询问要安装�
 | `OPENVIKING_MEMORY_ENABLED` | (auto) | 强制开启或关闭插件 |
 | `OPENVIKING_DEBUG` | `false` | 将调试日志输出至 `~/.openviking/logs/cc-hooks.log` |
 
-在多租户场景下，请额外配置 `OPENVIKING_ACCOUNT` 和 `OPENVIKING_USER`。完整的环境变量列表请参阅 [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md#configuration)。
+在多租户场景下，请额外配置 `OPENVIKING_ACCOUNT` 和 `OPENVIKING_USER`。完整的环境变量列表请参阅 [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README_CN.md#配置)。
 
 </details>
 
@@ -101,4 +101,4 @@ Claude Code 和 Codex 共用这一个安装脚本。它会依次询问要安装�
 ## 参考文档
 
 - [博客：在 Claude Code / Codex 中接入 OpenViking](https://blog.openviking.ai/post/openviking-coding-agent/) — 探讨为 Coding Agent 添加长期记忆的动机与实际效果。
-- [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md) — 查看完整的环境变量列表、Hook 运行细节及系统架构图。
+- [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README_CN.md) — 查看完整的环境变量列表、Hook 运行细节及系统架构图。

--- a/docs/images/agents/zh/cursor.md
+++ b/docs/images/agents/zh/cursor.md
@@ -14,7 +14,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 2. 在 **Cursor Settings → Hooks** 中确认生命周期 Hook 执行了 `cursor-hook.mjs`、URI 保护 Hook 执行了 `uri-guard.mjs`，且 prompt Hook 返回 `additional_context`。
 3. 在 **Cursor Settings → Tools & MCPs** 中确认 `openviking` 已连接。
 
-完整说明见 [Cursor 接入文档](../../../zh/agent-integrations/12-cursor.md)。
+完整说明见 [Cursor 接入文档](https://docs.openviking.ai/zh/agent-integrations/12-cursor)。
 
 ## 故障排查
 

--- a/docs/images/agents/zh/opencode.md
+++ b/docs/images/agents/zh/opencode.md
@@ -53,4 +53,4 @@ OpenCode 与 Claude Code、Codex 共用这一个安装器。它会询问要安�
 ## 参考文档
 
 - [插件 README](https://github.com/volcengine/OpenViking/tree/main/examples/opencode-plugin) - 完整 tools、配置字段和运行时说明
-- [部署指南](https://www.openviking.ai/zh/guides/03-deployment) - OpenViking server 与 CLI 配置
+- [部署指南](https://docs.openviking.ai/zh/guides/03-deployment) - OpenViking server 与 CLI 配置

--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -22,7 +22,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 3. 新建会话并提问一个与过往项目或个人偏好相关的问题。
 4. 告诉 Agent 一个临时偏好；下一会话再次询问，验证捕获和提交。
 
-完整说明见 [TRAE 接入文档](../../../zh/agent-integrations/13-trae.md)。
+完整说明见 [TRAE 接入文档](https://docs.openviking.ai/zh/agent-integrations/13-trae)。
 
 ## 故障排查
 


### PR DESCRIPTION
## Description

Use stable absolute documentation URLs in `docs/images/agents` and keep localized pages pointing to matching language targets. This avoids relative-link resolution issues when these Markdown files are served from the agent documentation CDN.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Replace relative Cursor and TRAE integration links with absolute `docs.openviking.ai` URLs in both English and Chinese documents.
- Update OpenCode deployment links from the old website path to the corresponding English and Chinese documentation URLs.
- Point Chinese Claude Code references to `README_CN.md` where a localized target exists.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated that no relative Markdown links remain under `docs/images/agents`, no English/Chinese documentation-site links cross locales, all changed HTTP targets return `200`, and `git diff --check` passes.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A — link-only documentation changes.

## Additional Notes

Localized links were changed only where a matching localized target exists. English-only references remain unchanged when the repository does not provide a Chinese counterpart.
