### PR TITLE
fix(service): retain strong refs for fire-and-forget background tasks

### DIFF
--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -40,6 +40,14 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
+# Strong refs for in-flight fire-and-forget legacy-migration tasks. Python
+# asyncio only keeps weak references to tasks created via asyncio.create_task,
+# so a task without an external strong reference can be garbage-collected
+# mid-execution and silently aborted — leaving the task-tracker entry stuck
+# "in progress" forever. Mirrors the pattern in
+# openviking/server/routers/watches.py.
+_BACKGROUND_MIGRATION_TASKS: set[asyncio.Task] = set()
+
 
 class CreateAccountRequest(BaseModel):
     account_id: str
@@ -263,7 +271,7 @@ async def migrate_legacy_data(
         account_id=SYSTEM_TASK_ACCOUNT_ID,
         user_id=SYSTEM_TASK_USER_ID,
     )
-    asyncio.create_task(
+    task_tracker_task = asyncio.create_task(
         _run_legacy_migration_task(
             task.task_id,
             migration,
@@ -272,6 +280,8 @@ async def migrate_legacy_data(
             user_id=SYSTEM_TASK_USER_ID,
         )
     )
+    _BACKGROUND_MIGRATION_TASKS.add(task_tracker_task)
+    task_tracker_task.add_done_callback(_BACKGROUND_MIGRATION_TASKS.discard)
     return Response(status="ok", result={"task_id": task.task_id})
 
 

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -47,6 +47,13 @@ REINDEX_TASK_TYPE = "admin_reindex"
 PRUNE_ORPHAN_CANDIDATE_LIMIT = 100000
 PRUNE_OUTPUT_FIELDS = ["id", "uri", "level", "context_type", "account_id", "owner_user_id"]
 
+# Strong refs for in-flight fire-and-forget reindex tasks. Python asyncio only
+# keeps weak references to tasks created via asyncio.create_task, so a task
+# without an external strong reference can be garbage-collected mid-execution
+# and silently aborted — leaving the task-tracker entry stuck "in progress"
+# forever. Mirrors the pattern in openviking/server/routers/watches.py.
+_BACKGROUND_REINDEX_TASKS: set[asyncio.Task] = set()
+
 
 # Trailing markers VikingFS appends when a directory has no generated .abstract.md/.overview.md
 # (see openviking/storage/viking_fs.py). The rendered value is a placeholder, not semantic
@@ -185,7 +192,7 @@ class ReindexExecutor:
                 details={"uri": uri},
             )
 
-        asyncio.create_task(
+        reindex_task = asyncio.create_task(
             self._run_tracked(
                 task.task_id,
                 uri=uri,
@@ -195,6 +202,8 @@ class ReindexExecutor:
                 ctx=ctx,
             )
         )
+        _BACKGROUND_REINDEX_TASKS.add(reindex_task)
+        reindex_task.add_done_callback(_BACKGROUND_REINDEX_TASKS.discard)
         return {
             "task_id": task.task_id,
             "status": "accepted",

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1771,7 +1771,7 @@ class ResourceService:
                 result["task_id"] = task.task_id
                 if telemetry_id:
                     monitor_started = True
-                    asyncio.create_task(
+                    monitor_task = asyncio.create_task(
                         self._monitor_queue_processing(
                             task.task_id,
                             telemetry_id,
@@ -1779,6 +1779,11 @@ class ResourceService:
                             ctx.user.user_id,
                         )
                     )
+                    # Retain a strong ref so the task isn't GC'd mid-flight
+                    # (asyncio only tracks tasks weakly). close_background_tasks
+                    # drains this set on shutdown.
+                    self._background_tasks.add(monitor_task)
+                    monitor_task.add_done_callback(self._background_tasks.discard)
                 else:
                     await task_tracker.start(
                         task.task_id, account_id=ctx.account_id, user_id=ctx.user.user_id

--- a/tests/unit/service/test_background_task_strong_refs.py
+++ b/tests/unit/service/test_background_task_strong_refs.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression guards for fire-and-forget ``asyncio.create_task`` call sites.
+
+Python's asyncio only keeps *weak* references to tasks created via
+``asyncio.create_task``: if the caller drops the returned Task without storing
+it somewhere, the garbage collector may reclaim the Task mid-execution and
+silently abort the background work. ``openviking/server/routers/watches.py``
+documents this exact hazard and fixes it by registering each task in a
+module-level ``set[asyncio.Task]`` and clearing it via ``add_done_callback``.
+
+The tests below statically verify that every ``asyncio.create_task(...)`` in
+the historically-affected files does the same — either by registering the task
+into a module-level ``set`` (the ``watches.py`` pattern) or into an instance
+``set`` that ``close_background_tasks`` drains on shutdown
+(the ``ResourceService`` / ``ConnectorDelegate`` pattern).
+
+If a new fire-and-forget site is added without a strong-ref, this test fails
+loudly at CI time instead of silently in production.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# (file, expected number of create_task call sites) — bumping the count is
+# fine, but every listed site must satisfy the strong-ref invariant below.
+TARGET_FILES = [
+    (REPO_ROOT / "openviking/server/routers/admin.py", 1),
+    (REPO_ROOT / "openviking/service/reindex_executor.py", 1),
+    (REPO_ROOT / "openviking/service/resource_service.py", 1),
+]
+
+
+def _find_create_task_calls(tree: ast.AST) -> list[ast.Call]:
+    """Return every ``asyncio.create_task(...)`` call node in *tree*."""
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "create_task"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "asyncio"
+        ):
+            calls.append(node)
+    return calls
+
+
+def _statement_lineno(node: ast.AST, source_lines: list[str]) -> int:
+    """Return the top-level statement line containing *node* — for error messages."""
+    return getattr(node, "lineno", 0)
+
+
+def _has_strong_ref_evidence(source: str, call_lineno: int) -> bool:
+    """Detect whether the ``create_task`` at *call_lineno* is followed by a
+    task-set registration + done-callback within a small window.
+
+    Accepts either:
+
+    - The module-level ``set`` pattern used by ``watches.py``::
+
+          task = asyncio.create_task(...)
+          _BACKGROUND_TASKS.add(task)
+          task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+    - The instance ``set`` pattern used by ``ResourceService``::
+
+          task = asyncio.create_task(...)
+          self._background_tasks.add(task)
+          task.add_done_callback(self._background_tasks.discard)
+
+    We use a lightweight textual scan over a 12-line window rather than a
+    full data-flow analysis: the goal is to *guard against regressions*, not
+    to prove correctness. A regressed site will simply lack both markers.
+    """
+    lines = source.splitlines()
+    # Look at the block containing the call: from a few lines before (to catch
+    # ``task = asyncio.create_task(...)`` where ``task`` is used later) through
+    # the next ~12 lines. ``asyncio.create_task`` blocks span multiple lines in
+    # the affected files (multi-line kwargs).
+    start = max(0, call_lineno - 3)
+    end = min(len(lines), call_lineno + 25)
+    window = "\n".join(lines[start:end])
+    has_set_add = ".add(" in window and ("_background_tasks" in window.lower() or "_BACKGROUND" in window)
+    has_done_cb = "add_done_callback" in window
+    return has_set_add and has_done_cb
+
+
+@pytest.mark.parametrize("path,expected_count", TARGET_FILES, ids=lambda p: str(p))
+def test_create_task_sites_have_strong_ref(path: Path, expected_count: int) -> None:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    calls = _find_create_task_calls(tree)
+
+    assert len(calls) >= expected_count, (
+        f"{path}: expected at least {expected_count} asyncio.create_task(...) "
+        f"site(s), found {len(calls)}. If a site was removed, adjust "
+        f"TARGET_FILES in this test."
+    )
+
+    offenders: list[str] = []
+    for call in calls:
+        if not _has_strong_ref_evidence(source, call.lineno):
+            offenders.append(f"  {path}:{call.lineno}")
+
+    assert not offenders, (
+        "asyncio.create_task(...) without a strong-reference registration + "
+        "done_callback detected. Follow the pattern in "
+        "openviking/server/routers/watches.py (module-level set) or "
+        "openviking/service/resource_service.py (instance _background_tasks).\n"
+        "Offending sites:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What

Three fire-and-forget `asyncio.create_task(...)` sites in the service layer drop the returned Task without storing it anywhere:

| # | File | Task |
|---|------|------|
| 1 | `openviking/server/routers/admin.py:266` | `_run_legacy_migration_task` |
| 2 | `openviking/service/reindex_executor.py:188` | `_run_tracked` (admin reindex) |
| 3 | `openviking/service/resource_service.py:1774` | `_monitor_queue_processing` (skill add) |

Python's asyncio only holds **weak** references to tasks created via `asyncio.create_task`. A task without an external strong ref can be garbage-collected mid-execution and silently aborted, leaving the corresponding `task_tracker` record stuck in `in_progress` forever — with no error surface.

## Why

The exact same hazard is already documented and fixed in `openviking/server/routers/watches.py:32-38`:

```python
# Strong refs for in-flight fire-and-forget trigger tasks. Python asyncio
# only keeps weak references to tasks created via asyncio.create_task, so a
# task without an external strong reference can be garbage-collected
# mid-execution and silently aborted. We hold each task here until it
# completes and discard via done_callback.
_BACKGROUND_TRIGGER_TASKS: set[asyncio.Task] = set()
```

`ResourceService` also owns a `self._background_tasks` set drained by `close_background_tasks` on shutdown — but the `_monitor_queue_processing` site was not wired into it.

This PR extends that pattern to the three remaining sites.

## How

- **`admin.py`** — add module-level `_BACKGROUND_MIGRATION_TASKS: set[asyncio.Task]` and register the migration task + `add_done_callback(_BACKGROUND_MIGRATION_TASKS.discard)`.
- **`reindex_executor.py`** — add module-level `_BACKGROUND_REINDEX_TASKS` and register the reindex task the same way.
- **`resource_service.py`** — reuse the existing `self._background_tasks` (already drained by `close_background_tasks` on shutdown).
- **`tests/unit/service/test_background_task_strong_refs.py`** — new static AST regression guard: for each of the three files it walks the tree, locates every `asyncio.create_task(...)` call, and asserts the surrounding block contains both `add_done_callback` and a `.add(` into a set whose name matches `_BACKGROUND*` or `_background_tasks`. No `openviking` imports, so it stays lightweight and runs even when native extensions aren't built.

## Verification

- **Red-before-green**: `git stash` the source changes → new test fails on all three files with the strong-ref assertion; `git stash pop` → all three pass.
- **New test**: passes locally on the branch.
- **Lint (`ruff check`) on touched files**: no new issues. One pre-existing `I001` in `resource_service.py:9` (an import ordering) is present on `main` and left untouched to avoid scope creep.
- **Full pytest suite**: not runnable locally — my Rust toolchain is 1.63.0 and the repo requires 1.91.1 to build the bundled `ov` CLI during `uv sync`. The new test is pure AST and imports no `openviking` module, so it is unaffected. Deferring the full-suite run to CI.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [ ] Documentation updated (if needed) — N/A, internal invariant only
- [ ] All tests pass — deferred to CI (see Verification above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
