### PR TITLE
fix(ov): raise clear error when singleton path conflicts

### DIFF
--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -43,37 +43,18 @@ class AsyncOpenViking:
 
     _instance: Optional["AsyncOpenViking"] = None
     _lock = threading.Lock()
+    # Serializes the LocalClient construction inside __init__.
+    # Python releases __new__'s lock before type.__call__ invokes __init__,
+    # so a lock inside __new__ does not prevent concurrent __init__ races.
+    _construct_lock = threading.Lock()
 
-    def __new__(cls, path: Optional[str] = None, actor_peer_id: Optional[str] = None, agent_id: Optional[str] = None):
-        """Construct the singleton. Holds _lock to serialize __init__ and prevent concurrent races."""
-        with cls._lock:
-            # Already have a singleton — check workspace unless it hasn't been __init__'d yet.
-            if cls._instance is not None:
-                inst = cls._instance
-                if hasattr(inst, "_singleton_initialized") and inst._singleton_initialized:
-                    # Already fully initialized — compare workspaces before returning.
-                    if path is not None:
-                        requested_workspace = os.path.realpath(os.path.expanduser(path))
-                    else:
-                        requested_workspace = os.path.realpath(
-                            inst._client._service._config.storage.workspace
-                        )
-                    live_workspace = os.path.realpath(inst._path)
-                    if requested_workspace != live_workspace:
-                        raise ValueError(
-                            f"Only one embedded OpenViking workspace can be live per process. "
-                            f"Requested path '{path}' differs from live workspace '{inst._path}'. "
-                            f"Close the existing client with `await client.close()` or "
-                            f"reset the singleton with `await AsyncOpenViking.reset()` before "
-                            f"constructing a new workspace."
-                        )
-                    return inst
-                # Instance exists but not yet __init__'d — another thread is mid-construction.
-                # Fall through to let __init__ run (still under lock) with this thread's args.
-            # Create uninitialized instance; __init__ will run after __new__ returns
-            # (still under the lock, so serialization is guaranteed).
-            if cls._instance is None:
-                cls._instance = object.__new__(cls)
+    def __new__(cls, *args, **kwargs):
+        # Simple double-check to create the singleton instance.
+        # Workspace comparison is done inside __init__ under _construct_lock.
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = object.__new__(cls)
         return cls._instance
 
     def __init__(
@@ -82,8 +63,7 @@ class AsyncOpenViking:
         actor_peer_id: Optional[str] = None,
         agent_id: Optional[str] = None,
     ):
-        """
-        Initialize OpenViking client (embedded mode).
+        """Initialize OpenViking client (embedded mode).
 
         Args:
             path: Local storage path (overrides ov.conf storage path).
@@ -94,26 +74,45 @@ class AsyncOpenViking:
             ValueError: If a singleton is already live with a different path and
                 the caller requests a new workspace without first calling close() or reset().
         """
-        # __new__ guarantees that at most one __init__ runs at a time (holds _lock).
-        # If the singleton is already fully initialized, __new__ returned the live
-        # instance without calling __init__ again.
-        if hasattr(self, "_singleton_initialized") and self._singleton_initialized:
-            return
+        # Hold _construct_lock so at most one thread constructs LocalClient.
+        # This is the true serialization point — __new__ only creates the raw
+        # object; Python's type.__call__ invokes __init__ separately.
+        with self._construct_lock:
+            if hasattr(self, "_singleton_initialized") and self._singleton_initialized:
+                # Re-entry: singleton is already live. Same workspace is a no-op;
+                # different workspace is a ValueError (caller must close()/reset()).
+                if path is not None:
+                    requested_workspace = os.path.realpath(os.path.expanduser(path))
+                else:
+                    requested_workspace = os.path.realpath(
+                        self._client._service._config.storage.workspace
+                    )
+                live_workspace = os.path.realpath(self._path)
+                if requested_workspace != live_workspace:
+                    raise ValueError(
+                        f"Only one embedded OpenViking workspace can be live per process. "
+                        f"Requested path '{path}' differs from live workspace '{self._path}'. "
+                        f"Close the existing client with `await client.close()` or "
+                        f"reset the singleton with `await AsyncOpenViking.reset()` before "
+                        f"constructing a new workspace."
+                    )
+                return
 
-        self.user = UserIdentifier.the_default_user()
-        self._initialized = False
-        self._snapshot: Optional["AsyncSnapshotNamespace"] = None
-        self._singleton_initialized = False
+            # First construction — serialized by _construct_lock.
+            self.user = UserIdentifier.the_default_user()
+            self._initialized = False
+            self._snapshot: Optional["AsyncSnapshotNamespace"] = None
+            self._singleton_initialized = False
 
-        self._client: BaseClient = LocalClient(
-            path=path,
-            actor_peer_id=actor_peer_id,
-            agent_id=agent_id,
-        )
-        self._path = os.path.realpath(
-            os.path.expanduser(self._client._service._config.storage.workspace)
-        )
-        self._singleton_initialized = True
+            self._client: BaseClient = LocalClient(
+                path=path,
+                actor_peer_id=actor_peer_id,
+                agent_id=agent_id,
+            )
+            self._path = os.path.realpath(
+                os.path.expanduser(self._client._service._config.storage.workspace)
+            )
+            self._singleton_initialized = True
 
     # ============= Lifecycle methods =============
 
@@ -130,17 +129,14 @@ class AsyncOpenViking:
     async def close(self) -> None:
         """Close OpenViking and release resources.
 
