### PR TITLE
fix(memory): attach session_id and message_ids source tracing to extraction

### DIFF
--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -140,6 +140,8 @@ class SessionCompressorV2:
         isolation_handler: Optional[MemoryIsolationHandler] = None,
         transaction_handle=None,
         context_provider: Optional[Any] = None,
+        session_id: Optional[str] = None,
+        message_ids: Optional[List[str]] = None,
     ) -> ExtractLoop:
         """Create new ExtractLoop instance with current ctx.
 
@@ -171,6 +173,8 @@ class SessionCompressorV2:
             ctx=ctx,
             context_provider=context_provider,
             isolation_handler=isolation_handler,
+            session_id=session_id,
+            message_ids=message_ids,
         )
 
     def _get_or_create_updater(self, registry, transaction_handle=None) -> MemoryUpdater:
@@ -328,6 +332,8 @@ class SessionCompressorV2:
                 isolation_handler=isolation_handler,
                 transaction_handle=transaction_handle,
                 context_provider=context_provider,
+                session_id=session_id,
+                message_ids=[str(getattr(m, "id", "")) for m in messages if getattr(m, "id", None)],
             )
             read_scope = isolation_handler.get_read_scope()
             if lock_manager:

--- a/openviking/session/memory/dataclass.py
+++ b/openviking/session/memory/dataclass.py
@@ -163,6 +163,7 @@ class MemoryOperationSource(BaseModel):
 
     extraction_id: Optional[str] = None
     session_id: Optional[str] = None
+    message_ids: Optional[List[str]] = None
     archive_uri: Optional[str] = None
     task_id: Optional[str] = None
     trace_id: Optional[str] = None

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -16,6 +16,7 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import (
     DeleteId,
     MemoryFile,
+    MemoryOperationSource,
     ResolvedOperation,
     ResolvedOperations,
     StoredLink,
@@ -100,6 +101,8 @@ class ExtractLoop:
         context_provider: Optional[Any] = None,  # ExtractContextProvider
         isolation_handler: MemoryIsolationHandler = None,
         thinking: bool = False,
+        session_id: Optional[str] = None,
+        message_ids: Optional[List[str]] = None,
     ):
         """
         Initialize the ExtractLoop.
@@ -112,6 +115,8 @@ class ExtractLoop:
             ctx: Request context
             context_provider: ExtractContextProvider - 必须提供（由 provider 加载 schema）
             thinking: Whether to explicitly enable model thinking for this extraction loop.
+            session_id: Session identifier for source tracing.
+            message_ids: List of message IDs that contributed to this extraction.
         """
         self.vlm = vlm
         self.viking_fs = viking_fs or get_viking_fs()
@@ -120,6 +125,8 @@ class ExtractLoop:
         self.ctx = ctx
         self.context_provider = context_provider
         self.thinking = bool(thinking)
+        self._session_id = session_id
+        self._message_ids = message_ids
         # Use provided isolation_handler or create one in run()
         self._isolation_handler = isolation_handler
         # Track format error retry (max 1 retry)
@@ -409,6 +416,12 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     uris=[],
                     page_id=page_id,
                 )
+
+                if self._session_id or self._message_ids:
+                    resolved_op.source = MemoryOperationSource(
+                        session_id=self._session_id,
+                        message_ids=self._message_ids,
+                    )
 
                 if page_id is not None and page_id_map is not None:
                     resolved_uri = page_id_map.resolve(page_id)

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -1005,6 +1005,12 @@ class MemoryUpdater:
             source_trace_id = _operation_trace_id(resolved_op)
             if source_trace_id:
                 metadata["last_update_trace_id"] = source_trace_id
+            source_session_id = getattr(source, "session_id", None) if source else None
+            if source_session_id:
+                metadata["source_session_id"] = str(source_session_id)
+            source_message_ids = getattr(source, "message_ids", None) if source else None
+            if source_message_ids:
+                metadata["source_message_ids"] = list(source_message_ids)
             # Process fields defined in schema (apply merge_op)
             for field in schema.fields:
                 if field.name in resolved_op.memory_fields:

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -1272,6 +1272,12 @@ def attach_source_to_request_operations(request: MemoryUpdateRequest) -> None:
         source_trace_id = getattr(op.source, "trace_id", None)
         if source_trace_id:
             op.memory_fields.setdefault("last_update_trace_id", source_trace_id)
+        source_session_id = getattr(op.source, "session_id", None)
+        if source_session_id:
+            op.memory_fields.setdefault("source_session_id", source_session_id)
+        source_message_ids = getattr(op.source, "message_ids", None)
+        if source_message_ids:
+            op.memory_fields.setdefault("source_message_ids", list(source_message_ids))
 
 
 def memory_operation_source_from_request(
@@ -1281,9 +1287,18 @@ def memory_operation_source_from_request(
     extraction_id = metadata.get("source_extraction_id") or metadata.get("extraction_id")
     if not extraction_id:
         return None
+    message_ids = metadata.get("message_ids")
+    if not message_ids:
+        messages = list(getattr(request, "messages", []) or [])
+        message_ids = [
+            str(getattr(m, "id", ""))
+            for m in messages
+            if getattr(m, "id", None)
+        ] or None
     return MemoryOperationSource(
         extraction_id=str(extraction_id),
         session_id=_optional_str(metadata.get("session_id")),
+        message_ids=list(message_ids) if message_ids else None,
         archive_uri=_optional_str(metadata.get("archive_uri")),
         task_id=_optional_str(metadata.get("task_id")),
         trace_id=_optional_str(metadata.get("trace_id")),


### PR DESCRIPTION
## Summary
- **Fix**: Memory extraction now attaches source-tracing metadata (`session_id`, `message_ids`) to memory files so each memory can be traced back to the session and messages that produced it (fixes #3329).
- **Impact**: Enables provenance tracking for Agent Memory — users and downstream systems can now answer "which session/messages produced this memory?"

## Changes
**5 files changed, +41 lines**

| File | Change |
|------|--------|
| `openviking/session/memory/dataclass.py` | Added `message_ids: Optional[List[str]] = None` to `MemoryOperationSource` |
| `openviking/session/memory/memory_updater.py` | In `_apply_upsert`, persist `source_session_id` / `source_message_ids` into the memory file's `extra_fields` when a `ResolvedOperation.source` is present |
| `openviking/session/memory/extract_loop.py` | Added optional `session_id` / `message_ids` params to `ExtractLoop.__init__`; `resolve_operations` attaches a `MemoryOperationSource` to each resolved operation |
| `openviking/session/memory/streaming_memory_updater.py` | `memory_operation_source_from_request` derives `message_ids` from the request's messages; `attach_source_to_request_operations` propagates `session_id` / `message_ids` to `memory_fields` |
| `openviking/session/compressor_v2.py` | `_get_or_create_react` and `extract_long_term_memories` plumb `session_id` / `message_ids` through |

## How it works
1. `MemoryOperationSource` now supports both `session_id` and `message_ids`.
2. On the write path, whenever a `ResolvedOperation` carries a `source`, its `session_id` / `message_ids` are persisted into the memory file's `extra_fields` as `source_session_id` / `source_message_ids`.
3. On the extraction path (both `ExtractLoop` and streaming memory updater), the current `session_id` and contributing message IDs are gathered and attached to each operation before persistence.

## Backwards compatibility
- All new fields are `Optional[...] = None`.
- The write path only writes the new metadata when it is actually present — existing memory files and extraction flows without source info are unaffected.