### PR TITLE
fix(session): remove actor scope from session lifecycle

### DIFF
--- a/docs/en/migration/01-user-peer-model.md
+++ b/docs/en/migration/01-user-peer-model.md
@@ -13,10 +13,9 @@ If you stay on 0.3.x, existing `agent_id`, `viking://agent/...`, and `viking://s
 
 If you upgrade to 0.4.0, you do not need to migrate data immediately. 0.4.0 keeps runtime compatibility so old data remains readable:
 
-- `agent_id` can still be configured temporarily. In current HTTP SDK clients it maps to request-level `actor_peer_id`; true legacy agent mode is selected only when requests send `X-OpenViking-Agent`.
+- `agent_id` can still be configured temporarily. In current HTTP SDK clients it maps to request-level `actor_peer_id`.
 - `viking://agent/...` can still read old agent data, but is read-only.
 - `viking://session/...` can still read old session data and merges with the new session view.
-- `find` / `search` read unmigrated legacy agent data only for true legacy requests that still send `X-OpenViking-Agent`; HTTP SDK `agent_id` now selects only the actor peer view.
 
 Recommended order:
 
@@ -81,10 +80,10 @@ The `viking://session` merged compatibility view is implemented on the server. U
 | `ov ls viking://session` | Supported for reads. It merges new and old sessions. |
 | Read `viking://session/<session_id>/...` | Supported. New path first, legacy path as fallback. |
 | Write `viking://session/...` | Not supported. New sessions are written to `viking://user/<user_id>/sessions/...`. |
-| `find` / `search` with HTTP SDK `agent_id` | Supported. It searches the selected actor peer view only; old agent data is searched only by true legacy requests that send `X-OpenViking-Agent`. |
+| `find` / `search` with HTTP SDK `agent_id` | Supported. It searches the selected actor peer view only and does not automatically search unmigrated agent data. |
 | `find` / `search` body `peer_id` | Not supported. Use `actor_peer_id` or `X-OpenViking-Actor-Peer` for the new peer view. |
 | Configure both `actor_peer_id` and `agent_id` | Not supported. The client/request fails. |
-| Explicit message `peer_id` while using HTTP SDK `agent_id` | Supported. The explicit message `peer_id` wins for that message; legacy fallback applies only when no message `peer_id` is provided. |
+| Explicit message `peer_id` while using HTTP SDK `agent_id` | Supported. The message uses the explicit `peer_id`; no identity is inferred from `agent_id` when it is omitted. |
 | `role_id` memory isolation | Not supported. It is ignored after upgrade. |
 
 ## Run Migration
@@ -277,20 +276,13 @@ viking://user/alice/sessions/sess-001/messages.jsonl
 
 ### find / search
 
-During the migration window, if you still need unmigrated old agent data, use a true legacy request path that sends `X-OpenViking-Agent`. Current HTTP SDK `agent_id` is an actor-peer alias and no longer makes `find` / `search` include old agent data:
-
-```json
-{
-  "query": "deployment notes",
-  "agent_id": "legacy-agent"
-}
-```
+`find` / `search` no longer accepts legacy agent identity fields and does not automatically include unmigrated agent data. Old `viking://agent/...` paths remain readable through content and filesystem APIs, but migrate them before using the new retrieval paths.
 
 After migration, when old agent data is no longer needed, move all clients to client/request-level `actor_peer_id`.
 
 ### Session Messages
 
-A legacy request without an explicit assistant-message `peer_id` can still fall back to its legacy agent id. Current HTTP SDK clients should not rely on `agent_id` for message attribution; use message `peer_id` when you need to identify the speaker.
+Session no longer derives message attribution from a legacy agent id. Use an explicit message `peer_id` whenever the speaker identity is required.
 
 ## Deferring Data Migration
 
@@ -298,7 +290,7 @@ It is acceptable as a short-term transition, with these limits:
 
 - Old agent/session data is readable, but legacy namespaces are not writable.
 - New sessions and new resources are written to the new namespace, so data can exist in both old and new paths for a while.
-- True legacy retrieval searches both old and new data when the request sends `X-OpenViking-Agent`; HTTP SDK `agent_id` and pure `actor_peer_id` do not search old `viking://agent` by default.
+- `find` / `search` does not search old `viking://agent` data by default.
 - In multi-user accounts, old sessions without clear owner metadata may be readable at runtime but will fail formal migration preflight.
 - Legacy directories and old vector records remain until cleanup.
 

