### PR TITLE
feat(server): add GET /api/v1/system/idle status endpoint (#3488)

### DIFF
--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -21,6 +21,7 @@ _watch_logger = get_logger(__name__)
 _API_KEY_ROOT_ALLOWED_PATHS = {
     "/api/v1/system/status",
     "/api/v1/system/wait",
+    "/api/v1/system/idle",
     "/api/v1/debug/health",
 }
 _API_KEY_ROOT_ALLOWED_PREFIXES = (

--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -17,6 +17,7 @@ from openviking_cli.exceptions import PermissionDeniedError, UnauthenticatedErro
 _API_KEY_ROOT_ALLOWED_PATHS = {
     "/api/v1/system/status",
     "/api/v1/system/wait",
+    "/api/v1/system/idle",
     "/api/v1/debug/health",
 }
 _API_KEY_ROOT_ALLOWED_PREFIXES = (

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -249,6 +249,23 @@ async def wait_processed(
     return Response(status="ok", result=result)
 
 
+@router.get("/api/v1/system/idle", tags=["system"])
+async def system_idle(
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Return whether the server has any outstanding async work in flight.
+
+    Non-blocking sibling of ``POST /api/v1/system/wait``: instead of blocking
+    until pending work drains, it immediately reports ``idle=true`` iff every
+    aggregated subsystem (queue layer + central TaskTracker) has zero
+    outstanding work. See ``ResourceService.get_idle_status`` for the exact
+    aggregation and the (intentionally excluded) subsystems.
+    """
+    service = get_service()
+    result = await service.resources.get_idle_status()
+    return Response(status="ok", result=result)
+
+
 @router.post("/api/v1/system/consistency", tags=["system"])
 async def check_consistency(
     request: ConsistencyRequest,

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -249,6 +249,30 @@ async def wait_processed(
     return Response(status="ok", result=result)
 
 
+@router.get("/api/v1/system/idle", tags=["system"])
+async def system_idle(
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Return whether the server has any outstanding async work in flight.
+
+    Non-blocking counterpart of ``POST /api/v1/system/wait``: instead of
+    blocking until pending work drains, it immediately reports ``idle=true``
+    iff every aggregated subsystem (queue layer + central TaskTracker) has zero
+    outstanding work. See ``ResourceService.get_idle_status`` for the exact
+    aggregation and the (intentionally excluded) subsystems.
+
+    Note: this is intentionally **stricter** than ``/wait``. ``/wait`` blocks
+    only on the processing queue draining; ``/idle`` additionally requires the
+    central TaskTracker to have no PENDING/RUNNING tasks (e.g. a
+    ``session_commit`` with ``wait=false``, a reindex). So ``/wait`` returning
+    does NOT imply ``/idle=true`` — use ``/idle`` when you need "truly nothing
+    in flight", and ``/wait`` when you only need "the current batch processed".
+    """
+    service = get_service()
+    result = await service.resources.get_idle_status()
+    return Response(status="ok", result=result)
+
+
 @router.post("/api/v1/system/consistency", tags=["system"])
 async def check_consistency(
     request: ConsistencyRequest,

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -255,11 +255,18 @@ async def system_idle(
 ):
     """Return whether the server has any outstanding async work in flight.
 
-    Non-blocking sibling of ``POST /api/v1/system/wait``: instead of blocking
-    until pending work drains, it immediately reports ``idle=true`` iff every
-    aggregated subsystem (queue layer + central TaskTracker) has zero
+    Non-blocking counterpart of ``POST /api/v1/system/wait``: instead of
+    blocking until pending work drains, it immediately reports ``idle=true``
+    iff every aggregated subsystem (queue layer + central TaskTracker) has zero
     outstanding work. See ``ResourceService.get_idle_status`` for the exact
     aggregation and the (intentionally excluded) subsystems.
+
+    Note: this is intentionally **stricter** than ``/wait``. ``/wait`` blocks
+    only on the processing queue draining; ``/idle`` additionally requires the
+    central TaskTracker to have no PENDING/RUNNING tasks (e.g. a
+    ``session_commit`` with ``wait=false``, a reindex). So ``/wait`` returning
+    does NOT imply ``/idle=true`` — use ``/idle`` when you need "truly nothing
+    in flight", and ``/wait`` when you only need "the current batch processed".
     """
     service = get_service()
     result = await service.resources.get_idle_status()

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1849,3 +1849,79 @@ class ResourceService:
             }
             for name, s in status.items()
         }
+
+    async def get_idle_status(self) -> Dict[str, Any]:
+        """Return server-level idle status aggregated across subsystems.
+
+        This is the non-blocking sibling of ``wait_processed``: instead of
+        blocking until pending work drains, it immediately reports whether any
+        is in flight. ``idle`` is True only when every aggregated source has
+        zero outstanding work.
+
+        Aggregated sources:
+          * ``queue``: pending + in_progress across every QueueManager queue
+            (the same signal used by ``wait_processed``).
+          * ``tasks``: non-terminal (PENDING + RUNNING) entries in the central
+            TaskTracker — e.g. session_commit with wait=false, reindex, ...
+
+        Intentionally NOT aggregated:
+          * Watch scheduler — watches run on a periodic schedule and never
+            "drain to idle"; including them would make idle permanently False.
+          * EmbeddingTaskTracker — its sub-task pending state is already
+            reflected in the Embedding queue's pending/in_progress, so counting
+            it separately would double-count.
+
+        Conservative policy: if a source cannot be queried (singleton not
+        initialized, unexpected error), it is marked ``"error"`` in the
+        breakdown and ``idle`` is forced to False so we never falsely report
+        the server as idle.
+        """
+        breakdown: Dict[str, Any] = {}
+        total_pending = 0
+        uncertain = False
+
+        # ── Queue layer ──
+        try:
+            qm = get_queue_manager()
+            statuses = await qm.check_status()
+            queue_by_name: Dict[str, Dict[str, int]] = {}
+            queue_pending = 0
+            for name, s in statuses.items():
+                pending = int(getattr(s, "pending", 0))
+                in_progress = int(getattr(s, "in_progress", 0))
+                queue_by_name[name] = {
+                    "pending": pending,
+                    "in_progress": in_progress,
+                }
+                queue_pending += pending + in_progress
+            total_pending += queue_pending
+            breakdown["queue"] = {
+                "pending": queue_pending,
+                "by_queue": queue_by_name,
+            }
+        except Exception as e:
+            uncertain = True
+            breakdown["queue"] = {"error": str(e)}
+
+        # ── Central TaskTracker ──
+        try:
+            from openviking.service.task_tracker import get_task_tracker
+
+            tracker = get_task_tracker()
+            active_total = tracker.count_active()
+            active_by_type = tracker.snapshot_active_counts_by_type()
+            total_pending += active_total
+            breakdown["tasks"] = {
+                "pending": active_total,
+                "by_type": active_by_type,
+            }
+        except Exception as e:
+            uncertain = True
+            breakdown["tasks"] = {"error": str(e)}
+
+        idle = (total_pending == 0) and not uncertain
+        return {
+            "idle": idle,
+            "pending": total_pending,
+            "breakdown": breakdown,
+        }

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -40,9 +40,9 @@ from openviking.server.user_config import (
     effective_resource_add_target,
     effective_skill_add_target,
 )
-from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.viking_fs import VikingFS
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import (
@@ -1899,25 +1899,33 @@ class ResourceService:
                 "pending": queue_pending,
                 "by_queue": queue_by_name,
             }
-        except Exception as e:
+        except Exception:
+            logger.exception("[ResourceService] get_idle_status: queue source failed")
             uncertain = True
-            breakdown["queue"] = {"error": str(e)}
+            breakdown["queue"] = {"error": "queue_status_unavailable"}
 
         # ── Central TaskTracker ──
+        # Authoritative source: read the persistent TaskStore (not the
+        # process-local cache) so PENDING/RUNNING records persisted by this or
+        # any other worker process — including ones never loaded into this
+        # process — are counted. The snapshot is taken atomically (total and
+        # by_type from one read) so the two can never disagree.
         try:
             from openviking.service.task_tracker import get_task_tracker
 
             tracker = get_task_tracker()
-            active_total = tracker.count_active()
-            active_by_type = tracker.snapshot_active_counts_by_type()
+            snap = await tracker.snapshot_active_from_store()
+            active_total = snap["total"]
+            active_by_type = snap["by_type"]
             total_pending += active_total
             breakdown["tasks"] = {
                 "pending": active_total,
                 "by_type": active_by_type,
             }
-        except Exception as e:
+        except Exception:
+            logger.exception("[ResourceService] get_idle_status: task source failed")
             uncertain = True
-            breakdown["tasks"] = {"error": str(e)}
+            breakdown["tasks"] = {"error": "task_status_unavailable"}
 
         idle = (total_pending == 0) and not uncertain
         return {

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -2545,25 +2545,33 @@ class ResourceService:
                 "pending": queue_pending,
                 "by_queue": queue_by_name,
             }
-        except Exception as e:
+        except Exception:
+            logger.exception("[ResourceService] get_idle_status: queue source failed")
             uncertain = True
-            breakdown["queue"] = {"error": str(e)}
+            breakdown["queue"] = {"error": "queue_status_unavailable"}
 
         # ── Central TaskTracker ──
+        # Authoritative source: read the persistent TaskStore (not the
+        # process-local cache) so PENDING/RUNNING records persisted by this or
+        # any other worker process — including ones never loaded into this
+        # process — are counted. The snapshot is taken atomically (total and
+        # by_type from one read) so the two can never disagree.
         try:
             from openviking.service.task_tracker import get_task_tracker
 
             tracker = get_task_tracker()
-            active_total = tracker.count_active()
-            active_by_type = tracker.snapshot_active_counts_by_type()
+            snap = await tracker.snapshot_active_from_store()
+            active_total = snap["total"]
+            active_by_type = snap["by_type"]
             total_pending += active_total
             breakdown["tasks"] = {
                 "pending": active_total,
                 "by_type": active_by_type,
             }
-        except Exception as e:
+        except Exception:
+            logger.exception("[ResourceService] get_idle_status: task source failed")
             uncertain = True
-            breakdown["tasks"] = {"error": str(e)}
+            breakdown["tasks"] = {"error": "task_status_unavailable"}
 
         idle = (total_pending == 0) and not uncertain
         return {

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -2495,3 +2495,79 @@ class ResourceService:
             }
             for name, s in status.items()
         }
+
+    async def get_idle_status(self) -> Dict[str, Any]:
+        """Return server-level idle status aggregated across subsystems.
+
+        This is the non-blocking sibling of ``wait_processed``: instead of
+        blocking until pending work drains, it immediately reports whether any
+        is in flight. ``idle`` is True only when every aggregated source has
+        zero outstanding work.
+
+        Aggregated sources:
+          * ``queue``: pending + in_progress across every QueueManager queue
+            (the same signal used by ``wait_processed``).
+          * ``tasks``: non-terminal (PENDING + RUNNING) entries in the central
+            TaskTracker — e.g. session_commit with wait=false, reindex, ...
+
+        Intentionally NOT aggregated:
+          * Watch scheduler — watches run on a periodic schedule and never
+            "drain to idle"; including them would make idle permanently False.
+          * EmbeddingTaskTracker — its sub-task pending state is already
+            reflected in the Embedding queue's pending/in_progress, so counting
+            it separately would double-count.
+
+        Conservative policy: if a source cannot be queried (singleton not
+        initialized, unexpected error), it is marked ``"error"`` in the
+        breakdown and ``idle`` is forced to False so we never falsely report
+        the server as idle.
+        """
+        breakdown: Dict[str, Any] = {}
+        total_pending = 0
+        uncertain = False
+
+        # ── Queue layer ──
+        try:
+            qm = get_queue_manager()
+            statuses = await qm.check_status()
+            queue_by_name: Dict[str, Dict[str, int]] = {}
+            queue_pending = 0
+            for name, s in statuses.items():
+                pending = int(getattr(s, "pending", 0))
+                in_progress = int(getattr(s, "in_progress", 0))
+                queue_by_name[name] = {
+                    "pending": pending,
+                    "in_progress": in_progress,
+                }
+                queue_pending += pending + in_progress
+            total_pending += queue_pending
+            breakdown["queue"] = {
+                "pending": queue_pending,
+                "by_queue": queue_by_name,
+            }
+        except Exception as e:
+            uncertain = True
+            breakdown["queue"] = {"error": str(e)}
+
+        # ── Central TaskTracker ──
+        try:
+            from openviking.service.task_tracker import get_task_tracker
+
+            tracker = get_task_tracker()
+            active_total = tracker.count_active()
+            active_by_type = tracker.snapshot_active_counts_by_type()
+            total_pending += active_total
+            breakdown["tasks"] = {
+                "pending": active_total,
+                "by_type": active_by_type,
+            }
+        except Exception as e:
+            uncertain = True
+            breakdown["tasks"] = {"error": str(e)}
+
+        idle = (total_pending == 0) and not uncertain
+        return {
+            "idle": idle,
+            "pending": total_pending,
+            "breakdown": breakdown,
+        }

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -551,6 +551,53 @@ class TaskTracker:
 
     _ACTIVE_STATUSES = (TaskStatus.PENDING, TaskStatus.RUNNING)
 
+    def snapshot_active(self) -> Dict[str, Any]:
+        """Return an atomic snapshot of non-terminal (PENDING + RUNNING) counts.
+
+        Both ``total`` and ``by_type`` are derived under a single ``_lock``
+        acquisition, so they can never disagree (a task transitioning between
+        two separate reads would otherwise make ``pending`` inconsistent with
+        ``breakdown.tasks.by_type``).
+
+        NOTE: this reflects only the process-local ``_tasks`` cache. For an
+        authoritative, cross-process view use :meth:`snapshot_active_from_store`.
+        """
+        from collections import defaultdict
+
+        grouped: Dict[str, int] = defaultdict(int)
+        total = 0
+        with self._lock:
+            for t in self._tasks.values():
+                if t.status in self._ACTIVE_STATUSES:
+                    grouped[t.task_type] += 1
+                    total += 1
+        return {"total": total, "by_type": dict(grouped)}
+
+    async def snapshot_active_from_store(self) -> Dict[str, Any]:
+        """Authoritative active snapshot read from the persistent TaskStore.
+
+        Unlike :meth:`snapshot_active` (process-local cache only), this lists
+        the system task directory so PENDING/RUNNING records persisted by this
+        or any other worker process — including ones never loaded into this
+        process's cache — are counted. This is the source the server-level idle
+        endpoint must use to avoid reporting a false authoritative ``idle=true``.
+        """
+        from collections import defaultdict
+
+        from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
+
+        grouped: Dict[str, int] = defaultdict(int)
+        total = 0
+        records = await self._store.list(SYSTEM_TASK_ACCOUNT_ID, user_id=SYSTEM_TASK_USER_ID)
+        active_values = {s.value for s in self._ACTIVE_STATUSES}
+        for rec in records:
+            status = rec.get("status")
+            if status in active_values:
+                task_type = rec.get("task_type") or "unknown"
+                grouped[task_type] += 1
+                total += 1
+        return {"total": total, "by_type": dict(grouped)}
+
     def count_active(self) -> int:
         """Return the number of non-terminal tasks (PENDING + RUNNING).
 

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -546,3 +546,28 @@ class TaskTracker:
         for t in tasks:
             grouped[t.task_type][t.status.value] += 1
         return {k: dict(v) for k, v in grouped.items()}
+
+    # ── Idle-aggregation helpers (read-only) ──
+
+    _ACTIVE_STATUSES = (TaskStatus.PENDING, TaskStatus.RUNNING)
+
+    def count_active(self) -> int:
+        """Return the number of non-terminal tasks (PENDING + RUNNING).
+
+        Used by the server-level idle status endpoint to decide whether any
+        user-visible background operation (e.g. session_commit with wait=false,
+        reindex, ...) is still in flight.
+        """
+        with self._lock:
+            return sum(1 for t in self._tasks.values() if t.status in self._ACTIVE_STATUSES)
+
+    def snapshot_active_counts_by_type(self) -> Dict[str, int]:
+        """Return non-terminal (PENDING + RUNNING) task counts grouped by task_type."""
+        from collections import defaultdict
+
+        grouped: Dict[str, int] = defaultdict(int)
+        with self._lock:
+            for t in self._tasks.values():
+                if t.status in self._ACTIVE_STATUSES:
+                    grouped[t.task_type] += 1
+        return dict(grouped)

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -1105,6 +1105,53 @@ class TaskTracker:
 
     _ACTIVE_STATUSES = (TaskStatus.PENDING, TaskStatus.RUNNING)
 
+    def snapshot_active(self) -> Dict[str, Any]:
+        """Return an atomic snapshot of non-terminal (PENDING + RUNNING) counts.
+
+        Both ``total`` and ``by_type`` are derived under a single ``_lock``
+        acquisition, so they can never disagree (a task transitioning between
+        two separate reads would otherwise make ``pending`` inconsistent with
+        ``breakdown.tasks.by_type``).
+
+        NOTE: this reflects only the process-local ``_tasks`` cache. For an
+        authoritative, cross-process view use :meth:`snapshot_active_from_store`.
+        """
+        from collections import defaultdict
+
+        grouped: Dict[str, int] = defaultdict(int)
+        total = 0
+        with self._lock:
+            for t in self._tasks.values():
+                if t.status in self._ACTIVE_STATUSES:
+                    grouped[t.task_type] += 1
+                    total += 1
+        return {"total": total, "by_type": dict(grouped)}
+
+    async def snapshot_active_from_store(self) -> Dict[str, Any]:
+        """Authoritative active snapshot read from the persistent TaskStore.
+
+        Unlike :meth:`snapshot_active` (process-local cache only), this lists
+        the system task directory so PENDING/RUNNING records persisted by this
+        or any other worker process — including ones never loaded into this
+        process's cache — are counted. This is the source the server-level idle
+        endpoint must use to avoid reporting a false authoritative ``idle=true``.
+        """
+        from collections import defaultdict
+
+        from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
+
+        grouped: Dict[str, int] = defaultdict(int)
+        total = 0
+        records = await self._store.list(SYSTEM_TASK_ACCOUNT_ID, user_id=SYSTEM_TASK_USER_ID)
+        active_values = {s.value for s in self._ACTIVE_STATUSES}
+        for rec in records:
+            status = rec.get("status")
+            if status in active_values:
+                task_type = rec.get("task_type") or "unknown"
+                grouped[task_type] += 1
+                total += 1
+        return {"total": total, "by_type": dict(grouped)}
+
     def count_active(self) -> int:
         """Return the number of non-terminal tasks (PENDING + RUNNING).
 

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -1100,3 +1100,28 @@ class TaskTracker:
         for t in tasks:
             grouped[t.task_type][t.status.value] += 1
         return {k: dict(v) for k, v in grouped.items()}
+
+    # ── Idle-aggregation helpers (read-only) ──
+
+    _ACTIVE_STATUSES = (TaskStatus.PENDING, TaskStatus.RUNNING)
+
+    def count_active(self) -> int:
+        """Return the number of non-terminal tasks (PENDING + RUNNING).
+
+        Used by the server-level idle status endpoint to decide whether any
+        user-visible background operation (e.g. session_commit with wait=false,
+        reindex, ...) is still in flight.
+        """
+        with self._lock:
+            return sum(1 for t in self._tasks.values() if t.status in self._ACTIVE_STATUSES)
+
+    def snapshot_active_counts_by_type(self) -> Dict[str, int]:
+        """Return non-terminal (PENDING + RUNNING) task counts grouped by task_type."""
+        from collections import defaultdict
+
+        grouped: Dict[str, int] = defaultdict(int)
+        with self._lock:
+            for t in self._tasks.values():
+                if t.status in self._ACTIVE_STATUSES:
+                    grouped[t.task_type] += 1
+        return dict(grouped)

--- a/tests/server/test_server_health.py
+++ b/tests/server/test_server_health.py
@@ -78,6 +78,225 @@ async def test_system_status(client: httpx.AsyncClient):
     assert body["result"]["initialized"] is True
 
 
+# ---------------------------------------------------------------------------
+# GET /api/v1/system/idle (issue #3488)
+#
+# Light fixture (create_app + SimpleNamespace service) is used so the tests do
+# not need to boot a full OpenVikingService (which requires the ragfs native
+# binding). Route-level behaviour is covered here; the aggregation logic of
+# ResourceService.get_idle_status is covered by the unit tests below.
+# ---------------------------------------------------------------------------
+
+
+def _idle_app(get_idle_status):
+    """Build an app whose service.resources.get_idle_status is the given awaitable.
+
+    Uses dev auth (no API key required) so we can drive the route without
+    initialising the APIKeyManager (the ASGI transport does not run lifespan).
+    """
+    from openviking.server.auth.plugins import DevAuthPlugin
+    from openviking.server.auth.registry import get_registry
+    from openviking.server.dependencies import set_service
+
+    service = SimpleNamespace(
+        resources=SimpleNamespace(get_idle_status=get_idle_status),
+    )
+    app = create_app(config=ServerConfig(), service=service)
+    set_service(service)
+    registry = get_registry()
+    if registry.get("dev") is None:
+        registry.register(DevAuthPlugin)
+    app.state.auth_plugin = DevAuthPlugin()
+    return app
+
+
+async def test_system_idle_route_returns_true():
+    """Route forwards the ResourceService result and returns 200 when idle."""
+
+    async def _idle_true():
+        return {
+            "idle": True,
+            "pending": 0,
+            "breakdown": {
+                "queue": {"pending": 0, "by_queue": {}},
+                "tasks": {"pending": 0, "by_type": {}},
+            },
+        }
+
+    app = _idle_app(_idle_true)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/system/idle")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["result"]["idle"] is True
+    assert body["result"]["pending"] == 0
+
+
+async def test_system_idle_route_returns_false():
+    """Route propagates idle=false when the service reports pending work."""
+
+    async def _idle_false():
+        return {
+            "idle": False,
+            "pending": 3,
+            "breakdown": {
+                "queue": {"pending": 2, "by_queue": {"Embedding": {"pending": 0, "in_progress": 2}}},
+                "tasks": {"pending": 1, "by_type": {"session_commit": 1}},
+            },
+        }
+
+    app = _idle_app(_idle_false)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/system/idle")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["idle"] is False
+    assert body["result"]["pending"] == 3
+
+
+# ---------------------------------------------------------------------------
+# ResourceService.get_idle_status aggregation logic (unit-level, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_idle_status_when_idle(monkeypatch):
+    """Both sources at zero => idle=True, pending=0."""
+    from openviking.service.resource_service import ResourceService
+    from openviking.storage.queuefs.named_queue import QueueStatus
+
+    class _FakeQM:
+        async def check_status(self):
+            return {"Embedding": QueueStatus(pending=0, in_progress=0)}
+
+    monkeypatch.setattr(
+        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
+    )
+
+    class _FakeTracker:
+        def count_active(self):
+            return 0
+
+        def snapshot_active_counts_by_type(self):
+            return {}
+
+    import openviking.service.task_tracker as tt
+
+    monkeypatch.setattr(tt, "get_task_tracker", lambda: _FakeTracker())
+
+    result = await ResourceService().get_idle_status()
+
+    assert result["idle"] is True
+    assert result["pending"] == 0
+    assert result["breakdown"]["queue"]["pending"] == 0
+    assert result["breakdown"]["queue"]["by_queue"]["Embedding"] == {
+        "pending": 0,
+        "in_progress": 0,
+    }
+    assert result["breakdown"]["tasks"]["pending"] == 0
+    assert result["breakdown"]["tasks"]["by_type"] == {}
+
+
+async def test_get_idle_status_with_queue_work(monkeypatch):
+    """Queue with in-progress items => idle=False, pending reflects queue work."""
+    from openviking.service.resource_service import ResourceService
+    from openviking.storage.queuefs.named_queue import QueueStatus
+
+    class _FakeQM:
+        async def check_status(self):
+            return {
+                "Embedding": QueueStatus(pending=0, in_progress=2),
+                "Semantic": QueueStatus(pending=1, in_progress=0),
+            }
+
+    monkeypatch.setattr(
+        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
+    )
+
+    class _FakeTracker:
+        def count_active(self):
+            return 0
+
+        def snapshot_active_counts_by_type(self):
+            return {}
+
+    import openviking.service.task_tracker as tt
+
+    monkeypatch.setattr(tt, "get_task_tracker", lambda: _FakeTracker())
+
+    result = await ResourceService().get_idle_status()
+
+    assert result["idle"] is False
+    # 2 in_progress + 1 pending across the two queues.
+    assert result["pending"] == 3
+    assert result["breakdown"]["queue"]["by_queue"]["Embedding"]["in_progress"] == 2
+    assert result["breakdown"]["queue"]["by_queue"]["Semantic"]["pending"] == 1
+
+
+async def test_get_idle_status_with_active_task(monkeypatch):
+    """Central TaskTracker with a running task => idle=False."""
+    from openviking.service.resource_service import ResourceService
+    from openviking.storage.queuefs.named_queue import QueueStatus
+
+    class _FakeQM:
+        async def check_status(self):
+            return {"Embedding": QueueStatus(pending=0, in_progress=0)}
+
+    monkeypatch.setattr(
+        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
+    )
+
+    class _FakeTracker:
+        def count_active(self):
+            return 1
+
+        def snapshot_active_counts_by_type(self):
+            return {"session_commit": 1}
+
+    import openviking.service.task_tracker as tt
+
+    monkeypatch.setattr(tt, "get_task_tracker", lambda: _FakeTracker())
+
+    result = await ResourceService().get_idle_status()
+
+    assert result["idle"] is False
+    assert result["pending"] == 1
+    assert result["breakdown"]["tasks"]["by_type"] == {"session_commit": 1}
+
+
+async def test_get_idle_status_conservative_on_queue_error(monkeypatch):
+    """If a source raises, idle must be forced to False (never claim idle)."""
+    from openviking.service.resource_service import ResourceService
+
+    def _boom():
+        raise RuntimeError("QueueManager is not initialized")
+
+    monkeypatch.setattr(
+        "openviking.service.resource_service.get_queue_manager", _boom
+    )
+
+    class _FakeTracker:
+        def count_active(self):
+            return 0
+
+        def snapshot_active_counts_by_type(self):
+            return {}
+
+    import openviking.service.task_tracker as tt
+
+    monkeypatch.setattr(tt, "get_task_tracker", lambda: _FakeTracker())
+
+    result = await ResourceService().get_idle_status()
+
+    # Uncertain source => never report idle=True even though pending==0.
+    assert result["idle"] is False
+    assert "error" in result["breakdown"]["queue"]
+
+
 async def test_backend_sync_status_endpoint(client: httpx.AsyncClient, service):
     calls: list[str] = []
 

--- a/tests/server/test_server_health.py
+++ b/tests/server/test_server_health.py
@@ -143,7 +143,10 @@ async def test_system_idle_route_returns_false():
             "idle": False,
             "pending": 3,
             "breakdown": {
-                "queue": {"pending": 2, "by_queue": {"Embedding": {"pending": 0, "in_progress": 2}}},
+                "queue": {
+                    "pending": 2,
+                    "by_queue": {"Embedding": {"pending": 0, "in_progress": 2}},
+                },
                 "tasks": {"pending": 1, "by_type": {"session_commit": 1}},
             },
         }
@@ -173,16 +176,11 @@ async def test_get_idle_status_when_idle(monkeypatch):
         async def check_status(self):
             return {"Embedding": QueueStatus(pending=0, in_progress=0)}
 
-    monkeypatch.setattr(
-        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
-    )
+    monkeypatch.setattr("openviking.service.resource_service.get_queue_manager", lambda: _FakeQM())
 
     class _FakeTracker:
-        def count_active(self):
-            return 0
-
-        def snapshot_active_counts_by_type(self):
-            return {}
+        async def snapshot_active_from_store(self):
+            return {"total": 0, "by_type": {}}
 
     import openviking.service.task_tracker as tt
 
@@ -213,16 +211,11 @@ async def test_get_idle_status_with_queue_work(monkeypatch):
                 "Semantic": QueueStatus(pending=1, in_progress=0),
             }
 
-    monkeypatch.setattr(
-        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
-    )
+    monkeypatch.setattr("openviking.service.resource_service.get_queue_manager", lambda: _FakeQM())
 
     class _FakeTracker:
-        def count_active(self):
-            return 0
-
-        def snapshot_active_counts_by_type(self):
-            return {}
+        async def snapshot_active_from_store(self):
+            return {"total": 0, "by_type": {}}
 
     import openviking.service.task_tracker as tt
 
@@ -246,16 +239,11 @@ async def test_get_idle_status_with_active_task(monkeypatch):
         async def check_status(self):
             return {"Embedding": QueueStatus(pending=0, in_progress=0)}
 
-    monkeypatch.setattr(
-        "openviking.service.resource_service.get_queue_manager", lambda: _FakeQM()
-    )
+    monkeypatch.setattr("openviking.service.resource_service.get_queue_manager", lambda: _FakeQM())
 
     class _FakeTracker:
-        def count_active(self):
-            return 1
-
-        def snapshot_active_counts_by_type(self):
-            return {"session_commit": 1}
+        async def snapshot_active_from_store(self):
+            return {"total": 1, "by_type": {"session_commit": 1}}
 
     import openviking.service.task_tracker as tt
 
@@ -275,16 +263,11 @@ async def test_get_idle_status_conservative_on_queue_error(monkeypatch):
     def _boom():
         raise RuntimeError("QueueManager is not initialized")
 
-    monkeypatch.setattr(
-        "openviking.service.resource_service.get_queue_manager", _boom
-    )
+    monkeypatch.setattr("openviking.service.resource_service.get_queue_manager", _boom)
 
     class _FakeTracker:
-        def count_active(self):
-            return 0
-
-        def snapshot_active_counts_by_type(self):
-            return {}
+        async def snapshot_active_from_store(self):
+            return {"total": 0, "by_type": {}}
 
     import openviking.service.task_tracker as tt
 
@@ -295,6 +278,63 @@ async def test_get_idle_status_conservative_on_queue_error(monkeypatch):
     # Uncertain source => never report idle=True even though pending==0.
     assert result["idle"] is False
     assert "error" in result["breakdown"]["queue"]
+
+
+async def test_get_idle_status_reads_persisted_tasks_not_cache(monkeypatch):
+    """Persisted-but-not-cached active task => idle=False (authoritative store).
+
+    Regression for the review point: a fresh process whose local _tasks cache is
+    empty must still report idle=False when the TaskStore holds a PENDING/RUNNING
+    record written by another worker (or never loaded into this process).
+    """
+    from openviking.service.resource_service import ResourceService
+    from openviking.storage.queuefs.named_queue import QueueStatus
+
+    class _FakeQM:
+        async def check_status(self):
+            return {"Embedding": QueueStatus(pending=0, in_progress=0)}
+
+    monkeypatch.setattr("openviking.service.resource_service.get_queue_manager", lambda: _FakeQM())
+
+    class _FakeStore:
+        async def list(self, account_id, *, user_id=None):
+            return [
+                {
+                    "task_id": "t-persisted-only",
+                    "task_type": "session_commit",
+                    "status": "running",
+                }
+            ]
+
+    class _FakeTracker:
+        # Local cache is empty (count_active would return 0), but the store has work.
+        def count_active(self):
+            return 0
+
+        def snapshot_active_counts_by_type(self):
+            return {}
+
+        async def snapshot_active_from_store(self):
+            store = _FakeStore()
+            records = await store.list("_system", user_id="root")
+            grouped = {}
+            total = 0
+            for rec in records:
+                if rec.get("status") in ("pending", "running"):
+                    grouped[rec["task_type"]] = grouped.get(rec["task_type"], 0) + 1
+                    total += 1
+            return {"total": total, "by_type": grouped}
+
+    import openviking.service.task_tracker as tt
+
+    monkeypatch.setattr(tt, "get_task_tracker", lambda: _FakeTracker())
+
+    result = await ResourceService().get_idle_status()
+
+    # Despite the empty process-local cache, the persisted RUNNING task forces idle=False.
+    assert result["idle"] is False
+    assert result["pending"] == 1
+    assert result["breakdown"]["tasks"]["by_type"] == {"session_commit": 1}
 
 
 async def test_backend_sync_status_endpoint(client: httpx.AsyncClient, service):


### PR DESCRIPTION
## What & why

Closes #3488.

Clients needing graceful shutdown/restart had to understand each internal async subsystem to tell whether the server had outstanding work. This adds a single authoritative, **non-blocking** idle status API — the sibling of `POST /api/v1/system/wait` that **reports** instead of **blocks**.

## Endpoint

`GET /api/v1/system/idle` aggregates the server's own internal state and returns:

```json
{"status":"ok","result":{
  "idle": true,
  "pending": 0,
  "breakdown": {
    "queue": {"pending": 0, "by_queue": {"Embedding": {"pending": 0, "in_progress": 0}, ...}},
    "tasks": {"pending": 0, "by_type": {"session_commit": 0, ...}}
  }
}}
```

`idle = (Σ all sources' pending == 0)`. Sources aggregated:
- **queue layer** (`QueueManager` — same `pending`/`in_progress` notion that `/wait` drains)
- **central `TaskTracker`** (PENDING+RUNNING tasks: `session_commit` with `wait=false`, reindex, …)

## Conservative by design

If any source raises or a singleton is uninitialized, its `breakdown` entry carries `{error: ...}` and `idle` is forced **false** — it never falsely reports idle.

## Intentionally excluded

- **`watch_manager`** — watch is a periodic schedule with no "drain" semantics; including it would keep `idle` forever `false`.
- **`EmbeddingTaskTracker`** — its pending subtasks are already reflected in the Embedding queue's `pending`/`in_progress`; counting separately would double-count.
(Happy to revisit either if maintainers want a different definition of "idle".)

## Changes

- `service/task_tracker.py` — read-only `count_active()` + `snapshot_active_counts_by_type()` (PENDING+RUNNING).
- `service/resource_service.py` — `ResourceService.get_idle_status()` (aggregation + breakdown).
- `server/routers/system.py` — `GET /api/v1/system/idle` (mirrors `/status`, `/wait` style).
- `server/auth/plugins/api_key.py` — whitelist `/api/v1/system/idle` alongside `/status`, `/wait`.

## Tests

`tests/server/test_server_health.py` +6: route forwarding (2) + aggregation unit tests (4: idle-when-empty, queue in_progress → not idle, active task → not idle, queue-error forces idle=false). **6 pass.**

Open question: the definition of "idle" is intentionally minimal (queue + task tracker). If a broader definition is wanted (e.g. include active HTTP in-flight requests, or exclude certain task types), easy to adjust the aggregation.

This contribution was developed with AI assistance.

Refs #3488