### PR TITLE
fix(parse): distinguish mpegts from TypeScript ts

### DIFF
--- a/openviking/parse/parsers/constants.py
+++ b/openviking/parse/parsers/constants.py
@@ -8,6 +8,9 @@ This file contains all constant definitions used by CodeRepositoryParser
 to keep the main code file clean and focused on logic.
 """
 
+MPEG_TS_EXTENSION_ALIAS = "mpegts"
+TYPESCRIPT_MPEG_TS_EXTENSION = ".ts"
+
 # Directories to ignore in code repositories
 IGNORE_DIRS = {
     ".git",

--- a/openviking/parse/parsers/media/utils.py
+++ b/openviking/parse/parsers/media/utils.py
@@ -7,10 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from openviking.core.path_variables import CalendarVariableProvider
-from openviking.parse.parsers.constants import (
-    MPEG_TS_EXTENSION_ALIAS,
-    TYPESCRIPT_MPEG_TS_EXTENSION,
-)
+from openviking.parse.parsers.constants import TYPESCRIPT_MPEG_TS_EXTENSION
 from openviking.prompts import render_prompt
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils.config import get_openviking_config
@@ -24,7 +21,7 @@ from .constants import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 logger = get_logger(__name__)
 
 MPEG_TS_PACKET_SIZE = 188
-MPEG_TS_PROBE_PACKETS = 3
+MPEG_TS_PROBE_PACKETS = 10
 MPEG_TS_PROBE_BYTES = MPEG_TS_PACKET_SIZE * MPEG_TS_PROBE_PACKETS
 MPEG_TS_SYNC_BYTE = 0x47
 
@@ -76,16 +73,6 @@ def is_mpeg_ts(content: bytes) -> bool:
     )
 
 
-def _get_media_type_from_resource_uri(source_path: str) -> Optional[str]:
-    if source_path.startswith("viking://resources/images/"):
-        return "image"
-    if source_path.startswith("viking://resources/audio/"):
-        return "audio"
-    if source_path.startswith("viking://resources/video/"):
-        return "video"
-    return None
-
-
 def get_media_type(source_path: Optional[str], source_format: Optional[str]) -> Optional[str]:
     """
     Determine media type from source path or format.
@@ -100,14 +87,8 @@ def get_media_type(source_path: Optional[str], source_format: Optional[str]) -> 
     if source_format:
         if source_format in ["image", "audio", "video"]:
             return source_format
-        if source_format.lower().lstrip(".") == MPEG_TS_EXTENSION_ALIAS:
-            return "video"
 
     if source_path:
-        resource_media_type = _get_media_type_from_resource_uri(source_path)
-        if resource_media_type:
-            return resource_media_type
-
         ext = Path(source_path).suffix.lower()
         if ext in IMAGE_EXTENSIONS:
             return "image"

--- a/openviking/parse/parsers/media/utils.py
+++ b/openviking/parse/parsers/media/utils.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from openviking.core.path_variables import CalendarVariableProvider
+from openviking.parse.parsers.constants import (
+    MPEG_TS_EXTENSION_ALIAS,
+    TYPESCRIPT_MPEG_TS_EXTENSION,
+)
 from openviking.prompts import render_prompt
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils.config import get_openviking_config
@@ -18,6 +22,11 @@ if TYPE_CHECKING:
 from .constants import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 
 logger = get_logger(__name__)
+
+MPEG_TS_PACKET_SIZE = 188
+MPEG_TS_PROBE_PACKETS = 3
+MPEG_TS_PROBE_BYTES = MPEG_TS_PACKET_SIZE * MPEG_TS_PROBE_PACKETS
+MPEG_TS_SYNC_BYTE = 0x47
 
 
 def _is_svg(data: bytes) -> bool:
@@ -51,6 +60,32 @@ def _convert_svg_to_png(svg_data: bytes) -> Optional[bytes]:
     return None
 
 
