### PR TITLE
feat: add structured memory schemas

### DIFF
--- a/hindsight-structured-memory-poc-issue.md
+++ b/hindsight-structured-memory-poc-issue.md
@@ -1,0 +1,312 @@
+# Hindsight-Style Structured Memory POC
+
+## Summary
+
+This POC introduces a Hindsight-style structured memory layer into OpenViking with minimal intrusion.
+
+The core idea is to keep the existing storage, vector index, transaction model, and `MemoryUpdater` flow unchanged, and only extend:
+
+- memory schema definitions
+- extraction JSON schema generation
+- recall type quota and rendering
+- MCP recall tool description
+
+The feature is gated behind `memory.experimental_memory_switch=true`, so default behavior remains unchanged.
+
+## Background
+
+OpenViking currently supports long-term memory extraction through configurable YAML memory schemas. Existing memory types such as `events`, `entities`, `preferences`, and `experiences` are useful, but they do not explicitly separate raw evidence, atomic facts, inferred patterns, and actionable agent beliefs.
+
+Hindsight-style memory introduces a clearer hierarchy:
+
+- `events`: episodic / experience evidence
+- `facts`: explicit atomic facts stated by the user
+- `observations`: stable patterns inferred from facts and events
+- `beliefs`: actionable working beliefs or strategies for the agent, with confidence and evidence
+
+This POC explores whether that structure can be represented using OpenViking's existing schema and recall mechanisms.
+
+## Goals
+
+- Add structured memory types without changing the storage layer.
+- Keep `events` as the existing episodic evidence layer.
+- Add `facts`, `observations`, and `beliefs` as experimental memory schemas.
+- Ensure new schemas only load when `memory.experimental_memory_switch=true`.
+- Use only existing primitive field types: `string` and `float32`.
+- Extend recall so structured memory can be retrieved and rendered by type quota.
+- Keep the default OpenViking behavior unchanged.
+
+## Non-Goals
+
+- Do not change VikingFS.
+- Do not change the vector backend.
+- Do not change transaction semantics.
+- Do not change indexing logic.
+- Do not change `MemoryUpdater` core flow.
+- Do not add a graph database.
+- Do not add new YAML field types such as list or object.
+- Do not add a separate reflection pass in this POC.
+- Do not introduce a new `episodes` type; reuse existing `events`.
+
+## Proposed Design
+
+### 1. Add Experimental Memory Schemas
+
+Add three new schema files under:
+
+```text
+openviking/prompts/templates/memory/experimental_memory/
+```
+
+New files:
+
+- `facts.yaml`
+- `observations.yaml`
+- `beliefs.yaml`
+
+These schemas should only be loaded when:
+
+```yaml
+memory:
+  experimental_memory_switch: true
+```
+
+When the switch is disabled, `facts`, `observations`, and `beliefs` should not appear in the memory type registry.
+
+### 2. Memory Type Mapping
+
+#### events
+
+Keep existing `events` unchanged.
+
+`events` represent episodic memory and experience evidence. They are the raw evidence layer for later structured memory.
+
+#### facts
+
+`facts` represent explicit atomic facts stated by the user.
+
+The type should be append-only so historical evidence is preserved instead of overwritten.
+
+Operation mode:
+
+```yaml
+operation_mode: add_only
+```
+
+Fields:
+
+| Field | Type | Merge Behavior | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | immutable | Entity, user, project, or topic the fact is about |
+| `fact_name` | `string` | immutable | Short stable fact key |
+| `claim` | `string` | immutable | Atomic factual claim |
+| `source` | `string` | immutable | Source description |
+| `ranges` | `string` | immutable | Source message ranges or evidence ranges |
+| `confidence` | `float32` | replace | Confidence score |
+| `content` | `string` | replace | Human-readable fact content |
+
+#### observations
+
+`observations` represent stable inferred patterns derived from events and facts.
+
+Operation mode:
+
+```yaml
+operation_mode: upsert
+```
+
+Fields:
+
+| Field | Type | Merge Behavior | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | immutable | Entity, user, project, or topic the observation is about |
+| `topic` | `string` | immutable | Observation topic |
+| `confidence` | `float32` | replace/patch | Confidence score |
+| `evidence` | `string` | patch | Markdown bullet list of event/fact URIs or source ranges |
+| `content` | `string` | patch | Inferred pattern; must be clearly marked as inferred, not raw fact |
+
+#### beliefs
+
+`beliefs` represent actionable working beliefs or strategies that guide future agent behavior.
+
+Operation mode:
+
+```yaml
+operation_mode: upsert
+```
+
+Fields:
+
+| Field | Type | Merge Behavior | Description |
+| --- | --- | --- | --- |
+| `subject` | `string` | immutable | Entity, user, project, or topic the belief is about |
+| `belief_name` | `string` | immutable | Short stable belief key |
+| `confidence` | `float32` | replace/patch | Confidence score |
+| `evidence` | `string` | patch | Markdown bullet list of evidence URIs or source ranges |
+| `content` | `string` | patch | Actionable guidance for future agent behavior; can be revised by new evidence |
+
+### 3. Recall Changes
+
+Extend:
+
+```text
+openviking/retrieve/type_quota_recall.py
+```
+
+Update `TYPE_ORDER` to include:
+
+```python
+TYPE_ORDER = (
+    "events",
+    "facts",
+    "entities",
+    "observations",
+    "beliefs",
+    "preferences",
+    "experiences",
+)
+```
+
+Update `DEFAULT_QUOTAS` with small quotas for the structured memory types:
+
+```python
+DEFAULT_QUOTAS = {
+    "events": 10,
+    "facts": 5,
+    "entities": 10,
+    "observations": 3,
+    "beliefs": 2,
+    "preferences": 3,
+    "experiences": 0,
+}
+```
+
+Update `DEFAULT_OTHER_PEER_PENALTIES` to support:
+
+- `facts`
+- `observations`
+- `beliefs`
+
+Update `type_char_budgets` to include:
+
+- `facts`
+- `observations`
+- `beliefs`
+
+Recall rendering should be able to produce groups such as:
+
+```xml
+<memory_group type="facts">
+...
+</memory_group>
+```
+
+```xml
+<memory_group type="observations">
+...
+</memory_group>
+```
+
+```xml
+<memory_group type="beliefs">
+...
+</memory_group>
+```
+
+### 4. MCP Recall Description
+
+Update the MCP recall tool docstring in:
+
+```text
+openviking/server/mcp_endpoint.py
+```
+
+The tool description should mention that recall searches:
+
+- events
+- facts
+- entities
+- observations
+- beliefs
+- preferences
+- experiences
+
+## Test Plan
+
+### Prompt Manager / Registry
+
+Update:
+
+```text
+tests/test_prompt_manager.py
+```
+
+Add coverage for:
+
+- `experimental_memory_switch=false`
+  - `facts` is not loaded
+  - `observations` is not loaded
+  - `beliefs` is not loaded
+
+- `experimental_memory_switch=true`
+  - `facts` is loaded
+  - `observations` is loaded
+  - `beliefs` is loaded
+
+### Schema Models
+
+Update:
+
+```text
+tests/session/memory/test_schema_models.py
+```
+
+Add coverage for:
+
+- new schemas can generate structured operations JSON schema
+- `facts`, `observations`, and `beliefs` appear as top-level operation fields
+- operation modes are correct:
+  - `facts`: `add_only`
+  - `observations`: `upsert`
+  - `beliefs`: `upsert`
+
+### Recall
+
+Update:
+
+```text
+tests/retrieve/test_type_quota_recall.py
+tests/server/test_recall_endpoint.py
+tests/server/test_mcp_endpoint.py
+tests/server/test_recall_peer_scope.py
+```
+
+Add or update coverage for:
+
+- quota normalization supports `facts`, `observations`, and `beliefs`
+- default penalties support the new types
+- recall can search structured memory groups
+- rendered recall output contains:
+  - `<memory_group type="facts">`
+  - `<memory_group type="observations">`
+  - `<memory_group type="beliefs">`
+- MCP recall can return structured memory groups
+
+## Assumptions
+
+- First version lets the existing session extraction flow directly produce structured memories.
+- There is no separate reflection pass in this POC.
+- `events` remain the experience/evidence layer.
+- Evidence references are represented as Markdown/string fields.
+- Future versions may add richer reflection, graph links, or stronger consistency semantics, but this POC intentionally avoids those changes.
+
+## Expected Outcome
+
+When `memory.experimental_memory_switch=true`, OpenViking can represent Hindsight-style structured memory:
+
+- `events` preserve episodic evidence
+- `facts` preserve explicit user-stated facts
+- `observations` summarize stable inferred patterns
+- `beliefs` provide actionable agent guidance with evidence and confidence
+
+When the switch is disabled, behavior remains compatible with the current default memory system.

