### PR TITLE
fix/add_resource_auto_create_dir

### DIFF
--- a/openviking/parse/tree_builder.py
+++ b/openviking/parse/tree_builder.py
@@ -21,11 +21,13 @@ IMPORTANT (v5.0 Architecture):
 - Content splitting is handled by Parser, not TreeBuilder
 """
 
+import os
 from typing import Optional
 
 from openviking.core.building_tree import BuildingTree
 from openviking.core.context import Context
 from openviking.core.namespace import is_content_root_uri
+from openviking.parse.parsers.constants import CODE_EXTENSIONS
 from openviking.parse.parsers.media.utils import get_media_base_uri, get_media_type
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import get_viking_fs
@@ -153,6 +155,7 @@ class TreeBuilder:
         source_path: Optional[str] = None,
         source_format: Optional[str] = None,
         create_parent: bool = False,
+        allow_file_root: bool = False,
     ) -> "BuildingTree":
         """
         Finalize URI metadata for a temp parse result.
@@ -161,6 +164,9 @@ class TreeBuilder:
             to_uri: Exact target URI, or resources root to import under
             parent_uri: Target parent URI (must exist unless create_parent is True)
             create_parent: Whether to automatically create parent directory if it doesn't exist
+            allow_file_root: Whether a single-code-file parse may resolve to a file
+                root instead of a wrapper directory. Only enable when the
+                downstream pipeline can handle file-shaped resource roots.
         """
 
         viking_fs = get_viking_fs()
@@ -183,6 +189,28 @@ class TreeBuilder:
         temp_doc_uri = f"{temp_uri}/{original_name}"  # use original name to find temp dir
         if original_name != doc_name:
             logger.debug(f"[TreeBuilder] Sanitized doc name: {original_name!r} -> {doc_name!r}")
+
+        # Single code files land as file nodes: MarkdownParser preserves a code
+        # source filename as the temp document directory (foo.py holding
+        # foo.md), so a code-suffixed doc dir with exactly one regular file and
+        # no other artifacts marks a single-file code import, and the resource
+        # root becomes that inner file instead of the wrapper directory.
+        # Directory-shaped parses (repository/directory/zip — where the dir
+        # name comes from the source, not from a code filename), non-code
+        # documents, and documents with extra artifacts (media, sidecars) keep
+        # the directory form.
+        if (
+            allow_file_root
+            and source_format not in ("repository", "directory", "zip")
+            and os.path.splitext(original_name)[1].lower() in CODE_EXTENSIONS
+        ):
+            doc_children = [
+                e
+                for e in await viking_fs.ls(temp_doc_uri, ctx=ctx)
+                if e.get("name") not in (".", "..")
+            ]
+            if len(doc_children) == 1 and not doc_children[0].get("isDir"):
+                temp_doc_uri = f"{temp_doc_uri}/{doc_children[0]['name']}"
 
         planned_uri, unique_candidate_uri = await self.resolve_target_uri(
             ctx=ctx,

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -31,7 +31,6 @@ from openviking.parse.parsers.media.utils import (
     get_media_type,
 )
 from openviking.prompts import render_prompt
-from openviking.utils.ingest_options import IngestOptions
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
@@ -49,7 +48,9 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI
 from openviking_cli.utils.config import get_openviking_config
@@ -262,7 +263,9 @@ class SemanticProcessor(DequeueHandlerBase):
             return
         self.report_success()
 
-    async def _enqueue_parent_refresh(self, msg: SemanticMsg, uri: str) -> None:
+    async def _enqueue_parent_refresh(
+        self, msg: SemanticMsg, uri: str, *, propagate_telemetry: bool = False
+    ) -> None:
         if msg.context_type not in {"resource", "skill"}:
             return
         parent = VikingURI(uri).parent
@@ -292,6 +295,10 @@ class SemanticProcessor(DequeueHandlerBase):
             role=msg.role,
             skip_vectorization=msg.skip_vectorization,
             changes={"modified": [uri]},
+            telemetry_id=msg.telemetry_id if propagate_telemetry else "",
+            # File-root callers delegate the file's vectorization to this
+            # refresh, so the import's ingest options must ride along.
+            ingest_options=msg.ingest_options if propagate_telemetry else None,
             coalesce_key=build_semantic_coalesce_key(
                 context_type=msg.context_type,
                 uri=parent_uri,
@@ -300,8 +307,84 @@ class SemanticProcessor(DequeueHandlerBase):
                 peer_id=msg.peer_id,
             ),
         )
-        await semantic_queue.enqueue(parent_msg)
+        tracked = bool(propagate_telemetry and parent_msg.telemetry_id and parent_msg.id)
+        if tracked:
+            # Register before enqueue so the request wait already sees this
+            # root when the caller marks its own message done.
+            get_request_wait_tracker().register_semantic_root(
+                parent_msg.telemetry_id, parent_msg.id
+            )
+        try:
+            enqueue_id = await semantic_queue.enqueue(parent_msg)
+        except Exception as e:
+            if tracked:
+                get_request_wait_tracker().mark_semantic_failed(
+                    parent_msg.telemetry_id, parent_msg.id, str(e)
+                )
+            raise
+        if tracked and enqueue_id == "deduplicated":
+            get_request_wait_tracker().mark_semantic_done(parent_msg.telemetry_id, parent_msg.id)
         logger.info("Enqueued parent semantic refresh: %s", parent_uri)
+
+    async def _process_file_root(
+        self,
+        msg: SemanticMsg,
+        *,
+        ctx: RequestContext,
+        lock: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Process a file-shaped resource root (flattened single code file).
+
+        There is no directory to walk and no .abstract/.overview to generate:
+        sync the file into its target when needed, vectorize it, and refresh
+        the parent directory so its semantics pick up the new leaf.
+
+        The file's summary and DETAIL vector are produced solely by the
+        parent's incremental refresh (which treats the file as modified),
+        never written directly here: two embeddings for the same URI share a
+        deterministic ID, so a direct empty-summary write could race with and
+        overwrite the summary-bearing one. The refresh is registered under
+        this request's telemetry before this message is marked done, so
+        wait=true covers both the embedding write and the parent semantics.
+        """
+        viking_fs = get_viking_fs()
+        final_uri = msg.uri
+        if msg.target_uri and msg.uri != msg.target_uri:
+            target_stat = None
+            try:
+                target_stat = await viking_fs.stat(msg.target_uri, ctx=ctx)
+            except (FileNotFoundError, NotFoundError):
+                target_stat = None
+            if target_stat and target_stat.get("isDir"):
+                # Previously imported in the wrapper-directory form: replace
+                # the directory with the flattened file.
+                await viking_fs.rm(
+                    msg.target_uri,
+                    recursive=True,
+                    ctx=ctx,
+                    lease_ref=lock,
+                )
+            await viking_fs.persist_temp_tree(
+                msg.uri,
+                msg.target_uri,
+                ctx=ctx,
+                lease_ref=lock,
+            )
+            final_uri = msg.target_uri
+            # persist_temp_tree copies rather than moves; drop the parse temp
+            # subtree like _sync_topdown_recursive does for directory sources.
+            temp_parent = VikingURI(msg.uri).parent
+            if temp_parent is not None and temp_parent.uri.startswith("viking://temp"):
+                try:
+                    await viking_fs.delete_temp(temp_parent.uri, ctx=ctx)
+                except Exception as e:
+                    logger.error(f"Failed to delete temp tree {temp_parent.uri}: {e}")
+
+        # Register the parent refresh before the semantic-done mark so the
+        # request wait cannot complete while the parent work is still pending.
+        await self._enqueue_parent_refresh(msg, final_uri, propagate_telemetry=True)
+        if msg.telemetry_id and msg.id:
+            get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
 
     async def on_dequeue(
         self,
@@ -380,76 +463,112 @@ class SemanticProcessor(DequeueHandlerBase):
                                 lock=semantic_lock.lock,
                             )
                         else:
