### PR TITLE
fix(import): avoid runtime storage package lazy imports for VikingDB …

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -21,7 +21,7 @@ from openviking.models.rerank import RerankClient
 from openviking.retrieve.memory_lifecycle import hotness_score
 from openviking.retrieve.retrieval_stats import get_stats_collector
 from openviking.server.identity import RequestContext
-from openviking.storage import VikingDBManager, VikingDBManagerProxy
+from openviking.storage.vikingdb_manager import VikingDBManager, VikingDBManagerProxy
 from openviking.storage.expr import FilterExpr
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.time_utils import parse_iso_datetime

--- a/openviking/server/routers/debug.py
+++ b/openviking/server/routers/debug.py
@@ -17,7 +17,7 @@ from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import ErrorInfo, Response
-from openviking.storage import VikingDBManagerProxy
+from openviking.storage.vikingdb_manager import VikingDBManagerProxy
 
 router = APIRouter(prefix="/api/v1/debug", tags=["debug"])
 

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -17,7 +17,7 @@ from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.routers.content import SetTagsRequest
 from openviking.server.routers.content import set_tags as content_set_tags
-from openviking.storage import VikingDBManagerProxy
+from openviking.storage.vikingdb_manager import VikingDBManagerProxy
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 
 router = APIRouter(prefix="/api/v1/fs", tags=["filesystem"])

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -25,7 +25,7 @@ from openviking.service.search_service import SearchService
 from openviking.service.session_service import SessionService
 from openviking.service.task_tracker import set_task_tracker
 from openviking.session import create_session_compressor
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.collection_schemas import init_context_collection
 from openviking.storage.index_consistency import check_index_consistency
 from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor

--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from openviking.server.identity import RequestContext
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.observers import (
     FilesystemObserver,
     ModelsObserver,

--- a/openviking/service/resource_memory_link_service.py
+++ b/openviking/service/resource_memory_link_service.py
@@ -33,7 +33,7 @@ from openviking.session.memory.utils.resource_refs import (
     resource_ref_matches,
     unlink_resource_references_from_memory,
 )
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.viking_fs import VikingFS, get_viking_fs
 from openviking_cli.exceptions import NotFoundError
 from openviking_cli.utils import get_logger

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -40,7 +40,7 @@ from openviking.server.user_config import (
     effective_resource_add_target,
     effective_skill_add_target,
 )
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.queuefs import QueueManager, get_queue_manager
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -16,7 +16,7 @@ from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory_policy import MemoryPolicy
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import (
     AlreadyExistsError,

--- a/openviking/session/__init__.py
+++ b/openviking/session/__init__.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from openviking.session.session import Session, SessionCompression, SessionMeta, SessionStats
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)

--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -28,7 +28,7 @@ from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.memory.utils.uri import render_template
 from openviking.session.skill import SkillOperationUpdater, dedup_session_skill_operations
 from openviking.session.skill.session_skill_context_provider import SESSION_SKILL_MEMORY_TYPE
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.viking_fs import VikingFS, get_viking_fs
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.utils.skill_processor import SkillProcessor

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -24,7 +24,7 @@ from openviking.resource.processing_mode import (
     normalize_processing_mode,
 )
 from openviking.server.identity import RequestContext
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.expr import And, Eq, PathScope
 from openviking.storage.internal_names import STORAGE_INTERNAL_ENTRY_NAMES

--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -27,7 +27,7 @@ from openviking.privacy import (
 )
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import deny_direct_local_skill_input
-from openviking.storage import VikingDBManager
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry


### PR DESCRIPTION
## Description

Avoid runtime imports of `VikingDBManager` / `VikingDBManagerProxy` through the `openviking.storage` package root, so the storage package no longer has to resolve these symbols via `__getattr__` lazy loading during module import.

## Related Issue

Related to #3565

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Replaced runtime imports of `VikingDBManager` / `VikingDBManagerProxy` from `openviking.storage` with direct imports from `openviking.storage.vikingdb_manager`
- Updated affected service, session, utility, retriever, and router modules without changing business logic or public behavior
- Kept `TYPE_CHECKING`-only imports unchanged so only runtime import resolution is affected

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Verification performed locally by importing the affected modules after the change and by scanning the codebase to confirm there are no remaining runtime imports of `VikingDBManager` / `VikingDBManagerProxy` from `openviking.storage`
- Temporary red/green verification script used during development was removed after validation
- Windows runtime reproduction has not been re-validated in this change; this PR removes the problematic runtime import path in the current codebase