### PR TITLE
fix(memory): bound Phase 2 extraction inputs

### DIFF
--- a/docs/design/session-memory-extraction-flow.md
+++ b/docs/design/session-memory-extraction-flow.md
@@ -1,12 +1,17 @@
 # Session Memory Extraction Flow
 
-This document records the current implementation. It is meant to be used as a
-code-modification reference, so it avoids proposed or removed flows.
+> **TL;DR:** Session commit archives the complete source first, then Phase 2
+> processes an immutable prompt copy through deterministic token-bounded windows.
+> Authored text is covered losslessly, bulky tool output keeps a head/tail
+> preview, and every model request has a final estimated-input guard.
+
+This document records the current implementation. It is the main-flow reference
+for changes to session memory extraction, not a proposal for a future pipeline.
 
 ## Policy
 
-`memory_policy` carries target switches plus an optional global memory type
-whitelist, and can disable per-archive Working Memory summaries:
+`memory_policy` decides which destinations and memory types Phase 2 may update;
+it does not change the bounded-input safety rules.
 
 ```json
 {
@@ -25,67 +30,128 @@ runs configured memory extraction, but skips the archive summary.
 
 ## Memory Type Groups
 
+The v3 runtime processes user and agent-derived memories from the same bounded
+window, while their existing storage and routing contracts remain separate.
+
 | Group | Types | Target |
 | --- | --- | --- |
-| Long-term memory extraction | Enabled registry schemas with `stage: user` | Self and peer |
-| Execution memory extraction | Execution-derived schemas, currently `trajectories`, `experiences` | Self only |
+| User memory extraction | Enabled registry schemas with `stage: user` | Self and peer |
+| Agent-derived extraction | `cases`, `trajectories`, `experiences` | Self only |
 | Session skills | `SESSION_SKILL_MEMORY_TYPE` output | Self only |
 
 Memory schemas default to `stage: user` and `peer_enabled: true`. Set
-`stage: agent` for schemas that are extracted only by the execution-memory
-providers. Set `peer_enabled: false` for user-stage schemas that should ignore
-`peer_id` and `ranges` peer targets and remain under the current user space
-(for example `cases`).
+`stage: agent` for agent-derived schemas. Set `peer_enabled: false` for
+user-stage schemas that should ignore `peer_id` and `ranges` peer targets and
+remain under the current user space, for example `cases`.
 
-Trajectory/experience extraction is controlled by `memory_types`: omitted or
-`null` allows both, while an explicit list must include those names. Session
-skill extraction also requires self memory to be enabled and only runs when the
-execution memory extraction phase has work.
+## Commit Main Flow
 
-## Commit Flow
+Phase 1 preserves the authoritative archive; Phase 2 derives bounded prompt
+copies and never rewrites the archived messages or externalized tool objects.
 
 Implemented in `openviking/session/session.py`:
 
 1. Load the session-level policy from session metadata.
-2. Archive the current message batch.
-3. Hydrate tool outputs for extraction.
-4. If peer memory is enabled, collect safe `message.peer_id` values from the
-   archived batch into `allowed_peer_ids`.
-5. Start archive summary generation.
-6. If long-term memory extraction is enabled and allowed by `memory_types`, call
-   `SessionCompressorV2.extract_long_term_memories` once with the full archived
-   batch, `allow_self_memory`, and `allowed_peer_ids`.
-7. If trajectory/experience extraction has work, call
-   `SessionCompressorV2.extract_execution_memories` once with the full archived
-   batch. When session skill extraction is enabled, it runs inside this execution
-   phase instead of starting a separate phase by itself.
+2. Archive the current message batch and clear the committed live messages.
+3. Build deterministic Phase 2 fragments and turn-aware windows from the
+   archived batch.
+4. Split an individually oversized `TextPart` or `ContextPart` into stable
+   plan-version, offset, and digest fragments. Across all windows, authored
+   text remains in source order without omission.
+5. Keep tool output as a copied head/tail preview plus its raw-storage
+   reference. Do not hydrate the raw result back into model input. Structured
+   `tool_input` remains unchanged; planning fails closed if that metadata alone
+   cannot fit a window.
+6. If usage reporting is enabled, hydrate a separate copy for the rule-based
+   reporter only.
+7. Run Working Memory and v3 memory extraction over the bounded windows.
+8. After each successful memory window, append its audit diff and persist the
+   completed fragment IDs. Retry skips recorded windows and retains their
+   existing audit entries.
+9. Update archive metadata and write `.done` only after every required Phase 2
+   step succeeds.
 
-The current flow does not build separate buckets such as
-`self_identity_messages`, `self_experience_messages`,
-`peer_user_message_groups`, or `peer_assistant_message_groups`.
+## Working Memory Reduction
+
+Working Memory folds windows sequentially, so no summary-generation request
+reconstructs the full archive.
+
+For window `N`, the previous seven-section overview is the reducer state and
+window `N` is the new input. Multi-window mode requires every model result to
+retain all seven canonical sections; malformed or unavailable results fail the
+Phase 2 task instead of publishing a generic partial overview.
+
+Checkpoint source IDs are remapped from archive-message IDs to the derived
+fragment IDs visible in each window. If one checkpoint spans multiple windows,
+its window-local notes are merged pairwise through separately guarded model
+requests before the existing retained-context budget is applied.
+
+## V3 Memory Reduction
+
+The runtime factory always creates `SessionCompressorV3`; it processes remaining
+windows sequentially and uses persisted memory as the reducer between windows.
+
+Each window covers user memories plus the enabled case, trajectory, experience,
+and skill paths. Every downstream request receives the same explicit
+`request_max_tokens` value, including process-global streaming updater and
+trainer work. Shared workers attach the strictest non-null budget to each
+batched chunk and store an unscoped base context, so a Phase 2 request cannot
+leak its cap into later non-session work.
+
+The retained `SessionCompressorV2` injection interface does not gain v3's
+windowed reduction. It receives the final request cap and fails before a
+provider call if its full-archive request is oversized.
+
+## Provider-Bound Request Guard
+
+Every Phase 2 provider call is estimated immediately before invocation; known
+tool-result envelopes may be compacted further, but authored content and system
+contracts are never silently truncated.
+
+`ExtractLoop` includes the messages and actual tool schemas for that iteration
+in its estimate. It recognizes the JSON envelope produced by
+`add_tool_call_pair_to_messages()` and may reduce only its `result` field to a
+head/tail preview while preserving structured result shape and metadata.
+`ExtractLoop.run()` invokes provider message preparation before building
+schemas or prompts, so V3 user, trajectory, and experience paths all route
+images through the guarded description request. Direct Working Memory and
+checkpoint-reduction calls use the same scoped guard. Residual overflow raises
+`ResourceExhaustedError` without calling the provider.
+
+The relevant configuration is:
+
+| Field | Meaning | Default |
+| --- | --- | --- |
+| `memory.phase2_window_max_tokens` | Maximum estimated archive-derived tokens in one Phase 2 window | `12000` |
+| `memory.extraction_request_max_tokens` | Maximum estimated serialized tokens in one Phase 2 model request | `32768` |
+
+The request cap must be greater than or equal to the window cap.
 
 ## Long-Term Routing
 
-Implemented in `openviking/session/memory/memory_isolation_handler.py`.
+Final write targets are resolved per operation, and each window may address
+only peers evidenced inside that same window.
 
-`MemoryIsolationHandler.calculate_memory_uris` resolves each extracted operation
-independently:
+Implemented in
+`openviking/session/memory/memory_isolation_handler.py`,
+`MemoryIsolationHandler.calculate_memory_uris` resolves operations as follows:
 
 | Operation fields | Result |
 | --- | --- |
 | No `peer_id`, no `ranges` | Write self if self memory is enabled |
-| Safe `peer_id` in `allowed_peer_ids` | Write that peer |
-| Unsafe `peer_id` | Skip |
-| Safe but unallowed `peer_id` | Skip |
-| `ranges` present | Read the message range; no-peer messages route to self, allowed peer messages route to peer |
-| Schema has `peer_enabled: false` | Ignore `peer_id` and `ranges` peer targets; write self if self memory is enabled |
+| Safe `peer_id` observed in this window | Write that peer |
+| Unsafe or window-unobserved `peer_id` | Skip |
+| `ranges` present | Resolve against the window-local `ExtractContext` |
+| Schema has `peer_enabled: false` | Ignore peer targets and write self if enabled |
 | Only disabled targets found | Skip |
 
-The router does not rewrite message roles. A `role=user` message remains user
-content, a `role=assistant` message remains assistant content, and tool parts
-stay on the message where they were recorded.
+The router does not rewrite message roles. Tool evidence remains attached to
+the message where it was recorded.
 
 ## Storage Targets
+
+Self and peer operations keep the existing namespace layout; bounded input does
+not alter storage paths.
 
 For current user space `viking://user/<user_id>`:
 
@@ -95,12 +161,19 @@ For current user space `viking://user/<user_id>`:
 | Peer | `viking://user/<user_id>/peers/<peer_id>/...` |
 
 Peer-only extraction does not initialize self default files. Default self files
-are initialized only when `allow_self_memory` is true.
+are initialized only when self memory is enabled.
 
 ## Practical Invariants
 
-- Long-term extraction sees the full archived batch once.
-- The extractor may emit self and peer operations in the same response.
-- Final write targets are decided per operation by the isolation handler.
-- Peer writes require safe peer IDs observed in the archived batch.
-- `trajectories`, `experiences`, and session skills never write peer memory.
+The safety boundary is source-preserving and provider-bounded: all derived
+windows are replayable from the archive, but no individual model request may
+exceed the configured input cap.
+
+- Archived messages and externalized tool objects remain unchanged.
+- All authored text appears across Phase 2 windows exactly once and in order.
+- Tool evidence exposed to agent-memory paths retains both its head and tail.
+- Working Memory, user memory, and agent-derived v3 paths consume bounded
+  windows and never concatenate them back into one archive-sized prompt.
+- Completed-window memory diffs survive retry.
+- Process-global worker contexts do not retain request-local budgets.
+- A residual oversized request fails before provider invocation.

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1397,6 +1397,8 @@ For memory-related settings, add a `memory` section in `ov.conf`:
 | `version` | Deprecated and ignored. OpenViking always uses the v3 memory extraction pipeline; existing configs that set this field still load without error. | `"v3"` |
 | `custom_templates_dir` | Custom memory templates directory. If set, templates from this directory are loaded in addition to built-in templates. | `""` |
 | `extraction_enabled` | Whether session commit runs long-term memory extraction. | `true` |
+| `phase2_window_max_tokens` | Maximum estimated archive-derived tokens in one loss-preserving Phase 2 extraction window. | `12000` |
+| `extraction_request_max_tokens` | Maximum estimated serialized input tokens in one Phase 2 model request. Must be at least `phase2_window_max_tokens`. | `32768` |
 | `session_skill_extraction_enabled` | Whether session commit also extracts reusable skills into the current user's skill directory. | `false` |
 | `link_enabled` | Whether memory extraction writes and resolves memory links. | `false` |
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1362,6 +1362,8 @@ openviking-server --config /path/to/ov.conf
 | `version` | 已废弃且会被忽略。OpenViking 始终使用 v3 记忆抽取链路；已有配置中保留该字段仍可正常加载，不会报错。 | `"v3"` |
 | `custom_templates_dir` | 自定义 memory templates 目录。设置后会在内置模板之外加载该目录中的模板。 | `""` |
 | `extraction_enabled` | session commit 时是否执行长期记忆抽取。 | `true` |
+| `phase2_window_max_tokens` | 单个无损 Phase 2 抽取窗口中，归档来源内容的最大估算 token 数。 | `12000` |
+| `extraction_request_max_tokens` | 单次 Phase 2 模型请求的最大估算序列化输入 token 数；必须不小于 `phase2_window_max_tokens`。 | `32768` |
 | `session_skill_extraction_enabled` | session commit 时是否同时抽取可复用 skill 到当前用户的 skill 目录。 | `false` |
 | `link_enabled` | 记忆抽取是否写入和解析 memory links。 | `false` |
 

--- a/openviking/prompts/templates/compression/checkpoint_reduce.yaml
+++ b/openviking/prompts/templates/compression/checkpoint_reduce.yaml
@@ -1,0 +1,36 @@
+metadata:
+  id: "compression.checkpoint_reduce"
+  name: "Checkpoint Summary Reduction"
+  description: "Merge two adjacent checkpoint notes into one continuation note."
+  version: "1.0.0"
+  language: "en"
+  category: "compression"
+
+variables:
+  - name: "accumulated_summary"
+    type: "string"
+    description: "Checkpoint note accumulated from earlier Phase 2 windows"
+    required: true
+  - name: "next_summary"
+    type: "string"
+    description: "Checkpoint note from the next Phase 2 window"
+    required: true
+
+template: |
+  Merge these adjacent continuation notes into one compact continuation note.
+  Preserve every concrete decision, tool action and result, conclusion, error,
+  correction, and unfinished task. Remove only repetition and wording overhead.
+  Do not mention summaries, windows, checkpoints, archiving, or this instruction.
+
+  <accumulated_note>
+  {{ accumulated_summary }}
+  </accumulated_note>
+
+  <next_note>
+  {{ next_summary }}
+  </next_note>
+
+  Output only the merged continuation note.
+
+llm_config:
+  temperature: 0.0

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -140,6 +140,7 @@ class SessionCompressorV2:
         isolation_handler: Optional[MemoryIsolationHandler] = None,
         transaction_handle=None,
         context_provider: Optional[Any] = None,
+        request_max_tokens: Optional[int] = None,
     ) -> ExtractLoop:
         """Create new ExtractLoop instance with current ctx.
 
@@ -163,6 +164,7 @@ class SessionCompressorV2:
                 ctx=ctx,
                 viking_fs=viking_fs,
                 transaction_handle=transaction_handle,
+                request_max_tokens=request_max_tokens,
             )
 
         return ExtractLoop(
@@ -171,6 +173,7 @@ class SessionCompressorV2:
             ctx=ctx,
             context_provider=context_provider,
             isolation_handler=isolation_handler,
+            request_max_tokens=request_max_tokens,
         )
 
     def _get_or_create_updater(self, registry, transaction_handle=None) -> MemoryUpdater:
@@ -232,6 +235,7 @@ class SessionCompressorV2:
         allowed_memory_types: Optional[set[str]] = None,
         allow_self_memory: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
+        request_max_tokens: Optional[int] = None,
     ) -> List[Context]:
         """Extract long-term memories from messages using v2 templating system.
 
@@ -307,6 +311,7 @@ class SessionCompressorV2:
                 ctx=ctx,
                 viking_fs=viking_fs,
                 transaction_handle=transaction_handle,
+                request_max_tokens=request_max_tokens,
             )
             await context_provider.prepare_extraction_messages()
             extract_context = context_provider.get_extract_context()
@@ -328,6 +333,7 @@ class SessionCompressorV2:
                 isolation_handler=isolation_handler,
                 transaction_handle=transaction_handle,
                 context_provider=context_provider,
+                request_max_tokens=request_max_tokens,
             )
             read_scope = isolation_handler.get_read_scope()
             if lock_manager:
@@ -503,6 +509,7 @@ class SessionCompressorV2:
         archive_uri: str = "",
         allowed_memory_types: Optional[set[str]] = None,
         include_session_skills: Optional[bool] = None,
+        request_max_tokens: Optional[int] = None,
     ) -> Dict[str, List[Any]]:
         """Extract trajectory, experience, and session-skill memories from execution context."""
         config = get_openviking_config()
@@ -539,6 +546,7 @@ class SessionCompressorV2:
             latest_archive_overview=latest_archive_overview,
             include_trajectories=include_trajectories,
             include_session_skills=include_session_skills,
+            request_max_tokens=request_max_tokens,
         )
         traj_result = await self._run_extract_phase(
             provider=traj_provider,
@@ -548,6 +556,7 @@ class SessionCompressorV2:
             phase_label="trajectory",
             allowed_memory_types=allowed_execution_types,
             thinking=True,
+            request_max_tokens=request_max_tokens,
         )
         if traj_result is None:
             return empty_result
@@ -586,6 +595,7 @@ class SessionCompressorV2:
                 messages=messages,
                 trajectory_summary=traj_content,
                 trajectory_uri=traj_uri,
+                request_max_tokens=request_max_tokens,
             )
             exp_dir = exp_provider._render_experience_dir(ctx)
 
@@ -624,6 +634,7 @@ class SessionCompressorV2:
                 post_apply=_append_sources_before_unlock,
                 allowed_memory_types=allowed_execution_types,
                 thinking=True,