-                            is_incremental = False
-                            target_uri = msg.target_uri
-                            run_uri = msg.uri
-                            changes = msg.changes
                             viking_fs = get_viking_fs()
-                            if msg.target_uri:
-                                target_exists = await viking_fs.exists(
-                                    msg.target_uri, ctx=current_ctx
+                            try:
+                                source_stat = await viking_fs.stat(msg.uri, ctx=current_ctx)
+                            except (FileNotFoundError, NotFoundError) as exc:
+                                if msg.target_uri and msg.uri != msg.target_uri:
+                                    # A pending temp source vanished before the
+                                    # sync: the target still holds old content,
+                                    # so this is a failure, not a completion
+                                    # (same contract as _sync_topdown_recursive).
+                                    raise FileNotFoundError(
+                                        "Semantic source no longer exists; refusing "
+                                        f"to sync into {msg.target_uri}: {msg.uri}"
+                                    ) from exc
+                                # The final resource itself was deleted after
+                                # enqueue: nothing left to process — complete
+                                # the message instead of retrying forever.
+                                logger.warning(
+                                    "Semantic source no longer exists, skipping: %s", msg.uri
                                 )
-                                if msg.uri != msg.target_uri:
-                                    logger.info(
-                                        "Syncing semantic source into target before processing: "
-                                        f"{msg.uri} -> {msg.target_uri}"
+                                source_stat = None
+                            if source_stat is None:
+                                if msg.telemetry_id and msg.id:
+                                    get_request_wait_tracker().mark_semantic_done(
+                                        msg.telemetry_id, msg.id
                                     )
-                                    diff = await self._sync_topdown_recursive(
-                                        msg.uri,
-                                        msg.target_uri,
-                                        ctx=current_ctx,
-                                        lock=semantic_lock.lock,
+                            elif not source_stat.get("isDir", False):
+                                # Flattened single-file resource root: no
+                                # directory DAG to run; the semantic lock is
+                                # closed by the enclosing finally.
+                                await self._process_file_root(
+                                    msg,
+                                    ctx=current_ctx,
+                                    lock=semantic_lock.lock,
+                                )
+                            else:
+                                is_incremental = False
+                                target_uri = msg.target_uri
+                                run_uri = msg.uri
+                                changes = msg.changes
+                                if msg.target_uri:
+                                    target_exists = await viking_fs.exists(
+                                        msg.target_uri, ctx=current_ctx
                                     )
-                                    logger.info(
-                                        "[SyncDiff] Diff computed: "
-                                        f"added_files={len(diff.added_files)}, "
-                                        f"deleted_files={len(diff.deleted_files)}, "
-                                        f"updated_files={len(diff.updated_files)}, "
-                                        f"added_dirs={len(diff.added_dirs)}, "
-                                        f"deleted_dirs={len(diff.deleted_dirs)}"
-                                    )
-                                    changes = diff.to_changes()
+                                    if msg.uri != msg.target_uri:
+                                        logger.info(
+                                            "Syncing semantic source into target before processing: "
+                                            f"{msg.uri} -> {msg.target_uri}"
+                                        )
+                                        diff = await self._sync_topdown_recursive(
+                                            msg.uri,
+                                            msg.target_uri,
+                                            ctx=current_ctx,
+                                            lock=semantic_lock.lock,
+                                        )
+                                        logger.info(
+                                            "[SyncDiff] Diff computed: "
+                                            f"added_files={len(diff.added_files)}, "
+                                            f"deleted_files={len(diff.deleted_files)}, "
+                                            f"updated_files={len(diff.updated_files)}, "
+                                            f"added_dirs={len(diff.added_dirs)}, "
+                                            f"deleted_dirs={len(diff.deleted_dirs)}"
+                                        )
+                                        changes = diff.to_changes()
+                                        is_incremental = True
+                                        target_uri = msg.target_uri
+                                        run_uri = msg.target_uri
+                                    elif (
+                                        target_exists and msg.changes and msg.uri == msg.target_uri
+                                    ):
+                                        is_incremental = True
+                                        logger.info(
+                                            f"Using direct incremental semantic update for: {msg.uri}"
+                                        )
+                                elif msg.changes:
                                     is_incremental = True
-                                    target_uri = msg.target_uri
-                                    run_uri = msg.target_uri
-                                elif target_exists and msg.changes and msg.uri == msg.target_uri:
-                                    is_incremental = True
+                                    target_uri = msg.uri
                                     logger.info(
                                         f"Using direct incremental semantic update for: {msg.uri}"
                                     )
-                            elif msg.changes:
-                                is_incremental = True
-                                target_uri = msg.uri
-                                logger.info(
-                                    f"Using direct incremental semantic update for: {msg.uri}"
-                                )
 
-                            executor = SemanticDagExecutor(
-                                processor=self,
-                                context_type=msg.context_type,
-                                max_concurrent_llm=self.max_concurrent_llm,
-                                ctx=current_ctx,
-                                incremental_update=is_incremental,
-                                target_uri=target_uri,
-                                semantic_msg_id=msg.id,
-                                telemetry_id=msg.telemetry_id,
-                                recursive=msg.recursive,
-                                lock=semantic_lock.lock,
-                                is_code_repo=msg.is_code_repo,
-                                changes=changes,
-                                skip_vectorization=msg.skip_vectorization,
-                                ingest_options=msg.ingest_options,
-                                coalesce_key=msg.coalesce_key,
-                                coalesce_version=msg.coalesce_version,
-                            )
-                            await executor.run(run_uri)
-                            self._cache_dag_stats(
-                                msg.telemetry_id,
-                                run_uri,
-                                executor.get_stats(),
-                            )
-                            if not executor.stale:
-                                await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
+                                executor = SemanticDagExecutor(
+                                    processor=self,
+                                    context_type=msg.context_type,
+                                    max_concurrent_llm=self.max_concurrent_llm,
+                                    ctx=current_ctx,
+                                    incremental_update=is_incremental,
+                                    target_uri=target_uri,
+                                    semantic_msg_id=msg.id,
+                                    telemetry_id=msg.telemetry_id,
+                                    recursive=msg.recursive,
+                                    lock=semantic_lock.lock,
+                                    is_code_repo=msg.is_code_repo,
+                                    changes=changes,
+                                    skip_vectorization=msg.skip_vectorization,
+                                    ingest_options=msg.ingest_options,
+                                    coalesce_key=msg.coalesce_key,
+                                    coalesce_version=msg.coalesce_version,
+                                )
+                                await executor.run(run_uri)
+                                self._cache_dag_stats(
+                                    msg.telemetry_id,
+                                    run_uri,
+                                    executor.get_stats(),
+                                )
+                                if not executor.stale:
+                                    await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
                     finally:
                         await semantic_lock.close()
                     self._merge_request_stats(msg.telemetry_id, processed=1)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -13,7 +13,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from openviking.core.context import ContextLevel
-from openviking.utils.ingest_options import IngestOptions
 from openviking.core.namespace import context_type_for_uri
 from openviking.parse.image_rewrite import rewrite_image_uris
 from openviking.parse.tree_builder import TreeBuilder
@@ -32,8 +31,9 @@ from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.embedding_utils import index_resource, vectorize_file
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.summarizer import Summarizer
-from openviking_cli.exceptions import OpenVikingError
+from openviking_cli.exceptions import NotFoundError, OpenVikingError
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.storage import StoragePath
 
@@ -287,6 +287,7 @@ class ResourceProcessor:
                         source_path=parse_result.source_path,
                         source_format=parse_result.source_format,
                         create_parent=kwargs.get("create_parent", False),
+                        allow_file_root=True,
                     )
                     if context_tree and context_tree.root:
                         result["root_uri"] = context_tree.root.uri
@@ -374,17 +375,22 @@ class ResourceProcessor:
                             dst_path = viking_fs._uri_to_path(root_uri, ctx=ctx)
                             resource_lock = await self.acquire_resource_lock(dst_path, uri=root_uri)
                     if not target_preexisting:
+                        temp_is_dir = bool((await viking_fs.stat(temp_uri, ctx=ctx)).get("isDir"))
                         await viking_fs.persist_temp_tree(
                             temp_uri,
                             root_uri,
                             ctx=ctx,
                             lease_ref=resource_lock,
                         )
-                        await rewrite_image_uris(root_uri, ctx=ctx, lease_ref=resource_lock)
-                        await viking_fs.delete_temp(
-                            parse_result.temp_dir_path,
-                            ctx=ctx,
-                        )
+                        if temp_is_dir:
+                            # Flattened file roots carry no image sidecars; the
+                            # rewrite pass only applies to directory roots.
+                            await rewrite_image_uris(
+                                root_uri,
+                                ctx=ctx,
+                                lease_ref=resource_lock,
+                            )
+                        await viking_fs.delete_temp(parse_result.temp_dir_path, ctx=ctx)
                         temp_uri = root_uri
                         source_committed = True
                 except Exception:
@@ -508,7 +514,8 @@ class ResourceProcessor:
                 sync_deleted_dirs: list[str] = []
                 if not should_summarize and temp_uri and not source_committed:
                     viking_fs = get_viking_fs()
-                    if vectors_only and target_preexisting:
+                    temp_is_dir = bool((await viking_fs.stat(temp_uri, ctx=ctx)).get("isDir"))
+                    if vectors_only and target_preexisting and temp_is_dir:
                         diff = await SemanticProcessor()._sync_topdown_recursive(
                             temp_uri,
                             root_uri,
@@ -518,17 +525,37 @@ class ResourceProcessor:
                         sync_deleted_files = list(getattr(diff, "deleted_files", []))
                         sync_deleted_dirs = list(getattr(diff, "deleted_dirs", []))
                     else:
+                        if not temp_is_dir and target_preexisting:
+                            # Re-import of a resource that previously landed in
+                            # the wrapper-directory form: replace the directory
+                            # with the flattened file and drop its old vectors.
+                            target_stat = None
+                            try:
+                                target_stat = await viking_fs.stat(root_uri, ctx=ctx)
+                            except (FileNotFoundError, NotFoundError):
+                                pass
+                            if target_stat and target_stat.get("isDir"):
+                                await viking_fs.rm(
+                                    root_uri,
+                                    recursive=True,
+                                    ctx=ctx,
+                                    lease_ref=resource_lock,
+                                )
+                                sync_deleted_dirs = [root_uri]
                         await viking_fs.persist_temp_tree(
                             temp_uri,
                             root_uri,
                             ctx=ctx,
                             lease_ref=resource_lock,
                         )
-                    await rewrite_image_uris(
-                        root_uri,
-                        ctx=ctx,
-                        lease_ref=resource_lock,
-                    )
+                    if temp_is_dir:
+                        # Flattened file roots carry no image sidecars; the
+                        # rewrite pass only applies to directory roots.
+                        await rewrite_image_uris(
+                            root_uri,
+                            ctx=ctx,
+                            lease_ref=resource_lock,
+                        )
                     if temp_dir_path:
                         await viking_fs.delete_temp(temp_dir_path, ctx=ctx)
                 if vectors_only:
@@ -575,11 +602,13 @@ class ResourceProcessor:
                 await self.vikingdb.delete(ids, ctx=ctx)
         for uri in dict.fromkeys(dirs):
             records = await self.vikingdb.filter(
-                filter=And([
-                    PathScope("uri", uri, depth=-1),
-                    Eq("level", int(ContextLevel.DETAIL)),
-                    Eq("account_id", ctx.account_id),
-                ]),
+                filter=And(
+                    [
+                        PathScope("uri", uri, depth=-1),
+                        Eq("level", int(ContextLevel.DETAIL)),
+                        Eq("account_id", ctx.account_id),
+                    ]
+                ),
                 limit=VECTORDB_MAX_QUERY_LIMIT,
                 output_fields=["id"],
                 ctx=ctx,
@@ -597,6 +626,22 @@ class ResourceProcessor:
     ) -> None:
         ingest_options = IngestOptions.from_value(ingest_options)
         viking_fs = get_viking_fs()
+        root_stat = await viking_fs.stat(root_uri, ctx=ctx)
+        if not root_stat.get("isDir"):
+            # Flattened single-file resource root: vectorize the file itself.
+            name = root_stat.get("name") or root_uri.rsplit("/", 1)[-1]
+            parent = VikingURI(root_uri).parent
+            if not str(name).startswith(".") and parent is not None:
+                await vectorize_file(
+                    file_path=root_uri,
+                    summary_dict={"name": name, "summary": ""},
+                    parent_uri=parent.uri,
+                    context_type=context_type_for_uri(root_uri),
+                    ctx=ctx,
+                    ingest_options=ingest_options,
+                    register_request_wait=True,
+                )
+            return
         entries = await viking_fs.tree(
             root_uri,
             node_limit=None,

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -84,6 +84,9 @@ class _FakeVikingFS:
             return uri in self._existing_uris
         return self._exists_result
 
+    async def stat(self, uri, ctx=None):
+        return {"name": uri.rstrip("/").rsplit("/", 1)[-1], "isDir": True}
+
     async def mkdir(self, uri, exist_ok=False, ctx=None):
         return None
 

--- a/tests/misc/test_tree_builder_dedup.py
+++ b/tests/misc/test_tree_builder_dedup.py
@@ -41,6 +41,10 @@ class TestFinalizeFromTemp:
 
         entries = {
             "viking://temp/import": [{"name": "tt_b", "isDir": True}],
+            "viking://temp/import/tt_b": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+            ],
         }
         fs = self._make_fs(entries, {"viking://resources"})
         builder = TreeBuilder()
@@ -66,6 +70,10 @@ class TestFinalizeFromTemp:
 
         entries = {
             "viking://temp/import": [{"name": "tt_b", "isDir": True}],
+            "viking://temp/import/tt_b": [
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+            ],
         }
         fs = self._make_fs(entries, {"viking://resources", "viking://resources/tt_b"})
         builder = TreeBuilder()
@@ -84,14 +92,72 @@ class TestFinalizeFromTemp:
         assert tree._candidate_uri == "viking://resources/tt_b"
 
     @pytest.mark.asyncio
-    async def test_resources_root_to_keeps_single_file_wrapper_directory(self):
+    async def test_resources_root_to_flattens_single_file_document(self):
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        # MarkdownParser preserves the code filename as the doc dir and writes
+        # the markdown body inside: aa.py/aa.md.
+        entries = {
+            "viking://temp/import": [{"name": "aa.py", "isDir": True}],
+            "viking://temp/import/aa.py": [{"name": "aa.md", "isDir": False}],
+        }
+        fs = self._make_fs(entries, {"viking://resources"})
+        builder = TreeBuilder()
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await builder.finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources",
+                allow_file_root=True,
+            )
+
+        assert tree.root.uri == "viking://resources/aa.py"
+        # Single-file code document: the resource root is the file itself,
+        # not a wrapper directory named after the document.
+        assert tree.root.temp_uri == "viking://temp/import/aa.py/aa.md"
+        assert tree._candidate_uri == "viking://resources/aa.py"
+
+    @pytest.mark.asyncio
+    async def test_exact_to_flattens_single_file_document(self):
         from openviking.parse.tree_builder import TreeBuilder
         from openviking.server.identity import RequestContext, Role
         from openviking_cli.session.user_id import UserIdentifier
 
         entries = {
-            "viking://temp/import": [{"name": "aa", "isDir": True}],
-            "viking://temp/import/aa": [{"name": "aa.md", "isDir": False}],
+            "viking://temp/import": [{"name": "build.rs", "isDir": True}],
+            "viking://temp/import/build.rs": [{"name": "build.md", "isDir": False}],
+        }
+        fs = self._make_fs(entries, {"viking://resources", "viking://resources/openviking-test"})
+        builder = TreeBuilder()
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await builder.finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources/openviking-test/build.rs",
+                allow_file_root=True,
+            )
+
+        assert tree.root.uri == "viking://resources/openviking-test/build.rs"
+        assert tree.root.temp_uri == "viking://temp/import/build.rs/build.md"
+        assert tree._candidate_uri is None
+
+    @pytest.mark.asyncio
+    async def test_file_root_disabled_keeps_directory(self):
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        entries = {
+            "viking://temp/import": [{"name": "aa.py", "isDir": True}],
+            "viking://temp/import/aa.py": [{"name": "aa.md", "isDir": False}],
         }
         fs = self._make_fs(entries, {"viking://resources"})
         builder = TreeBuilder()
@@ -105,6 +171,93 @@ class TestFinalizeFromTemp:
                 to_uri="viking://resources",
             )
 
