### PR TITLE
fix(langchain): preserve injected clients during deepcopy

### DIFF
--- a/openviking/integrations/langchain/client.py
+++ b/openviking/integrations/langchain/client.py
@@ -75,6 +75,26 @@ class OpenVikingConnection:
     auto_initialize: bool = True
     async_client: Any = None
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> OpenVikingConnection:
+        """Copy configuration while preserving caller-owned client identities."""
+
+        copied = type(self)(
+            client=self.client,
+            async_client=self.async_client,
+            url=self.url,
+            api_key=self.api_key,
+            account=self.account,
+            user=self.user,
+            user_id=self.user_id,
+            actor_peer_id=self.actor_peer_id,
+            path=self.path,
+            timeout=self.timeout,
+            extra_headers=copy.deepcopy(self.extra_headers, memo),
+            auto_initialize=self.auto_initialize,
+        )
+        memo[id(self)] = copied
+        return copied
+
 
 @dataclass(slots=True)
 class OpenVikingCommitPolicy:

--- a/openviking/integrations/langchain/retrievers.py
+++ b/openviking/integrations/langchain/retrievers.py
@@ -68,6 +68,29 @@ class OpenVikingRetriever(BaseRetriever):
     _owns_client_cache: bool = PrivateAttr(default=False)
     _closed: bool = PrivateAttr(default=False)
 
+    def __deepcopy__(
+        self,
+        memo: dict[int, Any] | None = None,
+    ) -> OpenVikingRetriever:
+        """Copy configuration without cloning clients or cached runtime state."""
+
+        memo = {} if memo is None else memo
+        for client in (self.client, self.async_client):
+            if client is not None:
+                memo[id(client)] = client
+
+        sync_client_cache = getattr(self, "_client_cache", None)
+        if getattr(self, "_owns_client_cache", False) and sync_client_cache is not None:
+            memo[id(sync_client_cache)] = None
+
+        copied = super().__deepcopy__(memo)
+        private_attributes = getattr(type(copied), "__private_attributes__", {})
+        private_state = copied.__pydantic_private__
+        if private_state is not None and "_client_cache" in private_attributes:
+            private_state["_client_cache"] = None
+            private_state["_owns_client_cache"] = False
+        return copied
+
     def _get_client(self) -> Any:
         self._raise_if_closed()
         if self._client_cache is None:

--- a/tests/unit/test_langchain_async_integration.py
+++ b/tests/unit/test_langchain_async_integration.py
@@ -63,6 +63,94 @@ class AsyncInMemoryOpenVikingClient:
         return call
 
 