+                request_max_tokens=request_max_tokens,
             )
             if exp_result is None:
                 fallback_uris = await self._single_existing_experience_uris(
@@ -722,6 +733,7 @@ class SessionCompressorV2:
         post_apply: Optional[ExtractPostApply] = None,
         allowed_memory_types: Optional[set[str]] = None,
         thinking: bool = False,
+        request_max_tokens: Optional[int] = None,
     ):
         """Run one ExtractLoop phase with its own lock scope, then apply operations.
 
@@ -762,6 +774,7 @@ class SessionCompressorV2:
             context_provider=provider,
             isolation_handler=isolation_handler,
             thinking=thinking,
+            request_max_tokens=request_max_tokens,
         )
 
         lock_manager = None

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -79,6 +79,7 @@ from openviking.session.train import (
 )
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import tracer
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
@@ -92,6 +93,10 @@ _TRAINING_CASE_SPEC_PROTOCOL = "openviking.batch_train.case_spec.v1"
 _TRAINING_CASE_SPEC_HEADER = "# OpenViking Batch Training CaseSpec v1"
 _TRAINING_FAST_PATH_MEMORY_TYPES = frozenset({"cases", "trajectories", "experiences"})
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+
+
+def _request_budget_kwargs(request_max_tokens: Optional[int]) -> dict[str, int]:
+    return {"request_max_tokens": request_max_tokens} if request_max_tokens is not None else {}
 
 
 async def _commit_experience_snapshot(
@@ -160,6 +165,7 @@ class SessionCompressorV3:
         latest_archive_overview: str = "",
         isolation_handler: Optional[MemoryIsolationHandler] = None,
         transaction_handle=None,
+        request_max_tokens: Optional[int] = None,
     ) -> ExtractLoop:
         config = get_openviking_config()
         vlm = config.vlm.get_vlm_instance()
@@ -171,6 +177,7 @@ class SessionCompressorV3:
             ctx=ctx,
             viking_fs=viking_fs,
             transaction_handle=transaction_handle,
+            request_max_tokens=request_max_tokens,
         )
         return ExtractLoop(
             vlm=vlm,
@@ -178,6 +185,7 @@ class SessionCompressorV3:
             ctx=ctx,
             context_provider=context_provider,
             isolation_handler=isolation_handler,
+            request_max_tokens=request_max_tokens,
         )
 
     def _get_or_create_updater(self, registry, transaction_handle=None) -> MemoryUpdater:
@@ -302,6 +310,8 @@ class SessionCompressorV3:
         agent_evolution_enabled: bool = True,
         allow_self_memory: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
+        request_max_tokens: Optional[int] = None,
+        publish_memory_diff: bool = True,
     ):
         if not agent_evolution_enabled:
             effective_types = (
@@ -323,6 +333,8 @@ class SessionCompressorV3:
                 strict_extract_errors=strict_extract_errors,
                 agent_evolution_enabled=agent_evolution_enabled,
                 allowed_memory_types=allowed_memory_types,
+                request_max_tokens=request_max_tokens,
+                publish_memory_diff=publish_memory_diff,
             )
 
         result = await self._extract_user_memories(
@@ -336,6 +348,7 @@ class SessionCompressorV3:
             allowed_memory_types=allowed_memory_types,
             allow_self_memory=allow_self_memory,
             allowed_peer_ids=allowed_peer_ids,
+            request_max_tokens=request_max_tokens,
         )
         agent_memory_types = _allowed_agent_memory_types(allowed_memory_types)
         cases_allowed = allowed_memory_types is None or _CASES_MEMORY_TYPE in allowed_memory_types
@@ -355,6 +368,7 @@ class SessionCompressorV3:
                 strict_extract_errors=strict_extract_errors,
                 collect_memory_diff=True,
                 allowed_memory_types=agent_memory_types,
+                request_max_tokens=request_max_tokens,
             )
         elif not agent_evolution_enabled and allow_self_memory and session_skills_enabled:
             train_result = await self.extract_session_skills(
@@ -362,6 +376,7 @@ class SessionCompressorV3:
                 ctx=ctx,
                 archive_uri=archive_uri or "",
                 strict_extract_errors=strict_extract_errors,
+                request_max_tokens=request_max_tokens,
             )
         else:
             train_result = {
@@ -373,18 +388,24 @@ class SessionCompressorV3:
                     else "memory_types_filtered"
                 ),
             }
-        await self._write_final_memory_diff(
+        memory_diff = await self._write_final_memory_diff(
             archive_uri=archive_uri or "",
             ctx=ctx,
             memory_diffs=[
                 getattr(result, "memory_diff", None),
                 train_result.get("memory_diff"),
             ],
+            publish=publish_memory_diff,
         )
-        return _v3_extraction_response(
+        response = _v3_extraction_response(
             contexts=result.contexts,
             train_result=train_result,
             archive_uri=archive_uri or "",
+        )
+        return (
+            response
+            if publish_memory_diff
+            else _v3_response_with_memory_diff(response, memory_diff)
         )
 
     async def _commit_training_case_fast_path(
@@ -398,6 +419,8 @@ class SessionCompressorV3:
         strict_extract_errors: bool,
         agent_evolution_enabled: bool,
         allowed_memory_types: Optional[set[str]],
+        request_max_tokens: Optional[int],
+        publish_memory_diff: bool,
     ) -> dict[str, Any]:
         if ctx is None:
             logger.warning("No RequestContext provided, skipping training case fast path")
@@ -421,6 +444,7 @@ class SessionCompressorV3:
                 strict_extract_errors=strict_extract_errors,
                 collect_memory_diff=True,
                 allowed_memory_types=agent_memory_types,
+                request_max_tokens=request_max_tokens,
             )
         else:
             train_result = {
@@ -428,18 +452,24 @@ class SessionCompressorV3:
                 "submitted": 0,
                 "reason": "agent_evolution_disabled",
             }
-        await self._write_final_memory_diff(
+        memory_diff = await self._write_final_memory_diff(
             archive_uri=archive_uri,
             ctx=ctx,
             memory_diffs=[
                 _applied_memory_diff(case_write),
                 train_result.get("memory_diff"),
             ],
+            publish=publish_memory_diff,
         )
-        return _v3_extraction_response(
+        response = _v3_extraction_response(
             contexts=contexts,
             train_result=train_result,
             archive_uri=archive_uri,
+        )
+        return (
+            response
+            if publish_memory_diff
+            else _v3_response_with_memory_diff(response, memory_diff)
         )
 
     @tracer("train.compressor_v3.fast_path.write_case", ignore_result=True, ignore_args=True)
@@ -529,6 +559,7 @@ class SessionCompressorV3:
         allowed_memory_types: Optional[set[str]] = None,
         allow_self_memory: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
+        request_max_tokens: Optional[int] = None,
     ) -> "_V3ExtractionResult":
         del user
         if not messages:
@@ -566,6 +597,7 @@ class SessionCompressorV3:
             latest_archive_overview=latest_archive_overview,
             isolation_handler=isolation_handler,
             transaction_handle=None,
+            request_max_tokens=request_max_tokens,
         )
         operations, _tools_used = await orchestrator.run()
         if operations is None:
@@ -587,6 +619,7 @@ class SessionCompressorV3:
                 messages=list(messages),
                 ctx=ctx,
                 strict_extract_errors=strict_extract_errors,
+                request_max_tokens=request_max_tokens,
                 isolation_options={
                     "allowed_memory_types": allowed_memory_types,
                     "allow_self": allow_self_memory,
@@ -642,6 +675,7 @@ class SessionCompressorV3:
         ctx: Optional[RequestContext],
         archive_uri: str = "",
         strict_extract_errors: bool = False,
+        request_max_tokens: Optional[int] = None,
     ) -> dict[str, Any]:
         """Extract reusable skills without producing Agent Evolution memories."""
         if not messages or ctx is None:
@@ -665,6 +699,7 @@ class SessionCompressorV3:
                 include_trajectories=False,
                 include_session_skills=True,
                 source_archive_uri=archive_uri,
+                **_request_budget_kwargs(request_max_tokens),
             )
             skill_gradients = [
                 gradient
@@ -686,8 +721,12 @@ class SessionCompressorV3:
                 messages=messages,
                 strict_extract_errors=strict_extract_errors,
                 archive_uri=archive_uri,
+                request_max_tokens=request_max_tokens,
             )
-            training_result = await skill_trainer.submit_gradients(skill_gradients)
+            training_result = await skill_trainer.submit_gradients(
+                skill_gradients,
+                **_request_budget_kwargs(request_max_tokens),
+            )
             apply_result = getattr(training_result, "apply_result", None)
             skill_uris = [
                 str(uri) for uri in list(getattr(apply_result, "written_uris", []) or []) if uri
@@ -712,6 +751,7 @@ class SessionCompressorV3:
         messages: list[Message],
         strict_extract_errors: bool,
         archive_uri: str,
+        request_max_tokens: Optional[int],
     ) -> Any:
         skill_root_uri = _skill_root_uri(ctx)
         skill_policy_set = await SkillSetLoader(viking_fs=viking_fs).load(
@@ -723,6 +763,7 @@ class SessionCompressorV3:
             strict_extract_errors=strict_extract_errors,
             include_session_skills=True,
             source_archive_uri=archive_uri,
+            request_max_tokens=request_max_tokens,
         )
         return await get_streaming_policy_trainer(
             key=_skill_trainer_key(ctx),
@@ -745,9 +786,11 @@ class SessionCompressorV3:
                     request_context=ctx,
                     messages=list(messages),
                     strict_extract_errors=strict_extract_errors,
+                    request_max_tokens=request_max_tokens,
                 ),
                 optimization_context=PatchMergePolicyOptimizerContext(
                     request_context=ctx,
+                    request_max_tokens=request_max_tokens,
                 ),
                 apply_context=ctx,
             ),
@@ -767,6 +810,7 @@ class SessionCompressorV3:
         strict_extract_errors: bool = False,
         collect_memory_diff: bool = False,
         allowed_memory_types: Optional[set[str]] = None,
+        request_max_tokens: Optional[int] = None,
     ) -> dict[str, Any]:
         if not messages or ctx is None:
             return {"case_count": 0, "submitted": 0, "reason": "missing_messages_or_ctx"}
@@ -794,17 +838,22 @@ class SessionCompressorV3:
                 exp_root_uri,
                 ctx=ctx,
             )
-            optimizer_context = PatchMergePolicyOptimizerContext(request_context=ctx)
+            optimizer_context = PatchMergePolicyOptimizerContext(
+                request_context=ctx,
+                request_max_tokens=request_max_tokens,
+            )
             gradient_context = ExperienceGradientContext(
                 request_context=ctx,
                 messages=list(messages),
                 strict_extract_errors=strict_extract_errors,
+                request_max_tokens=request_max_tokens,
             )
             analysis_context = TrajectoryAnalyzerContext(
                 request_context=ctx,
                 strict_extract_errors=strict_extract_errors,
                 include_session_skills=skill_enabled,
                 source_archive_uri=archive_uri or "",
+                request_max_tokens=request_max_tokens,
             )
             exp_trainer = await get_streaming_policy_trainer(
                 key=make_streaming_policy_trainer_key(
@@ -839,6 +888,7 @@ class SessionCompressorV3:
                     messages=messages,
                     strict_extract_errors=strict_extract_errors,
                     archive_uri=archive_uri,
+                    request_max_tokens=request_max_tokens,
                 )
 
             submitted = 0
@@ -879,6 +929,7 @@ class SessionCompressorV3:
                         exp_gradients,
                         analysis=analysis,
                         rollout=rollout,
+                        **_request_budget_kwargs(request_max_tokens),
                     )
                 if case_uri:
                     await self._link_case_to_training_outputs(
@@ -910,6 +961,7 @@ class SessionCompressorV3:
                             skill_gradients,
                             analysis=analysis,
                             rollout=rollout,
+                            **_request_budget_kwargs(request_max_tokens),
                         )
                         skill_submitted += 1
                         apply_result = getattr(skill_training_result, "apply_result", None)
@@ -1087,20 +1139,56 @@ class SessionCompressorV3:
         archive_uri: str,
         ctx: Optional[RequestContext],
         memory_diffs: list[Any],
-    ) -> None:
-        if not archive_uri or ctx is None:
-            return
+        publish: bool = True,
+    ) -> dict[str, Any]:
         merged = _merge_memory_diffs(
             [diff for diff in memory_diffs if isinstance(diff, dict)],
             archive_uri=archive_uri,
         )
+        if not publish or not archive_uri or ctx is None:
+            return merged
         viking_fs = get_viking_fs()
         if viking_fs is None:
-            return
+            return merged
         await viking_fs.write_file(
             uri=f"{archive_uri.rstrip('/')}/memory_diff.json",
             content=json.dumps(merged, ensure_ascii=False, indent=4),
             ctx=ctx,
+        )
+        return merged
+
+    async def publish_memory_diffs(
+        self,
+        *,
+        archive_uri: str,
+        ctx: Optional[RequestContext],
+        memory_diffs: list[Any],
+    ) -> dict[str, Any]:
+        """Append completed-window diffs to the persisted archive audit."""
+
+        persisted_diff: dict[str, Any] | None = None
+        viking_fs = get_viking_fs()
+        if archive_uri and ctx is not None and viking_fs is not None:
+            diff_uri = f"{archive_uri.rstrip('/')}/memory_diff.json"
+            try:
+                exists = getattr(viking_fs, "exists", None)
+                if not callable(exists) or await exists(diff_uri, ctx=ctx):
+                    raw = await viking_fs.read_file(diff_uri, ctx=ctx)
+                    if raw:
+                        parsed = json.loads(raw)
+                        if not isinstance(parsed, dict):
+                            raise ValueError("Existing memory_diff.json must contain an object")
+                        persisted_diff = parsed
+            except (FileNotFoundError, NotFoundError):
+                persisted_diff = None
+        return await self._write_final_memory_diff(
+            archive_uri=archive_uri,
+            ctx=ctx,
+            memory_diffs=[
+                *([persisted_diff] if persisted_diff is not None else []),
+                *memory_diffs,
+            ],
+            publish=True,
         )
 
 
@@ -1853,6 +1941,20 @@ def _v3_extraction_response(
     return {"contexts": contexts, "session_skills": skill_dicts}
 
 
+def _v3_response_with_memory_diff(
+    response: list[Context] | dict[str, Any],
+    memory_diff: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach an unpublished per-window diff without changing the default API."""
+
+    if isinstance(response, dict):
+        deferred = dict(response)
+    else:
+        deferred = {"contexts": list(response), "session_skills": []}
+    deferred["memory_diff"] = memory_diff
+    return deferred
+
+
 def _make_memory_diff(
     *,
     archive_uri: str,
@@ -1885,7 +1987,7 @@ def _merge_memory_diffs(
     adds: list[dict[str, Any]] = []
     updates: list[dict[str, Any]] = []
     deletes: list[dict[str, Any]] = []
-    trace_id = tracer.get_trace_id() or None
+    trace_id = None
     for diff in diffs:
         if not isinstance(diff, dict):
             continue
@@ -1903,7 +2005,7 @@ def _merge_memory_diffs(
         updates=updates,
         deletes=deletes,
     )
-    merged["trace_id"] = trace_id
+    merged["trace_id"] = trace_id or tracer.get_trace_id() or None
     return merged
 
 

--- a/openviking/session/memory/agent_experience_context_provider.py
+++ b/openviking/session/memory/agent_experience_context_provider.py
@@ -50,8 +50,13 @@ class AgentExperienceContextProvider(SessionExtractContextProvider):
         trajectory_summary: str,
         trajectory_uri: str,
         latest_archive_overview: str = "",
+        request_max_tokens: Optional[int] = None,
     ):
-        super().__init__(messages=messages, latest_archive_overview=latest_archive_overview)
+        super().__init__(
+            messages=messages,
+            latest_archive_overview=latest_archive_overview,
+            request_max_tokens=request_max_tokens,
+        )
         self.trajectory_summary = trajectory_summary
         self.trajectory_uri = trajectory_uri
         self.prefetched_uris: List[str] = []

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -7,6 +7,7 @@ Reference: bot/vikingbot/agent/loop.py AgentLoop structure
 """
 
 import asyncio
+import inspect
 import json
 import re
 from typing import Any, Dict, List, Optional, Tuple
@@ -22,6 +23,7 @@ from openviking.session.memory.dataclass import (
 )
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.merge_op import MergeOp
+from openviking.session.memory.request_budget import prepare_bounded_model_request
 from openviking.session.memory.schema_model_generator import SchemaModelGenerator
 from openviking.session.memory.tools import (
     MEMORY_TOOLS_REGISTRY,
@@ -100,6 +102,7 @@ class ExtractLoop:
         context_provider: Optional[Any] = None,  # ExtractContextProvider
         isolation_handler: MemoryIsolationHandler = None,
         thinking: bool = False,
+        request_max_tokens: Optional[int] = None,
     ):
         """
         Initialize the ExtractLoop.
@@ -112,6 +115,7 @@ class ExtractLoop:
             ctx: Request context
             context_provider: ExtractContextProvider - 必须提供（由 provider 加载 schema）
             thinking: Whether to explicitly enable model thinking for this extraction loop.
+            request_max_tokens: Optional estimated input cap applied at the provider boundary.
         """
         self.vlm = vlm
         self.viking_fs = viking_fs or get_viking_fs()
@@ -120,6 +124,7 @@ class ExtractLoop:
         self.ctx = ctx
         self.context_provider = context_provider
         self.thinking = bool(thinking)
+        self.request_max_tokens = request_max_tokens
         # Use provided isolation_handler or create one in run()
         self._isolation_handler = isolation_handler
         # Track format error retry (max 1 retry)
@@ -157,6 +162,14 @@ class ExtractLoop:
         # Reset format retry counter for each run
         self._format_retry_count = 0
         patch_repair_count = 0
+
+        prepare_messages = getattr(
+            self.context_provider,
+            "prepare_extraction_messages",
+            None,
+        )
+        if inspect.iscoroutinefunction(prepare_messages):
+            await prepare_messages()
 
         # 从 provider 获取 schemas（内部自动加载 registry）
         schemas = self.context_provider.get_memory_schemas(self.ctx)
@@ -630,10 +643,20 @@ The final output of the model must strictly follow the JSON Schema format shown 
         if not self._disable_tools_for_iteration and self._tool_schemas:
             tools = self._tool_schemas
             tool_choice = "auto"
-        with bind_telemetry_stage("memory_extract"):
-            response = await self.vlm.get_completion_async(
+        request_messages = messages
+        request_tools = tools
+        if self.request_max_tokens is not None:
+            bounded_request = prepare_bounded_model_request(
                 messages=messages,
                 tools=tools,
+                max_tokens=self.request_max_tokens,
+            )
+            request_messages = bounded_request.messages
+            request_tools = bounded_request.tools
+        with bind_telemetry_stage("memory_extract"):
+            response = await self.vlm.get_completion_async(
+                messages=request_messages,
+                tools=request_tools,
                 tool_choice=tool_choice,
                 thinking=self.thinking,
             )

--- a/openviking/session/memory/request_budget.py
+++ b/openviking/session/memory/request_budget.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Bound Phase 2 model requests without truncating authored prompt content."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from openviking.utils.token_estimation import (
+    estimate_serialized_tokens,
+    estimate_text_tokens,
+    truncate_text_to_token_budget,
+)
+from openviking_cli.exceptions import ResourceExhaustedError
+
+_TOOL_RESULT_MAX_TOKENS = 4096
+_TOOL_RESULT_MARKER = "\n… [middle omitted from extraction prompt] …\n"
+_STRUCTURED_TEXT_MIN_TOKENS = 64
+
+
+@dataclass(frozen=True)
+class BoundedModelRequest:
+    """A prompt copy proven to fit its configured estimated input budget."""
+
+    messages: List[Dict[str, Any]]
+    tools: Optional[List[Dict[str, Any]]]
+    estimated_tokens: int
+
+
+@dataclass
+class _ToolResultEnvelope:
+    message_index: int
+    payload: Dict[str, Any]
+    original_result: Any
+
+
+def strictest_request_budget(*budgets: Optional[int]) -> Optional[int]:
+    """Return the smallest active budget without imposing one on unscoped work."""
+
+    active = [budget for budget in budgets if budget is not None]
+    return min(active) if active else None
+
+
+def _request_tokens(
+    messages: List[Dict[str, Any]],
+    tools: Optional[List[Dict[str, Any]]],
+) -> int:
+    return estimate_serialized_tokens({"messages": messages, "tools": tools or []})
+
+
+def _find_tool_result_envelopes(
+    messages: List[Dict[str, Any]],
+) -> List[_ToolResultEnvelope]:
+    envelopes: List[_ToolResultEnvelope] = []
+    for index, message in enumerate(messages):
+        content = message.get("content")
+        if message.get("role") != "user" or not isinstance(content, str):
+            continue
+        try:
+            payload = json.loads(content)
+        except (TypeError, ValueError):
+            continue
+        if (
+            not isinstance(payload, dict)
+            or "tool_call_name" not in payload
+            or "result" not in payload
+        ):
+            continue
+        envelopes.append(
+            _ToolResultEnvelope(
+                message_index=index,
+                payload=payload,
+                original_result=copy.deepcopy(payload["result"]),
+            )
+        )
+    return envelopes
+
+
+def _structured_text_paths(
+    value: Any,
+    path: tuple[str | int, ...] = (),
+) -> List[tuple[tuple[str | int, ...], str]]:
+    paths: List[tuple[tuple[str | int, ...], str]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            paths.extend(_structured_text_paths(item, (*path, key)))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            paths.extend(_structured_text_paths(item, (*path, index)))
+    elif isinstance(value, str) and estimate_text_tokens(value) > _STRUCTURED_TEXT_MIN_TOKENS:
+        paths.append((path, value))
+    return paths
+
+
+def _set_path(value: Any, path: tuple[str | int, ...], replacement: str) -> None:
+    target = value
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = replacement
+
+
+def _compact_tool_result(result: Any, result_budget: int) -> Any:
+    if isinstance(result, str):
+        return truncate_text_to_token_budget(
+            result,
+            max(0, result_budget),
+            marker=_TOOL_RESULT_MARKER,
+            head_ratio=0.5,
+        )
+    if not isinstance(result, (dict, list)):
+        return copy.deepcopy(result)
+
+    compacted = copy.deepcopy(result)
+    if estimate_serialized_tokens(compacted) <= result_budget:
+        return compacted
+    candidates = sorted(
+        _structured_text_paths(compacted),
+        key=lambda item: estimate_text_tokens(item[1]),
+        reverse=True,
+    )
+    for path, original_text in candidates:
+        excess = estimate_serialized_tokens(compacted) - result_budget
+        if excess <= 0:
+            break
+        current_tokens = estimate_text_tokens(original_text)
+        text_budget = max(0, current_tokens - excess - 8)
+        _set_path(
+            compacted,
+            path,
+            truncate_text_to_token_budget(
+                original_text,
+                text_budget,
+                marker=_TOOL_RESULT_MARKER,
+                head_ratio=0.5,
+            ),
+        )
+    return compacted
+
+
+def _write_envelope(
+    messages: List[Dict[str, Any]],
+    envelope: _ToolResultEnvelope,
+    result_budget: int,
+) -> None:
+    payload = copy.deepcopy(envelope.payload)
+    payload["result"] = _compact_tool_result(
+        envelope.original_result,
+        max(0, result_budget),
+    )
+    messages[envelope.message_index]["content"] = json.dumps(payload, ensure_ascii=False)
+
+
+def prepare_bounded_model_request(
+    *,
+    messages: List[Dict[str, Any]],
+    tools: Optional[List[Dict[str, Any]]],
+    max_tokens: int,
+) -> BoundedModelRequest:
+    """Compact recognized tool results, then fail closed if the request is still too large."""
+
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be greater than zero")
+
+    bounded_messages = copy.deepcopy(messages)
+    bounded_tools = copy.deepcopy(tools)
+    envelopes = _find_tool_result_envelopes(bounded_messages)
+
+    per_result_budget = min(_TOOL_RESULT_MAX_TOKENS, max(16, max_tokens // 4))
+    for envelope in envelopes:
+        if estimate_serialized_tokens(envelope.original_result) > per_result_budget:
+            _write_envelope(bounded_messages, envelope, per_result_budget)
+
+    estimated_tokens = _request_tokens(bounded_messages, bounded_tools)
+    if estimated_tokens > max_tokens:
+        for envelope in sorted(
+            envelopes,
+            key=lambda item: estimate_serialized_tokens(item.original_result),
+            reverse=True,
+        ):
+            current_content = bounded_messages[envelope.message_index].get("content", "")
+            try:
+                current_result = json.loads(current_content).get("result", "")
+            except (AttributeError, TypeError, ValueError):
+                current_result = ""
+            current_result_tokens = estimate_serialized_tokens(current_result)
+            if current_result_tokens <= 0:
+                continue
+            excess = estimated_tokens - max_tokens
+            result_budget = max(0, current_result_tokens - excess - 8)
+            _write_envelope(bounded_messages, envelope, result_budget)
+            estimated_tokens = _request_tokens(bounded_messages, bounded_tools)
+            if estimated_tokens <= max_tokens:
+                break
+
+    if estimated_tokens > max_tokens:
+        raise ResourceExhaustedError(
+            "Memory extraction request exceeds configured Phase 2 input limit: "
+            f"estimated_tokens={estimated_tokens}, max_tokens={max_tokens}. "
+            "Increase memory.extraction_request_max_tokens or reduce the upstream "
+            "Phase 2 window size."
+        )
+
+    return BoundedModelRequest(
+        messages=bounded_messages,
+        tools=bounded_tools,
+        estimated_tokens=estimated_tokens,
+    )
+
+
+def ensure_model_request_within_budget(
+    request: Dict[str, Any],
+    *,
+    max_tokens: int,
+    request_name: str,
+) -> int:
+    """Fail closed when a non-ExtractLoop Phase 2 request exceeds its input budget."""
+
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be greater than zero")
+    estimated_tokens = estimate_serialized_tokens(request)
+    if estimated_tokens > max_tokens:
+        raise ResourceExhaustedError(
+            f"{request_name} exceeds configured Phase 2 input limit: "
+            f"estimated_tokens={estimated_tokens}, max_tokens={max_tokens}"
+        )
+    return estimated_tokens

--- a/openviking/session/memory/session_extract_context_provider.py
+++ b/openviking/session/memory/session_extract_context_provider.py
@@ -33,6 +33,7 @@ from openviking.session.memory.vision_message_normalizer import (
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import tracer
 from openviking.utils.time_utils import parse_iso_datetime
+from openviking.utils.token_estimation import truncate_text_to_token_budget
 from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
@@ -45,6 +46,8 @@ _PREFETCH_SEARCH_QUERY_MAX_CHARS = 5000
 _PREFETCH_SEARCH_TEXT_PART_MAX_CHARS = 1000
 _PREFETCH_SEARCH_ASSISTANT_TEXT_PART_MAX_CHARS = 500
 _PREFETCH_SEARCH_TOOL_FIELD_MAX_CHARS = 500
+_EXTRACTION_TOOL_OUTPUT_MAX_TOKENS = 512
+_EXTRACTION_TOOL_OUTPUT_MARKER = "\n… [middle omitted from extraction prompt] …\n"
 _RESOURCE_REASON_LANGUAGE_RE = re.compile(
     r"(?im)^\s*(?:User reason|用户说明|用户原因|用户理由)[:：]\s*(.+?)\s*$"
 )
@@ -64,6 +67,7 @@ class SessionExtractContextProvider(ExtractContextProvider):
         ctx: RequestContext = None,
         viking_fs: VikingFS = None,
         transaction_handle=None,
+        request_max_tokens: Optional[int] = None,
     ):
         self.messages = list(messages) if isinstance(messages, list) else messages
         self.latest_archive_overview = latest_archive_overview
@@ -83,6 +87,7 @@ class SessionExtractContextProvider(ExtractContextProvider):
         self._link_enabled = config.memory.link_enabled if config.memory else False
         self._vision_messages_prepared = False
         self._vision_vlm = None
+        self._request_max_tokens = request_max_tokens
 
     @property
     def read_file_contents(self) -> Dict[str, MemoryFile]:
@@ -121,6 +126,7 @@ class SessionExtractContextProvider(ExtractContextProvider):
                 self.messages,
                 get_vlm=self._get_vision_vlm,
                 logger=logger,
+                request_max_tokens=self._request_max_tokens,
             )
             self._extract_context = None
             self._output_language = self._detect_language()
@@ -313,7 +319,15 @@ After exploring, analyze the conversation and output ALL memory write/edit/delet
                     if part.tool_input:
                         fields.append(f"input={part.tool_input}")
                     if part.tool_output:
-                        fields.append(f"output={part.tool_output[:500]}")
+                        fields.append(
+                            "output="
+                            + truncate_text_to_token_budget(
+                                part.tool_output,
+                                _EXTRACTION_TOOL_OUTPUT_MAX_TOKENS,
+                                marker=_EXTRACTION_TOOL_OUTPUT_MARKER,
+                                head_ratio=0.5,
+                            )
+                        )
                     if part.duration_ms is not None:
                         fields.append(f"duration_ms={part.duration_ms}")
                     if part.skill_uri:

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -45,6 +45,7 @@ from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
 )
+from openviking.session.memory.request_budget import strictest_request_budget
 from openviking.session.memory.session_extract_context_provider import SessionExtractContextProvider
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils, next_memory_version
 from openviking.session.memory.utils.streaming_batcher import (
@@ -104,6 +105,7 @@ class MemoryUpdateRequest:
     strict_extract_errors: bool = False
     isolation_options: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
+    request_max_tokens: int | None = None
 
 
 @dataclass(slots=True)
@@ -475,6 +477,9 @@ class StreamingMemoryUpdater:
             ctx=requests[0].ctx,
             registry=self.registry or create_default_registry(),
             strict_extract_errors=any(request.strict_extract_errors for request in requests),
+            request_max_tokens=strictest_request_budget(
+                *(request.request_max_tokens for request in requests)
+            ),
             trace_console=self.config.trace_console,
         )
 
@@ -573,6 +578,7 @@ async def merge_memory_operations(
     ctx: RequestContext,
     registry: MemoryTypeRegistry | None = None,
     strict_extract_errors: bool = False,
+    request_max_tokens: int | None = None,
     trace_console: bool = False,
 ) -> ResolvedOperations:
     """Merge resolved memory operations by memory type/URI using patch context."""
@@ -635,6 +641,7 @@ async def merge_memory_operations(
                 ctx=ctx,
                 registry=registry,
                 peer_id=peer_id,
+                request_max_tokens=request_max_tokens,
                 trace_console=trace_console,
             )
             for (peer_id, memory_type) in all_group_keys
@@ -719,6 +726,7 @@ async def merge_one_memory_type_operations(
     ctx: RequestContext,
     registry: MemoryTypeRegistry | None = None,
     peer_id: str | None = None,
+    request_max_tokens: int | None = None,
     trace_console: bool = False,
 ) -> ResolvedOperations:
     registry = registry or create_default_registry()
@@ -875,6 +883,7 @@ async def merge_one_memory_type_operations(
         context_provider=provider,
         isolation_handler=isolation_handler,
         max_iterations=1,
+        request_max_tokens=request_max_tokens,
     )
     merged, _ = await orchestrator.run()
     merged = merged or ResolvedOperations(upsert_operations=[], delete_file_contents=[], errors=[])
@@ -1450,6 +1459,7 @@ def clone_memory_update_request(
         messages=list(request.messages or []),
         ctx=request.ctx,
         strict_extract_errors=request.strict_extract_errors,
+        request_max_tokens=request.request_max_tokens,
         isolation_options=dict(request.isolation_options or {}),
         metadata=dict(request.metadata or {}),
     )

--- a/openviking/session/memory/vision_message_normalizer.py
+++ b/openviking/session/memory/vision_message_normalizer.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List
 
 from openviking.message import Message
 from openviking.message.part import ImagePart, TextPart
+from openviking.session.memory.request_budget import ensure_model_request_within_budget
+from openviking_cli.exceptions import ResourceExhaustedError
 
 IMAGE_DESCRIPTION_PROMPT = (
     "Describe this image for later memory extraction. Focus on durable, user-relevant "
@@ -58,17 +60,27 @@ async def describe_image_message(
     *,
     vlm: Any,
     logger: Any = None,
+    request_max_tokens: int | None = None,
 ) -> str:
     if vlm is None:
         return fallback_image_description(message)
 
     try:
-        response = await vlm.get_vision_completion_async(
-            messages=build_vision_description_messages(message),
-            thinking=False,
-        )
+        request = {
+            "messages": build_vision_description_messages(message),
+            "thinking": False,
+        }
+        if request_max_tokens is not None:
+            ensure_model_request_within_budget(
+                request,
+                max_tokens=request_max_tokens,
+                request_name="Phase 2 image description request",
+            )
+        response = await vlm.get_vision_completion_async(**request)
         description = normalize_vision_response(response)
         return description or fallback_image_description(message)
+    except ResourceExhaustedError:
+        raise
     except Exception as exc:
         if logger is not None:
             logger.warning("Failed to describe image message %s: %s", message.id, exc)
@@ -80,6 +92,7 @@ async def replace_image_parts_with_descriptions(
     *,
     get_vlm: Callable[[], Any],
     logger: Any = None,
+    request_max_tokens: int | None = None,
 ) -> List[Message]:
     prepared_messages: List[Message] = []
     for message in messages:
@@ -91,6 +104,7 @@ async def replace_image_parts_with_descriptions(
             message,
             vlm=get_vlm(),
             logger=logger,
+            request_max_tokens=request_max_tokens,
         )
         parts = _original_text_parts(message)
         if description:

--- a/openviking/session/phase2_input.py
+++ b/openviking/session/phase2_input.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Build bounded, loss-preserving model inputs for session commit Phase 2."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Iterable, List
+
+from openviking.message import Message
+from openviking.message.part import ContextPart, Part, TextPart, ToolPart
+from openviking.session.retention import build_turns
+from openviking.utils.token_estimation import (
+    estimate_text_tokens,
+    truncate_text_to_token_budget,
+)
+
+_PLAN_VERSION = "v1"
+_TOOL_OUTPUT_PREVIEW_MAX_TOKENS = 2048
+
+
+@dataclass(frozen=True)
+class Phase2Window:
+    """One turn-aware, bounded Phase 2 extraction input."""
+
+    messages: List[Message]
+    fragment_ids: tuple[str, ...]
+    source_message_ids: tuple[str, ...]
+    estimated_tokens: int
+
+
+@dataclass(frozen=True)
+class Phase2InputPlan:
+    """Deterministic windows derived from immutable archived messages."""
+
+    windows: List[Phase2Window]
+    version: str = _PLAN_VERSION
+
+
+def _clone_message(message: Message, *, message_id: str, parts: List[Part]) -> Message:
+    cloned = copy.deepcopy(message)
+    cloned.id = message_id
+    cloned.parts = parts
+    cloned.source_message_ids = list(message.source_message_ids or [message.id])
+    return cloned
+
+
+def _fragment_id(
+    source_message_id: str,
+    part_index: int,
+    start: int,
+    end: int,
+    content: str,
+) -> str:
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+    return f"{source_message_id}#phase2:{_PLAN_VERSION}:{part_index}:{start}:{end}:{digest}"
+
+
+def _largest_prefix_within_budget(text: str, token_budget: int) -> int:
+    low = 0
+    high = len(text)
+    while low < high:
+        middle = (low + high + 1) // 2
+        if estimate_text_tokens(text[:middle]) <= token_budget:
+            low = middle
+        else:
+            high = middle - 1
+    return low
+
+
+def _split_text(text: str, token_budget: int) -> List[tuple[int, int, str]]:
+    if not text:
+        return [(0, 0, "")]
+    chunks: List[tuple[int, int, str]] = []
+    start = 0
+    while start < len(text):
+        length = _largest_prefix_within_budget(text[start:], token_budget)
+        if length <= 0:
+            # Every supported code point fits in at least two estimated tokens,
+            # while validated Phase 2 budgets are much larger than that.
+            length = 1
+        end = start + length
+        chunks.append((start, end, text[start:end]))
+        start = end
+    return chunks
+
+
+def _tool_output_marker(part: ToolPart) -> str:
+    reference = part.tool_output_source_ref or part.tool_output_ref or part.tool_uri
+    suffix = f"; full output: {reference}" if reference else "; full output remains archived"
+    return f"\n… [middle omitted from Phase 2 prompt{suffix}] …\n"
+
+
+def _compact_tool_part(part: ToolPart, message_budget: int) -> ToolPart:
+    compacted = copy.deepcopy(part)
+    output = compacted.tool_output or ""
+    output_budget = min(_TOOL_OUTPUT_PREVIEW_MAX_TOKENS, max(16, message_budget // 2))
+    if estimate_text_tokens(output) > output_budget:
+        compacted.tool_output = truncate_text_to_token_budget(
+            output,
+            output_budget,
+            marker=_tool_output_marker(compacted),
+            head_ratio=0.5,
+        )
+        compacted.tool_output_truncated = True
+        compacted.tool_output_original_chars = compacted.tool_output_original_chars or len(output)
+        compacted.tool_output_preview_chars = len(compacted.tool_output)
+        compacted.tool_output_sha256 = (
+            compacted.tool_output_sha256 or hashlib.sha256(output.encode("utf-8")).hexdigest()
+        )
+
+    return compacted
+
+
+def _fragment_message(message: Message, token_budget: int) -> List[Message]:
+    unchanged = copy.deepcopy(message)
+    unchanged.parts = [
+        _compact_tool_part(part, token_budget) if isinstance(part, ToolPart) else part
+        for part in unchanged.parts
+    ]
+    if unchanged.estimated_tokens <= token_budget and unchanged.parts == message.parts:
+        unchanged.source_message_ids = list(message.source_message_ids or [message.id])
+        return [unchanged]
+
+    fragments: List[Message] = []
+    pending_parts: List[Part] = []
+    pending_start_index = 0
+
+    def flush_pending(end_index: int) -> None:
+        nonlocal pending_parts, pending_start_index
+        if not pending_parts:
+            return
+        serialized = json.dumps(
+            {
+                "role": message.role,
+                "parts": [asdict(part) for part in pending_parts],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        fragment_message_id = _fragment_id(
+            message.id,
+            pending_start_index,
+            0,
+            end_index,
+            serialized,
+        )
+        fragments.append(
+            _clone_message(
+                message,
+                message_id=fragment_message_id,
+                parts=copy.deepcopy(pending_parts),
+            )
+        )
+        pending_parts = []
+
+    for part_index, original_part in enumerate(message.parts):
+        part = (
+            _compact_tool_part(original_part, token_budget)
+            if isinstance(original_part, ToolPart)
+            else copy.deepcopy(original_part)
+        )
+        probe = _clone_message(message, message_id=message.id, parts=[part])
+
+        if isinstance(part, (TextPart, ContextPart)) and probe.estimated_tokens > token_budget:
+            flush_pending(part_index)
+            attribute = "text" if isinstance(part, TextPart) else "abstract"
+            original_text = getattr(part, attribute)
+            for start, end, chunk in _split_text(original_text, token_budget):
+                chunk_part = copy.deepcopy(part)
+                setattr(chunk_part, attribute, chunk)
+                message_id = _fragment_id(message.id, part_index, start, end, chunk)
+                fragments.append(_clone_message(message, message_id=message_id, parts=[chunk_part]))
+            pending_start_index = part_index + 1
+            continue
+
+        candidate_parts = [*pending_parts, part]
+        candidate = _clone_message(message, message_id=message.id, parts=candidate_parts)
+        if pending_parts and candidate.estimated_tokens > token_budget:
+            flush_pending(part_index)
+            pending_start_index = part_index
+            candidate_parts = [part]
+            candidate = _clone_message(message, message_id=message.id, parts=candidate_parts)
+
+        if candidate.estimated_tokens > token_budget:
+            # Tool metadata can still exceed a very small configured window.
+            # Preserve pairing fields and bound only prompt-copy payload fields.
+            if isinstance(part, ToolPart):
+                part.tool_output = truncate_text_to_token_budget(
+                    part.tool_output,
+                    max(0, token_budget // 4),
+                    marker=_tool_output_marker(part),
+                    head_ratio=0.5,
+                )
+                candidate_parts = [part]
+                candidate = _clone_message(
+                    message,
+                    message_id=message.id,
+                    parts=candidate_parts,
+                )
+            if candidate.estimated_tokens > token_budget:
+                raise ValueError(
+                    f"Phase 2 message metadata exceeds window_max_tokens={token_budget}: "
+                    f"{message.id}"
+                )
+
+        pending_parts = candidate_parts
+
+    flush_pending(len(message.parts))
+    return fragments or [_clone_message(message, message_id=message.id, parts=[])]
+
+
+def _make_window(messages: Iterable[Message]) -> Phase2Window:
+    window_messages = list(messages)
+    source_ids: List[str] = []
+    for message in window_messages:
+        for source_id in message.source_message_ids or [message.id]:
+            if source_id not in source_ids:
+                source_ids.append(source_id)
+    return Phase2Window(
+        messages=window_messages,
+        fragment_ids=tuple(message.id for message in window_messages),
+        source_message_ids=tuple(source_ids),
+        estimated_tokens=sum(message.estimated_tokens for message in window_messages),
+    )
+
+
+def build_phase2_input_plan(
+    messages: Iterable[Message],
+    *,
+    window_max_tokens: int,
+) -> Phase2InputPlan:
+    """Return deterministic turn-aware windows without mutating archived input."""
+
+    if window_max_tokens <= 0:
+        raise ValueError("window_max_tokens must be greater than zero")
+
+    windows: List[Phase2Window] = []
+    current: List[Message] = []
+    current_tokens = 0
+
+    for turn in build_turns(messages):
+        fragments = [
+            fragment
+            for message in turn.messages
+            for fragment in _fragment_message(message, window_max_tokens)
+        ]
+        turn_tokens = sum(fragment.estimated_tokens for fragment in fragments)
+
+        if turn_tokens <= window_max_tokens:
+            if current and current_tokens + turn_tokens > window_max_tokens:
+                windows.append(_make_window(current))
+                current = []
+                current_tokens = 0
+            current.extend(fragments)
+            current_tokens += turn_tokens
+            continue
+
+        if current:
+            windows.append(_make_window(current))
+            current = []
+            current_tokens = 0
+        for fragment in fragments:
+            fragment_tokens = fragment.estimated_tokens
+            if current and current_tokens + fragment_tokens > window_max_tokens:
+                windows.append(_make_window(current))
+                current = []
+                current_tokens = 0
+            current.append(fragment)
+            current_tokens += fragment_tokens
+
+    if current:
+        windows.append(_make_window(current))
+
+    return Phase2InputPlan(windows=windows)

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -24,7 +24,13 @@ from openviking.session.memory.constants import (
     AGENT_EVOLUTION_MEMORY_TYPES,
     EXECUTION_MEMORY_TYPES,
 )
+from openviking.session.memory.request_budget import ensure_model_request_within_budget
 from openviking.session.memory_policy import MemoryPolicy
+from openviking.session.phase2_input import (
+    Phase2InputPlan,
+    Phase2Window,
+    build_phase2_input_plan,
+)
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
     RetentionPlan,
@@ -52,6 +58,7 @@ from openviking.utils.token_estimation import estimate_text_tokens, truncate_tex
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     NotFoundError,
+    ResourceExhaustedError,
 )
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
@@ -74,6 +81,15 @@ _MEMORY_EXTRACTION_RETRY_MAX_DELAY_SECONDS = 8.0
 _AGENT_TRAINING_REQUIRED_MEMORY_TYPES = frozenset({"cases", "trajectories"})
 _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS = 30.0
 _MEMORY_STEP_NAMES = ("long_term", "execution")
+
+
+def _positive_memory_config_int(memory_config: Any, name: str, default: int) -> int:
+    """Read a positive integer while tolerating legacy test/config doubles."""
+
+    value = getattr(memory_config, name, default)
+    return (
+        value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else default
+    )
 
 
 class _ArchiveMessagesCorruptError(ValueError):
@@ -167,6 +183,59 @@ def _message_peer_ids(messages: List[Message]) -> set[str]:
         for message in messages
         if (peer_id := safe_peer_id(getattr(message, "peer_id", None)))
     }
+
+
+def _phase2_window_peer_ids(
+    allowed_peer_ids: set[str],
+    messages: List[Message],
+) -> set[str]:
+    """Restrict one Phase 2 request to peers evidenced in that window."""
+
+    return allowed_peer_ids.intersection(_message_peer_ids(messages))
+
+
+def _phase2_message_is_completed(
+    message: Message,
+    completed_ids: set[str],
+) -> bool:
+    """Match either the current fragment or its fully covered source message."""
+
+    return message.id in completed_ids or any(
+        source_id in completed_ids for source_id in (message.source_message_ids or [message.id])
+    )
+
+
+def _record_fully_completed_phase2_sources(
+    plan: Phase2InputPlan,
+    completed_ids: set[str],
+) -> None:
+    """Record source IDs once every derived fragment that covers them is complete."""
+
+    fragment_ids_by_source: Dict[str, set[str]] = {}
+    for window in plan.windows:
+        for message in window.messages:
+            for source_id in message.source_message_ids or [message.id]:
+                fragment_ids_by_source.setdefault(source_id, set()).add(message.id)
+    completed_ids.update(
+        source_id
+        for source_id, fragment_ids in fragment_ids_by_source.items()
+        if fragment_ids.issubset(completed_ids)
+    )
+
+
+def _v2_phase2_request_budget_kwargs(
+    compressor: Any,
+    request_max_tokens: int,
+) -> Dict[str, int]:
+    """Pass the hard cap only to the retained v2-compatible implementation."""
+
+    from openviking.session.compressor_v2 import SessionCompressorV2
+
+    return (
+        {"request_max_tokens": request_max_tokens}
+        if isinstance(compressor, SessionCompressorV2)
+        else {}
+    )
 
 
 @dataclass(frozen=True)
@@ -2153,6 +2222,16 @@ class Session:
         )
         return await reporter.extract_and_report(messages=messages, context=context)
 
+    async def _usage_reporting_messages(
+        self,
+        messages: List[Message],
+    ) -> List[Message]:
+        """Hydrate a usage-only copy without changing Phase 2 model input."""
+
+        if getattr(self, "_usage_reporter", None) is None:
+            return messages
+        return await self._hydrate_tool_outputs_for_extraction(messages)
+
     @tracer("session.commit.phase2", ignore_result=True, ignore_args=True)
     async def _run_memory_extraction(
         self,
@@ -2227,12 +2306,30 @@ class Session:
                         if working_memory_enabled
                         else ""
                     )
-                    extraction_messages = await self._hydrate_tool_outputs_for_extraction(messages)
+                    phase2_window_max_tokens = _positive_memory_config_int(
+                        getattr(ov_config, "memory", None),
+                        "phase2_window_max_tokens",
+                        12_000,
+                    )
+                    extraction_request_max_tokens = _positive_memory_config_int(
+                        getattr(ov_config, "memory", None),
+                        "extraction_request_max_tokens",
+                        32_768,
+                    )
+                    phase2_plan = build_phase2_input_plan(
+                        messages,
+                        window_max_tokens=phase2_window_max_tokens,
+                    )
+                    phase2_windows = phase2_plan.windows
+                    extraction_messages = [
+                        message for window in phase2_windows for message in window.messages
+                    ]
+                    usage_messages = await self._usage_reporting_messages(messages)
                     usage_events_extracted = len(
                         await self._run_usage_reporting(
                             task_id=task_id,
                             archive_uri=archive_uri,
-                            messages=extraction_messages,
+                            messages=usage_messages,
                         )
                     )
 
@@ -2248,8 +2345,9 @@ class Session:
                         }
                         if checkpoint_requests:
                             summary_kwargs["checkpoint_requests"] = checkpoint_requests
-                        generated = await self._generate_archive_summary_async(
-                            extraction_messages,
+                        generated = await self._generate_archive_summary_for_phase2_windows(
+                            phase2_windows,
+                            request_max_tokens=extraction_request_max_tokens,
                             **summary_kwargs,
                         )
                         summary_result = (
@@ -2316,6 +2414,10 @@ class Session:
                         completed_memory_steps.setdefault(step, set()).update(
                             message.id for message in step_messages
                         )
+                        _record_fully_completed_phase2_sources(
+                            phase2_plan,
+                            completed_memory_steps[step],
+                        )
                         # Persist progress before waiting for sibling Phase 2
                         # tasks. A process restart or a sibling failure can then
                         # resume without applying this memory step twice.
@@ -2360,12 +2462,18 @@ class Session:
                     long_term_messages = [
                         message
                         for message in extraction_messages
-                        if message.id not in completed_memory_steps.get("long_term", set())
+                        if not _phase2_message_is_completed(
+                            message,
+                            completed_memory_steps.get("long_term", set()),
+                        )
                     ]
                     execution_messages = [
                         message
                         for message in extraction_messages
-                        if message.id not in completed_memory_steps.get("execution", set())
+                        if not _phase2_message_is_completed(
+                            message,
+                            completed_memory_steps.get("execution", set()),
+                        )
                     ]
 
                     long_term_has_work = (
@@ -2405,28 +2513,100 @@ class Session:
                                 # surface so _run_retryable_phase2_step can retry them
                                 # (and so a final failure is recorded as a skipped
                                 # archive instead of silently dropping the memory).
-                                return await self._session_compressor.extract_long_term_memories(
-                                    messages=long_term_messages,
-                                    user=self.user,
-                                    session_id=self.session_id,
-                                    ctx=self.ctx,
-                                    strict_extract_errors=True,
-                                    latest_archive_overview=latest_archive_overview,
-                                    archive_uri=archive_uri,
-                                    allowed_memory_types=long_term_memory_types,
-                                    agent_evolution_enabled=agent_evolution_enabled,
-                                    allow_self_memory=self_memory_enabled,
-                                    allowed_peer_ids=allowed_peer_ids,
-                                )
+                                from openviking.session.compressor_v3 import SessionCompressorV3
 
-                            extraction_tasks.append(
-                                _run_recorded_memory_step(
-                                    "long_term_memory_extraction",
-                                    "long_term",
-                                    long_term_messages,
-                                    _run_long_term_memory_extraction,
-                                )
-                            )
+                                if not isinstance(
+                                    self._session_compressor,
+                                    SessionCompressorV3,
+                                ):
+                                    request_budget_kwargs = _v2_phase2_request_budget_kwargs(
+                                        self._session_compressor,
+                                        extraction_request_max_tokens,
+                                    )
+                                    return (
+                                        await self._session_compressor.extract_long_term_memories(
+                                            messages=long_term_messages,
+                                            user=self.user,
+                                            session_id=self.session_id,
+                                            ctx=self.ctx,
+                                            strict_extract_errors=True,
+                                            latest_archive_overview=latest_archive_overview,
+                                            archive_uri=archive_uri,
+                                            allowed_memory_types=long_term_memory_types,
+                                            agent_evolution_enabled=agent_evolution_enabled,
+                                            allow_self_memory=self_memory_enabled,
+                                            allowed_peer_ids=allowed_peer_ids,
+                                            **request_budget_kwargs,
+                                        )
+                                    )
+
+                                contexts: list[Any] = []
+                                session_skills: list[Any] = []
+                                for window_index, window in enumerate(phase2_windows):
+                                    pending_messages = [
+                                        message
+                                        for message in window.messages
+                                        if not _phase2_message_is_completed(
+                                            message,
+                                            completed_memory_steps.get("long_term", set()),
+                                        )
+                                    ]
+                                    if not pending_messages:
+                                        continue
+
+                                    async def _extract_window(
+                                        window_messages: List[Message] = pending_messages,
+                                    ) -> Any:
+                                        result = await (
+                                            self._session_compressor.extract_long_term_memories(
+                                                messages=window_messages,
+                                                user=self.user,
+                                                session_id=self.session_id,
+                                                ctx=self.ctx,
+                                                strict_extract_errors=True,
+                                                latest_archive_overview=latest_archive_overview,
+                                                archive_uri=archive_uri,
+                                                allowed_memory_types=long_term_memory_types,
+                                                agent_evolution_enabled=(agent_evolution_enabled),
+                                                allow_self_memory=self_memory_enabled,
+                                                allowed_peer_ids=_phase2_window_peer_ids(
+                                                    allowed_peer_ids,
+                                                    window_messages,
+                                                ),
+                                                request_max_tokens=(extraction_request_max_tokens),
+                                                publish_memory_diff=False,
+                                            )
+                                        )
+                                        window_diff = (
+                                            result.get("memory_diff")
+                                            if isinstance(result, dict)
+                                            else None
+                                        )
+                                        if isinstance(window_diff, dict):
+                                            await self._session_compressor.publish_memory_diffs(
+                                                archive_uri=archive_uri,
+                                                ctx=self.ctx,
+                                                memory_diffs=[window_diff],
+                                            )
+                                        return result
+
+                                    result = await _run_recorded_memory_step(
+                                        (f"long_term_memory_extraction.window_{window_index + 1}"),
+                                        "long_term",
+                                        pending_messages,
+                                        _extract_window,
+                                    )
+                                    if isinstance(result, dict):
+                                        contexts.extend(result.get("contexts", []))
+                                        session_skills.extend(result.get("session_skills", []))
+                                    else:
+                                        contexts.extend(result or [])
+                                return {
+                                    "contexts": contexts,
+                                    "session_skills": session_skills,
+                                }
+
+                            extraction_tasks.append(_run_long_term_memory_extraction())
                             extraction_labels.append("long_term")
 
                         if has_execution_memory and execution_memory_has_work:
@@ -2434,6 +2614,10 @@ class Session:
                             async def _run_execution_memory_extraction() -> Any:
                                 # See _run_long_term_memory_extraction: surface errors
                                 # so retries can engage and final failures are visible.
+                                request_budget_kwargs = _v2_phase2_request_budget_kwargs(
+                                    self._session_compressor,
+                                    extraction_request_max_tokens,
+                                )
                                 return await self._session_compressor.extract_execution_memories(
                                     messages=execution_messages,
                                     ctx=self.ctx,
@@ -2442,6 +2626,7 @@ class Session:
                                     archive_uri=archive_uri,
                                     allowed_memory_types=execution_memory_types,
                                     include_session_skills=session_skill_extraction_enabled,
+                                    **request_budget_kwargs,
                                 )
 
                             extraction_tasks.append(
@@ -3749,11 +3934,162 @@ class Session:
             )
         return tuple(raw)
 
+    @staticmethod
+    def _checkpoint_requests_for_phase2_window(
+        window: Phase2Window,
+        checkpoint_requests: List[_CheckpointRequest],
+    ) -> tuple[List[_CheckpointRequest], List[int]]:
+        local_requests: List[_CheckpointRequest] = []
+        original_indexes: List[int] = []
+        for index, request in enumerate(checkpoint_requests):
+            source_ids = set(request.source_message_ids)
+            matching = [
+                message
+                for message in window.messages
+                if source_ids.intersection(message.source_message_ids or [message.id])
+            ]
+            if not matching:
+                continue
+            anchor = next(
+                (
+                    message.id
+                    for message in window.messages
+                    if request.turn_anchor_message_id
+                    in (message.source_message_ids or [message.id])
+                ),
+                request.turn_anchor_message_id,
+            )
+            local_requests.append(
+                _CheckpointRequest(
+                    turn_anchor_message_id=anchor,
+                    source_message_ids=tuple(message.id for message in matching),
+                    retained_message_token_budget=request.retained_message_token_budget,
+                    estimated_active_tokens=request.estimated_active_tokens,
+                )
+            )
+            original_indexes.append(index)
+        return local_requests, original_indexes
+
+    async def _generate_archive_summary_for_phase2_windows(
+        self,
+        windows: List[Phase2Window],
+        *,
+        latest_archive_overview: str = "",
+        checkpoint_requests: Optional[List[_CheckpointRequest]] = None,
+        request_max_tokens: int,
+    ) -> str | _ArchiveSummaryResult:
+        """Fold bounded Phase 2 windows into one Working Memory document."""
+
+        if not windows:
+            return ""
+        checkpoint_requests = list(checkpoint_requests or [])
+        if len(windows) == 1:
+            local_requests, original_indexes = self._checkpoint_requests_for_phase2_window(
+                windows[0],
+                checkpoint_requests,
+            )
+            if original_indexes != list(range(len(checkpoint_requests))):
+                raise ValueError("A checkpoint source is missing from its Phase 2 window")
+            kwargs: Dict[str, Any] = {
+                "latest_archive_overview": latest_archive_overview,
+            }
+            if local_requests:
+                kwargs["checkpoint_requests"] = local_requests
+            return await self._generate_archive_summary_async(
+                windows[0].messages,
+                request_max_tokens=request_max_tokens,
+                **kwargs,
+            )
+
+        overview = latest_archive_overview
+        partial_checkpoint_summaries: List[List[str]] = [[] for _request in checkpoint_requests]
+        for window in windows:
+            local_requests, original_indexes = self._checkpoint_requests_for_phase2_window(
+                window,
+                checkpoint_requests,
+            )
+            generated = await self._generate_archive_summary_async(
+                window.messages,
+                latest_archive_overview=overview,
+                checkpoint_requests=local_requests or None,
+                strict=True,
+                request_max_tokens=request_max_tokens,
+            )
+            result = (
+                generated
+                if isinstance(generated, _ArchiveSummaryResult)
+                else _ArchiveSummaryResult(overview=str(generated or ""))
+            )
+            overview = result.overview
+            for original_index, partial in zip(
+                original_indexes,
+                result.checkpoint_summaries,
+                strict=True,
+            ):
+                if partial.strip():
+                    partial_checkpoint_summaries[original_index].append(partial.strip())
+
+        if not checkpoint_requests:
+            return overview
+        reduced_checkpoint_summaries = []
+        for partials in partial_checkpoint_summaries:
+            reduced_checkpoint_summaries.append(
+                await self._reduce_checkpoint_summaries(
+                    partials,
+                    request_max_tokens=request_max_tokens,
+                )
+            )
+        return _ArchiveSummaryResult(
+            overview=overview,
+            checkpoint_summaries=tuple(reduced_checkpoint_summaries),
+        )
+
+    async def _reduce_checkpoint_summaries(
+        self,
+        partials: List[str],
+        *,
+        request_max_tokens: int,
+    ) -> str:
+        """Fold window-local checkpoint notes without concatenating them into one prompt."""
+
+        normalized = [partial.strip() for partial in partials if partial.strip()]
+        if not normalized:
+            raise ValueError("Working Memory output contains no checkpoint summary")
+        merged = normalized[0]
+        if len(normalized) == 1:
+            return merged
+
+        from openviking.prompts import render_prompt
+
+        vlm = get_openviking_config().vlm
+        for partial in normalized[1:]:
+            prompt = render_prompt(
+                "compression.checkpoint_reduce",
+                {
+                    "accumulated_summary": merged,
+                    "next_summary": partial,
+                },
+            )
+            request = {"prompt": prompt}
+            ensure_model_request_within_budget(
+                request,
+                max_tokens=request_max_tokens,
+                request_name="Phase 2 checkpoint reduction request",
+            )
+            response = await vlm.get_completion_async(**request)
+            merged = str(getattr(response, "content", response) or "").strip()
+            if not merged:
+                raise ValueError("Checkpoint reduction returned an empty summary")
+        return merged
+
     async def _generate_archive_summary_async(
         self,
         messages: List[Message],
         latest_archive_overview: str = "",
         checkpoint_requests: Optional[List[_CheckpointRequest]] = None,
+        *,
+        strict: bool = False,
+        request_max_tokens: Optional[int] = None,
     ) -> str | _ArchiveSummaryResult:
         """Generate Working Memory document for the current archive (async).
 
@@ -3780,10 +4116,26 @@ class Session:
         formatted = self._format_messages_for_wm(messages, checkpoint_requests)
         checkpoint_instructions = self._checkpoint_prompt_instructions(len(checkpoint_requests))
 
-        vlm = get_openviking_config().vlm
+        ov_config = get_openviking_config()
+        vlm = ov_config.vlm
+        if request_max_tokens is None:
+            request_max_tokens = _positive_memory_config_int(
+                getattr(ov_config, "memory", None),
+                "extraction_request_max_tokens",
+                32_768,
+            )
+
+        async def _complete(**request: Any) -> Any:
+            ensure_model_request_within_budget(
+                request,
+                max_tokens=request_max_tokens,
+                request_name="Working Memory request",
+            )
+            return await vlm.get_completion_async(**request)
+
         if not (vlm and vlm.is_available()):
-            if checkpoint_requests:
-                raise ValueError("A configured VLM is required to generate checkpoint summaries")
+            if checkpoint_requests or strict:
+                raise ValueError("A configured VLM is required for strict Working Memory")
             turn_count = len([m for m in messages if is_user_query(m)])
             return (
                 f"# Session Summary\n\n**Overview**: {turn_count} turns, {len(messages)} messages"
@@ -3792,7 +4144,7 @@ class Session:
         try:
             from openviking.prompts import render_prompt
         except Exception as e:
-            if checkpoint_requests:
+            if checkpoint_requests or strict:
                 raise RuntimeError("Prompt module is required to generate checkpoints") from e
             logger.warning(f"Prompt module unavailable: {e}")
             turn_count = len([m for m in messages if is_user_query(m)])
@@ -3821,7 +4173,7 @@ class Session:
                     },
                 )
                 if checkpoint_requests:
-                    response = await vlm.get_completion_async(
+                    response = await _complete(
                         prompt=prompt,
                         tools=[WM_CREATE_WITH_CHECKPOINTS_TOOL],
                         tool_choice={
@@ -3844,6 +4196,8 @@ class Session:
                     working_memory = args.get("working_memory")
                     if not isinstance(working_memory, str) or not working_memory.strip():
                         raise ValueError("create_working_memory.working_memory is empty")
+                    if strict:
+                        self._validate_strict_working_memory(working_memory)
                     return _ArchiveSummaryResult(
                         overview=working_memory,
                         checkpoint_summaries=self._parse_required_checkpoint_summaries(
@@ -3851,11 +4205,16 @@ class Session:
                             len(checkpoint_requests),
                         ),
                     )
-                return await vlm.get_completion_async(prompt)
+                working_memory = await _complete(prompt=prompt)
+                if strict:
+                    self._validate_strict_working_memory(working_memory)
+                return working_memory
+            except ResourceExhaustedError:
+                raise
             except Exception as e:
                 _wm_debug(f"creation failed: {e}")
                 logger.warning(f"WM creation failed: {e}")
-                if checkpoint_requests:
+                if checkpoint_requests or strict:
                     raise
                 turn_count = len([m for m in messages if is_user_query(m)])
                 return (
@@ -3878,7 +4237,7 @@ class Session:
                     "checkpoint_instructions": checkpoint_instructions,
                 },
             )
-            resp = await vlm.get_completion_async(
+            resp = await _complete(
                 prompt=update_prompt,
                 tools=[WM_UPDATE_TOOL],
                 tool_choice={
@@ -3886,15 +4245,20 @@ class Session:
                     "function": {"name": "update_working_memory"},
                 },
             )
+        except ResourceExhaustedError:
+            raise
         except Exception as e:
             import traceback as _tb
 
             _wm_debug(f"tool_call raised: {type(e).__name__}: {e} tb={_tb.format_exc()[-400:]}")
-            if checkpoint_requests:
+            if checkpoint_requests or strict:
                 raise
             logger.warning("WM update tool_call failed (%s); falling back to creation prompt", e)
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted,
+                messages,
+                latest_archive_overview,
+                request_max_tokens=request_max_tokens,
             )
 
         has_tc = bool(getattr(resp, "has_tool_calls", False) and getattr(resp, "tool_calls", None))
@@ -3907,11 +4271,14 @@ class Session:
         )
 
         if not has_tc:
-            if checkpoint_requests:
+            if checkpoint_requests or strict:
                 raise ValueError("Working Memory update returned no tool call for checkpoints")
             logger.warning("WM update: LLM returned no tool_call; falling back to creation prompt")
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted,
+                messages,
+                latest_archive_overview,
+                request_max_tokens=request_max_tokens,
             )
 
         checkpoint_summaries: tuple[str, ...] = ()