--- a/openviking/prompts/templates/memory/experimental_memory/beliefs.yaml
+++ b/openviking/prompts/templates/memory/experimental_memory/beliefs.yaml
@@ -1,0 +1,71 @@
+memory_type: beliefs
+description: |
+  Belief memory - captures revisable agent working guidance derived from facts,
+  observations, preferences, and interaction outcomes.
+
+  Beliefs are action-oriented and should help the agent decide how to respond or
+  operate later. They are not raw facts and must include evidence. Keep them
+  neutral, concrete, and easy to revise.
+directory: "viking://user/{{ user_space }}/memories/beliefs"
+filename_template: "{{ subject }}/{{ belief_name }}.md"
+enabled: true
+operation_mode: "upsert"
+content_template: |
+  # {{ belief_name }}
+  Subject: {{ subject }}
+  Confidence: {{ confidence }}
+
+  ## Working Belief
+  {{ content }}
+
+  ## Evidence
+  {{ evidence }}
+embedding_template: |-
+  Subject: {{ subject }}
+  Belief: {{ belief_name }}
+  Guidance: {{ content }}
+  Evidence: {{ evidence }}
+overview_template: |-
+  # Beliefs Overview
+  {% if items %}**Subject:** {{ items[0].file_content.subject|default(directory_name, true) }}{% endif %}
+  {% for item in items %}
+  - [{{ item.file_content.belief_name|default(item.file_name, true) }}](./{{ item.file_name }})
+  {% endfor %}
+
+fields:
+  - name: subject
+    type: string
+    description: |
+      The user, project, workflow, entity, or topic this working belief is about.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+    merge_op: immutable
+
+  - name: belief_name
+    type: string
+    description: |
+      Concise name for this agent working belief.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+    merge_op: immutable
+
+  - name: confidence
+    type: float32
+    description: |
+      Confidence from 0.0 to 1.0. Use moderate confidence unless the guidance is
+      repeatedly supported by evidence.
+    merge_op: replace
+
+  - name: evidence
+    type: string
+    description: |
+      Markdown bullet list of evidence supporting this working belief. Prefer
+      fact/event/observation URIs when available; otherwise cite message ranges.
+      Preserve old evidence unless it is contradicted or duplicated.
+    merge_op: patch
+
+  - name: content
+    type: string
+    description: |
+      Markdown action guidance for the agent in {{ language }}. Explain how the
+      agent should behave or decide in future interactions. Do not treat this as
+      a hard rule when confidence is low or evidence changes.
+    merge_op: patch

