### PR TITLE
[codex] Support Lark drive folder and file URLs

### DIFF
--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -14,11 +14,12 @@ import json
 import mimetypes
 import os
 import re
+import shutil
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from openviking.parse.base import format_table_to_markdown
 from openviking.utils.exceptions import error_code_from_http_status
@@ -34,6 +35,16 @@ _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
 _FEISHU_BITABLE_PERMISSION_REQUIRED = 99991672
 _MAX_MEDIA_DOWNLOAD_CONTEXTS = 8
+_FEISHU_DOC_PATH_TYPES = {"docx", "wiki", "sheets", "base"}
+_FEISHU_DRIVE_DOC_TYPES = {
+    "doc": "docx",
+    "docx": "docx",
+    "sheet": "sheets",
+    "sheets": "sheets",
+    "bitable": "base",
+    "base": "base",
+    "wiki": "wiki",
+}
 
 _MediaDownloadExtras = Dict[str, List[Optional[str]]]
 
@@ -46,6 +57,20 @@ def _title_as_filename(title: str) -> str:
     field makes ``Path(...).name`` silently discard the title prefix.
     """
     return title.replace("/", "_").replace("\\", "_")
+
+
+def _safe_path_segment(name: str, *, fallback: str = "untitled", max_len: int = 120) -> str:
+    """Return one portable path segment while preserving readable names."""
+    safe_name = re.sub(r"[\x00-\x1f/\\:*?\"<>|]+", "_", str(name or "")).strip(" ._")
+    safe_name = re.sub(r"\s+", " ", safe_name)
+    if not safe_name:
+        safe_name = fallback
+    if len(safe_name) > max_len:
+        stem = Path(safe_name).stem
+        suffix = Path(safe_name).suffix
+        max_stem = max_len - len(suffix)
+        safe_name = f"{stem[:max_stem].rstrip(' ._')}{suffix}" if max_stem > 0 else stem[:max_len]
+    return safe_name or fallback
 
 
 def _getattr_safe(obj, key: str, default=None):
@@ -122,6 +147,8 @@ class FeishuAccessor(DataAccessor):
     - Wiki pages: https://*.feishu.cn/wiki/{token}
     - Spreadsheets: https://*.feishu.cn/sheets/{token}
     - Bitable: https://*.feishu.cn/base/{app_token}
+    - Drive files: https://*.feishu.cn/file/{file_token}
+    - Drive folders: https://*.feishu.cn/drive/folder/{folder_token}
 
     Requires:
     - lark-oapi package
@@ -260,6 +287,55 @@ class FeishuAccessor(DataAccessor):
         feishu_access_token = kwargs.get("feishu_access_token")
 
         try:
+            doc_type, token = self._parse_feishu_url(source_str)
+            if doc_type == "file":
+                content, content_type, filename = await asyncio.to_thread(
+                    self._download_drive_file,
+                    token,
+                    feishu_access_token=feishu_access_token,
+                )
+                local_path = self._write_temp_drive_file(
+                    token,
+                    content,
+                    content_type,
+                    filename_hint=filename,
+                )
+                return LocalResource(
+                    path=local_path,
+                    source_type=SourceType.FEISHU,
+                    original_source=source_str,
+                    meta={
+                        "feishu_doc_type": doc_type,
+                        "feishu_token": token,
+                        "original_filename": local_path.name,
+                        "_cleanup_path": str(local_path.parent),
+                    },
+                    is_temporary=True,
+                )
+
+            if doc_type == "folder":
+                temp_dir = Path(tempfile.mkdtemp(prefix="ov_feishu_folder_"))
+                try:
+                    await self._materialize_drive_folder(
+                        token,
+                        temp_dir,
+                        feishu_access_token=feishu_access_token,
+                    )
+                except Exception:
+                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    raise
+                return LocalResource(
+                    path=temp_dir,
+                    source_type=SourceType.FEISHU,
+                    original_source=source_str,
+                    meta={
+                        "feishu_doc_type": doc_type,
+                        "feishu_token": token,
+                        "original_filename": _safe_path_segment(token, fallback="folder"),
+                    },
+                    is_temporary=True,
+                )
+
             # Fetch the document and convert to Markdown
             doc = await self._fetch_document(
                 source_str,
@@ -400,15 +476,17 @@ class FeishuAccessor(DataAccessor):
         """Check if URL is a Feishu/Lark cloud document."""
         parsed = urlparse(url)
         host = (parsed.hostname or "").lower().rstrip(".")
-        path = parsed.path
+        path_parts = [p for p in parsed.path.split("/") if p]
         is_feishu_domain = any(
             host == allowed_host or host.endswith(f".{allowed_host}")
             for allowed_host in ("feishu.cn", "larksuite.com", "larkoffice.com")
         )
-        has_doc_path = any(
-            path == f"/{t}" or path.startswith(f"/{t}/") for t in ("docx", "wiki", "sheets", "base")
-        )
-        return is_feishu_domain and has_doc_path
+        if not is_feishu_domain or len(path_parts) < 2:
+            return False
+        has_doc_path = path_parts[0] in _FEISHU_DOC_PATH_TYPES
+        has_drive_folder_path = len(path_parts) >= 3 and path_parts[:2] == ["drive", "folder"]
+        has_file_path = path_parts[0] == "file"
+        return is_feishu_domain and (has_doc_path or has_drive_folder_path or has_file_path)
 
     @staticmethod
     def _parse_feishu_url(url: str) -> Tuple[str, str]:
@@ -422,9 +500,332 @@ class FeishuAccessor(DataAccessor):
         path_parts = [p for p in parsed.path.split("/") if p]
         if len(path_parts) < 2:
             raise ValueError(f"Cannot parse Feishu URL: {url}")
+        if len(path_parts) >= 3 and path_parts[:2] == ["drive", "folder"]:
+            return "folder", path_parts[2]
+        if path_parts[0] == "file":
+            return "file", path_parts[1]
         doc_type = path_parts[0]  # docx, wiki, sheets, base
         token = path_parts[1]
         return doc_type, token
+
+    async def _materialize_drive_folder(
+        self,
+        folder_token: str,
+        target_dir: Path,
+        *,
+        feishu_access_token: Optional[str] = None,
+        _seen: Optional[set[str]] = None,
+    ) -> None:
+        """Expand a Feishu Drive folder into a local directory tree."""
+        target_dir.mkdir(parents=True, exist_ok=True)
+        seen = _seen or set()
+        if folder_token in seen:
+            logger.warning("[FeishuAccessor] Skipping recursive Drive folder %s", folder_token)
+            return
+        seen.add(folder_token)
+
+        children = await asyncio.to_thread(
+            self._list_drive_folder_children,
+            folder_token,
+            feishu_access_token=feishu_access_token,
+        )
+        for item in children:
+            item_type, item_token, item_name, item_url = self._normalize_drive_item(item)
+            if not item_token:
+                logger.warning("[FeishuAccessor] Skipping Drive item without token: %s", item)
+                continue
+
+            if item_type == "folder":
+                folder_name = _safe_path_segment(item_name or item_token, fallback=item_token)
+                child_dir = self._unique_child_path(target_dir, folder_name)
+                await self._materialize_drive_folder(
+                    item_token,
+                    child_dir,
+                    feishu_access_token=feishu_access_token,
+                    _seen=seen,
+                )
+                continue
+
+            doc_path_type = _FEISHU_DRIVE_DOC_TYPES.get(item_type)
+            if doc_path_type:
+                url = item_url or self._build_feishu_doc_url(doc_path_type, item_token)
+                doc = await self._fetch_document(
+                    url,
+                    feishu_access_token=feishu_access_token,
+                )
+                markdown_content, downloaded_images = await asyncio.to_thread(
+                    self._resolve_image_refs,
+                    doc.markdown_content,
+                    feishu_access_token=feishu_access_token,
+                    media_download_extras=doc.media_download_extras,
+                )
+                doc_name = _safe_path_segment(
+                    item_name or doc.title or item_token,
+                    fallback=item_token,
+                )
+                markdown_path = self._unique_child_path(
+                    target_dir,
+                    self._markdown_file_name(doc_name),
+                )
+                markdown_path.write_text(markdown_content, encoding="utf-8")
+                for rel_path, image_bytes in downloaded_images.items():
+                    image_path = markdown_path.parent / rel_path
+                    image_path.parent.mkdir(parents=True, exist_ok=True)
+                    image_path.write_bytes(image_bytes)
+                continue
+
+            if item_type == "file":
+                content, content_type, downloaded_name = await asyncio.to_thread(
+                    self._download_drive_file,
+                    item_token,
+                    feishu_access_token=feishu_access_token,
+                    filename_hint=item_name,
+                )
+                file_name = self._drive_file_name(
+                    item_token,
+                    content,
+                    content_type,
+                    filename_hint=downloaded_name or item_name,
+                )
+                file_path = self._unique_child_path(target_dir, file_name)
+                file_path.write_bytes(content)
+                continue
+
+            logger.warning(
+                "[FeishuAccessor] Skipping unsupported Drive item type %s for token %s",
+                item_type,
+                item_token,
+            )
+
+        seen.remove(folder_token)
+
+    def _list_drive_folder_children(
+        self,
+        folder_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> List[Any]:
+        """List direct children under a Feishu Drive folder token."""
+        import lark_oapi as lark
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        token_type = (
+            lark.AccessTokenType.USER if feishu_access_token else lark.AccessTokenType.TENANT
+        )
+        all_children: List[Any] = []
+        page_token = None
+
+        while True:
+            raw_req = (
+                lark.BaseRequest.builder()
+                .http_method(lark.HttpMethod.GET)
+                .uri("/open-apis/drive/v1/files")
+                .token_types({token_type})
+                .build()
+            )
+            raw_req.add_query("folder_token", folder_token)
+            raw_req.add_query("page_size", 200)
+            if page_token:
+                raw_req.add_query("page_token", page_token)
+
+            response = self._call_api(client.request, raw_req, feishu_access_token)
+            if not response.success():
+                _raise_from_lark_response(
+                    response,
+                    operation=f"list Drive folder {folder_token}",
+                    resource=folder_token,
+                )
+
+            data = self._drive_response_data(response)
+            items = _getattr_safe(data, "files", None) or _getattr_safe(data, "items", None) or []
+            all_children.extend(items)
+
+            has_more = bool(_getattr_safe(data, "has_more", False))
+            if not has_more:
+                break
+            page_token = _getattr_safe(data, "next_page_token", None) or _getattr_safe(
+                data, "page_token", None
+            )
+            if not page_token:
+                raise RuntimeError(
+                    f"Feishu returned more Drive folder items for {folder_token} "
+                    "without a page token"
+                )
+
+        return all_children
+
+    def _download_drive_file(
+        self,
+        file_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+        filename_hint: Optional[str] = None,
+    ) -> Tuple[bytes, Optional[str], Optional[str]]:
+        """Download a Feishu Drive binary file by file token."""
+        import lark_oapi as lark
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        token_type = (
+            lark.AccessTokenType.USER if feishu_access_token else lark.AccessTokenType.TENANT
+        )
+        raw_req = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri(f"/open-apis/drive/v1/files/{file_token}/download")
+            .token_types({token_type})
+            .build()
+        )
+        response = self._call_api(client.request, raw_req, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"download Drive file {file_token}",
+                resource=file_token,
+            )
+
+        raw = getattr(response, "raw", None)
+        content = getattr(raw, "content", None)
+        if content is None:
+            raise OpenVikingError(
+                f"Feishu Drive file download returned empty content: {file_token}",
+                code="NOT_FOUND",
+                details={"operation": "download Drive file", "resource": file_token},
+            )
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+
+        content_type = self._response_content_type(raw)
+        filename = self._filename_from_content_disposition(
+            self._response_header(raw, "content-disposition")
+        )
+        return content, content_type, filename or filename_hint
+
+    def _write_temp_drive_file(
+        self,
+        file_token: str,
+        content: bytes,
+        content_type: Optional[str],
+        *,
+        filename_hint: Optional[str] = None,
+    ) -> Path:
+        filename = self._drive_file_name(
+            file_token,
+            content,
+            content_type,
+            filename_hint=filename_hint,
+        )
+        temp_dir = Path(tempfile.mkdtemp(prefix="ov_feishu_file_"))
+        path = temp_dir / filename
+        path.write_bytes(content)
+        return path
+
+    @staticmethod
+    def _drive_response_data(response: Any) -> Any:
+        data = getattr(response, "data", None)
+        if data is not None:
+            return data
+        raw_content = getattr(getattr(response, "raw", None), "content", None)
+        if not raw_content:
+            return {}
+        if isinstance(raw_content, bytes):
+            raw_content = raw_content.decode("utf-8")
+        return json.loads(raw_content).get("data", {})
+
+    @classmethod
+    def _normalize_drive_item(cls, item: Any) -> Tuple[str, str, str, str]:
+        item_type = str(_getattr_safe(item, "type", "") or "").lower()
+        token = str(_getattr_safe(item, "token", "") or "")
+        name = str(_getattr_safe(item, "name", "") or "")
+        url = str(_getattr_safe(item, "url", "") or "")
+        shortcut_info = _getattr_safe(item, "shortcut_info", None)
+        if shortcut_info:
+            item_type = str(
+                _getattr_safe(shortcut_info, "target_type", item_type) or item_type
+            ).lower()
+            token = str(_getattr_safe(shortcut_info, "target_token", token) or token)
+        return item_type, token, name, url
+
+    @staticmethod
+    def _build_feishu_doc_url(doc_type: str, token: str) -> str:
+        return f"https://open.feishu.cn/{doc_type}/{token}"
+
+    @staticmethod
+    def _unique_child_path(parent: Path, name: str) -> Path:
+        path = parent / _safe_path_segment(name)
+        if not path.exists():
+            return path
+        suffix = path.suffix
+        stem = path.stem
+        for index in range(2, 10000):
+            candidate = parent / f"{stem} ({index}){suffix}"
+            if not candidate.exists():
+                return candidate
+        raise RuntimeError(f"Unable to allocate unique path under {parent}")
+
+    @classmethod
+    def _drive_file_name(
+        cls,
+        file_token: str,
+        content: bytes,
+        content_type: Optional[str],
+        *,
+        filename_hint: Optional[str] = None,
+    ) -> str:
+        filename = _safe_path_segment(filename_hint or file_token, fallback=file_token)
+        if Path(filename).suffix:
+            return filename
+        return f"{filename}{cls._guess_drive_file_ext(content, content_type)}"
+
+    @staticmethod
+    def _markdown_file_name(name: str) -> str:
+        safe_name = _safe_path_segment(name)
+        if safe_name.lower().endswith((".md", ".markdown")):
+            return safe_name
+        return f"{safe_name}.md"
+
+    @staticmethod
+    def _guess_drive_file_ext(content: bytes, content_type: Optional[str]) -> str:
+        if content.startswith(b"%PDF-"):
+            return ".pdf"
+        if (
+            content.startswith(b"PK\x03\x04")
+            or content.startswith(b"PK\x05\x06")
+            or content.startswith(b"PK\x07\x08")
+        ):
+            return ".zip"
+        if content.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"):
+            return ".doc"
+        if content_type:
+            ext = get_preferred_extension(content_type)
+            if ext:
+                return ext
+        return ".bin"
+
+    @staticmethod
+    def _response_header(raw: Any, name: str) -> Optional[str]:
+        headers = getattr(raw, "headers", None)
+        if not headers:
+            return None
+        try:
+            get = headers.get
+        except AttributeError:
+            return None
+        return get(name) or get(name.title()) or get(name.lower())
+
+    @staticmethod
+    def _filename_from_content_disposition(content_disposition: Optional[str]) -> Optional[str]:
+        if not content_disposition:
+            return None
+        utf8_match = re.search(r"filename\*=UTF-8''([^;]+)", content_disposition, re.I)
+        if utf8_match:
+            return unquote(utf8_match.group(1))
+        quoted_match = re.search(r'filename="([^"]+)"', content_disposition, re.I)
+        if quoted_match:
+            return quoted_match.group(1)
+        simple_match = re.search(r"filename=([^;]+)", content_disposition, re.I)
+        if simple_match:
+            return simple_match.group(1).strip()
+        return None
 
     # ========== Configuration & Client ==========
 

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -315,11 +315,14 @@ class FeishuAccessor(DataAccessor):
 
             if doc_type == "folder":
                 temp_dir = Path(tempfile.mkdtemp(prefix="ov_feishu_folder_"))
+                skipped_items: list[dict[str, Any]] = []
                 try:
                     await self._materialize_drive_folder(
                         token,
                         temp_dir,
                         feishu_access_token=feishu_access_token,
+                        skipped_items=skipped_items,
+                        strict=bool(kwargs.get("strict", False)),
                     )
                 except Exception:
                     shutil.rmtree(temp_dir, ignore_errors=True)
@@ -332,6 +335,7 @@ class FeishuAccessor(DataAccessor):
                         "feishu_doc_type": doc_type,
                         "feishu_token": token,
                         "original_filename": _safe_path_segment(token, fallback="folder"),
+                        "feishu_folder_skipped_items": skipped_items,
                     },
                     is_temporary=True,
                 )
@@ -515,6 +519,8 @@ class FeishuAccessor(DataAccessor):
         *,
         feishu_access_token: Optional[str] = None,
         _seen: Optional[set[str]] = None,
+        skipped_items: Optional[list[dict[str, Any]]] = None,
+        strict: bool = False,
     ) -> None:
         """Expand a Feishu Drive folder into a local directory tree."""
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -524,80 +530,157 @@ class FeishuAccessor(DataAccessor):
             return
         seen.add(folder_token)
 
-        children = await asyncio.to_thread(
-            self._list_drive_folder_children,
-            folder_token,
-            feishu_access_token=feishu_access_token,
-        )
-        for item in children:
-            item_type, item_token, item_name, item_url = self._normalize_drive_item(item)
-            if not item_token:
-                logger.warning("[FeishuAccessor] Skipping Drive item without token: %s", item)
-                continue
-
-            if item_type == "folder":
-                folder_name = _safe_path_segment(item_name or item_token, fallback=item_token)
-                child_dir = self._unique_child_path(target_dir, folder_name)
-                await self._materialize_drive_folder(
-                    item_token,
-                    child_dir,
-                    feishu_access_token=feishu_access_token,
-                    _seen=seen,
-                )
-                continue
-
-            doc_path_type = _FEISHU_DRIVE_DOC_TYPES.get(item_type)
-            if doc_path_type:
-                url = item_url or self._build_feishu_doc_url(doc_path_type, item_token)
-                doc = await self._fetch_document(
-                    url,
-                    feishu_access_token=feishu_access_token,
-                )
-                markdown_content, downloaded_images = await asyncio.to_thread(
-                    self._resolve_image_refs,
-                    doc.markdown_content,
-                    feishu_access_token=feishu_access_token,
-                    media_download_extras=doc.media_download_extras,
-                )
-                doc_name = _safe_path_segment(
-                    item_name or doc.title or item_token,
-                    fallback=item_token,
-                )
-                markdown_path = self._unique_child_path(
-                    target_dir,
-                    self._markdown_file_name(doc_name),
-                )
-                markdown_path.write_text(markdown_content, encoding="utf-8")
-                for rel_path, image_bytes in downloaded_images.items():
-                    image_path = markdown_path.parent / rel_path
-                    image_path.parent.mkdir(parents=True, exist_ok=True)
-                    image_path.write_bytes(image_bytes)
-                continue
-
-            if item_type == "file":
-                content, content_type, downloaded_name = await asyncio.to_thread(
-                    self._download_drive_file,
-                    item_token,
-                    feishu_access_token=feishu_access_token,
-                    filename_hint=item_name,
-                )
-                file_name = self._drive_file_name(
-                    item_token,
-                    content,
-                    content_type,
-                    filename_hint=downloaded_name or item_name,
-                )
-                file_path = self._unique_child_path(target_dir, file_name)
-                file_path.write_bytes(content)
-                continue
-
-            logger.warning(
-                "[FeishuAccessor] Skipping unsupported Drive item type %s for token %s",
-                item_type,
-                item_token,
+        try:
+            children = await asyncio.to_thread(
+                self._list_drive_folder_children,
+                folder_token,
+                feishu_access_token=feishu_access_token,
             )
+            for item in children:
+                item_type, item_token, item_name, item_url = self._normalize_drive_item(item)
+                if not item_token:
+                    logger.warning("[FeishuAccessor] Skipping Drive item without token: %s", item)
+                    continue
 
-        seen.remove(folder_token)
+                if item_type == "folder":
+                    folder_name = _safe_path_segment(item_name or item_token, fallback=item_token)
+                    child_dir = self._unique_child_path(target_dir, folder_name)
+                    try:
+                        await self._materialize_drive_folder(
+                            item_token,
+                            child_dir,
+                            feishu_access_token=feishu_access_token,
+                            _seen=seen,
+                            skipped_items=skipped_items,
+                            strict=strict,
+                        )
+                    except Exception as exc:
+                        shutil.rmtree(child_dir, ignore_errors=True)
+                        self._record_skipped_drive_item(
+                            skipped_items,
+                            item_type=item_type,
+                            token=item_token,
+                            name=item_name,
+                            target_dir=target_dir,
+                            error=exc,
+                        )
+                        if strict:
+                            raise
+                    continue
+
+                doc_path_type = _FEISHU_DRIVE_DOC_TYPES.get(item_type)
+                if doc_path_type:
+                    try:
+                        url = item_url or self._build_feishu_doc_url(doc_path_type, item_token)
+                        doc = await self._fetch_document(
+                            url,
+                            feishu_access_token=feishu_access_token,
+                        )
+                        markdown_content, downloaded_images = await asyncio.to_thread(
+                            self._resolve_image_refs,
+                            doc.markdown_content,
+                            feishu_access_token=feishu_access_token,
+                            media_download_extras=doc.media_download_extras,
+                        )
+                        doc_name = _safe_path_segment(
+                            item_name or doc.title or item_token,
+                            fallback=item_token,
+                        )
+                        markdown_path = self._unique_child_path(
+                            target_dir,
+                            self._markdown_file_name(doc_name),
+                        )
+                        markdown_path.write_text(markdown_content, encoding="utf-8")
+                        for rel_path, image_bytes in downloaded_images.items():
+                            image_path = markdown_path.parent / rel_path
+                            image_path.parent.mkdir(parents=True, exist_ok=True)
+                            image_path.write_bytes(image_bytes)
+                    except Exception as exc:
+                        self._record_skipped_drive_item(
+                            skipped_items,
+                            item_type=item_type,
+                            token=item_token,
+                            name=item_name,
+                            target_dir=target_dir,
+                            error=exc,
+                        )
+                        if strict:
+                            raise
+                    continue
+
+                if item_type == "file":
+                    try:
+                        content, content_type, downloaded_name = await asyncio.to_thread(
+                            self._download_drive_file,
+                            item_token,
+                            feishu_access_token=feishu_access_token,
+                            filename_hint=item_name,
+                        )
+                        file_name = self._drive_file_name(
+                            item_token,
+                            content,
+                            content_type,
+                            filename_hint=downloaded_name or item_name,
+                        )
+                        file_path = self._unique_child_path(target_dir, file_name)
+                        file_path.write_bytes(content)
+                    except Exception as exc:
+                        self._record_skipped_drive_item(
+                            skipped_items,
+                            item_type=item_type,
+                            token=item_token,
+                            name=item_name,
+                            target_dir=target_dir,
+                            error=exc,
+                        )
+                        if strict:
+                            raise
+                    continue
+
+                error = ValueError(f"Unsupported Feishu Drive item type: {item_type}")
+                self._record_skipped_drive_item(
+                    skipped_items,
+                    item_type=item_type,
+                    token=item_token,
+                    name=item_name,
+                    target_dir=target_dir,
+                    error=error,
+                )
+                if strict:
+                    raise error
+
+        finally:
+            seen.discard(folder_token)
+
+    @staticmethod
+    def _record_skipped_drive_item(
+        skipped_items: Optional[list[dict[str, Any]]],
+        *,
+        item_type: str,
+        token: str,
+        name: str,
+        target_dir: Path,
+        error: Exception,
+    ) -> None:
+        message = str(error).replace("\n", " ")
+        logger.warning(
+            "[FeishuAccessor] Skipping Drive %s %s under %s: %s",
+            item_type,
+            token,
+            target_dir,
+            message,
+        )
+        if skipped_items is None:
+            return
+        skipped_items.append(
+            {
+                "path": str(target_dir / _safe_path_segment(name or token, fallback=token)),
+                "name": name or token,
+                "type": item_type,
+                "token": token,
+                "reason": message,
+            }
+        )
 
     def _list_drive_folder_children(
         self,

--- a/openviking/parse/parsers/directory.py
+++ b/openviking/parse/parsers/directory.py
@@ -142,6 +142,14 @@ class DirectoryParser(BaseParser):
                     preserve_structure = True
             processable_files = scan_result.all_processable_files()
             warnings.extend(scan_result.warnings)
+            source_skipped_items = self._source_skipped_items(
+                kwargs.get("_source_meta"),
+                source_path,
+            )
+            warnings.extend(
+                f"Skipped Feishu Drive item {item['path']}: {item.get('reason', 'unknown error')}"
+                for item in source_skipped_items
+            )
 
             viking_fs = self._get_viking_fs()
             temp_uri = self._create_temp_uri()
@@ -164,6 +172,13 @@ class DirectoryParser(BaseParser):
                     warnings=warnings,
                 )
                 result.temp_dir_path = temp_uri
+                result.meta["file_count"] = 0
+                result.meta["dir_name"] = dir_name
+                result.meta["total_processable"] = 0
+                result.meta["processed_files"] = []
+                result.meta["failed_files"] = source_skipped_items
+                result.meta["unsupported_files"] = []
+                result.meta["skipped_files"] = []
                 return result
 
             # ── Phase 2: process each file ────────────────────────────
@@ -258,7 +273,7 @@ class DirectoryParser(BaseParser):
             result.meta["dir_name"] = dir_name
             result.meta["total_processable"] = len(processable_files)
             result.meta["processed_files"] = processed_files
-            result.meta["failed_files"] = failed_files
+            result.meta["failed_files"] = failed_files + source_skipped_items
             result.meta["unsupported_files"] = unsupported_files
             result.meta["skipped_files"] = skipped_files
 
@@ -327,6 +342,41 @@ class DirectoryParser(BaseParser):
             status = DirectoryParser._REASON_TO_STATUS.get(reason, "skip")
             result.append({"path": path, "status": status})
         return result
+
+    @staticmethod
+    def _source_skipped_items(source_meta: Any, source_path: Path) -> List[Dict[str, str]]:
+        """Normalize skipped items reported by a remote source accessor."""
+        if not isinstance(source_meta, dict):
+            return []
+        items = source_meta.get("feishu_folder_skipped_items") or []
+        if not isinstance(items, list):
+            return []
+
+        normalized: List[Dict[str, str]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            raw_path = str(item.get("path") or item.get("name") or item.get("token") or "unknown")
+            display_path = raw_path
+            try:
+                path = Path(raw_path).resolve(strict=False)
+                if path.is_absolute():
+                    display_path = str(path.relative_to(source_path.resolve(strict=False)))
+            except Exception:
+                pass
+            display_path = display_path.replace("\\", "/")
+
+            normalized.append(
+                {
+                    "path": display_path,
+                    "parser": "feishu",
+                    "status": "failed",
+                    "type": str(item.get("type") or ""),
+                    "token": str(item.get("token") or ""),
+                    "reason": str(item.get("reason") or "unknown error"),
+                }
+            )
+        return normalized
 
     # ------------------------------------------------------------------
     # Parser assignment

--- a/tests/parse/test_add_directory.py
+++ b/tests/parse/test_add_directory.py
@@ -65,7 +65,7 @@ class FakeVikingFS:
     async def read(self, uri: str, offset: int = 0, size: int = -1) -> bytes:
         return self.files.get(uri, b"")
 
-    async def ls(self, uri: str) -> List[Dict[str, Any]]:
+    async def ls(self, uri: str, **kwargs: Any) -> List[Dict[str, Any]]:
         """List direct children of *uri* (mirrors real AGFS entry format)."""
         prefix = uri.rstrip("/") + "/"
         children: Dict[str, bool] = {}  # name → is_dir
@@ -710,6 +710,42 @@ class TestParseResultMetadata:
         assert result.meta["dir_name"] == tmp_code.name
         assert result.meta["total_processable"] == 3
         assert result.meta["file_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_feishu_accessor_skipped_items_are_reported(
+        self, tmp_path: Path, parser, fake_fs
+    ) -> None:
+        (tmp_path / "ok.py").write_text("print('ok')", encoding="utf-8")
+        blocked_path = tmp_path / "slides.pptx"
+
+        result = await parser.parse(
+            str(tmp_path),
+            _source_meta={
+                "feishu_folder_skipped_items": [
+                    {
+                        "path": str(blocked_path),
+                        "name": "slides.pptx",
+                        "type": "file",
+                        "token": "file-token",
+                        "reason": "HTTP 403",
+                    }
+                ]
+            },
+        )
+
+        assert result.meta["file_count"] == 1
+        assert result.meta["processed_files"] == [{"path": "ok.py", "parser": "direct"}]
+        assert result.meta["failed_files"] == [
+            {
+                "path": "slides.pptx",
+                "parser": "feishu",
+                "status": "failed",
+                "type": "file",
+                "token": "file-token",
+                "reason": "HTTP 403",
+            }
+        ]
+        assert any("Skipped Feishu Drive item slides.pptx: HTTP 403" in w for w in result.warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -187,6 +187,161 @@ def test_fetch_all_blocks_uses_user_access_token_option(monkeypatch):
     assert option.user_access_token == "u-test"
 
 
+def test_feishu_url_detection_supports_drive_folder_and_file_paths():
+    assert FeishuAccessor._is_feishu_url(
+        "https://bytedance.larkoffice.com/drive/folder/ZihPfsmbBlK4iCdFK8ocMA0Onre"
+    )
+    assert FeishuAccessor._is_feishu_url(
+        "https://bytedance.larkoffice.com/file/G0wKbPjCooZ7LUxktDOc56Ysnlg"
+    )
+
+    assert FeishuAccessor._parse_feishu_url(
+        "https://bytedance.larkoffice.com/drive/folder/ZihPfsmbBlK4iCdFK8ocMA0Onre"
+    ) == ("folder", "ZihPfsmbBlK4iCdFK8ocMA0Onre")
+    assert FeishuAccessor._parse_feishu_url(
+        "https://bytedance.larkoffice.com/file/G0wKbPjCooZ7LUxktDOc56Ysnlg"
+    ) == ("file", "G0wKbPjCooZ7LUxktDOc56Ysnlg")
+
+
+def test_access_downloads_lark_file_url(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    request = MagicMock(
+        return_value=_FakeMediaResponse(
+            b"%PDF-1.7",
+            headers={"content-type": "application/pdf"},
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+    accessor._user_token_client = SimpleNamespace(request=request)
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://bytedance.larkoffice.com/file/G0wKbPjCooZ7LUxktDOc56Ysnlg",
+            feishu_access_token="u-test",
+        )
+    )
+    try:
+        assert resource.path.read_bytes() == b"%PDF-1.7"
+        assert resource.path.suffix == ".pdf"
+        assert resource.meta["feishu_doc_type"] == "file"
+        assert resource.meta["feishu_token"] == "G0wKbPjCooZ7LUxktDOc56Ysnlg"
+        assert resource.meta["original_filename"] == "G0wKbPjCooZ7LUxktDOc56Ysnlg.pdf"
+        raw_request, option = request.call_args.args
+        assert raw_request.http_method == "GET"
+        assert raw_request.uri == "/open-apis/drive/v1/files/G0wKbPjCooZ7LUxktDOc56Ysnlg/download"
+        assert raw_request.token_types == {"user"}
+        assert option.user_access_token == "u-test"
+    finally:
+        resource.cleanup()
+
+
+def test_access_expands_drive_folder_recursively(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    folder_children = {
+        "root_folder": [
+            SimpleNamespace(token="doc_token", name="Spec Doc", type="docx", url=""),
+            SimpleNamespace(token="versioned_doc", name="Spec v1.2", type="docx", url=""),
+            SimpleNamespace(token="child_folder", name="Nested Folder", type="folder", url=""),
+            SimpleNamespace(token="file_token", name="Design.pdf", type="file", url=""),
+        ],
+        "child_folder": [
+            SimpleNamespace(token="sheet_token", name="Metrics", type="sheet", url=""),
+        ],
+    }
+    request = MagicMock(
+        return_value=_FakeMediaResponse(
+            b"%PDF-1.7",
+            headers={"content-type": "application/pdf"},
+        )
+    )
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+    accessor._user_token_client = SimpleNamespace(request=request)
+
+    def fake_list_children(folder_token, **_kwargs):
+        return folder_children[folder_token]
+
+    async def fake_fetch_document(url, **_kwargs):
+        from openviking.parse.accessors.feishu_accessor import FeishuDocument
+
+        doc_type, token = accessor._parse_feishu_url(url)
+        return FeishuDocument(
+            doc_type=doc_type,
+            token=token,
+            markdown_content=f"# {token}",
+            title=f"{token} title",
+            meta={},
+        )
+
+    monkeypatch.setattr(accessor, "_list_drive_folder_children", fake_list_children)
+    monkeypatch.setattr(accessor, "_fetch_document", fake_fetch_document)
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://bytedance.larkoffice.com/drive/folder/root_folder",
+            feishu_access_token="u-test",
+        )
+    )
+    try:
+        assert resource.path.is_dir()
+        assert (resource.path / "Spec Doc.md").read_text(encoding="utf-8") == "# doc_token"
+        assert (resource.path / "Spec v1.2.md").read_text(encoding="utf-8") == "# versioned_doc"
+        assert (resource.path / "Nested Folder" / "Metrics.md").read_text(
+            encoding="utf-8"
+        ) == "# sheet_token"
+        assert (resource.path / "Design.pdf").read_bytes() == b"%PDF-1.7"
+        assert resource.meta["feishu_doc_type"] == "folder"
+        assert resource.meta["feishu_token"] == "root_folder"
+        assert resource.meta["original_filename"] == "root_folder"
+    finally:
+        resource.cleanup()
+
+
+def test_list_drive_folder_children_paginates_with_user_token(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    request = MagicMock(
+        side_effect=[
+            _SuccessResponse(
+                SimpleNamespace(
+                    files=[SimpleNamespace(token="doc_token")],
+                    has_more=True,
+                    next_page_token="page-2",
+                )
+            ),
+            _SuccessResponse(
+                SimpleNamespace(
+                    files=[SimpleNamespace(token="file_token")],
+                    has_more=False,
+                    next_page_token=None,
+                )
+            ),
+        ]
+    )
+    accessor = FeishuAccessor()
+    accessor._user_token_client = SimpleNamespace(request=request)
+
+    children = accessor._list_drive_folder_children(
+        "folder_token",
+        feishu_access_token="u-test",
+    )
+
+    assert [child.token for child in children] == ["doc_token", "file_token"]
+    first_request, first_option = request.call_args_list[0].args
+    second_request, second_option = request.call_args_list[1].args
+    assert first_request.http_method == "GET"
+    assert first_request.uri == "/open-apis/drive/v1/files"
+    assert first_request.token_types == {"user"}
+    assert first_request.queries == {"folder_token": "folder_token", "page_size": 200}
+    assert second_request.queries == {
+        "folder_token": "folder_token",
+        "page_size": 200,
+        "page_token": "page-2",
+    }
+    assert first_option.user_access_token == "u-test"
+    assert second_option.user_access_token == "u-test"
+
+
 def test_resolve_image_refs_respects_download_images_disabled():
     accessor = FeishuAccessor()
     accessor._config = SimpleNamespace(download_images=False)

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -298,6 +298,118 @@ def test_access_expands_drive_folder_recursively(monkeypatch):
         resource.cleanup()
 
 
+def test_access_drive_folder_skips_item_failures_by_default(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+
+    monkeypatch.setattr(
+        accessor,
+        "_list_drive_folder_children",
+        lambda folder_token, **_kwargs: [
+            SimpleNamespace(token="doc_token", name="Spec Doc", type="docx", url=""),
+            SimpleNamespace(token="blocked_file", name="Blocked.pptx", type="file", url=""),
+        ],
+    )
+
+    async def fake_fetch_document(url, **_kwargs):
+        from openviking.parse.accessors.feishu_accessor import FeishuDocument
+
+        doc_type, token = accessor._parse_feishu_url(url)
+        return FeishuDocument(
+            doc_type=doc_type,
+            token=token,
+            markdown_content="# ok",
+            title="Spec Doc",
+            meta={},
+        )
+
+    def fake_download(file_token, **_kwargs):
+        raise RuntimeError("HTTP 403")
+
+    monkeypatch.setattr(accessor, "_fetch_document", fake_fetch_document)
+    monkeypatch.setattr(accessor, "_download_drive_file", fake_download)
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://bytedance.larkoffice.com/drive/folder/root_folder",
+            feishu_access_token="u-test",
+        )
+    )
+    try:
+        assert (resource.path / "Spec Doc.md").read_text(encoding="utf-8") == "# ok"
+        skipped = resource.meta["feishu_folder_skipped_items"]
+        assert len(skipped) == 1
+        assert skipped[0]["name"] == "Blocked.pptx"
+        assert skipped[0]["type"] == "file"
+        assert skipped[0]["token"] == "blocked_file"
+        assert "HTTP 403" in skipped[0]["reason"]
+    finally:
+        resource.cleanup()
+
+
+def test_access_drive_folder_reports_unsupported_items(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+
+    monkeypatch.setattr(
+        accessor,
+        "_list_drive_folder_children",
+        lambda folder_token, **_kwargs: [
+            SimpleNamespace(token="slides_token", name="Deck", type="slides", url=""),
+        ],
+    )
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://bytedance.larkoffice.com/drive/folder/root_folder",
+            feishu_access_token="u-test",
+        )
+    )
+    try:
+        skipped = resource.meta["feishu_folder_skipped_items"]
+        assert skipped == [
+            {
+                "path": str(resource.path / "Deck"),
+                "name": "Deck",
+                "type": "slides",
+                "token": "slides_token",
+                "reason": "Unsupported Feishu Drive item type: slides",
+            }
+        ]
+    finally:
+        resource.cleanup()
+
+
+def test_access_drive_folder_strict_raises_item_failures(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=False)
+
+    monkeypatch.setattr(
+        accessor,
+        "_list_drive_folder_children",
+        lambda folder_token, **_kwargs: [
+            SimpleNamespace(token="blocked_file", name="Blocked.pptx", type="file", url=""),
+        ],
+    )
+    monkeypatch.setattr(
+        accessor,
+        "_download_drive_file",
+        lambda file_token, **_kwargs: (_ for _ in ()).throw(RuntimeError("HTTP 403")),
+    )
+
+    with pytest.raises(RuntimeError, match="HTTP 403"):
+        asyncio.run(
+            accessor.access(
+                "https://bytedance.larkoffice.com/drive/folder/root_folder",
+                feishu_access_token="u-test",
+                strict=True,
+            )
+        )
+
+
 def test_list_drive_folder_children_paginates_with_user_token(monkeypatch):
     _install_fake_lark_modules(monkeypatch)
     request = MagicMock(


### PR DESCRIPTION
## What changed

- Recognize Lark/Feishu Drive folder URLs like /drive/folder/{token} and file URLs like /file/{token}.
- Expand Drive folders recursively into a temporary local directory so the existing directory parser can ingest the resulting tree.
- Download Drive binary files through /open-apis/drive/v1/files/{file_token}/download with matching tenant/user token mode.
- Preserve readable local filenames, de-duplicate sibling paths, and cover Drive folder pagination.

## Why

The previous URL parser only accepted document-style paths: docx, wiki, sheets, base. It also treated the first two path segments as type and token. That made /drive/folder/{token} parse incorrectly and left /file/{token} unsupported, so these links fell through or failed as unsupported Feishu document types.

## Validation

- uv run --extra test pytest tests/parse/test_feishu_accessor.py tests/parse/test_parser_router.py -q
- uv run --extra dev ruff check openviking/parse/accessors/feishu_accessor.py tests/parse/test_feishu_accessor.py
- uv run --extra dev ruff format --check openviking/parse/accessors/feishu_accessor.py tests/parse/test_feishu_accessor.py
- uv run openviking --help