### PR TITLE
fix(memory): event write-path residuals (Partially addresses #3598)

### DIFF
--- a/openviking/prompts/templates/memory/events.yaml
+++ b/openviking/prompts/templates/memory/events.yaml
@@ -100,7 +100,7 @@ content_template: |
   # Summary
   {{ summary }}
   # {{extract_context.get_first_message_time_with_weekday_from_ranges(ranges|default(''))|default('N/A')}} ChatLog:
-  {{ extract_context.get_event_content(ranges, summary, 0) }}
+  {{ extract_context.get_event_content(ranges, summary) }}
   {% endif %}
 embedding_template: |-
   EventName: {{ event_name }}

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -578,7 +578,8 @@ class MessageRange:
             if not current_messages:
                 return
             content = self._format_merged_content(current_messages)
-            formatted.append(f"**{self._speaker_for(current_messages[0])}**: {content}")
+            if content.strip():
+                formatted.append(f"**{self._speaker_for(current_messages[0])}**: {content}")
             current_messages = []
 
         for msg in msg_group:

--- a/tests/unit/session/memory/test_event_write_path_contracts.py
+++ b/tests/unit/session/memory/test_event_write_path_contracts.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Event write-path behavior contracts.
+
+Pins two memory-write behaviors so future template / formatter changes
+do not regress:
+  - events.yaml prefers a short summary over the full transcript
+  - _format_contiguous_group suppresses turns with no text content
+"""
+
+from openviking.message import Message
+from openviking.message.part import TextPart, ToolPart
+from openviking.prompts.manager import PromptManager
+from openviking.session.memory.dataclass import MemoryFile
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
+from openviking.session.memory.memory_updater import (
+    ExtractContext,
+    MessageRange,
+)
+from openviking.session.memory.utils import MemoryFileUtils
+
+
+def test_events_template_uses_short_summary_instead_of_full_transcript():
+    """When summary is much shorter than the transcript, the rendered
+    event body should contain the summary, not the full pretty-print."""
+    long_text = "hello world " * 100
+    short_summary = "User talked about expanding a clothing store."
+
+    extract_ctx = ExtractContext(
+        messages=[
+            Message(
+                id="1",
+                role="user",
+                parts=[TextPart(text=long_text)],
+                created_at="2024-01-01T00:00:00",
+            )
+        ]
+    )
+
+    registry = MemoryTypeRegistry(load_schemas=False)
+    registry.load_from_yaml(
+        str(PromptManager._get_bundled_templates_dir() / "memory" / "events.yaml")
+    )
+
+    rendered = MemoryFileUtils.write(
+        MemoryFile(
+            extra_fields={
+                "event_name": "user_message",
+                "goal": "",
+                "summary": short_summary,
+                "ranges": "0",
+            }
+        ),
+        content_template=registry.get("events").content_template,
+        extract_context=extract_ctx,
+    )
+
+    assert short_summary in rendered
+    assert "hello world " * 10 not in rendered
+
+
+def test_format_contiguous_group_skips_turns_with_no_text():
+    """Turns with only non-text parts (e.g. ToolPart) do not produce
+    an empty speaker line."""
+    mr = MessageRange(elements=[])
+    msgs = [
+        Message(
+            id="1",
+            role="user",
+            parts=[TextPart(text="hello")],
+            created_at="2024-01-01T00:00:00",
+        ),
+        Message(
+            id="2",
+            role="assistant",
+            parts=[ToolPart(tool_name="tool_a")],
+            created_at="2024-01-01T00:00:00",
+        ),
+        Message(
+            id="3",
+            role="assistant",
+            parts=[TextPart(text="done")],
+            created_at="2024-01-01T00:00:00",
+        ),
+    ]
+
+    lines = mr._format_contiguous_group(msgs)
+    non_empty = [l for l in lines if l.strip()]
+    assert len(non_empty) == 2


### PR DESCRIPTION
Partially addresses #3598 — fixes the two **write-path** residuals not covered by #3534.

### Scope

Issue #3598 lists four items; this PR only addresses items 3 and 4 (write path). Item 1 is handled by #3534 on the read path; item 2 was clarified by the reporter as intentional policy and is out of scope.

This change set does **not** overlap with #3534 — it touches only `events.yaml` (write template) and `_format_contiguous_group` (write-time formatting), neither of which #3534 modifies.

### Changes

1. **`events.yaml`**: Remove hardcoded `ratio_threshold=0` from the `get_event_content(ranges, summary, 0)` call in the event content template. The method defaults to `0.2`, which means a short summary is preferred over the full transcript.

2. **`memory_updater.py`** (`_format_contiguous_group`): Add a `content.strip()` guard so turns with no text content (e.g. only ToolPart) do not emit an empty `**speaker**: ` line in formatted contiguous groups.

### Tests

New test file `tests/unit/session/memory/test_event_write_path_contracts.py` with two focused contract tests:
- `test_events_template_uses_short_summary_instead_of_full_transcript` — renders the real events.yaml template against a long transcript + short summary and asserts the summary (not the transcript) appears in output.
- `test_format_contiguous_group_skips_turns_with_no_text` — asserts tool-only turns produce no empty speaker line.

Both tests pass locally (pytest 2/2 passed, ruff check + format clean on Python files).