### PR TITLE
fix(bot): make max_tokens optional and configurable

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -105,13 +105,14 @@ Edit `~/.openviking/ov.conf`:
     "agents": {
       "provider": "openai",
       "model": "gpt-4o-mini",
-      "api_key": "<your-model-api-key>"
+      "api_key": "<your-model-api-key>",
+      "max_tokens": 8192
     }
   }
 }
 ```
 
-Alternatively, configure only the root-level `vlm` section. VikingBot inherits its model, provider, API key, API base, and timeout settings.
+Alternatively, configure only the root-level `vlm` section. VikingBot inherits its model, provider, API key, API base, timeout, and output-token settings. `bot.agents.max_tokens` is optional; when omitted, VikingBot lets the model provider choose the output limit. A `max_tokens` value on an individual credential overrides the Agent-level value.
 
 #### 2. Start chatting
 

--- a/bot/README_CN.md
+++ b/bot/README_CN.md
@@ -105,13 +105,14 @@ ov find "我的回答偏好"
     "agents": {
       "provider": "openai",
       "model": "gpt-4o-mini",
-      "api_key": "<your-model-api-key>"
+      "api_key": "<your-model-api-key>",
+      "max_tokens": 8192
     }
   }
 }
 ```
 
-也可以只配置根级 `vlm`，VikingBot 会继承其中的模型、Provider、API Key、API Base 和超时配置。
+也可以只配置根级 `vlm`，VikingBot 会继承其中的模型、Provider、API Key、API Base、超时和输出 Token 配置。`bot.agents.max_tokens` 是可选项；不配置时由模型服务决定输出上限。单个 credential 上的 `max_tokens` 会覆盖 Agent 级值。
 
 #### 2. 开始对话
 

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -319,6 +319,7 @@ def _make_provider(config, langfuse_client: Any = None):
     provider_name = p.provider if p else None
     extra_headers = p.extra_headers if p else {}
     timeout = p.timeout if p else None
+    max_tokens = getattr(p, "max_tokens", None) if p else None
     credentials = list(getattr(p, "credentials", None) or [])
 
     if not model and not credentials:
@@ -345,6 +346,8 @@ def _make_provider(config, langfuse_client: Any = None):
         root_vlm_data["thinking"] = thinking
         if timeout is not None:
             root_vlm_data["timeout"] = timeout
+        if max_tokens is not None:
+            root_vlm_data["max_tokens"] = max_tokens
         if extra_headers:
             root_vlm_data["extra_headers"] = extra_headers
         effective_vlm = VLMConfig.model_validate(root_vlm_data)
@@ -385,6 +388,8 @@ def _make_provider(config, langfuse_client: Any = None):
             bot_vlm_data["provider"] = provider_name
         if timeout is not None:
             bot_vlm_data["timeout"] = timeout
+        if max_tokens is not None:
+            bot_vlm_data["max_tokens"] = max_tokens
         if api_key:
             bot_vlm_data["api_key"] = api_key
         if api_base:
@@ -415,6 +420,8 @@ def _make_provider(config, langfuse_client: Any = None):
         }
         if timeout is not None:
             vlm_config["timeout"] = timeout
+        if max_tokens is not None:
+            vlm_config["max_tokens"] = max_tokens
         if api_key:
             vlm_config["api_key"] = api_key
         if api_base:

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -455,6 +455,14 @@ class AgentsConfig(BaseModel):
             "inherits vlm.timeout from ov.conf if present."
         ),
     )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Maximum completion output tokens for VikingBot agent calls. "
