### PR TITLE
fix(codex-memory): preserve session peer during sweeps

### DIFF
--- a/examples/codex-memory-plugin/DESIGN.md
+++ b/examples/codex-memory-plugin/DESIGN.md
@@ -218,6 +218,8 @@ OV session id, while commits create additional archives under that session.
 {
   "codexSessionId": "0193af...",   // codex thread id
   "ovSessionId": "cx-0193af...-or-null", // null means "committed, awaiting next Stop"
+  "actorPeerId": "-Users-x-Dev-OpenViking", // effective peer fixed for this session
+  "workspacePeerId": "-Users-x-Dev-OpenViking", // compatibility for older plugin versions
   "capturedTurnCount": 7,            // turns from transcript already appended
   "createdAt": 1715000000000,
   "lastUpdatedAt": 1715000300000
@@ -228,6 +230,15 @@ Legacy state files from earlier plugin versions may still contain a UUID
 `ovSessionId`; those are now overwritten with the derived `cx-*` id on the
 next resolve. The migration window for preserving old UUID sessions has
 closed.
+
+`actorPeerId` records the effective actor identity at session creation so a
+later SessionStart sweep can commit orphaned state from another workspace
+without borrowing the new session's peer. An empty string records that peer
+isolation was intentionally disabled; `null` means the state has not recorded
+an identity yet. `workspacePeerId` remains as a fallback for state written
+before `actorPeerId` was introduced. If neither field identifies the actor,
+the sweep preserves the state and skips automatic commit instead of guessing
+or broadening peer access.
 
 State files are atomic-write (tmpfile + rename) to survive crash mid-write.
 

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -105,6 +105,13 @@ Auth is sent as `Authorization: Bearer <api_key>` to both the REST API (used by 
 
 By default the plugin derives a peer from the current workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. Hooks pass the effective peer as `peer_id` for captured session messages and as `X-OpenViking-Actor-Peer` for retrieval/filesystem calls; MCP gets the same header mapping.
 
+The effective actor peer is persisted with each Codex session state. When
+SessionStart cleans up an orphaned session from another workspace, it commits
+with that orphan's saved peer rather than the workspace that is starting now.
+Legacy state that predates both saved peer fields is preserved for manual
+recovery instead of guessing an unrelated workspace identity or removing the
+peer isolation filter.
+
 Set `actor_peer_id` in `ovcli.conf` (or `OPENVIKING_PEER_ID` with `OPENVIKING_CREDENTIAL_SOURCE=env`) to override the workspace-derived peer. The legacy `codex.peerId` / `codex.peer_id` fields in `ov.conf` still resolve as a fallback. Set `OPENVIKING_WORKSPACE_PEER=0` or `codex.workspacePeer=false` to turn off workspace-derived peers.
 
 Recall defaults to the broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces penalized and rendered later. Set `OPENVIKING_RECALL_PEER_SCOPE=actor` or `codex.recallPeerScope="actor"` for the isolation mode, which only sees global memory plus the current workspace. In deployments where one bot serves multiple real people, such as zouk, vikingbot, or AstrBot, use the isolation mode with an explicit actor peer so one person's memories are not recalled into another person's session.

--- a/examples/codex-memory-plugin/scripts/auto-capture.mjs
+++ b/examples/codex-memory-plugin/scripts/auto-capture.mjs
@@ -190,7 +190,10 @@ async function main() {
   const sessionId = input.session_id || "unknown";
   const transcriptPath = input.transcript_path || null;
   const state = await loadState(sessionId);
-  activePeerId = cfg.peerId || state.workspacePeerId || resolveEffectivePeerId({ cfg, cwd: process.cwd() }).peerId;
+  activePeerId = state.actorPeerId !== null && state.actorPeerId !== undefined
+    ? state.actorPeerId
+    : (state.workspacePeerId || resolveEffectivePeerId({ cfg, cwd: process.cwd() }).peerId);
+  state.actorPeerId = activePeerId;
   log("start", { sessionId, transcriptPath, hasPeer: Boolean(activePeerId) });
 
   const health = await fetchJSON("/health");

--- a/examples/codex-memory-plugin/scripts/pre-compact-capture.mjs
+++ b/examples/codex-memory-plugin/scripts/pre-compact-capture.mjs
@@ -141,7 +141,10 @@ async function main() {
   const transcriptPath = input.transcript_path || null;
   const trigger = input.trigger || "auto";
   const state = await loadState(sessionId);
-  activePeerId = cfg.peerId || state.workspacePeerId || resolveEffectivePeerId({ cfg, cwd: process.cwd() }).peerId;
+  activePeerId = state.actorPeerId !== null && state.actorPeerId !== undefined
+    ? state.actorPeerId
+    : (state.workspacePeerId || resolveEffectivePeerId({ cfg, cwd: process.cwd() }).peerId);
+  state.actorPeerId = activePeerId;
   log("start", { sessionId, transcriptPath, trigger, hasPeer: Boolean(activePeerId) });
 
   const health = await fetchJSON("/health");

--- a/examples/codex-memory-plugin/scripts/session-start-commit.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.mjs
@@ -78,7 +78,7 @@ function emitAdditionalContext(additionalContext) {
   });
 }
 
-async function fetchJSON(path, init = {}) {
+async function fetchJSON(path, init = {}, actorPeerId = activePeerId) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), cfg.captureTimeoutMs);
   try {
@@ -89,7 +89,7 @@ async function fetchJSON(path, init = {}) {
     }
     if (cfg.sendIdentityHeaders && cfg.account) headers["X-OpenViking-Account"] = cfg.account;
     if (cfg.sendIdentityHeaders && cfg.user) headers["X-OpenViking-User"] = cfg.user;
-    if (activePeerId) headers["X-OpenViking-Actor-Peer"] = activePeerId;
+    if (actorPeerId) headers["X-OpenViking-Actor-Peer"] = actorPeerId;
     if (cfg.userAgent) headers["User-Agent"] = cfg.userAgent;
     const res = await fetch(`${cfg.baseUrl}${path}`, { ...init, headers, signal: controller.signal });
     const body = await res.json().catch(() => null);
@@ -103,11 +103,12 @@ async function fetchJSON(path, init = {}) {
   }
 }
 
-async function commitOvSession(ovSessionId) {
+async function commitOvSession(ovSessionId, actorPeerId) {
   if (!ovSessionId) return null;
   return fetchJSON(
     `/api/v1/sessions/${encodeURIComponent(ovSessionId)}/commit`,
     { method: "POST", body: JSON.stringify({}) },
+    actorPeerId,
   );
 }
 
@@ -189,7 +190,26 @@ async function injectResumeArchive(newSessionId) {
 async function commitAndClear(state, reason) {
   if (state.ovSessionId) {
     const ovSessionId = state.ovSessionId;
-    const commit = await commitOvSession(state.ovSessionId);
+    // A SessionStart sweep may commit state created by another workspace.
+    // Use that session's persisted actor identity instead of the peer derived
+    // from the workspace that happens to be starting now. For state written
+    // before actorPeerId existed, workspacePeerId is the exact prior identity.
+    // An explicitly persisted empty actorPeerId means peer isolation was
+    // intentionally disabled. If neither identity field is known, preserve
+    // the state instead of guessing or broadening access.
+    const hasActorPeerId = Object.prototype.hasOwnProperty.call(state, "actorPeerId")
+      && state.actorPeerId !== null
+      && state.actorPeerId !== undefined;
+    const actorPeerId = hasActorPeerId ? state.actorPeerId : (state.workspacePeerId || "");
+    if (!hasActorPeerId && !actorPeerId) {
+      logError("commit_missing_peer_keep_state", {
+        reason,
+        codexSessionId: state.codexSessionId,
+        ovSessionId: state.ovSessionId,
+      });
+      return { committed: false, ovSessionId: null };
+    }
+    const commit = await commitOvSession(state.ovSessionId, actorPeerId);
     if (!commit) {
       logError("commit_failed_keep_state", {
         reason,
@@ -242,9 +262,15 @@ async function main() {
   activePeerId = effectivePeer.peerId;
   if (newSessionId !== "unknown") {
     const state = await loadState(newSessionId);
+    const hasActorPeerId = state.actorPeerId !== null && state.actorPeerId !== undefined;
+    activePeerId = hasActorPeerId
+      ? state.actorPeerId
+      : (state.workspacePeerId || effectivePeer.peerId);
     await saveState({
       ...state,
-      workspacePeerId: effectivePeer.source === "workspace" ? effectivePeer.peerId : "",
+      actorPeerId: activePeerId,
+      workspacePeerId: state.workspacePeerId
+        || (!hasActorPeerId && effectivePeer.source === "workspace" ? effectivePeer.peerId : ""),
     });
   }
   log("start", {

--- a/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+function writeJson(res, value) {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(value));
+}
+
+async function withMockOpenViking(fn) {
+  const commitCalls = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    if (req.method === "GET" && url.pathname === "/health") {
+      writeJson(res, { status: "ok", result: { ok: true } });
+      return;
+    }
+    if (req.method === "POST" && url.pathname.endsWith("/commit")) {
+      commitCalls.push({
+        path: url.pathname,
+        actorPeerId: req.headers["x-openviking-actor-peer"],
+      });
+      writeJson(res, {
+        status: "ok",
+        result: { archived: true, task_id: "task-test", status: "done" },
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "error", error: "not found" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address();
+    return await fn({
+      baseUrl: `http://127.0.0.1:${port}`,
+      commitCalls,
+    });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function runSessionStart(input, env, cwd) {
+  return new Promise((resolve, reject) => {
+    const cleanEnv = { ...process.env };
+    for (const key of Object.keys(cleanEnv)) {
+      if (key.startsWith("OPENVIKING_")) delete cleanEnv[key];
+    }
+    const child = spawn(process.execPath, [join(SCRIPT_DIR, "session-start-commit.mjs")], {
+      cwd,
+      env: { ...cleanEnv, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`session-start-commit exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+function baseEnv(stateDir, baseUrl, extra = {}) {
+  return {
+    OPENVIKING_CODEX_STATE_DIR: stateDir,
+    OPENVIKING_CONFIG_FILE: join(stateDir, "missing-ov.conf"),
+    OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
+    OPENVIKING_CREDENTIAL_SOURCE: "env",
+    OPENVIKING_RECALL_COMPRESS_DETECT_ON_STARTUP: "0",
+    OPENVIKING_TIMEOUT_MS: "5000",
+    OPENVIKING_URL: baseUrl,
+    ...extra,
+  };
+}
+
+async function writeState(stateDir, state) {
+  await writeFile(join(stateDir, `${state.codexSessionId}.json`), JSON.stringify(state));
+}
+
+test("SessionStart commits a recently active session with that session's actor peer", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-peer-"));
+  try {
+    await writeState(stateDir, {
+      codexSessionId: "old-session",
+      ovSessionId: "cx-old-session",
+      actorPeerId: "peer-from-old-session",
+      workspacePeerId: "legacy-workspace-peer",
+      capturedTurnCount: 2,
+      createdAt: Date.now(),
+      lastUpdatedAt: Date.now(),
+    });
+
+    await withMockOpenViking(async ({ baseUrl, commitCalls }) => {
+      await runSessionStart(
+        { session_id: "new-session", source: "startup" },
+        baseEnv(stateDir, baseUrl, { OPENVIKING_PEER_ID: "peer-from-new-session" }),
+        stateDir,
+      );
+
+      assert.deepEqual(commitCalls, [{
+        path: "/api/v1/sessions/cx-old-session/commit",
+        actorPeerId: "peer-from-old-session",
+      }]);
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart falls back to workspacePeerId for pre-actorPeerId state", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-workspace-peer-"));
+  try {
+    await writeState(stateDir, {
+      codexSessionId: "legacy-session",
+      ovSessionId: "cx-legacy-session",
+      workspacePeerId: "peer-from-legacy-state",
+      capturedTurnCount: 1,
+      createdAt: Date.now(),
+      lastUpdatedAt: Date.now(),
+    });
+
+    await withMockOpenViking(async ({ baseUrl, commitCalls }) => {
+      await runSessionStart(
+        { session_id: "new-session", source: "startup" },
+        baseEnv(stateDir, baseUrl, { OPENVIKING_PEER_ID: "peer-from-new-session" }),
+        stateDir,
+      );
+
+      assert.equal(commitCalls[0]?.actorPeerId, "peer-from-legacy-state");
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart preserves legacy state whose actor peer is unknown", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-unknown-peer-"));
+  try {
+    await writeState(stateDir, {
+      codexSessionId: "unknown-peer-session",
+      ovSessionId: "cx-unknown-peer-session",
+      capturedTurnCount: 1,
+      createdAt: Date.now(),
+      lastUpdatedAt: Date.now(),
+    });
+
+    await withMockOpenViking(async ({ baseUrl, commitCalls }) => {
+      await runSessionStart(
+        { session_id: "new-session", source: "startup" },
+        baseEnv(stateDir, baseUrl, { OPENVIKING_PEER_ID: "peer-from-new-session" }),
+        stateDir,
+      );
+
+      assert.deepEqual(commitCalls, []);
+      const preserved = JSON.parse(
+        await readFile(join(stateDir, "unknown-peer-session.json"), "utf-8"),
+      );
+      assert.equal(preserved.ovSessionId, "cx-unknown-peer-session");
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart commits without actor header when state records peer isolation as disabled", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-global-peer-"));
+  try {
+    await writeState(stateDir, {
+      codexSessionId: "global-session",
+      ovSessionId: "cx-global-session",
+      actorPeerId: "",
+      workspacePeerId: "",
+      capturedTurnCount: 1,
+      createdAt: Date.now(),
+      lastUpdatedAt: Date.now(),
+    });
+
+    await withMockOpenViking(async ({ baseUrl, commitCalls }) => {
+      await runSessionStart(
+        { session_id: "new-session", source: "startup" },
+        baseEnv(stateDir, baseUrl, { OPENVIKING_PEER_ID: "peer-from-new-session" }),
+        stateDir,
+      );
+
+      assert.deepEqual(commitCalls, [{
+        path: "/api/v1/sessions/cx-global-session/commit",
+        actorPeerId: undefined,
+      }]);
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart idle sweep uses the stale session's actor peer", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-idle-peer-"));
+  try {
+    const staleAt = Date.now() - 3_600_000;
+    await writeState(stateDir, {
+      codexSessionId: "stale-session",
+      ovSessionId: "cx-stale-session",
+      actorPeerId: "peer-from-stale-session",
+      workspacePeerId: "legacy-stale-peer",
+      capturedTurnCount: 1,
+      createdAt: staleAt,
+      lastUpdatedAt: staleAt,
+    });
+
+    await withMockOpenViking(async ({ baseUrl, commitCalls }) => {
+      await runSessionStart(
+        { session_id: "new-session", source: "startup" },
+        baseEnv(stateDir, baseUrl, { OPENVIKING_PEER_ID: "peer-from-new-session" }),
+        stateDir,
+      );
+
+      assert.deepEqual(commitCalls, [{
+        path: "/api/v1/sessions/cx-stale-session/commit",
+        actorPeerId: "peer-from-stale-session",
+      }]);
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart persists the effective actor peer on the new session state", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-persist-peer-"));
+  try {
+    await runSessionStart(
+      { session_id: "new-session", source: "unknown" },
+      baseEnv(stateDir, "http://127.0.0.1:1", { OPENVIKING_PEER_ID: "configured-peer" }),
+      stateDir,
+    );
+
+    const state = JSON.parse(await readFile(join(stateDir, "new-session.json"), "utf-8"));
+    assert.equal(state.actorPeerId, "configured-peer");
+    assert.equal(state.workspacePeerId, "");
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("SessionStart preserves a session's persisted actor peer across resume", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-session-start-preserve-peer-"));
+  try {
+    await writeState(stateDir, {
+      codexSessionId: "resumed-session",
+      ovSessionId: "cx-resumed-session",
+      actorPeerId: "original-session-peer",
+      workspacePeerId: "original-session-peer",
+      capturedTurnCount: 3,
+      createdAt: Date.now(),
+      lastUpdatedAt: Date.now(),
+    });
+
+    await runSessionStart(
+      { session_id: "resumed-session", source: "unknown" },
+      baseEnv(stateDir, "http://127.0.0.1:1", { OPENVIKING_PEER_ID: "changed-config-peer" }),
+      stateDir,
+    );
+
+    const state = JSON.parse(await readFile(join(stateDir, "resumed-session.json"), "utf-8"));
+    assert.equal(state.actorPeerId, "original-session-peer");
+    assert.equal(state.workspacePeerId, "original-session-peer");
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/examples/codex-memory-plugin/scripts/session-state.mjs
+++ b/examples/codex-memory-plugin/scripts/session-state.mjs
@@ -47,6 +47,9 @@ function defaultState(codexSessionId) {
   return {
     codexSessionId,
     ovSessionId: null,
+    // null means this state has not recorded an actor identity yet. An empty
+    // string is distinct: it means peer isolation was intentionally disabled.
+    actorPeerId: null,
     workspacePeerId: "",
     capturedTurnCount: 0,
     createdAt: now,


### PR DESCRIPTION
## Summary
- persist the effective actor peer with each Codex session state
- commit orphaned sessions with their own saved peer instead of the newly-started workspace peer
- preserve legacy state when its peer identity is unknown, while retaining explicit peer-disabled behavior
- keep auto-capture and pre-compact hooks on the persisted session identity

## Root cause
SessionStart derived one global activePeerId from the workspace being started, then reused it while committing state files belonging to other workspaces. OpenViking correctly rejected those commits because the actor peer did not match the target peer namespace.

## Tests
- added cross-workspace, idle-TTL, legacy-state, peer-disabled, persistence, and resume regression coverage
- node --test scripts/*.test.mjs servers/*.test.mjs (78 passed)
