### PR TITLE
fix(resource): restore queue status for waited imports

### DIFF
--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -15,6 +15,7 @@ from openviking.service.task_work_index import bind_task_context, extract_task_m
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.telemetry import bind_telemetry, resolve_telemetry, unregister_telemetry
+from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import record_resource_queue_metrics
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.logger import get_logger
@@ -130,6 +131,8 @@ class AddResourceProcessor(DequeueHandlerBase):
             telemetry = OperationTelemetry(operation="add_resource_job", enabled=False)
             if telemetry_id:
                 telemetry.telemetry_id = telemetry_id
+        request_wait_tracker = get_request_wait_tracker()
+        request_wait_tracker.register_request(telemetry_id)
 
         async def _set_stage(stage: str) -> None:
             await tracker.update_stage(
@@ -169,6 +172,7 @@ class AddResourceProcessor(DequeueHandlerBase):
                     self.report_error("resource processing failed", data)
                     return None
                 await tracker.wait_for_descendants(msg.task_id, metadata.work_id)
+                result["queue_status"] = request_wait_tracker.build_queue_status(telemetry_id)
                 record_resource_queue_metrics(
                     telemetry=telemetry,
                     telemetry_id=telemetry_id,
@@ -200,6 +204,7 @@ class AddResourceProcessor(DequeueHandlerBase):
                 self.report_error(str(exc), data)
                 return None
             finally:
+                request_wait_tracker.cleanup(telemetry_id)
                 unregister_telemetry(telemetry_id)
                 with suppress(Exception):
                     if resource_lock is not None:

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -840,7 +840,24 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
     )
     task_tracker.complete.assert_awaited_once_with(
         "task-1",
-        {"status": "success", "root_uri": final_uri},
+        {
+            "status": "success",
+            "root_uri": final_uri,
+            "queue_status": {
+                "Semantic": {
+                    "processed": 0,
+                    "requeue_count": 0,
+                    "error_count": 0,
+                    "errors": [],
+                },
+                "Embedding": {
+                    "processed": 0,
+                    "requeue_count": 0,
+                    "error_count": 0,
+                    "errors": [],
+                },
+            },
+        },
         account_id="account-1",
         user_id="user-1",
         resource_id=final_uri,


### PR DESCRIPTION
## Description

Restore the documented `queue_status` result for `add_resource(wait=True)` after add-resource completion moved to the task-owned queue lifecycle.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Register request-scoped queue statistics inside the add-resource task owner.
- Attach final Semantic and Embedding queue statistics after all task descendants settle.
- Clean up the request tracker and align the existing processor assertion with the restored result.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Focused validation:

- `./.venv/bin/pytest -q tests/parse/test_feishu_parser_api.py::test_add_resource_processor_persists_final_resource_uri`
- `./.venv/bin/ruff check openviking/storage/queuefs/add_resource_processor.py tests/parse/test_feishu_parser_api.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The API documentation already describes `queue_status` as part of the `wait=true` response, so no documentation change was required.