-        Raises the close error if client.close() fails but still resets singleton
-        state so a new workspace can be constructed (or re-raises if cancellation
-        is required to propagate).
+        Only clears the singleton guard on success. On failure or cancellation
+        the guard stays active so a different workspace cannot be accepted.
         """
         client = getattr(self, "_client", None)
-        try:
-            if client is not None:
-                await client.close()
-        finally:
-            self._initialized = False
-            self._singleton_initialized = False
+        if client is not None:
+            await client.close()
+        self._initialized = False
+        self._singleton_initialized = False
 
     @classmethod
     async def reset(cls) -> None:

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -77,14 +77,19 @@ class AsyncOpenViking:
             # Compare effective workspaces resolved by the config, not raw arguments.
             # LocalClient resolves path=None through the shared config, so we must
             # compare the resolved workspace paths to handle the implicit/explicit case.
+            # Resolve path through LocalClient's config to get the effective workspace.
+            # This handles path=None correctly (it resolves to the config's default
+            # workspace) and ensures implicit and explicit forms of the same path
+            # compare equal.
             if path is not None:
                 requested_workspace = os.path.realpath(path)
             else:
-                requested_workspace = None
-            if self._path is not None:
-                live_workspace = os.path.realpath(self._path)
-            else:
-                live_workspace = None
+                # path=None resolves through the already-constructed LocalClient's
+                # shared config, which gives the effective workspace.
+                requested_workspace = os.path.realpath(
+                    self._client._service._config.storage.workspace
+                )
+            live_workspace = os.path.realpath(self._path)
             if requested_workspace != live_workspace:
                 raise ValueError(
                     f"Only one embedded OpenViking workspace can be live per process. "

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -74,9 +74,18 @@ class AsyncOpenViking:
             # Reconstructing with the same effective path is fine (no-op).
             # Constructing with a different path while the singleton is live is an error —
             # the caller must close() or reset() first.
-            normalized_new = os.path.realpath(path) if path else None
-            normalized_old = os.path.realpath(self._path) if self._path else None
-            if normalized_new != normalized_old:
+            # Compare effective workspaces resolved by the config, not raw arguments.
+            # LocalClient resolves path=None through the shared config, so we must
+            # compare the resolved workspace paths to handle the implicit/explicit case.
+            if path is not None:
+                requested_workspace = os.path.realpath(path)
+            else:
+                requested_workspace = None
+            if self._path is not None:
+                live_workspace = os.path.realpath(self._path)
+            else:
+                live_workspace = None
+            if requested_workspace != live_workspace:
                 raise ValueError(
                     f"Only one embedded OpenViking workspace can be live per process. "
                     f"Requested path '{path}' differs from live workspace '{self._path}'. "
@@ -88,7 +97,6 @@ class AsyncOpenViking:
 
         self.user = UserIdentifier.the_default_user()
         self._initialized = False
-        self._path = path  # store for singleton path validation
         self._snapshot: Optional["AsyncSnapshotNamespace"] = None
         # Mark initialized only after LocalClient is successfully constructed.
         self._singleton_initialized = False
@@ -98,6 +106,11 @@ class AsyncOpenViking:
             actor_peer_id=actor_peer_id,
             agent_id=agent_id,
         )
+        # Store the effective workspace path resolved by LocalClient's config,
+        # not the raw constructor argument. This handles path=None correctly
+        # (it resolves to the config's default workspace) and ensures implicit
+        # and explicit forms of the same path compare equal.
+        self._path = self._client._service._config.storage.workspace
         self._singleton_initialized = True
 
     # ============= Lifecycle methods =============

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -8,6 +8,7 @@ For HTTP mode, use AsyncHTTPClient or SyncHTTPClient.
 
 from __future__ import annotations
 
+import os
 import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -63,13 +64,31 @@ class AsyncOpenViking:
             path: Local storage path (overrides ov.conf storage path).
             actor_peer_id: Optional view filter for the current user's peer collection.
             agent_id: Legacy alias for actor_peer_id.
+
+        Raises:
+            ValueError: If a singleton is already live with a different path and
+                the caller requests a new workspace without first calling close() or reset().
         """
         # Singleton guard for repeated initialization
         if hasattr(self, "_singleton_initialized") and self._singleton_initialized:
+            # Reconstructing with the same effective path is fine (no-op).
+            # Constructing with a different path while the singleton is live is an error —
+            # the caller must close() or reset() first.
+            normalized_new = os.path.realpath(path) if path else None
+            normalized_old = os.path.realpath(self._path) if self._path else None
+            if normalized_new != normalized_old:
+                raise ValueError(
+                    f"Only one embedded OpenViking workspace can be live per process. "
+                    f"Requested path '{path}' differs from live workspace '{self._path}'. "
+                    f"Close the existing client with `await client.close()` or "
+                    f"reset the singleton with `await AsyncOpenViking.reset()` before "
+                    f"constructing a new workspace."
+                )
             return
 
         self.user = UserIdentifier.the_default_user()
         self._initialized = False
+        self._path = path  # store for singleton path validation
         self._snapshot: Optional["AsyncSnapshotNamespace"] = None
         # Mark initialized only after LocalClient is successfully constructed.
         self._singleton_initialized = False

--- a/openviking/async_client.py
+++ b/openviking/async_client.py
@@ -44,11 +44,36 @@ class AsyncOpenViking:
     _instance: Optional["AsyncOpenViking"] = None
     _lock = threading.Lock()
 
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = object.__new__(cls)
+    def __new__(cls, path: Optional[str] = None, actor_peer_id: Optional[str] = None, agent_id: Optional[str] = None):
+        """Construct the singleton. Holds _lock to serialize __init__ and prevent concurrent races."""
+        with cls._lock:
+            # Already have a singleton — check workspace unless it hasn't been __init__'d yet.
+            if cls._instance is not None:
+                inst = cls._instance
+                if hasattr(inst, "_singleton_initialized") and inst._singleton_initialized:
+                    # Already fully initialized — compare workspaces before returning.
+                    if path is not None:
+                        requested_workspace = os.path.realpath(os.path.expanduser(path))
+                    else:
+                        requested_workspace = os.path.realpath(
+                            inst._client._service._config.storage.workspace
+                        )
+                    live_workspace = os.path.realpath(inst._path)
+                    if requested_workspace != live_workspace:
+                        raise ValueError(
+                            f"Only one embedded OpenViking workspace can be live per process. "
+                            f"Requested path '{path}' differs from live workspace '{inst._path}'. "
+                            f"Close the existing client with `await client.close()` or "
+                            f"reset the singleton with `await AsyncOpenViking.reset()` before "
+                            f"constructing a new workspace."
+                        )
+                    return inst
+                # Instance exists but not yet __init__'d — another thread is mid-construction.
+                # Fall through to let __init__ run (still under lock) with this thread's args.
+            # Create uninitialized instance; __init__ will run after __new__ returns
+            # (still under the lock, so serialization is guaranteed).
+            if cls._instance is None:
+                cls._instance = object.__new__(cls)
         return cls._instance
 
     def __init__(
@@ -69,41 +94,15 @@ class AsyncOpenViking:
             ValueError: If a singleton is already live with a different path and
                 the caller requests a new workspace without first calling close() or reset().
         """
-        # Singleton guard for repeated initialization
+        # __new__ guarantees that at most one __init__ runs at a time (holds _lock).
+        # If the singleton is already fully initialized, __new__ returned the live
+        # instance without calling __init__ again.
         if hasattr(self, "_singleton_initialized") and self._singleton_initialized:
-            # Reconstructing with the same effective path is fine (no-op).
-            # Constructing with a different path while the singleton is live is an error —
-            # the caller must close() or reset() first.
-            # Compare effective workspaces resolved by the config, not raw arguments.
-            # LocalClient resolves path=None through the shared config, so we must
-            # compare the resolved workspace paths to handle the implicit/explicit case.
-            # Resolve path through LocalClient's config to get the effective workspace.
-            # This handles path=None correctly (it resolves to the config's default
-            # workspace) and ensures implicit and explicit forms of the same path
-            # compare equal.
-            if path is not None:
-                requested_workspace = os.path.realpath(path)
-            else:
-                # path=None resolves through the already-constructed LocalClient's
-                # shared config, which gives the effective workspace.
-                requested_workspace = os.path.realpath(
-                    self._client._service._config.storage.workspace
-                )
-            live_workspace = os.path.realpath(self._path)
-            if requested_workspace != live_workspace:
-                raise ValueError(
-                    f"Only one embedded OpenViking workspace can be live per process. "
-                    f"Requested path '{path}' differs from live workspace '{self._path}'. "
-                    f"Close the existing client with `await client.close()` or "
-                    f"reset the singleton with `await AsyncOpenViking.reset()` before "
-                    f"constructing a new workspace."
-                )
             return
 
         self.user = UserIdentifier.the_default_user()
         self._initialized = False
         self._snapshot: Optional["AsyncSnapshotNamespace"] = None
-        # Mark initialized only after LocalClient is successfully constructed.
         self._singleton_initialized = False
 
         self._client: BaseClient = LocalClient(
@@ -111,11 +110,9 @@ class AsyncOpenViking:
             actor_peer_id=actor_peer_id,
             agent_id=agent_id,
         )
-        # Store the effective workspace path resolved by LocalClient's config,
-        # not the raw constructor argument. This handles path=None correctly
-        # (it resolves to the config's default workspace) and ensures implicit
-        # and explicit forms of the same path compare equal.
-        self._path = self._client._service._config.storage.workspace
+        self._path = os.path.realpath(
+            os.path.expanduser(self._client._service._config.storage.workspace)
+        )
         self._singleton_initialized = True
 
     # ============= Lifecycle methods =============
@@ -131,12 +128,19 @@ class AsyncOpenViking:
             await self.initialize()
 
     async def close(self) -> None:
-        """Close OpenViking and release resources."""
+        """Close OpenViking and release resources.
+
+        Raises the close error if client.close() fails but still resets singleton
+        state so a new workspace can be constructed (or re-raises if cancellation
+        is required to propagate).
+        """
         client = getattr(self, "_client", None)
-        if client is not None:
-            await client.close()
-        self._initialized = False
-        self._singleton_initialized = False
+        try:
+            if client is not None:
+                await client.close()
+        finally:
+            self._initialized = False
+            self._singleton_initialized = False
 
     @classmethod
     async def reset(cls) -> None:

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import pytest_asyncio
 
 import openviking_cli.client.http as http_module
 import openviking_cli.utils.async_utils as async_utils
@@ -21,6 +22,24 @@ from openviking_cli.utils.config import OPENVIKING_CLI_CONFIG_ENV
 def clear_ovcli_config(monkeypatch):
     monkeypatch.delenv(OPENVIKING_CLI_CONFIG_ENV, raising=False)
     monkeypatch.setattr(http_module, "load_ovcli_config", lambda: None, raising=False)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_singleton():
+    """Reset AsyncOpenViking singleton between tests.
+
+    The new path guard (#3546) prevents creating a second embedded workspace
+    while the singleton is live. This fixture ensures each test starts clean.
+    """
+    try:
+        await AsyncOpenViking.reset()
+    except Exception:
+        pass
+    yield
+    try:
+        await AsyncOpenViking.reset()
+    except Exception:
+        pass
 
 
 def test_async_http_client_zip_directory_skips_symlinked_entries(tmp_path):

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for AsyncOpenViking singleton path enforcement (issue #3546)."""
 
+import asyncio
+import concurrent.futures
 import os
 import tempfile
 from unittest.mock import AsyncMock
@@ -10,6 +12,7 @@ import pytest
 import pytest_asyncio
 
 from openviking import AsyncOpenViking, SyncOpenViking
+from openviking.client import LocalClient
 
 
 @pytest_asyncio.fixture
@@ -78,12 +81,12 @@ class TestAsyncOpenVikingSingletonPath:
             client_b = AsyncOpenViking(path=workspace_b)
             assert client_b is not client_a
 
-    async def test_close_failure_still_resets_singleton_guard(self, clean_singleton):
-        """If close() fails, singleton state is still reset so a new workspace can be constructed.
+    async def test_close_failure_preserves_singleton_guard(self, clean_singleton):
+        """If close() fails, the singleton guard stays active.
 
-        Regression: close() must use try/finally so that even if client.close() raises,
-        the singleton guard is re-established for the next construction (requiring
-        close() or reset() again before a different workspace is accepted).
+        Only a successful close clears _singleton_initialized, so a failed close
+        leaves the guard in place — same workspace re-entry is a no-op and a
+        different workspace is still rejected.
         """
         with tempfile.TemporaryDirectory() as root:
             workspace_a = os.path.join(root, "a")
@@ -130,19 +133,84 @@ class TestAsyncOpenVikingSingletonPath:
             client_b = AsyncOpenViking(path=symlink_path)
             assert client_a is client_b
 
-    async def test_tilde_expanded_paths_are_compared_with_expanduser(self, clean_singleton):
-        """Paths with ~ are expanded before comparison, matching LocalClient behavior.
+    async def test_tilde_re_entry_with_expanduser(self, clean_singleton):
+        """AsyncOpenViking re-entry with ~ and absolute paths is treated as equal.
 
-        os.path.realpath() alone does not expand ~, but LocalClient uses
-        Path(path).expanduser().resolve(). Without expanduser(), ~/workspace
-        would compare unequal to /home/<user>/workspace and raise a false conflict.
+        Exercises the actual guard: first construction with the absolute path,
+        then re-entry with the tilde form. Without expanduser(), the two forms
+        compare unequal and raise a false ValueError.
         """
-        # Test that expanduser()+realpath() normalizes paths the same way.
-        # We verify the normalization logic independently of a real home dir.
         import pathlib
-        real_path = str(pathlib.Path.home())
-        tilde_path = "~" + real_path[len(str(pathlib.Path.home())):]
-        assert os.path.realpath(os.path.expanduser(tilde_path)) == os.path.realpath(real_path)
+
+        home = str(pathlib.Path.home())
+        with tempfile.TemporaryDirectory(dir=home) as tmpdir:
+            workspace = os.path.realpath(os.path.join(tmpdir, "tilde_ws"))
+            os.makedirs(workspace)
+            tilde_form = "~" + workspace[len(home) :]
+
+            # First construction with absolute path
+            client_a = AsyncOpenViking(path=workspace)
+            # Re-entry with tilde form — must be treated as equal
+            client_b = AsyncOpenViking(path=tilde_form)
+            assert client_b is client_a
+
+    async def test_close_cancelled_preserves_singleton_guard(self, clean_singleton):
+        """Cancelled close() preserves the singleton guard.
+
+        CancelledError propagates up but _singleton_initialized stays True,
+        so the guard is still active afterward.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+
+            client_a = AsyncOpenViking(path=workspace_a)
+            client_a._client.close = AsyncMock(
+                side_effect=asyncio.CancelledError("simulated cancellation")
+            )
+
+            with pytest.raises(asyncio.CancelledError):
+                await client_a.close()
+
+            # Guard still active — different workspace rejected
+            with pytest.raises(ValueError):
+                AsyncOpenViking(path=workspace_b)
+
+            # Same workspace still accepted
+            client_a2 = AsyncOpenViking(path=workspace_a)
+            assert client_a2 is client_a
+
+    async def test_concurrent_first_construction_is_serialized(self, clean_singleton):
+        """Two threads racing to construct the singleton produce exactly one workspace.
+
+        Regression: Python releases __new__'s lock before type.__call__ invokes
+        __init__, so a lock inside __new__ does NOT serialize concurrent first
+        construction. The _construct_lock inside __init__ guarantees single-flight
+        initialization.
+        """
+        run_count = 0
+        original_init = LocalClient.__init__
+
+        def counting_init(self, *args, **kwargs):
+            nonlocal run_count
+            run_count += 1
+            return original_init(self, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as root:
+            workspace = os.path.join(root, "ws")
+            os.makedirs(workspace)
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(AsyncOpenViking, path=workspace),
+                    pool.submit(AsyncOpenViking, path=workspace),
+                ]
+                results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+            # Both calls return the same singleton
+            assert results[0] is results[1]
+            # _path is set exactly once with the correct workspace
+            assert os.path.realpath(results[0]._path) == os.path.realpath(workspace)
 
     async def test_explicit_then_implicit_same_workspace(self, clean_singleton):
         """AsyncOpenViking(path=<workspace>) followed by AsyncOpenViking() succeeds.

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -4,6 +4,7 @@
 
 import os
 import tempfile
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -77,6 +78,44 @@ class TestAsyncOpenVikingSingletonPath:
             client_b = AsyncOpenViking(path=workspace_b)
             assert client_b is not client_a
 
+    async def test_close_failure_still_resets_singleton_guard(self, clean_singleton):
+        """If close() fails, singleton state is still reset so a new workspace can be constructed.
+
+        Regression: close() must use try/finally so that even if client.close() raises,
+        the singleton guard is re-established for the next construction (requiring
+        close() or reset() again before a different workspace is accepted).
+        """
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+
+            client_a = AsyncOpenViking(path=workspace_a)
+
+            # Simulate close() failure by patching client.close to raise
+            original_close = client_a._client.close
+            client_a._client.close = AsyncMock(side_effect=IOError("simulated close failure"))
+
+            # close() propagates the error
+            with pytest.raises(IOError):
+                await client_a.close()
+
+            # After failed close, singleton guard is still active (requires close/reset)
+            # so a different workspace is still rejected
+            with pytest.raises(ValueError) as exc_info:
+                AsyncOpenViking(path=workspace_b)
+
+            assert "only one embedded" in str(exc_info.value).lower()
+
+            # But same workspace is still accepted (no-op re-entry)
+            client_a2 = AsyncOpenViking(path=workspace_a)
+            assert client_a2 is client_a
+
+            # Restore and do a successful close to allow workspace switch
+            client_a._client.close = original_close
+            await client_a.close()
+            client_b = AsyncOpenViking(path=workspace_b)
+            assert os.path.realpath(client_b._path) == os.path.realpath(workspace_b)
+
     async def test_resolved_paths_are_compared(self, clean_singleton):
         """Paths that resolve to the same realpath are treated as equal."""
         with tempfile.TemporaryDirectory() as root:
@@ -90,6 +129,20 @@ class TestAsyncOpenVikingSingletonPath:
             client_a = AsyncOpenViking(path=real_path)
             client_b = AsyncOpenViking(path=symlink_path)
             assert client_a is client_b
+
+    async def test_tilde_expanded_paths_are_compared_with_expanduser(self, clean_singleton):
+        """Paths with ~ are expanded before comparison, matching LocalClient behavior.
+
+        os.path.realpath() alone does not expand ~, but LocalClient uses
+        Path(path).expanduser().resolve(). Without expanduser(), ~/workspace
+        would compare unequal to /home/<user>/workspace and raise a false conflict.
+        """
+        # Test that expanduser()+realpath() normalizes paths the same way.
+        # We verify the normalization logic independently of a real home dir.
+        import pathlib
+        real_path = str(pathlib.Path.home())
+        tilde_path = "~" + real_path[len(str(pathlib.Path.home())):]
+        assert os.path.realpath(os.path.expanduser(tilde_path)) == os.path.realpath(real_path)
 
     async def test_explicit_then_implicit_same_workspace(self, clean_singleton):
         """AsyncOpenViking(path=<workspace>) followed by AsyncOpenViking() succeeds.

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -44,7 +44,11 @@ class TestAsyncOpenVikingSingletonPath:
             assert workspace_a in str(exc_info.value)
 
     async def test_different_path_after_close_is_allowed(self, clean_singleton):
-        """After close(), a different workspace can be constructed."""
+        """After close(), a different workspace can be constructed.
+
+        close() leaves the singleton instance in place (__new__ returns the same
+        object, __init__ reconfigures it). The effective workspace must change.
+        """
         with tempfile.TemporaryDirectory() as root:
             workspace_a = os.path.join(root, "a")
             workspace_b = os.path.join(root, "b")
@@ -53,7 +57,10 @@ class TestAsyncOpenVikingSingletonPath:
             await client_a.close()
 
             client_b = AsyncOpenViking(path=workspace_b)
-            assert client_b is not client_a
+            # Singleton instance is reused; only the effective workspace changes
+            assert client_b is client_a
+            assert client_b._path == workspace_b
+            assert client_a._path == workspace_b
 
     async def test_different_path_after_reset_is_allowed(self, clean_singleton):
         """After reset(), a different workspace can be constructed."""

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -6,7 +6,7 @@ import asyncio
 import concurrent.futures
 import os
 import tempfile
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -165,20 +165,25 @@ class TestAsyncOpenVikingSingletonPath:
             workspace_b = os.path.join(root, "b")
 
             client_a = AsyncOpenViking(path=workspace_a)
+            original_close = client_a._client.close
             client_a._client.close = AsyncMock(
                 side_effect=asyncio.CancelledError("simulated cancellation")
             )
 
-            with pytest.raises(asyncio.CancelledError):
+            try:
+                with pytest.raises(asyncio.CancelledError):
+                    await client_a.close()
+
+                # Guard still active — different workspace rejected
+                with pytest.raises(ValueError):
+                    AsyncOpenViking(path=workspace_b)
+
+                # Same workspace still accepted
+                client_a2 = AsyncOpenViking(path=workspace_a)
+                assert client_a2 is client_a
+            finally:
+                client_a._client.close = original_close
                 await client_a.close()
-
-            # Guard still active — different workspace rejected
-            with pytest.raises(ValueError):
-                AsyncOpenViking(path=workspace_b)
-
-            # Same workspace still accepted
-            client_a2 = AsyncOpenViking(path=workspace_a)
-            assert client_a2 is client_a
 
     async def test_concurrent_first_construction_is_serialized(self, clean_singleton):
         """Two threads racing to construct the singleton produce exactly one workspace.
@@ -200,15 +205,18 @@ class TestAsyncOpenVikingSingletonPath:
             workspace = os.path.join(root, "ws")
             os.makedirs(workspace)
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-                futures = [
-                    pool.submit(AsyncOpenViking, path=workspace),
-                    pool.submit(AsyncOpenViking, path=workspace),
-                ]
-                results = [f.result() for f in concurrent.futures.as_completed(futures)]
+            with patch.object(LocalClient, "__init__", counting_init):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                    futures = [
+                        pool.submit(AsyncOpenViking, path=workspace),
+                        pool.submit(AsyncOpenViking, path=workspace),
+                    ]
+                    results = [f.result() for f in concurrent.futures.as_completed(futures)]
 
             # Both calls return the same singleton
             assert results[0] is results[1]
+            # Exactly one LocalClient constructed under _construct_lock
+            assert run_count == 1
             # _path is set exactly once with the correct workspace
             assert os.path.realpath(results[0]._path) == os.path.realpath(workspace)
 

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for AsyncOpenViking singleton path enforcement (issue #3546)."""
+
+import os
+import tempfile
+
+import pytest
+import pytest_asyncio
+
+from openviking import AsyncOpenViking, SyncOpenViking
+
+
+@pytest_asyncio.fixture
+async def clean_singleton():
+    """Ensure singleton is reset before and after each test."""
+    await AsyncOpenViking.reset()
+    yield
+    await AsyncOpenViking.reset()
+
+
+class TestAsyncOpenVikingSingletonPath:
+    """Regression tests for the singleton path check."""
+
+    async def test_same_path_returns_singleton_without_error(self, clean_singleton):
+        """Constructing the singleton twice with the same path is a no-op (idempotent)."""
+        with tempfile.TemporaryDirectory() as root:
+            client_a = AsyncOpenViking(path=root)
+            client_b = AsyncOpenViking(path=root)
+            assert client_a is client_b
+
+    async def test_different_path_raises_clear_error(self, clean_singleton):
+        """Reconstructing with a different path raises ValueError with actionable message."""
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+            AsyncOpenViking(path=workspace_a)
+
+            with pytest.raises(ValueError) as exc_info:
+                AsyncOpenViking(path=workspace_b)
+
+            assert "only one embedded" in str(exc_info.value).lower()
+            assert workspace_b in str(exc_info.value)
+            assert workspace_a in str(exc_info.value)
+
+    async def test_different_path_after_close_is_allowed(self, clean_singleton):
+        """After close(), a different workspace can be constructed."""
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+
+            client_a = AsyncOpenViking(path=workspace_a)
+            await client_a.close()
+
+            client_b = AsyncOpenViking(path=workspace_b)
+            assert client_b is not client_a
+
+    async def test_different_path_after_reset_is_allowed(self, clean_singleton):
+        """After reset(), a different workspace can be constructed."""
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+
+            client_a = AsyncOpenViking(path=workspace_a)
+            await AsyncOpenViking.reset()
+
+            client_b = AsyncOpenViking(path=workspace_b)
+            assert client_b is not client_a
+
+    async def test_resolved_paths_are_compared(self, clean_singleton):
+        """Paths that resolve to the same realpath are treated as equal."""
+        with tempfile.TemporaryDirectory() as root:
+            real_path = os.path.join(root, "workspace")
+            os.makedirs(real_path)
+            # Symlink to the same directory
+            symlink_path = os.path.join(root, "symlink")
+            os.symlink(real_path, symlink_path)
+
+            # Both should work — same real path
+            client_a = AsyncOpenViking(path=real_path)
+            client_b = AsyncOpenViking(path=symlink_path)
+            assert client_a is client_b
+
+    async def test_sync_client_raises_same_error(self, clean_singleton):
+        """SyncOpenViking raises the same error when its underlying AsyncOpenViking has a different path."""
+        with tempfile.TemporaryDirectory() as root:
+            workspace_a = os.path.join(root, "a")
+            workspace_b = os.path.join(root, "b")
+
+            _ = SyncOpenViking(path=workspace_a)
+
+            with pytest.raises(ValueError) as exc_info:
+                SyncOpenViking(path=workspace_b)
+
+            assert "only one embedded" in str(exc_info.value).lower()

--- a/tests/test_async_client_singleton.py
+++ b/tests/test_async_client_singleton.py
@@ -57,10 +57,13 @@ class TestAsyncOpenVikingSingletonPath:
             await client_a.close()
 
             client_b = AsyncOpenViking(path=workspace_b)
-            # Singleton instance is reused; only the effective workspace changes
+            # Singleton instance is reused; only the effective workspace changes.
+            # Compare resolved forms to be portable across platforms where
+            # TemporaryDirectory() exposes /var/... but Path.resolve() stores
+            # /private/var/... on macOS.
             assert client_b is client_a
-            assert client_b._path == workspace_b
-            assert client_a._path == workspace_b
+            assert os.path.realpath(client_b._path) == os.path.realpath(workspace_b)
+            assert os.path.realpath(client_a._path) == os.path.realpath(workspace_b)
 
     async def test_different_path_after_reset_is_allowed(self, clean_singleton):
         """After reset(), a different workspace can be constructed."""
@@ -87,6 +90,42 @@ class TestAsyncOpenVikingSingletonPath:
             client_a = AsyncOpenViking(path=real_path)
             client_b = AsyncOpenViking(path=symlink_path)
             assert client_a is client_b
+
+    async def test_explicit_then_implicit_same_workspace(self, clean_singleton):
+        """AsyncOpenViking(path=<workspace>) followed by AsyncOpenViking() succeeds.
+
+        The implicit call (path=None) resolves through the shared config to the
+        same effective workspace that was set explicitly, so no error is raised.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            workspace = os.path.join(root, "workspace")
+            os.makedirs(workspace)
+
+            # Set an explicit workspace first
+            client_a = AsyncOpenViking(path=workspace)
+            # Implicit call resolves through config to the same workspace
+            client_b = AsyncOpenViking()
+            assert client_b is client_a
+            assert os.path.realpath(client_b._path) == os.path.realpath(workspace)
+
+    async def test_implicit_then_explicit_same_workspace(self, clean_singleton):
+        """AsyncOpenViking() followed by AsyncOpenViking(path=<same workspace>) succeeds.
+
+        The first implicit call establishes the workspace from config.
+        The second explicit call requests the same effective workspace.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            workspace = os.path.join(root, "workspace")
+            os.makedirs(workspace)
+
+            # First call uses config's default workspace
+            client_a = AsyncOpenViking()
+            default_path = client_a._path
+
+            # Second call explicitly requests the same path as the implicit default
+            client_b = AsyncOpenViking(path=default_path)
+            assert client_b is client_a
+            assert os.path.realpath(client_b._path) == os.path.realpath(default_path)
 
     async def test_sync_client_raises_same_error(self, clean_singleton):
         """SyncOpenViking raises the same error when its underlying AsyncOpenViking has a different path."""


### PR DESCRIPTION
## Summary

`AsyncOpenViking` is a process-wide singleton, but constructing it with a different `path` while the singleton is live silently returns the existing instance and ignores the newly requested workspace. Code that asks for workspace B can unknowingly continue using workspace A — particularly risky for applications building multiple embedded integrations.

## Root Cause

`AsyncOpenViking.__new__()` returns the existing singleton, then the guard at the start of `__init__()` returns without comparing the requested path to the live workspace. The second path is silently ignored.

## Fix

When `__init__` is called on an already-initialized singleton, compare the requested path (via `os.path.realpath` for normalization) against the stored `_path`. If they differ, raise `ValueError` with an actionable message:

```
ValueError: Only one embedded OpenViking workspace can be live per process.
Requested path '/tmp/workspace-b' differs from live workspace '/tmp/workspace-a'.
Close the existing client with `await client.close()` or reset the singleton with
`await AsyncOpenViking.reset()` before constructing a new workspace.
```

`SyncOpenViking` is also fixed since it wraps `AsyncOpenViking`.

## Changes

- `openviking/async_client.py`: store `_path` on first init; compare on re-init; raise `ValueError` if paths conflict
- `tests/test_async_client_singleton.py`: 6 regression tests covering same-path idempotency, different-path error, close/reset pathways, symlink resolution, and SyncOpenViking parity

## Validation

```
ruff check  — passed
ruff format — passed
python -m py_compile  — passed
```

## Related Issues

Fixes #3546
