### PR TITLE
Feat/content write support tag

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -44,6 +44,8 @@ class WriteContentRequest(BaseModel):
     mode: str = "replace"
     wait: bool = False
     timeout: float | None = None
+    tags: list[str] | None = None
+    tag_mode: str = "replace"
     telemetry: TelemetryRequest = False
 
 
@@ -269,6 +271,8 @@ async def write(
             mode=request.mode,
             wait=request.wait,
             timeout=request.timeout,
+            tags=request.tags,
+            tag_mode=request.tag_mode,
         ),
     )
     return Response(

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -555,6 +555,8 @@ class FSService:
         mode: str = "replace",
         wait: bool = False,
         timeout: Optional[float] = None,
+        tags: Optional[list[str]] = None,
+        tag_mode: str = "replace",
     ) -> Dict[str, Any]:
         """Write to an existing file and refresh semantics/vectors."""
         uri = validate_viking_uri(uri)
@@ -567,6 +569,8 @@ class FSService:
             mode=mode,
             wait=wait,
             timeout=timeout,
+            tags=tags,
+            tag_mode=tag_mode,
         )
 
     async def batch_write(

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -34,6 +34,7 @@ from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.path_safety import validate_safe_viking_uri_path
 from openviking.utils.tags import normalize_search_tags
 from openviking_cli.exceptions import (
@@ -86,6 +87,8 @@ class ContentWriteCoordinator:
         mode: str = "replace",
         wait: bool = False,
         timeout: Optional[float] = None,
+        tags: Optional[list[str]] = None,
+        tag_mode: str = "replace",
     ) -> Dict[str, Any]:
         try:
             normalized_uri = canonicalize_uri(uri, ctx)
@@ -95,6 +98,13 @@ class ContentWriteCoordinator:
         self._validate_target_uri(normalized_uri)
         self._viking_fs._ensure_mutable_access(normalized_uri, ctx)
 
+        ingest_options: Optional[IngestOptions] = None
+        if tags is not None:
+            if context_type_for_uri(normalized_uri) == "memory":
+                raise InvalidArgumentError("tags are not supported for memory writes")
+            self._validate_tag_mode(tag_mode)
+            ingest_options = IngestOptions.from_search_tags(tags, mode=tag_mode)
+
         if mode == "create":
             return await self._create_and_write(
                 uri=normalized_uri,
@@ -102,6 +112,7 @@ class ContentWriteCoordinator:
                 ctx=ctx,
                 wait=wait,
                 timeout=timeout,
+                ingest_options=ingest_options,
             )
 
         stat = await self._safe_stat(normalized_uri, ctx=ctx)
@@ -137,6 +148,7 @@ class ContentWriteCoordinator:
             ctx=ctx,
             written_bytes=written_bytes,
             telemetry_id=telemetry_id,
+            ingest_options=ingest_options,
         )
 
     async def batch_write(
@@ -509,6 +521,7 @@ class ContentWriteCoordinator:
         ctx: RequestContext,
         target_uri: str = "",
         recursive: bool = False,
+        ingest_options: Optional[IngestOptions] = None,
     ) -> None:
         queue_manager = get_queue_manager()
         semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC, allow_create=True)
@@ -523,6 +536,7 @@ class ContentWriteCoordinator:
             role=str(ctx.role),
             skip_vectorization=False,
             telemetry_id=telemetry.telemetry_id,
+            ingest_options=ingest_options,
             coalesce_key=(
                 build_semantic_coalesce_key(
                     context_type=context_type,
@@ -692,6 +706,7 @@ class ContentWriteCoordinator:
         ctx: RequestContext,
         written_bytes: int,
         telemetry_id: str,
+        ingest_options: Optional[IngestOptions] = None,
     ) -> Dict[str, Any]:
         lock_path = self._viking_fs._uri_to_path(uri, ctx=ctx)
         try:
@@ -719,6 +734,7 @@ class ContentWriteCoordinator:
                 context_type=context_type,
                 ctx=ctx,
                 change_type="added" if mode == "create" else "modified",
+                ingest_options=ingest_options,
             )
             semantic_enqueued = True
             await self._viking_fs._async_agfs.pathlock_release(lease)
