### PR TITLE
fix(memory): recover legacy/list LLM responses, fix silent empty adds (#3508)

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -832,6 +832,35 @@ The final output of the model must strictly follow the JSON Schema format shown 
             )
             return None
 
+        # Per-item tolerance: validate each item against its target type BEFORE the
+        # whole-batch validate. Without this, a single malformed item (e.g. a
+        # legacy item missing a required immutable field after key-cleaning) makes
+        # model_validate fail the ENTIRE memory_type bucket, losing every valid item
+        # alongside it — reproducing the very silent-drop this recovery exists to
+        # prevent. Drop only the bad items, keep the good ones.
+        for mt in list(bucketed.keys()):
+            items = bucketed[mt]
+            if not items:
+                continue
+            item_type = self._get_item_model_type(mt)
+            if item_type is None:
+                continue
+            kept: List[Dict[str, Any]] = []
+            for item in items:
+                try:
+                    item_type.model_validate(item, strict=False)
+                    kept.append(item)
+                except Exception:
+                    dropped += 1
+                    tracer.info(
+                        f"legacy recovery: dropped malformed {mt} item: {item!r}"
+                    )
+            bucketed[mt] = kept
+
+        if all(len(v) == 0 for v in bucketed.values()):
+            tracer.info(f"legacy recovery: every item failed per-item validation (dropped {dropped})")
+            return None
+
         try:
             recovered = self._operations_model.model_validate(bucketed, strict=False)
         except Exception as exc:

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -777,9 +777,11 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         # Gather a flat list of item dicts.
         if isinstance(raw, dict):
-            # If it already carries an expected top-level field, the normal path
-            # should have handled it; nothing to recover here.
-            if any(k in raw for k in (self._expected_fields or [])):
+            # If it already carries an expected top-level field *as a list* (the
+            # conforming per-type operations shape), the normal path handled it.
+            # Only a list value counts — a stray {"entities": "some string"} must
+            # NOT short-circuit recovery of a sibling envelope (e.g. "memories").
+            if any(isinstance(raw.get(k), list) for k in (self._expected_fields or [])):
                 return None
             # Otherwise look for the single list-of-dicts field (e.g. "memories").
             item_lists = [

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -875,6 +875,22 @@ The final output of the model must strictly follow the JSON Schema format shown 
         )
         return recovered
 
+    def _get_item_model_type(self, memory_type: str) -> Optional[Any]:
+        """Return the per-item Pydantic model for a memory_type field, or None.
+
+        The structured operations model stores each memory_type as ``List[FlatModel]``;
+        this pulls out ``FlatModel`` so callers can validate items individually
+        (used by legacy recovery to tolerate one bad item without losing the batch).
+        """
+        model = self._operations_model
+        if model is None:
+            return None
+        field = model.model_fields.get(memory_type)
+        if field is None:
+            return None
+        args = getattr(field.annotation, "__args__", ())
+        return args[0] if args else None
+
     @staticmethod
     def _singularize_type(name: str) -> str:
         """Canonicalize a memory_type or discriminator to a singular lowercased form."""

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -1158,6 +1158,24 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     )
                     return (None, None)
 
+                # #3508: a non-conforming response (root JSON list or a legacy
+                # envelope like {"memories": [...]} / {"current_status": ...,
+                # "memories": [...]}) parses "successfully" but to an *empty*
+                # operation set, because the generic parser drops every key not
+                # in the dynamic top-level schema fields. Recover the memory
+                # items by routing them into the matching memory_type field so
+                # they are no longer silently lost. Conforming responses are
+                # unaffected: this only fires when the normal parse came back
+                # empty despite non-empty content.
+                if (
+                    operations is not None
+                    and callable(getattr(operations, "is_empty", None))
+                    and operations.is_empty()
+                ):
+                    recovered = self._recover_legacy_operations(content)
+                    if recovered is not None and not recovered.is_empty():
+                        operations = recovered
+
                 return (None, operations)
             except Exception as e:
                 logger.exception(f"Error parsing operations: {e}")
@@ -1171,6 +1189,190 @@ The final output of the model must strictly follow the JSON Schema format shown 
             f"response_preview={_preview_text(self._last_llm_failure_content)!r}"
         )
         return (None, None)
