### PR TITLE
feat(add-resource): 支持 Embedding-first 叶子索引与 leaf_indexed 阶段

### DIFF
--- a/docs/design/add-resource-leaf-indexed-pipeline.md
+++ b/docs/design/add-resource-leaf-indexed-pipeline.md
@@ -1,0 +1,146 @@
+# add-resource Embedding-first 与 `leaf_indexed` 流程
+
+## 本次改动的核心变化
+
+```text
+调用方
+  |
+  +--> add-resource(wait=false)
+  |       |
+  |       +--> 返回 task_id
+  |
+  +--> getTask(task_id)
+          |
+          +--> queued
+          +--> processing_queue
+          +--> leaf_indexed       叶子已经可检索
+          +--> completed/failed   完整任务结束
+```
+
+原流程必须等叶子 summary、目录 overview 和所有 Embedding 全部完成，调用方才能确认任务成功。
+
+现在增加 `leaf_indexed` 中间阶段，并让默认 `content_only` 文本叶子先做 Embedding、再生成 summary。
+
+## 主处理链路
+
+```text
+ResourceService.add_resource
+  |
+  +--> AddResource Queue
+          |
+          +--> ResourceProcessor 完成解析和资源落盘
+          |
+          +--> Semantic Queue
+                  |
+                  v
+          SemanticDagExecutor
+                  |
+                  +--> 发现本次需要更新的叶子
+                  |
+                  +--> 根据文本源策略选择处理方式
+                          |
+                          +----------------------------------------------------+
+                          |                                                    |
+                          v                                                    v
+                 Embedding-first                                      Summary-first
+                 content_only 文本                                    summary_first
+                          |                                            summary_only
+                          |                                            图片/音频等
+                          |                                                    |
+                          +--> 原文 Embedding                                  +--> LLM summary
+                          |                                                    |
+                          +--> LLM summary                                     +--> Embedding
+                          |                                                    |
+                          +--------------------------+-------------------------+
+                                                     |
+                                                     v
+                                      等待全部必要叶子 Embedding 完成
+                                                     |
+                                  +------------------+------------------+
+                                  |                                     |
+                            有叶子错误                              全部成功
+                                  |                                     |
+                                  v                                     v
+                           最终进入 failed                    stage=leaf_indexed
+                                                                        |
+                                                                        | 叶子已经可检索
+                                                                        | 调用方可提前返回
+                                                                        v
+                                                         继续后台完整语义处理
+                                                                        |
+                                       +--------------------------------+------------------+
+                                       |                                                   |
+                                       v                                                   v
+                         回填叶子 summary 元数据                               生成目录 overview
+                         operation=metadata_patch                                       |
+                                       |                                                  +--> 子目录 L0/L1 Embedding
+                                       |                                                  +--> 父目录 overview
+                                       |                                                  +--> 根目录 L0/L1 Embedding
+                                       |                                                   |
+                                       +-------------------------+-------------------------+
+                                                                 |
+                                                                 v
+                                               等待完整 Embedding tracker 收敛
+                                                                 |
+                                                    +------------+------------+
+                                                    |                         |
+                                                  有错误                    无错误
+                                                    |                         |
+                                                    v                         v
+                                            stage=failed              stage=completed
+```
+
+## `leaf_indexed` 的准确语义
+
+```text
+stage=leaf_indexed
+  |
+  +--> 本次新增或修改、且需要向量化的所有叶子 Embedding 已成功
+  +--> 叶子已经可以参与检索
+  |
+  +-- 不保证叶子 summary/abstract 已回填
+  +-- 不保证子目录 L0/L1 已完成
+  +-- 不保证根目录 L0/L1 已完成
+```
+
+`leaf_indexed` 是 `running` 状态下的持久化里程碑。后续的 `processing_queue` 更新不会把它覆盖；任务最终只会进入 `completed` 或 `failed`。
+
+## Metadata patch
+
+```text
+Embedding-first 叶子
+  |
+  +--> 初始 Embedding 使用原文
+  |       +--> dense/sparse vector = 原文
+  |       +--> full text = 原文
+  |       +--> abstract = 空
+  |
+  +--> LLM summary 完成
+          |
+          +--> 先登记 metadata patch
+          +--> 等全部叶子 Embedding 完成
+          +--> 先发布 leaf_indexed
+          +--> 再投递 metadata patch
+                  |
+                  +--> 仅 partial update abstract
+                  +--> 不重新调用 embedder
+                  +--> 不覆盖原有 vector 和 full text
+```
+
+## 调用方使用方式
+
+```text
+只需要叶子可检索：
+    add-resource(wait=false)
+      -> getTask 轮询
+      -> stage == leaf_indexed 时即可返回
+
+需要完整目录语义：
+    add-resource(wait=false)
+      -> getTask 轮询
+      -> status == completed 时返回
+
+使用 wait=true：
+    保持原有行为，等待完整任务结束；
+    不会在 leaf_indexed 提前返回。
+```

--- a/docs/en/api/17-tasks.md
+++ b/docs/en/api/17-tasks.md
@@ -94,7 +94,7 @@ ov task status uuid-xxx
 }
 ```
 
-`stage` is nullable. Git repository resource import tasks may report `queued`, `fetching`, `parsing`, `finalizing`, or `processing_queue`; other task types may leave it as `null`. Live queue counters are intentionally not part of task status; use observer queue APIs for live counts, or read `result.queue_status` after completion.
+`stage` is nullable. Resource import tasks may report `queued`, `fetching`, `parsing`, `finalizing`, `processing_queue`, or `leaf_indexed`. For an `add_resource` task, `leaf_indexed` means every leaf file discovered by that task has been written to the vector index; directory summaries and directory indexes may still be processing, so the task remains `running`. Once reported, this milestone is retained until the task becomes `completed` or `failed`, allowing callers to stop polling when leaf retrieval is sufficient. Other task types may leave `stage` as `null`. Live queue counters are intentionally not part of task status; use observer queue APIs for live counts, or read `result.queue_status` after completion.
 
 **Response Example (completed)**
 

--- a/docs/zh/api/17-tasks.md
+++ b/docs/zh/api/17-tasks.md
@@ -94,7 +94,7 @@ ov task status uuid-xxx
 }
 ```
 
-`stage` 可以为 `null`。Git 仓库资源导入任务可能报告 `queued`、`fetching`、`parsing`、`finalizing`、`processing_queue`；其他任务类型可能将其留空。实时队列计数不会出现在任务状态中；需要实时数量时使用 observer queue，任务完成后可读取 `result.queue_status`。
+`stage` 可以为 `null`。资源导入任务可能报告 `queued`、`fetching`、`parsing`、`finalizing`、`processing_queue` 或 `leaf_indexed`。对于 `add_resource` 任务，`leaf_indexed` 表示本任务发现的所有叶子文件都已写入向量索引；目录摘要和目录索引此时可能仍在后台处理，因此任务状态仍为 `running`。该里程碑一旦出现，会保留到任务进入 `completed` 或 `failed`，调用方只需要叶子检索能力时可以据此停止轮询。其他任务类型可能将其留空。实时队列计数不会出现在任务状态中；需要实时数量时使用 observer queue，任务完成后可读取 `result.queue_status`。
 
 **响应示例（完成）**
 

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -436,9 +436,16 @@ class ResourceService:
                 summarize=msg.summarize,
                 build_index=msg.build_index,
             )
+
+            async def _on_leaf_indexed() -> None:
+                stage_result = stage_callback("leaf_indexed")
+                if inspect.isawaitable(stage_result):
+                    await stage_result
+
             await request_wait_tracker.wait_for_request(
                 telemetry_id,
                 timeout=msg.timeout,
+                on_leaf_indexed=_on_leaf_indexed,
             )
             status = request_wait_tracker.build_queue_status(telemetry_id)
             result["queue_status"] = status
@@ -1022,10 +1029,19 @@ class ResourceService:
                 try:
                     with telemetry.measure("resource.wait"):
                         if telemetry_id:
+                            on_leaf_indexed = None
+                            if stage_callback is not None:
+
+                                async def on_leaf_indexed() -> None:
+                                    stage_result = stage_callback("leaf_indexed")
+                                    if inspect.isawaitable(stage_result):
+                                        await stage_result
+
                             await request_wait_tracker.wait_for_request(
                                 telemetry_id,
                                 timeout=timeout,
                                 poll_interval=0.05,
+                                on_leaf_indexed=on_leaf_indexed,
                             )
                             status = request_wait_tracker.build_queue_status(telemetry_id)
                         else:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -234,6 +234,17 @@ class TaskTracker:
         if not account_id or not user_id:
             raise ValueError("Task ownership requires non-empty account_id and user_id")
 
