### PR TITLE
feat(semantic): add per-task aggregate VLM summary input limit (max_summary_input_chars)

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -15,6 +15,7 @@ from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.ingest_options import IngestOptions
 from openviking_cli.utils import VikingURI
+from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -85,6 +86,93 @@ class DagWork:
 class ScheduledDagWork:
     executor: "SemanticDagExecutor"
     work: DagWork
+
+
+class SummaryBudget:
+    """Concurrency-safe per-task aggregate VLM input limit for summary/overview generation.
+
+    Tracks cumulative characters of rendered prompt input sent to the VLM
+    across file summaries, directory overviews, and batched overview merges.
+    When a single call's prompt would exceed the remaining budget, that call
+    is rejected and an empty summary/overview is returned so that indexing
+    and embedding can continue. Smaller subsequent calls may still succeed
+    if they fit within what remains — the limit is aggregate, not a
+    one-shot exhaustion gate.
+
+    A budget of 0 means unlimited (no enforcement).
+    """
+
+    def __init__(self, budget_chars: int):
+        self._budget = max(0, budget_chars)
+        self._remaining = self._budget
+        self._lock = threading.Lock()
+        self._rejected = False  # monotonic: set True on first reservation failure
+        self._warning_taken = False  # one-time latch: True after warning is claimed
+
+    @property
+    def unlimited(self) -> bool:
+        return self._budget == 0
+
+    @property
+    def exhausted(self) -> bool:
+        """True when remaining budget is zero or negative (no call can fit).
+
+        Note that a call may be rejected before the aggregate limit is
+        fully spent if that single prompt is larger than the remainder.
+        """
+        if self._budget == 0:
+            return False
+        with self._lock:
+            return self._remaining <= 0
+
+    def try_reserve(self, cost: int) -> bool:
+        """Attempt to reserve ``cost`` chars from the aggregate budget.
+
+        Returns True if the reservation succeeded (call may proceed).
+        Returns False if the call would exceed the remaining budget.
+        When unlimited, always returns True without tracking.
+
+        A single oversized call is rejected without consuming budget,
+        so smaller subsequent calls may still succeed. The first rejection
+        sets the ``rejected`` flag monotonically so callers can emit
+        exactly one warning per task.
+        """
+        if self._budget == 0:
+            return True
+        if cost <= 0:
+            return True
+        with self._lock:
+            if self._remaining < cost:
+                self._rejected = True
+                return False
+            self._remaining -= cost
+            return True
+
+    def take_first_rejection_warning(self) -> bool:
+        """Atomically return True exactly once when budget has ever rejected.
+
+        Used for one-time observability: the caller that gets True emits a
+        warning; all subsequent callers get False. This guarantees at most
+        one warning per task regardless of how many calls are skipped.
+        """
+        if self._budget == 0:
+            return False
+        with self._lock:
+            if not self._rejected or self._warning_taken:
+                return False
+            self._warning_taken = True
+            return True
+
+    @property
+    def remaining(self) -> int:
+        if self._budget == 0:
+            return -1
+        with self._lock:
+            return self._remaining
+
+    @property
+    def total_budget(self) -> int:
+        return self._budget
 
 
 class SemanticNodeScheduler:
@@ -222,6 +310,9 @@ class SemanticDagExecutor:
         self._dir_change_status: Dict[str, bool] = {}
         self._overview_cache: Dict[str, Dict[str, str]] = {}
         self._overview_cache_lock = asyncio.Lock()
+        self._summary_budget = SummaryBudget(
+            get_openviking_config().semantic.max_summary_input_chars
+        )
 
     async def run(self, root_uri: str) -> None:
         """Run DAG execution starting from root_uri."""
@@ -696,7 +787,10 @@ class SemanticDagExecutor:
                 self._file_change_status[file_path] = True
             if summary_dict is None:
                 summary_dict = await self._processor._generate_single_file_summary(
-                    file_path, llm_sem=self._llm_sem, ctx=self._ctx
+                    file_path,
+                    llm_sem=self._llm_sem,
+                    ctx=self._ctx,
+                    summary_budget=self._summary_budget,
                 )
         except Exception as e:
             logger.warning(f"Failed to generate summary for {file_path}: {e}")
