### PR TITLE
fix(pi): resolve config path from module URL

### DIFF
--- a/examples/pi-coding-agent-extension/config.ts
+++ b/examples/pi-coding-agent-extension/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
 
@@ -77,6 +78,10 @@ const DEFAULT_CONFIG: OVConfig = {
   bypassPatterns: [],
   logLevel: "error",
 };
+
+export function loadConfigFromModuleUrl(moduleUrl: string): OVConfig {
+  return loadConfig(dirname(fileURLToPath(moduleUrl)));
+}
 
 export function loadConfig(extensionDir: string): OVConfig {
   const configPath = join(extensionDir, "config.json");

--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -12,7 +12,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { loadConfig, type OVConfig } from "./config.js";
+import { loadConfigFromModuleUrl, type OVConfig } from "./config.js";
 import { OVClient } from "./client.js";
 import { RecallManager } from "./recall.js";
 import { SyncManager } from "./sync.js";
@@ -23,7 +23,7 @@ import { createTakeoverManager } from "./takeover.js";
 
 export default async function (pi: ExtensionAPI) {
   // --- Load config ---
-  const config = loadConfig(dirname(new URL(import.meta.url).pathname));
+  const config = loadConfigFromModuleUrl(import.meta.url);
   if (!config.enabled) return;
 
   // Env overrides

--- a/examples/pi-coding-agent-extension/tests/config.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/config.test.mjs
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig } from "../config.ts";
+import { pathToFileURL } from "node:url";
+import { loadConfig, loadConfigFromModuleUrl } from "../config.ts";
 
 async function withConfigFile(body, fn, env = {}) {
-  const dir = await mkdtemp(join(tmpdir(), "ov-pi-config-"));
+  const dir = await mkdtemp(join(tmpdir(), "ov-pi-config-用户-"));
   const oldEnv = {
     OPENVIKING_URL: process.env.OPENVIKING_URL,
     OPENVIKING_API_KEY: process.env.OPENVIKING_API_KEY,
@@ -36,7 +37,7 @@ async function withConfigFile(body, fn, env = {}) {
 
   try {
     await writeFile(join(dir, "config.json"), JSON.stringify(body), "utf8");
-    return await fn(loadConfig(dir));
+    return await fn(loadConfig(dir), dir);
   } finally {
     for (const [key, value] of Object.entries(oldEnv)) {
       if (value === undefined) delete process.env[key];
@@ -74,6 +75,18 @@ test("loadConfig maps nested takeover block", async () => {
     assert.equal(cfg.takeoverOverviewBudget, 1200);
     assert.equal(cfg.takeoverOverviewPollMs, 10);
     assert.equal(cfg.takeoverOverviewPollMax, 2);
+  });
+});
+
+test("loadConfigFromModuleUrl decodes Unicode paths", async () => {
+  await withConfigFile({
+    takeover: {
+      tokenThreshold: 2000,
+    },
+  }, (_cfg, dir) => {
+    const moduleUrl = pathToFileURL(join(dir, "index.ts")).href;
+    const cfg = loadConfigFromModuleUrl(moduleUrl);
+    assert.equal(cfg.takeoverTokenThreshold, 2000);
   });
 });
 


### PR DESCRIPTION
## Description

Resolve the Pi extension directory from `import.meta.url` with Node's filesystem-aware `fileURLToPath()` API. The previous `URL.pathname` usage kept Unicode path segments percent-encoded and did not produce a valid Windows filesystem path, so `config.json` was missed and all values fell back to defaults.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3648

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a config entrypoint that converts module URLs with `fileURLToPath()` before reading `config.json`.
- Use that entrypoint from the Pi extension instead of passing `URL.pathname` as a filesystem path.
- Cover a real Unicode temporary directory and verify the nested takeover threshold is loaded.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:
- Node 24.18.0, complete memory-plugin command from `.github/workflows/pr.yml`: 171 passed, 0 failed, 0 skipped.
- All installer shell scripts checked by `.github/workflows/pr.yml` parse successfully.
- Pi 0.82.0 loaded the extension from a path containing `用户测试` and returned `OV3648-CONFIG`.
- With the temporary config set to `tokenThreshold: 1` and `keepRecentTurns: 0`, the HTTP probe observed the immediate session `/commit` request with `keep_recent_count: 0`; the default config would not commit that short turn.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The standard Node URL conversion also handles Windows drive letters correctly. The reporter's original Windows environment remains the final platform-specific verification target.