-        assert tree.root.uri == "viking://resources/aa"
-        assert tree.root.temp_uri == "viking://temp/import/aa"
-        assert tree._candidate_uri == "viking://resources/aa"
+        # Flattening is opt-in: callers outside the resource import pipeline
+        # keep the wrapper-directory shape unless they ask for file roots.
+        assert tree.root.temp_uri == "viking://temp/import/aa.py"
+
+    @pytest.mark.asyncio
+    async def test_repository_source_keeps_directory(self):
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        # A repository named with a code-like suffix (e.g. "next.js") whose
+        # top level holds a single file must stay a directory: the doc dir
+        # name comes from the source, not from a code filename.
+        entries = {
+            "viking://temp/import": [{"name": "next.js", "isDir": True}],
+            "viking://temp/import/next.js": [{"name": "README.md", "isDir": False}],
+        }
+        fs = self._make_fs(entries, {"viking://resources"})
+        builder = TreeBuilder()
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await builder.finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources",
+                source_format="repository",
+                allow_file_root=True,
+            )
+
+        assert tree.root.temp_uri == "viking://temp/import/next.js"
+
+    @pytest.mark.asyncio
+    async def test_single_file_non_code_document_keeps_directory(self):
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        entries = {
+            "viking://temp/import": [{"name": "SECURITY.md", "isDir": True}],
+            "viking://temp/import/SECURITY.md": [{"name": "SECURITY.md", "isDir": False}],
+        }
+        fs = self._make_fs(entries, {"viking://resources", "viking://resources/openviking-test"})
+        builder = TreeBuilder()
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await builder.finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources/openviking-test/SECURITY.md",
+                allow_file_root=True,
+            )
+
+        # Non-code suffixes (.md is a documentation extension) keep the
+        # directory form even when the parse output is a single file.
+        assert tree.root.uri == "viking://resources/openviking-test/SECURITY.md"
+        assert tree.root.temp_uri == "viking://temp/import/SECURITY.md"
+        assert tree._candidate_uri is None
+
+    @pytest.mark.asyncio
+    async def test_document_with_artifacts_keeps_directory(self):
+        from openviking.parse.tree_builder import TreeBuilder
+        from openviking.server.identity import RequestContext, Role
+        from openviking_cli.session.user_id import UserIdentifier
+
+        entries = {
+            "viking://temp/import": [{"name": "report.py", "isDir": True}],
+            "viking://temp/import/report.py": [
+                {"name": "report.md", "isDir": False},
+                {"name": "media", "isDir": True},
+            ],
+        }
+        fs = self._make_fs(entries, {"viking://resources"})
+        builder = TreeBuilder()
+        ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+
+        with patch("openviking.parse.tree_builder.get_viking_fs", return_value=fs):
+            tree = await builder.finalize_from_temp(
+                temp_dir_path="viking://temp/import",
+                ctx=ctx,
+                scope="resources",
+                to_uri="viking://resources",
+                allow_file_root=True,
+            )
+
+        assert tree.root.uri == "viking://resources/report.py"
+        assert tree.root.temp_uri == "viking://temp/import/report.py"

