### PR TITLE
feat(openclaw-plugin): support SecretRef for config.apiKey (#3522)

### DIFF
--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -232,7 +232,7 @@ openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer
 - 如果配置中已有 `plugins.allow`，把 `openviking` 追加进去；如果没有，不要仅为本插件新建 allowlist。
 - `contextEngine` 是独占 slot；若已有其他 context engine，只有确认替换后再修改该字段。使用 root API key 时，还需在 `config` 中设置 `accountId` 和 `userId`。
 - 容器连接其他服务时，`baseUrl` 应使用容器内可访问的服务地址，而不是 `127.0.0.1`。
-- `apiKey` 会以明文保存；请限制文件权限或使用受控的 Secret 卷。修改后重启 Gateway、容器或 Pod。
+- `apiKey` 既接受明文字符串（支持 `${ENV_VAR}` 插值），也接受通过 OpenClaw 秘密解析路径解析的 `SecretRef` 对象。为避免在 `openclaw.json` 中明文存储 key，推荐使用 `SecretRef`（详见 [为 apiKey 使用秘密引用](#为-apikey-使用秘密引用)）。若仍使用明文字符串，请限制文件权限或使用受控的 Secret 卷，修改后重启 Gateway、容器或 Pod。
 
 ### 3. 重启 OpenClaw Gateway
 
@@ -308,6 +308,59 @@ openclaw openviking setup --reconfigure
 ```bash
 openclaw config get plugins.entries.openviking.config
 ```
+
+## 为 apiKey 使用秘密引用
+
+为避免把 OpenViking API key 以明文写在 `openclaw.json` 中，`config.apiKey` 支持以 `SecretRef` 对象形式配置，与 OpenClaw 核心 provider 配置（LLM/TTS/MCP）使用的凭据字段形状一致：
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openviking": {
+        "enabled": true,
+        "config": {
+          "mode": "remote",
+          "baseUrl": "http://openviking:1933",
+          "apiKey": { "source": "env", "id": "OPENVIKING_API_KEY" }
+        }
+      }
+    }
+  }
+}
+```
+
+`source` 取值：
+
+| `source` | `id` | 行为 |
+| --- | --- | --- |
+| `env` | 环境变量名 | 读取该环境变量；未设置或为空时报错。 |
+| `file` | 文件路径（支持 `~` 展开） | 读取文件内容（UTF-8，去掉末尾换行/空白）；缺失或为空时报错。 |
+| `exec` | provider 专属秘密引用 | 委托给 `provider` 指定的秘密 provider 插件（如 `@transmitt0r/openclaw-plugin-onepassword`）。需先安装该插件并注册为 exec resolver。 |
+
+示例：
+
+```jsonc
+// 环境变量
+"apiKey": { "source": "env", "id": "OPENVIKING_API_KEY" }
+
+// 文件（例如挂载的 Kubernetes Secret）
+"apiKey": { "source": "file", "id": "/etc/openviking-secrets/api-key" }
+
+// exec 秘密 provider（1Password、HashiCorp Vault 等）
+"apiKey": {
+  "source": "exec",
+  "provider": "@transmitt0r/openclaw-plugin-onepassword",
+  "id": "op://Vault/OpenViking/api-key"
+}
+```
+
+注意事项：
+
+- 明文字符串（含 `${ENV_VAR}` 插值）仍向后兼容，已有配置无需改动。
+- 使用 `SecretRef` 时，`openclaw.json` 中只保存引用，不再出现明文 key。
+- 使用 `source: "exec"` 时，请先安装对应的 provider 插件（例如 `openclaw plugins install clawhub:@transmitt0r/openclaw-plugin-onepassword`），并确保 gateway 在本插件解析 key 之前注册了其 resolver。若未注册 resolver，插件会立即报错，而不是发送空 key。
+- CLI `openclaw openviking setup --api-key <KEY>` 仍写入明文字符串；如需使用 `SecretRef`，请直接编辑 `openclaw.json`（或用 `openclaw config set plugins.entries.openviking.config.apiKey` 传入 JSON 对象）。
 
 ### 配置参数
 

--- a/examples/openclaw-plugin/INSTALL.md
+++ b/examples/openclaw-plugin/INSTALL.md
@@ -176,7 +176,7 @@ If the `openclaw` CLI cannot run inside the container, merge the following field
 - If `plugins.allow` already exists, append `openviking`; otherwise, do not create an allowlist only for this plugin.
 - `contextEngine` is an exclusive slot. If another context engine is configured, change it only after confirming the replacement. Root API keys also require `accountId` and `userId` in `config`.
 - When connecting to another service from a container, use a `baseUrl` that is reachable from the container rather than `127.0.0.1`.
-- `apiKey` is stored as plaintext. Restrict file permissions or provide the file through a managed Secret volume, then restart the Gateway, container, or Pod.
+- `apiKey` accepts either a plaintext string (with `${ENV_VAR}` interpolation) or a `SecretRef` object resolved through OpenClaw's secret-resolution path. To avoid storing the key in `openclaw.json`, use a `SecretRef` (see [Secret references](#secret-references-for-apikey)). When a plaintext string is still used, restrict file permissions or mount a managed Secret volume, then restart the Gateway, container, or Pod.
 
 ### 3. Restart OpenClaw Gateway
 
@@ -252,6 +252,59 @@ Manual config inspection:
 ```bash
 openclaw config get plugins.entries.openviking.config
 ```
+
+## Secret references for apiKey
+
+Instead of keeping the OpenViking API key as plaintext in `openclaw.json`, `config.apiKey` accepts a `SecretRef` object with the same shape OpenClaw's core provider configs (LLM/TTS/MCP) use for credential fields:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openviking": {
+        "enabled": true,
+        "config": {
+          "mode": "remote",
+          "baseUrl": "http://openviking:1933",
+          "apiKey": { "source": "env", "id": "OPENVIKING_API_KEY" }
+        }
+      }
+    }
+  }
+}
+```
+
+Supported `source` values:
+
+| `source` | `id` | Behavior |
+| --- | --- | --- |
+| `env` | Environment variable name | Reads the variable. Fails if unset/empty. |
+| `file` | File path (`~` expanded) | Reads the file (UTF-8, trailing newline/whitespace trimmed). Fails if missing/empty. |
+| `exec` | Provider-specific secret reference | Delegates to the secret-provider plugin named by `provider` (e.g. `@transmitt0r/openclaw-plugin-onepassword`). Requires that plugin to be installed and registered as the exec resolver. |
+
+Examples:
+
+```jsonc
+// env var
+"apiKey": { "source": "env", "id": "OPENVIKING_API_KEY" }
+
+// file on disk (e.g. a mounted Kubernetes Secret)
+"apiKey": { "source": "file", "id": "/etc/openviking-secrets/api-key" }
+
+// exec-backed secret provider (1Password, HashiCorp Vault, …)
+"apiKey": {
+  "source": "exec",
+  "provider": "@transmitt0r/openclaw-plugin-onepassword",
+  "id": "op://Vault/OpenViking/api-key"
+}
+```
+
+Notes:
+
+- A plaintext string (with `${ENV_VAR}` interpolation) remains supported for backward compatibility. Existing setups need no changes.
+- The plaintext string never appears in `openclaw.json` when a `SecretRef` is used; only the reference is stored.
+- For `source: "exec"`, install the corresponding provider plugin (e.g. `openclaw plugins install clawhub:@transmitt0r/openclaw-plugin-onepassword`) and ensure the gateway registers its resolver before this plugin resolves the key. If no resolver is registered, the plugin fails fast with a clear error rather than sending an empty key.
+- The CLI `openclaw openviking setup --api-key <KEY>` path still writes a plaintext string; use a `SecretRef` only when editing `openclaw.json` directly (or via `openclaw config set plugins.entries.openviking.config.apiKey` with a JSON object).
 
 ## Upgrade
 

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -1,13 +1,161 @@
 import { homedir } from "node:os";