+            "None leaves the limit to the model provider."
+        ),
+    )
     max_tool_iterations: int = 50
     memory_window: int = 50
     subagent_enabled: bool = Field(

--- a/bot/vikingbot/providers/base.py
+++ b/bot/vikingbot/providers/base.py
@@ -149,7 +149,7 @@ class LLMProvider(ABC):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> LLMResponse:
@@ -160,7 +160,7 @@ class LLMProvider(ABC):
             messages: List of message dicts with 'role' and 'content'.
             tools: Optional list of tool definitions.
             model: Model identifier (provider-specific).
-            max_tokens: Maximum tokens in response.
+            max_tokens: Maximum tokens in response. None uses the model provider default.
             temperature: Sampling temperature.
             session_id: Optional session ID for tracing.
 
@@ -174,7 +174,7 @@ class LLMProvider(ABC):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> AsyncIterator[LLMStreamEvent]:

--- a/bot/vikingbot/providers/litellm_provider.py
+++ b/bot/vikingbot/providers/litellm_provider.py
@@ -213,7 +213,7 @@ class LiteLLMProvider(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> LLMResponse:
@@ -224,7 +224,7 @@ class LiteLLMProvider(LLMProvider):
             messages: List of message dicts with 'role' and 'content'.
             tools: Optional list of tool definitions in OpenAI format.
             model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
-            max_tokens: Maximum tokens in response.
+            max_tokens: Maximum tokens in response. None uses the model provider default.
             temperature: Sampling temperature.
             session_id: Optional session ID for tracing.
 
@@ -239,9 +239,10 @@ class LiteLLMProvider(LLMProvider):
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "max_tokens": max_tokens,
             "temperature": temperature,
         }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
 
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)
@@ -393,7 +394,7 @@ class LiteLLMProvider(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> AsyncIterator[LLMStreamEvent]:
@@ -404,10 +405,11 @@ class LiteLLMProvider(LLMProvider):
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "max_tokens": max_tokens,
             "temperature": temperature,
             "stream": True,
         }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
         self._apply_model_overrides(model, kwargs)
         self._apply_thinking_overrides(model, kwargs)
 