@@ -840,7 +934,10 @@ class SemanticDagExecutor:
                     children_abstracts = await self._finalize_children_abstracts(node)
                 async with self._llm_sem:
                     overview = await self._processor._generate_overview(
-                        dir_uri, file_summaries, children_abstracts
+                        dir_uri,
+                        file_summaries,
+                        children_abstracts,
+                        summary_budget=self._summary_budget,
                     )
                 overview, abstract = self._processor._normalize_overview_generation(overview)
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -7,7 +7,10 @@ import re
 import threading
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+
+if TYPE_CHECKING:
+    from openviking.storage.queuefs.semantic_dag import SummaryBudget
 
 from openviking.observability.context import (
     bind_root_observability_context,
@@ -31,7 +34,6 @@ from openviking.parse.parsers.media.utils import (
     get_media_type,
 )
 from openviking.prompts import render_prompt
-from openviking.utils.ingest_options import IngestOptions
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
@@ -49,6 +51,7 @@ from openviking.utils.circuit_breaker import (
     CircuitBreakerOpen,
     classify_api_error,
 )
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.model_retry import ERROR_CLASS_INPUT_TOO_LARGE, ERROR_CLASS_PERMANENT
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI
@@ -1059,12 +1062,49 @@ class SemanticProcessor(DequeueHandlerBase):
         except Exception as e:
             logger.error(f"[SyncDiff] Failed to rewrite image URIs for {target_uri}: {e}")
 
+    async def _vlm_summary_call(
+        self,
+        prompt: str,
+        llm_sem: asyncio.Semaphore,
+        summary_budget: Optional["SummaryBudget"] = None,
+    ) -> Optional[str]:
+        """Call VLM for a summary/overview prompt with aggregate budget enforcement.
+
+        Atomically reserves the exact rendered-prompt character count from
+        the task-level aggregate limit immediately before each real
+        get_completion_async call. Returns None if this specific prompt
+        would exceed the remaining budget.
+
+        Logs one warning per task on the first rejection (not per skipped
+        call) so operators can see the guardrail activated without log spam.
+        Note: a single oversized prompt is rejected without consuming
+        budget, so smaller subsequent calls may still succeed.
+        """
+        prompt_len = len(prompt)
+        if summary_budget is not None and not summary_budget.try_reserve(prompt_len):
+            if summary_budget.take_first_rejection_warning():
+                logger.warning(
+                    "VLM summary input limit (%d chars) reached: "
+                    "rejected prompt of %d chars with %d remaining. "
+                    "Oversized individual calls are skipped; smaller "
+                    "subsequent calls may still succeed. "
+                    "Vectorization and indexing continue with empty summaries.",
+                    summary_budget.total_budget,
+                    prompt_len,
+                    summary_budget.remaining,
+                )
+            return None
+        async with llm_sem:
+            with bind_telemetry_stage("resource_summarize"):
+                return await get_openviking_config().vlm.get_completion_async(prompt)
+
     async def _generate_text_summary(
         self,
         file_path: str,
         file_name: str,
         llm_sem: asyncio.Semaphore,
         ctx: Optional[RequestContext] = None,
+        summary_budget: Optional["SummaryBudget"] = None,
     ) -> Dict[str, Any]:
         """Generate summary for a single text file (code, documentation, or other text)."""
         viking_fs = get_viking_fs()
@@ -1113,9 +1153,9 @@ class SemanticProcessor(DequeueHandlerBase):
                 "semantic.code_summary",
                 {"file_name": file_name, "content": content, "output_language": output_language},
             )
-            async with llm_sem:
-                with bind_telemetry_stage("resource_summarize"):
-                    summary = await vlm.get_completion_async(prompt)
+            summary = await self._vlm_summary_call(prompt, llm_sem, summary_budget=summary_budget)
+            if summary is None:
+                return result("")
             return result(summary.strip())
 
         if not vlm.is_available():
@@ -1135,9 +1175,9 @@ class SemanticProcessor(DequeueHandlerBase):
             {"file_name": file_name, "content": content, "output_language": output_language},
         )
 
-        async with llm_sem:
-            with bind_telemetry_stage("resource_summarize"):
-                summary = await vlm.get_completion_async(prompt)
+        summary = await self._vlm_summary_call(prompt, llm_sem, summary_budget=summary_budget)
+        if summary is None:
+            return result("")
         return result(summary.strip())
 
     async def _generate_single_file_summary(
@@ -1145,11 +1185,15 @@ class SemanticProcessor(DequeueHandlerBase):
         file_path: str,
         llm_sem: Optional[asyncio.Semaphore] = None,
         ctx: Optional[RequestContext] = None,
+        summary_budget: Optional["SummaryBudget"] = None,
     ) -> Dict[str, Any]:
         """Generate summary for a single file.
 
         Args:
             file_path: File path
+            summary_budget: Optional per-task aggregate VLM input limit.
+                When provided and a single prompt would exceed the
+                remaining budget, that VLM summary call is skipped.
 
         Returns:
             {"name": file_name, "summary": summary_content}; text files also carry
@@ -1165,7 +1209,9 @@ class SemanticProcessor(DequeueHandlerBase):
         elif media_type == "video":
             return await generate_video_summary(file_path, file_name, llm_sem, ctx=ctx)
         else:
-            return await self._generate_text_summary(file_path, file_name, llm_sem, ctx=ctx)
+            return await self._generate_text_summary(
+                file_path, file_name, llm_sem, ctx=ctx, summary_budget=summary_budget
+            )
 
     def _replace_index_references(
         self, generated_content: str, file_index_map: Dict[int, str]
@@ -1303,6 +1349,7 @@ class SemanticProcessor(DequeueHandlerBase):
         file_summaries: List[Dict[str, str]],
         children_abstracts: List[Dict[str, str]],
         llm_sem: Optional[asyncio.Semaphore] = None,
+        summary_budget: Optional["SummaryBudget"] = None,
     ) -> str:
         """Generate raw directory overview model output.
 