+def test_connection_handle_and_retriever_deepcopy_preserve_injected_clients():
+    class NonCopyableClient:
+        def __deepcopy__(self, _memo: dict[int, Any]) -> None:
+            raise AssertionError("live clients must not be deep-copied")
+
+    client = NonCopyableClient()
+    async_client = NonCopyableClient()
+    connection = OpenVikingConnection(
+        client=client,
+        async_client=async_client,
+        url="http://localhost:1933",
+        extra_headers={"X-Tenant": "tenant-a"},
+    )
+
+    copied_connection = copy.deepcopy(connection)
+
+    assert copied_connection is not connection
+    assert copied_connection.client is client
+    assert copied_connection.async_client is async_client
+    assert copied_connection.extra_headers == connection.extra_headers
+    assert copied_connection.extra_headers is not connection.extra_headers
+
+    async_handle = OpenVikingAsyncClientHandle(connection)
+    async_handle._client = async_client
+    copied_async_handle = copy.deepcopy(async_handle)
+
+    assert copied_async_handle is not async_handle
+    assert copied_async_handle._connection.async_client is async_client
+    assert copied_async_handle._client is None
+
+    retriever = OpenVikingRetriever(
+        client=client,
+        async_client=async_client,
+        extra_headers={"X-Tenant": "tenant-a"},
+        target_uri=["viking://resources"],
+        filter={"category": ["guide"]},
+        tags=["stable"],
+    )
+    copied_retriever = copy.deepcopy(retriever)
+
+    assert copied_retriever is not retriever
+    assert copied_retriever.client is client
+    assert copied_retriever.async_client is async_client
+    assert copied_retriever.extra_headers == retriever.extra_headers
+    assert copied_retriever.extra_headers is not retriever.extra_headers
+    assert copied_retriever.target_uri == retriever.target_uri
+    assert copied_retriever.target_uri is not retriever.target_uri
+    assert copied_retriever.filter == retriever.filter
+    assert copied_retriever.filter is not retriever.filter
+    assert copied_retriever.tags == retriever.tags
+    assert copied_retriever.tags is not retriever.tags
+
+
+def test_retriever_deepcopy_discards_owned_sync_client(monkeypatch):
+    instances: list[Any] = []
+
+    class NonCopyableSyncHTTPClient:
+        def __init__(self, **_kwargs: Any):
+            self.closed = False
+            instances.append(self)
+
+        def __deepcopy__(self, _memo: dict[int, Any]) -> None:
+            raise AssertionError("owned live clients must not be deep-copied")
+
+        def initialize(self) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+        def find(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"memories": [], "resources": [], "skills": []}
+
+    import openviking.client as client_module
+
+    monkeypatch.setattr(client_module, "SyncHTTPClient", NonCopyableSyncHTTPClient)
+    retriever = OpenVikingRetriever(url="http://localhost:1933")
+
+    assert retriever.invoke("original") == []
+    copied = copy.deepcopy(retriever)
+    assert copied.invoke("copied") == []
+
+    assert len(instances) == 2
+    asyncio.run(copied.aclose())
+    asyncio.run(retriever.aclose())
+    assert all(client.closed for client in instances)
+
+
 @pytest.mark.asyncio
 async def test_ensure_async_client_defaults_to_native_http_client(monkeypatch):
     created: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

- define deep-copy semantics for `OpenVikingConnection` that preserve caller-owned `client` and `async_client` identities
- make `OpenVikingRetriever` deep-copy configuration without cloning injected clients or carrying adapter-owned live client caches into the copy
- guard optional Pydantic private state before resetting compatibility caches
- add regression coverage for non-copyable injected clients, independently copied mutable configuration, and fresh internally owned clients

## Why

Python's default deep copy recursively copies object fields. That is unsafe for live HTTP clients: objects such as `httpx.Client` contain locks and connection pools, so copying a connection or LangChain retriever failed with:

```text
TypeError: cannot pickle '_thread.RLock' object
```

Cloning a live injected client would also violate the ownership contract even when a test double happened to be copyable.

Before:

```text
deepcopy(connection or retriever)
  -> recursively copy injected client / active cache
  -> TypeError or duplicated live resource
```

After:

```text
deepcopy(connection or retriever)
  -> preserve caller-owned client identity
  -> independently copy mutable configuration
  -> discard adapter-owned runtime caches
```

The copied retriever therefore starts with clean adapter-owned runtime state while retaining the same caller-managed injected clients.

## Compatibility

- no public constructor or method signatures change
- ordinary mutable configuration remains independently deep-copied
- injected clients remain caller-owned and are never cloned or closed by the copied adapter
- the PR is independent from #3599 and merges cleanly with it

## Validation

- Python 3.11: 157 LangChain/LangGraph tests passed
- Python 3.12: 157 LangChain/LangGraph tests passed
- Python 3.10: 155 passed, 1 skipped, 1 deselected; the deselected tool-schema assertion also fails on clean upstream `main`
- combined with #3599: 174 tests passed on Python 3.11
- real `httpx.Client` probes pass and preserve injected client identity
- `ruff format --check` and `ruff check`
- `mypy --follow-imports=silent openviking/integrations/langchain/retrievers.py`

Related to #3599.
