### PR TITLE
feat(plugins): identify memory plugin traffic with a User-Agent

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.mjs
@@ -43,8 +43,14 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 
+import { buildUserAgent, readManifestVersion } from "./shared/credentials.mjs";
+
 const DEFAULT_OV_CONF_PATH = join(homedir(), ".openviking", "ov.conf");
 const DEFAULT_OVCLI_CONF_PATH = join(homedir(), ".openviking", "ovcli.conf");
+const USER_AGENT = buildUserAgent(
+  "claude-code",
+  readManifestVersion(new URL("../.claude-plugin/plugin.json", import.meta.url)),
+);
 
 function num(val, fallback) {
   if (typeof val === "number" && Number.isFinite(val)) return val;
@@ -218,6 +224,7 @@ export function loadConfig() {
     peerId,
     workspacePeer,
     timeoutMs,
+    userAgent: USER_AGENT,
 
     // Recall
     autoRecall: envBool("OPENVIKING_AUTO_RECALL") ?? (cc.autoRecall !== false),

--- a/examples/claude-code-memory-plugin/scripts/debug-capture.mjs
+++ b/examples/claude-code-memory-plugin/scripts/debug-capture.mjs
@@ -197,6 +197,7 @@ async function fetchJSON(path, init = {}) {
     if (cfg.apiKey) headers["Authorization"] = `Bearer ${cfg.apiKey}`;
     if (cfg.accountId) headers["X-OpenViking-Account"] = cfg.accountId;
     if (cfg.userId) headers["X-OpenViking-User"] = cfg.userId;
+    if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
     const res = await fetch(url, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     dim(`  ${init.method || "GET"} ${path} -> ${res.status}`);

--- a/examples/claude-code-memory-plugin/scripts/debug-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/debug-recall.mjs
@@ -73,6 +73,7 @@ async function fetchJSON(path, init = {}, options = {}) {
     if (cfg.userId) headers["X-OpenViking-User"] = cfg.userId;
     const actorPeerId = options.actorPeerId ?? "";
     if (actorPeerId) headers["X-OpenViking-Actor-Peer"] = actorPeerId;
+    if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
     const res = await fetch(url, { ...init, headers, signal: controller.signal });
     const body = await res.json();
     if (!res.ok || body.status === "error") {

--- a/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
@@ -58,6 +58,7 @@ export function makeFetchJSON(cfg, timeoutKey = "timeoutMs") {
       if (cfg.userId) headers["X-OpenViking-User"] = cfg.userId;
       const actorPeerId = options.actorPeerId ?? "";
       if (actorPeerId) headers["X-OpenViking-Actor-Peer"] = actorPeerId;
+      if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
       const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
       const body = await res.json().catch(() => ({}));
       if (!res.ok || body.status === "error") {

--- a/examples/claude-code-memory-plugin/scripts/lib/server-probe.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/server-probe.mjs
@@ -66,6 +66,7 @@ export async function probeServer(cfg, { ttlMs = DEFAULT_TTL_MS } = {}) {
   if (cfg.apiKey) headers["Authorization"] = `Bearer ${cfg.apiKey}`;
   if (cfg.accountId) headers["X-OpenViking-Account"] = cfg.accountId;
   if (cfg.userId) headers["X-OpenViking-User"] = cfg.userId;
+  if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
 
   const t0 = Date.now();
   let healthy = false;

--- a/examples/claude-code-memory-plugin/scripts/shared/credentials.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/credentials.mjs
@@ -30,6 +30,27 @@ function tryLoadJson(path) {
   }
 }
 
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
 function looksLikeOvcli(obj) {
   if (!obj || typeof obj !== "object") return false;
   if (obj.server && typeof obj.server === "object") return false;

--- a/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -253,6 +253,7 @@ export function createOpenVikingMcpProxy({
     if (proxyConfig.account) headers["X-OpenViking-Account"] = proxyConfig.account;
     if (proxyConfig.user) headers["X-OpenViking-User"] = proxyConfig.user;
     if (proxyConfig.peerId) headers["X-OpenViking-Actor-Peer"] = proxyConfig.peerId;
+    if (proxyConfig.userAgent) headers["User-Agent"] = proxyConfig.userAgent;
     return headers;
   }
 

--- a/examples/claude-code-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/claude-code-memory-plugin/servers/mcp-proxy.mjs
@@ -44,6 +44,7 @@ function readProxyConfig() {
     account: cfg.accountId || "",
     user: cfg.userId || "",
     peerId: effectivePeer.peerId,
+    userAgent: cfg.userAgent || "",
     timeoutMs: Math.max(1000, Number(cfg.timeoutMs) || DEFAULT_TIMEOUT_MS),
     debug: cfg.debug === true,
     debugLogPath: cfg.debugLogPath,

--- a/examples/codex-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-capture.mjs
@@ -57,6 +57,7 @@ function makeHeaders() {
   if (cfg.sendIdentityHeaders && cfg.account) headers["X-OpenViking-Account"] = cfg.account;
   if (cfg.sendIdentityHeaders && cfg.user) headers["X-OpenViking-User"] = cfg.user;
   if (activePeerId) headers["X-OpenViking-Actor-Peer"] = activePeerId;
+  if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
   return headers;
 }
 

--- a/examples/codex-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-recall.mjs
@@ -99,6 +99,7 @@ async function fetchJSON(path, init = {}) {
     if (cfg.sendIdentityHeaders && cfg.account) headers["X-OpenViking-Account"] = cfg.account;
     if (cfg.sendIdentityHeaders && cfg.user) headers["X-OpenViking-User"] = cfg.user;
     if (effectivePeer.peerId) headers["X-OpenViking-Actor-Peer"] = effectivePeer.peerId;
+    if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
     const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
     const body = await res.json().catch(() => null);
     if (!body) return { ok: false, status: res.status };

--- a/examples/codex-memory-plugin/scripts/config.mjs
+++ b/examples/codex-memory-plugin/scripts/config.mjs
@@ -40,6 +40,12 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { resolveOpenVikingCredentials } from "./ov-credentials.mjs";
+import { buildUserAgent, readManifestVersion } from "./shared/credentials.mjs";
+
+const USER_AGENT = buildUserAgent(
+  "codex",
+  readManifestVersion(new URL("../.codex-plugin/plugin.json", import.meta.url)),
+);
 
 function num(val, fallback) {
   if (typeof val === "number" && Number.isFinite(val)) return val;
@@ -141,6 +147,7 @@ export function loadConfig() {
     user: creds.user,
     peerId: creds.peerId,
     workspacePeer,
+    userAgent: USER_AGENT,
     timeoutMs,
     recallTimeoutMs,
 

--- a/examples/codex-memory-plugin/scripts/pre-compact-capture.mjs
+++ b/examples/codex-memory-plugin/scripts/pre-compact-capture.mjs
@@ -51,6 +51,7 @@ function makeHeaders() {
   if (cfg.sendIdentityHeaders && cfg.account) headers["X-OpenViking-Account"] = cfg.account;
   if (cfg.sendIdentityHeaders && cfg.user) headers["X-OpenViking-User"] = cfg.user;
   if (activePeerId) headers["X-OpenViking-Actor-Peer"] = activePeerId;
+  if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
   return headers;
 }
 

--- a/examples/codex-memory-plugin/scripts/session-start-commit.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.mjs
@@ -90,6 +90,7 @@ async function fetchJSON(path, init = {}) {
     if (cfg.sendIdentityHeaders && cfg.account) headers["X-OpenViking-Account"] = cfg.account;
     if (cfg.sendIdentityHeaders && cfg.user) headers["X-OpenViking-User"] = cfg.user;
     if (activePeerId) headers["X-OpenViking-Actor-Peer"] = activePeerId;
+    if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
     const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
     const body = await res.json().catch(() => null);
     if (!body) return null;

--- a/examples/codex-memory-plugin/scripts/shared/credentials.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/credentials.mjs
@@ -30,6 +30,27 @@ function tryLoadJson(path) {
   }
 }
 
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
 function looksLikeOvcli(obj) {
   if (!obj || typeof obj !== "object") return false;
   if (obj.server && typeof obj.server === "object") return false;

--- a/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -253,6 +253,7 @@ export function createOpenVikingMcpProxy({
     if (proxyConfig.account) headers["X-OpenViking-Account"] = proxyConfig.account;
     if (proxyConfig.user) headers["X-OpenViking-User"] = proxyConfig.user;
     if (proxyConfig.peerId) headers["X-OpenViking-Actor-Peer"] = proxyConfig.peerId;
+    if (proxyConfig.userAgent) headers["User-Agent"] = proxyConfig.userAgent;
     return headers;
   }
 

--- a/examples/codex-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-proxy.mjs
@@ -50,6 +50,7 @@ function readProxyConfig() {
     account: creds.account || "",
     user: creds.user || "",
     peerId: effectivePeer.peerId,
+    userAgent: cfg.userAgent || "",
     timeoutMs: Math.max(1000, Number(cfg.timeoutMs) || DEFAULT_TIMEOUT_MS),
     debug: cfg.debug === true,
     debugLogPath: cfg.debugLogPath,

--- a/examples/codex-memory-plugin/servers/mcp-proxy.test.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-proxy.test.mjs
@@ -58,6 +58,7 @@ function makeProxy({ url, configOverrides = {}, stdout, localToolProvider, readC
       account: "default",
       user: "zeus",
       peerId: "peer-a",
+      userAgent: "openviking-memory-codex/9.9.9",
       timeoutMs: 5000,
       debug: false,
       debugLogPath: "",
@@ -86,6 +87,7 @@ test("captures initialize session id and forwards SSE JSON-RPC response", async 
     assert.equal(entry.headers["x-openviking-account"], "default");
     assert.equal(entry.headers["x-openviking-user"], "zeus");
     assert.equal(entry.headers["x-openviking-actor-peer"], "peer-a");
+    assert.equal(entry.headers["user-agent"], "openviking-memory-codex/9.9.9");
     assert.equal(entry.headers["mcp-protocol-version"], "2025-06-18");
     assert.equal(entry.headers["mcp-session-id"], undefined);
     res.writeHead(200, {

--- a/examples/cursor-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/cursor-memory-plugin/servers/mcp-proxy.mjs
@@ -15,6 +15,7 @@ function readConfig() {
     account: cfg.account,
     user: cfg.user,
     peerId: cfg.peerId,
+    userAgent: cfg.userAgent,
     timeoutMs: cfg.timeoutMs,
     debug: cfg.debug,
     debugLogPath: cfg.debugLogPath,

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -3,7 +3,7 @@ import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { resolveOpenVikingCredentials } from "./credentials.mjs";
+import { buildUserAgent, resolveOpenVikingCredentials } from "./credentials.mjs";
 import { createLogger } from "./debug-log.mjs";
 import { sendSessionMessages } from "./batch-send.mjs";
 import { enqueue, replayPending } from "./pending-queue.mjs";
@@ -44,6 +44,7 @@ export function loadAgentHookConfig(clientId) {
   return {
     ...credentials,
     clientId,
+    userAgent: buildUserAgent(clientId, process.env.OPENVIKING_INTEGRATION_VERSION),
     enabled: envBool("OPENVIKING_MEMORY_ENABLED", true),
     autoRecall: envBool("OPENVIKING_AUTO_RECALL", true),
     autoCapture: envBool("OPENVIKING_AUTO_CAPTURE", true),
@@ -175,6 +176,7 @@ export function makeAgentFetchJSON(cfg, cwd = process.cwd()) {
       if (cfg.user) headers["X-OpenViking-User"] = cfg.user;
       const peerId = options.actorPeerId ?? effectivePeer.peerId;
       if (peerId) headers["X-OpenViking-Actor-Peer"] = peerId;
+      if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
       const response = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
       const body = await response.json().catch(() => ({}));
       if (!response.ok || body.status === "error") {

--- a/examples/memory-plugin-shared/lib/credentials.mjs
+++ b/examples/memory-plugin-shared/lib/credentials.mjs
@@ -29,6 +29,27 @@ function tryLoadJson(path) {
   }
 }
 
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
 function looksLikeOvcli(obj) {
   if (!obj || typeof obj !== "object") return false;
   if (obj.server && typeof obj.server === "object") return false;

--- a/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
+++ b/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
@@ -252,6 +252,7 @@ export function createOpenVikingMcpProxy({
     if (proxyConfig.account) headers["X-OpenViking-Account"] = proxyConfig.account;
     if (proxyConfig.user) headers["X-OpenViking-User"] = proxyConfig.user;
     if (proxyConfig.peerId) headers["X-OpenViking-Actor-Peer"] = proxyConfig.peerId;
+    if (proxyConfig.userAgent) headers["User-Agent"] = proxyConfig.userAgent;
     return headers;
   }
 

--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -1,8 +1,13 @@
 import fs from "fs"
 import path from "path"
 import { homedir } from "os"
-import { resolveOpenVikingCredentials } from "./shared/credentials.mjs"
+import { buildUserAgent, readManifestVersion, resolveOpenVikingCredentials } from "./shared/credentials.mjs"
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs"
+
+const USER_AGENT = buildUserAgent(
+  "opencode",
+  readManifestVersion(new URL("../package.json", import.meta.url)),
+)
 
 const DEFAULT_CONFIG = {
   endpoint: "http://127.0.0.1:1933",
@@ -216,6 +221,7 @@ function normalizeConfig(config) {
   config.baseUrl = config.endpoint
   config.accountId = config.account
   config.userId = config.user
+  config.userAgent = USER_AGENT
   config.timeoutMs = normalizeNumber(config.timeoutMs, DEFAULT_CONFIG.timeoutMs, 1000, 300000)
   config.repoContext.cacheTtlMs = normalizeNumber(
     config.repoContext.cacheTtlMs,

--- a/examples/opencode-plugin/lib/runtime.mjs
+++ b/examples/opencode-plugin/lib/runtime.mjs
@@ -6,6 +6,7 @@ export async function checkServiceHealth(config, timeoutMs = 3000) {
   try {
     const response = await fetch(`${normalizeEndpoint(config.endpoint)}/health`, {
       method: "GET",
+      headers: config.userAgent ? { "User-Agent": config.userAgent } : undefined,
       signal: controller.signal,
     })
     return response.ok

--- a/examples/opencode-plugin/lib/shared/credentials.mjs
+++ b/examples/opencode-plugin/lib/shared/credentials.mjs
@@ -30,6 +30,27 @@ function tryLoadJson(path) {
   }
 }
 
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
 function looksLikeOvcli(obj) {
   if (!obj || typeof obj !== "object") return false;
   if (obj.server && typeof obj.server === "object") return false;

--- a/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
+++ b/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
@@ -253,6 +253,7 @@ export function createOpenVikingMcpProxy({
     if (proxyConfig.account) headers["X-OpenViking-Account"] = proxyConfig.account;
     if (proxyConfig.user) headers["X-OpenViking-User"] = proxyConfig.user;
     if (proxyConfig.peerId) headers["X-OpenViking-Actor-Peer"] = proxyConfig.peerId;
+    if (proxyConfig.userAgent) headers["User-Agent"] = proxyConfig.userAgent;
     return headers;
   }
 

--- a/examples/opencode-plugin/lib/utils.mjs
+++ b/examples/opencode-plugin/lib/utils.mjs
@@ -213,6 +213,7 @@ function makeAuthHeaders(config, headers = {}, actorPeerId = "") {
   if (config.user) result["X-OpenViking-User"] = config.user
   const peerId = String(actorPeerId || "").trim()
   if (peerId) result["X-OpenViking-Actor-Peer"] = peerId
+  if (config.userAgent) result["User-Agent"] = config.userAgent
   return result
 }
 

--- a/examples/opencode-plugin/servers/mcp-proxy.mjs
+++ b/examples/opencode-plugin/servers/mcp-proxy.mjs
@@ -46,6 +46,7 @@ function readProxyConfig() {
     account: cfg.account || "",
     user: cfg.user || "",
     peerId: effectivePeer.peerId,
+    userAgent: cfg.userAgent || "",
     timeoutMs: Math.max(1000, Number(cfg.timeoutMs) || DEFAULT_TIMEOUT_MS),
     debug: cfg.debug === true,
     debugLogPath: cfg.debugLogPath,

--- a/examples/opencode-plugin/servers/mcp-proxy.test.mjs
+++ b/examples/opencode-plugin/servers/mcp-proxy.test.mjs
@@ -56,6 +56,7 @@ function makeProxy(url) {
       account: "acct",
       user: "user",
       peerId: "peer",
+      userAgent: "openviking-memory-opencode/9.9.9",
       timeoutMs: 5000,
       debug: false,
       debugLogPath: "",
@@ -81,6 +82,7 @@ test("OpenCode MCP proxy forwards initialize with auth and identity headers", as
     assert.equal(entry.headers["x-openviking-account"], "acct")
     assert.equal(entry.headers["x-openviking-user"], "user")
     assert.equal(entry.headers["x-openviking-actor-peer"], "peer")
+    assert.equal(entry.headers["user-agent"], "openviking-memory-opencode/9.9.9")
     res.writeHead(200, {
       "content-type": "text/event-stream",
       "mcp-session-id": "sid-oc",

--- a/examples/pi-coding-agent-extension/client.ts
+++ b/examples/pi-coding-agent-extension/client.ts
@@ -92,6 +92,7 @@ export class OVClient {
     if (this.account) h["X-OpenViking-Account"] = this.account;
     if (this.user) h["X-OpenViking-User"] = this.user;
     if (this.peerId) h["X-OpenViking-Actor-Peer"] = this.peerId;
+    if (this.cfg.userAgent) h["User-Agent"] = this.cfg.userAgent;
     return h;
   }
 

--- a/examples/pi-coding-agent-extension/config.ts
+++ b/examples/pi-coding-agent-extension/config.ts
@@ -1,7 +1,10 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { resolveOpenVikingCredentials } from "./shared/credentials.mjs";
+import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
+
+/** Hand-maintained: this extension ships no manifest to read a version from. */
+export const EXTENSION_VERSION = "0.1.0";
 
 export interface OVConfig {
   enabled: boolean;
@@ -10,6 +13,7 @@ export interface OVConfig {
   account: string;
   user: string;
   peerId: string;
+  userAgent: string;
   workspacePeer: boolean;
   recallPeerScope: "actor" | "all";
   syncTurns: boolean;
@@ -45,6 +49,7 @@ const DEFAULT_CONFIG: OVConfig = {
   account: "",
   user: "",
   peerId: "",
+  userAgent: "",
   workspacePeer: true,
   recallPeerScope: "all",
   syncTurns: true,
@@ -92,6 +97,7 @@ export function loadConfig(extensionDir: string): OVConfig {
     account: creds.account,
     user: creds.user,
     peerId: creds.peerId,
+    userAgent: buildUserAgent("pi", EXTENSION_VERSION),
     recallTokenBudget: file.recallTokenBudget ?? file.recallBudget ?? DEFAULT_CONFIG.recallTokenBudget,
     scoreThreshold: file.scoreThreshold ?? file.recallScoreThreshold ?? DEFAULT_CONFIG.scoreThreshold,
     minQueryLength: file.minQueryLength ?? file.recallMinQueryLength ?? DEFAULT_CONFIG.minQueryLength,

--- a/examples/pi-coding-agent-extension/shared/credentials.d.mts
+++ b/examples/pi-coding-agent-extension/shared/credentials.d.mts
@@ -1,3 +1,7 @@
+export function buildUserAgent(harness: string, version?: string): string;
+
+export function readManifestVersion(manifest: string | URL): string;
+
 export function resolveOpenVikingCredentials(env?: Record<string, string | undefined>): {
   credentialSource: string;
   baseUrl: string;

--- a/examples/pi-coding-agent-extension/shared/credentials.mjs
+++ b/examples/pi-coding-agent-extension/shared/credentials.mjs
@@ -30,6 +30,27 @@ function tryLoadJson(path) {
   }
 }
 
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
 function looksLikeOvcli(obj) {
   if (!obj || typeof obj !== "object") return false;
   if (obj.server && typeof obj.server === "object") return false;

--- a/examples/trae-memory-hooks/servers/mcp-proxy.mjs
+++ b/examples/trae-memory-hooks/servers/mcp-proxy.mjs
@@ -16,6 +16,7 @@ function readConfig() {
     account: cfg.account,
     user: cfg.user,
     peerId: cfg.peerId,
+    userAgent: cfg.userAgent,
     timeoutMs: cfg.timeoutMs,
     debug: cfg.debug,
     debugLogPath: cfg.debugLogPath,


### PR DESCRIPTION
## Description

Every harness memory plugin sent its OpenViking requests under Node's default `user-agent: node`, so nothing downstream could tell which harness or which plugin version a request came from. This adds a per-harness User-Agent of the form `openviking-memory-<harness>/<version>`.

The header is purely informational: neither the open-source server nor the commercial gateway reads it (both pass unknown headers through untouched). No auth or identity header behavior changes.

`X-OpenViking-Agent` was considered and rejected for this purpose — the server rejects it with 400 when it disagrees with `X-OpenViking-Actor-Peer`, and when it agrees it still marks the request as a legacy one, which widens `find`/`search` to unmigrated `viking://agent/...` data.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `buildUserAgent()` and `readManifestVersion()` to the shared `credentials.mjs`, and thread an optional `userAgent` through `mcp-proxy-core.mjs` and `agent-hook-runtime.mjs` (source of truth under `examples/memory-plugin-shared/lib/`, redistributed by `sync.mjs`).
- Wire the header into all six harnesses on both the data plane and the MCP proxy: claude-code, codex, opencode, pi, cursor, trae/trae-cn.
- Resolve the version from each harness's own manifest (`plugin.json` / `package.json`), or from `OPENVIKING_INTEGRATION_VERSION` for cursor/trae. An unreadable manifest degrades to `0.0.0` instead of throwing inside a short-lived hook process.
- Add `EXTENSION_VERSION` to the pi extension, which previously carried no version anywhere. The installer preserves the user's `config.json`, so the version has to live in source.
- Set the header on the OpenCode health check, which previously sent no headers at all. Only the User-Agent was added there — no auth was introduced on that path.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Verified against a local HTTP listener that prints the received `user-agent`, driving the real code paths rather than reading code:

| harness | observed User-Agent | paths exercised |
|---|---|---|
| claude-code | `openviking-memory-claude-code/0.4.3` | hook data plane, statusline probe, MCP POST + DELETE |
| codex | `openviking-memory-codex/0.7.4` | `loadConfig`, MCP POST + DELETE |
| opencode | `openviking-memory-opencode/0.2.3` | health check, `fetchJSON`, MCP POST + DELETE |
| pi | `openviking-memory-pi/0.1.0` | `OVClient.fetchJSON` |
| cursor | `openviking-memory-cursor/0.1.2` | hook fetch, MCP POST + DELETE |
| trae / trae-cn | `openviking-memory-trae{,-cn}/0.1.2` | hook fetch, MCP POST + DELETE |

Test suites, all passing: shared 29 (including the sync drift guard), codex 65, claude-code 16, opencode 20, pi 41. Added User-Agent assertions to the codex and opencode MCP proxy tests to guard against regressions.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Files under each harness's `shared/` directory are generated by `examples/memory-plugin-shared/sync.mjs` and do not need separate review — only `examples/memory-plugin-shared/lib/` was edited by hand.

The cursor/trae version comes from an installer-injected env var, so running those hooks straight from the repo (without the installer) yields `openviking-memory-cursor/0.0.0`. Installed environments carry the real version.
