### PR TITLE
fix(server): honor bot.gateway.host in Mode A --with-bot subprocess

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -21,9 +21,13 @@ from openviking.server.app import (
     WORKER_WITH_BOT_ENV,
     create_app,
 )
-from openviking.server.config import get_server_url_from_server_data, load_server_config
+from openviking.server.config import (
+    get_server_url_from_server_data,
+    load_server_config,
+    map_bind_host_to_loopback,
+)
 from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
-from openviking_cli.utils.config.config_loader import resolve_config_path
+from openviking_cli.utils.config.config_loader import load_json_config, resolve_config_path
 from openviking_cli.utils.config.consts import (
     DEFAULT_CONFIG_DIR,
     DEFAULT_OV_CONF,
@@ -255,7 +259,11 @@ def main():
     bot_process: Optional[BotProcess] = None
     if config.with_bot:
         bot_port = args.bot_port
-        config.bot_api_url = f"http://{VIKINGBOT_DEFAULT_HOST}:{bot_port}"
+        bot_gateway_host = (
+            _read_bot_gateway_host(resolved_config_path) or VIKINGBOT_DEFAULT_HOST
+        )
+        bot_proxy_host = map_bind_host_to_loopback(bot_gateway_host)
+        config.bot_api_url = f"http://{bot_proxy_host}:{bot_port}"
         _abort_if_port_in_use(bot_port, "vikingbot gateway")
         print(f"Bot API proxy enabled, forwarding to {config.bot_api_url}")
         # Determine if bot logging should be enabled
@@ -273,6 +281,7 @@ def main():
             enable_bot_logging,
             bot_log_dir,
             bot_port,
+            host=bot_gateway_host,
             config_path=args.config,
             managed_server_url=get_server_url_from_server_data(config),
         )
@@ -337,10 +346,35 @@ def _handle_vikingbot_failure(output: str, returncode: int) -> None:
         print(f"\nDetailed error:\n{output}", file=sys.stderr)
 
 
+def _read_bot_gateway_host(resolved_config_path: Optional[Path]) -> Optional[str]:
+    """Read ``bot.gateway.host`` from a resolved ov.conf ``Path``.
+
+    Returns ``None`` when the path is ``None`` or the key is absent / not a
+    string.  The caller is responsible for resolving and validating the
+    config path (as ``main()`` already does) so this helper does not repeat
+    resolution or swallow validation errors.
+    """
+    if resolved_config_path is None:
+        return None
+    data = load_json_config(resolved_config_path)
+    bot_section = data.get("bot") or {}
+    if not isinstance(bot_section, dict):
+        return None
+    gateway = bot_section.get("gateway") or {}
+    if not isinstance(gateway, dict):
+        return None
+    host = gateway.get("host")
+    if not isinstance(host, str):
+        return None
+    host = host.strip()
+    return host or None
+
+
 def _start_vikingbot_gateway(
     enable_logging: bool,
     log_dir: str,
     port: int = VIKINGBOT_DEFAULT_PORT,
+    host: Optional[str] = None,
     config_path: Optional[str] = None,
     managed_server_url: Optional[str] = None,
 ) -> Optional[BotProcess]:
@@ -368,7 +402,8 @@ def _start_vikingbot_gateway(
         print("  uv pip install -e '.[bot,dev]'")
         return None
 
-    vikingbot_cmd.extend(["--host", VIKINGBOT_DEFAULT_HOST, "--port", str(port)])
+    effective_host = host if host else VIKINGBOT_DEFAULT_HOST
+    vikingbot_cmd.extend(["--host", effective_host, "--port", str(port)])
 
     # Prepare logging
     log_file = None

--- a/tests/unit/test_server_bootstrap_bot_gateway.py
+++ b/tests/unit/test_server_bootstrap_bot_gateway.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 
+import json
+
 import openviking.server.bootstrap as bootstrap
 from openviking_cli.utils.config.consts import OPENVIKING_CLI_CONFIG_ENV
 
@@ -13,7 +15,7 @@ class _FakeProcess:
         return None
 
 
-def test_start_vikingbot_gateway_forces_localhost_host(monkeypatch):
+def test_start_vikingbot_gateway_defaults_to_localhost_host(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/usr/bin/vikingbot")
@@ -39,6 +41,101 @@ def test_start_vikingbot_gateway_forces_localhost_host(monkeypatch):
     )
 
 
+def test_start_vikingbot_gateway_honors_host_argument(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: "/usr/bin/vikingbot")
+    monkeypatch.delenv(OPENVIKING_CLI_CONFIG_ENV, raising=False)
+
+    def _fake_popen(cmd, stdout=None, stderr=None, text=None, env=None):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return _FakeProcess()
+
+    monkeypatch.setattr(bootstrap.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(bootstrap.time, "sleep", lambda _: None)
+
+    process = bootstrap._start_vikingbot_gateway(
+        enable_logging=False,
+        log_dir="/tmp/logs",
+        host="0.0.0.0",
+    )
+
+    assert process is not None
+    host_idx = captured["cmd"].index("--host")
+    assert captured["cmd"][host_idx + 1] == "0.0.0.0"
+
+
+def test_read_bot_gateway_host_reads_from_config(tmp_path):
+    conf_path = tmp_path / "ov.conf"
+    conf_path.write_text(
+        json.dumps({"bot": {"gateway": {"host": "0.0.0.0", "port": 18790}}}),
+        encoding="utf-8",
+    )
+
+    host = bootstrap._read_bot_gateway_host(conf_path)
+    assert host == "0.0.0.0"
+
+
+def test_read_bot_gateway_host_returns_none_when_absent(tmp_path):
+    conf_path = tmp_path / "ov.conf"
+    conf_path.write_text("{}", encoding="utf-8")
+
+    assert bootstrap._read_bot_gateway_host(conf_path) is None
+    assert bootstrap._read_bot_gateway_host(None) is None
+
+
+def test_read_bot_gateway_host_ignores_non_string_host(tmp_path):
+    conf_path = tmp_path / "ov.conf"
+    conf_path.write_text(
+        json.dumps({"bot": {"gateway": {"host": 123}}}),
+        encoding="utf-8",
+    )
+    assert bootstrap._read_bot_gateway_host(conf_path) is None
+
+
+def test_read_bot_gateway_host_strips_whitespace_and_empty(tmp_path):
+    conf_path = tmp_path / "ov.conf"
+    conf_path.write_text(
+        json.dumps({"bot": {"gateway": {"host": "  0.0.0.0  "}}}),
+        encoding="utf-8",
+    )
+    assert bootstrap._read_bot_gateway_host(conf_path) == "0.0.0.0"
+
+    # Empty string (after strip) returns None
+    conf_path.write_text(
+        json.dumps({"bot": {"gateway": {"host": "   "}}}),
+        encoding="utf-8",
+    )
+    assert bootstrap._read_bot_gateway_host(conf_path) is None
+
+
+def test_resolved_config_path_env_file_feeds_bot_gateway_host(monkeypatch, tmp_path):
+    """Regression: config resolution through env/default path, not just explicit --config.
+
+    ``main()`` calls ``resolve_config_path(args.config, ...)`` which honors
+    ``OPENVIKING_CONFIG_FILE`` and the default ``~/.openviking/ov.conf``.
+    The bot gateway host must come from that same resolved path, not just
+    the explicit ``args.config`` argument.
+    """
+    from openviking_cli.utils.config.config_loader import resolve_config_path
+    from openviking_cli.utils.config.consts import OPENVIKING_CONFIG_ENV
+
+    env_conf = tmp_path / "from-env.conf"
+    env_conf.write_text(
+        json.dumps({"bot": {"gateway": {"host": "192.168.1.10"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(env_conf))
+
+    # Simulate what main() does: resolve without explicit --config argument
+    resolved = resolve_config_path(None, OPENVIKING_CONFIG_ENV, "ov.conf")
+    assert resolved == env_conf
+
+    host = bootstrap._read_bot_gateway_host(resolved)
+    assert host == "192.168.1.10"
+
+
 def test_start_vikingbot_gateway_uses_custom_port(monkeypatch):
     captured = {}
 
@@ -60,6 +157,7 @@ def test_start_vikingbot_gateway_uses_custom_port(monkeypatch):
     )
 
     assert process is not None
+    # Host defaults to 127.0.0.1 when not explicitly provided
     assert captured["cmd"][captured["cmd"].index("--host") + 1] == "127.0.0.1"
     assert captured["cmd"][captured["cmd"].index("--port") + 1] == "19990"
 


### PR DESCRIPTION
## 动机

Issue #3520 reports two Mode A / Mode C behaviors. This PR fixes **Mode A only**: in all-in-one mode (`--with-bot`), the built-in vikingbot gateway subprocess always binds to 127.0.0.1 and silently ignores `bot.gateway.host` from ov.conf. Setting `bot.gateway.host: "0.0.0.0"` has no effect.

Mode C (standalone gateway + Web Studio shows "Please enable bot mode") is a separate architecture question about whether Web Studio can target an external gateway — the `/bot/v1/*` proxy is gated by `config.with_bot` / `--with-bot`, so a standalone gateway cannot drive Web Studio. This is by design and explicitly out of scope for this PR.

## 改动思路

The root cause is in `openviking/server/bootstrap.py`: `_start_vikingbot_gateway()` hardcoded `--host 127.0.0.1` when constructing the vikingbot subprocess command, never reading the `bot.gateway.host` config value.

The fix reads `bot.gateway.host` from the already-resolved ov.conf path (same path used to load the server config, so `--config`, `OPENVIKING_CONFIG_FILE`, and default paths all work) and passes it through to the subprocess. The server-side proxy URL uses `map_bind_host_to_loopback()` so wildcard bind addresses like `0.0.0.0` are translated to connectable loopback URLs.

Security is preserved: vikingbot's own startup guard (gateway token required when host is non-loopback) still applies — we just pass the host through, we don't bypass the guard.

## 关键代码或伪代码

```python
# openviking/server/bootstrap.py - in main(), with_bot block:
bot_gateway_host = (
    _read_bot_gateway_host(resolved_config_path) or VIKINGBOT_DEFAULT_HOST
)
bot_proxy_host = map_bind_host_to_loopback(bot_gateway_host)
config.bot_api_url = f"http://{bot_proxy_host}:{bot_port}"
# ...
bot_process = _start_vikingbot_gateway(
    # ...
    host=bot_gateway_host,
    # ...
)
```

```python
def _read_bot_gateway_host(resolved_config_path):
    if resolved_config_path is None:
        return None
    data = load_json_config(resolved_config_path)
    bot_section = data.get("bot") or {}
    if not isinstance(bot_section, dict):
        return None
    gateway = bot_section.get("gateway") or {}
    if not isinstance(gateway, dict):
        return None
    host = gateway.get("host")
    if not isinstance(host, str):
        return None
    host = host.strip()
    return host or None
```

## 具体改动

- **`openviking/server/bootstrap.py`**:
  - Added `_read_bot_gateway_host()` helper that reads `bot.gateway.host` from a resolved ov.conf path.
  - Added `host` parameter to `_start_vikingbot_gateway()` and pass it to the vikingbot subprocess.
  - Updated `main()` to read the gateway host from resolved config and use `map_bind_host_to_loopback()` for the proxy URL.
  - Consolidated `config_loader` imports into one line.

- **`tests/unit/test_server_bootstrap_bot_gateway.py`**:
  - Renamed `test_start_vikingbot_gateway_forces_localhost_host` → `test_start_vikingbot_gateway_defaults_to_localhost_host` (accurate name).
  - Added `test_start_vikingbot_gateway_honors_host_argument`.
  - Added focused tests for `_read_bot_gateway_host`: happy path, absent, non-string type, whitespace/empty, and a regression test for env-var config resolution.

## 修复后复现

Set `bot.gateway.host: "0.0.0.0"` and `bot.gateway.token: "your-token"` in ov.conf, then start the server with `--with-bot`. The vikingbot subprocess now receives `--host 0.0.0.0` and binds accordingly. Without a token, vikingbot still rejects non-loopback hosts with a clear error.

## 验证

| Command | Result |
|---------|--------|
| `ruff check openviking/server/bootstrap.py tests/unit/test_server_bootstrap_bot_gateway.py` | ✅ Pass |
| `uv run --extra bot --extra test python -m pytest tests/unit/test_server_bootstrap_bot_gateway.py tests/server/test_bootstrap.py --no-cov` | ✅ 20 passed |
| `uv run --extra bot --extra test python -m pytest bot/tests/test_gateway_startup_security.py --no-cov` | ✅ 4 passed (security guard intact) |
| `git diff --check` | ✅ Pass |

## 对主干的风险与未覆盖

- Low risk: change is confined to the Mode A startup path; default behavior (no `bot.gateway.host` set) is identical.
- The gateway security guard (token required for non-loopback) is tested and verified intact.
- Not run: full integration test with a live vikingbot gateway bound to 0.0.0.0; not run: multi-worker mode with bot.
- Mode C (standalone gateway + Web Studio) is explicitly not addressed — that would require a separate design discussion about whether Web Studio / the bot proxy should target an external gateway.

## 关联 Issue

Related to #3520 (Mode A part fixed; Mode C is a design limitation and remains open).