@@ -1315,6 +1362,9 @@ class SemanticProcessor(DequeueHandlerBase):
             dir_uri: Directory URI
             file_summaries: File summary list
             children_abstracts: Subdirectory summary list
+            summary_budget: Optional per-task aggregate VLM input limit.
+                When provided and a prompt would exceed the remaining
+                budget, that overview call is skipped (returns placeholder).
 
         Returns:
             Markdown overview content generated by the model.
@@ -1375,6 +1425,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 file_index_map,
                 llm_sem=llm_sem,
                 output_language=output_language,
+                summary_budget=summary_budget,
             )
         elif over_budget:
             # Few files but long summaries → truncate summaries to fit budget
@@ -1397,6 +1448,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 children_abstracts_str,
                 file_index_map,
                 output_language=output_language,
+                summary_budget=summary_budget,
             )
         else:
             overview = await self._single_generate_overview(
@@ -1405,6 +1457,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 children_abstracts_str,
                 file_index_map,
                 output_language=output_language,
+                summary_budget=summary_budget,
             )
 
         return overview
@@ -1416,11 +1469,9 @@ class SemanticProcessor(DequeueHandlerBase):
         children_abstracts_str: str,
         file_index_map: Dict[int, str],
         output_language: str = "en",
+        summary_budget: Optional["SummaryBudget"] = None,
     ) -> str:
         """Generate overview from a single prompt (small directories)."""
-        config = get_openviking_config()
-        vlm = config.vlm
-
         try:
             prompt = render_prompt(
                 "semantic.overview_generation",
@@ -1432,8 +1483,13 @@ class SemanticProcessor(DequeueHandlerBase):
                 },
             )
 
-            with bind_telemetry_stage("resource_summarize"):
-                overview = await vlm.get_completion_async(prompt)
+            overview = await self._vlm_summary_call(
+                prompt,
+                asyncio.Semaphore(self.max_concurrent_llm),
+                summary_budget=summary_budget,
+            )
+            if overview is None:
+                return f"# {dir_uri.split('/')[-1]}\n\n[Directory overview is not generated]"
 
             overview = self._replace_index_references(overview, file_index_map)
 
@@ -1454,15 +1510,14 @@ class SemanticProcessor(DequeueHandlerBase):
         file_index_map: Dict[int, str],
         llm_sem: Optional[asyncio.Semaphore] = None,
         output_language: str = "en",
+        summary_budget: Optional["SummaryBudget"] = None,
     ) -> str:
         """Generate overview by batching file and subdirectory summaries.
 
         Splits both input kinds into batches, generates a partial overview per
         batch, then merges the partials without repeating the raw inputs.
         """
-        config = get_openviking_config()
-        vlm = config.vlm
-        semantic = config.semantic
+        semantic = get_openviking_config().semantic
         batch_size = semantic.overview_batch_size
         dir_name = dir_uri.split("/")[-1]
 
@@ -1475,7 +1530,7 @@ class SemanticProcessor(DequeueHandlerBase):
         # Generate partial overviews concurrently using global file indices.
         if llm_sem is None:
             llm_sem = asyncio.Semaphore(self.max_concurrent_llm)
-        partial_overviews = [None] * len(batches)
+        partial_overviews: List[Optional[str]] = [None] * len(batches)
         batch_prompts: List[Tuple[int, str, Dict[int, str]]] = []
 
         for batch_idx, batch in enumerate(batches):
@@ -1503,11 +1558,12 @@ class SemanticProcessor(DequeueHandlerBase):
 
         async def _run_batch(batch_idx: int, prompt: str, batch_index_map: Dict[int, str]) -> None:
             try:
-                async with llm_sem:
-                    with bind_telemetry_stage("resource_summarize"):
-                        partial = await vlm.get_completion_async(prompt)
-                partial = self._replace_index_references(partial, batch_index_map)
-                partial_overviews[batch_idx] = partial.strip()
+                partial = await self._vlm_summary_call(
+                    prompt, llm_sem, summary_budget=summary_budget
+                )
+                if partial is not None:
+                    partial = self._replace_index_references(partial, batch_index_map)
+                    partial_overviews[batch_idx] = partial.strip()
             except Exception as e:
                 logger.warning(
                     f"Failed to generate partial overview batch "
@@ -1536,8 +1592,9 @@ class SemanticProcessor(DequeueHandlerBase):
                     "output_language": output_language,
                 },
             )