@@ -4004,7 +4371,12 @@ class Session:
                     len(salvaged),
                     len(WM_SEVEN_SECTIONS),
                 )
-                return self._merge_wm_sections(latest_archive_overview, salvaged)
+                overview = self._merge_wm_sections(latest_archive_overview, salvaged)
+                if strict:
+                    self._validate_strict_working_memory(overview)
+                return overview
+            if strict:
+                raise
             _wm_debug("regex recovery salvaged 0 sections; falling back to creation prompt")
             logger.warning(
                 "WM update: tool_call arguments parse failed (%s); "
@@ -4012,7 +4384,10 @@ class Session:
                 e,
             )
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted,
+                messages,
+                latest_archive_overview,
+                request_max_tokens=request_max_tokens,
             )
 
         _wm_debug(
@@ -4020,6 +4395,8 @@ class Session:
             f"ops_summary={[(k, v.get('op') if isinstance(v, dict) else type(v).__name__) for k, v in ops.items()][:7]}"
         )
         overview = self._merge_wm_sections(latest_archive_overview, ops)
+        if strict:
+            self._validate_strict_working_memory(overview)
         if checkpoint_requests:
             return _ArchiveSummaryResult(
                 overview=overview,
@@ -4027,11 +4404,22 @@ class Session:
             )
         return overview
 
