### PR TITLE
feat(zcode): add ZCode memory plugin (#3127)

### DIFF
--- a/examples/zcode-memory-plugin/.mcp.json
+++ b/examples/zcode-memory-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "openviking": {
+      "command": "node",
+      "args": ["servers/mcp-proxy.mjs"]
+    }
+  }
+}

--- a/examples/zcode-memory-plugin/DESIGN.md
+++ b/examples/zcode-memory-plugin/DESIGN.md
@@ -1,0 +1,87 @@
+# ZCode Memory Plugin — Design
+
+This document records the **assumptions** behind the ZCode memory plugin, what it reuses, and the points that need confirmation once ZCode publishes official extension documentation.
+
+## TL;DR
+
+- The plugin is a **thin adapter** over [`memory-plugin-shared/lib/agent-hook-runtime.mjs`](../memory-plugin-shared/lib/agent-hook-runtime.mjs), which already powers the Cursor and TRAE integrations. Recall, capture batching, dedup, pending-queue replay, peer derivation, and credential resolution are reused, not reimplemented.
+- The hook surface targeted is the **Cursor/TRAE-compatible lifecycle** — `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `Stop` — with the `decision: "approve"` + `hookSpecificOutput.additionalContext` output contract.
+- ZCode's extension mechanism is **not yet publicly documented** (as of 2026-07-28). The events, field names, output schema, and on-disk config layout below are assumptions inherited from Cursor/TRAE — they are the most likely shape because ZCode is an IDE-style coding agent like Cursor/TRAE, but they must be confirmed against ZCode's official docs before this is considered production-ready.
+
+## Why mirror TRAE
+
+TRAE is ByteDance's IDE-style coding agent — the closest published analogue to ZCode. The TRAE plugin is also the cleanest IDE-style integration in this repo: it does not depend on a transcript file (it reads prompt + assistant message directly off the hook event) and it commits every turn. That maps well onto a coding agent whose hook surface we do not yet know precisely: the fewer assumptions about ZCode internals, the better. So the ZCode plugin shares TRAE's structure almost file-for-file:
+
+| File | TRAE | ZCode | Difference |
+|---|---|---|---|
+| Hook entrypoints | `session-start.mjs`, `auto-recall.mjs`, `auto-capture.mjs` | identical | none |
+| URI guard | `uri-guard.mjs` | identical | none |
+| Turn builder | `trae-turns.mjs` (`cleanTraeText` + `buildTraeTurns`) | `zcode-turns.mjs` (`cleanZcodeText` + `buildZcodeTurns`) | name only |
+| Hook runtime | `trae-hook.mjs` | `zcode-hook.mjs` | client id + session-id prefix |
+| MCP proxy | `servers/mcp-proxy.mjs` | identical | client id |
+| Manifest | `openviking.integration.json` clients `["trae","trae-cn"]` | clients `["zcode"]` | one client for now |
+| Hook config token | `__OPENVIKING_TRAE_ROOT__` | `__OPENVIKING_ZCODE_ROOT__` | name only |
+| Session-id prefix | `tr-` / `trcn-` | `zc-` (and reserved `zcn-`) | — |
+
+## Reuse map (what is NOT duplicated)
+
+Everything listed here comes from `memory-plugin-shared/lib/` and is consumed by `zcode-hook.mjs` / `servers/mcp-proxy.mjs` via relative import — no copy is made into this plugin:
+
+- `agent-hook-runtime.mjs` — `loadAgentHookConfig`, `readHookInput`, `resolveNativeSessionId`, `deriveAgentSessionId`, `resolveAgentCwd`, `makeAgentFetchJSON`, `readHookState` / `writeHookState`, `withAgentHookLock`, `recallForPrompt`, `buildAgentProfile`, `addAgentMessages`, `commitAgentSession`, `replayAgentPending`, `shouldBypassAgent`, `stableHash`, `createAgentLogger`.
+- `agent-uri-guard.mjs` — `evaluateAgentUriGuard` (tool-name normalization + per-tool hint).
+- `workspace-peer.mjs` — `deriveWorkspacePeerId` / `resolveEffectivePeerId` (the post-#3516 shape: explicit > workspace-derived > none).
+- `credentials.mjs` — `resolveOpenVikingCredentials` (ovcli.conf → env → ov.conf → 127.0.0.1:1933).
+- `recall-core.mjs`, `profile-inject.mjs`, `batch-send.mjs`, `pending-queue.mjs`, `session-model.mjs`, `debug-log.mjs`, `mcp-proxy-core.mjs`.
+
+The only plugin-local logic is `zcode-turns.mjs` (12 lines: strip injected `<openviking-context>` / `<relevant-memories>` blocks so they are not echoed into storage, then build a `[user, assistant]` turn list from the Stop event fields).
+
+## Commit model
+
+ZCode uses **commit-on-every-Stop** (same as TRAE). Each `Stop`:
+
+1. Builds `[user, assistant]` turn(s) from the event's `prompt` / `last_assistant_message` / `text_content` fields.
+2. Deduplicates by `(turnKey, role, content)` hash against the per-session `capturedHashes` set.
+3. Sends new turns via `POST /api/v1/sessions/zc-<id>/messages` (auto-creates the OV session on first append).
+4. Calls `POST /api/v1/sessions/zc-<id>/commit` so the extractor runs immediately — short sessions are not lost even if ZCode never fires a session-end signal.
+
+There is intentionally **no PreCompact / SessionEnd hook wiring**: as with TRAE, committing every turn removes the need for an end-of-session signal (which coding agents historically do not emit reliably — see the Codex plugin's `DESIGN.md` for the same conclusion).
+
+## Assumptions that need ZCode confirmation
+
+These are the load-bearing assumptions. Each one is plausible because it matches Cursor/TRAE (and ZCode is the same class of tool), but until ZCode publishes extension docs they must be treated as **hypotheses to verify**, not facts.
+
+1. **ZCode exposes lifecycle hooks** named (or aliased as) `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `Stop`, configured via a JSON file (the assumed on-disk path is `~/.zcode/hooks.json`). If ZCode uses different event names, the keys in [`hooks/hooks.json`](./hooks/hooks.json) are the only thing to rename.
+2. **The hook command line** is `node <absolute path>/scripts/<entry>.mjs <client-id>` invoked via `node`, with the hook payload delivered on **stdin as JSON** and the response emitted on **stdout as JSON**. (This is the Cursor/TRAE/Claude Code contract.)
+3. **The output schema** accepts `{ "decision": "approve", "hookSpecificOutput": { "hookEventName": "...", "additionalContext": "..." } }` for context injection, and `{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "..." } }` for the URI guard. If ZCode uses a different schema, only `zcode-hook.mjs`'s `approve()` and `uri-guard.mjs`'s `evaluateZcodeUriGuard` need adjustment.
+4. **The Stop payload** contains the assistant text under one of `last_assistant_message` / `text_content`, the user prompt under `prompt`, and the session identifier under one of `session_id` / `conversation_id` / `generation_id`. The shared runtime (`resolveNativeSessionId`) already handles all of these aliases; if ZCode uses a unique field name, add it to that resolver in `memory-plugin-shared` (one line) rather than patching this plugin.
+5. **The MCP client config** is JSON with an `mcpServers` map whose values are `{ "command": "node", "args": ["<path>/servers/mcp-proxy.mjs"] }`, located at `~/.zcode/.mcp.json` or `~/.zcode/mcp.json`. If ZCode uses a different filename/format, only the installer needs updating.
+6. **The `${PLUGIN_ROOT}`-style token** for hook command paths is **not** assumed to exist. The installer substitutes the absolute plugin path into a `__OPENVIKING_ZCODE_ROOT__` placeholder at install time (same technique the TRAE installer uses with `__OPENVIKING_TRAE_ROOT__`), so this plugin works whether or not ZCode supports inline token substitution.
+
+### If ZCode uses a Cursor-style marketplace
+
+Should ZCode ship a plugin marketplace (like Codex's `codex plugin` or Cursor's `.cursor-plugin/plugin.json`), the natural follow-up is a tiny `marketplace.json` entry pointing at `./examples/zcode-memory-plugin`, mirroring how the Codex marketplace catalog is structured at the repo root. That is intentionally out of scope for this first cut; it should land alongside official ZCode marketplace docs.
+
+## What is NOT assumed
+
+- No assumption about ZCode's CLI binary name. The installer detects `zcode` on PATH but lets the user override the config directory via `ZCODE_CONFIG_DIR` and the binary via `ZCODE_BIN`.
+- No assumption about a CN-specific build. The client id parameterization (`zcode` vs `zcode-cn`) is reserved so a future TRAE-CN-style split is a one-line change; only `zcode` is wired today.
+- No write into ZCode's system settings, no installation of skills or rules — just hooks + MCP, matching the minimal TRAE footprint.
+
+## Testing
+
+`scripts/zcode-hooks.test.mjs` (run with `node --test`) covers:
+
+- The plugin ships the required hook + MCP + integration-manifest files.
+- `hooks.json` commands reference all four entrypoints via the `__OPENVIKING_ZCODE_ROOT__` token.
+- The URI guard follows the Cursor/TRAE PreToolUse deny contract for `viking://` paths and passes through local paths.
+- The turn builder reads event fields (no transcript file) and strips previously injected memory blocks.
+- End-to-end: a `UserPromptSubmit` hook against a stub OpenViking server injects the recall digest; a duplicate event (same `generation_id`) is deduped; `Stop` captures the turn and commits it under the `zc-<session-id>` id; a later identical turn is not mistaken for a duplicate.
+
+These tests mirror [`trae-hooks.test.mjs`](../trae-memory-hooks/scripts/trae-hooks.test.mjs) almost exactly — the structural parity is intentional and is the main signal that the shared runtime is being exercised rather than reimplemented.
+
+## Open questions / future work
+
+- **Official ZCode hook docs**: replace assumptions 1–5 above with verified facts and adjust file/field names as needed.
+- **ZCode plugin marketplace**: add a `marketplace.json` entry once the marketplace contract is documented.
+- **Per-turn commit cadence**: if ZCode's hook surface emits a reliable SessionEnd, consider switching from commit-on-every-Stop to commit-on-SessionEnd + threshold (closer to the Codex plugin's policy).
+- **CN build**: if a `zcode-cn` build ships separately, add it to `openviking.integration.json` clients and let the installer select the prefix (`zcn-`), mirroring the trae/trae-cn split.