-            with bind_telemetry_stage("resource_summarize"):
-                overview = await vlm.get_completion_async(prompt)
+            overview = await self._vlm_summary_call(prompt, llm_sem, summary_budget=summary_budget)
+            if overview is None:
+                return partial_overviews[0]
             overview = self._replace_index_references(overview, file_index_map)
             return overview.strip()
         except Exception as e:

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -762,6 +762,19 @@ class SemanticConfig:
     memory_chunk_overlap: int = 200
     """Character overlap between adjacent memory chunks for context continuity."""
 
+    max_summary_input_chars: int = 2_000_000
+    """Aggregate character limit on VLM prompt input per task for summary/overview generation.
+
+    0 means unlimited. This caps cumulative input across all per-file summaries,
+    directory overviews, and batched overview merges within a single semantic
+    processing task (one SemanticMsg / one DAG executor). When a single
+    prompt would exceed the remaining budget, that call is rejected and an
+    empty summary/overview is returned so that indexing and embedding
+    continue without unbounded VLM cost.
+
+    Default is 2M chars.
+    """
+
     def __post_init__(self):
         if self.memory_chunk_chars <= 0:
             raise ValueError("memory_chunk_chars must be positive")
@@ -769,6 +782,8 @@ class SemanticConfig:
             raise ValueError("memory_chunk_overlap must be non-negative")
         if self.memory_chunk_overlap >= self.memory_chunk_chars:
             raise ValueError("memory_chunk_overlap must be smaller than memory_chunk_chars")
+        if self.max_summary_input_chars < 0:
+            raise ValueError("max_summary_input_chars must be non-negative")
 
 
 # Configuration registry for dynamic loading

