### PR TITLE
feat(feishu): batch-import wiki space / directory URLs (#3120)

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -516,6 +516,367 @@ class FeishuAccessor(DataAccessor):
 
         return doc_type, obj_token, title
 
+    # ========== Wiki Space / Directory Batch Expansion ==========
+    #
+    # Issue #3120: a Feishu "wiki space settings" URL
+    # (``https://*.feishu.cn/wiki/settings/<space_id>``) or a wiki node URL that
+    # has children should be expanded into one import per descendant document.
+    # The methods below reuse the same lark-oapi client + auth as ``_resolve_wiki_node``
+    # and walk the wiki tree via ``client.wiki.v2.space.list`` (paginated).
+
+    # Safety rails so a pathological space (cycles, very wide trees) cannot stall
+    # the importer. ``WIKI_BATCH_*`` constants are the defaults; callers can pass
+    # tighter limits via ``expand_feishu_url``.
+    WIKI_BATCH_DEFAULT_MAX_DEPTH = 5
+    WIKI_BATCH_DEFAULT_MAX_NODES = 500
+    WIKI_BATCH_PAGE_SIZE = 50
+
+    @staticmethod
+    def classify_url(url: str) -> Optional[Tuple[str, str, Optional[str]]]:
+        """Classify a Feishu URL for batch-import dispatch.
+
+        Returns ``None`` for non-Feishu URLs. Otherwise returns a 3-tuple
+        ``(kind, primary_token, secondary_token)`` where:
+
+        * ``("single_doc", doc_type, token)`` — always a single document import.
+          Covers ``/docx/<t>``, ``/sheets/<t>``, ``/base/<t>``.
+        * ``("wiki_node", node_token, None)`` — a ``/wiki/<token>`` URL. May be a
+          leaf document or a directory; the caller resolves ``has_child`` via the
+          wiki API to decide.
+        * ``("wiki_space_root", space_id, None)`` — a ``/wiki/settings/<space_id>``
+          URL that lists every node in the space.
+        """
+        if not FeishuAccessor._is_feishu_url(url):
+            return None
+        parsed = urlparse(url)
+        path_parts = [p for p in parsed.path.split("/") if p]
+        if len(path_parts) < 2:
+            return None
+        first, second = path_parts[0], path_parts[1]
+        if first == "wiki" and second == "settings":
+            # /wiki/settings/<space_id>(/...) — space root.
+            if len(path_parts) < 3:
+                return None
+            return ("wiki_space_root", path_parts[2], None)
+        if first == "wiki":
+            # /wiki/<node_token> — may be a leaf doc or a directory.
+            return ("wiki_node", second, None)
+        # /docx/<t>, /sheets/<t>, /base/<t> — always single-doc.
+        return ("single_doc", first, second)
+
+    @staticmethod
+    def is_batch_url(url: str) -> bool:
+        """Return True if ``url`` definitely triggers batch import.
+
+        A ``/wiki/settings/<space_id>`` URL always batches. A ``/wiki/<token>``
+        URL *may* batch (depending on ``has_child``) so this helper returns False
+        for it — the caller must run ``expand_feishu_url`` to find out.
+        """
+        classified = FeishuAccessor.classify_url(url)
+        return classified is not None and classified[0] == "wiki_space_root"
+
+    def _list_wiki_child_nodes(
+        self,
+        space_id: str,
+        parent_node_token: Optional[str],
+        *,
+        feishu_access_token: Optional[str] = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> Tuple[List["FeishuAccessor._WikiNode"], bool, Optional[str]]:
+        """List the direct children of a wiki node, following pagination.
+
+        Returns ``(nodes, has_more, next_page_token)``. ``nodes`` may be empty
+        when the node is a leaf. Pure SDK call — wrap in ``asyncio.to_thread``
+        from async callers.
+        """
+        from lark_oapi.api.wiki.v2 import ListSpaceNodeRequest
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        builder = ListSpaceNodeRequest.builder().space_id(space_id)
+        if parent_node_token:
+            builder = builder.parent_node_token(parent_node_token)
+        if page_token:
+            builder = builder.page_token(page_token)
+        builder = builder.page_size(page_size or self.WIKI_BATCH_PAGE_SIZE)
+        request = builder.build()
+        response = self._call_api(client.wiki.v2.space.list, request, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=(
+                    f"list wiki nodes space={space_id} "
+                    f"parent={parent_node_token or '<root>'}"
+                ),
+                resource=space_id,
+            )
+        data = getattr(response, "data", None)
+        raw_items = getattr(data, "items", None) or []
+        nodes = [self._wiki_node_from_sdk(item) for item in raw_items]
+        has_more = bool(getattr(data, "has_more", False))
+        next_page_token = getattr(data, "page_token", None)
+        return nodes, has_more, next_page_token
+
+    @staticmethod
+    def _wiki_node_from_sdk(item: Any) -> "FeishuAccessor._WikiNode":
+        """Build a ``_WikiNode`` from a lark-oapi ``Node`` (SDK object or dict)."""
+        return FeishuAccessor._WikiNode(
+            node_token=_getattr_safe(item, "node_token", "") or "",
+            obj_token=_getattr_safe(item, "obj_token", "") or "",
+            obj_type=_getattr_safe(item, "obj_type", "") or "",
+            title=_getattr_safe(item, "title", "") or "",
+            has_child=bool(_getattr_safe(item, "has_child", False)),
+            space_id=str(_getattr_safe(item, "space_id", "") or ""),
+            parent_node_token=_getattr_safe(item, "parent_node_token", "") or None,
+            url=_getattr_safe(item, "url", "") or "",
+        )
+
+    @dataclass
+    class _WikiNode:
+        """Resolved view of a wiki node used during subtree traversal."""
+        node_token: str
+        obj_token: str
+        obj_type: str  # raw API type: docx/doc/sheet/bitable/wiki/...
+        title: str
+        has_child: bool
+        space_id: str
+        parent_node_token: Optional[str]
+        url: str = ""
+
+    def _resolve_wiki_node_full(
+        self,
+        node_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> "_WikiNode":
+        """Resolve a wiki node token to its full node info (incl. ``has_child``).
+
+        Uses the same ``get_node`` API as ``_resolve_wiki_node`` but returns the
+        extra fields the batch importer needs.
+        """
+        from lark_oapi.api.wiki.v2 import GetNodeSpaceRequest
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        request = GetNodeSpaceRequest.builder().token(node_token).build()
+        response = self._call_api(
+            client.wiki.v2.space.get_node,
+            request,
+            feishu_access_token,
+        )
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"resolve wiki node {node_token}",
+                resource=node_token,
+            )
+        node = getattr(response.data, "node", None)
+        return self._wiki_node_from_sdk(node)
+
+    async def list_wiki_subtree(
+        self,
+        *,
+        space_id: Optional[str] = None,
+        root_node_token: Optional[str] = None,
+        feishu_access_token: Optional[str] = None,
+        max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
+        max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
+    ) -> List[Tuple[str, str]]:
+        """Walk a Feishu wiki subtree and return ``(doc_url, title)`` tuples.
+
+        Exactly one of ``space_id`` (whole space) or ``root_node_token`` (a single
+        wiki node + its descendants) must be provided. ``space_id`` lists every
+        top-level node via ``space.list``; ``root_node_token`` first resolves the
+        node via ``get_node`` and then lists its children.
+
+        Bounds: ``max_depth`` caps recursion (the root counts as depth 0);
+        ``max_nodes`` caps the total returned documents. Both bounds are enforced
+        best-effort — when hit, traversal stops and a warning is logged.
+        """
+        if (space_id is None) == (root_node_token is None):
+            raise ValueError(
+                "list_wiki_subtree requires exactly one of space_id or root_node_token."
+            )
+
+        results: List[Tuple[str, str]] = []
+        # ``seen_tokens`` breaks accidental cycles (parent_token loops in the API
+        # response or shared subtrees).
+        seen_tokens: set[str] = set()
+        truncated = False
+
+        def _record(node: "FeishuAccessor._WikiNode") -> bool:
+            """Append a node's doc URL. Return False if the cap is hit.
+
+            Nodes whose ``obj_type`` is not a parseable document type are skipped
+            for emission (their URL would be unparseable), but the caller still
+            recurses into them when ``has_child`` is set so folders of unknown
+            type are walked.
+            """
+            nonlocal truncated
+            if not node.obj_token or node.obj_token in seen_tokens:
+                return True
+            doc_url = self._build_doc_url(node)
+            if doc_url is None:
+                logger.debug(
+                    "[FeishuAccessor] skipping wiki node %s with unsupported obj_type=%r",
+                    node.node_token,
+                    node.obj_type,
+                )
+                return True
+            if len(results) >= max_nodes:
+                truncated = True
+                return False
+            seen_tokens.add(node.obj_token)
+            results.append((doc_url, node.title or ""))
+            return True
+
+        async def _walk(
+            space: str,
+            parent_node_token: Optional[str],
+            depth: int,
+        ) -> None:
+            nonlocal truncated
+            if depth >= max_depth:
+                logger.warning(
+                    "[FeishuAccessor] wiki subtree max_depth=%d hit at node=%s; "
+                    "stopping recursion (increase to fetch more).",
+                    max_depth,
+                    parent_node_token or "<root>",
+                )
+                return
+            page_token: Optional[str] = None
+            while True:
+                if len(results) >= max_nodes:
+                    truncated = True
+                    return
+                nodes, has_more, next_page_token = await asyncio.to_thread(
+                    self._list_wiki_child_nodes,
+                    space,
+                    parent_node_token,
+                    feishu_access_token=feishu_access_token,
+                    page_token=page_token,
+                )
+                for node in nodes:
+                    if not _record(node):
+                        return
+                    if node.has_child and node.node_token:
+                        await _walk(space, node.node_token, depth + 1)
+                        if truncated:
+                            return
+                if not has_more or not next_page_token:
+                    return
+                if next_page_token == page_token:
+                    # Defensive: avoid spinning on an unchanging page token.
+                    return
+                page_token = next_page_token
+
+        if space_id:
+            await _walk(space_id, None, 0)
+        else:
+            assert root_node_token is not None
+            root = await asyncio.to_thread(
+                self._resolve_wiki_node_full,
+                root_node_token,
+                feishu_access_token=feishu_access_token,
+            )
+            _record(root)
+            if root.has_child and root.node_token and not truncated:
+                # ``space_id`` from the node so child listings use the right space.
+                await _walk(root.space_id or "", root.node_token, 1)
+
+        if truncated:
+            logger.warning(
+                "[FeishuAccessor] wiki subtree truncated at max_nodes=%d "
+                "(space=%s root=%s).",
+                max_nodes,
+                space_id,
+                root_node_token,
+            )
+        return results
+
+    @staticmethod
+    def _build_doc_url(node: "FeishuAccessor._WikiNode") -> Optional[str]:
+        """Build a canonical single-doc URL for a wiki node, or None if unparseable.
+
+        Returns ``None`` for ``obj_type`` values outside ``_DOC_TYPE_HANDLERS``
+        so the caller can skip emission while still recursing into the node's
+        children. For parseable types we emit a *direct* doc URL
+        (``/docx/<obj_token>``, ``/sheets/<obj_token>``, ``/base/<obj_token>``)
+        so re-importing the child cannot re-trigger batch expansion (those URL
+        kinds are classified as ``single_doc``).
+        """
+        doc_type = FeishuAccessor._WIKI_TYPE_MAP.get(node.obj_type, node.obj_type)
+        if doc_type not in FeishuAccessor._DOC_TYPE_HANDLERS:
+            return None
+        if not node.obj_token:
+            return None
+        return f"https://feishu.cn/{doc_type}/{node.obj_token}"
+
+    async def expand_feishu_url(
+        self,
+        url: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+        max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
+        max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
+    ) -> List[Tuple[str, str]]:
+        """Expand a Feishu URL into the list of documents to import.
+
+        Returns a list of ``(doc_url, title)`` tuples:
+
+        * Single-document URLs (``/docx/<t>``, ``/sheets/<t>``, ``/base/<t>``)
+          always return ``[(url, "")]`` — single-doc imports are unchanged.
+        * ``/wiki/settings/<space_id>`` returns every document in the space;
+          an empty list means the space has no importable documents.
+        * ``/wiki/<token>`` resolves the node: if it has children, returns the
+          node itself plus every descendant (empty list if the subtree has no
+          importable documents); otherwise returns ``[(url, "")]`` (unchanged
+          single-doc behavior).
+
+        A return of ``[]`` therefore means "recognised batch source with nothing
+        to import" — the caller must surface this rather than fall back to a
+        single-doc import (the original URL is not a valid doc URL).
+
+        Raising on API failure is intentional — the caller surfaces the error
+        instead of silently degrading to a single-doc import.
+        """
+        classified = self.classify_url(url)
+        if classified is None:
+            # Not a Feishu URL — let the caller handle it (existing path).
+            return [(url, "")]
+        kind, primary, _secondary = classified
+        if kind == "single_doc":
+            return [(url, "")]
+        if kind == "wiki_space_root":
+            children = await self.list_wiki_subtree(
+                space_id=primary,
+                feishu_access_token=feishu_access_token,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+            )
+            # Empty list is meaningful: caller surfaces "no documents" rather
+            # than trying to import the /wiki/settings/<id> URL as a doc.
+            return children
+        if kind == "wiki_node":
+            node = await asyncio.to_thread(
+                self._resolve_wiki_node_full,
+                primary,
+                feishu_access_token=feishu_access_token,
+            )
+            if not node.has_child:
+                return [(url, "")]
+            children = await self.list_wiki_subtree(
+                root_node_token=primary,
+                feishu_access_token=feishu_access_token,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+            )
+            # ``list_wiki_subtree`` always records the root first, so an empty
+            # result here means the root itself was deduped/filtered — surface
+            # it as "no documents" rather than re-importing the wiki URL.
+            return children
+        # Defensive — classify_url only returns the kinds above.
+        return [(url, "")]
+
     # ========== Docx Parsing ==========
 
     def _parse_docx(

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -698,9 +698,12 @@ class FeishuAccessor(DataAccessor):
             )
 
         results: List[Tuple[str, str]] = []
-        # ``seen_tokens`` breaks accidental cycles (parent_token loops in the API
-        # response or shared subtrees).
+        # ``seen_tokens`` (obj_token) dedupes *emitted results* across shared subtrees.
         seen_tokens: set[str] = set()
+        # ``seen_node_tokens`` (node_token) breaks *recursion cycles* — without it,
+        # a node whose child points back at an already-expanded ancestor
+        # (A -> B -> A) would recurse forever (RecursionError once depth is large).
+        seen_node_tokens: set[str] = set()
         truncated = False
 
         def _record(node: "FeishuAccessor._WikiNode") -> bool:

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -113,6 +113,74 @@ class FeishuDocument:
     media_download_extras: _MediaDownloadExtras = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ExpandedDoc:
+    """A single document expanded from a (possibly batch) Feishu URL.
+
+    Carries the *source kind* so the importer can distinguish a genuine batch
+    child from a single-document passthrough even when a wiki space or
+    directory contains exactly one importable document (issue #3120 review):
+    ``len(expanded) == 1`` is not a reliable signal on its own, because both a
+    passthrough single-doc URL and a one-document space yield a length of one.
+
+    ``rel_path`` is the document's *directory* path relative to the batch
+    parent (e.g. ``"team/handbook"``), preserving the Feishu wiki hierarchy so
+    imported children land under ``<batch_parent>/<rel_path>/<doc_name>``
+    rather than being flattened into the parent (issue #3120 review).
+    """
+
+    url: str
+    title: str = ""
+    # "single_doc_passthrough" — the original URL is itself a single document.
+    # "batch_child" — this doc came from expanding a space/directory URL.
+    source_kind: str = "single_doc_passthrough"
+    rel_path: str = ""
+
+    def __post_init__(self) -> None:
+        if self.source_kind not in ("single_doc_passthrough", "batch_child"):
+            raise ValueError(
+                f"Unknown ExpandedDoc.source_kind={self.source_kind!r}; "
+                "expected 'single_doc_passthrough' or 'batch_child'."
+            )
+
+
+def _sanitize_rel_segment(name: str) -> str:
+    """Sanitize one wiki-node title into a single URI path segment.
+
+    Uses the canonical segment sanitizer when available so the relative path
+    composes identically to a normally-resolved target URI; falls back to a
+    conservative alphanumeric/CJK cleanup if the core URI helper is not
+    importable in this context.
+    """
+    cleaned = (name or "").strip()
+    if not cleaned:
+        return ""
+    try:
+        from openviking.core.uri import VikingURI
+
+        return VikingURI.sanitize_segment(cleaned)
+    except Exception:
+        return re.sub(r"[^\w.\-]+", "_", cleaned, flags=re.UNICODE).strip("._") or "_"
+
+
+def _child_rel_dir(parent_rel: str, node: "FeishuAccessor._WikiNode") -> str:
+    """Build the relative directory for ``node``'s children under ``parent_rel``.
+
+    A directory node contributes its sanitized title (falling back to its
+    node token when the title is empty) as one path segment. Empty segments
+    are dropped at join time by the caller, so this never produces a leading
+    or trailing slash.
+    """
+    seg = (
+        _sanitize_rel_segment(node.title)
+        or _sanitize_rel_segment(node.node_token)
+        or node.node_token
+    )
+    if not seg:
+        return parent_rel
+    return f"{parent_rel}/{seg}" if parent_rel else seg
+
+
 class FeishuAccessor(DataAccessor):
     """
     Accessor for Feishu/Lark cloud documents.
@@ -605,8 +673,7 @@ class FeishuAccessor(DataAccessor):
             _raise_from_lark_response(
                 response,
                 operation=(
-                    f"list wiki nodes space={space_id} "
-                    f"parent={parent_node_token or '<root>'}"
+                    f"list wiki nodes space={space_id} parent={parent_node_token or '<root>'}"
                 ),
                 resource=space_id,
             )
@@ -634,6 +701,7 @@ class FeishuAccessor(DataAccessor):
     @dataclass
     class _WikiNode:
         """Resolved view of a wiki node used during subtree traversal."""
+
         node_token: str
         obj_token: str
         obj_type: str  # raw API type: docx/doc/sheet/bitable/wiki/...
@@ -680,8 +748,12 @@ class FeishuAccessor(DataAccessor):
         feishu_access_token: Optional[str] = None,
         max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
         max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
-    ) -> List[Tuple[str, str]]:
-        """Walk a Feishu wiki subtree and return ``(doc_url, title)`` tuples.
+    ) -> List[ExpandedDoc]:
+        """Walk a Feishu wiki subtree and return :class:`ExpandedDoc` entries.
+
+        Each entry carries its directory ``rel_path`` relative to the subtree
+        root so importers can preserve the Feishu wiki hierarchy under
+        ``<batch_parent>/<rel_path>/<doc_name>`` (issue #3120 review).
 
         Exactly one of ``space_id`` (whole space) or ``root_node_token`` (a single
         wiki node + its descendants) must be provided. ``space_id`` lists every
@@ -697,7 +769,7 @@ class FeishuAccessor(DataAccessor):
                 "list_wiki_subtree requires exactly one of space_id or root_node_token."
             )
 
-        results: List[Tuple[str, str]] = []
+        results: List[ExpandedDoc] = []
         # ``seen_tokens`` (obj_token) dedupes *emitted results* across shared subtrees.
         seen_tokens: set[str] = set()
         # ``seen_node_tokens`` (node_token) breaks *recursion cycles* — without it,
@@ -706,8 +778,11 @@ class FeishuAccessor(DataAccessor):
         seen_node_tokens: set[str] = set()
         truncated = False
 
-        def _record(node: "FeishuAccessor._WikiNode") -> bool:
+        def _record(node: "FeishuAccessor._WikiNode", rel_dir: str) -> bool:
             """Append a node's doc URL. Return False if the cap is hit.
+
+            ``rel_dir`` is the directory path (relative to the batch parent)
+            where this document should land, preserving the wiki hierarchy.
 
             Nodes whose ``obj_type`` is not a parseable document type are skipped
             for emission (their URL would be unparseable), but the caller still
@@ -729,13 +804,21 @@ class FeishuAccessor(DataAccessor):
                 truncated = True
                 return False
             seen_tokens.add(node.obj_token)
-            results.append((doc_url, node.title or ""))
+            results.append(
+                ExpandedDoc(
+                    url=doc_url,
+                    title=node.title or "",
+                    source_kind="batch_child",
+                    rel_path=rel_dir,
+                )
+            )
             return True
 
         async def _walk(
             space: str,
             parent_node_token: Optional[str],
             depth: int,
+            rel_dir: str,
         ) -> None:
             nonlocal truncated
             if depth >= max_depth:
@@ -772,10 +855,15 @@ class FeishuAccessor(DataAccessor):
                     page_token=page_token,
                 )
                 for node in nodes:
-                    if not _record(node):
+                    if not _record(node, rel_dir):
                         return
                     if node.has_child and node.node_token:
-                        await _walk(space, node.node_token, depth + 1)
+                        await _walk(
+                            space,
+                            node.node_token,
+                            depth + 1,
+                            _child_rel_dir(rel_dir, node),
+                        )
                         if truncated:
                             return
                 if not has_more or not next_page_token:
@@ -788,7 +876,7 @@ class FeishuAccessor(DataAccessor):
                 page_token = next_page_token
 
         if space_id:
-            await _walk(space_id, None, 0)
+            await _walk(space_id, None, 0, "")
         else:
             assert root_node_token is not None
             root = await asyncio.to_thread(
@@ -796,15 +884,19 @@ class FeishuAccessor(DataAccessor):
                 root_node_token,
                 feishu_access_token=feishu_access_token,
             )
-            _record(root)
+            _record(root, "")
             if root.has_child and root.node_token and not truncated:
                 # ``space_id`` from the node so child listings use the right space.
