### PR TITLE
fix(markdown): keep force-split chunks within the token budget

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -150,6 +150,9 @@ class MarkdownParser(BaseParser):
     # Configuration constants
     DEFAULT_MAX_SECTION_SIZE = 2048  # Maximum tokens per section
     DEFAULT_MIN_SECTION_TOKENS = 512  # Minimum tokens to create a separate section
+    # Worst-case token density used by _estimate_token_count (CJK ~0.7 tok/char).
+    # Used to bound force-split chunk size so it also respects the token budget.
+    MAX_TOKENS_PER_CHAR = 0.7
     MAX_MERGED_FILENAME_LENGTH = 32  # Maximum length for merged section filenames
 
     # Image validation constants
@@ -581,8 +584,14 @@ class MarkdownParser(BaseParser):
                         parts.append(current.strip())
                     current = ""
                     current_tokens = 0
-                for i in range(0, len(para), max_chars):
-                    parts.append(para[i : i + max_chars].strip())
+                # Step by the smaller of the char limit and the token-safe
+                # width, so a paragraph that is under max_chars but over
+                # max_size tokens (e.g. dense CJK text) is still split enough
+                # to keep every chunk within the token budget.
+                token_safe_chars = max(1, int(max_size / self.MAX_TOKENS_PER_CHAR))
+                step = min(max_chars, token_safe_chars)
+                for i in range(0, len(para), step):
+                    parts.append(para[i : i + step].strip())
             elif (
                 current_tokens + para_tokens > max_size or len(current) + len(para) + 2 > max_chars
             ) and current:
@@ -1574,4 +1583,4 @@ class MarkdownParser(BaseParser):
         # This provides better coverage for multilingual documents
         cjk_chars = len(re.findall(r"[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]", content))
         other_chars = len(re.findall(r"[^\s]", content)) - cjk_chars
-        return int(cjk_chars * 0.7 + other_chars * 0.3)
+        return int(cjk_chars * self.MAX_TOKENS_PER_CHAR + other_chars * 0.3)

--- a/tests/parse/test_markdown_split_token_budget.py
+++ b/tests/parse/test_markdown_split_token_budget.py
@@ -1,0 +1,27 @@
+"""Regression test: _smart_split_content must respect the token budget.
+
+The force-split branch previously stepped through an oversized paragraph by
+``max_chars`` only. A paragraph that is under the character limit but over the
+token budget (e.g. dense CJK text, weighted ~0.7 token/char) was therefore
+emitted as a single chunk that exceeded ``max_size`` tokens.
+"""
+
+from openviking.parse.parsers.markdown import MarkdownParser
+
+
+def test_smart_split_enforces_token_budget_for_cjk_paragraph():
+    parser = MarkdownParser()
+    max_size = 2048
+    # 5000 CJK chars ~= 3500 estimated tokens (> max_size) but < the default
+    # char limit, so the char-only force-split produced one over-budget chunk.
+    paragraph = "\u4e2d" * 5000
+    parts = parser._smart_split_content(paragraph, max_size=max_size)
+    worst = max(parser._estimate_token_count(p) for p in parts)
+    assert worst <= max_size, f"chunk has {worst} tokens, exceeds max_size={max_size}"
+
+
+def test_smart_split_preserves_content():
+    parser = MarkdownParser()
+    paragraph = "\u4e2d" * 5000
+    parts = parser._smart_split_content(paragraph, max_size=2048)
+    assert "".join(parts) == paragraph


### PR DESCRIPTION
## Summary

`MarkdownParser._smart_split_content` documents that it "Enforces both a token estimate limit (`max_size`) and a hard character limit", but the force-split branch only enforced the **character** limit. A paragraph oversized by tokens but under the character limit was emitted as a single chunk that exceeded `max_size` tokens — silently violating the documented contract.

## Root cause

`openviking/parse/parsers/markdown.py` ~L584 (force-split path):

```python
# before
for i in range(0, len(para), max_chars):   # steps by chars only
    parts.append(para[i : i + max_chars].strip())
```

The step size `max_chars` only guards the **character** budget. `_estimate_token_count` weights CJK characters at ~0.7 token/char. A 5 000-character Chinese paragraph is ~3 500 estimated tokens (> the 2 048 default `max_size`) but stays under the 6 000-character limit, so the loop runs **once** and emits a single 3 500-token chunk — blowing the budget that downstream tiered loading and embedding relies on.

## Why it matters

The tiered-loading architecture (L0/L1/L2) and embedding pipelines expect chunks within the token budget. An over-budget chunk can cause context-window overflow or degrade embedding quality for long-form CJK content — a common and valuable document type.

## Fix

Bound the step by `min(max_chars, max_size / MAX_TOKENS_PER_CHAR)`, where `MAX_TOKENS_PER_CHAR = 0.7` is the worst-case (CJK) density already used by `_estimate_token_count`, now extracted into a shared class constant so the estimator and the splitter cannot drift apart.

## Test plan

- Added `tests/parse/test_markdown_split_token_budget.py`: a 5 000-char CJK paragraph must split into chunks each ≤ `max_size` tokens; content must be fully preserved.
- Fails before the fix (single 3 500-token chunk), passes after.
- `tests/parse/` suite: same pre-existing failure count (13) on both `main` and this branch — no regressions. Branch adds 2 new passing tests.

---

## 中文说明

### 问题
`_smart_split_content` 声称同时强制 token 上限和字符上限,但强制分块分支只按字符步进,忽略了 token 预算。token 超限但字符未超限的段落(典型:长中文文本)被吐成单个超预算块,静默违背了该函数自己的文档契约。

### 根因
`_estimate_token_count` 中 CJK 字符按 0.7 token/字符加权。5000 字中文段 ≈ 3500 token(超过默认 max_size=2048),但 <6000 字符上限,所以强制分块循环只跑一次,吐出一个 3500-token 的超预算块。

### 影响
分层加载(L0/L1/L2)和 embedding 流水线依赖 chunk 在 token 预算内。超预算块可能导致上下文窗口溢出,或降低长篇 CJK 内容的 embedding 质量。

### 修复
步长改为 `min(max_chars, max_size / MAX_TOKENS_PER_CHAR)`,其中 `MAX_TOKENS_PER_CHAR = 0.7` 就是 `_estimate_token_count` 里已有的 CJK 密度常量,现在提取成类常量,让估算器和分割器不再能独立漂移。

### 测试
新增 `tests/parse/test_markdown_split_token_budget.py`:5000 字中文段拆出的每个 chunk 必须 ≤ max_size token,且内容完整保留;修复前单块 3500 token(失败),修复后全通过。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)