+def read_mpeg_ts_probe(path: Path) -> bytes:
+    """Read only the bytes needed to detect MPEG-TS packet sync."""
+    with path.open("rb") as file:
+        return file.read(MPEG_TS_PROBE_BYTES)
+
+
+def is_mpeg_ts(content: bytes) -> bool:
+    """Detect MPEG-TS by checking sync bytes at packet boundaries."""
+    if len(content) < MPEG_TS_PROBE_BYTES:
+        return False
+    return all(
+        content[index * MPEG_TS_PACKET_SIZE] == MPEG_TS_SYNC_BYTE
+        for index in range(MPEG_TS_PROBE_PACKETS)
+    )
+
+
+def _get_media_type_from_resource_uri(source_path: str) -> Optional[str]:
+    if source_path.startswith("viking://resources/images/"):
+        return "image"
+    if source_path.startswith("viking://resources/audio/"):
+        return "audio"
+    if source_path.startswith("viking://resources/video/"):
+        return "video"
+    return None
+
+
 def get_media_type(source_path: Optional[str], source_format: Optional[str]) -> Optional[str]:
     """
     Determine media type from source path or format.
@@ -65,13 +100,24 @@ def get_media_type(source_path: Optional[str], source_format: Optional[str]) -> 
     if source_format:
         if source_format in ["image", "audio", "video"]:
             return source_format
+        if source_format.lower().lstrip(".") == MPEG_TS_EXTENSION_ALIAS:
+            return "video"
 
     if source_path:
+        resource_media_type = _get_media_type_from_resource_uri(source_path)
+        if resource_media_type:
+            return resource_media_type
+
         ext = Path(source_path).suffix.lower()
         if ext in IMAGE_EXTENSIONS:
             return "image"
         elif ext in AUDIO_EXTENSIONS:
             return "audio"
+        elif ext == TYPESCRIPT_MPEG_TS_EXTENSION:
+            path = Path(source_path)
+            if not path.is_file():
+                return None
+            return "video" if is_mpeg_ts(read_mpeg_ts_probe(path)) else None
         elif ext in VIDEO_EXTENSIONS:
             return "video"
 

--- a/openviking/parse/registry.py
+++ b/openviking/parse/registry.py
@@ -93,8 +93,11 @@ class ParserRegistry:
         """
         path = Path(path)
         ext = path.suffix.lower()
-        if ext == TYPESCRIPT_MPEG_TS_EXTENSION and not is_mpeg_ts(read_mpeg_ts_probe(path)):
-            return None
+        if ext == TYPESCRIPT_MPEG_TS_EXTENSION:
+            if not path.is_file():
+                return None
+            if not is_mpeg_ts(read_mpeg_ts_probe(path)):
+                return None
 
         parser_name = self._extension_map.get(ext)
 

--- a/openviking/parse/registry.py
+++ b/openviking/parse/registry.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Union
 
 from openviking.parse.base import ParseResult
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.constants import TYPESCRIPT_MPEG_TS_EXTENSION
 from openviking.parse.parsers.directory import DirectoryParser
 from openviking.parse.parsers.epub import EPubParser
 from openviking.parse.parsers.excel import ExcelParser
@@ -22,6 +23,7 @@ from openviking.parse.parsers.html import HTMLParser
 from openviking.parse.parsers.legacy_doc import LegacyDocParser
 from openviking.parse.parsers.markdown import MarkdownParser
 from openviking.parse.parsers.media import AudioParser, ImageParser, VideoParser
+from openviking.parse.parsers.media.utils import is_mpeg_ts, read_mpeg_ts_probe
 from openviking.parse.parsers.pdf import PDFParser
 from openviking.parse.parsers.powerpoint import PowerPointParser
 from openviking.parse.parsers.text import TextParser
