### PR TITLE
fix(langchain): isolate async history and preserve cancellation semantics

### DIFF
--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -87,7 +87,7 @@ serialized per session and event loop.
 
 If cancellation occurs after a recorder has confirmed part of a write,
 `arecord()` re-raises the original `asyncio.CancelledError`. Pass that exception,
-or a wrapping `TimeoutError`, to
+or a wrapping `asyncio.TimeoutError`, to
 `get_openviking_cancellation_progress()` to inspect the confirmed message
 prefix or pending-commit state before retrying. Preserving the original
 cancellation object also preserves the standard `asyncio.wait_for()` and

--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -78,16 +78,20 @@ or reset it before selecting another workspace.
 and `aclear()`. `OpenVikingSessionRecorder` provides `arecord()`, `aflush()`,
 and `aclose()`. Async LangGraph runs select `awrap_model_call()` and
 `aafter_agent()` automatically. Concurrent first use creates one internal HTTP
-client per adapter and event loop. To preserve LangChain's history read/append
-semantics, async calls through one `with_openviking_context()` wrapper are
-serialized on the same event loop when they share a session ID; calls for
-different sessions remain concurrent.
+client per adapter and event loop. Each `with_openviking_context()` invocation
+owns the history snapshot, peer identity, and recalled-context references used
+to record its turn. Concurrent calls may therefore share a session without a
+second live history read losing messages, and an abandoned stream does not hold
+a session-wide lifecycle lock. Only the final append-and-commit step is
+serialized per session and event loop.
 
 If cancellation occurs after a recorder has confirmed part of a write,
-`arecord()` raises `OpenVikingRecordingCancelledError`. It remains an
-`asyncio.CancelledError`, while exposing the confirmed message prefix or
-pending-commit state so integrations can retry without duplicating durable
-messages.
+`arecord()` re-raises the original `asyncio.CancelledError`. Pass that exception,
+or a wrapping `TimeoutError`, to
+`get_openviking_cancellation_progress()` to inspect the confirmed message
+prefix or pending-commit state before retrying. Preserving the original
+cancellation object also preserves the standard `asyncio.wait_for()` and
+`asyncio.timeout()` timeout behavior.
 
 Adapters never close an injected client. When an adapter creates its own client,
 release it with `await retriever.aclose()`, `await assembler.aclose()`,

--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -78,7 +78,16 @@ or reset it before selecting another workspace.
 and `aclear()`. `OpenVikingSessionRecorder` provides `arecord()`, `aflush()`,
 and `aclose()`. Async LangGraph runs select `awrap_model_call()` and
 `aafter_agent()` automatically. Concurrent first use creates one internal HTTP
-client per adapter and event loop.
+client per adapter and event loop. To preserve LangChain's history read/append
+semantics, async calls through one `with_openviking_context()` wrapper are
+serialized on the same event loop when they share a session ID; calls for
+different sessions remain concurrent.
+
+If cancellation occurs after a recorder has confirmed part of a write,
+`arecord()` raises `OpenVikingRecordingCancelledError`. It remains an
+`asyncio.CancelledError`, while exposing the confirmed message prefix or
+pending-commit state so integrations can retry without duplicating durable
+messages.
 
 Adapters never close an injected client. When an adapter creates its own client,
 release it with `await retriever.aclose()`, `await assembler.aclose()`,

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -75,7 +75,14 @@ workspace；切换 workspace 前应先关闭或 reset 当前 client。
 `aclear()`；`OpenVikingSessionRecorder` 提供 `arecord()`、`aflush()` 和
 `aclose()`。异步 LangGraph 运行会自动选择 `awrap_model_call()` 和
 `aafter_agent()`。同一 adapter 首次被并发调用时，每个 event loop 只会创建一个内部
-HTTP client。
+HTTP client。为保持 LangChain history 的读取/追加语义，通过同一个
+`with_openviking_context()` wrapper 在同一个 event loop 中发起的异步调用若使用相同
+session ID，会按顺序执行；不同 session 的调用仍可并发执行。
+
+如果 recorder 已确认部分写入后任务被取消，`arecord()` 会抛出
+`OpenVikingRecordingCancelledError`。它仍然属于 `asyncio.CancelledError`，同时提供
+已确认写入的消息前缀或待 commit 状态，使 integration 可以重试而不重复写入已持久化
+的消息。
 
 Adapter 不会关闭调用方注入的 client。对于 adapter 自行创建的 client，应按实际使用的组件调用
 `await retriever.aclose()`、`await assembler.aclose()`、

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -82,7 +82,7 @@ lifecycle lock。只有最终的 append-and-commit 步骤会在同一个 event l
 串行执行。
 
 如果 recorder 已确认部分写入后任务被取消，`arecord()` 会重新抛出原始
-`asyncio.CancelledError`。可将该异常或外层的 `TimeoutError` 传给
+`asyncio.CancelledError`。可将该异常或外层的 `asyncio.TimeoutError` 传给
 `get_openviking_cancellation_progress()`，在重试前读取已确认写入的消息前缀或待
 commit 状态，避免重复写入。保留原始取消异常也会保留 `asyncio.wait_for()` 和
 `asyncio.timeout()` 的标准超时行为。

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -75,14 +75,17 @@ workspace；切换 workspace 前应先关闭或 reset 当前 client。
 `aclear()`；`OpenVikingSessionRecorder` 提供 `arecord()`、`aflush()` 和
 `aclose()`。异步 LangGraph 运行会自动选择 `awrap_model_call()` 和
 `aafter_agent()`。同一 adapter 首次被并发调用时，每个 event loop 只会创建一个内部
-HTTP client。为保持 LangChain history 的读取/追加语义，通过同一个
-`with_openviking_context()` wrapper 在同一个 event loop 中发起的异步调用若使用相同
-session ID，会按顺序执行；不同 session 的调用仍可并发执行。
+HTTP client。每次 `with_openviking_context()` 调用都独立持有本次写入所需的 history
+快照、peer 身份和召回上下文引用。因此，同一 session 的调用可以并发执行，不会因为
+退出时再次读取实时 history 而丢失消息；未消费完的 stream 也不会占用 session 级
+lifecycle lock。只有最终的 append-and-commit 步骤会在同一个 event loop 中按 session
+串行执行。
 
-如果 recorder 已确认部分写入后任务被取消，`arecord()` 会抛出
-`OpenVikingRecordingCancelledError`。它仍然属于 `asyncio.CancelledError`，同时提供
-已确认写入的消息前缀或待 commit 状态，使 integration 可以重试而不重复写入已持久化
-的消息。
+如果 recorder 已确认部分写入后任务被取消，`arecord()` 会重新抛出原始
+`asyncio.CancelledError`。可将该异常或外层的 `TimeoutError` 传给
+`get_openviking_cancellation_progress()`，在重试前读取已确认写入的消息前缀或待
+commit 状态，避免重复写入。保留原始取消异常也会保留 `asyncio.wait_for()` 和
+`asyncio.timeout()` 的标准超时行为。
 
 Adapter 不会关闭调用方注入的 client。对于 adapter 自行创建的 client，应按实际使用的组件调用
 `await retriever.aclose()`、`await assembler.aclose()`、

--- a/openviking/integrations/langchain/__init__.py
+++ b/openviking/integrations/langchain/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "OpenVikingContextMiddleware",
     "OpenVikingPartialWriteError",
     "OpenVikingRecordResult",
+    "OpenVikingRecordingCancelledError",
     "OpenVikingRetriever",
     "OpenVikingSessionContextAssembler",
     "OpenVikingSessionRecorder",
@@ -59,6 +60,12 @@ def __getattr__(name: str) -> Any:
         from openviking.integrations.langchain.recording import OpenVikingRecordResult
 
         return OpenVikingRecordResult
+    if name == "OpenVikingRecordingCancelledError":
+        from openviking.integrations.langchain.recording import (
+            OpenVikingRecordingCancelledError,
+        )
+
+        return OpenVikingRecordingCancelledError
     if name == "OpenVikingCommitPolicy":
         from openviking.integrations.langchain.client import OpenVikingCommitPolicy
 

