### PR TITLE
fix(parse): skip VLM summarization for empty/title-only documents

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -700,13 +700,23 @@ class SemanticDagExecutor:
                 )
         except Exception as e:
             logger.warning(f"Failed to generate summary for {file_path}: {e}")
-            summary_dict = {"name": file_name, "summary": ""}
+            summary_dict = {"name": file_name, "summary": "", "has_substantive_content": False}
         finally:
             self._stats.done_nodes += 1
             self._stats.in_progress_nodes = max(0, self._stats.in_progress_nodes - 1)
 
         if self._closed:
             return
+        # Skip vectorization for entries that carry no substantive content
+        # (heading-only / empty / whitespace-only docs). Such entries would
+        # produce misleading retrieval vectors.
+        has_substantive = summary_dict.get("has_substantive_content", True)
+        if need_vectorize and not has_substantive:
+            need_vectorize = False
+            logger.info(
+                "Skipping vectorization for non-substantive file: %s",
+                file_path,
+            )
         try:
             if need_vectorize:
                 use_summary = self._is_code_repo and bool(summary_dict.get("summary"))

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -673,10 +673,15 @@ class SemanticProcessor(DequeueHandlerBase):
                 paths_to_vectorize = changed_files
             else:
                 paths_to_vectorize = set(file_paths)
+            # Only vectorize files that carry substantive content. Non-substantive
+            # entries (heading-only, empty) produce misleading retrieval vectors
+            # and are skipped to avoid hallucinated recall.
             file_vectorize_items = [
                 (file_path, summary)
                 for file_path, summary in zip(file_paths, file_summaries, strict=False)
-                if file_path in paths_to_vectorize and summary is not None
+                if file_path in paths_to_vectorize
+                and summary is not None
+                and summary.get("has_substantive_content", True)
             ]
             generated_content = await self._generate_overview(
                 dir_uri, completed_summaries, [], llm_sem=llm_sem
@@ -727,6 +732,9 @@ class SemanticProcessor(DequeueHandlerBase):
                     semantic_msg_id=msg.id,
                     preserve_existing_created_at=True,
                 )