+import { readFileSync } from "node:fs";
 
 import { getEnv } from "./runtime-utils.js";
+
+/**
+ * Reference to a secret resolved through OpenClaw's secret-resolution path,
+ * mirroring the `{ source, provider, id }` shape that OpenClaw core's provider
+ * configs (LLM/TTS/MCP) accept for their credential fields.
+ *
+ * Resolution semantics (compatible with OpenClaw core):
+ *  - `source: "env"`  — read the value from the environment variable named by `id`.
+ *  - `source: "file"` — read the value from the file at path `id` (leading `~` expanded,
+ *                       trailing whitespace/newline trimmed).
+ *  - `source: "exec"` — delegate to a secret-provider plugin keyed by `provider`
+ *                       (e.g. `@transmitt0r/openclaw-plugin-onepassword`). Requires a
+ *                       resolver to be registered via {@link registerSecretExecResolver};
+ *                       the gateway or a provider plugin is expected to supply one.
+ *
+ * NOTE: This plugin does not bundle `@openclaw/sdk` as a direct dependency, so the
+ * env/file sources are resolved inline. The exec source stays extensible so that the
+ * gateway (or a dedicated provider plugin) can register its own resolver, matching how
+ * OpenClaw core routes exec secrets through a provider plugin.
+ */
+export type SecretRef =
+  | { source: "env"; id: string }
+  | { source: "file"; id: string }
+  | { source: "exec"; provider: string; id: string };
+
+/**
+ * Resolver invoked for `SecretRef` entries with `source: "exec"`. The gateway or a
+ * secret-provider plugin (e.g. `@transmitt0r/openclaw-plugin-onepassword`) is expected
+ * to register one during startup. If none is registered, exec refs fail loudly instead
+ * of silently leaking an empty key.
+ */
+export type SecretExecResolver = (provider: string, id: string) => string;
+
+let secretExecResolver: SecretExecResolver | null = null;
+
+/**
+ * Register the resolver used for `source: "exec"` SecretRefs. Intended to be called by
+ * the OpenClaw gateway or a secret-provider plugin at startup. Idempotent: the last
+ * registration wins.
+ */
+export function registerSecretExecResolver(resolver: SecretExecResolver): void {
+  if (typeof resolver !== "function") {
+    throw new Error("registerSecretExecResolver: expected a function");
+  }
+  secretExecResolver = resolver;
+}
+
+/** Reset the exec resolver (primarily for tests). */
+export function resetSecretExecResolver(): void {
+  secretExecResolver = null;
+}
+
+/** Returns true when a value looks like a SecretRef object. */
+export function isSecretRef(value: unknown): value is SecretRef {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.source === "string" &&
+    (ref.source === "env" || ref.source === "file" || ref.source === "exec") &&
+    typeof ref.id === "string" &&
+    ref.id.trim() !== "" &&
+    (ref.source !== "exec" || typeof ref.provider === "string")
+  );
+}
+
+function assertSecretRefShape(value: unknown): asserts value is SecretRef {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("openviking config.apiKey SecretRef must be an object");
+  }
+  const ref = value as Record<string, unknown>;
+  const known = new Set(["source", "provider", "id"]);
+  for (const key of Object.keys(ref)) {
+    if (!known.has(key)) {
+      throw new Error(
+        `openviking config.apiKey SecretRef has unknown key: ${key}`,
+      );
+    }
+  }
+  if (typeof ref.source !== "string") {
+    throw new Error('openviking config.apiKey SecretRef.source must be "env", "file", or "exec"');
+  }
+  if (ref.source !== "env" && ref.source !== "file" && ref.source !== "exec") {
+    throw new Error(`openviking config.apiKey SecretRef.source "${ref.source}" is not supported (use env, file, or exec)`);
+  }
+  if (typeof ref.id !== "string" || ref.id.trim() === "") {
+    throw new Error("openviking config.apiKey SecretRef.id must be a non-empty string");
+  }
+  if (ref.source === "exec") {
+    if (typeof ref.provider !== "string" || ref.provider.trim() === "") {
+      throw new Error('openviking config.apiKey SecretRef.provider is required when source is "exec"');
+    }
+  } else if (ref.provider !== undefined && typeof ref.provider !== "string") {
+    throw new Error("openviking config.apiKey SecretRef.provider must be a string when provided");
+  }
+}
+
+/**
+ * Resolve a {@link SecretRef} to its plaintext value. Used for `config.apiKey` so the
+ * OpenViking key never has to sit in `openclaw.json` as plaintext — it can reference
+ * env vars, files on disk, or an exec-backed secret provider (1Password, Vault, …).
+ */
+export function resolveSecret(ref: SecretRef): string {
+  assertSecretRefShape(ref);
+  switch (ref.source) {
+    case "env": {
+      const value = getEnv(ref.id);
+      if (value === undefined || value === "") {
+        throw new Error(`openviking config.apiKey SecretRef env variable "${ref.id}" is not set`);
+      }
+      return value;
+    }
+    case "file": {
+      const path = expandHomeDir(ref.id);
+      let content: string;
+      try {
+        content = readFileSync(path, "utf8");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`openviking config.apiKey SecretRef file "${ref.id}" could not be read: ${message}`);
+      }
+      const trimmed = content.replace(/\r?\n$/, "").trim();
+      if (trimmed === "") {
+        throw new Error(`openviking config.apiKey SecretRef file "${ref.id}" is empty`);
+      }
+      return trimmed;
+    }
+    case "exec": {
+      if (!secretExecResolver) {
+        throw new Error(
+          `openviking config.apiKey SecretRef source "exec" (provider "${ref.provider}") requires a registered secret-provider resolver. ` +
+            'Install/register a provider plugin such as @transmitt0r/openclaw-plugin-onepassword, or have the gateway call registerSecretExecResolver().',
+        );
+      }
+      const value = secretExecResolver(ref.provider, ref.id);
+      if (typeof value !== "string" || value === "") {
+        throw new Error(
+          `openviking config.apiKey SecretRef exec resolver for provider "${ref.provider}" returned an empty value for id "${ref.id}"`,
+        );
+      }
+      return value;
+    }
+  }
+}
 
 export type MemoryOpenVikingConfig = {
   mode?: "remote";
   baseUrl?: string;
   peer_role?: "none" | "assistant" | "person";
   peer_prefix?: string;
-  apiKey?: string;
+  /** OpenViking API key. Accepts a plaintext string (with `${ENV_VAR}` interpolation)
+   *  or a {@link SecretRef} resolved through OpenClaw's secret-resolution path. */
+  apiKey?: string | SecretRef;
   /** Optional HTTP headers merged into every OpenViking request. */
   headers?: Record<string, string>;
   /** Advanced option. Only needed when explicitly sending tenant identity headers. With a user key the server derives identity from the key. */
@@ -102,8 +250,10 @@ export type MemoryOpenVikingConfig = {
 
 /** Runtime config after memoryOpenVikingConfigSchema.parse() has applied defaults. */
 export type ParsedMemoryOpenVikingConfig = Required<
-  Omit<MemoryOpenVikingConfig, "agentExperience" | "recallTargetTypes">
+  Omit<MemoryOpenVikingConfig, "agentExperience" | "apiKey" | "recallTargetTypes">
 > & {
+  /** The parsed runtime always holds the resolved plaintext key (SecretRefs are resolved during parse). */
+  apiKey: string;
   agentExperience: Required<NonNullable<MemoryOpenVikingConfig["agentExperience"]>>;
   recallTargetTypes: Array<"resource" | "user" | "agent">;
 };
@@ -202,6 +352,19 @@ function resolvePeerRole(configured: unknown) {
   return DEFAULT_PEER_ROLE;
 }
 
+function readRawApiKey(value: unknown): string | SecretRef | undefined {
+  if (value === null || value === undefined) {
+    return getEnv("OPENVIKING_API_KEY");
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  // Object form: must be a SecretRef. Validate strictly so a misconfigured ref
+  // surfaces immediately instead of silently falling back to an empty key.
+  assertSecretRefShape(value);
+  return value as SecretRef;
+}
+
 function resolveEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
     const envValue = getEnv(envVar);
@@ -210,6 +373,23 @@ function resolveEnvVars(value: string): string {
     }
     return envValue;
   });
+}
+
+/**
+ * Resolve the configured apiKey into the plaintext string the runtime client expects.
+ * Accepts:
+ *  - undefined / empty  → ""  (server-side may not require auth)
+ *  - SecretRef object   → resolved via resolveSecret() (env / file / exec)
+ *  - string             → existing ${ENV_VAR} interpolation path (backward compatible)
+ */
+function resolveApiKey(rawApiKey: string | SecretRef | undefined): string {
+  if (rawApiKey === undefined || rawApiKey === "") {
+    return "";
+  }
+  if (isSecretRef(rawApiKey)) {
+    return resolveSecret(rawApiKey);
+  }
+  return resolveEnvVars(rawApiKey);
 }
 
 function expandHomeDir(value: string): string {
@@ -465,7 +645,10 @@ export const memoryOpenVikingConfigSchema = {
     const peerPrefix = resolvePeerPrefix(cfg.peer_prefix);
     const rawBaseUrl = typeof cfg.baseUrl === "string" ? cfg.baseUrl : resolveDefaultBaseUrl();
     const resolvedBaseUrl = resolveEnvVars(rawBaseUrl).replace(/\/+$/, "");
-    const rawApiKey = typeof cfg.apiKey === "string" ? cfg.apiKey : getEnv("OPENVIKING_API_KEY");
+    // apiKey accepts either a plaintext string (with ${ENV_VAR} interpolation, for
+    // parity with existing setups) or a SecretRef resolved via OpenClaw's
+    // secret-resolution path — same shape other OpenClaw provider configs accept.
+    const rawApiKey = readRawApiKey(cfg.apiKey);
     const captureMode = cfg.captureMode;
     if (
       typeof captureMode !== "undefined" &&
@@ -508,7 +691,7 @@ export const memoryOpenVikingConfigSchema = {
       baseUrl: resolvedBaseUrl,
       peer_role: peerRole,
       peer_prefix: peerPrefix,
-      apiKey: rawApiKey ? resolveEnvVars(rawApiKey) : "",
+      apiKey: resolveApiKey(rawApiKey),
       headers: toStringRecord(cfg.headers, "openviking config headers"),
       accountId,
       userId,
@@ -678,7 +861,9 @@ export const memoryOpenVikingConfigSchema = {
       label: "OpenViking API Key",
       sensitive: true,
       placeholder: "${OPENVIKING_API_KEY}",
-      help: "Optional API key for OpenViking server",
+      help:
+        "Optional API key for OpenViking server. Accepts a plaintext string with ${ENV_VAR} interpolation, " +
+        'or a SecretRef {"source":"env|file|exec","provider":"...","id":"..."} resolved through OpenClaw\'s secret-resolution path (see INSTALL.md).',
     },
     headers: {
       label: "Headers",

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -98,7 +98,7 @@
       "label": "OpenViking API Key",
       "sensitive": true,
       "placeholder": "${OPENVIKING_API_KEY}",
-      "help": "Optional API key for OpenViking server"
+      "help": "Optional API key for OpenViking server. Accepts a plaintext string with ${ENV_VAR} interpolation, or a SecretRef {\"source\":\"env|file|exec\",\"provider\":\"...\",\"id\":\"...\"} resolved through OpenClaw's secret-resolution path (see INSTALL.md)."
     },
     "headers": {
       "label": "Headers",
@@ -292,7 +292,32 @@
         "description": "Deprecated and ignored. Tenant identity headers are controlled by explicit accountId/userId."
       },
       "apiKey": {
-        "type": "string"
+        "description": "OpenViking API key. Accepts a plaintext string (with ${ENV_VAR} interpolation) or a SecretRef object resolved through OpenClaw's secret-resolution path.",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "description": "SecretRef: resolve the key from env, file, or an exec-backed secret provider.",
+            "required": ["source", "id"],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": ["env", "file", "exec"]
+              },
+              "id": {
+                "type": "string",
+                "description": "Env var name (source=env), file path (source=file), or provider-specific secret reference (source=exec)."
+              },
+              "provider": {
+                "type": "string",
+                "description": "Required when source=exec. Secret-provider plugin name, e.g. @transmitt0r/openclaw-plugin-onepassword."
+              }
+            }
+          }
+        ]
       },
       "headers": {
         "type": "object",

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { memoryOpenVikingConfigSchema } from "../../config.js";
+import {
+  memoryOpenVikingConfigSchema,
+  registerSecretExecResolver,
+  resetSecretExecResolver,
+} from "../../config.js";
 
 describe("memoryOpenVikingConfigSchema.parse()", () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    resetSecretExecResolver();
   });
 
   it("empty object uses all defaults", () => {
@@ -229,6 +237,91 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
         apiKey: "${NOT_SET_OV_VAR}",
       }),
     ).toThrow("NOT_SET_OV_VAR");
