### PR TITLE
fix(parser): drop duplicate images when a PDF stacks XObjects on one spot

### DIFF
--- a/openviking/parse/parsers/pdf.py
+++ b/openviking/parse/parsers/pdf.py
@@ -13,6 +13,7 @@ to the MarkdownParser after conversion.
 """
 
 import asyncio
+import hashlib
 import io
 import re
 import time
@@ -244,6 +245,7 @@ class PDFParser(BaseParser):
             "library": "pdfplumber",
             "pages_processed": 0,
             "images_extracted": 0,
+            "images_deduplicated": 0,
             "tables_extracted": 0,
             "bookmarks_found": 0,
             "bookmarks_resolved": 0,
@@ -329,13 +331,44 @@ class PDFParser(BaseParser):
                                     )
                                     meta["tables_extracted"] += 1
 
-                        # Extract images
+                        # Extract images.
+                        #
+                        # A page can stack several image XObjects on the exact same
+                        # spot — print-to-PDF producers routinely emit a background
+                        # layer plus a content layer. Since extraction rasterises the
+                        # page *region* rather than the XObject itself, every one of
+                        # them renders to identical bytes. Skip the repeats: bbox
+                        # first, which avoids the (expensive) render entirely, then a
+                        # content hash as a backstop. Both sets are per-page, so a
+                        # header logo repeated across pages is still kept once per
+                        # page.
                         images = page.images
+                        seen_boxes = set()
+                        seen_digests = set()
                         for img_idx, img in enumerate(images or []):
                             try:
+                                bbox_key = (
+                                    round(img["x0"], 1),
+                                    round(img["top"], 1),
+                                    round(img["x1"], 1),
+                                    round(img["bottom"], 1),
+                                )
+                                if bbox_key in seen_boxes:
+                                    meta["images_deduplicated"] += 1
+                                    continue
+                                seen_boxes.add(bbox_key)
+
                                 # Extract image using underlying PDF object
                                 image_obj = self._extract_image_from_page(page, img)
                                 if image_obj:
+                                    # Dedup only — md5 keeps this cheap, and the
+                                    # flag keeps it working on FIPS-locked hosts.
+                                    digest = hashlib.md5(image_obj, usedforsecurity=False).digest()
+                                    if digest in seen_digests:
+                                        meta["images_deduplicated"] += 1
+                                        continue
+                                    seen_digests.add(digest)
+
                                     # Save image
                                     filename = f"page{page_num}_img{img_idx + 1}"
                                     image_path = storage.save_image(
@@ -366,7 +399,9 @@ class PDFParser(BaseParser):
                 f"{meta['headings_found']} headings ({meta['heading_source']}, "
                 f"bookmarks={meta['bookmarks_found']}, "
                 f"resolved={meta['bookmarks_resolved']}), "
-                f"{meta['images_extracted']} images, {meta['tables_extracted']} tables → "
+                f"{meta['images_extracted']} images "
+                f"({meta['images_deduplicated']} duplicates skipped), "
+                f"{meta['tables_extracted']} tables → "
                 f"{len(markdown_content)} chars"
             )
 

--- a/tests/parse/test_pdf_bookmark_extraction.py
+++ b/tests/parse/test_pdf_bookmark_extraction.py
@@ -8,6 +8,7 @@ and that _convert_local injects them as markdown headings.
 """
 
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -328,6 +329,106 @@ class TestConvertLocalBookmarks:
         assert meta["bookmarks_unresolved"] == 1
         assert meta["headings_found"] == 1
         assert meta["heading_source"] == "font_analysis"