+    @staticmethod
+    def _validate_strict_working_memory(overview: Any) -> None:
+        if not isinstance(overview, str) or not overview.strip():
+            raise ValueError("Strict Working Memory output is empty")
+        missing = [section for section in WM_SEVEN_SECTIONS if f"## {section}" not in overview]
+        if missing:
+            raise ValueError(
+                "Strict Working Memory output is missing required sections: " + ", ".join(missing)
+            )
+
     async def _fallback_generate_wm_creation(
         self,
         formatted_messages: str,
         messages: List[Message],
         prior_overview: str = "",
+        request_max_tokens: Optional[int] = None,
     ) -> str:
         """Re-run WM creation prompt when the update tool_call path fails.
 
@@ -4053,7 +4441,21 @@ class Session:
                     "checkpoint_instructions": "",
                 },
             )
-            return await get_openviking_config().vlm.get_completion_async(prompt)
+            ov_config = get_openviking_config()
+            effective_request_max_tokens = request_max_tokens or _positive_memory_config_int(
+                getattr(ov_config, "memory", None),
+                "extraction_request_max_tokens",
+                32_768,
+            )
+            request = {"prompt": prompt}
+            ensure_model_request_within_budget(
+                request,
+                max_tokens=effective_request_max_tokens,
+                request_name="Working Memory fallback request",
+            )
+            return await ov_config.vlm.get_completion_async(**request)
+        except ResourceExhaustedError:
+            raise
         except Exception as e:
             logger.warning(f"WM creation fallback failed: {e}")
             turn_count = len([m for m in messages if is_user_query(m)])

--- a/openviking/session/train/components/gradient_estimator.py
+++ b/openviking/session/train/components/gradient_estimator.py
@@ -35,6 +35,7 @@ class ExperienceGradientContext:
     messages: list[Message]
     strict_extract_errors: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
+    request_max_tokens: int | None = None
 
 
 @dataclass(slots=True)
@@ -107,6 +108,7 @@ class ExperienceGradientEstimator:
             messages=context.messages,
             trajectory_summary=trajectory.content,
             trajectory_uri=trajectory.uri,
+            request_max_tokens=context.request_max_tokens,
         )
         if hasattr(provider, "get_extract_context"):
             extract_context = provider.get_extract_context()
@@ -130,6 +132,7 @@ class ExperienceGradientEstimator:
             context_provider=provider,
             isolation_handler=isolation_handler,
             thinking=True,
+            request_max_tokens=context.request_max_tokens,
         )
         operations, _ = await orchestrator.run()
         return operations
@@ -146,6 +149,7 @@ def _context_with_analysis_messages(
         request_context=context.request_context,
         messages=list(messages),
         strict_extract_errors=context.strict_extract_errors,
+        request_max_tokens=context.request_max_tokens,
         metadata=dict(context.metadata),
     )
 

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -39,6 +39,7 @@ class PatchMergePolicyOptimizerContext:
 
     request_context: RequestContext
     messages: list[Message] = field(default_factory=list)
+    request_max_tokens: int | None = None
 
 
 @dataclass(slots=True)
@@ -162,6 +163,7 @@ class PatchMergePolicyOptimizer:
             isolation_handler=isolation_handler,
             max_iterations=1,
             thinking=self.memory_type in {"trajectories", "experiences"},
+            request_max_tokens=context.request_max_tokens,
         )
         operations, _ = await orchestrator.run()
         return operations

--- a/openviking/session/train/components/policy_trainer.py
+++ b/openviking/session/train/components/policy_trainer.py
@@ -11,10 +11,12 @@ case rollout execution.
 from __future__ import annotations
 
 import asyncio
+import copy
 import threading
 from dataclasses import dataclass, field
 from typing import Any, Hashable
 
+from openviking.session.memory.request_budget import strictest_request_budget
 from openviking.session.memory.utils.streaming_batcher import (
     StreamingBatcher,
     StreamingBatcherConfig,
@@ -153,7 +155,7 @@ class StreamingPolicyTrainer:
     _closed: bool = field(init=False, default=False, repr=False)
 
     def __post_init__(self) -> None:
-        self.context = _coerce_pipeline_context(self.context)
+        self.context = _unscoped_pipeline_context(_coerce_pipeline_context(self.context))
         self._core = PolicyTrainingEngine(
             rollout_analyzer=self.rollout_analyzer,
             gradient_estimator=self.gradient_estimator,
@@ -250,6 +252,7 @@ class StreamingPolicyTrainer:
         *,
         analysis: RolloutAnalysis | None = None,
         rollout: Rollout | None = None,
+        request_max_tokens: int | None = None,
     ) -> RolloutTrainingResult | ScopedRolloutTrainingResult:
         """Submit pre-computed gradients directly to the streaming trainer.
 