+
+    def _recover_legacy_operations(self, content: str) -> Optional[Any]:
+        """
+        Best-effort recovery for non-conforming LLM responses (#3508).
+
+        Local models (e.g. llama.cpp) sometimes return memory items as a root
+        JSON list ``[{...}, {...}]`` or wrapped in a legacy envelope
+        (``{"memories": [...]}`` / ``{"current_status": ..., "memories": [...]}``)
+        instead of the expected per-type operations object
+        (``{"entities": [...], "preferences": [...]}``).
+
+        The generic ``parse_json_with_stability`` reduces a root list to its
+        first item and filters out every non-top-level key, silently yielding
+        empty operations. This method re-routes such items into the matching
+        ``memory_type`` field: by item discriminator when several schemas are
+        active, or into the single active schema otherwise. It only runs after
+        a successful parse produced an empty operation set, so conforming
+        responses are unaffected.
+
+        Returns a validated ``StructuredMemoryOperations`` instance, or ``None``
+        if the response could not be coerced.
+        """
+        try:
+            import json_repair
+
+            from openviking.session.memory.utils.json_parser import extract_json_content
+
+            raw = json_repair.loads(extract_json_content(content) or content)
+        except Exception as exc:
+            tracer.info(f"legacy recovery: raw parse failed: {exc}")
+            return None
+
+        # Gather a flat list of item dicts.
+        if isinstance(raw, dict):
+            # If it already carries an expected top-level field *as a list* (the
+            # conforming per-type operations shape), the normal path handled it.
+            # Only a list value counts — a stray {"entities": "some string"} must
+            # NOT short-circuit recovery of a sibling envelope (e.g. "memories").
+            if any(isinstance(raw.get(k), list) for k in (self._expected_fields or [])):
+                return None
+            # Otherwise look for the single list-of-dicts field (e.g. "memories").
+            item_lists = [
+                v
+                for v in raw.values()
+                if isinstance(v, list) and v and all(isinstance(x, dict) for x in v)
+            ]
+            if len(item_lists) != 1:
+                return None
+            items = item_lists[0]
+        elif isinstance(raw, list):
+            items = [x for x in raw if isinstance(x, dict)]
+        else:
+            return None
+
+        if not items:
+            return None
+
+        schemas = self.context_provider.get_memory_schemas(self.ctx)
+        active_types = [s.memory_type for s in schemas]
+        if not active_types or self._operations_model is None:
+            return None
+
+        single_type = active_types[0] if len(active_types) == 1 else None
+        # Drop keys the target schema does not know (the model uses extra="ignore",
+        # but cleaning keeps tracer output readable and avoids surprising merges).
+        allowed_fields = {s.memory_type: {f.name for f in s.fields} for s in schemas}
+
+        bucketed: Dict[str, List[Dict[str, Any]]] = {mt: [] for mt in active_types}
+        next_page_id = 100
+        dropped = 0
+        for item in items:
+            mt = single_type or self._match_memory_type(item, active_types)
+            if mt is None:
+                dropped += 1
+                continue
+            allowed = allowed_fields.get(mt, set())
+            clean = {k: v for k, v in item.items() if k in allowed}
+            # page_id is required by every item model; legacy items lack it.
+            clean.setdefault("page_id", next_page_id)
+            next_page_id += 1
+            bucketed[mt].append(clean)
+
+        if all(len(v) == 0 for v in bucketed.values()):
+            tracer.info(
+                f"legacy recovery: no items matched active types {active_types} "
+                f"(dropped {dropped})"
+            )
+            return None
+
+        # Per-item tolerance: validate each item against its target type BEFORE the
+        # whole-batch validate. Without this, a single malformed item (e.g. a
+        # legacy item missing a required immutable field after key-cleaning) makes
+        # model_validate fail the ENTIRE memory_type bucket, losing every valid item
+        # alongside it — reproducing the very silent-drop this recovery exists to
+        # prevent. Drop only the bad items, keep the good ones.
+        for mt in list(bucketed.keys()):
+            items = bucketed[mt]
+            if not items:
+                continue
+            item_type = self._get_item_model_type(mt)
+            if item_type is None:
+                continue
+            kept: List[Dict[str, Any]] = []
+            for item in items:
+                try:
+                    item_type.model_validate(item, strict=False)
+                    kept.append(item)
+                except Exception:
+                    dropped += 1
+                    tracer.info(
+                        f"legacy recovery: dropped malformed {mt} item: {item!r}"
+                    )
+            bucketed[mt] = kept
+
+        if all(len(v) == 0 for v in bucketed.values()):
+            tracer.info(f"legacy recovery: every item failed per-item validation (dropped {dropped})")
+            return None
+
+        try:
+            recovered = self._operations_model.model_validate(bucketed, strict=False)
+        except Exception as exc:
+            tracer.info(
+                f"legacy recovery: validation failed for { {mt: len(v) for mt, v in bucketed.items() if v} }: {exc}"
+            )
+            return None
+
+        tracer.info(
+            "legacy recovery: routed items into "
+            f"{ {mt: len(v) for mt, v in bucketed.items() if v} } (dropped {dropped})"
+        )
+        return recovered
+
+    def _get_item_model_type(self, memory_type: str) -> Optional[Any]:
+        """Return the per-item Pydantic model for a memory_type field, or None.
+
+        The structured operations model stores each memory_type as ``List[FlatModel]``;
+        this pulls out ``FlatModel`` so callers can validate items individually
+        (used by legacy recovery to tolerate one bad item without losing the batch).
+        """
+        model = self._operations_model
+        if model is None:
+            return None
+        field = model.model_fields.get(memory_type)
+        if field is None:
+            return None
+        args = getattr(field.annotation, "__args__", ())
+        return args[0] if args else None
+
+    @staticmethod
+    def _singularize_type(name: str) -> str:
+        """Canonicalize a memory_type or discriminator to a singular lowercased form."""
+        n = name.strip().lower()
+        if n.endswith("ies"):
+            return n[:-3] + "y"  # entities -> entity
+        if n.endswith("s") and not n.endswith("ss"):
+            return n[:-1]  # preferences -> preference, cases -> case
+        return n
+
+    def _match_memory_type(
+        self, item: Dict[str, Any], active_types: List[str]
+    ) -> Optional[str]:
+        """
+        Map a legacy item's type discriminator to an active ``memory_type``.
+
+        Recognizes the keys ``memory_type`` / ``type`` / ``kind`` and matches
+        case-insensitively, tolerating singular vs plural differences
+        (``entity`` -> ``entities``, ``preference`` -> ``preferences``).
+        Returns ``None`` when no active type matches.
+        """
+        disc: Optional[str] = None
+        for key in ("memory_type", "type", "kind"):
+            val = item.get(key)
+            if isinstance(val, str) and val.strip():
+                disc = val.strip()
+                break
+        if not disc:
+            return None
+        disc_norm = self._singularize_type(disc)
+        for t in active_types:
+            if t.strip().lower() == disc.strip().lower():
+                return t
+            if self._singularize_type(t) == disc_norm:
+                return t
+        return None
 
     async def _check_unread_existing_files(self, operations: ResolvedOperations) -> Dict:
         refetch_uris = {}

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -712,6 +712,24 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     )
                     return (None, None)
 