--- a/openviking/integrations/langchain/__init__.py
+++ b/openviking/integrations/langchain/__init__.py
@@ -13,16 +13,17 @@ from typing import Any
 __all__ = [
     "InMemoryOpenVikingClient",
     "OpenVikingChatMessageHistory",
+    "OpenVikingCancellationProgress",
     "OpenVikingCommitPolicy",
     "OpenVikingContextMiddleware",
     "OpenVikingPartialWriteError",
     "OpenVikingRecordResult",
-    "OpenVikingRecordingCancelledError",
     "OpenVikingRetriever",
     "OpenVikingSessionContextAssembler",
     "OpenVikingSessionRecorder",
     "OpenVikingStore",
     "create_openviking_tools",
+    "get_openviking_cancellation_progress",
     "with_openviking_context",
 ]
 
@@ -60,12 +61,18 @@ def __getattr__(name: str) -> Any:
         from openviking.integrations.langchain.recording import OpenVikingRecordResult
 
         return OpenVikingRecordResult
-    if name == "OpenVikingRecordingCancelledError":
+    if name == "OpenVikingCancellationProgress":
         from openviking.integrations.langchain.recording import (
-            OpenVikingRecordingCancelledError,
+            OpenVikingCancellationProgress,
         )
 
-        return OpenVikingRecordingCancelledError
+        return OpenVikingCancellationProgress
+    if name == "get_openviking_cancellation_progress":
+        from openviking.integrations.langchain.recording import (
+            get_openviking_cancellation_progress,
+        )
+
+        return get_openviking_cancellation_progress
     if name == "OpenVikingCommitPolicy":
         from openviking.integrations.langchain.client import OpenVikingCommitPolicy
 

--- a/openviking/integrations/langchain/context.py
+++ b/openviking/integrations/langchain/context.py
@@ -6,18 +6,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from typing import Any, cast
 
 try:
     from langchain_core.messages import SystemMessage
-    from langchain_core.runnables import ConfigurableFieldSpec, RunnableLambda
+    from langchain_core.runnables import ConfigurableFieldSpec, Runnable, RunnableLambda
+    from langchain_core.runnables.config import RunnableConfig
     from langchain_core.runnables.history import RunnableWithMessageHistory
 except ImportError as exc:  # pragma: no cover - exercised by optional import path
     from openviking.integrations.langchain.client import missing_dependency
 
     raise missing_dependency("langchain", "langchain-core") from exc
+from pydantic import PrivateAttr
 
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
@@ -49,6 +52,152 @@ class OpenVikingAssembledContext:
     context_parts: list[dict[str, Any]] = field(default_factory=list)
     session_context: dict[str, Any] = field(default_factory=dict)
     recall_documents: list[Any] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _AsyncSessionLockEntry:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