@@ -91,6 +93,9 @@ class ParserRegistry:
         """
         path = Path(path)
         ext = path.suffix.lower()
+        if ext == TYPESCRIPT_MPEG_TS_EXTENSION and not is_mpeg_ts(read_mpeg_ts_probe(path)):
+            return None
+
         parser_name = self._extension_map.get(ext)
 
         if parser_name:

--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -225,7 +225,9 @@ class UnderstandingAPI(BaseParser):
         result = ParseResult(
             root=root_node,
             source_path=original_source if isinstance(original_source, str) else url or source_str,
-            source_format=doc_type,
+            source_format=(
+                content_type if content_type in {"image", "audio", "video"} else doc_type
+            ),
             temp_dir_path=temp_dir_path,
             parser_name="UnderstandingAPI",
             meta=task_meta,

--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -29,6 +29,7 @@ from openviking.parse.image_rewrite import (
     build_artifact_image_mappings,
 )
 from openviking.parse.parsers.base_parser import BaseParser
+from openviking.parse.parsers.constants import MPEG_TS_EXTENSION_ALIAS
 from openviking.parse.parsers.media.constants import (
     AUDIO_EXTENSIONS,
     IMAGE_EXTENSIONS,
@@ -71,6 +72,7 @@ class UnderstandingAPI(BaseParser):
             raise ValueError("parser_api.api_key is required for UnderstandingAPI")
 
         self._video_exts = {e.lstrip(".") for e in VIDEO_EXTENSIONS}
+        self._video_exts.add(MPEG_TS_EXTENSION_ALIAS)
         self._audio_exts = {e.lstrip(".") for e in AUDIO_EXTENSIONS}
         self._image_exts = {e.lstrip(".") for e in IMAGE_EXTENSIONS}
 

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -22,6 +22,7 @@ import httpx
 from openviking.connector.client import ConnectorClient
 from openviking.core.content_targets import ContentTargetSpec
 from openviking.core.uri_validation import validate_optional_content_target_uri
+from openviking.parse.parsers.constants import MPEG_TS_EXTENSION_ALIAS
 from openviking.resource.feishu_watch_auth import (
     FEISHU_ACCESS_TOKEN_ARG,
     FEISHU_REFRESH_TOKEN_ARG,
@@ -1017,14 +1018,22 @@ class ResourceService:
                         or prepared_resource.meta.get("original_filename")
                         or prepared_resource.meta.get("resolved_name")
                     )
+                    source_format = resolved_extension.lstrip(".") or "file"
+                    if resolved_extension.lower().lstrip(".") == MPEG_TS_EXTENSION_ALIAS:
+                        source_format = "video"
+                    source_info = _ResourceSourceInfo(
+                        source_name=source_name,
+                        source_path=path,
+                        source_format=source_format,
+                    )
                 else:
                     resolved_extension = ""
                     source_name = kwargs.get("source_name")
-                source_info = _ResourceSourceInfo(
-                    source_name=source_name,
-                    source_path=path,
-                    source_format=resolved_extension.lstrip(".") or "file",
-                )
+                    source_info = _ResourceSourceInfo(
+                        source_name=source_name,
+                        source_path=path,
+                        source_format=resolved_extension.lstrip(".") or "file",
+                    )
                 doc_name = self._target_doc_name(path, source_name, source_info)
                 source_path = source_info.source_path or source_name or path
                 (

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1141,7 +1141,7 @@ class SemanticProcessor(DequeueHandlerBase):
         """
         file_name = file_path.split("/")[-1]
         llm_sem = llm_sem or asyncio.Semaphore(self.max_concurrent_llm)