+                # #3508: a non-conforming response (root JSON list or a legacy
+                # envelope like {"memories": [...]} / {"current_status": ...,
+                # "memories": [...]}) parses "successfully" but to an *empty*
+                # operation set, because the generic parser drops every key not
+                # in the dynamic top-level schema fields. Recover the memory
+                # items by routing them into the matching memory_type field so
+                # they are no longer silently lost. Conforming responses are
+                # unaffected: this only fires when the normal parse came back
+                # empty despite non-empty content.
+                if (
+                    operations is not None
+                    and callable(getattr(operations, "is_empty", None))
+                    and operations.is_empty()
+                ):
+                    recovered = self._recover_legacy_operations(content)
+                    if recovered is not None and not recovered.is_empty():
+                        operations = recovered
+
                 return (None, operations)
             except Exception as e:
                 logger.exception(f"Error parsing operations: {e}")
@@ -725,6 +743,143 @@ The final output of the model must strictly follow the JSON Schema format shown 
             f"response_preview={_preview_text(self._last_llm_failure_content)!r}"
         )
         return (None, None)
+
+    def _recover_legacy_operations(self, content: str) -> Optional[Any]:
+        """
+        Best-effort recovery for non-conforming LLM responses (#3508).
+
+        Local models (e.g. llama.cpp) sometimes return memory items as a root
+        JSON list ``[{...}, {...}]`` or wrapped in a legacy envelope
+        (``{"memories": [...]}`` / ``{"current_status": ..., "memories": [...]}``)
+        instead of the expected per-type operations object
+        (``{"entities": [...], "preferences": [...]}``).
+
+        The generic ``parse_json_with_stability`` reduces a root list to its
+        first item and filters out every non-top-level key, silently yielding
+        empty operations. This method re-routes such items into the matching
+        ``memory_type`` field: by item discriminator when several schemas are
+        active, or into the single active schema otherwise. It only runs after
+        a successful parse produced an empty operation set, so conforming
+        responses are unaffected.
+
+        Returns a validated ``StructuredMemoryOperations`` instance, or ``None``
+        if the response could not be coerced.
+        """
+        try:
+            import json_repair
+
+            from openviking.session.memory.utils.json_parser import extract_json_content
+
+            raw = json_repair.loads(extract_json_content(content) or content)
+        except Exception as exc:
+            tracer.info(f"legacy recovery: raw parse failed: {exc}")
+            return None
+
+        # Gather a flat list of item dicts.
+        if isinstance(raw, dict):
+            # If it already carries an expected top-level field, the normal path
+            # should have handled it; nothing to recover here.
+            if any(k in raw for k in (self._expected_fields or [])):
+                return None
+            # Otherwise look for the single list-of-dicts field (e.g. "memories").
+            item_lists = [
+                v
+                for v in raw.values()
+                if isinstance(v, list) and v and all(isinstance(x, dict) for x in v)
+            ]
+            if len(item_lists) != 1:
+                return None
+            items = item_lists[0]
+        elif isinstance(raw, list):
+            items = [x for x in raw if isinstance(x, dict)]
+        else:
+            return None
+
+        if not items:
+            return None
+
+        schemas = self.context_provider.get_memory_schemas(self.ctx)
+        active_types = [s.memory_type for s in schemas]
+        if not active_types or self._operations_model is None:
+            return None
+
+        single_type = active_types[0] if len(active_types) == 1 else None
+        # Drop keys the target schema does not know (the model uses extra="ignore",
+        # but cleaning keeps tracer output readable and avoids surprising merges).
+        allowed_fields = {s.memory_type: {f.name for f in s.fields} for s in schemas}
+
+        bucketed: Dict[str, List[Dict[str, Any]]] = {mt: [] for mt in active_types}
+        next_page_id = 100
+        dropped = 0
+        for item in items:
+            mt = single_type or self._match_memory_type(item, active_types)
+            if mt is None:
+                dropped += 1
+                continue
+            allowed = allowed_fields.get(mt, set())
+            clean = {k: v for k, v in item.items() if k in allowed}
+            # page_id is required by every item model; legacy items lack it.
+            clean.setdefault("page_id", next_page_id)
+            next_page_id += 1
+            bucketed[mt].append(clean)
+
+        if all(len(v) == 0 for v in bucketed.values()):
+            tracer.info(
+                f"legacy recovery: no items matched active types {active_types} "
+                f"(dropped {dropped})"
+            )
+            return None
+
+        try:
+            recovered = self._operations_model.model_validate(bucketed, strict=False)
+        except Exception as exc:
+            tracer.info(
+                f"legacy recovery: validation failed for { {mt: len(v) for mt, v in bucketed.items() if v} }: {exc}"
+            )
+            return None
+
+        tracer.info(
+            "legacy recovery: routed items into "
+            f"{ {mt: len(v) for mt, v in bucketed.items() if v} } (dropped {dropped})"
+        )
+        return recovered
+
+    @staticmethod
+    def _singularize_type(name: str) -> str:
+        """Canonicalize a memory_type or discriminator to a singular lowercased form."""
+        n = name.strip().lower()
+        if n.endswith("ies"):
+            return n[:-3] + "y"  # entities -> entity
+        if n.endswith("s") and not n.endswith("ss"):
+            return n[:-1]  # preferences -> preference, cases -> case
+        return n
+
+    def _match_memory_type(
+        self, item: Dict[str, Any], active_types: List[str]
+    ) -> Optional[str]:
+        """
+        Map a legacy item's type discriminator to an active ``memory_type``.
+
+        Recognizes the keys ``memory_type`` / ``type`` / ``kind`` and matches
+        case-insensitively, tolerating singular vs plural differences
+        (``entity`` -> ``entities``, ``preference`` -> ``preferences``).
+        Returns ``None`` when no active type matches.
+        """
+        disc: Optional[str] = None
+        for key in ("memory_type", "type", "kind"):
+            val = item.get(key)
+            if isinstance(val, str) and val.strip():
+                disc = val.strip()
+                break
+        if not disc:
+            return None
+        disc_norm = self._singularize_type(disc)
+        for t in active_types:
+            if t.strip().lower() == disc.strip().lower():
+                return t
+            if self._singularize_type(t) == disc_norm:
+                return t
+        return None
 
     async def _check_unread_existing_files(self, operations: ResolvedOperations) -> Dict:
         refetch_uris = {}