--- a/docs/zh/migration/01-user-peer-model.md
+++ b/docs/zh/migration/01-user-peer-model.md
@@ -13,10 +13,9 @@
 
 如果升级到 0.4.0，可以先不迁移数据。0.4.0 提供运行期兼容，旧数据不会因为升级立即不可读：
 
-- `agent_id` 仍可临时配置。当前 HTTP SDK client 会把它映射成请求级 `actor_peer_id`；只有仍发送 `X-OpenViking-Agent` 的请求才进入真正的 legacy agent 模式。
+- `agent_id` 仍可临时配置。当前 HTTP SDK client 会把它映射成请求级 `actor_peer_id`。
 - `viking://agent/...` 仍可读旧 agent 数据，但只读。
 - `viking://session/...` 仍可读旧 session 数据，并会合并新 session 视图。
-- 只有真正发送 `X-OpenViking-Agent` 的 legacy 请求会让 `find` / `search` 同时查未迁移的旧 agent 数据；HTTP SDK `agent_id` 现在只选择 actor peer 视图。
 
 推荐顺序：
 
@@ -81,10 +80,10 @@ ov session list
 | `ov ls viking://session` | 支持读，会合并新 session 和旧 session。 |
 | 读 `viking://session/<session_id>/...` | 支持读，按新路径优先、旧路径兜底。 |
 | 写 `viking://session/...` | 不支持。新 session 写入 `viking://user/<user_id>/sessions/...`。 |
-| HTTP SDK `find` / `search` 传 `agent_id` | 支持，只查选中的 actor peer 视图；只有发送 `X-OpenViking-Agent` 的真正 legacy 请求才会查旧 agent 数据。 |
+| HTTP SDK `find` / `search` 传 `agent_id` | 支持，只查选中的 actor peer 视图，不会自动查未迁移的旧 agent 数据。 |
 | `find` / `search` body 传旧 `peer_id` | 不支持。新 peer 视图使用 `actor_peer_id` 或 `X-OpenViking-Actor-Peer`。 |
 | 同时配置 `actor_peer_id` 和 `agent_id` | 不支持，会报错。 |
-| HTTP SDK `agent_id` client 下显式传 message `peer_id` | 支持。该 message 使用显式 `peer_id`；只有没有 message `peer_id` 时才走 legacy fallback。 |
+| HTTP SDK `agent_id` client 下显式传 message `peer_id` | 支持。该 message 使用显式 `peer_id`；未提供时不会从 `agent_id` 推导。 |
 | `role_id` 记忆隔离 | 不再支持，升级后忽略。 |
 
 ## 执行数据迁移
@@ -277,20 +276,13 @@ viking://user/alice/sessions/sess-001/messages.jsonl
 
 ### find / search
 
-迁移窗口内，如果还需要读取未迁移的旧 agent 数据，需要使用仍发送 `X-OpenViking-Agent` 的真正 legacy 请求路径。当前 HTTP SDK `agent_id` 是 actor-peer alias，不再让 `find` / `search` 包含旧 agent 数据：
-
-```json
-{
-  "query": "deployment notes",
-  "agent_id": "legacy-agent"
-}
-```
+`find` / `search` 不再接受 legacy agent 身份字段，也不会自动包含未迁移的旧 agent 数据。旧 `viking://agent/...` 路径仍可通过内容和文件系统接口只读访问，但应先完成迁移再使用新检索路径。
 
 迁移完成并确认不再需要旧 agent 数据后，所有 client 都改为 client/request 级 `actor_peer_id`。
 
 ### 会话消息
 
-没有显式 assistant message `peer_id` 的 legacy 请求仍可 fallback 到 legacy agent id。当前 HTTP SDK client 不应再依赖 `agent_id` 做消息归属；需要表达说话人时使用 message `peer_id`。
+Session 不再从 legacy agent id 推导消息归属；需要表达说话人时必须显式使用 message `peer_id`。
 
 ## 暂不迁移数据
 
@@ -298,7 +290,7 @@ viking://user/alice/sessions/sess-001/messages.jsonl
 
 - 旧 agent/session 数据可读，但旧 namespace 不可写。
 - 新 session 和新资源会写入新 namespace，数据会在新旧路径并存一段时间。
-- 发送 `X-OpenViking-Agent` 的真正 legacy 检索会同时查新旧数据；HTTP SDK `agent_id` 和纯 `actor_peer_id` 不会默认查旧 `viking://agent`。
+- `find` / `search` 不会默认查旧 `viking://agent` 数据。
 - 多用户 account 下 owner 不明确的旧 session，运行期可能可读，但正式迁移会被 preflight 拦截。
 - cleanup 之前旧目录和旧向量记录仍会保留。
 