@@ -834,6 +850,7 @@ class ContentWriteCoordinator:
         ctx: RequestContext,
         wait: bool,
         timeout: Optional[float],
+        ingest_options: Optional[IngestOptions] = None,
     ) -> Dict[str, Any]:
         self._validate_create_extension(uri)
 
@@ -872,6 +889,7 @@ class ContentWriteCoordinator:
             ctx=ctx,
             written_bytes=written_bytes,
             telemetry_id=telemetry_id,
+            ingest_options=ingest_options,
         )
 
     async def _write_in_place(
@@ -922,6 +940,7 @@ class ContentWriteCoordinator:
         change_type: str = "modified",
         target_uri: str = "",
         recursive: bool = False,
+        ingest_options: Optional[IngestOptions] = None,
     ) -> None:
         await self._enqueue_semantic_refresh_changes(
             root_uri=root_uri,
@@ -930,6 +949,7 @@ class ContentWriteCoordinator:
             changes={change_type: [changed_uri]},
             target_uri=target_uri,
             recursive=recursive,
+            ingest_options=ingest_options,
         )
 
     async def _wait_for_queues(self, *, timeout: Optional[float]) -> Dict[str, Any]:

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -548,6 +548,21 @@ class SemanticDagExecutor:
         prefix = uri.rstrip("/") + "/"
         return any(path.startswith(prefix) for path in self._changed_paths)
 
+    def _file_ingest_options(self, file_path: str) -> IngestOptions:
+        """Full-tree runs tag every generated record; changes-scoped runs
+        (content writes, incremental refreshes) tag only the changed files."""
+        if not self._changed_paths or file_path in self._changed_paths:
+            return self._ingest_options
+        return IngestOptions()
+
+    def _directory_ingest_options(self) -> IngestOptions:
+        """Directory L0/L1 records summarize sibling files, so per-file tags
+        from changes-scoped runs must not leak into them; the embedding
+        partial_update then keeps the directory's existing tags."""
+        if not self._changed_paths:
+            return self._ingest_options
+        return IngestOptions()
+
     async def _check_file_content_changed(self, file_path: str) -> bool:
         if self._is_direct_incremental_update():
             return file_path in self._changed_paths
@@ -720,7 +735,7 @@ class SemanticDagExecutor:
                     summary_dict=summary_dict,
                     parent_uri=parent_uri,
                     use_summary=use_summary,
-                    ingest_options=self._ingest_options,
+                    ingest_options=self._file_ingest_options(file_path),
                 )
                 await self._add_vectorize_task(task)
         except Exception as e:
@@ -865,7 +880,7 @@ class SemanticDagExecutor:
                         semantic_msg_id=self._semantic_msg_id,
                         abstract=abstract,
                         overview=overview,
-                        ingest_options=self._ingest_options,
+                        ingest_options=self._directory_ingest_options(),
                     )
                     await self._add_vectorize_task(task)
             except Exception as e:

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1545,3 +1545,121 @@ async def test_set_tags_does_not_return_write_queue_fields(monkeypatch):
     assert "semantic_status" not in result
     assert "vector_status" not in result
     assert "queue_status" not in result
