### PR TITLE
fix(pi): respect peerId from extension config

### DIFF
--- a/docs/en/agent-integrations/11-pi.md
+++ b/docs/en/agent-integrations/11-pi.md
@@ -52,10 +52,13 @@ Credentials resolve from `OPENVIKING_*` environment variables, then `~/.openviki
 node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
 ```
 
-`~/.pi/agent/extensions/openviking/config.json` holds behavior knobs only, and reinstalls preserve your edits:
+`~/.pi/agent/extensions/openviking/config.json` holds behavior and peer-scoping knobs, and reinstalls preserve your edits. Connection and authentication credentials still come from the shared sources above:
 
 ```json
 {
+  "peerId": "",
+  "workspacePeer": true,
+  "recallPeerScope": "all",
   "scoreThreshold": 0.35,
   "recallTokenBudget": 2000,
   "profileTokenBudget": 10000,
@@ -74,6 +77,8 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
   "bypassPatterns": []
 }
 ```
+
+An explicit peer from `OPENVIKING_PEER_ID`, `ovcli.conf`, or `ov.conf` takes precedence over `config.json`'s `peerId`. The local `peerId` takes precedence over the workspace-derived peer, which is used only when `workspacePeer` is enabled and neither explicit source provides a peer.
 
 Takeover is fail-open: if pending writes cannot flush, commit fails, the archive overview is not ready, or the branch fingerprint no longer matches, pi keeps full local history or falls back to its default compaction. Set `OV_DEBUG_LOG=/tmp/ov-pi.log` when validating boundary advances.
 