--- a/tests/session/memory/test_legacy_response_recovery.py
+++ b/tests/session/memory/test_legacy_response_recovery.py
@@ -193,3 +193,38 @@ class TestSingularizeType:
         assert ExtractLoop._singularize_type("cases") == "case"
         assert ExtractLoop._singularize_type("profile") == "profile"
         assert ExtractLoop._singularize_type("Entities") == "entity"
+
+
+class TestAdversaryRegression:
+    """Regression tests from same-model adversarial review (per-item tolerance)."""
+
+    def test_one_bad_item_does_not_poison_the_batch(self):
+        """A single malformed item must not lose the valid items in the same type."""
+        loop = _make_loop([_preferences_schema()])
+        # 2 valid preferences + 1 junk (no user/topic -> missing required immutable).
+        content = (
+            '[{"user": "alice", "topic": "drink", "content": "coffee"}, '
+            '{"user": "bob", "topic": "editor", "content": "vscode"}, '
+            '{"type": "entity", "name": "stray"}]'
+        )
+        recovered = loop._recover_legacy_operations(content)
+        assert recovered is not None
+        # Both valid preferences survive; the junk item is dropped, not the batch.
+        assert len(recovered.preferences) == 2
+        topics = {p.topic for p in recovered.preferences}
+        assert topics == {"drink", "editor"}
+
+    def test_envelope_with_non_list_expected_field_is_not_short_circuited(self):
+        """A stray {expected_field: non-list} must not skip a sibling envelope."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        # "preferences" is an expected field but a STRING, not a list -> must NOT
+        # short-circuit; the "memories" envelope must still be recovered.
+        content = (
+            '{"preferences": "user likes tea", "memories": ['
+            '{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "admin"}]}'
+        )
+        recovered = loop._recover_legacy_operations(content)
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+        assert recovered.entities[0].name == "sinking"

--- a/tests/session/memory/test_legacy_response_recovery.py
+++ b/tests/session/memory/test_legacy_response_recovery.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Regression tests for legacy / non-conforming LLM response recovery (#3508).
+
+Local models (e.g. llama.cpp) may return memory items as a root JSON list or a
+legacy envelope (``{"memories": [...]}``) instead of the expected per-type
+operations object. ``ExtractLoop._recover_legacy_operations`` re-routes such
+items into the matching ``memory_type`` field so they are not silently dropped.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.session.memory.dataclass import MemoryField, MemoryTypeSchema
+from openviking.session.memory.extract_loop import ExtractLoop
+from openviking.session.memory.merge_op import MergeOp
+from openviking.session.memory.merge_op.base import FieldType
+from openviking.session.memory.schema_model_generator import SchemaModelGenerator
+
+
+def _field(name: str, merge_op: MergeOp = MergeOp.PATCH) -> MemoryField:
+    return MemoryField(name=name, field_type=FieldType.STRING, merge_op=merge_op)
+
+
+def _preferences_schema() -> MemoryTypeSchema:
+    return MemoryTypeSchema(
+        memory_type="preferences",
+        fields=[
+            _field("user", MergeOp.IMMUTABLE),
+            _field("topic", MergeOp.IMMUTABLE),
+            _field("content", MergeOp.PATCH),
+        ],
+    )
+
+
+def _entities_schema() -> MemoryTypeSchema:
+    return MemoryTypeSchema(
+        memory_type="entities",
+        fields=[
+            _field("category", MergeOp.IMMUTABLE),
+            _field("name", MergeOp.IMMUTABLE),
+            _field("content", MergeOp.PATCH),
+        ],
+    )
+
+
+def _mock_config(link_enabled: bool = False):
+    """Mock get_openviking_config so tests don't need an ov.conf file."""
+    cfg = type("Cfg", (), {"memory": type("Mem", (), {"link_enabled": link_enabled})()})
+    return cfg
+
+
+def _make_loop(schemas):
+    """Build an ExtractLoop shell wired only enough for recovery."""
+    gen = SchemaModelGenerator(list(schemas), template_context={"language": "en"})
+    gen.generate_all_models()
+    with patch(
+        "openviking_cli.utils.config.get_openviking_config", return_value=_mock_config()
+    ):
+        ops_model = gen.create_structured_operations_model(role_scope=None)
+
+    loop = object.__new__(ExtractLoop)
+    loop.ctx = None
+    loop._operations_model = ops_model
+    # Mirror ExtractLoop.run(): top-level fields are the active memory_types
+    # (links/delete_ids are handled separately and not part of expected_fields).
+    loop._expected_fields = [s.memory_type for s in schemas]
+
+    provider = MagicMock()
+    provider.get_memory_schemas.return_value = list(schemas)
+    loop.context_provider = provider
+    return loop
+
+
+class TestLegacyResponseRecovery:
+    """Tests for ExtractLoop._recover_legacy_operations (#3508)."""
+
+    def test_root_list_routed_by_type_discriminator(self):
+        """A root list of typed items is bucketed into the right memory_type."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        content = (
+            '[{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "admin"}, {"type": "preference", "user": "sinking", '
+            '"topic": "drink", "content": "- likes black tea"}]'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert not recovered.is_empty()
+        assert len(recovered.entities) == 1
+        assert len(recovered.preferences) == 1
+        assert recovered.entities[0].name == "sinking"
+        assert recovered.preferences[0].topic == "drink"
+
+    def test_legacy_memories_envelope_is_unwrapped(self):
+        """The legacy {current_status, memories:[...]} envelope is recovered."""
+        loop = _make_loop([_entities_schema()])
+        content = (
+            '{"current_status": "测试", "memories": ['
+            '{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "likes black tea"}]}'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+        assert recovered.entities[0].content == "likes black tea"
+
+    def test_single_active_schema_routes_untyped_items(self):
+        """With one active schema, untyped root-list items route to it."""
+        loop = _make_loop([_preferences_schema()])
+        content = (
+            '[{"user": "sinking", "topic": "drink", "content": "- tea"}, '
+            '{"user": "sinking", "topic": "editor", "content": "- vscode"}]'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert len(recovered.preferences) == 2
+        topics = {p.topic for p in recovered.preferences}
+        assert topics == {"drink", "editor"}
+
+    def test_singular_plural_discriminator_matching(self):
+        """Singular 'entity'/'preference' map to plural memory_types."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+
+        # Singular discriminators.
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "entity", "category": "c", "name": "n", "content": "x"}]'
+        )
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "preference", "user": "u", "topic": "t", "content": "x"}]'
+        )
+        assert recovered is not None
+        assert len(recovered.preferences) == 1
+
+    def test_page_id_auto_assigned_when_missing(self):
+        """Legacy items lacking page_id get synthetic ids >= 100."""
+        loop = _make_loop([_entities_schema()])
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "entity", "category": "c", "name": "n1", "content": "a"},'
+            ' {"type": "entity", "category": "c", "name": "n2", "content": "b"}]'
+        )
+        assert recovered is not None
+        ids = [e.page_id for e in recovered.entities]
+        assert all(i >= 100 for i in ids)
+        assert len(set(ids)) == 2  # unique
+
+    def test_conforming_response_is_not_recovered(self):
+        """A dict already carrying an expected top-level field is left alone."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        # Already a proper operations object -> recovery must return None.
+        content = (
+            '{"preferences": [{"page_id": 100, "user": "u", "topic": "t", '
+            '"content": "x"}]}'
+        )
+        assert loop._recover_legacy_operations(content) is None
+
+    def test_unmatched_items_yield_none(self):
+        """Items whose type matches no active schema yield no recovery."""
+        loop = _make_loop([_preferences_schema()])
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "unknown_thing", "foo": "bar"}]'
+        )
+        assert recovered is None
+
+    def test_empty_or_non_json_returns_none(self):
+        loop = _make_loop([_preferences_schema()])
+        assert loop._recover_legacy_operations("") is None
+        assert loop._recover_legacy_operations("not json at all") is None
+        assert loop._recover_legacy_operations("[]") is None
+        assert loop._recover_legacy_operations("{}") is None
+
+    def test_envelope_with_multiple_list_fields_not_guessed(self):
+        """Ambiguous envelopes (several list fields) are not blindly guessed."""
+        loop = _make_loop([_preferences_schema()])
+        content = (
+            '{"a": [{"x": 1}], "b": [{"y": 2}]}'  # two list-of-dicts fields
+        )
+        assert loop._recover_legacy_operations(content) is None
+
+
+class TestSingularizeType:
+    def test_plural_and_ies_forms(self):
+        assert ExtractLoop._singularize_type("entities") == "entity"
+        assert ExtractLoop._singularize_type("preferences") == "preference"
+        assert ExtractLoop._singularize_type("cases") == "case"
+        assert ExtractLoop._singularize_type("profile") == "profile"
+        assert ExtractLoop._singularize_type("Entities") == "entity"
+
+
+class TestAdversaryRegression:
+    """Regression tests from same-model adversarial review (per-item tolerance)."""
+
+    def test_one_bad_item_does_not_poison_the_batch(self):
+        """A single malformed item must not lose the valid items in the same type."""
+        loop = _make_loop([_preferences_schema()])
+        # 2 valid preferences + 1 junk (no user/topic -> missing required immutable).
+        content = (
+            '[{"user": "alice", "topic": "drink", "content": "coffee"}, '
+            '{"user": "bob", "topic": "editor", "content": "vscode"}, '
+            '{"type": "entity", "name": "stray"}]'
+        )
+        recovered = loop._recover_legacy_operations(content)
+        assert recovered is not None
+        # Both valid preferences survive; the junk item is dropped, not the batch.
+        assert len(recovered.preferences) == 2
+        topics = {p.topic for p in recovered.preferences}
+        assert topics == {"drink", "editor"}
+
+    def test_envelope_with_non_list_expected_field_is_not_short_circuited(self):
+        """A stray {expected_field: non-list} must not skip a sibling envelope."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        # "preferences" is an expected field but a STRING, not a list -> must NOT
+        # short-circuit; the "memories" envelope must still be recovered.
+        content = (
+            '{"preferences": "user likes tea", "memories": ['
+            '{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "admin"}]}'
+        )
+        recovered = loop._recover_legacy_operations(content)
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+        assert recovered.entities[0].name == "sinking"

