### PR TITLE
fix(memory): merge multi-item list responses in parse_json_with_stability

### DIFF
--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -411,8 +411,38 @@ def parse_json_with_stability(
     # Layer 3: Structure tolerance
     # Handle case where model returns [{"xxx": ...}] instead of {"xxx": ...}
     if isinstance(parsed_data, list) and len(parsed_data) > 0:
-        parsed_data = parsed_data[0]
-        tracer.info("Extracted first item from list response")
+        # Attempt to merge all list items into a single dict
+        # (some LLMs, e.g. llama.cpp, emit separate operation objects
+        #  as a JSON array rather than a single compound object).
+        try:
+            merged: Dict[str, Any] = {}
+            for item in parsed_data:
+                if not isinstance(item, dict):
+                    # Skip non-dict items but keep going
+                    tracer.info(f"Skipping non-dict list item: {type(item).__name__}")
+                    continue
+                for k, v in item.items():
+                    if k not in merged:
+                        merged[k] = v
+                    elif isinstance(merged[k], list) and isinstance(v, list):
+                        merged[k] = merged[k] + v
+                    elif isinstance(merged[k], list):
+                        merged[k] = merged[k] + ([v] if not isinstance(v, list) else v)
+                    elif isinstance(v, list) and not isinstance(merged[k], list):
+                        merged[k] = [merged[k]] + v
+                    else:
+                        # Later values win for scalar / overlapping keys
+                        merged[k] = v
+            if merged:
+                parsed_data = merged
+                tracer.info(f"Merged {len(parsed_data)} list items into single dict")
+            else:
+                # Fall back to original single-item behavior
+                parsed_data = parsed_data[0]
+                tracer.info("Extracted first item from list response (merge yielded no dict)")
+        except Exception:
+            parsed_data = parsed_data[0]
+            tracer.info("Extracted first item from list response (merge failed)")
     elif (
         isinstance(parsed_data, list)
         and len(parsed_data) == 0


### PR DESCRIPTION
## Summary
- **Fix**: `parse_json_with_stability()` now correctly merges multi-item list responses (e.g. `[{write_uris: ...}, {edit_uris: ...}]`) instead of silently dropping all but the first item (fixes #3508).
- **Impact**: llama.cpp and other local-deployment LLMs that emit separate operation objects as a JSON array will now produce correct multi-operation memory extraction results.

## Root Cause
In `openviking/session/memory/utils/json_parser.py`, Layer 3 (Structure Tolerance) handled the case where an LLM wraps its response in a JSON array by taking only the first element: `parsed_data = parsed_data[0]`. While this works for single-item arrays like `[{write_uris: [...]}]`, it silently drops all subsequent operations when LLMs like llama.cpp emit separate objects per operation, e.g. `[{write_uris: [...]}, {edit_uris: [...]}]`.

## Changes
- **File**: `openviking/session/memory/utils/json_parser.py`
- The list-merging logic now:
  1. Iterates all list items and merges them into a single dict
  2. Concatenates list-valued fields (e.g. `write_uris`, `edit_uris`, `delete_ids`)
  3. Last-wins for scalar fields (e.g. `reasoning`)
  4. Skips non-dict items gracefully
  5. Falls back to the original first-item behavior if merge yields empty or raises

## Why this is safe
- Single-element lists produce identical results to the old behavior (merge of one item = same as taking `[0]`).
- Empty lists and non-dict lists still fall through to the existing code paths.
- The merge logic only activates when the parsed response is a list with dict elements; normal dict responses are completely unaffected.
- All existing tests pass; the new behavior is only exercised by the specific multi-item-list scenario reported in the issue.