### PR TITLE
fix(sdk): consolidate model, client, and evaluation correctness

### DIFF
--- a/openviking/eval/ragas/pipeline.py
+++ b/openviking/eval/ragas/pipeline.py
@@ -154,15 +154,21 @@ class RAGQueryPipeline:
         contexts = []
         retrieved_uris = []
 
-        if search_result and "results" in search_result:
-            for item in search_result["results"]:
+        items = (
+            search_result.get("results", []) if isinstance(search_result, dict) else search_result
+        )
+        for item in items or []:
+            if isinstance(item, dict):
                 uri = item.get("uri", "")
                 content = (
                     item.get("content", "") or item.get("overview", "") or item.get("abstract", "")
                 )
-                if content:
-                    contexts.append(content)
-                    retrieved_uris.append(uri)
+            else:
+                uri = getattr(item, "uri", "")
+                content = getattr(item, "overview", None) or getattr(item, "abstract", "")
+            if content:
+                contexts.append(content)
+                retrieved_uris.append(uri)
 
         result = {
             "question": question,

--- a/openviking/eval/recorder/async_writer.py
+++ b/openviking/eval/recorder/async_writer.py
@@ -91,7 +91,7 @@ class AsyncRecordWriter:
         batch: list[Dict[str, Any]] = []
         last_flush = time.time()
 
-        while not self._stop_event.is_set():
+        while True:
             try:
                 record = self._queue.get(timeout=0.1)
 

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -150,7 +150,7 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        return True
+        return self._input_type == "multimodal"
 
     @staticmethod
     def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:
@@ -164,6 +164,13 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 if url:
                     contents.append({"image": str(url)})
         return contents
+
+    def _standard_input_fusion(self, contents: List[Dict[str, str]]) -> Optional[bool]:
+        if len(contents) <= 1:
+            return None
+        if self.model_name.startswith(("qwen3-vl-embedding", "qwen2.5-vl-embedding")):
+            return True
+        raise ValueError(f"{self.model_name} cannot fuse multiple multimodal input parts")
 
     def _multimodal_params(self) -> Dict[str, Any]:
         """Build parameters dict for multimodal requests, excluding None values."""
@@ -214,7 +221,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     def embed(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
         if isinstance(text, list):
-            return self.embed_content(self._to_dashscope_contents(text))
+            contents = self._to_dashscope_contents(text)
+            return self.embed_content(contents, enable_fusion=self._standard_input_fusion(contents))
 
         def _call() -> EmbedResult:
             if self._input_type == "text":
@@ -244,7 +252,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     async def embed_async(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
         if isinstance(text, list):
-            return await self.embed_content_async(self._to_dashscope_contents(text))
+            contents = self._to_dashscope_contents(text)
+            return await self.embed_content_async(
+                contents, enable_fusion=self._standard_input_fusion(contents)
+            )
 
         async def _call() -> EmbedResult:
             if self._input_type == "text":
@@ -274,7 +285,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed_content — multimodal content (text + image URLs)
     # ------------------------------------------------------------------
 
-    def embed_content(self, contents: List[Dict[str, str]]) -> EmbedResult:
+    def embed_content(
+        self, contents: List[Dict[str, str]], *, enable_fusion: Optional[bool] = None
+    ) -> EmbedResult:
         """Embed multimodal content (text + image URLs) via native DashScope API.
 
         Args:
@@ -290,6 +303,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 "input": {"contents": contents},
             }
             params = self._multimodal_params()
+            if enable_fusion is not None:
+                params["enable_fusion"] = enable_fusion
             if params:
                 body["parameters"] = params
             resp = self._httpx_client.post(self._multimodal_url, json=body)
@@ -305,7 +320,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
         except Exception as e:
             raise RuntimeError(f"DashScope content embedding failed: {e}") from e
 
-    async def embed_content_async(self, contents: List[Dict[str, str]]) -> EmbedResult:
+    async def embed_content_async(
+        self, contents: List[Dict[str, str]], *, enable_fusion: Optional[bool] = None
+    ) -> EmbedResult:
         """Async version of embed_content."""
 
         client = self._get_async_httpx_client()
@@ -316,6 +333,8 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
                 "input": {"contents": contents},
             }
             params = self._multimodal_params()
+            if enable_fusion is not None:
+                params["enable_fusion"] = enable_fusion
             if params:
                 body["parameters"] = params
             resp = await client.post(self._multimodal_url, json=body)

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -14,6 +14,7 @@ import openai
 from openviking.models.embedder.base import (
     DenseEmbedderBase,
     EmbedResult,
+    EmbeddingInput,
     truncate_and_normalize,
 )
 from openviking.telemetry import get_current_telemetry
@@ -147,6 +148,23 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # Multimodal helpers
     # ------------------------------------------------------------------
 
+    @property
+    def supports_multimodal(self) -> bool:
+        return True
+
+    @staticmethod
+    def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        contents = []
+        for part in content:
+            if part.get("type") == "text":
+                contents.append({"text": str(part.get("text", ""))})
+            elif part.get("type") == "image_url":
+                image_url = part.get("image_url")
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+                if url:
+                    contents.append({"image": str(url)})
+        return contents
+
     def _multimodal_params(self) -> Dict[str, Any]:
         """Build parameters dict for multimodal requests, excluding None values."""
         return {
@@ -194,7 +212,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed
     # ------------------------------------------------------------------
 
-    def embed(self, text: str, is_query: bool = False) -> EmbedResult:
+    def embed(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
+        if isinstance(text, list):
+            return self.embed_content(self._to_dashscope_contents(text))
+
         def _call() -> EmbedResult:
             if self._input_type == "text":
                 response = self._openai_client.embeddings.create(
@@ -221,7 +242,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     # embed_async
     # ------------------------------------------------------------------
 
-    async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+    async def embed_async(self, text: EmbeddingInput, is_query: bool = False) -> EmbedResult:
+        if isinstance(text, list):
+            return await self.embed_content_async(self._to_dashscope_contents(text))
+
         async def _call() -> EmbedResult:
             if self._input_type == "text":
                 client = self._get_async_openai_client()

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -168,8 +168,10 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
     def _standard_input_fusion(self, contents: List[Dict[str, str]]) -> Optional[bool]:
         if len(contents) <= 1:
             return None
-        if self.model_name.startswith(("qwen3-vl-embedding", "qwen2.5-vl-embedding")):
+        if self.model_name.startswith("qwen3-vl-embedding"):
             return True
+        if self.model_name.startswith("qwen2.5-vl-embedding"):
+            return None
         raise ValueError(f"{self.model_name} cannot fuse multiple multimodal input parts")
 
     def _multimodal_params(self) -> Dict[str, Any]:

--- a/openviking/models/embedder/dashscope_embedders.py
+++ b/openviking/models/embedder/dashscope_embedders.py
@@ -13,8 +13,8 @@ import openai
 
 from openviking.models.embedder.base import (
     DenseEmbedderBase,
-    EmbedResult,
     EmbeddingInput,
+    EmbedResult,
     truncate_and_normalize,
 )
 from openviking.telemetry import get_current_telemetry
@@ -150,7 +150,9 @@ class DashScopeDenseEmbedder(DenseEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        return self._input_type == "multimodal"
+        return self._input_type == "multimodal" and self.model_name.startswith(
+            ("qwen3-vl-embedding", "qwen2.5-vl-embedding")
+        )
 
     @staticmethod
     def _to_dashscope_contents(content: List[Dict[str, Any]]) -> List[Dict[str, str]]:

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -126,6 +126,7 @@ Implemented:
 | Watch management | `ListWatches`, `GetWatch`, `UpdateWatch`, `DeleteWatch`, `TriggerWatch` |
 | Filesystem and content | `List`, `Tree`, `Stat`, `Attrs`, `Mkdir`, `Remove`, `Move`, `Read`, `Abstract`, `Overview`, `Write`, `SetTags`, `Reindex` |
 | Retrieval | `Find`, `Search`, `Grep`, `Glob` |
+| Relations | `Relations`, `Link`, `Unlink` |
 | Sessions and tasks | `CreateSession`, `ListSessions`, `GetSession`, `SessionExists`, `GetSessionContext`, `GetSessionArchive`, `DeleteSession`, `AddMessage`, `BatchAddMessages`, `CommitSession`, `GetTask`, `ListTasks` |
 | Packs | `ExportOVPack`, `BackupOVPack`, `ImportOVPack`, `RestoreOVPack` |
 | System and observer | `Health`, `CheckConsistency`, `GetStatus`, `IsHealthy`, `QueueStatus`, `VikingDBStatus`, `ModelsStatus` |

--- a/sdk/go/README_CN.md
+++ b/sdk/go/README_CN.md
@@ -70,6 +70,7 @@ _, _, _ = imageResults, storedImageResults, similarPosters
 | Watch 管理 | `ListWatches`, `GetWatch`, `UpdateWatch`, `DeleteWatch`, `TriggerWatch` |
 | 文件系统和内容 | `List`, `Tree`, `Stat`, `Attrs`, `Mkdir`, `Remove`, `Move`, `Read`, `Abstract`, `Overview`, `Write`, `SetTags`, `Reindex` |
 | 检索 | `Find`, `Search`, `Grep`, `Glob` |
+| 关系 | `Relations`, `Link`, `Unlink` |
 | 会话和任务 | `CreateSession`, `ListSessions`, `GetSession`, `SessionExists`, `GetSessionContext`, `GetSessionArchive`, `DeleteSession`, `AddMessage`, `BatchAddMessages`, `CommitSession`, `GetTask`, `ListTasks` |
 | OVPack | `ExportOVPack`, `BackupOVPack`, `ImportOVPack`, `RestoreOVPack` |
 | 系统和 observer | `Health`, `CheckConsistency`, `GetStatus`, `IsHealthy`, `QueueStatus`, `VikingDBStatus`, `ModelsStatus` |

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -124,6 +124,9 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		if !ok || len(levels) != 2 || levels[0] != float64(0) || levels[1] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if tags, ok := body["tags"].([]any); !ok || len(tags) != 2 || tags[0] != "topic=docs" || tags[1] != "kind=api" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		requireBodyKeysAbsent(t, body, "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{
 			"resources": []map[string]any{
@@ -141,6 +144,7 @@ func TestFindSendsHeadersQueryAndBody(t *testing.T) {
 		Until:       "2026-06-18",
 		TimeField:   "created_at",
 		Level:       []int{0, 2},
+		Tags:        []string{"topic=docs", "kind=api"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +160,7 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -406,6 +410,9 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		if !ok || len(levels) != 1 || levels[0] != float64(2) {
 			t.Fatalf("level = %#v", body["level"])
 		}
+		if tags, ok := body["tags"].([]any); !ok || len(tags) != 1 || tags[0] != "topic=docs" {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
 		requireBodyKeysAbsent(t, body, "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
@@ -418,6 +425,7 @@ func TestSearchSendsSessionAndSearchFilters(t *testing.T) {
 		Until:     "2026-06-18",
 		TimeField: "updated_at",
 		Level:     []int{2},
+		Tags:      []string{"topic=docs"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +437,7 @@ func TestSearchOmitsSearchFiltersWhenUnset(t *testing.T) {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
 		body := readJSONBody(t, r)
-		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "agent_id", "agent_uri")
+		requireBodyKeysAbsent(t, body, "since", "until", "time_field", "level", "tags", "agent_id", "agent_uri")
 		writeOK(t, w, map[string]any{"resources": []any{}})
 	}))
 	defer closeServer()
@@ -456,6 +464,46 @@ func TestSearchSendsImageURI(t *testing.T) {
 		TargetURI: "viking://resources/images",
 		Image:     "viking://resources/images/cat.png",
 	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRelationRequests(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/relations":
+			if got := r.URL.Query().Get("uri"); got != "viking://resources/from" {
+				t.Fatalf("uri = %q", got)
+			}
+			writeOK(t, w, []map[string]any{{"uri": "viking://resources/to"}})
+		case "POST /api/v1/relations/link":
+			body := readJSONBody(t, r)
+			targets, ok := body["to_uris"].([]any)
+			if body["from_uri"] != "viking://resources/from" || body["reason"] != "related" ||
+				!ok || len(targets) != 1 || targets[0] != "viking://resources/to" {
+				t.Fatalf("link body = %#v", body)
+			}
+			writeOK(t, w, map[string]any{"linked": true})
+		case "DELETE /api/v1/relations/link":
+			body := readJSONBody(t, r)
+			if body["from_uri"] != "viking://resources/from" || body["to_uri"] != "viking://resources/to" {
+				t.Fatalf("unlink body = %#v", body)
+			}
+			writeOK(t, w, map[string]any{"unlinked": true})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer closeServer()
+
+	relations, err := client.Relations(context.Background(), "resources/from")
+	if err != nil || len(relations) != 1 {
+		t.Fatalf("relations = %#v, err = %v", relations, err)
+	}
+	if err := client.Link(context.Background(), "resources/from", []string{"resources/to"}, "related"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Unlink(context.Background(), "resources/from", "resources/to"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/sdk/go/relations.go
+++ b/sdk/go/relations.go
@@ -1,0 +1,34 @@
+package openviking
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Relations returns the relations associated with a resource.
+func (c *Client) Relations(ctx context.Context, uri string) ([]map[string]any, error) {
+	query := url.Values{"uri": []string{NormalizeURI(uri)}}
+	var result []map[string]any
+	err := c.doJSON(ctx, http.MethodGet, "/api/v1/relations", query, nil, &result)
+	return result, err
+}
+
+// Link creates relations from one resource to a string or []string target.
+func (c *Client) Link(ctx context.Context, fromURI string, toURIs any, reason string) error {
+	payload := map[string]any{
+		"from_uri": NormalizeURI(fromURI),
+		"to_uris":  normalizeTarget(toURIs),
+		"reason":   reason,
+	}
+	return c.doJSON(ctx, http.MethodPost, "/api/v1/relations/link", nil, payload, nil)
+}
+
+// Unlink removes a resource relation.
+func (c *Client) Unlink(ctx context.Context, fromURI, toURI string) error {
+	payload := map[string]any{
+		"from_uri": NormalizeURI(fromURI),
+		"to_uri":   NormalizeURI(toURI),
+	}
+	return c.doJSON(ctx, http.MethodDelete, "/api/v1/relations/link", nil, payload, nil)
+}

--- a/sdk/go/retrieval.go
+++ b/sdk/go/retrieval.go
@@ -37,6 +37,9 @@ func (c *Client) Find(ctx context.Context, queryText string, opts *FindOptions) 
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
 	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
+	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult
 	err = c.doJSON(ctx, http.MethodPost, "/api/v1/search/find", nil, payload, &result)
@@ -75,6 +78,9 @@ func (c *Client) Search(ctx context.Context, queryText string, opts *SearchOptio
 	setString(payload, "time_field", opts.TimeField)
 	if len(opts.Level) > 0 {
 		payload["level"] = opts.Level
+	}
+	if len(opts.Tags) > 0 {
+		payload["tags"] = opts.Tags
 	}
 	setAny(payload, "telemetry", opts.Telemetry)
 	var result FindResult

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -203,6 +203,7 @@ type FindOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // SearchOptions controls Search.
@@ -220,6 +221,7 @@ type SearchOptions struct {
 	Until          string
 	TimeField      string
 	Level          []int
+	Tags           []string
 }
 
 // GrepOptions controls Grep.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -98,6 +98,8 @@ print("session:", session)
 client.session("demo-session").add_message("user", "hello from sdk")
 context = client.session("demo-session").get_session_context(token_budget=4096)
 print("context:", context)
+
+client.close()
 ```
 
 ## Quick Start: Async Client

--- a/sdk/python/README_CN.md
+++ b/sdk/python/README_CN.md
@@ -98,6 +98,8 @@ print("session:", session)
 client.session("demo-session").add_message("user", "hello from sdk")
 context = client.session("demo-session").get_session_context(token_budget=4096)
 print("context:", context)
+
+client.close()
 ```
 
 ## 快速开始：异步客户端

--- a/sdk/python/openviking_sdk/_utils.py
+++ b/sdk/python/openviking_sdk/_utils.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import os
 import threading
-from contextvars import copy_context
 from typing import Any, Coroutine
 
 _worker_lock = threading.Lock()
@@ -11,17 +11,21 @@ _worker_loop: asyncio.AbstractEventLoop | None = None
 _worker_thread: threading.Thread | None = None
 
 
+async def _capture_result(coro: Coroutine[Any, Any, Any]) -> tuple[bool, Any]:
+    try:
+        return True, await coro
+    except BaseException as exc:
+        return False, exc
+
+
 def _get_worker_loop() -> asyncio.AbstractEventLoop:
     global _worker_loop, _worker_thread
-    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
-        return _worker_loop
     with _worker_lock:
-        if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
-            return _worker_loop
-        _worker_loop = asyncio.new_event_loop()
-        _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
-        _worker_thread.start()
-        atexit.register(_shutdown_worker_loop)
+        if _worker_loop is None or _worker_thread is None or not _worker_thread.is_alive():
+            _worker_loop = asyncio.new_event_loop()
+            _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
+            _worker_thread.start()
+            atexit.register(_shutdown_worker_loop)
         return _worker_loop
 
 
@@ -36,6 +40,16 @@ def _shutdown_worker_loop() -> None:
     _worker_thread = None
 
 
+def _reset_worker_after_fork() -> None:
+    global _worker_lock, _worker_loop, _worker_thread
+    _worker_lock = threading.Lock()
+    _worker_loop = _worker_thread = None
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_worker_after_fork)
+
+
 def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     try:
         running_loop = asyncio.get_running_loop()
@@ -46,5 +60,8 @@ def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     if running_loop is worker_loop:
         coro.close()
         raise RuntimeError("run_async cannot be called from its worker event loop")
-    future = copy_context().run(asyncio.run_coroutine_threadsafe, coro, worker_loop)
-    return future.result()
+    future = asyncio.run_coroutine_threadsafe(_capture_result(coro), worker_loop)
+    succeeded, value = future.result()
+    if succeeded:
+        return value
+    raise value

--- a/sdk/python/openviking_sdk/_utils.py
+++ b/sdk/python/openviking_sdk/_utils.py
@@ -1,20 +1,50 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
+import threading
+from contextvars import copy_context
 from typing import Any, Coroutine
+
+_worker_lock = threading.Lock()
+_worker_loop: asyncio.AbstractEventLoop | None = None
+_worker_thread: threading.Thread | None = None
+
+
+def _get_worker_loop() -> asyncio.AbstractEventLoop:
+    global _worker_loop, _worker_thread
+    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+        return _worker_loop
+    with _worker_lock:
+        if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+            return _worker_loop
+        _worker_loop = asyncio.new_event_loop()
+        _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
+        _worker_thread.start()
+        atexit.register(_shutdown_worker_loop)
+        return _worker_loop
+
+
+def _shutdown_worker_loop() -> None:
+    global _worker_loop, _worker_thread
+    if _worker_loop is not None and _worker_thread is not None and _worker_thread.is_alive():
+        _worker_loop.call_soon_threadsafe(_worker_loop.stop)
+        _worker_thread.join(timeout=5)
+    if _worker_loop is not None and not _worker_loop.is_running():
+        _worker_loop.close()
+    _worker_loop = None
+    _worker_thread = None
 
 
 def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     try:
-        loop = asyncio.get_event_loop()
+        running_loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        running_loop = None
 
-    if loop.is_running():
-        new_loop = asyncio.new_event_loop()
-        try:
-            return new_loop.run_until_complete(coro)
-        finally:
-            new_loop.close()
-    return loop.run_until_complete(coro)
+    worker_loop = _get_worker_loop()
+    if running_loop is worker_loop:
+        coro.close()
+        raise RuntimeError("run_async cannot be called from its worker event loop")
+    future = copy_context().run(asyncio.run_coroutine_threadsafe, coro, worker_loop)
+    return future.result()

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -343,7 +343,7 @@ class AsyncHTTPClient:
         user: Optional[str] = None,
         actor_peer_id: Optional[str] = None,
         agent_id: Optional[str] = None,
-        timeout: float = 60.0,
+        timeout: Optional[float] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         profile_enabled: Optional[bool] = None,
         upload_mode: Optional[str] = None,
@@ -1590,7 +1590,8 @@ class AsyncHTTPClient:
         return self._handle_response(response)
 
     async def admin_migrate(self, cleanup: bool = False) -> Dict[str, Any]:
-        response = await self._request("POST", "/api/v1/admin/migrate", json={"cleanup": cleanup})
+        action = "cleanup" if cleanup else "migrate"
+        response = await self._request("POST", "/api/v1/admin/migrate", json={"action": action})
         return self._handle_response(response)
 
     def get_status(self) -> Dict[str, Any]:

--- a/sdk/python/openviking_sdk/config.py
+++ b/sdk/python/openviking_sdk/config.py
@@ -186,7 +186,7 @@ def resolve_client_config(
     account: Optional[str] = None,
     user: Optional[str] = None,
     actor_peer_id: Optional[str] = None,
-    timeout: float = 60.0,
+    timeout: Optional[float] = None,
     extra_headers: Optional[dict[str, str]] = None,
     profile_enabled: Optional[bool] = None,
     upload_mode: Optional[str] = None,
@@ -211,13 +211,16 @@ def resolve_client_config(
     if resolved_actor_peer_id is None and cli_config is not None and cli_config.agent_id:
         resolved_actor_peer_id = cli_config.agent_id
 
-    resolved_timeout = timeout
-    if timeout == 60.0:
+    if timeout is not None:
+        resolved_timeout = timeout
+    else:
         env_timeout = os.getenv("OPENVIKING_TIMEOUT")
         if env_timeout:
             resolved_timeout = float(env_timeout)
         elif cli_config is not None:
             resolved_timeout = cli_config.timeout
+        else:
+            resolved_timeout = 60.0
 
     resolved_profile_enabled = bool(profile_enabled)
     if profile_enabled is None and cli_config is not None:

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -155,6 +155,19 @@ async def test_async_http_client_reindex_posts_content_reindex():
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("cleanup", "action"), [(False, "migrate"), (True, "cleanup")])
+async def test_async_http_client_admin_migrate_posts_action_payload(cleanup, action):
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    client._request = AsyncMock(return_value=object())
+    client._handle_response = lambda _response: {"status": "accepted"}
+
+    assert await client.admin_migrate(cleanup=cleanup) == {"status": "accepted"}
+    client._request.assert_awaited_once_with(
+        "POST", "/api/v1/admin/migrate", json={"action": action}
+    )
+
+
 def test_sync_http_client_reindex_forwards_to_async_client():
     client = SyncHTTPClient(url="http://localhost:1933")
     with patch.object(

--- a/sdk/python/tests/test_ovcli_config_compat.py
+++ b/sdk/python/tests/test_ovcli_config_compat.py
@@ -102,6 +102,19 @@ def test_async_http_client_explicit_arguments_override_ovcli_config(tmp_path, mo
     assert client._upload_mode == "local"
 
 
+def test_async_http_client_explicit_default_timeout_overrides_lower_priority_sources(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(json.dumps({"url": "http://config-host:1933", "timeout": 12.5}))
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("OPENVIKING_TIMEOUT", "20")
+
+    client = AsyncHTTPClient(timeout=60.0)
+
+    assert client._timeout == 60.0
+
+
 def test_async_http_client_reports_invalid_ovcli_config(tmp_path, monkeypatch):
     config_path = tmp_path / "ovcli.conf"
     config_path.write_text(json.dumps({"url": "http://localhost:1933", "timeout": "fast"}))

--- a/sdk/python/tests/test_utils.py
+++ b/sdk/python/tests/test_utils.py
@@ -1,0 +1,47 @@
+import asyncio
+import contextvars
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+from openviking_sdk import SyncHTTPClient
+from openviking_sdk._utils import run_async
+
+
+def test_run_async_reuses_worker_loop_across_contexts_and_copies_caller_context():
+    caller_thread = threading.get_ident()
+    marker = contextvars.ContextVar("marker", default="missing")
+    marker.set("caller")
+
+    async def identify_execution():
+        return threading.get_ident(), asyncio.get_running_loop(), marker.get()
+
+    first_thread, first_loop, first_context = run_async(identify_execution())
+    marker.set("updated")
+
+    async def call_from_running_loop():
+        return run_async(identify_execution())
+
+    second_thread, second_loop, second_context = asyncio.run(call_from_running_loop())
+
+    assert first_thread == second_thread != caller_thread
+    assert first_loop is second_loop
+    assert (first_context, second_context) == ("caller", "updated")
+
+
+@pytest.mark.asyncio
+async def test_sync_client_method_inside_running_loop():
+    client = SyncHTTPClient(url="http://localhost:1933")
+    client._async_client.list_sessions = AsyncMock(return_value=[{"session_id": "demo"}])
+
+    assert client.list_sessions() == [{"session_id": "demo"}]
+
+
+@pytest.mark.asyncio
+async def test_run_async_inside_running_loop_propagates_exceptions():
+    async def fail():
+        await asyncio.sleep(0)
+        raise ValueError("worker failed")
+
+    with pytest.raises(ValueError, match="worker failed"):
+        run_async(fail())

--- a/sdk/python/tests/test_utils.py
+++ b/sdk/python/tests/test_utils.py
@@ -1,47 +1,27 @@
 import asyncio
-import contextvars
-import threading
-from unittest.mock import AsyncMock
 
 import pytest
-from openviking_sdk import SyncHTTPClient
 from openviking_sdk._utils import run_async
 
 
-def test_run_async_reuses_worker_loop_across_contexts_and_copies_caller_context():
-    caller_thread = threading.get_ident()
-    marker = contextvars.ContextVar("marker", default="missing")
-    marker.set("caller")
-
+def test_run_async_reuses_worker_loop_across_sync_and_async_contexts():
     async def identify_execution():
-        return threading.get_ident(), asyncio.get_running_loop(), marker.get()
+        return asyncio.get_running_loop()
 
-    first_thread, first_loop, first_context = run_async(identify_execution())
-    marker.set("updated")
+    first_loop = run_async(identify_execution())
 
     async def call_from_running_loop():
         return run_async(identify_execution())
 
-    second_thread, second_loop, second_context = asyncio.run(call_from_running_loop())
+    second_loop = asyncio.run(call_from_running_loop())
 
-    assert first_thread == second_thread != caller_thread
     assert first_loop is second_loop
-    assert (first_context, second_context) == ("caller", "updated")
 
 
 @pytest.mark.asyncio
-async def test_sync_client_method_inside_running_loop():
-    client = SyncHTTPClient(url="http://localhost:1933")
-    client._async_client.list_sessions = AsyncMock(return_value=[{"session_id": "demo"}])
+async def test_run_async_preserves_cancelled_error():
+    async def cancel():
+        raise asyncio.CancelledError("cancelled by caller")
 
-    assert client.list_sessions() == [{"session_id": "demo"}]
-
-
-@pytest.mark.asyncio
-async def test_run_async_inside_running_loop_propagates_exceptions():
-    async def fail():
-        await asyncio.sleep(0)
-        raise ValueError("worker failed")
-
-    with pytest.raises(ValueError, match="worker failed"):
-        run_async(fail())
+    with pytest.raises(asyncio.CancelledError, match="cancelled by caller"):
+        run_async(cancel())

--- a/tests/eval/test_ragas_basic.py
+++ b/tests/eval/test_ragas_basic.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import json
+import queue
 import tempfile
+import threading
 from pathlib import Path
 
 from openviking.eval.ragas.generator import DatasetGenerator
 from openviking.eval.ragas.pipeline import RAGQueryPipeline
 from openviking.eval.ragas.types import EvalDataset, EvalSample
+from openviking.eval.recorder.async_writer import AsyncRecordWriter
+from openviking_cli.retrieve.types import ContextType, FindResult, MatchedContext
 
 
 def test_eval_types():
@@ -34,6 +38,63 @@ def test_pipeline_initialization():
     assert pipeline.config_path == "./test.conf"
     assert pipeline.data_path == "./test_data/test_ragas"
     assert pipeline._client is None
+
+
+def test_async_record_writer_drains_records_before_stop_sentinel():
+    writer = AsyncRecordWriter.__new__(AsyncRecordWriter)
+    writer._queue = queue.Queue()
+    writer._stop_event = threading.Event()
+    writer._stop_event.set()
+    writer.batch_size = 100
+    writer.flush_interval = 60
+    writer._queue.put({"id": 1})
+    writer._queue.put({"id": 2})
+    writer._queue.put(None)
+    flushed = []
+    writer._flush_batch = lambda batch: flushed.extend(batch)
+
+    writer._writer_loop()
+
+    assert flushed == [{"id": 1}, {"id": 2}]
+
+
+def test_pipeline_query_consumes_find_result_and_generates_answer():
+    class Client:
+        def search(self, **kwargs):
+            return FindResult(
+                memories=[
+                    MatchedContext(
+                        uri="viking://user/memories/profile.md",
+                        context_type=ContextType.MEMORY,
+                        overview="Profile overview",
+                    )
+                ],
+                resources=[
+                    MatchedContext(
+                        uri="viking://resources/guide.md",
+                        context_type=ContextType.RESOURCE,
+                        abstract="Guide abstract",
+                    )
+                ],
+                skills=[],
+            )
+
+    class LLM:
+        def get_completion(self, prompt):
+            return "Generated answer"
+
+    pipeline = RAGQueryPipeline()
+    pipeline._client = Client()
+    pipeline._llm = LLM()
+
+    result = pipeline.query("How does it work?")
+
+    assert result["contexts"] == ["Profile overview", "Guide abstract"]
+    assert result["retrieved_uris"] == [
+        "viking://user/memories/profile.md",
+        "viking://resources/guide.md",
+    ]
+    assert result["answer"] == "Generated answer"
 
 
 def test_question_loader():

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -13,6 +13,7 @@ from openviking.models.embedder.dashscope_embedders import (
     DashScopeDenseEmbedder,
     get_dashscope_model_default_dimension,
 )
+from openviking.models.embedder.base import embed_compat
 
 # ---------------------------------------------------------------------------
 # Dimension helper
@@ -236,6 +237,29 @@ class TestDashScopeMultimodalEmbed:
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    def test_embed_routes_standard_multimodal_parts(self, mock_httpx_class, mock_openai):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.1] * 2560}]}
+        }
+        mock_httpx_class.return_value.post.return_value = mock_response
+        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+
+        embedder.embed(
+            [
+                {"type": "text", "text": "cat"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ]
+        )
+
+        body = mock_httpx_class.return_value.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [
+            {"text": "cat"},
+            {"image": "https://example.com/cat.png"},
+        ]
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
     def test_embed_sends_multimodal_params(self, mock_httpx_class, mock_openai):
         mock_client = MagicMock()
         mock_httpx_class.return_value = mock_client
@@ -388,6 +412,25 @@ class TestDashScopeAsync:
         )
         result = await embedder.embed_async("hello multimodal async")
         assert result.dense_vector == [0.4] * 768
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    @pytest.mark.anyio
+    async def test_embed_compat_preserves_image(self, mock_httpx, mock_openai):
+        response = MagicMock()
+        response.json.return_value = {
+            "output": {"embeddings": [{"embedding": [0.2] * 2560}]}
+        }
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+        embedder._get_async_httpx_client = MagicMock(return_value=client)
+        parts = [{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}]
+
+        await embed_compat(embedder, parts, is_query=True)
+
+        body = client.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [{"image": "https://example.com/cat.png"}]
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -239,13 +239,19 @@ class TestDashScopeMultimodalEmbed:
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
-    def test_embed_routes_standard_multimodal_parts(self, mock_httpx_class, mock_openai):
+    @pytest.mark.parametrize(
+        ("model_name", "expected_fusion"),
+        [("qwen3-vl-embedding", True), ("qwen2.5-vl-embedding", None)],
+    )
+    def test_embed_routes_standard_multimodal_parts(
+        self, mock_httpx_class, mock_openai, model_name, expected_fusion
+    ):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "output": {"embeddings": [{"embedding": [0.1] * 2560}]}
         }
         mock_httpx_class.return_value.post.return_value = mock_response
-        embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
+        embedder = DashScopeDenseEmbedder(model_name, api_key="sk-test")
 
         embedder.embed(
             [
@@ -259,7 +265,7 @@ class TestDashScopeMultimodalEmbed:
             {"text": "cat"},
             {"image": "https://example.com/cat.png"},
         ]
-        assert body["parameters"]["enable_fusion"] is True
+        assert body["parameters"].get("enable_fusion") is expected_fusion
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -80,6 +80,8 @@ class TestDashScopeInit:
         assert embedder.api_key == "sk-test"
         assert embedder.api_base == "https://dashscope.aliyuncs.com"
         assert embedder.provider == "dashscope"
+        assert embedder.supports_multimodal is False
+        assert embedder.prepare_embedding_input([{"type": "text", "text": "cat"}]) == "cat"
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
@@ -257,6 +259,7 @@ class TestDashScopeMultimodalEmbed:
             {"text": "cat"},
             {"image": "https://example.com/cat.png"},
         ]
+        assert body["parameters"]["enable_fusion"] is True
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")

--- a/tests/unit/test_dashscope_embedder.py
+++ b/tests/unit/test_dashscope_embedder.py
@@ -9,11 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from openviking.models.embedder.base import embed_compat
 from openviking.models.embedder.dashscope_embedders import (
     DashScopeDenseEmbedder,
     get_dashscope_model_default_dimension,
 )
-from openviking.models.embedder.base import embed_compat
 
 # ---------------------------------------------------------------------------
 # Dimension helper
@@ -247,9 +247,7 @@ class TestDashScopeMultimodalEmbed:
         self, mock_httpx_class, mock_openai, model_name, expected_fusion
     ):
         mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "output": {"embeddings": [{"embedding": [0.1] * 2560}]}
-        }
+        mock_response.json.return_value = {"output": {"embeddings": [{"embedding": [0.1] * 2560}]}}
         mock_httpx_class.return_value.post.return_value = mock_response
         embedder = DashScopeDenseEmbedder(model_name, api_key="sk-test")
 
@@ -427,9 +425,7 @@ class TestDashScopeAsync:
     @pytest.mark.anyio
     async def test_embed_compat_preserves_image(self, mock_httpx, mock_openai):
         response = MagicMock()
-        response.json.return_value = {
-            "output": {"embeddings": [{"embedding": [0.2] * 2560}]}
-        }
+        response.json.return_value = {"output": {"embeddings": [{"embedding": [0.2] * 2560}]}}
         client = MagicMock()
         client.post = AsyncMock(return_value=response)
         embedder = DashScopeDenseEmbedder("qwen3-vl-embedding", api_key="sk-test")
@@ -440,6 +436,29 @@ class TestDashScopeAsync:
 
         body = client.post.call_args.kwargs["json"]
         assert body["input"]["contents"] == [{"image": "https://example.com/cat.png"}]
+
+    @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
+    @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
+    @pytest.mark.anyio
+    async def test_embed_compat_downgrades_non_fusing_multimodal_model(
+        self, mock_httpx, mock_openai
+    ):
+        response = MagicMock()
+        response.json.return_value = {"output": {"embeddings": [{"embedding": [0.2] * 768}]}}
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        embedder = DashScopeDenseEmbedder("tongyi-embedding-vision-flash", api_key="sk-test")
+        embedder._get_async_httpx_client = MagicMock(return_value=client)
+        parts = [
+            {"type": "text", "text": "cat"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+
+        await embed_compat(embedder, parts, is_query=False)
+
+        assert embedder.supports_multimodal is False
+        body = client.post.call_args.kwargs["json"]
+        assert body["input"]["contents"] == [{"text": "cat"}]
 
     @patch("openviking.models.embedder.dashscope_embedders.openai.OpenAI")
     @patch("openviking.models.embedder.dashscope_embedders.httpx.Client")
@@ -498,6 +517,7 @@ class TestDashScopeErrors:
         with pytest.raises(RuntimeError, match="DashScope embedding failed") as exc_info:
             embedder.embed("hello")
         assert "503" in str(exc_info.value.__cause__)
+
 
 # ---------------------------------------------------------------------------
 # Multimodal params builder


### PR DESCRIPTION
## Summary

Consolidates the valid provider, SDK, and evaluation fixes from #3400, #3404, #3409, #3420, and #3431.

- route DashScope multimodal inputs through the native embedding API without regressing Tongyi models
- make Python SDK quickstarts runnable, send the correct admin migration action, and preserve explicit timeout precedence
- flush queued evaluation records and adapt the RAGAS pipeline to real `FindResult` values
- support Python sync SDK calls from an already-running event loop with cancellation and fork safety
- add Go SDK parity for tag filters and relations

## Validation

- `git diff --check upstream/main...HEAD`
- Ruff check on all changed Python files
- Ruff format check on nine changed files; the two excluded SDK files have unrelated formatter drift already present on `main`
- DashScope and evaluation tests: 47 passed
- focused Python SDK tests: 48 passed
- Go SDK: `go test ./...`, `go vet ./...`, and `go build ./...` passed

One Python SDK test, `test_glob_normalizes_scope_uri`, still fails because current `main` sends the newer default `node_limit=256` while its assertion expects the older payload. The same failure reproduces unchanged on the upstream baseline and is unrelated to this consolidation.