+
+    @pytest.mark.asyncio
+    async def test_convert_local_skips_images_stacked_on_same_bbox(self):
+        """Two image XObjects at the same spot must render (and save) only once."""
+        parser = PDFParser()
+        stacked = {"x0": 0.0, "top": 0.1, "x1": 595.0, "bottom": 841.9}
+        page = _FakePage("Page one")
+        page.images = [dict(stacked), dict(stacked)]
+        fake_pdf = SimpleNamespace(pages=[page])
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+        storage = MagicMock()
+        storage.save_image.return_value = Path("/media/dummy/images/page1_img1.png")
+        storage.media_dir = Path("/media")
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+            patch.object(parser, "_extract_image_from_page", return_value=b"png") as extract,
+        ):
+            markdown, meta = await parser._convert_local(
+                "dummy.pdf", storage=storage, resource_name="dummy"
+            )
+
+        # The duplicate is dropped before rendering, so it never costs a render.
+        assert extract.call_count == 1
+        assert storage.save_image.call_count == 1
+        assert meta["images_extracted"] == 1
+        assert meta["images_deduplicated"] == 1
+        assert markdown.count("![Page 1 Image") == 1
+
+    @pytest.mark.asyncio
+    async def test_convert_local_skips_images_rendering_to_same_bytes(self):
+        """Distinct bboxes that still render identically are caught by the hash."""
+        parser = PDFParser()
+        page = _FakePage("Page one")
+        page.images = [
+            {"x0": 0.0, "top": 0.0, "x1": 100.0, "bottom": 100.0},
+            {"x0": 5.0, "top": 5.0, "x1": 105.0, "bottom": 105.0},
+        ]
+        fake_pdf = SimpleNamespace(pages=[page])
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+        storage = MagicMock()
+        storage.save_image.return_value = Path("/media/dummy/images/page1_img1.png")
+        storage.media_dir = Path("/media")
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+            patch.object(parser, "_extract_image_from_page", return_value=b"png") as extract,
+        ):
+            _markdown, meta = await parser._convert_local(
+                "dummy.pdf", storage=storage, resource_name="dummy"
+            )
+
+        # Both are rendered (bboxes differ), but only one is saved.
+        assert extract.call_count == 2
+        assert storage.save_image.call_count == 1
+        assert meta["images_extracted"] == 1
+        assert meta["images_deduplicated"] == 1
+
+    @pytest.mark.asyncio
+    async def test_convert_local_keeps_distinct_images_and_repeats_across_pages(self):
+        """Dedup is per-page: a logo on every page survives on every page."""
+        parser = PDFParser()
+        logo = {"x0": 0.0, "top": 0.0, "x1": 50.0, "bottom": 50.0}
+        figure = {"x0": 0.0, "top": 200.0, "x1": 300.0, "bottom": 400.0}
+        page1, page2 = _FakePage("Page one"), _FakePage("Page two")
+        page1.images = [dict(logo), dict(figure)]
+        page2.images = [dict(logo)]
+        fake_pdf = SimpleNamespace(pages=[page1, page2])
+        fake_pdfplumber = SimpleNamespace(open=lambda _path: nullcontext(fake_pdf))
+        storage = MagicMock()
+        storage.save_image.return_value = Path("/media/dummy/images/img.png")
+        storage.media_dir = Path("/media")
+
+        renders = {
+            (0.0, 0.0, 50.0, 50.0): b"logo-png",
+            (0.0, 200.0, 300.0, 400.0): b"figure-png",
+        }
+
+        with (
+            patch("openviking.parse.parsers.pdf.lazy_import", return_value=fake_pdfplumber),
+            patch.object(parser, "_extract_bookmarks", return_value=[]),
+            patch.object(parser, "_detect_headings_by_font", return_value=[]),
+            patch.object(
+                parser,
+                "_extract_image_from_page",
+                side_effect=lambda _page, img: renders[
+                    (img["x0"], img["top"], img["x1"], img["bottom"])
+                ],
+            ),
+        ):
+            _markdown, meta = await parser._convert_local(
+                "dummy.pdf", storage=storage, resource_name="dummy"
+            )
+
+        assert meta["images_extracted"] == 3
+        assert meta["images_deduplicated"] == 0
 
     @pytest.mark.asyncio
     async def test_convert_local_closes_page_after_each_page(self):


### PR DESCRIPTION
## 问题

上传一份从网页导出的 PDF 后，每页都抽出了**两张一模一样的图**（8 页 → 16 个 PNG，两两 md5 完全相同），并且 markdown 里也生成了 16 处图片引用。

根因有两层：

1. **PDF 本身**每页叠了两个整页 image XObject —— 这是"打印成 PDF"类工具的常见产物（背景层 + 内容层），两个对象画在完全相同的位置：

   ```
   page 1  size=595x842  images=2
     img1: bbox=(0.0, 0.1, 595.0, 841.9)  793x1122  DeviceRGB+SMask
     img2: bbox=(0.0, 0.1, 595.0, 841.9)  793x1122  DeviceRGB+SMask
   ```

2. **解析侧没有去重**。`_extract_image_from_page` 并不解码 XObject，而是用 `page.crop(bbox).to_image()` 把**页面的那块区域**重新光栅化。于是位置重合的多个图片对象必然渲染出逐字节相同的结果，而循环里既没有 bbox 去重也没有内容去重，全部照单落盘。

## 改动

在页面的图片循环里加两道去重，作用域都限定在**单页内**：

- **bbox 去重**（渲染前）—— 位置重合的直接跳过，连渲染开销都省掉；
- **内容哈希去重**（渲染后）—— 兜住 bbox 有细微差异但渲染结果相同的情况。

两个集合都是每页重置的，所以跨页重复出现的页眉 logo 仍然每页保留一份，不会出现"第 2 页图片凭空消失"。

新增 `meta["images_deduplicated"]` 计数并打进日志，便于观察。

## 效果

用触发该问题的 8 页 PDF 实测：

| | 修复前 | 修复后 |
|---|---|---|
| 落盘 PNG | 16 | **8** |
| markdown 图片引用 | 16 | **8** |
| `_convert_local` 耗时 | 3.8 s | **2.4 s** |

## 测试

`tests/parse/test_pdf_bookmark_extraction.py` 新增 3 个用例：

- 同位置叠图只渲染、只保存一次（并断言 `_extract_image_from_page` 只被调用一次，确认省掉了渲染）；
- bbox 不同但渲染结果相同时被哈希拦下；
- 跨页重复的 logo 每页都保留，验证去重不跨页。

`21 passed`；`ruff format --check`、`ruff check`、`mypy openviking/parse/parsers/pdf.py` 均无新增问题。

## 已知未覆盖

去重后剩下的图仍然是**整页截图**，内容与已抽取的正文重复。更彻底的做法是"整页尺寸的图 + 该页存在文字层 → 判定为背景层跳过"，但需要先想清楚扫描件 PDF（整页即图、无文字层）的边界，本次未纳入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)