--- a/tests/misc/test_semantic_config.py
+++ b/tests/misc/test_semantic_config.py
@@ -105,3 +105,21 @@ def test_memory_chunk_config_rejects_non_progressing_overlap(chunk_chars, overla
     """Memory chunk settings must guarantee chunking advances."""
     with pytest.raises(ValueError, match="memory_chunk"):
         SemanticConfig(memory_chunk_chars=chunk_chars, memory_chunk_overlap=overlap)
+
+
+def test_max_summary_input_chars_default_is_exact_2m():
+    """Default aggregate limit is a concrete 2M chars."""
+    config = SemanticConfig()
+    assert config.max_summary_input_chars == 2_000_000
+
+
+def test_max_summary_input_chars_zero_means_unlimited():
+    """0 disables the budget (unlimited — opt-out for advanced users)."""
+    config = SemanticConfig(max_summary_input_chars=0)
+    assert config.max_summary_input_chars == 0
+
+
+def test_max_summary_input_chars_rejects_negative():
+    """Negative budget is invalid and rejected."""
+    with pytest.raises(ValueError, match="max_summary_input_chars"):
+        SemanticConfig(max_summary_input_chars=-1)

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -58,11 +58,15 @@ class _FakeProcessor:
             results[m.group("name").strip()] = m.group("summary").strip()
         return results
 
-    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+    async def _generate_single_file_summary(
+        self, file_path, llm_sem=None, ctx=None, summary_budget=None
+    ):
         self.summarized_files.append(file_path)
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
-    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+    async def _generate_overview(
+        self, dir_uri, file_summaries, children_abstracts, summary_budget=None
+    ):
         lines = ["FILES:"]
         for item in file_summaries:
             name = item.get("name", "")

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import re
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,6 +17,10 @@ class _FakeVikingFS:
         self._tree = {self._norm(k): v for k, v in tree.items()}
         self._file_contents = {self._norm(k): v for k, v in file_contents.items()}
         self.writes = []
+        self._async_agfs = SimpleNamespace(
+            pathlock_acquire_exact_batch=AsyncMock(return_value={}),
+            pathlock_release=AsyncMock(),
+        )
 
     def _norm(self, path):
         if "://" not in path:
@@ -34,7 +39,8 @@ class _FakeVikingFS:
     async def read_file(self, path, ctx=None):
         return self._file_contents.get(self._norm(path), "")
 
-    async def write_file(self, path, content, ctx=None):
+    async def write_file(self, path, content, ctx=None, **kwargs):
+        del kwargs
         norm_path = self._norm(path)
         self._file_contents[norm_path] = content
         self.writes.append((norm_path, content))

--- a/tests/storage/test_semantic_dag_skip_files.py
+++ b/tests/storage/test_semantic_dag_skip_files.py
@@ -28,11 +28,15 @@ class _FakeProcessor:
         self.summarized_files = []
         self.vectorized_files = []
 
-    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+    async def _generate_single_file_summary(
+        self, file_path, llm_sem=None, ctx=None, summary_budget=None
+    ):
         self.summarized_files.append(file_path)
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
-    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+    async def _generate_overview(
+        self, dir_uri, file_summaries, children_abstracts, summary_budget=None
+    ):
         return "overview"
 
     def _normalize_overview_generation(self, overview):

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -38,10 +38,14 @@ class _FakeProcessor:
         self.vectorized_dirs = []
         self.vectorized_files = []
 
-    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+    async def _generate_single_file_summary(
+        self, file_path, llm_sem=None, ctx=None, summary_budget=None
+    ):
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
-    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+    async def _generate_overview(
+        self, dir_uri, file_summaries, children_abstracts, summary_budget=None
+    ):
         return "overview"
 
     def _normalize_overview_generation(self, overview):
@@ -74,7 +78,9 @@ class _TrackingProcessor(_FakeProcessor):
         self.active_summaries = 0
         self.max_active_summaries = 0
 
-    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+    async def _generate_single_file_summary(
+        self, file_path, llm_sem=None, ctx=None, summary_budget=None
+    ):
         self.active_summaries += 1
         self.max_active_summaries = max(self.max_active_summaries, self.active_summaries)
         try:

--- a/tests/storage/test_semantic_dag_stats.py
+++ b/tests/storage/test_semantic_dag_stats.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -21,12 +23,17 @@ class _FakeVikingFS:
     def __init__(self, tree):
         self._tree = tree
         self.writes = []
+        self._async_agfs = SimpleNamespace(
+            pathlock_acquire_exact_batch=AsyncMock(return_value={}),
+            pathlock_release=AsyncMock(),
+        )
 
     async def ls(self, uri, node_limit=None, ctx=None):
         del node_limit
         return self._tree.get(uri, [])
 
-    async def write_file(self, path, content, ctx=None, lock_handle=None):
+    async def write_file(self, path, content, ctx=None, **kwargs):
+        del kwargs
         self.writes.append((path, content))
 
     def _uri_to_path(self, uri, ctx=None):
@@ -52,8 +59,9 @@ class _FakeProcessor:
         return overview, "abstract"
 
     async def _vectorize_directory(
-        self, uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None
+        self, uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None, **kwargs
     ):
+        del kwargs
         self.vectorized_dirs.append(uri)
 
     async def _vectorize_single_file(
@@ -65,7 +73,9 @@ class _FakeProcessor:
         ctx=None,
         semantic_msg_id=None,
         use_summary=False,
+        **kwargs,
     ):
+        del kwargs
         self.vectorized_files.append(file_path)
 
     async def _vectorize_directory_simple(self, uri, context_type, abstract, overview, ctx=None):

--- a/tests/storage/test_semantic_processor_summary_budget.py
+++ b/tests/storage/test_semantic_processor_summary_budget.py
@@ -1,0 +1,370 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs import semantic_processor as semantic_processor_module
+from openviking.storage.queuefs.semantic_dag import SummaryBudget
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+
+class RecordingVLM:
+    """VLM mock that records every prompt sent to get_completion_async."""
+
+    def __init__(self, response: str = "summary response"):
+        self.prompts = []
+        self._response = response
+
+    def is_available(self):
+        return True
+
+    async def get_completion_async(self, prompt):
+        self.prompts.append(prompt)
+        return self._response
+
+
+def _make_config(vlm, max_summary_input_chars: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        vlm=vlm,
+        semantic=SimpleNamespace(
+            max_file_content_chars=1000,
+            max_skeleton_chars=500,
+            max_overview_prompt_chars=10_000,
+            overview_batch_size=10,
+            max_summary_input_chars=max_summary_input_chars,
+            abstract_max_chars=256,
+            overview_max_chars=4000,
+            memory_chunk_chars=2000,
+            memory_chunk_overlap=200,
+        ),
+        code=SimpleNamespace(
+            code_summary_mode="llm",
+        ),
+        output_language_override="en",
+    )
+
+
+def _patch_config(monkeypatch, config):
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "get_openviking_config",
+        lambda: config,
+    )
+
+
+# ── SummaryBudget unit tests ─────────────────────────────────────────
+
+
+def test_summary_budget_unlimited():
+    budget = SummaryBudget(0)
+    assert budget.unlimited is True
+    assert budget.exhausted is False
+    assert budget.try_reserve(999_999) is True
+
+
+def test_summary_budget_atomic_reserve_and_exact_consumption():
+    """try_reserve is atomic: exact debit, exhaustion at 0, oversize denied."""
+    budget = SummaryBudget(100)
+    assert budget.try_reserve(30) is True
+    assert budget.remaining == 70
+    assert budget.try_reserve(70) is True
+    assert budget.remaining == 0
+    assert budget.exhausted is True
+    # Any further request of any positive size fails
+    assert budget.try_reserve(1) is False
+    # Zero cost always passes (no-op)
+    assert budget.try_reserve(0) is True
+
+
+def test_summary_budget_oversize_call_denied_without_consuming():
+    """A single call larger than remaining budget is denied; budget intact."""
+    budget = SummaryBudget(50)
+    assert budget.try_reserve(100) is False
+    assert budget.remaining == 50
+    assert budget.exhausted is False
+    # A smaller call can still succeed
+    assert budget.try_reserve(50) is True
+    assert budget.exhausted is True
+
+
+def test_summary_budget_concurrent_no_overspend():
+    """Concurrent try_reserve from many threads never exceeds budget."""
+    budget = SummaryBudget(1000)
+    success_count = 0
+    lock = threading.Lock()
+
+    def worker(n: int, size: int) -> None:
+        nonlocal success_count
+        local_success = 0
+        for _ in range(n):
+            if budget.try_reserve(size):
+                local_success += 1
+        with lock:
+            success_count += local_success
+
+    threads = [threading.Thread(target=worker, args=(200, 3)) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    total_spent = success_count * 3
+    assert total_spent <= 1000
+    assert budget.remaining >= 0
+    assert budget.remaining < 3  # next call would fail (or already did)
+
+
+def test_summary_budget_first_rejection_warning_fires_once():
+    """take_first_rejection_warning returns True exactly once, monotonically.
+
+    Consecutive rejections must not re-trigger the warning, and concurrent
+    callers must not both get True.
+    """
+    budget = SummaryBudget(10)
+    # No rejection yet → False
+    assert budget.take_first_rejection_warning() is False
+    # First rejection sets the flag
+    assert budget.try_reserve(100) is False
+    # First take returns True
+    assert budget.take_first_rejection_warning() is True
+    # Subsequent takes return False (already consumed)
+    assert budget.take_first_rejection_warning() is False
+    # More rejections do not re-arm the warning
+    assert budget.try_reserve(100) is False
+    assert budget.try_reserve(100) is False
+    assert budget.take_first_rejection_warning() is False
+
+
+def test_summary_budget_concurrent_first_rejection_warning_once():
+    """Concurrent take_first_rejection_warning calls — exactly one wins."""
+    budget = SummaryBudget(5)
+    budget.try_reserve(100)  # trigger rejection
+
+    warning_count = 0
+    lock = threading.Lock()
+
+    def worker():
+        nonlocal warning_count
+        if budget.take_first_rejection_warning():
+            with lock:
+                warning_count += 1
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert warning_count == 1, f"expected 1 warning, got {warning_count}"
+
+
+def test_summary_budget_separate_instances_are_isolated():
+    """Two SummaryBudget instances do not share state (task isolation)."""
+    budget_a = SummaryBudget(100)
+    budget_b = SummaryBudget(100)
+    budget_a.try_reserve(80)
+    assert budget_a.remaining == 20
+    assert budget_b.remaining == 100
+
+
+# ── SemanticProcessor integration tests ──────────────────────────────
+
+
+PROMPT_LEN = 40  # fixed prompt length used in tests with patched render_prompt
+
+
+@pytest.mark.asyncio
+async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch, caplog):
+    """File summaries charge exact rendered-prompt length; over-budget calls skip VLM.
+
+    Proves:
+    - Cumulative VLM input chars == budget exactly (not less, not more)
+    - Files that exceed remaining budget get empty summary but full content
+      (vectorization still works)
+    - Exactly one warning per task (not per rejected call), with limit/requested/remaining
+    """
+    import logging
+
+    vlm = RecordingVLM()
+    config = _make_config(vlm)
+    _patch_config(monkeypatch, config)
+
+    # Fixed-length prompts for deterministic budget math
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "render_prompt",
+        lambda name, vals: "x" * PROMPT_LEN,
+    )
+
+    content = "hello world"
+    mock_fs = MagicMock()
+    mock_fs.read_file = AsyncMock(return_value=content)
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "get_viking_fs",
+        lambda: mock_fs,
+    )
+
+    processor = SemanticProcessor()
+    BUDGET = PROMPT_LEN * 3  # exactly 3 calls fit
+    budget = SummaryBudget(BUDGET)
+
+    with caplog.at_level(logging.WARNING, logger="openviking"):
+        results = []
+        for i in range(5):
+            result = await processor._generate_text_summary(
+                f"viking://resources/test/file{i}.txt",
+                f"file{i}.txt",
+                asyncio.Semaphore(1),
+                summary_budget=budget,
+            )
+            results.append(result)
+
+    # Exactly 3 calls fit in the budget
+    assert len(vlm.prompts) == 3
+    # Cumulative input matches budget exactly
+    assert sum(len(p) for p in vlm.prompts) == BUDGET
+    # 3 non-empty summaries, 2 empty
+    assert sum(1 for r in results if r["summary"]) == 3
+    assert sum(1 for r in results if not r["summary"]) == 2
+    # All files retain full content for vectorization
+    assert all(r["content"] == content for r in results)
+    # Budget is exactly exhausted
+    assert budget.remaining == 0
+    assert budget.exhausted is True
+    # Exactly one warning for 2 consecutive rejections, with numeric details
+    warning_records = [r for r in caplog.records if "VLM summary input limit" in r.message]
+    assert len(warning_records) == 1, (
+        f"Expected exactly 1 budget warning, got {len(warning_records)}: "
+        f"{[r.message for r in warning_records]}"
+    )
+    assert str(BUDGET) in warning_records[0].message  # limit
+    assert str(PROMPT_LEN) in warning_records[0].message  # requested
+
+
+@pytest.mark.asyncio
+async def test_text_summary_ast_only_does_not_consume_budget(monkeypatch):
+    """AST-only code mode never calls VLM, so budget is not consumed."""
+    vlm = RecordingVLM()
+    config = _make_config(vlm)
+    config.code.code_summary_mode = "ast"
+    _patch_config(monkeypatch, config)
+
+    # 200-line file triggers AST path
+    content = "\n".join([f"line {i}" for i in range(200)])
+    mock_fs = MagicMock()
+    mock_fs.read_file = AsyncMock(return_value=content)
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "get_viking_fs",
+        lambda: mock_fs,
+    )
+
+    processor = SemanticProcessor()
+    budget = SummaryBudget(10_000)
+
+    result = await processor._generate_text_summary(
+        "viking://resources/test/main.py",
+        "main.py",
+        asyncio.Semaphore(1),
+        summary_budget=budget,
+    )
+
+    assert len(vlm.prompts) == 0
+    assert budget.remaining == 10_000  # nothing charged
+    assert result["summary"]  # AST skeleton is non-empty
+
+
+@pytest.mark.asyncio
+async def test_overview_and_file_summaries_share_one_budget(monkeypatch):
+    """File summaries and directory overview draw from the same budget."""
+    vlm = RecordingVLM(response="ok")
+    config = _make_config(vlm)
+    _patch_config(monkeypatch, config)
+
+    # Fixed prompt length for both summaries and overviews
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "render_prompt",
+        lambda name, vals: "x" * PROMPT_LEN,
+    )
+
+    content = "x" * 10
+    mock_fs = MagicMock()
+    mock_fs.read_file = AsyncMock(return_value=content)
+    monkeypatch.setattr(
+        semantic_processor_module,
+        "get_viking_fs",
+        lambda: mock_fs,
+    )
+
+    processor = SemanticProcessor()
+    # Budget fits exactly 4 calls total. 2 file summaries + 1 overview = 3,
+    # leaving room. If overview came from a separate budget, we'd see more calls.
+    BUDGET = PROMPT_LEN * 4
+    budget = SummaryBudget(BUDGET)
+
+    # Generate 2 file summaries (2 calls)
+    for i in range(2):
+        await processor._generate_text_summary(
+            f"viking://resources/test/file{i}.txt",
+            f"file{i}.txt",
+            asyncio.Semaphore(1),
+            summary_budget=budget,
+        )
+
+    file_calls = len(vlm.prompts)
+    assert file_calls == 2
+
+    # Generate overview for a directory (1 call — fits in remaining budget)
+    file_summaries = [{"name": f"f{i}.txt", "summary": f"summary{i}"} for i in range(3)]
+    await processor._generate_overview(
+        "viking://resources/test",
+        file_summaries=file_summaries,
+        children_abstracts=[],
+        summary_budget=budget,
+    )
+
+    total_calls = len(vlm.prompts)
+    assert total_calls == 3  # 2 file + 1 overview
+    total_input = sum(len(p) for p in vlm.prompts)
+    assert total_input == PROMPT_LEN * 3
+    assert total_input <= BUDGET
+
+
+@pytest.mark.asyncio
+async def test_batched_overview_total_input_never_exceeds_budget(monkeypatch):
+    """Batched overview: sum of all batch + merge prompt chars <= budget."""
+    vlm = RecordingVLM(response="partial")
+    config = _make_config(vlm)
+    config.semantic.max_overview_prompt_chars = 200  # force batching
+    config.semantic.overview_batch_size = 2
+    _patch_config(monkeypatch, config)
+
+    # Prompts proportional to input size (not fixed — so batches vary)
+    def render(name, vals):
+        return f"[{name}] {vals['file_summaries']}"
+
+    monkeypatch.setattr(semantic_processor_module, "render_prompt", render)
+
+    processor = SemanticProcessor()
+    file_summaries = [{"name": f"f{i}.txt", "summary": "s" * 20} for i in range(6)]
+
+    BUDGET = 300
+    budget = SummaryBudget(BUDGET)
+
+    await processor._generate_overview(
+        "viking://resources/test",
+        file_summaries=file_summaries,
+        children_abstracts=[],
+        summary_budget=budget,
+    )
+
+    # Core invariant: cumulative rendered prompt chars never exceed budget
+    total_input = sum(len(p) for p in vlm.prompts)
+    assert total_input <= BUDGET, f"Cumulative VLM input ({total_input}) exceeded budget ({BUDGET})"

