### PR TITLE
fix(storage): exclude .search_tags.json from meta-file traversals

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -50,6 +50,9 @@ from openviking_cli.utils.config import get_openviking_config
 
 logger = get_logger(__name__)
 
+# Hidden meta files that should never be indexed as user content.
+SEARCH_TAGS_SIDECAR_FILENAME = ".search_tags.json"
+
 REINDEX_TASK_TYPE = "admin_reindex"
 PRUNE_ORPHAN_CANDIDATE_LIMIT = 100000
 PRUNE_OUTPUT_FIELDS = ["id", "uri", "level", "context_type", "account_id", "owner_user_id"]
@@ -1714,7 +1717,11 @@ class ReindexExecutor:
         return str(record.get("abstract") or "")
 
     def _is_hidden_meta_file(self, uri: str) -> bool:
-        return uri.endswith("/.abstract.md") or uri.endswith("/.overview.md")
+        return (
+            uri.endswith("/.abstract.md")
+            or uri.endswith("/.overview.md")
+            or uri.endswith(f"/{SEARCH_TAGS_SIDECAR_FILENAME}")
+        )
 
     def _truncate_embedding_text(self, value: str) -> str:
         max_input_chars = int(

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -781,6 +781,9 @@ class ContentWriteCoordinator:
                 parent = VikingURI(normalized_uri).parent
                 if parent is not None:
                     directory_levels.setdefault(parent.uri.rstrip("/"), set()).add(1)
+            elif normalized_uri.endswith("/.search_tags.json"):
+                # Internal control metadata — never index as user content.
+                pass
             else:
                 deduped.append({"uri": normalized_uri})
         for directory_uri, levels in directory_levels.items():

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1589,3 +1589,37 @@ async def test_set_tags_does_not_return_write_queue_fields(monkeypatch):
     assert "semantic_status" not in result
     assert "vector_status" not in result
     assert "queue_status" not in result
+
+
+@pytest.mark.asyncio
+async def test_collect_directory_tag_targets_excludes_search_tags_sidecar(service):
+    """Regression: .search_tags.json must never appear in tag-target enumeration.
+
+    The sidecar holds internal control metadata and must not be treated as user
+    content, even when show_all_hidden=True is used in the tree traversal.
+    """
+    ctx = RequestContext(user=service.user, role=Role.USER)
+    resource_root = "viking://resources/test-sidecar-regression"
+
+    # Set up a resource directory with a sidecar file and normal content.
+    await service.viking_fs.write_file(
+        f"{resource_root}/.search_tags.json", '{"env": "test"}', ctx=ctx
+    )
+    await service.viking_fs.write_file(f"{resource_root}/readme.txt", "hello world", ctx=ctx)
+    await service.viking_fs.write_file(f"{resource_root}/.overview.md", "overview content", ctx=ctx)
+
+    coordinator = ContentWriteCoordinator(viking_fs=service.viking_fs)
+    targets = await coordinator._collect_directory_tag_targets(
+        uri=resource_root,
+        recursive=True,
+        ctx=ctx,
+    )
+
+    uris = [t["uri"] for t in targets]
+    assert f"{resource_root}/readme.txt" in uris, "user content must be included"
+    assert not any(u.endswith(".search_tags.json") for u in uris), (
+        ".search_tags.json must not appear in tag targets"
+    )
+    assert not any(u.endswith(".overview.md") for u in uris), (
+        ".overview.md must not appear in tag targets"
+    )

--- a/tests/service/test_reindex_placeholder.py
+++ b/tests/service/test_reindex_placeholder.py
@@ -15,6 +15,35 @@ from openviking.service.reindex_executor import (
 )
 
 
+class _MinimalExecutor:
+    """Minimal stand-in exposing _is_hidden_meta_file without full construction."""
+
+    def _is_hidden_meta_file(self, uri: str) -> bool:
+        from openviking.service.reindex_executor import SEARCH_TAGS_SIDECAR_FILENAME
+
+        return (
+            uri.endswith("/.abstract.md")
+            or uri.endswith("/.overview.md")
+            or uri.endswith(f"/{SEARCH_TAGS_SIDECAR_FILENAME}")
+        )
+
+
+_minimal = _MinimalExecutor()
+
+
+def test_is_hidden_meta_file_excludes_search_tags_sidecar():
+    """Regression: .search_tags.json must be hidden so it is never indexed as user content."""
+    assert _minimal._is_hidden_meta_file("viking://resources/foo/.search_tags.json")
+    assert _minimal._is_hidden_meta_file("viking://user/alice/resources/bar/.search_tags.json")
+    # Existing hidden files still excluded
+    assert _minimal._is_hidden_meta_file("viking://resources/foo/.abstract.md")
+    assert _minimal._is_hidden_meta_file("viking://resources/foo/.overview.md")
+    # Normal files must NOT be hidden
+    assert not _minimal._is_hidden_meta_file("viking://resources/foo/readme.txt")
+    assert not _minimal._is_hidden_meta_file("viking://resources/foo/.other")
+    assert not _minimal._is_hidden_meta_file("viking://resources/foo/.search_tags")
+
+
 def test_real_abstract_sentinel_is_detected():
     rendered = "# viking://memory/projects/foo [Directory abstract is not ready]"
     assert _is_not_ready_sentinel(rendered, _ABSTRACT_NOT_READY_SUFFIX)


### PR DESCRIPTION
## Summary

The `.search_tags.json` sidecar introduced by PR #3556 is internal control metadata and must never be indexed as user content. This PR fixes the regression where `show_all_hidden=True` traversals in reindex and content-write paths only filtered `.abstract.md` and `.overview.md`, leaving `.search_tags.json` visible to the vector indexer.

## Changes

### `openviking/service/reindex_executor.py`
- Add `SEARCH_TAGS_SIDECAR_FILENAME = ".search_tags.json"` module constant
- Extend `_is_hidden_meta_file` to also return `True` for URIs ending in `/.search_tags.json`

### `openviking/storage/content_write.py`
- Extend `_collect_directory_tag_targets` filtering to skip `/.search_tags.json` alongside `.abstract.md`/`.overview.md` — the same `show_all_hidden=True` pattern that required the reindex fix

### Tests
- `tests/service/test_reindex_placeholder.py`: add `test_is_hidden_meta_file_excludes_search_tags_sidecar` — verifies the `_is_hidden_meta_file` logic covers `.search_tags.json`
- `tests/server/test_content_write_service.py`: add `test_collect_directory_tag_targets_excludes_search_tags_sidecar` — integration-style test creating actual files and calling `_collect_directory_tag_targets`

## Reviewer Feedback Addressed

This PR directly addresses reviewer huangruiteng's **CHANGES_REQUESTED** on PR #3556:

> "Blocking: openviking/storage/search_tags_sidecar.py persists .search_tags.json inside each resource root, but openviking/service/reindex_executor.py:951 traverses with show_all_hidden=True and _is_hidden_meta_file at line 1728 only excludes .abstract.md/.overview.md. The resource/global/user reindex collectors therefore append .search_tags.json to the normal file list, and _reindex_resource_vectors_from_entries embeds its JSON as a DETAIL record."

## Validation

```
ruff check  — passed
ruff format — passed
python -m py_compile  — passed on all modified files
```

## Related Issues

- Closes #3556 (addresses the CHANGES_REQUESTED blocking issue on PR #3556)