+
+
+@pytest.mark.asyncio
+async def test_resource_write_tags_thread_into_semantic_msg(monkeypatch):
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    queue = _FakeSemanticQueue()
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_queue_manager",
+        lambda: _FakeQueueManager(queue),
+    )
+
+    result = await coordinator.write(
+        uri=file_uri,
+        content="updated",
+        ctx=ctx,
+        mode="replace",
+        tags=["Team=Search", " env=test "],
+        tag_mode="append",
+    )
+
+    assert result["content_updated"] is True
+    assert len(queue.messages) == 1
+    msg = queue.messages[0]
+    assert msg.ingest_options.search_tags == ["team=search", "env=test"]
+    assert msg.ingest_options.search_tag_mode == "append"
+
+
+@pytest.mark.asyncio
+async def test_resource_write_without_tags_keeps_default_ingest_options(monkeypatch):
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+    queue = _FakeSemanticQueue()
+
+    monkeypatch.setattr(
+        "openviking.storage.content_write.get_queue_manager",
+        lambda: _FakeQueueManager(queue),
+    )
+
+    await coordinator.write(
+        uri=file_uri,
+        content="updated",
+        ctx=ctx,
+        mode="replace",
+    )
+
+    assert len(queue.messages) == 1
+    assert queue.messages[0].ingest_options.search_tags is None
+    assert queue.messages[0].ingest_options.search_tag_mode == "replace"
+
+
+@pytest.mark.asyncio
+async def test_resource_write_rejects_invalid_tag_mode():
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    with pytest.raises(InvalidArgumentError, match="unsupported tag mode"):
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+            mode="replace",
+            tags=["env=prod"],
+            tag_mode="merge",
+        )
+
+    assert viking_fs.content[file_uri] == "original"
+    assert viking_fs.write_file_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resource_write_rejects_malformed_tag():
+    file_uri = "viking://resources/demo/doc.md"
+    root_uri = "viking://resources/demo"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    with pytest.raises(InvalidArgumentError, match="expected strict k=v"):
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+            mode="replace",
+            tags=["no-equals-sign"],
+        )
+
+    assert viking_fs.write_file_calls == []
+
+
+@pytest.mark.asyncio
+async def test_memory_write_rejects_tags():
+    file_uri = "viking://user/default/memories/preferences/theme.md"
+    root_uri = "viking://user/default/memories/preferences"
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
+    viking_fs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    coordinator = ContentWriteCoordinator(viking_fs=viking_fs)
+
+    with pytest.raises(InvalidArgumentError, match="not supported for memory writes"):
+        await coordinator.write(
+            uri=file_uri,
+            content="updated",
+            ctx=ctx,
+            mode="replace",
+            tags=["env=prod"],
+        )
+
+    assert viking_fs.write_file_calls == []