@@ -283,6 +286,7 @@ class StreamingPolicyTrainer:
             gradients=list(gradients),
             analysis=analysis,
             rollout=rollout,
+            request_max_tokens=request_max_tokens,
         )
         result = await self._batcher.submit(buffered)
         self._last_apply_result = result.apply_result
@@ -340,7 +344,10 @@ class StreamingPolicyTrainer:
             plan, apply_result = await self._core.plan_and_apply(
                 gradients=gradient_chunk,
                 policy_set=self.policy_set,
-                ctx=self.context,
+                ctx=_pipeline_context_with_request_budget(
+                    self.context,
+                    chunk.request_max_tokens,
+                ),
             )
             self.policy_set = apply_result.updated_policy_set
             plans.append(plan)
@@ -394,18 +401,69 @@ def _chunks_buffered_items_by_gradient_count(
     if size <= 0:
         raise ValueError("chunk size must be > 0")
 
-    all_gradients: list[SemanticGradient] = []
+    all_gradients: list[tuple[SemanticGradient, int | None]] = []
     for item in items:
-        all_gradients.extend(item.gradients)
+        all_gradients.extend((gradient, item.request_max_tokens) for gradient in item.gradients)
 
     if not all_gradients:
         return [_BufferedRolloutTrainingChunk(gradients=[])]
 
     chunks: list[_BufferedRolloutTrainingChunk] = []
     for start in range(0, len(all_gradients), size):
-        chunk_gradients = all_gradients[start : start + size]
-        chunks.append(_BufferedRolloutTrainingChunk(gradients=chunk_gradients))
+        chunk_items = all_gradients[start : start + size]
+        chunks.append(
+            _BufferedRolloutTrainingChunk(
+                gradients=[gradient for gradient, _budget in chunk_items],
+                request_max_tokens=strictest_request_budget(
+                    *[budget for _gradient, budget in chunk_items]
+                ),
+            )
+        )
     return chunks
+
+
+def _pipeline_context_with_request_budget(
+    context: PipelineContext,
+    request_max_tokens: int | None,
+) -> PipelineContext:
+    """Copy one worker context and scope its optimizer to this buffered chunk."""
+
+    if request_max_tokens is None:
+        return context
+    scoped = copy.copy(context)
+    optimization_context = copy.copy(context.optimization_context)
+    if optimization_context is None or not hasattr(
+        optimization_context,
+        "request_max_tokens",
+    ):
+        raise ValueError(
+            "A request-scoped streaming policy update requires an optimization "
+            "context with request_max_tokens"
+        )
+    optimization_context.request_max_tokens = strictest_request_budget(
+        optimization_context.request_max_tokens,
+        request_max_tokens,
+    )
+    scoped.optimization_context = optimization_context
+    return scoped
+
+
+def _unscoped_pipeline_context(context: PipelineContext) -> PipelineContext:
+    """Remove request-local budgets before storing a process-global context."""
+
+    unscoped = copy.copy(context)
+    for field_name in (
+        "analysis_context",
+        "gradient_context",
+        "optimization_context",
+    ):
+        component = getattr(context, field_name)
+        if component is None or not hasattr(component, "request_max_tokens"):
+            continue
+        component_copy = copy.copy(component)
+        component_copy.request_max_tokens = None
+        setattr(unscoped, field_name, component_copy)
+    return unscoped
 
 
 def _combine_update_plans(plans: list[PolicyUpdatePlan]) -> PolicyUpdatePlan:
@@ -594,11 +652,13 @@ class _BufferedRolloutTraining:
     gradients: list[SemanticGradient]
     analysis: RolloutAnalysis | None = None
     rollout: Rollout | None = None
+    request_max_tokens: int | None = None
 
 
 @dataclass(slots=True)
 class _BufferedRolloutTrainingChunk:
     gradients: list[SemanticGradient]
+    request_max_tokens: int | None = None
 
 
 _streaming_policy_trainer_registry: dict[Hashable, StreamingPolicyTrainer] = {}

--- a/openviking/session/train/components/trajectory_analyzer.py
+++ b/openviking/session/train/components/trajectory_analyzer.py
@@ -55,6 +55,7 @@ class TrajectoryAnalyzerContext:
     inject_evaluation_feedback: bool = True
     include_session_skills: bool = False
     source_archive_uri: str = ""
+    request_max_tokens: int | None = None
 
 
 @dataclass(slots=True)
@@ -94,6 +95,7 @@ class TrajectoryRolloutAnalyzer:
             include_session_skills=context.include_session_skills,
             case_name=getattr(rollout.case, "name", ""),
             source_archive_uri=context.source_archive_uri,
+            request_max_tokens=context.request_max_tokens,
         )
         contexts = list((result or {}).get("contexts", []))
         skill_gradients = list((result or {}).get("skill_gradients", []))
@@ -143,6 +145,7 @@ class TrajectoryRolloutAnalyzer:
         include_session_skills: bool = False,
         case_name: str = "",
         source_archive_uri: str = "",
