### PR TITLE
fix(search): event summary unreachable regex + ratio threshold + blank speaker turns (#3598)

### DIFF
--- a/openviking/prompts/templates/memory/events.yaml
+++ b/openviking/prompts/templates/memory/events.yaml
@@ -100,7 +100,7 @@ content_template: |
   # Summary
   {{ summary }}
   # {{extract_context.get_first_message_time_with_weekday_from_ranges(ranges|default(''))|default('N/A')}} ChatLog:
-  {{ extract_context.get_event_content(ranges, summary, 0) }}
+  {{ extract_context.get_event_content(ranges, summary) }}
   {% endif %}
 embedding_template: |-
   EventName: {{ event_name }}

--- a/openviking/retrieve/type_quota_recall.py
+++ b/openviking/retrieve/type_quota_recall.py
@@ -218,10 +218,30 @@ def _filename_from_uri(uri: str) -> str:
 
 
 def _extract_event_summary(content: str, fallback: str = "") -> str:
+    """Extract only the summary section from an events memory document.
+
+    The extractor writes the document in two shapes depending on whether the
+    session had externally-provided ``resource_event_content``. The common
+    (larger) ``else`` branch in ``events.yaml`` emits ``# Summary`` followed
+    by ``# <date> (<weekday>) ChatLog:``; the resource branch produces a
+    single prose string without a ChatLog. The legacy regex expected the
+    long-superseded ``Summary:`` prefix (no ``#``) paired with a terminator
+    that had no heading marker, so neither anchor matched and the fallback
+    was always used (issue #3598, defect #1 + correction #1).
+
+    The relaxed pattern accepts:
+    * an optional leading ``#`` on the summary anchor, optional colon
+      (supports both the current ``# Summary`` title form and any legacy
+      ``Summary:`` field form that may still appear in older documents).
+    * an optional leading ``#`` before the date/ChatLog terminator so the
+      current markdown heading style terminates the capture correctly.
+    * the usual MEMORY_FIELDS sentinel and end-of-string for resource-event
+      or summary-only documents that lack a ChatLog block.
+    """
     if content:
         match = re.search(
-            r"(?is)^\s*Summary:\s*(.*?)(?:\n\s*\d{4}-\d{2}-\d{2}"
-            r"(?:\s*\([^)]+\))?\s*ChatLog:|\n\s*ChatLog:|\n\s*<!--\s*MEMORY_FIELDS|$)",
+            r"(?is)^\s*\#*\s*Summary:?\s*(.*?)(?:\n\s*\#*\s*\d{4}-\d{2}-\d{2}"
+            r"(?:\s*\([^)]+\))?\s*ChatLog:|\n\s*\#*\s*ChatLog:|\n\s*<!--\s*MEMORY_FIELDS|$)",
             content,
         )
         if match:

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -578,7 +578,14 @@ class MessageRange:
             if not current_messages:
                 return
             content = self._format_merged_content(current_messages)
-            formatted.append(f"**{self._speaker_for(current_messages[0])}**: {content}")
+            # Defect #3598-4: tool-call-only turns carry no TextPart, so the
+            # merged content can be empty. Writing a bare "**speaker**: " line
+            # wastes 36 bytes/turn with no semantic value; observed 55% blank
+            # turns across 17 production event documents, accounting for ~40% of
+            # some documents' bytes. Those bytes then leak into the embedding
+            # template as well (embedding_template uses the rendered transcript).
+            if content.strip():
+                formatted.append(f"**{self._speaker_for(current_messages[0])}**: {content}")
             current_messages = []
 
         for msg in msg_group:

--- a/tests/unit/test_issue3598_event_summary.py
+++ b/tests/unit/test_issue3598_event_summary.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit regressions for the four event-sum / recall defects from issue #3598.
+
+The issue describes defects #1..#4 that compound to eat nearly the entire
+``max_chars`` recall budget on verbatim chat transcripts (including blank
+speaker lines from tool-call-only turns). Defect #2 (fallback fragment type
+budget charging) was corrected by the reporter as an intentional design call
+(summary-mode fallbacks are charged only to the shared pool because the
+summary-only fragment still degrades further to URI at the end of the
+pipeline), so this file only exercises defects #1, #3, #4.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestExtractEventSummaryAnchorMatch:
+    """Defect #1 + comment correction: regex didn't match the current template output.
+
+    The extractor writes a markdown heading (``# Summary``) and the terminator
+    line is also a markdown heading (``# YYYY-MM-DD (Weekday) ChatLog:``).
+    The old regex expected a field form (``Summary:`` followed by a bare date
+    line with no heading marker), so neither anchor nor terminator matched,
+    and ``fallback`` (the full stripped document) was always returned. The
+    template also has a resource-event content branch that has no ChatLog at
+    all, so end-of-string must terminate the capture for that shape.
+    """
+
+    @pytest.mark.parametrize(
+        ("heading", "terminator", "expected"),
+        [
+            # The exact template shape that caused the original bug report
+            (
+                "# Summary\nShipped the thing.\n",
+                "# 2026-07-24 (Friday) ChatLog:\n",
+                "Shipped the thing.",
+            ),
+            # Legacy "Summary:" field form, any of the three terminator options
+            (
+                "Summary: Planned agenda.\n",
+                "2026-07-24 ChatLog:\n",
+                "Planned agenda.",
+            ),
+            # Bare ChatLog: terminator (no date) with heading marker
+            (
+                "# Summary\nA short summary.\n",
+                "# ChatLog:\n",
+                "A short summary.",
+            ),
+            # MEMORY_FIELDS sentinel terminator (metadata block form)
+            (
+                "# Summary\nMeta summary line.\n",
+                "<!-- MEMORY_FIELDS {\"k\":\"v\"} -->\n",
+                "Meta summary line.",
+            ),
+            # Summary-only shape (resource-event branch) — end-of-string terminator
+            (
+                "# Summary\nSingle paragraph.\nSecond line of summary.\n",
+                "",
+                "Single paragraph. Second line of summary.",
+            ),
+            # Whitespace + heading number variations are tolerated on both sides
+            (
+                "  ##  Summary :   Spaces.  \n",
+                "  ### 2026-01-01 (Thu)  ChatLog: \n",
+                "Spaces.",
+            ),
+        ],
+    )
+    def test_anchor_and_terminators_match_all_writer_shapes(
+        self, heading: str, terminator: str, expected: str
+    ) -> None:
+        from openviking.retrieve.type_quota_recall import _extract_event_summary
+
+        doc = heading + terminator + "irrelevant conversation lines here."
+        got = _extract_event_summary(doc, fallback=doc)
+        assert got == expected, f"mismatch for doc={doc!r}"
+
+    def test_fallback_returned_when_no_summary_shape_present(self) -> None:
+        from openviking.retrieve.type_quota_recall import _extract_event_summary
+
+        fallback = "Random raw text that has no Summary heading at all."
+        assert _extract_event_summary(fallback, fallback=fallback) == fallback
+        assert _extract_event_summary("", fallback=fallback) == fallback
+
+    def test_reporter_minimal_example_from_issue_body(self) -> None:
+        from openviking.retrieve.type_quota_recall import _extract_event_summary
+
+        # Exact scenario reproduced verbatim from issue minimal repro
+        doc = (
+            "# Summary\n"
+            "Shipped the thing.\n"
+            "# 2026-07-24 (Friday) ChatLog:\n"
+            "**alice**: did we ship?\n"
+            "**alice**: \n"
+        )
+        assert _extract_event_summary(doc, fallback=doc) == "Shipped the thing."
+
+
+class TestGetEventContentDefaultRatio:
+    """Defect #3: the single template call-site hardcoded ``ratio_threshold=0``.
+
+    With ``0`` the ``len(summary)/len(original) >= 0`` check always passes,
+    so the function would return the full pretty-printed transcript every
+    time, never the summary. The template now drops the third argument so
+    the method's own default (``0.2``) kicks in, which is the original
+    intent. This test guards the default value at the function boundary, so
+    a future regression that re-adds the literal ``0`` on the template side
+    will still get caught by a reviewer comparing the numeric literals here.
+    """
+
+    def test_method_default_ratio_is_0pt2_not_zero(self) -> None:
+        import inspect
+
+        from openviking.session.memory.memory_updater import ExtractContext
+
+        sig = inspect.signature(ExtractContext.get_event_content)
+        default = sig.parameters["ratio_threshold"].default
+        assert default == 0.2, (
+            f"Expected ratio_threshold default to be 0.2 (summary must be "
+            f"under a 5x size gain), got {default!r}. Zero would short-circuit "
+            f"the comparison and always return the full verbatim transcript."
+        )
+
+    def test_ratio_0pt2_returns_summary_when_it_saves_space(self) -> None:
+        from unittest.mock import MagicMock
+
+        from openviking.session.memory.memory_updater import ExtractContext
+
+        class _FakeMsgRange:
+            def __init__(self, s: str) -> None:
+                self._s = s
+
+            def pretty_print(self) -> str:
+                return self._s
+
+        ctx = ExtractContext.__new__(ExtractContext)
+        ctx.read_message_ranges = lambda r, _s=_FakeMsgRange: _s(
+            "x" * 500,  # original = 500 chars -> len(summary)/len(original)=0.04 < 0.2
+        )  # type: ignore[attr-defined]
+
+        # Summary is 4% the size of the original => should return the summary
+        assert ctx.get_event_content("r", "Short summary text.", 0.2) == (
+            "Short summary text."
+        )
+
+        # Summary is >= 0.2 => returns original (defect #3 path, ratio=0)
+        ctx.read_message_ranges = lambda r, _s=_FakeMsgRange: _s(
+            "x" * 100
+        )  # type: ignore[attr-defined]
+        assert ctx.get_event_content("r", "Short.", 0.2) == "x" * 100
+
+
+class TestFormatContiguousGroupSkipsBlankTurns:
+    """Defect #4: ``flush_current`` appended speaker lines even for empty content.
+
+    A tool-call-only turn has no TextPart, so ``_format_merged_content``
+    returns ``""`` and the rendered ChatLog gets a ``**speaker**: `` line
+    (roughly 36 bytes of nothing). Across a real session this can easily
+    account for 40%+ of the rendered bytes once tool calls dominate. The
+    embedding template also mirrors the rendered transcript, so those
+    blank lines pollute recall vectors as well.
+    """
+
+    def test_blank_text_message_group_returns_no_speaker_line(self) -> None:
+        from openviking.message.message import Message
+        from openviking.message.part import ToolCallPart, ToolPart
+        from openviking.session.memory.memory_updater import ExtractContext
+
+        ctx = ExtractContext.__new__(ExtractContext)
+        tool_call_msg = Message(
+            id="m1",
+            role="assistant",
+            parts=[
+                ToolCallPart(tool_call_id="t1", tool_name="noop", arguments="{}")
+            ],
+        )
+        tool_result_msg = Message(
+            id="m2",
+            role="tool",
+            parts=[ToolPart(tool_call_id="t1", content='{"ok":true}')],
+        )
+        assert ctx._format_contiguous_group([tool_call_msg, tool_result_msg]) == []  # no TextParts
+
+    def test_blank_then_text_mixture_preserves_only_text_turns(self) -> None:
+        from openviking.message.message import Message
+        from openviking.message.part import TextPart, ToolCallPart
+        from openviking.session.memory.memory_updater import ExtractContext
+
+        ctx = ExtractContext.__new__(ExtractContext)
+        text_msg = Message(
+            id="m1",
+            role="user",
+            peer_id="bob",
+            parts=[TextPart(text="hello world")],
+        )
+        only_tool = Message(
+            id="m2",
+            role="assistant",
+            parts=[
+                ToolCallPart(tool_call_id="t1", tool_name="noop", arguments="{}")
+            ],
+        )
+        lines = ctx._format_contiguous_group([text_msg, only_tool])
+        # Only the user's line (bob) appears. The assistant tool-only turn is
+        # skipped completely instead of emitting "**assistant**: ".
+        assert lines == ["**bob**: hello world"]


