### PR TITLE
fix(vectordb): accept WGS-84 boundary coordinates in parse_geo_point

### DIFF
--- a/openviking/storage/vectordb/utils/data_processor.py
+++ b/openviking/storage/vectordb/utils/data_processor.py
@@ -260,10 +260,10 @@ class DataProcessor:
             lat = float(parts[1].strip())
         except ValueError as exc:
             raise ValueError("geo_point lon/lat must be float") from exc
-        if not (-180.0 < lon < 180.0):
-            raise ValueError("geo_point longitude out of range (-180, 180)")
-        if not (-90.0 < lat < 90.0):
-            raise ValueError("geo_point latitude out of range (-90, 90)")
+        if not (-180.0 <= lon <= 180.0):
+            raise ValueError("geo_point longitude out of range [-180, 180]")
+        if not (-90.0 <= lat <= 90.0):
+            raise ValueError("geo_point latitude out of range [-90, 90]")
         return lon, lat
 
     def parse_radius(self, value: Any) -> float:

--- a/tests/vectordb/test_geo_point_boundary.py
+++ b/tests/vectordb/test_geo_point_boundary.py
@@ -1,0 +1,40 @@
+"""Regression test: parse_geo_point must accept valid WGS-84 boundary coordinates.
+
+The geographic standard defines a *closed* interval for both axes:
+  longitude ∈ [-180, 180]  (includes the antimeridian / International Date Line)
+  latitude  ∈ [ -90,  90]  (includes the North and South Poles)
+
+Using strict inequalities (< instead of <=) incorrectly rejects these
+legal endpoints, breaking both writes (boundary-coordinate resources cannot
+be indexed) and geo_range queries centred on poles or the date line.
+"""
+
+import pytest
+
+from openviking.storage.vectordb.utils.data_processor import DataProcessor
+
+_PROCESSOR = DataProcessor({"geo": {"FieldType": "geo_point"}})
+
+
+@pytest.mark.parametrize(
+    "coord, expected",
+    [
+        ("0,90", (0.0, 90.0)),      # North Pole
+        ("0,-90", (0.0, -90.0)),    # South Pole
+        ("180,0", (180.0, 0.0)),    # antimeridian east
+        ("-180,0", (-180.0, 0.0)),  # antimeridian west
+    ],
+)
+def test_geo_point_accepts_valid_boundary_coordinates(coord, expected):
+    """Boundary values are valid WGS-84 coordinates and must not raise."""
+    assert _PROCESSOR.parse_geo_point(coord) == expected
+
+
+@pytest.mark.parametrize(
+    "coord",
+    ["181,0", "-181,0", "0,91", "0,-91"],
+)
+def test_geo_point_rejects_out_of_range_coordinates(coord):
+    """Values strictly outside the valid range must still raise ValueError."""
+    with pytest.raises(ValueError):
+        _PROCESSOR.parse_geo_point(coord)


### PR DESCRIPTION
## Summary

`parse_geo_point` rejected valid **WGS-84 boundary coordinates** — the poles (±90 latitude) and the antimeridian / International Date Line (±180 longitude) — because the range checks used strict inequalities.

## Root cause

`openviking/storage/vectordb/utils/data_processor.py` (L263–266):

```python
if not (-180.0 < lon < 180.0):
    raise ValueError("geo_point longitude out of range (-180, 180)")
if not (-90.0 < lat < 90.0):
    raise ValueError("geo_point latitude out of range (-90, 90)")
```

WGS-84 defines **closed** intervals: longitude ∈ [-180, 180], latitude ∈ [-90, 90]. The endpoints are real, addressable locations — `lat = ±90` is the North/South Pole, `lon = ±180` is the antimeridian. Using `<` treats the interval as open and rejects these legitimate points.

## Why it matters — two code paths

1. **Write / index** — a resource whose `geo_point` is exactly on a pole or the date line raises `ValueError` and cannot be indexed.
2. **Search** — a `geo_range` query centered on a pole or the date line raises `ValueError`, aborting the whole query.

## Fix

Change both checks to `<=` (closed interval). Strictly out-of-range values (`181`, `-91`, …) still raise, so validation is not weakened.

## Test plan

- Added `tests/vectordb/test_geo_point_boundary.py`: 4 boundary endpoints must be accepted (N/S Poles, ±antimeridian) + 4 out-of-range values must still be rejected.
- Fails on unpatched code (boundary inputs raise `ValueError`); passes after the fix; existing `test_data_processor.py` unchanged.

---

## 中文说明

### 问题
`parse_geo_point` 拒绝了合法的 WGS-84 边界坐标——南北极(纬度 ±90)和国际日期变更线(经度 ±180)——因为范围校验用了严格不等号。

### 根因
`data_processor.py` 第 263–266 行用 `<` 而非 `<=`。WGS-84 是**闭区间**:经度 ∈ [-180,180]、纬度 ∈ [-90,90],端点是真实可寻址的位置(极点、日期变更线)。用 `<` 把区间当成开区间,合法端点被误拒。

### 影响(两条路径)
1. **写入/索引**:geo_point 正好落在极点或日期变更线上的资源会抛错,根本无法入库。
2. **检索**:以极点或日期变更线为中心的 `geo_range` 查询会抛错,整个查询中断。

### 修复
两处 `<` 改 `<=`(闭区间)。严格越界值(如 `181`、`-91`)仍然抛错,校验强度不变。

### 测试
新增 `tests/vectordb/test_geo_point_boundary.py`:4 个边界端点必须被接受 + 4 个越界值仍被拒绝;修复前边界用例失败,修复后全通过,原有测试不受影响。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)