### PR TITLE
fix(admin): fail-closed cascading user deletion (#3660)

### DIFF
--- a/openviking/observability/usage_audit/runtime.py
+++ b/openviking/observability/usage_audit/runtime.py
@@ -36,6 +36,19 @@ class UsageAuditRuntime:
     api_service: UsageAuditQueryService
     shutdown_flush_timeout_seconds: float
 
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
+        """Drain accepted events, then purge one user's persisted projections.
+
+        Events already accepted by the background worker must be flushed before
+        the purge; otherwise a later flush could re-insert rows for a user that
+        was just deleted.
+        """
+        await self.worker.flush()
+        return await self.store.delete_user_data(
+            account_id=account_id,
+            user_id=user_id,
+        )
+
 
 def _resolve_sqlite_path(config: ServerConfig) -> Path:
     configured = config.observability.usage_audit.sqlite_path

--- a/openviking/observability/usage_audit/sqlite_store.py
+++ b/openviking/observability/usage_audit/sqlite_store.py
@@ -103,14 +103,10 @@ class SQLiteUsageAuditStore:
             self._conn.close()
             self._conn = None
 
-    async def delete_user_data(
-        self, *, account_id: str, user_id: str
-    ) -> dict[str, int]:
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
         """Delete all usage/audit rows for a (account, user) pair."""
         async with self._lock:
-            return await asyncio.to_thread(
-                self._delete_user_data_sync, account_id, user_id
-            )
+            return await asyncio.to_thread(self._delete_user_data_sync, account_id, user_id)
 
     def _delete_user_data_sync(self, account_id: str, user_id: str) -> dict[str, int]:
         assert self._conn is not None
@@ -361,9 +357,7 @@ class SQLiteUsageAuditStore:
         assert self._conn is not None
         day = date.fromisoformat(user_date)
         utc_start, utc_end = _user_day_window_utc(day, tz)
-        rows = self._fetch_hourly_token_rows(
-            account_id, utc_start, utc_end, user_id=user_id
-        )
+        rows = self._fetch_hourly_token_rows(account_id, utc_start, utc_end, user_id=user_id)
         result = {"vlm_input": 0, "vlm_output": 0, "embedding_input": 0}
         for source, token_type, _, _, total in rows:
             key = f"{source}_{token_type}"

--- a/openviking/observability/usage_audit/sqlite_store.py
+++ b/openviking/observability/usage_audit/sqlite_store.py
@@ -103,6 +103,42 @@ class SQLiteUsageAuditStore:
             self._conn.close()
             self._conn = None
 
+    async def delete_user_data(
+        self, *, account_id: str, user_id: str
+    ) -> dict[str, int]:
+        """Delete all usage/audit rows for a (account, user) pair."""
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._delete_user_data_sync, account_id, user_id
+            )
+
+    def _delete_user_data_sync(self, account_id: str, user_id: str) -> dict[str, int]:
+        assert self._conn is not None
+        conn = self._conn
+        tables = (
+            "usage_token_hourly",
+            "usage_retrieval_hourly",
+            "usage_context_write_bucket",
+            "request_audit",
+        )
+        # Connection uses isolation_level=None (autocommit); wrap the multi-table
+        # purge in an explicit transaction so a failure mid-way rolls back
+        # instead of leaving a partially purged user (neither fully present nor
+        # fully deleted, which would break idempotent retry).
+        conn.execute("BEGIN")
+        try:
+            deleted: dict[str, int] = {}
+            for table in tables:
+                deleted[table] = conn.execute(
+                    f"DELETE FROM {table} WHERE account_id = ? AND user_id = ?",
+                    (account_id, user_id),
+                ).rowcount
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        return deleted
+
     async def record_batch(self, events: Sequence[ObservabilityEvent]) -> None:
         if not events:
             return

--- a/openviking/observability/usage_audit/store.py
+++ b/openviking/observability/usage_audit/store.py
@@ -26,6 +26,9 @@ class UsageAuditStore(Protocol):
     async def record_batch(self, events: Sequence[ObservabilityEvent]) -> None:
         """Persist a batch of observability events."""
 
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
+        """Delete every persisted usage/audit row owned by one user."""
+
     async def get_today_tokens(
         self,
         *,

--- a/openviking/observability/usage_audit/worker.py
+++ b/openviking/observability/usage_audit/worker.py
@@ -106,6 +106,8 @@ class UsageAuditWorker:
                 )
                 raise
             else:
+                for _ in batch:
+                    self._queue.task_done()
                 self._current_batch = None
 
     async def _flush(self, batch: list[ObservabilityEvent]) -> None:
@@ -119,6 +121,12 @@ class UsageAuditWorker:
                 exc,
                 exc_info=logger.isEnabledFor(logging.DEBUG),
             )
+
+    async def flush(self) -> None:
+        """Wait until every event already accepted by this worker is handled."""
+        if self._queue is None or self._task is None or self._closed:
+            raise RuntimeError("Usage/Audit worker is not running")
+        await self._queue.join()
 
     async def close(self, *, timeout_seconds: float = 3.0) -> None:
         """Stop the worker and flush remaining queued events."""

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -368,6 +368,8 @@ class LegacyAPIKeyManager:
 
         user_info = account.users.pop(user_id)
         key_or_hash = user_info.get("key", "")
+        key_prefix = ""
+        original_prefix_entries: list[UserKeyEntry] | None = None
 
         if key_or_hash:
             # Get key_prefix - if not in user_info, compute from key
@@ -377,6 +379,7 @@ class LegacyAPIKeyManager:
 
             # Remove from prefix index
             if key_prefix in self._prefix_index:
+                original_prefix_entries = list(self._prefix_index[key_prefix])
                 self._prefix_index[key_prefix] = [
                     entry
                     for entry in self._prefix_index[key_prefix]
@@ -386,7 +389,18 @@ class LegacyAPIKeyManager:
                 if not self._prefix_index[key_prefix]:
                     del self._prefix_index[key_prefix]
 
-        await self._save_users_json(account_id)
+        try:
+            await self._save_users_json(account_id)
+        except Exception:
+            # The in-memory registry is the live authentication source. If
+            # persistence fails, restore the popped entry and prefix index so
+            # the caller observes a consistent state and can safely retry the
+            # whole deletion instead of a split-brain (gone in memory, still
+            # present on disk) registry.
+            account.users[user_id] = user_info
+            if original_prefix_entries is not None:
+                self._prefix_index[key_prefix] = original_prefix_entries
+            raise
 
     async def regenerate_key(
         self, account_id: str, user_id: str, seed: Optional[str] = None

--- a/openviking/server/oauth/storage.py
+++ b/openviking/server/oauth/storage.py
@@ -593,10 +593,20 @@ class OAuthStore:
                 "UPDATE oauth_codes SET used = 1 WHERE account_id = ? AND user_id = ? AND used = 0",
                 (account_id, user_id),
             ).rowcount
+            # Verified-but-not-yet-exchanged pending authorizations carry the
+            # verifier's (account, user); delete them so a deletion in flight
+            # cannot be completed into fresh tokens afterward. Unverified rows
+            # have null verified_user_id and cannot be tied to this user.
+            pending = self._conn.execute(
+                "DELETE FROM oauth_pending_authorizations "
+                "WHERE verified_account_id = ? AND verified_user_id = ?",
+                (account_id, user_id),
+            ).rowcount
             return {
                 "access_tokens_revoked": access,
                 "refresh_tokens_revoked": refresh,
                 "codes_revoked": codes,
+                "pending_authorizations_revoked": pending,
             }
 
         async with self._lock:

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -408,7 +408,9 @@ async def remove_user(
     storage = getattr(viking_fs, "vector_store", None)
     if storage is not None:
         try:
-            deleted = await storage.delete_user_data(account_id, user_id)
+            deleted = await storage.delete_user_data(
+                account_id, user_id, ctx=cleanup_ctx
+            )
             logger.info(
                 f"VectorDB cascade delete for user {account_id}/{user_id}: {deleted} records"
             )
@@ -450,6 +452,12 @@ async def remove_user(
         )
 
     # All configured cleanups succeeded; only now remove the registry entry.
+    # This invalidates the user's credential, so subsequent requests cannot
+    # authenticate as this user and recreate residual state. The cascade is
+    # not atomic against a request already past authentication when deletion
+    # began; such an in-flight write can land in the cleanup-to-removal
+    # window. Closing that window requires a per-user deletion barrier
+    # (tombstone) checked on the write path and is left as follow-up.
     await manager.remove_user(account_id, user_id)
     return Response(status="ok", result={"deleted": True})
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -30,6 +30,7 @@ from openviking.service.task_tracker import (
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.exceptions import (
     FailedPreconditionError,
+    InternalError,
     InvalidArgumentError,
     PermissionDeniedError,
 )
@@ -367,9 +368,86 @@ async def remove_user(
     user_id: str = Path(..., description="User ID"),
     ctx: RequestContext = Depends(get_request_context),
 ):
-    """Remove a user from an account."""
+    """Remove a user and cascade-delete all their data.
+
+    The deletion fails closed: every *configured* cleanup stage must succeed
+    before the user credential/registry entry is removed. If a configured
+    subsystem fails, the request returns an error and the user stays
+    registered so the caller can retry; partial cleanup is idempotent because
+    each stage (AGFS rm, owner-filtered vector delete, OAuth revocation, and
+    usage/audit purge) treats already-removed data as a no-op. An *absent*
+    optional subsystem (no vector store attached, OAuth/usage disabled) is
+    skipped rather than treated as a failure.
+    """
     _check_account_access(ctx, account_id)
     manager = _get_api_key_manager(request)
+
+    # Build a ROOT-level context scoped to the target user for cleanup.
+    cleanup_ctx = RequestContext(
+        user=UserIdentifier(account_id, user_id),
+        role=Role.ROOT,
+    )
+
+    viking_fs = get_viking_fs()
+    failures: list[str] = []
+
+    # Remove AGFS data under the user's subtree. A missing subtree is a
+    # successful no-op (rm is idempotent); any other error aborts deletion.
+    user_prefix = f"viking://user/{user_id}/"
+    try:
+        await viking_fs.rm(user_prefix, recursive=True, ctx=cleanup_ctx)
+    except Exception as e:
+        failures.append(f"agfs: {e}")
+        logger.warning(f"AGFS cleanup failed for {account_id}/{user_id}: {e}")
+
+    # Remove VectorDB records owned by the user. The vector store is an
+    # optional backend exposed publicly as viking_fs.vector_store; absent
+    # backend => disabled => skip, present but failing => abort. viking_fs.rm
+    # already prunes vectors under the removed URI subtree; this owner-filtered
+    # pass also catches orphan records that live outside the subtree.
+    storage = getattr(viking_fs, "vector_store", None)
+    if storage is not None:
+        try:
+            deleted = await storage.delete_user_data(account_id, user_id)
+            logger.info(
+                f"VectorDB cascade delete for user {account_id}/{user_id}: {deleted} records"
+            )
+        except Exception as e:
+            failures.append(f"vectordb: {e}")
+            logger.warning(f"VectorDB cleanup failed for {account_id}/{user_id}: {e}")
+
+    # Revoke OAuth tokens/codes. Absent OAuth store => disabled => skip.
+    oauth_store = getattr(request.app.state, "oauth_store", None)
+    if oauth_store is not None:
+        try:
+            await oauth_store.revoke_user_tokens(
+                account_id=account_id, user_id=user_id
+            )
+        except Exception as e:
+            failures.append(f"oauth: {e}")
+            logger.warning(f"OAuth cleanup failed for {account_id}/{user_id}: {e}")
+
+    # Purge usage/audit rows. Absent runtime => disabled => skip.
+    usage_runtime = getattr(request.app.state, "usage_audit_runtime", None)
+    if usage_runtime is not None and getattr(usage_runtime, "store", None) is not None:
+        try:
+            await usage_runtime.store.delete_user_data(
+                account_id=account_id, user_id=user_id
+            )
+        except Exception as e:
+            failures.append(f"usage_audit: {e}")
+            logger.warning(
+                f"Usage/audit cleanup failed for {account_id}/{user_id}: {e}"
+            )
+
+    if failures:
+        # Keep the user registered so deletion can be retried safely.
+        raise InternalError(
+            f"User cleanup failed for {account_id}/{user_id}; user remains registered. "
+            "Retry after resolving: " + "; ".join(failures),
+        )
+
+    # All configured cleanups succeeded; only now remove the registry entry.
     await manager.remove_user(account_id, user_id)
     return Response(status="ok", result={"deleted": True})
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -408,9 +408,7 @@ async def remove_user(
     storage = getattr(viking_fs, "vector_store", None)
     if storage is not None:
         try:
-            deleted = await storage.delete_user_data(
-                account_id, user_id, ctx=cleanup_ctx
-            )
+            deleted = await storage.delete_user_data(account_id, user_id, ctx=cleanup_ctx)
             logger.info(
                 f"VectorDB cascade delete for user {account_id}/{user_id}: {deleted} records"
             )
@@ -422,9 +420,7 @@ async def remove_user(
     oauth_store = getattr(request.app.state, "oauth_store", None)
     if oauth_store is not None:
         try:
-            await oauth_store.revoke_user_tokens(
-                account_id=account_id, user_id=user_id
-            )
+            await oauth_store.revoke_user_tokens(account_id=account_id, user_id=user_id)
         except Exception:
             failed_stages.append("oauth")
             logger.exception(f"OAuth cleanup failed for {account_id}/{user_id}")
@@ -435,9 +431,7 @@ async def remove_user(
     usage_runtime = getattr(request.app.state, "usage_audit_runtime", None)
     if usage_runtime is not None and getattr(usage_runtime, "store", None) is not None:
         try:
-            await usage_runtime.delete_user_data(
-                account_id=account_id, user_id=user_id
-            )
+            await usage_runtime.delete_user_data(account_id=account_id, user_id=user_id)
         except Exception:
             failed_stages.append("usage_audit")
             logger.exception(f"Usage/audit cleanup failed for {account_id}/{user_id}")

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -389,16 +389,16 @@ async def remove_user(
     )
 
     viking_fs = get_viking_fs()
-    failures: list[str] = []
+    failed_stages: list[str] = []
 
     # Remove AGFS data under the user's subtree. A missing subtree is a
     # successful no-op (rm is idempotent); any other error aborts deletion.
     user_prefix = f"viking://user/{user_id}/"
     try:
         await viking_fs.rm(user_prefix, recursive=True, ctx=cleanup_ctx)
-    except Exception as e:
-        failures.append(f"agfs: {e}")
-        logger.warning(f"AGFS cleanup failed for {account_id}/{user_id}: {e}")
+    except Exception:
+        failed_stages.append("agfs")
+        logger.exception(f"AGFS cleanup failed for {account_id}/{user_id}")
 
     # Remove VectorDB records owned by the user. The vector store is an
     # optional backend exposed publicly as viking_fs.vector_store; absent
@@ -412,9 +412,9 @@ async def remove_user(
             logger.info(
                 f"VectorDB cascade delete for user {account_id}/{user_id}: {deleted} records"
             )
-        except Exception as e:
-            failures.append(f"vectordb: {e}")
-            logger.warning(f"VectorDB cleanup failed for {account_id}/{user_id}: {e}")
+        except Exception:
+            failed_stages.append("vectordb")
+            logger.exception(f"VectorDB cleanup failed for {account_id}/{user_id}")
 
     # Revoke OAuth tokens/codes. Absent OAuth store => disabled => skip.
     oauth_store = getattr(request.app.state, "oauth_store", None)
@@ -423,28 +423,30 @@ async def remove_user(
             await oauth_store.revoke_user_tokens(
                 account_id=account_id, user_id=user_id
             )
-        except Exception as e:
-            failures.append(f"oauth: {e}")
-            logger.warning(f"OAuth cleanup failed for {account_id}/{user_id}: {e}")
+        except Exception:
+            failed_stages.append("oauth")
+            logger.exception(f"OAuth cleanup failed for {account_id}/{user_id}")
 
-    # Purge usage/audit rows. Absent runtime => disabled => skip.
+    # Purge usage/audit rows. Absent runtime => disabled => skip. The runtime
+    # drains already-accepted events before purging so a queued event cannot
+    # re-create deleted rows after the purge.
     usage_runtime = getattr(request.app.state, "usage_audit_runtime", None)
     if usage_runtime is not None and getattr(usage_runtime, "store", None) is not None:
         try:
-            await usage_runtime.store.delete_user_data(
+            await usage_runtime.delete_user_data(
                 account_id=account_id, user_id=user_id
             )
-        except Exception as e:
-            failures.append(f"usage_audit: {e}")
-            logger.warning(
-                f"Usage/audit cleanup failed for {account_id}/{user_id}: {e}"
-            )
+        except Exception:
+            failed_stages.append("usage_audit")
+            logger.exception(f"Usage/audit cleanup failed for {account_id}/{user_id}")
 
-    if failures:
-        # Keep the user registered so deletion can be retried safely.
+    if failed_stages:
+        # Keep the user registered so deletion can be retried safely. Stage
+        # names only are surfaced; backend exception details stay in logs and
+        # are not leaked to clients.
         raise InternalError(
             f"User cleanup failed for {account_id}/{user_id}; user remains registered. "
-            "Retry after resolving: " + "; ".join(failures),
+            "Retry after resolving stages: " + ", ".join(failed_stages),
         )
 
     # All configured cleanups succeeded; only now remove the registry entry.

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1375,6 +1375,16 @@ class VikingVectorIndexBackend:
         root_backend = self._get_root_backend()
         return await root_backend.delete_by_filter(Eq("account_id", account_id))
 
+    async def delete_user_data(
+        self, account_id: str, user_id: str, *, ctx: RequestContext
+    ) -> int:
+        """删除指定 account 下某个 user 的所有向量数据（仅限，root 角色操作）"""
+        self._check_root_role(ctx)
+        root_backend = self._get_root_backend()
+        return await root_backend.delete_by_filter(
+            And([Eq("account_id", account_id), Eq("owner_user_id", user_id)])
+        )
+
     async def delete_uris(self, ctx: RequestContext, uris: List[str]) -> None:
         for uri in uris:
             canonical_uri = canonicalize_uri(uri, ctx)

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1375,9 +1375,7 @@ class VikingVectorIndexBackend:
         root_backend = self._get_root_backend()
         return await root_backend.delete_by_filter(Eq("account_id", account_id))
 
-    async def delete_user_data(
-        self, account_id: str, user_id: str, *, ctx: RequestContext
-    ) -> int:
+    async def delete_user_data(self, account_id: str, user_id: str, *, ctx: RequestContext) -> int:
         """删除指定 account 下某个 user 的所有向量数据（仅限，root 角色操作）"""
         self._check_root_role(ctx)
         root_backend = self._get_root_backend()

--- a/openviking/storage/vikingdb_manager.py
+++ b/openviking/storage/vikingdb_manager.py
@@ -498,6 +498,9 @@ class VikingDBManagerProxy:
     async def delete_account_data(self, account_id: str) -> int:
         return await self._manager.delete_account_data(account_id, ctx=self._ctx)
 
+    async def delete_user_data(self, account_id: str, user_id: str) -> int:
+        return await self._manager.delete_user_data(account_id, user_id, ctx=self._ctx)
+
     async def delete_uris(self, uris: List[str]) -> None:
         return await self._manager.delete_uris(self._ctx, uris)
 

--- a/tests/observability/test_usage_audit_runtime.py
+++ b/tests/observability/test_usage_audit_runtime.py
@@ -60,3 +60,51 @@ async def test_usage_audit_runtime_subscribes_to_shared_event_bus(tmp_path):
     assert retrievals["find"] == 1
     assert audit["total"] == 1
     assert audit["items"][0]["request_id"] == "req-runtime"
+
+
+@pytest.mark.asyncio
+async def test_runtime_delete_user_data_flushes_pending_events_before_purge(tmp_path):
+    """Already-accepted events must be persisted before the purge so they cannot
+    re-create rows for a deleted user after the DELETE commits."""
+    _GLOBAL_EVENT_BUS.clear()
+    app = SimpleNamespace(state=SimpleNamespace())
+    config = ServerConfig(
+        observability=ObservabilityConfig(
+            usage_audit=UsageAuditConfig(
+                sqlite_path=str(tmp_path / "usage.sqlite3"),
+                # Long interval: the event only lands in the DB via flush().
+                flush_interval_seconds=10.0,
+                timezone="UTC",
+            )
+        )
+    )
+    runtime = await init_usage_audit_from_server_config(config, app=app, service=object())
+    assert runtime is not None
+    try:
+        try_publish_event(
+            "http.request",
+            {
+                "request_id": "req-delete",
+                "account_id": "acct-delete",
+                "user_id": "user-delete",
+                "method": "POST",
+                "route": "/api/v1/sessions/abc/messages",
+                "status": "200",
+                "duration_seconds": 0.01,
+            },
+        )
+
+        deleted = await runtime.delete_user_data(
+            account_id="acct-delete",
+            user_id="user-delete",
+        )
+        # The pending event was drained and then purged; no rows must remain.
+        assert sum(deleted.values()) >= 1
+        audit = await runtime.store.query_audit_logs(
+            account_id="acct-delete",
+            user_id="user-delete",
+        )
+        assert audit["total"] == 0
+    finally:
+        await shutdown_usage_audit(app=app)
+        _GLOBAL_EVENT_BUS.clear()

--- a/tests/observability/test_usage_audit_store.py
+++ b/tests/observability/test_usage_audit_store.py
@@ -582,3 +582,68 @@ async def test_context_heatmap_rebuckets_hour_for_shanghai(tmp_path):
         assert match["total"] == 1
     finally:
         await store.close()
+
+
+async def test_delete_user_data_purges_only_target_user_and_is_idempotent(tmp_path):
+    store = SQLiteUsageAuditStore(tmp_path / "usage.sqlite3")
+    await store.initialize()
+    try:
+        await store.record_batch(
+            [
+                _event(
+                    "vlm.call",
+                    {
+                        "provider": "p",
+                        "model_name": "m",
+                        "prompt_tokens": 3,
+                        "completion_tokens": 2,
+                    },
+                    user_id="victim",
+                ),
+                _event(
+                    "http.request",
+                    {
+                        "request_id": "req-victim",
+                        "method": "POST",
+                        "route": "/api/v1/sessions/abc/messages",
+                        "status": "200",
+                        "duration_seconds": 0.1,
+                    },
+                    user_id="victim",
+                ),
+                _event(
+                    "vlm.call",
+                    {
+                        "provider": "p",
+                        "model_name": "m",
+                        "prompt_tokens": 9,
+                        "completion_tokens": 9,
+                    },
+                    user_id="sibling",
+                ),
+            ]
+        )
+
+        deleted = await store.delete_user_data(account_id="acct-1", user_id="victim")
+        assert sum(deleted.values()) >= 2
+        again = await store.delete_user_data(account_id="acct-1", user_id="victim")
+        assert sum(again.values()) == 0
+
+        conn = store._conn
+        assert conn is not None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM usage_token_hourly "
+            "WHERE account_id = ? AND user_id = ?",
+            ("acct-1", "victim"),
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COALESCE(SUM(token_count), 0) FROM usage_token_hourly "
+            "WHERE account_id = ? AND user_id = ?",
+            ("acct-1", "sibling"),
+        ).fetchone()[0] > 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM request_audit WHERE account_id = ? AND user_id = ?",
+            ("acct-1", "victim"),
+        ).fetchone()[0] == 0
+    finally:
+        await store.close()

--- a/tests/observability/test_usage_audit_store.py
+++ b/tests/observability/test_usage_audit_store.py
@@ -256,9 +256,7 @@ async def test_sqlite_usage_audit_store_aggregates_dashboard_data(tmp_path):
             bucket="hour",
             tz=UTC,
         )
-        assert any(
-            row["hour"] == 1 and row["session_add_message"] == 2 for row in account_commits
-        )
+        assert any(row["hour"] == 1 and row["session_add_message"] == 2 for row in account_commits)
         assert any(row["hour"] == 1 and row["session_add_message"] == 1 for row in commits)
         audit = await store.query_audit_logs(account_id="acct-1")
         assert audit["total"] == 4
@@ -631,19 +629,27 @@ async def test_delete_user_data_purges_only_target_user_and_is_idempotent(tmp_pa
 
         conn = store._conn
         assert conn is not None
-        assert conn.execute(
-            "SELECT COUNT(*) FROM usage_token_hourly "
-            "WHERE account_id = ? AND user_id = ?",
-            ("acct-1", "victim"),
-        ).fetchone()[0] == 0
-        assert conn.execute(
-            "SELECT COALESCE(SUM(token_count), 0) FROM usage_token_hourly "
-            "WHERE account_id = ? AND user_id = ?",
-            ("acct-1", "sibling"),
-        ).fetchone()[0] > 0
-        assert conn.execute(
-            "SELECT COUNT(*) FROM request_audit WHERE account_id = ? AND user_id = ?",
-            ("acct-1", "victim"),
-        ).fetchone()[0] == 0
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM usage_token_hourly WHERE account_id = ? AND user_id = ?",
+                ("acct-1", "victim"),
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COALESCE(SUM(token_count), 0) FROM usage_token_hourly "
+                "WHERE account_id = ? AND user_id = ?",
+                ("acct-1", "sibling"),
+            ).fetchone()[0]
+            > 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM request_audit WHERE account_id = ? AND user_id = ?",
+                ("acct-1", "victim"),
+            ).fetchone()[0]
+            == 0
+        )
     finally:
         await store.close()

--- a/tests/observability/test_usage_audit_worker.py
+++ b/tests/observability/test_usage_audit_worker.py
@@ -68,3 +68,23 @@ async def test_usage_audit_worker_close_waits_for_inflight_batch_after_timeout()
 
     assert store.calls == 1
     assert [[event.event_name for event in batch] for batch in store.batches] == [["demo"]]
+
+
+@pytest.mark.asyncio
+async def test_worker_flush_returns_after_accepted_events_persisted():
+    store = SlowFirstFlushStore()
+    worker = UsageAuditWorker(
+        store,
+        queue_size=10,
+        batch_size=10,
+        flush_interval_seconds=1.0,
+    )
+    await worker.start()
+    worker.enqueue(ObservabilityEvent(event_name="demo", payload={"value": 1}))
+
+    # Must not hang: queue.join() only completes once task_done() is called for
+    # every accepted event, which the worker does after a successful flush.
+    await asyncio.wait_for(worker.flush(), timeout=1.0)
+
+    assert [[event.event_name for event in batch] for batch in store.batches] == [["demo"]]
+    await worker.close(timeout_seconds=0.5)

--- a/tests/server/oauth/test_storage.py
+++ b/tests/server/oauth/test_storage.py
@@ -338,15 +338,67 @@ async def test_revoke_user_tokens_cascades(store):
     )
     await _insert_code(store, "code-alice", account_id="acct", user_id="alice")
 
+    # A verified-but-not-yet-exchanged pending authorization for alice must be
+    # removed so it cannot be completed into fresh tokens after deletion; an
+    # unverified one (no bound identity) and bob's are left alone.
+    alice_pending = await store.create_pending_authorization(
+        client_id="cx",
+        redirect_uri="https://example/cb",
+        redirect_uri_provided_explicitly=True,
+        code_challenge="chal",
+        scopes=None,
+        resource=None,
+        state=None,
+        display_code="ALICE-1",
+    )
+    assert await store.mark_pending_verified(
+        pending_id=alice_pending,
+        account_id="acct",
+        user_id="alice",
+        role="user",
+        verified_key_fp=_FP,
+    )
+    bob_pending = await store.create_pending_authorization(
+        client_id="cx",
+        redirect_uri="https://example/cb",
+        redirect_uri_provided_explicitly=True,
+        code_challenge="chal",
+        scopes=None,
+        resource=None,
+        state=None,
+        display_code="BOB-1",
+    )
+    assert await store.mark_pending_verified(
+        pending_id=bob_pending,
+        account_id="acct",
+        user_id="bob",
+        role="user",
+        verified_key_fp=_FP_OTHER,
+    )
+    unverified_pending = await store.create_pending_authorization(
+        client_id="cx",
+        redirect_uri="https://example/cb",
+        redirect_uri_provided_explicitly=True,
+        code_challenge="chal",
+        scopes=None,
+        resource=None,
+        state=None,
+        display_code="OPEN-1",
+    )
+
     counts = await store.revoke_user_tokens(account_id="acct", user_id="alice")
     assert counts["access_tokens_revoked"] == 1
     assert counts["refresh_tokens_revoked"] == 1
     assert counts["codes_revoked"] == 1
+    assert counts["pending_authorizations_revoked"] == 1
 
-    # Alice's everything dead, Bob's untouched.
+    # Alice's everything dead, Bob's and the unverified pending untouched.
     assert await store.load_access("at-1") is None
     assert await store.load_access("at-other") is not None
     assert await store.consume_auth_code("code-alice") is None
+    assert await store.load_pending_authorization(alice_pending) is None
+    assert await store.load_pending_authorization(bob_pending) is not None
+    assert await store.load_pending_authorization(unverified_pending) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_admin_remove_user_cascade.py
+++ b/tests/server/test_admin_remove_user_cascade.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for issue #3660: remove_user must cascade-delete user data.
+
+The endpoint must fail closed: every *configured* cleanup stage has to succeed
+before the credential/registry entry is removed. A present subsystem that
+raises must abort (user stays registered, response fails); an absent optional
+subsystem is skipped. Partial cleanup is idempotently retryable because each
+stage treats already-removed data as a no-op.
+"""
+
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from openviking.pyagfs.exceptions import AGFSNotFoundError
+from openviking.server.api_keys import APIKeyManager
+from openviking.server.config import ServerConfig
+from openviking.server.dependencies import set_service
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import admin as admin_router
+from openviking_cli.exceptions import OpenVikingError
+
+ROOT_KEY = "issue-3660-root-key-abcdef1234567890ab"
+
+
+def _acct(prefix="acct") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+class _FakeVectorStore:
+    def __init__(self):
+        self.delete_user_calls: list[tuple[str, str]] = []
+        self.raise_on_delete: Exception | None = None
+
+    async def delete_user_data(self, account_id: str, user_id: str) -> int:
+        self.delete_user_calls.append((account_id, user_id))
+        if self.raise_on_delete is not None:
+            raise self.raise_on_delete
+        return 3
+
+
+class _FakeOAuthStore:
+    def __init__(self):
+        self.revoke_calls: list[dict] = []
+        self.raise_on_revoke: Exception | None = None
+
+    async def revoke_user_tokens(self, *, account_id: str, user_id: str) -> dict:
+        self.revoke_calls.append({"account_id": account_id, "user_id": user_id})
+        if self.raise_on_revoke is not None:
+            raise self.raise_on_revoke
+        return {
+            "access_tokens_revoked": 1,
+            "refresh_tokens_revoked": 1,
+            "codes_revoked": 0,
+        }
+
+
+class _FakeUsageStore:
+    def __init__(self):
+        self.delete_calls: list[dict] = []
+        self.raise_on_delete: Exception | None = None
+
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict:
+        self.delete_calls.append({"account_id": account_id, "user_id": user_id})
+        if self.raise_on_delete is not None:
+            raise self.raise_on_delete
+        return {
+            "usage_token_hourly": 2,
+            "usage_retrieval_hourly": 1,
+            "usage_context_write_bucket": 0,
+            "request_audit": 5,
+        }
+
+
+class _FakeUsageRuntime:
+    def __init__(self, store):
+        self.store = store
+
+
+class _RecordingAGFS:
+    """Minimal in-memory sync AGFS surface used by AsyncAGFSClient."""
+
+    def __init__(self):
+        self._files: dict[str, bytes] = {}
+
+    def read(self, path, **_kwargs):
+        if path not in self._files:
+            raise AGFSNotFoundError(path)
+        return self._files[path]
+
+    def write(self, path, content, **_kwargs):
+        self._files[path] = content
+
+    def ensure_parent_dirs(self, path, **_kwargs):
+        return None
+
+    def pathlock_acquire_exact(
+        self, fs_ctx, path, timeout_secs=0.0, owner_lease_ref=None
+    ):
+        return {"lease_ref": f"test:{path}"}
+
+    def pathlock_release(self, fs_ctx, lease):
+        return None
+
+
+class _RecordingVikingFS:
+    def __init__(self):
+        self.rm_calls: list[dict] = []
+        self.raise_on_rm: Exception | None = None
+        self._vector_store = _FakeVectorStore()
+        self.agfs = _RecordingAGFS()
+
+    @property
+    def vector_store(self):
+        return self._vector_store
+
+    @vector_store.setter
+    def vector_store(self, value):
+        self._vector_store = value
+
+    async def rm(self, uri, *, recursive=False, ctx=None):
+        self.rm_calls.append({"uri": uri, "recursive": recursive, "ctx": ctx})
+        if self.raise_on_rm is not None:
+            raise self.raise_on_rm
+
+
+class _FakeService:
+    def __init__(self, viking_fs):
+        self.viking_fs = viking_fs
+        self.sessions = type(
+            "S", (), {"get_agent_evolution_enabled": lambda self: False}
+        )()
+
+    async def initialize_account_directories(self, ctx):
+        return None
+
+    async def initialize_user_directories(self, ctx):
+        return None
+
+
+@pytest_asyncio.fixture()
+async def cascade_client(monkeypatch):
+    from openviking.server.auth.plugins import ApiKeyAuthPlugin
+    from openviking.server.auth.registry import get_registry
+
+    viking_fs = _RecordingVikingFS()
+    oauth_store = _FakeOAuthStore()
+    usage_runtime = _FakeUsageRuntime(_FakeUsageStore())
+
+    app = FastAPI()
+
+    @app.exception_handler(OpenVikingError)
+    async def _ov_error_handler(_request, exc: OpenVikingError):
+        from fastapi.responses import JSONResponse
+
+        from openviking.server.models import ErrorInfo, Response
+
+        return JSONResponse(
+            status_code=500,
+            content=Response(
+                status="error",
+                error=ErrorInfo(
+                    code=exc.code, message=exc.message, details=exc.details
+                ),
+            ).model_dump(),
+        )
+
+    app.state.config = ServerConfig(root_api_key=ROOT_KEY)
+    app.state.oauth_store = oauth_store
+    app.state.usage_audit_runtime = usage_runtime
+
+    service = _FakeService(viking_fs)
+    app.state.fake_service = service
+    set_service(service)
+
+    monkeypatch.setattr(admin_router, "get_viking_fs", lambda: viking_fs)
+
+    manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=viking_fs)
+    await manager.load()
+    app.state.api_key_manager = manager
+
+    registry = get_registry()
+    if registry.get("api_key") is None:
+        registry.register(ApiKeyAuthPlugin)
+    app.state.auth_plugin = registry.get("api_key")()
+
+    app.include_router(admin_router.router)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as c:
+        c.app = app
+        c.viking_fs = viking_fs
+        c.manager = manager
+        c._oauth_store = oauth_store
+        c._usage_store = usage_runtime.store
+        yield c
+
+    set_service(None)
+
+
+def _root_headers():
+    return {"X-API-Key": ROOT_KEY}
+
+
+async def _register_account(client, acct):
+    resp = await client.post(
+        "/api/v1/admin/accounts",
+        json={"account_id": acct, "admin_user_id": "alice"},
+        headers=_root_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def _register_user(client, acct, user_id, role="user"):
+    resp = await client.post(
+        f"/api/v1/admin/accounts/{acct}/users",
+        json={"user_id": user_id, "role": role},
+        headers=_root_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["result"]["user_key"]
+
+
+async def _register_account_and_user(client, acct, user_id="bob"):
+    await _register_account(client, acct)
+    return await _register_user(client, acct, user_id)
+
+
+def _user_exists(manager, acct, user_id):
+    account = manager._accounts.get(acct)
+    return account is not None and user_id in account.users
+
+
+# ---- success path ---------------------------------------------------------
+
+
+async def test_remove_user_cascades_agfs_vectors_oauth_and_usage(cascade_client):
+    acct = _acct("cascade")
+    await _register_account_and_user(cascade_client, acct, "bob")
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["result"]["deleted"] is True
+
+    assert len(cascade_client.viking_fs.rm_calls) == 1
+    rm = cascade_client.viking_fs.rm_calls[0]
+    assert rm["uri"] == "viking://user/bob/"
+    assert rm["recursive"] is True
+    assert isinstance(rm["ctx"], RequestContext)
+    assert rm["ctx"].role == Role.ROOT
+    assert rm["ctx"].account_id == acct
+    assert rm["ctx"].user.user_id == "bob"
+
+    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]
+    assert cascade_client._oauth_store.revoke_calls == [
+        {"account_id": acct, "user_id": "bob"}
+    ]
+    assert cascade_client._usage_store.delete_calls == [
+        {"account_id": acct, "user_id": "bob"}
+    ]
+    assert not _user_exists(cascade_client.manager, acct, "bob")
+
+
+async def test_remove_user_invalidates_api_key(cascade_client):
+    acct = _acct("key")
+    user_key = await _register_account_and_user(cascade_client, acct, "carol")
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/carol", headers=_root_headers()
+    )
+    assert resp.status_code == 200
+
+    # The removed user's key must no longer resolve to an identity.
+    from openviking_cli.exceptions import UnauthenticatedError
+
+    with pytest.raises(UnauthenticatedError):
+        cascade_client.manager.resolve(user_key)
+
+
+async def test_remove_user_cascade_is_per_user(cascade_client):
+    acct = _acct("sibling")
+    await _register_account(cascade_client, acct)
+    await _register_user(cascade_client, acct, "bob")
+    await _register_user(cascade_client, acct, "carol")
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code == 200
+
+    assert len(cascade_client.viking_fs.rm_calls) == 1
+    rm = cascade_client.viking_fs.rm_calls[0]
+    assert rm["uri"] == "viking://user/bob/"
+    assert rm["recursive"] is True
+    assert rm["ctx"].user.user_id == "bob"
+    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]
+    assert _user_exists(cascade_client.manager, acct, "carol")
+
+
+# ---- fail-closed: each configured cleanup stage failing -------------------
+
+
+@pytest.mark.parametrize(
+    "stage",
+    ["agfs", "vectordb", "oauth", "usage_audit"],
+)
+async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client, stage):
+    acct = _acct(f"fail_{stage}")
+    await _register_account_and_user(cascade_client, acct, "bob")
+
+    if stage == "agfs":
+        cascade_client.viking_fs.raise_on_rm = RuntimeError("agfs boom")
+    elif stage == "vectordb":
+        cascade_client.viking_fs.vector_store.raise_on_delete = RuntimeError(
+            "vector boom"
+        )
+    elif stage == "oauth":
+        cascade_client._oauth_store.raise_on_revoke = RuntimeError("oauth boom")
+    elif stage == "usage_audit":
+        cascade_client._usage_store.raise_on_delete = RuntimeError("usage boom")
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code >= 400, resp.text
+    assert _user_exists(
+        cascade_client.manager, acct, "bob"
+    ), f"user must remain registered after {stage} failure for safe retry"
+
+    # The failed stage must still have been attempted so retry can resume.
+    if stage == "agfs":
+        assert len(cascade_client.viking_fs.rm_calls) == 1
+    elif stage == "vectordb":
+        assert cascade_client.viking_fs.vector_store.delete_user_calls == [
+            (acct, "bob")
+        ]
+    elif stage == "oauth":
+        assert cascade_client._oauth_store.revoke_calls == [
+            {"account_id": acct, "user_id": "bob"}
+        ]
+    elif stage == "usage_audit":
+        assert cascade_client._usage_store.delete_calls == [
+            {"account_id": acct, "user_id": "bob"}
+        ]
+
+
+async def test_remove_user_retry_succeeds_after_transient_failure(cascade_client):
+    """Partial cleanup must be idempotently retryable."""
+    acct = _acct("retry")
+    await _register_account_and_user(cascade_client, acct, "bob")
+
+    # First attempt: AGFS cleanup fails before vector/oauth/usage run.
+    cascade_client.viking_fs.raise_on_rm = RuntimeError("transient agfs")
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code >= 400, resp.text
+    assert _user_exists(cascade_client.manager, acct, "bob")
+
+    # Retry: AGFS recovers; remaining stages run and the user is removed.
+    cascade_client.viking_fs.raise_on_rm = None
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code == 200, resp.text
+    assert not _user_exists(cascade_client.manager, acct, "bob")
+    assert len(cascade_client.viking_fs.rm_calls) == 2
+    # Vector delete runs on the successful retry; it is idempotent, so any
+    # extra prior invocation (if stages were partially reached) is harmless.
+    assert cascade_client.viking_fs.vector_store.delete_user_calls[-1] == (acct, "bob")
+
+
+# ---- absent optional subsystems are skipped, not failed -------------------
+
+
+async def test_remove_user_skips_absent_vector_store(cascade_client, monkeypatch):
+    acct = _acct("no_vector")
+    await _register_account_and_user(cascade_client, acct, "bob")
+
+    class _NoVectorFS(_RecordingVikingFS):
+        @property
+        def vector_store(self):
+            return None
+
+    no_vector_fs = _NoVectorFS()
+    # Preserve the AGFS/manager that holds the registered account.
+    no_vector_fs.agfs = cascade_client.viking_fs.agfs
+    cascade_client.manager._viking_fs = no_vector_fs
+    monkeypatch.setattr(admin_router, "get_viking_fs", lambda: no_vector_fs)
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code == 200, resp.text
+    assert not _user_exists(cascade_client.manager, acct, "bob")
+    assert len(no_vector_fs.rm_calls) == 1
+    assert cascade_client._oauth_store.revoke_calls
+    assert cascade_client._usage_store.delete_calls
+
+
+async def test_remove_user_skips_absent_oauth_and_usage(cascade_client):
+    acct = _acct("no_optional")
+    await _register_account_and_user(cascade_client, acct, "bob")
+
+    # Simulate disabled OAuth / usage runtimes by clearing them from app state.
+    cascade_client.app.state.oauth_store = None
+    cascade_client.app.state.usage_audit_runtime = None
+
+    resp = await cascade_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
+    )
+    assert resp.status_code == 200, resp.text
+    assert not _user_exists(cascade_client.manager, acct, "bob")
+    assert len(cascade_client.viking_fs.rm_calls) == 1
+    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]

--- a/tests/server/test_admin_remove_user_cascade.py
+++ b/tests/server/test_admin_remove_user_cascade.py
@@ -38,9 +38,7 @@ class _FakeVectorStore:
         self.delete_user_calls: list[tuple[str, str, object]] = []
         self.raise_on_delete: Exception | None = None
 
-    async def delete_user_data(
-        self, account_id: str, user_id: str, *, ctx: object
-    ) -> int:
+    async def delete_user_data(self, account_id: str, user_id: str, *, ctx: object) -> int:
         self.delete_user_calls.append((account_id, user_id, ctx))
         if self.raise_on_delete is not None:
             raise self.raise_on_delete
@@ -118,9 +116,7 @@ class _RecordingAGFS:
     def ensure_parent_dirs(self, path, **_kwargs):
         return None
 
-    def pathlock_acquire_exact(
-        self, fs_ctx, path, timeout_secs=0.0, owner_lease_ref=None
-    ):
+    def pathlock_acquire_exact(self, fs_ctx, path, timeout_secs=0.0, owner_lease_ref=None):
         return {"lease_ref": f"test:{path}"}
 
     def pathlock_release(self, fs_ctx, lease):
@@ -151,9 +147,7 @@ class _RecordingVikingFS:
 class _FakeService:
     def __init__(self, viking_fs):
         self.viking_fs = viking_fs
-        self.sessions = type(
-            "S", (), {"get_agent_evolution_enabled": lambda self: False}
-        )()
+        self.sessions = type("S", (), {"get_agent_evolution_enabled": lambda self: False})()
 
     async def initialize_account_directories(self, ctx):
         return None
@@ -183,9 +177,7 @@ async def cascade_client(monkeypatch):
             status_code=500,
             content=Response(
                 status="error",
-                error=ErrorInfo(
-                    code=exc.code, message=exc.message, details=exc.details
-                ),
+                error=ErrorInfo(code=exc.code, message=exc.message, details=exc.details),
             ).model_dump(),
         )
 
@@ -211,9 +203,7 @@ async def cascade_client(monkeypatch):
     app.include_router(admin_router.router)
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://testserver"
-    ) as c:
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
         c.app = app
         c.viking_fs = viking_fs
         c.manager = manager
@@ -284,12 +274,8 @@ async def test_remove_user_cascades_agfs_vectors_oauth_and_usage(cascade_client)
     assert isinstance(vector_calls[0][2], RequestContext)
     assert vector_calls[0][2].role == Role.ROOT
     assert vector_calls[0][2].user.user_id == "bob"
-    assert cascade_client._oauth_store.revoke_calls == [
-        {"account_id": acct, "user_id": "bob"}
-    ]
-    assert cascade_client._usage_store.delete_calls == [
-        {"account_id": acct, "user_id": "bob"}
-    ]
+    assert cascade_client._oauth_store.revoke_calls == [{"account_id": acct, "user_id": "bob"}]
+    assert cascade_client._usage_store.delete_calls == [{"account_id": acct, "user_id": "bob"}]
     assert not _user_exists(cascade_client.manager, acct, "bob")
 
 
@@ -345,9 +331,7 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
     if stage == "agfs":
         cascade_client.viking_fs.raise_on_rm = RuntimeError("agfs boom")
     elif stage == "vectordb":
-        cascade_client.viking_fs.vector_store.raise_on_delete = RuntimeError(
-            "vector boom"
-        )
+        cascade_client.viking_fs.vector_store.raise_on_delete = RuntimeError("vector boom")
     elif stage == "oauth":
         cascade_client._oauth_store.raise_on_revoke = RuntimeError("oauth boom")
     elif stage == "usage_audit":
@@ -357,9 +341,9 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
         f"/api/v1/admin/accounts/{acct}/users/bob", headers=_root_headers()
     )
     assert resp.status_code >= 400, resp.text
-    assert _user_exists(
-        cascade_client.manager, acct, "bob"
-    ), f"user must remain registered after {stage} failure for safe retry"
+    assert _user_exists(cascade_client.manager, acct, "bob"), (
+        f"user must remain registered after {stage} failure for safe retry"
+    )
 
     # Public error must name only the failed stage, never leak raw backend text.
     body = resp.text
@@ -374,13 +358,9 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
         assert [c[:2] for c in vector_calls] == [(acct, "bob")]
         assert isinstance(vector_calls[0][2], RequestContext)
     elif stage == "oauth":
-        assert cascade_client._oauth_store.revoke_calls == [
-            {"account_id": acct, "user_id": "bob"}
-        ]
+        assert cascade_client._oauth_store.revoke_calls == [{"account_id": acct, "user_id": "bob"}]
     elif stage == "usage_audit":
-        assert cascade_client._usage_store.delete_calls == [
-            {"account_id": acct, "user_id": "bob"}
-        ]
+        assert cascade_client._usage_store.delete_calls == [{"account_id": acct, "user_id": "bob"}]
         # The accepted-event drain must run before the purge.
         assert cascade_client.app.state.usage_audit_runtime.worker.flushed == 1
 

--- a/tests/server/test_admin_remove_user_cascade.py
+++ b/tests/server/test_admin_remove_user_cascade.py
@@ -33,11 +33,15 @@ def _acct(prefix="acct") -> str:
 
 class _FakeVectorStore:
     def __init__(self):
-        self.delete_user_calls: list[tuple[str, str]] = []
+        # Mirrors production VikingVectorIndexBackend.delete_user_data signature:
+        # ctx is keyword-only and required.
+        self.delete_user_calls: list[tuple[str, str, object]] = []
         self.raise_on_delete: Exception | None = None
 
-    async def delete_user_data(self, account_id: str, user_id: str) -> int:
-        self.delete_user_calls.append((account_id, user_id))
+    async def delete_user_data(
+        self, account_id: str, user_id: str, *, ctx: object
+    ) -> int:
+        self.delete_user_calls.append((account_id, user_id, ctx))
         if self.raise_on_delete is not None:
             raise self.raise_on_delete
         return 3
@@ -275,7 +279,11 @@ async def test_remove_user_cascades_agfs_vectors_oauth_and_usage(cascade_client)
     assert rm["ctx"].account_id == acct
     assert rm["ctx"].user.user_id == "bob"
 
-    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]
+    vector_calls = cascade_client.viking_fs.vector_store.delete_user_calls
+    assert [c[:2] for c in vector_calls] == [(acct, "bob")]
+    assert isinstance(vector_calls[0][2], RequestContext)
+    assert vector_calls[0][2].role == Role.ROOT
+    assert vector_calls[0][2].user.user_id == "bob"
     assert cascade_client._oauth_store.revoke_calls == [
         {"account_id": acct, "user_id": "bob"}
     ]
@@ -317,7 +325,9 @@ async def test_remove_user_cascade_is_per_user(cascade_client):
     assert rm["uri"] == "viking://user/bob/"
     assert rm["recursive"] is True
     assert rm["ctx"].user.user_id == "bob"
-    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]
+    vector_calls = cascade_client.viking_fs.vector_store.delete_user_calls
+    assert [c[:2] for c in vector_calls] == [(acct, "bob")]
+    assert isinstance(vector_calls[0][2], RequestContext)
     assert _user_exists(cascade_client.manager, acct, "carol")
 
 
@@ -360,9 +370,9 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
     if stage == "agfs":
         assert len(cascade_client.viking_fs.rm_calls) == 1
     elif stage == "vectordb":
-        assert cascade_client.viking_fs.vector_store.delete_user_calls == [
-            (acct, "bob")
-        ]
+        vector_calls = cascade_client.viking_fs.vector_store.delete_user_calls
+        assert [c[:2] for c in vector_calls] == [(acct, "bob")]
+        assert isinstance(vector_calls[0][2], RequestContext)
     elif stage == "oauth":
         assert cascade_client._oauth_store.revoke_calls == [
             {"account_id": acct, "user_id": "bob"}
@@ -398,7 +408,9 @@ async def test_remove_user_retry_succeeds_after_transient_failure(cascade_client
     assert len(cascade_client.viking_fs.rm_calls) == 2
     # Vector delete runs on the successful retry; it is idempotent, so any
     # extra prior invocation (if stages were partially reached) is harmless.
-    assert cascade_client.viking_fs.vector_store.delete_user_calls[-1] == (acct, "bob")
+    last_call = cascade_client.viking_fs.vector_store.delete_user_calls[-1]
+    assert last_call[:2] == (acct, "bob")
+    assert isinstance(last_call[2], RequestContext)
 
 
 async def test_remove_user_rolls_back_live_registry_on_persistence_failure(
@@ -470,4 +482,6 @@ async def test_remove_user_skips_absent_oauth_and_usage(cascade_client):
     assert resp.status_code == 200, resp.text
     assert not _user_exists(cascade_client.manager, acct, "bob")
     assert len(cascade_client.viking_fs.rm_calls) == 1
-    assert cascade_client.viking_fs.vector_store.delete_user_calls == [(acct, "bob")]
+    vector_calls = cascade_client.viking_fs.vector_store.delete_user_calls
+    assert [c[:2] for c in vector_calls] == [(acct, "bob")]
+    assert isinstance(vector_calls[0][2], RequestContext)

--- a/tests/server/test_admin_remove_user_cascade.py
+++ b/tests/server/test_admin_remove_user_cascade.py
@@ -76,9 +76,25 @@ class _FakeUsageStore:
         }
 
 
+class _FakeUsageWorker:
+    def __init__(self):
+        self.flushed = 0
+
+    async def flush(self):
+        self.flushed += 1
+
+
 class _FakeUsageRuntime:
     def __init__(self, store):
         self.store = store
+        self.worker = _FakeUsageWorker()
+
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict:
+        await self.worker.flush()
+        return await self.store.delete_user_data(
+            account_id=account_id,
+            user_id=user_id,
+        )
 
 
 class _RecordingAGFS:
@@ -335,6 +351,11 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
         cascade_client.manager, acct, "bob"
     ), f"user must remain registered after {stage} failure for safe retry"
 
+    # Public error must name only the failed stage, never leak raw backend text.
+    body = resp.text
+    assert stage in body
+    assert "boom" not in body
+
     # The failed stage must still have been attempted so retry can resume.
     if stage == "agfs":
         assert len(cascade_client.viking_fs.rm_calls) == 1
@@ -350,6 +371,8 @@ async def test_remove_user_fails_closed_when_cleanup_stage_fails(cascade_client,
         assert cascade_client._usage_store.delete_calls == [
             {"account_id": acct, "user_id": "bob"}
         ]
+        # The accepted-event drain must run before the purge.
+        assert cascade_client.app.state.usage_audit_runtime.worker.flushed == 1
 
 
 async def test_remove_user_retry_succeeds_after_transient_failure(cascade_client):
@@ -376,6 +399,33 @@ async def test_remove_user_retry_succeeds_after_transient_failure(cascade_client
     # Vector delete runs on the successful retry; it is idempotent, so any
     # extra prior invocation (if stages were partially reached) is harmless.
     assert cascade_client.viking_fs.vector_store.delete_user_calls[-1] == (acct, "bob")
+
+
+async def test_remove_user_rolls_back_live_registry_on_persistence_failure(
+    cascade_client, monkeypatch
+):
+    """If registry persistence fails, the in-memory auth state must roll back."""
+    acct = _acct("registry_retry")
+    user_key = await _register_account_and_user(cascade_client, acct, "bob")
+
+    legacy = cascade_client.manager._legacy
+    original_save = legacy._save_users_json
+
+    async def _fail_save(_account_id):
+        raise RuntimeError("registry persistence unavailable")
+
+    monkeypatch.setattr(legacy, "_save_users_json", _fail_save)
+    with pytest.raises(RuntimeError, match="registry persistence unavailable"):
+        await cascade_client.manager.remove_user(acct, "bob")
+
+    # User is still resolvable after the failed persistence (rollback).
+    assert _user_exists(cascade_client.manager, acct, "bob")
+    assert cascade_client.manager.resolve(user_key).user_id == "bob"
+
+    # Retry after persistence recovers succeeds and removes the user.
+    monkeypatch.setattr(legacy, "_save_users_json", original_save)
+    await cascade_client.manager.remove_user(acct, "bob")
+    assert not _user_exists(cascade_client.manager, acct, "bob")
 
 
 # ---- absent optional subsystems are skipped, not failed -------------------


### PR DESCRIPTION
## Description

Closes #3660. Deleting a user under an account left residual data (AGFS subtree, vector records, OAuth tokens/codes, usage/audit projections), and recreating a same-named user could inherit stale state. This change makes user deletion **cascade across every configured subsystem and fail closed**: if any present subsystem raises, the API returns an error and the user (with credentials) stays registered so the operation can be retried idempotently. An absent/disabled optional subsystem is skipped, not treated as an error.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Closes #3660.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- **Cascade stages (all run before the registry entry is removed):**
  1. **AGFS** — `viking_fs.rm("viking://user/{uid}/", recursive=True)` under a ROOT `RequestContext`; a missing subtree is an idempotent no-op, any other error aborts.
  2. **VectorDB** — `vector_store.delete_user_data(account_id, user_id, ctx=cleanup_ctx)` filters on both `account_id` and `owner_user_id` (public API, no private `_get_vector_store`), catching orphan records outside the removed subtree. The ROOT cleanup ctx is passed through the production boundary (`delete_user_data` requires keyword-only `ctx`).
  3. **OAuth** — `oauth_store.revoke_user_tokens(account_id=, user_id=)` revokes access tokens, refresh tokens, codes, and verified-but-not-yet-exchanged `oauth_pending_authorizations` bound to the user, so a deletion in flight cannot be completed into fresh tokens afterward (unverified rows have no bound identity and are left alone).
  4. **Usage/audit** — explicit-SQLite transaction purges `usage_token_hourly`, `usage_retrieval_hourly`, `usage_context_write_bucket`, and `request_audit` for the target user only.
- **Flush-before-purge**: the usage/audit worker calls `task_done()` for every flushed event and exposes `flush()`; `UsageAuditRuntime.delete_user_data` drains already-accepted events before purging, so a previously queued event cannot recreate deleted-user rows after the purge.
- **Registry rollback**: `LegacyAPIKeyManager.remove_user` restores the popped user entry and prefix index if JSON persistence fails, preventing an in-memory/on-disk split-brain and preserving fail-closed retry.
- **No raw exception leakage**: the public `InternalError` message lists failed **stage names only** (`agfs`, `vectordb`, `oauth`, `usage_audit`); backend exception details are logged server-side via `logger.exception`.

Scope note: this fully resolves the reported **sequential** delete/recreate residual-data bug (the registry entry is removed only after every configured stage succeeds, and the credential is invalidated so a recreated user starts clean). The cascade is **not atomic** against a request already past authentication at the instant deletion begins — such a write can land between a stage's purge and the final registry removal. Closing that narrower cross-request window would require a per-user deletion barrier/tombstone on the write path, which is a broader concurrency change beyond this issue's reported scope.

## Testing

- [x] `tests/server/test_admin_remove_user_cascade.py` — per-stage fail-closed behavior (user and key remain, no raw backend string in the response), idempotent retry, vector owner filtering and ROOT ctx, AGFS ROOT context, registry rollback on persistence failure, credential invalidation after deletion, and successful end-to-end cascade. The vector-store fake mirrors the production `delete_user_data(account_id, user_id, *, ctx)` signature so a missing-ctx call fails like production.
- [x] Usage/audit tests — store purge is user-scoped and idempotent; `worker.flush()` returns after accepted events persist (no hang); runtime flushes pending events before purge.
- [x] 24 cascade + usage-audit tests pass locally; full CI green on the latest push.
- [x] `ruff check` / `ruff format` clean on all changed files.

## Risk

Fail-closed behavior preserves the user/registry on any stage failure (retry safe); successful deletion is strictly more thorough than before. Changes are localized to the admin removal path and the usage-audit worker/runtime.


## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A — backend logic changes with no UI impact.

## Additional Notes

This PR was generated entirely by AI agents. All tests pass locally and in CI.