--- a/openviking/prompts/templates/memory/experimental_memory/facts.yaml
+++ b/openviking/prompts/templates/memory/experimental_memory/facts.yaml
@@ -1,0 +1,91 @@
+memory_type: facts
+description: |
+  Atomic fact memory - captures durable facts explicitly stated or confirmed by
+  the user. A fact is evidence, not interpretation.
+
+  Extract facts only when the conversation directly supports the claim. Do not
+  infer motives, preferences, personality, or strategy here. Use observations
+  for inferred patterns and beliefs for agent working guidance.
+
+  Each fact must be small, sourceable, and useful on its own. Split independent
+  claims into separate fact records.
+directory: "viking://user/{{ user_space }}/memories/facts"
+filename_template: "{{ subject }}/{{ extract_context.get_timestamp_from_ranges(ranges) }}_{{ fact_name }}.md"
+enabled: true
+operation_mode: "add_only"
+content_template: |
+  # {{ fact_name }}
+  Claim: {{ claim }}
+  Source: {{ source }}
+  Confidence: {{ confidence }}
+
+  {{ content }}
+
+  # Evidence
+  {{ extract_context.get_event_content(ranges, claim, 0) }}
+embedding_template: |-
+  Subject: {{ subject }}
+  Fact: {{ fact_name }}
+  Claim: {{ claim }}
+  {{ content }}
+overview_template: |-
+  # Facts Overview
+  {% if items %}**Subject:** {{ items[0].file_content.subject|default(directory_name, true) }}{% endif %}
+  {% for item in items %}
+  - [{{ item.file_content.claim|default(item.file_name, true) }}](./{{ item.file_name }})
+  {% endfor %}
+
+fields:
+  - name: subject
+    type: string
+    description: |
+      The entity, user, project, object, or topic the fact is about.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+    merge_op: immutable
+
+  - name: fact_name
+    type: string
+    description: |
+      Concise name for this atomic fact.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+      Do not include dates or timestamps.
+    merge_op: immutable
+
+  - name: claim
+    type: string
+    description: |
+      A single objective claim directly stated or confirmed in the conversation.
+      Write it as a complete sentence in {{ language }}. Do not include guesses,
+      inferred preferences, or recommendations.
+    merge_op: immutable
+
+  - name: source
+    type: string
+    description: |
+      Short source label describing where the claim came from, such as
+      "user_statement", "user_confirmation", "tool_result_shared_by_user", or
+      "quoted_requirement". Use lowercase snake_case.
+    merge_op: immutable
+
+  - name: ranges
+    type: string
+    description: |
+      Conversation message index ranges that directly support the claim. Supports:
+      - Range: "start-end" (e.g., "0-3")
+      - Single index: "N" (e.g., "7")
+      - Mixed: "0-3,7,15-20"
+    merge_op: immutable
+
+  - name: confidence
+    type: float32
+    description: |
+      Confidence from 0.0 to 1.0 based only on how directly the conversation
+      supports the claim. Use high confidence for explicit user statements.
+    merge_op: immutable
+
+  - name: content
+    type: string
+    description: |
+      Compact Markdown note explaining why this fact is worth remembering.
+      Include only source-backed context. Do not add inferred conclusions.
+    merge_op: immutable