--- a/tests/storage/test_semantic_dag_ingest_options_scope.py
+++ b/tests/storage/test_semantic_dag_ingest_options_scope.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Ingest-options (search tags) scoping across DAG vectorize tasks.
+
+Directory L0/L1 records summarize sibling files, so tags carried by a
+changes-scoped run (content write / incremental refresh) must reach only
+the changed files' records — never the directory records, whose existing
+tags survive via the embedding partial_update.
+"""
+
+import re
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking.utils.ingest_options import IngestOptions
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeVikingFS:
+    def __init__(self, tree, file_contents):
+        self._tree = {self._norm(k): v for k, v in tree.items()}
+        self._file_contents = {self._norm(k): v for k, v in file_contents.items()}
+        self.writes = []
+
+    def _norm(self, path):
+        if "://" not in path:
+            return path
+        scheme, rest = path.split("://", 1)
+        rest = re.sub(r"/{2,}", "/", rest)
+        return f"{scheme}://{rest}"
+
+    async def ls(self, uri, node_limit=None, ctx=None):
+        return self._tree.get(self._norm(uri), [])
+
+    async def stat(self, uri, ctx=None):
+        content = self._file_contents.get(self._norm(uri), "")
+        return {"size": len(content)}
+
+    async def read_file(self, path, ctx=None):
+        return self._file_contents.get(self._norm(path), "")
+
+    async def write_file(self, path, content, ctx=None):
+        norm_path = self._norm(path)
+        self._file_contents[norm_path] = content
+        self.writes.append((norm_path, content))
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/acc1/")
+
+
+class _FakeProcessor:
+    def __init__(self, viking_fs):
+        self._fs = viking_fs
+        self.summarized_files = []
+        self.sync_calls = []
+
+    def _parse_overview_md(self, overview_content):
+        results = {}
+        for line in overview_content.splitlines():
+            m = re.match(r"^-\s*(?P<name>[^:]+):\s*(?P<summary>.*)$", line.strip())
+            if not m:
+                continue
+            results[m.group("name").strip()] = m.group("summary").strip()
+        return results
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.summarized_files.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": "summary"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        lines = ["FILES:"]
+        for item in file_summaries:
+            name = item.get("name", "")
+            summary = item.get("summary", "")
+            lines.append(f"- {name}: {summary}")
+        return "\n".join(lines)
+
+    def _normalize_overview_generation(self, overview):
+        return overview, "abstract"
+
+    async def _sync_topdown_recursive(
+        self, root_uri, target_uri, ctx=None, file_change_status=None, lock=None
+    ):
+        self.sync_calls.append((root_uri, target_uri))
+        root_uri = self._fs._norm(root_uri)
+        target_uri = self._fs._norm(target_uri)
+        for path, content in list(self._fs._file_contents.items()):
+            if path.startswith(root_uri + "/"):
+                mapped = target_uri + path[len(root_uri) :]
+                self._fs._file_contents[mapped] = content
+        return MagicMock(
+            added_files=[],
+            deleted_files=[],
+            updated_files=[],
+            added_dirs=[],
+            deleted_dirs=[],
+        )
+
+
+_ROOT = "viking://resources/root"
+_TAGS = ["team=security"]
+
+
+def _build_executor(monkeypatch, *, incremental_update, changes):
+    fake_fs = _FakeVikingFS(
+        tree={
+            _ROOT: [
+                {"name": "a.txt", "isDir": False},
+                {"name": "b.txt", "isDir": False},
+            ],
+        },
+        file_contents={
+            f"{_ROOT}/a.txt": "new content",
+            f"{_ROOT}/b.txt": "sibling content",
+            f"{_ROOT}/.overview.md": "FILES:\n- a.txt: old-a\n- b.txt: old-b",
+            f"{_ROOT}/.abstract.md": "old-abstract",
+        },
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    executor = SemanticDagExecutor(
+        processor=_FakeProcessor(fake_fs),
+        context_type="resource",
+        max_concurrent_llm=2,
+        ctx=RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER),
+        incremental_update=incremental_update,
+        target_uri=_ROOT,
+        changes=changes,
+        ingest_options=IngestOptions(search_tags=list(_TAGS), search_tag_mode="replace"),
+    )
+    capture = AsyncMock()
+    monkeypatch.setattr(executor, "_add_vectorize_task", capture)
+    return executor, capture
+
+
+def _tasks_by_type(capture):
+    tasks = [call.args[0] for call in capture.call_args_list]
+    return (
+        [t for t in tasks if t.task_type == "file"],
+        [t for t in tasks if t.task_type == "directory"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_changes_scoped_run_tags_only_the_changed_file(monkeypatch):
+    executor, capture = _build_executor(
+        monkeypatch,
+        incremental_update=True,
+        changes={"modified": [f"{_ROOT}/a.txt"]},
+    )
+
+    await executor.run(_ROOT)
+
+    file_tasks, dir_tasks = _tasks_by_type(capture)
+    assert [t.uri for t in file_tasks] == [f"{_ROOT}/a.txt"]
+    assert file_tasks[0].ingest_options.search_tags == _TAGS
+    assert dir_tasks, "directory refresh should still be vectorized"
+    for task in dir_tasks:
+        assert task.ingest_options.search_tags is None
+
+
+@pytest.mark.asyncio
+async def test_full_run_tags_files_and_directories(monkeypatch):
+    executor, capture = _build_executor(
+        monkeypatch,
+        incremental_update=False,
+        changes=None,
+    )
+
+    await executor.run(_ROOT)
+
+    file_tasks, dir_tasks = _tasks_by_type(capture)
+    assert {t.uri for t in file_tasks} == {f"{_ROOT}/a.txt", f"{_ROOT}/b.txt"}
+    for task in file_tasks + dir_tasks:
+        assert task.ingest_options.search_tags == _TAGS

--- a/tests/unit/test_fs_service_write_forwarding.py
+++ b/tests/unit/test_fs_service_write_forwarding.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""FSService.write must accept and forward tags/tag_mode.
+
+Regression guard: the /content/write router passes tags/tag_mode
+unconditionally, so a missing kwarg on this wrapper breaks every write
+request — including ones that carry no tags.
+"""
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.fs_service import FSService
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx():
+    return RequestContext(
+        user=UserIdentifier(account_id="acc", user_id="user"),
+        role=Role.ROOT,
+    )
+
+
+class _FakeCoordinator:
+    captured: dict = {}
+
+    def __init__(self, *, viking_fs, vikingdb=None):
+        del viking_fs, vikingdb
+
+    async def write(self, **kwargs):
+        _FakeCoordinator.captured = kwargs
+        return {"content_updated": True}
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    _FakeCoordinator.captured = {}
+    monkeypatch.setattr(
+        "openviking.service.fs_service.ContentWriteCoordinator",
+        _FakeCoordinator,
+    )
+    return FSService(viking_fs=object())
+
+
+@pytest.mark.asyncio
+async def test_write_forwards_tags_and_tag_mode(svc):
+    out = await svc.write(
+        "viking://resources/demo/doc.md",
+        "hello",
+        _ctx(),
+        tags=["env=prod"],
+        tag_mode="append",
+    )
+
+    assert out == {"content_updated": True}
+    assert _FakeCoordinator.captured["uri"] == "viking://resources/demo/doc.md"
+    assert _FakeCoordinator.captured["tags"] == ["env=prod"]
+    assert _FakeCoordinator.captured["tag_mode"] == "append"
+
+
+@pytest.mark.asyncio
+async def test_write_router_style_call_without_tags(svc):
+    # Mirrors the router's unconditional kwargs for a tag-less request.
+    await svc.write(
+        "viking://resources/demo/doc.md",
+        "hello",
+        _ctx(),
+        mode="replace",
+        wait=False,
+        timeout=None,
+        tags=None,
+        tag_mode="replace",
+    )
+
+    assert _FakeCoordinator.captured["tags"] is None
+    assert _FakeCoordinator.captured["tag_mode"] == "replace"


