### PR TITLE
feat(langchain): add native async integration support

### DIFF
--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -23,6 +23,42 @@ tools = create_openviking_tools(
 
 When `url` is omitted, the adapters load connection settings from the OpenViking CLI config. Embedding and VLM providers are configured in OpenViking, not in your app.
 
+### Async applications
+
+The retriever, context wrapper, chat history, session recorder, and LangGraph
+middleware all have native async paths. URL-based adapters create an async
+OpenViking HTTP client automatically:
+
+```python
+docs = await retriever.ainvoke("What did the user decide?")
+result = await chain.ainvoke(
+    {"messages": [...]},
+    config={"configurable": {"session_id": "support-thread-1"}},
+)
+```
+
+Long-lived applications can initialize one caller-owned client and reuse it
+across adapters:
+
+```python
+from openviking.client import AsyncHTTPClient
+from openviking.integrations.langchain import OpenVikingRetriever
+
+client = AsyncHTTPClient(url="http://localhost:1933", api_key="...")
+await client.initialize()
+try:
+    retriever = OpenVikingRetriever(async_client=client)
+    docs = await retriever.ainvoke("deployment decision")
+finally:
+    await client.close()
+```
+
+`OpenVikingChatMessageHistory` provides `aget_messages()`, `aadd_messages()`,
+and `aclear()`. `OpenVikingSessionRecorder` provides `arecord()`, `aflush()`,
+and `aclose()`. Async LangGraph runs select `awrap_model_call()` and
+`aafter_agent()` automatically. A synchronous injected client remains
+supported; its calls run in a worker thread instead of blocking the event loop.
+
 ## Peer Identity
 
 Pass `actor_peer_id` to filter the current user's peer collection for filesystem and retrieval operations. Session message capture can still use `peer_id` for per-message speaker attribution.
@@ -151,6 +187,9 @@ commit. When supplying `context_parts`, resend them only if
 `exc.context_attached` is false. `flush()` forces a commit only when the session
 has pending content. After `close()`, the recorder cannot be reused; injected
 clients remain owned by the caller.
+
+For async lifecycles, use the equivalent `await recorder.arecord(...)`,
+`await recorder.aflush(...)`, and `await recorder.aclose()` methods.
 
 ## Try the examples
 

--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -1,6 +1,6 @@
 # LangChain and LangGraph
 
-Wire OpenViking into your LangChain or LangGraph agent as the context backend. The SDK provides a retriever, chat history, context wrapper, agent tools, LangGraph store, and middleware — all connecting to a running OpenViking server over HTTP.
+Wire OpenViking into your LangChain or LangGraph agent as the context backend. The SDK provides a retriever, chat history, context wrapper, agent tools, LangGraph store, and middleware for HTTP-backed or embedded OpenViking deployments.
 
 ## Install
 
@@ -21,7 +21,7 @@ tools = create_openviking_tools(
 )
 ```
 
-When `url` is omitted, the adapters load connection settings from the OpenViking CLI config. Embedding and VLM providers are configured in OpenViking, not in your app.
+When both `url` and `path` are omitted, adapters use the HTTP connection settings from the OpenViking CLI config. Pass `path` to use an embedded workspace through OpenViking's synchronous client. Embedding and VLM providers are configured in OpenViking, not in your app.
 
 ### Async applications
 
@@ -37,8 +37,16 @@ result = await chain.ainvoke(
 )
 ```
 
-Long-lived applications can initialize one caller-owned client and reuse it
-across adapters:
+Async adapters support three client modes:
+
+| Configuration | Async interface | Ownership |
+|---------------|-----------------|-----------|
+| `client=` or `async_client=` | The injected client is returned unchanged | Caller |
+| `url=`, or neither `url` nor `path` | One recovery-capable HTTP handle per event loop | Adapter |
+| `path=` | A synchronous embedded client invoked in a worker thread | Adapter |
+
+Long-lived applications can initialize one caller-owned async client and reuse
+it across adapters running on the same event loop:
 
 ```python
 from openviking.client import AsyncHTTPClient
@@ -53,12 +61,24 @@ finally:
     await client.close()
 ```
 
+Injected async clients are bound to the event loop that initializes them. Do
+not share one injected async client across event loops; create and manage one
+client per loop instead. An injected synchronous client remains safe to use
+from async adapter methods because its calls run in a worker thread.
+
+For embedded `path=` adapters, the synchronous fallback is intentional:
+`SyncOpenViking` keeps the stateful embedded engine on OpenViking's shared
+background loop while the application event loop remains non-blocking. To use
+native embedded async methods, construct and initialize `AsyncOpenViking`
+yourself, inject it with `async_client=`, use it from that same event loop, and
+close it yourself. Only one embedded workspace can be live per process; close
+or reset it before selecting another workspace.
+
 `OpenVikingChatMessageHistory` provides `aget_messages()`, `aadd_messages()`,
 and `aclear()`. `OpenVikingSessionRecorder` provides `arecord()`, `aflush()`,
 and `aclose()`. Async LangGraph runs select `awrap_model_call()` and
-`aafter_agent()` automatically. A synchronous injected client remains
-supported; its calls run in a worker thread instead of blocking the event loop.
-Concurrent first use initializes one shared client per adapter.
+`aafter_agent()` automatically. Concurrent first use creates one internal HTTP
+client per adapter and event loop.
 
 Adapters never close an injected client. When an adapter creates its own client,
 release it with `await retriever.aclose()`, `await assembler.aclose()`,
@@ -66,6 +86,12 @@ release it with `await retriever.aclose()`, `await assembler.aclose()`,
 `await recorder.aclose()` as appropriate. Calling synchronous
 `recorder.close()` after an async operation raises and intentionally leaves the
 recorder open so `await recorder.aclose()` can still release every resource.
+When possible, close HTTP-backed adapters before shutting down their event
+loops; cleanup after an originating loop has already ended is best-effort.
+`with_openviking_context()` returns LangChain's standard
+`RunnableWithMessageHistory`, which has no close hook. Long-lived async
+applications using that helper should therefore inject and close a
+caller-owned async client as shown above.
 
 ## Peer Identity
 

--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -58,6 +58,14 @@ and `aclear()`. `OpenVikingSessionRecorder` provides `arecord()`, `aflush()`,
 and `aclose()`. Async LangGraph runs select `awrap_model_call()` and
 `aafter_agent()` automatically. A synchronous injected client remains
 supported; its calls run in a worker thread instead of blocking the event loop.
+Concurrent first use initializes one shared client per adapter.
+
+Adapters never close an injected client. When an adapter creates its own client,
+release it with `await retriever.aclose()`, `await assembler.aclose()`,
+`await middleware.aclose()`, `await history.aclose()`, or
+`await recorder.aclose()` as appropriate. Calling synchronous
+`recorder.close()` after an async operation raises and intentionally leaves the
+recorder open so `await recorder.aclose()` can still release every resource.
 
 ## Peer Identity
 
@@ -189,7 +197,8 @@ has pending content. After `close()`, the recorder cannot be reused; injected
 clients remain owned by the caller.
 
 For async lifecycles, use the equivalent `await recorder.arecord(...)`,
-`await recorder.aflush(...)`, and `await recorder.aclose()` methods.
+`await recorder.aflush(...)`, and `await recorder.aclose()` methods. Do not
+finish an async lifecycle with `recorder.close()`.
 
 ## Try the examples
 

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -56,7 +56,14 @@ finally:
 `aclear()`；`OpenVikingSessionRecorder` 提供 `arecord()`、`aflush()` 和
 `aclose()`。异步 LangGraph 运行会自动选择 `awrap_model_call()` 和
 `aafter_agent()`。原有同步 client 仍可注入，其调用会在 worker thread 中执行，不会阻塞
-event loop。
+event loop。同一 adapter 首次被并发调用时只会初始化一个共享 client。
+
+Adapter 不会关闭调用方注入的 client。对于 adapter 自行创建的 client，应按实际使用的组件调用
+`await retriever.aclose()`、`await assembler.aclose()`、
+`await middleware.aclose()`、`await history.aclose()` 或
+`await recorder.aclose()`。如果 async 操作完成后误调用同步
+`recorder.close()`，该方法会抛出异常并保持 recorder 可用，以便后续
+`await recorder.aclose()` 仍能释放全部资源。
 
 ## Peer 身份
 
@@ -184,7 +191,8 @@ commit 策略。如果后续批次或写入后的 commit 失败，`OpenVikingPar
 仍归调用方管理。
 
 异步生命周期使用对应的 `await recorder.arecord(...)`、
-`await recorder.aflush(...)` 和 `await recorder.aclose()`。
+`await recorder.aflush(...)` 和 `await recorder.aclose()`。不要用
+`recorder.close()` 结束异步生命周期。
 
 ## 运行示例
 

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -1,6 +1,6 @@
 # LangChain 和 LangGraph
 
-把 OpenViking 接入你的 LangChain 或 LangGraph Agent 作为上下文后端。SDK 提供 retriever、chat history、context wrapper、agent tools、LangGraph store 和 middleware——全部通过 HTTP 连接运行中的 OpenViking 服务。
+把 OpenViking 接入你的 LangChain 或 LangGraph Agent 作为上下文后端。SDK 提供 retriever、chat history、context wrapper、agent tools、LangGraph store 和 middleware，可连接 HTTP 服务或嵌入式 OpenViking。
 
 ## 安装
 
@@ -21,7 +21,7 @@ tools = create_openviking_tools(
 )
 ```
 
-省略 `url` 时，适配器自动从 OpenViking CLI 配置加载连接信息。Embedding 和 VLM 在 OpenViking 侧配置，不在你的应用中。
+同时省略 `url` 和 `path` 时，适配器会使用 OpenViking CLI 配置中的 HTTP 连接信息。传入 `path` 时，通过 OpenViking 同步 client 使用嵌入式 workspace。Embedding 和 VLM 在 OpenViking 侧配置，不在你的应用中。
 
 ### 异步应用
 
@@ -37,7 +37,16 @@ result = await chain.ainvoke(
 )
 ```
 
-长期运行的应用可以初始化一个由调用方管理的 client，并在多个适配器之间复用：
+异步适配器支持三种 client 模式：
+
+| 配置 | 异步接口 | 所有权 |
+|------|----------|--------|
+| `client=` 或 `async_client=` | 原样返回注入的 client | 调用方 |
+| `url=`，或同时省略 `url` 和 `path` | 每个 event loop 一个支持恢复的 HTTP handle | Adapter |
+| `path=` | 在 worker thread 中调用同步嵌入式 client | Adapter |
+
+长期运行的应用可以初始化一个由调用方管理的异步 client，并在同一 event loop
+内的多个适配器之间复用：
 
 ```python
 from openviking.client import AsyncHTTPClient
@@ -52,11 +61,21 @@ finally:
     await client.close()
 ```
 
+注入的异步 client 会绑定到初始化它的 event loop。不要跨 event loop 共享同一个
+注入异步 client；应为每个 loop 分别创建并管理 client。注入的同步 client 仍可安全地
+用于异步 adapter 方法，因为调用会在 worker thread 中执行。
+
+`path=` 嵌入式 adapter 使用同步 fallback 是有意设计：`SyncOpenViking` 会让有状态的
+嵌入式引擎保持在 OpenViking 的共享后台 loop 上，同时不阻塞应用 event loop。若要使用
+原生嵌入式异步方法，请自行创建并初始化 `AsyncOpenViking`，通过 `async_client=` 注入，
+在同一个 event loop 中使用，并由调用方自行关闭。每个进程同时只能运行一个嵌入式
+workspace；切换 workspace 前应先关闭或 reset 当前 client。
+
 `OpenVikingChatMessageHistory` 提供 `aget_messages()`、`aadd_messages()` 和
 `aclear()`；`OpenVikingSessionRecorder` 提供 `arecord()`、`aflush()` 和
 `aclose()`。异步 LangGraph 运行会自动选择 `awrap_model_call()` 和
-`aafter_agent()`。原有同步 client 仍可注入，其调用会在 worker thread 中执行，不会阻塞
-event loop。同一 adapter 首次被并发调用时只会初始化一个共享 client。
+`aafter_agent()`。同一 adapter 首次被并发调用时，每个 event loop 只会创建一个内部
+HTTP client。
 
 Adapter 不会关闭调用方注入的 client。对于 adapter 自行创建的 client，应按实际使用的组件调用
 `await retriever.aclose()`、`await assembler.aclose()`、
@@ -64,6 +83,11 @@ Adapter 不会关闭调用方注入的 client。对于 adapter 自行创建的 c
 `await recorder.aclose()`。如果 async 操作完成后误调用同步
 `recorder.close()`，该方法会抛出异常并保持 recorder 可用，以便后续
 `await recorder.aclose()` 仍能释放全部资源。
+如果条件允许，应在关闭 event loop 前关闭 HTTP-backed adapter；原始 loop 已结束后的
+清理属于 best-effort。
+`with_openviking_context()` 返回 LangChain 标准的
+`RunnableWithMessageHistory`，而该类型没有 close hook。因此长期运行的异步应用使用此
+helper 时，应按上例注入并关闭由调用方管理的异步 client。
 
 ## Peer 身份
 

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -23,6 +23,41 @@ tools = create_openviking_tools(
 
 省略 `url` 时，适配器自动从 OpenViking CLI 配置加载连接信息。Embedding 和 VLM 在 OpenViking 侧配置，不在你的应用中。
 
+### 异步应用
+
+Retriever、context wrapper、chat history、session recorder 和 LangGraph
+middleware 都支持原生异步路径。通过 URL 配置时，适配器会自动创建异步 OpenViking HTTP
+client：
+
+```python
+docs = await retriever.ainvoke("用户之前做了什么决定？")
+result = await chain.ainvoke(
+    {"messages": [...]},
+    config={"configurable": {"session_id": "support-thread-1"}},
+)
+```
+
+长期运行的应用可以初始化一个由调用方管理的 client，并在多个适配器之间复用：
+
+```python
+from openviking.client import AsyncHTTPClient
+from openviking.integrations.langchain import OpenVikingRetriever
+
+client = AsyncHTTPClient(url="http://localhost:1933", api_key="...")
+await client.initialize()
+try:
+    retriever = OpenVikingRetriever(async_client=client)
+    docs = await retriever.ainvoke("部署决定")
+finally:
+    await client.close()
+```
+
+`OpenVikingChatMessageHistory` 提供 `aget_messages()`、`aadd_messages()` 和
+`aclear()`；`OpenVikingSessionRecorder` 提供 `arecord()`、`aflush()` 和
+`aclose()`。异步 LangGraph 运行会自动选择 `awrap_model_call()` 和
+`aafter_agent()`。原有同步 client 仍可注入，其调用会在 worker thread 中执行，不会阻塞
+event loop。
+
 ## Peer 身份
 
 传入 `actor_peer_id` 可以在文件系统和检索操作中过滤当前用户的 peer 集合。session message capture 仍可使用 `peer_id` 表达每条消息的说话人归属。
@@ -147,6 +182,9 @@ commit 策略。如果后续批次或写入后的 commit 失败，`OpenVikingPar
 传入 `context_parts` 时，仅在 `exc.context_attached` 为 false 时重传。`flush()` 仅在 session
 存在待提交内容时强制 commit。`close()` 后 recorder 不可复用；由调用方注入的 client
 仍归调用方管理。
+
+异步生命周期使用对应的 `await recorder.arecord(...)`、
+`await recorder.aflush(...)` 和 `await recorder.aclose()`。
 
 ## 运行示例
 

--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -349,6 +349,8 @@ async def ensure_async_client(
             return handle
         if embedded_client_factory is not None:
             if client_cache is not None:
+                # The thread hop is load-bearing: without a running event loop,
+                # the embedded singleton occupies the cache's shared fallback slot.
                 return await asyncio.to_thread(
                     client_cache.get,
                     embedded_client_factory,

--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -40,6 +41,7 @@ _RECOVERABLE_RUNTIME_MESSAGE_FRAGMENTS = (
     "attached to a different loop",
     "bound to a different event loop",
 )
+_ASYNC_INITIALIZATION_LOCK_ATTR = "_openviking_integration_initialize_lock"
 
 
 class OptionalDependencyError(ImportError):
@@ -149,28 +151,37 @@ class OpenVikingAsyncClientHandle:
     def __init__(self, connection: OpenVikingConnection):
         self._connection = connection
         self._client: Any = None
+        self._client_lock = asyncio.Lock()
+
+    @property
+    def _initialized(self) -> bool:
+        client = self._client
+        return bool(client is not None and _async_client_is_initialized(client))
+
+    async def initialize(self) -> None:
+        """Initialize the underlying client once."""
+
+        await self.get()
 
     async def close(self) -> None:
         await self.reset()
 
     async def reset(self) -> None:
-        client = self._client
-        self._client = None
+        async with self._client_lock:
+            client = self._client
+            self._client = None
         if client is None:
             return
-        close = getattr(client, "close", None)
-        if not callable(close):
-            return
         try:
-            result = close()
-            if inspect.isawaitable(result):
-                await result
+            await aclose_openviking_client(client)
         except Exception:
             logger.debug("OpenViking async client close during recovery failed", exc_info=True)
 
     async def get(self) -> Any:
         if self._client is None:
-            self._client = await _create_async_client_from_connection(self._connection)
+            async with self._client_lock:
+                if self._client is None:
+                    self._client = await _create_async_client_from_connection(self._connection)
         return self._client
 
     async def _openviking_acall(self, method_name: str, /, **kwargs: Any) -> Any:
@@ -208,7 +219,24 @@ class OpenVikingAsyncClientHandle:
                     await self.reset()
                 raise
 
+    def __copy__(self) -> OpenVikingAsyncClientHandle:
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> OpenVikingAsyncClientHandle:
+        copied = type(self)(copy.deepcopy(self._connection, memo))
+        memo[id(self)] = copied
+        return copied
+
     def __getattr__(self, name: str) -> Any:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        client = self._client
+        if client is None:
+            raise AttributeError(name)
+        attr = getattr(client, name)
+        if not callable(attr):
+            return attr
+
         async def recovered_method(*args: Any, **kwargs: Any) -> Any:
             return await self._call_with_recovery(name, *args, **kwargs)
 
@@ -394,9 +422,51 @@ async def _create_async_client_from_connection(connection: OpenVikingConnection)
 
         client = AsyncOpenViking(path=connection.path, actor_peer_id=connection.actor_peer_id)
 
-    if connection.auto_initialize and hasattr(client, "initialize"):
-        await _ainitialize_client(client)
+    try:
+        if connection.auto_initialize and hasattr(client, "initialize"):
+            await _ainitialize_client(client)
+    except BaseException:
+        try:
+            await aclose_openviking_client(client)
+        except Exception:
+            logger.debug(
+                "OpenViking async client close after initialization failure failed",
+                exc_info=True,
+            )
+        raise
     return client
+
+
+async def aclose_openviking_client(client: Any) -> None:
+    """Close an async or sync OpenViking client without blocking the event loop."""
+
+    close = getattr(client, "close", None)
+    if not callable(close):
+        return
+    if inspect.iscoroutinefunction(close):
+        await close()
+        return
+    result = await asyncio.to_thread(close)
+    if inspect.isawaitable(result):
+        await result
+
+
+async def aclose_openviking_clients(*clients: Any) -> None:
+    """Close every distinct client and re-raise the first cleanup failure."""
+
+    seen: set[int] = set()
+    first_error: BaseException | None = None
+    for client in clients:
+        if client is None or id(client) in seen:
+            continue
+        seen.add(id(client))
+        try:
+            await aclose_openviking_client(client)
+        except BaseException as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
 
 
 def _call_client_method(
@@ -430,11 +500,27 @@ async def _acall_client_method(
 async def _ainitialize_client(client: Any) -> None:
     if _async_client_is_initialized(client):
         return
-    await _acall_client_method(client, "initialize")
+    lock = _async_client_initialization_lock(client)
+    async with lock:
+        if _async_client_is_initialized(client):
+            return
+        await _acall_client_method(client, "initialize")
+        try:
+            client._openviking_integration_initialized = True
+        except Exception:
+            pass
+
+
+def _async_client_initialization_lock(client: Any) -> asyncio.Lock:
     try:
-        client._openviking_integration_initialized = True
-    except Exception:
-        pass
+        lock = inspect.getattr_static(client, _ASYNC_INITIALIZATION_LOCK_ATTR)
+    except AttributeError:
+        lock = asyncio.Lock()
+        try:
+            setattr(client, _ASYNC_INITIALIZATION_LOCK_ATTR, lock)
+        except Exception:
+            return lock
+    return lock
 
 
 def _async_client_is_initialized(client: Any) -> bool:

--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -10,7 +10,9 @@ import inspect
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterable, Literal
+from typing import Any, Callable, Iterable, Literal
+
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,7 @@ _RECOVERABLE_RUNTIME_MESSAGE_FRAGMENTS = (
     "attached to a different loop",
     "bound to a different event loop",
 )
-_ASYNC_INITIALIZATION_LOCK_ATTR = "_openviking_integration_initialize_lock"
+_ASYNC_INITIALIZATION_LOCKS_ATTR = "_openviking_integration_initialize_locks"
 
 
 class OptionalDependencyError(ImportError):
@@ -146,12 +148,21 @@ class OpenVikingClientHandle:
 
 
 class OpenVikingAsyncClientHandle:
-    """Lazy async client wrapper with one-shot recovery for safe reads."""
+    """Lazy, loop-local async client wrapper with one-shot recovery for safe reads.
+
+    Method calls through the handle are recovery-safe. Direct client attribute
+    access is best-effort and may be unavailable while recovery replaces the
+    underlying client.
+    """
 
     def __init__(self, connection: OpenVikingConnection):
         self._connection = connection
         self._client: Any = None
         self._client_lock = asyncio.Lock()
+        try:
+            self._loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
 
     @property
     def _initialized(self) -> bool:
@@ -164,12 +175,45 @@ class OpenVikingAsyncClientHandle:
         await self.get()
 
     async def close(self) -> None:
-        await self.reset()
+        owner_loop = self._loop
+        current_loop = asyncio.get_running_loop()
+        if owner_loop is None or owner_loop is current_loop:
+            await self.reset()
+            return
+        if owner_loop.is_running():
+            reset = self.reset()
+            try:
+                future = asyncio.run_coroutine_threadsafe(reset, owner_loop)
+            except RuntimeError:
+                reset.close()
+            else:
+                await asyncio.wrap_future(future)
+                return
+        await self._reset_without_lock()
 
     async def reset(self) -> None:
         async with self._client_lock:
             client = self._client
             self._client = None
+        await self._close_client(client)
+
+    async def _reset_if_current(self, client: Any) -> None:
+        """Reset only when ``client`` is still the active snapshot."""
+
+        async with self._client_lock:
+            if self._client is not client:
+                return
+            self._client = None
+        await self._close_client(client)
+
+    async def _reset_without_lock(self) -> None:
+        """Detach a client after its originating loop has stopped."""
+
+        client = self._client
+        self._client = None
+        await self._close_client(client)
+
+    async def _close_client(self, client: Any) -> None:
         if client is None:
             return
         try:
@@ -178,6 +222,20 @@ class OpenVikingAsyncClientHandle:
             logger.debug("OpenViking async client close during recovery failed", exc_info=True)
 
     async def get(self) -> Any:
+        """Return the current client snapshot, initializing it when necessary.
+
+        Read raw properties immediately and do not retain this client: a later
+        recovery may replace and close it.
+        """
+
+        current_loop = asyncio.get_running_loop()
+        if self._loop is None:
+            self._loop = current_loop
+        elif self._loop is not current_loop:
+            raise RuntimeError(
+                "OpenVikingAsyncClientHandle is loop-local and cannot be reused "
+                "from another event loop"
+            )
         if self._client is None:
             async with self._client_lock:
                 if self._client is None:
@@ -194,9 +252,10 @@ class OpenVikingAsyncClientHandle:
         *args: Any,
         **kwargs: Any,
     ) -> Any:
+        client = await self.get()
         try:
             return await _acall_client_method(
-                await self.get(),
+                client,
                 method_name,
                 *args,
                 **kwargs,
@@ -204,19 +263,20 @@ class OpenVikingAsyncClientHandle:
         except Exception as exc:
             if not _is_recoverable_client_error(exc):
                 raise
-            await self.reset()
+            await self._reset_if_current(client)
             if not _should_retry_method(method_name):
                 raise
+            retry_client = await self.get()
             try:
                 return await _acall_client_method(
-                    await self.get(),
+                    retry_client,
                     method_name,
                     *args,
                     **kwargs,
                 )
             except Exception as retry_exc:
                 if _is_recoverable_client_error(retry_exc):
-                    await self.reset()
+                    await self._reset_if_current(retry_client)
                 raise
 
     def __copy__(self) -> OpenVikingAsyncClientHandle:
@@ -231,11 +291,10 @@ class OpenVikingAsyncClientHandle:
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
         client = self._client
-        if client is None:
-            raise AttributeError(name)
-        attr = getattr(client, name)
-        if not callable(attr):
-            return attr
+        if client is not None:
+            attr = getattr(client, name)
+            if not callable(attr):
+                return attr
 
         async def recovered_method(*args: Any, **kwargs: Any) -> Any:
             return await self._call_with_recovery(name, *args, **kwargs)
@@ -260,22 +319,42 @@ def ensure_client(connection: OpenVikingConnection) -> Any:
     return client
 
 
-async def ensure_async_client(connection: OpenVikingConnection) -> Any:
+async def ensure_async_client(
+    connection: OpenVikingConnection,
+    *,
+    client_cache: LoopScopedAsyncClientCache | None = None,
+    embedded_client_factory: Callable[[], Any] | None = None,
+) -> Any:
     """Return a client suitable for non-blocking OpenViking calls.
 
     An explicitly supplied async client is preferred. Existing synchronous
     clients remain supported and are dispatched through a worker thread by
-    :func:`acall_openviking`.
+    :func:`acall_openviking`. Internally created HTTP handles can be scoped to
+    the running loop with ``client_cache``. Embedded ``path=`` connections
+    intentionally use the synchronous client so their stateful async internals
+    remain on OpenViking's shared background loop.
     """
 
     client = connection.async_client
     if client is None and connection.client is not None:
         client = connection.client
     if client is None:
-        handle = OpenVikingAsyncClientHandle(connection)
-        if connection.auto_initialize:
-            await handle.get()
-        return handle
+        if _uses_http_client(connection):
+            if client_cache is None:
+                handle = OpenVikingAsyncClientHandle(connection)
+            else:
+                handle = client_cache.get(lambda: OpenVikingAsyncClientHandle(connection))
+            if connection.auto_initialize:
+                await handle.get()
+            return handle
+        if embedded_client_factory is not None:
+            if client_cache is not None:
+                return await asyncio.to_thread(
+                    client_cache.get,
+                    embedded_client_factory,
+                )
+            return await asyncio.to_thread(embedded_client_factory)
+        return await asyncio.to_thread(_create_client_from_connection, connection)
     if connection.auto_initialize and hasattr(client, "initialize"):
         await _ainitialize_client(client)
     return client
@@ -403,24 +482,21 @@ def _create_client_from_connection(connection: OpenVikingConnection) -> Any:
 
 
 async def _create_async_client_from_connection(connection: OpenVikingConnection) -> Any:
-    client: Any
-    if connection.url or connection.path is None:
-        from openviking.client import AsyncHTTPClient
+    if not _uses_http_client(connection):
+        raise ValueError("Native async clients are created automatically only for HTTP connections")
 
-        client = AsyncHTTPClient(
-            url=connection.url,
-            api_key=connection.api_key,
-            account=connection.account,
-            user=connection.user,
-            user_id=connection.user_id,
-            actor_peer_id=connection.actor_peer_id,
-            timeout=connection.timeout,
-            extra_headers=connection.extra_headers,
-        )
-    else:
-        from openviking.async_client import AsyncOpenViking
+    from openviking.client import AsyncHTTPClient
 
-        client = AsyncOpenViking(path=connection.path, actor_peer_id=connection.actor_peer_id)
+    client: Any = AsyncHTTPClient(
+        url=connection.url,
+        api_key=connection.api_key,
+        account=connection.account,
+        user=connection.user,
+        user_id=connection.user_id,
+        actor_peer_id=connection.actor_peer_id,
+        timeout=connection.timeout,
+        extra_headers=connection.extra_headers,
+    )
 
     try:
         if connection.auto_initialize and hasattr(client, "initialize"):
@@ -513,14 +589,26 @@ async def _ainitialize_client(client: Any) -> None:
 
 def _async_client_initialization_lock(client: Any) -> asyncio.Lock:
     try:
-        lock = inspect.getattr_static(client, _ASYNC_INITIALIZATION_LOCK_ATTR)
+        locks = inspect.getattr_static(client, _ASYNC_INITIALIZATION_LOCKS_ATTR)
     except AttributeError:
-        lock = asyncio.Lock()
+        locks = LoopScopedAsyncClientCache()
         try:
-            setattr(client, _ASYNC_INITIALIZATION_LOCK_ATTR, lock)
+            setattr(client, _ASYNC_INITIALIZATION_LOCKS_ATTR, locks)
         except Exception:
-            return lock
-    return lock
+            return asyncio.Lock()
+    if not isinstance(locks, LoopScopedAsyncClientCache):
+        locks = LoopScopedAsyncClientCache()
+        try:
+            setattr(client, _ASYNC_INITIALIZATION_LOCKS_ATTR, locks)
+        except Exception:
+            return asyncio.Lock()
+    return locks.get(asyncio.Lock)
+
+
+def _uses_http_client(connection: OpenVikingConnection) -> bool:
+    """Return whether connection settings select the HTTP transport."""
+
+    return bool(connection.url) or connection.path is None
 
 
 def _async_client_is_initialized(client: Any) -> bool:

--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import logging
@@ -68,6 +69,7 @@ class OpenVikingConnection:
     timeout: float = 60.0
     extra_headers: dict[str, str] | None = None
     auto_initialize: bool = True
+    async_client: Any = None
 
 
 @dataclass(slots=True)
@@ -141,6 +143,78 @@ class OpenVikingClientHandle:
         return recovered_method
 
 
+class OpenVikingAsyncClientHandle:
+    """Lazy async client wrapper with one-shot recovery for safe reads."""
+
+    def __init__(self, connection: OpenVikingConnection):
+        self._connection = connection
+        self._client: Any = None
+
+    async def close(self) -> None:
+        await self.reset()
+
+    async def reset(self) -> None:
+        client = self._client
+        self._client = None
+        if client is None:
+            return
+        close = getattr(client, "close", None)
+        if not callable(close):
+            return
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug("OpenViking async client close during recovery failed", exc_info=True)
+
+    async def get(self) -> Any:
+        if self._client is None:
+            self._client = await _create_async_client_from_connection(self._connection)
+        return self._client
+
+    async def _openviking_acall(self, method_name: str, /, **kwargs: Any) -> Any:
+        return await self._call_with_recovery(method_name, **kwargs)
+
+    async def _call_with_recovery(
+        self,
+        method_name: str,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        try:
+            return await _acall_client_method(
+                await self.get(),
+                method_name,
+                *args,
+                **kwargs,
+            )
+        except Exception as exc:
+            if not _is_recoverable_client_error(exc):
+                raise
+            await self.reset()
+            if not _should_retry_method(method_name):
+                raise
+            try:
+                return await _acall_client_method(
+                    await self.get(),
+                    method_name,
+                    *args,
+                    **kwargs,
+                )
+            except Exception as retry_exc:
+                if _is_recoverable_client_error(retry_exc):
+                    await self.reset()
+                raise
+
+    def __getattr__(self, name: str) -> Any:
+        async def recovered_method(*args: Any, **kwargs: Any) -> Any:
+            return await self._call_with_recovery(name, *args, **kwargs)
+
+        return recovered_method
+
+
 def ensure_client(connection: OpenVikingConnection) -> Any:
     """Return an initialized OpenViking client from explicit or connection settings."""
 
@@ -155,6 +229,27 @@ def ensure_client(connection: OpenVikingConnection) -> Any:
     if connection.auto_initialize and hasattr(client, "initialize"):
         if not getattr(client, "_initialized", False):
             client.initialize()
+    return client
+
+
+async def ensure_async_client(connection: OpenVikingConnection) -> Any:
+    """Return a client suitable for non-blocking OpenViking calls.
+
+    An explicitly supplied async client is preferred. Existing synchronous
+    clients remain supported and are dispatched through a worker thread by
+    :func:`acall_openviking`.
+    """
+
+    client = connection.async_client
+    if client is None and connection.client is not None:
+        client = connection.client
+    if client is None:
+        handle = OpenVikingAsyncClientHandle(connection)
+        if connection.auto_initialize:
+            await handle.get()
+        return handle
+    if connection.auto_initialize and hasattr(client, "initialize"):
+        await _ainitialize_client(client)
     return client
 
 
@@ -194,6 +289,47 @@ def apply_commit_policy(
     )
 
 
+async def aapply_commit_policy(
+    client: Any,
+    session_id: str,
+    policy: OpenVikingCommitPolicy | None,
+) -> dict[str, Any] | None:
+    """Apply the configured session commit policy without blocking the event loop."""
+
+    if policy is None or policy.mode == "never":
+        return None
+    if policy.mode == "always":
+        return await acall_openviking(
+            client,
+            "commit_session",
+            session_id=session_id,
+        )
+    if policy.mode != "pending_tokens":
+        raise ValueError(f"Unsupported OpenViking commit policy: {policy.mode}")
+
+    try:
+        session = await acall_openviking(
+            client,
+            "get_session",
+            session_id=session_id,
+            auto_create=False,
+        )
+    except Exception:
+        logger.debug(
+            "Skipping OpenViking pending-token commit because session lookup failed",
+            exc_info=True,
+        )
+        return None
+    pending_tokens = int(item_value(session, "pending_tokens", 0) or 0)
+    if pending_tokens < policy.pending_token_threshold:
+        return None
+    return await acall_openviking(
+        client,
+        "commit_session",
+        session_id=session_id,
+    )
+
+
 def call_openviking(client: Any, method_name: str, /, **kwargs: Any) -> Any:
     """Call a client method, filtering kwargs unsupported by local/HTTP variants."""
 
@@ -203,7 +339,17 @@ def call_openviking(client: Any, method_name: str, /, **kwargs: Any) -> Any:
     return _call_client_method(client, method_name, **kwargs)
 
 
+async def acall_openviking(client: Any, method_name: str, /, **kwargs: Any) -> Any:
+    """Call an async or sync client method without blocking the event loop."""
+
+    openviking_call = getattr(client, "_openviking_acall", None)
+    if callable(openviking_call):
+        return await openviking_call(method_name, **kwargs)
+    return await _acall_client_method(client, method_name, **kwargs)
+
+
 def _create_client_from_connection(connection: OpenVikingConnection) -> Any:
+    client: Any
     if connection.url or connection.path is None:
         from openviking.client import SyncHTTPClient
 
@@ -228,6 +374,31 @@ def _create_client_from_connection(connection: OpenVikingConnection) -> Any:
     return client
 
 
+async def _create_async_client_from_connection(connection: OpenVikingConnection) -> Any:
+    client: Any
+    if connection.url or connection.path is None:
+        from openviking.client import AsyncHTTPClient
+
+        client = AsyncHTTPClient(
+            url=connection.url,
+            api_key=connection.api_key,
+            account=connection.account,
+            user=connection.user,
+            user_id=connection.user_id,
+            actor_peer_id=connection.actor_peer_id,
+            timeout=connection.timeout,
+            extra_headers=connection.extra_headers,
+        )
+    else:
+        from openviking.async_client import AsyncOpenViking
+
+        client = AsyncOpenViking(path=connection.path, actor_peer_id=connection.actor_peer_id)
+
+    if connection.auto_initialize and hasattr(client, "initialize"):
+        await _ainitialize_client(client)
+    return client
+
+
 def _call_client_method(
     client: Any,
     method_name: str,
@@ -236,27 +407,72 @@ def _call_client_method(
     **kwargs: Any,
 ) -> Any:
     method = getattr(client, method_name)
+    return method(*args, **_filter_client_kwargs(method, kwargs))
+
+
+async def _acall_client_method(
+    client: Any,
+    method_name: str,
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    method = getattr(client, method_name)
+    filtered_kwargs = _filter_client_kwargs(method, kwargs)
+    if inspect.iscoroutinefunction(method):
+        return await method(*args, **filtered_kwargs)
+    result = await asyncio.to_thread(method, *args, **filtered_kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def _ainitialize_client(client: Any) -> None:
+    if _async_client_is_initialized(client):
+        return
+    await _acall_client_method(client, "initialize")
+    try:
+        client._openviking_integration_initialized = True
+    except Exception:
+        pass
+
+
+def _async_client_is_initialized(client: Any) -> bool:
+    for name in ("_initialized", "_http"):
+        try:
+            inspect.getattr_static(client, name)
+        except AttributeError:
+            continue
+        value = getattr(client, name, None)
+        if name == "_http":
+            return value is not None
+        return bool(value)
+    try:
+        inspect.getattr_static(client, "_openviking_integration_initialized")
+    except AttributeError:
+        return False
+    return bool(getattr(client, "_openviking_integration_initialized", False))
+
+
+def _filter_client_kwargs(method: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Drop ``None`` and arguments unsupported by a concrete client variant."""
+
     try:
         signature = inspect.signature(method)
     except (TypeError, ValueError):
-        return method(
-            *args,
-            **{key: value for key, value in kwargs.items() if value is not None},
-        )
+        return {key: value for key, value in kwargs.items() if value is not None}
 
     accepts_kwargs = any(
         parameter.kind == inspect.Parameter.VAR_KEYWORD
         for parameter in signature.parameters.values()
     )
     if accepts_kwargs:
-        filtered = {key: value for key, value in kwargs.items() if value is not None}
-    else:
-        filtered = {
-            key: value
-            for key, value in kwargs.items()
-            if value is not None and key in signature.parameters
-        }
-    return method(*args, **filtered)
+        return {key: value for key, value in kwargs.items() if value is not None}
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if value is not None and key in signature.parameters
+    }
 
 
 def _should_retry_method(method_name: str) -> bool:

--- a/openviking/integrations/langchain/context.py
+++ b/openviking/integrations/langchain/context.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,6 +23,7 @@ from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
     OpenVikingConnection,
     acall_openviking,
+    aclose_openviking_clients,
     call_openviking,
     ensure_async_client,
     ensure_client,
@@ -113,8 +115,13 @@ class OpenVikingSessionContextAssembler:
         self.include_active_messages = include_active_messages
         self.include_recall = include_recall
         self.recall_header = recall_header
+        self._owns_client = client is None
+        self._owns_async_client = async_client is None and client is None
+        self._owns_retriever = retriever is None
         self._client_cache: Any = None
         self._async_client_cache: Any = None
+        self._async_client_lock = asyncio.Lock()
+        self._closed = False
 
     def assemble(
         self,
@@ -162,14 +169,57 @@ class OpenVikingSessionContextAssembler:
         )
 
     def _get_client(self) -> Any:
+        self._raise_if_closed()
         if self._client_cache is None:
             self._client_cache = ensure_client(self._connection)
         return self._client_cache
 
-    async def _get_async_client(self) -> Any:
+    async def get_async_client(self) -> Any:
+        """Return the lazily initialized client used by async assembly."""
+
+        self._raise_if_closed()
         if self._async_client_cache is None:
-            self._async_client_cache = await ensure_async_client(self._connection)
+            async with self._async_client_lock:
+                self._raise_if_closed()
+                if self._async_client_cache is None:
+                    self._async_client_cache = await ensure_async_client(self._connection)
         return self._async_client_cache
+
+    async def _get_async_client(self) -> Any:
+        return await self.get_async_client()
+
+    async def aclose(self) -> None:
+        """Release clients and the default retriever owned by this assembler."""
+
+        if self._closed:
+            return
+        self._closed = True
+        sync_client = self._client_cache
+        self._client_cache = None
+        async with self._async_client_lock:
+            async_client = self._async_client_cache
+            self._async_client_cache = None
+
+        first_error: BaseException | None = None
+        try:
+            await aclose_openviking_clients(
+                sync_client if self._owns_client else None,
+                async_client if self._owns_async_client else None,
+            )
+        except BaseException as exc:
+            first_error = exc
+        if self._owns_retriever:
+            try:
+                await self.retriever.aclose()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise RuntimeError("OpenVikingSessionContextAssembler is closed")
 
     def _ensure_session(self, client: Any, session_id: str) -> None:
         try:

--- a/openviking/integrations/langchain/context.py
+++ b/openviking/integrations/langchain/context.py
@@ -36,6 +36,7 @@ from openviking.integrations.langchain.history import (
 )
 from openviking.integrations.langchain.messages import OPENVIKING_CONTEXT_MARKER
 from openviking.integrations.langchain.retrievers import OpenVikingRetriever
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 
 logger = logging.getLogger(__name__)
 
@@ -116,11 +117,9 @@ class OpenVikingSessionContextAssembler:
         self.include_recall = include_recall
         self.recall_header = recall_header
         self._owns_client = client is None
-        self._owns_async_client = async_client is None and client is None
         self._owns_retriever = retriever is None
         self._client_cache: Any = None
-        self._async_client_cache: Any = None
-        self._async_client_lock = asyncio.Lock()
+        self._async_clients = LoopScopedAsyncClientCache()
         self._closed = False
 
     def assemble(
@@ -175,15 +174,25 @@ class OpenVikingSessionContextAssembler:
         return self._client_cache
 
     async def get_async_client(self) -> Any:
-        """Return the lazily initialized client used by async assembly."""
+        """Return the async client interface used by this assembler.
+
+        Injected clients are returned unchanged and remain caller-owned.
+        HTTP-backed connections return an internally managed, loop-local handle
+        whose method calls support recovery. Direct attributes on that handle
+        are best-effort during recovery; use ``await handle.get()`` only to read
+        raw properties immediately because recovery may replace that snapshot.
+        Embedded ``path=`` connections return an adapter-owned synchronous
+        client whose calls are dispatched through a worker thread.
+        """
 
         self._raise_if_closed()
-        if self._async_client_cache is None:
-            async with self._async_client_lock:
-                self._raise_if_closed()
-                if self._async_client_cache is None:
-                    self._async_client_cache = await ensure_async_client(self._connection)
-        return self._async_client_cache
+        client = await ensure_async_client(
+            self._connection,
+            client_cache=self._async_clients,
+            embedded_client_factory=self._get_client,
+        )
+        self._raise_if_closed()
+        return client
 
     async def _get_async_client(self) -> Any:
         return await self.get_async_client()
@@ -196,15 +205,13 @@ class OpenVikingSessionContextAssembler:
         self._closed = True
         sync_client = self._client_cache
         self._client_cache = None
-        async with self._async_client_lock:
-            async_client = self._async_client_cache
-            self._async_client_cache = None
+        async_clients = await asyncio.to_thread(self._async_clients.pop_all)
 
         first_error: BaseException | None = None
         try:
             await aclose_openviking_clients(
                 sync_client if self._owns_client else None,
-                async_client if self._owns_async_client else None,
+                *async_clients,
             )
         except BaseException as exc:
             first_error = exc

--- a/openviking/integrations/langchain/context.py
+++ b/openviking/integrations/langchain/context.py
@@ -21,7 +21,9 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
     OpenVikingConnection,
+    acall_openviking,
     call_openviking,
+    ensure_async_client,
     ensure_client,
     extract_message_text,
     get_latest_user_text,
@@ -53,6 +55,7 @@ class OpenVikingSessionContextAssembler:
         self,
         *,
         client: Any = None,
+        async_client: Any = None,
         retriever: OpenVikingRetriever | None = None,
         url: str | None = None,
         api_key: str | None = None,
@@ -75,6 +78,7 @@ class OpenVikingSessionContextAssembler:
     ):
         self._connection = OpenVikingConnection(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -88,6 +92,7 @@ class OpenVikingSessionContextAssembler:
         )
         self.retriever = retriever or OpenVikingRetriever(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -109,6 +114,7 @@ class OpenVikingSessionContextAssembler:
         self.include_recall = include_recall
         self.recall_header = recall_header
         self._client_cache: Any = None
+        self._async_client_cache: Any = None
 
     def assemble(
         self,
@@ -123,6 +129,30 @@ class OpenVikingSessionContextAssembler:
             session_id,
             query,
         )
+        return self._assembled_context(session_context, recall_documents)
+
+    async def aassemble(
+        self,
+        *,
+        session_id: str,
+        query: str = "",
+    ) -> OpenVikingAssembledContext:
+        """Asynchronously assemble session and recall context."""
+
+        client = await self._get_async_client()
+        await self._aensure_session(client, session_id)
+        session_context = await self._aget_session_context(client, session_id)
+        recall_documents = await self._aget_recall_documents(
+            session_id,
+            query,
+        )
+        return self._assembled_context(session_context, recall_documents)
+
+    def _assembled_context(
+        self,
+        session_context: dict[str, Any],
+        recall_documents: list[Any],
+    ) -> OpenVikingAssembledContext:
         block = self._format_context_block(session_context, recall_documents)
         return OpenVikingAssembledContext(
             block=block,
@@ -136,6 +166,11 @@ class OpenVikingSessionContextAssembler:
             self._client_cache = ensure_client(self._connection)
         return self._client_cache
 
+    async def _get_async_client(self) -> Any:
+        if self._async_client_cache is None:
+            self._async_client_cache = await ensure_async_client(self._connection)
+        return self._async_client_cache
+
     def _ensure_session(self, client: Any, session_id: str) -> None:
         try:
             call_openviking(client, "create_session", session_id=session_id)
@@ -143,11 +178,35 @@ class OpenVikingSessionContextAssembler:
             logger.debug("OpenViking session ensure failed", exc_info=True)
             pass
 
+    async def _aensure_session(self, client: Any, session_id: str) -> None:
+        try:
+            await acall_openviking(client, "create_session", session_id=session_id)
+        except Exception:
+            logger.debug("OpenViking session ensure failed", exc_info=True)
+
     def _get_session_context(self, client: Any, session_id: str) -> dict[str, Any]:
         if not self.include_session_context:
             return {}
         try:
             return call_openviking(
+                client,
+                "get_session_context",
+                session_id=session_id,
+                token_budget=self.token_budget,
+            )
+        except Exception:
+            logger.debug("OpenViking session context assembly failed", exc_info=True)
+            return {}
+
+    async def _aget_session_context(
+        self,
+        client: Any,
+        session_id: str,
+    ) -> dict[str, Any]:
+        if not self.include_session_context:
+            return {}
+        try:
+            return await acall_openviking(
                 client,
                 "get_session_context",
                 session_id=session_id,
@@ -170,6 +229,24 @@ class OpenVikingSessionContextAssembler:
                     self.retriever,
                     session_id,
                 ).invoke(query)
+            )
+        except Exception:
+            logger.debug("OpenViking recall retrieval failed", exc_info=True)
+            return []
+
+    async def _aget_recall_documents(
+        self,
+        session_id: str,
+        query: str,
+    ) -> list[Any]:
+        if not self.include_recall or not query:
+            return []
+        try:
+            return list(
+                await _retriever_for_session(
+                    self.retriever,
+                    session_id,
+                ).ainvoke(query)
             )
         except Exception:
             logger.debug("OpenViking recall retrieval failed", exc_info=True)
@@ -220,6 +297,7 @@ def with_openviking_context(
     runnable: Any,
     *,
     client: Any = None,
+    async_client: Any = None,
     url: str | None = None,
     api_key: str | None = None,
     account: str | None = None,
@@ -248,6 +326,7 @@ def with_openviking_context(
 
     assembler = OpenVikingSessionContextAssembler(
         client=client,
+        async_client=async_client,
         url=url,
         api_key=api_key,
         account=account,
@@ -289,6 +368,7 @@ def with_openviking_context(
                 peer_id,
             ),
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -335,7 +415,10 @@ def with_openviking_context(
         session_history_factory = fixed_session_history_factory
         history_factory_config = None
 
-    def inject(input_value: Any, config: dict[str, Any] | None = None) -> Any:
+    def prepare_injection(
+        input_value: Any,
+        config: dict[str, Any] | None,
+    ) -> tuple[str, tuple[str, str], str] | None:
         resolved_session_id = session_id or _session_id_from_config(
             config,
             key=session_id_config_key,
@@ -347,25 +430,52 @@ def with_openviking_context(
         )
         active_peer_ids[resolved_session_id] = resolved_peer_id
         if not inject_context:
-            return input_value
+            return None
         pending_key = _pending_context_key(resolved_session_id, resolved_peer_id)
         pending_context_parts.pop(pending_key, None)
         query = _latest_user_text_from_input(input_value, input_messages_key)
-        assembled = assembler.assemble(
-            session_id=resolved_session_id,
-            query=query,
-        )
+        return resolved_session_id, pending_key, query
+
+    def apply_injection(
+        input_value: Any,
+        pending_key: tuple[str, str],
+        assembled: OpenVikingAssembledContext,
+    ) -> Any:
         if not assembled.block:
             return input_value
         if assembled.context_parts:
             pending_context_parts[pending_key] = assembled.context_parts
         return _inject_system_context(input_value, assembled.block, input_messages_key)
 
+    def inject(input_value: Any, config: dict[str, Any] | None = None) -> Any:
+        prepared = prepare_injection(input_value, config)
+        if prepared is None:
+            return input_value
+        resolved_session_id, pending_key, query = prepared
+        assembled = assembler.assemble(
+            session_id=resolved_session_id,
+            query=query,
+        )
+        return apply_injection(input_value, pending_key, assembled)
+
+    async def ainject(input_value: Any, config: dict[str, Any] | None = None) -> Any:
+        prepared = prepare_injection(input_value, config)
+        if prepared is None:
+            return input_value
+        resolved_session_id, pending_key, query = prepared
+        assembled = await assembler.aassemble(
+            session_id=resolved_session_id,
+            query=query,
+        )
+        return apply_injection(input_value, pending_key, assembled)
+
     def clear_pending_on_error(_run: Any, config: dict[str, Any] | None = None) -> None:
         del config
         pending_context_parts.clear()
 
-    bound = (RunnableLambda(inject) | runnable).with_listeners(on_error=clear_pending_on_error)
+    bound = (RunnableLambda(inject, afunc=ainject) | runnable).with_listeners(
+        on_error=clear_pending_on_error
+    )
     return RunnableWithMessageHistory(
         bound,
         session_history_factory,

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -202,7 +202,7 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
         return self._recorder.client
 
     async def _get_async_client(self) -> Any:
-        return await self._recorder._get_async_client()
+        return await self._recorder.get_async_client()
 
     def _ensure_session(self, client: Any) -> None:
         try:

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -18,6 +18,7 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
+    acall_openviking,
     call_openviking,
 )
 from openviking.integrations.langchain.messages import (
@@ -45,6 +46,7 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
         session_id: str,
         *,
         client: Any = None,
+        async_client: Any = None,
         url: str | None = None,
         api_key: str | None = None,
         account: str | None = None,
@@ -75,6 +77,7 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
         self._pending_context_parts: list[dict[str, Any]] = []
         self._recorder = OpenVikingSessionRecorder(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -115,11 +118,48 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
 
         return restore_openviking_messages(context.get("messages") or [])
 
+    async def aget_messages(self) -> list[BaseMessage]:
+        """Asynchronously return active messages from the OpenViking session."""
+
+        client = await self._get_async_client()
+        try:
+            context = await acall_openviking(
+                client,
+                "get_session_context",
+                session_id=self.session_id,
+                token_budget=self.token_budget,
+            )
+        except Exception:
+            logger.debug("OpenViking chat history context fetch failed", exc_info=True)
+            await self._aensure_session(client)
+            return []
+
+        return restore_openviking_messages(context.get("messages") or [])
+
     def add_messages(self, messages: Sequence[BaseMessage]) -> None:
         if not self._pending_context_parts and self.context_parts_provider:
             self._pending_context_parts = list(self.context_parts_provider(self.session_id))
         try:
             result = self._recorder.record(
+                self.session_id,
+                messages,
+                peer_id=self._effective_peer_id(),
+                context_parts=self._pending_context_parts,
+            )
+        except OpenVikingPartialWriteError as exc:
+            if exc.context_attached:
+                self._acknowledge_context_parts()
+            raise
+        if result.context_attached:
+            self._acknowledge_context_parts()
+
+    async def aadd_messages(self, messages: Sequence[BaseMessage]) -> None:
+        """Asynchronously persist messages through the shared session recorder."""
+
+        if not self._pending_context_parts and self.context_parts_provider:
+            self._pending_context_parts = list(self.context_parts_provider(self.session_id))
+        try:
+            result = await self._recorder.arecord(
                 self.session_id,
                 messages,
                 peer_id=self._effective_peer_id(),
@@ -138,14 +178,31 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
         self._ensure_session(client)
         self._acknowledge_context_parts()
 
+    async def aclear(self) -> None:
+        """Asynchronously reset this OpenViking session."""
+
+        client = await self._get_async_client()
+        await acall_openviking(client, "delete_session", session_id=self.session_id)
+        await self._aensure_session(client)
+        self._acknowledge_context_parts()
+
     def close(self) -> None:
         """Release resources owned by this history adapter."""
 
         self._acknowledge_context_parts()
         self._recorder.close()
 
+    async def aclose(self) -> None:
+        """Asynchronously release resources owned by this history adapter."""
+
+        self._acknowledge_context_parts()
+        await self._recorder.aclose()
+
     def _get_client(self) -> Any:
         return self._recorder.client
+
+    async def _get_async_client(self) -> Any:
+        return await self._recorder._get_async_client()
 
     def _ensure_session(self, client: Any) -> None:
         try:
@@ -153,6 +210,12 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
         except Exception:
             logger.debug("OpenViking chat history session ensure failed", exc_info=True)
             pass
+
+    async def _aensure_session(self, client: Any) -> None:
+        try:
+            await acall_openviking(client, "create_session", session_id=self.session_id)
+        except Exception:
+            logger.debug("OpenViking chat history session ensure failed", exc_info=True)
 
     def _effective_peer_id(self) -> str | None:
         if self.peer_id_provider is None:

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -150,6 +150,19 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         self._captured_signatures: dict[tuple[str, str], tuple[str, ...]] = {}
         self._pending_context_parts: dict[tuple[str, str], list[dict[str, Any]]] = {}
 
+    async def aclose(self) -> None:
+        """Release all clients internally owned by this middleware."""
+
+        first_error: BaseException | None = None
+        for component in (self.recorder, self.assembler, self.retriever):
+            try:
+                await component.aclose()
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
     def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Any]) -> Any:
         plan = self._model_context_plan(request)
         if plan is None:

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -206,6 +206,8 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         try:
             return await handler(updated_request)
         except BaseException:
+            # CancelledError is a BaseException, so cancellation must also discard
+            # context references prepared for the interrupted model call.
             self._pending_context_parts.pop(pending_key, None)
             raise
 

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -5,11 +5,12 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any, Callable
 
 try:
     from langchain.agents.middleware import AgentMiddleware
-    from langchain.agents.middleware.types import ModelRequest
+    from langchain.agents.middleware.types import AgentState, ModelRequest
     from langchain_core.messages import (
         AIMessage,
         BaseMessage,
@@ -27,7 +28,10 @@ from openviking.integrations.langchain.client import (
     extract_message_text,
     get_latest_user_text,
 )
-from openviking.integrations.langchain.context import OpenVikingSessionContextAssembler
+from openviking.integrations.langchain.context import (
+    OpenVikingAssembledContext,
+    OpenVikingSessionContextAssembler,
+)
 from openviking.integrations.langchain.recording import (
     OpenVikingPartialWriteError,
     OpenVikingSessionRecorder,
@@ -39,6 +43,18 @@ _SESSION_ID_ERROR = (
     'config={"configurable": {"thread_id": "..."}}, set state["session_id"], '
     "or provide session_id_resolver."
 )
+
+
+@dataclass(slots=True)
+class _CapturePlan:
+    session_id: str
+    peer_id: str | None
+    key: tuple[str, str]
+    messages: list[Any]
+    signatures: tuple[str, ...]
+    start: int
+    context_parts: list[dict[str, Any]]
+    unchanged: bool = False
 
 
 class OpenVikingContextMiddleware(AgentMiddleware):
@@ -53,6 +69,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         self,
         *,
         client: Any = None,
+        async_client: Any = None,
         retriever: OpenVikingRetriever | None = None,
         url: str | None = None,
         api_key: str | None = None,
@@ -77,6 +94,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         super().__init__()
         self.recorder = OpenVikingSessionRecorder(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -88,6 +106,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         )
         self.retriever = retriever or OpenVikingRetriever(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -102,6 +121,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         )
         self.assembler = OpenVikingSessionContextAssembler(
             client=client,
+            async_client=async_client,
             retriever=self.retriever,
             url=url,
             api_key=api_key,
@@ -131,26 +151,71 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         self._pending_context_parts: dict[tuple[str, str], list[dict[str, Any]]] = {}
 
     def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Any]) -> Any:
-        query = get_latest_user_text(request.messages)
-        if not query:
+        plan = self._model_context_plan(request)
+        if plan is None:
             return handler(request)
-        session_id = self._resolve_session_id(
-            getattr(request, "state", {}) or {},
-            getattr(request, "runtime", None),
-        )
-        peer_id = self._resolve_peer_id(
-            getattr(request, "state", {}) or {},
-            getattr(request, "runtime", None),
-        )
-        pending_key = _capture_key(session_id, peer_id)
-        self._pending_context_parts.pop(pending_key, None)
+        session_id, pending_key, query = plan
         assembled = self.assembler.assemble(
             session_id=session_id,
             query=query,
         )
+        updated_request = self._request_with_context(request, pending_key, assembled)
+        if updated_request is None:
+            return handler(request)
+        try:
+            return handler(updated_request)
+        except Exception:
+            self._pending_context_parts.pop(pending_key, None)
+            raise
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Any],
+    ) -> Any:
+        """Asynchronously inject OpenViking context before a model call."""
+
+        plan = self._model_context_plan(request)
+        if plan is None:
+            return await handler(request)
+        session_id, pending_key, query = plan
+        assembled = await self.assembler.aassemble(
+            session_id=session_id,
+            query=query,
+        )
+        updated_request = self._request_with_context(request, pending_key, assembled)
+        if updated_request is None:
+            return await handler(request)
+        try:
+            return await handler(updated_request)
+        except Exception:
+            self._pending_context_parts.pop(pending_key, None)
+            raise
+
+    def _model_context_plan(
+        self,
+        request: ModelRequest,
+    ) -> tuple[str, tuple[str, str], str] | None:
+        query = get_latest_user_text(request.messages)
+        if not query:
+            return None
+        state = getattr(request, "state", {}) or {}
+        runtime = getattr(request, "runtime", None)
+        session_id = self._resolve_session_id(state, runtime)
+        peer_id = self._resolve_peer_id(state, runtime)
+        pending_key = _capture_key(session_id, peer_id)
+        self._pending_context_parts.pop(pending_key, None)
+        return session_id, pending_key, query
+
+    def _request_with_context(
+        self,
+        request: ModelRequest,
+        pending_key: tuple[str, str],
+        assembled: OpenVikingAssembledContext,
+    ) -> ModelRequest | None:
         context_block = assembled.block
         if not context_block:
-            return handler(request)
+            return None
         if assembled.context_parts:
             self._pending_context_parts[pending_key] = assembled.context_parts
 
@@ -160,13 +225,65 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         else:
             content = extract_message_text(system_message.content)
             updated_system = SystemMessage(content=f"{content}\n\n{context_block}".strip())
+        return request.override(system_message=updated_system)
+
+    def after_agent(self, state: AgentState[Any], runtime: Any) -> dict[str, Any] | None:
+        plan = self._capture_plan(state, runtime)
+        if plan is None:
+            return None
+        self.recorder.commit_policy = self.commit_policy
+        if plan.unchanged:
+            self.recorder.record(plan.session_id, ())
+            self._pending_context_parts.pop(plan.key, None)
+            return None
         try:
-            return handler(request.override(system_message=updated_system))
-        except Exception:
-            self._pending_context_parts.pop(pending_key, None)
+            result = self.recorder.record(
+                plan.session_id,
+                plan.messages[plan.start :],
+                peer_id=plan.peer_id,
+                context_parts=plan.context_parts,
+            )
+        except OpenVikingPartialWriteError as exc:
+            self._handle_partial_capture(plan, exc)
             raise
 
-    def after_agent(self, state: dict[str, Any], runtime: Any) -> dict[str, Any] | None:
+        self._complete_capture(plan, context_attached=result.context_attached)
+        return None
+
+    async def aafter_agent(
+        self,
+        state: AgentState[Any],
+        runtime: Any,
+    ) -> dict[str, Any] | None:
+        """Asynchronously capture messages after an agent run."""
+
+        plan = self._capture_plan(state, runtime)
+        if plan is None:
+            return None
+        self.recorder.commit_policy = self.commit_policy
+        if plan.unchanged:
+            await self.recorder.arecord(plan.session_id, ())
+            self._pending_context_parts.pop(plan.key, None)
+            return None
+        try:
+            result = await self.recorder.arecord(
+                plan.session_id,
+                plan.messages[plan.start :],
+                peer_id=plan.peer_id,
+                context_parts=plan.context_parts,
+            )
+        except OpenVikingPartialWriteError as exc:
+            self._handle_partial_capture(plan, exc)
+            raise
+
+        self._complete_capture(plan, context_attached=result.context_attached)
+        return None
+
+    def _capture_plan(
+        self,
+        state: AgentState[Any],
+        runtime: Any,
+    ) -> _CapturePlan | None:
         if not self.capture_on_after_agent:
             return None
         messages = list(state.get("messages") or [])
@@ -174,46 +291,51 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             return None
         session_id = self._resolve_session_id(state, runtime)
         peer_id = self._resolve_peer_id(state, runtime)
-        capture_key = _capture_key(session_id, peer_id)
-        previous_signatures = self._captured_signatures.get(capture_key, ())
-        current_signatures = tuple(_message_signature(message) for message in messages)
-
-        if current_signatures == previous_signatures:
-            self.recorder.commit_policy = self.commit_policy
-            self.recorder.record(session_id, ())
-            self._pending_context_parts.pop(capture_key, None)
-            return None
+        key = _capture_key(session_id, peer_id)
+        previous_signatures = self._captured_signatures.get(key, ())
+        signatures = tuple(_message_signature(message) for message in messages)
+        unchanged = signatures == previous_signatures
         start = 0
         if (
-            previous_signatures
-            and len(current_signatures) > len(previous_signatures)
-            and current_signatures[: len(previous_signatures)] == previous_signatures
+            not unchanged
+            and previous_signatures
+            and len(signatures) > len(previous_signatures)
+            and signatures[: len(previous_signatures)] == previous_signatures
         ):
             start = len(previous_signatures)
+        return _CapturePlan(
+            session_id=session_id,
+            peer_id=peer_id,
+            key=key,
+            messages=messages,
+            signatures=signatures,
+            start=start,
+            context_parts=list(self._pending_context_parts.get(key, [])),
+            unchanged=unchanged,
+        )
 
-        pending_context_parts = list(self._pending_context_parts.get(capture_key, []))
-        self.recorder.commit_policy = self.commit_policy
-        try:
-            result = self.recorder.record(
-                session_id,
-                messages[start:],
-                peer_id=peer_id,
-                context_parts=pending_context_parts,
-            )
-        except OpenVikingPartialWriteError as exc:
-            if exc.input_messages_consumed:
-                consumed_end = start + exc.input_messages_consumed
-                self._captured_signatures[capture_key] = current_signatures[:consumed_end]
-            if exc.context_attached:
-                self._pending_context_parts.pop(capture_key, None)
-            raise
+    def _handle_partial_capture(
+        self,
+        plan: _CapturePlan,
+        error: OpenVikingPartialWriteError,
+    ) -> None:
+        if error.input_messages_consumed:
+            consumed_end = plan.start + error.input_messages_consumed
+            self._captured_signatures[plan.key] = plan.signatures[:consumed_end]
+        if error.context_attached:
+            self._pending_context_parts.pop(plan.key, None)
 
-        self._captured_signatures[capture_key] = current_signatures
-        if result.context_attached:
-            self._pending_context_parts.pop(capture_key, None)
-        return None
+    def _complete_capture(
+        self,
+        plan: _CapturePlan,
+        *,
+        context_attached: bool,
+    ) -> None:
+        self._captured_signatures[plan.key] = plan.signatures
+        if context_attached:
+            self._pending_context_parts.pop(plan.key, None)
 
-    def _resolve_session_id(self, state: dict[str, Any], runtime: Any) -> str:
+    def _resolve_session_id(self, state: Any, runtime: Any) -> str:
         if self.session_id_resolver:
             resolved = _normalize_session_id(self.session_id_resolver(state, runtime))
             if resolved:
@@ -232,7 +354,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 return resolved
         raise ValueError(_SESSION_ID_ERROR)
 
-    def _resolve_peer_id(self, state: dict[str, Any], runtime: Any) -> str | None:
+    def _resolve_peer_id(self, state: Any, runtime: Any) -> str | None:
         if self.peer_id_resolver:
             return _normalize_peer_id(self.peer_id_resolver(state, runtime))
         candidates = [

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -104,6 +104,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             path=path,
             commit_policy=None,
         )
+        self._owns_retriever = retriever is None
         self.retriever = retriever or OpenVikingRetriever(
             client=client,
             async_client=async_client,
@@ -154,7 +155,10 @@ class OpenVikingContextMiddleware(AgentMiddleware):
         """Release all clients internally owned by this middleware."""
 
         first_error: BaseException | None = None
-        for component in (self.recorder, self.assembler, self.retriever):
+        components: list[Any] = [self.recorder, self.assembler]
+        if self._owns_retriever:
+            components.append(self.retriever)
+        for component in components:
             try:
                 await component.aclose()
             except BaseException as exc:
@@ -201,7 +205,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
             return await handler(request)
         try:
             return await handler(updated_request)
-        except Exception:
+        except BaseException:
             self._pending_context_parts.pop(pending_key, None)
             raise
 

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -34,6 +34,7 @@ from openviking.integrations.langchain.messages import (
     is_recordable_langchain_message,
     langchain_message_to_openviking,
 )
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 
 MAX_RECORDING_BATCH_SIZE = 100
 
@@ -152,10 +153,8 @@ class OpenVikingSessionRecorder:
             auto_initialize=auto_initialize,
         )
         self._owns_client = client is None
-        self._owns_async_client = async_client is None and client is None
         self._client_cache: Any = None
-        self._async_client_cache: Any = None
-        self._async_client_lock = asyncio.Lock()
+        self._async_clients = LoopScopedAsyncClientCache()
         self._pending_commit_sessions: set[str] = set()
         self._closed = False
         self.commit_policy = commit_policy
@@ -365,15 +364,25 @@ class OpenVikingSessionRecorder:
         self._pending_commit_sessions.discard(session_id)
 
     async def get_async_client(self) -> Any:
-        """Return the lazily initialized client used by async recorder methods."""
+        """Return the async client interface used by this recorder.
+
+        Injected clients are returned unchanged and remain caller-owned.
+        HTTP-backed connections return an internally managed, loop-local handle
+        whose method calls support recovery. Direct attributes on that handle
+        are best-effort during recovery; use ``await handle.get()`` only to read
+        raw properties immediately because recovery may replace that snapshot.
+        Embedded ``path=`` connections return an adapter-owned synchronous
+        client whose calls are dispatched through a worker thread.
+        """
 
         self._raise_if_closed()
-        if self._async_client_cache is None:
-            async with self._async_client_lock:
-                self._raise_if_closed()
-                if self._async_client_cache is None:
-                    self._async_client_cache = await ensure_async_client(self._connection)
-        return self._async_client_cache
+        client = await ensure_async_client(
+            self._connection,
+            client_cache=self._async_clients,
+            embedded_client_factory=lambda: self.client,
+        )
+        self._raise_if_closed()
+        return client
 
     async def _get_async_client(self) -> Any:
         return await self.get_async_client()
@@ -389,13 +398,14 @@ class OpenVikingSessionRecorder:
 
         if self._closed:
             return
-        if self._owns_async_client and (
-            self._async_client_cache is not None or self._async_client_lock.locked()
-        ):
+        uses_http_client = bool(self._connection.url) or self._connection.path is None
+        if uses_http_client and self._async_clients.has_clients():
             raise RuntimeError(
                 "OpenVikingSessionRecorder has an active async client; "
                 "use `await recorder.aclose()`"
             )
+        if not uses_http_client:
+            self._async_clients.pop_all()
         self._closed = True
         self._pending_commit_sessions.clear()
         client = self._client_cache
@@ -415,13 +425,11 @@ class OpenVikingSessionRecorder:
         self._pending_commit_sessions.clear()
         sync_client = self._client_cache
         self._client_cache = None
-        async with self._async_client_lock:
-            async_client = self._async_client_cache
-            self._async_client_cache = None
+        async_clients = await asyncio.to_thread(self._async_clients.pop_all)
 
         await aclose_openviking_clients(
             sync_client if self._owns_client else None,
-            async_client if self._owns_async_client else None,
+            *async_clients,
         )
 
     def _raise_if_closed(self) -> None:

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -23,6 +22,7 @@ from openviking.integrations.langchain.client import (
     OpenVikingConnection,
     aapply_commit_policy,
     acall_openviking,
+    aclose_openviking_clients,
     apply_commit_policy,
     call_openviking,
     ensure_async_client,
@@ -155,6 +155,7 @@ class OpenVikingSessionRecorder:
         self._owns_async_client = async_client is None and client is None
         self._client_cache: Any = None
         self._async_client_cache: Any = None
+        self._async_client_lock = asyncio.Lock()
         self._pending_commit_sessions: set[str] = set()
         self._closed = False
         self.commit_policy = commit_policy
@@ -256,7 +257,7 @@ class OpenVikingSessionRecorder:
             return OpenVikingRecordResult(input_messages_consumed=len(input_messages))
 
         batches = _prepare_batches(prepared_messages, batch_size=self.batch_size)
-        client = await self._get_async_client()
+        client = await self.get_async_client()
         messages_written = 0
         input_messages_consumed = 0
         context_attached = False
@@ -334,7 +335,7 @@ class OpenVikingSessionRecorder:
         return call_openviking(client, "commit_session", session_id=session_id)
 
     async def _aflush_pending_content(self, session_id: str) -> dict[str, Any] | None:
-        client = await self._get_async_client()
+        client = await self.get_async_client()
         try:
             session = await acall_openviking(
                 client,
@@ -363,21 +364,34 @@ class OpenVikingSessionRecorder:
         await self._aflush_pending_content(session_id)
         self._pending_commit_sessions.discard(session_id)
 
-    async def _get_async_client(self) -> Any:
+    async def get_async_client(self) -> Any:
+        """Return the lazily initialized client used by async recorder methods."""
+
         self._raise_if_closed()
         if self._async_client_cache is None:
-            self._async_client_cache = await ensure_async_client(self._connection)
+            async with self._async_client_lock:
+                self._raise_if_closed()
+                if self._async_client_cache is None:
+                    self._async_client_cache = await ensure_async_client(self._connection)
         return self._async_client_cache
 
+    async def _get_async_client(self) -> Any:
+        return await self.get_async_client()
+
     def close(self) -> None:
-        """Release an internally created client.
+        """Release resources after exclusively synchronous use.
 
         Injected clients remain owned by their caller and are never closed here.
+        After any async operation has initialized an owned client, callers must
+        use :meth:`aclose`; this method leaves the recorder open so that async
+        cleanup can still complete.
         """
 
         if self._closed:
             return
-        if self._async_client_cache is not None and self._owns_async_client:
+        if self._owns_async_client and (
+            self._async_client_cache is not None or self._async_client_lock.locked()
+        ):
             raise RuntimeError(
                 "OpenVikingSessionRecorder has an active async client; "
                 "use `await recorder.aclose()`"
@@ -400,14 +414,15 @@ class OpenVikingSessionRecorder:
         self._closed = True
         self._pending_commit_sessions.clear()
         sync_client = self._client_cache
-        async_client = self._async_client_cache
         self._client_cache = None
-        self._async_client_cache = None
+        async with self._async_client_lock:
+            async_client = self._async_client_cache
+            self._async_client_cache = None
 
-        if sync_client is not None and self._owns_client:
-            await _aclose_client(sync_client)
-        if async_client is not None and self._owns_async_client and async_client is not sync_client:
-            await _aclose_client(async_client)
+        await aclose_openviking_clients(
+            sync_client if self._owns_client else None,
+            async_client if self._owns_async_client else None,
+        )
 
     def _raise_if_closed(self) -> None:
         if self._closed:
@@ -496,15 +511,3 @@ def _normalize_peer_id(peer_id: str | None) -> str | None:
         return None
     text = str(peer_id).strip()
     return text or None
-
-
-async def _aclose_client(client: Any) -> None:
-    close = getattr(client, "close", None)
-    if not callable(close):
-        return
-    if inspect.iscoroutinefunction(close):
-        await close()
-        return
-    result = await asyncio.to_thread(close)
-    if inspect.isawaitable(result):
-        await result

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -19,8 +21,11 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
     OpenVikingConnection,
+    aapply_commit_policy,
+    acall_openviking,
     apply_commit_policy,
     call_openviking,
+    ensure_async_client,
     ensure_client,
     item_value,
 )
@@ -116,6 +121,7 @@ class OpenVikingSessionRecorder:
         self,
         *,
         client: Any = None,
+        async_client: Any = None,
         url: str | None = None,
         api_key: str | None = None,
         account: str | None = None,
@@ -133,6 +139,7 @@ class OpenVikingSessionRecorder:
             raise ValueError(f"batch_size must be between 1 and {MAX_RECORDING_BATCH_SIZE}")
         self._connection = OpenVikingConnection(
             client=client,
+            async_client=async_client,
             url=url,
             api_key=api_key,
             account=account,
@@ -145,7 +152,9 @@ class OpenVikingSessionRecorder:
             auto_initialize=auto_initialize,
         )
         self._owns_client = client is None
+        self._owns_async_client = async_client is None and client is None
         self._client_cache: Any = None
+        self._async_client_cache: Any = None
         self._pending_commit_sessions: set[str] = set()
         self._closed = False
         self.commit_policy = commit_policy
@@ -226,10 +235,83 @@ class OpenVikingSessionRecorder:
             ) from exc
         return result
 
+    async def arecord(
+        self,
+        session_id: str,
+        messages: Iterable[BaseMessage],
+        peer_id: str | None = None,
+        context_parts: Sequence[dict[str, Any]] = (),
+    ) -> OpenVikingRecordResult:
+        """Asynchronously persist messages and apply the configured commit policy."""
+
+        self._raise_if_closed()
+        await self._aretry_pending_commit(session_id)
+        input_messages = list(messages)
+        prepared_messages = _prepare_messages(
+            input_messages,
+            peer_id=peer_id,
+            context_parts=context_parts,
+        )
+        if not prepared_messages:
+            return OpenVikingRecordResult(input_messages_consumed=len(input_messages))
+
+        batches = _prepare_batches(prepared_messages, batch_size=self.batch_size)
+        client = await self._get_async_client()
+        messages_written = 0
+        input_messages_consumed = 0
+        context_attached = False
+        for batch in batches:
+            try:
+                await acall_openviking(
+                    client,
+                    "batch_add_messages",
+                    session_id=session_id,
+                    messages=batch.payloads,
+                )
+            except Exception as exc:
+                if messages_written == 0:
+                    raise
+                result = OpenVikingRecordResult(
+                    messages_written=messages_written,
+                    input_messages_consumed=input_messages_consumed,
+                    context_attached=context_attached,
+                )
+                raise OpenVikingPartialWriteError(
+                    session_id=session_id,
+                    result=result,
+                    cause=exc,
+                ) from exc
+            messages_written += len(batch.payloads)
+            input_messages_consumed = batch.input_end
+            context_attached = context_attached or batch.context_attached
+        result = OpenVikingRecordResult(
+            messages_written=messages_written,
+            input_messages_consumed=len(input_messages),
+            context_attached=context_attached,
+        )
+        try:
+            await aapply_commit_policy(client, session_id, self.commit_policy)
+        except Exception as exc:
+            self._pending_commit_sessions.add(session_id)
+            raise OpenVikingPartialWriteError(
+                session_id=session_id,
+                result=result,
+                cause=exc,
+                stage="commit",
+            ) from exc
+        return result
+
     def flush(self, session_id: str) -> dict[str, Any] | None:
         """Commit a session only when it contains pending, uncommitted content."""
 
         result = self._flush_pending_content(session_id)
+        self._pending_commit_sessions.discard(session_id)
+        return result
+
+    async def aflush(self, session_id: str) -> dict[str, Any] | None:
+        """Asynchronously commit pending, uncommitted session content."""
+
+        result = await self._aflush_pending_content(session_id)
         self._pending_commit_sessions.discard(session_id)
         return result
 
@@ -251,11 +333,41 @@ class OpenVikingSessionRecorder:
             return None
         return call_openviking(client, "commit_session", session_id=session_id)
 
+    async def _aflush_pending_content(self, session_id: str) -> dict[str, Any] | None:
+        client = await self._get_async_client()
+        try:
+            session = await acall_openviking(
+                client,
+                "get_session",
+                session_id=session_id,
+                auto_create=False,
+            )
+        except Exception as exc:
+            error_code = str(getattr(exc, "code", "")).upper()
+            if isinstance(exc, FileNotFoundError) or error_code == "NOT_FOUND":
+                return None
+            raise
+        if int(item_value(session, "pending_tokens", 0) or 0) <= 0:
+            return None
+        return await acall_openviking(client, "commit_session", session_id=session_id)
+
     def _retry_pending_commit(self, session_id: str) -> None:
         if session_id not in self._pending_commit_sessions:
             return
         self._flush_pending_content(session_id)
         self._pending_commit_sessions.discard(session_id)
+
+    async def _aretry_pending_commit(self, session_id: str) -> None:
+        if session_id not in self._pending_commit_sessions:
+            return
+        await self._aflush_pending_content(session_id)
+        self._pending_commit_sessions.discard(session_id)
+
+    async def _get_async_client(self) -> Any:
+        self._raise_if_closed()
+        if self._async_client_cache is None:
+            self._async_client_cache = await ensure_async_client(self._connection)
+        return self._async_client_cache
 
     def close(self) -> None:
         """Release an internally created client.
@@ -265,6 +377,11 @@ class OpenVikingSessionRecorder:
 
         if self._closed:
             return
+        if self._async_client_cache is not None and self._owns_async_client:
+            raise RuntimeError(
+                "OpenVikingSessionRecorder has an active async client; "
+                "use `await recorder.aclose()`"
+            )
         self._closed = True
         self._pending_commit_sessions.clear()
         client = self._client_cache
@@ -274,6 +391,23 @@ class OpenVikingSessionRecorder:
         close = getattr(client, "close", None)
         if callable(close):
             close()
+
+    async def aclose(self) -> None:
+        """Release internally created sync and async clients."""
+
+        if self._closed:
+            return
+        self._closed = True
+        self._pending_commit_sessions.clear()
+        sync_client = self._client_cache
+        async_client = self._async_client_cache
+        self._client_cache = None
+        self._async_client_cache = None
+
+        if sync_client is not None and self._owns_client:
+            await _aclose_client(sync_client)
+        if async_client is not None and self._owns_async_client and async_client is not sync_client:
+            await _aclose_client(async_client)
 
     def _raise_if_closed(self) -> None:
         if self._closed:
@@ -362,3 +496,15 @@ def _normalize_peer_id(peer_id: str | None) -> str | None:
         return None
     text = str(peer_id).strip()
     return text or None
+
+
+async def _aclose_client(client: Any) -> None:
+    close = getattr(client, "close", None)
+    if not callable(close):
+        return
+    if inspect.iscoroutinefunction(close):
+        await close()
+        return
+    result = await asyncio.to_thread(close)
+    if inspect.isawaitable(result):
+        await result

--- a/openviking/integrations/langchain/retrievers.py
+++ b/openviking/integrations/langchain/retrievers.py
@@ -28,6 +28,7 @@ from openviking.integrations.langchain.client import (
     iter_result_items,
     stringify,
 )
+from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 
 
 class OpenVikingRetriever(BaseRetriever):
@@ -61,10 +62,10 @@ class OpenVikingRetriever(BaseRetriever):
     tags: list[str] | None = Field(default=None, exclude=True)
 
     _client_cache: Any = PrivateAttr(default=None)
-    _async_client_cache: Any = PrivateAttr(default=None)
-    _async_client_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
+    _async_clients: LoopScopedAsyncClientCache = PrivateAttr(
+        default_factory=LoopScopedAsyncClientCache
+    )
     _owns_client_cache: bool = PrivateAttr(default=False)
-    _owns_async_client_cache: bool = PrivateAttr(default=False)
     _closed: bool = PrivateAttr(default=False)
 
     def _get_client(self) -> Any:
@@ -89,33 +90,38 @@ class OpenVikingRetriever(BaseRetriever):
         return self._client_cache
 
     async def get_async_client(self) -> Any:
-        """Return the lazily initialized client used by async retrieval."""
+        """Return the async client interface used by this retriever.
+
+        Injected clients are returned unchanged and remain caller-owned.
+        HTTP-backed connections return an internally managed, loop-local handle
+        whose method calls support recovery. Direct attributes on that handle
+        are best-effort during recovery; use ``await handle.get()`` only to read
+        raw properties immediately because recovery may replace that snapshot.
+        Embedded ``path=`` connections return an adapter-owned synchronous
+        client whose calls are dispatched through a worker thread.
+        """
 
         self._raise_if_closed()
-        if self._async_client_cache is None:
-            async with self._async_client_lock:
-                self._raise_if_closed()
-                if self._async_client_cache is None:
-                    self._owns_async_client_cache = (
-                        self.async_client is None and self.client is None
-                    )
-                    self._async_client_cache = await ensure_async_client(
-                        OpenVikingConnection(
-                            client=self.client,
-                            async_client=self.async_client,
-                            url=self.url,
-                            api_key=self.api_key,
-                            account=self.account,
-                            user=self.user,
-                            user_id=self.user_id,
-                            actor_peer_id=self.actor_peer_id,
-                            path=self.path,
-                            timeout=self.timeout,
-                            extra_headers=self.extra_headers,
-                            auto_initialize=self.auto_initialize,
-                        )
-                    )
-        return self._async_client_cache
+        client = await ensure_async_client(
+            OpenVikingConnection(
+                client=self.client,
+                async_client=self.async_client,
+                url=self.url,
+                api_key=self.api_key,
+                account=self.account,
+                user=self.user,
+                user_id=self.user_id,
+                actor_peer_id=self.actor_peer_id,
+                path=self.path,
+                timeout=self.timeout,
+                extra_headers=self.extra_headers,
+                auto_initialize=self.auto_initialize,
+            ),
+            client_cache=self._async_clients,
+            embedded_client_factory=self._get_client,
+        )
+        self._raise_if_closed()
+        return client
 
     async def _get_async_client(self) -> Any:
         return await self.get_async_client()
@@ -128,13 +134,11 @@ class OpenVikingRetriever(BaseRetriever):
         self._closed = True
         sync_client = self._client_cache
         self._client_cache = None
-        async with self._async_client_lock:
-            async_client = self._async_client_cache
-            self._async_client_cache = None
+        async_clients = await asyncio.to_thread(self._async_clients.pop_all)
 
         await aclose_openviking_clients(
             sync_client if self._owns_client_cache else None,
-            async_client if self._owns_async_client_cache else None,
+            *async_clients,
         )
 
     def _raise_if_closed(self) -> None:

--- a/openviking/integrations/langchain/retrievers.py
+++ b/openviking/integrations/langchain/retrievers.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Literal
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -19,7 +18,9 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 
 from openviking.integrations.langchain.client import (
     OpenVikingConnection,
+    acall_openviking,
     call_openviking,
+    ensure_async_client,
     ensure_client,
     item_value,
     iter_result_items,
@@ -33,6 +34,7 @@ class OpenVikingRetriever(BaseRetriever):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     client: Any = None
+    async_client: Any = None
     url: str | None = None
     api_key: str | None = None
     account: str | None = None
@@ -57,6 +59,7 @@ class OpenVikingRetriever(BaseRetriever):
     tags: list[str] | None = Field(default=None, exclude=True)
 
     _client_cache: Any = PrivateAttr(default=None)
+    _async_client_cache: Any = PrivateAttr(default=None)
 
     def _get_client(self) -> Any:
         if self._client_cache is None:
@@ -77,6 +80,26 @@ class OpenVikingRetriever(BaseRetriever):
             )
         return self._client_cache
 
+    async def _get_async_client(self) -> Any:
+        if self._async_client_cache is None:
+            self._async_client_cache = await ensure_async_client(
+                OpenVikingConnection(
+                    client=self.client,
+                    async_client=self.async_client,
+                    url=self.url,
+                    api_key=self.api_key,
+                    account=self.account,
+                    user=self.user,
+                    user_id=self.user_id,
+                    actor_peer_id=self.actor_peer_id,
+                    path=self.path,
+                    timeout=self.timeout,
+                    extra_headers=self.extra_headers,
+                    auto_initialize=self.auto_initialize,
+                )
+            )
+        return self._async_client_cache
+
     def _get_relevant_documents(self, query: str, *, run_manager: Any) -> list[Document]:
         client = self._get_client()
         method = "search" if self.search_mode == "search" else "find"
@@ -93,9 +116,40 @@ class OpenVikingRetriever(BaseRetriever):
         )
         documents: list[Document] = []
         for context_type, item in iter_result_items(result, self.context_types):
-            uri = item_value(item, "uri", "")
             content = self._content_for_item(client, item)
-            metadata = {
+            documents.append(self._document_from_item(context_type, item, content))
+        return documents
+
+    async def _aget_relevant_documents(self, query: str, *, run_manager: Any) -> list[Document]:
+        client = await self._get_async_client()
+        method = "search" if self.search_mode == "search" else "find"
+        result = await acall_openviking(
+            client,
+            method,
+            query=query,
+            target_uri=self.target_uri,
+            session_id=self.session_id,
+            limit=self.limit,
+            score_threshold=self.score_threshold,
+            filter=self.filter,
+            tags=self.tags,
+        )
+        documents: list[Document] = []
+        for context_type, item in iter_result_items(result, self.context_types):
+            content = await self._acontent_for_item(client, item)
+            documents.append(self._document_from_item(context_type, item, content))
+        return documents
+
+    def _document_from_item(
+        self,
+        context_type: str,
+        item: Any,
+        content: str,
+    ) -> Document:
+        uri = item_value(item, "uri", "")
+        return Document(
+            page_content=content,
+            metadata={
                 "source": uri,
                 f"{self.metadata_prefix}_uri": uri,
                 f"{self.metadata_prefix}_context_type": context_type,
@@ -105,13 +159,7 @@ class OpenVikingRetriever(BaseRetriever):
                 f"{self.metadata_prefix}_match_reason": item_value(item, "match_reason"),
                 f"{self.metadata_prefix}_abstract": item_value(item, "abstract"),
                 f"{self.metadata_prefix}_overview": item_value(item, "overview"),
-            }
-            documents.append(Document(page_content=content, metadata=metadata))
-        return documents
-
-    async def _aget_relevant_documents(self, query: str, *, run_manager: Any) -> list[Document]:
-        return await asyncio.to_thread(
-            lambda: self._get_relevant_documents(query, run_manager=run_manager)
+            },
         )
 
     def _content_for_item(self, client: Any, item: Any) -> str:
@@ -130,10 +178,35 @@ class OpenVikingRetriever(BaseRetriever):
             return self._read_or_fallback(client, uri, overview or abstract)
         return stringify(overview or abstract, max_chars=self.max_content_chars)
 
+    async def _acontent_for_item(self, client: Any, item: Any) -> str:
+        uri = item_value(item, "uri", "")
+        abstract = item_value(item, "abstract", "")
+        overview = item_value(item, "overview", "")
+        level = item_value(item, "level")
+
+        if self.content_mode == "abstract":
+            return stringify(abstract or overview, max_chars=self.max_content_chars)
+        if self.content_mode == "overview":
+            return stringify(overview or abstract, max_chars=self.max_content_chars)
+        if self.content_mode == "read":
+            return await self._aread_or_fallback(client, uri, overview or abstract)
+        if level == 2 and uri:
+            return await self._aread_or_fallback(client, uri, overview or abstract)
+        return stringify(overview or abstract, max_chars=self.max_content_chars)
+
     def _read_or_fallback(self, client: Any, uri: str, fallback: Any) -> str:
         if uri:
             try:
                 content = call_openviking(client, "read", uri=uri)
+                return stringify(content, max_chars=self.max_content_chars)
+            except Exception:
+                pass
+        return stringify(fallback, max_chars=self.max_content_chars)
+
+    async def _aread_or_fallback(self, client: Any, uri: str, fallback: Any) -> str:
+        if uri:
+            try:
+                content = await acall_openviking(client, "read", uri=uri)
                 return stringify(content, max_chars=self.max_content_chars)
             except Exception:
                 pass

--- a/openviking/integrations/langchain/retrievers.py
+++ b/openviking/integrations/langchain/retrievers.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -19,6 +20,7 @@ except ImportError as exc:  # pragma: no cover - exercised by optional import pa
 from openviking.integrations.langchain.client import (
     OpenVikingConnection,
     acall_openviking,
+    aclose_openviking_clients,
     call_openviking,
     ensure_async_client,
     ensure_client,
@@ -60,9 +62,15 @@ class OpenVikingRetriever(BaseRetriever):
 
     _client_cache: Any = PrivateAttr(default=None)
     _async_client_cache: Any = PrivateAttr(default=None)
+    _async_client_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
+    _owns_client_cache: bool = PrivateAttr(default=False)
+    _owns_async_client_cache: bool = PrivateAttr(default=False)
+    _closed: bool = PrivateAttr(default=False)
 
     def _get_client(self) -> Any:
+        self._raise_if_closed()
         if self._client_cache is None:
+            self._owns_client_cache = self.client is None
             self._client_cache = ensure_client(
                 OpenVikingConnection(
                     client=self.client,
@@ -80,25 +88,58 @@ class OpenVikingRetriever(BaseRetriever):
             )
         return self._client_cache
 
-    async def _get_async_client(self) -> Any:
+    async def get_async_client(self) -> Any:
+        """Return the lazily initialized client used by async retrieval."""
+
+        self._raise_if_closed()
         if self._async_client_cache is None:
-            self._async_client_cache = await ensure_async_client(
-                OpenVikingConnection(
-                    client=self.client,
-                    async_client=self.async_client,
-                    url=self.url,
-                    api_key=self.api_key,
-                    account=self.account,
-                    user=self.user,
-                    user_id=self.user_id,
-                    actor_peer_id=self.actor_peer_id,
-                    path=self.path,
-                    timeout=self.timeout,
-                    extra_headers=self.extra_headers,
-                    auto_initialize=self.auto_initialize,
-                )
-            )
+            async with self._async_client_lock:
+                self._raise_if_closed()
+                if self._async_client_cache is None:
+                    self._owns_async_client_cache = (
+                        self.async_client is None and self.client is None
+                    )
+                    self._async_client_cache = await ensure_async_client(
+                        OpenVikingConnection(
+                            client=self.client,
+                            async_client=self.async_client,
+                            url=self.url,
+                            api_key=self.api_key,
+                            account=self.account,
+                            user=self.user,
+                            user_id=self.user_id,
+                            actor_peer_id=self.actor_peer_id,
+                            path=self.path,
+                            timeout=self.timeout,
+                            extra_headers=self.extra_headers,
+                            auto_initialize=self.auto_initialize,
+                        )
+                    )
         return self._async_client_cache
+
+    async def _get_async_client(self) -> Any:
+        return await self.get_async_client()
+
+    async def aclose(self) -> None:
+        """Release clients created internally by this retriever."""
+
+        if self._closed:
+            return
+        self._closed = True
+        sync_client = self._client_cache
+        self._client_cache = None
+        async with self._async_client_lock:
+            async_client = self._async_client_cache
+            self._async_client_cache = None
+
+        await aclose_openviking_clients(
+            sync_client if self._owns_client_cache else None,
+            async_client if self._owns_async_client_cache else None,
+        )
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise RuntimeError("OpenVikingRetriever is closed")
 
     def _get_relevant_documents(self, query: str, *, run_manager: Any) -> list[Document]:
         client = self._get_client()

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -43,6 +43,18 @@ class LoopScopedAsyncClientCache:
         self._fallback_client: Any = None
         self._lock = threading.Lock()
 
+    def __copy__(self) -> LoopScopedAsyncClientCache:
+        """Return an empty cache instead of sharing live async clients."""
+
+        return type(self)()
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> LoopScopedAsyncClientCache:
+        """Return an empty cache instead of copying loop-bound clients."""
+
+        copied = type(self)()
+        memo[id(self)] = copied
+        return copied
+
     def get(self, factory: Callable[[], Any]) -> Any:
         """Return a client for the current loop, creating it with factory if needed."""
         try:
@@ -59,6 +71,12 @@ class LoopScopedAsyncClientCache:
                 client = factory()
                 self._clients_by_loop[loop] = client
             return client
+
+    def has_clients(self) -> bool:
+        """Return whether the cache currently retains any clients."""
+
+        with self._lock:
+            return bool(self._clients_by_loop) or self._fallback_client is not None
 
     def pop_all(self) -> list[Any]:
         """Remove and return all cached clients."""

--- a/tests/integration/langchain_langgraph/test_async_recording.py
+++ b/tests/integration/langchain_langgraph/test_async_recording.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_core")
+pytest.importorskip("langgraph")
+
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import RunnableLambda
+from langchain_core.runnables.history import RunnableWithMessageHistory
+
+from openviking.integrations.langchain import (
+    InMemoryOpenVikingClient,
+    OpenVikingChatMessageHistory,
+    OpenVikingContextMiddleware,
+    with_openviking_context,
+)
+
+
+class AsyncTrackingClient:
+    """Native async facade for deterministic real-framework integration tests."""
+
+    def __init__(self, records: dict[str, str] | None = None):
+        self.backing = InMemoryOpenVikingClient(records)
+        self.calls: list[str] = []
+        self.batch_sizes: list[int] = []
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def close(self) -> None:
+        self._initialized = False
+
+    def __getattr__(self, name: str) -> Any:
+        method = getattr(self.backing, name)
+        if not callable(method):
+            return method
+
+        async def call(*args: Any, **kwargs: Any) -> Any:
+            self.calls.append(name)
+            if name == "batch_add_messages":
+                self.batch_sizes.append(len(kwargs["messages"]))
+            return method(*args, **kwargs)
+
+        return call
+
+
+@pytest.mark.asyncio
+async def test_real_runnable_with_message_history_ainvoke_uses_async_history():
+    client = AsyncTrackingClient()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        remembered_azure = any(
+            "azure" in str(message.content).lower()
+            for message in messages
+            if isinstance(message, HumanMessage)
+        )
+        return AIMessage(content="I remember azure." if remembered_azure else "No preference.")
+
+    app = RunnableWithMessageHistory(
+        RunnableLambda(answer),
+        lambda session_id: OpenVikingChatMessageHistory(
+            session_id=session_id,
+            async_client=client,
+        ),
+    )
+    config = {"configurable": {"session_id": "real-async-history"}}
+
+    await app.ainvoke(
+        [HumanMessage(content="Remember that the deployment color is azure.")],
+        config=config,
+    )
+    response = await app.ainvoke(
+        [HumanMessage(content="Which deployment color do you remember?")],
+        config=config,
+    )
+
+    assert response.content == "I remember azure."
+    assert client.batch_sizes == [2, 2]
+    assert len(client.backing.sessions["real-async-history"]) == 4
+    assert client.calls.count("get_session_context") == 4
+
+
+@pytest.mark.asyncio
+async def test_real_openviking_context_wrapper_ainvoke_uses_async_lifecycle():
+    client = AsyncTrackingClient(
+        {"viking://resources/runbooks/async.md": "Async deployment color is teal."}
+    )
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        assert "Async deployment color is teal." in str(messages[0].content)
+        return AIMessage(content="OpenViking says teal.")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-wrapper",
+        target_uri="viking://resources",
+    )
+
+    result = await app.ainvoke([HumanMessage(content="What is the async deployment color?")])
+
+    assert result.content == "OpenViking says teal."
+    assert client.batch_sizes == [2]
+    assert {"create_session", "get_session_context", "search", "read"}.issubset(client.calls)
+    assistant_parts = client.backing.sessions["real-async-wrapper"][1]["parts"]
+    assert any(part["type"] == "context" for part in assistant_parts)
+
+
+@pytest.mark.asyncio
+async def test_real_async_context_wrapper_clears_pending_context_after_failure():
+    client = AsyncTrackingClient(
+        {"viking://resources/runbooks/failure.md": "Async failure context is amber."}
+    )
+    calls = 0
+
+    async def answer(_messages: list[BaseMessage]) -> AIMessage:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("synthetic async model failure")
+        return AIMessage(content="Recovered asynchronously.")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-failure",
+        target_uri="viking://resources",
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic async model failure"):
+        await app.ainvoke([HumanMessage(content="What amber failure context?")])
+
+    client.backing.records.clear()
+    result = await app.ainvoke([HumanMessage(content="No matching context on this retry.")])
+
+    assert result.content == "Recovered asynchronously."
+    assistant_parts = client.backing.sessions["real-async-failure"][-1]["parts"]
+    assert not any(part["type"] == "context" for part in assistant_parts)
+
+
+@pytest.mark.asyncio
+async def test_real_create_agent_ainvoke_uses_async_middleware_hooks():
+    client = AsyncTrackingClient()
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        session_id_resolver=lambda _state, _runtime: "real-async-agent",
+    )
+    agent = create_agent(
+        model=FakeListChatModel(responses=["Stored by async middleware."]),
+        tools=[],
+        middleware=[middleware],
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Remember this async agent turn.")]},
+        config={"configurable": {"thread_id": "real-async-agent"}},
+    )
+
+    assert result["messages"][-1].content == "Stored by async middleware."
+    assert client.batch_sizes == [2]
+    assert [
+        message["parts"][0]["text"] for message in client.backing.sessions["real-async-agent"]
+    ] == [
+        "Remember this async agent turn.",
+        "Stored by async middleware.",
+    ]

--- a/tests/unit/test_async_client_cache.py
+++ b/tests/unit/test_async_client_cache.py
@@ -3,6 +3,7 @@
 """Tests for event-loop scoped async client caching."""
 
 import asyncio
+import copy
 import threading
 
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
@@ -44,3 +45,17 @@ def test_loop_scoped_async_client_cache_reuses_within_loop_and_isolates_between_
     assert worker_results[0][0] is worker_results[0][1]
     assert main_first is not worker_results[0][0]
     assert len(created) == 2
+
+
+def test_loop_scoped_async_client_cache_copies_without_live_clients():
+    cache = LoopScopedAsyncClientCache()
+    client = object()
+
+    assert cache.get(lambda: client) is client
+
+    shallow = copy.copy(cache)
+    deep = copy.deepcopy(cache)
+
+    assert cache.has_clients()
+    assert not shallow.has_clients()
+    assert not deep.has_clients()

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+pytest.importorskip("langchain_core")
+pytest.importorskip("langgraph")
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from openviking.integrations.langchain import (
+    InMemoryOpenVikingClient,
+    OpenVikingChatMessageHistory,
+    OpenVikingCommitPolicy,
+    OpenVikingContextMiddleware,
+    OpenVikingPartialWriteError,
+    OpenVikingRetriever,
+    OpenVikingSessionContextAssembler,
+    OpenVikingSessionRecorder,
+)
+from openviking.integrations.langchain.client import (
+    OpenVikingConnection,
+    acall_openviking,
+    ensure_async_client,
+)
+
+
+class AsyncInMemoryOpenVikingClient:
+    """Async facade that records whether adapters use native coroutine methods."""
+
+    def __init__(self, backing: InMemoryOpenVikingClient | None = None):
+        self.backing = backing or InMemoryOpenVikingClient()
+        self.calls: list[str] = []
+        self.call_thread_ids: list[int] = []
+        self._initialized = False
+        self.closed = False
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def close(self) -> None:
+        self.closed = True
+        self._initialized = False
+
+    def __getattr__(self, name: str) -> Any:
+        method = getattr(self.backing, name)
+        if not callable(method):
+            return method
+
+        async def call(*args: Any, **kwargs: Any) -> Any:
+            self.calls.append(name)
+            self.call_thread_ids.append(threading.get_ident())
+            return method(*args, **kwargs)
+
+        return call
+
+
+@pytest.mark.asyncio
+async def test_ensure_async_client_defaults_to_native_http_client(monkeypatch):
+    created: dict[str, Any] = {}
+
+    class FakeAsyncHTTPClient:
+        def __init__(self, **kwargs: Any):
+            created.update(kwargs)
+            self.initialized = False
+
+        async def initialize(self) -> None:
+            self.initialized = True
+
+        async def find(self, query: str) -> dict[str, str]:
+            return {"query": query}
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+
+    client = await ensure_async_client(
+        OpenVikingConnection(api_key="test-key", user_id="test-user")
+    )
+
+    assert await acall_openviking(
+        client,
+        "find",
+        query="async",
+        unsupported="ignored",
+    ) == {"query": "async"}
+    assert created["api_key"] == "test-key"
+    assert created["user_id"] == "test-user"
+    assert created["url"] is None
+    assert (await client.get()).initialized is True
+
+
+@pytest.mark.asyncio
+async def test_injected_async_client_is_initialized_only_once_across_adapters():
+    class AsyncClientWithoutInitializedFlag:
+        def __init__(self):
+            self.initialize_calls = 0
+
+        async def initialize(self) -> None:
+            self.initialize_calls += 1
+
+    client = AsyncClientWithoutInitializedFlag()
+    connection = OpenVikingConnection(async_client=client)
+
+    assert await ensure_async_client(connection) is client
+    assert await ensure_async_client(connection) is client
+    assert client.initialize_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_injected_async_client_respects_disabled_auto_initialize():
+    class AsyncClient:
+        def __init__(self):
+            self.initialize_calls = 0
+
+        async def initialize(self) -> None:
+            self.initialize_calls += 1
+
+    client = AsyncClient()
+
+    assert (
+        await ensure_async_client(
+            OpenVikingConnection(
+                async_client=client,
+                auto_initialize=False,
+            )
+        )
+        is client
+    )
+    assert client.initialize_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_async_client_retries_safe_read_with_fresh_client(monkeypatch):
+    instances: list[Any] = []
+
+    class FlakyAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.index = len(instances)
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+        async def find(self, **_kwargs: Any) -> dict[str, Any]:
+            if self.index == 0:
+                raise ConnectionError("OpenViking server was not ready")
+            return {"memories": [], "resources": [], "skills": []}
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FlakyAsyncHTTPClient)
+
+    client = await ensure_async_client(OpenVikingConnection(url="http://localhost:1933"))
+    result = await acall_openviking(client, "find", query="recover")
+
+    assert result == {"memories": [], "resources": [], "skills": []}
+    assert len(instances) == 2
+    assert instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_client_evicts_without_replaying_mutating_call(monkeypatch):
+    instances: list[Any] = []
+
+    class FlakyAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+        async def batch_add_messages(self, **_kwargs: Any) -> dict[str, Any]:
+            raise ConnectionError("OpenViking connection dropped during write")
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FlakyAsyncHTTPClient)
+
+    client = await ensure_async_client(OpenVikingConnection(url="http://localhost:1933"))
+    with pytest.raises(ConnectionError):
+        await acall_openviking(
+            client,
+            "batch_add_messages",
+            session_id="async-mutation",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert len(instances) == 1
+    assert instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_client_async_fallback_runs_outside_event_loop_thread():
+    main_thread_id = threading.get_ident()
+    call_thread_ids: list[int] = []
+
+    class SyncClient:
+        def find(self, query: str) -> dict[str, Any]:
+            call_thread_ids.append(threading.get_ident())
+            return {"memories": [], "resources": [], "skills": [], "query": query}
+
+    result = await acall_openviking(SyncClient(), "find", query="fallback")
+
+    assert result["query"] == "fallback"
+    assert call_thread_ids
+    assert call_thread_ids[0] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_async_retriever_uses_native_client_for_search_and_read():
+    backing = InMemoryOpenVikingClient(
+        {"viking://resources/runbooks/async.md": "Native async retrieval."}
+    )
+    client = AsyncInMemoryOpenVikingClient(backing)
+    main_thread_id = threading.get_ident()
+    retriever = OpenVikingRetriever(
+        async_client=client,
+        target_uri="viking://resources",
+    )
+
+    documents = await retriever.ainvoke("async retrieval")
+
+    assert [document.page_content for document in documents] == ["Native async retrieval."]
+    assert client.calls == ["find", "read"]
+    assert set(client.call_thread_ids) == {main_thread_id}
+
+
+@pytest.mark.asyncio
+async def test_async_recorder_preserves_batch_and_commit_semantics():
+    class BatchTrackingClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes: list[int] = []
+
+        def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_sizes.append(len(messages))
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    backing = BatchTrackingClient()
+    client = AsyncInMemoryOpenVikingClient(backing)
+    recorder = OpenVikingSessionRecorder(
+        async_client=client,
+        commit_policy=OpenVikingCommitPolicy(mode="always"),
+    )
+
+    result = await recorder.arecord(
+        "async-recorder",
+        [HumanMessage(content=f"Message {index}") for index in range(205)],
+    )
+
+    assert result.messages_written == 205
+    assert result.input_messages_consumed == 205
+    assert backing.batch_sizes == [100, 100, 5]
+    assert backing.sessions["async-recorder"] == []
+    assert len(backing.archives["async-recorder"][0]["messages"]) == 205
+
+
+@pytest.mark.asyncio
+async def test_async_recorder_retries_only_pending_commit_without_duplicate_writes():
+    class FailFirstCommitClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls = 0
+            self.commit_calls = 0
+
+        def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_calls += 1
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+        def commit_session(self, session_id: str, **kwargs: Any) -> dict[str, Any]:
+            self.commit_calls += 1
+            if self.commit_calls == 1:
+                raise RuntimeError("commit failed")
+            return super().commit_session(session_id, **kwargs)
+
+    backing = FailFirstCommitClient()
+    recorder = OpenVikingSessionRecorder(
+        async_client=AsyncInMemoryOpenVikingClient(backing),
+        commit_policy=OpenVikingCommitPolicy(mode="always"),
+    )
+
+    with pytest.raises(OpenVikingPartialWriteError) as captured:
+        await recorder.arecord(
+            "async-commit-retry",
+            [HumanMessage(content="Persist once.")],
+        )
+    result = await recorder.arecord("async-commit-retry", ())
+
+    assert captured.value.commit_pending is True
+    assert result.messages_written == 0
+    assert backing.batch_calls == 1
+    assert backing.commit_calls == 2
+    assert len(backing.archives["async-commit-retry"][0]["messages"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_recorder_reports_confirmed_prefix_for_partial_batch_retry():
+    class FailSecondBatchClient(InMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_sizes: list[int] = []
+
+        def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_sizes.append(len(messages))
+            if len(self.batch_sizes) == 2:
+                raise RuntimeError("second batch failed")
+            return super().batch_add_messages(session_id, messages, **kwargs)
+
+    backing = FailSecondBatchClient()
+    recorder = OpenVikingSessionRecorder(async_client=AsyncInMemoryOpenVikingClient(backing))
+    messages = [HumanMessage(content=f"Message {index}") for index in range(101)]
+
+    with pytest.raises(OpenVikingPartialWriteError) as captured:
+        await recorder.arecord("async-partial-retry", messages)
+    await recorder.arecord(
+        "async-partial-retry",
+        messages[captured.value.input_messages_consumed :],
+    )
+
+    assert captured.value.messages_written == 100
+    assert captured.value.input_messages_consumed == 100
+    assert backing.batch_sizes == [100, 1, 1]
+    assert len(backing.sessions["async-partial-retry"]) == 101
+
+
+@pytest.mark.asyncio
+async def test_async_recorder_closes_only_internally_created_client(monkeypatch):
+    instances: list[Any] = []
+
+    class FakeAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def batch_add_messages(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"added": 1}
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+    owned_recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+
+    await owned_recorder.arecord(
+        "async-owned-client",
+        [HumanMessage(content="Close owned client.")],
+    )
+    await owned_recorder.aclose()
+    await owned_recorder.aclose()
+
+    assert instances[0].closed is True
+    with pytest.raises(RuntimeError, match="closed"):
+        await owned_recorder.arecord(
+            "async-owned-client",
+            [HumanMessage(content="Rejected.")],
+        )
+
+    injected_client = AsyncInMemoryOpenVikingClient()
+    injected_recorder = OpenVikingSessionRecorder(async_client=injected_client)
+    await injected_recorder.arecord(
+        "async-injected-client",
+        [HumanMessage(content="Keep injected client open.")],
+    )
+    await injected_recorder.aclose()
+
+    assert injected_client.closed is False
+
+
+@pytest.mark.asyncio
+async def test_async_chat_history_reads_writes_and_clears_natively():
+    backing = InMemoryOpenVikingClient()
+    client = AsyncInMemoryOpenVikingClient(backing)
+    history = OpenVikingChatMessageHistory(
+        session_id="async-history",
+        async_client=client,
+    )
+
+    await history.aadd_messages(
+        [
+            HumanMessage(content="Remember async history."),
+            AIMessage(content="Stored asynchronously."),
+        ]
+    )
+    messages = await history.aget_messages()
+    await history.aclear()
+
+    assert [message.content for message in messages] == [
+        "Remember async history.",
+        "Stored asynchronously.",
+    ]
+    assert backing.sessions["async-history"] == []
+    assert client.calls == [
+        "batch_add_messages",
+        "get_session_context",
+        "delete_session",
+        "create_session",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_context_assembler_combines_session_and_recall():
+    backing = InMemoryOpenVikingClient(
+        {"viking://resources/runbooks/async.md": "Async context is azure."}
+    )
+    backing.add_message("async-assembler", "user", content="Active async turn.")
+    client = AsyncInMemoryOpenVikingClient(backing)
+    assembler = OpenVikingSessionContextAssembler(
+        async_client=client,
+        target_uri="viking://resources",
+    )
+
+    assembled = await assembler.aassemble(
+        session_id="async-assembler",
+        query="azure",
+    )
+
+    assert "Active async turn." in assembled.block
+    assert "Async context is azure." in assembled.block
+    assert assembled.context_parts[0]["uri"] == "viking://resources/runbooks/async.md"
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_injects_and_captures_context():
+    backing = InMemoryOpenVikingClient(
+        {"viking://user/memories/profile.md": "Async middleware prefers teal."}
+    )
+    client = AsyncInMemoryOpenVikingClient(backing)
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        target_uri="viking://user/memories",
+        session_id_resolver=lambda _state, _runtime: "async-middleware",
+    )
+    captured_request: dict[str, Any] = {}
+
+    class Request:
+        state: dict[str, Any] = {}
+        runtime = None
+        messages = [HumanMessage(content="What teal preference?")]
+        system_message = None
+
+        def override(self, **overrides: Any) -> Request:
+            request = Request()
+            request.system_message = overrides.get("system_message", self.system_message)
+            return request
+
+    async def handler(request: Any) -> AIMessage:
+        captured_request["request"] = request
+        return AIMessage(content="teal")
+
+    await middleware.awrap_model_call(Request(), handler)
+    await middleware.aafter_agent(
+        {
+            "messages": [
+                HumanMessage(content="What color?"),
+                AIMessage(content="teal"),
+            ]
+        },
+        runtime=None,
+    )
+
+    assert "Async middleware prefers teal." in (captured_request["request"].system_message.content)
+    assistant_parts = backing.sessions["async-middleware"][1]["parts"]
+    assert any(part["type"] == "context" for part in assistant_parts)

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -115,6 +115,37 @@ async def test_injected_async_client_is_initialized_only_once_across_adapters():
 
 
 @pytest.mark.asyncio
+async def test_shared_injected_async_client_initializes_once_across_real_adapters():
+    class SharedAsyncClient:
+        def __init__(self):
+            self.initialize_calls = 0
+            self.closed = False
+
+        async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
+            self.initialize_calls += 1
+
+        async def close(self) -> None:
+            self.closed = True
+
+    client = SharedAsyncClient()
+    recorder = OpenVikingSessionRecorder(async_client=client)
+    retriever = OpenVikingRetriever(async_client=client)
+
+    resolved = await asyncio.gather(
+        recorder.get_async_client(),
+        retriever.get_async_client(),
+    )
+
+    assert resolved == [client, client]
+    assert client.initialize_calls == 1
+
+    await recorder.aclose()
+    await retriever.aclose()
+    assert client.closed is False
+
+
+@pytest.mark.asyncio
 async def test_injected_async_client_respects_disabled_auto_initialize():
     class AsyncClient:
         def __init__(self):
@@ -234,6 +265,140 @@ async def test_async_adapter_client_caches_initialize_once_under_concurrency(mon
     assert all(client.closed for client in instances)
 
 
+def test_async_adapter_clients_are_scoped_per_event_loop(monkeypatch):
+    instances: list[Any] = []
+
+    class LoopBoundAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.loop: asyncio.AbstractEventLoop | None = None
+            self.closed = False
+            self.writes = 0
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
+            self.loop = asyncio.get_running_loop()
+
+        async def batch_add_messages(self, **_kwargs: Any) -> dict[str, Any]:
+            if asyncio.get_running_loop() is not self.loop:
+                raise RuntimeError("client used from a different event loop")
+            self.writes += 1
+            return {}
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", LoopBoundAsyncHTTPClient)
+    recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+
+    async def use_recorder(session_id: str) -> tuple[Any, Any]:
+        handles = await asyncio.gather(*(recorder.get_async_client() for _ in range(8)))
+        assert all(handle is handles[0] for handle in handles)
+        client = await handles[0].get()
+        await recorder.arecord(session_id, [HumanMessage(content=session_id)])
+        return handles[0], client
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        handle_a, client_a = loop_a.run_until_complete(use_recorder("loop-a"))
+        handle_b, client_b = loop_b.run_until_complete(use_recorder("loop-b"))
+
+        assert handle_a is not handle_b
+        assert client_a is not client_b
+        assert len(instances) == 2
+        assert [client.writes for client in instances] == [1, 1]
+
+        loop_b.run_until_complete(recorder.aclose())
+        assert all(client.closed for client in instances)
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+
+def test_async_adapter_aclose_after_originating_loop_ends_is_best_effort(monkeypatch):
+    class LoopBoundAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            pass
+
+        async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
+
+        async def close(self) -> None:
+            raise RuntimeError("event loop is closed")
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", LoopBoundAsyncHTTPClient)
+    recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+
+    async def initialize_with_contention() -> None:
+        await asyncio.gather(*(recorder.get_async_client() for _ in range(4)))
+
+    asyncio.run(initialize_with_contention())
+    asyncio.run(recorder.aclose())
+    assert recorder._closed is True
+
+
+def test_async_adapter_aclose_routes_to_live_originating_loop(monkeypatch):
+    instances: list[Any] = []
+
+    class LoopBoundAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.initialized_loop: asyncio.AbstractEventLoop | None = None
+            self.closed_loop: asyncio.AbstractEventLoop | None = None
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            self.initialized_loop = asyncio.get_running_loop()
+
+        async def close(self) -> None:
+            self.closed_loop = asyncio.get_running_loop()
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", LoopBoundAsyncHTTPClient)
+    recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+    worker_loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    worker_errors: list[BaseException] = []
+
+    async def initialize() -> None:
+        await recorder.get_async_client()
+
+    def run_worker_loop() -> None:
+        asyncio.set_event_loop(worker_loop)
+        try:
+            try:
+                worker_loop.run_until_complete(initialize())
+            except BaseException as exc:
+                worker_errors.append(exc)
+                return
+            ready.set()
+            worker_loop.run_forever()
+        finally:
+            ready.set()
+            asyncio.set_event_loop(None)
+
+    thread = threading.Thread(target=run_worker_loop)
+    thread.start()
+    assert ready.wait(timeout=2)
+    try:
+        assert not worker_errors
+        asyncio.run(recorder.aclose())
+    finally:
+        worker_loop.call_soon_threadsafe(worker_loop.stop)
+        thread.join(timeout=2)
+        worker_loop.close()
+
+    assert not thread.is_alive()
+    assert len(instances) == 1
+    assert instances[0].initialized_loop is worker_loop
+    assert instances[0].closed_loop is worker_loop
+
+
 @pytest.mark.asyncio
 async def test_async_handle_copy_and_missing_attribute_behavior(monkeypatch):
     class FakeAsyncHTTPClient:
@@ -255,16 +420,141 @@ async def test_async_handle_copy_and_missing_attribute_behavior(monkeypatch):
     handle = await retriever.get_async_client()
 
     copied = copy.deepcopy(retriever)
-    copied_handle = copied._async_client_cache
+    assert not copied._async_clients.has_clients()
+    copied_handle = await copied.get_async_client()
 
     assert isinstance(copied_handle, OpenVikingAsyncClientHandle)
     assert copied_handle is not handle
-    assert copied_handle._client is None
     assert (await copied_handle.get()).marker == "async-client"
     assert handle.marker == "async-client"
     assert not hasattr(handle, "definitely_not_an_openviking_client_attribute")
     await copied.aclose()
     await retriever.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_handle_method_lookup_survives_recovery_reset(monkeypatch):
+    instances: list[Any] = []
+    reset_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class RecoveringAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.index = len(instances)
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def find(self, **kwargs: Any) -> dict[str, Any]:
+            if self.index == 0:
+                raise ConnectionError("replace this client")
+            return {"query": kwargs["query"], "client": self.index}
+
+        async def close(self) -> None:
+            if self.index == 0:
+                reset_started.set()
+                await release_close.wait()
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", RecoveringAsyncHTTPClient)
+    handle = OpenVikingAsyncClientHandle(OpenVikingConnection(url="http://localhost:1933"))
+    await handle.initialize()
+
+    recovering_call = asyncio.create_task(handle.find(query="first"))
+    await asyncio.wait_for(reset_started.wait(), timeout=1)
+
+    sibling_method = handle.find
+    sibling_call = asyncio.create_task(sibling_method(query="second"))
+    release_close.set()
+
+    first_result, second_result = await asyncio.gather(recovering_call, sibling_call)
+
+    assert {first_result["query"], second_result["query"]} == {"first", "second"}
+    assert first_result["client"] == second_result["client"] == 1
+    assert len(instances) == 2
+    await handle.close()
+
+
+@pytest.mark.asyncio
+async def test_async_handle_stale_failure_does_not_reset_replacement(monkeypatch):
+    instances: list[Any] = []
+    stale_call_started = asyncio.Event()
+    release_stale_failure = asyncio.Event()
+    reset_started = asyncio.Event()
+    release_old_close = asyncio.Event()
+
+    class RecoveringAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.index = len(instances)
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def find(self, *, query: str) -> dict[str, Any]:
+            if self.index != 0:
+                return {"query": query, "client": self.index}
+            if query == "stale":
+                stale_call_started.set()
+                await release_stale_failure.wait()
+            raise ConnectionError(f"{query} failed on the old client")
+
+        async def close(self) -> None:
+            self.closed = True
+            if self.index == 0:
+                reset_started.set()
+                await release_old_close.wait()
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", RecoveringAsyncHTTPClient)
+    handle = OpenVikingAsyncClientHandle(OpenVikingConnection(url="http://localhost:1933"))
+    await handle.initialize()
+
+    stale_call = asyncio.create_task(handle.find(query="stale"))
+    await asyncio.wait_for(stale_call_started.wait(), timeout=1)
+
+    recovering_call = asyncio.create_task(handle.find(query="first"))
+    await asyncio.wait_for(reset_started.wait(), timeout=1)
+
+    fresh_result = await handle.find(query="fresh")
+    release_stale_failure.set()
+    stale_result = await stale_call
+    release_old_close.set()
+    recovering_result = await recovering_call
+
+    assert fresh_result["client"] == stale_result["client"] == recovering_result["client"] == 1
+    assert len(instances) == 2
+    assert instances[0].closed is True
+    assert instances[1].closed is False
+    await handle.close()
+
+
+@pytest.mark.asyncio
+async def test_async_handle_missing_method_fails_when_called(monkeypatch):
+    class FakeAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            pass
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+    handle = OpenVikingAsyncClientHandle(OpenVikingConnection(url="http://localhost:1933"))
+
+    missing_method = handle.definitely_not_an_openviking_client_attribute
+    with pytest.raises(AttributeError, match="definitely_not_an_openviking_client_attribute"):
+        await missing_method()
+
+    await handle.close()
 
 
 @pytest.mark.asyncio
@@ -358,6 +648,23 @@ async def test_async_middleware_does_not_close_injected_client():
 
 
 @pytest.mark.asyncio
+async def test_async_middleware_does_not_close_injected_retriever():
+    client = AsyncInMemoryOpenVikingClient()
+    retriever = OpenVikingRetriever(async_client=client)
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        retriever=retriever,
+    )
+
+    await middleware.aclose()
+
+    assert retriever._closed is False
+    assert await retriever.ainvoke("still usable") == []
+    assert client.closed is False
+    await retriever.aclose()
+
+
+@pytest.mark.asyncio
 async def test_async_client_retries_safe_read_with_fresh_client(monkeypatch):
     instances: list[Any] = []
 
@@ -440,6 +747,70 @@ async def test_sync_client_async_fallback_runs_outside_event_loop_thread():
     assert result["query"] == "fallback"
     assert call_thread_ids
     assert call_thread_ids[0] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_embedded_path_async_uses_owned_sync_client_in_worker(monkeypatch, tmp_path):
+    main_thread_id = threading.get_ident()
+    instances: list[Any] = []
+
+    class FakeSyncOpenViking:
+        def __init__(self, *, path: str, actor_peer_id: str | None = None):
+            self.path = path
+            self.actor_peer_id = actor_peer_id
+            self._initialized = False
+            self.initialize_thread_id: int | None = None
+            self.find_thread_id: int | None = None
+            self.closed = False
+            instances.append(self)
+
+        def initialize(self) -> None:
+            self.initialize_thread_id = threading.get_ident()
+            self._initialized = True
+
+        def find(self, **_kwargs: Any) -> dict[str, Any]:
+            self.find_thread_id = threading.get_ident()
+            return {
+                "memories": [
+                    {
+                        "uri": "viking://user/memories/example",
+                        "abstract": "Embedded result.",
+                        "level": 1,
+                    }
+                ],
+                "resources": [],
+                "skills": [],
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    import openviking.sync_client as sync_client_module
+
+    monkeypatch.setattr(sync_client_module, "SyncOpenViking", FakeSyncOpenViking)
+    retriever = OpenVikingRetriever(path=str(tmp_path), actor_peer_id="assistant-a")
+
+    documents = await retriever.ainvoke("embedded")
+    client = await retriever.get_async_client()
+
+    assert [document.page_content for document in documents] == ["Embedded result."]
+    assert len(instances) == 1
+    assert client is instances[0]
+    assert client is retriever._get_client()
+    assert client.actor_peer_id == "assistant-a"
+    assert client.initialize_thread_id != main_thread_id
+    assert client.find_thread_id != main_thread_id
+
+    await retriever.aclose()
+    assert client.closed is True
+
+    recorder = OpenVikingSessionRecorder(path=str(tmp_path / "recorder"))
+    recorder_client = await recorder.get_async_client()
+
+    assert recorder_client is recorder.client
+    recorder.close()
+    assert recorder._closed is True
+    assert recorder_client.closed is True
 
 
 @pytest.mark.asyncio
@@ -717,3 +1088,42 @@ async def test_async_middleware_injects_and_captures_context():
     assert "Async middleware prefers teal." in (captured_request["request"].system_message.content)
     assistant_parts = backing.sessions["async-middleware"][1]["parts"]
     assert any(part["type"] == "context" for part in assistant_parts)
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_clears_pending_context_when_model_call_is_cancelled():
+    backing = InMemoryOpenVikingClient(
+        {"viking://user/memories/profile.md": "Cancelled context must not be reused."}
+    )
+    client = AsyncInMemoryOpenVikingClient(backing)
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        target_uri="viking://user/memories",
+        session_id_resolver=lambda _state, _runtime: "async-cancelled-middleware",
+    )
+    handler_started = asyncio.Event()
+
+    class Request:
+        state: dict[str, Any] = {}
+        runtime = None
+        messages = [HumanMessage(content="Find the cancelled context.")]
+        system_message = None
+
+        def override(self, **overrides: Any) -> Request:
+            request = Request()
+            request.system_message = overrides.get("system_message", self.system_message)
+            return request
+
+    async def handler(_request: Any) -> AIMessage:
+        handler_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    model_call = asyncio.create_task(middleware.awrap_model_call(Request(), handler))
+    await asyncio.wait_for(handler_started.wait(), timeout=1)
+    model_call.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await model_call
+
+    assert middleware._pending_context_parts == {}

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import copy
 import threading
 from typing import Any
 
@@ -21,6 +23,7 @@ from openviking.integrations.langchain import (
     OpenVikingSessionRecorder,
 )
 from openviking.integrations.langchain.client import (
+    OpenVikingAsyncClientHandle,
     OpenVikingConnection,
     acall_openviking,
     ensure_async_client,
@@ -99,13 +102,15 @@ async def test_injected_async_client_is_initialized_only_once_across_adapters():
             self.initialize_calls = 0
 
         async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
             self.initialize_calls += 1
 
     client = AsyncClientWithoutInitializedFlag()
     connection = OpenVikingConnection(async_client=client)
 
-    assert await ensure_async_client(connection) is client
-    assert await ensure_async_client(connection) is client
+    clients = await asyncio.gather(*(ensure_async_client(connection) for _ in range(5)))
+
+    assert all(resolved is client for resolved in clients)
     assert client.initialize_calls == 1
 
 
@@ -130,6 +135,226 @@ async def test_injected_async_client_respects_disabled_auto_initialize():
         is client
     )
     assert client.initialize_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_async_client_handle_initializes_once_under_concurrency(monkeypatch):
+    instances: list[Any] = []
+
+    class SlowAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", SlowAsyncHTTPClient)
+    handle = OpenVikingAsyncClientHandle(OpenVikingConnection(url="http://localhost:1933"))
+
+    clients = await asyncio.gather(*(handle.get() for _ in range(5)))
+
+    assert len(instances) == 1
+    assert all(client is clients[0] for client in clients)
+    await handle.close()
+    assert instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_client_initialization_failure_closes_candidate(monkeypatch):
+    instances: list[Any] = []
+
+    class FailingAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            raise RuntimeError("initialization failed")
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FailingAsyncHTTPClient)
+
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        await ensure_async_client(OpenVikingConnection(url="http://localhost:1933"))
+
+    assert len(instances) == 1
+    assert instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_adapter_client_caches_initialize_once_under_concurrency(monkeypatch):
+    instances: list[Any] = []
+
+    class SlowAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            await asyncio.sleep(0.01)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", SlowAsyncHTTPClient)
+    recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+    assembler = OpenVikingSessionContextAssembler(
+        url="http://localhost:1933",
+        include_recall=False,
+    )
+    retriever = OpenVikingRetriever(url="http://localhost:1933")
+
+    recorder_clients = await asyncio.gather(*(recorder.get_async_client() for _ in range(5)))
+    assembler_clients = await asyncio.gather(*(assembler.get_async_client() for _ in range(5)))
+    retriever_clients = await asyncio.gather(*(retriever.get_async_client() for _ in range(5)))
+
+    assert len(instances) == 3
+    assert all(client is recorder_clients[0] for client in recorder_clients)
+    assert all(client is assembler_clients[0] for client in assembler_clients)
+    assert all(client is retriever_clients[0] for client in retriever_clients)
+
+    await assembler.retriever.get_async_client()
+    assert len(instances) == 4
+
+    await recorder.aclose()
+    await assembler.aclose()
+    await retriever.aclose()
+    assert all(client.closed for client in instances)
+
+
+@pytest.mark.asyncio
+async def test_async_handle_copy_and_missing_attribute_behavior(monkeypatch):
+    class FakeAsyncHTTPClient:
+        marker = "async-client"
+
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+    retriever = OpenVikingRetriever(url="http://localhost:1933")
+    handle = await retriever.get_async_client()
+
+    copied = copy.deepcopy(retriever)
+    copied_handle = copied._async_client_cache
+
+    assert isinstance(copied_handle, OpenVikingAsyncClientHandle)
+    assert copied_handle is not handle
+    assert copied_handle._client is None
+    assert (await copied_handle.get()).marker == "async-client"
+    assert handle.marker == "async-client"
+    assert not hasattr(handle, "definitely_not_an_openviking_client_attribute")
+    await copied.aclose()
+    await retriever.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sync_close_after_async_use_remains_recoverable(monkeypatch):
+    class FakeAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+    class FakeSyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            self._initialized = False
+
+        def initialize(self) -> None:
+            self._initialized = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+    monkeypatch.setattr(client_module, "SyncHTTPClient", FakeSyncHTTPClient)
+    recorder = OpenVikingSessionRecorder(url="http://localhost:1933")
+    sync_handle = recorder.client
+    async_handle = await recorder.get_async_client()
+    sync_client = sync_handle.get()
+    async_client = await async_handle.get()
+
+    with pytest.raises(RuntimeError, match=r"await recorder\.aclose"):
+        recorder.close()
+
+    assert recorder._closed is False
+    assert sync_client.closed is False
+    assert async_client.closed is False
+
+    await recorder.aclose()
+
+    assert recorder._closed is True
+    assert sync_client.closed is True
+    assert async_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_closes_all_internally_owned_clients(monkeypatch):
+    instances: list[Any] = []
+
+    class FakeAsyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        async def initialize(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "AsyncHTTPClient", FakeAsyncHTTPClient)
+    middleware = OpenVikingContextMiddleware(url="http://localhost:1933")
+
+    await middleware.recorder.get_async_client()
+    await middleware.assembler.get_async_client()
+    await middleware.retriever.get_async_client()
+    assert len(instances) == 3
+
+    await middleware.aclose()
+
+    assert all(client.closed for client in instances)
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_does_not_close_injected_client():
+    client = AsyncInMemoryOpenVikingClient()
+    middleware = OpenVikingContextMiddleware(async_client=client)
+
+    await middleware.recorder.get_async_client()
+    await middleware.assembler.get_async_client()
+    await middleware.retriever.get_async_client()
+    await middleware.aclose()
+
+    assert client.closed is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Add native async execution across the existing LangChain and LangGraph integration adapters. Async applications can now retrieve context, record sessions, manage chat history, wrap runnables, and use LangGraph middleware without blocking the application event loop. Existing synchronous APIs and behavior remain unchanged.

Primary area: `openviking.integrations.langchain`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issues

- Follow-up to #3530, which established the shared session recorder.
- Related to #3546, the separate embedded-client singleton path bug. This PR does not depend on that core fix: `path=` adapters intentionally use `SyncOpenViking` through a worker thread and document the one-workspace-per-process constraint.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add async parity for session recording, chat history, retrieval, context assembly, runnable wrapping, and LangGraph middleware while reusing the existing batching, commit, retry, context-attribution, and capture logic.
- Use one internally managed HTTP client handle per adapter and event loop. Concurrent first use initializes once, safe reads can recover with a fresh client, and stale failures cannot evict a newer replacement.
- Preserve explicit ownership: injected clients and retrievers remain caller-owned; internally created clients are released through `aclose()`, including clients created on multiple event loops.
- Keep embedded `path=` behavior safe and non-blocking by dispatching the existing synchronous client through a worker thread. Native `AsyncOpenViking` remains available through explicit caller-owned injection.
- Handle cancellation and partial failure without reusing stale recalled-context attribution or duplicating confirmed session writes.
- Document the three async connection modes and lifecycle requirements in English and Chinese.

### Async connection contract

| Configuration | Async interface | Ownership |
| --- | --- | --- |
| `client=` or `async_client=` | Injected client returned unchanged | Caller |
| `url=`, or neither `url` nor `path` | Recovery-capable HTTP handle scoped to the current event loop | Adapter |
| `path=` | `SyncOpenViking` invoked in a worker thread | Adapter |

## Compatibility

- All existing synchronous entry points remain available.
- Constructor changes are additive keyword arguments.
- Injected clients are never closed by adapters.
- `OpenVikingSessionRecorder.close()` still supports synchronous and embedded use. If an internally owned HTTP async client exists, it raises without closing partial state so `await recorder.aclose()` can perform complete cleanup.

## Testing

- Focused LangChain/LangGraph suite: 142 passed.
- Full unit comparison: this branch produced 1,556 passed, 1 skipped, and 26 failed; pristine upstream `main` produced 1,524 passed, 1 skipped, and the same 26 failures in the same environment. The branch adds 32 passing unit tests without changing the upstream failure set.
- Ruff check and formatting, scoped mypy, and `git diff --check`: passed.
- Isolated live validation on macOS:
  - Started a real OpenViking server on a temporary workspace and free loopback port.
  - Ran `RunnableWithMessageHistory.ainvoke()` against a real model and verified two persisted/reloaded turns.
  - Ran LangGraph `create_agent().ainvoke()` against a real model and verified recalled context plus the captured user/assistant turn.
  - Removed the temporary server, workspace, and configuration after the run.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand concurrency and lifecycle behavior
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots

Not applicable.
