### PR TITLE
fix(viking_fs): remove child vector entries on rm() orphan cleanup

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -650,9 +650,15 @@ class VikingFS:
                     raise mapped from exc
                 raise
             # Path does not exist: clean up any orphan index records and return
+            real_ctx = self._ctx_or_default(ctx)
             uris_to_delete = await self._collect_uris(path, recursive, ctx=ctx)
             uris_to_delete.append(target_uri)
-            real_ctx = self._ctx_or_default(ctx)
+            orphan_child_uris = await self._collect_child_uris_from_vector_store(
+                target_uri, ctx=ctx
+            )
+            for child_uri in orphan_child_uris:
+                if child_uri not in uris_to_delete:
+                    uris_to_delete.append(child_uri)
             estimated_count = await _estimate_deleted_count(path, real_ctx)
             await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
             logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
@@ -3068,6 +3074,57 @@ class VikingFS:
 
         await _collect(path)
         return uris
+
+    async def _collect_child_uris_from_vector_store(
+        self, parent_uri: str, ctx: Optional[RequestContext] = None
+    ) -> List[str]:
+        """Query vector store for all descendant URIs under a parent path.
+
+        Used in the orphan cleanup path when the filesystem entry no longer
+        exists but child vector index records may still be present.
+        """
+        vector_store = self._get_vector_store()
+        if not vector_store:
+            return []
+        real_ctx = self._ctx_or_default(ctx)
+        try:
+            target_canonical_uri = canonicalize_uri(parent_uri, real_ctx)
+        except Exception:
+            target_canonical_uri = parent_uri.rstrip("/")
+
+        child_uris: List[str] = []
+        seen: set = set()
+        filter_expr = PathScope("uri", target_canonical_uri, depth=-1)
+        try:
+            records, next_cursor = await vector_store.scroll(
+                filter=filter_expr,
+                limit=200,
+                output_fields=["uri"],
+                ctx=real_ctx,
+            )
+            for record in records:
+                record_uri = record.get("uri", "")
+                if record_uri and record_uri != target_canonical_uri and record_uri not in seen:
+                    seen.add(record_uri)
+                    child_uris.append(record_uri)
+            while next_cursor:
+                records, next_cursor = await vector_store.scroll(
+                    filter=filter_expr,
+                    limit=200,
+                    cursor=next_cursor,
+                    output_fields=["uri"],
+                    ctx=real_ctx,
+                )
+                for record in records:
+                    record_uri = record.get("uri", "")
+                    if record_uri and record_uri != target_canonical_uri and record_uri not in seen:
+                        seen.add(record_uri)
+                        child_uris.append(record_uri)
+        except Exception as e:
+            logger.warning(
+                f"[VikingFS] Failed to collect child URIs from vector store for orphan cleanup: {e}"
+            )
+        return child_uris
 
     async def _delete_from_vector_store(
         self, uris: List[str], ctx: Optional[RequestContext] = None

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -653,12 +653,18 @@ class VikingFS:
             real_ctx = self._ctx_or_default(ctx)
             uris_to_delete = await self._collect_uris(path, recursive, ctx=ctx)
             uris_to_delete.append(target_uri)
-            orphan_child_uris = await self._collect_child_uris_from_vector_store(
-                target_uri, ctx=ctx
-            )
-            for child_uri in orphan_child_uris:
-                if child_uri not in uris_to_delete:
-                    uris_to_delete.append(child_uri)
+            if recursive:
+                # Only walk descendant vector URIs when the caller requested
+                # recursive deletion. With recursive=False we must not delete
+                # indexed children we never enumerated via the filesystem (the
+                # non-recursive directory guard never runs for missing AGFS
+                # entries, so an explicit flag guard is required here).
+                orphan_child_uris = await self._collect_child_uris_from_vector_store(
+                    target_uri, ctx=ctx
+                )
+                for child_uri in orphan_child_uris:
+                    if child_uri not in uris_to_delete:
+                        uris_to_delete.append(child_uri)
             estimated_count = await _estimate_deleted_count(path, real_ctx)
             await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
             logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -316,3 +316,90 @@ class TestVikingFSURITraversalGuard:
         entries = await fs._ls_entries("/local/default")
 
         assert [entry["name"] for entry in entries] == ["resources"]
+
+
+def _not_found_error() -> Exception:
+    """Build a canonical AGFS not-found error matching rm()'s is_not_found_error path."""
+    from openviking.pyagfs.exceptions import AGFSNotFoundError
+
+    return AGFSNotFoundError("missing", code="NOT_FOUND")
+
+
+class TestRmOrphanCleanupRecursiveFlag:
+    """Missing-path rm() must honour recursive=True vs recursive=False for descendant vectors."""
+
+    @pytest.mark.asyncio
+    async def test_non_recursive_missing_deletes_only_exact_target(self) -> None:
+        from openviking.pyagfs.exceptions import AGFSNotFoundError
+
+        fs = _make_viking_fs()
+        recorded: list[list[str]] = []
+
+        async def _fake_delete(uris, ctx=None):
+            recorded.append(list(uris))
+
+        async def _fake_collect(target_uri, ctx=None):
+            # Two "indexed" children the caller must NOT touch when recursive=False.
+            return [
+                "viking://resources/foo/child.md",
+                "viking://resources/foo/nested/deep.md",
+            ]
+
+        fs._delete_from_vector_store = _fake_delete
+        fs._collect_child_uris_from_vector_store = _fake_collect
+        fs._collect_uris = AsyncMock(return_value=[])
+        fs._ctx_or_default = lambda ctx: ctx or _user_ctx()
+        fs._get_vector_store = MagicMock(return_value=None)
+        fs._ensure_delete_access = MagicMock()
+        fs._uri_to_path = MagicMock(return_value="/local/default/resources/foo")
+        fs._path_to_uri = MagicMock(return_value="viking://resources/foo")
+        fs.agfs.stat = AsyncMock(side_effect=AGFSNotFoundError("missing"))
+
+        result = await fs.rm("viking://resources/foo", recursive=False)
+
+        assert result["estimated_deleted_count"] == 0
+        assert len(recorded) == 1, f"expected exactly one delete call, got {recorded}"
+        deleted_uris = recorded[0]
+        # Exact target + any _collect_uris output (mocked empty). No children.
+        assert deleted_uris == ["viking://resources/foo"]
+        # _collect_child_uris_from_vector_store should not even be invoked.
+        fs._collect_child_uris_from_vector_store = _fake_collect  # keep reference happy
+
+    @pytest.mark.asyncio
+    async def test_recursive_missing_deletes_exact_target_and_descendants(self) -> None:
+        from openviking.pyagfs.exceptions import AGFSNotFoundError
+
+        fs = _make_viking_fs()
+        recorded: list[list[str]] = []
+
+        async def _fake_delete(uris, ctx=None):
+            recorded.append(list(uris))
+
+        child_uris = [
+            "viking://resources/foo/child.md",
+            "viking://resources/foo/nested/deep.md",
+        ]
+
+        async def _fake_collect(target_uri, ctx=None):
+            return list(child_uris)
+
+        fs._delete_from_vector_store = _fake_delete
+        fs._collect_child_uris_from_vector_store = _fake_collect
+        fs._collect_uris = AsyncMock(return_value=[])
+        fs._ctx_or_default = lambda ctx: ctx or _user_ctx()
+        fs._get_vector_store = MagicMock(return_value=None)
+        fs._ensure_delete_access = MagicMock()
+        fs._uri_to_path = MagicMock(return_value="/local/default/resources/foo")
+        fs._path_to_uri = MagicMock(return_value="viking://resources/foo")
+        fs.agfs.stat = AsyncMock(side_effect=AGFSNotFoundError("missing"))
+
+        result = await fs.rm("viking://resources/foo", recursive=True)
+
+        assert result["estimated_deleted_count"] == 0
+        assert len(recorded) == 1
+        deleted_uris = recorded[0]
+        assert "viking://resources/foo" in deleted_uris
+        for child in child_uris:
+            assert child in deleted_uris, (
+                f"recursive=True should clean descendant {child}; got {deleted_uris}"
+            )


### PR DESCRIPTION
## Summary
- **Fix**: `Viking_FS.rm()` orphan cleanup path now recursively removes child vector entries (fixes #3064).
- **Impact**: Prevents orphan vector index entries from being left behind when removing a directory or file whose path no longer exists.

## Root Cause
In the `rm()` method's orphan cleanup path, when the filesystem path no longer exists, `_collect_uris()` returns an empty list because it relies on filesystem enumeration. Only the immediate `target_uri` was deleted from the vector store, leaving all child vector entries as orphans.

## Changes
- **File**: `openviking/storage/viking_fs.py`
- Modified the orphan cleanup path to also query the vector store for descendant entries via a new helper `_collect_child_uris_from_vector_store()`.
- The helper uses `scroll()` with a `PathScope("uri", target_canonical_uri, depth=-1)` filter to collect all nested entries.
- Handles pagination via `next_cursor`, deduplicates URIs, and excludes the parent URI.

## Why this is safe
- Only affects the orphan cleanup path (filesystem path no longer exists) — not the normal deletion flow.
- Falls back gracefully if the vector store is unavailable.
- Deduplication avoids double-deletion when the normal enumeration also succeeds.