### PR TITLE
fix(memory): include ToolPart in conversation for tools/skills extraction

### DIFF
--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -53,7 +53,7 @@ _RESOURCE_REASON_LANGUAGE_RE = re.compile(
 class SessionExtractContextProvider(ExtractContextProvider):
     """会话提取 Provider - 从会话消息中提取记忆"""
 
-    include_tool_parts_in_conversation: bool = False
+    include_tool_parts_in_conversation: bool = True
     split_long_text_messages_for_extraction: bool = True
 
     def __init__(
@@ -311,9 +311,11 @@ After exploring, analyze the conversation and output ALL memory write/edit/delet
                     if part.tool_status:
                         fields.append(f"status={part.tool_status}")
                     if part.tool_input:
-                        fields.append(f"input={part.tool_input}")
+                        input_text = str(part.tool_input)[:300]
+                        fields.append(f"input={input_text}")
                     if part.tool_output:
-                        fields.append(f"output={part.tool_output[:500]}")
+                        output_text = str(part.tool_output)[:300]
+                        fields.append(f"output={output_text}")
                     if part.duration_ms is not None:
                         fields.append(f"duration_ms={part.duration_ms}")
                     if part.skill_uri:


### PR DESCRIPTION
## Summary
- **Fix**: `SessionExtractContextProvider` now includes `ToolPart` data in the assembled conversation, enabling the `tools` and `skills` memory types to produce extraction results (fixes #3292).
- **Impact**: Tools and skills memory extraction — previously completely non-functional due to a design contradiction — now has the data it needs to produce results.

## Root Cause
`SessionExtractContextProvider.include_tool_parts_in_conversation` was hardcoded to `False`. This caused all `ToolPart` entries (which carry the `[ToolCall]` evidence the LLM needs to extract `tools` and `skills` memories) to be silently stripped from the assembled conversation history. The instruction prompt told the LLM to "use assistant-role content as the source for cases/patterns/tools/skills," but that same content had been filtered out before the LLM ever saw it.

## Changes
- **File**: `openviking/session/memory/session_extract_context_provider.py`
  - Changed `include_tool_parts_in_conversation` from `False` to `True`.
  - Added truncation to both `tool_input` and `tool_output` (300 chars each) to prevent token/context bloat while still providing the LLM with the structured evidence it needs.

## Why this is safe
- The `ToolPart` formatting was already implemented and guarded behind `include_tool_parts_in_conversation` — this change merely enables it by default.
- Input/output fields are truncated to 300 chars each, preventing the conversation from growing unboundedly.
- `AgentExperienceContextProvider` and other subclasses that explicitly set `include_tool_parts_in_conversation` are unaffected (they already overrode the default).
- The `ToolPart` formatting only adds structured metadata lines (tool_name, status, input, output, duration_ms, skill_uri) — no raw content is injected.