### PR TITLE
fix(bot): preserve token usage for no-tool responses

### DIFF
--- a/bot/vikingbot/providers/vlm_adapter.py
+++ b/bot/vikingbot/providers/vlm_adapter.py
@@ -82,13 +82,16 @@ class VLMProviderAdapter(LLMProvider):
 
             # --- Call VLM backend ---
             attempt = 1
+            # An explicit empty list asks VLM backends for a structured response
+            # without exposing tools, so per-response usage is preserved.
+            response_tools = tools if tools is not None else []
             while True:
                 try:
                     result = await self._vlm.get_completion_async(
                         messages=messages,
                         thinking=getattr(self._vlm, "thinking", None),
-                        tools=tools,
-                        tool_choice="auto" if tools else None,
+                        tools=response_tools,
+                        tool_choice="auto" if response_tools else None,
                     )
                     break
                 except Exception as e:

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -308,7 +308,7 @@ class OpenAIVLM(VLMBase):
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
             elapsed = time.perf_counter() - t0
-            if tools:
+            if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return self._extract_completion_content(response, elapsed)
@@ -338,7 +338,7 @@ class OpenAIVLM(VLMBase):
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
             elapsed = time.perf_counter() - t0
-            if tools:
+            if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return await self._extract_completion_content_async(response, elapsed)
@@ -424,7 +424,7 @@ class OpenAIVLM(VLMBase):
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
             elapsed = time.perf_counter() - t0
-            if tools:
+            if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return self._extract_completion_content(response, elapsed)
@@ -456,7 +456,7 @@ class OpenAIVLM(VLMBase):
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
             elapsed = time.perf_counter() - t0
-            if tools:
+            if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return await self._extract_completion_content_async(response, elapsed)

--- a/tests/unit/test_vikingbot_vlm_adapter_retry.py
+++ b/tests/unit/test_vikingbot_vlm_adapter_retry.py
@@ -149,6 +149,48 @@ async def test_chat_accepts_string_response_from_openai_backend_with_tools(monke
 
 
 @pytest.mark.asyncio
+async def test_chat_without_tools_preserves_usage_from_openai_backend(monkeypatch):
+    raw_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="plain response", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=13,
+            completion_tokens=5,
+            total_tokens=18,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+        ),
+    )
+
+    async def create(**kwargs):
+        assert "tools" not in kwargs
+        return raw_response
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    vlm = OpenAIVLM({"provider": "openai", "model": "gpt-5.6-terra"})
+    monkeypatch.setattr(vlm, "get_async_client", lambda: client)
+    adapter = VLMProviderAdapter(vlm, "gpt-5.6-terra", langfuse_client=_DisabledLangfuse())
+
+    response = await adapter.chat(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "plain response"
+    assert response.tool_calls == []
+    assert response.finish_reason == "stop"
+    assert response.usage == {
+        "prompt_tokens": 13,
+        "completion_tokens": 5,
+        "total_tokens": 18,
+        "prompt_tokens_details": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_retries_rate_limit_until_success(monkeypatch):
     sleep_delays: list[float] = []
 

--- a/tests/unit/test_vlm_response_formats.py
+++ b/tests/unit/test_vlm_response_formats.py
@@ -111,3 +111,49 @@ async def test_openai_async_completion_from_str_with_tools(monkeypatch):
     assert response.content == "plain string response"
     assert response.tool_calls == []
     assert response.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_openai_async_completion_with_empty_tools_preserves_usage(monkeypatch):
+    usage = SimpleNamespace(
+        prompt_tokens=11,
+        completion_tokens=4,
+        total_tokens=15,
+        prompt_tokens_details=None,
+        completion_tokens_details=None,
+    )
+    raw_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="plain response", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+
+    async def create(**kwargs):
+        assert "tools" not in kwargs
+        return raw_response
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    vlm = OpenAIVLM({"provider": "openai", "model": "gpt-5.6-terra"})
+    monkeypatch.setattr(vlm, "get_async_client", lambda: client)
+
+    response = await vlm.get_completion_async(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[],
+    )
+
+    assert isinstance(response, VLMResponse)
+    assert response.content == "plain response"
+    assert response.tool_calls == []
+    assert response.finish_reason == "stop"
+    assert response.usage == {
+        "prompt_tokens": 11,
+        "completion_tokens": 4,
+        "total_tokens": 15,
+        "prompt_tokens_details": None,
+    }


### PR DESCRIPTION
## Description

Fix Bot token usage being reported as zero for no-tool model responses. The Bot adapter now explicitly requests a structured VLM response when no tools are exposed, allowing OpenAI-compatible backends to preserve the provider's usage metadata.

Root cause: `OpenAIVLM` used the truthiness of `tools` to choose its return format. An empty list therefore selected the legacy plain-string path, discarding usage metadata before `VLMProviderAdapter` built the final response. The fix distinguishes `tools=[]` from `tools=None`: an explicit empty list returns `VLMResponse`, while omitted tools retain the existing string-response compatibility behavior.

This covers both `max_tool_iterations=0` and the final no-tool response after reaching the tool-iteration limit.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI without human review

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Normalize missing Bot tools to an explicit empty list so the adapter receives a structured response with usage metadata.
- Make OpenAI-compatible text and vision paths return `VLMResponse` for explicit empty tool lists without serializing tools into upstream requests.
- Add async backend and Bot adapter regression tests for no-tool usage preservation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platform(s): macOS

Commands run:

```bash
python -m pytest --no-cov -q \
  tests/unit/test_vlm_response_formats.py \
  tests/unit/test_vikingbot_vlm_adapter_retry.py \
  tests/unit/test_vlm_reasoning_models.py \
  tests/unit/test_extra_headers_vlm.py \
  bot/vikingbot/tests/unit/test_bot_provider_thinking.py \
  bot/tests/test_agent_loop_outcome.py::test_agent_loop_makes_final_no_tool_call_when_iteration_limit_reached
# 91 passed, 5 pre-existing warnings

ruff check bot/vikingbot/providers/vlm_adapter.py openviking/models/vlm/backends/openai_vlm.py tests/unit/test_vikingbot_vlm_adapter_retry.py tests/unit/test_vlm_response_formats.py
ruff format --check bot/vikingbot/providers/vlm_adapter.py openviking/models/vlm/backends/openai_vlm.py tests/unit/test_vikingbot_vlm_adapter_retry.py tests/unit/test_vlm_response_formats.py
git diff --check
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots

N/A

## Additional Notes

An empty tool list remains absent from the upstream OpenAI request. Only the local response-format selection changes, preserving compatibility for direct VLM callers that omit `tools` and expect a plain string.