--- a/tests/storage/test_semantic_processor_target_preexisting.py
+++ b/tests/storage/test_semantic_processor_target_preexisting.py
@@ -11,6 +11,9 @@ class _FakeVikingFS:
     async def exists(self, uri, ctx=None):
         return True
 
+    async def stat(self, uri, ctx=None):
+        return {"isDir": True}
+
 
 class _SyncVikingFS:
     def __init__(self):
@@ -44,7 +47,7 @@ class _SyncVikingFS:
         return self.entries.get(uri, [])
 
     async def stat(self, uri, ctx=None):
-        return {"size": len(self.contents.get(uri, ""))}
+        return {"size": len(self.contents.get(uri, "")), "isDir": uri in self.entries}
 
     async def read_file(self, uri, ctx=None):
         return self.contents.get(uri, "")
@@ -185,3 +188,67 @@ async def test_sync_missing_source_never_touches_target(monkeypatch):
 
     fake_fs.ls.assert_not_awaited()
     fake_fs.rm.assert_not_awaited()
+
+
+class _FileRootFS:
+    def __init__(self):
+        self.persist_calls = []
+        self.deleted_temp = []
+
+    async def stat(self, uri, ctx=None):
+        return {"isDir": False}
+
+    async def exists(self, uri, ctx=None):
+        return False
+
+    async def persist_temp_tree(self, temp_uri, target_uri, ctx=None, lease_ref=None):
+        self.persist_calls.append((temp_uri, target_uri))
+
+    async def delete_temp(self, uri, ctx=None):
+        self.deleted_temp.append(uri)
+
+
+@pytest.mark.asyncio
+async def test_file_root_source_skips_dag_and_vectorizes(monkeypatch):
+    fake_fs = _FileRootFS()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: fake_fs,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticDagExecutor",
+        _FakeDagExecutor,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=SimpleNamespace(lock=None, close=AsyncMock())),
+    )
+
+    _FakeDagExecutor.calls = []
+    _FakeDagExecutor.runs = []
+    processor = SemanticProcessor()
+    processor._enqueue_parent_refresh = AsyncMock()
+    processor._vectorize_single_file = AsyncMock()
+    msg = SemanticMsg(
+        uri="viking://temp/import/foo.py/foo.md",
+        target_uri="viking://resources/foo.py",
+        context_type="resource",
+    )
+
+    await processor.on_dequeue(msg.to_dict())
+
+    # File-shaped source: synced straight into the target, no directory DAG,
+    # and the parse temp subtree is cleaned up after the copy.
+    assert fake_fs.persist_calls == [
+        ("viking://temp/import/foo.py/foo.md", "viking://resources/foo.py")
+    ]
+    assert fake_fs.deleted_temp == ["viking://temp/import/foo.py"]
+    assert _FakeDagExecutor.calls == []
+    assert _FakeDagExecutor.runs == []
+    # The file's summary + vector come solely from the parent refresh; a
+    # direct write here would race the refresh on the same embedding ID.
+    processor._vectorize_single_file.assert_not_awaited()
+    processor._enqueue_parent_refresh.assert_awaited_once()
+    refresh_args = processor._enqueue_parent_refresh.await_args
+    assert refresh_args.args[1] == "viking://resources/foo.py"
+    assert refresh_args.kwargs.get("propagate_telemetry") is True

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from openviking.utils.ingest_options import IngestOptions
 from openviking.server.identity import RequestContext, Role
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -53,6 +53,7 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
         persist_temp_tree=AsyncMock(),
         delete_temp=AsyncMock(),
