### PR TITLE
feat: add resource api support set tags

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -575,7 +575,8 @@ async def add_resource(
         parent: Parent URI under viking://resources/ for remote imports. Mutually exclusive
             with ``to``.
         args: Parser-specific options, e.g. {"feishu_access_token": "..."} for Feishu imports,
-            or {"site": true} for whole-site ingestion.
+            {"site": true} for whole-site ingestion, or {"search_tags": ["team=infra"]} to
+            stamp "k=v" retrieval tags on every record indexed for this resource.
     """
     from openviking.server.local_input_guard import require_remote_resource_source
 

--- a/openviking/server/routers/resources.py
+++ b/openviking/server/routers/resources.py
@@ -48,6 +48,9 @@ class AddResourceRequest(BaseModel):
         exclude: Glob pattern for files to exclude during parsing.
         directly_upload_media: Whether to directly upload media files. Default is True.
         preserve_structure: Whether to preserve directory structure when adding directories.
+        search_tags: Explicit "k=v" retrieval tags applied to every vector record
+            built for this resource, equivalent to calling set_tags after indexing
+            completes. Persisted beside the resource so rebuilds keep the tags.
         args: Parser-specific import options. For Feishu one-time user-token imports,
             pass {"feishu_access_token": "..."}. For Feishu user-token watches,
             pass {"feishu_access_token": "...", "feishu_refresh_token": "..."}.
@@ -82,6 +85,7 @@ class AddResourceRequest(BaseModel):
     exclude: Optional[str] = None
     directly_upload_media: bool = True
     preserve_structure: Optional[bool] = None
+    search_tags: Optional[list[str]] = None
     args: Dict[str, Any] = Field(default_factory=dict)
     telemetry: TelemetryRequest = False
     watch_interval: float = 0
@@ -207,6 +211,8 @@ async def add_resource(
         "directly_upload_media": request.directly_upload_media,
         "watch_interval": request.watch_interval,
     }
+    if request.search_tags is not None:
+        kwargs["search_tags"] = request.search_tags
     # Connector routing needs to distinguish an omitted create_parent from an
     # explicit false.  Standard imports still observe false when the field is
     # omitted because ResourceService reads it with kwargs.get(..., False).

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -1645,6 +1645,14 @@ class ReindexExecutor:
             and "search_tags" not in merged_meta
         ):
             merged_meta["search_tags"] = existing.get("search_tags")
+        if "search_tags" not in merged_meta:
+            # No live record to inherit from (e.g. rebuild after a collection
+            # drop): fall back to the add-time sidecar.
+            from openviking.storage.search_tags_sidecar import load_search_tags_for_uri
+
+            sidecar_tags = await load_search_tags_for_uri(uri, ctx=owner_ctx)
+            if sidecar_tags:
+                merged_meta["search_tags"] = sidecar_tags
 
         context = Context(
             uri=uri,
@@ -1666,6 +1674,10 @@ class ReindexExecutor:
                 code="FAILED_PRECONDITION",
                 details={"uri": uri},
             )
+        if merged_meta.get("search_tags") is not None:
+            # ``meta`` is not a collection schema field, so nested tags are
+            # dropped at upsert; stamp the top-level record field explicitly.
+            msg.context_data["search_tags"] = merged_meta["search_tags"]
         wait_tracker = get_request_wait_tracker()
         wait_tracker.register_embedding_root(msg.telemetry_id, msg.id)
         enqueued = await service.vikingdb_manager.enqueue_embedding_msg(msg)

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -822,7 +822,10 @@ class ResourceService:
             enforce_public_remote_targets: When True, reject non-public remote hosts and
                 validate each outbound HTTP request URL during fetch.
             args: Parser/accessor-specific options forwarded to the processing chain.
-            **kwargs: Extra options forwarded to the parser chain
+            **kwargs: Extra options forwarded to the parser chain. ``search_tags``
+                (list of "k=v" strings) stamps explicit retrieval tags on every
+                vector record built for the resource and persists them in a
+                sidecar next to the resource root.
 
         Returns:
             Processing result containing 'root_uri' and other metadata
@@ -834,6 +837,17 @@ class ResourceService:
         self._ensure_initialized()
         normalized_args = self._normalize_add_resource_args(args, watch_interval=watch_interval)
         kwargs.update(normalized_args.processor_kwargs)
+        raw_search_tags = kwargs.get("search_tags")
+        if raw_search_tags is not None:
+            from openviking.utils.tags import normalize_search_tags
+
+            if isinstance(raw_search_tags, str) or not isinstance(raw_search_tags, (list, tuple)):
+                raise InvalidArgumentError("search_tags must be a list of 'k=v' strings")
+            normalized_tags = normalize_search_tags(raw_search_tags)
+            if normalized_tags:
+                kwargs["search_tags"] = normalized_tags
+            else:
+                kwargs.pop("search_tags")
         if watch_interval > 0 and kwargs.get("temp_file_id"):
             # Fail fast, before any ingestion: an uploaded source is a one-time
             # snapshot, so a watch on it can never observe the live source (see the
@@ -1089,6 +1103,8 @@ class ResourceService:
                     processor_args["parser_backend"] = "understanding"
                     if resolved_extension:
                         processor_args["resolved_extension"] = resolved_extension
+                    if kwargs.get("search_tags"):
+                        processor_args["search_tags"] = list(kwargs["search_tags"])
 
                     lock_handoff = lock_lease.to_handoff()
                     msg = AddResourceMsg(
@@ -1554,6 +1570,8 @@ class ResourceService:
             unsupported.append("directly_upload_media=false")
         if kwargs.get("source_name"):
             unsupported.append("source_name")
+        if kwargs.get("search_tags"):
+            unsupported.append("search_tags (Connector imports cannot apply retrieval tags yet)")
         supported_args = CONNECTOR_SUPPORTED_ARGS.get(
             add_type, frozenset()
         ) | CONNECTOR_CREDENTIAL_ARGS.get(add_type, frozenset())

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1542,9 +1542,16 @@ class SemanticProcessor(DequeueHandlerBase):
     ) -> None:
         """Create directory Context and enqueue to EmbeddingQueue."""
 
+        from openviking.storage.search_tags_sidecar import load_search_tags_for_uri
         from openviking.utils.embedding_utils import vectorize_directory_meta
 
         active_ctx = ctx or self._default_ctx
+        sidecar_tags = await load_search_tags_for_uri(uri, ctx=active_ctx)
+        scalar_overrides = (
+            {0: {"search_tags": sidecar_tags}, 1: {"search_tags": sidecar_tags}}
+            if sidecar_tags
+            else None
+        )
         await vectorize_directory_meta(
             uri=uri,
             abstract=abstract,
@@ -1552,6 +1559,7 @@ class SemanticProcessor(DequeueHandlerBase):
             context_type=context_type,
             ctx=active_ctx,
             semantic_msg_id=semantic_msg_id,
+            scalar_overrides=scalar_overrides,
         )
 
     async def _vectorize_single_file(
@@ -1566,9 +1574,11 @@ class SemanticProcessor(DequeueHandlerBase):
         preserve_existing_created_at: bool = False,
     ) -> None:
         """Vectorize a single file using its content or summary."""
+        from openviking.storage.search_tags_sidecar import load_search_tags_for_uri
         from openviking.utils.embedding_utils import vectorize_file
 
         active_ctx = ctx or self._default_ctx
+        sidecar_tags = await load_search_tags_for_uri(file_path, ctx=active_ctx)
         await vectorize_file(
             file_path=file_path,
             summary_dict=summary_dict,
@@ -1578,4 +1588,5 @@ class SemanticProcessor(DequeueHandlerBase):
             semantic_msg_id=semantic_msg_id,
             use_summary=use_summary,
             preserve_existing_created_at=preserve_existing_created_at,
+            scalar_override={"search_tags": sidecar_tags} if sidecar_tags else None,
         )

--- a/openviking/storage/search_tags_sidecar.py
+++ b/openviking/storage/search_tags_sidecar.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Persist add-time search tags beside a resource root.
+
+The sidecar is the durable source for ``search_tags`` supplied at
+``add_resource`` time: vector records are rebuildable artifacts, so tags stored
+only on them would vanish on a collection rebuild. Vector build paths
+(semantic processing and reindex) read the sidecar and stamp its tags onto
+every record created under the resource root.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from openviking.server.identity import RequestContext
+from openviking.utils.tags import normalize_search_tags
+from openviking_cli.utils import get_logger
+from openviking_cli.utils.uri import VikingURI
+
+logger = get_logger(__name__)
+
+SEARCH_TAGS_SIDECAR_FILENAME = ".search_tags.json"
+
+
+def resource_root_uri_for(uri: str) -> Optional[str]:
+    """Return the resource root that owns ``uri``, or None outside resources.
+
+    Mirrors the root resolution in ContentWriteCoordinator._resolve_root_uri:
+    ``viking://resources/<name>/...`` roots at ``viking://resources/<name>``,
+    ``viking://user/<u>/resources/<name>/...`` at its resource directory.
+    Memory, skill, and temp URIs have no resource root and return None, as
+    does the bare resources collection root itself.
+    """
+    try:
+        parsed = VikingURI(uri)
+        parts = [part for part in parsed.full_path.split("/") if part]
+    except Exception:
+        return None
+    if not parts:
+        return None
+    if parts[0] == "resources":
+        if len(parts) < 2:
+            return None
+        return VikingURI.build("resources", parts[1])
+    if parts[0] == "user" and "resources" in parts:
+        resources_idx = parts.index("resources")
+        if len(parts) <= resources_idx + 1:
+            return None
+        return VikingURI.build(*parts[: resources_idx + 2])
+    return None
+
+
+def sidecar_uri_for_root(root_uri: str) -> str:
+    return f"{root_uri.rstrip('/')}/{SEARCH_TAGS_SIDECAR_FILENAME}"
+
+
+async def write_search_tags_sidecar(
+    root_uri: str,
+    tags: list[str],
+    *,
+    ctx: RequestContext,
+    viking_fs: Any = None,
+    lock_handle: Any = None,
+) -> None:
+    """Write normalized add-time tags to ``<root>/.search_tags.json``."""
+    if viking_fs is None:
+        from openviking.storage import get_viking_fs
+
+        viking_fs = get_viking_fs()
+    content = json.dumps({"search_tags": list(tags)}, ensure_ascii=False, indent=2)
+    await viking_fs.write_file(
+        sidecar_uri_for_root(root_uri),
+        content,
+        ctx=ctx,
+        lock_handle=lock_handle,
+    )
+
+
+async def load_search_tags_for_uri(
+    uri: str,
+    *,
+    ctx: RequestContext,
+    viking_fs: Any = None,
+) -> Optional[list[str]]:
+    """Load the sidecar tags that apply to ``uri``, or None when absent.
+
+    Any read or parse failure returns None: sidecar tags must never block
+    vector building, and a missing sidecar is the common case.
+    """
+    root_uri = resource_root_uri_for(uri)
+    if not root_uri:
+        return None
+    if viking_fs is None:
+        from openviking.storage import get_viking_fs
+
+        viking_fs = get_viking_fs()
+    sidecar_uri = sidecar_uri_for_root(root_uri)
+    try:
+        if not await viking_fs.exists(sidecar_uri, ctx=ctx):
+            return None
+        content = await viking_fs.read_file(sidecar_uri, ctx=ctx)
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        payload = json.loads(content or "{}")
+        tags = normalize_search_tags(payload.get("search_tags"))
+        return tags or None
+    except Exception as exc:
+        logger.debug("Failed to load search tags sidecar %s: %s", sidecar_uri, exc)
+        return None

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -49,6 +49,7 @@ _PORTABLE_SCALAR_FIELDS = frozenset(
         "name",
         "description",
         "tags",
+        "search_tags",
         "abstract",
     }
 )

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -399,6 +399,7 @@ class ResourceProcessor:
                 "source_committed": source_committed,
                 "target_preexisting": target_preexisting,
                 "is_code_repo": parse_result.source_format == "repository",
+                "search_tags": kwargs.get("search_tags") or None,
             }
             if defer_post_processing:
                 result["_post_process"] = prepared
@@ -440,6 +441,33 @@ class ResourceProcessor:
         build_index = bool(kwargs.get("build_index", True))
         should_summarize = summarize or build_index
         result: Dict[str, Any] = {"status": "success", "root_uri": root_uri}
+
+        # Persist add-time search tags before any semantic work is enqueued, so
+        # the vector build always finds the sidecar when it stamps records.
+        search_tags = prepared.get("search_tags") or kwargs.get("search_tags")
+        if search_tags and root_uri:
+            from openviking.storage.search_tags_sidecar import (
+                resource_root_uri_for,
+                write_search_tags_sidecar,
+            )
+
+            if resource_root_uri_for(root_uri) == root_uri.rstrip("/"):
+                try:
+                    await write_search_tags_sidecar(
+                        root_uri,
+                        list(search_tags),
+                        ctx=ctx,
+                        lock_handle=getattr(resource_lock, "handle", None),
+                    )
+                except Exception as exc:
+                    logger.error("Failed to persist search_tags for %s: %s", root_uri, exc)
+                    result.setdefault("warnings", []).append(
+                        f"Failed to persist search_tags: {exc}"
+                    )
+            else:
+                result.setdefault("warnings", []).append(
+                    "search_tags skipped: import target is not a single resource root"
+                )
 
         if should_summarize:
             stage_start = time.perf_counter()

--- a/tests/unit/test_search_tags_sidecar.py
+++ b/tests/unit/test_search_tags_sidecar.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import json
+
+import pytest
+
+from openviking.service.resource_service import ResourceService
+from openviking.storage.search_tags_sidecar import (
+    SEARCH_TAGS_SIDECAR_FILENAME,
+    load_search_tags_for_uri,
+    resource_root_uri_for,
+    sidecar_uri_for_root,
+    write_search_tags_sidecar,
+)
+from openviking.utils.embedding_utils import _apply_scalar_overrides
+
+
+class _FakeVikingFS:
+    def __init__(self):
+        self.files: dict[str, bytes] = {}
+
+    async def write_file(self, uri, content, ctx=None, lock_handle=None):
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.files[uri] = content
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.files
+
+    async def read_file(self, uri, ctx=None):
+        return self.files[uri].decode("utf-8")
+
+
+class _FakeEmbeddingMsg:
+    def __init__(self):
+        self.context_data = {}
+
+
+def test_resource_root_for_public_resource_paths():
+    assert (
+        resource_root_uri_for("viking://resources/myrepo/docs/a.md")
+        == "viking://resources/myrepo"
+    )
+    assert resource_root_uri_for("viking://resources/myrepo") == "viking://resources/myrepo"
+
+
+def test_resource_root_for_user_scoped_resource_paths():
+    assert (
+        resource_root_uri_for("viking://user/alice/resources/notes/a.md")
+        == "viking://user/alice/resources/notes"
+    )
+
+
+def test_resource_root_rejects_non_resource_paths():
+    assert resource_root_uri_for("viking://resources") is None
+    assert resource_root_uri_for("viking://user/alice/memories/profile.md") is None
+    assert resource_root_uri_for("viking://temp/abc/file.md") is None
+
+
+@pytest.mark.asyncio
+async def test_sidecar_write_load_roundtrip():
+    fs = _FakeVikingFS()
+    root = "viking://resources/myrepo"
+    await write_search_tags_sidecar(root, ["team=infra", "env=prod"], ctx=None, viking_fs=fs)
+
+    assert sidecar_uri_for_root(root) == f"{root}/{SEARCH_TAGS_SIDECAR_FILENAME}"
+    tags = await load_search_tags_for_uri(f"{root}/docs/a.md", ctx=None, viking_fs=fs)
+    assert tags == ["team=infra", "env=prod"]
+
+
+@pytest.mark.asyncio
+async def test_sidecar_load_missing_returns_none():
+    fs = _FakeVikingFS()
+    tags = await load_search_tags_for_uri(
+        "viking://resources/myrepo/docs/a.md", ctx=None, viking_fs=fs
+    )
+    assert tags is None
+
+
+@pytest.mark.asyncio
+async def test_sidecar_load_tolerates_corrupt_content():
+    fs = _FakeVikingFS()
+    root = "viking://resources/myrepo"
+    fs.files[sidecar_uri_for_root(root)] = b"not json"
+    assert await load_search_tags_for_uri(f"{root}/a.md", ctx=None, viking_fs=fs) is None
+
+    fs.files[sidecar_uri_for_root(root)] = json.dumps({"search_tags": ["notkv"]}).encode()
+    assert await load_search_tags_for_uri(f"{root}/a.md", ctx=None, viking_fs=fs) is None
+
+
+@pytest.mark.asyncio
+async def test_sidecar_load_normalizes_tags():
+    fs = _FakeVikingFS()
+    root = "viking://resources/myrepo"
+    fs.files[sidecar_uri_for_root(root)] = json.dumps(
+        {"search_tags": ["Team=Infra", " team=infra "]}
+    ).encode()
+    assert await load_search_tags_for_uri(f"{root}/a.md", ctx=None, viking_fs=fs) == [
+        "team=infra"
+    ]
+
+
+def test_scalar_override_carries_search_tags():
+    msg = _FakeEmbeddingMsg()
+    _apply_scalar_overrides(msg, {"search_tags": ["team=infra"], "ignored": "x"})
+    assert msg.context_data == {"search_tags": ["team=infra"]}
+
+
+def test_connector_rejects_search_tags():
+    unsupported = ResourceService._unsupported_connector_params(
+        add_type="tos",
+        wait=False,
+        instruction="",
+        build_index=True,
+        summarize=False,
+        watch_interval=0,
+        connector_args={},
+        kwargs={"search_tags": ["team=infra"]},
+        to="viking://resources/x",
+        parent=None,
+    )
+    assert any("search_tags" in item for item in unsupported)
+
+
+def test_connector_allows_requests_without_search_tags():
+    unsupported = ResourceService._unsupported_connector_params(
+        add_type="tos",
+        wait=False,
+        instruction="",
+        build_index=True,
+        summarize=False,
+        watch_interval=0,
+        connector_args={},
+        kwargs={},
+        to="viking://resources/x",
+        parent=None,
+    )
+    assert not any("search_tags" in item for item in unsupported)


### PR DESCRIPTION
## Description

Add a `search_tags` parameter to `add_resource` so explicit `"k=v"` retrieval tags are applied to every vector record built for the resource at ingestion time — equivalent to calling `set_tags` after indexing completes, but without the second call and without the race against asynchronous index building (`set_tags` only updates records that already exist).

Tags are persisted in a hidden `.search_tags.json` sidecar next to the resource root, so they survive re-summarization, refresh, and full index rebuilds (including rebuilds after a collection drop, where record-level inheritance has nothing to inherit from).

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)                                                                                                                           
## Changes Made                                                                                                                                                                           
- **HTTP API**: `AddResourceRequest` accepts `search_tags: list[str]` (strict `"k=v"` format). Tags are normalized and validated early in `ResourceService._submit_resource_ingestion`, somalformed input fails the request instead of a background job. The MCP `add_resome via `args={"search_tags": [...]}` (documented in the tool docstring).
- **New module** `openviking/storage/search_tags_sidecar.py`: resource-root resolution for a URI plus write/load helpers for the `<root>/.search_tags.json` sidecar. Load failures always degrade to "no tags" and never block vector building. Dot-files are already skip so the sidecar itself is never parsed or vectorized.
- **Ingestion threading**: tags travel through all ingestion routes — inline processing, the deferred post-processing job (`prepared` payload), the durable git import queue, and the understanding-API queue (`AddResourceMsg.args`). `finish_prepared_resource` writsemantic work is enqueued. Watch tasks persist the tags in their processorkwargs, so scheduled refreshes reapply them.
- **Vector build stamping**: the semantic processor loads sidecar tags and stampy records and L2 file records through the existing `scalar_override` mechanism(`search_tags` added to `_PORTABLE_SCALAR_FIELDS` in `embedding_utils`).
- **Reindex**: `ReindexExecutor._upsert_context` falls back to the sidecar when  inherit tags from, and stamps the top-level `search_tags` record fieldexplicitly (nested `meta` entries are dropped by schema filtering at upsert).
- **Connector routing**: `search_tags` joins the unsupported-parameter degradati fall back to the native import pipeline (which supports tags), whileConnector-only sources (tos) reject with a clear error instead of silently dropping the tags.

## Testing

- New unit tests in `tests/unit/test_search_tags_sidecar.py` (10 cases): resource-root resolution across public/user/memory/temp URIs, sidecar write/load roundtrip, tolerance of
missing/corrupt sidecar content, tag normalization on load, `scalar_override` cand Connector unsupported-parameter detection.
- Ran the full `tests/unit` suite plus targeted suites (`test_search_tags_filter.py`, `test_vectorize_file_strategy.py`, `tests/connector/test_client.py`). All tests in the areas touched
by this change pass; the only failures observed are pre-existing ones in unrelatthis PR.



  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have tested this on the following platforms:
    - [ ] Linux
    - [x] macOS
    - [ ] Windows



## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- `set_tags` semantics are unchanged. Tags supplied at `add_resource` time act athe resource; tags changed later via `set_tags` are not written back to thesidecar yet, so a subsequent refresh or rebuild restores the add-time tags. Sidecar write-back from `set_tags` is planned as a follow-up.
- Importing multiple resources directly under the bare `viking://resources` root-level sidecar would tag the whole collection) and surfaces a warning in theresult instead.
- Records re-embedded without tag overrides keep their existing `search_tags` vipartial update, so this change does not disturb tags on resources that never pass `search_tags`.