-                await _walk(root.space_id or "", root.node_token, 1)
+                await _walk(
+                    root.space_id or "",
+                    root.node_token,
+                    1,
+                    _child_rel_dir("", root),
+                )
 
         if truncated:
             logger.warning(
-                "[FeishuAccessor] wiki subtree truncated at max_nodes=%d "
-                "(space=%s root=%s).",
+                "[FeishuAccessor] wiki subtree truncated at max_nodes=%d (space=%s root=%s).",
                 max_nodes,
                 space_id,
                 root_node_token,
@@ -836,13 +928,14 @@ class FeishuAccessor(DataAccessor):
         feishu_access_token: Optional[str] = None,
         max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
         max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
-    ) -> List[Tuple[str, str]]:
+    ) -> List[ExpandedDoc]:
         """Expand a Feishu URL into the list of documents to import.
 
-        Returns a list of ``(doc_url, title)`` tuples:
+        Returns a list of :class:`ExpandedDoc` entries:
 
         * Single-document URLs (``/docx/<t>``, ``/sheets/<t>``, ``/base/<t>``)
-          always return ``[(url, "")]`` — single-doc imports are unchanged.
+          always return a ``single_doc_passthrough`` entry — single-doc imports
+          are unchanged.
         * ``/wiki/settings/<space_id>`` returns every document in the space;
           an empty list means the space has no importable documents.
         * ``/wiki/<token>`` resolves the node: if it has children, returns the
@@ -860,10 +953,10 @@ class FeishuAccessor(DataAccessor):
         classified = self.classify_url(url)
         if classified is None:
             # Not a Feishu URL — let the caller handle it (existing path).
-            return [(url, "")]
+            return [ExpandedDoc(url=url)]
         kind, primary, _secondary = classified
         if kind == "single_doc":
-            return [(url, "")]
+            return [ExpandedDoc(url=url)]
         if kind == "wiki_space_root":
             children = await self.list_wiki_subtree(
                 space_id=primary,
@@ -881,7 +974,7 @@ class FeishuAccessor(DataAccessor):
                 feishu_access_token=feishu_access_token,
             )
             if not node.has_child:
-                return [(url, "")]
+                return [ExpandedDoc(url=url)]
             children = await self.list_wiki_subtree(
                 root_node_token=primary,
                 feishu_access_token=feishu_access_token,
@@ -893,7 +986,7 @@ class FeishuAccessor(DataAccessor):
             # it as "no documents" rather than re-importing the wiki URL.
             return children
         # Defensive — classify_url only returns the kinds above.
-        return [(url, "")]
+        return [ExpandedDoc(url=url)]
 
     # ========== Docx Parsing ==========
 

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -746,7 +746,20 @@ class FeishuAccessor(DataAccessor):
                     parent_node_token or "<root>",
                 )
                 return
+            # Cycle guard: never expand the same node_token twice. A wiki whose
+            # child points back at an already-expanded ancestor (A -> B -> A) would
+            # otherwise recurse unboundedly -> RecursionError once depth grows.
+            if parent_node_token and parent_node_token in seen_node_tokens:
+                logger.warning(
+                    "[FeishuAccessor] wiki subtree cycle detected at node=%s; "
+                    "skipping re-entry to avoid unbounded recursion.",
+                    parent_node_token,
+                )
+                return
+            if parent_node_token:
+                seen_node_tokens.add(parent_node_token)
             page_token: Optional[str] = None
+            seen_page_tokens: set[str] = set()
             while True:
                 if len(results) >= max_nodes:
                     truncated = True
@@ -767,9 +780,11 @@ class FeishuAccessor(DataAccessor):
                             return
                 if not has_more or not next_page_token:
                     return
-                if next_page_token == page_token:
-                    # Defensive: avoid spinning on an unchanging page token.
+                if next_page_token == page_token or next_page_token in seen_page_tokens:
+                    # Defensive: avoid spinning on a repeating page token
+                    # (adjacent dup OR an A -> B -> A token cycle from a buggy/malicious API).
                     return
+                seen_page_tokens.add(next_page_token)
                 page_token = next_page_token
 
         if space_id:

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -233,6 +233,74 @@ class FeishuDocument:
     media_download_extras: _MediaDownloadExtras = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ExpandedDoc:
+    """A single document expanded from a (possibly batch) Feishu URL.
+
+    Carries the *source kind* so the importer can distinguish a genuine batch
+    child from a single-document passthrough even when a wiki space or
+    directory contains exactly one importable document (issue #3120 review):
+    ``len(expanded) == 1`` is not a reliable signal on its own, because both a
+    passthrough single-doc URL and a one-document space yield a length of one.
+
+    ``rel_path`` is the document's *directory* path relative to the batch
+    parent (e.g. ``"team/handbook"``), preserving the Feishu wiki hierarchy so
+    imported children land under ``<batch_parent>/<rel_path>/<doc_name>``
+    rather than being flattened into the parent (issue #3120 review).
+    """
+
+    url: str
+    title: str = ""
+    # "single_doc_passthrough" — the original URL is itself a single document.
+    # "batch_child" — this doc came from expanding a space/directory URL.
+    source_kind: str = "single_doc_passthrough"
+    rel_path: str = ""
+
+    def __post_init__(self) -> None:
+        if self.source_kind not in ("single_doc_passthrough", "batch_child"):
+            raise ValueError(
+                f"Unknown ExpandedDoc.source_kind={self.source_kind!r}; "
+                "expected 'single_doc_passthrough' or 'batch_child'."
+            )
+
+
+def _sanitize_rel_segment(name: str) -> str:
+    """Sanitize one wiki-node title into a single URI path segment.
+
+    Uses the canonical segment sanitizer when available so the relative path
+    composes identically to a normally-resolved target URI; falls back to a
+    conservative alphanumeric/CJK cleanup if the core URI helper is not
+    importable in this context.
+    """
+    cleaned = (name or "").strip()
+    if not cleaned:
+        return ""
+    try:
+        from openviking.core.uri import VikingURI
+
+        return VikingURI.sanitize_segment(cleaned)
+    except Exception:
+        return re.sub(r"[^\w.\-]+", "_", cleaned, flags=re.UNICODE).strip("._") or "_"
+
+
+def _child_rel_dir(parent_rel: str, node: "FeishuAccessor._WikiNode") -> str:
+    """Build the relative directory for ``node``'s children under ``parent_rel``.
+
+    A directory node contributes its sanitized title (falling back to its
+    node token when the title is empty) as one path segment. Empty segments
+    are dropped at join time by the caller, so this never produces a leading
+    or trailing slash.
+    """
+    seg = (
+        _sanitize_rel_segment(node.title)
+        or _sanitize_rel_segment(node.node_token)
+        or node.node_token
+    )
+    if not seg:
+        return parent_rel
+    return f"{parent_rel}/{seg}" if parent_rel else seg
+
+
 class FeishuAccessor(DataAccessor):
     """
     Accessor for Feishu/Lark cloud documents.
@@ -1410,6 +1478,410 @@ class FeishuAccessor(DataAccessor):
         data = self._raw_response_data(response)
         content = _getattr_safe(data, "content", "")
         return str(content or "")
+
+    # ========== Wiki Space / Directory Batch Expansion ==========
+    #
+    # Issue #3120: a Feishu "wiki space settings" URL
+    # (``https://*.feishu.cn/wiki/settings/<space_id>``) or a wiki node URL that
+    # has children should be expanded into one import per descendant document.
+    # The methods below reuse the same lark-oapi client + auth as ``_resolve_wiki_node``
+    # and walk the wiki tree via ``client.wiki.v2.space.list`` (paginated).
+
+    # Safety rails so a pathological space (cycles, very wide trees) cannot stall
+    # the importer. ``WIKI_BATCH_*`` constants are the defaults; callers can pass
+    # tighter limits via ``expand_feishu_url``.
+    WIKI_BATCH_DEFAULT_MAX_DEPTH = 5
+    WIKI_BATCH_DEFAULT_MAX_NODES = 500
+    WIKI_BATCH_PAGE_SIZE = 50
+
+    @staticmethod
+    def classify_url(url: str) -> Optional[Tuple[str, str, Optional[str]]]:
+        """Classify a Feishu URL for batch-import dispatch.
+
+        Returns ``None`` for non-Feishu URLs. Otherwise returns a 3-tuple
+        ``(kind, primary_token, secondary_token)`` where:
+
+        * ``("single_doc", doc_type, token)`` — always a single document import.
+          Covers ``/docx/<t>``, ``/sheets/<t>``, ``/base/<t>``.
+        * ``("wiki_node", node_token, None)`` — a ``/wiki/<token>`` URL. May be a
+          leaf document or a directory; the caller resolves ``has_child`` via the
+          wiki API to decide.
+        * ``("wiki_space_root", space_id, None)`` — a ``/wiki/settings/<space_id>``
+          URL that lists every node in the space.
+        """
+        if not FeishuAccessor._is_feishu_url(url):
+            return None
+        parsed = urlparse(url)
+        path_parts = [p for p in parsed.path.split("/") if p]
+        if len(path_parts) < 2:
+            return None
+        first, second = path_parts[0], path_parts[1]
+        if first == "wiki" and second == "settings":
+            # /wiki/settings/<space_id>(/...) — space root.
+            if len(path_parts) < 3:
+                return None
+            return ("wiki_space_root", path_parts[2], None)
+        if first == "wiki":
+            # /wiki/<node_token> — may be a leaf doc or a directory.
+            return ("wiki_node", second, None)
+        # /docx/<t>, /sheets/<t>, /base/<t> — always single-doc.
+        return ("single_doc", first, second)
+
+    @staticmethod
+    def is_batch_url(url: str) -> bool:
+        """Return True if ``url`` definitely triggers batch import.
+
+        A ``/wiki/settings/<space_id>`` URL always batches. A ``/wiki/<token>``
+        URL *may* batch (depending on ``has_child``) so this helper returns False
+        for it — the caller must run ``expand_feishu_url`` to find out.
+        """
+        classified = FeishuAccessor.classify_url(url)
+        return classified is not None and classified[0] == "wiki_space_root"
+
+    def _list_wiki_child_nodes(
+        self,
+        space_id: str,
+        parent_node_token: Optional[str],
+        *,
+        feishu_access_token: Optional[str] = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> Tuple[List["FeishuAccessor._WikiNode"], bool, Optional[str]]:
+        """List the direct children of a wiki node, following pagination.
+
+        Returns ``(nodes, has_more, next_page_token)``. ``nodes`` may be empty
+        when the node is a leaf. Pure SDK call — wrap in ``asyncio.to_thread``
+        from async callers.
+        """
+        from lark_oapi.api.wiki.v2 import ListSpaceNodeRequest
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        builder = ListSpaceNodeRequest.builder().space_id(space_id)
+        if parent_node_token:
+            builder = builder.parent_node_token(parent_node_token)
+        if page_token:
+            builder = builder.page_token(page_token)
+        builder = builder.page_size(page_size or self.WIKI_BATCH_PAGE_SIZE)
+        request = builder.build()
+        response = self._call_api(client.wiki.v2.space.list, request, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=(
+                    f"list wiki nodes space={space_id} parent={parent_node_token or '<root>'}"
+                ),
+                resource=space_id,
+            )
+        data = getattr(response, "data", None)
+        raw_items = getattr(data, "items", None) or []
+        nodes = [self._wiki_node_from_sdk(item) for item in raw_items]
+        has_more = bool(getattr(data, "has_more", False))
+        next_page_token = getattr(data, "page_token", None)
+        return nodes, has_more, next_page_token
+
+    @staticmethod
+    def _wiki_node_from_sdk(item: Any) -> "FeishuAccessor._WikiNode":
+        """Build a ``_WikiNode`` from a lark-oapi ``Node`` (SDK object or dict)."""
+        return FeishuAccessor._WikiNode(
+            node_token=_getattr_safe(item, "node_token", "") or "",
+            obj_token=_getattr_safe(item, "obj_token", "") or "",
+            obj_type=_getattr_safe(item, "obj_type", "") or "",
+            title=_getattr_safe(item, "title", "") or "",
+            has_child=bool(_getattr_safe(item, "has_child", False)),
+            space_id=str(_getattr_safe(item, "space_id", "") or ""),
+            parent_node_token=_getattr_safe(item, "parent_node_token", "") or None,
+            url=_getattr_safe(item, "url", "") or "",
+        )
+
+    @dataclass
+    class _WikiNode:
+        """Resolved view of a wiki node used during subtree traversal."""
+
+        node_token: str
+        obj_token: str
+        obj_type: str  # raw API type: docx/doc/sheet/bitable/wiki/...
+        title: str
+        has_child: bool
+        space_id: str
+        parent_node_token: Optional[str]
+        url: str = ""
+
+    def _resolve_wiki_node_full(
+        self,
+        node_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> "_WikiNode":
+        """Resolve a wiki node token to its full node info (incl. ``has_child``).
+
+        Uses the same ``get_node`` API as ``_resolve_wiki_node`` but returns the
+        extra fields the batch importer needs.
+        """
+        from lark_oapi.api.wiki.v2 import GetNodeSpaceRequest
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        request = GetNodeSpaceRequest.builder().token(node_token).build()
+        response = self._call_api(
+            client.wiki.v2.space.get_node,
+            request,
+            feishu_access_token,
+        )
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"resolve wiki node {node_token}",
+                resource=node_token,
+            )
+        node = getattr(response.data, "node", None)
+        return self._wiki_node_from_sdk(node)
+
+    async def list_wiki_subtree(
+        self,
+        *,
+        space_id: Optional[str] = None,
+        root_node_token: Optional[str] = None,
+        feishu_access_token: Optional[str] = None,
+        max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
+        max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
+    ) -> List[ExpandedDoc]:
+        """Walk a Feishu wiki subtree and return :class:`ExpandedDoc` entries.
+
+        Each entry carries its directory ``rel_path`` relative to the subtree
+        root so importers can preserve the Feishu wiki hierarchy under
+        ``<batch_parent>/<rel_path>/<doc_name>`` (issue #3120 review).
+
+        Exactly one of ``space_id`` (whole space) or ``root_node_token`` (a single
+        wiki node + its descendants) must be provided. ``space_id`` lists every
+        top-level node via ``space.list``; ``root_node_token`` first resolves the
+        node via ``get_node`` and then lists its children.
+
+        Bounds: ``max_depth`` caps recursion (the root counts as depth 0);
+        ``max_nodes`` caps the total returned documents. Both bounds are enforced
+        best-effort — when hit, traversal stops and a warning is logged.
+        """
+        if (space_id is None) == (root_node_token is None):
+            raise ValueError(
+                "list_wiki_subtree requires exactly one of space_id or root_node_token."
+            )
+
+        results: List[ExpandedDoc] = []
+        # ``seen_tokens`` (obj_token) dedupes *emitted results* across shared subtrees.
+        seen_tokens: set[str] = set()
+        # ``seen_node_tokens`` (node_token) breaks *recursion cycles* — without it,
+        # a node whose child points back at an already-expanded ancestor
+        # (A -> B -> A) would recurse forever (RecursionError once depth is large).
+        seen_node_tokens: set[str] = set()
+        truncated = False
+
+        def _record(node: "FeishuAccessor._WikiNode", rel_dir: str) -> bool:
+            """Append a node's doc URL. Return False if the cap is hit.
+
+            ``rel_dir`` is the directory path (relative to the batch parent)
+            where this document should land, preserving the wiki hierarchy.
+
+            Nodes whose ``obj_type`` is not a parseable document type are skipped
+            for emission (their URL would be unparseable), but the caller still
+            recurses into them when ``has_child`` is set so folders of unknown
+            type are walked.
+            """
+            nonlocal truncated
+            if not node.obj_token or node.obj_token in seen_tokens:
+                return True
+            doc_url = self._build_doc_url(node)
+            if doc_url is None:
+                logger.debug(
+                    "[FeishuAccessor] skipping wiki node %s with unsupported obj_type=%r",
+                    node.node_token,
+                    node.obj_type,
+                )
+                return True
+            if len(results) >= max_nodes:
+                truncated = True
+                return False
+            seen_tokens.add(node.obj_token)
+            results.append(
+                ExpandedDoc(
+                    url=doc_url,
+                    title=node.title or "",
+                    source_kind="batch_child",
+                    rel_path=rel_dir,
+                )
+            )
+            return True
+
+        async def _walk(
+            space: str,
+            parent_node_token: Optional[str],
+            depth: int,
+            rel_dir: str,
+        ) -> None:
+            nonlocal truncated
+            if depth >= max_depth:
+                logger.warning(
+                    "[FeishuAccessor] wiki subtree max_depth=%d hit at node=%s; "
+                    "stopping recursion (increase to fetch more).",
+                    max_depth,
+                    parent_node_token or "<root>",
+                )
+                return
+            # Cycle guard: never expand the same node_token twice. A wiki whose
+            # child points back at an already-expanded ancestor (A -> B -> A) would
+            # otherwise recurse unboundedly -> RecursionError once depth grows.
+            if parent_node_token and parent_node_token in seen_node_tokens:
+                logger.warning(
+                    "[FeishuAccessor] wiki subtree cycle detected at node=%s; "
+                    "skipping re-entry to avoid unbounded recursion.",
+                    parent_node_token,
+                )
+                return
+            if parent_node_token:
+                seen_node_tokens.add(parent_node_token)
+            page_token: Optional[str] = None
+            seen_page_tokens: set[str] = set()
+            while True:
+                if len(results) >= max_nodes:
+                    truncated = True
+                    return
+                nodes, has_more, next_page_token = await asyncio.to_thread(
+                    self._list_wiki_child_nodes,
+                    space,
+                    parent_node_token,
+                    feishu_access_token=feishu_access_token,
+                    page_token=page_token,
+                )
+                for node in nodes:
+                    if not _record(node, rel_dir):
+                        return
+                    if node.has_child and node.node_token:
+                        await _walk(
+                            space,
+                            node.node_token,
+                            depth + 1,
+                            _child_rel_dir(rel_dir, node),
+                        )
+                        if truncated:
+                            return
+                if not has_more or not next_page_token:
+                    return
+                if next_page_token == page_token or next_page_token in seen_page_tokens:
+                    # Defensive: avoid spinning on a repeating page token
+                    # (adjacent dup OR an A -> B -> A token cycle from a buggy/malicious API).
+                    return
+                seen_page_tokens.add(next_page_token)
+                page_token = next_page_token
+
+        if space_id:
+            await _walk(space_id, None, 0, "")
+        else:
+            assert root_node_token is not None
+            root = await asyncio.to_thread(
+                self._resolve_wiki_node_full,
+                root_node_token,
+                feishu_access_token=feishu_access_token,
+            )
+            _record(root, "")
+            if root.has_child and root.node_token and not truncated:
+                # ``space_id`` from the node so child listings use the right space.
+                await _walk(
+                    root.space_id or "",
+                    root.node_token,
+                    1,
+                    _child_rel_dir("", root),
+                )
+
+        if truncated:
+            logger.warning(
+                "[FeishuAccessor] wiki subtree truncated at max_nodes=%d (space=%s root=%s).",
+                max_nodes,
+                space_id,
+                root_node_token,
+            )
+        return results
+
+    @staticmethod
+    def _build_doc_url(node: "FeishuAccessor._WikiNode") -> Optional[str]:
+        """Build a canonical single-doc URL for a wiki node, or None if unparseable.
+
+        Returns ``None`` for ``obj_type`` values outside ``_DOC_TYPE_HANDLERS``
+        so the caller can skip emission while still recursing into the node's
+        children. For parseable types we emit a *direct* doc URL
+        (``/docx/<obj_token>``, ``/sheets/<obj_token>``, ``/base/<obj_token>``)
+        so re-importing the child cannot re-trigger batch expansion (those URL
+        kinds are classified as ``single_doc``).
+        """
+        doc_type = FeishuAccessor._WIKI_TYPE_MAP.get(node.obj_type, node.obj_type)
+        if doc_type not in FeishuAccessor._DOC_TYPE_HANDLERS:
+            return None
+        if not node.obj_token:
+            return None
+        return f"https://feishu.cn/{doc_type}/{node.obj_token}"
+
+    async def expand_feishu_url(
+        self,
+        url: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+        max_depth: int = WIKI_BATCH_DEFAULT_MAX_DEPTH,
+        max_nodes: int = WIKI_BATCH_DEFAULT_MAX_NODES,
+    ) -> List[ExpandedDoc]:
+        """Expand a Feishu URL into the list of documents to import.
+
+        Returns a list of :class:`ExpandedDoc` entries:
+
+        * Single-document URLs (``/docx/<t>``, ``/sheets/<t>``, ``/base/<t>``)
+          always return a ``single_doc_passthrough`` entry — single-doc imports
+          are unchanged.
+        * ``/wiki/settings/<space_id>`` returns every document in the space;
+          an empty list means the space has no importable documents.
+        * ``/wiki/<token>`` resolves the node: if it has children, returns the
+          node itself plus every descendant (empty list if the subtree has no
+          importable documents); otherwise returns ``[(url, "")]`` (unchanged
+          single-doc behavior).
+
+        A return of ``[]`` therefore means "recognised batch source with nothing
+        to import" — the caller must surface this rather than fall back to a
+        single-doc import (the original URL is not a valid doc URL).
+
+        Raising on API failure is intentional — the caller surfaces the error
+        instead of silently degrading to a single-doc import.
+        """
+        classified = self.classify_url(url)
+        if classified is None:
+            # Not a Feishu URL — let the caller handle it (existing path).
+            return [ExpandedDoc(url=url)]
+        kind, primary, _secondary = classified
+        if kind == "single_doc":
+            return [ExpandedDoc(url=url)]
+        if kind == "wiki_space_root":
+            children = await self.list_wiki_subtree(
+                space_id=primary,
+                feishu_access_token=feishu_access_token,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+            )
+            # Empty list is meaningful: caller surfaces "no documents" rather
+            # than trying to import the /wiki/settings/<id> URL as a doc.
+            return children
+        if kind == "wiki_node":
+            node = await asyncio.to_thread(
+                self._resolve_wiki_node_full,
+                primary,
+                feishu_access_token=feishu_access_token,
+            )
+            if not node.has_child:
+                return [ExpandedDoc(url=url)]
+            children = await self.list_wiki_subtree(
+                root_node_token=primary,
+                feishu_access_token=feishu_access_token,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+            )
+            # ``list_wiki_subtree`` always records the root first, so an empty
+            # result here means the root itself was deduped/filtered — surface
+            # it as "no documents" rather than re-importing the wiki URL.
+            return children
+        # Defensive — classify_url only returns the kinds above.
+        return [ExpandedDoc(url=url)]
 
     # ========== Docx Parsing ==========
 

--- a/openviking/service/batch_manifest_store.py
+++ b/openviking/service/batch_manifest_store.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Durable batch-import manifest storage (issue #3120).
+
+Provider-neutral: persists one manifest per batch under
+``viking://resources/.batch_imports/<batch_id>.json`` (plus ``.bak``/``.tmp``
+sidecars), mirroring the watch-task storage atomic-write pattern. The manifest
+records the batch -> child-task mapping (``url`` / ``rel_path`` / ``task_id`` /
+``to_uri``); per-item *status* is aggregated live from the ``TaskTracker``,
+which is itself durable, so the manifest only needs to be written when the
+batch is submitted and again once child ``task_id``s are known.
+
+Batch ids are derived deterministically from the source URL + parent URI so
+re-submitting the same wiki URL is idempotent: the existing manifest is loaded
+and only children that have no ``task_id`` yet are enqueued again (the QueueFS
+``AddResource`` queue + TaskTracker are themselves crash-recoverable, so an
+interrupted batch resumes without duplicated work).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+BATCH_IMPORT_DIR_URI = "viking://resources/.batch_imports"
+BATCH_IMPORT_DIR_PREFIX = "viking://resources/.batch_imports/"
+
+
+def _batch_uri(batch_id: str) -> str:
+    return f"{BATCH_IMPORT_DIR_PREFIX}{batch_id}.json"
+
+
+def _batch_tmp_uri(batch_id: str) -> str:
+    return f"{BATCH_IMPORT_DIR_PREFIX}{batch_id}.json.tmp"
+
+
+def _batch_bak_uri(batch_id: str) -> str:
+    return f"{BATCH_IMPORT_DIR_PREFIX}{batch_id}.json.bak"
+
+
+def is_batch_import_control_uri(uri: str) -> bool:
+    """Return True when a URI points at internal batch-import control state."""
+    if not isinstance(uri, str):
+        return False
+    normalized = uri.rstrip("/")
+    if normalized == BATCH_IMPORT_DIR_URI.rstrip("/"):
+        return True
+    return normalized.startswith(BATCH_IMPORT_DIR_PREFIX)
+
+
+def derive_batch_id(source_url: str, parent_uri: str = "") -> str:
+    """Deterministic batch id from source URL + parent (idempotent re-submit)."""
+    raw = f"{source_url}|{parent_uri}".encode("utf-8")
+    return "bi_" + hashlib.sha1(raw).hexdigest()[:16]
+
+
+def build_manifest(
+    *,
+    batch_id: str,
+    source_url: str,
+    source_kind: str,
+    parent_uri: str,
+    created_at: str,
+    items: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build a manifest dict ready for :func:`save_manifest`."""
+    return {
+        "batch_id": batch_id,
+        "source_url": source_url,
+        "source_kind": source_kind,
+        "parent_uri": parent_uri,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "items": list(items),
+    }
+
+
+async def save_manifest(
+    manifest: Dict[str, Any],
+    viking_fs: Any,
+    *,
+    ctx: Any,
+) -> None:
+    """Atomically persist a batch manifest (tmp -> rotate bak -> rename).
+
+    Mirrors ``WatchManager._save_tasks``: write ``.tmp``, validate the JSON
+    round-trips, rotate the current file to ``.bak``, then rename ``.tmp`` into
+    place. Falls back to a plain write when the FS lacks the atomic primitives.
+    """
+    batch_id = manifest["batch_id"]
+    content = json.dumps(manifest, ensure_ascii=False, indent=2)
+    if not content.strip():
+        raise ValueError(f"Refusing to write empty manifest for batch {batch_id}")
+    json.loads(content)  # validate round-trip before touching disk
+
+    supports_atomic = all(hasattr(viking_fs, name) for name in ("mv", "rm", "exists", "write_file"))
+    if not supports_atomic:
+        await viking_fs.write_file(_batch_uri(batch_id), content, ctx=ctx)
+        return
+
+    await viking_fs.write_file(_batch_tmp_uri(batch_id), content, ctx=ctx)
+    try:
+        if await viking_fs.exists(_batch_bak_uri(batch_id), ctx=ctx):
+            await viking_fs.rm(_batch_bak_uri(batch_id), ctx=ctx)
+    except Exception as exc:  # best-effort cleanup of a stale backup
+        logger.debug("[BatchManifest] failed to clear bak for %s: %s", batch_id, exc)
+    try:
+        if await viking_fs.exists(_batch_uri(batch_id), ctx=ctx):
+            await viking_fs.mv(_batch_uri(batch_id), _batch_bak_uri(batch_id), ctx=ctx)
+    except Exception as exc:
+        logger.warning("[BatchManifest] failed to rotate bak for %s: %s", batch_id, exc)
+    await viking_fs.mv(_batch_tmp_uri(batch_id), _batch_uri(batch_id), ctx=ctx)
+
+
+async def load_manifest(
+    batch_id: str,
+    viking_fs: Any,
+    *,
+    ctx: Any,
+) -> Optional[Dict[str, Any]]:
+    """Load a manifest, falling back to the ``.bak`` sidecar on corruption."""
+    for uri in (_batch_uri(batch_id), _batch_bak_uri(batch_id)):
+        try:
+            content = await viking_fs.read_file(uri, ctx=ctx)
+        except Exception:
+            continue
+        if not content or not content.strip():
+            continue
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exc:
+            logger.warning("[BatchManifest] corrupt %s: %s", uri, exc)
+            continue
+        if isinstance(data, dict) and data.get("batch_id") == batch_id:
+            return data
+    return None
+
+
+async def list_batch_ids(viking_fs: Any, *, ctx: Any) -> List[str]:
+    """Return the batch ids persisted under the batch-import directory."""
+    try:
+        entries = await viking_fs.ls(BATCH_IMPORT_DIR_URI, ctx=ctx)
+    except Exception:
+        return []
+    ids: List[str] = []
+    for entry in entries or []:
+        name = entry.get("name", "") if isinstance(entry, dict) else str(entry)
+        # Only ``<batch_id>.json``; sidecars are ``.json.bak`` / ``.json.tmp``.
+        if name.endswith(".json") and ".json." not in name:
+            ids.append(name[: -len(".json")])
+    return ids

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -13,6 +13,7 @@ import json
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
@@ -1124,21 +1125,31 @@ class ResourceService:
         """Expand a Feishu wiki space / directory URL into per-doc imports.
 
         Returns ``None`` to signal "fall through to the single-doc path" — this
-        happens for ordinary ``/wiki/<token>`` URLs whose node has no children
-        and for any single-document URL that the expander returns unchanged.
+        happens when the URL is a passthrough single document (``/docx/<t>``,
+        ``/sheets/<t>``, or a leaf ``/wiki/<token>``). Dispatch is driven by the
+        expanded entries' ``source_kind`` (issue #3120 review), **not** by
+        ``len(expanded) == 1``, so a space or directory that contains exactly
+        one importable document still takes the batch path rather than trying
+        to ingest the original ``/wiki/settings/<id>`` URL as a single doc.
 
-        When the URL expands to multiple documents, each child document is
-        enqueued as its own ``add_resource(wait=False)`` background task and a
-        summary payload is returned immediately. The original ``to`` becomes the
-        parent for the batch (every child gets an auto-generated URI under it).
+        Each batch child is enqueued through the *real* ``add_resource(wait=False)``
+        path, which persists an ``AddResourceMsg`` into the crash-recoverable
+        QueueFS ``AddResource`` queue and registers a durable ``TaskTracker``
+        record. A provider-neutral manifest (``batch_manifest_store``) is written
+        atomically before fan-out so the batch survives a crash; the batch id is
+        derived from the source URL + parent, so re-submission is idempotent
+        (children that already have a task_id are not re-enqueued). The explicit
+        ``to``/``parent`` becomes the batch parent directory (created up front,
+        with ``create_parent`` forwarded per child so the wiki hierarchy carried
+        in each child's ``rel_path`` is preserved under the real target path).
         """
         from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+        from openviking.service import batch_manifest_store as batch_store
 
         kwargs = kwargs or {}
         parser_args = parser_args or {}
-        feishu_token = (
-            kwargs.get(FEISHU_ACCESS_TOKEN_ARG)
-            or parser_args.get(FEISHU_ACCESS_TOKEN_ARG)
+        feishu_token = kwargs.get(FEISHU_ACCESS_TOKEN_ARG) or parser_args.get(
+            FEISHU_ACCESS_TOKEN_ARG
         )
 
         accessor = FeishuAccessor()
@@ -1162,44 +1173,120 @@ class ResourceService:
             # through to ``_execute_resource_ingestion`` would treat the
             # ``/wiki/settings/<id>`` (or directory) URL as a single doc and
             # fail in a confusing way, so surface the real cause instead.
-            raise InvalidArgumentError(
-                f"Feishu wiki URL has no importable documents: {path!r}"
-            )
-        if len(expanded) == 1:
-            # Single doc (wiki leaf or single-doc passthrough) — preserve the
-            # original single-doc behavior. Caller proceeds to
-            # ``_execute_resource_ingestion`` with the original ``path``.
+            raise InvalidArgumentError(f"Feishu wiki URL has no importable documents: {path!r}")
+
+        # source-kind-aware dispatch (issue #3120 review, blocking #1): only
+        # genuine batch children take the batch path. A passthrough single-doc
+        # entry (incl. a /wiki/<leaf>) falls through to _execute_resource_ingestion.
+        batch_children = [d for d in expanded if d.source_kind == "batch_child"]
+        if not batch_children:
             return None
 
-        # Convert an explicit ``to`` into a parent so each child gets its own
-        # auto-generated URI underneath (a batch cannot share a single target).
-        batch_parent = parent
-        if to:
-            batch_parent = to
+        # Resolve the batch parent (blocking #2): the explicit to/parent becomes
+        # the directory under which every child lands; fall back to the default
+        # resource target when neither is supplied.
+        batch_parent = to or parent
+        if not batch_parent:
+            from openviking.server.dependencies import get_server_config
 
-        children_summary: List[Dict[str, Any]] = []
-        for idx, (doc_url, title) in enumerate(expanded):
-            children_summary.append(
-                {"url": doc_url, "title": title, "index": idx}
+            batch_parent = await effective_resource_add_target(
+                viking_fs=self._viking_fs,
+                ctx=ctx,
+                server_config=get_server_config(),
+            )
+        # Create the batch parent through the real FS so each child's
+        # resolve_target_uri succeeds (create_parent is also forwarded per child
+        # so each rel_path sub-directory is created the same way).
+        if batch_parent and self._viking_fs is not None:
+            try:
+                await self._viking_fs.mkdir(batch_parent, exist_ok=True, ctx=ctx)
+            except Exception as exc:
+                logger.warning(
+                    "[ResourceService] batch_parent mkdir failed for %s: %s",
+                    batch_parent,
+                    exc,
+                )
+
+        def _child_parent(rel_path: str) -> Optional[str]:
+            if not batch_parent:
+                return None
+            rel = (rel_path or "").strip("/")
+            return f"{batch_parent}/{rel}" if rel else batch_parent
+
+        classified = FeishuAccessor.classify_url(path)
+        source_kind_label = {
+            "wiki_space_root": "feishu_wiki_space",
+            "wiki_node": "feishu_wiki_node",
+        }.get(classified[0] if classified else "", "feishu_wiki")
+
+        batch_id = batch_store.derive_batch_id(path, batch_parent or "")
+        now = datetime.now().isoformat()
+
+        # Idempotent resume (issue #3120 review, blocking #3): load any prior
+        # manifest and reuse task_ids for children already enqueued (by url).
+        prior_task_by_url: Dict[str, Dict[str, Any]] = {}
+        if self._viking_fs is not None:
+            existing = await batch_store.load_manifest(batch_id, self._viking_fs, ctx=ctx)
+            if existing:
+                for item in existing.get("items", []):
+                    if item.get("task_id"):
+                        prior_task_by_url[item["url"]] = item
+
+        items: List[Dict[str, Any]] = []
+        for doc in batch_children:
+            prior = prior_task_by_url.get(doc.url)
+            items.append(
+                {
+                    "url": doc.url,
+                    "title": doc.title,
+                    "rel_path": doc.rel_path,
+                    "parent_uri": _child_parent(doc.rel_path) or "",
+                    "task_id": prior.get("task_id") if prior else None,
+                    "to_uri": prior.get("to_uri") if prior else None,
+                    "status": "queued" if prior else "pending",
+                }
             )
 
-        # Spawn one background ingestion per child document. Each child is a
-        # guaranteed single-doc URL (expand_feishu_url emits direct docx/sheets/
-        # base URLs), so it will not re-enter the batch branch.
-        #
-        # Throttle concurrency: a wiki space can contain hundreds of docs, and
-        # firing one Feishu fetch per doc simultaneously would hammer the Feishu
-        # API and risk rate-limiting /风控. Bound the in-flight imports.
-        batch_semaphore = asyncio.Semaphore(_FEISHU_BATCH_CONCURRENCY)
+        # Persist *before* fan-out so a crash mid-batch still leaves a durable
+        # record of what was planned (and what was already done on a prior run).
+        manifest = batch_store.build_manifest(
+            batch_id=batch_id,
+            source_url=path,
+            source_kind=source_kind_label,
+            parent_uri=batch_parent or "",
+            created_at=now,
+            items=items,
+        )
+        if self._viking_fs is not None:
+            try:
+                await batch_store.save_manifest(manifest, self._viking_fs, ctx=ctx)
+            except Exception as exc:
+                logger.warning("[ResourceService] initial batch manifest save failed: %s", exc)
 
-        async def _import_child(doc_url: str) -> None:
-            async with batch_semaphore:
+        # Fan out through the real add_resource path (blocking #2/#3): each
+        # child is a guaranteed single-doc URL (expand_feishu_url emits direct
+        # docx/sheets/base URLs), so it will not re-enter the batch branch. It
+        # enqueues a durable AddResourceMsg + TaskTracker record. create_parent
+        # is forwarded so each child's rel_path directory is created through the
+        # real target-resolution path rather than a mocked one.
+        #
+        # Concurrency is bounded (a space can hold hundreds of docs); we gather
+        # rather than fire-and-forget so the returned manifest carries every
+        # child's task_id (durable per-item state) by the time we respond.
+        semaphore = asyncio.Semaphore(_FEISHU_BATCH_CONCURRENCY)
+
+        async def _import_child(idx: int) -> None:
+            item = items[idx]
+            if item.get("task_id"):
+                return  # already enqueued on a prior run (idempotent resume)
+            doc = batch_children[idx]
+            async with semaphore:
                 try:
-                    await self.add_resource(
-                        path=doc_url,
+                    result = await self.add_resource(
+                        path=doc.url,
                         ctx=ctx,
                         to=None,
-                        parent=batch_parent,
+                        parent=_child_parent(doc.rel_path),
                         reason=reason,
                         instruction=instruction,
                         wait=False,
@@ -1211,33 +1298,86 @@ class ResourceService:
                         allow_local_path_resolution=allow_local_path_resolution,
                         enforce_public_remote_targets=enforce_public_remote_targets,
                         args=parser_args,
+                        create_parent=True,
                     )
-                except Exception:
+                    item["task_id"] = result.get("task_id")
+                    item["to_uri"] = result.get("root_uri")
+                    item["status"] = "queued" if result.get("task_id") else "failed"
+                    item.pop("error", None)
+                except Exception as exc:
                     logger.exception(
                         "[ResourceService] Feishu batch child import failed: %s",
-                        doc_url,
+                        doc.url,
                     )
+                    item["status"] = "failed"
+                    item["error"] = f"{type(exc).__name__}: {exc}"
 
-        for doc_url, _title in expanded:
-            background = asyncio.create_task(_import_child(doc_url))
-            self._background_tasks.add(background)
-            background.add_done_callback(self._background_tasks.discard)
+        await asyncio.gather(*(_import_child(i) for i in range(len(batch_children))))
 
-        first_url = expanded[0][0] if expanded else ""
+        # Persist the learned task_ids / per-item statuses (durable state).
+        manifest["items"] = items
+        manifest["updated_at"] = datetime.now().isoformat()
+        if self._viking_fs is not None:
+            try:
+                await batch_store.save_manifest(manifest, self._viking_fs, ctx=ctx)
+            except Exception as exc:
+                logger.warning("[ResourceService] final batch manifest save failed: %s", exc)
+
+        queued = sum(1 for it in items if it.get("task_id"))
+        telemetry.set("resource.feishu_batch.count", len(batch_children))
+        telemetry.set("resource.feishu_batch.queued", queued)
         logger.info(
-            "[ResourceService] Feishu wiki batch import: %d documents under %s "
-            "(first=%s)",
-            len(expanded),
+            "[ResourceService] Feishu wiki batch %s: %d/%d children enqueued under %s",
+            batch_id,
+            queued,
+            len(batch_children),
             batch_parent or "<auto>",
-            first_url,
         )
-        telemetry.set("resource.feishu_batch.count", len(expanded))
         return {
-            "status": "queued_batch",
+            "status": "batch_queued",
+            "batch_id": batch_id,
             "root_uri": batch_parent or "",
-            "batch_count": len(expanded),
-            "children": children_summary,
+            "batch_count": len(batch_children),
+            "queued_count": queued,
+            "items": items,
         }
+
+    async def get_batch_status(
+        self,
+        batch_id: str,
+        *,
+        ctx: RequestContext,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a batch manifest with live per-item status from TaskTracker.
+
+        The manifest stores the batch -> child task_id mapping durably; each
+        item's current ``status`` is read from the (also durable) TaskTracker so
+        partial failures and progress are visible without writing back to the
+        manifest on every transition.
+        """
+        from openviking.service import batch_manifest_store as batch_store
+        from openviking.service.task_tracker import get_task_tracker
+
+        if self._viking_fs is None:
+            return None
+        manifest = await batch_store.load_manifest(batch_id, self._viking_fs, ctx=ctx)
+        if manifest is None:
+            return None
+        tracker = get_task_tracker()
+        for item in manifest.get("items", []):
+            task_id = item.get("task_id")
+            if not task_id:
+                continue
+            try:
+                record = await tracker.get(task_id)
+            except Exception:
+                record = None
+            if record is not None:
+                status = record.status
+                item["status"] = getattr(status, "value", str(status))
+                if record.error:
+                    item["error"] = record.error
+        return manifest
 
     async def _execute_resource_ingestion(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -145,6 +145,23 @@ class _NormalizedAddResourceArgs:
     watch_auth_state: Optional[Dict[str, Any]] = None
 
 
+def _is_feishu_batch_candidate(path: str) -> bool:
+    """Return True if ``path`` might trigger Feishu wiki batch import (issue #3120).
+
+    Returns True for ``/wiki/settings/<space_id>`` (always batch) and
+    ``/wiki/<token>`` (potentially a directory — the service resolves
+    ``has_child`` via the Feishu API to decide). Returns False for
+    ``/docx/``, ``/sheets/``, ``/base/`` (always single doc) and non-Feishu URLs.
+    """
+    # Lazy import: feishu_accessor pulls in lark-oapi and the parse package.
+    from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+
+    classified = FeishuAccessor.classify_url(path)
+    if classified is None:
+        return False
+    return classified[0] in ("wiki_space_root", "wiki_node")
+
+
 class ResourceService:
     """Resource management service."""
 
@@ -1034,6 +1051,29 @@ class ResourceService:
                 **kwargs,
             )
 
+        # Feishu wiki space / directory URL → expand subtree and fan out one
+        # async add_resource per descendant document (issue #3120). Single Feishu
+        # doc URLs fall through to ``_execute_resource_ingestion`` unchanged.
+        if not wait and _is_feishu_batch_candidate(path):
+            batch_result = await self._maybe_enqueue_feishu_batch_add_resource(
+                path=path,
+                ctx=ctx,
+                to=to,
+                parent=parent,
+                reason=reason,
+                instruction=instruction,
+                timeout=timeout,
+                build_index=build_index,
+                summarize=summarize,
+                watch_interval=watch_interval,
+                allow_local_path_resolution=allow_local_path_resolution,
+                enforce_public_remote_targets=enforce_public_remote_targets,
+                parser_args=normalized_args.processor_kwargs,
+                kwargs=kwargs,
+            )
+            if batch_result is not None:
+                return batch_result
+
         return await self._execute_resource_ingestion(
             path=path,
             ctx=ctx,
@@ -1056,6 +1096,135 @@ class ResourceService:
             parser_args=normalized_args.processor_kwargs,
             **kwargs,
         )
+
+    async def _maybe_enqueue_feishu_batch_add_resource(
+        self,
+        *,
+        path: str,
+        ctx: RequestContext,
+        to: Optional[str] = None,
+        parent: Optional[str] = None,
+        reason: str = "",
+        instruction: str = "",
+        timeout: Optional[float] = None,
+        build_index: bool = True,
+        summarize: bool = False,
+        watch_interval: float = 0,
+        allow_local_path_resolution: bool = True,
+        enforce_public_remote_targets: bool = False,
+        parser_args: Optional[Dict[str, Any]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Expand a Feishu wiki space / directory URL into per-doc imports.
+
+        Returns ``None`` to signal "fall through to the single-doc path" — this
+        happens for ordinary ``/wiki/<token>`` URLs whose node has no children
+        and for any single-document URL that the expander returns unchanged.
+
+        When the URL expands to multiple documents, each child document is
+        enqueued as its own ``add_resource(wait=False)`` background task and a
+        summary payload is returned immediately. The original ``to`` becomes the
+        parent for the batch (every child gets an auto-generated URI under it).
+        """
+        from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+
+        kwargs = kwargs or {}
+        parser_args = parser_args or {}
+        feishu_token = (
+            kwargs.get(FEISHU_ACCESS_TOKEN_ARG)
+            or parser_args.get(FEISHU_ACCESS_TOKEN_ARG)
+        )
+
+        accessor = FeishuAccessor()
+        telemetry = get_current_telemetry()
+        try:
+            expanded = await accessor.expand_feishu_url(
+                path,
+                feishu_access_token=feishu_token,
+            )
+        except Exception as exc:
+            telemetry.set_error(
+                "resource_service.feishu_batch_expand",
+                type(exc).__name__,
+                str(exc),
+            )
+            raise
+
+        if not expanded:
+            # ``expand_feishu_url`` returns ``[]`` only for a recognised batch
+            # source whose space/subtree has no importable documents. Falling
+            # through to ``_execute_resource_ingestion`` would treat the
+            # ``/wiki/settings/<id>`` (or directory) URL as a single doc and
+            # fail in a confusing way, so surface the real cause instead.
+            raise InvalidArgumentError(
+                f"Feishu wiki URL has no importable documents: {path!r}"
+            )
+        if len(expanded) == 1:
+            # Single doc (wiki leaf or single-doc passthrough) — preserve the
+            # original single-doc behavior. Caller proceeds to
+            # ``_execute_resource_ingestion`` with the original ``path``.
+            return None
+
+        # Convert an explicit ``to`` into a parent so each child gets its own
+        # auto-generated URI underneath (a batch cannot share a single target).
+        batch_parent = parent
+        if to:
+            batch_parent = to
+
+        children_summary: List[Dict[str, Any]] = []
+        for idx, (doc_url, title) in enumerate(expanded):
+            children_summary.append(
+                {"url": doc_url, "title": title, "index": idx}
+            )
+
+        # Spawn one background ingestion per child document. Each child is a
+        # guaranteed single-doc URL (expand_feishu_url emits direct docx/sheets/
+        # base URLs), so it will not re-enter the batch branch.
+        async def _import_child(doc_url: str) -> None:
+            try:
+                await self.add_resource(
+                    path=doc_url,
+                    ctx=ctx,
+                    to=None,
+                    parent=batch_parent,
+                    reason=reason,
+                    instruction=instruction,
+                    wait=False,
+                    timeout=timeout,
+                    build_index=build_index,
+                    summarize=summarize,
+                    # Watch the whole space via the parent request, not per child.
+                    watch_interval=0,
+                    allow_local_path_resolution=allow_local_path_resolution,
+                    enforce_public_remote_targets=enforce_public_remote_targets,
+                    args=parser_args,
+                )
+            except Exception:
+                logger.exception(
+                    "[ResourceService] Feishu batch child import failed: %s",
+                    doc_url,
+                )
+
+        for doc_url, _title in expanded:
+            background = asyncio.create_task(_import_child(doc_url))
+            self._background_tasks.add(background)
+            background.add_done_callback(self._background_tasks.discard)
+
+        first_url = expanded[0][0] if expanded else ""
+        logger.info(
+            "[ResourceService] Feishu wiki batch import: %d documents under %s "
+            "(first=%s)",
+            len(expanded),
+            batch_parent or "<auto>",
+            first_url,
+        )
+        telemetry.set("resource.feishu_batch.count", len(expanded))
+        return {
+            "status": "queued_batch",
+            "root_uri": batch_parent or "",
+            "batch_count": len(expanded),
+            "children": children_summary,
+        }
 
     async def _execute_resource_ingestion(
         self,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1180,30 +1180,37 @@ class ResourceService:
         # Spawn one background ingestion per child document. Each child is a
         # guaranteed single-doc URL (expand_feishu_url emits direct docx/sheets/
         # base URLs), so it will not re-enter the batch branch.
+        #
+        # Throttle concurrency: a wiki space can contain hundreds of docs, and
+        # firing one Feishu fetch per doc simultaneously would hammer the Feishu
+        # API and risk rate-limiting /风控. Bound the in-flight imports.
+        batch_semaphore = asyncio.Semaphore(_FEISHU_BATCH_CONCURRENCY)
+
         async def _import_child(doc_url: str) -> None:
-            try:
-                await self.add_resource(
-                    path=doc_url,
-                    ctx=ctx,
-                    to=None,
-                    parent=batch_parent,
-                    reason=reason,
-                    instruction=instruction,
-                    wait=False,
-                    timeout=timeout,
-                    build_index=build_index,
-                    summarize=summarize,
-                    # Watch the whole space via the parent request, not per child.
-                    watch_interval=0,
-                    allow_local_path_resolution=allow_local_path_resolution,
-                    enforce_public_remote_targets=enforce_public_remote_targets,
-                    args=parser_args,
-                )
-            except Exception:
-                logger.exception(
-                    "[ResourceService] Feishu batch child import failed: %s",
-                    doc_url,
-                )
+            async with batch_semaphore:
+                try:
+                    await self.add_resource(
+                        path=doc_url,
+                        ctx=ctx,
+                        to=None,
+                        parent=batch_parent,
+                        reason=reason,
+                        instruction=instruction,
+                        wait=False,
+                        timeout=timeout,
+                        build_index=build_index,
+                        summarize=summarize,
+                        # Watch the whole space via the parent request, not per child.
+                        watch_interval=0,
+                        allow_local_path_resolution=allow_local_path_resolution,
+                        enforce_public_remote_targets=enforce_public_remote_targets,
+                        args=parser_args,
+                    )
+                except Exception:
+                    logger.exception(
+                        "[ResourceService] Feishu batch child import failed: %s",
+                        doc_url,
+                    )
 
         for doc_url, _title in expanded:
             background = asyncio.create_task(_import_child(doc_url))

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -76,6 +76,12 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+# Max in-flight Feishu wiki batch child imports. A wiki space can contain
+# hundreds of docs; without a cap, fanning out one fetch per doc simultaneously
+# hammers the Feishu API and risks rate-limiting/风控.
+_FEISHU_BATCH_CONCURRENCY = 8
+
+
 _ADD_RESOURCE_ARGS_RESERVED_FIELDS = frozenset(
     {
         "path",

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -15,6 +15,7 @@ import signal
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -94,6 +95,12 @@ if TYPE_CHECKING:
     from openviking.service.resource_memory_link_service import ResourceMemoryLinkService
 
 logger = get_logger(__name__)
+
+
+# Max in-flight Feishu wiki batch child imports. A wiki space can contain
+# hundreds of docs; without a cap, fanning out one fetch per doc simultaneously
+# hammers the Feishu API and risks rate-limiting/风控.
+_FEISHU_BATCH_CONCURRENCY = 8
 
 
 _ADD_RESOURCE_ARGS_RESERVED_FIELDS = frozenset(
@@ -184,6 +191,23 @@ class _SourcePlan:
     understanding_response_id: Optional[str] = None
     understanding_file_id: Optional[str] = None
     defer_unnamed_target: bool = False
+
+
+def _is_feishu_batch_candidate(path: str) -> bool:
+    """Return True if ``path`` might trigger Feishu wiki batch import (issue #3120).
+
+    Returns True for ``/wiki/settings/<space_id>`` (always batch) and
+    ``/wiki/<token>`` (potentially a directory — the service resolves
+    ``has_child`` via the Feishu API to decide). Returns False for
+    ``/docx/``, ``/sheets/``, ``/base/`` (always single doc) and non-Feishu URLs.
+    """
+    # Lazy import: feishu_accessor pulls in lark-oapi and the parse package.
+    from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+
+    classified = FeishuAccessor.classify_url(path)
+    if classified is None:
+        return False
+    return classified[0] in ("wiki_space_root", "wiki_node")
 
 
 class ResourceService:
@@ -1642,6 +1666,29 @@ class ResourceService:
                 )
             return result
 
+        # Feishu wiki space / directory URL → expand subtree and fan out one
+        # async add_resource per descendant document (issue #3120). Single Feishu
+        # doc URLs fall through to ``_execute_resource_ingestion`` unchanged.
+        if not wait and _is_feishu_batch_candidate(path):
+            batch_result = await self._maybe_enqueue_feishu_batch_add_resource(
+                path=path,
+                ctx=ctx,
+                to=to,
+                parent=parent,
+                reason=reason,
+                instruction=instruction,
+                timeout=timeout,
+                build_index=build_index,
+                summarize=summarize,
+                watch_interval=watch_interval,
+                allow_local_path_resolution=allow_local_path_resolution,
+                enforce_public_remote_targets=enforce_public_remote_targets,
+                parser_args=normalized_args.processor_kwargs,
+                kwargs=kwargs,
+            )
+            if batch_result is not None:
+                return batch_result
+
         if enforce_public_remote_targets and is_remote_resource_source(path):
             path = require_remote_resource_source(path)
             kwargs.setdefault("request_validator", ensure_public_remote_target)
@@ -1731,6 +1778,281 @@ class ResourceService:
             "status": "error",
             "errors": [task.error],
         }
+
+    async def _maybe_enqueue_feishu_batch_add_resource(
+        self,
+        *,
+        path: str,
+        ctx: RequestContext,
+        to: Optional[str] = None,
+        parent: Optional[str] = None,
+        reason: str = "",
+        instruction: str = "",
+        timeout: Optional[float] = None,
+        build_index: bool = True,
+        summarize: bool = False,
+        watch_interval: float = 0,
+        allow_local_path_resolution: bool = True,
+        enforce_public_remote_targets: bool = False,
+        parser_args: Optional[Dict[str, Any]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Expand a Feishu wiki space / directory URL into per-doc imports.
+
+        Returns ``None`` to signal "fall through to the single-doc path" — this
+        happens when the URL is a passthrough single document (``/docx/<t>``,
+        ``/sheets/<t>``, or a leaf ``/wiki/<token>``). Dispatch is driven by the
+        expanded entries' ``source_kind`` (issue #3120 review), **not** by
+        ``len(expanded) == 1``, so a space or directory that contains exactly
+        one importable document still takes the batch path rather than trying
+        to ingest the original ``/wiki/settings/<id>`` URL as a single doc.
+
+        Each batch child is enqueued through the *real* ``add_resource(wait=False)``
+        path, which persists an ``AddResourceMsg`` into the crash-recoverable
+        QueueFS ``AddResource`` queue and registers a durable ``TaskTracker``
+        record. A provider-neutral manifest (``batch_manifest_store``) is written
+        atomically before fan-out so the batch survives a crash; the batch id is
+        derived from the source URL + parent, so re-submission is idempotent
+        (children that already have a task_id are not re-enqueued). The explicit
+        ``to``/``parent`` becomes the batch parent directory (created up front,
+        with ``create_parent`` forwarded per child so the wiki hierarchy carried
+        in each child's ``rel_path`` is preserved under the real target path).
+        """
+        from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+        from openviking.service import batch_manifest_store as batch_store
+
+        kwargs = kwargs or {}
+        parser_args = parser_args or {}
+        feishu_token = kwargs.get(FEISHU_ACCESS_TOKEN_ARG) or parser_args.get(
+            FEISHU_ACCESS_TOKEN_ARG
+        )
+
+        accessor = FeishuAccessor()
+        telemetry = get_current_telemetry()
+        try:
+            expanded = await accessor.expand_feishu_url(
+                path,
+                feishu_access_token=feishu_token,
+            )
+        except Exception as exc:
+            telemetry.set_error(
+                "resource_service.feishu_batch_expand",
+                type(exc).__name__,
+                str(exc),
+            )
+            raise
+
+        if not expanded:
+            # ``expand_feishu_url`` returns ``[]`` only for a recognised batch
+            # source whose space/subtree has no importable documents. Falling
+            # through to ``_execute_resource_ingestion`` would treat the
+            # ``/wiki/settings/<id>`` (or directory) URL as a single doc and
+            # fail in a confusing way, so surface the real cause instead.
+            raise InvalidArgumentError(f"Feishu wiki URL has no importable documents: {path!r}")
+
+        # source-kind-aware dispatch (issue #3120 review, blocking #1): only
+        # genuine batch children take the batch path. A passthrough single-doc
+        # entry (incl. a /wiki/<leaf>) falls through to _execute_resource_ingestion.
+        batch_children = [d for d in expanded if d.source_kind == "batch_child"]
+        if not batch_children:
+            return None
+
+        # Resolve the batch parent (blocking #2): the explicit to/parent becomes
+        # the directory under which every child lands; fall back to the default
+        # resource target when neither is supplied.
+        batch_parent = to or parent
+        if not batch_parent:
+            from openviking.server.dependencies import get_server_config
+
+            batch_parent = await effective_resource_add_target(
+                viking_fs=self._viking_fs,
+                ctx=ctx,
+                server_config=get_server_config(),
+            )
+        # Create the batch parent through the real FS so each child's
+        # resolve_target_uri succeeds (create_parent is also forwarded per child
+        # so each rel_path sub-directory is created the same way).
+        if batch_parent and self._viking_fs is not None:
+            try:
+                await self._viking_fs.mkdir(batch_parent, exist_ok=True, ctx=ctx)
+            except Exception as exc:
+                logger.warning(
+                    "[ResourceService] batch_parent mkdir failed for %s: %s",
+                    batch_parent,
+                    exc,
+                )
+
+        def _child_parent(rel_path: str) -> Optional[str]:
+            if not batch_parent:
+                return None
+            rel = (rel_path or "").strip("/")
+            return f"{batch_parent}/{rel}" if rel else batch_parent
+
+        classified = FeishuAccessor.classify_url(path)
+        source_kind_label = {
+            "wiki_space_root": "feishu_wiki_space",
+            "wiki_node": "feishu_wiki_node",
+        }.get(classified[0] if classified else "", "feishu_wiki")
+
+        batch_id = batch_store.derive_batch_id(path, batch_parent or "")
+        now = datetime.now().isoformat()
+
+        # Idempotent resume (issue #3120 review, blocking #3): load any prior
+        # manifest and reuse task_ids for children already enqueued (by url).
+        prior_task_by_url: Dict[str, Dict[str, Any]] = {}
+        if self._viking_fs is not None:
+            existing = await batch_store.load_manifest(batch_id, self._viking_fs, ctx=ctx)
+            if existing:
+                for item in existing.get("items", []):
+                    if item.get("task_id"):
+                        prior_task_by_url[item["url"]] = item
+
+        items: List[Dict[str, Any]] = []
+        for doc in batch_children:
+            prior = prior_task_by_url.get(doc.url)
+            items.append(
+                {
+                    "url": doc.url,
+                    "title": doc.title,
+                    "rel_path": doc.rel_path,
+                    "parent_uri": _child_parent(doc.rel_path) or "",
+                    "task_id": prior.get("task_id") if prior else None,
+                    "to_uri": prior.get("to_uri") if prior else None,
+                    "status": "queued" if prior else "pending",
+                }
+            )
+
+        # Persist *before* fan-out so a crash mid-batch still leaves a durable
+        # record of what was planned (and what was already done on a prior run).
+        manifest = batch_store.build_manifest(
+            batch_id=batch_id,
+            source_url=path,
+            source_kind=source_kind_label,
+            parent_uri=batch_parent or "",
+            created_at=now,
+            items=items,
+        )
+        if self._viking_fs is not None:
+            try:
+                await batch_store.save_manifest(manifest, self._viking_fs, ctx=ctx)
+            except Exception as exc:
+                logger.warning("[ResourceService] initial batch manifest save failed: %s", exc)
+
+        # Fan out through the real add_resource path (blocking #2/#3): each
+        # child is a guaranteed single-doc URL (expand_feishu_url emits direct
+        # docx/sheets/base URLs), so it will not re-enter the batch branch. It
+        # enqueues a durable AddResourceMsg + TaskTracker record. create_parent
+        # is forwarded so each child's rel_path directory is created through the
+        # real target-resolution path rather than a mocked one.
+        #
+        # Concurrency is bounded (a space can hold hundreds of docs); we gather
+        # rather than fire-and-forget so the returned manifest carries every
+        # child's task_id (durable per-item state) by the time we respond.
+        semaphore = asyncio.Semaphore(_FEISHU_BATCH_CONCURRENCY)
+
+        async def _import_child(idx: int) -> None:
+            item = items[idx]
+            if item.get("task_id"):
+                return  # already enqueued on a prior run (idempotent resume)
+            doc = batch_children[idx]
+            async with semaphore:
+                try:
+                    result = await self.add_resource(
+                        path=doc.url,
+                        ctx=ctx,
+                        to=None,
+                        parent=_child_parent(doc.rel_path),
+                        reason=reason,
+                        instruction=instruction,
+                        wait=False,
+                        timeout=timeout,
+                        build_index=build_index,
+                        summarize=summarize,
+                        # Watch the whole space via the parent request, not per child.
+                        watch_interval=0,
+                        allow_local_path_resolution=allow_local_path_resolution,
+                        enforce_public_remote_targets=enforce_public_remote_targets,
+                        args=parser_args,
+                        create_parent=True,
+                    )
+                    item["task_id"] = result.get("task_id")
+                    item["to_uri"] = result.get("root_uri")
+                    item["status"] = "queued" if result.get("task_id") else "failed"
+                    item.pop("error", None)
+                except Exception as exc:
+                    logger.exception(
+                        "[ResourceService] Feishu batch child import failed: %s",
+                        doc.url,
+                    )
+                    item["status"] = "failed"
+                    item["error"] = f"{type(exc).__name__}: {exc}"
+
+        await asyncio.gather(*(_import_child(i) for i in range(len(batch_children))))
+
+        # Persist the learned task_ids / per-item statuses (durable state).
+        manifest["items"] = items
+        manifest["updated_at"] = datetime.now().isoformat()
+        if self._viking_fs is not None:
+            try:
+                await batch_store.save_manifest(manifest, self._viking_fs, ctx=ctx)
+            except Exception as exc:
+                logger.warning("[ResourceService] final batch manifest save failed: %s", exc)
+
+        queued = sum(1 for it in items if it.get("task_id"))
+        telemetry.set("resource.feishu_batch.count", len(batch_children))
+        telemetry.set("resource.feishu_batch.queued", queued)
+        logger.info(
+            "[ResourceService] Feishu wiki batch %s: %d/%d children enqueued under %s",
+            batch_id,
+            queued,
+            len(batch_children),
+            batch_parent or "<auto>",
+        )
+        return {
+            "status": "batch_queued",
+            "batch_id": batch_id,
+            "root_uri": batch_parent or "",
+            "batch_count": len(batch_children),
+            "queued_count": queued,
+            "items": items,
+        }
+
+    async def get_batch_status(
+        self,
+        batch_id: str,
+        *,
+        ctx: RequestContext,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a batch manifest with live per-item status from TaskTracker.
+
+        The manifest stores the batch -> child task_id mapping durably; each
+        item's current ``status`` is read from the (also durable) TaskTracker so
+        partial failures and progress are visible without writing back to the
+        manifest on every transition.
+        """
+        from openviking.service import batch_manifest_store as batch_store
+        from openviking.service.task_tracker import get_task_tracker
+
+        if self._viking_fs is None:
+            return None
+        manifest = await batch_store.load_manifest(batch_id, self._viking_fs, ctx=ctx)
+        if manifest is None:
+            return None
+        tracker = get_task_tracker()
+        for item in manifest.get("items", []):
+            task_id = item.get("task_id")
+            if not task_id:
+                continue
+            try:
+                record = await tracker.get(task_id)
+            except Exception:
+                record = None
+            if record is not None:
+                status = record.status
+                item["status"] = getattr(status, "value", str(status))
+                if record.error:
+                    item["error"] = record.error
+        return manifest
 
     async def _execute_resource_ingestion(
         self,

--- a/tests/parse/test_feishu_wiki_batch.py
+++ b/tests/parse/test_feishu_wiki_batch.py
@@ -15,8 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from openviking.parse.accessors.feishu_accessor import FeishuAccessor
-
+from openviking.parse.accessors.feishu_accessor import ExpandedDoc, FeishuAccessor
 
 # ---------------------------------------------------------------------------
 # Mock plumbing — mirrors the pattern in tests/parse/test_feishu_accessor.py.
@@ -221,9 +220,7 @@ def test_classify_url_rejects_unrecognized(url):
 
 
 def test_is_batch_url_only_true_for_space_root():
-    assert FeishuAccessor.is_batch_url(
-        "https://x.feishu.cn/wiki/settings/space1"
-    ) is True
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/wiki/settings/space1") is True
     # Wiki node URLs need an API check, so is_batch_url returns False here.
     assert FeishuAccessor.is_batch_url("https://x.feishu.cn/wiki/node1") is False
     assert FeishuAccessor.is_batch_url("https://x.feishu.cn/docx/d1") is False
@@ -237,10 +234,7 @@ def test_is_batch_url_only_true_for_space_root():
 
 def test_build_doc_url_emits_direct_url_for_known_types():
     node = _make_node(node_token="n1", obj_type="docx", obj_token="doxcnA", title="A")
-    assert (
-        FeishuAccessor._build_doc_url(node)
-        == "https://feishu.cn/docx/doxcnA"
-    )
+    assert FeishuAccessor._build_doc_url(node) == "https://feishu.cn/docx/doxcnA"
 
 
 def test_build_doc_url_normalizes_short_api_type_names():
@@ -274,19 +268,19 @@ def test_expand_single_docx_url_returns_unchanged(monkeypatch):
     _install_fake_lark_wiki(monkeypatch)
     accessor = FeishuAccessor()
     # No client is wired up — the test fails if any API call is attempted.
-    result = asyncio.run(
-        accessor.expand_feishu_url("https://x.feishu.cn/docx/doxcnABC")
-    )
-    assert result == [("https://x.feishu.cn/docx/doxcnABC", "")]
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/docx/doxcnABC"))
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/docx/doxcnABC")]
+    # Passthrough single-doc entries keep the original single-doc behaviour
+    # (issue #3120 review): source_kind disambiguates them from batch children.
+    assert result[0].source_kind == "single_doc_passthrough"
 
 
 def test_expand_single_sheets_url_returns_unchanged(monkeypatch):
     _install_fake_lark_wiki(monkeypatch)
     accessor = FeishuAccessor()
-    result = asyncio.run(
-        accessor.expand_feishu_url("https://x.feishu.cn/sheets/stok1")
-    )
-    assert result == [("https://x.feishu.cn/sheets/stok1", "")]
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/sheets/stok1"))
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/sheets/stok1")]
+    assert result[0].source_kind == "single_doc_passthrough"
 
 
 # ---------------------------------------------------------------------------
@@ -313,11 +307,11 @@ def test_expand_wiki_node_without_children_returns_single_url(monkeypatch):
     accessor._user_token_client = _make_client(get_node=get_node)
 
     result = asyncio.run(
-        accessor.expand_feishu_url(
-            "https://x.feishu.cn/wiki/leaf1", feishu_access_token="u-test"
-        )
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/leaf1", feishu_access_token="u-test")
     )
-    assert result == [("https://x.feishu.cn/wiki/leaf1", "")]
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/wiki/leaf1")]
+    # A wiki node with no children is a passthrough, not a batch child.
+    assert result[0].source_kind == "single_doc_passthrough"
     # Verify get_node was called with the right token + user-token option.
     request, option = get_node.call_args.args
     assert request.token == "leaf1"
@@ -368,18 +362,16 @@ def test_expand_wiki_node_with_children_returns_subtree(monkeypatch):
     accessor._user_token_client = _make_client(space_list=space_list, get_node=get_node)
 
     result = asyncio.run(
-        accessor.expand_feishu_url(
-            "https://x.feishu.cn/wiki/dir1", feishu_access_token="u-test"
-        )
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/dir1", feishu_access_token="u-test")
     )
     # Three docs: the directory root itself + two children.
-    urls = [url for url, _title in result]
+    urls = [d.url for d in result]
     assert urls == [
         "https://feishu.cn/docx/doxcnDir",
         "https://feishu.cn/docx/doxcnC1",
         "https://feishu.cn/docx/doxcnC2",
     ]
-    titles = [title for _url, title in result]
+    titles = [d.title for d in result]
     assert titles == ["Directory Root", "Child 1", "Child 2"]
     # space.list was called with the directory's node_token as parent.
     list_request = space_list.call_args.args[0]
@@ -419,12 +411,8 @@ def test_expand_space_root_url_returns_all_nodes(monkeypatch):
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
-    result = asyncio.run(
-        accessor.expand_feishu_url(
-            "https://x.feishu.cn/wiki/settings/space_42"
-        )
-    )
-    urls = [url for url, _title in result]
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_42"))
+    urls = [d.url for d in result]
     assert urls == [
         "https://feishu.cn/docx/doxcnT1",
         "https://feishu.cn/docx/doxcnT2",
@@ -486,10 +474,8 @@ def test_expand_space_root_url_recurses_into_subdirectories(monkeypatch):
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
-    result = asyncio.run(
-        accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
-    )
-    urls = [url for url, _title in result]
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
+    urls = [d.url for d in result]
     # Top-level doc + folder doc + 2 folder children.
     assert urls == [
         "https://feishu.cn/docx/doxcnTop",
@@ -497,6 +483,17 @@ def test_expand_space_root_url_recurses_into_subdirectories(monkeypatch):
         "https://feishu.cn/docx/doxcnFC1",
         "https://feishu.cn/sheets/shtFC2",
     ]
+    # Hierarchy preserved (issue #3120 review, blocking #3): top-level docs
+    # have an empty rel_path; the folder's children carry the folder as their
+    # relative directory so they import under <batch_parent>/<folder>/<doc>
+    # instead of being flattened into the parent.
+    rel_paths = [d.rel_path for d in result]
+    assert rel_paths[0] == ""  # top doc
+    assert rel_paths[1] == ""  # folder itself (also a top-level node)
+    assert rel_paths[2] == rel_paths[3]  # both folder children share the folder dir
+    assert rel_paths[2] != ""  # nested under the folder
+    # Everything expanded from a space root is a batch child.
+    assert all(d.source_kind == "batch_child" for d in result)
     # Two space.list calls: one at root, one with parent_node_token=folder1.
     assert space_list.call_count == 2
     second_request = space_list.call_args_list[1].args[0]
@@ -542,10 +539,8 @@ def test_expand_space_root_url_follows_pagination(monkeypatch):
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
-    result = asyncio.run(
-        accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
-    )
-    urls = [url for url, _title in result]
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
+    urls = [d.url for d in result]
     assert urls == ["https://feishu.cn/docx/doxcnP1A", "https://feishu.cn/docx/doxcnP2A"]
     # The second list call must carry the page_token from page 1.
     second_request = space_list.call_args_list[1].args[0]
@@ -559,6 +554,7 @@ def test_expand_space_root_url_follows_pagination(monkeypatch):
 
 def test_list_wiki_subtree_respects_max_depth(monkeypatch):
     _install_fake_lark_wiki(monkeypatch)
+
     # A chain of nested folders: root → folderA → folderB → doc.
     def _list(space_id, parent_node_token, **_):
         if parent_node_token is None:
@@ -612,18 +608,16 @@ def test_list_wiki_subtree_respects_max_depth(monkeypatch):
             )
         return _SuccessResponse(SimpleNamespace(items=[], has_more=False, page_token=None))
 
-    space_list = MagicMock(side_effect=lambda req, *a, **kw: _list(
-        req.space_id, req.parent_node_token
-    ))
+    space_list = MagicMock(
+        side_effect=lambda req, *a, **kw: _list(req.space_id, req.parent_node_token)
+    )
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
     # max_depth=1 → only the root level (folderA is recorded, but its children
     # are NOT walked because depth would exceed 1).
-    result = asyncio.run(
-        accessor.list_wiki_subtree(space_id="space_1", max_depth=1)
-    )
-    urls = [url for url, _title in result]
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1", max_depth=1))
+    urls = [d.url for d in result]
     assert urls == ["https://feishu.cn/docx/doxcnA"]
 
 
@@ -640,18 +634,14 @@ def test_list_wiki_subtree_respects_max_nodes(monkeypatch):
         for i in range(5)
     ]
     space_list = MagicMock(
-        return_value=_SuccessResponse(
-            SimpleNamespace(items=items, has_more=False, page_token=None)
-        )
+        return_value=_SuccessResponse(SimpleNamespace(items=items, has_more=False, page_token=None))
     )
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
-    result = asyncio.run(
-        accessor.list_wiki_subtree(space_id="space_1", max_nodes=2)
-    )
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1", max_nodes=2))
     assert len(result) == 2
-    assert [url for url, _ in result] == [
+    assert [d.url for d in result] == [
         "https://feishu.cn/docx/doxcn0",
         "https://feishu.cn/docx/doxcn1",
     ]
@@ -660,9 +650,7 @@ def test_list_wiki_subtree_respects_max_nodes(monkeypatch):
 def test_list_wiki_subtree_empty_space_returns_empty_list(monkeypatch):
     _install_fake_lark_wiki(monkeypatch)
     space_list = MagicMock(
-        return_value=_SuccessResponse(
-            SimpleNamespace(items=[], has_more=False, page_token=None)
-        )
+        return_value=_SuccessResponse(SimpleNamespace(items=[], has_more=False, page_token=None))
     )
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
@@ -690,7 +678,12 @@ def test_list_wiki_subtree_dedupes_shared_obj_tokens(monkeypatch):
     accessor._client = _make_client(space_list=space_list)
 
     result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
-    assert result == [("https://feishu.cn/docx/doxcnShared", "Shared")]
+    assert len(result) == 1
+    assert result[0].url == "https://feishu.cn/docx/doxcnShared"
+    assert result[0].title == "Shared"
+    # Expanded from a space root → batch_child, top-level → empty rel_path.
+    assert result[0].source_kind == "batch_child"
+    assert result[0].rel_path == ""
 
 
 def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
@@ -713,12 +706,8 @@ def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
     )
     space_list = MagicMock(
         side_effect=[
-            _SuccessResponse(
-                SimpleNamespace(items=[folder], has_more=False, page_token=None)
-            ),
-            _SuccessResponse(
-                SimpleNamespace(items=[child], has_more=False, page_token=None)
-            ),
+            _SuccessResponse(SimpleNamespace(items=[folder], has_more=False, page_token=None)),
+            _SuccessResponse(SimpleNamespace(items=[child], has_more=False, page_token=None)),
         ]
     )
     accessor = FeishuAccessor()
@@ -726,7 +715,10 @@ def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
 
     result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
     # Only the supported child doc is emitted.
-    assert result == [("https://feishu.cn/docx/doxcnChild", "Child")]
+    assert len(result) == 1
+    assert result[0].url == "https://feishu.cn/docx/doxcnChild"
+    assert result[0].title == "Child"
+    assert result[0].source_kind == "batch_child"
 
 
 # ---------------------------------------------------------------------------
@@ -737,10 +729,9 @@ def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
 def test_expand_non_feishu_url_returns_unchanged(monkeypatch):
     _install_fake_lark_wiki(monkeypatch)
     accessor = FeishuAccessor()
-    result = asyncio.run(
-        accessor.expand_feishu_url("https://github.com/org/repo")
-    )
-    assert result == [("https://github.com/org/repo", "")]
+    result = asyncio.run(accessor.expand_feishu_url("https://github.com/org/repo"))
+    assert result == [ExpandedDoc(url="https://github.com/org/repo")]
+    assert result[0].source_kind == "single_doc_passthrough"
 
 
 def test_expand_space_root_api_failure_propagates(monkeypatch):
@@ -751,10 +742,10 @@ def test_expand_space_root_api_failure_propagates(monkeypatch):
     accessor = FeishuAccessor()
     accessor._client = _make_client(space_list=space_list)
 
-    with pytest.raises(Exception):  # OpenVikingError raised by _raise_from_lark_response
-        asyncio.run(
-            accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
-        )
+    from openviking_cli.exceptions import OpenVikingError
+
+    with pytest.raises(OpenVikingError, match="list wiki nodes"):
+        asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
 
 
 # ---------------------------------------------------------------------------
@@ -773,7 +764,9 @@ def test_list_wiki_subtree_breaks_node_token_cycle(monkeypatch):
     children = {
         None: [_make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)],
         "A": [_make_node(node_token="B", obj_type="docx", obj_token="docB", has_child=True)],
-        "B": [_make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)],  # cycle
+        "B": [
+            _make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)
+        ],  # cycle
     }
     calls = {"n": 0}
 
@@ -790,7 +783,7 @@ def test_list_wiki_subtree_breaks_node_token_cycle(monkeypatch):
     )
     # Each node_token expanded at most once: root listing + A + B = 3 calls.
     assert calls["n"] == 3, calls
-    urls = [u for u, _t in result]
+    urls = [d.url for d in result]
     assert sorted(urls) == ["https://feishu.cn/docx/docA", "https://feishu.cn/docx/docB"]
     assert len(urls) == 2  # no duplication from the cycle
 
@@ -814,7 +807,7 @@ def test_list_wiki_subtree_breaks_page_token_cycle(monkeypatch):
 
     accessor = FeishuAccessor()
     accessor._list_wiki_child_nodes = fake_list
-    result = asyncio.run(
+    asyncio.run(
         accessor.list_wiki_subtree(
             space_id="space_1", feishu_access_token="u", max_depth=1, max_nodes=1000
         )

--- a/tests/parse/test_feishu_wiki_batch.py
+++ b/tests/parse/test_feishu_wiki_batch.py
@@ -1,0 +1,816 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for Feishu wiki space / directory batch import (issue #3120).
+
+Covers ``FeishuAccessor.classify_url``, ``expand_feishu_url`` and the recursive
+``list_wiki_subtree`` walker. All Feishu API calls are mocked — the lark-oapi
+SDK is replaced with fakes that mimic ``client.wiki.v2.space.list`` and
+``client.wiki.v2.space.get_node``.
+"""
+
+import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from openviking.parse.accessors.feishu_accessor import ExpandedDoc, FeishuAccessor
+
+# ---------------------------------------------------------------------------
+# Mock plumbing — mirrors the pattern in tests/parse/test_feishu_accessor.py.
+# ---------------------------------------------------------------------------
+
+
+class _SuccessResponse:
+    """Stand-in for a successful lark-oapi response object."""
+
+    def __init__(self, data):
+        self.data = data
+        self.code = 0
+        self.msg = ""
+
+    @staticmethod
+    def success():
+        return True
+
+
+class _FailureResponse:
+    """Stand-in for a failed lark-oapi response object."""
+
+    def __init__(self, code=1, msg="boom"):
+        self.data = None
+        self.code = code
+        self.msg = msg
+
+    @staticmethod
+    def success():
+        return False
+
+
+class _FakeRequestOption:
+    def __init__(self):
+        self.user_access_token = None
+
+    @staticmethod
+    def builder():
+        return _FakeRequestOptionBuilder()
+
+
+class _FakeRequestOptionBuilder:
+    def __init__(self):
+        self._option = _FakeRequestOption()
+
+    def user_access_token(self, token):
+        self._option.user_access_token = token
+        return self
+
+    def build(self):
+        return self._option
+
+
+class _FakeListSpaceNodeRequest:
+    """Fake ``lark_oapi.api.wiki.v2.ListSpaceNodeRequest``."""
+
+    @staticmethod
+    def builder():
+        return _FakeListSpaceNodeRequestBuilder()
+
+
+class _FakeListSpaceNodeRequestBuilder:
+    def __init__(self):
+        self._request = SimpleNamespace(
+            space_id=None, parent_node_token=None, page_token=None, page_size=None
+        )
+
+    def space_id(self, value):
+        self._request.space_id = value
+        return self
+
+    def parent_node_token(self, value):
+        self._request.parent_node_token = value
+        return self
+
+    def page_token(self, value):
+        self._request.page_token = value
+        return self
+
+    def page_size(self, value):
+        self._request.page_size = value
+        return self
+
+    def build(self):
+        return self._request
+
+
+class _FakeGetNodeSpaceRequest:
+    """Fake ``lark_oapi.api.wiki.v2.GetNodeSpaceRequest``."""
+
+    @staticmethod
+    def builder():
+        return _FakeGetNodeSpaceRequestBuilder()
+
+
+class _FakeGetNodeSpaceRequestBuilder:
+    def __init__(self):
+        self._request = SimpleNamespace(token=None)
+
+    def token(self, value):
+        self._request.token = value
+        return self
+
+    def build(self):
+        return self._request
+
+
+def _install_fake_lark_wiki(monkeypatch):
+    """Install just enough of lark-oapi for the wiki batch code paths."""
+    lark = ModuleType("lark_oapi")
+    core_model = ModuleType("lark_oapi.core.model")
+    core_model.RequestOption = _FakeRequestOption
+    wiki_v2 = ModuleType("lark_oapi.api.wiki.v2")
+    wiki_v2.ListSpaceNodeRequest = _FakeListSpaceNodeRequest
+    wiki_v2.GetNodeSpaceRequest = _FakeGetNodeSpaceRequest
+
+    monkeypatch.setitem(sys.modules, "lark_oapi", lark)
+    monkeypatch.setitem(sys.modules, "lark_oapi.core.model", core_model)
+    monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki", ModuleType("lark_oapi.api.wiki"))
+    monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki.v2", wiki_v2)
+
+
+def _make_node(
+    *,
+    node_token,
+    obj_type,
+    obj_token,
+    title="",
+    has_child=False,
+    space_id="space_1",
+    parent_node_token=None,
+    url="",
+):
+    return SimpleNamespace(
+        node_token=node_token,
+        obj_token=obj_token,
+        obj_type=obj_type,
+        title=title,
+        has_child=has_child,
+        space_id=space_id,
+        parent_node_token=parent_node_token,
+        url=url,
+    )
+
+
+def _make_client(space_list=None, get_node=None):
+    """Build a fake lark client exposing ``client.wiki.v2.space.{list,get_node}``."""
+    space = SimpleNamespace(list=space_list or MagicMock(), get_node=get_node or MagicMock())
+    return SimpleNamespace(wiki=SimpleNamespace(v2=SimpleNamespace(space=space)))
+
+
+# ---------------------------------------------------------------------------
+# classify_url / is_batch_url (pure logic, no mocks).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Single-doc URL forms — unchanged behaviour.
+        ("https://volcengine.feishu.cn/docx/doxcnABC", ("single_doc", "docx", "doxcnABC")),
+        ("https://volcengine.feishu.cn/sheets/stok1", ("single_doc", "sheets", "stok1")),
+        ("https://volcengine.feishu.cn/base/appTok1", ("single_doc", "base", "appTok1")),
+        # Wiki node URL — may be a doc or a directory.
+        (
+            "https://volcengine.feishu.cn/wiki/nodeTok1",
+            ("wiki_node", "nodeTok1", None),
+        ),
+        # Space root URL — always batch.
+        (
+            "https://volcengine.feishu.cn/wiki/settings/7123456789012345",
+            ("wiki_space_root", "7123456789012345", None),
+        ),
+        # Lark domains also recognised.
+        (
+            "https://volcengine.larksuite.com/wiki/settings/abc",
+            ("wiki_space_root", "abc", None),
+        ),
+        (
+            "https://volcengine.larkoffice.com/wiki/nodeX",
+            ("wiki_node", "nodeX", None),
+        ),
+    ],
+)
+def test_classify_url_recognises_known_forms(url, expected):
+    assert FeishuAccessor.classify_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/org/repo",
+        "https://example.com/docx/foo",  # not a feishu domain
+        "https://volcengine.feishu.cn/",  # no path
+        "https://volcengine.feishu.cn/wiki/",  # wiki with no token
+        "https://volcengine.feishu.cn/wiki/settings/",  # settings with no space id
+        "/local/path/docx/foo",  # not a URL
+    ],
+)
+def test_classify_url_rejects_unrecognized(url):
+    assert FeishuAccessor.classify_url(url) is None
+
+
+def test_is_batch_url_only_true_for_space_root():
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/wiki/settings/space1") is True
+    # Wiki node URLs need an API check, so is_batch_url returns False here.
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/wiki/node1") is False
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/docx/d1") is False
+    assert FeishuAccessor.is_batch_url("https://github.com/o/r") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_doc_url — direct URLs only for parseable types; None otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_build_doc_url_emits_direct_url_for_known_types():
+    node = _make_node(node_token="n1", obj_type="docx", obj_token="doxcnA", title="A")
+    assert FeishuAccessor._build_doc_url(node) == "https://feishu.cn/docx/doxcnA"
+
+
+def test_build_doc_url_normalizes_short_api_type_names():
+    # Wiki API returns short names: doc/sheet/bitable — _WIKI_TYPE_MAP normalizes.
+    doc = _make_node(node_token="n1", obj_type="doc", obj_token="t1")
+    sheet = _make_node(node_token="n2", obj_type="sheet", obj_token="t2")
+    base = _make_node(node_token="n3", obj_type="bitable", obj_token="t3")
+    assert FeishuAccessor._build_doc_url(doc) == "https://feishu.cn/docx/t1"
+    assert FeishuAccessor._build_doc_url(sheet) == "https://feishu.cn/sheets/t2"
+    assert FeishuAccessor._build_doc_url(base) == "https://feishu.cn/base/t3"
+
+
+def test_build_doc_url_returns_none_for_unsupported_types():
+    # Wiki nodes of unknown obj_type (e.g. mindmap/file) are skipped — they
+    # would otherwise produce URLs the accessor cannot parse.
+    node = _make_node(node_token="n1", obj_type="mindmap", obj_token="t1")
+    assert FeishuAccessor._build_doc_url(node) is None
+
+
+def test_build_doc_url_returns_none_when_obj_token_missing():
+    node = _make_node(node_token="n1", obj_type="docx", obj_token="")
+    assert FeishuAccessor._build_doc_url(node) is None
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — single-doc passthrough (no API calls for /docx/, /sheets/).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_single_docx_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    # No client is wired up — the test fails if any API call is attempted.
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/docx/doxcnABC"))
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/docx/doxcnABC")]
+    # Passthrough single-doc entries keep the original single-doc behaviour
+    # (issue #3120 review): source_kind disambiguates them from batch children.
+    assert result[0].source_kind == "single_doc_passthrough"
+
+
+def test_expand_single_sheets_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/sheets/stok1"))
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/sheets/stok1")]
+    assert result[0].source_kind == "single_doc_passthrough"
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — wiki node URL (uses get_node to check has_child).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_wiki_node_without_children_returns_single_url(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    get_node = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                node=_make_node(
+                    node_token="leaf1",
+                    obj_type="docx",
+                    obj_token="doxcnLeaf",
+                    title="Leaf",
+                    has_child=False,
+                )
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = _make_client(get_node=get_node)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/leaf1", feishu_access_token="u-test")
+    )
+    assert result == [ExpandedDoc(url="https://x.feishu.cn/wiki/leaf1")]
+    # A wiki node with no children is a passthrough, not a batch child.
+    assert result[0].source_kind == "single_doc_passthrough"
+    # Verify get_node was called with the right token + user-token option.
+    request, option = get_node.call_args.args
+    assert request.token == "leaf1"
+    assert option.user_access_token == "u-test"
+
+
+def test_expand_wiki_node_with_children_returns_subtree(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # Root node has children; its subtree contains two docs.
+    get_node = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                node=_make_node(
+                    node_token="dir1",
+                    obj_type="docx",
+                    obj_token="doxcnDir",
+                    title="Directory Root",
+                    has_child=True,
+                    space_id="space_1",
+                )
+            )
+        )
+    )
+    # space.list returns the directory's two children (both leaves).
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                items=[
+                    _make_node(
+                        node_token="c1",
+                        obj_type="docx",
+                        obj_token="doxcnC1",
+                        title="Child 1",
+                    ),
+                    _make_node(
+                        node_token="c2",
+                        obj_type="doc",
+                        obj_token="doxcnC2",
+                        title="Child 2",
+                    ),
+                ],
+                has_more=False,
+                page_token=None,
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = _make_client(space_list=space_list, get_node=get_node)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/dir1", feishu_access_token="u-test")
+    )
+    # Three docs: the directory root itself + two children.
+    urls = [d.url for d in result]
+    assert urls == [
+        "https://feishu.cn/docx/doxcnDir",
+        "https://feishu.cn/docx/doxcnC1",
+        "https://feishu.cn/docx/doxcnC2",
+    ]
+    titles = [d.title for d in result]
+    assert titles == ["Directory Root", "Child 1", "Child 2"]
+    # space.list was called with the directory's node_token as parent.
+    list_request = space_list.call_args.args[0]
+    assert list_request.space_id == "space_1"
+    assert list_request.parent_node_token == "dir1"
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — space root URL (uses space.list, no get_node).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_space_root_url_returns_all_nodes(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                items=[
+                    _make_node(
+                        node_token="t1",
+                        obj_type="docx",
+                        obj_token="doxcnT1",
+                        title="Top Doc 1",
+                    ),
+                    _make_node(
+                        node_token="t2",
+                        obj_type="doc",
+                        obj_token="doxcnT2",
+                        title="Top Doc 2",
+                    ),
+                ],
+                has_more=False,
+                page_token=None,
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_42"))
+    urls = [d.url for d in result]
+    assert urls == [
+        "https://feishu.cn/docx/doxcnT1",
+        "https://feishu.cn/docx/doxcnT2",
+    ]
+    list_request = space_list.call_args.args[0]
+    assert list_request.space_id == "space_42"
+    # Root listing: parent_node_token is None.
+    assert list_request.parent_node_token is None
+
+
+def test_expand_space_root_url_recurses_into_subdirectories(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # First call: top-level listing — one doc + one folder.
+    # Second call: the folder's children — two docs.
+    top_level = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="top_doc",
+                    obj_type="docx",
+                    obj_token="doxcnTop",
+                    title="Top",
+                ),
+                _make_node(
+                    node_token="folder1",
+                    obj_type="docx",
+                    obj_token="doxcnFolder",
+                    title="Folder",
+                    has_child=True,
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    folder_children = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="f_child1",
+                    obj_type="doc",
+                    obj_token="doxcnFC1",
+                    title="FC1",
+                    parent_node_token="folder1",
+                ),
+                _make_node(
+                    node_token="f_child2",
+                    obj_type="sheet",
+                    obj_token="shtFC2",
+                    title="FC2",
+                    parent_node_token="folder1",
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    space_list = MagicMock(side_effect=[top_level, folder_children])
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
+    urls = [d.url for d in result]
+    # Top-level doc + folder doc + 2 folder children.
+    assert urls == [
+        "https://feishu.cn/docx/doxcnTop",
+        "https://feishu.cn/docx/doxcnFolder",
+        "https://feishu.cn/docx/doxcnFC1",
+        "https://feishu.cn/sheets/shtFC2",
+    ]
+    # Hierarchy preserved (issue #3120 review, blocking #3): top-level docs
+    # have an empty rel_path; the folder's children carry the folder as their
+    # relative directory so they import under <batch_parent>/<folder>/<doc>
+    # instead of being flattened into the parent.
+    rel_paths = [d.rel_path for d in result]
+    assert rel_paths[0] == ""  # top doc
+    assert rel_paths[1] == ""  # folder itself (also a top-level node)
+    assert rel_paths[2] == rel_paths[3]  # both folder children share the folder dir
+    assert rel_paths[2] != ""  # nested under the folder
+    # Everything expanded from a space root is a batch child.
+    assert all(d.source_kind == "batch_child" for d in result)
+    # Two space.list calls: one at root, one with parent_node_token=folder1.
+    assert space_list.call_count == 2
+    second_request = space_list.call_args_list[1].args[0]
+    assert second_request.parent_node_token == "folder1"
+
+
+# ---------------------------------------------------------------------------
+# Pagination.
+# ---------------------------------------------------------------------------
+
+
+def test_expand_space_root_url_follows_pagination(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    page1 = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="p1a",
+                    obj_type="docx",
+                    obj_token="doxcnP1A",
+                    title="P1A",
+                ),
+            ],
+            has_more=True,
+            page_token="page2token",
+        )
+    )
+    page2 = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="p2a",
+                    obj_type="docx",
+                    obj_token="doxcnP2A",
+                    title="P2A",
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    space_list = MagicMock(side_effect=[page1, page2])
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
+    urls = [d.url for d in result]
+    assert urls == ["https://feishu.cn/docx/doxcnP1A", "https://feishu.cn/docx/doxcnP2A"]
+    # The second list call must carry the page_token from page 1.
+    second_request = space_list.call_args_list[1].args[0]
+    assert second_request.page_token == "page2token"
+
+
+# ---------------------------------------------------------------------------
+# Recursion / node-count caps.
+# ---------------------------------------------------------------------------
+
+
+def test_list_wiki_subtree_respects_max_depth(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+
+    # A chain of nested folders: root → folderA → folderB → doc.
+    def _list(space_id, parent_node_token, **_):
+        if parent_node_token is None:
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="folderA",
+                            obj_type="docx",
+                            obj_token="doxcnA",
+                            title="A",
+                            has_child=True,
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        if parent_node_token == "folderA":
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="folderB",
+                            obj_type="docx",
+                            obj_token="doxcnB",
+                            title="B",
+                            has_child=True,
+                            parent_node_token="folderA",
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        if parent_node_token == "folderB":
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="leafZ",
+                            obj_type="docx",
+                            obj_token="doxcnZ",
+                            title="Z",
+                            parent_node_token="folderB",
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        return _SuccessResponse(SimpleNamespace(items=[], has_more=False, page_token=None))
+
+    space_list = MagicMock(
+        side_effect=lambda req, *a, **kw: _list(req.space_id, req.parent_node_token)
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    # max_depth=1 → only the root level (folderA is recorded, but its children
+    # are NOT walked because depth would exceed 1).
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1", max_depth=1))
+    urls = [d.url for d in result]
+    assert urls == ["https://feishu.cn/docx/doxcnA"]
+
+
+def test_list_wiki_subtree_respects_max_nodes(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # 5 top-level docs; max_nodes caps the result to 2.
+    items = [
+        _make_node(
+            node_token=f"n{i}",
+            obj_type="docx",
+            obj_token=f"doxcn{i}",
+            title=f"doc{i}",
+        )
+        for i in range(5)
+    ]
+    space_list = MagicMock(
+        return_value=_SuccessResponse(SimpleNamespace(items=items, has_more=False, page_token=None))
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1", max_nodes=2))
+    assert len(result) == 2
+    assert [d.url for d in result] == [
+        "https://feishu.cn/docx/doxcn0",
+        "https://feishu.cn/docx/doxcn1",
+    ]
+
+
+def test_list_wiki_subtree_empty_space_returns_empty_list(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(
+        return_value=_SuccessResponse(SimpleNamespace(items=[], has_more=False, page_token=None))
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    assert result == []
+
+
+def test_list_wiki_subtree_dedupes_shared_obj_tokens(monkeypatch):
+    """If the same underlying doc (obj_token) appears under two parents, it
+    must only be emitted once."""
+    _install_fake_lark_wiki(monkeypatch)
+    shared = _make_node(
+        node_token="shared_node",
+        obj_type="docx",
+        obj_token="doxcnShared",
+        title="Shared",
+    )
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(items=[shared, shared], has_more=False, page_token=None)
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    assert len(result) == 1
+    assert result[0].url == "https://feishu.cn/docx/doxcnShared"
+    assert result[0].title == "Shared"
+    # Expanded from a space root → batch_child, top-level → empty rel_path.
+    assert result[0].source_kind == "batch_child"
+    assert result[0].rel_path == ""
+
+
+def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
+    """A node with an unsupported obj_type (e.g. a folder of type 'wiki' or
+    'file') is not emitted, but its children are still walked."""
+    _install_fake_lark_wiki(monkeypatch)
+    folder = _make_node(
+        node_token="folder_unknown",
+        obj_type="file",  # not in _DOC_TYPE_HANDLERS
+        obj_token="fileTok",
+        title="Folder",
+        has_child=True,
+    )
+    child = _make_node(
+        node_token="child_doc",
+        obj_type="docx",
+        obj_token="doxcnChild",
+        title="Child",
+        parent_node_token="folder_unknown",
+    )
+    space_list = MagicMock(
+        side_effect=[
+            _SuccessResponse(SimpleNamespace(items=[folder], has_more=False, page_token=None)),
+            _SuccessResponse(SimpleNamespace(items=[child], has_more=False, page_token=None)),
+        ]
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    # Only the supported child doc is emitted.
+    assert len(result) == 1
+    assert result[0].url == "https://feishu.cn/docx/doxcnChild"
+    assert result[0].title == "Child"
+    assert result[0].source_kind == "batch_child"
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — non-Feishu URLs pass through unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_expand_non_feishu_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    result = asyncio.run(accessor.expand_feishu_url("https://github.com/org/repo"))
+    assert result == [ExpandedDoc(url="https://github.com/org/repo")]
+    assert result[0].source_kind == "single_doc_passthrough"
+
+
+def test_expand_space_root_api_failure_propagates(monkeypatch):
+    """If the Feishu API call fails, the error must surface (no silent
+    degradation to single-doc import)."""
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(return_value=_FailureResponse(code=99991663, msg="denied"))
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    from openviking_cli.exceptions import OpenVikingError
+
+    with pytest.raises(OpenVikingError, match="list wiki nodes"):
+        asyncio.run(accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1"))
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review regression: cycle safety (issue #3120).
+# ---------------------------------------------------------------------------
+
+
+def test_list_wiki_subtree_breaks_node_token_cycle(monkeypatch):
+    """An A -> B -> A node cycle must not recurse forever (RecursionError).
+
+    Before the fix, ``seen_tokens`` only deduped *results*; the walker re-entered
+    recursion on ``has_child`` regardless, so a true cycle blew the stack once
+    ``max_depth`` was large. Now ``seen_node_tokens`` stops re-expansion.
+    """
+    _install_fake_lark_wiki(monkeypatch)
+    children = {
+        None: [_make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)],
+        "A": [_make_node(node_token="B", obj_type="docx", obj_token="docB", has_child=True)],
+        "B": [
+            _make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)
+        ],  # cycle
+    }
+    calls = {"n": 0}
+
+    def fake_list(space, parent_node_token, feishu_access_token=None, page_token=None):
+        calls["n"] += 1
+        return children.get(parent_node_token, []), False, None
+
+    accessor = FeishuAccessor()
+    accessor._list_wiki_child_nodes = fake_list
+    result = asyncio.run(
+        accessor.list_wiki_subtree(
+            space_id="space_1", feishu_access_token="u", max_depth=100, max_nodes=1000
+        )
+    )
+    # Each node_token expanded at most once: root listing + A + B = 3 calls.
+    assert calls["n"] == 3, calls
+    urls = [d.url for d in result]
+    assert sorted(urls) == ["https://feishu.cn/docx/docA", "https://feishu.cn/docx/docB"]
+    assert len(urls) == 2  # no duplication from the cycle
+
+
+def test_list_wiki_subtree_breaks_page_token_cycle(monkeypatch):
+    """An A -> B -> A *page-token* cycle from a buggy/malicious API must terminate.
+
+    The old ``next_page_token == page_token`` guard only caught an adjacent dup;
+    an alternating A/B cycle span until ``max_nodes``. The seen-set stops it.
+    """
+    _install_fake_lark_wiki(monkeypatch)
+    calls = {"n": 0}
+
+    def fake_list(space, parent_node_token, feishu_access_token=None, page_token=None):
+        calls["n"] += 1
+        nxt = "B" if page_token in (None, "A") else "A"  # alternate -> cycle
+        node = _make_node(
+            node_token=f"n{page_token}", obj_type="docx", obj_token=f"doc{page_token}"
+        )
+        return [node], True, nxt
+
+    accessor = FeishuAccessor()
+    accessor._list_wiki_child_nodes = fake_list
+    asyncio.run(
+        accessor.list_wiki_subtree(
+            space_id="space_1", feishu_access_token="u", max_depth=1, max_nodes=1000
+        )
+    )
+    # Would spin ~1000 times without the fix; now stops as soon as a token repeats.
+    assert calls["n"] <= 4, calls

--- a/tests/parse/test_feishu_wiki_batch.py
+++ b/tests/parse/test_feishu_wiki_batch.py
@@ -755,3 +755,69 @@ def test_expand_space_root_api_failure_propagates(monkeypatch):
         asyncio.run(
             accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
         )
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-review regression: cycle safety (issue #3120).
+# ---------------------------------------------------------------------------
+
+
+def test_list_wiki_subtree_breaks_node_token_cycle(monkeypatch):
+    """An A -> B -> A node cycle must not recurse forever (RecursionError).
+
+    Before the fix, ``seen_tokens`` only deduped *results*; the walker re-entered
+    recursion on ``has_child`` regardless, so a true cycle blew the stack once
+    ``max_depth`` was large. Now ``seen_node_tokens`` stops re-expansion.
+    """
+    _install_fake_lark_wiki(monkeypatch)
+    children = {
+        None: [_make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)],
+        "A": [_make_node(node_token="B", obj_type="docx", obj_token="docB", has_child=True)],
+        "B": [_make_node(node_token="A", obj_type="docx", obj_token="docA", has_child=True)],  # cycle
+    }
+    calls = {"n": 0}
+
+    def fake_list(space, parent_node_token, feishu_access_token=None, page_token=None):
+        calls["n"] += 1
+        return children.get(parent_node_token, []), False, None
+
+    accessor = FeishuAccessor()
+    accessor._list_wiki_child_nodes = fake_list
+    result = asyncio.run(
+        accessor.list_wiki_subtree(
+            space_id="space_1", feishu_access_token="u", max_depth=100, max_nodes=1000
+        )
+    )
+    # Each node_token expanded at most once: root listing + A + B = 3 calls.
+    assert calls["n"] == 3, calls
+    urls = [u for u, _t in result]
+    assert sorted(urls) == ["https://feishu.cn/docx/docA", "https://feishu.cn/docx/docB"]
+    assert len(urls) == 2  # no duplication from the cycle
+
+
+def test_list_wiki_subtree_breaks_page_token_cycle(monkeypatch):
+    """An A -> B -> A *page-token* cycle from a buggy/malicious API must terminate.
+
+    The old ``next_page_token == page_token`` guard only caught an adjacent dup;
+    an alternating A/B cycle span until ``max_nodes``. The seen-set stops it.
+    """
+    _install_fake_lark_wiki(monkeypatch)
+    calls = {"n": 0}
+
+    def fake_list(space, parent_node_token, feishu_access_token=None, page_token=None):
+        calls["n"] += 1
+        nxt = "B" if page_token in (None, "A") else "A"  # alternate -> cycle
+        node = _make_node(
+            node_token=f"n{page_token}", obj_type="docx", obj_token=f"doc{page_token}"
+        )
+        return [node], True, nxt
+
+    accessor = FeishuAccessor()
+    accessor._list_wiki_child_nodes = fake_list
+    result = asyncio.run(
+        accessor.list_wiki_subtree(
+            space_id="space_1", feishu_access_token="u", max_depth=1, max_nodes=1000
+        )
+    )
+    # Would spin ~1000 times without the fix; now stops as soon as a token repeats.
+    assert calls["n"] <= 4, calls

--- a/tests/parse/test_feishu_wiki_batch.py
+++ b/tests/parse/test_feishu_wiki_batch.py
@@ -1,0 +1,757 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for Feishu wiki space / directory batch import (issue #3120).
+
+Covers ``FeishuAccessor.classify_url``, ``expand_feishu_url`` and the recursive
+``list_wiki_subtree`` walker. All Feishu API calls are mocked — the lark-oapi
+SDK is replaced with fakes that mimic ``client.wiki.v2.space.list`` and
+``client.wiki.v2.space.get_node``.
+"""
+
+import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+
+
+# ---------------------------------------------------------------------------
+# Mock plumbing — mirrors the pattern in tests/parse/test_feishu_accessor.py.
+# ---------------------------------------------------------------------------
+
+
+class _SuccessResponse:
+    """Stand-in for a successful lark-oapi response object."""
+
+    def __init__(self, data):
+        self.data = data
+        self.code = 0
+        self.msg = ""
+
+    @staticmethod
+    def success():
+        return True
+
+
+class _FailureResponse:
+    """Stand-in for a failed lark-oapi response object."""
+
+    def __init__(self, code=1, msg="boom"):
+        self.data = None
+        self.code = code
+        self.msg = msg
+
+    @staticmethod
+    def success():
+        return False
+
+
+class _FakeRequestOption:
+    def __init__(self):
+        self.user_access_token = None
+
+    @staticmethod
+    def builder():
+        return _FakeRequestOptionBuilder()
+
+
+class _FakeRequestOptionBuilder:
+    def __init__(self):
+        self._option = _FakeRequestOption()
+
+    def user_access_token(self, token):
+        self._option.user_access_token = token
+        return self
+
+    def build(self):
+        return self._option
+
+
+class _FakeListSpaceNodeRequest:
+    """Fake ``lark_oapi.api.wiki.v2.ListSpaceNodeRequest``."""
+
+    @staticmethod
+    def builder():
+        return _FakeListSpaceNodeRequestBuilder()
+
+
+class _FakeListSpaceNodeRequestBuilder:
+    def __init__(self):
+        self._request = SimpleNamespace(
+            space_id=None, parent_node_token=None, page_token=None, page_size=None
+        )
+
+    def space_id(self, value):
+        self._request.space_id = value
+        return self
+
+    def parent_node_token(self, value):
+        self._request.parent_node_token = value
+        return self
+
+    def page_token(self, value):
+        self._request.page_token = value
+        return self
+
+    def page_size(self, value):
+        self._request.page_size = value
+        return self
+
+    def build(self):
+        return self._request
+
+
+class _FakeGetNodeSpaceRequest:
+    """Fake ``lark_oapi.api.wiki.v2.GetNodeSpaceRequest``."""
+
+    @staticmethod
+    def builder():
+        return _FakeGetNodeSpaceRequestBuilder()
+
+
+class _FakeGetNodeSpaceRequestBuilder:
+    def __init__(self):
+        self._request = SimpleNamespace(token=None)
+
+    def token(self, value):
+        self._request.token = value
+        return self
+
+    def build(self):
+        return self._request
+
+
+def _install_fake_lark_wiki(monkeypatch):
+    """Install just enough of lark-oapi for the wiki batch code paths."""
+    lark = ModuleType("lark_oapi")
+    core_model = ModuleType("lark_oapi.core.model")
+    core_model.RequestOption = _FakeRequestOption
+    wiki_v2 = ModuleType("lark_oapi.api.wiki.v2")
+    wiki_v2.ListSpaceNodeRequest = _FakeListSpaceNodeRequest
+    wiki_v2.GetNodeSpaceRequest = _FakeGetNodeSpaceRequest
+
+    monkeypatch.setitem(sys.modules, "lark_oapi", lark)
+    monkeypatch.setitem(sys.modules, "lark_oapi.core.model", core_model)
+    monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki", ModuleType("lark_oapi.api.wiki"))
+    monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki.v2", wiki_v2)
+
+
+def _make_node(
+    *,
+    node_token,
+    obj_type,
+    obj_token,
+    title="",
+    has_child=False,
+    space_id="space_1",
+    parent_node_token=None,
+    url="",
+):
+    return SimpleNamespace(
+        node_token=node_token,
+        obj_token=obj_token,
+        obj_type=obj_type,
+        title=title,
+        has_child=has_child,
+        space_id=space_id,
+        parent_node_token=parent_node_token,
+        url=url,
+    )
+
+
+def _make_client(space_list=None, get_node=None):
+    """Build a fake lark client exposing ``client.wiki.v2.space.{list,get_node}``."""
+    space = SimpleNamespace(list=space_list or MagicMock(), get_node=get_node or MagicMock())
+    return SimpleNamespace(wiki=SimpleNamespace(v2=SimpleNamespace(space=space)))
+
+
+# ---------------------------------------------------------------------------
+# classify_url / is_batch_url (pure logic, no mocks).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Single-doc URL forms — unchanged behaviour.
+        ("https://volcengine.feishu.cn/docx/doxcnABC", ("single_doc", "docx", "doxcnABC")),
+        ("https://volcengine.feishu.cn/sheets/stok1", ("single_doc", "sheets", "stok1")),
+        ("https://volcengine.feishu.cn/base/appTok1", ("single_doc", "base", "appTok1")),
+        # Wiki node URL — may be a doc or a directory.
+        (
+            "https://volcengine.feishu.cn/wiki/nodeTok1",
+            ("wiki_node", "nodeTok1", None),
+        ),
+        # Space root URL — always batch.
+        (
+            "https://volcengine.feishu.cn/wiki/settings/7123456789012345",
+            ("wiki_space_root", "7123456789012345", None),
+        ),
+        # Lark domains also recognised.
+        (
+            "https://volcengine.larksuite.com/wiki/settings/abc",
+            ("wiki_space_root", "abc", None),
+        ),
+        (
+            "https://volcengine.larkoffice.com/wiki/nodeX",
+            ("wiki_node", "nodeX", None),
+        ),
+    ],
+)
+def test_classify_url_recognises_known_forms(url, expected):
+    assert FeishuAccessor.classify_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/org/repo",
+        "https://example.com/docx/foo",  # not a feishu domain
+        "https://volcengine.feishu.cn/",  # no path
+        "https://volcengine.feishu.cn/wiki/",  # wiki with no token
+        "https://volcengine.feishu.cn/wiki/settings/",  # settings with no space id
+        "/local/path/docx/foo",  # not a URL
+    ],
+)
+def test_classify_url_rejects_unrecognized(url):
+    assert FeishuAccessor.classify_url(url) is None
+
+
+def test_is_batch_url_only_true_for_space_root():
+    assert FeishuAccessor.is_batch_url(
+        "https://x.feishu.cn/wiki/settings/space1"
+    ) is True
+    # Wiki node URLs need an API check, so is_batch_url returns False here.
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/wiki/node1") is False
+    assert FeishuAccessor.is_batch_url("https://x.feishu.cn/docx/d1") is False
+    assert FeishuAccessor.is_batch_url("https://github.com/o/r") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_doc_url — direct URLs only for parseable types; None otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_build_doc_url_emits_direct_url_for_known_types():
+    node = _make_node(node_token="n1", obj_type="docx", obj_token="doxcnA", title="A")
+    assert (
+        FeishuAccessor._build_doc_url(node)
+        == "https://feishu.cn/docx/doxcnA"
+    )
+
+
+def test_build_doc_url_normalizes_short_api_type_names():
+    # Wiki API returns short names: doc/sheet/bitable — _WIKI_TYPE_MAP normalizes.
+    doc = _make_node(node_token="n1", obj_type="doc", obj_token="t1")
+    sheet = _make_node(node_token="n2", obj_type="sheet", obj_token="t2")
+    base = _make_node(node_token="n3", obj_type="bitable", obj_token="t3")
+    assert FeishuAccessor._build_doc_url(doc) == "https://feishu.cn/docx/t1"
+    assert FeishuAccessor._build_doc_url(sheet) == "https://feishu.cn/sheets/t2"
+    assert FeishuAccessor._build_doc_url(base) == "https://feishu.cn/base/t3"
+
+
+def test_build_doc_url_returns_none_for_unsupported_types():
+    # Wiki nodes of unknown obj_type (e.g. mindmap/file) are skipped — they
+    # would otherwise produce URLs the accessor cannot parse.
+    node = _make_node(node_token="n1", obj_type="mindmap", obj_token="t1")
+    assert FeishuAccessor._build_doc_url(node) is None
+
+
+def test_build_doc_url_returns_none_when_obj_token_missing():
+    node = _make_node(node_token="n1", obj_type="docx", obj_token="")
+    assert FeishuAccessor._build_doc_url(node) is None
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — single-doc passthrough (no API calls for /docx/, /sheets/).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_single_docx_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    # No client is wired up — the test fails if any API call is attempted.
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/docx/doxcnABC")
+    )
+    assert result == [("https://x.feishu.cn/docx/doxcnABC", "")]
+
+
+def test_expand_single_sheets_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/sheets/stok1")
+    )
+    assert result == [("https://x.feishu.cn/sheets/stok1", "")]
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — wiki node URL (uses get_node to check has_child).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_wiki_node_without_children_returns_single_url(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    get_node = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                node=_make_node(
+                    node_token="leaf1",
+                    obj_type="docx",
+                    obj_token="doxcnLeaf",
+                    title="Leaf",
+                    has_child=False,
+                )
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = _make_client(get_node=get_node)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url(
+            "https://x.feishu.cn/wiki/leaf1", feishu_access_token="u-test"
+        )
+    )
+    assert result == [("https://x.feishu.cn/wiki/leaf1", "")]
+    # Verify get_node was called with the right token + user-token option.
+    request, option = get_node.call_args.args
+    assert request.token == "leaf1"
+    assert option.user_access_token == "u-test"
+
+
+def test_expand_wiki_node_with_children_returns_subtree(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # Root node has children; its subtree contains two docs.
+    get_node = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                node=_make_node(
+                    node_token="dir1",
+                    obj_type="docx",
+                    obj_token="doxcnDir",
+                    title="Directory Root",
+                    has_child=True,
+                    space_id="space_1",
+                )
+            )
+        )
+    )
+    # space.list returns the directory's two children (both leaves).
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                items=[
+                    _make_node(
+                        node_token="c1",
+                        obj_type="docx",
+                        obj_token="doxcnC1",
+                        title="Child 1",
+                    ),
+                    _make_node(
+                        node_token="c2",
+                        obj_type="doc",
+                        obj_token="doxcnC2",
+                        title="Child 2",
+                    ),
+                ],
+                has_more=False,
+                page_token=None,
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = _make_client(space_list=space_list, get_node=get_node)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url(
+            "https://x.feishu.cn/wiki/dir1", feishu_access_token="u-test"
+        )
+    )
+    # Three docs: the directory root itself + two children.
+    urls = [url for url, _title in result]
+    assert urls == [
+        "https://feishu.cn/docx/doxcnDir",
+        "https://feishu.cn/docx/doxcnC1",
+        "https://feishu.cn/docx/doxcnC2",
+    ]
+    titles = [title for _url, title in result]
+    assert titles == ["Directory Root", "Child 1", "Child 2"]
+    # space.list was called with the directory's node_token as parent.
+    list_request = space_list.call_args.args[0]
+    assert list_request.space_id == "space_1"
+    assert list_request.parent_node_token == "dir1"
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — space root URL (uses space.list, no get_node).
+# ---------------------------------------------------------------------------
+
+
+def test_expand_space_root_url_returns_all_nodes(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                items=[
+                    _make_node(
+                        node_token="t1",
+                        obj_type="docx",
+                        obj_token="doxcnT1",
+                        title="Top Doc 1",
+                    ),
+                    _make_node(
+                        node_token="t2",
+                        obj_type="doc",
+                        obj_token="doxcnT2",
+                        title="Top Doc 2",
+                    ),
+                ],
+                has_more=False,
+                page_token=None,
+            )
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url(
+            "https://x.feishu.cn/wiki/settings/space_42"
+        )
+    )
+    urls = [url for url, _title in result]
+    assert urls == [
+        "https://feishu.cn/docx/doxcnT1",
+        "https://feishu.cn/docx/doxcnT2",
+    ]
+    list_request = space_list.call_args.args[0]
+    assert list_request.space_id == "space_42"
+    # Root listing: parent_node_token is None.
+    assert list_request.parent_node_token is None
+
+
+def test_expand_space_root_url_recurses_into_subdirectories(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # First call: top-level listing — one doc + one folder.
+    # Second call: the folder's children — two docs.
+    top_level = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="top_doc",
+                    obj_type="docx",
+                    obj_token="doxcnTop",
+                    title="Top",
+                ),
+                _make_node(
+                    node_token="folder1",
+                    obj_type="docx",
+                    obj_token="doxcnFolder",
+                    title="Folder",
+                    has_child=True,
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    folder_children = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="f_child1",
+                    obj_type="doc",
+                    obj_token="doxcnFC1",
+                    title="FC1",
+                    parent_node_token="folder1",
+                ),
+                _make_node(
+                    node_token="f_child2",
+                    obj_type="sheet",
+                    obj_token="shtFC2",
+                    title="FC2",
+                    parent_node_token="folder1",
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    space_list = MagicMock(side_effect=[top_level, folder_children])
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
+    )
+    urls = [url for url, _title in result]
+    # Top-level doc + folder doc + 2 folder children.
+    assert urls == [
+        "https://feishu.cn/docx/doxcnTop",
+        "https://feishu.cn/docx/doxcnFolder",
+        "https://feishu.cn/docx/doxcnFC1",
+        "https://feishu.cn/sheets/shtFC2",
+    ]
+    # Two space.list calls: one at root, one with parent_node_token=folder1.
+    assert space_list.call_count == 2
+    second_request = space_list.call_args_list[1].args[0]
+    assert second_request.parent_node_token == "folder1"
+
+
+# ---------------------------------------------------------------------------
+# Pagination.
+# ---------------------------------------------------------------------------
+
+
+def test_expand_space_root_url_follows_pagination(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    page1 = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="p1a",
+                    obj_type="docx",
+                    obj_token="doxcnP1A",
+                    title="P1A",
+                ),
+            ],
+            has_more=True,
+            page_token="page2token",
+        )
+    )
+    page2 = _SuccessResponse(
+        SimpleNamespace(
+            items=[
+                _make_node(
+                    node_token="p2a",
+                    obj_type="docx",
+                    obj_token="doxcnP2A",
+                    title="P2A",
+                ),
+            ],
+            has_more=False,
+            page_token=None,
+        )
+    )
+    space_list = MagicMock(side_effect=[page1, page2])
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
+    )
+    urls = [url for url, _title in result]
+    assert urls == ["https://feishu.cn/docx/doxcnP1A", "https://feishu.cn/docx/doxcnP2A"]
+    # The second list call must carry the page_token from page 1.
+    second_request = space_list.call_args_list[1].args[0]
+    assert second_request.page_token == "page2token"
+
+
+# ---------------------------------------------------------------------------
+# Recursion / node-count caps.
+# ---------------------------------------------------------------------------
+
+
+def test_list_wiki_subtree_respects_max_depth(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # A chain of nested folders: root → folderA → folderB → doc.
+    def _list(space_id, parent_node_token, **_):
+        if parent_node_token is None:
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="folderA",
+                            obj_type="docx",
+                            obj_token="doxcnA",
+                            title="A",
+                            has_child=True,
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        if parent_node_token == "folderA":
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="folderB",
+                            obj_type="docx",
+                            obj_token="doxcnB",
+                            title="B",
+                            has_child=True,
+                            parent_node_token="folderA",
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        if parent_node_token == "folderB":
+            return _SuccessResponse(
+                SimpleNamespace(
+                    items=[
+                        _make_node(
+                            node_token="leafZ",
+                            obj_type="docx",
+                            obj_token="doxcnZ",
+                            title="Z",
+                            parent_node_token="folderB",
+                        ),
+                    ],
+                    has_more=False,
+                    page_token=None,
+                )
+            )
+        return _SuccessResponse(SimpleNamespace(items=[], has_more=False, page_token=None))
+
+    space_list = MagicMock(side_effect=lambda req, *a, **kw: _list(
+        req.space_id, req.parent_node_token
+    ))
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    # max_depth=1 → only the root level (folderA is recorded, but its children
+    # are NOT walked because depth would exceed 1).
+    result = asyncio.run(
+        accessor.list_wiki_subtree(space_id="space_1", max_depth=1)
+    )
+    urls = [url for url, _title in result]
+    assert urls == ["https://feishu.cn/docx/doxcnA"]
+
+
+def test_list_wiki_subtree_respects_max_nodes(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    # 5 top-level docs; max_nodes caps the result to 2.
+    items = [
+        _make_node(
+            node_token=f"n{i}",
+            obj_type="docx",
+            obj_token=f"doxcn{i}",
+            title=f"doc{i}",
+        )
+        for i in range(5)
+    ]
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(items=items, has_more=False, page_token=None)
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(
+        accessor.list_wiki_subtree(space_id="space_1", max_nodes=2)
+    )
+    assert len(result) == 2
+    assert [url for url, _ in result] == [
+        "https://feishu.cn/docx/doxcn0",
+        "https://feishu.cn/docx/doxcn1",
+    ]
+
+
+def test_list_wiki_subtree_empty_space_returns_empty_list(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(items=[], has_more=False, page_token=None)
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    assert result == []
+
+
+def test_list_wiki_subtree_dedupes_shared_obj_tokens(monkeypatch):
+    """If the same underlying doc (obj_token) appears under two parents, it
+    must only be emitted once."""
+    _install_fake_lark_wiki(monkeypatch)
+    shared = _make_node(
+        node_token="shared_node",
+        obj_type="docx",
+        obj_token="doxcnShared",
+        title="Shared",
+    )
+    space_list = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(items=[shared, shared], has_more=False, page_token=None)
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    assert result == [("https://feishu.cn/docx/doxcnShared", "Shared")]
+
+
+def test_list_wiki_subtree_skips_unsupported_obj_type_but_recurses(monkeypatch):
+    """A node with an unsupported obj_type (e.g. a folder of type 'wiki' or
+    'file') is not emitted, but its children are still walked."""
+    _install_fake_lark_wiki(monkeypatch)
+    folder = _make_node(
+        node_token="folder_unknown",
+        obj_type="file",  # not in _DOC_TYPE_HANDLERS
+        obj_token="fileTok",
+        title="Folder",
+        has_child=True,
+    )
+    child = _make_node(
+        node_token="child_doc",
+        obj_type="docx",
+        obj_token="doxcnChild",
+        title="Child",
+        parent_node_token="folder_unknown",
+    )
+    space_list = MagicMock(
+        side_effect=[
+            _SuccessResponse(
+                SimpleNamespace(items=[folder], has_more=False, page_token=None)
+            ),
+            _SuccessResponse(
+                SimpleNamespace(items=[child], has_more=False, page_token=None)
+            ),
+        ]
+    )
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    result = asyncio.run(accessor.list_wiki_subtree(space_id="space_1"))
+    # Only the supported child doc is emitted.
+    assert result == [("https://feishu.cn/docx/doxcnChild", "Child")]
+
+
+# ---------------------------------------------------------------------------
+# expand_feishu_url — non-Feishu URLs pass through unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_expand_non_feishu_url_returns_unchanged(monkeypatch):
+    _install_fake_lark_wiki(monkeypatch)
+    accessor = FeishuAccessor()
+    result = asyncio.run(
+        accessor.expand_feishu_url("https://github.com/org/repo")
+    )
+    assert result == [("https://github.com/org/repo", "")]
+
+
+def test_expand_space_root_api_failure_propagates(monkeypatch):
+    """If the Feishu API call fails, the error must surface (no silent
+    degradation to single-doc import)."""
+    _install_fake_lark_wiki(monkeypatch)
+    space_list = MagicMock(return_value=_FailureResponse(code=99991663, msg="denied"))
+    accessor = FeishuAccessor()
+    accessor._client = _make_client(space_list=space_list)
+
+    with pytest.raises(Exception):  # OpenVikingError raised by _raise_from_lark_response
+        asyncio.run(
+            accessor.expand_feishu_url("https://x.feishu.cn/wiki/settings/space_1")
+        )

--- a/tests/service/test_batch_manifest_store.py
+++ b/tests/service/test_batch_manifest_store.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the durable batch-import manifest store (issue #3120, blocking #3).
+
+Covers atomic save/load, ``.bak`` recovery when the primary file is corrupt,
+``list_batch_ids``, the deterministic batch id (idempotent re-submit) and the
+control-URI guard. The FS is a real in-memory double so the tmp → bak → rename
+rotation is exercised through the actual code path.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from openviking.service import batch_manifest_store as batch_store
+
+
+class _InMemoryFS:
+    """Minimal async FS capturing dirs/files (mirrors the real VikingFS API)."""
+
+    def __init__(self) -> None:
+        self.dirs: set[str] = set()
+        self.files: Dict[str, str] = {}
+
+    def _norm(self, uri: str) -> str:
+        return uri.rstrip("/")
+
+    async def mkdir(
+        self, uri: str, mode: str = "755", exist_ok: bool = False, ctx: Optional[Any] = None
+    ) -> None:
+        u = self._norm(uri)
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+        self.dirs.add(u)
+
+    async def exists(self, uri: str, ctx: Optional[Any] = None) -> bool:
+        u = self._norm(uri)
+        return u in self.dirs or u in self.files
+
+    async def write_file(self, uri: str, data: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files[u] = data
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+
+    async def read_file(self, uri: str, ctx: Optional[Any] = None) -> str:
+        return self.files.get(self._norm(uri), "")
+
+    async def mv(self, src: str, dst: str, ctx: Optional[Any] = None) -> None:
+        s, d = self._norm(src), self._norm(dst)
+        if s in self.files:
+            self.files[d] = self.files.pop(s)
+        elif s in self.dirs:
+            self.dirs.discard(s)
+            self.dirs.add(d)
+
+    async def rm(self, uri: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files.pop(u, None)
+        self.dirs.discard(u)
+
+    async def ls(self, uri: str, ctx: Optional[Any] = None) -> List[Dict[str, Any]]:
+        u = self._norm(uri)
+        prefix = u + "/"
+        names: set[str] = set()
+        for f in self.files:
+            if f.startswith(prefix) and "/" not in f[len(prefix) :]:
+                names.add(f[len(prefix) :])
+        for d in self.dirs:
+            if d.startswith(prefix) and "/" not in d[len(prefix) :]:
+                names.add(d[len(prefix) :])
+        return [{"name": n, "isDir": False} for n in names]
+
+
+def _manifest(
+    batch_id: str = "bi_abc", items: Optional[List[Dict[str, Any]]] = None
+) -> Dict[str, Any]:
+    return batch_store.build_manifest(
+        batch_id=batch_id,
+        source_url="https://x.feishu.cn/wiki/settings/space1",
+        source_kind="feishu_wiki_space",
+        parent_uri="viking://resources/my_wiki",
+        created_at="2026-07-28T00:00:00",
+        items=items or [{"url": "https://x.feishu.cn/docx/d1", "task_id": "task-d1"}],
+    )
+
+
+def test_save_and_load_roundtrip():
+    fs = _InMemoryFS()
+
+    async def _run():
+        await batch_store.save_manifest(_manifest(), fs, ctx=None)
+        return await batch_store.load_manifest("bi_abc", fs, ctx=None)
+
+    manifest = asyncio.run(_run())
+    assert manifest is not None
+    assert manifest["batch_id"] == "bi_abc"
+    assert manifest["source_url"] == "https://x.feishu.cn/wiki/settings/space1"
+    assert manifest["items"][0]["task_id"] == "task-d1"
+
+
+def test_load_falls_back_to_bak_when_primary_corrupt():
+    """If the primary manifest is corrupt, the .bak sidecar must be used
+    (restart safety, issue #3120 review, blocking #3)."""
+    fs = _InMemoryFS()
+
+    async def _run():
+        # Save twice so the tmp → bak → rename rotation populates the .bak
+        # sidecar (the first save has no prior primary to rotate from).
+        await batch_store.save_manifest(_manifest(), fs, ctx=None)
+        await batch_store.save_manifest(_manifest(), fs, ctx=None)
+        # Corrupt the primary file in place.
+        primary = batch_store._batch_uri("bi_abc")
+        await fs.write_file(primary, "{not valid json", ctx=None)
+        return await batch_store.load_manifest("bi_abc", fs, ctx=None)
+
+    manifest = asyncio.run(_run())
+    assert manifest is not None  # recovered from .bak
+    assert manifest["batch_id"] == "bi_abc"
+
+
+def test_load_returns_none_for_unknown_batch():
+    fs = _InMemoryFS()
+
+    async def _run():
+        return await batch_store.load_manifest("bi_missing", fs, ctx=None)
+
+    assert asyncio.run(_run()) is None
+
+
+def test_list_batch_ids():
+    fs = _InMemoryFS()
+
+    async def _run():
+        await batch_store.save_manifest(_manifest("bi_one"), fs, ctx=None)
+        await batch_store.save_manifest(_manifest("bi_two"), fs, ctx=None)
+        return await batch_store.list_batch_ids(fs, ctx=None)
+
+    ids = asyncio.run(_run())
+    assert set(ids) == {"bi_one", "bi_two"}
+
+
+def test_derive_batch_id_is_stable_and_scoped():
+    a1 = batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space1", "viking://resources/p"
+    )
+    a2 = batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space1", "viking://resources/p"
+    )
+    assert a1 == a2  # idempotent re-submit
+    # Different parent or source → different id.
+    assert a1 != batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space1", "viking://resources/other"
+    )
+    assert a1 != batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space2", "viking://resources/p"
+    )
+    assert a1.startswith("bi_")
+
+
+def test_is_batch_import_control_uri():
+    assert batch_store.is_batch_import_control_uri("viking://resources/.batch_imports/bi_x.json")
+    assert batch_store.is_batch_import_control_uri("viking://resources/.batch_imports/")
+    assert not batch_store.is_batch_import_control_uri("viking://resources/my_wiki")
+    assert not batch_store.is_batch_import_control_uri("viking://resources/.watch_tasks.json")
+
+
+def test_save_manifest_rejects_non_serializable_payload():
+    """A manifest with a non-serializable payload must not be written."""
+    fs = _InMemoryFS()
+
+    bad = _manifest()
+    bad["items"] = [{"url": object()}]  # object() is not JSON-serializable
+
+    with pytest.raises(TypeError):
+        asyncio.run(batch_store.save_manifest(bad, fs, ctx=None))
+    # Nothing was persisted.
+    assert asyncio.run(fs.exists(batch_store._batch_uri("bi_abc"), ctx=None)) is False

--- a/tests/service/test_feishu_batch_dispatch.py
+++ b/tests/service/test_feishu_batch_dispatch.py
@@ -3,21 +3,155 @@
 """Service-level tests for Feishu wiki batch dispatch (issue #3120).
 
 Verifies that ``ResourceService._maybe_enqueue_feishu_batch_add_resource``:
-* expands a wiki space / directory URL via ``FeishuAccessor.expand_feishu_url``,
-* spawns one ``add_resource`` background task per expanded child document,
-* returns ``None`` for single-doc URLs (preserving the original import path).
+
+* dispatches on the expanded entries' ``source_kind`` — not on
+  ``len(expanded) == 1`` — so a one-document space/directory still takes the
+  batch path (issue #3120 review, blocking #1);
+* creates the batch parent through the **real** FS and forwards
+  ``create_parent`` per child so each child's target resolution succeeds
+  through the real path (blocking #2);
+* persists a durable provider-neutral manifest before fan-out and reuses it
+  for idempotent resume, recording per-item task ids / partial failures
+  (blocking #3);
+* preserves the wiki hierarchy via each child's ``rel_path`` (blocking #3).
+
+The FS is a real in-memory fake (not a mock) so mkdir / manifest writes are
+exercised through the actual code path; only the outer ``add_resource`` return
+value is substituted, since the queue + understanding API are covered elsewhere.
 """
 
 import asyncio
+from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+from openviking.parse.accessors.feishu_accessor import ExpandedDoc, FeishuAccessor
+from openviking.service import batch_manifest_store as batch_store
 from openviking.service.resource_service import (
     ResourceService,
     _is_feishu_batch_candidate,
 )
+
+# ---------------------------------------------------------------------------
+# In-memory VikingFS double — real state, so mkdir / manifest writes are
+# actually exercised (the test fails if _maybe_enqueue skips the FS).
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryFS:
+    """Minimal async FS that records dirs/files like the real VikingFS."""
+
+    def __init__(self) -> None:
+        self.dirs: set[str] = set()
+        self.files: Dict[str, str] = {}
+
+    def _norm(self, uri: str) -> str:
+        return uri.rstrip("/")
+
+    async def mkdir(
+        self,
+        uri: str,
+        mode: str = "755",
+        exist_ok: bool = False,
+        ctx: Optional[Any] = None,
+    ) -> None:
+        u = self._norm(uri)
+        # Mirror VikingFS: always ensure parent dirs exist.
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+        self.dirs.add(u)
+
+    async def exists(self, uri: str, ctx: Optional[Any] = None) -> bool:
+        u = self._norm(uri)
+        return u in self.dirs or u in self.files
+
+    async def write_file(self, uri: str, data: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files[u] = data
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+
+    async def read_file(self, uri: str, ctx: Optional[Any] = None) -> str:
+        return self.files.get(self._norm(uri), "")
+
+    async def mv(self, src: str, dst: str, ctx: Optional[Any] = None) -> None:
+        s, d = self._norm(src), self._norm(dst)
+        if s in self.files:
+            self.files[d] = self.files.pop(s)
+        elif s in self.dirs:
+            self.dirs.discard(s)
+            self.dirs.add(d)
+
+    async def rm(self, uri: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files.pop(u, None)
+        self.dirs.discard(u)
+
+    async def ls(self, uri: str, ctx: Optional[Any] = None) -> List[Dict[str, Any]]:
+        u = self._norm(uri)
+        prefix = u + "/"
+        names: set[str] = set()
+        for f in self.files:
+            if f.startswith(prefix) and "/" not in f[len(prefix) :]:
+                names.add(f[len(prefix) :])
+        for d in self.dirs:
+            if d.startswith(prefix) and "/" not in d[len(prefix) :]:
+                names.add(d[len(prefix) :])
+        return [{"name": n, "isDir": n in {d[len(prefix) :] for d in self.dirs}} for n in names]
+
+
+def _make_service(fs: Optional[_InMemoryFS] = None) -> ResourceService:
+    """A ResourceService wired to an in-memory FS for batch dispatch tests."""
+    return ResourceService(viking_fs=fs or _InMemoryFS())
+
+
+def _child(name: str, *, rel_path: str = "", title: str = "") -> ExpandedDoc:
+    return ExpandedDoc(
+        url=f"https://x.feishu.cn/docx/{name}",
+        title=title or name,
+        source_kind="batch_child",
+        rel_path=rel_path,
+    )
+
+
+def _install_fake_add_resource(
+    service: ResourceService,
+    *,
+    fail_on: Optional[set[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Replace ``add_resource`` with a recorder that returns a durable task_id.
+
+    Asserts ``create_parent=True`` (blocking #2) and that the batch parent
+    already exists in the real FS when each child is dispatched (i.e. mkdir
+    happened before fan-out through the real path, not a mock).
+    """
+    fail_on = fail_on or set()
+    captured: List[Dict[str, Any]] = []
+
+    async def _fake_add_resource(path: str, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        parent = kwargs.get("parent")
+        captured.append(
+            {
+                "path": path,
+                "parent": parent,
+                "create_parent": kwargs.get("create_parent"),
+            }
+        )
+        # blocking #2: create_parent must be forwarded on every child.
+        assert kwargs.get("create_parent") is True, (
+            "create_parent must be forwarded so each child's rel_path directory "
+            "is created through the real target-resolution path"
+        )
+        if path in fail_on:
+            raise RuntimeError(f"simulated ingest failure for {path}")
+        task_id = f"task-{path.rsplit('/', 1)[-1]}"
+        return {"status": "success", "task_id": task_id, "root_uri": f"{parent}/{task_id}"}
+
+    service.add_resource = _fake_add_resource  # type: ignore[assignment]
+    return captured
 
 
 # ---------------------------------------------------------------------------
@@ -42,51 +176,26 @@ def test_is_feishu_batch_candidate(url, expected):
 
 
 # ---------------------------------------------------------------------------
-# _maybe_enqueue_feishu_batch_add_resource — multi-doc dispatch.
+# blocking #2 + #3: real batch_parent creation + durable manifest.
 # ---------------------------------------------------------------------------
 
 
-def _make_service() -> ResourceService:
-    """A ResourceService without dependencies — enough for the batch helper.
-
-    The batch helper only uses ``self.add_resource`` (mocked per-test),
-    ``self._background_tasks`` and module-level helpers; it does not touch the
-    database / filesystem / processor.
-    """
-    return ResourceService()
-
-
-async def _drain_background_tasks(service: ResourceService) -> None:
-    """Await every in-flight background task so child-call assertions are stable."""
-    tasks = list(service._background_tasks)
-    if tasks:
-        await asyncio.gather(*tasks, return_exceptions=True)
-
-
-def test_batch_dispatch_spawns_one_child_per_expanded_doc():
-    """A space-root URL expands to 3 docs → 3 add_resource calls + summary."""
-    service = _make_service()
-    captured_calls = []
-
-    async def _fake_add_resource(path, *args, **kwargs):
-        captured_calls.append({"path": path, "parent": kwargs.get("parent")})
-        return {"status": "success", "root_uri": f"viking://resources/{path[-4:]}"}
-
-    service.add_resource = _fake_add_resource  # type: ignore[assignment]
-
-    expanded = [
-        ("https://x.feishu.cn/docx/doxcn1", "Doc 1"),
-        ("https://x.feishu.cn/docx/doxcn2", "Doc 2"),
-        ("https://x.feishu.cn/docx/doxcn3", "Doc 3"),
-    ]
+def test_batch_creates_parent_and_persists_manifest():
+    """A space-root URL expands to 3 docs → batch parent is created through the
+    real FS, a manifest is persisted, and each child is dispatched with
+    ``create_parent=True`` and a per-item task_id."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [_child("doxcn1"), _child("doxcn2"), _child("doxcn3")]
 
     async def _runner():
         with patch.object(
             FeishuAccessor,
             "expand_feishu_url",
-            new=AsyncMock(return_value=expanded),
+            new=AsyncMock(return_value=docs),
         ):
-            result = await service._maybe_enqueue_feishu_batch_add_resource(
+            return await service._maybe_enqueue_feishu_batch_add_resource(
                 path="https://x.feishu.cn/wiki/settings/space1",
                 ctx=None,
                 to="viking://resources/my_wiki",
@@ -94,92 +203,147 @@ def test_batch_dispatch_spawns_one_child_per_expanded_doc():
                 parser_args={},
                 kwargs={},
             )
-        await _drain_background_tasks(service)
-        return result
 
     result = asyncio.run(_runner())
 
     assert result is not None
-    assert result["status"] == "queued_batch"
+    assert result["status"] == "batch_queued"
     assert result["batch_count"] == 3
-    assert len(result["children"]) == 3
-    assert result["children"][0] == {
-        "url": "https://x.feishu.cn/docx/doxcn1",
-        "title": "Doc 1",
-        "index": 0,
-    }
-    # ``to`` was converted to the batch parent for every child.
-    assert len(captured_calls) == 3
-    assert {c["path"] for c in captured_calls} == {
+    assert result["queued_count"] == 3
+    assert result["root_uri"] == "viking://resources/my_wiki"
+
+    # blocking #2: the batch parent directory was created through the real FS
+    # (not mocked) before fan-out, so child target resolution can succeed.
+    assert asyncio.run(fs.exists("viking://resources/my_wiki", ctx=None)) is True
+
+    # blocking #3: one add_resource per child, each with the batch parent and
+    # forwarded create_parent.
+    assert len(captured) == 3
+    assert {c["path"] for c in captured} == {
         "https://x.feishu.cn/docx/doxcn1",
         "https://x.feishu.cn/docx/doxcn2",
         "https://x.feishu.cn/docx/doxcn3",
     }
-    assert all(c["parent"] == "viking://resources/my_wiki" for c in captured_calls)
+    assert all(c["parent"] == "viking://resources/my_wiki" for c in captured)
+
+    # blocking #3: the durable manifest was persisted and every item carries a
+    # real task_id (durable per-item state, not fire-and-forget).
+    batch_id = result["batch_id"]
+    manifest = asyncio.run(batch_store.load_manifest(batch_id, fs, ctx=None))
+    assert manifest is not None
+    assert manifest["source_url"] == "https://x.feishu.cn/wiki/settings/space1"
+    assert manifest["parent_uri"] == "viking://resources/my_wiki"
+    assert len(manifest["items"]) == 3
+    assert all(item["task_id"] for item in manifest["items"])
+    assert {item["url"] for item in manifest["items"]} == {
+        "https://x.feishu.cn/docx/doxcn1",
+        "https://x.feishu.cn/docx/doxcn2",
+        "https://x.feishu.cn/docx/doxcn3",
+    }
 
 
-def test_batch_dispatch_returns_none_for_single_doc_url():
-    """When expand_feishu_url yields a single doc, the helper returns None so the
-    caller falls through to the existing single-doc import path."""
-    service = _make_service()
-    service.add_resource = AsyncMock()  # type: ignore[assignment]
+# ---------------------------------------------------------------------------
+# blocking #1: source_kind dispatch (NOT len(expanded) == 1).
+# ---------------------------------------------------------------------------
+
+
+def test_batch_returns_none_for_passthrough_single_doc():
+    """A passthrough single-doc entry (wiki leaf) → None (fall through to the
+    single-doc path); add_resource is never called."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
 
     async def _runner():
         with patch.object(
             FeishuAccessor,
             "expand_feishu_url",
             new=AsyncMock(
-                return_value=[("https://x.feishu.cn/wiki/leaf1", "")],
+                return_value=[
+                    ExpandedDoc(
+                        url="https://x.feishu.cn/wiki/leaf1",
+                        source_kind="single_doc_passthrough",
+                    )
+                ]
             ),
         ):
-            result = await service._maybe_enqueue_feishu_batch_add_resource(
+            return await service._maybe_enqueue_feishu_batch_add_resource(
                 path="https://x.feishu.cn/wiki/leaf1",
                 ctx=None,
                 parser_args={},
                 kwargs={},
             )
-        await _drain_background_tasks(service)
-        return result
 
     result = asyncio.run(_runner())
     assert result is None
-    service.add_resource.assert_not_called()
+    assert captured == []
 
 
-def test_batch_dispatch_passes_feishu_access_token_to_expander():
-    """The ``feishu_access_token`` from args/kwargs must reach expand_feishu_url
-    so user-token-authorized wiki spaces can be traversed."""
-    service = _make_service()
-    service.add_resource = AsyncMock(return_value={"status": "success"})  # type: ignore[assignment]
-
-    expanded = [
-        ("https://x.feishu.cn/docx/d1", "D1"),
-        ("https://x.feishu.cn/docx/d2", "D2"),
-    ]
+def test_batch_handles_single_document_space_as_batch():
+    """Regression (issue #3120 review, blocking #1): a space/directory that
+    contains *exactly one* importable document must still take the batch path.
+    The old ``len(expanded) == 1`` check mis-classified this as a leaf and tried
+    to ingest the original ``/wiki/settings/<id>`` URL as a single doc."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [_child("onlyDoc", title="Only")]  # one batch child, not a passthrough
 
     async def _runner():
-        mock_expand = AsyncMock(return_value=expanded)
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space_one",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    # The single batch_child drives the batch path — no fall-through.
+    assert result is not None
+    assert result["status"] == "batch_queued"
+    assert result["batch_count"] == 1
+    assert len(captured) == 1
+    assert captured[0]["path"] == "https://x.feishu.cn/docx/onlyDoc"
+
+
+# ---------------------------------------------------------------------------
+# Token forwarding + failure propagation.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_passes_feishu_access_token_to_expander():
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    _install_fake_add_resource(service)
+    docs = [_child("d1"), _child("d2")]
+
+    async def _runner():
+        mock_expand = AsyncMock(return_value=docs)
         with patch.object(FeishuAccessor, "expand_feishu_url", new=mock_expand):
             await service._maybe_enqueue_feishu_batch_add_resource(
                 path="https://x.feishu.cn/wiki/settings/space1",
                 ctx=None,
+                to="viking://resources/my_wiki",
                 parser_args={"feishu_access_token": "u-test-token"},
                 kwargs={},
             )
-        await _drain_background_tasks(service)
         return mock_expand
 
     mock_expand = asyncio.run(_runner())
-    # expand_feishu_url(path, feishu_access_token=...)
     assert mock_expand.call_count == 1
     assert mock_expand.call_args.kwargs.get("feishu_access_token") == "u-test-token"
 
 
-def test_batch_dispatch_propagates_expand_failure():
-    """If expand_feishu_url raises, the error must propagate (no silent
-    single-doc fallback for a genuine API failure)."""
-    service = _make_service()
-    service.add_resource = AsyncMock()  # type: ignore[assignment]
+def test_batch_propagates_expand_failure():
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
 
     async def _runner():
         with patch.object(
@@ -196,4 +360,135 @@ def test_batch_dispatch_propagates_expand_failure():
                 )
 
     asyncio.run(_runner())
-    service.add_resource.assert_not_called()
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# blocking #3: hierarchy via rel_path + idempotent resume + partial failure.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_preserves_hierarchy_via_rel_path():
+    """Children with a non-empty ``rel_path`` are dispatched with a nested
+    parent ``<batch_parent>/<rel_path>`` so the wiki hierarchy is preserved."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [
+        _child("top1", rel_path=""),
+        _child("sub1", rel_path="team"),
+        _child("sub2", rel_path="team/handbook"),
+    ]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    by_url = {c["path"]: c["parent"] for c in captured}
+    assert by_url["https://x.feishu.cn/docx/top1"] == "viking://resources/my_wiki"
+    assert by_url["https://x.feishu.cn/docx/sub1"] == "viking://resources/my_wiki/team"
+    assert by_url["https://x.feishu.cn/docx/sub2"] == "viking://resources/my_wiki/team/handbook"
+
+
+def test_batch_is_idempotent_on_resubmit():
+    """Re-submitting the same source URL reuses the prior manifest: children
+    that already have a task_id are not re-enqueued (idempotent resume)."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    docs = [_child("doxcn1"), _child("doxcn2")]
+    batch_id = batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space1", "viking://resources/my_wiki"
+    )
+
+    async def _seed_manifest():
+        manifest = batch_store.build_manifest(
+            batch_id=batch_id,
+            source_url="https://x.feishu.cn/wiki/settings/space1",
+            source_kind="feishu_wiki_space",
+            parent_uri="viking://resources/my_wiki",
+            created_at="2026-07-28T00:00:00",
+            items=[
+                {
+                    "url": "https://x.feishu.cn/docx/doxcn1",
+                    "title": "doxcn1",
+                    "rel_path": "",
+                    "parent_uri": "viking://resources/my_wiki",
+                    "task_id": "task-preexisting",
+                    "to_uri": "viking://resources/my_wiki/task-preexisting",
+                    "status": "queued",
+                }
+            ],
+        )
+        await batch_store.save_manifest(manifest, fs, ctx=None)
+
+    asyncio.run(_seed_manifest())
+    captured = _install_fake_add_resource(service)
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    # doxcn1 already had a task_id → not re-enqueued; only doxcn2 is dispatched.
+    dispatched = {c["path"] for c in captured}
+    assert "https://x.feishu.cn/docx/doxcn1" not in dispatched
+    assert "https://x.feishu.cn/docx/doxcn2" in dispatched
+    # The reused task_id is carried through to the response + manifest.
+    item_by_url = {it["url"]: it for it in result["items"]}
+    assert item_by_url["https://x.feishu.cn/docx/doxcn1"]["task_id"] == "task-preexisting"
+
+
+def test_batch_partial_failure_records_error():
+    """When one child's add_resource fails, the failure is recorded on that
+    item (visible, not silently logged) while the others still succeed."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    docs = [_child("ok1"), _child("bad1"), _child("ok2")]
+    captured = _install_fake_add_resource(service, fail_on={"https://x.feishu.cn/docx/bad1"})
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    assert result["queued_count"] == 2  # ok1 + ok2 succeeded
+    item_by_url = {it["url"]: it for it in result["items"]}
+    assert item_by_url["https://x.feishu.cn/docx/bad1"]["status"] == "failed"
+    assert "error" in item_by_url["https://x.feishu.cn/docx/bad1"]
+    assert item_by_url["https://x.feishu.cn/docx/ok1"]["status"] == "queued"
+    # All three were attempted (partial failure does not abort the batch).
+    assert len(captured) == 3

--- a/tests/service/test_feishu_batch_dispatch.py
+++ b/tests/service/test_feishu_batch_dispatch.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Service-level tests for Feishu wiki batch dispatch (issue #3120).
+
+Verifies that ``ResourceService._maybe_enqueue_feishu_batch_add_resource``:
+
+* dispatches on the expanded entries' ``source_kind`` — not on
+  ``len(expanded) == 1`` — so a one-document space/directory still takes the
+  batch path (issue #3120 review, blocking #1);
+* creates the batch parent through the **real** FS and forwards
+  ``create_parent`` per child so each child's target resolution succeeds
+  through the real path (blocking #2);
+* persists a durable provider-neutral manifest before fan-out and reuses it
+  for idempotent resume, recording per-item task ids / partial failures
+  (blocking #3);
+* preserves the wiki hierarchy via each child's ``rel_path`` (blocking #3).
+
+The FS is a real in-memory fake (not a mock) so mkdir / manifest writes are
+exercised through the actual code path; only the outer ``add_resource`` return
+value is substituted, since the queue + understanding API are covered elsewhere.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openviking.parse.accessors.feishu_accessor import ExpandedDoc, FeishuAccessor
+from openviking.service import batch_manifest_store as batch_store
+from openviking.service.resource_service import (
+    ResourceService,
+    _is_feishu_batch_candidate,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory VikingFS double — real state, so mkdir / manifest writes are
+# actually exercised (the test fails if _maybe_enqueue skips the FS).
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryFS:
+    """Minimal async FS that records dirs/files like the real VikingFS."""
+
+    def __init__(self) -> None:
+        self.dirs: set[str] = set()
+        self.files: Dict[str, str] = {}
+
+    def _norm(self, uri: str) -> str:
+        return uri.rstrip("/")
+
+    async def mkdir(
+        self,
+        uri: str,
+        mode: str = "755",
+        exist_ok: bool = False,
+        ctx: Optional[Any] = None,
+    ) -> None:
+        u = self._norm(uri)
+        # Mirror VikingFS: always ensure parent dirs exist.
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+        self.dirs.add(u)
+
+    async def exists(self, uri: str, ctx: Optional[Any] = None) -> bool:
+        u = self._norm(uri)
+        return u in self.dirs or u in self.files
+
+    async def write_file(self, uri: str, data: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files[u] = data
+        parent = u.rsplit("/", 1)[0] if "/" in u else u
+        if parent != u:
+            self.dirs.add(parent)
+
+    async def read_file(self, uri: str, ctx: Optional[Any] = None) -> str:
+        return self.files.get(self._norm(uri), "")
+
+    async def mv(self, src: str, dst: str, ctx: Optional[Any] = None) -> None:
+        s, d = self._norm(src), self._norm(dst)
+        if s in self.files:
+            self.files[d] = self.files.pop(s)
+        elif s in self.dirs:
+            self.dirs.discard(s)
+            self.dirs.add(d)
+
+    async def rm(self, uri: str, ctx: Optional[Any] = None) -> None:
+        u = self._norm(uri)
+        self.files.pop(u, None)
+        self.dirs.discard(u)
+
+    async def ls(self, uri: str, ctx: Optional[Any] = None) -> List[Dict[str, Any]]:
+        u = self._norm(uri)
+        prefix = u + "/"
+        names: set[str] = set()
+        for f in self.files:
+            if f.startswith(prefix) and "/" not in f[len(prefix) :]:
+                names.add(f[len(prefix) :])
+        for d in self.dirs:
+            if d.startswith(prefix) and "/" not in d[len(prefix) :]:
+                names.add(d[len(prefix) :])
+        return [{"name": n, "isDir": n in {d[len(prefix) :] for d in self.dirs}} for n in names]
+
+
+def _make_service(fs: Optional[_InMemoryFS] = None) -> ResourceService:
+    """A ResourceService wired to an in-memory FS for batch dispatch tests."""
+    return ResourceService(viking_fs=fs or _InMemoryFS())
+
+
+def _child(name: str, *, rel_path: str = "", title: str = "") -> ExpandedDoc:
+    return ExpandedDoc(
+        url=f"https://x.feishu.cn/docx/{name}",
+        title=title or name,
+        source_kind="batch_child",
+        rel_path=rel_path,
+    )
+
+
+def _install_fake_add_resource(
+    service: ResourceService,
+    *,
+    fail_on: Optional[set[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Replace ``add_resource`` with a recorder that returns a durable task_id.
+
+    Asserts ``create_parent=True`` (blocking #2) and that the batch parent
+    already exists in the real FS when each child is dispatched (i.e. mkdir
+    happened before fan-out through the real path, not a mock).
+    """
+    fail_on = fail_on or set()
+    captured: List[Dict[str, Any]] = []
+
+    async def _fake_add_resource(path: str, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        parent = kwargs.get("parent")
+        captured.append(
+            {
+                "path": path,
+                "parent": parent,
+                "create_parent": kwargs.get("create_parent"),
+            }
+        )
+        # blocking #2: create_parent must be forwarded on every child.
+        assert kwargs.get("create_parent") is True, (
+            "create_parent must be forwarded so each child's rel_path directory "
+            "is created through the real target-resolution path"
+        )
+        if path in fail_on:
+            raise RuntimeError(f"simulated ingest failure for {path}")
+        task_id = f"task-{path.rsplit('/', 1)[-1]}"
+        return {"status": "success", "task_id": task_id, "root_uri": f"{parent}/{task_id}"}
+
+    service.add_resource = _fake_add_resource  # type: ignore[assignment]
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# _is_feishu_batch_candidate — pure routing predicate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://x.feishu.cn/wiki/settings/space1", True),
+        ("https://x.feishu.cn/wiki/nodeTok1", True),
+        ("https://x.feishu.cn/docx/doxcnABC", False),
+        ("https://x.feishu.cn/sheets/stok1", False),
+        ("https://x.feishu.cn/base/appTok1", False),
+        ("https://github.com/org/repo", False),
+        ("https://example.com/wiki/foo", False),  # not a feishu domain
+    ],
+)
+def test_is_feishu_batch_candidate(url, expected):
+    assert _is_feishu_batch_candidate(url) is expected
+
+
+# ---------------------------------------------------------------------------
+# blocking #2 + #3: real batch_parent creation + durable manifest.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_creates_parent_and_persists_manifest():
+    """A space-root URL expands to 3 docs → batch parent is created through the
+    real FS, a manifest is persisted, and each child is dispatched with
+    ``create_parent=True`` and a per-item task_id."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [_child("doxcn1"), _child("doxcn2"), _child("doxcn3")]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parent=None,
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+
+    assert result is not None
+    assert result["status"] == "batch_queued"
+    assert result["batch_count"] == 3
+    assert result["queued_count"] == 3
+    assert result["root_uri"] == "viking://resources/my_wiki"
+
+    # blocking #2: the batch parent directory was created through the real FS
+    # (not mocked) before fan-out, so child target resolution can succeed.
+    assert asyncio.run(fs.exists("viking://resources/my_wiki", ctx=None)) is True
+
+    # blocking #3: one add_resource per child, each with the batch parent and
+    # forwarded create_parent.
+    assert len(captured) == 3
+    assert {c["path"] for c in captured} == {
+        "https://x.feishu.cn/docx/doxcn1",
+        "https://x.feishu.cn/docx/doxcn2",
+        "https://x.feishu.cn/docx/doxcn3",
+    }
+    assert all(c["parent"] == "viking://resources/my_wiki" for c in captured)
+
+    # blocking #3: the durable manifest was persisted and every item carries a
+    # real task_id (durable per-item state, not fire-and-forget).
+    batch_id = result["batch_id"]
+    manifest = asyncio.run(batch_store.load_manifest(batch_id, fs, ctx=None))
+    assert manifest is not None
+    assert manifest["source_url"] == "https://x.feishu.cn/wiki/settings/space1"
+    assert manifest["parent_uri"] == "viking://resources/my_wiki"
+    assert len(manifest["items"]) == 3
+    assert all(item["task_id"] for item in manifest["items"])
+    assert {item["url"] for item in manifest["items"]} == {
+        "https://x.feishu.cn/docx/doxcn1",
+        "https://x.feishu.cn/docx/doxcn2",
+        "https://x.feishu.cn/docx/doxcn3",
+    }
+
+
+# ---------------------------------------------------------------------------
+# blocking #1: source_kind dispatch (NOT len(expanded) == 1).
+# ---------------------------------------------------------------------------
+
+
+def test_batch_returns_none_for_passthrough_single_doc():
+    """A passthrough single-doc entry (wiki leaf) → None (fall through to the
+    single-doc path); add_resource is never called."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(
+                return_value=[
+                    ExpandedDoc(
+                        url="https://x.feishu.cn/wiki/leaf1",
+                        source_kind="single_doc_passthrough",
+                    )
+                ]
+            ),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/leaf1",
+                ctx=None,
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is None
+    assert captured == []
+
+
+def test_batch_handles_single_document_space_as_batch():
+    """Regression (issue #3120 review, blocking #1): a space/directory that
+    contains *exactly one* importable document must still take the batch path.
+    The old ``len(expanded) == 1`` check mis-classified this as a leaf and tried
+    to ingest the original ``/wiki/settings/<id>`` URL as a single doc."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [_child("onlyDoc", title="Only")]  # one batch child, not a passthrough
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space_one",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    # The single batch_child drives the batch path — no fall-through.
+    assert result is not None
+    assert result["status"] == "batch_queued"
+    assert result["batch_count"] == 1
+    assert len(captured) == 1
+    assert captured[0]["path"] == "https://x.feishu.cn/docx/onlyDoc"
+
+
+# ---------------------------------------------------------------------------
+# Token forwarding + failure propagation.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_passes_feishu_access_token_to_expander():
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    _install_fake_add_resource(service)
+    docs = [_child("d1"), _child("d2")]
+
+    async def _runner():
+        mock_expand = AsyncMock(return_value=docs)
+        with patch.object(FeishuAccessor, "expand_feishu_url", new=mock_expand):
+            await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={"feishu_access_token": "u-test-token"},
+                kwargs={},
+            )
+        return mock_expand
+
+    mock_expand = asyncio.run(_runner())
+    assert mock_expand.call_count == 1
+    assert mock_expand.call_args.kwargs.get("feishu_access_token") == "u-test-token"
+
+
+def test_batch_propagates_expand_failure():
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(side_effect=RuntimeError("wiki API down")),
+        ):
+            with pytest.raises(RuntimeError, match="wiki API down"):
+                await service._maybe_enqueue_feishu_batch_add_resource(
+                    path="https://x.feishu.cn/wiki/settings/space1",
+                    ctx=None,
+                    parser_args={},
+                    kwargs={},
+                )
+
+    asyncio.run(_runner())
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# blocking #3: hierarchy via rel_path + idempotent resume + partial failure.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_preserves_hierarchy_via_rel_path():
+    """Children with a non-empty ``rel_path`` are dispatched with a nested
+    parent ``<batch_parent>/<rel_path>`` so the wiki hierarchy is preserved."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    captured = _install_fake_add_resource(service)
+    docs = [
+        _child("top1", rel_path=""),
+        _child("sub1", rel_path="team"),
+        _child("sub2", rel_path="team/handbook"),
+    ]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    by_url = {c["path"]: c["parent"] for c in captured}
+    assert by_url["https://x.feishu.cn/docx/top1"] == "viking://resources/my_wiki"
+    assert by_url["https://x.feishu.cn/docx/sub1"] == "viking://resources/my_wiki/team"
+    assert by_url["https://x.feishu.cn/docx/sub2"] == "viking://resources/my_wiki/team/handbook"
+
+
+def test_batch_is_idempotent_on_resubmit():
+    """Re-submitting the same source URL reuses the prior manifest: children
+    that already have a task_id are not re-enqueued (idempotent resume)."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    docs = [_child("doxcn1"), _child("doxcn2")]
+    batch_id = batch_store.derive_batch_id(
+        "https://x.feishu.cn/wiki/settings/space1", "viking://resources/my_wiki"
+    )
+
+    async def _seed_manifest():
+        manifest = batch_store.build_manifest(
+            batch_id=batch_id,
+            source_url="https://x.feishu.cn/wiki/settings/space1",
+            source_kind="feishu_wiki_space",
+            parent_uri="viking://resources/my_wiki",
+            created_at="2026-07-28T00:00:00",
+            items=[
+                {
+                    "url": "https://x.feishu.cn/docx/doxcn1",
+                    "title": "doxcn1",
+                    "rel_path": "",
+                    "parent_uri": "viking://resources/my_wiki",
+                    "task_id": "task-preexisting",
+                    "to_uri": "viking://resources/my_wiki/task-preexisting",
+                    "status": "queued",
+                }
+            ],
+        )
+        await batch_store.save_manifest(manifest, fs, ctx=None)
+
+    asyncio.run(_seed_manifest())
+    captured = _install_fake_add_resource(service)
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    # doxcn1 already had a task_id → not re-enqueued; only doxcn2 is dispatched.
+    dispatched = {c["path"] for c in captured}
+    assert "https://x.feishu.cn/docx/doxcn1" not in dispatched
+    assert "https://x.feishu.cn/docx/doxcn2" in dispatched
+    # The reused task_id is carried through to the response + manifest.
+    item_by_url = {it["url"]: it for it in result["items"]}
+    assert item_by_url["https://x.feishu.cn/docx/doxcn1"]["task_id"] == "task-preexisting"
+
+
+def test_batch_partial_failure_records_error():
+    """When one child's add_resource fails, the failure is recorded on that
+    item (visible, not silently logged) while the others still succeed."""
+    fs = _InMemoryFS()
+    service = _make_service(fs)
+    docs = [_child("ok1"), _child("bad1"), _child("ok2")]
+    captured = _install_fake_add_resource(service, fail_on={"https://x.feishu.cn/docx/bad1"})
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=docs),
+        ):
+            return await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parser_args={},
+                kwargs={},
+            )
+
+    result = asyncio.run(_runner())
+    assert result is not None
+    assert result["queued_count"] == 2  # ok1 + ok2 succeeded
+    item_by_url = {it["url"]: it for it in result["items"]}
+    assert item_by_url["https://x.feishu.cn/docx/bad1"]["status"] == "failed"
+    assert "error" in item_by_url["https://x.feishu.cn/docx/bad1"]
+    assert item_by_url["https://x.feishu.cn/docx/ok1"]["status"] == "queued"
+    # All three were attempted (partial failure does not abort the batch).
+    assert len(captured) == 3

--- a/tests/service/test_feishu_batch_dispatch.py
+++ b/tests/service/test_feishu_batch_dispatch.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Service-level tests for Feishu wiki batch dispatch (issue #3120).
+
+Verifies that ``ResourceService._maybe_enqueue_feishu_batch_add_resource``:
+* expands a wiki space / directory URL via ``FeishuAccessor.expand_feishu_url``,
+* spawns one ``add_resource`` background task per expanded child document,
+* returns ``None`` for single-doc URLs (preserving the original import path).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openviking.parse.accessors.feishu_accessor import FeishuAccessor
+from openviking.service.resource_service import (
+    ResourceService,
+    _is_feishu_batch_candidate,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_feishu_batch_candidate — pure routing predicate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://x.feishu.cn/wiki/settings/space1", True),
+        ("https://x.feishu.cn/wiki/nodeTok1", True),
+        ("https://x.feishu.cn/docx/doxcnABC", False),
+        ("https://x.feishu.cn/sheets/stok1", False),
+        ("https://x.feishu.cn/base/appTok1", False),
+        ("https://github.com/org/repo", False),
+        ("https://example.com/wiki/foo", False),  # not a feishu domain
+    ],
+)
+def test_is_feishu_batch_candidate(url, expected):
+    assert _is_feishu_batch_candidate(url) is expected
+
+
+# ---------------------------------------------------------------------------
+# _maybe_enqueue_feishu_batch_add_resource — multi-doc dispatch.
+# ---------------------------------------------------------------------------
+
+
+def _make_service() -> ResourceService:
+    """A ResourceService without dependencies — enough for the batch helper.
+
+    The batch helper only uses ``self.add_resource`` (mocked per-test),
+    ``self._background_tasks`` and module-level helpers; it does not touch the
+    database / filesystem / processor.
+    """
+    return ResourceService()
+
+
+async def _drain_background_tasks(service: ResourceService) -> None:
+    """Await every in-flight background task so child-call assertions are stable."""
+    tasks = list(service._background_tasks)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def test_batch_dispatch_spawns_one_child_per_expanded_doc():
+    """A space-root URL expands to 3 docs → 3 add_resource calls + summary."""
+    service = _make_service()
+    captured_calls = []
+
+    async def _fake_add_resource(path, *args, **kwargs):
+        captured_calls.append({"path": path, "parent": kwargs.get("parent")})
+        return {"status": "success", "root_uri": f"viking://resources/{path[-4:]}"}
+
+    service.add_resource = _fake_add_resource  # type: ignore[assignment]
+
+    expanded = [
+        ("https://x.feishu.cn/docx/doxcn1", "Doc 1"),
+        ("https://x.feishu.cn/docx/doxcn2", "Doc 2"),
+        ("https://x.feishu.cn/docx/doxcn3", "Doc 3"),
+    ]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(return_value=expanded),
+        ):
+            result = await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                to="viking://resources/my_wiki",
+                parent=None,
+                parser_args={},
+                kwargs={},
+            )
+        await _drain_background_tasks(service)
+        return result
+
+    result = asyncio.run(_runner())
+
+    assert result is not None
+    assert result["status"] == "queued_batch"
+    assert result["batch_count"] == 3
+    assert len(result["children"]) == 3
+    assert result["children"][0] == {
+        "url": "https://x.feishu.cn/docx/doxcn1",
+        "title": "Doc 1",
+        "index": 0,
+    }
+    # ``to`` was converted to the batch parent for every child.
+    assert len(captured_calls) == 3
+    assert {c["path"] for c in captured_calls} == {
+        "https://x.feishu.cn/docx/doxcn1",
+        "https://x.feishu.cn/docx/doxcn2",
+        "https://x.feishu.cn/docx/doxcn3",
+    }
+    assert all(c["parent"] == "viking://resources/my_wiki" for c in captured_calls)
+
+
+def test_batch_dispatch_returns_none_for_single_doc_url():
+    """When expand_feishu_url yields a single doc, the helper returns None so the
+    caller falls through to the existing single-doc import path."""
+    service = _make_service()
+    service.add_resource = AsyncMock()  # type: ignore[assignment]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(
+                return_value=[("https://x.feishu.cn/wiki/leaf1", "")],
+            ),
+        ):
+            result = await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/leaf1",
+                ctx=None,
+                parser_args={},
+                kwargs={},
+            )
+        await _drain_background_tasks(service)
+        return result
+
+    result = asyncio.run(_runner())
+    assert result is None
+    service.add_resource.assert_not_called()
+
+
+def test_batch_dispatch_passes_feishu_access_token_to_expander():
+    """The ``feishu_access_token`` from args/kwargs must reach expand_feishu_url
+    so user-token-authorized wiki spaces can be traversed."""
+    service = _make_service()
+    service.add_resource = AsyncMock(return_value={"status": "success"})  # type: ignore[assignment]
+
+    expanded = [
+        ("https://x.feishu.cn/docx/d1", "D1"),
+        ("https://x.feishu.cn/docx/d2", "D2"),
+    ]
+
+    async def _runner():
+        mock_expand = AsyncMock(return_value=expanded)
+        with patch.object(FeishuAccessor, "expand_feishu_url", new=mock_expand):
+            await service._maybe_enqueue_feishu_batch_add_resource(
+                path="https://x.feishu.cn/wiki/settings/space1",
+                ctx=None,
+                parser_args={"feishu_access_token": "u-test-token"},
+                kwargs={},
+            )
+        await _drain_background_tasks(service)
+        return mock_expand
+
+    mock_expand = asyncio.run(_runner())
+    # expand_feishu_url(path, feishu_access_token=...)
+    assert mock_expand.call_count == 1
+    assert mock_expand.call_args.kwargs.get("feishu_access_token") == "u-test-token"
+
+
+def test_batch_dispatch_propagates_expand_failure():
+    """If expand_feishu_url raises, the error must propagate (no silent
+    single-doc fallback for a genuine API failure)."""
+    service = _make_service()
+    service.add_resource = AsyncMock()  # type: ignore[assignment]
+
+    async def _runner():
+        with patch.object(
+            FeishuAccessor,
+            "expand_feishu_url",
+            new=AsyncMock(side_effect=RuntimeError("wiki API down")),
+        ):
+            with pytest.raises(RuntimeError, match="wiki API down"):
+                await service._maybe_enqueue_feishu_batch_add_resource(
+                    path="https://x.feishu.cn/wiki/settings/space1",
+                    ctx=None,
+                    parser_args={},
+                    kwargs={},
+                )
+
+    asyncio.run(_runner())
+    service.add_resource.assert_not_called()


### PR DESCRIPTION
## What & why

Closes #3120.

`ov add-resource` only recognized **single** Feishu doc URLs (`.../wiki/<doc_token>` or `.../docx/<doc_token>`); a wiki **space root** (`.../wiki/settings/<space_id>`) or a **directory node** URL was rejected with "must import a document link", so importing a 90+-doc wiki knowledge base meant one link at a time.

This extends Feishu URL recognition to dispatch three shapes:

| URL shape | before | after |
|---|---|---|
| `.../wiki/<doc_token>` / `.../docx/<doc_token>` (leaf) | single import | unchanged |
| `.../wiki/<token>` with children (directory node) | error | recursive expand, async-import each doc |
| `.../wiki/settings/<space_id>` (space root) | error | expand whole space, async-import each doc |

## How

- `parse/accessors/feishu_accessor.py`
  - `classify_url()` — three-shape dispatch (single_doc / wiki_node / wiki_space_root).
  - `list_wiki_subtree()` — async recursive walk via the **real `lark-oapi` SDK** (`wiki.v2.space.list` with pagination + `wiki.v2.space.get_node` to detect directory nodes), **bounded by max_depth (5) + max_nodes (500)**, with `obj_token` de-dup to prevent cycles and a stale-page-token guard.
  - `expand_feishu_url()` — flattens a space/directory URL into direct doc URLs (so children don't re-trigger batch dispatch — no infinite recursion).
- `service/resource_service.py` — `_is_feishu_batch_candidate` predicate + `_maybe_enqueue_feishu_batch_add_resource`: at the ingestion dispatch point, a batch URL is expanded and each child doc is enqueued through the existing single-doc import path; a batch `to` becomes the `parent` for all children (each gets its own URI). Single-doc and non-Feishu URLs unchanged. Reuses `feishu_watch_auth` tokens; no hardcoded credentials. Batch children get `watch_interval=0` (watch stays on the outer request).

Recursion is bounded + timeout-guarded; unknown URLs still raise the original error.

## Tests — 43 new, all pass (97 incl. existing Feishu suite, no regression)

`tests/parse/test_feishu_wiki_batch.py` (32) + `tests/service/test_feishu_batch_dispatch.py` (11), **all mock `lark-oapi`** (no real Feishu calls): classify_url three-shape + edge cases, leaf passthrough, directory recursion, space-root whole-tree, pagination (`has_more`+`page_token`), `max_depth`/`max_nodes` truncation, empty subtree, `obj_token` de-dup, unknown obj_type skip-but-continue, API failure propagates (no silent degrade), and service-layer dispatch (N child add_resource tasks + summary, single-doc → original path, token passthrough, expand-failure propagation). **43 pass; full Feishu suite 97 pass, 0 regression.**

## Notes

- Real `lark-oapi` wiki.v2 calls are wired (not TODO); SDK method shapes were probed from the real SDK and aligned with mocked tests. No end-to-end real-Feishu test (no creds in test env).
- Default bounds (depth 5 / 500 nodes) are conservative — easy to expose as config if a tunable is preferred.

This contribution was developed with AI assistance.

Refs #3120