+        stat=AsyncMock(return_value={"isDir": True}),
         tree=AsyncMock(
             return_value=[
                 {"uri": "viking://resources/demo/section", "isDir": True},
@@ -72,7 +73,9 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
     vectorize_file = AsyncMock()
     rewrite_image_uris = AsyncMock()
     monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.rewrite_image_uris", rewrite_image_uris)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.rewrite_image_uris", rewrite_image_uris
+    )
     monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
     processor = ResourceProcessor(_FakeVikingDB())
     processor._get_summarizer = Mock(side_effect=AssertionError("summarizer should not run"))
@@ -133,6 +136,7 @@ async def test_vectors_only_skips_vectorization_when_build_index_false(monkeypat
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
         persist_temp_tree=AsyncMock(),
         delete_temp=AsyncMock(),
+        stat=AsyncMock(return_value={"isDir": True}),
         tree=AsyncMock(return_value=[]),
     )
     vectorize_file = AsyncMock()
@@ -167,6 +171,7 @@ async def test_vectors_only_syncs_preexisting_target_instead_of_merging(monkeypa
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
         persist_temp_tree=AsyncMock(),
         delete_temp=AsyncMock(),
+        stat=AsyncMock(return_value={"isDir": True}),
         tree=AsyncMock(return_value=[]),
     )
     sync = AsyncMock()
@@ -211,6 +216,7 @@ async def test_vectors_only_leaves_existing_semantic_vectors_untouched(monkeypat
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
         persist_temp_tree=AsyncMock(),
         delete_temp=AsyncMock(),
+        stat=AsyncMock(return_value={"isDir": True}),
         tree=AsyncMock(return_value=[]),
     )
     monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
@@ -242,6 +248,7 @@ async def test_vectors_only_deletes_sync_removed_detail_vectors(monkeypatch, ctx
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
         persist_temp_tree=AsyncMock(),
         delete_temp=AsyncMock(),
+        stat=AsyncMock(return_value={"isDir": True}),
         tree=AsyncMock(return_value=[]),
     )
     diff = SimpleNamespace(


### PR DESCRIPTION
## Description

  修复单文件导入的落地形态：此前对单个文件执行 `add_resource`（精确 `to` 或自动命名）时，解析产物会以一个"以文档命名的包裹目录"挂载到目标 URI，导致 `viking://.../demo.md` 这类目标变成目录节点。
  本 PR 使"解析产物恰好为单个内容文件"的导入直接以**文件节点**落在目标 URI 上，与目录导入中同名叶子文件的节点形态保持一致；带媒体等多产物的文档保持目录形态不变。

  ## Human Involvement

  - [x] A human participated in the implementation or review loop
  - [ ] This PR was generated entirely by AI agents without human participation in the loop

  ## Related Issue

  N/A

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Test update

  ## Changes Made

  - **`openviking/parse/tree_builder.py`**：`finalize_from_temp` 定位解析文档目录后
    增加单文件判定——目录内恰好一个普通文件且无其他产物时，资源根的 `temp_uri`
    指向该文件本身，后续 `persist_temp_tree` 原样将其持久化为目标 URI 上的文件
    节点；多产物文档（含 media/附件）不受影响。
  - **`openviking/utils/resource_processor.py`**：`_vectorize_resource_files` 增加
    文件型资源根分支，root 为文件时直接对其向量化（原目录遍历逻辑不适用），
    避免扁平化后向量构建被静默跳过。
  - **`tests/misc/test_tree_builder_dedup.py`**：翻转原先锁定"单文件保留包裹目录"
    行为的用例（重命名为 `test_resources_root_to_flattens_single_file_document`）；
    新增精确 `to` 指向文件路径的扁平化用例，以及多产物文档保持目录形态的守护
    用例。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

TreeBuilder 定向测试 5/5 通过（含 2 个新增用例与 1 个语义翻转用例）；连同
markdown 链接重写、Connector 路由等关联套件共 112 个测试通过；`ruff check`
与 `ruff format` 通过。`tests/misc` 下另有若干失败项经分支基线复跑确认为
既有环境问题，与本改动无关。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- **行为变化说明**：单文件导入的资源根从"目录节点（内含解析产物）"变为
  "文件节点"。依赖旧目录形态的调用方需注意；存量已导入的单文件资源不会自动
  迁移，重新导入即可获得新形态。