--- a/openviking/prompts/templates/memory/experimental_memory/observations.yaml
+++ b/openviking/prompts/templates/memory/experimental_memory/observations.yaml
@@ -1,0 +1,71 @@
+memory_type: observations
+description: |
+  Observation memory - captures inferred stable patterns from multiple facts,
+  events, or repeated conversational evidence.
+
+  Observations are not raw facts. They should clearly state that the content is
+  an inference, include evidence, and remain revisable when new evidence appears.
+  Do not use observations for one-off events or direct factual claims.
+directory: "viking://user/{{ user_space }}/memories/observations"
+filename_template: "{{ subject }}/{{ topic }}.md"
+enabled: true
+operation_mode: "upsert"
+content_template: |
+  # {{ topic }}
+  Subject: {{ subject }}
+  Confidence: {{ confidence }}
+
+  ## Observation
+  {{ content }}
+
+  ## Evidence
+  {{ evidence }}
+embedding_template: |-
+  Subject: {{ subject }}
+  Topic: {{ topic }}
+  Observation: {{ content }}
+  Evidence: {{ evidence }}
+overview_template: |-
+  # Observations Overview
+  {% if items %}**Subject:** {{ items[0].file_content.subject|default(directory_name, true) }}{% endif %}
+  {% for item in items %}
+  - [{{ item.file_content.topic|default(item.file_name, true) }}](./{{ item.file_name }})
+  {% endfor %}
+
+fields:
+  - name: subject
+    type: string
+    description: |
+      The entity, user, project, object, or topic this inferred pattern is about.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+    merge_op: immutable
+
+  - name: topic
+    type: string
+    description: |
+      Concise topic for this observation.
+      {% if language == 'en' %}Use lowercase with underscores, max 4 words.{% else %}Keep it concise and natural in {{ language }}.{% endif %}
+    merge_op: immutable
+
+  - name: confidence
+    type: float32
+    description: |
+      Confidence from 0.0 to 1.0. Increase only when there is repeated or strong
+      supporting evidence; lower it when evidence is weak or mixed.
+    merge_op: replace
+
+  - name: evidence
+    type: string
+    description: |
+      Markdown bullet list of supporting evidence. Prefer fact/event URIs when
+      available; otherwise cite message ranges such as "ranges: 0-3".
+      Preserve old evidence unless it is contradicted or duplicated.
+    merge_op: patch
+
+  - name: content
+    type: string
+    description: |
+      Markdown description of the inferred pattern in {{ language }}.
+      State the inference carefully, without presenting it as a directly stated
+      fact. Mention uncertainty or boundary conditions when relevant.
+    merge_op: patch

