### PR TITLE
fix(markdown): match GitHub anchor slugs for headings with removed punctuation

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -97,7 +97,12 @@ def _gh_slug(text: str) -> str:
     """GitHub-style heading slug: lowercase, strip punctuation, spaces→'-', keep CJK."""
     s = text.strip().lower()
     s = re.sub(r"[^\w\s-]", "", s)
-    s = re.sub(r"\s+", "-", s)
+    # Map each whitespace character to its own hyphen (do NOT collapse runs).
+    # GitHub's reference slugger does `.replace(/ /g, '-')` — one hyphen per
+    # space, no collapsing. Removing punctuation can leave adjacent spaces
+    # (e.g. "Foo & Bar" → "foo  bar"); collapsing them produces "foo-bar"
+    # while GitHub generates "foo--bar", breaking intra-doc anchor links.
+    s = re.sub(r"\s", "-", s)
     return s
 
 

--- a/tests/parse/test_gh_slug.py
+++ b/tests/parse/test_gh_slug.py
@@ -1,0 +1,26 @@
+"""Regression test: _gh_slug must match GitHub's heading-anchor algorithm.
+
+GitHub's reference slugger (github-slugger) lowercases, strips a set of
+punctuation, then maps *each* space to a hyphen individually
+(``.replace(/ /g, '-')``) — it does not collapse consecutive whitespace.
+
+Because punctuation is removed *before* spaces are converted, a heading like
+"Foo & Bar" leaves two adjacent spaces where "&" was, which GitHub renders as
+a double hyphen ("foo--bar"). The intra-document link rewriter compares
+_gh_slug(heading) against the link fragment, so collapsing whitespace made
+links such as `guide.md#foo--bar` fail to resolve.
+"""
+
+from openviking.parse.parsers.markdown import _gh_slug
+
+
+def test_gh_slug_matches_github_for_removed_punctuation():
+    # "&" removed -> "foo  bar" (two spaces) -> "foo--bar" on GitHub.
+    assert _gh_slug("Foo & Bar") == "foo--bar"
+    assert _gh_slug("Terms & Conditions") == "terms--conditions"
+
+
+def test_gh_slug_simple_headings_unchanged():
+    assert _gh_slug("Hello World") == "hello-world"
+    assert _gh_slug("Section 1") == "section-1"
+    assert _gh_slug("C++ Guide") == "c-guide"


### PR DESCRIPTION
## Summary
`_gh_slug` claims to produce GitHub-style heading slugs but collapsed runs of whitespace, diverging from GitHub's reference slugger and breaking intra-document anchor links.

## Root cause
`re.sub(r"\s+", "-", s)` collapses consecutive whitespace. GitHub's [github-slugger](https://github.com/Flet/github-slugger) maps each space individually (`.replace(/ /g, '-')`, no collapse). Since punctuation is stripped before spaces are converted, `## Foo & Bar` → `"foo  bar"` (two spaces) → GitHub `foo--bar`, but `_gh_slug` produced `foo-bar`. The link rewriter compares `_gh_slug(heading)` against the link fragment, so a link like `guide.md#foo--bar` fails to match and is left unrewritten after the doc is split into sections.

## Fix
`\s+` → `\s` (one hyphen per whitespace char), matching github-slugger. Simple single-space headings are unaffected.

## Test plan
Added `tests/parse/test_gh_slug.py` (punctuation headings → double hyphen; ordinary headings unchanged). Fails before, passes after.

---
## 中文说明
### 问题
`_gh_slug` 声称生成 GitHub 风格锚点,却折叠了连续空白,与 GitHub 参考实现不一致,导致文档内锚点链接失配。
### 根因
`re.sub(r"\s+", "-", s)` 折叠连续空白;GitHub 的 github-slugger 是每个空格单独映射一个连字符(不折叠)。因为标点先被去掉再转空格,`## Foo & Bar` → `"foo  bar"`(两个空格)→ GitHub 生成 `foo--bar`,而 `_gh_slug` 生成 `foo-bar`。链接重写器拿 `_gh_slug(标题)` 和链接片段比对,于是 `guide.md#foo--bar` 这类链接在文档被拆分后无法匹配、未被重写。
### 修复
`\s+` 改 `\s`(每个空白一个连字符),对齐 github-slugger;单空格标题不受影响。
### 测试
新增 `tests/parse/test_gh_slug.py`(带标点标题→双连字符;普通标题不变),修复前失败、修复后通过。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)