### PR DESCRIPTION
## 背景

Issue #3598 报告召回（`POST /api/v1/search/recall`）在 mode=summary 时，事件（events）层几乎把全部 `max_chars` 预算花在完整逐字聊天记录上——观测到线上 17 篇事件文档共 51,752 字符，其中 92.5% 是 ChatLog，单篇最高 88% 的 turn 是工具调用空 turn。一个 `type="summary"` 片段本应只有 465 字符，却渲染出 6466 字符（相当于 full 片段）。原因是 3 个小缺陷各自独立，但组合起来放大了开销：

1. **`_extract_event_summary()` 正则从未匹配**：模板写 `# Summary` / `# 2026-07-24 (Friday) ChatLog:`，旧正则要求 `Summary:` / `<date> ChatLog:`（均无 `# ` 标题前缀），两个端点都错位 → 始终走 fallback（全文）。Reporter 第一次验证时以为只改锚点即可，重验后确认 **锚点 + 终止符** 都需要放松（#3598 correction #1）。
2. **模板硬编码 `ratio_threshold=0`**：`events.yaml` 的 `content_template` 把 `get_event_content(ranges, summary, 0)` 第三参写死为 0，`len(summary) / len(original) >= 0` 永远为 true → 永远返回逐字 pretty-print transcript，而不是当 summary 是原文 20% 以内时优先用 summary。方法默认值 0.2，模板单点覆写使分支成为死代码。
3. **工具调用空 turn 也写 speaker 行**：`_format_contiguous_group.flush_current()` 无条件追加 `**speaker**: {content}`。纯 ToolCallPart / ToolPart 的 turn 没有 TextPart，`_format_merged_content` 为空串，每 turn 产生 36 字节 `**alice**: `空行；样本里 55% 的 turn 是空 turn，占单文档字节数 40%，并且这些空行继续进入 embedding template。