--- a/openviking/retrieve/type_quota_recall.py
+++ b/openviking/retrieve/type_quota_recall.py
@@ -18,11 +18,30 @@ from openviking.core.namespace import canonical_user_root
 from openviking.server.identity import RequestContext
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 
-TYPE_ORDER = ("events", "entities", "preferences", "experiences")
-DEFAULT_QUOTAS = {"events": 10, "entities": 10, "preferences": 3, "experiences": 0}
+TYPE_ORDER = (
+    "events",
+    "facts",
+    "entities",
+    "observations",
+    "beliefs",
+    "preferences",
+    "experiences",
+)
+DEFAULT_QUOTAS = {
+    "events": 10,
+    "facts": 5,
+    "entities": 10,
+    "observations": 3,
+    "beliefs": 2,
+    "preferences": 3,
+    "experiences": 0,
+}
 DEFAULT_OTHER_PEER_PENALTIES = {
     "events": 0.1,
+    "facts": 0.1,
     "entities": 0.1,
+    "observations": 0.05,
+    "beliefs": 0.05,
     "preferences": 0.02,
     "experiences": 0.02,
 }
@@ -233,7 +252,10 @@ def type_char_budgets(max_chars: int) -> dict[str, int]:
     max_chars = max(1, int(max_chars))
     return {
         "events": int(max_chars * EVENTS_BUDGET_RATIO),
+        "facts": max_chars,
         "entities": max_chars,
+        "observations": max_chars,
+        "beliefs": max_chars,
         "preferences": max_chars,
         "experiences": max_chars,
     }

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -342,7 +342,11 @@ async def recall(
     peer_scope: str = "all",
     other_peer_penalty: Optional[Union[float, Dict[str, float]]] = None,
 ) -> str:
-    """Type-quota memory recall. Searches events, entities, preferences, and experiences separately, then returns a bounded memory_group block."""
+    """Type-quota memory recall.
+
+    Searches events, facts, entities, observations, beliefs, preferences, and
+    experiences separately, then returns a bounded memory_group block.
+    """
     service = get_service()
     effective_peer_scope = "actor" if peer_scope == "actor" else "all"
     result = await search_type_quota_recall(

--- a/tests/retrieve/test_type_quota_recall.py
+++ b/tests/retrieve/test_type_quota_recall.py
@@ -43,7 +43,10 @@ async def test_independent_type_searches_start_concurrently():
             peer_scope="actor",
             quotas={
                 "events": 1,
+                "facts": 0,
                 "entities": 1,
+                "observations": 0,
+                "beliefs": 0,
                 "preferences": 0,
                 "experiences": 0,
             },
@@ -59,7 +62,10 @@ async def test_independent_type_searches_start_concurrently():
     }
     assert result.stats["searched"] == {
         "events": 0,
+        "facts": 0,
         "entities": 0,
+        "observations": 0,
+        "beliefs": 0,
         "preferences": 0,
         "experiences": 0,
     }
