### PR TITLE
fix(pathlock): restore idempotent lock directory creation in Rust

### DIFF
--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -19,7 +19,8 @@ fn pathlock_err_to_py(err: PathLockError) -> PyErr {
     match &err {
         PathLockError::Conflict { .. }
         | PathLockError::Timeout { .. }
-        | PathLockError::HandoffFailed(_) => {
+        | PathLockError::HandoffFailed(_)
+        | PathLockError::Io(_) => {
             #[allow(deprecated)]
             Python::with_gil(|py| {
                 let ty = LOCK_ACQUISITION_ERROR_TYPE
@@ -2592,6 +2593,25 @@ mod tests {
         Python::attach(|py| {
             let value: i32 = py_detach_blocking(py, || 40 + 2);
             assert_eq!(value, 42);
+        });
+    }
+
+    #[test]
+    fn pathlock_io_error_maps_to_lock_acquisition_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let errors_mod = py.import("openviking.storage.errors").unwrap();
+            let lock_error_type: Py<PyType> = errors_mod
+                .getattr("LockAcquisitionError")
+                .unwrap()
+                .extract()
+                .unwrap();
+            let _ = LOCK_ACQUISITION_ERROR_TYPE.set(lock_error_type.clone_ref(py));
+
+            let error =
+                pathlock_err_to_py(PathLockError::Io("failed to create lock dir".to_string()));
+
+            assert!(error.is_instance(py, lock_error_type.bind(py)));
         });
     }
 

--- a/crates/ragfs/src/lock/manager.rs
+++ b/crates/ragfs/src/lock/manager.rs
@@ -1039,9 +1039,16 @@ impl PathLockManager {
                 }
             }
             for dir in missing.into_iter().rev() {
-                self.resolver.fs.mkdir(&dir, 0o755).await.map_err(|e| {
-                    PathLockError::Io(format!("failed to create lock dir '{dir}': {e}"))
-                })?;
+                if let Err(mkdir_error) = self.resolver.fs.mkdir(&dir, 0o755).await {
+                    match self.resolver.fs.stat(&dir).await {
+                        Ok(info) if info.is_dir => continue,
+                        _ => {
+                            return Err(PathLockError::Io(format!(
+                                "failed to create lock dir '{dir}': {mkdir_error}"
+                            )));
+                        }
+                    }
+                }
             }
         }
         Ok(())
@@ -1517,9 +1524,90 @@ impl PathLockManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
+    use crate::core::{Error, FileInfo, Result as FsResult, WriteFlag};
     use crate::plugins::memfs::MemFileSystem;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::sync::Barrier;
+
+    struct ConcurrentParentCreationFs {
+        inner: Arc<MemFileSystem>,
+        shared_parent: String,
+        initial_missing_stats: AtomicUsize,
+        initial_stat_barrier: Barrier,
+        shared_parent_mkdir_attempts: AtomicUsize,
+    }
+
+    impl ConcurrentParentCreationFs {
+        fn new(inner: Arc<MemFileSystem>, shared_parent: &str) -> Self {
+            Self {
+                inner,
+                shared_parent: shared_parent.to_string(),
+                initial_missing_stats: AtomicUsize::new(0),
+                initial_stat_barrier: Barrier::new(2),
+                shared_parent_mkdir_attempts: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl FileSystem for ConcurrentParentCreationFs {
+        async fn create(&self, path: &str) -> FsResult<()> {
+            self.inner.create(path).await
+        }
+
+        async fn mkdir(&self, path: &str, mode: u32) -> FsResult<()> {
+            if path == self.shared_parent {
+                self.shared_parent_mkdir_attempts
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+            self.inner.mkdir(path, mode).await
+        }
+
+        async fn remove(&self, path: &str) -> FsResult<()> {
+            self.inner.remove(path).await
+        }
+
+        async fn remove_all(&self, path: &str) -> FsResult<()> {
+            self.inner.remove_all(path).await
+        }
+
+        async fn read(&self, path: &str, offset: u64, size: u64) -> FsResult<Vec<u8>> {
+            self.inner.read(path, offset, size).await
+        }
+
+        async fn write(
+            &self,
+            path: &str,
+            data: &[u8],
+            offset: u64,
+            flags: WriteFlag,
+        ) -> FsResult<u64> {
+            self.inner.write(path, data, offset, flags).await
+        }
+
+        async fn read_dir(&self, path: &str) -> FsResult<Vec<FileInfo>> {
+            self.inner.read_dir(path).await
+        }
+
+        async fn stat(&self, path: &str) -> FsResult<FileInfo> {
+            if path == self.shared_parent
+                && self.initial_missing_stats.fetch_add(1, Ordering::SeqCst) < 2
+            {
+                self.initial_stat_barrier.wait().await;
+                return Err(Error::not_found(path));
+            }
+            self.inner.stat(path).await
+        }
+
+        async fn rename(&self, old_path: &str, new_path: &str) -> FsResult<()> {
+            self.inner.rename(old_path, new_path).await
+        }
+
+        async fn chmod(&self, path: &str, mode: u32) -> FsResult<()> {
+            self.inner.chmod(path, mode).await
+        }
+    }
 
     struct FailNextRemoveProvider {
         inner: crate::lock::provider::MemoryPathLockProvider,
@@ -1626,6 +1714,39 @@ mod tests {
             PathLockManager::new(fs.clone(), provider, PathLockConfig::default()),
             fs,
         )
+    }
+
+    #[tokio::test]
+    async fn exact_locks_tolerate_concurrent_parent_directory_creation() {
+        let inner = Arc::new(MemFileSystem::new());
+        inner.mkdir("/local", 0o755).await.unwrap();
+        inner.mkdir("/local/default", 0o755).await.unwrap();
+        inner
+            .mkdir("/local/default/resources", 0o755)
+            .await
+            .unwrap();
+        let shared_parent = "/local/default/resources/shared";
+        let fs = Arc::new(ConcurrentParentCreationFs::new(
+            inner.clone(),
+            shared_parent,
+        ));
+        let provider = Arc::new(crate::lock::provider::MemoryPathLockProvider::new());
+        let first_manager =
+            PathLockManager::new(fs.clone(), provider.clone(), PathLockConfig::default());
+        let second_manager =
+            PathLockManager::new(fs.clone(), provider, PathLockConfig::default());
+        let first_path = format!("{shared_parent}/a.md");
+        let second_path = format!("{shared_parent}/b.md");
+
+        let (first, second) = tokio::join!(
+            first_manager.acquire_exact(&first_path, Duration::ZERO, None),
+            second_manager.acquire_exact(&second_path, Duration::ZERO, None),
+        );
+
+        assert!(first.is_ok(), "first lock failed: {first:?}");
+        assert!(second.is_ok(), "second lock failed: {second:?}");
+        assert_eq!(fs.shared_parent_mkdir_attempts.load(Ordering::SeqCst), 2);
+        assert!(inner.stat(shared_parent).await.unwrap().is_dir);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

参考 #3353，恢复并发精确路径锁场景下父目录创建的幂等语义，并修复 Rust path-lock 错误向 Python 异常类型的映射。

## 问题

两个并发写请求分别写入同一父目录下的不同文件时，两个 path-lock 流程可能同时执行首次 `stat`，都观察到父目录不存在，随后同时调用 `mkdir`。其中一个创建成功，另一个收到 `already exists`。

#3353 曾在 Python `PathLockEngine` 中通过 `mkdir` 失败后重新 `stat` 解决该竞态。path-lock 迁移到 Rust 后，`PathLockManager::ensure_lock_dir` 再次把第二个 `mkdir` 的失败直接包装成 `PathLockError::Io`，导致竞争失败的一方中止加锁。

同时，Rust Python binding 当前将 `PathLockError::Io` 映射为 `RuntimeError`，上层无法将该错误识别为锁获取失败并按既有锁错误语义处理。

## 预期行为

- `mkdir` 失败后，如果重新 `stat` 确认目标已经是目录，则认为其他并发请求已经完成创建，继续获取锁。
- 如果目标仍不存在、查询失败或目标不是目录，则保留原始失败行为。
- `PathLockError::Io` 映射为 Python `LockAcquisitionError`，不再暴露为 `RuntimeError`。
- 不增加通用重试循环，不改变精确路径锁与目录树锁的冲突规则。

## 实现方案

1. 在 Rust `PathLockManager::ensure_lock_dir` 中保留现有的缺失祖先目录扫描和顺序创建逻辑。
2. 当 `mkdir` 返回错误时立即重新执行 `stat`。
3. 仅当重新查询确认目标为目录时忽略该错误；否则返回包含原始 `mkdir` 错误的 `PathLockError::Io`。
4. 在 PyO3 binding 中将 `PathLockError::Io` 与 conflict、timeout、handoff failure 一样映射为 `LockAcquisitionError`。

## 回归测试

新增可稳定复现竞态的 Rust 异步测试：

- 初始存在 `/local/default/resources`，但不存在共享子目录 `shared`。
- 使用 barrier 保证两个 manager 首次查询 `shared` 时都得到 NotFound。
- 两个 manager 随后分别为 `shared/a.md` 和 `shared/b.md` 获取精确路径锁。
- 断言两个 `mkdir(shared)` 都发生，且两个锁都成功获取。

新增 Python binding 单测，断言 `PathLockError::Io` 生成的异常是 `LockAcquisitionError`。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #3353

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Make Rust lock-directory creation tolerate a concurrent creator when the resulting path is a directory.
- Map `PathLockError::Io` to Python `LockAcquisitionError`.
- Add deterministic regression tests for the directory race and error mapping.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `cargo test -p ragfs lock::manager::tests --no-fail-fast` — 11 passed
- `cargo test -p ragfs-python --no-default-features pathlock_io_error_maps_to_lock_acquisition_error -- --nocapture` — passed
- `cargo test --workspace --no-default-features --no-fail-fast` — new tests passed; two unrelated existing `ragfs` tests fail because disabling default features leaves their path-lock manager uninitialized
- `cargo check -p ragfs-python` — passed, matching the repository CI workspace-build check
- `git diff --check` — passed

The default macOS `cargo test --workspace` command cannot link the `ragfs-python` test binary while its `extension-module` feature is enabled because libpython symbols are intentionally unresolved for extension builds. The binding test was therefore run with `--no-default-features`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is the Rust path-lock equivalent of the idempotent parent-directory handling introduced by #3353. It deliberately verifies filesystem state after the failed `mkdir` instead of matching backend-specific error strings.