--- a/examples/zcode-memory-plugin/INSTALL-ZH.md
+++ b/examples/zcode-memory-plugin/INSTALL-ZH.md
@@ -1,0 +1,107 @@
+# 安装 OpenViking ZCode 记忆 Hooks
+
+为 ZCode（字节跳动 AI coding agent）安装生命周期 hooks（自动 recall、turn 捕获、`viking://` URI 守卫）、OpenViking stdio MCP proxy 以及凭据配置，让 ZCode 把 [OpenViking](https://github.com/volcengine/OpenViking) 当作长期记忆后端使用。
+
+结构镜像 TRAE 和 Cursor 集成，复用同一份 shared runtime。
+
+## 前置条件
+
+- ZCode（字节跳动 AI coding agent）
+- 本地或远端运行的 [OpenViking](https://github.com/volcengine/OpenViking) HTTP Server
+- Node.js 18+
+- 如果服务端启用了认证，需要可用的 OpenViking API Key
+
+建议先启动 OpenViking：
+
+```bash
+openviking-server --config ~/.openviking/ov.conf
+curl http://localhost:1933/health
+```
+
+## 安装
+
+在本仓库 checkout 目录下执行：
+
+```bash
+bash examples/zcode-memory-plugin/setup-helper/install.sh
+```
+
+安装器会：
+
+1. 把 `hooks/hooks.json` 里的 `__OPENVIKING_ZCODE_ROOT__` 渲染成插件绝对路径，写到 ZCode 配置目录（默认 `~/.zcode/hooks.json`）。
+2. 在 ZCode 的 MCP 配置（默认 `~/.zcode/mcp.json`）里追加一个 `openviking` 条目，指向 `servers/mcp-proxy.mjs`。已存在的 `mcpServers` 条目会被保留。
+3. 如果 `~/.openviking/ovcli.conf` 不存在，会交互式询问 URL 与 API Key（或在非交互模式下读取 `OPENVIKING_URL` / `OPENVIKING_API_KEY`）并写入。
+4. 跑一次插件的 hook 测试做 smoke test。
+
+### 非交互式安装
+
+```bash
+OPENVIKING_URL=https://your-openviking.example.com \
+OPENVIKING_API_KEY=sk-... \
+bash examples/zcode-memory-plugin/setup-helper/install.sh --yes
+```
+
+### 路径覆盖
+
+| 环境变量 | 默认值 | 用途 |
+|---|---|---|
+| `ZCODE_CONFIG_DIR` | `~/.zcode` | ZCode 配置目录 |
+| `ZCODE_HOOKS_FILE` | `hooks.json` | 配置目录里的 hooks 文件名 |
+| `ZCODE_MCP_FILE` | `mcp.json` | MCP 配置文件名 |
+| `OPENVIKING_HOME` | `~/.openviking` | OpenViking 主目录 |
+| `OPENVIKING_CLI_CONFIG_FILE` | `~/.openviking/ovcli.conf` | OpenViking CLI 配置路径 |
+
+## 配置
+
+连接与身份由 shared runtime 解析。hooks 和 MCP proxy 读同一份来源，所以总是指向同一个 server。
+
+1. **默认**：`~/.openviking/ovcli.conf` 优先 — 用 `ov config switch <name>` 同时切换 hooks、MCP、ZCode 内 `ov` 命令使用的凭据。
+2. **环境变量强制**：设置 `OPENVIKING_CREDENTIAL_SOURCE=env`，强制使用 `OPENVIKING_URL` / `OPENVIKING_API_KEY` / `OPENVIKING_ACCOUNT` / `OPENVIKING_USER` / `OPENVIKING_PEER_ID`。
+3. **兜底**：`~/.openviking/ov.conf` 老字段，然后是 `http://127.0.0.1:1933`（无认证）。
+
+API key 会作为 `Authorization: Bearer <api_key>` 同时发给 REST API（hooks 用）和 `/mcp` endpoint（模型用）。actor peer 默认按 Claude 的项目目录命名规则从当前 workspace 路径推导 — 完整规则和关闭方法见 [shared library README](../memory-plugin-shared/README.md)。
+
+## 验证
+
+1. 完全退出 ZCode，再重启。
+2. 新建一个 ZCode session，确认 OpenViking MCP server 已连接（在 ZCode 的 MCP 界面）。
+3. 让 ZCode 记住一个临时偏好，等回答结束后，新建 session 再问一次，验证捕获 + 跨 session recall。
+4. 需要 hook 诊断时，用 `OPENVIKING_DEBUG=1` 启动 ZCode，查看 `~/.openviking/logs/zcode-hooks.log`。
+
+## 可用 MCP 工具
+
+stdio proxy 直接转发 server 实际返回的 `tools/list`。当前 OpenViking server 暴露：
+
+- `recall`、`search`、`find` — 语义检索
+- `remember`、`forget`、`add_resource` — 记忆 / 资源管理
+- `read`、`list`、`grep`、`glob` — `viking://` 文件系统
+- `code_search`、`code_outline`、`code_expand` — 已索引代码导航
+- `list_watches`、`cancel_watch`、`health`
+
+工具名前缀由 ZCode 的 MCP 客户端按其命名规则自动添加。
+
+## 升级与卸载
+
+升级：在原 checkout 下重新跑一次安装器。卸载只移除 OpenViking 管理的文件：
+
+```bash
+rm ~/.zcode/hooks.json          # 如果是 ZCode 独占；否则编辑掉 OpenViking 块
+# 再从 ~/.zcode/mcp.json 里删除 `openviking` 条目
+```
+
+之后重启 ZCode。
+
+## 故障排查
+
+| 现象 | 原因与修复 |
+|------|-----------|
+| Hooks 没跑 | 完全退出 ZCode、重启、新建 Agent session。确认 `~/.zcode/hooks.json` 里写的是插件绝对路径。 |
+| MCP 连不上 | 检查 `~/.openviking/ovcli.conf` 里的 URL/API Key，再重启 ZCode。 |
+| 新 session 召不回上一轮 | 用 `OPENVIKING_DEBUG=1` 查看 `~/.openviking/logs/zcode-hooks.log`，确认 `Stop` 没有出现 `/commit` 连接或认证错误。 |
+| Hook 事件名不一致 | ZCode 的扩展面目前没有公开文档。如果它用了不同的事件名，只需重命名 `hooks/hooks.json` 里的 key；脚本本身与事件名无关。详见 [DESIGN.md](./DESIGN.md)。 |
+
+## 相关文档
+
+- [DESIGN.md](./DESIGN.md) — 关于 ZCode 扩展面的假设与待确认事项。
+- [认证](../../docs/zh/guides/04-authentication.md)
+- [MCP 集成指南](../../docs/zh/guides/06-mcp-integration.md)

--- a/examples/zcode-memory-plugin/INSTALL.md
+++ b/examples/zcode-memory-plugin/INSTALL.md
@@ -1,0 +1,107 @@
+# Install the OpenViking Memory Hooks for ZCode
+
+This installs ZCode lifecycle hooks (auto-recall, turn capture, `viking://` URI guard), an OpenViking stdio MCP proxy, and the credential glue so ZCode can use [OpenViking](https://github.com/volcengine/OpenViking) as its long-term memory backend.
+
+It mirrors the structure of the TRAE and Cursor integrations and reuses the same shared runtime.
+
+## Prerequisites
+
+- ZCode (the ByteDance AI coding agent)
+- [OpenViking](https://github.com/volcengine/OpenViking) HTTP server running locally or remotely
+- Node.js 18+
+- An OpenViking API key if your server requires authentication
+
+Start OpenViking first:
+
+```bash
+openviking-server --config ~/.openviking/ov.conf
+curl http://localhost:1933/health
+```
+
+## Install
+
+From a checkout of this repository:
+
+```bash
+bash examples/zcode-memory-plugin/setup-helper/install.sh
+```
+
+The installer:
+
+1. Renders `hooks/hooks.json` with the absolute plugin path substituted in for `__OPENVIKING_ZCODE_ROOT__`, and writes it to the ZCode config directory (default `~/.zcode/hooks.json`).
+2. Adds an `openviking` entry to the ZCode MCP config (default `~/.zcode/mcp.json`) pointing at `servers/mcp-proxy.mjs`. Any other `mcpServers` entries you already have are preserved.
+3. Sets up `~/.openviking/ovcli.conf` if it does not already exist (prompts for URL and API key, or uses `OPENVIKING_URL` / `OPENVIKING_API_KEY` in non-interactive mode).
+4. Runs the plugin's hook tests as a smoke test.
+
+### Non-interactive install
+
+```bash
+OPENVIKING_URL=https://your-openviking.example.com \
+OPENVIKING_API_KEY=sk-... \
+bash examples/zcode-memory-plugin/setup-helper/install.sh --yes
+```
+
+### Path overrides
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ZCODE_CONFIG_DIR` | `~/.zcode` | ZCode config directory |
+| `ZCODE_HOOKS_FILE` | `hooks.json` | hooks file name inside the config dir |
+| `ZCODE_MCP_FILE` | `mcp.json` | MCP config file name |
+| `OPENVIKING_HOME` | `~/.openviking` | OpenViking home directory |
+| `OPENVIKING_CLI_CONFIG_FILE` | `~/.openviking/ovcli.conf` | OpenViking CLI config path |
+
+## Configuration
+
+Connection and identity are resolved by the shared runtime. Both the hooks and the MCP proxy read the same source, so they always target the same server.
+
+1. **Default**: active `~/.openviking/ovcli.conf` wins — use `ov config switch <name>` to change it for hooks, MCP, and any `ov` command run inside ZCode together.
+2. **Env-forced**: set `OPENVIKING_CREDENTIAL_SOURCE=env` to force `OPENVIKING_URL` / `OPENVIKING_API_KEY` / `OPENVIKING_ACCOUNT` / `OPENVIKING_USER` / `OPENVIKING_PEER_ID`.
+3. **Fallback**: `~/.openviking/ov.conf` legacy fields, then `http://127.0.0.1:1933` unauthenticated.
+
+Auth is sent as `Authorization: Bearer <api_key>` to both the REST API (used by hooks) and the `/mcp` endpoint (used by the model). The actor peer is derived from the current workspace path using Claude's project-directory naming rule unless overridden — see the [shared library README](../memory-plugin-shared/README.md) for the full rule and how to disable it.
+
+## Verify
+
+1. Quit ZCode completely and restart it.
+2. In a new ZCode session, confirm the OpenViking MCP server is connected (per ZCode's MCP UI).
+3. Tell ZCode a temporary preference, wait for the response to finish, then create a new session and ask for that preference back to verify capture and cross-session recall.
+4. For hook diagnostics, start ZCode with `OPENVIKING_DEBUG=1` and inspect `~/.openviking/logs/zcode-hooks.log`.
+
+## Available MCP Tools
+
+The stdio proxy forwards the server's real `tools/list` response. Current OpenViking servers expose:
+
+- `recall`, `search`, `find` — semantic retrieval
+- `remember`, `forget`, `add_resource` — memory / resource management
+- `read`, `list`, `grep`, `glob` — `viking://` filesystem
+- `code_search`, `code_outline`, `code_expand` — indexed code navigation
+- `list_watches`, `cancel_watch`, `health`
+
+Tool names are namespaced by ZCode per its MCP client convention.
+
+## Upgrade and uninstall
+
+Re-run the installer from the same checkout to upgrade. Uninstall removes only OpenViking-managed files:
+
+```bash
+rm ~/.zcode/hooks.json          # if ZCode owns it; otherwise edit out the OpenViking block
+# then remove the `openviking` entry from ~/.zcode/mcp.json
+```
+
+Restart ZCode afterwards.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---------|---------------|
+| Hooks do not run | Quit ZCode completely, restart it, and create a new Agent session. Confirm `~/.zcode/hooks.json` references the absolute plugin path. |
+| MCP does not connect | Check the URL/API key in `~/.openviking/ovcli.conf`, then restart ZCode. |
+| A new session cannot recall the previous turn | Inspect `~/.openviking/logs/zcode-hooks.log` with `OPENVIKING_DEBUG=1` and confirm `Stop` ran without `/commit` connection or authentication errors. |
+| Hook event names differ | ZCode's extension surface is not yet publicly documented. If ZCode uses different event names, rename the keys in `hooks/hooks.json`; the scripts themselves are event-name-agnostic. See [DESIGN.md](./DESIGN.md). |
+
+## See also
+
+- [DESIGN.md](./DESIGN.md) — assumptions about ZCode's extension surface and what needs confirmation.
+- [Authentication](../../docs/en/guides/04-authentication.md)
+- [MCP Integration Guide](../../docs/en/guides/06-mcp-integration.md)

--- a/examples/zcode-memory-plugin/README.md
+++ b/examples/zcode-memory-plugin/README.md
@@ -1,0 +1,111 @@
+# OpenViking Memory Hooks for ZCode
+
+Long-term semantic memory for the [ZCode](https://www.volcengine.com/) AI coding agent, powered by [OpenViking](https://github.com/volcengine/OpenViking). This is the ZCode counterpart to [`trae-memory-hooks`](../trae-memory-hooks) and [`codex-memory-plugin`](../codex-memory-plugin) — it gives ZCode the same auto-recall, incremental turn capture, lifecycle commit, and OpenViking MCP tools that Claude Code, Codex, Cursor, TRAE, and OpenCode already have.
+
+It hooks the ZCode lifecycle to:
+
+- **Recall on `UserPromptSubmit`** — fetch relevant OpenViking memories for the current prompt and inject them as `additionalContext` so the model sees them without an extra tool call.
+- **Capture on `Stop`** — append the completed user/assistant turn to a deterministic OpenViking session id `zc-<zcode_session_id>` and immediately commit it so OpenViking's memory extractor runs on every turn.
+- **Profile on `SessionStart`** — load the actor's OpenViking profile (global + workspace memory digest) once per session.
+- **Guard `viking://` URIs on `PreToolUse`** — block accidental local filesystem / shell access to `viking://` virtual paths and point the agent back to the OpenViking MCP tools.
+
+It also starts a local stdio MCP proxy that forwards to OpenViking's native `/mcp` endpoint with credentials resolved from `~/.openviking/ovcli.conf` (or `OPENVIKING_*` env vars), so the model has direct access to the server's retrieval, memory, resource, watch, filesystem, and code-navigation tools.
+
+## Status
+
+Functional, reuses the same shared runtime as the Cursor and TRAE plugins. The hook surface it targets is the **Cursor/TRAE-compatible lifecycle** (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `Stop`) with `decision: "approve"` + `hookSpecificOutput.additionalContext` output. See [DESIGN.md](./DESIGN.md) for the assumptions about ZCode's extension surface and what needs confirmation once ZCode publishes official hook/MCP documentation.
+
+## Quick Start
+
+```bash
+bash examples/zcode-memory-plugin/setup-helper/install.sh
+```
+
+The installer writes the lifecycle `hooks.json` and MCP config into your ZCode config directory and walks you through the OpenViking connection settings. See [INSTALL.md](./INSTALL.md) (or [INSTALL-ZH.md](./INSTALL-ZH.md) for Chinese).
+
+## How It Works
+
+ZCode fires lifecycle hook events; each event invokes the matching `scripts/*.mjs` entrypoint, which delegates to [`scripts/zcode-hook.mjs`](./scripts/zcode-hook.mjs). That file is a thin adapter around [`memory-plugin-shared/lib/agent-hook-runtime.mjs`](../memory-plugin-shared/lib/agent-hook-runtime.mjs) — the same runtime used by the TRAE and Cursor integrations — so peer derivation, recall, capture batching, dedup, pending-queue replay, and idle commit are all reused, not reimplemented.
+
+```
+   ┌──────────────────────────────────────────────────────────┐
+   │                          ZCode                            │
+   └──┬──────────────┬────────────────┬──────────────────┬─────┘
+      │              │                │                  │
+ SessionStart   UserPromptSubmit   PreToolUse           Stop
+      │              │                │                  │
+ ┌────▼─────┐  ┌─────▼──────┐  ┌──────▼──────┐  ┌───────▼───────┐
+ │ session- │  │ auto-      │  │ uri-guard   │  │ auto-capture  │
+ │ start.mjs│  │ recall.mjs │  │ .mjs        │  │ .mjs          │
+ └─────┬────┘  └─────┬──────┘  └─────────────┘  └───────┬───────┘
+       │             │                                 │
+       └──► zcode-hook.mjs ◄───────────────────────────┘
+                  │
+                  ▼
+       memory-plugin-shared/lib/agent-hook-runtime.mjs
+                  │
+                  ▼
+          OpenViking REST API + /mcp
+```
+
+The shared runtime reads credentials from `~/.openviking/ovcli.conf` (or `OPENVIKING_*` env vars), derives a workspace peer using Claude's project-directory naming rule, and sends `peer_id` / `X-OpenViking-Actor-Peer` on every request. Each ZCode session becomes `zc-<safe-session-id>` on the OpenViking side. Capture filters previously injected `<openviking-context>` blocks so the model's own recall context is not echoed back into storage.
+
+## Files
+
+```text
+examples/zcode-memory-plugin/
+├── openviking.integration.json   # OpenViking integration manifest
+├── .mcp.json                     # stdio MCP wiring (openviking server)
+├── hooks/
+│   └── hooks.json                # SessionStart + UserPromptSubmit + PreToolUse + Stop
+├── scripts/
+│   ├── session-start.mjs         # SessionStart entrypoint
+│   ├── auto-recall.mjs           # UserPromptSubmit entrypoint
+│   ├── auto-capture.mjs          # Stop entrypoint
+│   ├── uri-guard.mjs             # PreToolUse viking:// guard
+│   ├── zcode-hook.mjs            # main hook logic (thin adapter over shared runtime)
+│   ├── zcode-turns.mjs           # turn builder + injected-block cleaner
+│   └── zcode-hooks.test.mjs      # node --test contract + e2e hook tests
+├── servers/
+│   └── mcp-proxy.mjs             # stdio -> OpenViking /mcp bridge
+├── setup-helper/
+│   └── install.sh                # self-contained installer
+├── DESIGN.md
+├── INSTALL.md
+├── INSTALL-ZH.md
+└── README.md
+```
+
+No `package.json` or build step: hook scripts and the MCP proxy are zero-dependency `.mjs` files running on a system Node.js 18+.
+
+## Configuration
+
+Connection and identity are resolved by the shared runtime in this order:
+
+1. `OPENVIKING_CREDENTIAL_SOURCE=env` forces `OPENVIKING_URL` / `OPENVIKING_API_KEY` / `OPENVIKING_ACCOUNT` / `OPENVIKING_USER` / `OPENVIKING_PEER_ID`.
+2. Active `~/.openviking/ovcli.conf` when present (`url`, `api_key`, `account`, `user`, `actor_peer_id`).
+3. `~/.openviking/ov.conf` legacy fallback, then `http://127.0.0.1:1933` unauthenticated.
+
+Auth is sent as `Authorization: Bearer <api_key>` to both the REST API (hooks) and the `/mcp` endpoint (model). By default a peer is derived from the current workspace path; set `OPENVIKING_WORKSPACE_PEER=0` to disable, or set `OPENVIKING_PEER_ID` to override.
+
+### Tuning
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `OPENVIKING_MEMORY_ENABLED` | `1` | Master switch for all hooks |
+| `OPENVIKING_AUTO_RECALL` | `1` | Set `0` to skip `UserPromptSubmit` recall |
+| `OPENVIKING_AUTO_CAPTURE` | `1` | Set `0` to skip `Stop` capture |
+| `OPENVIKING_RECALL_LIMIT` | `6` | Max recall candidates per prompt |
+| `OPENVIKING_RECALL_TOKEN_BUDGET` | `2000` | Soft char budget for the recall digest |
+| `OPENVIKING_COMMIT_TURN_THRESHOLD` | `8` | Reserved for batched commit (ZCode commits every turn) |
+| `OPENVIKING_TIMEOUT_MS` | `15000` | Per-request timeout |
+| `OPENVIKING_DEBUG` | `0` | Enable structured JSONL debug log |
+| `OPENVIKING_DEBUG_LOG` | `~/.openviking/logs/zcode-hooks.log` | Debug log path |
+
+## MCP Tools
+
+The stdio proxy forwards OpenViking's real `tools/list` response. Current OpenViking servers expose: `recall`, `search`, `find`, `remember`, `read`, `list`, `grep`, `glob`, `add_resource`, `forget`, `list_watches`, `cancel_watch`, `code_search`, `code_outline`, `code_expand`, `health`. Tool names are namespaced by ZCode per its MCP client convention.
+
+## License
+
+Apache-2.0 — same as [OpenViking](https://github.com/volcengine/OpenViking).

--- a/examples/zcode-memory-plugin/hooks/hooks.json
+++ b/examples/zcode-memory-plugin/hooks/hooks.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node __OPENVIKING_ZCODE_ROOT__/scripts/session-start.mjs zcode",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node __OPENVIKING_ZCODE_ROOT__/scripts/auto-recall.mjs zcode",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|Glob|Grep|Bash|RunCommand",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node __OPENVIKING_ZCODE_ROOT__/scripts/uri-guard.mjs zcode",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node __OPENVIKING_ZCODE_ROOT__/scripts/auto-capture.mjs zcode",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/zcode-memory-plugin/openviking.integration.json
+++ b/examples/zcode-memory-plugin/openviking.integration.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "openviking-memory",
+  "version": "0.1.0",
+  "clients": ["zcode"],
+  "capabilities": ["hooks", "mcp"]
+}

--- a/examples/zcode-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/zcode-memory-plugin/scripts/auto-capture.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "stop";
+process.env.OPENVIKING_HOOK_SOURCE ||= process.argv[2] || "zcode";
+await import("./zcode-hook.mjs");

--- a/examples/zcode-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/zcode-memory-plugin/scripts/auto-recall.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "user-prompt-submit";
+process.env.OPENVIKING_HOOK_SOURCE ||= process.argv[2] || "zcode";
+await import("./zcode-hook.mjs");

--- a/examples/zcode-memory-plugin/scripts/session-start.mjs
+++ b/examples/zcode-memory-plugin/scripts/session-start.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "session-start";
+process.env.OPENVIKING_HOOK_SOURCE ||= process.argv[2] || "zcode";
+await import("./zcode-hook.mjs");

--- a/examples/zcode-memory-plugin/scripts/uri-guard.mjs
+++ b/examples/zcode-memory-plugin/scripts/uri-guard.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  evaluateAgentUriGuard,
+} from "../../memory-plugin-shared/lib/agent-uri-guard.mjs";
+
+function readInput() {
+  try {
+    const raw = readFileSync(0, "utf8").trim();
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function evaluateZcodeUriGuard(input = {}) {
+  const toolName = input.tool_name ?? input.toolName ?? input.name ?? input.tool;
+  const toolInput = input.tool_input ?? input.toolInput ?? input.input ?? {};
+  const decision = evaluateAgentUriGuard(toolName, toolInput);
+  if (!decision) return {};
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: decision.reason,
+    },
+  };
+}
+
+const isEntrypoint = process.argv[1]
+  && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+if (isEntrypoint) {
+  const output = evaluateZcodeUriGuard(readInput());
+  if (Object.keys(output).length > 0) process.stdout.write(`${JSON.stringify(output)}\n`);
+}

--- a/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import {
+  addAgentMessages,
+  buildAgentProfile,
+  commitAgentSession,
+  createAgentLogger,
+  deriveAgentSessionId,
+  loadAgentHookConfig,
+  makeAgentFetchJSON,
+  readHookInput,
+  readHookState,
+  recallForPrompt,
+  replayAgentPending,
+  resolveAgentCwd,
+  resolveNativeSessionId,
+  shouldBypassAgent,
+  stableHash,
+  withAgentHookLock,
+  writeHookState,
+} from "../../memory-plugin-shared/lib/agent-hook-runtime.mjs";
+import { buildZcodeTurns, cleanZcodeText } from "./zcode-turns.mjs";
+
+const eventName = process.env.OPENVIKING_HOOK_EVENT || process.argv[2] || "";
+const requestedSource = process.env.OPENVIKING_HOOK_SOURCE || process.argv[3];
+const requestedClient = requestedSource === "zcode-cn" ? "zcode-cn" : "zcode";
+// Session-id prefix on the OpenViking side. `zc-` for ZCode, `zcn-` reserved
+// for a future CN-specific build (mirrors the trae/trae-cn split).
+const prefix = requestedClient === "zcode-cn" ? "zcn-" : "zc-";
+const cfg = loadAgentHookConfig(requestedClient);
+const { log, logError } = createAgentLogger(requestedClient, eventName, cfg);
+
+function output(value = {}) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function approve(additionalContext = "") {
+  const value = { decision: "approve" };
+  if (additionalContext) {
+    value.hookSpecificOutput = {
+      hookEventName: eventName === "session-start" ? "SessionStart" : "UserPromptSubmit",
+      additionalContext,
+    };
+  }
+  output(value);
+}
+
+const input = await readHookInput();
+const nativeSessionId = resolveNativeSessionId(input);
+const sessionId = deriveAgentSessionId(prefix, input);
+const cwd = resolveAgentCwd(input);
+const { fetchJSON } = makeAgentFetchJSON(cfg, cwd);
+
+async function main() {
+  if (!cfg.enabled || shouldBypassAgent(cfg, input)) { approve(); return; }
+  let state = await readHookState(requestedClient, nativeSessionId);
+
+  if (eventName === "session-start") {
+    const profile = await withAgentHookLock(requestedClient, nativeSessionId, async () => {
+      state = await readHookState(requestedClient, nativeSessionId);
+      const now = Date.now();
+      if (now - Number(state.lastSessionStartAt || 0) < 2000) return null;
+      state = { ...state, lastSessionStartAt: now };
+      await writeHookState(requestedClient, nativeSessionId, state);
+      await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      return buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
+        logError("profile", error);
+        return null;
+      });
+    });
+    approve(profile ? `<openviking-context source="session-start">\n${profile}\n</openviking-context>` : "");
+    return;
+  }
+
+  if (eventName === "user-prompt-submit") {
+    const prompt = cleanZcodeText(input.prompt);
+    if (!prompt) { approve(); return; }
+    const recallBlock = await withAgentHookLock(requestedClient, nativeSessionId, async () => {
+      state = await readHookState(requestedClient, nativeSessionId);
+      const promptHash = stableHash(prompt);
+      const now = Date.now();
+      const promptEventId = input.generation_id || input.request_id || input.message_id || input.prompt_id || "";
+      const duplicateEvent = promptEventId
+        ? state.promptEventId === promptEventId
+        : state.promptHash === promptHash && now - Number(state.promptAt || 0) < 500;
+      if (duplicateEvent) return null;
+      const block = state.promptHash === promptHash && state.recallBlock
+        ? state.recallBlock
+        : await recallForPrompt(fetchJSON, cfg, prompt, cwd, log).catch((error) => {
+          logError("recall", error);
+          return null;
+        });
+      await writeHookState(requestedClient, nativeSessionId, {
+        ...state,
+        promptHash,
+        promptEventId,
+        promptAt: now,
+        recallBlock: block,
+        pendingPrompt: { prompt, hash: promptHash, at: now },
+      });
+      return block;
+    });
+    approve(recallBlock || "");
+    return;
+  }
+
+  if (eventName === "stop") {
+    if (!cfg.autoCapture) { approve(); return; }
+    await withAgentHookLock(requestedClient, nativeSessionId, async () => {
+      state = await readHookState(requestedClient, nativeSessionId);
+      const hashes = new Set(Array.isArray(state.capturedHashes) ? state.capturedHashes : []);
+      const turnKey = state.pendingPrompt?.at || state.lastTurnKey || state.promptHash || "unknown-turn";
+      const toSend = [];
+      for (const turn of buildZcodeTurns(input, state)) {
+        const hash = stableHash(turnKey, turn.role, turn.content);
+        if (hashes.has(hash)) continue;
+        toSend.push({ hash, turn });
+      }
+      const result = await addAgentMessages(fetchJSON, sessionId, toSend.map((item) => item.turn));
+      const captured = result.sent + result.queued;
+      for (const item of toSend.slice(0, captured)) hashes.add(item.hash);
+      let nextCount = Number(state.capturedSinceCommit || 0) + captured;
+      if (captured > 0) {
+        const committed = await commitAgentSession(fetchJSON, sessionId);
+        if (committed.ok) nextCount = 0;
+      }
+      await writeHookState(requestedClient, nativeSessionId, {
+        ...state,
+        capturedHashes: [...hashes].slice(-1000),
+        capturedSinceCommit: nextCount,
+        pendingPrompt: null,
+        lastTurnKey: turnKey,
+      });
+    });
+    approve();
+    return;
+  }
+
+  approve();
+}
+
+main().catch((error) => {
+  logError("uncaught", error);
+  approve();
+});

--- a/examples/zcode-memory-plugin/scripts/zcode-hooks.test.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-hooks.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { buildZcodeTurns, cleanZcodeText } from "./zcode-turns.mjs";
+import { evaluateZcodeUriGuard } from "./uri-guard.mjs";
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("ZCode integration contains native Hook and MCP declarations", () => {
+  for (const file of [
+    "hooks/hooks.json",
+    ".mcp.json",
+    "openviking.integration.json",
+    "scripts/zcode-hook.mjs",
+    "scripts/session-start.mjs",
+    "scripts/auto-recall.mjs",
+    "scripts/auto-capture.mjs",
+    "scripts/uri-guard.mjs",
+  ]) {
+    assert.ok(existsSync(join(pluginRoot, file)), `${file} must exist`);
+  }
+  const integration = JSON.parse(readFileSync(join(pluginRoot, "openviking.integration.json"), "utf8"));
+  const hooks = JSON.parse(readFileSync(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
+  assert.deepEqual(integration.clients, ["zcode"]);
+  assert.deepEqual(Object.keys(hooks.hooks), [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "Stop",
+  ]);
+});
+
+test("hooks.json commands point at the ZCode scripts via the OPENVIKING_ZCODE_ROOT token", () => {
+  const hooks = JSON.parse(readFileSync(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
+  const commands = JSON.stringify(hooks);
+  assert.match(commands, /__OPENVIKING_ZCODE_ROOT__\/scripts\/session-start\.mjs/);
+  assert.match(commands, /__OPENVIKING_ZCODE_ROOT__\/scripts\/auto-recall\.mjs/);
+  assert.match(commands, /__OPENVIKING_ZCODE_ROOT__\/scripts\/auto-capture\.mjs/);
+  assert.match(commands, /__OPENVIKING_ZCODE_ROOT__\/scripts\/uri-guard\.mjs/);
+});
+
+test("ZCode URI guard follows the Cursor/TRAE PreToolUse deny contract", () => {
+  const denied = evaluateZcodeUriGuard({
+    tool_name: "Read",
+    tool_input: { file_path: "viking://resources/project/file.md" },
+  });
+  assert.equal(denied.hookSpecificOutput?.hookEventName, "PreToolUse");
+  assert.equal(denied.hookSpecificOutput?.permissionDecision, "deny");
+  assert.match(
+    denied.hookSpecificOutput?.permissionDecisionReason ?? "",
+    /OpenViking MCP read/,
+  );
+  assert.deepEqual(evaluateZcodeUriGuard({
+    tool_name: "Read",
+    tool_input: { file_path: "/tmp/file.md" },
+  }), {});
+});
+
+test("ZCode capture uses event fields rather than a transcript path", () => {
+  const turns = buildZcodeTurns({ prompt: "question", last_assistant_message: "answer" });
+  assert.deepEqual(turns, [
+    { role: "user", content: "question" },
+    { role: "assistant", content: "answer" },
+  ]);
+});
+
+test("ZCode capture removes previously injected memory blocks", () => {
+  assert.equal(cleanZcodeText("before<openviking-context>secret</openviking-context>after"), "beforeafter");
+});
+
+function runHook(event, client, input, env) {
+  const entrypoint = {
+    "session-start": "session-start.mjs",
+    "user-prompt-submit": "auto-recall.mjs",
+    stop: "auto-capture.mjs",
+  }[event];
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [join(pluginRoot, "scripts", entrypoint), client], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) reject(new Error(stderr || `hook exited ${code}`));
+      else resolveRun(JSON.parse(stdout.trim() || "{}"));
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+test("ZCode prompt hook injects recall and Stop captures committed turns under the zc- session id", async () => {
+  const messages = [];
+  const commits = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      if (request.url === "/api/v1/search/recall") {
+        response.end(JSON.stringify({ result: { rendered: "zcode memory" } }));
+      } else if (request.url?.includes("/messages")) {
+        const parsed = JSON.parse(body);
+        messages.push(...(parsed.messages ?? [parsed]).map((message) => ({ url: request.url, body: message })));
+        response.end(JSON.stringify({ result: { ok: true } }));
+      } else if (request.url?.endsWith("/commit")) {
+        commits.push(request.url);
+        response.end(JSON.stringify({ result: { ok: true } }));
+      } else {
+        response.end(JSON.stringify({ result: { ok: true } }));
+      }
+    });
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const root = mkdtempSync(join(tmpdir(), "openviking-zcode-hook-"));
+  const env = {
+    HOME: root,
+    OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
+    OPENVIKING_HOOK_STATE_DIR: join(root, "state"),
+    OPENVIKING_MEMORY_ENABLED: "1",
+  };
+  try {
+    const base = { session_id: "same-session", cwd: "/workspace" };
+    const promptInput = { ...base, prompt: "remember this", generation_id: "prompt-1" };
+    const recalled = await Promise.all([
+      runHook("user-prompt-submit", "zcode", promptInput, env),
+      runHook("user-prompt-submit", "zcode", promptInput, env),
+    ]);
+    // Dedup: the second Hook invocation with the same generation_id must not
+    // re-call recall and must emit an empty approve.
+    assert.equal(
+      recalled.filter((item) => /zcode memory/.test(item.hookSpecificOutput?.additionalContext || "")).length,
+      1,
+    );
+    await Promise.all([
+      runHook("stop", "zcode", { ...base, last_assistant_message: "done" }, env),
+      runHook("stop", "zcode", { ...base, last_assistant_message: "done" }, env),
+    ]);
+    assert.equal(messages.length, 2);
+    assert.equal(commits.length, 1, "the completed ZCode turn must be committed immediately");
+    assert.ok(messages.every((item) => item.url.includes("zc-same-session")));
+
+    await runHook("user-prompt-submit", "zcode", { ...base, prompt: "remember this", generation_id: "prompt-2" }, env);
+    await runHook("stop", "zcode", { ...base, last_assistant_message: "done" }, env);
+    assert.equal(messages.length, 4, "a later identical turn must not be mistaken for a duplicate Hook run");
+    assert.equal(commits.length, 2);
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/examples/zcode-memory-plugin/scripts/zcode-turns.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-turns.mjs
@@ -1,0 +1,13 @@
+export function cleanZcodeText(value) {
+  return String(value || "")
+    .replace(/<openviking-context\b[^>]*>[\s\S]*?<\/openviking-context>/gi, "")
+    .replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/gi, "")
+    .trim();
+}
+
+export function buildZcodeTurns(input = {}, state = {}) {
+  return [
+    { role: "user", content: cleanZcodeText(input.prompt || state.pendingPrompt?.prompt) },
+    { role: "assistant", content: cleanZcodeText(input.last_assistant_message || input.text_content) },
+  ].filter((turn) => turn.content);
+}

--- a/examples/zcode-memory-plugin/scripts/zcode-turns.test.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-turns.test.mjs
@@ -1,0 +1,59 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanZcodeText, buildZcodeTurns } from "./zcode-turns.mjs";
+
+test("cleanZcodeText strips openviking-context blocks", () => {
+  const out = cleanZcodeText(
+    'hello <openviking-context version="1">secret</openviking-context> world'
+  );
+  assert.equal(out, "hello  world");
+});
+
+test("cleanZcodeText strips relevant-memories blocks", () => {
+  const out = cleanZcodeText("a <relevant-memories>x</relevant-memories> b");
+  assert.equal(out, "a  b");
+});
+
+test("cleanZcodeText is null/undefined safe and trims", () => {
+  assert.equal(cleanZcodeText(undefined), "");
+  assert.equal(cleanZcodeText(null), "");
+  assert.equal(cleanZcodeText("  hi  "), "hi");
+});
+
+test("buildZcodeTurns builds user+assistant turns from input", () => {
+  const turns = buildZcodeTurns({ prompt: "hello", last_assistant_message: "hi back" });
+  assert.deepEqual(
+    turns,
+    [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi back" },
+    ]
+  );
+});
+
+test("buildZcodeTurns falls back to state.pendingPrompt", () => {
+  const turns = buildZcodeTurns(
+    { last_assistant_message: "reply" },
+    { pendingPrompt: { prompt: "from-state" } }
+  );
+  assert.equal(turns[0].role, "user");
+  assert.equal(turns[0].content, "from-state");
+});
+
+test("buildZcodeTurns drops empty turns", () => {
+  const turns = buildZcodeTurns({ prompt: "", last_assistant_message: "" });
+  assert.deepEqual(turns, []);
+  const one = buildZcodeTurns({ prompt: "only-user" });
+  assert.equal(one.length, 1);
+  assert.equal(one[0].role, "user");
+});
+
+test("buildZcodeTurns strips injected context tags from turn content", () => {
+  const turns = buildZcodeTurns({
+    prompt: "q <openviking-context>x</openviking-context>",
+    text_content: "<relevant-memories>y</relevant-memories> a",
+  });
+  assert.equal(turns[0].content, "q");
+  assert.equal(turns[1].content, "a");
+});

--- a/examples/zcode-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/zcode-memory-plugin/servers/mcp-proxy.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { resolve as resolvePath } from "node:path";
+
+import { loadAgentHookConfig } from "../../memory-plugin-shared/lib/agent-hook-runtime.mjs";
+import { createLogger } from "../../memory-plugin-shared/lib/debug-log.mjs";
+import { createOpenVikingMcpProxy } from "../../memory-plugin-shared/lib/mcp-proxy-core.mjs";
+
+function readConfig() {
+  // ZCode is currently a single client. If a CN-specific build appears later
+  // it can be selected via OPENVIKING_HOOK_SOURCE=zcode-cn, mirroring trae.
+  const clientId = process.env.OPENVIKING_HOOK_SOURCE === "zcode-cn" ? "zcode-cn" : "zcode";
+  const cfg = loadAgentHookConfig(clientId);
+  return {
+    mcpUrl: cfg.mcpUrl,
+    apiKey: cfg.apiKey,
+    account: cfg.account,
+    user: cfg.user,
+    peerId: cfg.peerId,
+    userAgent: cfg.userAgent,
+    timeoutMs: cfg.timeoutMs,
+    debug: cfg.debug,
+    debugLogPath: cfg.debugLogPath,
+    credentialSource: cfg.credentialSource,
+    credentialPath: cfg.cliPath || cfg.ovPath || "",
+    watchedPaths: [cfg.cliPath, cfg.ovPath].filter(Boolean),
+  };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolvePath(process.argv[1])) {
+  createOpenVikingMcpProxy({ readConfig, loggerFactory: createLogger }).start();
+}

--- a/examples/zcode-memory-plugin/setup-helper/install.sh
+++ b/examples/zcode-memory-plugin/setup-helper/install.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# OpenViking Memory Hooks for ZCode — installer.
+#
+# One-liner (from a repo checkout):
+#   bash examples/zcode-memory-plugin/setup-helper/install.sh
+#
+# What it does:
+#   1. Resolves the absolute path to this examples/zcode-memory-plugin checkout.
+#   2. Renders hooks/hooks.json with __OPENVIKING_ZCODE_ROOT__ -> that path,
+#      and writes it into the ZCode config directory (default ~/.zcode/hooks.json).
+#   3. Writes the OpenViking MCP server entry into the ZCode MCP config so
+#      `node <plugin>/servers/mcp-proxy.mjs` is launched as a stdio MCP server.
+#   4. If OPENVIKING_URL / OPENVIKING_API_KEY are set, mirrors them into
+#      ~/.openviking/ovcli.conf (only if that file does not already exist).
+#   5. Prints verify instructions.
+#
+# Env overrides:
+#   ZCODE_CONFIG_DIR     ZCode config directory (default ~/.zcode)
+#   ZCODE_HOOKS_FILE     hooks file name inside that dir (default hooks.json)
+#   ZCODE_MCP_FILE       MCP config file name (default mcp.json)
+#   OPENVIKING_HOME      OpenViking home (default ~/.openviking)
+#   OPENVIKING_URL       OpenViking server URL
+#   OPENVIKING_API_KEY   OpenViking API key
+#   OPENVIKING_ACCOUNT   Trusted-mode account id (optional)
+#   OPENVIKING_USER      Trusted-mode user id (optional)
+#   OPENVIKING_PEER_ID   Explicit actor peer (optional; default: workspace-derived)
+#
+# Non-interactive: set the env vars above and run with --yes.
+
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
+OV_HOME="${OPENVIKING_HOME:-$HOME/.openviking}"
+ZCODE_CONFIG_DIR="${ZCODE_CONFIG_DIR:-$HOME/.zcode}"
+ZCODE_HOOKS_FILE="${ZCODE_HOOKS_FILE:-hooks.json}"
+ZCODE_MCP_FILE="${ZCODE_MCP_FILE:-mcp.json}"
+OVCLI_CONF="${OPENVIKING_CLI_CONFIG_FILE:-$OV_HOME/ovcli.conf}"
+INTERACTIVE=1
+[ "${1:-}" = "--yes" ] && INTERACTIVE=0
+
+color() { printf '\033[%sm%s\033[0m' "$1" "$2"; }
+step()   { printf '\n%s %s\n' "$(color '1;36' '▶')" "$*"; }
+note()   { printf '  %s %s\n' "$(color '0;37' '·')" "$*"; }
+warn()   { printf '  %s %s\n' "$(color '0;33' '!')" "$*" >&2; }
+die()    { printf '  %s %s\n' "$(color '1;31' '✗')" "$*" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || die "Node.js 18+ is required (could not find 'node' on PATH)."
+NODE_MAJOR="$(node -e 'process.stdout.write(String((process.versions.node||"0").split(".")[0]))')"
+[ "$NODE_MAJOR" -ge 18 ] || die "Node.js 18+ is required (found Node $(node -v))."
+
+# --- 1. Render hooks.json with the absolute plugin root ---------------------
+step "Rendering lifecycle hooks"
+mkdir -p "$ZCODE_CONFIG_DIR"
+HOOKS_DST="$ZCODE_CONFIG_DIR/$ZCODE_HOOKS_FILE"
+sed "s|__OPENVIKING_ZCODE_ROOT__|$PLUGIN_DIR|g" "$PLUGIN_DIR/hooks/hooks.json" > "$HOOKS_DST"
+note "wrote $HOOKS_DST"
+
+# --- 2. Render MCP config ---------------------------------------------------
+step "Wiring OpenViking MCP server"
+MCP_DST="$ZCODE_CONFIG_DIR/$ZCODE_MCP_FILE"
+node - "$PLUGIN_DIR" "$MCP_DST" <<'NODE'
+const pluginRoot = process.argv[2];
+const dst = process.argv[3];
+const fs = require("fs");
+const path = require("path");
+const dir = path.dirname(dst);
+fs.mkdirSync(dir, { recursive: true });
+// Preserve any user-authored mcpServers entries, only add/replace `openviking`.
+let existing = {};
+try { existing = JSON.parse(fs.readFileSync(dst, "utf8")); } catch {}
+if (!existing.mcpServers || typeof existing.mcpServers !== "object") existing.mcpServers = {};
+existing.mcpServers.openviking = {
+  command: "node",
+  args: [path.join(pluginRoot, "servers", "mcp-proxy.mjs")],
+};
+fs.writeFileSync(dst, `${JSON.stringify(existing, null, 2)}\n`);
+process.stdout.write(`  · wrote ${dst}\n`);
+NODE
+
+# --- 3. Credentials ---------------------------------------------------------
+step "Checking OpenViking credentials"
+if [ -f "$OVCLI_CONF" ]; then
+  note "found $OVCLI_CONF — hooks and MCP will read it at runtime"
+else
+  if [ "$INTERACTIVE" -eq 1 ] && [ -t 0 ]; then
+    printf '  %s OpenViking server URL [http://127.0.0.1:1933]: ' "$(color '0;37' '?')"
+    read -r OV_URL
+    OV_URL="${OV_URL:-http://127.0.0.1:1933}"
+    printf '  %s OpenViking API key (blank for local unauthenticated): ' "$(color '0;37' '?')"
+    read -r OV_KEY
+  else
+    OV_URL="${OPENVIKING_URL:-http://127.0.0.1:1933}"
+    OV_KEY="${OPENVIKING_API_KEY:-}"
+  fi
+  mkdir -p "$OV_HOME"
+  cat > "$OVCLI_CONF" <<EOF
+{
+  "url": "${OV_URL%/}",
+  "api_key": "${OV_KEY}"
+}
+EOF
+  chmod 600 "$OVCLI_CONF"
+  note "wrote $OVCLI_CONF"
+fi
+
+# --- 4. Verify --------------------------------------------------------------
+step "Smoke test"
+if node "$PLUGIN_DIR/scripts/zcode-hooks.test.mjs" >/dev/null 2>&1; then
+  note "hook tests passed"
+else
+  warn "hook test runner did not report success — run: node --test $PLUGIN_DIR/scripts/zcode-hooks.test.mjs"
+fi
+
+cat <<EOF
+
+$(color '1;32' 'Done.') ZCode OpenViking memory hooks are installed.
+
+Next:
+  1. Quit ZCode completely and restart it so it picks up the new hooks + MCP.
+  2. In a new ZCode session, ask the agent to search OpenViking memory, or
+     tell it a temporary preference and (in a fresh session) ask for it back.
+  3. To enable debug logging: start ZCode with OPENVIKING_DEBUG=1 and inspect
+     $(color '0;37' '~/.openviking/logs/zcode-hooks.log')
+
+Uninstall: remove the OpenViking block from $MCP_DST
+and delete $HOOKS_DST, then restart ZCode.
+
+EOF


### PR DESCRIPTION
## What & why

Closes #3127 (also requested in #3442).

ZCode (ByteDance's AI coding agent, used with the GLM model family) had no OpenViking memory plugin. This adds `examples/zcode-memory-plugin`, the ZCode counterpart to the existing Codex / Claude Code / Cursor / OpenCode plugins.

## Design: reuse > copy

It consumes the **shared runtime** ([`memory-plugin-shared`](../memory-plugin-shared)) for recall, incremental capture, commit, workspace peer identity, and the stdio MCP proxy. No memory logic is duplicated. Only a thin ZCode adapter is new:
- `scripts/zcode-hook.mjs` — adapts ZCode lifecycle events to the shared `agent-hook-runtime.mjs`.
- `scripts/zcode-turns.mjs` — parses ZCode transcript into user/assistant turns (pure).
- `servers/mcp-proxy.mjs` — stdio MCP proxy → OpenViking `/mcp` (credentials from env / `ovcli.conf`).
- `hooks/hooks.json`, `openviking.integration.json`, `.mcp.json`, `setup-helper/install.sh`.

It mirrors the **TRAE** plugin structure (the closest IDE-style coding-agent analogue) file-for-file.

## ⚠️ Honest status — assumptions need ZCode confirmation

**ZCode's official extension surface is not publicly documented.** The hook event names (`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `Stop`), the output schema for context injection + URI guard, and the on-disk config layout are inherited from Cursor/TRAE — the most likely shape because ZCode is the same class of tool, but they are **hypotheses to verify, not facts**.

[DESIGN.md](./examples/zcode-memory-plugin/DESIGN.md) lists each load-bearing assumption and **exactly which file changes if ZCode's real surface differs** (e.g. if hook names differ, only the keys in `hooks/hooks.json` change; if the output schema differs, only `approve()` in `zcode-hook.mjs` and `evaluateZcodeUriGuard` in `uri-guard.mjs`). The memory side is harness-agnostic.

Opening as **draft** until the ZCode hook surface is confirmed against ZCode's docs (or by a ZCode user). Happy to adjust the adapter once the real event names/schema are known.

## Tests

`scripts/zcode-turns.test.mjs` + `scripts/zcode-hooks.test.mjs` — `node:test`, **13 cases** covering the pure transcript parsing (tag stripping, turn building, empty-turn dropping, state fallback) and the hook adapter shaping. **13 pass.** (The shared runtime has its own tests in `memory-plugin-shared`.)

This contribution was developed with AI assistance.

Refs #3127