Defect #2（fallback 片段不计入 type 级 budget）Reporter 已纠正为**有意设计**（见代码里 `type_quota_recall.py:449-451` 原注释），因此未改动。

## 改动内容

### `openviking/retrieve/type_quota_recall.py` — 放松正则两端
`_extract_event_summary()`：

```python
r"(?is)^\s*\#*\s*Summary:?\s*(.*?)(?:\n\s*\#*\s*\d{4}-\d{2}-\d{2}"
r"(?:\s*\([^)]+\))?\s*ChatLog:|\n\s*\#*\s*ChatLog:|\n\s*<!--\s*MEMORY_FIELDS|$)"
```

- **锚点**：`^\s*\#*\s*Summary:?\s*` — 支持当前 `# Summary` 标题风格 / 历史 `Summary:` 字段形式 / 不带 chatlog 的 resource branch 散文形式。
- **终止符**：日期行 / 纯 ChatLog 行都加上可选的 `\s*\#*\s*` 前缀，保留 MEMORY_FIELDS sentinel 与 `$`，保证 resource-event 分支 / summary-only 文档正确终止。
- 增加 docstring，列出 #3598 defect #1 与 correction #1 以便后续回溯。

### `openviking/prompts/templates/memory/events.yaml` — 删除 ratio_threshold=0
L103 原来：`{{ extract_context.get_event_content(ranges, summary, 0) }}`
改成：`{{ extract_context.get_event_content(ranges, summary) }}`
→ 走 `ExtractContext.get_event_content` 方法签名默认值 `0.2`。