+    @staticmethod
+    def _nonterminal_stage(task: TaskRecord, requested_stage: str) -> str:
+        """Keep the externally observable add-resource milestone until terminal."""
+        if (
+            task.task_type == "add_resource"
+            and task.stage == "leaf_indexed"
+            and requested_stage != "leaf_indexed"
+        ):
+            return task.stage
+        return requested_stage
+
     # ── CRUD ──
 
     async def create(
@@ -339,7 +350,7 @@ class TaskTracker:
             if task and task.status not in _TERMINAL_STATUSES:
                 task.status = TaskStatus.RUNNING
                 if stage is not None:
-                    task.stage = stage
+                    task.stage = self._nonterminal_stage(task, stage)
                 task.updated_at = time.time()
                 await self._store.update(task)
                 with self._lock:
@@ -356,7 +367,7 @@ class TaskTracker:
         async with self._async_lock:
             task = await self._load_for_update(task_id, account_id, user_id)
             if task and task.status not in _TERMINAL_STATUSES:
-                task.stage = stage
+                task.stage = self._nonterminal_stage(task, stage)
                 task.updated_at = time.time()
                 await self._store.update(task)
                 with self._lock:

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -207,8 +207,7 @@ def _embedding_metadata_compatible(
     if existing_meta is None:
         return False
     return all(
-        existing_meta.get(key) == current_meta.get(key)
-        for key in _EMBEDDING_COMPATIBILITY_KEYS
+        existing_meta.get(key) == current_meta.get(key) for key in _EMBEDDING_COMPATIBILITY_KEYS
     )
 
 
@@ -437,6 +436,11 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         config = get_openviking_config()
         self._collection_name = config.storage.vectordb.name
         self._vector_dim = config.embedding.dimension
+        self._max_retries = getattr(config.embedding, "max_retries", 3)
+        # Metadata patches can overtake their original embed under concurrent
+        # consumers. Keep this ordering retry separate from provider retries.
+        self._metadata_patch_max_retries = max(self._max_retries, 60)
+        self._metadata_patch_retry_delay = 0.5
         self._initialize_embedder(config)
         breaker_cfg = config.embedding.circuit_breaker
         self._circuit_breaker = CircuitBreaker(
@@ -545,6 +549,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         report_success = False
         report_error_args: Optional[tuple[str, Optional[Dict[str, Any]]]] = None
         request_failed_message: Optional[str] = None
+        tracker_attempt_terminal = True
         try:
             queue_data = json.loads(data["data"])
             # Parse EmbeddingMsg from data
@@ -556,20 +561,106 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             with telemetry_ctx:
                 if self._vikingdb.is_closing:
                     logger.debug("Skip embedding dequeue during shutdown")
+                    tracker_attempt_terminal = False
+                    raise asyncio.CancelledError
+
+                if embedding_msg.operation == "metadata_patch":
+                    uri = inserted_data.get("uri")
+                    account_id = inserted_data.get("account_id", "default")
+                    seed_uri = self._seed_uri_for_id(uri, inserted_data.get("level", 2))
+                    record_id = hashlib.md5(f"{account_id}:{seed_uri}".encode("utf-8")).hexdigest()
+                    user = UserIdentifier(account_id=account_id, user_id="default")
+                    ctx = RequestContext(user=user, role=Role.ROOT)
+                    existing_records = await self._vikingdb.get([record_id], ctx=ctx)
+                    if not existing_records:
+                        if embedding_msg.retry_count < self._metadata_patch_max_retries and getattr(
+                            self._vikingdb, "has_queue_manager", False
+                        ):
+                            if self._metadata_patch_retry_delay > 0:
+                                await asyncio.sleep(self._metadata_patch_retry_delay)
+                            embedding_msg.retry_count += 1
+                            requeued = await self._vikingdb.enqueue_embedding_msg(embedding_msg)
+                            if requeued:
+                                tracker_attempt_terminal = False
+                                self._merge_request_stats(
+                                    embedding_msg.telemetry_id,
+                                    requeue_count=1,
+                                )
+                                get_request_wait_tracker().record_embedding_requeue(
+                                    embedding_msg.telemetry_id
+                                )
+                                self.report_requeue()
+                                report_success = True
+                                return None
+
+                            error_msg = self._embedding_error_msg(
+                                embedding_msg,
+                                "Failed to persist metadata patch retry",
+                            )
+                            self._merge_request_stats(
+                                embedding_msg.telemetry_id,
+                                error_count=1,
+                            )
+                            request_failed_message = error_msg
+                            report_error_args = (error_msg, data)
+                            return None
+
+                        error_msg = self._embedding_error_msg(
+                            embedding_msg,
+                            "Metadata patch target is not indexed",
+                        )
+                        self._merge_request_stats(
+                            embedding_msg.telemetry_id,
+                            error_count=1,
+                        )
+                        request_failed_message = error_msg
+                        report_error_args = (error_msg, data)
+                        return None
+
+                    patch_data = {
+                        "id": record_id,
+                        "uri": uri,
+                        "account_id": account_id,
+                        "abstract": inserted_data.get("abstract", ""),
+                    }
+                    patch_result = await self._vikingdb.upsert(
+                        patch_data,
+                        ctx=ctx,
+                        partial_update=True,
+                    )
+                    if not patch_result:
+                        error_msg = self._embedding_error_msg(
+                            embedding_msg,
+                            "Metadata patch did not update a record",
+                        )
+                        self._merge_request_stats(
+                            embedding_msg.telemetry_id,
+                            error_count=1,
+                        )
+                        request_failed_message = error_msg
+                        report_error_args = (error_msg, data)
+                        return None
+
                     self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
                     self._record_request_success(embedding_msg)
                     report_success = True
-                    return None
+                    patch_data["id"] = patch_result
+                    return patch_data
 
                 # Process string (text) or list (multimodal) messages
                 if not isinstance(embedding_msg.message, (str, list)):
-                    logger.debug(
-                        f"Skipping unsupported message type: {type(embedding_msg.message)}"
+                    error_msg = self._embedding_error_msg(
+                        embedding_msg,
+                        f"Unsupported embedding message type: {type(embedding_msg.message)}",
                     )
-                    self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
-                    self._record_request_success(embedding_msg)
-                    report_success = True
-                    return data
+                    logger.error(error_msg)
+                    self._merge_request_stats(
+                        embedding_msg.telemetry_id,
+                        error_count=1,
+                    )
+                    request_failed_message = error_msg
+                    report_error_args = (error_msg, data)
+                    return None
 
                 # Circuit breaker: if API is known-broken, re-enqueue and wait
                 try:
@@ -582,16 +673,29 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         wait = self._circuit_breaker.retry_after
                         if wait > 0:
                             await asyncio.sleep(wait)
-                        await self._vikingdb.enqueue_embedding_msg(embedding_msg)
+                        requeued = await self._vikingdb.enqueue_embedding_msg(embedding_msg)
+                        if requeued:
+                            tracker_attempt_terminal = False
+                            self._merge_request_stats(
+                                embedding_msg.telemetry_id,
+                                requeue_count=1,
+                            )
+                            get_request_wait_tracker().record_embedding_requeue(
+                                embedding_msg.telemetry_id
+                            )
+                            self.report_requeue()
+                            report_success = True
+                            return None
+                        error_msg = self._embedding_error_msg(
+                            embedding_msg,
+                            "Circuit breaker retry could not be persisted",
+                        )
                         self._merge_request_stats(
                             embedding_msg.telemetry_id,
-                            requeue_count=1,
+                            error_count=1,
                         )
-                        get_request_wait_tracker().record_embedding_requeue(
-                            embedding_msg.telemetry_id
-                        )
-                        self.report_requeue()
-                        report_success = True
+                        request_failed_message = error_msg
+                        report_error_args = (error_msg, data)
                         return None
                     # No queue manager — cannot re-enqueue, drop with error
                     error_msg = self._embedding_error_msg(
@@ -677,7 +781,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         self._circuit_breaker.record_failure(embed_err)
                         if getattr(self._vikingdb, "has_queue_manager", False):
                             try:
-                                await self._vikingdb.enqueue_embedding_msg(embedding_msg)
+                                requeued = await self._vikingdb.enqueue_embedding_msg(embedding_msg)
+                                if not requeued:
+                                    raise RuntimeError("embedding retry could not be persisted")
+                                tracker_attempt_terminal = False
                                 self._merge_request_stats(
                                     embedding_msg.telemetry_id,
                                     requeue_count=1,
@@ -769,14 +876,25 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         logger.debug(
                             f"Successfully wrote embedding to database: {record_id} abstract {inserted_data['abstract']} vector {inserted_data['vector'][:5]}"
                         )
+                    else:
+                        error_msg = self._embedding_error_msg(
+                            embedding_msg,
+                            "Vector database write did not persist a record",
+                        )
+                        logger.error(error_msg)
+                        self._merge_request_stats(
+                            embedding_msg.telemetry_id,
+                            error_count=1,
+                        )
+                        request_failed_message = error_msg
+                        report_error_args = (error_msg, data)
+                        return None
                 except CollectionNotFoundError as db_err:
                     # During shutdown, queue workers may finish one dequeued item.
                     if self._vikingdb.is_closing:
                         logger.debug(f"Skip embedding write during shutdown: {db_err}")
-                        self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
-                        self._record_request_success(embedding_msg)
-                        report_success = True
-                        return None
+                        tracker_attempt_terminal = False
+                        raise asyncio.CancelledError
                     error_msg = self._embedding_error_msg(
                         embedding_msg,
                         f"Failed to write to vector database: {db_err}",
@@ -789,10 +907,8 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                 except Exception as db_err:
                     if self._vikingdb.is_closing:
                         logger.debug(f"Skip embedding write during shutdown: {db_err}")
-                        self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
-                        self._record_request_success(embedding_msg)
-                        report_success = True
-                        return None
+                        tracker_attempt_terminal = False
+                        raise asyncio.CancelledError
                     error_msg = self._embedding_error_msg(
                         embedding_msg,
                         f"Failed to write to vector database: {db_err}",
@@ -829,12 +945,18 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         finally:
             if embedding_msg is not None and request_failed_message is not None:
                 self._record_request_failure(embedding_msg, request_failed_message)
-            if embedding_msg and embedding_msg.semantic_msg_id:
+            if tracker_attempt_terminal and embedding_msg and embedding_msg.semantic_msg_id:
                 from openviking.storage.queuefs.embedding_tracker import EmbeddingTaskTracker
 
                 tracker = EmbeddingTaskTracker.get_instance()
                 try:
-                    await tracker.decrement(embedding_msg.semantic_msg_id)
+                    await tracker.decrement(
+                        embedding_msg.semantic_msg_id,
+                        is_leaf=bool(
+                            embedding_msg.operation == "embed"
+                            and embedding_msg.context_data.get("is_leaf", False)
+                        ),
+                    )
                 except Exception as tracker_err:
                     logger.warning(f"Failed to decrement embedding tracker: {tracker_err}")
             if report_error_args is not None:
@@ -854,6 +976,13 @@ class TextEmbeddingHandler(DequeueHandlerBase):
     def _record_request_failure(embedding_msg: EmbeddingMsg, message: str) -> None:
         tracker = get_request_wait_tracker()
         if embedding_msg.semantic_msg_id:
-            tracker.record_embedding_error(embedding_msg.telemetry_id, message)
+            tracker.record_embedding_error(
+                embedding_msg.telemetry_id,
+                message,
+                is_leaf=bool(
+                    embedding_msg.operation == "embed"
+                    and embedding_msg.context_data.get("is_leaf", False)
+                ),
+            )
         else:
             tracker.mark_embedding_failed(embedding_msg.telemetry_id, embedding_msg.id, message)

--- a/openviking/storage/queuefs/embedding_msg.py
+++ b/openviking/storage/queuefs/embedding_msg.py
@@ -13,6 +13,8 @@ class EmbeddingMsg:
     id: str = field(default_factory=lambda: str(uuid4()))
     telemetry_id: str = ""
     semantic_msg_id: Optional[str] = None
+    operation: str = "embed"
+    retry_count: int = 0
 
     def __init__(
         self,
@@ -20,12 +22,16 @@ class EmbeddingMsg:
         context_data: Dict[str, Any],
         telemetry_id: str = "",
         semantic_msg_id: Optional[str] = None,
+        operation: str = "embed",
+        retry_count: int = 0,
     ):
         self.id = str(uuid4())
         self.message = message
         self.context_data = context_data
         self.telemetry_id = telemetry_id
         self.semantic_msg_id = semantic_msg_id
+        self.operation = operation
+        self.retry_count = retry_count
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert embedding message to dictionary format."""
@@ -43,6 +49,8 @@ class EmbeddingMsg:
             context_data=data["context_data"],
             telemetry_id=data.get("telemetry_id", ""),
             semantic_msg_id=data.get("semantic_msg_id"),
+            operation=data.get("operation", "embed"),
+            retry_count=data.get("retry_count", 0),
         )
         obj.id = data.get("id", obj.id)
         return obj

--- a/openviking/storage/queuefs/embedding_tracker.py
+++ b/openviking/storage/queuefs/embedding_tracker.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import threading
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from openviking_cli.utils.logger import get_logger
 
@@ -22,6 +22,13 @@ class _EmbeddingTaskRecord:
     on_complete: Optional[Callable[[], Any]]
     metadata: Dict[str, Any]
     owner_loop: Optional[asyncio.AbstractEventLoop]
+    sealed: bool = True
+    tracks_leaf: bool = False
+    leaf_remaining: int = 0
+    leaf_total: int = 0
+    leaf_sealed: bool = True
+    on_leaf_complete: Optional[Callable[[], Any]] = None
+    leaf_callback_fired: bool = False
 
 
 class EmbeddingTaskTracker:
@@ -61,15 +68,15 @@ class EmbeddingTaskTracker:
         """Invoke a completion callback and await async results."""
         await self._await_callback_result(on_complete())
 
-    async def _run_on_complete(
+    async def _run_callback(
         self,
         semantic_msg_id: str,
-        record: _EmbeddingTaskRecord,
+        callback_name: str,
+        callback: Optional[Callable[[], Any]],
+        owner_loop: Optional[asyncio.AbstractEventLoop],
     ) -> None:
-        """Execute the completion callback on the loop that registered it."""
-        on_complete = record.on_complete
-        owner_loop = record.owner_loop
-        if on_complete is None:
+        """Execute a tracker callback on the loop that registered it."""
+        if callback is None:
             return
 
         try:
@@ -93,7 +100,7 @@ class EmbeddingTaskTracker:
                 else:
                     try:
                         fut = asyncio.run_coroutine_threadsafe(
-                            self._execute_callback(on_complete),
+                            self._execute_callback(callback),
                             owner_loop,
                         )
                     except RuntimeError:
@@ -106,11 +113,26 @@ class EmbeddingTaskTracker:
                         await asyncio.wrap_future(fut)
                         return
 
-            await self._execute_callback(on_complete)
+            await self._execute_callback(callback)
         except Exception as e:
             logger.error(
-                f"Error in completion callback for {semantic_msg_id}: {e}",
+                f"Error in {callback_name} callback for {semantic_msg_id}: {e}",
                 exc_info=True,
+            )
+
+    async def _run_callbacks(
+        self,
+        semantic_msg_id: str,
+        callbacks: List[
+            Tuple[str, Optional[Callable[[], Any]], Optional[asyncio.AbstractEventLoop]]
+        ],
+    ) -> None:
+        for callback_name, callback, owner_loop in callbacks:
+            await self._run_callback(
+                semantic_msg_id,
+                callback_name,
+                callback,
+                owner_loop,
             )
 
     @classmethod
@@ -166,9 +188,119 @@ class EmbeddingTaskTracker:
                 )
 
         if record_to_finalize is not None:
-            await self._run_on_complete(semantic_msg_id, record_to_finalize)
+            await self._run_callback(
+                semantic_msg_id,
+                "completion",
+                record_to_finalize.on_complete,
+                record_to_finalize.owner_loop,
+            )
 
-    async def decrement(self, semantic_msg_id: str) -> Optional[int]:
+    async def register_open(
+        self,
+        semantic_msg_id: str,
+        on_complete: Optional[Callable[[], Any]] = None,
+        on_leaf_complete: Optional[Callable[[], Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Register a tracker whose task counts will be discovered incrementally."""
+        owner_loop = asyncio.get_running_loop()
+        with self._lock:
+            existing = self._tasks.get(semantic_msg_id)
+            if existing is not None:
+                logger.warning(
+                    "Overwriting existing embedding tracker record for SemanticMsg %s",
+                    semantic_msg_id,
+                )
+
+            self._tasks[semantic_msg_id] = _EmbeddingTaskRecord(
+                remaining=0,
+                total=0,
+                on_complete=on_complete,
+                metadata=metadata or {},
+                owner_loop=owner_loop,
+                sealed=False,
+                tracks_leaf=True,
+                leaf_sealed=False,
+                on_leaf_complete=on_leaf_complete,
+            )
+
+    async def add(
+        self,
+        semantic_msg_id: str,
+        count: int,
+        leaf_count: int = 0,
+    ) -> None:
+        """Add newly discovered embedding tasks to an open tracker."""
+        if count < 0 or leaf_count < 0 or leaf_count > count:
+            raise ValueError("count and leaf_count must satisfy 0 <= leaf_count <= count")
+
+        with self._lock:
+            record = self._tasks.get(semantic_msg_id)
+            if record is None:
+                raise KeyError(f"Embedding tracker not found: {semantic_msg_id}")
+            if record.sealed and count:
+                raise RuntimeError(f"Embedding tracker is sealed: {semantic_msg_id}")
+            if record.leaf_sealed and leaf_count:
+                raise RuntimeError(f"Leaf embedding tracker is sealed: {semantic_msg_id}")
+
+            record.remaining += count
+            record.total += count
+            record.leaf_remaining += leaf_count
+            record.leaf_total += leaf_count
+
+    async def seal_leaf(self, semantic_msg_id: str) -> Optional[int]:
+        """Seal leaf discovery and fire the leaf callback once all leaves finish."""
+        callbacks: List[
+            Tuple[str, Optional[Callable[[], Any]], Optional[asyncio.AbstractEventLoop]]
+        ] = []
+        with self._lock:
+            record = self._tasks.get(semantic_msg_id)
+            if record is None:
+                return None
+
+            record.leaf_sealed = True
+            if record.leaf_remaining <= 0 and not record.leaf_callback_fired:
+                record.leaf_callback_fired = True
+                callbacks.append(("leaf completion", record.on_leaf_complete, record.owner_loop))
+            remaining = record.leaf_remaining
+
+        await self._run_callbacks(semantic_msg_id, callbacks)
+        return remaining
+
+    async def seal(self, semantic_msg_id: str) -> Optional[int]:
+        """Seal all task discovery and complete once all registered tasks finish."""
+        callbacks: List[
+            Tuple[str, Optional[Callable[[], Any]], Optional[asyncio.AbstractEventLoop]]
+        ] = []
+        with self._lock:
+            record = self._tasks.get(semantic_msg_id)
+            if record is None:
+                return None
+
+            record.sealed = True
+            record.leaf_sealed = True
+            if record.leaf_remaining <= 0 and not record.leaf_callback_fired:
+                record.leaf_callback_fired = True
+                callbacks.append(("leaf completion", record.on_leaf_complete, record.owner_loop))
+
+            remaining = record.remaining
+            if remaining <= 0:
+                self._tasks.pop(semantic_msg_id)
+                callbacks.append(("completion", record.on_complete, record.owner_loop))
+
+        await self._run_callbacks(semantic_msg_id, callbacks)
+        return remaining
+
+    async def discard(self, semantic_msg_id: str) -> bool:
+        """Remove a tracker without running completion callbacks."""
+        with self._lock:
+            return self._tasks.pop(semantic_msg_id, None) is not None
+
+    async def decrement(
+        self,
+        semantic_msg_id: str,
+        is_leaf: bool = False,
+    ) -> Optional[int]:
         """Decrement the remaining task count for a SemanticMsg.
 
         This method should be called when an embedding task is completed.
@@ -181,7 +313,9 @@ class EmbeddingTaskTracker:
         Returns:
             The remaining count after decrement, or None if not found
         """
-        record_to_finalize: Optional[_EmbeddingTaskRecord] = None
+        callbacks: List[
+            Tuple[str, Optional[Callable[[], Any]], Optional[asyncio.AbstractEventLoop]]
+        ] = []
 
         with self._lock:
             record = self._tasks.get(semantic_msg_id)
@@ -190,13 +324,24 @@ class EmbeddingTaskTracker:
 
             record.remaining -= 1
             remaining = record.remaining
+            if is_leaf and record.tracks_leaf:
+                record.leaf_remaining -= 1
 
-            if remaining <= 0:
-                record_to_finalize = self._tasks.pop(semantic_msg_id)
+            if (
+                record.tracks_leaf
+                and record.leaf_sealed
+                and record.leaf_remaining <= 0
+                and not record.leaf_callback_fired
+            ):
+                record.leaf_callback_fired = True
+                callbacks.append(("leaf completion", record.on_leaf_complete, record.owner_loop))
+
+            if record.sealed and remaining <= 0:
+                self._tasks.pop(semantic_msg_id)
                 logger.info(
                     f"All embedding tasks({record.total}) completed for SemanticMsg {semantic_msg_id}"
                 )
+                callbacks.append(("completion", record.on_complete, record.owner_loop))
 
-        if record_to_finalize is not None:
-            await self._run_on_complete(semantic_msg_id, record_to_finalize)
+        await self._run_callbacks(semantic_msg_id, callbacks)
         return remaining

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -6,6 +6,7 @@ import asyncio
 import threading
 from dataclasses import dataclass, field
 from typing import ClassVar, Dict, List, Optional, Set
+from uuid import uuid4
 from weakref import WeakKeyDictionary
 
 from openviking.server.identity import RequestContext
@@ -182,6 +183,7 @@ class SemanticDagExecutor:
         self._incremental_update = incremental_update
         self._target_uri = target_uri
         self._semantic_msg_id = semantic_msg_id
+        self._embedding_tracker_id = f"{semantic_msg_id}:{uuid4().hex}" if semantic_msg_id else None
         self._telemetry_id = telemetry_id
         self._recursive = recursive
         self._lock = lock
@@ -257,15 +259,18 @@ class SemanticDagExecutor:
 
         try:
             self._register_active()
-            if not self._skip_vectorization and self._semantic_msg_id:
+            if not self._skip_vectorization and self._embedding_tracker_id:
                 from .embedding_tracker import EmbeddingTaskTracker
 
                 self._embedding_tracker = EmbeddingTaskTracker.get_instance()
                 await self._embedding_tracker.register_open(
-                    semantic_msg_id=self._semantic_msg_id,
+                    semantic_msg_id=self._embedding_tracker_id,
                     on_complete=wrapped_on_complete,
                     on_leaf_complete=wrapped_on_leaf_complete,
-                    metadata={"uri": root_uri},
+                    metadata={
+                        "uri": root_uri,
+                        "semantic_msg_id": self._semantic_msg_id,
+                    },
                 )
 
             self._schedule_dir(root_uri, parent_uri=None)
@@ -278,8 +283,8 @@ class SemanticDagExecutor:
             if pending_vectorize_work > 0:
                 await self._vectorize_done.wait()
 
-            if self._embedding_tracker is not None and self._semantic_msg_id is not None:
-                await self._embedding_tracker.seal(self._semantic_msg_id)
+            if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
+                await self._embedding_tracker.seal(self._embedding_tracker_id)
             else:
                 try:
                     await wrapped_on_complete()
@@ -287,9 +292,9 @@ class SemanticDagExecutor:
                     logger.error(f"Error in on_complete callback: {e}", exc_info=True)
         except BaseException:
             self._closed = True
-            if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+            if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
                 try:
-                    await self._embedding_tracker.discard(self._semantic_msg_id)
+                    await self._embedding_tracker.discard(self._embedding_tracker_id)
                 except Exception:
                     pass
             try:
@@ -431,8 +436,8 @@ class SemanticDagExecutor:
         ):
             return
         self._leaf_sealed = True
-        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
-            await self._embedding_tracker.seal_leaf(self._semantic_msg_id)
+        if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
+            await self._embedding_tracker.seal_leaf(self._embedding_tracker_id)
 
     async def _run_vectorize_work(self, task: Optional[VectorizeTask]) -> None:
         try:
@@ -746,7 +751,7 @@ class SemanticDagExecutor:
                     uri=file_path,
                     context_type=self._context_type,
                     ctx=self._ctx,
-                    semantic_msg_id=self._semantic_msg_id,
+                    semantic_msg_id=self._embedding_tracker_id,
                     file_path=file_path,
                     summary_dict={"name": file_name, "summary": ""},
                     parent_uri=parent_uri,
@@ -777,7 +782,7 @@ class SemanticDagExecutor:
                     uri=file_path,
                     context_type=self._context_type,
                     ctx=self._ctx,
-                    semantic_msg_id=self._semantic_msg_id,
+                    semantic_msg_id=self._embedding_tracker_id,
                     file_path=file_path,
                     summary_dict=summary_dict,
                     parent_uri=parent_uri,
@@ -792,9 +797,9 @@ class SemanticDagExecutor:
         await self._on_file_done(parent_uri, file_path, summary_dict)
 
     async def _add_metadata_patch(self, file_path: str, summary: str) -> None:
-        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+        if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
             await self._embedding_tracker.add(
-                self._semantic_msg_id,
+                self._embedding_tracker_id,
                 count=1,
                 leaf_count=0,
             )
@@ -814,15 +819,15 @@ class SemanticDagExecutor:
         await self._enqueue_registered_metadata_patch(file_path, summary)
 
     async def _discard_registered_metadata_patch(self) -> None:
-        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+        if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
             await self._embedding_tracker.decrement(
-                self._semantic_msg_id,
+                self._embedding_tracker_id,
                 is_leaf=False,
             )
 
     async def _enqueue_registered_metadata_patch(self, file_path: str, summary: str) -> None:
         tracker = self._embedding_tracker
-        semantic_msg_id = self._semantic_msg_id
+        semantic_msg_id = self._embedding_tracker_id
         if tracker is None or semantic_msg_id is None:
             return
 
@@ -843,14 +848,14 @@ class SemanticDagExecutor:
                         file_path=file_path,
                         summary=summary,
                         ctx=self._ctx,
-                        semantic_msg_id=self._semantic_msg_id,
+                        semantic_msg_id=semantic_msg_id,
                     )
             else:
                 enqueued = await self._processor._patch_file_summary(
                     file_path=file_path,
                     summary=summary,
                     ctx=self._ctx,
-                    semantic_msg_id=self._semantic_msg_id,
+                    semantic_msg_id=semantic_msg_id,
                 )
         except Exception as exc:
             logger.error(
@@ -1006,7 +1011,7 @@ class SemanticDagExecutor:
                         uri=dir_uri,
                         context_type=self._context_type,
                         ctx=self._ctx,
-                        semantic_msg_id=self._semantic_msg_id,
+                        semantic_msg_id=self._embedding_tracker_id,
                         abstract=abstract,
                         overview=overview,
                     )
@@ -1066,9 +1071,9 @@ class SemanticDagExecutor:
 
         task_count = 1 if task.task_type == "file" else 2
         leaf_count = 1 if task.task_type == "file" else 0
-        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+        if self._embedding_tracker is not None and self._embedding_tracker_id is not None:
             await self._embedding_tracker.add(
-                self._semantic_msg_id,
+                self._embedding_tracker_id,
                 count=task_count,
                 leaf_count=leaf_count,
             )

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -13,6 +13,7 @@ from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.transaction import NO_LOCK, LockLease
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+from openviking.utils.embedding_utils import resolve_leaf_vectorization_plan
 from openviking_cli.utils import VikingURI
 from openviking_cli.utils.logger import get_logger
 
@@ -63,6 +64,7 @@ class VectorizeTask:
     summary_dict: Optional[Dict[str, str]] = None
     parent_uri: Optional[str] = None
     use_summary: bool = False
+    record_failure: bool = True
     # For directory tasks
     abstract: Optional[str] = None
     overview: Optional[str] = None
@@ -203,11 +205,16 @@ class SemanticDagExecutor:
         self._closed = False
         self._failure: Optional[Exception] = None
         self._stats = DagStats()
-        self._vectorize_task_count: int = 0
-        self._pending_vectorize_tasks: List[VectorizeTask] = []
+        self._embedding_tracker: Optional["EmbeddingTaskTracker"] = None
         self._pending_vectorize_work = 0
         self._vectorize_done: Optional[asyncio.Event] = None
         self._vectorize_lock = asyncio.Lock()
+        self._pending_dir_discovery = 0
+        self._pending_leaf_registration = 0
+        self._registered_leaf_paths: Set[str] = set()
+        self._leaf_sealed = False
+        self._leaf_embeddings_terminal = False
+        self._pending_metadata_patches: List[tuple[str, str]] = []
         self._file_change_status: Dict[str, bool] = {}
         self._dir_change_status: Dict[str, bool] = {}
         self._overview_cache: Dict[str, Dict[str, str]] = {}
@@ -217,49 +224,74 @@ class SemanticDagExecutor:
         """Run DAG execution starting from root_uri."""
         self._root_uri = root_uri
         self._root_done = asyncio.Event()
+        self._vectorize_done = asyncio.Event()
         self._scheduler = get_semantic_node_scheduler(self._node_concurrency)
+
+        # Release owned semantic locks after downstream vectorization finishes.
+        async def wrapped_on_complete() -> None:
+            try:
+                if self._telemetry_id and self._semantic_msg_id:
+                    get_request_wait_tracker().mark_semantic_done(
+                        self._telemetry_id, self._semantic_msg_id
+                    )
+            finally:
+                await self._lock.close()
+
+        async def wrapped_on_leaf_complete() -> None:
+            self._leaf_embeddings_terminal = True
+            pending_patches = self._pending_metadata_patches
+            self._pending_metadata_patches = []
+            leaf_failed = bool(
+                self._telemetry_id
+                and get_request_wait_tracker().has_leaf_embedding_errors(self._telemetry_id)
+            )
+            if self._telemetry_id and self._semantic_msg_id:
+                get_request_wait_tracker().mark_semantic_leaf_done(
+                    self._telemetry_id, self._semantic_msg_id
+                )
+            for file_path, summary in pending_patches:
+                if leaf_failed:
+                    await self._discard_registered_metadata_patch()
+                else:
+                    await self._enqueue_registered_metadata_patch(file_path, summary)
 
         try:
             self._register_active()
+            if not self._skip_vectorization and self._semantic_msg_id:
+                from .embedding_tracker import EmbeddingTaskTracker
+
+                self._embedding_tracker = EmbeddingTaskTracker.get_instance()
+                await self._embedding_tracker.register_open(
+                    semantic_msg_id=self._semantic_msg_id,
+                    on_complete=wrapped_on_complete,
+                    on_leaf_complete=wrapped_on_leaf_complete,
+                    metadata={"uri": root_uri},
+                )
+
             self._schedule_dir(root_uri, parent_uri=None)
             await self._root_done.wait()
             if self._failure:
                 raise self._failure
 
-            # Release owned semantic locks after downstream vectorization finishes.
-            async def wrapped_on_complete() -> None:
-                try:
-                    if self._telemetry_id and self._semantic_msg_id:
-                        get_request_wait_tracker().mark_semantic_done(
-                            self._telemetry_id, self._semantic_msg_id
-                        )
-                finally:
-                    await self._lock.close()
-
             async with self._vectorize_lock:
-                task_count = self._vectorize_task_count
-                tasks = list(self._pending_vectorize_tasks)
+                pending_vectorize_work = self._pending_vectorize_work
+            if pending_vectorize_work > 0:
+                await self._vectorize_done.wait()
 
-            if task_count > 0:
-                from .embedding_tracker import EmbeddingTaskTracker
-
-                tracker = EmbeddingTaskTracker.get_instance()
-                await tracker.register(
-                    semantic_msg_id=self._semantic_msg_id,
-                    total_count=task_count,
-                    on_complete=wrapped_on_complete,
-                    metadata={"uri": root_uri},
-                )
-
-                await self._dispatch_vectorize_tasks(tasks)
+            if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+                await self._embedding_tracker.seal(self._semantic_msg_id)
             else:
-                # No vectorize tasks — release lock immediately (via wrapped callback)
                 try:
                     await wrapped_on_complete()
                 except Exception as e:
                     logger.error(f"Error in on_complete callback: {e}", exc_info=True)
         except BaseException:
             self._closed = True
+            if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+                try:
+                    await self._embedding_tracker.discard(self._semantic_msg_id)
+                except Exception:
+                    pass
             try:
                 await self._lock.close()
             except Exception:
@@ -279,6 +311,7 @@ class SemanticDagExecutor:
     def _schedule_dir(self, dir_uri: str, parent_uri: Optional[str]) -> None:
         if self._closed:
             return
+        self._pending_dir_discovery += 1
         self._stats.total_nodes += 1
         self._stats.pending_nodes += 1
         self._schedule_work(DagWork(kind="dir", dir_uri=dir_uri, parent_uri=parent_uri))
@@ -286,6 +319,7 @@ class SemanticDagExecutor:
     def _schedule_file(self, parent_uri: str, file_path: str) -> None:
         if self._closed:
             return
+        self._pending_leaf_registration += 1
         self._stats.total_nodes += 1
         self._stats.pending_nodes += 1
         self._schedule_work(DagWork(kind="file", dir_uri=parent_uri, file_path=file_path))
@@ -356,13 +390,18 @@ class SemanticDagExecutor:
                     self._mark_node_done()
                 else:
                     self._mark_node_waiting()
+                await self._finish_dir_discovery()
             return
 
         if work.kind == "file":
             if work.file_path is None:
                 self._mark_node_done()
+                await self._finish_leaf_registration("")
                 return
-            await self._file_summary_task(work.dir_uri, work.file_path)
+            try:
+                await self._file_summary_task(work.dir_uri, work.file_path)
+            finally:
+                await self._finish_leaf_registration(work.file_path)
             return
 
         if work.kind == "overview":
@@ -372,23 +411,33 @@ class SemanticDagExecutor:
         self._mark_node_done()
         logger.warning("Unknown semantic DAG work kind: %s", work.kind)
 
-    async def _dispatch_vectorize_tasks(self, tasks: List[VectorizeTask]) -> None:
-        self._vectorize_done = asyncio.Event()
-        self._pending_vectorize_work = len(tasks)
-        for task in tasks:
-            self._schedule_work(
-                DagWork(
-                    kind="vectorize",
-                    dir_uri=task.uri,
-                    vectorize_task=task,
-                )
-            )
-        await self._vectorize_done.wait()
+    async def _finish_dir_discovery(self) -> None:
+        self._pending_dir_discovery = max(0, self._pending_dir_discovery - 1)
+        await self._maybe_seal_leaf()
+
+    async def _finish_leaf_registration(self, file_path: str) -> None:
+        if file_path in self._registered_leaf_paths:
+            return
+        self._registered_leaf_paths.add(file_path)
+        self._pending_leaf_registration = max(0, self._pending_leaf_registration - 1)
+        await self._maybe_seal_leaf()
+
+    async def _maybe_seal_leaf(self) -> None:
+        if (
+            self._leaf_sealed
+            or self._failure is not None
+            or self._pending_dir_discovery > 0
+            or self._pending_leaf_registration > 0
+        ):
+            return
+        self._leaf_sealed = True
+        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+            await self._embedding_tracker.seal_leaf(self._semantic_msg_id)
 
     async def _run_vectorize_work(self, task: Optional[VectorizeTask]) -> None:
         try:
             if task is not None:
-                await self._run_vectorize_task(task)
+                await self._run_vectorize_with_telemetry(task)
         except Exception as exc:
             logger.error("Vectorization dispatch task failed: %s", exc, exc_info=True)
         finally:
@@ -396,9 +445,9 @@ class SemanticDagExecutor:
             if self._pending_vectorize_work == 0 and self._vectorize_done:
                 self._vectorize_done.set()
 
-    async def _run_vectorize_task(self, task: VectorizeTask) -> None:
+    async def _run_vectorize_task(self, task: VectorizeTask) -> bool:
         if task.task_type == "file":
-            await self._processor._vectorize_single_file(
+            return await self._processor._vectorize_single_file(
                 parent_uri=task.parent_uri,
                 context_type=task.context_type,
                 file_path=task.file_path,
@@ -406,8 +455,8 @@ class SemanticDagExecutor:
                 ctx=task.ctx,
                 semantic_msg_id=task.semantic_msg_id,
                 use_summary=task.use_summary,
+                record_failure=task.record_failure,
             )
-            return
 
         await self._processor._vectorize_directory(
             task.uri,
@@ -417,6 +466,25 @@ class SemanticDagExecutor:
             ctx=task.ctx,
             semantic_msg_id=task.semantic_msg_id,
         )
+        return True
+
+    async def _run_vectorize_with_telemetry(self, task: VectorizeTask) -> bool:
+        if not self._telemetry_id:
+            return await self._run_vectorize_task(task)
+
+        from openviking.telemetry import bind_telemetry, resolve_telemetry
+
+        telemetry = resolve_telemetry(self._telemetry_id)
+        if telemetry is None:
+            from openviking.telemetry.operation import OperationTelemetry
+
+            telemetry = OperationTelemetry(
+                operation="semantic_vectorize",
+                enabled=False,
+            )
+            telemetry.telemetry_id = self._telemetry_id
+        with bind_telemetry(telemetry):
+            return await self._run_vectorize_task(task)
 
     async def _dispatch_dir(self, dir_uri: str, parent_uri: Optional[str]) -> bool:
         """Lazy-dispatch tasks for a directory when it is triggered."""
@@ -461,10 +529,7 @@ class SemanticDagExecutor:
             return False
         except Exception as e:
             logger.error(f"Failed to dispatch directory {dir_uri}: {e}", exc_info=True)
-            if parent_uri:
-                await self._on_child_done(parent_uri, dir_uri, "")
-            elif self._root_done:
-                self._root_done.set()
+            self.fail(e)
             return True
 
     async def _list_dir(self, uri: str, from_hint: str) -> tuple[list[str], list[str]]:
@@ -475,7 +540,7 @@ class SemanticDagExecutor:
             logger.warning(
                 f"[SemanticDagExecutor] Failed to list directory {uri}: {e} from {from_hint}"
             )
-            return [], []
+            raise
 
         children_dirs: List[str] = []
         file_paths: List[str] = []
@@ -653,6 +718,7 @@ class SemanticDagExecutor:
 
         file_name = file_path.split("/")[-1]
         need_vectorize = True
+        embedding_first = False
         try:
             summary_dict = None
             if self._incremental_update:
@@ -667,6 +733,31 @@ class SemanticDagExecutor:
                         self._file_change_status[file_path] = True
             else:
                 self._file_change_status[file_path] = True
+
+            use_summary = self._is_code_repo
+            plan = resolve_leaf_vectorization_plan(
+                file_name,
+                use_summary=use_summary,
+            )
+            embedding_first = need_vectorize and not plan.requires_summary
+            if embedding_first:
+                task = VectorizeTask(
+                    task_type="file",
+                    uri=file_path,
+                    context_type=self._context_type,
+                    ctx=self._ctx,
+                    semantic_msg_id=self._semantic_msg_id,
+                    file_path=file_path,
+                    summary_dict={"name": file_name, "summary": ""},
+                    parent_uri=parent_uri,
+                    record_failure=False,
+                )
+                embedding_first = await self._dispatch_vectorize_task(task)
+                if embedding_first:
+                    await self._finish_leaf_registration(file_path)
+            elif not need_vectorize:
+                await self._finish_leaf_registration(file_path)
+
             if summary_dict is None:
                 summary_dict = await self._processor._generate_single_file_summary(
                     file_path, llm_sem=self._llm_sem, ctx=self._ctx
@@ -679,7 +770,7 @@ class SemanticDagExecutor:
             self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)
 
         try:
-            if need_vectorize:
+            if need_vectorize and not embedding_first:
                 use_summary = self._is_code_repo and bool(summary_dict.get("summary"))
                 task = VectorizeTask(
                     task_type="file",
@@ -693,9 +784,96 @@ class SemanticDagExecutor:
                     use_summary=use_summary,
                 )
                 await self._add_vectorize_task(task)
+                await self._finish_leaf_registration(file_path)
+            elif embedding_first and summary_dict.get("summary"):
+                await self._add_metadata_patch(file_path, summary_dict["summary"])
         except Exception as e:
             logger.error(f"Failed to schedule vectorization for {file_path}: {e}", exc_info=True)
         await self._on_file_done(parent_uri, file_path, summary_dict)
+
+    async def _add_metadata_patch(self, file_path: str, summary: str) -> None:
+        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+            await self._embedding_tracker.add(
+                self._semantic_msg_id,
+                count=1,
+                leaf_count=0,
+            )
+        else:
+            return
+
+        if not self._leaf_embeddings_terminal:
+            self._pending_metadata_patches.append((file_path, summary))
+            return
+
+        if self._telemetry_id and get_request_wait_tracker().has_leaf_embedding_errors(
+            self._telemetry_id
+        ):
+            await self._discard_registered_metadata_patch()
+            return
+
+        await self._enqueue_registered_metadata_patch(file_path, summary)
+
+    async def _discard_registered_metadata_patch(self) -> None:
+        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+            await self._embedding_tracker.decrement(
+                self._semantic_msg_id,
+                is_leaf=False,
+            )
+
+    async def _enqueue_registered_metadata_patch(self, file_path: str, summary: str) -> None:
+        tracker = self._embedding_tracker
+        semantic_msg_id = self._semantic_msg_id
+        if tracker is None or semantic_msg_id is None:
+            return
+
+        try:
+            if self._telemetry_id:
+                from openviking.telemetry import bind_telemetry, resolve_telemetry
+                from openviking.telemetry.operation import OperationTelemetry
+
+                telemetry = resolve_telemetry(self._telemetry_id)
+                if telemetry is None:
+                    telemetry = OperationTelemetry(
+                        operation="semantic_metadata_patch",
+                        enabled=False,
+                    )
+                    telemetry.telemetry_id = self._telemetry_id
+                with bind_telemetry(telemetry):
+                    enqueued = await self._processor._patch_file_summary(
+                        file_path=file_path,
+                        summary=summary,
+                        ctx=self._ctx,
+                        semantic_msg_id=self._semantic_msg_id,
+                    )
+            else:
+                enqueued = await self._processor._patch_file_summary(
+                    file_path=file_path,
+                    summary=summary,
+                    ctx=self._ctx,
+                    semantic_msg_id=self._semantic_msg_id,
+                )
+        except Exception as exc:
+            logger.error(
+                "Failed to enqueue metadata patch for %s: %s",
+                file_path,
+                exc,
+                exc_info=True,
+            )
+            enqueued = False
+
+        if enqueued:
+            return
+
+        if self._telemetry_id:
+            get_request_wait_tracker().record_embedding_error(
+                self._telemetry_id,
+                f"Failed to enqueue metadata patch for {file_path}",
+                is_leaf=False,
+            )
+        await tracker.decrement(
+            semantic_msg_id,
+            is_leaf=False,
+        )
 
     async def _on_file_done(
         self, parent_uri: str, file_path: str, summary_dict: Dict[str, str]
@@ -792,10 +970,9 @@ class SemanticDagExecutor:
             return
         need_vectorize = True
         children_changed = True
-        abstract = ""
+        overview: Optional[str] = None
+        abstract: Optional[str] = None
         try:
-            overview = None
-            abstract = None
             if self._incremental_update:
                 children_changed = await self._check_dir_children_changed(
                     dir_uri, node.file_paths, node.children_dirs
@@ -852,23 +1029,50 @@ class SemanticDagExecutor:
                 self._root_done.set()
             return
 
-        await self._on_child_done(parent_uri, dir_uri, abstract)
+        await self._on_child_done(parent_uri, dir_uri, abstract or "")
         self._release_dir_node(dir_uri)
 
     async def _add_vectorize_task(self, task: VectorizeTask) -> None:
-        """Add a vectorize task to the pending list."""
+        """Register and immediately dispatch a newly discovered vectorize task."""
+        registered = await self._register_vectorize_task(task)
+        if not registered:
+            return
+
+        async with self._vectorize_lock:
+            self._pending_vectorize_work += 1
+            if self._vectorize_done:
+                self._vectorize_done.clear()
+        self._schedule_work(
+            DagWork(
+                kind="vectorize",
+                dir_uri=task.uri,
+                vectorize_task=task,
+            )
+        )
+
+    async def _dispatch_vectorize_task(self, task: VectorizeTask) -> bool:
+        """Register and persist vectorize work in the current DAG worker."""
+        if await self._register_vectorize_task(task):
+            return await self._run_vectorize_with_telemetry(task)
+        return False
+
+    async def _register_vectorize_task(self, task: VectorizeTask) -> bool:
         if self._skip_vectorization:
             logger.info(
                 "Skipping vectorization task for %s (requested via SemanticMsg)",
                 task.uri,
             )
-            return
-        async with self._vectorize_lock:
-            self._pending_vectorize_tasks.append(task)
-            if task.task_type == "file":
-                self._vectorize_task_count += 1
-            else:  # directory
-                self._vectorize_task_count += 2
+            return False
+
+        task_count = 1 if task.task_type == "file" else 2
+        leaf_count = 1 if task.task_type == "file" else 0
+        if self._embedding_tracker is not None and self._semantic_msg_id is not None:
+            await self._embedding_tracker.add(
+                self._semantic_msg_id,
+                count=task_count,
+                leaf_count=leaf_count,
+            )
+        return True
 
     def get_stats(self) -> DagStats:
         return DagStats(
@@ -880,4 +1084,5 @@ class SemanticDagExecutor:
 
 
 if False:  # pragma: no cover - for type checkers only
+    from openviking.storage.queuefs.embedding_tracker import EmbeddingTaskTracker
     from openviking.storage.queuefs.semantic_processor import SemanticProcessor

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1564,12 +1564,13 @@ class SemanticProcessor(DequeueHandlerBase):
         semantic_msg_id: Optional[str] = None,
         use_summary: bool = False,
         preserve_existing_created_at: bool = False,
-    ) -> None:
+        record_failure: bool = True,
+    ) -> bool:
         """Vectorize a single file using its content or summary."""
         from openviking.utils.embedding_utils import vectorize_file
 
         active_ctx = ctx or self._default_ctx
-        await vectorize_file(
+        return await vectorize_file(
             file_path=file_path,
             summary_dict=summary_dict,
             parent_uri=parent_uri,
@@ -1578,4 +1579,23 @@ class SemanticProcessor(DequeueHandlerBase):
             semantic_msg_id=semantic_msg_id,
             use_summary=use_summary,
             preserve_existing_created_at=preserve_existing_created_at,
+            record_failure=record_failure,
+        )
+
+    async def _patch_file_summary(
+        self,
+        file_path: str,
+        summary: str,
+        ctx: Optional[RequestContext] = None,
+        semantic_msg_id: Optional[str] = None,
+    ) -> bool:
+        """Enqueue a metadata-only abstract update for an indexed file."""
+        from openviking.utils.embedding_utils import enqueue_file_metadata_patch
+
+        active_ctx = ctx or self._default_ctx
+        return await enqueue_file_metadata_patch(
+            file_path=file_path,
+            summary=summary,
+            ctx=active_ctx,
+            semantic_msg_id=semantic_msg_id,
         )

--- a/openviking/telemetry/request_wait_tracker.py
+++ b/openviking/telemetry/request_wait_tracker.py
@@ -5,16 +5,19 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 
 @dataclass
 class _RequestWaitState:
     pending_semantic_roots: Set[str] = field(default_factory=set)
+    pending_leaf_semantic_roots: Set[str] = field(default_factory=set)
     pending_embedding_roots: Set[str] = field(default_factory=set)
+    leaf_tracking_started: bool = False
     semantic_processed: int = 0
     semantic_requeue_count: int = 0
     semantic_error_count: int = 0
@@ -22,6 +25,7 @@ class _RequestWaitState:
     embedding_processed: int = 0
     embedding_requeue_count: int = 0
     embedding_error_count: int = 0
+    leaf_embedding_error_count: int = 0
     embedding_errors: List[str] = field(default_factory=list)
     created_at: float = field(default_factory=time.time)
 
@@ -63,6 +67,8 @@ class RequestWaitTracker:
             if state is None:
                 return
             state.pending_semantic_roots.add(semantic_msg_id)
+            state.pending_leaf_semantic_roots.add(semantic_msg_id)
+            state.leaf_tracking_started = True
 
     def register_embedding_root(self, telemetry_id: str, root_id: str) -> None:
         if not telemetry_id or not root_id:
@@ -91,7 +97,13 @@ class RequestWaitTracker:
                 return
             state.embedding_requeue_count += max(delta, 0)
 
-    def record_embedding_error(self, telemetry_id: str, message: str) -> None:
+    def record_embedding_error(
+        self,
+        telemetry_id: str,
+        message: str,
+        *,
+        is_leaf: bool = False,
+    ) -> None:
         if not telemetry_id:
             return
         with self._lock:
@@ -99,8 +111,23 @@ class RequestWaitTracker:
             if state is None:
                 return
             state.embedding_error_count += 1
+            if is_leaf:
+                state.leaf_embedding_error_count += 1
             if message:
                 state.embedding_errors.append(message)
+
+    def mark_semantic_leaf_done(
+        self,
+        telemetry_id: str,
+        semantic_msg_id: str,
+    ) -> None:
+        if not telemetry_id:
+            return
+        with self._lock:
+            state = self._states.get(telemetry_id)
+            if state is None:
+                return
+            state.pending_leaf_semantic_roots.discard(semantic_msg_id)
 
     def mark_semantic_done(
         self,
@@ -134,6 +161,7 @@ class RequestWaitTracker:
             if state is None:
                 return
             state.pending_semantic_roots.discard(semantic_msg_id)
+            state.pending_leaf_semantic_roots.discard(semantic_msg_id)
             state.semantic_error_count += 1
             if message:
                 state.semantic_errors.append(message)
@@ -174,16 +202,48 @@ class RequestWaitTracker:
                 return True
             return not state.pending_semantic_roots and not state.pending_embedding_roots
 
+    def is_leaf_indexed(self, telemetry_id: str) -> bool:
+        if not telemetry_id:
+            return False
+        with self._lock:
+            state = self._states.get(telemetry_id)
+            if state is None:
+                return False
+            return (
+                state.leaf_tracking_started
+                and not state.pending_leaf_semantic_roots
+                and state.semantic_error_count == 0
+                and state.leaf_embedding_error_count == 0
+            )
+
+    def has_leaf_embedding_errors(self, telemetry_id: str) -> bool:
+        if not telemetry_id:
+            return False
+        with self._lock:
+            state = self._states.get(telemetry_id)
+            return bool(state and state.leaf_embedding_error_count > 0)
+
     async def wait_for_request(
         self,
         telemetry_id: str,
         timeout: Optional[float] = None,
         poll_interval: float = 0.05,
+        on_leaf_indexed: Optional[Callable[[], Any]] = None,
     ) -> None:
         if not telemetry_id:
             return
         start = time.time()
+        leaf_callback_fired = False
         while True:
+            if (
+                on_leaf_indexed is not None
+                and not leaf_callback_fired
+                and self.is_leaf_indexed(telemetry_id)
+            ):
+                leaf_callback_fired = True
+                callback_result = on_leaf_indexed()
+                if inspect.isawaitable(callback_result):
+                    await callback_result
             if self.is_complete(telemetry_id):
                 return
             if timeout is not None and (time.time() - start) > timeout:

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -7,6 +7,7 @@ Common logic for creating Context objects and enqueuing them to EmbeddingQueue.
 """
 
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -16,8 +17,11 @@ from openviking.core.context import Context, ContextLevel, ResourceContentType, 
 from openviking.core.namespace import context_type_for_uri, is_session_uri, owner_space_for_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.queuefs import get_queue_manager
+from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
+from openviking.telemetry import get_current_telemetry
+from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.image_search import image_bytes_to_data_uri
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.utils import VikingURI, get_logger
@@ -63,7 +67,12 @@ def _apply_scalar_overrides(embedding_msg, overrides: Optional[Dict[str, Any]]) 
             embedding_msg.context_data[field] = value
 
 
-async def _decrement_embedding_tracker(semantic_msg_id: Optional[str], count: int) -> None:
+async def _decrement_embedding_tracker(
+    semantic_msg_id: Optional[str],
+    count: int,
+    *,
+    is_leaf: bool = False,
+) -> None:
     if not semantic_msg_id or count <= 0:
         return
     try:
@@ -71,12 +80,24 @@ async def _decrement_embedding_tracker(semantic_msg_id: Optional[str], count: in
 
         tracker = EmbeddingTaskTracker.get_instance()
         for _ in range(count):
-            await tracker.decrement(semantic_msg_id)
+            await tracker.decrement(semantic_msg_id, is_leaf=is_leaf)
     except Exception as e:
         logger.error(
             f"Failed to decrement embedding tracker for semantic_msg_id={semantic_msg_id}: {e}",
             exc_info=True,
         )
+
+
+def _record_vectorization_error(uri: str, *, is_leaf: bool) -> None:
+    telemetry_id = get_current_telemetry().telemetry_id
+    if not telemetry_id:
+        return
+    kind = "leaf" if is_leaf else "directory"
+    get_request_wait_tracker().record_embedding_error(
+        telemetry_id,
+        f"Failed to enqueue {kind} embedding for {uri}",
+        is_leaf=is_leaf,
+    )
 
 
 def _coerce_datetime(value: object) -> Optional[datetime]:
@@ -215,6 +236,35 @@ def get_resource_content_type(file_name: str) -> Optional[ResourceContentType]:
         return ResourceContentType.AUDIO
 
     return None
+
+
+@dataclass(frozen=True)
+class LeafVectorizationPlan:
+    requires_summary: bool
+    effective_text_source: str
+    reason: str
+
+
+def resolve_leaf_vectorization_plan(
+    file_name: str,
+    *,
+    text_source: Optional[str] = None,
+    use_summary: bool = False,
+) -> LeafVectorizationPlan:
+    configured_text_source = text_source or getattr(
+        get_openviking_config().embedding,
+        "text_source",
+        "content_only",
+    )
+    effective_text_source = "summary_only" if use_summary else configured_text_source
+
+    if use_summary:
+        return LeafVectorizationPlan(True, effective_text_source, "summary_override")
+    if effective_text_source != "content_only":
+        return LeafVectorizationPlan(True, effective_text_source, "configured_summary")
+    if get_resource_content_type(file_name) != ResourceContentType.TEXT:
+        return LeafVectorizationPlan(True, effective_text_source, "non_text")
+    return LeafVectorizationPlan(False, effective_text_source, "content_only_text")
 
 
 async def _build_image_data_uri(
@@ -409,7 +459,10 @@ async def vectorize_directory_meta(
         )
         raise
     finally:
-        await _decrement_embedding_tracker(semantic_msg_id, expected - enqueued)
+        missing = expected - enqueued
+        if missing > 0:
+            _record_vectorization_error(uri, is_leaf=False)
+        await _decrement_embedding_tracker(semantic_msg_id, missing)
 
 
 async def vectorize_file(
@@ -422,7 +475,8 @@ async def vectorize_file(
     use_summary: bool = False,
     preserve_existing_created_at: bool = False,
     scalar_override: Optional[Dict[str, Any]] = None,
-) -> None:
+    record_failure: bool = True,
+) -> bool:
     """
     Vectorize a single file.
 
@@ -435,7 +489,7 @@ async def vectorize_file(
     try:
         if not ctx:
             logger.warning("No context provided for vectorization")
-            return
+            return False
 
         queue_manager = get_queue_manager()
         embedding_queue = queue_manager.get_queue(queue_manager.EMBEDDING)
@@ -472,7 +526,12 @@ async def vectorize_file(
         content_type = get_resource_content_type(file_name)
         embedding_cfg = get_openviking_config().embedding
         configured_text_source = getattr(embedding_cfg, "text_source", "content_only")
-        effective_text_source = "summary_only" if use_summary else configured_text_source
+        vectorization_plan = resolve_leaf_vectorization_plan(
+            file_name,
+            text_source=configured_text_source,
+            use_summary=use_summary,
+        )
+        effective_text_source = vectorization_plan.effective_text_source
 
         if content_type is None:
             # Unsupported file type: fall back to summary if available
@@ -490,7 +549,7 @@ async def vectorize_file(
                 logger.warning(
                     f"Unsupported file type for {file_path} and no summary available, skipping vectorization"
                 )
-                return
+                return False
         elif content_type == ResourceContentType.TEXT:
             # Known text files use VikingFS' text read path once, then reuse that
             # content for BM25 regardless of whether embedding uses summary or raw text.
@@ -508,7 +567,7 @@ async def vectorize_file(
                     context.set_vectorize(Vectorize(text=summary, full_text=summary))
                 else:
                     logger.warning(f"No summary available for {file_path}, skipping vectorization")
-                    return
+                    return False
             else:
                 if summary and effective_text_source in {"summary_first", "summary_only"}:
                     # Use summary for vectorization, but reuse the single raw text read for BM25.
@@ -527,29 +586,66 @@ async def vectorize_file(
                 logger.debug(
                     f"Skipping image {file_path} (image unreadable and no summary available)"
                 )
-                return
+                return False
         elif summary:
             # For non-text files, use summary
             context.set_vectorize(Vectorize(text=summary, full_text=summary))
         else:
             logger.debug(f"Skipping file {file_path} (no text content or summary)")
-            return
+            return False
 
         embedding_msg = EmbeddingMsgConverter.from_context(context)
         if not embedding_msg:
-            return
+            return False
 
         _apply_scalar_overrides(embedding_msg, scalar_override)
         embedding_msg.semantic_msg_id = semantic_msg_id
         await embedding_queue.enqueue(embedding_msg)
         enqueued = True
         logger.debug(f"Enqueued file for vectorization: {file_path}")
+        return True
 
     except Exception as e:
         logger.error(f"Failed to vectorize file {file_path}: {e}", exc_info=True)
+        return False
     finally:
         if not enqueued:
-            await _decrement_embedding_tracker(semantic_msg_id, 1)
+            if record_failure:
+                _record_vectorization_error(file_path, is_leaf=True)
+            await _decrement_embedding_tracker(
+                semantic_msg_id,
+                1,
+                is_leaf=True,
+            )
+
+
+async def enqueue_file_metadata_patch(
+    file_path: str,
+    summary: str,
+    ctx: RequestContext,
+    semantic_msg_id: Optional[str] = None,
+) -> bool:
+    normalized_summary = _truncate_abstract_bytes(summary)
+    if not normalized_summary:
+        return False
+
+    queue_manager = get_queue_manager()
+    embedding_queue = queue_manager.get_queue(queue_manager.EMBEDDING)
+    message = EmbeddingMsg(
+        message="",
+        context_data={
+            "uri": file_path,
+            "account_id": ctx.account_id,
+            "level": int(ContextLevel.DETAIL.value),
+            "is_leaf": False,
+            "abstract": normalized_summary,
+        },
+        telemetry_id=get_current_telemetry().telemetry_id,
+        semantic_msg_id=semantic_msg_id,
+        operation="metadata_patch",
+    )
+    await embedding_queue.enqueue(message)
+    return True
 
 
 async def index_resource(

--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -25,9 +25,19 @@ class _FakeRequestWaitTracker:
     def register_request(self, telemetry_id: str) -> None:
         self.registered_requests.append(telemetry_id)
 
-    async def wait_for_request(self, telemetry_id: str, timeout, poll_interval=None):
+    async def wait_for_request(
+        self,
+        telemetry_id: str,
+        timeout,
+        poll_interval=None,
+        on_leaf_indexed=None,
+    ):
         del poll_interval
         self.wait_calls.append((telemetry_id, timeout))
+        if on_leaf_indexed is not None:
+            result = on_leaf_indexed()
+            if hasattr(result, "__await__"):
+                await result
 
     def build_queue_status(self, telemetry_id: str):
         self.build_calls.append(telemetry_id)
@@ -87,6 +97,7 @@ async def test_add_resource_wait_uses_request_tracker(service, monkeypatch):
     )
     ctx = RequestContext(user=service.user, role=Role.ROOT)
     telemetry = OperationTelemetry(operation="resources.add_resource", enabled=True)
+    stages = []
 
     async def _fake_process_resource(**kwargs):
         del kwargs
@@ -112,6 +123,7 @@ async def test_add_resource_wait_uses_request_tracker(service, monkeypatch):
             reason="request wait test",
             wait=True,
             timeout=12.0,
+            stage_callback=stages.append,
         )
 
     assert result["queue_status"] == tracker.queue_status
@@ -119,6 +131,7 @@ async def test_add_resource_wait_uses_request_tracker(service, monkeypatch):
     assert tracker.wait_calls == [(telemetry.telemetry_id, 12.0)]
     assert tracker.build_calls == [telemetry.telemetry_id]
     assert tracker.cleaned == [telemetry.telemetry_id]
+    assert stages == ["processing_queue", "leaf_indexed"]
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -22,12 +22,12 @@ from openviking.storage.errors import EmbeddingRebuildRequiredError
 from openviking.storage.expr import Eq
 from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.storage.vectordb import engine as vectordb_engine
+from openviking.storage.vectordb.collection.result import UpsertDataResult
+from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
     VolcengineApiKeyCollection,
 )
-from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb.collection.volcengine_collection import VolcengineCollection
-from openviking.storage.vectordb.collection.result import UpsertDataResult
 from openviking.storage.vectordb_adapters.base import (
     VIKINGDB_TEXT_FIELD_BYTE_LIMIT,
     _truncate_text_field,
@@ -126,6 +126,273 @@ def _build_queue_payload_for_account(account_id: str) -> dict:
         telemetry_id="telemetry-1",
     )
     return {"data": json.dumps(msg.to_dict())}
+
+
+def _build_metadata_patch_payload(retry_count: int = 0) -> dict:
+    msg = EmbeddingMsg(
+        message="",
+        context_data={
+            "uri": "viking://resources/a.md",
+            "account_id": "acct",
+            "level": 2,
+            "is_leaf": True,
+            "abstract": "generated summary",
+        },
+        semantic_msg_id="semantic-1",
+        operation="metadata_patch",
+        retry_count=retry_count,
+    )
+    return {"data": json.dumps(msg.to_dict())}
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_metadata_patch_updates_abstract_without_embedding(monkeypatch):
+    captured = {}
+
+    class _PatchVikingDB:
+        is_closing = False
+
+        async def get(self, ids, *, ctx):
+            captured["fetched_ids"] = list(ids)
+            return [{"id": ids[0]}]
+
+        async def upsert(self, data, *, ctx, partial_update=False):
+            captured["data"] = dict(data)
+            captured["partial_update"] = partial_update
+            return data["id"]
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    result = await TextEmbeddingHandler(_PatchVikingDB()).on_dequeue(
+        _build_metadata_patch_payload()
+    )
+
+    expected_id = hashlib.md5(b"acct:viking://resources/a.md").hexdigest()
+    assert result["id"] == expected_id
+    assert captured["fetched_ids"] == [expected_id]
+    assert captured["partial_update"] is True
+    assert captured["data"] == {
+        "id": expected_id,
+        "uri": "viking://resources/a.md",
+        "account_id": "acct",
+        "abstract": "generated summary",
+    }
+    assert embedder.calls == 0
+    assert tracker.calls == [("semantic-1", False)]
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_metadata_patch_requeues_until_target_exists(monkeypatch):
+    class _PatchVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def get(self, _ids, *, ctx):
+            return []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg)
+            return True
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    vikingdb = _PatchVikingDB()
+    result = await TextEmbeddingHandler(vikingdb).on_dequeue(_build_metadata_patch_payload())
+
+    assert result is None
+    assert len(vikingdb.enqueued) == 1
+    assert vikingdb.enqueued[0].operation == "metadata_patch"
+    assert vikingdb.enqueued[0].retry_count == 1
+    assert embedder.calls == 0
+    assert tracker.calls == []
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_metadata_patch_requeue_requires_persistence_ack(monkeypatch):
+    class _PatchVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        async def get(self, _ids, *, ctx):
+            return []
+
+        async def enqueue_embedding_msg(self, _msg):
+            return False
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    handler = TextEmbeddingHandler(_PatchVikingDB())
+    handler._metadata_patch_retry_delay = 0
+    errors = []
+    handler.set_callbacks(
+        on_success=lambda: None,
+        on_requeue=lambda: None,
+        on_error=lambda *_args: errors.append(True),
+    )
+
+    result = await handler.on_dequeue(_build_metadata_patch_payload())
+
+    assert result is None
+    assert tracker.calls == [("semantic-1", False)]
+    assert errors == [True]
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_metadata_patch_waits_before_ordering_retry(monkeypatch):
+    class _PatchVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def get(self, _ids, *, ctx):
+            return []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg)
+            return True
+
+    class _FakeTracker:
+        async def decrement(self, _semantic_msg_id, is_leaf=False):
+            raise AssertionError("ordering retry must keep the tracker pending")
+
+    sleeps = []
+
+    async def _fake_sleep(delay):
+        sleeps.append(delay)
+
+    embedder = _DummyEmbedder()
+    config = _DummyConfig(embedder)
+    config.embedding.max_retries = 0
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _FakeTracker(),
+    )
+    monkeypatch.setattr("openviking.storage.collection_schemas.asyncio.sleep", _fake_sleep)
+
+    vikingdb = _PatchVikingDB()
+    handler = TextEmbeddingHandler(vikingdb)
+    result = await handler.on_dequeue(_build_metadata_patch_payload())
+
+    assert result is None
+    assert sleeps == [handler._metadata_patch_retry_delay]
+    assert len(vikingdb.enqueued) == 1
+    assert vikingdb.enqueued[0].retry_count == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_metadata_patch_fails_after_retry_budget(monkeypatch):
+    class _PatchVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def get(self, _ids, *, ctx):
+            return []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg)
+            return True
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    config = _DummyConfig(embedder)
+    config.embedding.max_retries = 3
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: config,
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    vikingdb = _PatchVikingDB()
+    handler = TextEmbeddingHandler(vikingdb)
+    handler._metadata_patch_max_retries = 3
+    handler._metadata_patch_retry_delay = 0
+    errors = []
+    handler.set_callbacks(
+        on_success=lambda: None,
+        on_requeue=lambda: None,
+        on_error=lambda *_args: errors.append(True),
+    )
+    result = await handler.on_dequeue(_build_metadata_patch_payload(retry_count=3))
+
+    assert result is None
+    assert vikingdb.enqueued == []
+    assert embedder.calls == 0
+    assert tracker.calls == [("semantic-1", False)]
+    assert errors == [True]
 
 
 def test_embedding_handler_builds_circuit_breaker_from_config(monkeypatch):
@@ -260,17 +527,25 @@ def test_build_embedding_metadata_hashes_resolved_local_model_path(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_embedding_handler_skip_all_work_when_manager_is_closing(monkeypatch):
+async def test_embedding_handler_does_not_complete_leaf_when_manager_is_closing(monkeypatch):
     class _ClosingVikingDB:
         is_closing = True
 
         async def upsert(self, _data, *, ctx):  # pragma: no cover - should never run
             raise AssertionError("upsert should not be called during shutdown")
 
+    class _FakeTracker:
+        async def decrement(self, _semantic_msg_id, is_leaf=False):
+            raise AssertionError("shutdown must keep the leaf tracker pending")
+
     embedder = _DummyEmbedder()
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
         lambda: _DummyConfig(embedder),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _FakeTracker(),
     )
 
     handler = TextEmbeddingHandler(_ClosingVikingDB())
@@ -280,14 +555,140 @@ async def test_embedding_handler_skip_all_work_when_manager_is_closing(monkeypat
         on_requeue=lambda: status.__setitem__("requeue", status["requeue"] + 1),
         on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
     )
+    msg = EmbeddingMsg(
+        message="hello",
+        context_data={
+            "uri": "viking://resources/leaf.md",
+            "account_id": "default",
+            "abstract": "",
+            "is_leaf": True,
+        },
+        semantic_msg_id="semantic-1",
+    )
 
-    result = await handler.on_dequeue(_build_queue_payload())
+    with pytest.raises(asyncio.CancelledError):
+        await handler.on_dequeue({"data": json.dumps(msg.to_dict())})
+
+    assert embedder.calls == 0
+    assert status["success"] == 0
+    assert status["requeue"] == 0
+    assert status["error"] == 0
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_rejects_unsupported_leaf_message_as_terminal_error(monkeypatch):
+    class _VikingDB:
+        is_closing = False
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+    handler = TextEmbeddingHandler(_VikingDB())
+    status = {"success": 0, "requeue": 0, "error": 0}
+    handler.set_callbacks(
+        on_success=lambda: status.__setitem__("success", status["success"] + 1),
+        on_requeue=lambda: status.__setitem__("requeue", status["requeue"] + 1),
+        on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
+    )
+    msg = EmbeddingMsg(
+        message={"unsupported": True},
+        context_data={
+            "uri": "viking://resources/leaf.md",
+            "account_id": "default",
+            "abstract": "",
+            "is_leaf": True,
+        },
+        semantic_msg_id="semantic-1",
+    )
+
+    result = await handler.on_dequeue({"data": json.dumps(msg.to_dict())})
 
     assert result is None
     assert embedder.calls == 0
-    assert status["success"] == 1
-    assert status["requeue"] == 0
-    assert status["error"] == 0
+    assert tracker.calls == [("semantic-1", True)]
+    assert status == {"success": 0, "requeue": 0, "error": 1}
+
+
+@pytest.mark.asyncio
+async def test_embedding_handler_empty_upsert_id_fails_leaf_terminally(monkeypatch):
+    class _EmptyWriteVikingDB:
+        is_closing = False
+
+        async def upsert(self, _data, *, ctx, partial_update=False):
+            assert partial_update is True
+            return ""
+
+    class _FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    class _FakeRequestTracker:
+        def __init__(self):
+            self.errors = []
+
+        def record_embedding_error(self, telemetry_id, message, *, is_leaf=False):
+            self.errors.append((telemetry_id, message, is_leaf))
+
+        def record_embedding_processed(self, _telemetry_id):
+            return None
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    request_tracker = _FakeRequestTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.collection_schemas.get_request_wait_tracker",
+        lambda: request_tracker,
+    )
+
+    payload = _build_queue_payload_for_account("acct")
+    queue_data = json.loads(payload["data"])
+    queue_data["semantic_msg_id"] = "semantic-1"
+    queue_data["context_data"]["is_leaf"] = True
+    payload["data"] = json.dumps(queue_data)
+    errors = []
+    handler = TextEmbeddingHandler(_EmptyWriteVikingDB())
+    handler.set_callbacks(
+        on_success=lambda: None,
+        on_requeue=lambda: None,
+        on_error=lambda *_args: errors.append(True),
+    )
+
+    result = await handler.on_dequeue(payload)
+
+    assert result is None
+    assert tracker.calls == [("semantic-1", True)]
+    assert errors == [True]
+    assert len(request_tracker.errors) == 1
+    assert request_tracker.errors[0][0] == "telemetry-1"
+    assert "did not persist a record" in request_tracker.errors[0][1]
+    assert request_tracker.errors[0][2] is True
 
 
 @pytest.mark.asyncio
@@ -305,7 +706,7 @@ async def test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_w
 
         async def enqueue_embedding_msg(self, msg):
             self.enqueued.append(msg.id)
-            return None
+            return True
 
     embedder = _DummyEmbedder()
     monkeypatch.setattr(
@@ -343,6 +744,60 @@ async def test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_w
 
 
 @pytest.mark.asyncio
+async def test_embedding_handler_does_not_complete_semantic_tracker_when_requeued(monkeypatch):
+    from openviking.utils.circuit_breaker import CircuitBreakerOpen
+
+    class _QueueingVikingDB:
+        is_closing = False
+        has_queue_manager = True
+
+        def __init__(self):
+            self.enqueued = []
+
+        async def enqueue_embedding_msg(self, msg):
+            self.enqueued.append(msg.id)
+            return True
+
+    class _FakeTracker:
+        def __init__(self):
+            self.decrement_calls = []
+
+        async def decrement(self, semantic_msg_id, is_leaf=False):
+            self.decrement_calls.append((semantic_msg_id, is_leaf))
+            return 0
+
+    embedder = _DummyEmbedder()
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: _DummyConfig(embedder),
+    )
+    tracker = _FakeTracker()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    vikingdb = _QueueingVikingDB()
+    handler = TextEmbeddingHandler(vikingdb)
+    monkeypatch.setattr(
+        handler._circuit_breaker,
+        "check",
+        lambda: (_ for _ in ()).throw(CircuitBreakerOpen("open")),
+    )
+
+    payload = _build_queue_payload()
+    queue_data = json.loads(payload["data"])
+    queue_data["semantic_msg_id"] = "semantic-1"
+    queue_data["context_data"]["is_leaf"] = False
+    payload["data"] = json.dumps(queue_data)
+
+    await handler.on_dequeue(payload)
+
+    assert vikingdb.enqueued == [queue_data["id"]]
+    assert tracker.decrement_calls == []
+
+
+@pytest.mark.asyncio
 async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypatch):
     """A credential (401/403) failure must fail terminally, not re-enqueue: an
     infinite re-enqueue holds the resource's tree lock and add-resource --wait
@@ -357,7 +812,7 @@ async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypat
 
         async def enqueue_embedding_msg(self, msg):
             self.enqueued.append(msg.id)
-            return None
+            return True
 
     class _AuthErrorEmbedder(_DummyEmbedder):
         async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
@@ -385,7 +840,7 @@ async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypatch):
+async def test_embedding_handler_keeps_leaf_pending_when_shutdown_interrupts_write(monkeypatch):
     class _ClosingDuringUpsertVikingDB:
         def __init__(self):
             self.is_closing = False
@@ -397,10 +852,18 @@ async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypat
             self.is_closing = True
             raise RuntimeError("IO error: lock /tmp/LOCK: already held by process")
 
+    class _FakeTracker:
+        async def decrement(self, _semantic_msg_id, is_leaf=False):
+            raise AssertionError("shutdown must keep the leaf tracker pending")
+
     embedder = _DummyEmbedder()
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
         lambda: _DummyConfig(embedder),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _FakeTracker(),
     )
 
     vikingdb = _ClosingDuringUpsertVikingDB()
@@ -411,13 +874,23 @@ async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypat
         on_requeue=lambda: status.__setitem__("requeue", status["requeue"] + 1),
         on_error=lambda *_: status.__setitem__("error", status["error"] + 1),
     )
+    msg = EmbeddingMsg(
+        message="hello",
+        context_data={
+            "uri": "viking://resources/leaf.md",
+            "account_id": "default",
+            "abstract": "",
+            "is_leaf": True,
+        },
+        semantic_msg_id="semantic-1",
+    )
 
-    result = await handler.on_dequeue(_build_queue_payload())
+    with pytest.raises(asyncio.CancelledError):
+        await handler.on_dequeue({"data": json.dumps(msg.to_dict())})
 
-    assert result is None
     assert vikingdb.calls == 1
     assert embedder.calls == 1
-    assert status["success"] == 1
+    assert status["success"] == 0
     assert status["requeue"] == 0
     assert status["error"] == 0
 
@@ -535,7 +1008,7 @@ async def test_embedding_handler_drops_input_too_large_without_requeue(monkeypat
 
         async def enqueue_embedding_msg(self, msg):
             self.enqueued.append(msg)
-            return None
+            return True
 
     class _OversizedInputEmbedder:
         def prepare_embedding_input(self, content):
@@ -620,9 +1093,12 @@ async def test_embedding_handler_marks_success_only_after_tracker_completion(mon
 
     decrement_started = asyncio.Event()
     allow_decrement_finish = asyncio.Event()
+    decrement_is_leaf = None
 
     class _FakeTracker:
-        async def decrement(self, _semantic_msg_id):
+        async def decrement(self, _semantic_msg_id, is_leaf=False):
+            nonlocal decrement_is_leaf
+            decrement_is_leaf = is_leaf
             decrement_started.set()
             await allow_decrement_finish.wait()
             return 0
@@ -643,6 +1119,7 @@ async def test_embedding_handler_marks_success_only_after_tracker_completion(mon
     payload = _build_queue_payload()
     queue_data = json.loads(payload["data"])
     queue_data["semantic_msg_id"] = "semantic-1"
+    queue_data["context_data"]["is_leaf"] = True
     payload["data"] = json.dumps(queue_data)
 
     task = asyncio.create_task(handler.on_dequeue(payload))
@@ -658,6 +1135,7 @@ async def test_embedding_handler_marks_success_only_after_tracker_completion(mon
     assert status["success"] == 1
     assert status["requeue"] == 0
     assert status["error"] == 0
+    assert decrement_is_leaf is True
 
 
 def test_context_collection_excludes_parent_uri():

--- a/tests/storage/test_embedding_msg.py
+++ b/tests/storage/test_embedding_msg.py
@@ -7,6 +7,35 @@ from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.telemetry.request_wait_tracker import RequestWaitTracker
 
 
+def test_embedding_msg_defaults_legacy_payload_to_embed_operation():
+    msg = EmbeddingMsg.from_dict(
+        {
+            "message": "text",
+            "context_data": {"uri": "viking://resources/a.md"},
+        }
+    )
+
+    assert msg.operation == "embed"
+    assert msg.retry_count == 0
+
+
+def test_embedding_msg_round_trips_metadata_patch_fields():
+    msg = EmbeddingMsg(
+        message="",
+        context_data={
+            "uri": "viking://resources/a.md",
+            "abstract": "summary",
+        },
+        operation="metadata_patch",
+        retry_count=2,
+    )
+
+    restored = EmbeddingMsg.from_json(msg.to_json())
+
+    assert restored.operation == "metadata_patch"
+    assert restored.retry_count == 2
+
+
 def test_embedding_msg_roundtrip_preserves_id_for_request_wait_tracker():
     telemetry_id = f"tm_{uuid4().hex}"
     tracker = RequestWaitTracker.get_instance()

--- a/tests/storage/test_embedding_tracker.py
+++ b/tests/storage/test_embedding_tracker.py
@@ -185,3 +185,82 @@ async def test_tracker_clears_zero_task_entry_without_callback():
     await tracker.register("semantic-msg", 0, on_complete=None)
 
     assert await tracker.decrement("semantic-msg") is None
+
+
+@pytest.mark.asyncio
+async def test_open_tracker_seals_leaf_and_full_independently():
+    tracker = EmbeddingTaskTracker.get_instance()
+    callback_calls = []
+
+    await tracker.register_open(
+        "semantic-msg",
+        on_leaf_complete=lambda: callback_calls.append("leaf"),
+        on_complete=lambda: callback_calls.append("full"),
+    )
+    await tracker.add("semantic-msg", count=3, leaf_count=1)
+
+    assert await tracker.decrement("semantic-msg", is_leaf=True) == 2
+    assert callback_calls == []
+
+    await tracker.seal_leaf("semantic-msg")
+    assert callback_calls == ["leaf"]
+
+    assert await tracker.decrement("semantic-msg") == 1
+    await tracker.seal("semantic-msg")
+    assert callback_calls == ["leaf"]
+
+    assert await tracker.decrement("semantic-msg") == 0
+    assert callback_calls == ["leaf", "full"]
+
+
+@pytest.mark.asyncio
+async def test_open_tracker_zero_leaf_callbacks_fire_once_when_sealed():
+    tracker = EmbeddingTaskTracker.get_instance()
+    callback_calls = []
+
+    await tracker.register_open(
+        "semantic-msg",
+        on_leaf_complete=lambda: callback_calls.append("leaf"),
+        on_complete=lambda: callback_calls.append("full"),
+    )
+
+    assert callback_calls == []
+    assert await tracker.seal_leaf("semantic-msg") == 0
+    assert await tracker.seal_leaf("semantic-msg") == 0
+    assert callback_calls == ["leaf"]
+
+    assert await tracker.seal("semantic-msg") == 0
+    assert callback_calls == ["leaf", "full"]
+
+
+@pytest.mark.asyncio
+async def test_open_tracker_rejects_add_after_relevant_seal():
+    tracker = EmbeddingTaskTracker.get_instance()
+
+    await tracker.register_open("semantic-msg")
+    await tracker.seal_leaf("semantic-msg")
+
+    await tracker.add("semantic-msg", count=1)
+    with pytest.raises(RuntimeError, match="Leaf embedding tracker is sealed"):
+        await tracker.add("semantic-msg", count=1, leaf_count=1)
+
+    await tracker.seal("semantic-msg")
+    with pytest.raises(RuntimeError, match="Embedding tracker is sealed"):
+        await tracker.add("semantic-msg", count=1)
+
+
+@pytest.mark.asyncio
+async def test_open_tracker_discard_removes_without_callbacks():
+    tracker = EmbeddingTaskTracker.get_instance()
+    callback_calls = []
+
+    await tracker.register_open(
+        "semantic-msg",
+        on_leaf_complete=lambda: callback_calls.append("leaf"),
+        on_complete=lambda: callback_calls.append("full"),
+    )
+
+    assert await tracker.discard("semantic-msg") is True
+    assert await tracker.discard("semantic-msg") is False
+    assert await tracker.decrement("semantic-msg", is_leaf=True) is None
+    assert callback_calls == []

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -143,6 +143,7 @@ async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypa
         changes={"modified": [f"{root_uri}/a.txt"]},
     )
     monkeypatch.setattr(executor, "_add_vectorize_task", AsyncMock())
+    monkeypatch.setattr(executor, "_dispatch_vectorize_task", AsyncMock())
 
     await executor.run(root_uri)
 

--- a/tests/storage/test_semantic_dag_skip_files.py
+++ b/tests/storage/test_semantic_dag_skip_files.py
@@ -74,8 +74,10 @@ class _FakeProcessor:
         ctx=None,
         semantic_msg_id=None,
         use_summary=False,
+        record_failure=True,
     ):
         self.vectorized_files.append(file_path)
+        return True
 
 
 class _DummyTracker:

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -181,6 +181,7 @@ class _EmbeddingFirstProcessor(_FakeProcessor):
         self.summary_started = asyncio.Event()
         self.allow_summary = asyncio.Event()
         self.vectorize_summaries = []
+        self.vectorize_semantic_msg_ids = []
         self.metadata_patches = []
 
     async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
@@ -202,6 +203,7 @@ class _EmbeddingFirstProcessor(_FakeProcessor):
     ):
         self.events.append("vectorize_persisted")
         self.vectorize_summaries.append(dict(summary_dict))
+        self.vectorize_semantic_msg_ids.append(semantic_msg_id)
         return True
 
     async def _patch_file_summary(
@@ -585,6 +587,47 @@ async def test_semantic_dag_marks_content_only_leaf_indexed_while_summary_is_blo
 
 
 @pytest.mark.asyncio
+async def test_semantic_dag_retry_ignores_stale_embedding_completion(monkeypatch):
+    root_uri = "viking://resources/root"
+    semantic_msg_id = "semantic-retry"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+
+    async def run_attempt():
+        processor = _EmbeddingFirstProcessor()
+        processor.allow_summary.set()
+        executor = SemanticDagExecutor(
+            processor=processor,
+            context_type="resource",
+            max_concurrent_llm=1,
+            ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+            semantic_msg_id=semantic_msg_id,
+        )
+        monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=False))
+        await executor.run(root_uri)
+        return processor.vectorize_semantic_msg_ids[0]
+
+    first_attempt_id = await run_attempt()
+    await embedding_tracker.discard(first_attempt_id)
+    second_attempt_id = await run_attempt()
+
+    try:
+        stale_remaining = await embedding_tracker.decrement(first_attempt_id, is_leaf=True)
+
+        assert first_attempt_id != second_attempt_id
+        assert stale_remaining is None
+    finally:
+        await embedding_tracker.discard(second_attempt_id)
+
+
+@pytest.mark.asyncio
 async def test_semantic_dag_keeps_summary_dependent_leaf_summary_first(monkeypatch):
     root_uri = "viking://resources/root"
     fake_fs = _FakeVikingFS(
@@ -707,7 +750,10 @@ async def test_semantic_dag_compensates_full_tracker_when_metadata_patch_is_not_
 
     try:
         await executor.run(root_uri)
-        leaf_done = asyncio.create_task(embedding_tracker.decrement(semantic_msg_id, is_leaf=True))
+        embedding_tracker_id = processor.vectorize_semantic_msg_ids[0]
+        leaf_done = asyncio.create_task(
+            embedding_tracker.decrement(embedding_tracker_id, is_leaf=True)
+        )
         await lock.close_started.wait()
 
         status = request_tracker.build_queue_status(telemetry_id)
@@ -717,7 +763,8 @@ async def test_semantic_dag_compensates_full_tracker_when_metadata_patch_is_not_
         lock.allow_close.set()
         if "leaf_done" in locals():
             await leaf_done
-        await embedding_tracker.discard(semantic_msg_id)
+        if "embedding_tracker_id" in locals():
+            await embedding_tracker.discard(embedding_tracker_id)
         request_tracker.cleanup(telemetry_id)
 
 
@@ -751,11 +798,12 @@ async def test_semantic_dag_enqueues_metadata_patch_only_after_leaf_embedding_fi
     await executor.run(root_uri)
 
     assert processor.metadata_patches == []
-    await embedding_tracker.decrement("semantic-1", is_leaf=True)
+    embedding_tracker_id = processor.vectorize_semantic_msg_ids[0]
+    await embedding_tracker.decrement(embedding_tracker_id, is_leaf=True)
     assert processor.metadata_patches == [
-        ("viking://resources/root/leaf.md", "generated summary", "semantic-1")
+        ("viking://resources/root/leaf.md", "generated summary", embedding_tracker_id)
     ]
-    await embedding_tracker.discard("semantic-1")
+    await embedding_tracker.discard(embedding_tracker_id)
 
 
 @pytest.mark.asyncio
@@ -810,7 +858,10 @@ async def test_semantic_dag_leaf_milestone_does_not_wait_for_metadata_patch_enqu
 
     try:
         await executor.run(root_uri)
-        leaf_done = asyncio.create_task(embedding_tracker.decrement(semantic_msg_id, is_leaf=True))
+        embedding_tracker_id = processor.vectorize_semantic_msg_ids[0]
+        leaf_done = asyncio.create_task(
+            embedding_tracker.decrement(embedding_tracker_id, is_leaf=True)
+        )
         await processor.patch_started.wait()
 
         assert request_tracker.is_leaf_indexed(telemetry_id) is True
@@ -818,7 +869,8 @@ async def test_semantic_dag_leaf_milestone_does_not_wait_for_metadata_patch_enqu
         processor.allow_patch.set()
         if "leaf_done" in locals():
             await leaf_done
-        await embedding_tracker.discard(semantic_msg_id)
+        if "embedding_tracker_id" in locals():
+            await embedding_tracker.discard(embedding_tracker_id)
         request_tracker.cleanup(telemetry_id)
 
 
@@ -861,13 +913,15 @@ async def test_semantic_dag_drops_pending_metadata_patch_after_leaf_embedding_fa
             "leaf embedding failed",
             is_leaf=True,
         )
-        await embedding_tracker.decrement(semantic_msg_id, is_leaf=True)
+        embedding_tracker_id = processor.vectorize_semantic_msg_ids[0]
+        await embedding_tracker.decrement(embedding_tracker_id, is_leaf=True)
 
         assert processor.metadata_patches == []
         assert request_tracker.is_leaf_indexed(telemetry_id) is False
         assert request_tracker.is_complete(telemetry_id) is True
     finally:
-        await embedding_tracker.discard(semantic_msg_id)
+        if "embedding_tracker_id" in locals():
+            await embedding_tracker.discard(embedding_tracker_id)
         request_tracker.cleanup(telemetry_id)
 
 

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.embedding_tracker import EmbeddingTaskTracker
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
+from openviking.telemetry import get_current_telemetry
+from openviking.telemetry.request_wait_tracker import RequestWaitTracker
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -25,6 +29,12 @@ class _FakeVikingFS:
 
     def _uri_to_path(self, uri, ctx=None):
         return uri.replace("viking://", "/local/acc1/")
+
+
+class _FailingListVikingFS(_FakeVikingFS):
+    async def ls(self, uri, node_limit=None, ctx=None):
+        del uri, node_limit, ctx
+        raise RuntimeError("directory listing unavailable")
 
 
 class _FakeProcessor:
@@ -55,11 +65,22 @@ class _FakeProcessor:
         ctx=None,
         semantic_msg_id=None,
         use_summary=False,
+        record_failure=True,
     ):
         self.vectorized_files.append(file_path)
+        return True
 
     async def _vectorize_directory_simple(self, uri, context_type, abstract, overview, ctx=None):
         await self._vectorize_directory(uri, context_type, abstract, overview, ctx=ctx)
+
+    async def _patch_file_summary(
+        self,
+        file_path,
+        summary,
+        ctx=None,
+        semantic_msg_id=None,
+    ):
+        return True
 
 
 class _TrackingProcessor(_FakeProcessor):
@@ -85,6 +106,303 @@ class _DummyTracker:
     async def register(self, **_kwargs):
         self.register_calls.append(_kwargs)
         return None
+
+
+class _StreamingTracker:
+    def __init__(self, events):
+        self.events = events
+
+    async def register(self, **_kwargs):
+        self.events.append("register")
+
+    async def register_open(self, **_kwargs):
+        self.events.append("register_open")
+
+    async def add(self, _semantic_msg_id, count, leaf_count=0):
+        self.events.append(f"add:{count}:{leaf_count}")
+
+    async def seal_leaf(self, _semantic_msg_id):
+        self.events.append("seal_leaf")
+
+    async def seal(self, _semantic_msg_id):
+        self.events.append("seal")
+
+    async def discard(self, _semantic_msg_id):
+        self.events.append("discard")
+
+
+class _CompensatingStreamingTracker(_StreamingTracker):
+    async def decrement(self, _semantic_msg_id, is_leaf=False):
+        self.events.append(f"decrement:{is_leaf}")
+        return 0
+
+
+class _StreamingProcessor(_FakeProcessor):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.events.append(f"summary:{file_path}")
+        return await super()._generate_single_file_summary(file_path, llm_sem=llm_sem, ctx=ctx)
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.events.append(f"overview:{dir_uri}")
+        return await super()._generate_overview(dir_uri, file_summaries, children_abstracts)
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        self.events.append(f"vectorize:{file_path}")
+        await super()._vectorize_single_file(
+            parent_uri,
+            context_type,
+            file_path,
+            summary_dict,
+            ctx=ctx,
+            semantic_msg_id=semantic_msg_id,
+            use_summary=use_summary,
+        )
+        return True
+
+
+class _EmbeddingFirstProcessor(_FakeProcessor):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+        self.summary_started = asyncio.Event()
+        self.allow_summary = asyncio.Event()
+        self.vectorize_summaries = []
+        self.metadata_patches = []
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.events.append("summary_started")
+        self.summary_started.set()
+        await self.allow_summary.wait()
+        return {"name": file_path.split("/")[-1], "summary": "generated summary"}
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        self.events.append("vectorize_persisted")
+        self.vectorize_summaries.append(dict(summary_dict))
+        return True
+
+    async def _patch_file_summary(
+        self,
+        file_path,
+        summary,
+        ctx=None,
+        semantic_msg_id=None,
+    ):
+        self.metadata_patches.append((file_path, summary, semantic_msg_id))
+        return True
+
+
+class _EmbeddingFirstCompletingProcessor(_EmbeddingFirstProcessor):
+    def __init__(self, embedding_tracker):
+        super().__init__()
+        self.embedding_tracker = embedding_tracker
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        await super()._vectorize_single_file(
+            parent_uri,
+            context_type,
+            file_path,
+            summary_dict,
+            ctx=ctx,
+            semantic_msg_id=semantic_msg_id,
+            use_summary=use_summary,
+        )
+        await self.embedding_tracker.decrement(semantic_msg_id, is_leaf=True)
+        return True
+
+
+class _MetadataPatchRejectingProcessor(_EmbeddingFirstProcessor):
+    async def _patch_file_summary(
+        self,
+        file_path,
+        summary,
+        ctx=None,
+        semantic_msg_id=None,
+    ):
+        return False
+
+
+class _EmbeddingFirstFallbackProcessor(_EmbeddingFirstProcessor):
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        self.events.append("vectorize_attempt")
+        self.vectorize_summaries.append(dict(summary_dict))
+        return bool(summary_dict.get("summary"))
+
+
+class _MixedLeafProcessor(_FakeProcessor):
+    def __init__(self, embedding_tracker):
+        super().__init__()
+        self.embedding_tracker = embedding_tracker
+        self.media_summary_started = asyncio.Event()
+        self.allow_media_summary = asyncio.Event()
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        if file_path.endswith(".png"):
+            self.media_summary_started.set()
+            await self.allow_media_summary.wait()
+        return {"name": file_path.split("/")[-1], "summary": "summary"}
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        await self.embedding_tracker.decrement(semantic_msg_id, is_leaf=True)
+        return True
+
+    async def _patch_file_summary(
+        self,
+        file_path,
+        summary,
+        ctx=None,
+        semantic_msg_id=None,
+    ):
+        await self.embedding_tracker.decrement(semantic_msg_id, is_leaf=False)
+        return True
+
+
+class _CompletingEmbeddingProcessor(_FakeProcessor):
+    def __init__(self, embedding_tracker, request_tracker, telemetry_id):
+        super().__init__()
+        self.embedding_tracker = embedding_tracker
+        self.request_tracker = request_tracker
+        self.telemetry_id = telemetry_id
+        self.leaf_indexed_at_overview = {}
+        self.vectorize_telemetry_ids = []
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.leaf_indexed_at_overview[dir_uri] = self.request_tracker.is_leaf_indexed(
+            self.telemetry_id
+        )
+        return await super()._generate_overview(dir_uri, file_summaries, children_abstracts)
+
+    async def _vectorize_single_file(
+        self,
+        parent_uri,
+        context_type,
+        file_path,
+        summary_dict,
+        ctx=None,
+        semantic_msg_id=None,
+        use_summary=False,
+        record_failure=True,
+    ):
+        self.vectorize_telemetry_ids.append(get_current_telemetry().telemetry_id)
+        await super()._vectorize_single_file(
+            parent_uri,
+            context_type,
+            file_path,
+            summary_dict,
+            ctx=ctx,
+            semantic_msg_id=semantic_msg_id,
+            use_summary=use_summary,
+        )
+        await self.embedding_tracker.decrement(semantic_msg_id, is_leaf=True)
+        return True
+
+    async def _vectorize_directory(
+        self, uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None
+    ):
+        self.vectorize_telemetry_ids.append(get_current_telemetry().telemetry_id)
+        await super()._vectorize_directory(
+            uri,
+            context_type,
+            abstract,
+            overview,
+            ctx=ctx,
+            semantic_msg_id=semantic_msg_id,
+        )
+        await self.embedding_tracker.decrement(semantic_msg_id)
+        await self.embedding_tracker.decrement(semantic_msg_id)
+
+    async def _patch_file_summary(
+        self,
+        file_path,
+        summary,
+        ctx=None,
+        semantic_msg_id=None,
+    ):
+        await self.embedding_tracker.decrement(semantic_msg_id, is_leaf=False)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_does_not_seal_leaf_when_directory_discovery_fails(monkeypatch):
+    root_uri = "viking://resources/root"
+    events = []
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_viking_fs",
+        lambda: _FailingListVikingFS({}),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _StreamingTracker(events),
+    )
+
+    executor = SemanticDagExecutor(
+        processor=_FakeProcessor(),
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-1",
+        telemetry_id="telemetry-1",
+    )
+
+    with pytest.raises(RuntimeError, match="directory listing unavailable"):
+        await executor.run(root_uri)
+
+    assert "seal_leaf" not in events
+    assert "seal" not in events
+    assert events[-1] == "discard"
 
 
 @pytest.mark.asyncio
@@ -143,6 +461,550 @@ async def test_semantic_dag_stats_collects_nodes(monkeypatch):
     assert sorted(processor.vectorized_files) == sorted(
         [f"{root_uri}/a.txt", f"{root_uri}/b.txt", f"{root_uri}/child/c.txt"]
     )
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_streams_file_vectorization_before_parent_overviews(monkeypatch):
+    root_uri = "viking://resources/root"
+    child_uri = f"{root_uri}/child"
+    file_uri = f"{child_uri}/leaf.txt"
+    tree = {
+        root_uri: [{"name": "child", "isDir": True}],
+        child_uri: [{"name": "leaf.txt", "isDir": False}],
+    }
+    events = []
+    tracker = _StreamingTracker(events)
+    fake_fs = _FakeVikingFS(tree)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    processor = _StreamingProcessor(events)
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=ctx,
+        semantic_msg_id="semantic-1",
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    await executor.run(root_uri)
+
+    assert events[0] == "register_open"
+    assert events.index(f"vectorize:{file_uri}") < events.index(f"overview:{child_uri}")
+    assert events.index(f"vectorize:{file_uri}") < events.index(f"overview:{root_uri}")
+    assert "add:1:1" in events
+    assert events.count("seal_leaf") == 1
+    assert events[-1] == "seal"
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_persists_content_only_text_embedding_before_summary(monkeypatch):
+    root_uri = "viking://resources/root"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    events = []
+    tracker = _StreamingTracker(events)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: tracker,
+    )
+
+    processor = _EmbeddingFirstProcessor()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-1",
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    run_task = asyncio.create_task(executor.run(root_uri))
+    await processor.summary_started.wait()
+
+    try:
+        assert processor.events == ["vectorize_persisted", "summary_started"]
+        assert processor.vectorize_summaries == [{"name": "leaf.md", "summary": ""}]
+    finally:
+        processor.allow_summary.set()
+        await run_task
+
+    assert processor.metadata_patches == []
+    assert "add:1:0" in events
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_marks_content_only_leaf_indexed_while_summary_is_blocked(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    telemetry_id = "telemetry-embedding-first"
+    semantic_msg_id = "semantic-embedding-first"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+
+    processor = _EmbeddingFirstCompletingProcessor(embedding_tracker)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    run_task = asyncio.create_task(executor.run(root_uri))
+    await processor.summary_started.wait()
+
+    try:
+        assert request_tracker.is_leaf_indexed(telemetry_id) is True
+    finally:
+        processor.allow_summary.set()
+        await run_task
+        request_tracker.cleanup(telemetry_id)
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_keeps_summary_dependent_leaf_summary_first(monkeypatch):
+    root_uri = "viking://resources/root"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.resolve_leaf_vectorization_plan",
+        lambda *_args, **_kwargs: SimpleNamespace(requires_summary=True),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _StreamingTracker([]),
+    )
+
+    processor = _EmbeddingFirstProcessor()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-1",
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    run_task = asyncio.create_task(executor.run(root_uri))
+    await processor.summary_started.wait()
+
+    try:
+        assert processor.events == ["summary_started"]
+    finally:
+        processor.allow_summary.set()
+        await run_task
+
+    assert processor.events == ["summary_started", "vectorize_persisted"]
+    assert processor.vectorize_summaries == [
+        {"name": "leaf.md", "summary": "generated summary"},
+    ]
+    assert processor.metadata_patches == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_falls_back_to_summary_when_direct_leaf_read_fails(monkeypatch):
+    root_uri = "viking://resources/root"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.embedding_tracker.EmbeddingTaskTracker.get_instance",
+        lambda: _StreamingTracker([]),
+    )
+
+    processor = _EmbeddingFirstFallbackProcessor()
+    processor.allow_summary.set()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-1",
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    await executor.run(root_uri)
+
+    assert processor.vectorize_summaries == [
+        {"name": "leaf.md", "summary": ""},
+        {"name": "leaf.md", "summary": "generated summary"},
+    ]
+    assert processor.metadata_patches == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_compensates_full_tracker_when_metadata_patch_is_not_enqueued(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    telemetry_id = "telemetry-patch-rejected"
+    semantic_msg_id = "semantic-patch-rejected"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+
+    class _BlockingCloseLock:
+        def __init__(self):
+            self.close_started = asyncio.Event()
+            self.allow_close = asyncio.Event()
+
+        async def close(self):
+            self.close_started.set()
+            await self.allow_close.wait()
+
+    lock = _BlockingCloseLock()
+    processor = _MetadataPatchRejectingProcessor()
+    processor.allow_summary.set()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+        lock=lock,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=False))
+
+    try:
+        await executor.run(root_uri)
+        leaf_done = asyncio.create_task(embedding_tracker.decrement(semantic_msg_id, is_leaf=True))
+        await lock.close_started.wait()
+
+        status = request_tracker.build_queue_status(telemetry_id)
+        assert status["Embedding"]["error_count"] == 1
+        assert request_tracker.is_complete(telemetry_id) is True
+    finally:
+        lock.allow_close.set()
+        if "leaf_done" in locals():
+            await leaf_done
+        await embedding_tracker.discard(semantic_msg_id)
+        request_tracker.cleanup(telemetry_id)
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_enqueues_metadata_patch_only_after_leaf_embedding_finishes(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+
+    processor = _EmbeddingFirstProcessor()
+    processor.allow_summary.set()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-1",
+        telemetry_id="telemetry-1",
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=False))
+
+    await executor.run(root_uri)
+
+    assert processor.metadata_patches == []
+    await embedding_tracker.decrement("semantic-1", is_leaf=True)
+    assert processor.metadata_patches == [
+        ("viking://resources/root/leaf.md", "generated summary", "semantic-1")
+    ]
+    await embedding_tracker.discard("semantic-1")
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_leaf_milestone_does_not_wait_for_metadata_patch_enqueue(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    telemetry_id = "telemetry-patch-blocked"
+    semantic_msg_id = "semantic-patch-blocked"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+
+    class _BlockingPatchProcessor(_EmbeddingFirstProcessor):
+        def __init__(self):
+            super().__init__()
+            self.patch_started = asyncio.Event()
+            self.allow_patch = asyncio.Event()
+
+        async def _patch_file_summary(
+            self,
+            file_path,
+            summary,
+            ctx=None,
+            semantic_msg_id=None,
+        ):
+            del file_path, summary, ctx, semantic_msg_id
+            self.patch_started.set()
+            await self.allow_patch.wait()
+            return True
+
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+    processor = _BlockingPatchProcessor()
+    processor.allow_summary.set()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=False))
+
+    try:
+        await executor.run(root_uri)
+        leaf_done = asyncio.create_task(embedding_tracker.decrement(semantic_msg_id, is_leaf=True))
+        await processor.patch_started.wait()
+
+        assert request_tracker.is_leaf_indexed(telemetry_id) is True
+    finally:
+        processor.allow_patch.set()
+        if "leaf_done" in locals():
+            await leaf_done
+        await embedding_tracker.discard(semantic_msg_id)
+        request_tracker.cleanup(telemetry_id)
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_drops_pending_metadata_patch_after_leaf_embedding_failure(
+    monkeypatch,
+):
+    root_uri = "viking://resources/root"
+    telemetry_id = "telemetry-leaf-failure"
+    semantic_msg_id = "semantic-leaf-failure"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [{"name": "leaf.md", "isDir": False}],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+
+    processor = _EmbeddingFirstProcessor()
+    processor.allow_summary.set()
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=False))
+
+    try:
+        await executor.run(root_uri)
+        request_tracker.record_embedding_error(
+            telemetry_id,
+            "leaf embedding failed",
+            is_leaf=True,
+        )
+        await embedding_tracker.decrement(semantic_msg_id, is_leaf=True)
+
+        assert processor.metadata_patches == []
+        assert request_tracker.is_leaf_indexed(telemetry_id) is False
+        assert request_tracker.is_complete(telemetry_id) is True
+    finally:
+        await embedding_tracker.discard(semantic_msg_id)
+        request_tracker.cleanup(telemetry_id)
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_metadata_patch_uses_own_request_telemetry(monkeypatch):
+    from openviking.telemetry import bind_telemetry
+    from openviking.telemetry.operation import OperationTelemetry
+
+    captured = []
+
+    class _TelemetryProcessor(_FakeProcessor):
+        async def _patch_file_summary(
+            self,
+            file_path,
+            summary,
+            ctx=None,
+            semantic_msg_id=None,
+        ):
+            del file_path, summary, ctx, semantic_msg_id
+            captured.append(get_current_telemetry().telemetry_id)
+            return True
+
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_viking_fs",
+        lambda: _FakeVikingFS({}),
+    )
+    executor = SemanticDagExecutor(
+        processor=_TelemetryProcessor(),
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id="semantic-b",
+        telemetry_id="telemetry-b",
+    )
+    executor._embedding_tracker = _CompensatingStreamingTracker([])
+    wrong_context = OperationTelemetry(operation="request-a", enabled=False)
+    wrong_context.telemetry_id = "telemetry-a"
+
+    with bind_telemetry(wrong_context):
+        await executor._enqueue_registered_metadata_patch(
+            "viking://resources/root/leaf.md",
+            "generated summary",
+        )
+
+    assert captured == ["telemetry-b"]
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_mixed_leaves_waits_for_summary_dependent_embedding(monkeypatch):
+    root_uri = "viking://resources/root"
+    telemetry_id = "telemetry-mixed"
+    semantic_msg_id = "semantic-mixed"
+    fake_fs = _FakeVikingFS(
+        {
+            root_uri: [
+                {"name": "early.md", "isDir": False},
+                {"name": "summary-dependent.png", "isDir": False},
+            ],
+        }
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+
+    processor = _MixedLeafProcessor(embedding_tracker)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    run_task = asyncio.create_task(executor.run(root_uri))
+    await processor.media_summary_started.wait()
+
+    try:
+        assert request_tracker.is_leaf_indexed(telemetry_id) is False
+    finally:
+        processor.allow_media_summary.set()
+        await run_task
+
+    assert request_tracker.is_leaf_indexed(telemetry_id) is True
+    request_tracker.cleanup(telemetry_id)
+
+
+@pytest.mark.asyncio
+async def test_semantic_dag_marks_leaf_indexed_after_leaf_embedding_before_overviews(monkeypatch):
+    root_uri = "viking://resources/root"
+    child_uri = f"{root_uri}/child"
+    telemetry_id = "telemetry-streaming"
+    semantic_msg_id = "semantic-streaming"
+    tree = {
+        root_uri: [{"name": "child", "isDir": True}],
+        child_uri: [{"name": "leaf.txt", "isDir": False}],
+    }
+    fake_fs = _FakeVikingFS(tree)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_instance", None)
+    monkeypatch.setattr(EmbeddingTaskTracker, "_initialized", False)
+    embedding_tracker = EmbeddingTaskTracker.get_instance()
+    request_tracker = RequestWaitTracker()
+    request_tracker.register_request(telemetry_id)
+    request_tracker.register_semantic_root(telemetry_id, semantic_msg_id)
+
+    processor = _CompletingEmbeddingProcessor(
+        embedding_tracker,
+        request_tracker,
+        telemetry_id,
+    )
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="resource",
+        max_concurrent_llm=1,
+        ctx=ctx,
+        semantic_msg_id=semantic_msg_id,
+        telemetry_id=telemetry_id,
+    )
+    monkeypatch.setattr(executor, "_write_directory_semantics", AsyncMock(return_value=True))
+
+    try:
+        await executor.run(root_uri)
+
+        assert processor.leaf_indexed_at_overview[child_uri] is True
+        assert processor.leaf_indexed_at_overview[root_uri] is True
+        assert processor.vectorize_telemetry_ids == [telemetry_id, telemetry_id, telemetry_id]
+        assert request_tracker.is_leaf_indexed(telemetry_id) is True
+        assert request_tracker.is_complete(telemetry_id) is True
+    finally:
+        request_tracker.cleanup(telemetry_id)
 
 
 @pytest.mark.asyncio

--- a/tests/telemetry/test_request_wait_tracker.py
+++ b/tests/telemetry/test_request_wait_tracker.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
+
 import pytest
 
 from openviking.telemetry.request_wait_tracker import RequestWaitTracker
@@ -63,3 +65,82 @@ async def test_wait_for_request_timeout_keeps_existing_error():
 
     with pytest.raises(TimeoutError, match="Request processing not complete after 0.01s"):
         await tracker.wait_for_request(telemetry_id, timeout=0.01, poll_interval=0.001)
+
+
+def test_leaf_indexed_requires_registered_roots_and_all_leaf_callbacks():
+    tracker = RequestWaitTracker()
+    telemetry_id = "tm_leaf_indexed"
+
+    tracker.register_request(telemetry_id)
+    assert tracker.is_leaf_indexed(telemetry_id) is False
+
+    tracker.register_semantic_root(telemetry_id, "semantic-1")
+    tracker.register_semantic_root(telemetry_id, "semantic-2")
+    assert tracker.is_leaf_indexed(telemetry_id) is False
+
+    tracker.mark_semantic_leaf_done(telemetry_id, "semantic-1")
+    assert tracker.is_leaf_indexed(telemetry_id) is False
+
+    tracker.mark_semantic_leaf_done(telemetry_id, "semantic-2")
+    assert tracker.is_leaf_indexed(telemetry_id) is True
+
+
+def test_leaf_embedding_error_blocks_leaf_indexed():
+    tracker = RequestWaitTracker()
+    telemetry_id = "tm_leaf_error"
+
+    tracker.register_request(telemetry_id)
+    tracker.register_semantic_root(telemetry_id, "semantic-1")
+    tracker.record_embedding_error(telemetry_id, "leaf failed", is_leaf=True)
+    tracker.mark_semantic_leaf_done(telemetry_id, "semantic-1")
+
+    assert tracker.is_leaf_indexed(telemetry_id) is False
+    assert tracker.build_queue_status(telemetry_id)["Embedding"]["error_count"] == 1
+
+
+def test_directory_embedding_error_does_not_block_leaf_indexed():
+    tracker = RequestWaitTracker()
+    telemetry_id = "tm_directory_error"
+
+    tracker.register_request(telemetry_id)
+    tracker.register_semantic_root(telemetry_id, "semantic-1")
+    tracker.record_embedding_error(telemetry_id, "directory failed")
+    tracker.mark_semantic_leaf_done(telemetry_id, "semantic-1")
+
+    assert tracker.is_leaf_indexed(telemetry_id) is True
+    assert tracker.build_queue_status(telemetry_id)["Embedding"]["error_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_request_reports_leaf_indexed_once_before_full_completion():
+    tracker = RequestWaitTracker()
+    telemetry_id = "tm_leaf_callback"
+    callback_calls = []
+
+    tracker.register_request(telemetry_id)
+    tracker.register_semantic_root(telemetry_id, "semantic-1")
+
+    async def on_leaf_indexed():
+        callback_calls.append("leaf")
+
+    wait_task = asyncio.create_task(
+        tracker.wait_for_request(
+            telemetry_id,
+            timeout=1,
+            poll_interval=0.001,
+            on_leaf_indexed=on_leaf_indexed,
+        )
+    )
+
+    tracker.mark_semantic_leaf_done(telemetry_id, "semantic-1")
+    for _ in range(100):
+        if callback_calls:
+            break
+        await asyncio.sleep(0.001)
+
+    assert callback_calls == ["leaf"]
+    assert wait_task.done() is False
+
+    tracker.mark_semantic_done(telemetry_id, "semantic-1")
+    await wait_task
+    assert callback_calls == ["leaf"]

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -140,6 +140,25 @@ async def test_update_stage(tracker: TaskTracker):
     assert retrieved.stage == "parsing"
 
 
+async def test_add_resource_leaf_indexed_stage_is_durable_until_terminal(tracker: TaskTracker):
+    task = await tracker.create("add_resource", **_owner_kwargs())
+    await tracker.start(task.task_id, stage="processing_queue")
+    await tracker.update_stage(task.task_id, "leaf_indexed")
+
+    await tracker.update_stage(task.task_id, "linking_reason")
+    await tracker.start(task.task_id, stage="queued")
+
+    running = await tracker.get(task.task_id)
+    assert running is not None
+    assert running.status == TaskStatus.RUNNING
+    assert running.stage == "leaf_indexed"
+
+    await tracker.complete(task.task_id, {})
+    completed = await tracker.get(task.task_id)
+    assert completed is not None
+    assert completed.stage == "completed"
+
+
 async def test_complete_task(tracker: TaskTracker):
     task = await tracker.create("session_commit", resource_id="s1", **_owner_kwargs())
     await tracker.start(task.task_id)

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -89,6 +89,135 @@ def test_get_resource_content_type_keeps_ts_as_text():
     assert embedding_utils.get_resource_content_type("source.ts") == ResourceContentType.TEXT
 
 
+@pytest.mark.parametrize(
+    ("file_name", "text_source", "use_summary", "requires_summary"),
+    [
+        ("notes.md", "content_only", False, False),
+        ("notes.md", "summary_first", False, True),
+        ("notes.md", "summary_only", False, True),
+        ("notes.md", "content_only", True, True),
+        ("photo.png", "content_only", False, True),
+        ("recording.mp3", "content_only", False, True),
+        ("archive.unknown", "content_only", False, True),
+    ],
+)
+def test_resolve_leaf_vectorization_plan_preserves_text_source_semantics(
+    file_name, text_source, use_summary, requires_summary
+):
+    plan = embedding_utils.resolve_leaf_vectorization_plan(
+        file_name,
+        text_source=text_source,
+        use_summary=use_summary,
+    )
+
+    assert plan.requires_summary is requires_summary
+
+
+@pytest.mark.asyncio
+async def test_enqueue_file_metadata_patch_builds_non_leaf_tracker_operation(monkeypatch):
+    queue = DummyQueue()
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+
+    enqueued = await embedding_utils.enqueue_file_metadata_patch(
+        file_path="viking://resources/a.md",
+        summary="generated summary",
+        ctx=DummyReq(),
+        semantic_msg_id="semantic-1",
+    )
+
+    assert enqueued is True
+    assert len(queue.items) == 1
+    msg = queue.items[0]
+    assert msg.operation == "metadata_patch"
+    assert msg.message == ""
+    assert msg.context_data == {
+        "uri": "viking://resources/a.md",
+        "account_id": "default",
+        "level": 2,
+        "is_leaf": False,
+        "abstract": "generated summary",
+    }
+    assert msg.semantic_msg_id == "semantic-1"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_file_metadata_patch_skips_empty_summary(monkeypatch):
+    queue = DummyQueue()
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+
+    enqueued = await embedding_utils.enqueue_file_metadata_patch(
+        file_path="viking://resources/a.md",
+        summary="",
+        ctx=DummyReq(),
+        semantic_msg_id="semantic-1",
+    )
+
+    assert enqueued is False
+    assert queue.items == []
+
+
+@pytest.mark.asyncio
+async def test_vectorize_file_reports_leaf_error_when_content_cannot_be_read(monkeypatch):
+    class UnreadableFS(DummyFS):
+        async def read_file(self, _path, ctx=None):
+            raise OSError("unreadable")
+
+    class RequestTracker:
+        def __init__(self):
+            self.errors = []
+
+        def record_embedding_error(self, telemetry_id, message, *, is_leaf=False):
+            self.errors.append((telemetry_id, message, is_leaf))
+
+    queue = DummyQueue()
+    request_tracker = RequestTracker()
+    decrements = []
+
+    async def _decrement(semantic_msg_id, count, *, is_leaf=False):
+        decrements.append((semantic_msg_id, count, is_leaf))
+
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: UnreadableFS(""))
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_openviking_config",
+        lambda: types.SimpleNamespace(
+            embedding=types.SimpleNamespace(text_source="content_only", max_input_tokens=1000)
+        ),
+    )
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_current_telemetry",
+        lambda: types.SimpleNamespace(telemetry_id="tm-1"),
+    )
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_request_wait_tracker",
+        lambda: request_tracker,
+        raising=False,
+    )
+    monkeypatch.setattr(embedding_utils, "_decrement_embedding_tracker", _decrement)
+
+    result = await embedding_utils.vectorize_file(
+        file_path="viking://resources/unreadable.md",
+        summary_dict={"name": "unreadable.md", "summary": ""},
+        parent_uri="viking://resources",
+        ctx=DummyReq(),
+        semantic_msg_id="semantic-1",
+    )
+
+    assert result is False
+    assert queue.items == []
+    assert decrements == [("semantic-1", 1, True)]
+    assert request_tracker.errors == [
+        (
+            "tm-1",
+            "Failed to enqueue leaf embedding for viking://resources/unreadable.md",
+            True,
+        )
+    ]
+
+
 @pytest.mark.asyncio
 async def test_vectorize_file_uses_summary_first(monkeypatch):
     queue = DummyQueue()
@@ -117,6 +246,43 @@ async def test_vectorize_file_uses_summary_first(monkeypatch):
     assert len(queue.items) == 1
     assert isinstance(queue.items[0], Context)
     assert queue.items[0].get_vectorization_text() == "short summary"
+
+
+@pytest.mark.asyncio
+async def test_vectorize_file_consumes_shared_leaf_plan(monkeypatch):
+    queue = DummyQueue()
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS("raw content"))
+    monkeypatch.setattr(
+        embedding_utils,
+        "get_openviking_config",
+        lambda: types.SimpleNamespace(
+            embedding=types.SimpleNamespace(text_source="content_only", max_input_tokens=1000)
+        ),
+    )
+    monkeypatch.setattr(
+        embedding_utils,
+        "resolve_leaf_vectorization_plan",
+        lambda *_args, **_kwargs: embedding_utils.LeafVectorizationPlan(
+            requires_summary=True,
+            effective_text_source="summary_only",
+            reason="test",
+        ),
+    )
+    monkeypatch.setattr(
+        embedding_utils.EmbeddingMsgConverter,
+        "from_context",
+        lambda context: context,
+    )
+
+    await embedding_utils.vectorize_file(
+        file_path="viking://user/default/resources/test.md",
+        summary_dict={"name": "test.md", "summary": "summary selected by plan"},
+        parent_uri="viking://user/default/resources",
+        ctx=DummyReq(),
+    )
+
+    assert queue.items[0].get_vectorization_text() == "summary selected by plan"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更说明

当前 `add-resource` 异步任务只有完整完成和失败两种可观察结果。调用方通过 getTask 轮询任务时，需要等待叶子文件 summary、目录 overview、根目录 overview 以及全部 Embedding 完成，才能确认资源是否可用。

对于默认配置 `embedding.text_source=content_only` 的文本叶子，向量和 BM25 内容来自原文，并不依赖 LLM summary。原流程仍然先生成 summary、再投递 Embedding，使叶子 summary 及多轮目录 VLM 处理进入了叶子可检索的关键路径。

本 PR 将符合条件的文本叶子调整为 Embedding-first，并新增持久化的 `leaf_indexed` 任务阶段：

1. 文本叶子完成解析和增量变化检查后，立即基于原文投递 Embedding。
2. 本次任务需要更新的全部叶子 Embedding 成功后，任务进入 `status=running, stage=leaf_indexed`。
3. 叶子 summary、`abstract` 元数据回填、目录 overview 和目录 Embedding 继续在后台执行。
4. 所有 Semantic 和 Embedding 工作完成后，任务才进入 `status=completed, stage=completed`。

调用方无需使用新的等待接口或 getTask 请求参数。默认异步调用仍然通过 `add-resource(wait=false)` 获取 `task_id`，随后轮询 getTask；只需要叶子检索能力时，可以在观察到 `leaf_indexed` 后提前返回。

完整流程图见：

- `docs/design/add-resource-leaf-indexed-pipeline.md`

## Human Involvement

- [x] 有人工参与需求设计、性能分析、实现确认和评审
- [ ] 完全由 AI Agent 独立生成，过程中没有人工参与

## 关联 Issue

无。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] Breaking change
- [x] 文档更新
- [ ] 纯重构
- [x] 性能优化
- [x] 测试更新

## 主要改动

### 1. 增加持久化 `leaf_indexed` 阶段

- RequestWaitTracker 单独跟踪请求级叶子 Semantic root 和叶子 Embedding 错误。
- 当所有必要叶子 Embedding 完成且没有叶子错误时，通过已有 `stage_callback` 更新 add-resource task。
- `leaf_indexed` 在最终 `completed` 或 `failed` 前保持单调，不会被后续 `processing_queue` 更新覆盖。
- 服务重启和任务恢复不会把已经持久化的 `leaf_indexed` 回退到早期阶段。

`leaf_indexed` 的准确语义是：

> 本次导入新增或修改、且需要重新向量化的全部叶子，已经按照各自的有效文本源成功完成 Embedding。

它不表示以下工作已经完成：

- 叶子 summary；
- 叶子 `abstract` 元数据；
- 子目录 L0/L1；
- 父目录或根目录 L0/L1；
- 完整 add-resource 任务。

### 2. 支持动态发现和双阶段 Embedding tracker

EmbeddingTaskTracker 增加开放式登记能力：

- `register_open()`：创建允许动态增加任务的 tracker；
- `add()`：DAG 发现叶子、metadata patch 或目录任务时动态登记；
- `seal_leaf()`：确认不会再发现新的叶子索引任务；
- `seal()`：确认不会再产生任何 Embedding 或 metadata 工作；
- `leaf_remaining`：仅统计影响 `leaf_indexed` 的叶子 Embedding；
- `remaining`：统计影响最终 `completed` 的全部 Embedding 和 metadata 工作；
- `on_leaf_complete`：叶子索引完成时触发一次；
- `on_complete`：所有完整任务收敛时触发一次。

Embedding 重试成功重新入队时不会提前递减 tracker。只有成功、终止失败或明确补偿时，才会结束一个逻辑任务。

Semantic 队列重试时，每次 DAG attempt 使用独立的内部 Embedding tracker ID。上一轮已经进入持久队列的叶子、目录或 metadata patch 消息即使延迟完成，也只会访问上一轮已经丢弃的 tracker，不会误扣新一轮计数或提前触发 `leaf_indexed/completed`。

### 3. Semantic DAG 流式投递

- 文本叶子完成变化检查后即可投递 Embedding，不再等待自身 summary。
- 子目录 overview 完成后立即投递该目录的 L0/L1 Embedding。
- 父目录和根目录 overview 继续并行推进。
- 叶子发现和索引计划登记完成后即可 seal leaf tracker。
- 父目录 overview 仍然等待完整的叶子 summary 和子目录 abstract，目录语义输入没有被削弱。

以下场景保持 Summary-first，避免改变现有向量语义：

- `embedding.text_source=summary_first`；
- `embedding.text_source=summary_only`；
- 调用路径显式指定 `use_summary=true`；
- 图片、音频等非文本内容；
- 无法直接使用原文进行向量化的内容类型。

### 4. 使用 metadata-only 操作回填 summary

Embedding-first 叶子的初始向量记录使用原文作为 dense/sparse Embedding 和 full-text 输入，`abstract` 暂时为空。

summary 生成后，通过新的 `operation=metadata_patch` 消息仅更新 `abstract`：

- 不调用 embedder；
- 不重新计算 dense/sparse vector；
- 不覆盖 full-text 和其他未提供字段；
- 使用与初始 Embedding 相同的确定性 record ID；
- 使用 partial update 保留已有向量字段；
- 旧消息缺少 `operation` 时仍按普通 `embed` 处理。

### 5. 避免 metadata patch 与初始 Embedding 乱序

summary 完成时，metadata patch 会立即登记到完整 tracker，但不会立即进入持久队列。

当本次请求的全部叶子 Embedding 进入终止状态后：

1. 如果所有叶子成功，先发布 `leaf_indexed`；
2. 再批量投递已经登记的 metadata patch；
3. 如果存在叶子终止失败，则丢弃尚未投递的 patch，并补偿对应的 full tracker 计数。

因此 patch 入队延迟不会阻塞 `leaf_indexed`，正常路径下 patch 也不会早于初始叶子记录。消费者仍保留“记录不存在则重新入队”的兜底，用于存储可见性延迟、历史消息及重启恢复场景。

### 6. 完善失败和关闭边界

- 服务关闭期间已经取出的 Embedding 消息通过取消语义退出，不会被误判为成功并 ACK。
- 向量库在写入期间关闭时保留消息和 tracker 待处理状态。
- 不支持的 Embedding 消息类型按终止失败处理，不再静默记为成功。
- 目录 `ls` 失败会使 Semantic DAG 失败，不再把目录错误解释为空目录并提前完成。
- executor 已失败时不会继续 seal leaf tracker。
- 叶子 Embedding 失败时不会出现 `leaf_indexed`。
- metadata patch 或目录阶段在 `leaf_indexed` 之后失败时，任务最终进入 `failed`，但已经成立的叶子可检索承诺不回退。
- 共享 worker 投递 metadata patch 前重新绑定当前请求 telemetry，避免并发请求之间串写统计信息。

### 7. API 和设计文档

- 中英文 task API 文档增加 `leaf_indexed` 阶段说明。
- 新增精简的 add-resource Embedding-first/`leaf_indexed` 流程图。

## 兼容性

- add-resource 请求结构不变；
- getTask 请求结构不变；
- 不新增 task wait 接口；
- 默认不带 `wait=true` 的异步入库方式不变；
- `wait=true` 仍等待完整任务完成，不会在 `leaf_indexed` 提前返回；
- 已有调用方如果只判断 `completed/failed`，行为不变；
- 旧 Embedding queue 消息保持兼容；
- `summary_first`、`summary_only`、显式 `use_summary` 和非文本内容继续遵循原有 summary 依赖；
- 增量导入中未变化的叶子不重复 Embedding，也不计入本次待完成叶子数量；
- 资源锁仍保持到完整 add-resource 任务结束。

## 测试

- [x] 已添加覆盖本功能的单元测试和回归测试
- [x] 新增及现有相关测试在本地通过
- [x] 已在 macOS 验证
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

### 自动化验证

- 相关 Python 回归：`193 passed, 6 deselected`；
- `ruff format --check`：通过；
- `ruff check`：通过；
- `mypy --follow-imports=skip`：3 个修改过的生产文件通过；
- `git diff --check`：通过；
- `npm --prefix docs run docs:build`：通过。

相关测试覆盖：

- add-resource stage callback 和任务阶段持久化；
- RequestWaitTracker 叶子里程碑；
- EmbeddingTaskTracker 动态登记、双阶段完成和跨 event loop callback；
- Embedding 消息兼容与 metadata patch；
- Semantic DAG 流式投递、增量更新、目录发现和失败处理；
- `content_only`、`summary_first`、`summary_only` 文本源策略；
- shutdown、重试、终止失败和 tracker 竞态；
- metadata partial update 对已有向量字段的保留。

### 真实资源回归

| 场景 | 结果 |
|---|---|
| 默认 `content_only`、15 个文本叶子的 PDF | 任务完成；Semantic 处理 1 条；Embedding 处理 34 条；零重试、零错误；首次成功轮询时已进入 `leaf_indexed` |
| 多模态图片 | 约 28.31 秒进入 `leaf_indexed`，约 45.95 秒完整完成；VLM abstract 正常生成；零重试、零错误 |
| `summary_first` 文本资源 | 约 21.77 秒完整完成；Embedding 正好处理 3 条；没有 metadata patch，证明没有错误进入 Embedding-first 路径 |

仓库当前没有可在根目录直接运行的统一全量 pytest：`tests/api_test` 和 `tests/oc2ov_test` 使用独立 workflow、独立工作目录及专用环境，`_test_full.yml` 也明确暂时禁用了 full unit suite。本 PR 因此使用与变更相关的聚焦回归、文档构建和真实资源回归作为提交前验证。

本机 quick-start lite 还受到工作区旧 VectorDB 原生二进制缺少 bounded store scan 接口的环境限制；该问题发生在 collection 初始化阶段，与本 PR 的测试断言无关。

## Checklist

- [x] 代码符合项目风格
- [x] 已完成自查和独立代码评审
- [x] 已为并发、失败和恢复边界补充必要注释
- [x] 已更新中英文 API 文档和设计流程图
- [x] 未引入新的静态检查错误
- [x] 不依赖尚未合入或发布的其他变更

## Screenshots

不适用。本 PR 修改后台任务阶段、Semantic/Embedding pipeline 和任务文档，不涉及界面变更。

## Additional Notes

- `leaf_indexed` 是 add-resource 专属的非终态里程碑。
- 调用方可以在轮询到 `leaf_indexed` 后提前使用叶子检索能力。
- 如果调用方依赖目录 overview、目录 L0/L1 或完整 summary 元数据，仍应等待 `completed`。
- 本 PR 不修改向量文本配置的既有含义，只根据现有配置判断是否允许叶子 Embedding 提前执行。