@@ -104,7 +110,10 @@ async def test_parallel_search_preserves_type_order():
         peer_scope="actor",
         quotas={
             "events": 1,
+            "facts": 0,
             "entities": 1,
+            "observations": 0,
+            "beliefs": 0,
             "preferences": 0,
             "experiences": 0,
         },

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -291,13 +291,63 @@ async def test_recall_tool_returns_type_quota_memory_groups(service, monkeypatch
 
     result = await recall(
         query="what happened",
-        quotas={"events": 1, "entities": 0, "preferences": 0, "experiences": 0},
+        quotas={
+            "events": 1,
+            "facts": 0,
+            "entities": 0,
+            "observations": 0,
+            "beliefs": 0,
+            "preferences": 0,
+            "experiences": 0,
+        },
         max_chars=200,
         min_score=0.1,
     )
 
     assert '<memory_group type="events"' in result
     assert "MCP recall event." in result
+
+
+async def test_mcp_recall_tool_returns_structured_memory_groups(service, monkeypatch):
+    from openviking.server.mcp_endpoint import recall
+
+    async def fake_find(**kwargs):
+        if kwargs["target_uri"].endswith("/facts"):
+            return SimpleNamespace(
+                memories=[
+                    SimpleNamespace(
+                        uri="viking://user/test_user/memories/facts/project/f.md",
+                        score=0.9,
+                        abstract="fact abstract",
+                    )
+                ]
+            )
+        return SimpleNamespace(memories=[])
+
+    async def fake_read(uri, **kwargs):
+        del uri, kwargs
+        return "Fact: structured memory is enabled."
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+    monkeypatch.setattr(service.fs, "read", fake_read)
+
+    result = await recall(
+        query="structured",
+        quotas={
+            "events": 0,
+            "facts": 1,
+            "entities": 0,
+            "observations": 0,
+            "beliefs": 0,
+            "preferences": 0,
+            "experiences": 0,
+        },
+        max_chars=500,
+        min_score=0.1,
+    )
+
+    assert '<memory_group type="facts"' in result
+    assert "structured memory is enabled" in result
 
 
 async def test_mcp_middleware_sets_actor_peer_context():

--- a/tests/server/test_recall_endpoint.py
+++ b/tests/server/test_recall_endpoint.py
@@ -68,7 +68,15 @@ async def test_recall_endpoint_searches_by_type_quota_and_renders(
         "/api/v1/search/recall",
         json={
             "query": "what should I remember",
-            "quotas": {"events": 1, "entities": 1, "preferences": 0, "experiences": 0},
+            "quotas": {
+                "events": 1,
+                "facts": 0,
+                "entities": 1,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "max_chars": 400,
             "min_score": 0.1,
             "render": True,
@@ -121,7 +129,15 @@ async def test_recall_endpoint_respects_max_chars_budget(
         "/api/v1/search/recall",
         json={
             "query": "budget",
-            "quotas": {"events": 2, "entities": 0, "preferences": 0},
+            "quotas": {
+                "events": 2,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "max_chars": 120,
             "min_score": 0.1,
             "render": True,
@@ -141,7 +157,15 @@ async def test_recall_endpoint_respects_max_chars_budget(
         "/api/v1/search/recall",
         json={
             "query": "budget",
-            "quotas": {"events": 2, "entities": 0, "preferences": 0},
+            "quotas": {
+                "events": 2,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "max_chars": 10,
             "min_score": 0.1,
             "render": True,
@@ -181,7 +205,18 @@ async def test_recall_endpoint_sanitizes_nonfinite_scores(
 
     resp = await client.post(
         "/api/v1/search/recall",
-        json={"query": "inf", "quotas": {"events": 1, "entities": 0, "preferences": 0}},
+        json={
+            "query": "inf",
+            "quotas": {
+                "events": 1,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
+        },
     )
 
     assert resp.status_code == 200
@@ -220,9 +255,77 @@ async def test_recall_endpoint_filters_profile_and_duplicates(
 
     resp = await client.post(
         "/api/v1/search/recall",
-        json={"query": "hello", "quotas": {"events": 3, "entities": 0, "preferences": 0}},
+        json={
+            "query": "hello",
+            "quotas": {
+                "events": 3,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
+        },
     )
 
     assert resp.status_code == 200
     entries = resp.json()["result"]["entries"]
     assert [entry["uri"] for entry in entries] == ["viking://user/test_user/memories/events/dup.md"]
+
+
+async def test_recall_endpoint_searches_structured_memory_groups(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    async def fake_find(**kwargs):
+        target_uri = kwargs["target_uri"]
+        if target_uri.endswith("/facts"):
+            return _FakeFindResult(
+                [_memory("viking://user/test_user/memories/facts/project/a.md", 0.93)]
+            )
+        if target_uri.endswith("/observations"):
+            return _FakeFindResult(
+                [_memory("viking://user/test_user/memories/observations/project/style.md", 0.87)]
+            )
+        if target_uri.endswith("/beliefs"):
+            return _FakeFindResult(
+                [_memory("viking://user/test_user/memories/beliefs/project/review.md", 0.81)]
+            )
+        return _FakeFindResult([])
+
+    async def fake_read(uri, **kwargs):
+        del kwargs
+        return f"structured content for {uri}"
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+    monkeypatch.setattr(service.fs, "read", fake_read)
+
+    resp = await client.post(
+        "/api/v1/search/recall",
+        json={
+            "query": "structured memory",
+            "quotas": {
+                "events": 0,
+                "facts": 1,
+                "entities": 0,
+                "observations": 1,
+                "beliefs": 1,
+                "preferences": 0,
+                "experiences": 0,
+            },
+            "max_chars": 2000,
+        },
+    )
+
+    assert resp.status_code == 200
+    result = resp.json()["result"]
+    assert [entry["type"] for entry in result["entries"]] == [
+        "facts",
+        "observations",
+        "beliefs",
+    ]
+    assert '<memory_group type="facts"' in result["rendered"]
+    assert '<memory_group type="observations"' in result["rendered"]
+    assert '<memory_group type="beliefs"' in result["rendered"]

--- a/tests/server/test_recall_peer_scope.py
+++ b/tests/server/test_recall_peer_scope.py
@@ -36,19 +36,28 @@ def _self_memory_target(target_uri: str, memory_type: str) -> bool:
 def test_normalize_penalties_defaults_scalar_dict_and_clamp():
     assert normalize_penalties() == {
         "events": 0.1,
+        "facts": 0.1,
         "entities": 0.1,
+        "observations": 0.05,
+        "beliefs": 0.05,
         "preferences": 0.02,
         "experiences": 0.02,
     }
     assert normalize_penalties(0.2) == {
         "events": 0.2,
+        "facts": 0.2,
         "entities": 0.2,
+        "observations": 0.2,
+        "beliefs": 0.2,
         "preferences": 0.2,
         "experiences": 0.2,
     }
     assert normalize_penalties({"events": 2, "preferences": -1, "unknown": 0.5}) == {
         "events": 1.0,
+        "facts": 0.1,
         "entities": 0.1,
+        "observations": 0.05,
+        "beliefs": 0.05,
         "preferences": 0.0,
         "experiences": 0.02,
     }
@@ -111,7 +120,15 @@ async def test_recall_default_all_searches_other_peers_and_reads_with_open_ctx(
         headers={"X-OpenViking-Actor-Peer": "current"},
         json={
             "query": "peer memory",
-            "quotas": {"events": 3, "entities": 0, "preferences": 0, "experiences": 0},
+            "quotas": {
+                "events": 3,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "max_chars": 5000,
         },
     )
@@ -163,7 +180,15 @@ async def test_recall_actor_scope_keeps_legacy_rendering(
         json={
             "query": "peer memory",
             "peer_scope": "actor",
-            "quotas": {"events": 1, "entities": 0, "preferences": 0, "experiences": 0},
+            "quotas": {
+                "events": 1,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "max_chars": 300,
         },
     )
@@ -220,7 +245,15 @@ async def test_recall_other_peer_penalty_is_type_aware(
         headers={"X-OpenViking-Actor-Peer": "current"},
         json={
             "query": "ranking",
-            "quotas": {"events": 1, "entities": 0, "preferences": 0, "experiences": 1},
+            "quotas": {
+                "events": 1,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 1,
+            },
             "max_chars": 5000,
         },
     )
@@ -259,7 +292,15 @@ async def test_recall_accepts_scalar_penalty_override(
         headers={"X-OpenViking-Actor-Peer": "current"},
         json={
             "query": "ranking",
-            "quotas": {"events": 1, "entities": 0, "preferences": 0, "experiences": 0},
+            "quotas": {
+                "events": 1,
+                "facts": 0,
+                "entities": 0,
+                "observations": 0,
+                "beliefs": 0,
+                "preferences": 0,
+                "experiences": 0,
+            },
             "other_peer_penalty": 0.0,
         },
     )

--- a/tests/session/memory/test_schema_models.py
+++ b/tests/session/memory/test_schema_models.py
@@ -368,6 +368,42 @@ class TestSchemaModelGenerator:
             assert "custom_field" in model.model_fields
             assert "memory_type" not in model.model_fields
 
+    def test_experimental_structured_memory_schemas_generate_operation_fields(self, monkeypatch):
+        monkeypatch.setattr(
+            "openviking_cli.utils.config.get_openviking_config",
+            lambda: type(
+                "Config",
+                (),
+                {
+                    "memory": type(
+                        "MemoryCfg",
+                        (),
+                        {
+                            "custom_templates_dir": "",
+                            "experimental_memory_switch": True,
+                            "link_enabled": False,
+                        },
+                    )(),
+                    "prompts": type("PromptCfg", (), {"templates_dir": ""})(),
+                },
+            )(),
+        )
+
+        registry = create_default_registry()
+        generator = SchemaModelGenerator(registry)
+        operations_model = generator.create_structured_operations_model(role_scope=None)
+        json_schema = operations_model.model_json_schema()
+
+        assert {"facts", "observations", "beliefs"}.issubset(
+            set(operations_model.model_fields)
+        )
+        assert "facts" in json_schema["properties"]
+        assert "observations" in json_schema["properties"]
+        assert "beliefs" in json_schema["properties"]
+        assert registry.get("facts").operation_mode == "add_only"
+        assert registry.get("observations").operation_mode == "upsert"
+        assert registry.get("beliefs").operation_mode == "upsert"
+
 
 class TestWikiLink:
     def test_invalid_link_type_keeps_freeform_short_label(self):

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -270,11 +270,14 @@ def test_memory_type_registry_loads_experimental_templates_when_switch_enabled(m
 
     registry = MemoryTypeRegistry(load_schemas=True)
 
-    # entities and profile should be loaded (overridden by experimental versions)
+    # Existing entities/profile are overridden, and structured memory schemas are added.
     entities = registry.get("entities")
     profile = registry.get("profile")
     assert entities is not None
     assert profile is not None
+    assert registry.get("facts") is not None
+    assert registry.get("observations") is not None
+    assert registry.get("beliefs") is not None
     # Experimental entities has specific description mentioning Zettelkasten
     assert "Zettelkasten" in entities.description
 
@@ -294,3 +297,6 @@ def test_memory_type_registry_does_not_load_experimental_templates_when_switch_d
 
     entities = registry.get("entities")
     assert entities is not None
+    assert registry.get("facts") is None
+    assert registry.get("observations") is None
+    assert registry.get("beliefs") is None


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Introduce a Hindsight-style structured memory POC for OpenViking memory extraction and recall. The change adds experimental structured memory types for facts, observations, and beliefs while keeping the existing storage, indexing, transaction, and MemoryUpdater layers unchanged.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->
https://github.com/volcengine/OpenViking/issues/3628

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->
- Added experimental memory schemas for facts, observations, and beliefs behind memory.experimental_memory_switch.
- Extended type-quota recall to search and render structured memory groups alongside existing memory types.
- Added registry, schema generation, and recall tests for the new structured memory types.


## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows
Manual/local checks:
- uvx ruff check openviking/retrieve/type_quota_recall.py openviking/server/mcp_endpoint.py tests/test_prompt_manager.py tests/session/memory/test_schema_models.py tests/server/test_recall_endpoint.py tests/server/test_mcp_endpoint.py tests/server/test_recall_peer_scope.py
- python -m py_compile on changed Python files
- Direct Python validation for experimental registry/schema generation and structured recall rendering
Note: full pytest could not complete locally because the environment is missing the ragfs_python native binding.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