--- a/bot/vikingbot/providers/vlm_adapter.py
+++ b/bot/vikingbot/providers/vlm_adapter.py
@@ -53,7 +53,7 @@ class VLMProviderAdapter(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> LLMResponse:
@@ -129,7 +129,7 @@ class VLMProviderAdapter(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         session_id: str | None = None,
     ) -> AsyncIterator[LLMStreamEvent]:
@@ -165,20 +165,25 @@ class VLMProviderAdapter(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None,
         model: str | None,
-        max_tokens: int,
+        max_tokens: int | None,
         temperature: float,
     ) -> AsyncIterator[LLMStreamEvent]:
+        configured_max_tokens = getattr(self._vlm, "max_tokens", None)
+        effective_max_tokens = (
+            configured_max_tokens if configured_max_tokens is not None else max_tokens
+        )
         kwargs: dict[str, Any] = {
             "model": model or getattr(self._vlm, "model", None) or self._default_model,
             "messages": messages,
             "temperature": getattr(self._vlm, "temperature", temperature),
-            "max_tokens": getattr(self._vlm, "max_tokens", None) or max_tokens,
             "thinking": {
                 "type": "enabled" if getattr(self._vlm, "thinking", False) else "disabled"
             },
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        if effective_max_tokens is not None:
+            kwargs["max_tokens"] = effective_max_tokens
         extra_headers = getattr(self._vlm, "extra_headers", None)
         if extra_headers:
             kwargs["extra_headers"] = extra_headers

--- a/bot/vikingbot/tests/unit/test_bot_provider_thinking.py
+++ b/bot/vikingbot/tests/unit/test_bot_provider_thinking.py
@@ -14,6 +14,11 @@ def test_agents_config_defaults_thinking_enabled():
     assert AgentsConfig(thinking=False).thinking is False
 
 
+def test_agents_config_defaults_max_tokens_unset():
+    assert AgentsConfig().max_tokens is None
+    assert AgentsConfig(max_tokens=8192).max_tokens == 8192
+
+
 def test_agents_openviking_retention_defaults_to_turn_budget_values():
     config = AgentsConfig()
 
@@ -206,6 +211,70 @@ async def test_litellm_bot_provider_does_not_send_thinking_to_generic_openai(mon
 
     assert "thinking" not in captured
     assert "extra_body" not in captured
+    assert "max_tokens" not in captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_max_tokens", "expected_max_tokens"),
+    [(None, None), (8192, 8192)],
+)
+async def test_vlm_adapter_volcengine_stream_respects_optional_max_tokens(
+    configured_max_tokens,
+    expected_max_tokens,
+):
+    captured = {}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+
+            async def chunks():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            finish_reason="stop",
+                            delta=SimpleNamespace(
+                                reasoning_content=None,
+                                content="ok",
+                                tool_calls=[],
+                            ),
+                        )
+                    ],
+                    usage=None,
+                )
+
+            return chunks()
+
+    vlm = SimpleNamespace(
+        provider="volcengine",
+        model="ep-test",
+        temperature=0.0,
+        max_tokens=configured_max_tokens,
+        thinking=False,
+        extra_headers=None,
+        get_async_client=lambda: SimpleNamespace(
+            chat=SimpleNamespace(completions=FakeCompletions())
+        ),
+    )
+    provider = VLMProviderAdapter(
+        vlm,
+        default_model="ep-test",
+        langfuse_client=SimpleNamespace(enabled=False, _client=None),
+    )
+
+    events = [
+        event
+        async for event in provider.chat_stream(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    ]
+
+    assert events[-1].response.content == "ok"
+    if expected_max_tokens is None:
+        assert "max_tokens" not in captured
+    else:
+        assert captured["max_tokens"] == expected_max_tokens
 
 
 @pytest.mark.asyncio

--- a/bot/vikingbot/tests/unit/test_bot_vlm_credentials.py
+++ b/bot/vikingbot/tests/unit/test_bot_vlm_credentials.py
@@ -58,6 +58,33 @@ def test_bot_inherits_root_vlm_credentials_when_agents_model_is_omitted(tmp_path
     ]
 
 
+def test_agent_max_tokens_overrides_inherited_root_limit(tmp_path, monkeypatch):
+    config = _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "vlm": {
+                "provider": "openai",
+                "model": "root-model",
+                "api_key": "root-key",
+                "max_tokens": 4096,
+            },
+            "bot": {
+                "agents": {
+                    "max_tokens": 8192,
+                }
+            },
+        },
+    )
+
+    from vikingbot.cli.commands import _make_provider
+
+    provider = _make_provider(config)
+
+    assert config.agents.inherits_root_vlm() is True
+    assert provider._vlm.max_tokens == 8192
+
+
 def test_explicit_bot_model_uses_bot_credentials_instead_of_root(tmp_path, monkeypatch):
     config = _write_config(
         tmp_path,
@@ -237,6 +264,66 @@ def test_explicit_bot_model_without_credentials_keeps_single_model_behavior(tmp_
     assert isinstance(provider, VLMProviderAdapter)
     assert not isinstance(provider._vlm, MultiCredentialVLM)
     assert provider._vlm.model == "bot-model"
+
+
+def test_explicit_bot_model_passes_agent_max_tokens(tmp_path, monkeypatch):
+    config = _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "bot": {
+                "agents": {
+                    "provider": "openai",
+                    "model": "bot-model",
+                    "api_key": "bot-key",
+                    "max_tokens": 8192,
+                }
+            }
+        },
+    )
+
+    from vikingbot.cli.commands import _make_provider
+
+    provider = _make_provider(config)
+
+    assert config.agents.max_tokens == 8192
+    assert provider._vlm.max_tokens == 8192
+
+
+def test_bot_credentials_override_or_inherit_agent_max_tokens(tmp_path, monkeypatch):
+    config = _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "bot": {
+                "agents": {
+                    "max_tokens": 8192,
+                    "credentials": [
+                        {
+                            "id": "bot-primary",
+                            "provider": "openai",
+                            "model": "bot-primary",
+                            "api_key": "bot-primary-key",
+                            "max_tokens": 2048,
+                        },
+                        {
+                            "id": "bot-backup",
+                            "provider": "openai",
+                            "model": "bot-backup",
+                            "api_key": "bot-backup-key",
+                        },
+                    ],
+                }
+            }
+        },
+    )
+
+    from vikingbot.cli.commands import _make_provider
+
+    provider = _make_provider(config)
+
+    assert isinstance(provider._vlm, MultiCredentialVLM)
+    assert [vlm.max_tokens for vlm in provider._vlm._vlm_instances] == [2048, 8192]
 
 
 def test_explicit_litellm_provider_uses_vlm_adapter(tmp_path, monkeypatch):