### PR DESCRIPTION
  ## Description

  Add search tag support to `POST /api/v1/content/write`, allowing resource content and its retrieval tags to be updated through the same request.

  The new `tags` and `tag_mode` fields are forwarded through the router, `FSService`, and `ContentWriteCoordinator` into the existing ingest-options
  pipeline. Incremental content writes apply tags only to the changed file’s vector record, preventing file-specific tags from leaking into parent directory
  L0/L1 records.

  ## Human Involvement

  - [x] A human participated in the implementation or review loop
  - [ ] This PR was generated entirely by AI agents without human participation in the loop

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [x] Test update

  ## Changes Made

  - Added optional `tags` and `tag_mode` fields to the content write API and forwarded them through `FSService` and `ContentWriteCoordinator`.
  - Reused the existing `IngestOptions` pipeline to normalize tags and support `replace` and `append` modes during vector upsert.
  - Scoped tags from incremental content writes to changed file records only, while preserving existing directory tags; full-tree ingestion behavior remains
  unchanged.
  - Rejected tags for memory writes, which do not use the resource semantic ingestion path.
  - Added regression tests for service-layer forwarding, tag validation, tag-less writes, memory rejection, and DAG tag scoping.

  ## Testing

  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
  - [ ] I have tested this on the following platforms:
    - [ ] Linux
    - [x] macOS
    - [ ] Windows

  Added coverage for:

  - Forwarding `tags` and `tag_mode` through `FSService.write`
  - Existing write requests that do not provide tags
  - Tag normalization and `append` mode propagation
  - Invalid tag formats and unsupported tag modes
  - Rejection of tags on memory writes
  - Per-file tag scoping for incremental DAG runs
  - Existing full-tree ingestion tag behavior

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  - Search tags must use strict `k=v` format.
  - `tag_mode` supports `replace` and `append`.
  - Tags are currently supported only for resource/skill content writes; memory writes with tags return an invalid-argument error.