--- a/tests/session/memory/test_legacy_response_recovery.py
+++ b/tests/session/memory/test_legacy_response_recovery.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""
+Regression tests for legacy / non-conforming LLM response recovery (#3508).
+
+Local models (e.g. llama.cpp) may return memory items as a root JSON list or a
+legacy envelope (``{"memories": [...]}``) instead of the expected per-type
+operations object. ``ExtractLoop._recover_legacy_operations`` re-routes such
+items into the matching ``memory_type`` field so they are not silently dropped.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from openviking.session.memory.dataclass import MemoryField, MemoryTypeSchema
+from openviking.session.memory.extract_loop import ExtractLoop
+from openviking.session.memory.merge_op import MergeOp
+from openviking.session.memory.merge_op.base import FieldType
+from openviking.session.memory.schema_model_generator import SchemaModelGenerator
+
+
+def _field(name: str, merge_op: MergeOp = MergeOp.PATCH) -> MemoryField:
+    return MemoryField(name=name, field_type=FieldType.STRING, merge_op=merge_op)
+
+
+def _preferences_schema() -> MemoryTypeSchema:
+    return MemoryTypeSchema(
+        memory_type="preferences",
+        fields=[
+            _field("user", MergeOp.IMMUTABLE),
+            _field("topic", MergeOp.IMMUTABLE),
+            _field("content", MergeOp.PATCH),
+        ],
+    )
+
+
+def _entities_schema() -> MemoryTypeSchema:
+    return MemoryTypeSchema(
+        memory_type="entities",
+        fields=[
+            _field("category", MergeOp.IMMUTABLE),
+            _field("name", MergeOp.IMMUTABLE),
+            _field("content", MergeOp.PATCH),
+        ],
+    )
+
+
+def _mock_config(link_enabled: bool = False):
+    """Mock get_openviking_config so tests don't need an ov.conf file."""
+    cfg = type("Cfg", (), {"memory": type("Mem", (), {"link_enabled": link_enabled})()})
+    return cfg
+
+
+def _make_loop(schemas):
+    """Build an ExtractLoop shell wired only enough for recovery."""
+    gen = SchemaModelGenerator(list(schemas), template_context={"language": "en"})
+    gen.generate_all_models()
+    with patch(
+        "openviking_cli.utils.config.get_openviking_config", return_value=_mock_config()
+    ):
+        ops_model = gen.create_structured_operations_model(role_scope=None)
+
+    loop = object.__new__(ExtractLoop)
+    loop.ctx = None
+    loop._operations_model = ops_model
+    # Mirror ExtractLoop.run(): top-level fields are the active memory_types
+    # (links/delete_ids are handled separately and not part of expected_fields).
+    loop._expected_fields = [s.memory_type for s in schemas]
+
+    provider = MagicMock()
+    provider.get_memory_schemas.return_value = list(schemas)
+    loop.context_provider = provider
+    return loop
+
+
+class TestLegacyResponseRecovery:
+    """Tests for ExtractLoop._recover_legacy_operations (#3508)."""
+
+    def test_root_list_routed_by_type_discriminator(self):
+        """A root list of typed items is bucketed into the right memory_type."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        content = (
+            '[{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "admin"}, {"type": "preference", "user": "sinking", '
+            '"topic": "drink", "content": "- likes black tea"}]'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert not recovered.is_empty()
+        assert len(recovered.entities) == 1
+        assert len(recovered.preferences) == 1
+        assert recovered.entities[0].name == "sinking"
+        assert recovered.preferences[0].topic == "drink"
+
+    def test_legacy_memories_envelope_is_unwrapped(self):
+        """The legacy {current_status, memories:[...]} envelope is recovered."""
+        loop = _make_loop([_entities_schema()])
+        content = (
+            '{"current_status": "测试", "memories": ['
+            '{"type": "entity", "category": "people", "name": "sinking", '
+            '"content": "likes black tea"}]}'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+        assert recovered.entities[0].content == "likes black tea"
+
+    def test_single_active_schema_routes_untyped_items(self):
+        """With one active schema, untyped root-list items route to it."""
+        loop = _make_loop([_preferences_schema()])
+        content = (
+            '[{"user": "sinking", "topic": "drink", "content": "- tea"}, '
+            '{"user": "sinking", "topic": "editor", "content": "- vscode"}]'
+        )
+
+        recovered = loop._recover_legacy_operations(content)
+
+        assert recovered is not None
+        assert len(recovered.preferences) == 2
+        topics = {p.topic for p in recovered.preferences}
+        assert topics == {"drink", "editor"}
+
+    def test_singular_plural_discriminator_matching(self):
+        """Singular 'entity'/'preference' map to plural memory_types."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+
+        # Singular discriminators.
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "entity", "category": "c", "name": "n", "content": "x"}]'
+        )
+        assert recovered is not None
+        assert len(recovered.entities) == 1
+
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "preference", "user": "u", "topic": "t", "content": "x"}]'
+        )
+        assert recovered is not None
+        assert len(recovered.preferences) == 1
+
+    def test_page_id_auto_assigned_when_missing(self):
+        """Legacy items lacking page_id get synthetic ids >= 100."""
+        loop = _make_loop([_entities_schema()])
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "entity", "category": "c", "name": "n1", "content": "a"},'
+            ' {"type": "entity", "category": "c", "name": "n2", "content": "b"}]'
+        )
+        assert recovered is not None
+        ids = [e.page_id for e in recovered.entities]
+        assert all(i >= 100 for i in ids)
+        assert len(set(ids)) == 2  # unique
+
+    def test_conforming_response_is_not_recovered(self):
+        """A dict already carrying an expected top-level field is left alone."""
+        loop = _make_loop([_preferences_schema(), _entities_schema()])
+        # Already a proper operations object -> recovery must return None.
+        content = (
+            '{"preferences": [{"page_id": 100, "user": "u", "topic": "t", '
+            '"content": "x"}]}'
+        )
+        assert loop._recover_legacy_operations(content) is None
+
+    def test_unmatched_items_yield_none(self):
+        """Items whose type matches no active schema yield no recovery."""
+        loop = _make_loop([_preferences_schema()])
+        recovered = loop._recover_legacy_operations(
+            '[{"type": "unknown_thing", "foo": "bar"}]'
+        )
+        assert recovered is None
+
+    def test_empty_or_non_json_returns_none(self):
+        loop = _make_loop([_preferences_schema()])
+        assert loop._recover_legacy_operations("") is None
+        assert loop._recover_legacy_operations("not json at all") is None
+        assert loop._recover_legacy_operations("[]") is None
+        assert loop._recover_legacy_operations("{}") is None
+
+    def test_envelope_with_multiple_list_fields_not_guessed(self):
+        """Ambiguous envelopes (several list fields) are not blindly guessed."""
+        loop = _make_loop([_preferences_schema()])
+        content = (
+            '{"a": [{"x": 1}], "b": [{"y": 2}]}'  # two list-of-dicts fields
+        )
+        assert loop._recover_legacy_operations(content) is None
+
+
+class TestSingularizeType:
+    def test_plural_and_ies_forms(self):
+        assert ExtractLoop._singularize_type("entities") == "entity"
+        assert ExtractLoop._singularize_type("preferences") == "preference"
+        assert ExtractLoop._singularize_type("cases") == "case"
+        assert ExtractLoop._singularize_type("profile") == "profile"
+        assert ExtractLoop._singularize_type("Entities") == "entity"