--- a/tests/storage/test_semantic_processor_summary_budget.py
+++ b/tests/storage/test_semantic_processor_summary_budget.py
@@ -17,7 +17,7 @@ class RecordingVLM:
     """VLM mock that records every prompt sent to get_completion_async."""
 
     def __init__(self, response: str = "summary response"):
-        self.prompts = []
+        self.prompts: list[str] = []
         self._response = response
 
     def is_available(self):
@@ -179,7 +179,7 @@ PROMPT_LEN = 40  # fixed prompt length used in tests with patched render_prompt
 
 
 @pytest.mark.asyncio
-async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch, caplog):
+async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch):
     """File summaries charge exact rendered-prompt length; over-budget calls skip VLM.
 
     Proves:
@@ -188,8 +188,6 @@ async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch, ca
       (vectorization still works)
     - Exactly one warning per task (not per rejected call), with limit/requested/remaining
     """
-    import logging
-
     vlm = RecordingVLM()
     config = _make_config(vlm)
     _patch_config(monkeypatch, config)
@@ -214,16 +212,22 @@ async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch, ca
     BUDGET = PROMPT_LEN * 3  # exactly 3 calls fit
     budget = SummaryBudget(BUDGET)
 
-    with caplog.at_level(logging.WARNING, logger="openviking"):
-        results = []
-        for i in range(5):
-            result = await processor._generate_text_summary(
-                f"viking://resources/test/file{i}.txt",
-                f"file{i}.txt",
-                asyncio.Semaphore(1),
-                summary_budget=budget,
-            )
-            results.append(result)
+    warnings = []
+
+    def capture_warning(message, *args):
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(semantic_processor_module.logger, "warning", capture_warning)
+
+    results = []
+    for i in range(5):
+        result = await processor._generate_text_summary(
+            f"viking://resources/test/file{i}.txt",
+            f"file{i}.txt",
+            asyncio.Semaphore(1),
+            summary_budget=budget,
+        )
+        results.append(result)
 
     # Exactly 3 calls fit in the budget
     assert len(vlm.prompts) == 3
