### PR TITLE
fix(vectordb): truncate oversized fields JSON blob before bytes_row write

### DIFF
--- a/openviking/storage/vectordb/collection/local_collection.py
+++ b/openviking/storage/vectordb/collection/local_collection.py
@@ -43,6 +43,7 @@ from openviking.storage.vectordb.utils.constants import (
 from openviking.storage.vectordb.utils.data_processor import DataProcessor
 from openviking.storage.vectordb.utils.dict_utils import ThreadSafeDictManager
 from openviking.storage.vectordb.utils.id_generator import generate_auto_id
+from openviking.storage.vectordb.store.bytes_row import STRING_MAX_UINT16_LENGTH
 from openviking.storage.vectordb.utils.json_safety import safe_json_dumps
 from openviking.storage.vectordb.utils.path_safety import (
     resolve_storage_path,
@@ -818,6 +819,53 @@ class LocalCollection(ICollection):
             data_list.append(data)
         return data_list
 
+    # Reserve headroom for JSON structural overhead (braces, quotes, commas,
+    # key names) so the *total* serialized blob stays under the uint16 limit.
+    _FIELDS_JSON_MAX_BYTES = STRING_MAX_UINT16_LENGTH - 2048
+
+    @staticmethod
+    def _truncate_fields_json(data: Dict[str, Any]) -> str:
+        """Serialize *data* to JSON, truncating oversized string values.
+
+        The local vectordb ``bytes_row`` format length-prefixes every string
+        field with a ``uint16``, capping each at 65 535 bytes.  The ``fields``
+        column stores **all** scalar metadata as a single JSON blob, so a
+        large ``abstract`` or ``description`` can push the combined payload
+        over the limit even though every individual value was independently
+        acceptable.
+
+        Strategy: serialize once; if the blob fits, return it unchanged.
+        Otherwise, iteratively halve the longest string value until the blob
+        fits or no string values remain.  This preserves as much information
+        as possible while guaranteeing the write succeeds.
+        """
+        blob = safe_json_dumps(data, ensure_ascii=False)
+        if len(blob.encode("utf-8")) <= LocalCollection._FIELDS_JSON_MAX_BYTES:
+            return blob
+
+        # Identify string keys sorted by descending encoded length.
+        str_keys = sorted(
+            (k for k, v in data.items() if isinstance(v, str)),
+            key=lambda k: len(data[k].encode("utf-8")),
+            reverse=True,
+        )
+        for k in str_keys:
+            encoded = data[k].encode("utf-8")
+            # Halve until the blob fits.
+            while len(encoded) > 256:
+                encoded = encoded[: len(encoded) // 2]
+                data[k] = encoded.decode("utf-8", errors="ignore") + "…[truncated]"
+                blob = safe_json_dumps(data, ensure_ascii=False)
+                if len(blob.encode("utf-8")) <= LocalCollection._FIELDS_JSON_MAX_BYTES:
+                    return blob
+            # Last resort: drop the field entirely.
+            data[k] = ""
+            blob = safe_json_dumps(data, ensure_ascii=False)
+            if len(blob.encode("utf-8")) <= LocalCollection._FIELDS_JSON_MAX_BYTES:
+                return blob
+
+        return blob
+
     def _write_data_list(self, data_list: List[Dict[str, Any]], ttl=0):
         result = UpsertDataResult()
 
@@ -841,7 +889,7 @@ class LocalCollection(ICollection):
                 if sparse_dict and isinstance(sparse_dict, dict):
                     cands_list[i].sparse_raw_terms = list(sparse_dict.keys())
                     cands_list[i].sparse_values = list(sparse_dict.values())
-            cands_list[i].fields = safe_json_dumps(data, ensure_ascii=False)
+            cands_list[i].fields = self._truncate_fields_json(data)
             cands_list[i].expire_ns_ts = time.time_ns() + ttl * 1000000000 if ttl > 0 else 0
 
         if not self.store_mgr:

--- a/tests/storage/test_fields_json_truncation.py
+++ b/tests/storage/test_fields_json_truncation.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for LocalCollection._truncate_fields_json.
+
+Verifies that the ``fields`` JSON blob written to the local vectordb
+``bytes_row`` store never exceeds the uint16 string-length limit (65 535
+bytes), even when scalar metadata (abstract, description, …) is large.
+
+Related: #2967 (content field), #2774 (abstract cap), #2117 / PR #2171.
+"""
+
+import json
+
+import pytest
+
+from openviking.storage.vectordb.collection.local_collection import LocalCollection
+from openviking.storage.vectordb.store.bytes_row import STRING_MAX_UINT16_LENGTH
+
+
+class TestTruncateFieldsJson:
+    """Unit tests for the static truncation helper."""
+
+    def test_small_payload_unchanged(self):
+        data = {"uri": "viking://x", "abstract": "short", "level": 2}
+        blob = LocalCollection._truncate_fields_json(data)
+        assert json.loads(blob) == data
+
+    def test_large_abstract_truncated(self):
+        data = {
+            "uri": "viking://user/memories/events/big.md",
+            "abstract": "A" * 70_000,
+            "level": 2,
+        }
+        blob = LocalCollection._truncate_fields_json(data)
+        assert len(blob.encode("utf-8")) <= STRING_MAX_UINT16_LENGTH
+        parsed = json.loads(blob)
+        assert parsed["uri"] == data["uri"]
+        assert parsed["level"] == 2
+        assert "truncated" in parsed["abstract"]
+
+    def test_multiple_large_fields(self):
+        data = {
+            "uri": "viking://res/big",
+            "abstract": "B" * 40_000,
+            "description": "C" * 40_000,
+            "name": "D" * 10_000,
+        }
+        blob = LocalCollection._truncate_fields_json(data)
+        assert len(blob.encode("utf-8")) <= STRING_MAX_UINT16_LENGTH
+        parsed = json.loads(blob)
+        # At least the URI must survive untouched.
+        assert parsed["uri"] == data["uri"]
+
+    def test_non_string_fields_preserved(self):
+        data = {
+            "uri": "viking://x",
+            "abstract": "E" * 70_000,
+            "level": 1,
+            "active_count": 42,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        blob = LocalCollection._truncate_fields_json(data)
+        parsed = json.loads(blob)
+        assert parsed["level"] == 1
+        assert parsed["active_count"] == 42
+        assert parsed["created_at"] == data["created_at"]
+
+    def test_empty_dict(self):
+        blob = LocalCollection._truncate_fields_json({})
+        assert json.loads(blob) == {}
+
+    def test_boundary_exact_fit(self):
+        # Build a payload that is exactly at the limit — should pass through.
+        base = {"uri": "viking://x", "abstract": ""}
+        base_blob = json.dumps(base, ensure_ascii=False)
+        overhead = len(base_blob.encode("utf-8"))
+        fill = STRING_MAX_UINT16_LENGTH - overhead - 2  # quotes around value
+        data = {"uri": "viking://x", "abstract": "F" * fill}
+        blob = LocalCollection._truncate_fields_json(data)
+        assert len(blob.encode("utf-8")) <= STRING_MAX_UINT16_LENGTH
+
+    def test_unicode_multibyte_truncation(self):
+        # Multi-byte UTF-8 chars (emoji = 4 bytes each).
+        data = {"uri": "viking://x", "abstract": "🔥" * 20_000}
+        blob = LocalCollection._truncate_fields_json(data)
+        assert len(blob.encode("utf-8")) <= STRING_MAX_UINT16_LENGTH
+        # Must be valid JSON (no broken surrogates).
+        json.loads(blob)


### PR DESCRIPTION
## Description

The local vectordb `bytes_row` format length-prefixes every string field with a `uint16`, capping each at 65 535 bytes. The `fields` column stores **all** scalar metadata (abstract, description, name, tags, uri, …) as a single JSON blob. When a large abstract (~50 KB after the #2774 cap) is combined with other scalar fields, the total serialized blob can exceed 65 535 bytes, causing:

```
RuntimeError: string field 'fields' exceeds 65535 bytes
```

This was partially addressed by #3114 (drop `content` field for non-VikingDB backends) and #2774 (cap abstract at 50 KB), but the combined JSON blob of all remaining scalars can still overflow.

### Root cause

`local_collection.py:844`:
```python
cands_list[i].fields = safe_json_dumps(data, ensure_ascii=False)
```

`data` contains every scalar field from the collection schema (uri, context_type, abstract, description, name, tags, account_id, owner_user_id, created_at, updated_at, level, active_count). The `abstract` alone can be up to 50 000 bytes after the #2774 truncation. Adding the remaining fields pushes the JSON blob past 65 535 bytes.

### Fix

Add `LocalCollection._truncate_fields_json()` which:
1. Serializes the payload once; if it fits, returns it unchanged (zero overhead for normal records).
2. If oversized, iteratively halves the longest string value until the blob fits.
3. Non-string fields (`level`, `active_count`, timestamps) are never modified.
4. As a last resort, drops the offending string field entirely.

The write path now calls `self._truncate_fields_json(data)` instead of `safe_json_dumps(data)`.

### Related

- Fixes the remaining gap after #2967 / #3114
- Related: #2117, #2774, #2966

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `openviking/storage/vectordb/collection/local_collection.py`: add `_truncate_fields_json()` static method + import `STRING_MAX_UINT16_LENGTH`; replace `safe_json_dumps` call in `_write_data_list`
- `tests/storage/test_fields_json_truncation.py`: 7 unit tests (small passthrough, single large field, multiple large fields, non-string preservation, empty dict, boundary exact fit, multi-byte UTF-8)

## Testing

```
$ python -m pytest tests/storage/test_fields_json_truncation.py -v
7 passed in 0.05s
```

Verified against a live deployment with 5 memory files (82–131 KB) that previously failed with `string field 'fields' exceeds 65535 bytes`. After the fix, all 5 records are written successfully.