+
+
+class _AsyncSessionLockPool:
+    """Keep active session locks without retaining inactive session ids."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, _AsyncSessionLockEntry] = {}
+
+    @asynccontextmanager
+    async def acquire(self, session_id: str) -> AsyncIterator[None]:
+        entry = self._entries.get(session_id)
+        if entry is None:
+            entry = _AsyncSessionLockEntry()
+            self._entries[session_id] = entry
+        entry.users += 1
+        acquired = False
+        try:
+            await entry.lock.acquire()
+            acquired = True
+            yield
+        finally:
+            if acquired:
+                entry.lock.release()
+            entry.users -= 1
+            if entry.users == 0 and self._entries.get(session_id) is entry:
+                self._entries.pop(session_id, None)
+
+
+class _OpenVikingRunnableWithMessageHistory(RunnableWithMessageHistory):
+    """Serialize async history lifecycles that target the same session."""
+
+    _async_session_lock_pools: LoopScopedAsyncClientCache = PrivateAttr(
+        default_factory=LoopScopedAsyncClientCache
+    )
+
+    def _lock_pool(self) -> _AsyncSessionLockPool:
+        return self._async_session_lock_pools.get(_AsyncSessionLockPool)
+
+    @staticmethod
+    def _merged_session_id(config: RunnableConfig) -> str:
+        history = config["configurable"]["message_history"]
+        return _validate_session_id(getattr(history, "session_id", None), key="session_id")
+
+    async def _ainvoke_merged(
+        self,
+        input_value: Any,
+        config: RunnableConfig,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        session_id = self._merged_session_id(config)
+        async with self._lock_pool().acquire(session_id):
+            return await self.bound.ainvoke(
+                input_value,
+                config,
+                **{**self.kwargs, **kwargs},
+            )
+
+    async def ainvoke(
+        self,
+        input: Any,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke while serializing the complete history lifecycle per session."""
+
+        return await self._ainvoke_merged(input, self._merge_configs(config), kwargs)
+
+    async def astream(
+        self,
+        input: Any,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        """Stream while serializing the complete history lifecycle per session."""
+
+        merged_config = self._merge_configs(config)
+        session_id = self._merged_session_id(merged_config)
+        async with self._lock_pool().acquire(session_id):
+            async for item in self.bound.astream(
+                input,
+                merged_config,
+                **{**self.kwargs, **kwargs},
+            ):
+                yield item
+
+    async def astream_events(
+        self,
+        input: Any,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        """Stream events while serializing the history lifecycle per session."""
+
+        merged_config = self._merge_configs(config)
+        session_id = self._merged_session_id(merged_config)
+        async with self._lock_pool().acquire(session_id):
+            async for item in self.bound.astream_events(
+                input,
+                merged_config,
+                **{**self.kwargs, **kwargs},
+            ):
+                yield item
+
+    async def abatch(
+        self,
+        inputs: list[Any],
+        config: RunnableConfig | list[RunnableConfig] | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any,
+    ) -> list[Any]:
+        """Batch through per-invocation locks so each lifecycle owns its lock."""
+
+        return await Runnable.abatch(
+            self,
+            inputs,
+            config,
+            return_exceptions=return_exceptions,
+            **kwargs,
+        )
+
+    async def abatch_as_completed(
+        self,
+        inputs: Sequence[Any],
+        config: RunnableConfig | Sequence[RunnableConfig] | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any,
+    ) -> AsyncIterator[tuple[int, Any]]:
+        """Yield batch results while preserving per-session serialization."""
+
+        batch_as_completed = cast(Any, Runnable.abatch_as_completed)
+        async for item in batch_as_completed(
+            self,
+            inputs,
+            config,
+            return_exceptions=return_exceptions,
+            **kwargs,
+        ):
+            yield item
 
 
 class OpenVikingSessionContextAssembler:
@@ -379,7 +528,7 @@ def with_openviking_context(
     peer_id_config_key: str = "peer_id",
     inject_context: bool = True,
 ) -> RunnableWithMessageHistory:
-    """Wrap a LangChain runnable with OpenViking context and message history."""
+    """Wrap a runnable and serialize async lifecycles that share a session."""
 
     assembler = OpenVikingSessionContextAssembler(
         client=client,
@@ -527,20 +676,39 @@ def with_openviking_context(
         return apply_injection(input_value, pending_key, assembled)
 
     def clear_pending_on_error(_run: Any, config: dict[str, Any] | None = None) -> None:
-        del config
-        pending_context_parts.clear()
+        try:
+            resolved_session_id = session_id or _session_id_from_config(
+                config,
+                key=session_id_config_key,
+            )
+            resolved_peer_id = _peer_id_from_config(
+                config,
+                key=peer_id_config_key,
+                default=peer_id,
+            )
+        except Exception:
+            logger.debug(
+                "OpenViking pending context cleanup could not resolve the failed session",
+                exc_info=True,
+            )
+            return
+        pending_context_parts.pop(
+            _pending_context_key(resolved_session_id, resolved_peer_id),
+            None,
+        )
 
     bound = (RunnableLambda(inject, afunc=ainject) | runnable).with_listeners(
         on_error=clear_pending_on_error
     )
-    return RunnableWithMessageHistory(
-        bound,
-        session_history_factory,
+    wrapped = _OpenVikingRunnableWithMessageHistory(
+        runnable=bound,
+        get_session_history=session_history_factory,
         input_messages_key=input_messages_key,
         output_messages_key=output_messages_key,
         history_messages_key=history_messages_key,
         history_factory_config=history_factory_config,
     )
+    return wrapped
 
 
 def _session_id_from_config(config: dict[str, Any] | None, *, key: str) -> str:

--- a/openviking/integrations/langchain/context.py
+++ b/openviking/integrations/langchain/context.py
@@ -9,18 +9,16 @@ import logging
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 try:
-    from langchain_core.messages import SystemMessage
-    from langchain_core.runnables import ConfigurableFieldSpec, Runnable, RunnableLambda
-    from langchain_core.runnables.config import RunnableConfig
+    from langchain_core.messages import BaseMessage, SystemMessage
+    from langchain_core.runnables import ConfigurableFieldSpec, RunnableLambda
     from langchain_core.runnables.history import RunnableWithMessageHistory
 except ImportError as exc:  # pragma: no cover - exercised by optional import path
     from openviking.integrations.langchain.client import missing_dependency
 
     raise missing_dependency("langchain", "langchain-core") from exc
-from pydantic import PrivateAttr
 
 from openviking.integrations.langchain.client import (
     OpenVikingCommitPolicy,
@@ -55,22 +53,22 @@ class OpenVikingAssembledContext:
 
 
 @dataclass(slots=True)
-class _AsyncSessionLockEntry:
+class _AsyncSessionWriteLockEntry:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     users: int = 0
 
 
-class _AsyncSessionLockPool:
-    """Keep active session locks without retaining inactive session ids."""
+class _AsyncSessionWriteLockPool:
+    """Serialize completed writes without retaining inactive session IDs."""
 
     def __init__(self) -> None:
-        self._entries: dict[str, _AsyncSessionLockEntry] = {}
+        self._entries: dict[str, _AsyncSessionWriteLockEntry] = {}
 
     @asynccontextmanager
     async def acquire(self, session_id: str) -> AsyncIterator[None]:
         entry = self._entries.get(session_id)
         if entry is None:
-            entry = _AsyncSessionLockEntry()
+            entry = _AsyncSessionWriteLockEntry()
             self._entries[session_id] = entry
         entry.users += 1
         acquired = False
@@ -86,118 +84,43 @@ class _AsyncSessionLockPool:
                 self._entries.pop(session_id, None)
 
 
-class _OpenVikingRunnableWithMessageHistory(RunnableWithMessageHistory):
-    """Serialize async history lifecycles that target the same session."""
+class _InvocationOpenVikingChatMessageHistory(OpenVikingChatMessageHistory):
+    """Hold the entry history snapshot for one runnable invocation."""
 
-    _async_session_lock_pools: LoopScopedAsyncClientCache = PrivateAttr(
-        default_factory=LoopScopedAsyncClientCache
-    )
-
-    def _lock_pool(self) -> _AsyncSessionLockPool:
-        return self._async_session_lock_pools.get(_AsyncSessionLockPool)
-
-    @staticmethod
-    def _merged_session_id(config: RunnableConfig) -> str:
-        history = config["configurable"]["message_history"]
-        return _validate_session_id(getattr(history, "session_id", None), key="session_id")
-
-    async def _ainvoke_merged(
+    def __init__(
         self,
-        input_value: Any,
-        config: RunnableConfig,
-        kwargs: dict[str, Any],
-    ) -> Any:
-        session_id = self._merged_session_id(config)
-        async with self._lock_pool().acquire(session_id):
-            return await self.bound.ainvoke(
-                input_value,
-                config,
-                **{**self.kwargs, **kwargs},
-            )
-
-    async def ainvoke(
-        self,
-        input: Any,
-        config: RunnableConfig | None = None,
+        *args: Any,
+        async_write_lock_pools: LoopScopedAsyncClientCache,
         **kwargs: Any,
-    ) -> Any:
-        """Invoke while serializing the complete history lifecycle per session."""
+    ):
+        super().__init__(*args, **kwargs)
+        self._entry_snapshot: list[BaseMessage] | None = None
+        self._async_write_lock_pools = async_write_lock_pools
 
-        return await self._ainvoke_merged(input, self._merge_configs(config), kwargs)
+    @property
+    def messages(self) -> list[BaseMessage]:
+        if self._entry_snapshot is None:
+            self._entry_snapshot = list(super().messages)
+        return list(self._entry_snapshot)
 
-    async def astream(
-        self,
-        input: Any,
-        config: RunnableConfig | None = None,
-        **kwargs: Any,
-    ) -> AsyncIterator[Any]:
-        """Stream while serializing the complete history lifecycle per session."""
+    async def aget_messages(self) -> list[BaseMessage]:
+        if self._entry_snapshot is None:
+            self._entry_snapshot = list(await super().aget_messages())
+        return list(self._entry_snapshot)
 
-        merged_config = self._merge_configs(config)
-        session_id = self._merged_session_id(merged_config)
-        async with self._lock_pool().acquire(session_id):
-            async for item in self.bound.astream(
-                input,
-                merged_config,
-                **{**self.kwargs, **kwargs},
-            ):
-                yield item
+    def add_messages(self, messages: Sequence[BaseMessage]) -> None:
+        try:
+            super().add_messages(messages)
+        finally:
+            self._entry_snapshot = None
 
-    async def astream_events(
-        self,
-        input: Any,
-        config: RunnableConfig | None = None,
-        **kwargs: Any,
-    ) -> AsyncIterator[Any]:
-        """Stream events while serializing the history lifecycle per session."""
-
-        merged_config = self._merge_configs(config)
-        session_id = self._merged_session_id(merged_config)
-        async with self._lock_pool().acquire(session_id):
-            async for item in self.bound.astream_events(
-                input,
-                merged_config,
-                **{**self.kwargs, **kwargs},
-            ):
-                yield item
-
-    async def abatch(
-        self,
-        inputs: list[Any],
-        config: RunnableConfig | list[RunnableConfig] | None = None,
-        *,
-        return_exceptions: bool = False,
-        **kwargs: Any,
-    ) -> list[Any]:
-        """Batch through per-invocation locks so each lifecycle owns its lock."""
-
-        return await Runnable.abatch(
-            self,
-            inputs,
-            config,
-            return_exceptions=return_exceptions,
-            **kwargs,
-        )
-
-    async def abatch_as_completed(
-        self,
-        inputs: Sequence[Any],
-        config: RunnableConfig | Sequence[RunnableConfig] | None = None,
-        *,
-        return_exceptions: bool = False,
-        **kwargs: Any,
-    ) -> AsyncIterator[tuple[int, Any]]:
-        """Yield batch results while preserving per-session serialization."""
-
-        batch_as_completed = cast(Any, Runnable.abatch_as_completed)
-        async for item in batch_as_completed(
-            self,
-            inputs,
-            config,
-            return_exceptions=return_exceptions,
-            **kwargs,
-        ):
-            yield item
+    async def aadd_messages(self, messages: Sequence[BaseMessage]) -> None:
+        try:
+            lock_pool = self._async_write_lock_pools.get(_AsyncSessionWriteLockPool)
+            async with lock_pool.acquire(self.session_id):
+                await super().aadd_messages(messages)
+        finally:
+            self._entry_snapshot = None
 
 
 class OpenVikingSessionContextAssembler:
@@ -528,7 +451,7 @@ def with_openviking_context(
     peer_id_config_key: str = "peer_id",
     inject_context: bool = True,
 ) -> RunnableWithMessageHistory:
-    """Wrap a runnable and serialize async lifecycles that share a session."""
+    """Wrap a runnable with invocation-scoped OpenViking history and context."""
 
     assembler = OpenVikingSessionContextAssembler(
         client=client,
@@ -550,29 +473,13 @@ def with_openviking_context(
         include_active_messages=False,
         include_recall=inject_context,
     )
-    pending_context_parts: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    active_peer_ids: dict[str, str | None] = {}
+    async_write_lock_pools = LoopScopedAsyncClientCache()
 
     def make_history(active_session_id: str) -> OpenVikingChatMessageHistory:
-        def pending_key(current_session_id: str) -> tuple[str, str]:
-            return _pending_context_key(
-                current_session_id,
-                active_peer_ids.get(current_session_id, peer_id),
-            )
-
-        def provide_context_parts(current_session_id: str) -> list[dict[str, Any]]:
-            return list(pending_context_parts.get(pending_key(current_session_id), []))
-
-        def acknowledge_context_parts(current_session_id: str) -> None:
-            pending_context_parts.pop(pending_key(current_session_id), None)
-
-        return OpenVikingChatMessageHistory(
+        return _InvocationOpenVikingChatMessageHistory(
             session_id=active_session_id,
+            async_write_lock_pools=async_write_lock_pools,
             peer_id=peer_id,
-            peer_id_provider=lambda current_session_id: active_peer_ids.get(
-                current_session_id,
-                peer_id,
-            ),
             client=client,
             async_client=async_client,
             url=url,
@@ -587,8 +494,6 @@ def with_openviking_context(
             auto_initialize=auto_initialize,
             token_budget=token_budget,
             commit_policy=commit_policy,
-            context_parts_provider=provide_context_parts,
-            context_parts_acknowledger=acknowledge_context_parts,
         )
 
     if session_id is None:
@@ -624,7 +529,7 @@ def with_openviking_context(
     def prepare_injection(
         input_value: Any,
         config: dict[str, Any] | None,
-    ) -> tuple[str, tuple[str, str], str] | None:
+    ) -> tuple[str, _InvocationOpenVikingChatMessageHistory, str] | None:
         resolved_session_id = session_id or _session_id_from_config(
             config,
             key=session_id_config_key,
@@ -634,75 +539,66 @@ def with_openviking_context(
             key=peer_id_config_key,
             default=peer_id,
         )
-        active_peer_ids[resolved_session_id] = resolved_peer_id
+        history = _invocation_history_from_config(config)
+        history._prepare_invocation(peer_id=resolved_peer_id)
         if not inject_context:
             return None
-        pending_key = _pending_context_key(resolved_session_id, resolved_peer_id)
-        pending_context_parts.pop(pending_key, None)
         query = _latest_user_text_from_input(input_value, input_messages_key)
-        return resolved_session_id, pending_key, query
+        return resolved_session_id, history, query
 
     def apply_injection(
         input_value: Any,
-        pending_key: tuple[str, str],
+        history: _InvocationOpenVikingChatMessageHistory,
         assembled: OpenVikingAssembledContext,
     ) -> Any:
         if not assembled.block:
             return input_value
         if assembled.context_parts:
-            pending_context_parts[pending_key] = assembled.context_parts
+            history._prepare_invocation(
+                peer_id=history.peer_id,
+                context_parts=assembled.context_parts,
+            )
         return _inject_system_context(input_value, assembled.block, input_messages_key)
 
     def inject(input_value: Any, config: dict[str, Any] | None = None) -> Any:
         prepared = prepare_injection(input_value, config)
         if prepared is None:
             return input_value
-        resolved_session_id, pending_key, query = prepared
+        resolved_session_id, history, query = prepared
         assembled = assembler.assemble(
             session_id=resolved_session_id,
             query=query,
         )
-        return apply_injection(input_value, pending_key, assembled)
+        return apply_injection(input_value, history, assembled)
 
     async def ainject(input_value: Any, config: dict[str, Any] | None = None) -> Any:
         prepared = prepare_injection(input_value, config)
         if prepared is None:
             return input_value
-        resolved_session_id, pending_key, query = prepared
+        resolved_session_id, history, query = prepared
         assembled = await assembler.aassemble(
             session_id=resolved_session_id,
             query=query,
         )
-        return apply_injection(input_value, pending_key, assembled)
+        return apply_injection(input_value, history, assembled)
 
     def clear_pending_on_error(_run: Any, config: dict[str, Any] | None = None) -> None:
         try:
-            resolved_session_id = session_id or _session_id_from_config(
-                config,
-                key=session_id_config_key,
-            )
-            resolved_peer_id = _peer_id_from_config(
-                config,
-                key=peer_id_config_key,
-                default=peer_id,
-            )
+            history = _invocation_history_from_config(config)
         except Exception:
             logger.debug(
-                "OpenViking pending context cleanup could not resolve the failed session",
+                "OpenViking pending context cleanup could not resolve invocation history",
                 exc_info=True,
             )
             return
-        pending_context_parts.pop(
-            _pending_context_key(resolved_session_id, resolved_peer_id),
-            None,
-        )
+        history._discard_invocation_context()
 
     bound = (RunnableLambda(inject, afunc=ainject) | runnable).with_listeners(
         on_error=clear_pending_on_error
     )
-    wrapped = _OpenVikingRunnableWithMessageHistory(
-        runnable=bound,
-        get_session_history=session_history_factory,
+    wrapped = RunnableWithMessageHistory(
+        bound,
+        session_history_factory,
         input_messages_key=input_messages_key,
         output_messages_key=output_messages_key,
         history_messages_key=history_messages_key,
@@ -741,6 +637,16 @@ def _validate_session_id(value: Any, *, key: str) -> str:
     return session_id
 
 
+def _invocation_history_from_config(
+    config: dict[str, Any] | None,
+) -> _InvocationOpenVikingChatMessageHistory:
+    configurable = (config or {}).get("configurable") or {}
+    history = configurable.get("message_history")
+    if not isinstance(history, _InvocationOpenVikingChatMessageHistory):
+        raise RuntimeError("OpenViking runnable invocation history is unavailable")
+    return history
+
+
 def _retriever_for_session(
     retriever: Any,
     session_id: str,
@@ -752,10 +658,6 @@ def _retriever_for_session(
         }
         return retriever.model_copy(update=update)
     return retriever
-
-
-def _pending_context_key(session_id: str, peer_id: str | None) -> tuple[str, str]:
-    return (session_id, peer_id or "")
 
 
 def _latest_user_text_from_input(input_value: Any, input_messages_key: str | None) -> str:

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Sequence
 from typing import Any, Callable
@@ -32,8 +33,8 @@ from openviking.integrations.langchain.messages import (
 )
 from openviking.integrations.langchain.recording import (
     OpenVikingPartialWriteError,
-    OpenVikingRecordingCancelledError,
     OpenVikingSessionRecorder,
+    get_openviking_cancellation_progress,
 )
 
 logger = logging.getLogger(__name__)
@@ -166,8 +167,13 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
                 peer_id=self._effective_peer_id(),
                 context_parts=self._pending_context_parts,
             )
-        except (OpenVikingPartialWriteError, OpenVikingRecordingCancelledError) as exc:
+        except OpenVikingPartialWriteError as exc:
             if exc.context_attached:
+                self._acknowledge_context_parts()
+            raise
+        except asyncio.CancelledError as exc:
+            progress = get_openviking_cancellation_progress(exc)
+            if progress is not None and progress.context_attached:
                 self._acknowledge_context_parts()
             raise
         if result.context_attached:
@@ -227,6 +233,22 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
             return None
         text = str(value).strip()
         return text or None
+
+    def _prepare_invocation(
+        self,
+        *,
+        peer_id: str | None,
+        context_parts: Sequence[dict[str, Any]] = (),
+    ) -> None:
+        """Set invocation-local attribution and recalled context."""
+
+        self.peer_id = peer_id
+        self._pending_context_parts = list(context_parts)
+
+    def _discard_invocation_context(self) -> None:
+        """Discard recalled context owned by an interrupted invocation."""
+
+        self._pending_context_parts = []
 
     def _acknowledge_context_parts(self) -> None:
         had_pending_context = bool(self._pending_context_parts)

--- a/openviking/integrations/langchain/history.py
+++ b/openviking/integrations/langchain/history.py
@@ -32,6 +32,7 @@ from openviking.integrations.langchain.messages import (
 )
 from openviking.integrations.langchain.recording import (
     OpenVikingPartialWriteError,
+    OpenVikingRecordingCancelledError,
     OpenVikingSessionRecorder,
 )
 
@@ -165,7 +166,7 @@ class OpenVikingChatMessageHistory(BaseChatMessageHistory):
                 peer_id=self._effective_peer_id(),
                 context_parts=self._pending_context_parts,
             )
-        except OpenVikingPartialWriteError as exc:
+        except (OpenVikingPartialWriteError, OpenVikingRecordingCancelledError) as exc:
             if exc.context_attached:
                 self._acknowledge_context_parts()
             raise

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -34,6 +34,7 @@ from openviking.integrations.langchain.context import (
 )
 from openviking.integrations.langchain.recording import (
     OpenVikingPartialWriteError,
+    OpenVikingRecordingCancelledError,
     OpenVikingSessionRecorder,
 )
 from openviking.integrations.langchain.retrievers import OpenVikingRetriever
@@ -291,7 +292,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 peer_id=plan.peer_id,
                 context_parts=plan.context_parts,
             )
-        except OpenVikingPartialWriteError as exc:
+        except (OpenVikingPartialWriteError, OpenVikingRecordingCancelledError) as exc:
             self._handle_partial_capture(plan, exc)
             raise
 
@@ -336,7 +337,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
     def _handle_partial_capture(
         self,
         plan: _CapturePlan,
-        error: OpenVikingPartialWriteError,
+        error: OpenVikingPartialWriteError | OpenVikingRecordingCancelledError,
     ) -> None:
         if error.input_messages_consumed:
             consumed_end = plan.start + error.input_messages_consumed

--- a/openviking/integrations/langchain/middleware.py
+++ b/openviking/integrations/langchain/middleware.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -33,9 +34,10 @@ from openviking.integrations.langchain.context import (
     OpenVikingSessionContextAssembler,
 )
 from openviking.integrations.langchain.recording import (
+    OpenVikingCancellationProgress,
     OpenVikingPartialWriteError,
-    OpenVikingRecordingCancelledError,
     OpenVikingSessionRecorder,
+    get_openviking_cancellation_progress,
 )
 from openviking.integrations.langchain.retrievers import OpenVikingRetriever
 
@@ -292,8 +294,13 @@ class OpenVikingContextMiddleware(AgentMiddleware):
                 peer_id=plan.peer_id,
                 context_parts=plan.context_parts,
             )
-        except (OpenVikingPartialWriteError, OpenVikingRecordingCancelledError) as exc:
+        except OpenVikingPartialWriteError as exc:
             self._handle_partial_capture(plan, exc)
+            raise
+        except asyncio.CancelledError as exc:
+            progress = get_openviking_cancellation_progress(exc)
+            if progress is not None:
+                self._handle_partial_capture(plan, progress)
             raise
 
         self._complete_capture(plan, context_attached=result.context_attached)
@@ -337,7 +344,7 @@ class OpenVikingContextMiddleware(AgentMiddleware):
     def _handle_partial_capture(
         self,
         plan: _CapturePlan,
-        error: OpenVikingPartialWriteError | OpenVikingRecordingCancelledError,
+        error: OpenVikingPartialWriteError | OpenVikingCancellationProgress,
     ) -> None:
         if error.input_messages_consumed:
             consumed_end = plan.start + error.input_messages_consumed

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -96,6 +96,54 @@ class OpenVikingPartialWriteError(RuntimeError):
         return self.stage == "commit"
 
 
+class OpenVikingRecordingCancelledError(asyncio.CancelledError):
+    """Preserve cancellation while reporting confirmed recording progress."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        result: OpenVikingRecordResult,
+        cause: asyncio.CancelledError,
+        stage: Literal["batch", "commit"] = "batch",
+    ):
+        if stage == "batch":
+            detail = "before a later batch was cancelled"
+        else:
+            detail = "before the commit policy was cancelled"
+        super().__init__(
+            f"OpenViking recorded {result.messages_written} messages for session "
+            f"{session_id!r} {detail}: {cause}"
+        )
+        self.session_id = session_id
+        self.result = result
+        self.stage = stage
+
+    @property
+    def messages_written(self) -> int:
+        """Return the number of payloads confirmed written before cancellation."""
+
+        return self.result.messages_written
+
+    @property
+    def input_messages_consumed(self) -> int:
+        """Return the caller-message prefix that is safe to skip on retry."""
+
+        return self.result.input_messages_consumed
+
+    @property
+    def context_attached(self) -> bool:
+        """Return whether recalled context was confirmed persisted."""
+
+        return self.result.context_attached
+
+    @property
+    def commit_pending(self) -> bool:
+        """Return whether only the post-write commit remains incomplete."""
+
+        return self.stage == "commit"
+
+
 @dataclass(slots=True)
 class _PreparedMessage:
     input_end: int
@@ -268,6 +316,19 @@ class OpenVikingSessionRecorder:
                     session_id=session_id,
                     messages=batch.payloads,
                 )
+            except asyncio.CancelledError as exc:
+                if messages_written == 0:
+                    raise
+                result = OpenVikingRecordResult(
+                    messages_written=messages_written,
+                    input_messages_consumed=input_messages_consumed,
+                    context_attached=context_attached,
+                )
+                raise OpenVikingRecordingCancelledError(
+                    session_id=session_id,
+                    result=result,
+                    cause=exc,
+                ) from exc
             except Exception as exc:
                 if messages_written == 0:
                     raise
@@ -291,6 +352,14 @@ class OpenVikingSessionRecorder:
         )
         try:
             await aapply_commit_policy(client, session_id, self.commit_policy)
+        except asyncio.CancelledError as exc:
+            self._pending_commit_sessions.add(session_id)
+            raise OpenVikingRecordingCancelledError(
+                session_id=session_id,
+                result=result,
+                cause=exc,
+                stage="commit",
+            ) from exc
         except Exception as exc:
             self._pending_commit_sessions.add(session_id)
             raise OpenVikingPartialWriteError(

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -96,28 +96,13 @@ class OpenVikingPartialWriteError(RuntimeError):
         return self.stage == "commit"
 
 
-class OpenVikingRecordingCancelledError(asyncio.CancelledError):
-    """Preserve cancellation while reporting confirmed recording progress."""
+@dataclass(frozen=True, slots=True)
+class OpenVikingCancellationProgress:
+    """Confirmed recording progress attached to an original cancellation."""
 
-    def __init__(
-        self,
-        *,
-        session_id: str,
-        result: OpenVikingRecordResult,
-        cause: asyncio.CancelledError,
-        stage: Literal["batch", "commit"] = "batch",
-    ):
-        if stage == "batch":
-            detail = "before a later batch was cancelled"
-        else:
-            detail = "before the commit policy was cancelled"
-        super().__init__(
-            f"OpenViking recorded {result.messages_written} messages for session "
-            f"{session_id!r} {detail}: {cause}"
-        )
-        self.session_id = session_id
-        self.result = result
-        self.stage = stage
+    session_id: str
+    result: OpenVikingRecordResult
+    stage: Literal["batch", "commit"] = "batch"
 
     @property
     def messages_written(self) -> int:
@@ -142,6 +127,45 @@ class OpenVikingRecordingCancelledError(asyncio.CancelledError):
         """Return whether only the post-write commit remains incomplete."""
 
         return self.stage == "commit"
+
+
+_CANCELLATION_PROGRESS_ATTRIBUTE = "_openviking_recording_progress"
+
+
+def get_openviking_cancellation_progress(
+    error: BaseException,
+) -> OpenVikingCancellationProgress | None:
+    """Return recording progress from a cancellation or a timeout wrapping it."""
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        progress = getattr(current, _CANCELLATION_PROGRESS_ATTRIBUTE, None)
+        if isinstance(progress, OpenVikingCancellationProgress):
+            return progress
+        current = current.__cause__
+    return None
+
+
+def _attach_cancellation_progress(
+    error: asyncio.CancelledError,
+    *,
+    session_id: str,
+    result: OpenVikingRecordResult,
+    stage: Literal["batch", "commit"] = "batch",
+) -> None:
+    """Annotate the original cancellation without changing its identity."""
+
+    setattr(
+        error,
+        _CANCELLATION_PROGRESS_ATTRIBUTE,
+        OpenVikingCancellationProgress(
+            session_id=session_id,
+            result=result,
+            stage=stage,
+        ),
+    )
 
 
 @dataclass(slots=True)
@@ -324,11 +348,12 @@ class OpenVikingSessionRecorder:
                     input_messages_consumed=input_messages_consumed,
                     context_attached=context_attached,
                 )
-                raise OpenVikingRecordingCancelledError(
+                _attach_cancellation_progress(
+                    exc,
                     session_id=session_id,
                     result=result,
-                    cause=exc,
-                ) from exc
+                )
+                raise
             except Exception as exc:
                 if messages_written == 0:
                     raise
@@ -354,12 +379,13 @@ class OpenVikingSessionRecorder:
             await aapply_commit_policy(client, session_id, self.commit_policy)
         except asyncio.CancelledError as exc:
             self._pending_commit_sessions.add(session_id)
-            raise OpenVikingRecordingCancelledError(
+            _attach_cancellation_progress(
+                exc,
                 session_id=session_id,
                 result=result,
-                cause=exc,
                 stage="commit",
-            ) from exc
+            )
+            raise
         except Exception as exc:
             self._pending_commit_sessions.add(session_id)
             raise OpenVikingPartialWriteError(

--- a/openviking/integrations/langchain/recording.py
+++ b/openviking/integrations/langchain/recording.py
@@ -144,7 +144,7 @@ def get_openviking_cancellation_progress(
         progress = getattr(current, _CANCELLATION_PROGRESS_ATTRIBUTE, None)
         if isinstance(progress, OpenVikingCancellationProgress):
             return progress
-        current = current.__cause__
+        current = current.__cause__ or current.__context__
     return None
 
 

--- a/tests/integration/langchain_langgraph/test_async_recording.py
+++ b/tests/integration/langchain_langgraph/test_async_recording.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -111,6 +112,185 @@ async def test_real_openviking_context_wrapper_ainvoke_uses_async_lifecycle():
     assert {"create_session", "get_session_context", "search", "read"}.issubset(client.calls)
     assistant_parts = client.backing.sessions["real-async-wrapper"][1]["parts"]
     assert any(part["type"] == "context" for part in assistant_parts)
+
+
+@pytest.mark.asyncio
+async def test_real_openviking_context_wrapper_serializes_same_session_ainvoke():
+    client = AsyncTrackingClient()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        if latest_user == "from-a":
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-concurrent-history",
+        inject_context=False,
+    )
+
+    first = asyncio.create_task(app.ainvoke([HumanMessage(content="from-a")]))
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    second = asyncio.create_task(app.ainvoke([HumanMessage(content="from-b")]))
+
+    try:
+        await asyncio.sleep(0.05)
+        assert second_started.is_set() is False
+    finally:
+        release_first.set()
+
+    await asyncio.gather(first, second)
+
+    assert [
+        message["parts"][0]["text"]
+        for message in client.backing.sessions["real-async-concurrent-history"]
+    ] == [
+        "from-a",
+        "answer:from-a",
+        "from-b",
+        "answer:from-b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_real_openviking_context_wrapper_keeps_different_sessions_concurrent():
+    client = AsyncTrackingClient()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        if latest_user == "from-a":
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        inject_context=False,
+    )
+
+    first = asyncio.create_task(
+        app.ainvoke(
+            [HumanMessage(content="from-a")],
+            config={"configurable": {"session_id": "real-async-session-a"}},
+        )
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    second = asyncio.create_task(
+        app.ainvoke(
+            [HumanMessage(content="from-b")],
+            config={"configurable": {"session_id": "real-async-session-b"}},
+        )
+    )
+
+    try:
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+    finally:
+        release_first.set()
+
+    await asyncio.gather(first, second)
+
+    assert len(client.backing.sessions["real-async-session-a"]) == 2
+    assert len(client.backing.sessions["real-async-session-b"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_session_failure_keeps_other_session_context_attribution():
+    client = AsyncTrackingClient(
+        {"viking://resources/runbooks/concurrent.md": "Concurrent context is violet."}
+    )
+    second_started = asyncio.Event()
+    release_second = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        if latest_user == "fail-a":
+            raise RuntimeError("session a failed")
+        second_started.set()
+        await release_second.wait()
+        return AIMessage(content="answer:from-b")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        target_uri="viking://resources",
+    )
+    second = asyncio.create_task(
+        app.ainvoke(
+            [HumanMessage(content="violet")],
+            config={"configurable": {"session_id": "real-async-context-b"}},
+        )
+    )
+    await asyncio.wait_for(second_started.wait(), timeout=1)
+
+    try:
+        with pytest.raises(RuntimeError, match="session a failed"):
+            await app.ainvoke(
+                [HumanMessage(content="fail-a")],
+                config={"configurable": {"session_id": "real-async-context-a"}},
+            )
+    finally:
+        release_second.set()
+    await second
+
+    assistant_parts = client.backing.sessions["real-async-context-b"][-1]["parts"]
+    assert any(part["type"] == "context" for part in assistant_parts)
+
+
+@pytest.mark.asyncio
+async def test_real_openviking_context_wrapper_serializes_same_session_abatch():
+    client = AsyncTrackingClient()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        await asyncio.sleep(0)
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-batch-history",
+        inject_context=False,
+    )
+
+    results = await app.abatch(
+        [
+            [HumanMessage(content="from-a")],
+            [HumanMessage(content="from-b")],
+        ]
+    )
+
+    assert [result.content for result in results] == ["answer:from-a", "answer:from-b"]
+    assert [
+        message["parts"][0]["text"]
+        for message in client.backing.sessions["real-async-batch-history"]
+    ] == [
+        "from-a",
+        "answer:from-a",
+        "from-b",
+        "answer:from-b",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/langchain_langgraph/test_async_recording.py
+++ b/tests/integration/langchain_langgraph/test_async_recording.py
@@ -115,7 +115,7 @@ async def test_real_openviking_context_wrapper_ainvoke_uses_async_lifecycle():
 
 
 @pytest.mark.asyncio
-async def test_real_openviking_context_wrapper_serializes_same_session_ainvoke():
+async def test_real_openviking_context_wrapper_preserves_concurrent_same_session_turns():
     client = AsyncTrackingClient()
     first_started = asyncio.Event()
     release_first = asyncio.Event()
@@ -144,22 +144,130 @@ async def test_real_openviking_context_wrapper_serializes_same_session_ainvoke()
     second = asyncio.create_task(app.ainvoke([HumanMessage(content="from-b")]))
 
     try:
-        await asyncio.sleep(0.05)
-        assert second_started.is_set() is False
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+        await asyncio.wait_for(second, timeout=1)
     finally:
         release_first.set()
 
-    await asyncio.gather(first, second)
+    await first
 
     assert [
         message["parts"][0]["text"]
         for message in client.backing.sessions["real-async-concurrent-history"]
     ] == [
-        "from-a",
-        "answer:from-a",
         "from-b",
         "answer:from-b",
+        "from-a",
+        "answer:from-a",
     ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_session_calls_serialize_only_final_persistence():
+    class BlockingWriteClient(AsyncTrackingClient):
+        def __init__(self):
+            super().__init__()
+            self.write_calls = 0
+            self.first_write_started = asyncio.Event()
+            self.release_first_write = asyncio.Event()
+            self.second_write_started = asyncio.Event()
+
+        async def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.write_calls += 1
+            self.calls.append("batch_add_messages")
+            self.batch_sizes.append(len(messages))
+            if self.write_calls == 1:
+                self.first_write_started.set()
+                await self.release_first_write.wait()
+            else:
+                self.second_write_started.set()
+            return self.backing.batch_add_messages(session_id, messages, **kwargs)
+
+    client = BlockingWriteClient()
+    both_models_ready = asyncio.Event()
+    model_calls = 0
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 2:
+            both_models_ready.set()
+        await both_models_ready.wait()
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-write-lock",
+        inject_context=False,
+    )
+    first = asyncio.create_task(app.ainvoke([HumanMessage(content="from-a")]))
+    second = asyncio.create_task(app.ainvoke([HumanMessage(content="from-b")]))
+
+    await asyncio.wait_for(both_models_ready.wait(), timeout=1)
+    await asyncio.wait_for(client.first_write_started.wait(), timeout=1)
+    await asyncio.sleep(0.05)
+
+    try:
+        assert client.second_write_started.is_set() is False
+    finally:
+        client.release_first_write.set()
+    await asyncio.gather(first, second)
+
+    assert client.second_write_started.is_set() is True
+    assert client.write_calls == 2
+
+
+def test_context_wrapper_write_lock_is_scoped_per_event_loop():
+    class SlowWriteClient(AsyncTrackingClient):
+        async def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            await asyncio.sleep(0.01)
+            return self.backing.batch_add_messages(session_id, messages, **kwargs)
+
+    client = SlowWriteClient()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-cross-loop-write-lock",
+        inject_context=False,
+    )
+
+    async def run_contended_pair(label: str) -> None:
+        results = await app.abatch(
+            [
+                [HumanMessage(content=f"{label}-a")],
+                [HumanMessage(content=f"{label}-b")],
+            ]
+        )
+        assert [result.content for result in results] == [
+            f"answer:{label}-a",
+            f"answer:{label}-b",
+        ]
+
+    asyncio.run(run_contended_pair("loop-one"))
+    asyncio.run(run_contended_pair("loop-two"))
+
+    assert len(client.backing.sessions["real-async-cross-loop-write-lock"]) == 8
 
 
 @pytest.mark.asyncio
@@ -212,6 +320,111 @@ async def test_real_openviking_context_wrapper_keeps_different_sessions_concurre
 
 
 @pytest.mark.asyncio
+async def test_concurrent_same_session_invocations_keep_peer_attribution_local():
+    client = AsyncTrackingClient()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        if latest_user == "from-a":
+            first_started.set()
+            await release_first.wait()
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-peer-attribution",
+        inject_context=False,
+    )
+    first = asyncio.create_task(
+        app.ainvoke(
+            [HumanMessage(content="from-a")],
+            config={"configurable": {"peer_id": "peer-a"}},
+        )
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    second = asyncio.create_task(
+        app.ainvoke(
+            [HumanMessage(content="from-b")],
+            config={"configurable": {"peer_id": "peer-b"}},
+        )
+    )
+
+    try:
+        await asyncio.wait_for(second, timeout=1)
+    finally:
+        release_first.set()
+    await first
+
+    stored = client.backing.sessions["real-async-peer-attribution"]
+    by_text = {message["parts"][0]["text"]: message.get("peer_id") for message in stored}
+    assert by_text == {
+        "from-a": "peer-a",
+        "answer:from-a": "peer-a",
+        "from-b": "peer-b",
+        "answer:from-b": "peer-b",
+    }
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_session_invocations_keep_recalled_context_local():
+    alpha_uri = "viking://resources/runbooks/alpha.md"
+    beta_uri = "viking://resources/runbooks/beta.md"
+    client = AsyncTrackingClient(
+        {
+            alpha_uri: "Alpha deployment instructions.",
+            beta_uri: "Beta deployment instructions.",
+        }
+    )
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]) -> AIMessage:
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        if latest_user == "alpha":
+            first_started.set()
+            await release_first.wait()
+        return AIMessage(content=f"answer:{latest_user}")
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-context-attribution",
+        target_uri="viking://resources",
+    )
+    first = asyncio.create_task(app.ainvoke([HumanMessage(content="alpha")]))
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    try:
+        await asyncio.wait_for(
+            app.ainvoke([HumanMessage(content="beta")]),
+            timeout=1,
+        )
+    finally:
+        release_first.set()
+    await first
+
+    context_uri_by_answer: dict[str, str] = {}
+    for message in client.backing.sessions["real-async-context-attribution"]:
+        if message["role"] != "assistant":
+            continue
+        answer_text = next(part["text"] for part in message["parts"] if part["type"] == "text")
+        context_uri = next(part["uri"] for part in message["parts"] if part["type"] == "context")
+        context_uri_by_answer[answer_text] = context_uri
+
+    assert context_uri_by_answer == {
+        "answer:alpha": alpha_uri,
+        "answer:beta": beta_uri,
+    }
+
+
+@pytest.mark.asyncio
 async def test_concurrent_session_failure_keeps_other_session_context_attribution():
     client = AsyncTrackingClient(
         {"viking://resources/runbooks/concurrent.md": "Concurrent context is violet."}
@@ -257,7 +470,7 @@ async def test_concurrent_session_failure_keeps_other_session_context_attributio
 
 
 @pytest.mark.asyncio
-async def test_real_openviking_context_wrapper_serializes_same_session_abatch():
+async def test_real_openviking_context_wrapper_preserves_same_session_abatch_turns():
     client = AsyncTrackingClient()
 
     async def answer(messages: list[BaseMessage]) -> AIMessage:
@@ -282,15 +495,53 @@ async def test_real_openviking_context_wrapper_serializes_same_session_abatch():
     )
 
     assert [result.content for result in results] == ["answer:from-a", "answer:from-b"]
-    assert [
+    stored = [
         message["parts"][0]["text"]
         for message in client.backing.sessions["real-async-batch-history"]
-    ] == [
-        "from-a",
-        "answer:from-a",
-        "from-b",
-        "answer:from-b",
     ]
+    assert len(stored) == 4
+    assert {tuple(stored[index : index + 2]) for index in range(0, len(stored), 2)} == {
+        ("from-a", "answer:from-a"),
+        ("from-b", "answer:from-b"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_abandoned_stream_does_not_block_same_session_invocation():
+    client = AsyncTrackingClient()
+    keep_stream_open = asyncio.Event()
+
+    async def answer(messages: list[BaseMessage]):
+        latest_user = next(
+            message.content for message in reversed(messages) if isinstance(message, HumanMessage)
+        )
+        yield AIMessage(content=f"answer:{latest_user}")
+        if latest_user == "stream":
+            await keep_stream_open.wait()
+
+    app = with_openviking_context(
+        RunnableLambda(answer),
+        async_client=client,
+        session_id="real-async-abandoned-stream",
+        inject_context=False,
+    )
+    stream = app.astream([HumanMessage(content="stream")])
+    first_chunk = await anext(stream)
+
+    try:
+        result = await asyncio.wait_for(
+            app.ainvoke([HumanMessage(content="next")]),
+            timeout=1,
+        )
+    finally:
+        await stream.aclose()
+
+    assert first_chunk.content == "answer:stream"
+    assert result.content == "answer:next"
+    assert [
+        message["parts"][0]["text"]
+        for message in client.backing.sessions["real-async-abandoned-stream"]
+    ] == ["next", "answer:next"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -18,6 +18,7 @@ from openviking.integrations.langchain import (
     OpenVikingCommitPolicy,
     OpenVikingContextMiddleware,
     OpenVikingPartialWriteError,
+    OpenVikingRecordingCancelledError,
     OpenVikingRetriever,
     OpenVikingSessionContextAssembler,
     OpenVikingSessionRecorder,
@@ -943,6 +944,97 @@ async def test_async_recorder_reports_confirmed_prefix_for_partial_batch_retry()
     assert captured.value.input_messages_consumed == 100
     assert backing.batch_sizes == [100, 1, 1]
     assert len(backing.sessions["async-partial-retry"]) == 101
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_preserves_partial_progress_when_recording_is_cancelled():
+    class CancelSecondBatchClient(AsyncInMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls = 0
+
+        async def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_calls += 1
+            if self.batch_calls == 2:
+                raise asyncio.CancelledError
+            return self.backing.batch_add_messages(session_id, messages, **kwargs)
+
+    client = CancelSecondBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        session_id_resolver=lambda _state, _runtime: "async-cancelled-batch",
+    )
+    messages = [HumanMessage(content=f"Message {index}") for index in range(150)]
+    state = {"messages": messages}
+
+    recording = asyncio.create_task(middleware.aafter_agent(state, runtime=None))
+    with pytest.raises(OpenVikingRecordingCancelledError) as captured:
+        await recording
+    await middleware.aafter_agent(state, runtime=None)
+
+    assert recording.cancelled() is True
+    assert isinstance(captured.value, asyncio.CancelledError)
+    assert not isinstance(captured.value, Exception)
+    assert captured.value.messages_written == 100
+    assert captured.value.input_messages_consumed == 100
+    assert client.batch_calls == 3
+    assert len(client.backing.sessions["async-cancelled-batch"]) == 150
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_retries_cancelled_commit_without_duplicate_writes():
+    class CancelFirstCommitClient(AsyncInMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls = 0
+            self.commit_calls = 0
+
+        async def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_calls += 1
+            return self.backing.batch_add_messages(session_id, messages, **kwargs)
+
+        async def commit_session(
+            self,
+            session_id: str,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.commit_calls += 1
+            if self.commit_calls == 1:
+                raise asyncio.CancelledError
+            return self.backing.commit_session(session_id, **kwargs)
+
+    client = CancelFirstCommitClient()
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        session_id_resolver=lambda _state, _runtime: "async-cancelled-commit",
+        commit_policy=OpenVikingCommitPolicy(mode="always"),
+    )
+    state = {
+        "messages": [
+            HumanMessage(content="Persist once."),
+            AIMessage(content="Commit once."),
+        ]
+    }
+
+    with pytest.raises(OpenVikingRecordingCancelledError) as captured:
+        await middleware.aafter_agent(state, runtime=None)
+    await middleware.aafter_agent(state, runtime=None)
+
+    assert captured.value.commit_pending is True
+    assert captured.value.input_messages_consumed == 2
+    assert client.batch_calls == 1
+    assert client.commit_calls == 2
+    assert len(client.backing.archives["async-cancelled-commit"][0]["messages"]) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import sys
 import threading
 from typing import Any
 
@@ -981,7 +982,10 @@ async def test_async_middleware_preserves_partial_progress_when_recording_is_can
 
     progress = get_openviking_cancellation_progress(captured.value)
     assert recording.cancelled() is True
-    assert captured.value is client.cancellation
+    if sys.version_info >= (3, 11):
+        # Python 3.10 rebuilds CancelledError at task boundaries via
+        # Future._make_cancelled_error(), preserving the original in __context__.
+        assert captured.value is client.cancellation
     assert not isinstance(captured.value, Exception)
     assert isinstance(progress, OpenVikingCancellationProgress)
     assert progress.messages_written == 100
@@ -1085,7 +1089,7 @@ async def test_async_recording_cancellation_preserves_timeout_contract_and_retry
     )
     state = {"messages": [HumanMessage(content=f"Message {index}") for index in range(150)]}
 
-    with pytest.raises(TimeoutError) as captured:
+    with pytest.raises(asyncio.TimeoutError) as captured:
         if timeout_api == "wait_for":
             await asyncio.wait_for(middleware.aafter_agent(state, runtime=None), timeout=0.05)
         else:

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -14,14 +14,15 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from openviking.integrations.langchain import (
     InMemoryOpenVikingClient,
+    OpenVikingCancellationProgress,
     OpenVikingChatMessageHistory,
     OpenVikingCommitPolicy,
     OpenVikingContextMiddleware,
     OpenVikingPartialWriteError,
-    OpenVikingRecordingCancelledError,
     OpenVikingRetriever,
     OpenVikingSessionContextAssembler,
     OpenVikingSessionRecorder,
+    get_openviking_cancellation_progress,
 )
 from openviking.integrations.langchain.client import (
     OpenVikingAsyncClientHandle,
@@ -952,6 +953,7 @@ async def test_async_middleware_preserves_partial_progress_when_recording_is_can
         def __init__(self):
             super().__init__()
             self.batch_calls = 0
+            self.cancellation = asyncio.CancelledError("cancel second batch")
 
         async def batch_add_messages(
             self,
@@ -961,7 +963,7 @@ async def test_async_middleware_preserves_partial_progress_when_recording_is_can
         ) -> dict[str, Any]:
             self.batch_calls += 1
             if self.batch_calls == 2:
-                raise asyncio.CancelledError
+                raise self.cancellation
             return self.backing.batch_add_messages(session_id, messages, **kwargs)
 
     client = CancelSecondBatchClient()
@@ -973,15 +975,17 @@ async def test_async_middleware_preserves_partial_progress_when_recording_is_can
     state = {"messages": messages}
 
     recording = asyncio.create_task(middleware.aafter_agent(state, runtime=None))
-    with pytest.raises(OpenVikingRecordingCancelledError) as captured:
+    with pytest.raises(asyncio.CancelledError) as captured:
         await recording
     await middleware.aafter_agent(state, runtime=None)
 
+    progress = get_openviking_cancellation_progress(captured.value)
     assert recording.cancelled() is True
-    assert isinstance(captured.value, asyncio.CancelledError)
+    assert captured.value is client.cancellation
     assert not isinstance(captured.value, Exception)
-    assert captured.value.messages_written == 100
-    assert captured.value.input_messages_consumed == 100
+    assert isinstance(progress, OpenVikingCancellationProgress)
+    assert progress.messages_written == 100
+    assert progress.input_messages_consumed == 100
     assert client.batch_calls == 3
     assert len(client.backing.sessions["async-cancelled-batch"]) == 150
 
@@ -993,6 +997,7 @@ async def test_async_middleware_retries_cancelled_commit_without_duplicate_write
             super().__init__()
             self.batch_calls = 0
             self.commit_calls = 0
+            self.cancellation = asyncio.CancelledError("cancel first commit")
 
         async def batch_add_messages(
             self,
@@ -1010,7 +1015,7 @@ async def test_async_middleware_retries_cancelled_commit_without_duplicate_write
         ) -> dict[str, Any]:
             self.commit_calls += 1
             if self.commit_calls == 1:
-                raise asyncio.CancelledError
+                raise self.cancellation
             return self.backing.commit_session(session_id, **kwargs)
 
     client = CancelFirstCommitClient()
@@ -1026,15 +1031,75 @@ async def test_async_middleware_retries_cancelled_commit_without_duplicate_write
         ]
     }
 
-    with pytest.raises(OpenVikingRecordingCancelledError) as captured:
+    with pytest.raises(asyncio.CancelledError) as captured:
         await middleware.aafter_agent(state, runtime=None)
     await middleware.aafter_agent(state, runtime=None)
 
-    assert captured.value.commit_pending is True
-    assert captured.value.input_messages_consumed == 2
+    progress = get_openviking_cancellation_progress(captured.value)
+    assert captured.value is client.cancellation
+    assert isinstance(progress, OpenVikingCancellationProgress)
+    assert progress.commit_pending is True
+    assert progress.input_messages_consumed == 2
     assert client.batch_calls == 1
     assert client.commit_calls == 2
     assert len(client.backing.archives["async-cancelled-commit"][0]["messages"]) == 2
+
+
+@pytest.mark.parametrize(
+    "timeout_api",
+    [
+        "wait_for",
+        pytest.param(
+            "timeout",
+            marks=pytest.mark.skipif(
+                not hasattr(asyncio, "timeout"),
+                reason="asyncio.timeout requires Python 3.11+",
+            ),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_recording_cancellation_preserves_timeout_contract_and_retry(
+    timeout_api: str,
+):
+    class BlockSecondBatchClient(AsyncInMemoryOpenVikingClient):
+        def __init__(self):
+            super().__init__()
+            self.batch_calls = 0
+
+        async def batch_add_messages(
+            self,
+            session_id: str,
+            messages: list[dict[str, Any]],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self.batch_calls += 1
+            if self.batch_calls == 2:
+                await asyncio.Event().wait()
+            return self.backing.batch_add_messages(session_id, messages, **kwargs)
+
+    client = BlockSecondBatchClient()
+    middleware = OpenVikingContextMiddleware(
+        async_client=client,
+        session_id_resolver=lambda _state, _runtime: f"async-{timeout_api}",
+    )
+    state = {"messages": [HumanMessage(content=f"Message {index}") for index in range(150)]}
+
+    with pytest.raises(TimeoutError) as captured:
+        if timeout_api == "wait_for":
+            await asyncio.wait_for(middleware.aafter_agent(state, runtime=None), timeout=0.05)
+        else:
+            async with asyncio.timeout(0.05):
+                await middleware.aafter_agent(state, runtime=None)
+
+    progress = get_openviking_cancellation_progress(captured.value)
+    assert isinstance(progress, OpenVikingCancellationProgress)
+    assert progress.input_messages_consumed == 100
+
+    await middleware.aafter_agent(state, runtime=None)
+
+    assert client.batch_calls == 3
+    assert len(client.backing.sessions[f"async-{timeout_api}"]) == 150
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This is a correctness follow-up to #3536 for async history recording under concurrency and cancellation.

Two root causes are addressed:

1. `RunnableWithMessageHistory` reads history at entry and again at exit. With overlapping calls on one session, the second live read could include another call's newly written turn and incorrectly strip the current user message. Serializing the entire lifecycle avoided that race but tied a session lock to stream consumption, so an abandoned stream could block the session indefinitely.
2. Wrapping cancellation in an `asyncio.CancelledError` subclass broke the standard `asyncio.wait_for()` and `asyncio.timeout()` contract on Python versions that require the exact built-in exception type.

## Solution

- Give each runnable invocation its own entry-history snapshot, peer identity, and recalled-context references.
- Keep model execution and stream consumption concurrent. Only the final append-and-commit step is briefly serialized per session and event loop.
- Return to LangChain's standard `RunnableWithMessageHistory` instead of overriding every async invocation and streaming method.
- Re-raise the original `asyncio.CancelledError` unchanged. Confirmed recording progress is attached separately and exposed through `get_openviking_cancellation_progress()`, including when a `TimeoutError` wraps the cancellation.
- Scope failed-invocation cleanup so it cannot discard another call's recalled context.
- Document the concurrency and cancellation contracts in English and Chinese.

The resulting flow is:

```text
concurrent invocation A ── own history snapshot / peer / context ──┐
                                                                   ├─ short per-session append + commit
concurrent invocation B ── own history snapshot / peer / context ──┘
```

An abandoned stream holds no session lock. Concurrent completed turns are persisted without lost user messages, crossed peer attribution, or crossed recalled-context references.

## Interaction with #3569

The designs are compatible, but both PRs modify the async recording loop. If this PR lands first, #3569 should rebase and retain the cancellation-progress handling while applying its pending-token optimization.

## Verification

- `153 passed`:
  - `tests/unit/test_langchain_integration.py`
  - `tests/unit/test_langchain_recording.py`
  - `tests/unit/test_langchain_async_integration.py`
  - `tests/integration/langchain_langgraph/`
- Deterministic regressions cover:
  - overlapping same-session turns;
  - append-and-commit serialization without model serialization;
  - abandoned streams;
  - peer and recalled-context isolation;
  - same-wrapper reuse under contended writes across event loops;
  - partial batch and commit cancellation;
  - `asyncio.wait_for()` and `asyncio.timeout()` conversion and retry.
- Ruff check and format check passed.
- Scoped mypy check passed.
- `git diff --check` passed.
