### PR TITLE
fix(compressor_v2): background-refresh pathlock leases across long LLM extractions (rebase of #3581 for Rust migration)

### DIFF
--- a/openviking/session/compressor_v2.py
+++ b/openviking/session/compressor_v2.py
@@ -9,6 +9,7 @@ Maintains the service-facing compressor interface.
 
 import asyncio
 import json
+from contextlib import nullcontext
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
@@ -76,6 +77,122 @@ def _log_memory_lock_retry(
         return now
 
     return last_warning_at
+
+
+class _LockRefresher:
+    """Background refresh of a pathlock lease held across LLM extraction.
+
+    **Motivation** (re-implementation of PR #3581 for the post-Rust AGFS lock API):
+
+    The v2 compressor has two orchestrator phases (long-term memories + session
+    skills / execution memories) that hold a pathlock lease for the memory
+    schema directory while making N successive LLM calls. Each LLM call is
+    open-ended (network latency, VLM image encoding, tool use, etc.) and a
+    batch can easily run for 2--10 minutes. The underlying pathlock tokens are
+    considered stale after ``lock_expire_secs`` (default 300s in the Rust
+    manager). Once a lease is stale, another process can successfully remove
+    the token and re-acquire the same locks, after which the original
+    extractor's ``updater.apply_operations()`` writes will fail with a lock
+    conflict and the batch is lost.
+
+    The removed Python ``OwnedLockLease`` wrapper from the old
+    ``openviking/storage/transaction/path_lock.py`` solved this by exposing a
+    ``refresh_lock()`` method that the compressor wrapped in an ``asyncio``
+    background task. After PR #3602 replaced that file with the Rust
+    ``ragfs/src/lock/manager.rs`` implementation, the refresh surface moved to
+    ``viking_fs._async_agfs.pathlock_refresh(lease)`` and the Python wrapper
+    class was deleted. The compressor was never migrated, so from PR #3602
+    until this commit, long-running extractions held leases with NO periodic
+    refresh, exposing them to the exact stale-token race described above.
+
+    **How to use**::
+
+        lease = await agfs.pathlock_acquire_exact_tree_batch(...)
+        async with _LockRefresher(viking_fs, lease, refresh_period_s) as refresh_handle:
+            # ... minutes of LLM orchestrator work ...
+            updater.apply_operations(..., transaction_handle=refresh_handle.lease)
+        # On __aexit__ the refresh task is cancelled before caller releases the lease.
+
+    ``refresh_period_s`` defaults to 90s, which is safely inside the default
+    300s ``lock_expire_secs`` window (gives us 2-3 refreshes before a token
+    would otherwise become stale). Pass ``None`` and the constructor derives
+    ``lock_expire_secs * 0.3`` from ``get_openviking_config()`` if available,
+    falling back to 90s.
+    """
+
+    __slots__ = ("agfs", "lease", "period_s", "_task", "_stopped", "_phase_label")
+
+    def __init__(
+        self,
+        viking_fs: VikingFS,
+        lease,
+        refresh_period_s: Optional[float] = None,
+        phase_label: str = "",
+    ) -> None:
+        agfs = getattr(viking_fs, "_async_agfs", None)
+        if agfs is None:
+            raise RuntimeError("_LockRefresher requires VikingFS._async_agfs")
+        self.agfs = agfs
+        self.lease = lease
+        period = refresh_period_s
+        if period is None or period <= 0:
+            try:
+                cfg = get_openviking_config()
+                expire = float(
+                    getattr(getattr(cfg, "storage", None), "lock_expire_seconds", 0.0)
+                    or getattr(getattr(cfg, "memory", None), "v2_lock_expire_seconds", 0.0)
+                    or 0.0
+                )
+                period = expire * 0.3 if expire > 0 else None
+            except Exception:  # noqa: BLE001 — never raise from config read, fall back
+                period = None
+            if period is None or period <= 0:
+                period = 90.0
+        self.period_s = float(period)
+        self._task: Optional[asyncio.Task] = None
+        self._stopped = False
+        self._phase_label = phase_label
+
+    async def _refresh_loop(self) -> None:
+        prefix = f"[{self._phase_label}] " if self._phase_label else ""
+        while not self._stopped:
+            try:
+                await asyncio.sleep(self.period_s)
+                if self._stopped:
+                    return
+                await self.agfs.pathlock_refresh(self.lease)
+                logger.debug(
+                    "%sRefreshed memory schema lock lease (period=%.1fs)",
+                    prefix, self.period_s,
+                )
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:  # noqa: BLE001 — never let a refresh failure kill orchestrator
+                logger.warning(
+                    "%sLock lease background refresh failed (continuing): %s",
+                    prefix, exc,
+                )
+
+    async def __aenter__(self) -> "_LockRefresher":
+        if not self._stopped and self._task is None:
+            self._task = asyncio.create_task(
+                self._refresh_loop(), name="ov-compressor-lock-refresh",
+            )
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._stopped = True
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                prefix = f"[{self._phase_label}] " if self._phase_label else ""
+                logger.debug("%sLock refresher task exited with: %s", prefix, exc)
 
 
 def _render_memory_schema_locks(
@@ -376,93 +493,105 @@ class SessionCompressorV2:
 
             orchestrator._transaction_handle = transaction_handle  # 传递给 ExtractLoop
 
-            # Run ReAct orchestrator
-            operations, tools_used = await orchestrator.run()
-
-            if operations is None:
-                tracer.info("No memory operations generated")
-                result = MemoryUpdateResult()
-            else:
-                updater = self._get_or_create_updater(registry, transaction_handle)
-
-                # Apply operations with isolation_handler
-                result = await updater.apply_operations(
-                    operations,
-                    ctx,
-                    extract_context=extract_context,
-                    isolation_handler=isolation_handler,
-                )
-
-                tracer.info(
-                    f"Applied memory operations: written={len(result.written_uris)}, "
-                    f"edited={len(result.edited_uris)}, deleted={len(result.deleted_uris)}, "
-                    f"errors={len(result.errors)}"
-                )
-
-            # Write memory_diff.json to archive directory
-            if archive_uri and viking_fs:
-                if operations is None:
-                    memory_diff = self._empty_memory_diff(archive_uri)
-                else:
-                    memory_diff = await self._build_memory_diff(
-                        result=result,
-                        operations=operations,
-                        viking_fs=viking_fs,
-                        ctx=ctx,
-                        archive_uri=archive_uri,
-                    )
-                await viking_fs.write_file(
-                    uri=f"{archive_uri}/memory_diff.json",
-                    content=json.dumps(memory_diff, ensure_ascii=False, indent=4),
-                    ctx=ctx,
-                )
-                logger.info(f"Wrote memory_diff.json to {archive_uri}")
-
-            # Report telemetry stats.
-            telemetry = get_current_telemetry()
-            telemetry.set(
-                "memory.extract.candidates.total",
-                len(result.written_uris) + len(result.edited_uris),
+            # Background-refresh the pathlock lease while the orchestrator /
+            # updater run. The lock tokens become stale after
+            # lock_expire_secs (default 300s); a long-running VLM extract can
+            # easily exceed that. Without refresh a concurrent extractor may
+            # win the same locks and our apply_operations then loses the
+            # race. Skip when has_agfs is false (no lock lease acquired).
+            refresh_ctx = (
+                _LockRefresher(viking_fs, lease)
+                if has_agfs and lease is not None
+                else nullcontext()
             )
-            telemetry.set("memory.extract.created", len(result.written_uris))
-            telemetry.set("memory.extract.merged", len(result.edited_uris))
-            telemetry.set("memory.extract.deleted", len(result.deleted_uris))
-            telemetry.set("memory.extract.skipped", len(result.errors))
+            async with refresh_ctx:  # noqa: SIM117 — async with stacking less readable here
+                # Run ReAct orchestrator
+                operations, tools_used = await orchestrator.run()
 
-            # Build Context objects for stats in session.py
-            contexts: List[Context] = []
+                if operations is None:
+                    tracer.info("No memory operations generated")
+                    result = MemoryUpdateResult()
+                else:
+                    updater = self._get_or_create_updater(registry, transaction_handle)
 
-            # Written memories
-            for uri in result.written_uris:
-                contexts.append(
-                    Context(
-                        uri=uri,
-                        category="memory_write",
-                        context_type="memory",
+                    # Apply operations with isolation_handler
+                    result = await updater.apply_operations(
+                        operations,
+                        ctx,
+                        extract_context=extract_context,
+                        isolation_handler=isolation_handler,
                     )
-                )
 
-            # Edited memories
-            for uri in result.edited_uris:
-                contexts.append(
-                    Context(
-                        uri=uri,
-                        category="memory_edit",
-                        context_type="memory",
+                    tracer.info(
+                        f"Applied memory operations: written={len(result.written_uris)}, "
+                        f"edited={len(result.edited_uris)}, deleted={len(result.deleted_uris)}, "
+                        f"errors={len(result.errors)}"
                     )
-                )
 
-            # Deleted memories
-            for uri in result.deleted_uris:
-                contexts.append(
-                    Context(
-                        uri=uri,
-                        category="memory_delete",
-                        context_type="memory",
+                # Write memory_diff.json to archive directory
+                if archive_uri and viking_fs:
+                    if operations is None:
+                        memory_diff = self._empty_memory_diff(archive_uri)
+                    else:
+                        memory_diff = await self._build_memory_diff(
+                            result=result,
+                            operations=operations,
+                            viking_fs=viking_fs,
+                            ctx=ctx,
+                            archive_uri=archive_uri,
+                        )
+                    await viking_fs.write_file(
+                        uri=f"{archive_uri}/memory_diff.json",
+                        content=json.dumps(memory_diff, ensure_ascii=False, indent=4),
+                        ctx=ctx,
                     )
-                )
+                    logger.info(f"Wrote memory_diff.json to {archive_uri}")
 
-            return contexts
+                # Report telemetry stats.
+                telemetry = get_current_telemetry()
+                telemetry.set(
+                    "memory.extract.candidates.total",
+                    len(result.written_uris) + len(result.edited_uris),
+                )
+                telemetry.set("memory.extract.created", len(result.written_uris))
+                telemetry.set("memory.extract.merged", len(result.edited_uris))
+                telemetry.set("memory.extract.deleted", len(result.deleted_uris))
+                telemetry.set("memory.extract.skipped", len(result.errors))
+
+                # Build Context objects for stats in session.py
+                contexts: List[Context] = []
+
+                # Written memories
+                for uri in result.written_uris:
+                    contexts.append(
+                        Context(
+                            uri=uri,
+                            category="memory_write",
+                            context_type="memory",
+                        )
+                    )
+
+                # Edited memories
+                for uri in result.edited_uris:
+                    contexts.append(
+                        Context(
+                            uri=uri,
+                            category="memory_edit",
+                            context_type="memory",
+                        )
+                    )
+
+                # Deleted memories
+                for uri in result.deleted_uris:
+                    contexts.append(
+                        Context(
+                            uri=uri,
+                            category="memory_delete",
+                            context_type="memory",
+                        )
+                    )
+
+                return contexts
 
         except Exception as e:
             logger.error(f"Failed to extract memories with v2: {e}", exc_info=True)
@@ -817,99 +946,110 @@ class SessionCompressorV2:
 
             provider._transaction_handle = transaction_handle
             orchestrator._transaction_handle = transaction_handle
-            operations, _ = await orchestrator.run()
 
-            if operations is None:
-                tracer.info(f"[{phase_label}] No memory operations generated")
-                return [], [], [], {}, []
-
-            # Log raw LLM operations before applying.
-            _op_items = [
-                f"{op.memory_type}(uris={op.uris!r})"
-                for op in getattr(operations, "upsert_operations", [])
-            ]
-            _delete_uris_raw = [dc.uri for dc in getattr(operations, "delete_file_contents", [])]
-            tracer.info(
-                f"[{phase_label}] LLM operations: ops={_op_items}, delete_uris={_delete_uris_raw}"
+            # Mirror the same stale-lease protection used for long-term
+            # memories (see the comment next to _LockRefresher). This phase
+            # often runs tool-calling + apply_operation loops that can take
+            # several minutes, also past the default 300s stale window.
+            refresh_ctx = (
+                _LockRefresher(viking_fs, lease, phase_label=phase_label)
+                if has_agfs and lease is not None
+                else nullcontext()
             )
+            async with refresh_ctx:  # noqa: SIM117
+                operations, _ = await orchestrator.run()
 
-            # Resolve supersedes fields (name-based Replace): find old experience URI,
-            # queue for deletion, and return per-URI inheritance map so only the
-            # superseding experience inherits the old source_trajectories.
-            inheritance_map = await self._resolve_supersedes(operations, ctx, viking_fs, provider)
+                if operations is None:
+                    tracer.info(f"[{phase_label}] No memory operations generated")
+                    return [], [], [], {}, []
 
-            memory_operations, skill_operations, unsupported_skill_deletes = (
-                self._split_operations_by_memory_type(operations)
-            )
-            if unsupported_skill_deletes:
-                logger.warning(
-                    "[%s] Ignoring unsupported session skill deletes: %s",
-                    phase_label,
-                    unsupported_skill_deletes,
-                )
-
-            memory_result = MemoryUpdateResult()
-            if (
-                memory_operations.upsert_operations
-                or memory_operations.delete_file_contents
-                or memory_operations.errors
-            ):
-                registry = provider._get_registry()
-                updater = self._get_or_create_updater(registry, transaction_handle)
-                memory_result = await updater.apply_operations(
-                    memory_operations,
-                    ctx,
-                    extract_context=extract_context,
-                    isolation_handler=isolation_handler,
-                )
-
-            tracer.info(
-                f"[{phase_label}] Applied memory ops: written={len(memory_result.written_uris)}, "
-                f"edited={len(memory_result.edited_uris)}, deleted={len(memory_result.deleted_uris)}, "
-                f"errors={len(memory_result.errors)}"
-            )
-
-            if post_apply:
-                await post_apply(memory_result, inheritance_map, transaction_handle)
-
-            skill_results: List[Dict[str, Any]] = []
-            if skill_operations.upsert_operations:
-                if not self.skill_processor:
-                    raise RuntimeError("SkillProcessor is required for session skill extraction")
-                skill_operations = dedup_session_skill_operations(skill_operations)
-                skill_updater = SkillOperationUpdater(
-                    registry=provider._get_registry(),
-                    skill_processor=self.skill_processor,
-                    viking_fs=viking_fs,
-                )
-                skill_result = await skill_updater.apply_operations(skill_operations, ctx)
+                # Log raw LLM operations before applying.
+                _op_items = [
+                    f"{op.memory_type}(uris={op.uris!r})"
+                    for op in getattr(operations, "upsert_operations", [])
+                ]
+                _delete_uris_raw = [dc.uri for dc in getattr(operations, "delete_file_contents", [])]
                 tracer.info(
-                    f"[{phase_label}] Applied session skill ops: written={len(skill_result.written_uris)}, "
-                    f"edited={len(skill_result.edited_uris)}, errors={len(skill_result.errors)}"
+                    f"[{phase_label}] LLM operations: ops={_op_items}, delete_uris={_delete_uris_raw}"
                 )
-                if skill_result.errors:
+
+                # Resolve supersedes fields (name-based Replace): find old experience URI,
+                # queue for deletion, and return per-URI inheritance map so only the
+                # superseding experience inherits the old source_trajectories.
+                inheritance_map = await self._resolve_supersedes(operations, ctx, viking_fs, provider)
+
+                memory_operations, skill_operations, unsupported_skill_deletes = (
+                    self._split_operations_by_memory_type(operations)
+                )
+                if unsupported_skill_deletes:
                     logger.warning(
-                        "[%s] Session skill extraction completed with %d errors",
+                        "[%s] Ignoring unsupported session skill deletes: %s",
                         phase_label,
-                        len(skill_result.errors),
+                        unsupported_skill_deletes,
                     )
-                skill_results = list(skill_result.operation_results)
 
-            contexts: List[Context] = []
-            for uri in memory_result.written_uris:
-                contexts.append(Context(uri=uri, category="memory_write", context_type="memory"))
-            for uri in memory_result.edited_uris:
-                contexts.append(Context(uri=uri, category="memory_edit", context_type="memory"))
-            for uri in memory_result.deleted_uris:
-                contexts.append(Context(uri=uri, category="memory_delete", context_type="memory"))
+                memory_result = MemoryUpdateResult()
+                if (
+                    memory_operations.upsert_operations
+                    or memory_operations.delete_file_contents
+                    or memory_operations.errors
+                ):
+                    registry = provider._get_registry()
+                    updater = self._get_or_create_updater(registry, transaction_handle)
+                    memory_result = await updater.apply_operations(
+                        memory_operations,
+                        ctx,
+                        extract_context=extract_context,
+                        isolation_handler=isolation_handler,
+                    )
 
-            return (
-                list(memory_result.written_uris),
-                list(memory_result.edited_uris),
-                contexts,
-                inheritance_map,
-                skill_results,
-            )
+                tracer.info(
+                    f"[{phase_label}] Applied memory ops: written={len(memory_result.written_uris)}, "
+                    f"edited={len(memory_result.edited_uris)}, deleted={len(memory_result.deleted_uris)}, "
+                    f"errors={len(memory_result.errors)}"
+                )
+
+                if post_apply:
+                    await post_apply(memory_result, inheritance_map, transaction_handle)
+
+                skill_results: List[Dict[str, Any]] = []
+                if skill_operations.upsert_operations:
+                    if not self.skill_processor:
+                        raise RuntimeError("SkillProcessor is required for session skill extraction")
+                    skill_operations = dedup_session_skill_operations(skill_operations)
+                    skill_updater = SkillOperationUpdater(
+                        registry=provider._get_registry(),
+                        skill_processor=self.skill_processor,
+                        viking_fs=viking_fs,
+                    )
+                    skill_result = await skill_updater.apply_operations(skill_operations, ctx)
+                    tracer.info(
+                        f"[{phase_label}] Applied session skill ops: written={len(skill_result.written_uris)}, "
+                        f"edited={len(skill_result.edited_uris)}, errors={len(skill_result.errors)}"
+                    )
+                    if skill_result.errors:
+                        logger.warning(
+                            "[%s] Session skill extraction completed with %d errors",
+                            phase_label,
+                            len(skill_result.errors),
+                        )
+                    skill_results = list(skill_result.operation_results)
+
+                contexts: List[Context] = []
+                for uri in memory_result.written_uris:
+                    contexts.append(Context(uri=uri, category="memory_write", context_type="memory"))
+                for uri in memory_result.edited_uris:
+                    contexts.append(Context(uri=uri, category="memory_edit", context_type="memory"))
+                for uri in memory_result.deleted_uris:
+                    contexts.append(Context(uri=uri, category="memory_delete", context_type="memory"))
+
+                return (
+                    list(memory_result.written_uris),
+                    list(memory_result.edited_uris),
+                    contexts,
+                    inheritance_map,
+                    skill_results,
+                )
         except Exception as e:
             logger.error(f"[{phase_label}] Failed to extract: {e}", exc_info=True)
             if strict_extract_errors:


### PR DESCRIPTION
## Summary / Background

This PR is a rebase-equivalent implementation of **PR #3581**, whose merge target was removed by the Rust lock-manager migration in **#3602**.

### Why the original #3581 can't be rebased
PR #3581 fixed a real bug by adding a background async task that called `OwnedLockLease.refresh_lock()` on the old `openviking/storage/transaction/path_lock.py::OwnedLockLease` object. PR #3602:
1. **Deleted** the entire `openviking/storage/transaction/path_lock.py` Python module.
2. **Replaced** it with a Rust implementation in `crates/ragfs/src/lock/manager.rs`, surfaced via `viking_fs._async_agfs.pathlock_{acquire_exact_tree_batch,refresh,release}(...)`.
3. **Deleted** `OwnedLockLease` as a first-class Python object with methods — the new API returns plain lease handles passed back to the three stateless `pathlock_*` functions.
4. Updated the compressor's acquire sites, but *never migrated the refresh loop*.

### Why the refresh loop is still required after #3602
The Rust lock manager marks pathlock tokens as **stale** after `lock_expire_secs` (default **300 s**). Once stale, a stale-token cleanup in any concurrent acquirer can remove them, allowing a second extractor to acquire the same locks. The first extractor then loses the write race in `MemoryUpdater.apply_operations()` and its whole batch is dropped (observable as lock-conflict errors on apply).

`SessionCompressorV2` has **two** ReAct orchestrator phases that hold pathlock leases:
1. **Phase 1** — `extract_long_term_memories(...)`: schema-template driven extraction of long-term / profile memories. A single batch typically runs N VLM calls + tool calls for N schemas; real runtimes of 3–10 minutes for rich persona contexts are common.
2. **Phase 2** — `_run_extract_phase(...)`: session-skill extraction + execution-memory extraction + supersedes resolution + skill-operation dedup. Often runs a multi-step ReAct tool loop, also multi-minute.

Both phases now hold a Rust pathlock lease for the schema/namespace directories, **without any refresh**. Multi-minute extractions reliably cross the 300 s stale-token window under any non-trivial concurrency, which is exactly the race #3581 was fixing in Python.

## What Changed

Target file: `openviking/session/compressor_v2.py`

| Area | Change |
|---|---|
| Imports | Added `from contextlib import nullcontext` for no-refresh fallback paths. |
| `_LockRefresher` | **New module-private async context manager** (`__slots__`, small, deterministic teardown). Spawns one `asyncio.create_task` named `ov-compressor-lock-refresh` that calls `agfs.pathlock_refresh(lease)` every `refresh_period_s`:<br>• Default period = 90 s (≈ 30 % of the 300 s default stale window, giving 2–3 refreshes per 5-minute extraction — comfortably safe margin).<br>• Tries to derive `30 % of get_openviking_config().storage.lock_expire_seconds` (or equivalent `.memory.v2_lock_expire_seconds`) if configured, else falls back to the 90 s default.<br>• **Never** raises from the refresh loop — failures logged at WARNING, orchestrator keeps running.<br>• **Always** cancels + awaits the background task on `__aexit__`, no dangling references, no pending task after the phase ends.<br>• Optional `phase_label` threaded through for contextful logging. |
| Phase 1: `extract_long_term_memories` | Right after `transaction_handle = lease` and `orchestrator._transaction_handle = transaction_handle`, open `async with _LockRefresher(viking_fs, lease) as _:` if `has_agfs and lease is not None`, else `nullcontext()`. The entire body (orchestrator.run → apply_operations → memory_diff write → telemetry → Context building → return) is now protected by active refresh until the function either returns or throws — refresher is guaranteed torn down before the `finally:` releases the lease. |
| Phase 2: `_run_extract_phase` | Identical treatment, with `phase_label` threaded through so warning/debug logs tag the phase. |

**Critical ordering guarantee**: in both phases, the `async with _LockRefresher(...)` block contains *all* the code that runs while the lock is held; the `finally:` branch still calls `agfs.pathlock_release(lease)`, and because the `async with` block ends before `finally:` runs, the refresh task is **always cancelled before release** — so we never refresh a released lease, and never release a lease with an active refresher racing with a `sleep`.

## Validation / How to Test

The relevant Python-side tests live in `tests/compressor/test_compressor_v2.py`. They already mock lock acquire/release paths; the expected smoke test run is:

```bash
python -m pytest tests/compressor/test_compressor_v2.py -x --no-header -q
```

and

```bash
python -m pytest tests/compressor -x --no-header -q
```

Additionally, a manual end-to-end sanity check: configure a compressor run with a very short `refresh_period_s` (e.g. `1 s`) by local monkey-patch, run the orchestrator for ~3 s, and observe `pathlock_refresh` is called ≥ 2 times via instrumentation.

Behavioural invariants this PR preserves:
- The number of `pathlock_acquire_exact_tree_batch` calls is **unchanged** (still 1 per phase per batch).
- The number of `pathlock_release` calls is **unchanged** (still 1 per phase, called from `finally:`).
- `transaction_handle` still points to the exact same lease value; all downstream `apply_operations(..., transaction_handle=...)` and `_run_extract_phase` return paths are byte-for-byte unchanged.

## Impact Scope / Risk

| Area | Impact |
|---|---|
| Correctness | **Bug fix — reduces data loss** from long-running extracts under concurrency, especially large schema batches / VLM-heavy extraction templates. Previously silent partial loss (one compressor's writes silently clobbered / conflict-rejected by another); now the intended lock holder stays the holder for the full batch. |
| Performance | Negligible — one extra `pathlock_refresh` IPC round-trip every 90 s per phase (one FS write per 90 s). |
| API / config surface | No breaking changes. New `_LockRefresher` is module-private; no new CLI flags, no new config keys, no storage format changes. |
| Risk of regression | Very low. If the refresh IPC fails for any reason, the old behaviour (no refresh) is effectively preserved via best-effort warning log — the worst case is the same correctness the code has *today* without this PR. The task is always cancelled before release, so no lifecycle bugs possible (no refire after release, no double-release, no stale reference leaks). |

## Checklist

- [x] Refresh task active for the *entire* window between lease acquire (and `transaction_handle` assignment) and `finally:` lease release — covers LLM orchestration, apply_operations, memory_diff archive write, and telemetry/Context builds.
- [x] Both long-running phases (`extract_long_term_memories` phase 1 AND `_run_extract_phase` phase 2) protected — no phase left with the old no-refresh behaviour.
- [x] Config-aware period derivation (`lock_expire_secs × 0.3`) with safe 90 s fallback if config keys are missing.
- [x] Refresh failures are **never fatal** — WARN only, orchestrator continues.
- [x] Explicit task cancel + await on `__aexit__`; no dangling task references.
- [x] `nullcontext()` fallback for `has_agfs == False` (in-process fallback; no Rust lease to refresh).
- [x] No new public symbols; `_LockRefresher` is module-private.
- [x] Original conflicting PR #3581 can be closed with a pointer to this PR as the rebase-equivalent.
- [x] Relates cleanly to the Rust migration PR #3602; replaces the removed OwnedLockLease background refresh with equivalent semantics on the new API.