+        request_max_tokens: int | None = None,
     ) -> dict[str, list[Any]]:
         """Extract trajectory and/or reusable skill operations from rollout messages.
 
@@ -163,6 +166,7 @@ class TrajectoryRolloutAnalyzer:
             latest_archive_overview=latest_archive_overview,
             include_trajectories=include_trajectories,
             include_session_skills=include_session_skills,
+            request_max_tokens=request_max_tokens,
         )
         phase_result = await self._run_trajectory_extract_phase(
             provider=provider,
@@ -173,6 +177,7 @@ class TrajectoryRolloutAnalyzer:
             include_session_skills=include_session_skills,
             case_name=case_name,
             source_archive_uri=source_archive_uri,
+            request_max_tokens=request_max_tokens,
         )
         if phase_result is None:
             return empty_result
@@ -191,6 +196,7 @@ class TrajectoryRolloutAnalyzer:
         include_session_skills: bool = False,
         case_name: str = "",
         source_archive_uri: str = "",
+        request_max_tokens: int | None = None,
     ) -> tuple[list[str], list[str], list[Context], list[PatchSemanticGradient]] | None:
         config = get_openviking_config()
         vlm = self.vlm or config.vlm.get_vlm_instance()
@@ -222,6 +228,7 @@ class TrajectoryRolloutAnalyzer:
             context_provider=provider,
             isolation_handler=isolation_handler,
             thinking=True,
+            request_max_tokens=request_max_tokens,
         )
 
         try:

--- a/openviking_cli/utils/config/memory_config.py
+++ b/openviking_cli/utils/config/memory_config.py
@@ -69,6 +69,21 @@ class MemoryConfig(BaseModel):
             "stateless deployments."
         ),
     )
+    phase2_window_max_tokens: int = Field(
+        default=12_000,
+        ge=256,
+        description=(
+            "Maximum estimated tokens in one loss-preserving session commit Phase 2 input window."
+        ),
+    )
+    extraction_request_max_tokens: int = Field(
+        default=32_768,
+        ge=256,
+        description=(
+            "Maximum estimated input tokens allowed immediately before a "
+            "Phase 2 memory model request."
+        ),
+    )
     session_skill_extraction_enabled: bool = Field(
         default=False,
         description=(
@@ -106,6 +121,15 @@ class MemoryConfig(BaseModel):
                     "use session memory_policy.working_memory.enabled to control archive summaries"
                 )
         return data
+
+    @model_validator(mode="after")
+    def validate_phase2_request_budget(self) -> "MemoryConfig":
+        if self.extraction_request_max_tokens < self.phase2_window_max_tokens:
+            raise ValueError(
+                "memory.extraction_request_max_tokens must be greater than or equal to "
+                "memory.phase2_window_max_tokens"
+            )
+        return self
 
     @field_validator("version", mode="before")
     @classmethod

--- a/tests/session/memory/test_memory_react_system_prompt.py
+++ b/tests/session/memory/test_memory_react_system_prompt.py
@@ -171,6 +171,34 @@ class TestSessionConversationToolFiltering:
         assert "input={'reservation_id': 'EHGLP3'}" in conversation
         assert "output=available" in conversation
 
+    def test_agent_provider_preserves_tool_output_head_and_tail(self):
+        from openviking.session.memory.agent_trajectory_context_provider import (
+            AgentTrajectoryContextProvider,
+        )
+
+        tool_output = "HEAD-" + ("middle-" * 2_000) + "-TAIL"
+        messages = [
+            Message(
+                id="m1",
+                role="assistant",
+                parts=[
+                    ToolPart(
+                        tool_id="tool_1",
+                        tool_name="read",
+                        tool_output=tool_output,
+                        tool_status="completed",
+                    )
+                ],
+            )
+        ]
+        provider = AgentTrajectoryContextProvider(messages=messages)
+
+        conversation = provider._assemble_conversation(messages)
+
+        assert "output=HEAD-" in conversation
+        assert conversation.rstrip().endswith("-TAIL")
+        assert "middle omitted from extraction prompt" in conversation
+
     def test_assemble_conversation_uses_peer_id_when_present(self):
         messages = [
             Message(

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -3,15 +3,20 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from openviking.message import Message, TextPart
+from openviking.message import ImagePart, Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
-from openviking.session.compressor_v3 import SessionCompressorV3, _experience_root_uri
+from openviking.session.compressor_v3 import (
+    SessionCompressorV3,
+    _experience_root_uri,
+    _merge_memory_diffs,
+)
 from openviking.session.memory.dataclass import (
     MemoryFile,
     ResolvedOperation,
@@ -36,6 +41,7 @@ from openviking.session.train import (
     Trajectory,
 )
 from openviking.session.train.components.session_commit import _case_spec_message_to_request
+from openviking_cli.exceptions import ResourceExhaustedError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -86,6 +92,161 @@ def test_factory_ignores_deprecated_memory_version():
         create_session_compressor(vikingdb=None, memory_version="unsupported"),
         SessionCompressorV3,
     )
+
+
+@pytest.mark.asyncio
+async def test_v3_prepares_images_through_the_guarded_provider_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingVLM:
+        called = False
+        model = "test-model"
+
+        async def get_vision_completion_async(self, **kwargs):
+            self.called = True
+            return "unused"
+
+    class VLMConfig:
+        def __init__(self, vlm) -> None:
+            self.vlm = vlm
+
+        def is_available(self) -> bool:
+            return True
+
+        def get_vlm_instance(self):
+            return self.vlm
+
+    class Registry:
+        async def initialize_memory_files(self, *args, **kwargs):
+            return None
+
+    vlm = RecordingVLM()
+    config = SimpleNamespace(
+        vlm=VLMConfig(vlm),
+        memory=SimpleNamespace(
+            eager_prefetch=False,
+            prefetch_search_topn=5,
+            link_enabled=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.create_default_registry",
+        Registry,
+    )
+    compressor = SessionCompressorV3(vikingdb=None, rollout_analyzer=object())
+    messages = [
+        Message(
+            id="image-message",
+            role="user",
+            parts=[ImagePart(url="data:image/png;base64," + ("A" * 10_000))],
+        )
+    ]
+
+    with pytest.raises(ResourceExhaustedError, match="image description"):
+        await compressor._extract_user_memories(
+            messages,
+            ctx=_ctx(),
+            request_max_tokens=100,
+        )
+
+    assert vlm.called is False
+    assert isinstance(messages[0].parts[0], ImagePart)
+
+
+def test_merge_memory_diffs_keeps_first_available_trace_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.tracer.get_trace_id",
+        lambda: "retry-trace",
+    )
+
+    merged = _merge_memory_diffs(
+        [
+            {
+                "trace_id": "first-window-trace",
+                "operations": {"adds": [], "updates": [], "deletes": []},
+            },
+            {
+                "trace_id": "retry-trace",
+                "operations": {"adds": [], "updates": [], "deletes": []},
+            },
+        ],
+        archive_uri="viking://user/u/session/s/archive_1",
+    )
+
+    assert merged["trace_id"] == "first-window-trace"
+
+
+@pytest.mark.asyncio
+async def test_publish_memory_diffs_preserves_completed_windows_on_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MemoryDiffFS:
+        def __init__(self) -> None:
+            self.files = {}
+
+        async def exists(self, uri, ctx=None):
+            return uri in self.files
+
+        async def read_file(self, uri, ctx=None):
+            return self.files[uri]
+
+        async def write_file(self, uri, content, ctx=None):
+            self.files[uri] = content
+
+    viking_fs = MemoryDiffFS()
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: viking_fs,
+    )
+    archive_uri = "viking://user/u/session/s/archive_1"
+    first_window = {
+        "operations": {
+            "adds": [{"uri": "viking://user/u/memories/profile.md"}],
+            "updates": [],
+            "deletes": [],
+        }
+    }
+    retry_window = {
+        "operations": {
+            "adds": [],
+            "updates": [{"uri": "viking://user/u/memories/preferences.md"}],
+            "deletes": [],
+        }
+    }
+
+    await SessionCompressorV3(vikingdb=None).publish_memory_diffs(
+        archive_uri=archive_uri,
+        ctx=_ctx(),
+        memory_diffs=[first_window],
+    )
+    await SessionCompressorV3(vikingdb=None).publish_memory_diffs(
+        archive_uri=archive_uri,
+        ctx=_ctx(),
+        memory_diffs=[retry_window],
+    )
+
+    persisted = json.loads(viking_fs.files[f"{archive_uri}/memory_diff.json"])
+    assert persisted["summary"] == {
+        "total_adds": 1,
+        "total_updates": 1,
+        "total_deletes": 0,
+    }
+    assert persisted["operations"]["adds"] == first_window["operations"]["adds"]
+    assert persisted["operations"]["updates"] == retry_window["operations"]["updates"]
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -79,6 +79,64 @@ class TestCommit:
         # Wait for semantic/embedding queues
         await client.wait_processed(timeout=60.0)
 
+    async def test_commit_windows_oversized_phase2_input_without_losing_authored_text(
+        self,
+        session_with_messages: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        config = MagicMock()
+        config.memory.extraction_enabled = True
+        config.memory.session_skill_extraction_enabled = False
+        config.memory.phase2_window_max_tokens = 40
+        config.memory.extraction_request_max_tokens = 300
+        monkeypatch.setattr("openviking.session.session.get_openviking_config", lambda: config)
+
+        session_with_messages.messages[0].peer_id = "peer-before"
+        authored_text = "authored-window-content-" * 120
+        session_with_messages.add_message("user", [TextPart(authored_text)])
+        session_with_messages.messages[-1].peer_id = "peer-authored"
+        source_message_id = session_with_messages.messages[-1].id
+        extractor = AsyncMock(
+            return_value={
+                "contexts": [],
+                "session_skills": [],
+                "memory_diff": {
+                    "adds": [],
+                    "updates": [],
+                    "deletes": [],
+                },
+            }
+        )
+        session_with_messages._session_compressor.extract_long_term_memories = extractor
+        publisher = AsyncMock(return_value={})
+        session_with_messages._session_compressor.publish_memory_diffs = publisher
+
+        result = await session_with_messages.commit_async(
+            memory_policy={
+                "peer": {"enabled": True},
+                "working_memory": {"enabled": False},
+            }
+        )
+        task_result = await _wait_for_task(result["task_id"])
+
+        assert task_result["status"] == "completed"
+        assert extractor.await_count > 1
+        source_fragments = []
+        for call in extractor.await_args_list:
+            assert call.kwargs["request_max_tokens"] == 300
+            assert call.kwargs["publish_memory_diff"] is False
+            window_peer_ids = {
+                message.peer_id for message in call.kwargs["messages"] if message.peer_id
+            }
+            assert call.kwargs["allowed_peer_ids"] == window_peer_ids
+            for message in call.kwargs["messages"]:
+                if source_message_id in (message.source_message_ids or [message.id]):
+                    source_fragments.extend(
+                        part.text for part in message.parts if isinstance(part, TextPart)
+                    )
+        assert "".join(source_fragments) == authored_text
+        publisher.assert_awaited()
+
     async def test_commit_default_disables_agent_memory_but_keeps_archive(
         self, session_with_messages: Session
     ):

--- a/tests/session/train/test_gradient_estimator_component.py
+++ b/tests/session/train/test_gradient_estimator_component.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
-import asyncio
 import pytest
 
 from openviking.session.memory.dataclass import MemoryFile
@@ -78,7 +78,11 @@ def _experience_set() -> ExperienceSet:
 
 
 def _context() -> ExperienceGradientContext:
-    return ExperienceGradientContext(request_context=SimpleNamespace(), messages=[])
+    return ExperienceGradientContext(
+        request_context=SimpleNamespace(),
+        messages=[],
+        request_max_tokens=321,
+    )
 
 
 @pytest.mark.asyncio
@@ -263,8 +267,10 @@ async def test_experience_gradient_estimator_runs_extract_loop(monkeypatch):
         "messages": context.messages,
         "trajectory_summary": analysis.trajectories[0].content,
         "trajectory_uri": analysis.trajectories[0].uri,
+        "request_max_tokens": 321,
     }
     assert captured["request_context"] is context.request_context
     assert captured["allowed_memory_types"] == {"experiences"}
     assert captured["prepare_messages_called"] is True
     assert captured["extract_loop_kwargs"]["context_provider"]._isolation_handler is not None
+    assert captured["extract_loop_kwargs"]["request_max_tokens"] == 321

--- a/tests/session/train/test_trajectory_analyzer_component.py
+++ b/tests/session/train/test_trajectory_analyzer_component.py
@@ -155,6 +155,7 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
             account_id="default",
         ),
         source_archive_uri="viking://user/u/sessions/s1/history/archive_001",
+        request_max_tokens=321,
     )
 
     analysis = await analyzer.analyze(_rollout(), context)
@@ -162,7 +163,9 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
     assert FakeExtractLoop.created
     created_loop = FakeExtractLoop.created[0]
     assert created_loop._transaction_handle is None
+    assert created_loop.kwargs["request_max_tokens"] == 321
     provider = created_loop.kwargs["context_provider"]
+    assert provider._request_max_tokens == 321
     assert provider._transaction_handle is None
     assert [
         schema.memory_type for schema in provider.get_memory_schemas(context.request_context)

--- a/tests/unit/session/memory/test_request_budget.py
+++ b/tests/unit/session/memory/test_request_budget.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import importlib
+import json
+
+import pytest
+
+from openviking.message import ImagePart, Message
+from openviking.session.memory.extract_loop import ExtractLoop
+from openviking.session.memory.vision_message_normalizer import describe_image_message
+from openviking.utils.token_estimation import estimate_serialized_tokens
+from openviking_cli.exceptions import ResourceExhaustedError
+
+
+def test_request_budget_compacts_tool_result_head_and_tail_on_a_copy() -> None:
+    request_budget = importlib.import_module("openviking.session.memory.request_budget")
+    result = "HEAD-" + ("large-result-" * 2_000) + "-TAIL"
+    messages = [
+        {"role": "system", "content": "extract memories"},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "tool_call_name": "read",
+                    "args": {"uri": "viking://user/memories/profile.md"},
+                    "result": result,
+                }
+            ),
+        },
+    ]
+
+    bounded = request_budget.prepare_bounded_model_request(
+        messages=messages,
+        tools=[],
+        max_tokens=300,
+    )
+
+    envelope = json.loads(bounded.messages[1]["content"])
+    assert envelope["result"].startswith("HEAD-")
+    assert envelope["result"].endswith("-TAIL")
+    assert "middle omitted from extraction prompt" in envelope["result"]
+    assert json.loads(messages[1]["content"])["result"] == result
+    assert estimate_serialized_tokens({"messages": bounded.messages, "tools": bounded.tools}) <= 300
+
+
+def test_request_budget_preserves_structured_tool_result_metadata() -> None:
+    request_budget = importlib.import_module("openviking.session.memory.request_budget")
+    result = {
+        "uri": "viking://user/resources/report.md",
+        "page_id": "page-17",
+        "content": "HEAD-" + ("large-result-" * 2_000) + "-TAIL",
+    }
+    messages = [
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "tool_call_name": "read",
+                    "args": {"uri": result["uri"]},
+                    "result": result,
+                }
+            ),
+        }
+    ]
+
+    bounded = request_budget.prepare_bounded_model_request(
+        messages=messages,
+        tools=[],
+        max_tokens=300,
+    )
+
+    bounded_result = json.loads(bounded.messages[0]["content"])["result"]
+    assert isinstance(bounded_result, dict)
+    assert bounded_result["uri"] == result["uri"]
+    assert bounded_result["page_id"] == result["page_id"]
+    assert bounded_result["content"].startswith("HEAD-")
+    assert bounded_result["content"].endswith("-TAIL")
+    assert json.loads(messages[0]["content"])["result"] == result
+
+
+def test_request_budget_fails_closed_for_oversized_non_tool_prompt() -> None:
+    request_budget = importlib.import_module("openviking.session.memory.request_budget")
+    messages = [{"role": "user", "content": "authored " * 2_000}]
+
+    with pytest.raises(ResourceExhaustedError, match="exceeds configured Phase 2"):
+        request_budget.prepare_bounded_model_request(
+            messages=messages,
+            tools=[],
+            max_tokens=100,
+        )
+
+
+def test_strictest_request_budget_ignores_unscoped_items() -> None:
+    request_budget = importlib.import_module("openviking.session.memory.request_budget")
+
+    assert request_budget.strictest_request_budget(None, 400, 200) == 200
+    assert request_budget.strictest_request_budget(None, None) is None
+
+
+@pytest.mark.asyncio
+async def test_extract_loop_applies_budget_immediately_before_provider_call() -> None:
+    class RecordingVLM:
+        model = "test-model"
+
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def get_completion_async(self, **kwargs):
+            self.calls.append(kwargs)
+            return None
+
+    vlm = RecordingVLM()
+    loop = ExtractLoop(
+        vlm=vlm,
+        viking_fs=object(),
+        request_max_tokens=300,
+    )
+    loop._tool_schemas = []
+    result = "HEAD-" + ("large-result-" * 2_000) + "-TAIL"
+    messages = [
+        {
+            "role": "user",
+            "content": json.dumps({"tool_call_name": "read", "args": {}, "result": result}),
+        }
+    ]
+
+    await loop._call_llm(messages)
+
+    sent = vlm.calls[0]
+    sent_result = json.loads(sent["messages"][0]["content"])["result"]
+    assert sent_result.startswith("HEAD-")
+    assert sent_result.endswith("-TAIL")
+    assert (
+        estimate_serialized_tokens({"messages": sent["messages"], "tools": sent["tools"] or []})
+        <= 300
+    )
+    assert json.loads(messages[0]["content"])["result"] == result
+
+
+@pytest.mark.asyncio
+async def test_image_description_fails_before_oversized_provider_call() -> None:
+    class RecordingVLM:
+        def __init__(self) -> None:
+            self.called = False
+
+        async def get_vision_completion_async(self, **kwargs):
+            self.called = True
+            return "unused"
+
+    vlm = RecordingVLM()
+    message = Message(
+        id="image-message",
+        role="user",
+        parts=[ImagePart(url="data:image/png;base64," + ("A" * 10_000))],
+    )
+
+    with pytest.raises(ResourceExhaustedError, match="image description"):
+        await describe_image_message(
+            message,
+            vlm=vlm,
+            request_max_tokens=100,
+        )
+
+    assert vlm.called is False

--- a/tests/unit/session/memory/test_request_budget_propagation.py
+++ b/tests/unit/session/memory/test_request_budget_propagation.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.session.compressor_v2 import SessionCompressorV2
+from openviking.session.compressor_v3 import SessionCompressorV3
+from openviking.session.memory.dataclass import ResolvedOperations
+from openviking.session.memory.streaming_memory_updater import (
+    MemoryUpdateRequest,
+    StreamingMemoryUpdater,
+)
+from openviking.session.train import PatchMergePolicyOptimizerContext, PipelineContext
+from openviking.session.train.components import policy_trainer
+from openviking.session.train.components.gradient_estimator import ExperienceGradientContext
+
+
+@pytest.mark.asyncio
+async def test_streaming_memory_updater_uses_strictest_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = {}
+
+    async def fake_merge_memory_operations(**kwargs):
+        observed.update(kwargs)
+        return kwargs["operations"]
+
+    monkeypatch.setattr(
+        "openviking.session.memory.streaming_memory_updater.merge_memory_operations",
+        fake_merge_memory_operations,
+    )
+    updater = StreamingMemoryUpdater()
+    empty_operations = ResolvedOperations(
+        upsert_operations=[],
+        delete_file_contents=[],
+        errors=[],
+    )
+    requests = [
+        MemoryUpdateRequest(
+            operations=empty_operations,
+            messages=[],
+            ctx=SimpleNamespace(),
+            request_max_tokens=None,
+        ),
+        MemoryUpdateRequest(
+            operations=empty_operations,
+            messages=[],
+            ctx=SimpleNamespace(),
+            request_max_tokens=400,
+        ),
+        MemoryUpdateRequest(
+            operations=empty_operations,
+            messages=[],
+            ctx=SimpleNamespace(),
+            request_max_tokens=200,
+        ),
+    ]
+
+    await updater._merge_requests(requests)
+
+    assert observed["request_max_tokens"] == 200
+
+
+def test_new_budget_fields_preserve_positional_api_compatibility() -> None:
+    operations = ResolvedOperations(
+        upsert_operations=[],
+        delete_file_contents=[],
+        errors=[],
+    )
+    isolation_options = {"allow_self": False}
+    metadata = {"caller": "metadata"}
+    update_request = MemoryUpdateRequest(
+        operations,
+        [],
+        SimpleNamespace(),
+        True,
+        isolation_options,
+        metadata,
+    )
+    gradient_context = ExperienceGradientContext(
+        SimpleNamespace(),
+        [],
+        True,
+        metadata,
+    )
+
+    assert update_request.isolation_options == isolation_options
+    assert update_request.metadata == metadata
+    assert update_request.request_max_tokens is None
+    assert gradient_context.metadata == metadata
+    assert gradient_context.request_max_tokens is None
+
+
+def test_streaming_policy_chunks_keep_strictest_item_budget() -> None:
+    items = [
+        policy_trainer._BufferedRolloutTraining(
+            gradients=[object()],
+            request_max_tokens=None,
+        ),
+        policy_trainer._BufferedRolloutTraining(
+            gradients=[object()],
+            request_max_tokens=400,
+        ),
+        policy_trainer._BufferedRolloutTraining(
+            gradients=[object()],
+            request_max_tokens=200,
+        ),
+    ]
+
+    chunks = policy_trainer._chunks_buffered_items_by_gradient_count(items, size=16)
+
+    assert chunks[0].request_max_tokens == 200
+
+
+def test_streaming_policy_chunks_leave_unscoped_work_unbounded() -> None:
+    items = [
+        policy_trainer._BufferedRolloutTraining(
+            gradients=[object()],
+            request_max_tokens=None,
+        )
+    ]
+
+    chunks = policy_trainer._chunks_buffered_items_by_gradient_count(items, size=16)
+
+    assert chunks[0].request_max_tokens is None
+
+
+def test_preexisting_policy_worker_context_is_scoped_per_chunk() -> None:
+    original = PipelineContext(
+        optimization_context=PatchMergePolicyOptimizerContext(
+            request_context=SimpleNamespace(),
+            request_max_tokens=None,
+        )
+    )
+
+    scoped = policy_trainer._pipeline_context_with_request_budget(original, 200)
+
+    assert scoped is not original
+    assert scoped.optimization_context.request_max_tokens == 200
+    assert original.optimization_context.request_max_tokens is None
+
+
+def test_capped_created_policy_worker_does_not_cap_later_unscoped_work() -> None:
+    capped_creation_context = PipelineContext(
+        optimization_context=PatchMergePolicyOptimizerContext(
+            request_context=SimpleNamespace(),
+            request_max_tokens=200,
+        )
+    )
+
+    trainer = policy_trainer.StreamingPolicyTrainer(
+        policy_set=SimpleNamespace(),
+        rollout_analyzer=SimpleNamespace(),
+        gradient_estimator=SimpleNamespace(),
+        policy_optimizer=SimpleNamespace(),
+        policy_updater=SimpleNamespace(),
+        context=capped_creation_context,
+    )
+    later_context = policy_trainer._pipeline_context_with_request_budget(
+        trainer.context,
+        None,
+    )
+
+    assert trainer.context.optimization_context.request_max_tokens is None
+    assert later_context.optimization_context.request_max_tokens is None
+    assert capped_creation_context.optimization_context.request_max_tokens == 200
+
+
+def test_v3_user_extract_loop_receives_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = {}
+
+    class RecordingExtractLoop:
+        def __init__(self, **kwargs):
+            observed.update(kwargs)
+
+    config = SimpleNamespace(
+        vlm=SimpleNamespace(get_vlm_instance=lambda: object()),
+        memory=SimpleNamespace(
+            eager_prefetch=False,
+            prefetch_search_topn=5,
+            link_enabled=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.ExtractLoop",
+        RecordingExtractLoop,
+    )
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        rollout_analyzer=object(),
+    )
+
+    compressor._get_or_create_react(messages=[], request_max_tokens=321)
+
+    assert observed["request_max_tokens"] == 321
+
+
+def test_v2_user_extract_loop_receives_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = {}
+
+    class RecordingExtractLoop:
+        def __init__(self, **kwargs):
+            observed.update(kwargs)
+
+    config = SimpleNamespace(
+        vlm=SimpleNamespace(get_vlm_instance=lambda: object()),
+        memory=SimpleNamespace(
+            eager_prefetch=False,
+            prefetch_search_topn=5,
+            link_enabled=False,
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v2.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v2.get_viking_fs",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v2.ExtractLoop",
+        RecordingExtractLoop,
+    )
+    compressor = SessionCompressorV2(vikingdb=None)
+
+    compressor._get_or_create_react(messages=[], request_max_tokens=321)
+
+    assert observed["request_max_tokens"] == 321

--- a/tests/unit/session/test_phase2_input.py
+++ b/tests/unit/session/test_phase2_input.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.message import Message, TextPart, ToolPart
+from openviking.session.session import (
+    Session,
+    _CheckpointRequest,
+    _phase2_message_is_completed,
+    _phase2_window_peer_ids,
+    _record_fully_completed_phase2_sources,
+)
+from openviking_cli.exceptions import ResourceExhaustedError
+from openviking_cli.utils.config.memory_config import MemoryConfig
+
+
+def test_phase2_plan_preserves_authored_text_across_windows() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    first_text = "alpha " * 80
+    second_text = "omega " * 80
+    messages = [
+        Message(id="user-1", role="user", parts=[TextPart(text=first_text)]),
+        Message(id="assistant-1", role="assistant", parts=[TextPart(text=second_text)]),
+    ]
+
+    plan = phase2_input.build_phase2_input_plan(messages, window_max_tokens=40)
+
+    fragments = [
+        part.text
+        for window in plan.windows
+        for message in window.messages
+        for part in message.parts
+        if isinstance(part, TextPart)
+    ]
+    assert "".join(fragments) == first_text + second_text
+    assert len(plan.windows) > 1
+    assert all(window.estimated_tokens <= 40 for window in plan.windows)
+
+
+def test_phase2_plan_bounds_tool_output_head_and_tail_without_mutating_source() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    output = "HEAD-" + ("middle-" * 2_000) + "-TAIL"
+    message = Message(
+        id="assistant-tool",
+        role="assistant",
+        parts=[
+            ToolPart(
+                tool_id="call-1",
+                tool_name="read",
+                tool_output=output,
+                tool_output_ref="viking://tool-results/call-1",
+                tool_status="completed",
+            )
+        ],
+    )
+
+    plan = phase2_input.build_phase2_input_plan([message], window_max_tokens=200)
+
+    planned_part = plan.windows[0].messages[0].parts[0]
+    assert isinstance(planned_part, ToolPart)
+    assert planned_part.tool_output.startswith("HEAD-")
+    assert planned_part.tool_output.endswith("-TAIL")
+    assert "middle omitted from Phase 2 prompt" in planned_part.tool_output
+    assert planned_part.tool_output_truncated is True
+    assert planned_part.tool_output_original_chars == len(output)
+    assert message.parts[0].tool_output == output
+    assert plan.windows[0].estimated_tokens <= 200
+
+
+def test_phase2_plan_preserves_structured_tool_input() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    tool_input = {
+        "command": "python -c " + ("print('important') " * 2_000),
+        "cwd": "/workspace",
+    }
+    message = Message(
+        id="assistant-tool-input",
+        role="assistant",
+        parts=[
+            ToolPart(
+                tool_id="call-1",
+                tool_name="shell",
+                tool_input=tool_input,
+                tool_output="completed",
+                tool_status="completed",
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="metadata exceeds"):
+        phase2_input.build_phase2_input_plan([message], window_max_tokens=200)
+
+    assert message.parts[0].tool_input == tool_input
+
+
+def test_phase2_plan_keeps_a_fitting_turn_together() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    messages = [
+        Message(
+            id="user-1",
+            role="user",
+            turn_id="turn-1",
+            parts=[TextPart(text="question")],
+        ),
+        Message(
+            id="assistant-1",
+            role="assistant",
+            turn_id="turn-1",
+            parts=[TextPart(text="answer")],
+        ),
+        Message(
+            id="user-2",
+            role="user",
+            turn_id="turn-2",
+            parts=[TextPart(text="later " * 40)],
+        ),
+    ]
+
+    plan = phase2_input.build_phase2_input_plan(messages, window_max_tokens=20)
+
+    assert plan.windows[0].source_message_ids == ("user-1", "assistant-1")
+    assert all(window.estimated_tokens <= 20 for window in plan.windows)
+
+
+def test_phase2_plan_fragment_ids_are_deterministic() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    messages = [
+        Message(
+            id="user-large",
+            role="user",
+            parts=[TextPart(text="stable content " * 200)],
+        )
+    ]
+
+    first = phase2_input.build_phase2_input_plan(messages, window_max_tokens=40)
+    second = phase2_input.build_phase2_input_plan(messages, window_max_tokens=40)
+
+    assert [window.fragment_ids for window in first.windows] == [
+        window.fragment_ids for window in second.windows
+    ]
+    assert all(
+        fragment_id.startswith("user-large#phase2:v1:")
+        for window in first.windows
+        for fragment_id in window.fragment_ids
+    )
+
+
+def test_compacted_tool_fragment_id_is_deterministic_without_created_at() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    messages = [
+        Message(
+            id="tool-large",
+            role="assistant",
+            parts=[
+                ToolPart(
+                    tool_id="call-1",
+                    tool_name="read",
+                    tool_input={"uri": "viking://user/resources/report.md"},
+                    tool_output="stable output " * 2_000,
+                    tool_status="completed",
+                )
+            ],
+        )
+    ]
+
+    first = phase2_input.build_phase2_input_plan(messages, window_max_tokens=200)
+    second = phase2_input.build_phase2_input_plan(messages, window_max_tokens=200)
+
+    assert first.windows[0].fragment_ids == second.windows[0].fragment_ids
+
+
+def test_phase2_plan_rejects_non_positive_budget() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        phase2_input.build_phase2_input_plan([], window_max_tokens=0)
+
+
+def test_memory_config_exposes_safe_phase2_defaults() -> None:
+    config = MemoryConfig()
+
+    assert config.phase2_window_max_tokens == 12_000
+    assert config.extraction_request_max_tokens == 32_768
+
+
+def test_memory_config_rejects_request_budget_below_window_budget() -> None:
+    with pytest.raises(ValueError, match="extraction_request_max_tokens"):
+        MemoryConfig(
+            phase2_window_max_tokens=2_000,
+            extraction_request_max_tokens=1_999,
+        )
+
+
+@pytest.mark.asyncio
+async def test_working_memory_folds_phase2_windows_in_order() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    messages = [
+        Message(id="user-1", role="user", parts=[TextPart(text="first " * 20)]),
+        Message(id="user-2", role="user", parts=[TextPart(text="second " * 20)]),
+    ]
+    plan = phase2_input.build_phase2_input_plan(messages, window_max_tokens=40)
+    session = object.__new__(Session)
+    session._generate_archive_summary_async = AsyncMock(
+        side_effect=["overview-after-first", "overview-after-second"]
+    )
+
+    result = await session._generate_archive_summary_for_phase2_windows(
+        plan.windows,
+        latest_archive_overview="overview-before",
+        request_max_tokens=300,
+    )
+
+    assert result == "overview-after-second"
+    assert session._generate_archive_summary_async.await_count == 2
+    first_call, second_call = session._generate_archive_summary_async.await_args_list
+    assert first_call.kwargs["latest_archive_overview"] == "overview-before"
+    assert second_call.kwargs["latest_archive_overview"] == "overview-after-first"
+    assert first_call.kwargs["strict"] is True
+    assert second_call.kwargs["strict"] is True
+    assert first_call.kwargs["request_max_tokens"] == 300
+
+
+@pytest.mark.asyncio
+async def test_single_window_working_memory_uses_explicit_request_budget() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    plan = phase2_input.build_phase2_input_plan(
+        [Message(id="user-1", role="user", parts=[TextPart(text="remember this")])],
+        window_max_tokens=40,
+    )
+    session = object.__new__(Session)
+    session._generate_archive_summary_async = AsyncMock(return_value="overview")
+
+    await session._generate_archive_summary_for_phase2_windows(
+        plan.windows,
+        request_max_tokens=300,
+    )
+
+    assert session._generate_archive_summary_async.await_args.kwargs[
+        "request_max_tokens"
+    ] == 300
+
+
+@pytest.mark.asyncio
+async def test_single_window_checkpoint_uses_fragment_ids() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    source = Message(
+        id="tool-source",
+        role="assistant",
+        parts=[
+            ToolPart(
+                tool_id="call-1",
+                tool_name="read",
+                tool_output="HEAD-" + ("middle-" * 2_000) + "-TAIL",
+            )
+        ],
+    )
+    plan = phase2_input.build_phase2_input_plan([source], window_max_tokens=200)
+    assert len(plan.windows) == 1
+    derived_id = plan.windows[0].messages[0].id
+    assert derived_id != source.id
+
+    session = object.__new__(Session)
+    session._generate_archive_summary_async = AsyncMock(return_value="overview")
+    request = _CheckpointRequest(
+        turn_anchor_message_id=source.id,
+        source_message_ids=(source.id,),
+        retained_message_token_budget=100,
+        estimated_active_tokens=10,
+    )
+
+    await session._generate_archive_summary_for_phase2_windows(
+        plan.windows,
+        checkpoint_requests=[request],
+        request_max_tokens=300,
+    )
+
+    local_request = session._generate_archive_summary_async.await_args.kwargs[
+        "checkpoint_requests"
+    ][0]
+    assert local_request.turn_anchor_message_id == derived_id
+    assert local_request.source_message_ids == (derived_id,)
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_partials_are_reduced_pairwise_within_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingVLM:
+        def __init__(self) -> None:
+            self.requests = []
+
+        async def get_completion_async(self, **request):
+            self.requests.append(request)
+            return "merged checkpoint"
+
+    vlm = RecordingVLM()
+    config = type("Config", (), {"vlm": vlm})()
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: config,
+    )
+    session = object.__new__(Session)
+
+    result = await session._reduce_checkpoint_summaries(
+        ["first concrete fact", "second concrete fact"],
+        request_max_tokens=300,
+    )
+
+    assert result == "merged checkpoint"
+    assert len(vlm.requests) == 1
+    assert "first concrete fact" in vlm.requests[0]["prompt"]
+    assert "second concrete fact" in vlm.requests[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_reduction_fails_before_oversized_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingVLM:
+        called = False
+
+        async def get_completion_async(self, **request):
+            self.called = True
+            return "unused"
+
+    vlm = RecordingVLM()
+    config = type("Config", (), {"vlm": vlm})()
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: config,
+    )
+    session = object.__new__(Session)
+
+    with pytest.raises(ResourceExhaustedError, match="checkpoint reduction"):
+        await session._reduce_checkpoint_summaries(
+            ["first " * 1_000, "second " * 1_000],
+            request_max_tokens=100,
+        )
+
+    assert vlm.called is False
+
+
+@pytest.mark.asyncio
+async def test_single_window_working_memory_budget_failure_is_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingVLM:
+        called = False
+
+        def is_available(self) -> bool:
+            return True
+
+        async def get_completion_async(self, **request):
+            self.called = True
+            return "unused"
+
+    vlm = RecordingVLM()
+    config = type(
+        "Config",
+        (),
+        {
+            "vlm": vlm,
+            "memory": type(
+                "Memory",
+                (),
+                {"extraction_request_max_tokens": 100},
+            )(),
+        },
+    )()
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: config,
+    )
+    session = object.__new__(Session)
+    message = Message(
+        id="large",
+        role="user",
+        parts=[TextPart(text="authored " * 2_000)],
+    )
+
+    with pytest.raises(ResourceExhaustedError, match="Working Memory request"):
+        await session._generate_archive_summary_async([message])
+
+    assert vlm.called is False
+
+
+def test_phase2_window_peer_scope_excludes_other_windows() -> None:
+    messages = [
+        Message(
+            id="peer-a-message",
+            role="user",
+            peer_id="peer-a",
+            parts=[TextPart(text="hello")],
+        )
+    ]
+
+    assert _phase2_window_peer_ids({"peer-a", "peer-b"}, messages) == {"peer-a"}
+
+
+def test_completed_source_id_survives_a_different_retry_fragmentation() -> None:
+    phase2_input = importlib.import_module("openviking.session.phase2_input")
+    source = Message(
+        id="large-source",
+        role="user",
+        parts=[TextPart(text="durable authored text " * 200)],
+    )
+    original_plan = phase2_input.build_phase2_input_plan(
+        [source],
+        window_max_tokens=40,
+    )
+    completed_ids = {message.id for window in original_plan.windows for message in window.messages}
+
+    _record_fully_completed_phase2_sources(original_plan, completed_ids)
+
+    retry_plan = phase2_input.build_phase2_input_plan(
+        [source],
+        window_max_tokens=60,
+    )
+    assert source.id in completed_ids
+    assert all(
+        _phase2_message_is_completed(message, completed_ids)
+        for window in retry_plan.windows
+        for message in window.messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_usage_reporting_hydrates_a_separate_non_model_copy() -> None:
+    source = [
+        Message(
+            id="source",
+            role="assistant",
+            parts=[TextPart(text="model-facing preview")],
+        )
+    ]
+    hydrated = [
+        Message(
+            id="usage-copy",
+            role="assistant",
+            parts=[TextPart(text="full tool output for rule-based usage")],
+        )
+    ]
+    session = object.__new__(Session)
+    session._usage_reporter = object()
+    session._hydrate_tool_outputs_for_extraction = AsyncMock(return_value=hydrated)
+
+    result = await session._usage_reporting_messages(source)
+
+    assert result is hydrated
+    assert source[0].parts[0].text == "model-facing preview"
+    session._hydrate_tool_outputs_for_extraction.assert_awaited_once_with(source)


### PR DESCRIPTION
## Description

Phase 2 no longer rebuilds one archive-wide extraction prompt. The archived
JSONL remains authoritative and unchanged while Working Memory and the current
V3 memory paths consume bounded prompt copies.

This addresses the full source-to-provider path behind #3226, including the
single huge-message case that automatic commit cannot prevent.

## Related Issue

This PR provides a loss-preserving complete fix for the open issue.

Fixes #3226.

## Changes Made

The implementation processes all authored input in bounded requests and uses
truncation only for copied tool-result bodies, never for archived source text or
structured tool input.

- Build deterministic, turn-aware Phase 2 windows; split individually oversized
  authored text into lossless plan-version/offset/digest fragments.
- Preserve tool-result head and tail plus source references while leaving
  structured tool input and the raw archive unchanged.
- Fold Working Memory across windows and reduce checkpoint notes through bounded
  pairwise requests.
- Run current V3 user, peer, case, trajectory, experience, and session-skill
  extraction window by window; persist per-window progress and cumulative audit
  diffs for retry.
- Propagate request-scoped limits through nested ExtractLoops and process-global
  updater/trainer work without leaking a cap into later unscoped work.
- Enforce the complete serialized request budget, including tool schemas,
  immediately before providers; structured read results retain their shape and
  metadata, while irreducible overflow raises `RESOURCE_EXHAUSTED`.
- Add `memory.phase2_window_max_tokens` and
  `memory.extraction_request_max_tokens`, plus English, Chinese, and main-flow
  documentation.

## Testing

The exact submitted commit passed all change-specific and directly affected
suites on macOS. Large fixture-backed suites were run in isolated processes to
avoid the repository's existing file-descriptor leak.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and directly affected unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Exact-head results:

```text
39 passed  # planner, request guard/propagation, source-to-provider, commit window
29 passed  # full tests/session/test_compressor_v3.py
22 passed  # gradient estimator + train components
29 passed  # trajectory analyzer + Working Memory
Ruff: All checks passed!
git diff --check: clean
```

Broader session runs also exposed pre-existing failures that reproduce on the
exact `upstream/main` baseline, including two `test_session_commit.py`
expectation failures and the retention integration `memory_types` failure; they
are not introduced by this commit.

## Additional Notes

This is intentionally broader than the other open #3226 proposals:

- #3342 adds a final fail-closed ExtractLoop guard but intentionally leaves the
  archive-wide prompt construction unchanged.
- #3595 truncates long message-content blobs in place and does not include tool
  schemas in its estimate or assert that the residual request fits.

This PR includes a final guard as a backstop, but its primary fix is
loss-preserving windowing and reduction across every current V3 Phase 2 path.
It remains complementary to the automatic-commit scheduling work in #2772.