@@ -237,14 +241,9 @@ async def test_text_summary_budget_exact_accounting_and_skipping(monkeypatch, ca
     # Budget is exactly exhausted
     assert budget.remaining == 0
     assert budget.exhausted is True
-    # Exactly one warning for 2 consecutive rejections, with numeric details
-    warning_records = [r for r in caplog.records if "VLM summary input limit" in r.message]
-    assert len(warning_records) == 1, (
-        f"Expected exactly 1 budget warning, got {len(warning_records)}: "
-        f"{[r.message for r in warning_records]}"
-    )
-    assert str(BUDGET) in warning_records[0].message  # limit
-    assert str(PROMPT_LEN) in warning_records[0].message  # requested
+    assert len(warnings) == 1
+    assert str(BUDGET) in warnings[0]
+    assert str(PROMPT_LEN) in warnings[0]
 
 
 @pytest.mark.asyncio
@@ -255,8 +254,7 @@ async def test_text_summary_ast_only_does_not_consume_budget(monkeypatch):
     config.code.code_summary_mode = "ast"
     _patch_config(monkeypatch, config)
 
-    # 200-line file triggers AST path
-    content = "\n".join([f"line {i}" for i in range(200)])
+    content = "def helper():\n    return 1\n\nclass Service:\n    def run(self):\n        return helper()\n"
     mock_fs = MagicMock()
     mock_fs.read_file = AsyncMock(return_value=content)
     monkeypatch.setattr(


### PR DESCRIPTION
Add a per-task aggregate VLM prompt input limit for semantic summary/overview generation to prevent unbounded VLM costs on large add-resource imports.

## Changes
- **SummaryBudget** in `semantic_dag.py`: concurrency-safe aggregate character limit with atomic `try_reserve` and one-time first-rejection warning latch.
- **`_vlm_summary_call`** helper in `SemanticProcessor`: consolidates budget check, semaphore, and telemetry wrapping for all VLM summary/overview calls. Warning message includes the configured limit, the rejected prompt size, and remaining budget.
- **`summary_budget` kwarg** threaded through `_generate_text_summary`, `_generate_single_file_summary`, `_generate_overview` (all three paths: single-prompt, batched, truncated) and `_single_generate_overview`.
- **`SemanticDagExecutor`** creates one `SummaryBudget` per task from config and passes it to all file + directory overview generation.
- **`SemanticConfig.max_summary_input_chars`** (default `2_000_000`, `0` = unlimited) with validation.
- **11 unit tests** for budget behavior + **3 config validation tests**.

## Behavior
- When a single prompt would exceed the remaining budget, that call is rejected and an empty summary/overview is returned so indexing and embedding continue.
- A single oversized prompt is rejected without consuming budget, so smaller subsequent calls may still succeed.
- At most one warning per task when the budget first rejects a call.

Fixes #1595