### PR TITLE
fix(pathlock): remove legacy encrypted lock files on read_token

### DIFF
--- a/crates/ragfs/src/lock/provider.rs
+++ b/crates/ragfs/src/lock/provider.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
+use crate::crypto;
 use crate::core::internal_names::is_hidden_runtime_lock_name;
 use crate::core::FileSystem;
 
@@ -191,6 +192,71 @@ impl FilesystemPathLockProvider {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::core::{Error, FileSystem, WriteFlag};
+    use crate::plugins::memfs::MemFileSystem;
+
+    use super::*;
+
+    /// Verify legacy encrypted lock files are treated as removable upgrade leftovers.
+    #[tokio::test]
+    async fn read_token_cleans_up_legacy_encrypted_lock() {
+        let fs = Arc::new(MemFileSystem::new());
+        fs.mkdir("/data", 0o755).await.unwrap();
+        fs.write("/data/.path.ovlock", b"OVE1legacy-ciphertext", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+        let provider = FilesystemPathLockProvider::new(fs.clone());
+
+        let token = provider.read_token("/data/.path.ovlock").await.unwrap();
+
+        assert!(token.is_none());
+        assert!(matches!(
+            fs.read("/data/.path.ovlock", 0, 0).await,
+            Err(Error::NotFound(_))
+        ));
+    }
+
+    /// Verify malformed non-legacy lock files still surface as invalid tokens.
+    #[tokio::test]
+    async fn read_token_rejects_non_legacy_invalid_lock() {
+        let fs = Arc::new(MemFileSystem::new());
+        fs.mkdir("/data", 0o755).await.unwrap();
+        fs.write("/data/.path.ovlock", b"not-a-token", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+        let provider = FilesystemPathLockProvider::new(fs.clone());
+
+        let err = provider.read_token("/data/.path.ovlock").await.unwrap_err();
+
+        assert!(matches!(err, PathLockError::InvalidToken(_)));
+        assert_eq!(
+            fs.read("/data/.path.ovlock", 0, 0).await.unwrap(),
+            b"not-a-token"
+        );
+    }
+
+    /// Verify valid plaintext lock files continue to decode unchanged.
+    #[tokio::test]
+    async fn read_token_accepts_plaintext_lock() {
+        let fs = Arc::new(MemFileSystem::new());
+        fs.mkdir("/data", 0o755).await.unwrap();
+        fs.write("/data/.path.ovlock", b"owner:123:E", 0, WriteFlag::Create)
+            .await
+            .unwrap();
+        let provider = FilesystemPathLockProvider::new(fs);
+
+        let token = provider.read_token("/data/.path.ovlock").await.unwrap().unwrap();
+
+        assert_eq!(token.owner_id, "owner");
+        assert_eq!(token.time_ns, 123);
+        assert_eq!(token.lock_type, crate::lock::PathLockKind::Exact);
+    }
+}
+
 #[async_trait]
 impl PathLockProvider for FilesystemPathLockProvider {
     fn name(&self) -> &'static str {
@@ -198,15 +264,36 @@ impl PathLockProvider for FilesystemPathLockProvider {
     }
 
     async fn read_token(&self, lock_path: &str) -> PathLockResult<Option<LockToken>> {
-        match self.read_token_raw(lock_path).await? {
-            Some(data) => {
-                let raw = String::from_utf8_lossy(&data).trim().to_string();
-                if raw.is_empty() {
-                    return Ok(None);
+        let mut current = self.read_token_raw(lock_path).await?;
+        loop {
+            match current {
+                Some(data) => {
+                    let raw = String::from_utf8_lossy(&data).trim().to_string();
+                    if raw.is_empty() {
+                        return Ok(None);
+                    }
+                    match LockTokenCodec::decode(&raw) {
+                        Ok(token) => return Ok(Some(token)),
+                        Err(error) if crypto::is_encrypted(&data) => {
+                            if self
+                                .fs
+                                .compare_and_remove(lock_path, &data)
+                                .await
+                                .map_err(|e| {
+                                    PathLockError::Io(format!(
+                                        "legacy encrypted lock cleanup failed: {e}"
+                                    ))
+                                })?
+                            {
+                                return Ok(None);
+                            }
+                            current = self.read_token_raw(lock_path).await?;
+                        }
+                        Err(error) => return Err(error),
+                    }
                 }
-                LockTokenCodec::decode(&raw).map(Some)
+                None => return Ok(None),
             }
-            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
## Description

本次修复是有关升级兼容问题的， 原本 Python Pathlock 在加密场景下.path.ovlock 是加密的, 但是下沉到 Rust 中，因为有.encrypt_stage ，如果pathlock 要加密，会有这个会导致循环死锁，因为在.encrypt_stage目录下写入pathlock文件需要加锁，但是加锁有需要可用的pathlock文件。

所以像 pathlock 这种临时文件，且没有业务语义， 走明文存储，用完即删。

因此，升级时，如果系统中存在加密的.path.ovlock  会导致读取错误

修复方案: 
parse 失败 && raw 以 OVE1 开头  -> 当旧密文锁处理，CAS 删除，然后重试。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
