### PR TITLE
fix(storage): clean temp directories recursively

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -3635,16 +3635,7 @@ class VikingFS:
         path = self._uri_to_path(temp_uri, ctx=ctx)
         fs_ctx = self._pathlock_fs_ctx(ctx, lease_ref)
         try:
-            for entry in await self._ls_entries(path, ctx=ctx):
-                name = entry.get("name", "")
-                if name in [".", ".."]:
-                    continue
-                entry_path = f"{path}/{name}"
-                if entry.get("isDir"):
-                    await self.delete_temp(f"{temp_uri}/{name}", ctx=ctx, lease_ref=lease_ref)
-                else:
-                    await self._async_agfs.rm(entry_path, fs_ctx=fs_ctx)
-            await self._async_agfs.rm(path, fs_ctx=fs_ctx)
+            await self._async_agfs.rm(path, recursive=True, fs_ctx=fs_ctx)
         except Exception as e:
             logger.warning(f"[VikingFS] Failed to delete temp {temp_uri}: {e}")
 

--- a/tests/server/test_temp_scope_acl.py
+++ b/tests/server/test_temp_scope_acl.py
@@ -9,6 +9,7 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -205,6 +206,24 @@ async def test_temp_root_destructive_operations_are_blocked_for_non_root_users(v
 
     with pytest.raises(PermissionError):
         await viking_fs.delete_temp("viking://temp", ctx=alice_ctx)
+
+
+@pytest.mark.asyncio
+async def test_delete_temp_removes_repository_tasks_directory(viking_fs):
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct1", user_id="alice"),
+        role=Role.ROOT,
+    )
+    temp_uri = viking_fs.create_temp_uri(ctx=ctx)
+    tasks_file_uri = f"{temp_uri}/repository/src/tasks/task-registry.ts"
+
+    await viking_fs.mkdir(f"{temp_uri}/repository/src/tasks", exist_ok=True, ctx=ctx)
+    await viking_fs.write(tasks_file_uri, "task registry", ctx=ctx)
+
+    await viking_fs.delete_temp(temp_uri, ctx=ctx)
+
+    with pytest.raises(NotFoundError):
+        await viking_fs.read(tasks_file_uri, ctx=ctx)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复代码仓库导入后 temp 目录清理不完整的问题。

`delete_temp()` 原来通过 `_ls_entries()` 手写递归删除 temp 树，但 `_ls_entries()` 会过滤内部目录名，导致仓库中真实存在的 `tasks/` 目录被跳过，最终残留 temp 空目录。

本 PR 改为使用 AGFS 原生递归删除，确保 temp 目录按物理目录树完整清理。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将 `VikingFS.delete_temp()` 改为调用 AGFS 原生递归删除。
- 添加覆盖 `repository/src/tasks/...` 的回归测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```bash
TMP_HOME=$(mktemp -d) && HOME="$TMP_HOME" uv run --extra test python -m pytest tests/server/test_temp_scope_acl.py::test_delete_temp_removes_repository_tasks_directory -v
```

结果：通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

N/A