### `openviking/session/memory/memory_updater.py` — flush_current 跳过空内容
`_format_contiguous_group.flush_current()` 在 append 前加 `if content.strip():`。纯 ToolCall/ToolResult 消息不再产生空 speaker 行，同时减少进入 `embedding_template: EventName / Goal / {{ content }}` 的垃圾字符。

### `tests/unit/test_issue3598_event_summary.py` — 回归测试 3 组
- **TestExtractEventSummaryAnchorMatch**：6 种 terminator/writer shape（当前模板风格、legacy field 形式、MEMORY_FIELDS sentinel、summary-only resource branch、heading 变体）+ fallback 分支 + issue body 内最小可复现样例，共 8 个用例。
- **TestGetEventContentDefaultRatio**：signature 默认值是 0.2（防止有人又把 0 写回去），以及 ratio=0.2 边界选择 summary vs original 的行为。
- **TestFormatContiguousGroupSkipsBlankTurns**：纯 tool-call-only 组结果为 `[]`，以及 text + tool 混合时只保留有文本的 speaker 行。

## 验证方式

- 纯 regex 断言用 `python3 <<'PYEOF'` 对 #3598 最小样例精确复现：修改前返回 `fallback=全文`，修改后返回 `"Shipped the thing."`。
- 历史形式向后兼容：`"Summary: Legacy.\n2025-01-01 ChatLog:\n..."` → 返回 `"Legacy."`。
- MEMORY_FIELDS sentinel 终止、summary-only（resource branch）`$` 终止均验证通过。
- AST parse 对三个改源文件均通过。

注：项目根 conftest 导入链路中 `openviking_cli/utils/async_utils.py:15` 使用了 `asyncio.AbstractEventLoop | None`（Python 3.10+ union 语法），而当前执行环境是 Python 3.9，这与本次改动无关，是仓库已有的 baseline 环境限制。在配备 Python 3.10+ 的 CI 环境中可正常跑 `pytest tests/unit/test_issue3598_event_summary.py`。

## 影响范围

- **召回 API**：`search_type_quota_recall` 在 mode="summary" 下的片段体积从「全文」量级降到「实际 Summary section」量级（即 Reporter 观察到的 6466 → 465 char）。
- **事件抽取大小**：`get_event_content` 激活 20% 比例门限，summary 紧凑时 ChatLog 改为 summary，减小落盘与向量 embedding 体积。
- **向量 embedding 质量**：embedding_template 里 `{{ content }}` 不再包含数百字节的 "**speaker**: " 空行，召回相关性可提升（纯噪声被移除）。
- **向后兼容**：正则放宽两端，旧文档上 `Summary:` 字段形式仍被正确识别；`$` 终止保证 resource-event branch 不被破坏。
- **无破坏性**：没有改签名 / 没有改 API contract / 没有移除任何字段。

## Checklist

- [x] 正则锚点 / 终止符 **两端** 全部按 Reporter correction #1 更新（非只改锚点）。
- [x] 模板 ratio_threshold=0 删除 → 方法签名默认 0.2。
- [x] flush_current 空串 guard。
- [x] 三个缺陷对应三组独立回归测试（失败时可精确定位到是哪一个 defect 回归）。
- [x] 最小可复现断言 1:1 对齐 issue body。
- [x] 向后兼容 legacy 文档形状。
- [ ] （CI）Python 3.10+ 环境执行 `pytest tests/unit/test_issue3598_event_summary.py -xvs`。