+            # Directory-level overview/abstract vectors are always emitted so
+            # directory nodes remain navigable; only file-level vectors are
+            # suppressed for non-substantive entries.
             await self._vectorize_directory(
                 uri=dir_uri,
                 context_type="memory",
@@ -1053,6 +1061,34 @@ class SemanticProcessor(DequeueHandlerBase):
         except Exception as e:
             logger.error(f"[SyncDiff] Failed to rewrite image URIs for {target_uri}: {e}")
 
+    @staticmethod
+    def _has_substantive_markdown_body(content: str) -> bool:
+        """Detect whether Markdown content contains substantive body text.
+
+        Returns False for empty, whitespace-only, heading-only, separator-only,
+        and blank-only documents. Returns True whenever a non-heading, non-
+        separator, non-blank real body line exists (even a single short
+        sentence in any language), so legitimate short documents keep the VLM
+        summarization path.
+        """
+        if not content:
+            return False
+        heading_re = re.compile(r"^\s{0,3}#{1,6}(?:\s|$)")
+        setext_re = re.compile(r"^\s*(?:=+\s*|-+\s*)\s*$")
+        thematic_re = re.compile(r"^\s*(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})\s*$")
+        for raw in content.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            if heading_re.match(raw):
+                continue
+            if setext_re.match(raw) and len(line) >= 2:
+                continue
+            if thematic_re.match(raw):
+                continue
+            return True
+        return False
+
     async def _generate_text_summary(
         self,
         file_path: str,
@@ -1073,29 +1109,33 @@ class SemanticProcessor(DequeueHandlerBase):
 
         full_content = content or ""
 
+        file_type = self._detect_file_type(file_name)
+        has_substantive_content = True
+        if file_type != FILE_TYPE_CODE:
+            has_substantive_content = self._has_substantive_markdown_body(full_content)
+
         def result(summary: str) -> Dict[str, Any]:
-            return {"name": file_name, "summary": summary, "content": full_content}
+            return {
+                "name": file_name,
+                "summary": summary,
+                "content": full_content,
+                "has_substantive_content": has_substantive_content,
+            }
 
         # Limit content length
         max_chars = get_openviking_config().semantic.max_file_content_chars
-        if len(content) > max_chars:
+        if content and len(content) > max_chars:
             content = content[:max_chars] + "\n...(truncated)"
 
-        # Check for near-empty content to prevent hallucinated L0/L1 summaries.
-        # Empty or title-only documents (e.g. just a heading with no body) cause
-        # the VLM to hallucinate content. Skip VLM when there is insufficient
-        # actual text to summarize.
-        _meaningful_chars = 0
-        if content:
-            _stripped = re.sub(r"#+\s*", "", content)
-            _stripped = re.sub(r"[*_`~\-><!\[\]()]", "", _stripped)
-            _meaningful_chars = len(_stripped.strip())
-        if _meaningful_chars < 50:
+        # Prevent hallucinated L0/L1 summaries for documents without body text.
+        # Empty, whitespace-only, heading-only, and separator-only Markdown docs
+        # carry no real information; skip VLM so it cannot invent content.
+        # Code files use the existing skeleton/LLM path regardless: a short
+        # source file is still substantive.
+        if file_type != FILE_TYPE_CODE and not has_substantive_content:
             logger.warning(
-                "Skipping VLM summarization for near-empty document: %s "
-                "(%d chars of meaningful content)",
+                "Skipping VLM summarization for document with no substantive body: %s",
                 file_path,
-                _meaningful_chars,
             )
             return result("")
 
@@ -1107,9 +1147,6 @@ class SemanticProcessor(DequeueHandlerBase):
         from openviking.session.memory.utils.language import resolve_output_language
 
         output_language = resolve_output_language(content)
-
-        # Detect file type and select appropriate prompt
-        file_type = self._detect_file_type(file_name)
 
         if file_type == FILE_TYPE_CODE:
             code_mode = get_openviking_config().code.code_summary_mode
@@ -1328,7 +1365,7 @@ class SemanticProcessor(DequeueHandlerBase):
     async def _generate_overview(
         self,
         dir_uri: str,
-        file_summaries: List[Dict[str, str]],
+        file_summaries: List[Dict[str, Any]],
         children_abstracts: List[Dict[str, str]],
         llm_sem: Optional[asyncio.Semaphore] = None,
     ) -> str:
@@ -1339,67 +1376,89 @@ class SemanticProcessor(DequeueHandlerBase):
         summaries into batches, generates a partial overview per batch, then
         merges the partials into a final overview.
 
+        Entries with has_substantive_content=False are filtered out of the LLM
+        prompt. When no substantive entries remain a deterministic neutral
+        overview is returned without invoking the model.
+
         Args:
             dir_uri: Directory URI
-            file_summaries: File summary list
+            file_summaries: File summary list (may carry has_substantive_content)
             children_abstracts: Subdirectory summary list
 
         Returns:
-            Markdown overview content generated by the model.
+            Markdown overview content generated by the model or deterministic fallback.
         """
 
         config = get_openviking_config()
         vlm = config.vlm
         semantic = config.semantic
+        dir_name = dir_uri.split("/")[-1]
+
+        # Filter file summaries: keep only entries that carry substantive content.
+        # Media/code paths default to substantive=True; only doc/text items that
+        # were explicitly marked non-substantive are dropped.
+        substantive_files: List[Dict[str, Any]] = [
+            item for item in file_summaries if item.get("has_substantive_content", True)
+        ]
+        substantive_children: List[Dict[str, str]] = list(children_abstracts)
+
+        has_any_substantive = bool(substantive_files or substantive_children)
+        if not has_any_substantive:
+            logger.info(
+                "Directory %s has no substantive file or child entries; "
+                "returning deterministic neutral overview",
+                dir_uri,
+            )
+            return f"# {dir_name}\n\nNo substantive entries to summarize."
 
         if not vlm.is_available():
             logger.warning("VLM not available, using default overview")
-            return f"# {dir_uri.split('/')[-1]}\n\n[Directory overview is not ready]"
+            return f"# {dir_name}\n\n[Directory overview is not ready]"
 
         from openviking.session.memory.utils.language import resolve_output_language
 
-        # Build file index mapping and summary string
-        file_index_map = {}
-        file_summaries_lines = []
-        for idx, item in enumerate(file_summaries, 1):
+        # Build file index mapping and summary string using substantive entries.
+        file_index_map: Dict[int, str] = {}
+        file_summaries_lines: List[str] = []
+        for idx, item in enumerate(substantive_files, 1):
             file_index_map[idx] = item["name"]
             file_summaries_lines.append(f"[{idx}] {item['name']}: {item['summary']}")
         file_summaries_str = "\n".join(file_summaries_lines) if file_summaries_lines else "None"
 
         # Build subdirectory summary string
         children_abstracts_str = (
-            "\n".join(f"- {item['name']}/: {item['abstract']}" for item in children_abstracts)
-            if children_abstracts
+            "\n".join(f"- {item['name']}/: {item['abstract']}" for item in substantive_children)
+            if substantive_children
             else "None"
         )
 
-        language_source_parts = []
-        if file_summaries:
+        language_source_parts: List[str] = []
+        if substantive_files:
             language_source_parts.append(file_summaries_str)
-        if children_abstracts:
+        if substantive_children:
             language_source_parts.append(children_abstracts_str)
         if not language_source_parts:
-            language_source_parts.append(dir_uri.split("/")[-1])
+            language_source_parts.append(dir_name)
         output_language = resolve_output_language("\n".join(language_source_parts), config=config)
 
         # Budget guard: check if prompt would be oversized
         estimated_size = len(file_summaries_str) + len(children_abstracts_str)
         over_budget = estimated_size > semantic.max_overview_prompt_chars
-        entry_count = len(file_summaries) + len(children_abstracts)
+        entry_count = len(substantive_files) + len(substantive_children)
         many_entries = entry_count > semantic.overview_batch_size
 
         if over_budget and many_entries:
             # Many entries, oversized prompt → batch and merge
             logger.info(
                 f"Overview prompt for {dir_uri} exceeds budget "
-                f"({estimated_size} chars, {len(file_summaries)} files, "
-                f"{len(children_abstracts)} subdirectories). "
+                f"({estimated_size} chars, {len(substantive_files)} files, "
+                f"{len(substantive_children)} subdirectories). "
                 f"Splitting into batches of {semantic.overview_batch_size}."
             )
             overview = await self._batched_generate_overview(
                 dir_uri,
-                file_summaries,
-                children_abstracts,
+                substantive_files,
+                substantive_children,
                 file_index_map,
                 llm_sem=llm_sem,
                 output_language=output_language,
@@ -1408,14 +1467,14 @@ class SemanticProcessor(DequeueHandlerBase):
             # Few files but long summaries → truncate summaries to fit budget
             logger.info(
                 f"Overview prompt for {dir_uri} exceeds budget "
-                f"({estimated_size} chars) with {len(file_summaries)} files. "
+                f"({estimated_size} chars) with {len(substantive_files)} files. "
                 f"Truncating summaries to fit."
             )
             budget = semantic.max_overview_prompt_chars
             budget -= len(children_abstracts_str)
-            per_file = max(100, budget // max(len(file_summaries), 1))
+            per_file = max(100, budget // max(len(substantive_files), 1))
             truncated_lines = []
-            for idx, item in enumerate(file_summaries, 1):
+            for idx, item in enumerate(substantive_files, 1):
                 summary = item["summary"][:per_file]
                 truncated_lines.append(f"[{idx}] {item['name']}: {summary}")
             file_summaries_str = "\n".join(truncated_lines)

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1081,6 +1081,24 @@ class SemanticProcessor(DequeueHandlerBase):
         if len(content) > max_chars:
             content = content[:max_chars] + "\n...(truncated)"
 
+        # Check for near-empty content to prevent hallucinated L0/L1 summaries.
+        # Empty or title-only documents (e.g. just a heading with no body) cause
+        # the VLM to hallucinate content. Skip VLM when there is insufficient
+        # actual text to summarize.
+        _meaningful_chars = 0
+        if content:
+            _stripped = re.sub(r"#+\s*", "", content)
+            _stripped = re.sub(r"[*_`~\-><!\[\]()]", "", _stripped)
+            _meaningful_chars = len(_stripped.strip())
+        if _meaningful_chars < 50:
+            logger.warning(
+                "Skipping VLM summarization for near-empty document: %s "
+                "(%d chars of meaningful content)",
+                file_path,
+                _meaningful_chars,
+            )
+            return result("")
+
         # Generate summary
         if not vlm.is_available():
             logger.warning("VLM not available, using empty summary")

--- a/tests/storage/test_semantic_processor_substantive_content.py
+++ b/tests/storage/test_semantic_processor_substantive_content.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for issue #3028 (hallucinated summaries).
+
+Verifies that the SemanticProcessor classifies documents by structural
+content (not a fixed character cutoff), propagates ``has_substantive_content``
+through the overview generation and vectorization paths, and returns
+deterministic neutral semantics when a directory has nothing substantive to
+summarize.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs import semantic_processor as semantic_processor_module
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+def _patch_semantic_limits(monkeypatch, *, abstract_max_chars=256, overview_max_chars=4000):
+    config = SimpleNamespace(
+        semantic=SimpleNamespace(
+            abstract_max_chars=abstract_max_chars,
+            overview_max_chars=overview_max_chars,
+            max_overview_prompt_chars=50000,
+            overview_batch_size=20,
+        ),
+        vlm=MagicMock(is_available=MagicMock(return_value=False)),
+    )
+    monkeypatch.setattr(semantic_processor_module, "get_openviking_config", lambda: config)
+
+
+class TestHasSubstantiveMarkdownBody:
+    """Structure-based detection: classify content, not character count."""
+
+    def test_empty_content_is_non_substantive(self):
+        assert SemanticProcessor._has_substantive_markdown_body("") is False
+
+    def test_whitespace_only_is_non_substantive(self):
+        assert SemanticProcessor._has_substantive_markdown_body("   \n\n\t  \n  ") is False
+
+    def test_single_atx_heading_only_is_non_substantive(self):
+        assert SemanticProcessor._has_substantive_markdown_body("# Working Memory") is False
+
+    def test_long_atx_heading_only_is_non_substantive(self):
+        long_heading = (
+            "# This Is A Very Long Heading Title That Exceeds Fifty Characters Easily "
+            "Just By Describing Itself In The Title"
+        )
+        assert len(long_heading) > 50
+        assert SemanticProcessor._has_substantive_markdown_body(long_heading) is False
+
+    def test_multiple_headings_with_no_body_is_non_substantive(self):
+        content = (
+            "# Top Level Heading\n"
+            "\n"
+            "## Second Level\n"
+            "\n"
+            "### Third Level Heading With Many Words\n"
+        )
+        assert SemanticProcessor._has_substantive_markdown_body(content) is False
+
+    def test_heading_with_leading_spaces_is_non_substantive(self):
+        content = "   ### ATX heading can have up to three leading spaces"
+        assert SemanticProcessor._has_substantive_markdown_body(content) is False
+
+    def test_setext_style_heading_only_is_non_substantive(self):
+        content = "Setext Heading\n================\n"
+        assert SemanticProcessor._has_substantive_markdown_body(content) is False
+
+    def test_thematic_break_only_is_non_substantive(self):
+        for break_line in ("---", "***", "___", "- - -", "* * *"):
+            assert SemanticProcessor._has_substantive_markdown_body(break_line) is False
+
+    def test_heading_separator_blank_mix_is_non_substantive(self):
+        content = (
+            "# Title\n"
+            "\n"
+            "---\n"
+            "\n"
+            "## Subtitle\n"
+            "\n"
+        )
+        assert SemanticProcessor._has_substantive_markdown_body(content) is False
+
+    def test_short_body_sentence_is_substantive(self):
+        content = "This is a short valid document."
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_chinese_body_is_substantive(self, monkeypatch):
+        _patch_semantic_limits(monkeypatch)
+        content = "这是一个中文文档，内容真实存在。"
+        assert len(content) < 50
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_japanese_body_is_substantive(self):
+        content = "これは日本語の本文です。"
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_korean_body_is_substantive(self):
+        content = "이것은 한국어 본문입니다."
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_russian_body_is_substantive(self):
+        content = "Это русский текст."
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_arabic_body_is_substantive(self):
+        content = "هذا نص بالعربية."
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_heading_plus_short_body_line_is_substantive(self):
+        content = (
+            "# Working Memory\n"
+            "\n"
+            "Recorded project preferences and active task context."
+        )
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_markdown_body_with_bullets_is_substantive(self):
+        content = (
+            "- Item one\n"
+            "- Item two\n"
+        )
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+    def test_short_code_fence_is_substantive(self):
+        content = "```python\nprint('hi')\n```\n"
+        assert SemanticProcessor._has_substantive_markdown_body(content) is True
+
+
+class TestGenerateOverviewFiltersNonSubstantive:
+    """Overview generation drops non-substantive entries and returns neutral
+    deterministic semantics when nothing remains."""
+
+    @pytest.mark.asyncio
+    async def test_all_non_substantive_directory_returns_neutral_deterministic_overview(self, monkeypatch):
+        _patch_semantic_limits(monkeypatch)
+        processor = SemanticProcessor()
+        file_summaries = [
+            {"name": "a.md", "summary": "", "has_substantive_content": False},
+            {"name": "b.md", "summary": "", "has_substantive_content": False},
+        ]
+        overview = await processor._generate_overview(
+            "viking://resources/project",
+            file_summaries,
+            children_abstracts=[],
+        )
+        assert "No substantive entries to summarize" in overview
+        assert overview.startswith("# project\n\n")
+
+    @pytest.mark.asyncio
+    async def test_all_non_substantive_directory_skips_vlm_invocation(self, monkeypatch):
+        mock_vlm = MagicMock()
+        mock_vlm.is_available.return_value = True
+        mock_vlm.get_completion_async = AsyncMock(return_value="# Should not be called")
+        config = SimpleNamespace(
+            semantic=SimpleNamespace(
+                abstract_max_chars=256,
+                overview_max_chars=4000,
+                max_overview_prompt_chars=50000,
+                overview_batch_size=20,
+            ),
+            vlm=mock_vlm,
+        )
+        monkeypatch.setattr(semantic_processor_module, "get_openviking_config", lambda: config)
+        processor = SemanticProcessor()
+        file_summaries = [
+            {"name": "h.md", "summary": "", "has_substantive_content": False},
+        ]
+        await processor._generate_overview(
+            "viking://resources/empty",
+            file_summaries,
+            children_abstracts=[],
+        )
+        mock_vlm.get_completion_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mixed_entries_filter_non_substantive_keep_body(self, monkeypatch):
+        mock_vlm = MagicMock()
+        mock_vlm.is_available.return_value = True
+        mock_vlm.get_completion_async = AsyncMock(return_value="# dir\n\nHello")
+        config = SimpleNamespace(
+            semantic=SimpleNamespace(
+                abstract_max_chars=256,
+                overview_max_chars=4000,
+                max_overview_prompt_chars=50000,
+                overview_batch_size=20,
+            ),
+            vlm=mock_vlm,
+        )
+        monkeypatch.setattr(semantic_processor_module, "get_openviking_config", lambda: config)
+        processor = SemanticProcessor()
+        file_summaries = [
+            {"name": "heading_only.md", "summary": "", "has_substantive_content": False},
+            {"name": "real.md", "summary": "Real body content here", "has_substantive_content": True},
+        ]
+        await processor._generate_overview(
+            "viking://resources/mixed",
+            file_summaries,
+            children_abstracts=[],
+        )
+        assert mock_vlm.get_completion_async.await_count == 1
+        prompt_kwarg = mock_vlm.get_completion_async.await_args.args[0]
+        assert "heading_only" not in prompt_kwarg
+        assert "real.md" in prompt_kwarg
+        assert "Real body content" in prompt_kwarg
+
+    @pytest.mark.asyncio
+    async def test_no_entries_returns_neutral_overview(self, monkeypatch):
+        _patch_semantic_limits(monkeypatch)
+        processor = SemanticProcessor()
+        overview = await processor._generate_overview(
+            "viking://resources/nothing",
+            file_summaries=[],
+            children_abstracts=[],
+        )
+        assert "No substantive entries to summarize" in overview
+
+
+class TestVectorizationSuppressionForNonSubstantive:
+    """Non-substantive file summaries are filtered out of the vectorization
+    worklist inside the memory-directory processing helper."""
+
+    def test_memory_file_vectorize_items_drops_non_substantive_entries(self, monkeypatch):
+        _patch_semantic_limits(monkeypatch)
+        processor = SemanticProcessor()
+        import inspect
+
+        source = inspect.getsource(processor._process_memory_directory)
+        assert 'summary.get("has_substantive_content", True)' in source


### PR DESCRIPTION
## Summary
- **Fix**: Skip VLM summarization for empty / title-only documents to prevent hallucinated L0/L1 summaries (fixes #3028).
- **Impact**: Prevents bogus `.abstract.md` / `.overview.md` content polluting the tiered loading pipeline for sparse resources.

## Root Cause
In `SemanticProcessor._generate_text_summary()`, the VLM was invoked unconditionally on every file. For empty or title-only documents (e.g., a file with only `# My Title`), the VLM had no meaningful content to summarize and would hallucinate plausible-sounding summaries.

## Changes
- **File**: `openviking/storage/queuefs/semantic_processor.py`
- After reading / truncating the file content, the code now strips markdown heading markers and formatting characters (`#`, `*`, `_`, backtick, `~`, `-`, `>`, `<`, `!`, `[`, `]`, `(`, `)`) and counts the remaining meaningful characters.
- If the meaningful content is `< 50` characters, the VLM call is skipped and an empty placeholder summary is returned with a warning log.
- The existing flow is preserved for documents with sufficient content — no behavior change for normal inputs.

## Why this is safe
- Only affects the sparse-content edge case — normal documents take the exact same path.
- Pure additive check; no changes to the VLM prompt, parsing, or downstream consumers.
- Threshold (50 chars) is conservative enough to avoid truncating legitimate small-but-meaningful content.