### PR TITLE
fix(memory): keep items whose required identity fields are missing

### DIFF
--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -362,6 +362,88 @@ def parse_value_with_tolerance(value, annotation):
         raise e
 
 
+# Conventional values for required identity fields that models routinely omit.
+# Only applied when the field is absent or empty - never overwrites real data.
+_REQUIRED_FIELD_DEFAULTS = {
+    "user": "default",
+    "category": "general",
+}
+
+# New memory items must carry a page_id; the extraction prompt reserves
+# values >= 100 for newly created pages.
+_MIN_GENERATED_PAGE_ID = 100
+
+
+def _fill_required_identity_defaults(parsed_data: Any, model_class: Any) -> None:
+    """Fill well-known missing REQUIRED fields on memory items, in place.
+
+    Models routinely omit boilerplate identity fields (``user`` on preferences,
+    ``category`` on entities, ``page_id`` on newly created items) while getting
+    the actual memory content right.  Pydantic then rejects the item, and the
+    per-field tolerance fallback silently drops the whole list while still
+    reporting ``error=None`` - the extraction reports success and stores nothing.
+
+    Supplying the conventional defaults keeps the model's real content instead
+    of discarding it.  Fields that already carry a value are never touched.
+    """
+    if not isinstance(parsed_data, dict) or model_class is None:
+        return
+    try:
+        schema = model_class.model_json_schema()
+    except Exception:
+        return
+    defs = schema.get("$defs") or {}
+    props = schema.get("properties") or {}
+
+    # First pass: collect all existing page_id values across all operation lists.
+    # This ensures generated IDs never collide with valid IDs already in the response.
+    used_page_ids: set[int] = set()
+    for field, spec in props.items():
+        value = parsed_data.get(field)
+        if not isinstance(value, list):
+            continue
+        ref = ((spec.get("items") or {}).get("$ref") or "").rsplit("/", 1)[-1]
+        item_required = set((defs.get(ref) or {}).get("required") or [])
+        if "page_id" not in item_required:
+            continue
+        for item in value:
+            if isinstance(item, dict) and item.get("page_id") not in (None, ""):
+                try:
+                    used_page_ids.add(int(item["page_id"]))
+                except (ValueError, TypeError):
+                    pass
+
+    # Second pass: fill missing identity fields.
+    # Start next_page_id from _MIN_GENERATED_PAGE_ID, skipping any already used.
+    next_page_id = _MIN_GENERATED_PAGE_ID
+    while next_page_id in used_page_ids:
+        next_page_id += 1
+
+    for field, spec in props.items():
+        value = parsed_data.get(field)
+        if not isinstance(value, list):
+            continue
+        ref = ((spec.get("items") or {}).get("$ref") or "").rsplit("/", 1)[-1]
+        required = set((defs.get(ref) or {}).get("required") or [])
+        if not required:
+            continue
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            for name in required:
+                if item.get(name) not in (None, ""):
+                    continue
+                if name == "page_id":
+                    # Find the next unused page_id to avoid collisions
+                    while next_page_id in used_page_ids:
+                        next_page_id += 1
+                    item[name] = next_page_id
+                    used_page_ids.add(next_page_id)
+                    next_page_id += 1
+                elif name in _REQUIRED_FIELD_DEFAULTS:
+                    item[name] = _REQUIRED_FIELD_DEFAULTS[name]
+
+
 def parse_json_with_stability(
     content: str,
     model_class: Optional[Type] = None,
@@ -439,6 +521,11 @@ def parse_json_with_stability(
     # If no model class, return the raw dict
     if model_class is None:
         return parsed_data, None
+
+    # Supply conventional values for required identity fields the model omitted;
+    # otherwise a single absent boilerplate field makes pydantic reject the item
+    # and the per-field tolerance below silently empties the whole list.
+    _fill_required_identity_defaults(parsed_data, model_class)
 
     # Layer 4 & 5: Validate with model
     try:

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -453,3 +453,129 @@ Content"""
         assert result["tool_name"] == "test"
         assert result["value"] == 42
         assert result["content"] == "Content"
+
+
+class TestRequiredIdentityDefaults:
+    """Regression tests: a missing required field must not empty the whole list.
+
+    Models often get the memory content right while omitting a boilerplate
+    identity field (``user``, ``category``, ``page_id``).  Before the fix,
+    pydantic rejected such an item and the per-field tolerance fallback
+    returned an empty list together with ``error=None`` - extraction reported
+    success and stored nothing.
+    """
+
+    class _PreferenceItem(BaseModel):
+        page_id: int
+        user: str
+        topic: str
+        content: Optional[str] = None
+
+    class _EntityItem(BaseModel):
+        page_id: int
+        category: str
+        name: str
+        content: Optional[str] = None
+
+    class _Operations(BaseModel):
+        preferences: List["TestRequiredIdentityDefaults._PreferenceItem"] = Field(
+            default_factory=list
+        )
+        entities: List["TestRequiredIdentityDefaults._EntityItem"] = Field(default_factory=list)
+
+    def test_missing_user_field_does_not_drop_preference(self):
+        """A preference without `user` must survive instead of being dropped."""
+        content = json.dumps(
+            {"preferences": [{"page_id": 101, "topic": "editor", "content": "spaces"}]}
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert len(result.preferences) == 1, "item was silently dropped"
+        assert result.preferences[0].topic == "editor"
+        assert result.preferences[0].user == "default"
+
+    def test_missing_category_field_does_not_drop_entity(self):
+        """An entity without `category` must survive."""
+        content = json.dumps(
+            {"entities": [{"page_id": 102, "name": "widget", "content": "a widget"}]}
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert len(result.entities) == 1
+        assert result.entities[0].name == "widget"
+        assert result.entities[0].category == "general"
+
+    def test_missing_page_id_is_generated(self):
+        """Items without page_id get generated ids >= 100, unique per item."""
+        content = json.dumps(
+            {
+                "preferences": [
+                    {"user": "alice", "topic": "theme", "content": "dark"},
+                    {"user": "alice", "topic": "font", "content": "mono"},
+                ]
+            }
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert len(result.preferences) == 2
+        page_ids = [p.page_id for p in result.preferences]
+        assert all(pid >= 100 for pid in page_ids)
+        assert len(set(page_ids)) == 2, "generated page_ids must be unique"
+
+    def test_existing_values_are_never_overwritten(self):
+        """Supplied values must win over the conventional defaults."""
+        content = json.dumps(
+            {
+                "preferences": [{"page_id": 7, "user": "bob", "topic": "shell", "content": "fish"}],
+                "entities": [{"page_id": 8, "category": "hardware", "name": "printer"}],
+            }
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert result.preferences[0].user == "bob"
+        assert result.preferences[0].page_id == 7
+        assert result.entities[0].category == "hardware"
+        assert result.entities[0].page_id == 8
+
+    def test_fully_valid_payload_is_unchanged(self):
+        """A complete payload must pass through untouched (no regression)."""
+        content = json.dumps(
+            {"preferences": [{"page_id": 100, "user": "carol", "topic": "lang", "content": "go"}]}
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert len(result.preferences) == 1
+        assert result.preferences[0].user == "carol"
+        assert result.preferences[0].content == "go"
+
+    def test_generated_page_id_avoids_existing_ids_in_same_response(self):
+        """Generated page_ids must not collide with valid ids already in the response.
+
+        The review comment on PR #3554 noted that naive page_id generation could
+        assign 100 to a missing item when page_id=100 already exists, making link
+        resolution order-dependent.  The fix pre-collects all existing ids and
+        skips them when filling in missing ones.
+        """
+        # page_id=100 is already used; another item has no page_id
+        content = json.dumps(
+            {
+                "preferences": [
+                    {"page_id": 100, "user": "alice", "topic": "theme"},
+                    {"user": "alice", "topic": "font"},  # missing page_id
+                ]
+            }
+        )
+        result, error = parse_json_with_stability(content, self._Operations)
+
+        assert error is None
+        assert len(result.preferences) == 2
+        page_ids = [p.page_id for p in result.preferences]
+        assert page_ids[0] == 100  # existing value preserved
+        assert page_ids[1] >= 100
+        assert page_ids[1] != 100, "generated id collided with existing 100"
+        assert len(set(page_ids)) == 2, "page_ids must all be unique"


### PR DESCRIPTION
## Summary

Memory extraction reports success while storing **nothing**: the commit returns
`status: completed`, `error: null`, `memories_extracted: {}`, yet the archive's
`.overview.md` summarises the conversation correctly — proof the model did the work.

Root cause is in `parse_json_with_stability`. When a memory item omits a boilerplate
required field, pydantic rejects it; the per-field tolerance fallback then rebuilds the
list without that item and **returns an empty list together with `error=None`**. The parse
"succeeds", so nothing is logged and the failure is silent.

Fields models routinely omit while getting the content right:

| memory type | omitted field |
|---|---|
| `preferences` | `user` |
| `entities` | `category` |
| any new item | `page_id` |

## Fix

Fill the conventional values for those fields immediately before validation:

- `user` → `"default"`
- `category` → `"general"`
- missing `page_id` → generated, `>= 100`, unique per item

Fields that already carry a value are never touched, so a complete payload passes through
byte-identically. The helper is schema-driven — it reads `required` from the generated
model's JSON schema rather than hardcoding a type list, so new memory types are covered
automatically.

Also pre-collects all existing `page_id` values across ALL operation lists before
allocating missing IDs, so generated IDs never collide with valid IDs already present
in the same response.

## Relationship to #3554

This PR follows up on and supersedes **#3554**: it carries the full fix from #3554
plus the collision fix requested by reviewer huangruiteng. When merging, please close
#3554 as superseded by this PR.

## Type of Change

- [x] Bug fix (fix)

## Testing

Added `TestRequiredIdentityDefaults` to `tests/session/memory/test_json_stability.py`:

- missing `user` does not drop the preference
- missing `category` does not drop the entity
- missing `page_id` is generated, `>= 100`, unique across items
- supplied values win over the defaults (no overwrite)
- a fully valid payload passes through untouched (regression guard)
- generated page_id avoids existing ids in the same response (collision test)

Verification:
```
ruff check  — passed
ruff format  — passed
python -m py_compile  — passed on all touched files
pytest tests/session/memory/test_json_stability.py::TestRequiredIdentityDefaults -v  — 6 passed
```

## Related Issues

- Follows up on and supersedes #3554