### PR TITLE
fix(deploy): harden bot and server deployment configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,14 +4,15 @@
 # that already reference it. Its primary remaining purpose is as the upstream
 # target for a TLS-terminating proxy (e.g. HTTPS via Caddy domain block).
 #
-# For new deployments, connect directly to the OV server on port 1933.
+# For new deployments, connect directly to the OV server on
+# OPENVIKING_SERVER_PORT (1933 by default).
 # Web Studio is served by OV itself at /studio — no separate proxy needed.
 #
 # To add public HTTPS, append a domain block below (Caddy auto-provisions
 # Let's Encrypt certs):
 #
 #   {$OPENVIKING_PUBLIC_BASE_URL} {
-#       reverse_proxy openviking:1933
+#       reverse_proxy openviking:{$OPENVIKING_SERVER_PORT:1933}
 #       # Optional: pin ACME email
 #       # tls {$OV_ACME_EMAIL}
 #   }
@@ -20,5 +21,5 @@
 # OPENVIKING_PUBLIC_BASE_URL=https://your-domain.com in .env.
 
 :1934 {
-	reverse_proxy openviking:1933
+	reverse_proxy openviking:{$OPENVIKING_SERVER_PORT:1933}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ ENV HOME="/app" \
 EXPOSE 1933
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:1933/health || exit 1
+    CMD ["openviking-entrypoint", "--healthcheck"]
 
 # All persistent state (ov.conf, ovcli.conf, workspace data) lives under
 # /app/.openviking, which mirrors the host's ~/.openviking layout. Mount one

--- a/bot/deploy/docker/README.md
+++ b/bot/deploy/docker/README.md
@@ -10,9 +10,12 @@
 - **Windows**: 下载 [Docker Desktop](https://www.docker.com/products/docker-desktop)
 - **Linux**: 参考 [Docker 官方文档](https://docs.docker.com/engine/install/)
 
-验证 Docker 安装：
+部署脚本还会使用 Python 3 验证现有 `ov.conf` 的 JSON 结构和 Gateway 端口。
+
+验证依赖：
 ```bash
 docker --version
+python3 --version
 ```
 
 ## 快速开始
@@ -212,30 +215,28 @@ REMOVE_IMAGE=true REMOVE_VOLUME=true ./deploy/docker/stop.sh
 
 ## 配置文件
 
-首次部署时，脚本会自动创建配置文件：`~/.vikingbot/config.json`
+首次部署时，脚本会自动创建配置文件：`~/.vikingbot/ov.conf`。脚本同时生成随机 Gateway Token；在非本机请求中通过 `X-Gateway-Token` 请求头传入该值。
 
 编辑该文件填入你的 API keys：
 
 ```json
 {
-  "providers": {
-    "openrouter": {
-      "apiKey": "sk-or-xxx"
+  "bot": {
+    "agents": {
+      "provider": "openrouter",
+      "model": "openrouter/anthropic/claude-3.5-sonnet",
+      "api_key": "sk-or-xxx"
+    },
+    "gateway": {
+      "host": "0.0.0.0",
+      "port": 18791,
+      "token": "脚本生成的随机值"
     }
-  },
-  "agents": {
-    "defaults": {
-      "model": "openrouter/anthropic/claude-3.5-sonnet"
-    }
-  },
-  "gateway": {
-    "host": "0.0.0.0",
-    "port": 18791
   }
 }
 ```
 
-**重要：** Console Web UI 端口是 **18791**，不是 18790！
+**重要：** `bot.gateway.port` 必须与 `CONTAINER_PORT` 一致；脚本默认都使用 **18791**。如果现有配置不是有效 JSON、缺少 `bot.gateway`，或端口不一致，部署会在替换旧容器前停止并提示修复配置。
 
 ## 访问控制台
 

--- a/bot/deploy/docker/deploy.sh
+++ b/bot/deploy/docker/deploy.sh
@@ -2,7 +2,7 @@
 # Vikingbot 本地一键部署脚本
 # ~/.vikingbot 会挂载到容器的 /root/.vikingbot（bridge 首次启动时自动初始化）
 # 用法: ./deploy/docker/deploy.sh
-# 变量: CONTAINER_NAME, IMAGE_NAME, IMAGE_TAG, HOST_PORT, COMMAND, AUTO_BUILD, PLATFORM
+# 变量: CONTAINER_NAME, IMAGE_NAME, IMAGE_TAG, HOST_PORT, CONTAINER_PORT, COMMAND, AUTO_BUILD, PLATFORM
 
 set -e
 
@@ -19,11 +19,12 @@ CONTAINER_NAME=${CONTAINER_NAME:-vikingbot}
 IMAGE_NAME=${IMAGE_NAME:-vikingbot}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 HOST_PORT=${HOST_PORT:-18791}
+CONTAINER_PORT=${CONTAINER_PORT:-18791}
 COMMAND=${COMMAND:-gateway}
 AUTO_BUILD=${AUTO_BUILD:-true}
 # openviking 只有 linux/amd64 wheel，固定使用 amd64（Apple Silicon 由 Docker Desktop Rosetta 模拟）
 PLATFORM=${PLATFORM:-linux/amd64}
-VIKINGBOT_DIR="$HOME/.vikingbot"
+VIKINGBOT_DIR=${VIKINGBOT_DIR:-"$HOME/.vikingbot"}
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}  Vikingbot 本地部署${NC}"
@@ -57,30 +58,31 @@ fi
 # 3. 初始化 ~/.vikingbot 目录
 echo -e "${GREEN}[3/6]${NC} 初始化 ${VIKINGBOT_DIR}..."
 mkdir -p "$VIKINGBOT_DIR/workspace" "$VIKINGBOT_DIR/sessions" "$VIKINGBOT_DIR/sandboxes" "$VIKINGBOT_DIR/bridge"
-# 创建 OpenViking 配置文件占位符
-touch "$VIKINGBOT_DIR/ov.conf"
 echo -e "  ${GREEN}✓${NC} 目录已就绪"
 
 # 4. 检查配置文件
 echo -e "${GREEN}[4/6]${NC} 检查配置文件..."
-CONFIG_FILE="$VIKINGBOT_DIR/config.json"
-if [ ! -f "$CONFIG_FILE" ]; then
+CONFIG_FILE="$VIKINGBOT_DIR/ov.conf"
+if [ ! -s "$CONFIG_FILE" ]; then
     echo -e "  ${YELLOW}配置文件不存在，创建默认配置...${NC}"
-    cat > "$CONFIG_FILE" << 'EOF'
+    if command -v openssl &> /dev/null; then
+        GATEWAY_TOKEN=$(openssl rand -hex 32)
+    else
+        GATEWAY_TOKEN=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')
+    fi
+    cat > "$CONFIG_FILE" << EOF
 {
-  "providers": {
-    "openrouter": {
-      "apiKey": ""
+  "bot": {
+    "agents": {
+      "provider": "openrouter",
+      "model": "openrouter/anthropic/claude-3.5-sonnet",
+      "api_key": ""
+    },
+    "gateway": {
+      "host": "0.0.0.0",
+      "port": ${CONTAINER_PORT},
+      "token": "${GATEWAY_TOKEN}"
     }
-  },
-  "agents": {
-    "defaults": {
-      "model": "openrouter/anthropic/claude-3.5-sonnet"
-    }
-  },
-  "gateway": {
-    "host": "0.0.0.0",
-    "port": 18791
   }
 }
 EOF
@@ -90,7 +92,51 @@ EOF
     echo ""
     exit 1
 else
-    echo -e "  ${GREEN}✓${NC} 配置文件已存在"
+    if ! command -v python3 &> /dev/null; then
+        echo -e "${RED}错误: 验证现有配置需要 python3${NC}"
+        exit 1
+    fi
+
+    if ! CONFIG_ERROR=$(python3 - "$CONFIG_FILE" "$CONTAINER_PORT" <<'PYEOF'
+import json
+import sys
+
+config_path, expected_port = sys.argv[1], int(sys.argv[2])
+
+try:
+    with open(config_path, encoding="utf-8") as config_file:
+        config = json.load(config_file)
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"无法读取有效 JSON: {exc}")
+    raise SystemExit(1)
+
+bot = config.get("bot")
+if not isinstance(bot, dict):
+    print("缺少 bot 配置对象")
+    raise SystemExit(1)
+
+gateway = bot.get("gateway")
+if not isinstance(gateway, dict):
+    print("缺少 bot.gateway 配置对象")
+    raise SystemExit(1)
+
+port = gateway.get("port")
+if isinstance(port, bool) or not isinstance(port, int):
+    print("bot.gateway.port 必须是整数")
+    raise SystemExit(1)
+if port != expected_port:
+    print(
+        f"bot.gateway.port ({port}) 与 CONTAINER_PORT ({expected_port}) 不一致"
+    )
+    raise SystemExit(1)
+PYEOF
+    ); then
+        echo -e "${RED}错误: 配置文件无效: ${CONFIG_ERROR}${NC}"
+        echo -e "请修复 ${YELLOW}$CONFIG_FILE${NC} 后重新运行"
+        exit 1
+    fi
+
+    echo -e "  ${GREEN}✓${NC} 配置文件已存在且端口配置有效"
 fi
 
 # 5. 清理旧容器
@@ -107,7 +153,7 @@ echo -e "${GREEN}[6/6]${NC} 启动容器..."
 echo "  容器名: ${CONTAINER_NAME}"
 echo "  镜像:   ${IMAGE_NAME}:${IMAGE_TAG}"
 echo "  命令:   vikingbot ${COMMAND}"
-echo "  端口:   ${HOST_PORT} → 18791"
+echo "  端口:   ${HOST_PORT} → ${CONTAINER_PORT}"
 echo "  挂载:   ${VIKINGBOT_DIR} → /root/.vikingbot"
 echo ""
 
@@ -116,7 +162,7 @@ docker run -d \
     --restart unless-stopped \
     --platform "${PLATFORM}" \
     -v "${VIKINGBOT_DIR}:/root/.vikingbot" \
-    -p "${HOST_PORT}:18791" \
+    -p "${HOST_PORT}:${CONTAINER_PORT}" \
     -e OPENVIKING_CONFIG_FILE=/root/.vikingbot/ov.conf \
     "${IMAGE_NAME}:${IMAGE_TAG}" \
     "${COMMAND}"

--- a/bot/deploy/vke/README.md
+++ b/bot/deploy/vke/README.md
@@ -10,7 +10,7 @@
   - [2. 创建 VKE 集群](#2-创建-vke-集群)
   - [3. 创建容器镜像仓库](#3-创建容器镜像仓库)
   - [4. 创建 TOS 存储桶（可选）](#4-创建-tos-存储桶可选)
-  - [5. 获取访问密钥](#5-获取访问密钥)
+  - [5. 获取访问凭证](#5-获取访问凭证)
   - [6. 配置本地环境](#6-配置本地环境)
 - [快速部署](#快速部署)
 - [配置详解](#配置详解)
@@ -121,9 +121,9 @@
 
 ---
 
-### 5. 获取访问密钥
+### 5. 获取访问凭证
 
-#### 5.1 创建 AccessKey
+#### 5.1 创建 AccessKey（仅 TOS 存储需要）
 
 1. 鼠标悬停在右上角头像，点击 **API 访问密钥**
 2. 点击 **新建密钥**
@@ -181,11 +181,7 @@ vim ~/.config/vikingbot/vke_deploy.yaml
 填入以下信息：
 
 ```yaml
-volcengine_access_key: AKLTxxxxxxxxxx      # 你的 AccessKey ID
-volcengine_secret_key: xxxxxxxxxx          # 你的 Secret Access Key
 volcengine_region: cn-beijing               # 地域
-
-vke_cluster_id: ccxxxxxxxxxx                # 集群 ID（从控制台获取）
 
 image_registry: vikingbot-cn-beijing.cr.volces.com  # 镜像仓库地址
 image_namespace: vikingbot
@@ -200,6 +196,8 @@ registry_password: "你的火山引擎密码"
 storage_type: tos
 
 # TOS 配置（仅 storage_type=tos 时需要）
+volcengine_access_key: AKLTxxxxxxxxxx
+volcengine_secret_key: xxxxxxxxxx
 tos_bucket: vikingbot_data
 tos_path: /.vikingbot/
 tos_region: cn-beijing
@@ -227,10 +225,9 @@ deploy/vke/deploy.sh
 
 | 配置项 | 说明 | 必填 | 示例 |
 |--------|------|------|------|
-| `volcengine_access_key` | 火山引擎 AccessKey ID | 是 | `AKLTxxxx` |
-| `volcengine_secret_key` | 火山引擎 Secret Access Key | 是 | `xxxx` |
+| `volcengine_access_key` | 火山引擎 AccessKey ID | 执行 TOS 部署时 | `AKLTxxxx` |
+| `volcengine_secret_key` | 火山引擎 Secret Access Key | 执行 TOS 部署时 | `xxxx` |
 | `volcengine_region` | 地域 | 是 | `cn-beijing` |
-| `vke_cluster_id` | VKE 集群 ID | 是 | `ccxxxx` |
 | `image_registry` | 镜像仓库地址 | 是 | `vikingbot-cn-beijing.cr.volces.com` |
 | `image_namespace` | 命名空间 | 是 | `vikingbot` |
 | `image_repository` | 仓库名称 | 是 | `vikingbot` |

--- a/bot/deploy/vke/deploy.sh
+++ b/bot/deploy/vke/deploy.sh
@@ -109,20 +109,23 @@ source "$TEMP_ENV"
 
 # ── 校验必要字段 ──────────────────────────────────────────────────────────────
 # 只拒绝明确的占位符值，不误伤真实 AK（Volcengine 真实 AK 本身就以 AKLT 开头）
-PLACEHOLDERS=("AKLTxxxxxxxxxx" "xxxxxxxxxx" "ccxxxxxxxxxx")
+storage_type="${storage_type:-local}"
+PLACEHOLDERS=("AKLTxxxxxxxxxx" "xxxxxxxxxx")
 missing=()
-for field in volcengine_access_key volcengine_secret_key vke_cluster_id; do
-    val="${!field:-}"
-    rejected=false
-    if [[ -z "$val" ]]; then
-        rejected=true
-    else
-        for ph in "${PLACEHOLDERS[@]}"; do
-            [[ "$val" == "$ph" ]] && rejected=true && break
-        done
-    fi
-    $rejected && missing+=("$field")
-done
+if [[ "$SKIP_DEPLOY" == false && "$storage_type" == "tos" ]]; then
+    for field in volcengine_access_key volcengine_secret_key; do
+        val="${!field:-}"
+        rejected=false
+        if [[ -z "$val" ]]; then
+            rejected=true
+        else
+            for ph in "${PLACEHOLDERS[@]}"; do
+                [[ "$val" == "$ph" ]] && rejected=true && break
+            done
+        fi
+        $rejected && missing+=("$field")
+    done
+fi
 
 if [[ ${#missing[@]} -gt 0 ]]; then
     log_error "Config validation failed! Missing or placeholder fields:"
@@ -145,7 +148,6 @@ k8s_deployment_name="${k8s_deployment_name:-vikingbot}"
 k8s_replicas="${k8s_replicas:-1}"
 k8s_manifest_path="${k8s_manifest_path:-deploy/vke/k8s/deployment.yaml}"
 kubeconfig_path="${kubeconfig_path:-}"
-storage_type="${storage_type:-local}"
 tos_bucket="${tos_bucket:-vikingbot_data}"
 tos_path="${tos_path:-/.vikingbot/}"
 tos_region="${tos_region:-cn-beijing}"
@@ -182,7 +184,6 @@ log_info "=================================================="
 cat <<EOF
 Config:        ${CONFIG_FILE}
 Region:        ${volcengine_region:-cn-beijing}
-Cluster ID:    ${vke_cluster_id}
 Image:         ${full_image_name}
 Timestamp tag: ${use_timestamp_tag}
 Dockerfile:    ${dockerfile_path}

--- a/bot/deploy/vke/vke_deploy.example.yaml
+++ b/bot/deploy/vke/vke_deploy.example.yaml
@@ -3,23 +3,15 @@
 #
 # 详细文档请参考: deploy/vke/README.md
 
-# ── 火山引擎凭证 ──────────────────────────────────────────────────────────────
+# ── 火山引擎配置 ──────────────────────────────────────────────────────────────
 #
-# 获取方式：
+# AK/SK 仅在 storage_type=tos 且实际执行部署时需要。获取方式：
 #   1. 登录火山引擎控制台 https://console.volcengine.com/
 #   2. 右上角头像 → API 访问密钥 → 新建密钥
 #
-volcengine_access_key: AKLTxxxxxxxxxx
-volcengine_secret_key: xxxxxxxxxx
+volcengine_access_key: ""
+volcengine_secret_key: ""
 volcengine_region: cn-beijing
-
-# ── VKE 集群信息 ────────────────────────────────────────────────────────────
-#
-# 获取方式：
-#   1. 进入容器服务 VKE → 集群
-#   2. 找到你的集群，集群 ID 形如 "ccxxxxxxxxxx"
-#
-vke_cluster_id: ccxxxxxxxxxx
 
 # ── 镜像仓库配置 ──────────────────────────────────────────────────────────────
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ version: "3.8"
 #   .env example for local-only (leave unset or empty):
 #     # no .env needed — just `docker compose up -d`
 #
+#   .env example for a custom OpenViking port:
+#     OPENVIKING_SERVER_PORT=2000
+#
 #   .env example for public HTTPS:
 #     OPENVIKING_PUBLIC_BASE_URL=https://ov.your-domain.com
 #     OV_ACME_EMAIL=admin@your-domain.com
@@ -19,13 +22,14 @@ services:
     # Direct access (optional — caddy:1934 is the recommended single entry
     # point). Comment this out once Caddy is your only ingress.
     ports:
-      - "1933:1933"
+      - "${OPENVIKING_SERVER_PORT:-1933}:${OPENVIKING_SERVER_PORT:-1933}"
     volumes:
       - ~/.openviking:/app/.openviking
     environment:
       OPENVIKING_PUBLIC_BASE_URL: ${OPENVIKING_PUBLIC_BASE_URL:-}
+      OPENVIKING_SERVER_PORT: ${OPENVIKING_SERVER_PORT:-1933}
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:1933/health || exit 1"]
+      test: ["CMD", "openviking-entrypoint", "--healthcheck"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -54,6 +58,7 @@ services:
       # - caddy_config:/config
     environment:
       OPENVIKING_PUBLIC_BASE_URL: ${OPENVIKING_PUBLIC_BASE_URL:-}
+      OPENVIKING_SERVER_PORT: ${OPENVIKING_SERVER_PORT:-1933}
       OV_ACME_EMAIL: ${OV_ACME_EMAIL:-}
     depends_on:
       - openviking

--- a/docker/openviking-entrypoint.sh
+++ b/docker/openviking-entrypoint.sh
@@ -1,14 +1,32 @@
 #!/bin/sh
 set -eu
 
-SERVER_URL="http://127.0.0.1:1933"
-SERVER_HEALTH_URL="${SERVER_URL}/health"
 WITH_BOT="${OPENVIKING_WITH_BOT:-1}"
 HEALTH_MAX_ATTEMPTS="${OPENVIKING_HEALTH_MAX_ATTEMPTS:-120}"
 CONFIG_FILE="${OPENVIKING_CONFIG_FILE:-/app/.openviking/ov.conf}"
 PENDING_HEALTH_SCRIPT="/usr/local/bin/openviking-pending-health"
 SERVER_PID=""
 PENDING_PID=""
+
+resolve_server_port() {
+    SERVER_PORT="$(python - "${CONFIG_FILE}" <<'PY'
+import json
+import os
+import sys
+
+port = os.environ.get("OPENVIKING_SERVER_PORT", "").strip()
+if not port and os.path.isfile(sys.argv[1]):
+    with open(sys.argv[1], encoding="utf-8-sig") as config_file:
+        config = json.loads(os.path.expandvars(config_file.read()))
+    port = str((config.get("server") or {}).get("port", 1933)).strip()
+port = port or "1933"
+if not port.isdigit() or not 1 <= int(port) <= 65535:
+    raise SystemExit(f"invalid OpenViking server port: {port}")
+print(port)
+PY
+    )"
+    SERVER_HEALTH_URL="http://127.0.0.1:${SERVER_PORT}/health"
+}
 
 stop_pending_health() {
     if [ -n "${PENDING_PID}" ] && kill -0 "${PENDING_PID}" 2>/dev/null; then
@@ -39,8 +57,9 @@ To start OpenViking, do one of:
 While waiting, every HTTP request to this container returns a 503 JSON
 describing the problem and the fix above.
 EOF
+    resolve_server_port
     OPENVIKING_CONFIG_FILE="${CONFIG_FILE}" \
-    OPENVIKING_PENDING_PORT="1933" \
+    OPENVIKING_PENDING_PORT="${SERVER_PORT}" \
         python "${PENDING_HEALTH_SCRIPT}" &
     PENDING_PID=$!
     trap 'stop_pending_health; exit 0' INT TERM
@@ -74,6 +93,11 @@ normalize_with_bot() {
     esac
 }
 
+if [ "$#" -eq 1 ] && [ "$1" = "--healthcheck" ]; then
+    resolve_server_port
+    exec curl -fsS "${SERVER_HEALTH_URL}"
+fi
+
 if [ "$#" -gt 0 ]; then
     for arg in "$@"; do
         case "${arg}" in
@@ -92,6 +116,7 @@ fi
 
 normalize_with_bot "${WITH_BOT}"
 ensure_config
+resolve_server_port
 
 forward_signal() {
     if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
@@ -104,9 +129,9 @@ trap 'forward_signal' INT TERM
 SERVER_HOST="${OPENVIKING_SERVER_HOST:-0.0.0.0}"
 
 if [ "${WITH_BOT}" = "1" ]; then
-    openviking-server --host "${SERVER_HOST}" --with-bot &
+    openviking-server --host "${SERVER_HOST}" --port "${SERVER_PORT}" --with-bot &
 else
-    openviking-server --host "${SERVER_HOST}" &
+    openviking-server --host "${SERVER_HOST}" --port "${SERVER_PORT}" &
 fi
 SERVER_PID=$!
 

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -61,6 +61,20 @@ from openviking_cli.utils.logger import init_otel_log_handler_from_server_config
 
 logger = get_logger(__name__)
 
+WORKER_WITH_BOT_ENV = "OPENVIKING_WORKER_WITH_BOT"
+WORKER_BOT_API_URL_ENV = "OPENVIKING_WORKER_BOT_API_URL"
+
+
+def create_worker_app() -> FastAPI:
+    """Load file config and replay parent-process Bot CLI overrides."""
+    config = load_server_config()
+    with_bot = os.environ.get(WORKER_WITH_BOT_ENV)
+    if with_bot is not None:
+        config.with_bot = with_bot == "1"
+    bot_api_url = os.environ.get(WORKER_BOT_API_URL_ENV)
+    if bot_api_url is not None:
+        config.bot_api_url = bot_api_url
+    return create_app(config)
 
 
 async def _initialize_auth_plugin(

--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -16,7 +16,11 @@ from typing import Optional
 
 import uvicorn
 
-from openviking.server.app import create_app
+from openviking.server.app import (
+    WORKER_BOT_API_URL_ENV,
+    WORKER_WITH_BOT_ENV,
+    create_app,
+)
 from openviking.server.config import get_server_url_from_server_data, load_server_config
 from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.config.config_loader import resolve_config_path
@@ -160,10 +164,6 @@ def main():
     )
     parser.add_argument(
         "--bot",
-        action="store_true",
-        help="Also start vikingbot gateway after server starts",
-    )
-    parser.add_argument(
         "--with-bot",
         action="store_true",
         dest="with_bot",
@@ -290,8 +290,10 @@ def main():
             # can independently import the application.  We stash the
             # resolved config path in an env-var so that the factory can
             # pick it up (ServerConfig already reads OPENVIKING_CONFIG_FILE).
+            os.environ[WORKER_WITH_BOT_ENV] = "1" if config.with_bot else "0"
+            os.environ[WORKER_BOT_API_URL_ENV] = config.bot_api_url
             uvicorn.run(
-                "openviking.server.app:create_app",
+                "openviking.server.app:create_worker_app",
                 factory=True,
                 host=config.host,
                 port=config.port,

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -242,7 +242,7 @@ class ObservabilityConfig(BaseModel):
 class TempUploadConfig(BaseModel):
     """Temporary upload configuration."""
 
-    default_mode: str = "local"
+    default_mode: Literal["local", "shared"] = "local"
     shared_max_size_bytes: int = 512 * 1024 * 1024
     shared_prefix: str = "viking://upload"
 

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Resource endpoints for OpenViking HTTP Server."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -126,7 +126,7 @@ async def temp_upload(
     request: Request,
     file: UploadFile = File(...),
     telemetry: bool = Form(False),
-    upload_mode: str = Form("local"),
+    upload_mode: Optional[Literal["local", "shared"]] = Form(None),
     _ctx: RequestContext = Depends(get_upload_request_context),
 ):
     """Upload a temporary file for add_resource or import_ovpack.
@@ -140,10 +140,11 @@ async def temp_upload(
     dependency.
     """
     signed = getattr(request.state, "signed_upload", None)
+    effective_upload_mode = upload_mode or request.app.state.config.temp_upload.default_mode
 
     async def _upload() -> dict[str, Any]:
         store = TempUploadStore.build(request.app.state.config)
-        temp_file_id = await store.save_upload(file, upload_mode, _ctx)
+        temp_file_id = await store.save_upload(file, effective_upload_mode, _ctx)
         if signed is None:
             return {"temp_file_id": temp_file_id}
         return await ingest_temp_upload(

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -5,9 +5,11 @@
 
 import asyncio
 import zipfile
+from types import SimpleNamespace
 
 import httpx
 
+from openviking.server.routers import resources as resources_router
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 
@@ -626,6 +628,37 @@ async def test_temp_upload_success(client: httpx.AsyncClient, upload_temp_dir):
     assert "telemetry" not in body
     assert body["result"]["temp_file_id"].endswith(".md")
     assert "/" not in body["result"]["temp_file_id"]
+
+
+async def test_temp_upload_uses_configured_shared_default(monkeypatch):
+    saved_modes = []
+
+    class Store:
+        async def save_upload(self, file, upload_mode, ctx):
+            saved_modes.append(upload_mode)
+            return "shared_123"
+
+    async def run_immediately(*, fn, **kwargs):
+        return SimpleNamespace(result=await fn(), telemetry=None)
+
+    config = SimpleNamespace(temp_upload=SimpleNamespace(default_mode="shared"))
+    request = SimpleNamespace(
+        state=SimpleNamespace(signed_upload=None),
+        app=SimpleNamespace(state=SimpleNamespace(config=config)),
+    )
+    monkeypatch.setattr(resources_router.TempUploadStore, "build", lambda _: Store())
+    monkeypatch.setattr(resources_router, "run_operation", run_immediately)
+
+    response = await resources_router.temp_upload(
+        request=request,
+        file=object(),
+        telemetry=False,
+        upload_mode=None,
+        _ctx=object(),
+    )
+
+    assert saved_modes == ["shared"]
+    assert response["result"]["temp_file_id"] == "shared_123"
 
 
 async def test_temp_upload_with_telemetry_returns_summary(

--- a/tests/server/test_bootstrap.py
+++ b/tests/server/test_bootstrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from types import SimpleNamespace
 
+import openviking.server.app as app_module
 import openviking.server.bootstrap as bootstrap
 from openviking.server.config import ServerConfig
 from openviking.utils.agfs_utils import resolve_queuefs_mount_point
@@ -172,6 +173,63 @@ def test_main_enables_bot_logging_when_with_bot_comes_from_config(monkeypatch):
         "log_dir": "/tmp/bot-logs",
         "port": bootstrap.VIKINGBOT_DEFAULT_PORT,
     }
+
+
+def test_bot_alias_propagates_resolved_config_to_workers(monkeypatch):
+    config = ServerConfig(host="127.0.0.1", port=1933)
+    captured = {}
+    original_parse_args = bootstrap.argparse.ArgumentParser.parse_args
+
+    def parse_bot_alias(parser):
+        args = original_parse_args(parser, ["--bot", "--workers", "2", "--bot-port", "19000"])
+        captured["with_bot"] = args.with_bot
+        return args
+
+    monkeypatch.setattr(bootstrap.argparse.ArgumentParser, "parse_args", parse_bot_alias)
+    monkeypatch.setattr(bootstrap, "load_server_config", lambda config_path: config)
+    monkeypatch.setattr(bootstrap, "create_app", lambda config: "parent-app")
+    monkeypatch.setattr(bootstrap, "configure_uvicorn_logging", lambda: None)
+    monkeypatch.setattr(bootstrap, "_abort_if_port_in_use", lambda port, label: None)
+    monkeypatch.setattr(bootstrap, "_start_vikingbot_gateway", lambda *args, **kwargs: object())
+    monkeypatch.setattr(bootstrap, "_stop_vikingbot_gateway", lambda process: None)
+    monkeypatch.setattr(
+        OpenVikingConfigSingleton,
+        "initialize",
+        classmethod(lambda cls, config_path: None),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.ollama.detect_ollama_in_config",
+        lambda config: (False, "127.0.0.1", 11434),
+    )
+    monkeypatch.setattr(
+        bootstrap.uvicorn,
+        "run",
+        lambda app, **kwargs: captured.update({"app": app, **kwargs}),
+    )
+
+    with monkeypatch.context() as worker_env:
+        worker_env.delenv(app_module.WORKER_WITH_BOT_ENV, raising=False)
+        worker_env.delenv(app_module.WORKER_BOT_API_URL_ENV, raising=False)
+
+        bootstrap.main()
+
+        assert captured["with_bot"] is True
+        assert captured["app"] == "openviking.server.app:create_worker_app"
+        assert os.environ[app_module.WORKER_WITH_BOT_ENV] == "1"
+        assert os.environ[app_module.WORKER_BOT_API_URL_ENV] == "http://127.0.0.1:19000"
+
+
+def test_worker_factory_replays_bot_overrides(monkeypatch):
+    config = ServerConfig(with_bot=False, bot_api_url="http://from-config")
+    monkeypatch.setenv(app_module.WORKER_WITH_BOT_ENV, "1")
+    monkeypatch.setenv(app_module.WORKER_BOT_API_URL_ENV, "http://127.0.0.1:19000")
+    monkeypatch.setattr(app_module, "load_server_config", lambda: config)
+    monkeypatch.setattr(app_module, "create_app", lambda worker_config: worker_config)
+
+    worker_config = app_module.create_worker_app()
+
+    assert worker_config.with_bot is True
+    assert worker_config.bot_api_url == "http://127.0.0.1:19000"
 
 
 def test_resolve_queuefs_mount_point_defaults_to_shared():


### PR DESCRIPTION
## Summary

Consolidates the valid deployment and server fixes from #3425, #3428, #3432, #3434, and #3435.

- generate and validate the active VikingBot `ov.conf` before replacing a running container
- require VKE AK/SK credentials only for an actual TOS deployment
- make `--bot` an effective alias and preserve resolved Bot settings in Uvicorn workers
- honor `temp_upload.default_mode` when a request omits `upload_mode`
- keep server startup, health checks, Docker Compose, and Caddy on the same configured port

## Review corrections

This reconstruction also addresses the blocking issues found on the source drafts:

- existing non-empty VikingBot configs are parsed and checked for `bot.gateway.port`
- the VKE credentials documentation anchor matches its renamed heading
- worker environment overrides are scoped in tests
- custom ports propagate through Compose and the Caddy upstream, not only the entrypoint

## Validation

- `git diff --check upstream/main...HEAD`
- `bash -n bot/deploy/docker/deploy.sh bot/deploy/vke/deploy.sh`
- `sh -n docker/openviking-entrypoint.sh`
- `docker compose config`
- `OPENVIKING_SERVER_PORT=2000 docker compose config`
- Ruff check and format verification on all changed Python files
- `pytest -q --no-cov tests/server/test_bootstrap.py` — 8 passed
- `pytest -q --no-cov tests/server/test_api_resources.py::test_temp_upload_uses_configured_shared_default` — 1 passed
- manual deploy-script checks for missing Bot config, mismatched ports, and a valid config

The complete `tests/server/test_api_resources.py` file requires the local `ragfs_python` native binding; the focused new regression test passes without it.