+  });
+
+  it("resolves apiKey from a SecretRef with source=env", () => {
+    process.env.TEST_OV_SECRET_ENV = "sk-env-ref-key";
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      apiKey: { source: "env", id: "TEST_OV_SECRET_ENV" },
+    });
+    expect(cfg.apiKey).toBe("sk-env-ref-key");
+    delete process.env.TEST_OV_SECRET_ENV;
+  });
+
+  it("throws when source=env references an unset env var", () => {
+    delete process.env.TEST_OV_SECRET_ENV_MISSING;
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "env", id: "TEST_OV_SECRET_ENV_MISSING" },
+      }),
+    ).toThrow("TEST_OV_SECRET_ENV_MISSING");
+  });
+
+  it("resolves apiKey from a SecretRef with source=file (trims trailing newline)", () => {
+    const keyFile = join(tmpdir(), `ov-secret-${Date.now()}.txt`);
+    writeFileSync(keyFile, "sk-file-ref-key\n");
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      apiKey: { source: "file", id: keyFile },
+    });
+    expect(cfg.apiKey).toBe("sk-file-ref-key");
+  });
+
+  it("throws when source=file points at a missing file", () => {
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "file", id: join(tmpdir(), "ov-secret-missing.txt") },
+      }),
+    ).toThrow("could not be read");
+  });
+
+  it("resolves apiKey from a SecretRef with source=exec via a registered resolver", () => {
+    registerSecretExecResolver((provider, id) => {
+      if (provider === "test-vault") {
+        return `sk-exec-${id}`;
+      }
+      throw new Error(`unknown provider ${provider}`);
+    });
+    const cfg = memoryOpenVikingConfigSchema.parse({
+      apiKey: {
+        source: "exec",
+        provider: "test-vault",
+        id: "op://Vault/OpenViking/api-key",
+      },
+    });
+    expect(cfg.apiKey).toBe("sk-exec-op://Vault/OpenViking/api-key");
+  });
+
+  it("throws for source=exec when no resolver is registered", () => {
+    resetSecretExecResolver();
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "exec", provider: "test-vault", id: "op://x/y/z" },
+      }),
+    ).toThrow("registered secret-provider resolver");
+  });
+
+  it("rejects an invalid SecretRef source", () => {
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "vault", id: "x" },
+      }),
+    ).toThrow("is not supported");
+  });
+
+  it("rejects an exec SecretRef without a provider", () => {
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "exec", id: "x" },
+      }),
+    ).toThrow("provider is required");
+  });
+
+  it("rejects a SecretRef with an unknown key", () => {
+    expect(() =>
+      memoryOpenVikingConfigSchema.parse({
+        apiKey: { source: "env", id: "X", extra: 1 },
+      }),
+    ).toThrow("unknown key");
   });
 
   it("clamps negative recallScoreThreshold to 0", () => {


### PR DESCRIPTION
## What & why

Closes #3522.

`examples/openclaw-plugin`'s `config.apiKey` was a plain `string`, resolved only through `${ENV_VAR}` interpolation, so the OpenViking API key had to live as **plaintext** in `openclaw.json` — even though OpenClaw core already has a `SecretRef` mechanism (`{source, provider, id}`) that its other provider configs (LLM/TTS/MCP) accept. This widens `apiKey` to `string | SecretRef` and resolves it through a secret-resolution path matching core providers.

## Changes (all under `examples/openclaw-plugin/`)

- **`config.ts`** — `SecretRef` type (`{source:"env"|"file"|"exec", provider?, id}`), `resolveSecret()`, `isSecretRef()`, `assertSecretRefShape()`; `apiKey` typed as `string | SecretRef`; `ParsedMemoryOpenVikingConfig.apiKey` stays `string` (runtime client unaware). `exec` delegates to a resolver registered via `registerSecretExecResolver()` — the gateway / a provider plugin (e.g. `@transmitt0r/openclaw-plugin-onepassword`) registers at startup; unregistered `exec` fails clearly and **never sends an empty key**.
- **`openclaw.plugin.json`** — `apiKey` schema is `oneOf [string, SecretRef object]` (`additionalProperties:false`, `source` enum, `provider` required for `exec`).
- **`INSTALL.md` / `INSTALL-ZH.md`** — plaintext caveat replaced with SecretRef usage (env / file / exec tables + examples).

## Design note

The plugin does not list `@openclaw/sdk` as a dependency, so the SDK's own resolver isn't directly available here. This is a minimal **compatible** implementation: `env`/`file` resolved inline, `exec` via the registered hook. Happy to switch to the SDK resolver if maintainers prefer adding the dep.

## Tests

`tests/ut/config.test.ts` +8 SecretRef cases (env resolve / env-unset error / file resolve w/ newline trim / file-missing error / exec via registered resolver / exec unregistered error / invalid source / exec missing provider / unknown key), resolver reset in `afterEach`.

- `tsc -p tsconfig.json` → no errors
- `npm run build` → success
- `vitest tests/ut/config.test.ts` → **60 pass / 0 fail** (52 original + 8 new)
- full `vitest` → 740 pass / 4 fail; the 4 failures are in `architecture-boundaries.test.ts` and were **confirmed pre-existing on baseline `8391d3a`** (this change doesn't touch the files they assert on).

## Open questions for maintainers

- `exec` resolver registration timing/ownership: gateway-registered, or each provider plugin self-registers? The plugin only exposes the `registerSecretExecResolver` entry point.
- `commands/setup.ts` status display still assumes plaintext `apiKey` (would show `[object Object]` for a SecretRef) — out of the issue's proposed-solution scope, flagged as follow-up.

This contribution was developed with AI assistance.

Refs #3522