--- a/examples/pi-coding-agent-extension/DESIGN.md
+++ b/examples/pi-coding-agent-extension/DESIGN.md
@@ -49,7 +49,7 @@ interface OVConfig {
   apiKey: string;                // API key (default: "" — dev mode)
   account: string;               // Multi-tenant account (default: "")
   user: string;                  // Multi-tenant user (default: "")
-  agentId: string;               // Agent identity for X-OpenViking-Agent header (default: "pi")
+  peerId: string;                // Actor peer identity for X-OpenViking-Actor-Peer
   syncTurns: boolean;            // Auto-sync conversation turns (default: true)
   recallBudget: number;          // Max tokens for <relevant-memories> block (default: 2000)
   recallMaxContentChars: number; // Max chars per recall result before truncation (default: 500)
@@ -102,7 +102,7 @@ Wraps these endpoints:
 
 All methods are async. All catch errors internally and return `null`/empty on failure. Timeouts: 5s health, 10s reads, 30s writes.
 
-Headers include `X-OpenViking-Account`, `X-OpenViking-User`, `X-OpenViking-Agent` for multi-tenant routing.
+Headers include `X-OpenViking-Account`, `X-OpenViking-User`, and `X-OpenViking-Actor-Peer` for multi-tenant routing and peer scope.
 
 ```typescript
 class OVClient {
@@ -882,7 +882,7 @@ Default: `~/.pi/agent/extensions/openviking/config.json`
   "apiKey": "",
   "account": "",
   "user": "",
-  "agentId": "pi",
+  "peerId": "",
   "syncTurns": true,
   "recallBudget": 2000,
   "recallMaxContentChars": 500,

--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -104,7 +104,6 @@ class LocalClient(BaseClient):
             user=self._user,
             role=Role.USER,
             actor_peer_id=normalize_peer_id(effective_actor_peer_id),
-            legacy_agent_id=normalize_peer_id(agent_id),
         )
 
     @property
@@ -1051,7 +1050,7 @@ class LocalClient(BaseClient):
         }
         add_async = getattr(session, "add_message_async", None)
         add_kwargs = {
-            "peer_id": self._resolve_message_peer_id(role, peer_id),
+            "peer_id": normalize_peer_id(peer_id),
             "created_at": created_at,
             **semantic_kwargs,
         }
@@ -1111,7 +1110,7 @@ class LocalClient(BaseClient):
                 {
                     "role": role,
                     "parts": message_parts,
-                    "peer_id": self._resolve_message_peer_id(role, message.get("peer_id")),
+                    "peer_id": normalize_peer_id(message.get("peer_id")),
                     "created_at": message.get("created_at"),
                     "turn_id": message.get("turn_id"),
                     "message_kind": message.get("message_kind"),
@@ -1145,19 +1144,6 @@ class LocalClient(BaseClient):
             return max(0, int(getattr(meta, "pending_tokens", 0) or 0))
         except (TypeError, ValueError):
             return 0
-
-    def _resolve_message_peer_id(
-        self,
-        role: str,
-        peer_id: Optional[str],
-    ) -> Optional[str]:
-        normalized_peer_id = normalize_peer_id(peer_id)
-        if normalized_peer_id is not None:
-            return normalized_peer_id
-        legacy_agent_id = getattr(self._ctx, "legacy_agent_id", None)
-        if legacy_agent_id is not None and role == "assistant":
-            return legacy_agent_id
-        return None
 
     # ============= Pack =============
 

--- a/openviking/core/directories.py
+++ b/openviking/core/directories.py
@@ -200,7 +200,7 @@ class DirectoryInitializer:
         # still protect peer subtrees during normal filesystem mutations, but
         # it must not prevent a fresh user from creating the container that
         # owns those subtrees in the first place.
-        initialization_ctx = replace(ctx, actor_peer_id=None, legacy_agent_id=None)
+        initialization_ctx = replace(ctx, actor_peer_id=None)
         user_tree = PRESET_DIRECTORIES["user"]
         parent_uri = "viking://user"
         count = 0

--- a/openviking/retrieve/type_quota_recall.py
+++ b/openviking/retrieve/type_quota_recall.py
@@ -304,7 +304,7 @@ async def search_type_quota_recall(
     peer_scope = "actor" if peer_scope == "actor" else "all"
     user_root = canonical_user_root(ctx)
     roots = memory_target_roots(ctx)
-    open_ctx = replace(ctx, actor_peer_id=None, legacy_agent_id=None)
+    open_ctx = replace(ctx, actor_peer_id=None)
     raw_by_type: dict[str, list[Any]] = {memory_type: [] for memory_type in TYPE_ORDER}
     selected: list[tuple[str, Any, int, str, RequestContext]] = []
 

--- a/openviking/server/auth/__init__.py
+++ b/openviking/server/auth/__init__.py
@@ -74,19 +74,6 @@ def normalize_actor_peer_header(value: Optional[str]) -> Optional[str]:
         raise InvalidArgumentError(str(exc)) from exc
 
 
-def resolve_actor_peer_headers(
-    actor_peer_header: Optional[str],
-    legacy_agent_header: Optional[str],
-) -> tuple[Optional[str], Optional[str]]:
-    actor_peer_id = normalize_actor_peer_header(actor_peer_header)
-    legacy_agent_id = normalize_actor_peer_header(legacy_agent_header)
-    if actor_peer_id and legacy_agent_id and actor_peer_id != legacy_agent_id:
-        raise InvalidArgumentError(
-            "X-OpenViking-Agent and X-OpenViking-Actor-Peer must match when both are set."
-        )
-    return actor_peer_id or legacy_agent_id, legacy_agent_id
-
-
 def _explicit_identity_from_request(request: Request) -> tuple[Optional[str], Optional[str]]:
     path_params = getattr(request, "path_params", {}) or {}
     query_params = request.query_params
@@ -108,6 +95,33 @@ def _get_plugin(request: Request):
     if plugin is None:
         raise UnauthenticatedError("Auth plugin not initialized")
     return plugin
+
+
+def _build_request_context(
+    request: Request,
+    identity: ResolvedIdentity,
+    *,
+    actor_peer_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> RequestContext:
+    plugin = _get_plugin(request)
+    plugin.get_request_context_checks(request.url.path, identity)
+    ctx = RequestContext(
+        user=UserIdentifier(
+            identity.account_id or "default",
+            identity.user_id or "default",
+        ),
+        role=identity.role,
+        actor_peer_id=actor_peer_id,
+        from_oauth=identity.from_oauth,
+        api_key=api_key,
+    )
+    update_root_span_identity(
+        request_state=request.state,
+        account_id=identity.account_id,
+        user_id=identity.user_id,
+    )
+    return ctx
 
 
 async def resolve_identity(
@@ -135,40 +149,30 @@ async def get_request_context(
     request: Request,
     identity: ResolvedIdentity = Depends(resolve_identity),
     x_openviking_actor_peer: Optional[str] = Header(None, alias="X-OpenViking-Actor-Peer"),
-    x_openviking_agent: Optional[str] = Header(None, alias="X-OpenViking-Agent"),
     x_api_key_ctx: Optional[str] = Header(None, alias="X-API-Key"),
     authorization_ctx: Optional[str] = Header(None, alias="Authorization"),
 ) -> RequestContext:
     """Convert ResolvedIdentity to RequestContext."""
-    path = request.url.path
-    plugin = _get_plugin(request)
-    plugin.get_request_context_checks(path, identity)
-    actor_peer_id, legacy_agent_id = resolve_actor_peer_headers(
-        x_openviking_actor_peer,
-        x_openviking_agent,
+    return _build_request_context(
+        request,
+        identity,
+        actor_peer_id=normalize_actor_peer_header(x_openviking_actor_peer),
+        api_key=_extract_api_key(x_api_key_ctx, authorization_ctx),
     )
 
-    raw_api_key = _extract_api_key(x_api_key_ctx, authorization_ctx)
 
-    ctx = RequestContext(
-        user=UserIdentifier(
-            identity.account_id or "default",
-            identity.user_id or "default",
-        ),
-        role=identity.role,
-        actor_peer_id=actor_peer_id,
-        legacy_agent_id=legacy_agent_id,
-        from_oauth=identity.from_oauth,
-        api_key=raw_api_key,
+async def get_session_request_context(
+    request: Request,
+    identity: ResolvedIdentity = Depends(resolve_identity),
+    x_api_key_ctx: Optional[str] = Header(None, alias="X-API-Key"),
+    authorization_ctx: Optional[str] = Header(None, alias="Authorization"),
+) -> RequestContext:
+    """Build a Session context without accepting an actor peer view."""
+    return _build_request_context(
+        request,
+        identity,
+        api_key=_extract_api_key(x_api_key_ctx, authorization_ctx),
     )
-    # Update the unified root observability context after authentication succeeds.
-    update_root_span_identity(
-        request_state=request.state,
-        account_id=identity.account_id,
-        user_id=identity.user_id,
-    )
-
-    return ctx
 
 
 async def get_upload_request_context(
@@ -179,7 +183,6 @@ async def get_upload_request_context(
     x_openviking_account: Optional[str] = Header(None, alias="X-OpenViking-Account"),
     x_openviking_user: Optional[str] = Header(None, alias="X-OpenViking-User"),
     x_openviking_actor_peer: Optional[str] = Header(None, alias="X-OpenViking-Actor-Peer"),
-    x_openviking_agent: Optional[str] = Header(None, alias="X-OpenViking-Agent"),
 ) -> RequestContext:
     """Two-layer auth for the ``temp_upload`` route: API key first, else a signed token.
 
@@ -220,7 +223,7 @@ async def get_upload_request_context(
     identity = await resolve_identity(
         request, x_api_key, authorization, x_openviking_account, x_openviking_user
     )
-    return await get_request_context(request, identity, x_openviking_actor_peer, x_openviking_agent)
+    return await get_request_context(request, identity, x_openviking_actor_peer)
 
 
 def require_role(*allowed_roles: Role):

--- a/openviking/server/identity.py
+++ b/openviking/server/identity.py
@@ -97,9 +97,6 @@ class RequestContext:
     # Request-level view filter for the current user's peers collection. This does
     # not change tenant/user identity or session ownership.
     actor_peer_id: Optional[str] = None
-    # Set only when the actor peer scope came from the historical
-    # X-OpenViking-Agent header.
-    legacy_agent_id: Optional[str] = None
     # Mirrors ResolvedIdentity.from_oauth. Routes that mint OAuth state
     # (OTP issuance, oauth-verify) reject callers with from_oauth=True to
     # prevent a stolen access token from laundering itself into a long-lived

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -15,7 +15,6 @@ are extracted from HTTP request scope and propagated via contextvars.
 
 from __future__ import annotations
 
-import asyncio
 import contextvars
 import os
 from contextlib import asynccontextmanager
@@ -37,7 +36,7 @@ from openviking.retrieve.type_quota_recall import (
     DEFAULT_QUOTAS,
     search_type_quota_recall,
 )
-from openviking.server.auth import _extract_api_key, resolve_actor_peer_headers, resolve_identity
+from openviking.server.auth import _extract_api_key, normalize_actor_peer_header, resolve_identity
 from openviking.server.dependencies import get_server_config, get_service
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import (
@@ -151,9 +150,8 @@ class _IdentityASGIMiddleware:
                 x_openviking_account=request.headers.get("x-openviking-account"),
                 x_openviking_user=request.headers.get("x-openviking-user"),
             )
-            actor_peer_id, legacy_agent_id = resolve_actor_peer_headers(
-                request.headers.get("x-openviking-actor-peer"),
-                request.headers.get("x-openviking-agent"),
+            actor_peer_id = normalize_actor_peer_header(
+                request.headers.get("x-openviking-actor-peer")
             )
         except (UnauthenticatedError, PermissionDeniedError, InvalidArgumentError) as exc:
             status = (
@@ -200,7 +198,6 @@ class _IdentityASGIMiddleware:
             ),
             role=identity.role,
             actor_peer_id=actor_peer_id,
-            legacy_agent_id=legacy_agent_id,
             from_oauth=identity.from_oauth,
             api_key=_extract_api_key(x_api_key, authorization),
         )

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -98,8 +98,6 @@ class FindRequest(BaseModel):
     image_url: Optional[str] = None
     target_uri: Union[str, List[str]] = ""
     context_type: Optional[Union[str, List[str]]] = None
-    agent_id: Optional[str] = None
-    agent_uri: Optional[str] = None
     limit: int = 10
     node_limit: Optional[int] = None
     score_threshold: Optional[float] = None
@@ -122,8 +120,6 @@ class SearchRequest(BaseModel):
     image_url: Optional[str] = None
     target_uri: Union[str, List[str]] = ""
     context_type: Optional[Union[str, List[str]]] = None
-    agent_id: Optional[str] = None
-    agent_uri: Optional[str] = None
     session_id: Optional[str] = None
     limit: int = 10
     node_limit: Optional[int] = None

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.peer_id import normalize_peer_id
 from openviking.message.part import Part, TextPart, part_from_dict
-from openviking.server.auth import get_request_context
+from openviking.server.auth import get_session_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
 from openviking.server.models import ErrorInfo, Response
@@ -85,8 +85,6 @@ class AddMessageRequest(BaseModel):
 
     role: str
     peer_id: Optional[str] = None
-    agent_id: Optional[str] = None
-    agent_uri: Optional[str] = None
     content: Optional[str] = None
     parts: Optional[List[Dict[str, Any]]] = None
     created_at: Optional[str] = None
@@ -151,14 +149,6 @@ def _session_pending_tokens(session: Any) -> int:
         return 0
 
 
-def _resolve_message_peer_id(msg_request: AddMessageRequest, ctx: RequestContext) -> Optional[str]:
-    if msg_request.peer_id is not None:
-        return msg_request.peer_id
-    if ctx.legacy_agent_id is not None and msg_request.role == "assistant":
-        return ctx.legacy_agent_id
-    return None
-
-
 def _part_request_to_part(raw_part: Dict[str, Any]) -> Part:
     """Convert request part payload into an internal Part."""
     if not isinstance(raw_part, dict):
@@ -201,7 +191,7 @@ def _to_jsonable(value: Any) -> Any:
 @router.post("")
 async def create_session(
     request: CreateSessionRequest = Body(default_factory=CreateSessionRequest),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Create a new session.
 
@@ -233,7 +223,7 @@ async def create_session(
 
 @router.get("")
 async def list_sessions(
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """List all sessions."""
     service = get_service()
@@ -245,7 +235,7 @@ async def list_sessions(
 async def get_session(
     session_id: str = Path(..., description="Session ID"),
     auto_create: bool = Query(False, description="Create the session if it does not exist"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Get session details."""
     from openviking_cli.exceptions import NotFoundError
@@ -267,7 +257,7 @@ async def list_tool_results(
     session_id: str = Path(..., description="Session ID"),
     tool_name: Optional[str] = Query(None, description="Filter by tool name"),
     limit: int = Query(50, ge=1, description="Maximum number of tool results"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """List externalized tool results for a session."""
     service = get_service()
@@ -283,7 +273,7 @@ async def read_tool_result(
     offset: int = Query(0, ge=0, description="Unicode character offset"),
     limit: int = Query(20_000, description="Maximum Unicode characters to return"),
     include_metadata: bool = Query(True, description="Include metadata in response"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Read an externalized tool result by Unicode character range."""
     if limit < -1:
@@ -310,7 +300,7 @@ async def search_tool_result(
     q: str = Query(..., min_length=1, description="Search query"),
     limit: int = Query(20, ge=1, description="Maximum matches"),
     context_chars: int = Query(300, ge=0, description="Context characters around each hit"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Search within an externalized tool result."""
     service = get_service()
@@ -328,7 +318,7 @@ async def search_tool_result(
 async def get_session_context(
     session_id: str = Path(..., description="Session ID"),
     token_budget: int = Query(128_000, description="Token budget for session context"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Get assembled session context."""
     if token_budget < 0:
@@ -348,7 +338,7 @@ async def get_session_context(
 async def get_session_archive(
     session_id: str = Path(..., description="Session ID"),
     archive_id: str = Path(..., description="Archive ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Get one completed archive for a session."""
     from openviking_cli.exceptions import NotFoundError
@@ -368,7 +358,7 @@ async def get_session_archive(
 @router.delete("/{session_id}")
 async def delete_session(
     session_id: str = Path(..., description="Session ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Delete a session."""
     service = get_service()
@@ -440,7 +430,7 @@ class CommitRequest(BaseModel):
 async def commit_session(
     session_id: str = Path(..., description="Session ID"),
     body: CommitRequest = Body(default_factory=CommitRequest),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Commit a session (archive and extract memories).
 
@@ -478,7 +468,7 @@ async def commit_session(
 @router.post("/{session_id}/extract")
 async def extract_session(
     session_id: str = Path(..., description="Session ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Extract memories from a session."""
     service = get_service()
@@ -490,7 +480,7 @@ async def extract_session(
 async def add_message(
     request: AddMessageRequest,
     session_id: str = Path(..., description="Session ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Add a message to a session.
 
@@ -517,7 +507,7 @@ async def add_message(
             {
                 "role": request.role,
                 "parts": parts,
-                "peer_id": _resolve_message_peer_id(request, _ctx),
+                "peer_id": request.peer_id,
                 "created_at": request.created_at,
                 "turn_id": request.turn_id,
                 "message_kind": request.message_kind,
@@ -549,7 +539,7 @@ async def add_message(
 async def batch_add_messages(
     request: BatchAddMessageRequest,
     session_id: str = Path(..., description="Session ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Add multiple messages to a session in a single request.
 
@@ -567,7 +557,7 @@ async def batch_add_messages(
                 {
                     "role": msg_request.role,
                     "parts": parts,
-                    "peer_id": _resolve_message_peer_id(msg_request, _ctx),
+                    "peer_id": msg_request.peer_id,
                     "created_at": msg_request.created_at,
                     "turn_id": msg_request.turn_id,
                     "message_kind": msg_request.message_kind,
@@ -600,7 +590,7 @@ async def batch_add_messages(
 async def record_used(
     request: UsedRequest,
     session_id: str = Path(..., description="Session ID"),
-    _ctx: RequestContext = Depends(get_request_context),
+    _ctx: RequestContext = Depends(get_session_request_context),
 ):
     """Record actually used contexts and skills in a session."""
     service = get_service()

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -134,7 +134,6 @@ class ReindexExecutor:
             user=UserIdentifier(ctx.account_id, owner),
             role=ctx.role,
             actor_peer_id=ctx.actor_peer_id,
-            legacy_agent_id=ctx.legacy_agent_id,
             from_oauth=ctx.from_oauth,
         )
 
@@ -854,7 +853,6 @@ class ReindexExecutor:
             user=UserIdentifier(ctx.account_id, str(owner)),
             role=ctx.role,
             actor_peer_id=ctx.actor_peer_id,
-            legacy_agent_id=ctx.legacy_agent_id,
             from_oauth=ctx.from_oauth,
         )
 

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -6,6 +6,7 @@ Session Service for OpenViking.
 Provides session management operations: session, sessions, add_message, commit, delete.
 """
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.core.namespace import canonical_session_uri
@@ -16,8 +17,8 @@ from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory_policy import MemoryPolicy
-from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.viking_fs import VikingFS
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking_cli.exceptions import (
     AlreadyExistsError,
     NotFoundError,
@@ -146,6 +147,7 @@ class SessionService:
             Session instance
         """
         self._ensure_initialized()
+        ctx = replace(ctx, actor_peer_id=None)
         return Session(
             viking_fs=self._viking_fs,
             vikingdb_manager=self._vikingdb,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1882,7 +1882,6 @@ class Session:
                 session_uri=self._session_uri,
                 archive_uri=archive_uri,
                 user=self.ctx.user.to_dict(),
-                actor_peer_id=self.ctx.actor_peer_id,
                 memory_policy=effective_memory_policy,
                 usage_uris=list(dict.fromkeys(u.uri for u in usage_snapshot if u.uri)),
             )

--- a/openviking/storage/queuefs/session_commit_msg.py
+++ b/openviking/storage/queuefs/session_commit_msg.py
@@ -3,7 +3,7 @@
 """Persistent Session Phase 2 queue message."""
 
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 @dataclass
@@ -13,7 +13,6 @@ class SessionCommitMsg:
     session_uri: str
     archive_uri: str
     user: Dict[str, str]
-    actor_peer_id: Optional[str] = None
     memory_policy: Dict[str, Any] = field(default_factory=dict)
     usage_uris: List[str] = field(default_factory=list)
 

--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -41,7 +41,6 @@ class SessionCommitProcessor(DequeueHandlerBase):
         ctx = RequestContext(
             user=UserIdentifier.from_dict(msg.user),
             role=Role.USER,
-            actor_peer_id=msg.actor_peer_id,
         )
         return msg, ctx
 

--- a/tests/client/test_lifecycle.py
+++ b/tests/client/test_lifecycle.py
@@ -5,8 +5,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from openviking import AsyncOpenViking
 
 
@@ -35,7 +33,6 @@ class TestClientInitialization:
         client = AsyncOpenViking(path=str(test_data_dir), agent_id="legacy-agent")
 
         assert client._client._ctx.actor_peer_id == "legacy-agent"
-        assert client._client._ctx.legacy_agent_id == "legacy-agent"
 
         await AsyncOpenViking.reset()
 
@@ -55,35 +52,6 @@ class TestClientInitialization:
                 raise AssertionError("mismatched agent_id should fail")
         finally:
             await AsyncOpenViking.reset()
-
-    async def test_agent_id_alias_tags_assistant_messages_only(self, test_data_dir: Path):
-        await AsyncOpenViking.reset()
-
-        client = AsyncOpenViking(path=str(test_data_dir), agent_id="legacy-agent")
-        try:
-            await client.add_message("legacy-session", "user", content="hi")
-            await client.add_message("legacy-session", "assistant", content="hello")
-
-            session = await client._client._service.sessions.get(
-                "legacy-session",
-                client._client._ctx,
-                auto_create=False,
-            )
-            assert [message.peer_id for message in session.messages] == [
-                None,
-                "legacy-agent",
-            ]
-
-            await client.add_message(
-                "legacy-session",
-                "assistant",
-                content="again",
-                peer_id="explicit-peer",
-            )
-            assert session.messages[-1].peer_id == "explicit-peer"
-        finally:
-            await AsyncOpenViking.reset()
-
 
 class TestClientClose:
     """Test Client close"""

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -225,7 +225,6 @@ async def test_local_client_batch_add_messages_forwards_to_session():
     client = LocalClient.__new__(LocalClient)
     client._service = SimpleNamespace(sessions=FakeSessions())
     client._ctx = SimpleNamespace(user=SimpleNamespace(user_id="user-1"))
-    client._legacy_agent_id = None
 
     result = await LocalClient.batch_add_messages(
         client,
@@ -285,7 +284,6 @@ async def test_local_client_add_message_accepts_image_parts():
     client = LocalClient.__new__(LocalClient)
     client._service = SimpleNamespace(sessions=FakeSessions())
     client._ctx = SimpleNamespace(user=SimpleNamespace(user_id="user-1"))
-    client._legacy_agent_id = None
 
     result = await LocalClient.add_message(
         client,

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -101,7 +101,6 @@ def _install_session_commit_queue_fallback(service: OpenVikingService, monkeypat
             ctx = RequestContext(
                 user=UserIdentifier.from_dict(msg.user),
                 role=Role.USER,
-                actor_peer_id=msg.actor_peer_id,
             )
             queued_session = service.sessions.session(
                 ctx,

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -762,7 +762,6 @@ async def test_actor_peer_header_sets_request_context_scope():
     ctx = await get_request_context(request, identity, "web-visitor-alice")
 
     assert ctx.actor_peer_id == "web-visitor-alice"
-    assert ctx.legacy_agent_id is None
 
 
 async def test_empty_actor_peer_header_is_unset():

--- a/tests/server/test_peer_id_compat.py
+++ b/tests/server/test_peer_id_compat.py
@@ -5,37 +5,13 @@
 
 import pytest
 
-from openviking.server.routers.search import (
-    FindRequest,
-    SearchRequest,
-)
+from openviking.server.routers.search import FindRequest
 from openviking.server.routers.sessions import AddMessageRequest
-
-
-def test_search_request_preserves_legacy_agent_fields_without_peer_selector():
-    request = SearchRequest.model_validate(
-        {
-            "query": "invoice",
-            "agent_id": "code-agent",
-            "agent_uri": "viking://agent/code-agent/skills",
-        }
-    )
-
-    assert request.agent_id == "code-agent"
-    assert request.agent_uri == "viking://agent/code-agent/skills"
 
 
 def test_find_request_rejects_unpublished_peer_id_body_field():
     with pytest.raises(ValueError):
         FindRequest.model_validate({"query": "invoice", "peer_id": "code-agent"})
-
-
-def test_add_message_request_does_not_map_agent_id_to_peer_id():
-    request = AddMessageRequest.model_validate(
-        {"role": "assistant", "content": "hello", "agent_id": "code-agent"}
-    )
-
-    assert request.peer_id is None
 
 
 def test_add_message_request_normalizes_explicit_peer_id():

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -203,9 +203,9 @@ def test_session_commit_message_ignores_unknown_fields():
             "session_uri": "viking://user/sessions/session-1",
             "archive_uri": "viking://user/sessions/session-1/history/archive_001",
             "user": {"account_id": "default", "user_id": "default"},
-            "future_field": "ignored",
+            "actor_peer_id": "visitor-a",
         }
     )
 
     assert message.task_id == "task-1"
-    assert "future_field" not in message.to_dict()
+    assert "actor_peer_id" not in message.to_dict()

--- a/tests/unit/test_directory_initializer.py
+++ b/tests/unit/test_directory_initializer.py
@@ -69,7 +69,6 @@ async def test_initialize_user_directories_ignores_actor_peer_view_for_preset_st
         user=UserIdentifier("acme", "support-bot"),
         role=Role.USER,
         actor_peer_id="customer-a",
-        legacy_agent_id="customer-a",
     )
 
     count = await initializer.initialize_user_directories(ctx)


### PR DESCRIPTION
## Description

Keep Session ownership user-scoped so request actor views cannot leak into commit-time memory writes and cause permission failures.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Remove `X-OpenViking-Agent`, `legacy_agent_id`, and the legacy assistant-message peer fallback.
- Stop Session routes and queued commits from accepting, persisting, or restoring actor peer scope.
- Remove unused Session/Search `agent_id` and `agent_uri` fields and update migration guidance.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with Ruff, `compileall`, `git diff --check`, and 13 focused existing tests.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The read-only `viking://agent/{agent_id}` legacy data path remains available independently of request identity handling.