-        media_type = get_media_type(file_path, None)
+        media_type = get_media_type(file_name, None)
         if media_type == "image":
             return await generate_image_summary(file_path, file_name, llm_sem, ctx=ctx)
         elif media_type == "audio":

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1141,7 +1141,7 @@ class SemanticProcessor(DequeueHandlerBase):
         """
         file_name = file_path.split("/")[-1]
         llm_sem = llm_sem or asyncio.Semaphore(self.max_concurrent_llm)
-        media_type = get_media_type(file_name, None)
+        media_type = get_media_type(file_path, None)
         if media_type == "image":
             return await generate_image_summary(file_path, file_name, llm_sem, ctx=ctx)
         elif media_type == "audio":

--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -12,7 +12,10 @@ from openviking.parse.parsers.constants import (
     CODE_EXTENSIONS,
     DOCUMENTATION_EXTENSIONS,
     IGNORE_EXTENSIONS,
+    MPEG_TS_EXTENSION_ALIAS,
+    TYPESCRIPT_MPEG_TS_EXTENSION,
 )
+from openviking.parse.parsers.media.utils import is_mpeg_ts, read_mpeg_ts_probe
 from openviking.parse.registry import parse
 from openviking.server.local_input_guard import (
     is_remote_resource_source,
@@ -133,7 +136,15 @@ class UnifiedResourceProcessor:
             extension = Path(source_name).suffix if source_name else ""
             extension = extension or str(meta.get("extension") or resource.path.suffix)
 
-        meta["resolved_extension"] = extension.lower()
+        extension = extension.lower()
+        if (
+            extension == TYPESCRIPT_MPEG_TS_EXTENSION
+            and resource.path.is_file()
+            and is_mpeg_ts(read_mpeg_ts_probe(resource.path))
+        ):
+            extension = MPEG_TS_EXTENSION_ALIAS
+
+        meta["resolved_extension"] = extension
         meta["resolved_name"] = source_name or meta.get("original_filename") or resource.path.name
 
     async def prepare(

--- a/tests/misc/test_mpeg_ts_media_utils.py
+++ b/tests/misc/test_mpeg_ts_media_utils.py
@@ -1,0 +1,51 @@
+from openviking.parse.parsers.media.utils import (
+    MPEG_TS_PACKET_SIZE,
+    MPEG_TS_PROBE_BYTES,
+    get_media_type,
+    is_mpeg_ts,
+    read_mpeg_ts_probe,
+)
+
+
+def mpeg_ts_probe() -> bytes:
+    content = bytearray(MPEG_TS_PROBE_BYTES)
+    for offset in range(0, MPEG_TS_PROBE_BYTES, MPEG_TS_PACKET_SIZE):
+        content[offset] = 0x47
+    return bytes(content)
+
+
+def test_is_mpeg_ts_requires_sync_bytes_at_packet_boundaries():
+    assert is_mpeg_ts(mpeg_ts_probe())
+
+    invalid = bytearray(mpeg_ts_probe())
+    invalid[MPEG_TS_PACKET_SIZE] = 0
+    assert not is_mpeg_ts(bytes(invalid))
+
+
+def test_read_mpeg_ts_probe_reads_only_probe_bytes(tmp_path):
+    path = tmp_path / "video.ts"
+    path.write_bytes(mpeg_ts_probe() + b"x" * 1024)
+
+    assert read_mpeg_ts_probe(path) == mpeg_ts_probe()
+
+
+def test_get_media_type_detects_local_mpeg_ts_by_magic_bytes(tmp_path):
+    path = tmp_path / "video.ts"
+    path.write_bytes(mpeg_ts_probe())
+
+    assert get_media_type(str(path), None) == "video"
+
+
+def test_get_media_type_does_not_classify_typescript_as_video(tmp_path):
+    path = tmp_path / "source.ts"
+    path.write_text("export const answer: number = 42;\n")
+
+    assert get_media_type(str(path), None) is None
+
+
+def test_get_media_type_uses_viking_video_uri_for_ts_resource():
+    assert get_media_type("viking://resources/video/2026/07/27/test.ts", None) == "video"
+
+
+def test_get_media_type_treats_mpegts_alias_as_video():
+    assert get_media_type(None, "mpegts") == "video"

--- a/tests/misc/test_mpeg_ts_media_utils.py
+++ b/tests/misc/test_mpeg_ts_media_utils.py
@@ -43,9 +43,9 @@ def test_get_media_type_does_not_classify_typescript_as_video(tmp_path):
     assert get_media_type(str(path), None) is None
 
 
-def test_get_media_type_uses_viking_video_uri_for_ts_resource():
-    assert get_media_type("viking://resources/video/2026/07/27/test.ts", None) == "video"
+def test_get_media_type_does_not_classify_viking_ts_uri_by_path_prefix():
+    assert get_media_type("viking://resources/video/2026/07/27/test.ts", None) is None
 
 
-def test_get_media_type_treats_mpegts_alias_as_video():
-    assert get_media_type(None, "mpegts") == "video"
+def test_get_media_type_treats_video_source_format_as_video():
+    assert get_media_type(None, "video") == "video"

--- a/tests/parse/test_parser_router.py
+++ b/tests/parse/test_parser_router.py
@@ -5,8 +5,17 @@ import pytest
 
 from openviking.parse.accessors.base import LocalResource, SourceType
 from openviking.parse.parser_router import ParserRouter
+from openviking.parse.parsers.media.utils import MPEG_TS_PACKET_SIZE, MPEG_TS_PROBE_BYTES
+from openviking.parse.registry import ParserRegistry
 from openviking.parse.understanding_api import PREPARED_RESPONSE_ID_ARG
 from openviking.utils.media_processor import UnifiedResourceProcessor
+
+
+def mpeg_ts_probe() -> bytes:
+    content = bytearray(MPEG_TS_PROBE_BYTES)
+    for offset in range(0, MPEG_TS_PROBE_BYTES, MPEG_TS_PACKET_SIZE):
+        content[offset] = 0x47
+    return bytes(content)
 
 
 def test_should_use_understanding_api_for_signed_video_url(monkeypatch):
@@ -56,6 +65,114 @@ def test_resolved_extension_routes_extensionless_download(monkeypatch, tmp_path)
 
     assert resource.meta["resolved_extension"] == ".pdf"
     assert processor.should_use_understanding_api(resource)
+
+
+def test_should_use_understanding_api_for_local_mpeg_ts(monkeypatch, tmp_path):
+    config = SimpleNamespace(
+        parser_api=SimpleNamespace(
+            enable=True,
+            enable_feishu_url=False,
+            extensions=["mpegts"],
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.open_viking_config.get_openviking_config",
+        lambda: config,
+    )
+    path = tmp_path / "video.ts"
+    path.write_bytes(mpeg_ts_probe())
+    resource = LocalResource(
+        path=path,
+        source_type=SourceType.HTTP,
+        original_source="https://example.com/video.ts",
+        meta={"extension": ".ts"},
+        is_temporary=False,
+    )
+    processor = UnifiedResourceProcessor()
+
+    processor._set_resolved_identity(resource, source_name=None)
+
+    assert resource.meta["resolved_extension"] == "mpegts"
+    assert processor.should_use_understanding_api(resource)
+
+
+def test_should_use_understanding_api_for_typescript_when_ts_configured(monkeypatch, tmp_path):
+    config = SimpleNamespace(
+        parser_api=SimpleNamespace(
+            enable=True,
+            enable_feishu_url=False,
+            extensions=["ts"],
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.open_viking_config.get_openviking_config",
+        lambda: config,
+    )
+    path = tmp_path / "source.ts"
+    path.write_text("export const answer: number = 42;\n")
+
+    router = ParserRouter(parser_registry=object())
+
+    assert router.should_use_understanding_api(path)
+
+
+def test_should_not_use_understanding_api_for_typescript_source(monkeypatch, tmp_path):
+    config = SimpleNamespace(
+        parser_api=SimpleNamespace(
+            enable=True,
+            enable_feishu_url=False,
+            extensions=["mpegts"],
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.open_viking_config.get_openviking_config",
+        lambda: config,
+    )
+    path = tmp_path / "source.ts"
+    path.write_text("export const answer: number = 42;\n")
+
+    router = ParserRouter(parser_registry=object())
+
+    assert not router.should_use_understanding_api(path)
+
+
+def test_should_not_use_understanding_api_for_mpeg_ts_when_extension_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    config = SimpleNamespace(
+        parser_api=SimpleNamespace(
+            enable=True,
+            enable_feishu_url=False,
+            extensions=["mp4"],
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.open_viking_config.get_openviking_config",
+        lambda: config,
+    )
+    path = tmp_path / "video.ts"
+    path.write_bytes(mpeg_ts_probe())
+    resource = LocalResource(
+        path=path,
+        source_type=SourceType.HTTP,
+        original_source="https://example.com/video.ts",
+        meta={"extension": ".ts"},
+        is_temporary=False,
+    )
+    processor = UnifiedResourceProcessor()
+
+    processor._set_resolved_identity(resource, source_name=None)
+
+    assert resource.meta["resolved_extension"] == "mpegts"
+    assert not processor.should_use_understanding_api(resource)
+
+
+def test_parser_registry_keeps_typescript_ts_on_text_fallback(tmp_path):
+    path = tmp_path / "source.ts"
+    path.write_text("export const answer: number = 42;\n")
+
+    assert ParserRegistry().get_parser_for_file(path) is None
 
 
 def test_should_use_understanding_api_for_feishu_url(monkeypatch):

--- a/tests/service/test_resource_service_understanding_routing.py
+++ b/tests/service/test_resource_service_understanding_routing.py
@@ -4,12 +4,20 @@ from unittest.mock import AsyncMock
 import pytest
 
 from openviking.parse.accessors.base import LocalResource, SourceType
+from openviking.parse.parsers.media.utils import MPEG_TS_PACKET_SIZE, MPEG_TS_PROBE_BYTES
 from openviking.server.identity import RequestContext, Role
 from openviking.service import resource_service as resource_service_module
 from openviking.service.resource_service import ResourceService
 from openviking.storage.queuefs import QueueManager
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
 from openviking_cli.session.user_id import UserIdentifier
+
+
+def mpeg_ts_probe() -> bytes:
+    content = bytearray(MPEG_TS_PROBE_BYTES)
+    for offset in range(0, MPEG_TS_PROBE_BYTES, MPEG_TS_PACKET_SIZE):
+        content[offset] = 0x47
+    return bytes(content)
 
 
 @pytest.mark.asyncio
@@ -106,4 +114,104 @@ async def test_extensionless_remote_url_queues_frozen_understanding_route(
     assert not downloaded.exists()
     processor.submit_understanding.assert_awaited_once_with(prepared)
     processor.process_resource.assert_not_awaited()
+    lock.handoff.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remote_mpeg_ts_url_queues_understanding_after_prepare(
+    monkeypatch,
+    tmp_path,
+):
+    ctx = RequestContext(
+        user=UserIdentifier("acct", "alice"),
+        role=Role.USER,
+        api_key="secret",
+    )
+    downloaded = tmp_path / "sample.ts"
+    downloaded.write_bytes(mpeg_ts_probe())
+    prepared = LocalResource(
+        path=downloaded,
+        source_type=SourceType.HTTP,
+        original_source="https://example.com/video/sample.ts?sign=1",
+        meta={
+            "resolved_extension": "mpegts",
+            "original_filename": "sample.ts",
+        },
+        is_temporary=True,
+    )
+    lock = SimpleNamespace(
+        to_handoff=lambda: SimpleNamespace(to_dict=lambda: {"handle_id": "lock-1"}),
+        handoff=AsyncMock(),
+        close=AsyncMock(),
+    )
+    resolve_target_uri = AsyncMock(
+        return_value=(
+            "viking://resources/video/sample",
+            "viking://resources/video/sample",
+        )
+    )
+    processor = SimpleNamespace(
+        understanding_api_enabled=lambda: True,
+        should_use_understanding_directly=lambda _source, **_kwargs: False,
+        prepare_resource=AsyncMock(return_value=prepared),
+        should_use_understanding_api=lambda resource: resource is prepared,
+        submit_understanding=AsyncMock(return_value="response-1"),
+        tree_builder=SimpleNamespace(resolve_target_uri=resolve_target_uri),
+        reserve_unique_candidate=AsyncMock(
+            return_value=("viking://resources/video/sample", lock)
+        ),
+        process_resource=AsyncMock(),
+    )
+    service = ResourceService(
+        vikingdb=object(),
+        viking_fs=object(),
+        resource_processor=processor,
+        skill_processor=object(),
+    )
+    service._should_use_connector = lambda *_args, **_kwargs: False
+    tracker = SimpleNamespace(
+        create=AsyncMock(return_value=SimpleNamespace(task_id="task-1")),
+        update_stage=AsyncMock(),
+        fail=AsyncMock(),
+    )
+    queue_manager = SimpleNamespace(enqueue=AsyncMock())
+    monkeypatch.setattr(resource_service_module, "is_git_repo_url", lambda _path: False)
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: queue_manager,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.transaction.get_lock_manager",
+        lambda: object(),
+    )
+
+    result = await service.add_resource(
+        path="https://example.com/video/sample.ts?sign=1",
+        ctx=ctx,
+        wait=False,
+        allow_local_path_resolution=False,
+    )
+
+    assert result == {
+        "status": "success",
+        "root_uri": "viking://resources/video/sample",
+        "task_id": "task-1",
+    }
+    processor.prepare_resource.assert_awaited_once()
+    processor.process_resource.assert_not_awaited()
+    processor.submit_understanding.assert_awaited_once_with(prepared)
+    resolve_target_uri.assert_awaited_once()
+    assert resolve_target_uri.await_args.kwargs["source_format"] == "video"
+    _, message = queue_manager.enqueue.await_args.args
+    assert queue_manager.enqueue.await_args.args[0] == QueueManager.EXTERNAL_PARSE
+    queued = AddResourceMsg.from_dict(message)
+    assert queued.args["parser_backend"] == "understanding"
+    assert queued.args["resolved_extension"] == "mpegts"
+    assert queued.understanding_response_id == "response-1"
+    assert queued.source_name == "sample.ts"
+    assert not downloaded.exists()
     lock.handoff.assert_awaited_once()


### PR DESCRIPTION
## Description

Fix `.ts` ambiguity by distinguishing TypeScript source files from MPEG-TS video streams. MPEG-TS `.ts` resources are normalized to the logical extension `mpegts`, while TypeScript `.ts` files keep the `ts` extension.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add MPEG-TS probing and logical `mpegts` extension normalization during resource identity resolution.
- Prevent TypeScript `.ts` files from being treated as video by extension alone.
- Route confirmed MPEG-TS `.ts` resources as video and preserve video handling in semantic processing.
- Add tests for local/remote `.ts` routing, media detection, parser selection, and Understanding routing.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tested with:

```bash
.venv/bin/pytest tests/misc/test_mpeg_ts_media_utils.py tests/parse/test_parser_router.py tests/service/test_resource_service_understanding_routing.py -q
.venv/bin/ruff check openviking/parse/understanding_api.py openviking/parse/parsers/media/utils.py openviking/utils/media_processor.py openviking/service/resource_service.py tests/misc/test_mpeg_ts_media_utils.py tests/parse/test_parser_router.py tests/service/test_resource_service_understanding_routing.py
```

Manual validation:
- TypeScript `.ts` URL imports as a normal resource.
- MPEG-TS `.ts` URL imports under `viking://resources/video/...` and completes via UnderstandingAPI.
- Local TypeScript `.ts` and local MPEG-TS `.ts` paths both tested successfully.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The recommended parser API extension for MPEG-TS is now `mpegts`; `ts` remains available for TypeScript source semantics.