--- a/docs/en/guides/17-vikingbot.md
+++ b/docs/en/guides/17-vikingbot.md
@@ -127,7 +127,8 @@ If `ov.conf` already contains a root-level `vlm`, VikingBot inherits it. You can
     "agents": {
       "provider": "openai",
       "model": "gpt-4o-mini",
-      "api_key": "<your-model-api-key>"
+      "api_key": "<your-model-api-key>",
+      "max_tokens": 8192
     }
   }
 }
@@ -140,12 +141,14 @@ credential defines `model`, the outer `bot.agents.model` may be omitted:
 {
   "bot": {
     "agents": {
+      "max_tokens": 8192,
       "credentials": [
         {
           "id": "bot-primary",
           "provider": "volcengine",
           "model": "bot-primary-model",
-          "api_key": "${BOT_PRIMARY_API_KEY}"
+          "api_key": "${BOT_PRIMARY_API_KEY}",
+          "max_tokens": 4096
         },
         {
           "id": "bot-backup",
@@ -165,7 +168,10 @@ The precedence is deterministic: a non-empty `bot.agents.model` or
 `bot.agents.credentials` uses the Bot's own model/credentials. When both are omitted,
 VikingBot inherits the complete root `vlm` model, credentials, and failover/failback
 settings. If Bot credentials are configured without an outer model, every credential
-must define its own `model`. The two credential chains are never mixed.
+must define its own `model`. The two credential chains are never mixed. `max_tokens`
+is optional: a credential-specific value overrides `bot.agents.max_tokens`; a
+credential without one inherits the Agent value. When neither is configured,
+VikingBot omits the request field and lets the model provider choose its default.
 
 ### 2. Start a Chat
 

--- a/docs/zh/guides/17-vikingbot.md
+++ b/docs/zh/guides/17-vikingbot.md
@@ -127,7 +127,8 @@ ov find "我的回答偏好"
     "agents": {
       "provider": "openai",
       "model": "gpt-4o-mini",
-      "api_key": "<your-model-api-key>"
+      "api_key": "<your-model-api-key>",
+      "max_tokens": 8192
     }
   }
 }
@@ -140,12 +141,14 @@ ov find "我的回答偏好"
 {
   "bot": {
     "agents": {
+      "max_tokens": 8192,
       "credentials": [
         {
           "id": "bot-primary",
           "provider": "volcengine",
           "model": "bot-primary-model",
-          "api_key": "${BOT_PRIMARY_API_KEY}"
+          "api_key": "${BOT_PRIMARY_API_KEY}",
+          "max_tokens": 4096
         },
         {
           "id": "bot-backup",
@@ -165,6 +168,9 @@ ov find "我的回答偏好"
 使用 Bot 自己的模型/credentials；两者都省略时，完整继承根级 `vlm` 的模型、
 credentials 和 failover/failback 设置。配置 Bot credentials 但省略外层 model
 时，每个 credential 都必须配置自己的 `model`。两条 credentials 链不会混用。
+`max_tokens` 是可选项：credential 自己的值优先于 `bot.agents.max_tokens`，未配置
+时继承 Agent 级值；两层都未配置时，VikingBot 不发送该请求字段，由模型服务决定
+默认输出上限。
 
 ### 2. 启动对话
 

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -42,6 +42,14 @@ class VLMCredential(BaseModel):
         default=None, description="Extra JSON body fields"
     )
     stream: Optional[bool] = Field(default=None, description="Enable streaming mode")
+    max_tokens: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Maximum completion output tokens for this credential. "
+            "Overrides the parent max_tokens when set."
+        ),
+    )
 
     model_config = {"extra": "forbid"}
 
@@ -282,6 +290,7 @@ class VLMConfig(BaseModel):
                     if primary_cfg.get("stream") is not None
                     else self.stream
                 ),
+                max_tokens=self.max_tokens,
             )
             migrated_credentials.append(primary_cred)
 
@@ -310,6 +319,7 @@ class VLMConfig(BaseModel):
                     if backup_cfg.get("stream") is not None
                     else self.backup.stream
                 ),
+                max_tokens=self.backup.max_tokens,
             )
             migrated_credentials.append(backup_cred)
 
@@ -549,7 +559,9 @@ class VLMConfig(BaseModel):
             "timeout": self.timeout,
             "provider": credential.provider,
             "thinking": self.thinking,
-            "max_tokens": self.max_tokens,
+            "max_tokens": (
+                credential.max_tokens if credential.max_tokens is not None else self.max_tokens
+            ),
             "stream": credential.stream if credential.stream is not None else self.stream,
             "api_version": credential.api_version,
         }