--- a/docs/zh/agent-integrations/11-pi.md
+++ b/docs/zh/agent-integrations/11-pi.md
@@ -52,10 +52,13 @@ cp -r examples/pi-coding-agent-extension ~/.pi/agent/extensions/openviking
 node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
 ```
 
-`~/.pi/agent/extensions/openviking/config.json` 只保留行为旋钮，重装时会保留你的修改：
+`~/.pi/agent/extensions/openviking/config.json` 保存行为与 peer 作用域配置，重装时会保留你的修改。连接和认证凭据仍来自上面的共享配置源：
 
 ```json
 {
+  "peerId": "",
+  "workspacePeer": true,
+  "recallPeerScope": "all",
   "scoreThreshold": 0.35,
   "recallTokenBudget": 2000,
   "profileTokenBudget": 10000,
@@ -74,6 +77,8 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
   "bypassPatterns": []
 }
 ```
+
+`OPENVIKING_PEER_ID`、`ovcli.conf` 或 `ov.conf` 中的显式 peer 优先于 `config.json` 的 `peerId`；本地 `peerId` 又优先于 workspace 派生值。只有启用 `workspacePeer` 且所有显式来源都未提供 peer 时，才会从当前工作目录派生。
 
 Takeover 是 fail-open：如果 pending 写入无法 flush、commit 失败、archive overview 尚未生成，或 branch 指纹不匹配，pi 会继续保留完整本地历史，或回退到默认 compaction。验证边界推进时可设置 `OV_DEBUG_LOG=/tmp/ov-pi.log`。
 

--- a/examples/pi-coding-agent-extension/README.md
+++ b/examples/pi-coding-agent-extension/README.md
@@ -40,12 +40,15 @@ Credentials are resolved from `OPENVIKING_*` environment variables, `~/.openviki
 node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
 ```
 
-`~/.pi/agent/extensions/openviking/config.json` is for behavior knobs only:
+`~/.pi/agent/extensions/openviking/config.json` is for behavior and peer-scoping knobs. Connection and authentication credentials still come from the shared sources above:
 
 ```json
 {
   "enabled": true,
   "syncTurns": true,
+  "peerId": "",
+  "workspacePeer": true,
+  "recallPeerScope": "all",
   "recallTokenBudget": 2000,
   "scoreThreshold": 0.35,
   "minQueryLength": 3,
@@ -81,7 +84,7 @@ tiers and cross-turn dedup are shared with every other harness. Deployments
 without that endpoint fall back to `/api/v1/search/recall`, and that outcome is
 cached so only the first turn pays for the probe.
 
-API keys are sent as `Authorization: Bearer ...`. By default the extension derives a peer from the process workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. The effective peer is sent as `X-OpenViking-Actor-Peer` and stored as `peer_id` on captured session messages. `OPENVIKING_PEER_ID` overrides the workspace-derived value.
+API keys are sent as `Authorization: Bearer ...`. By default the extension derives a peer from the process workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. The effective peer is sent as `X-OpenViking-Actor-Peer` and stored as `peer_id` on captured session messages. An explicit peer from the shared credential sources (`OPENVIKING_PEER_ID`, `ovcli.conf`, or `ov.conf`) takes precedence over `config.json`'s `peerId`; the local `peerId` in turn takes precedence over workspace derivation.
 
 Recall defaults to the broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces penalized and rendered later. Set `OPENVIKING_RECALL_PEER_SCOPE=actor` for the isolation mode, which only sees global memory plus the current workspace. In deployments where one bot serves multiple real people, such as zouk, vikingbot, or AstrBot, use the isolation mode with an explicit actor peer so one person's memories are not recalled into another person's session.
 
@@ -103,6 +106,14 @@ All fields below live in `config.json`. Defaults are shown.
 |--------------------------|------------|--------------------------------------------------------------------------|
 | `enabled`                | `true`     | Set `false` to disable the extension entirely                            |
 | `syncTurns`              | `true`     | Enable auto-capture of conversation turns                                |
+
+### Peer scoping
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `peerId`                 | `""`      | Local explicit peer fallback; shared credential sources take precedence  |
+| `workspacePeer`          | `true`     | Derive a peer from the current workspace when no explicit peer is set    |
+| `recallPeerScope`        | `"all"`   | Use `"actor"` for strict current-peer recall or `"all"` for broad recall |
 
 ### Recall tuning
 

--- a/examples/pi-coding-agent-extension/config.ts
+++ b/examples/pi-coding-agent-extension/config.ts
@@ -109,7 +109,7 @@ export function loadConfig(extensionDir: string): OVConfig {
     apiKey: creds.apiKey,
     account: creds.account,
     user: creds.user,
-    peerId: creds.peerId,
+    peerId: creds.peerId || (typeof file.peerId === "string" ? file.peerId : DEFAULT_CONFIG.peerId),
     userAgent: buildUserAgent("pi", EXTENSION_VERSION),
     recallLimitConfigured: Object.prototype.hasOwnProperty.call(file, "recallLimit"),
     recallQueryExpansionConfigured: Object.prototype.hasOwnProperty.call(file, "recallQueryExpansion"),

--- a/examples/pi-coding-agent-extension/tests/config.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/config.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { loadConfig, loadConfigFromModuleUrl } from "../config.ts";
 
-async function withConfigFile(body, fn, env = {}) {
+async function withConfigFile(body, fn, env = {}, cliConfig = null) {
   const dir = await mkdtemp(join(tmpdir(), "ov-pi-config-用户-"));
   const oldEnv = {
     OPENVIKING_URL: process.env.OPENVIKING_URL,
@@ -22,14 +22,14 @@ async function withConfigFile(body, fn, env = {}) {
   };
   process.env.OPENVIKING_CREDENTIAL_SOURCE = "env";
   process.env.OPENVIKING_URL = "http://127.0.0.1:1933";
+  process.env.OPENVIKING_CLI_CONFIG_FILE = join(dir, "ovcli.conf");
+  process.env.OPENVIKING_CONFIG_FILE = join(dir, "ov.conf");
   delete process.env.OPENVIKING_API_KEY;
   delete process.env.OPENVIKING_ACCOUNT;
   delete process.env.OPENVIKING_USER;
   delete process.env.OPENVIKING_PEER_ID;
   delete process.env.OPENVIKING_WORKSPACE_PEER;
   delete process.env.OPENVIKING_RECALL_PEER_SCOPE;
-  delete process.env.OPENVIKING_CLI_CONFIG_FILE;
-  delete process.env.OPENVIKING_CONFIG_FILE;
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -37,6 +37,9 @@ async function withConfigFile(body, fn, env = {}) {
 
   try {
     await writeFile(join(dir, "config.json"), JSON.stringify(body), "utf8");
+    if (cliConfig !== null) {
+      await writeFile(join(dir, "ovcli.conf"), JSON.stringify(cliConfig), "utf8");
+    }
     return await fn(loadConfig(dir), dir);
   } finally {
     for (const [key, value] of Object.entries(oldEnv)) {
@@ -129,8 +132,28 @@ test("loadConfig derives workspace peer by default", async () => {
   });
 });
 
-test("loadConfig keeps explicit peer and actor recall scope", async () => {
+test("loadConfig prefers config peer over workspace derivation", async () => {
   await withConfigFile({
+    peerId: " pi ",
+    workspacePeer: true,
+  }, (cfg) => {
+    assert.equal(cfg.peerId, "pi");
+  });
+});
+
+test("loadConfig keeps config peer when workspace derivation is disabled", async () => {
+  await withConfigFile({
+    peerId: "pi",
+    workspacePeer: false,
+  }, (cfg) => {
+    assert.equal(cfg.peerId, "pi");
+    assert.equal(cfg.workspacePeer, false);
+  });
+});
+
+test("loadConfig gives environment peer precedence over config peer", async () => {
+  await withConfigFile({
+    peerId: "config-peer",
     recallPeerScope: "actor",
     workspacePeer: false,
   }, (cfg) => {
@@ -138,4 +161,18 @@ test("loadConfig keeps explicit peer and actor recall scope", async () => {
     assert.equal(cfg.workspacePeer, false);
     assert.equal(cfg.recallPeerScope, "actor");
   }, { OPENVIKING_PEER_ID: "explicit-peer" });
+});
+
+test("loadConfig gives ovcli peer precedence over config peer", async () => {
+  await withConfigFile({
+    peerId: "config-peer",
+  }, (cfg) => {
+    assert.equal(cfg.peerId, "ovcli-peer");
+  }, {
+    OPENVIKING_CREDENTIAL_SOURCE: "cli",
+    OPENVIKING_URL: undefined,
+  }, {
+    url: "http://127.0.0.1:1933",
+    actor_peer_id: "ovcli-peer",
+  });
 });


### PR DESCRIPTION
## Description

Preserve `config.json`'s `peerId` when shared credential sources do not provide one. The effective precedence is shared credentials > Pi extension config > workspace-derived peer.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3649

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve a string `peerId` from Pi extension config when shared credentials do not define one.
- Isolate configuration tests and cover extension, environment, ovcli, and workspace precedence.
- Document Pi peer scoping and precedence in the extension README and English/Chinese integration guides.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:
- The complete memory-plugin command from `.github/workflows/pr.yml`: 173 passed, 0 failed, 0 skipped.
- A focused precedence matrix: extension-only, environment override, ovcli override, workspace fallback, and workspace-disabled cases all passed.
- Pi 0.82.0 with a local HTTP probe: both user and assistant capture requests carried `X-OpenViking-Actor-Peer: pi-e2e` and `peer_id: pi-e2e`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The implementation intentionally reuses the shared peer resolver. It changes only the input fallback so all integrations keep one precedence model. No new configuration source or parallel resolution path is introduced.