### PR DESCRIPTION
## What & why

Closes #3508 (partial — see open question below).

When a local model (e.g. llama.cpp) returns memory items as a **root JSON list** or a **legacy envelope** (`{"memories": [...]}` / `{"current_status": ..., "memories": [...]}`) instead of the expected per-type operations object (`{"entities": [...], "preferences": [...]}`), `parse_json_with_stability` reduces a root list to its first item and then `expected_fields` filtering drops every key that isn't a current top-level schema field. The result validates successfully against default-empty lists — `error=None`, `memory_diff.json` shows `"adds": []` — so memory content is **silently lost**.

This is exactly the failure mode @huangruiteng traced on `main`: a successful parse to an empty operation set with no parse error.

## Approach (domain layer, not the generic parser)

Per @huangruiteng's note that hard-coding `{"memories": parsed_data}` would not match current dynamic top-level fields (`preferences` / `profile` / `events` / `entities` / …), the fix lives in `ExtractLoop` (domain), not in the shared `json_parser`.

`ExtractLoop._recover_legacy_operations` runs **only after a successful parse produced an empty operation set** (conforming responses are completely unaffected):

1. Re-parse the raw content and gather a flat item list — from a root list, or from the single list-of-dicts field of a legacy envelope (ambiguous envelopes with several list fields are not guessed).
2. Route each item into the matching `memory_type`: single active schema → route all items there; multiple schemas → match by discriminator (`type`/`kind`/`memory_type`), singular⇄plural tolerant.
3. Synthesize the required `page_id` (≥100, unique).
4. Drop unknown keys, re-validate against the operations model.
5. Unmatched items are logged, not silently dropped.

## Tests — 10/10 pass under real pytest

`tests/session/memory/test_legacy_response_recovery.py`: root-list routing, legacy envelope unwrap, single-schema fallback, singular/plural matching, page_id auto-assignment, conforming-response no-op, unmatched→None, ambiguous-envelope no-guess, empty/non-JSON, singularize unit. **Verified locally with the full pytest suite (incl. conftest) — 10 passed.**

## Honest limitations / open question

- Legacy items (`{content, type}`) don't carry the full field set current schemas expect; after recovery these fall back to defaults — items are no longer lost, but not as complete as a schema-conforming response. Durable fix remains upgrading custom/old templates to the dynamic-schema contract.
- **Question:** is "single active schema → route all" acceptable, or should recovery require an explicit discriminator even then? Happy to gate behind a config flag.

This contribution was developed with AI assistance. Draft until maintainers confirm the routing policy.

Refs #3508