--- a/tests/unit/test_vlm_failover.py
+++ b/tests/unit/test_vlm_failover.py
@@ -121,6 +121,33 @@ class TestVLMBackupConfig:
         # Falls back to parent model when credential.model is not set.
         assert dict_b["model"] == "parent-model"
 
+    def test_per_credential_max_tokens_overrides_parent_value(self):
+        from openviking_cli.utils.config.vlm_config import VLMCredential
+
+        config = VLMConfig(
+            model="parent-model",
+            max_tokens=8192,
+            credentials=[
+                VLMCredential(
+                    id="cred-a",
+                    provider="volcengine",
+                    api_key="key-a",
+                    max_tokens=2048,
+                ),
+                VLMCredential(
+                    id="cred-b",
+                    provider="volcengine",
+                    api_key="key-b",
+                ),
+            ],
+        )
+
+        dict_a = config._build_vlm_config_dict_for_credential(config.credentials[0])
+        dict_b = config._build_vlm_config_dict_for_credential(config.credentials[1])
+
+        assert dict_a["max_tokens"] == 2048
+        assert dict_b["max_tokens"] == 8192
+
 
 class TestLegacyProvidersDictMigration:
     """Tests for migrating legacy ``providers: {name: {...}}`` configs into credentials.


### PR DESCRIPTION
## Summary

- remove VikingBot's hard-coded `4096` output-token default and omit `max_tokens` when it is not configured
- add optional `bot.agents.max_tokens` configuration
- add per-credential `max_tokens`, with credential values overriding the Agent-level value
- preserve root VLM inheritance and document the new configuration in English and Chinese

## Why

VikingBot's Provider interface defaulted `max_tokens` to `4096`. In particular, the native VolcEngine streaming path always sent that value even though the underlying OpenViking VLM layer otherwise leaves the output limit to the model provider. Also, `bot.agents.max_tokens` was not part of the schema, so configuring it had no effect.

This could unexpectedly cap model output, including reasoning-heavy responses, and there was no supported Bot-specific way to override the limit.

## Behavior

The effective precedence is:

1. credential-level `max_tokens`
2. `bot.agents.max_tokens`
3. model provider default when neither is configured

## Validation

- `30 passed`: VikingBot Provider, Agent configuration, inheritance, and credential tests
- `42 passed`: OpenViking VLM failover and credential configuration tests
- Ruff lint and formatting checks passed
- `git diff --check` passed
