### PR TITLE
fix(vectordb): fill all missing schema fields in fix_fields_data

### DIFF
--- a/openviking/storage/vectordb/utils/validation.py
+++ b/openviking/storage/vectordb/utils/validation.py
@@ -408,9 +408,6 @@ def is_valid_fields_data(field_data_dict: dict, field_meta_dict: dict) -> bool:
 
 
 def fix_fields_data(field_data_dict: dict, field_meta_dict: dict) -> dict:
-    if len(field_data_dict) >= len(field_meta_dict):
-        return field_data_dict
-
     for field_name, field_meta in field_meta_dict.items():
         if field_name not in field_data_dict:
             # Handle both dict access and object access if field_meta is a Model (though here it's likely a dict)

--- a/tests/vectordb/test_fix_fields_data.py
+++ b/tests/vectordb/test_fix_fields_data.py
@@ -1,0 +1,53 @@
+"""Regression test: fix_fields_data must fill every missing schema field.
+
+The function backfills schema fields that are absent from a row's data with
+their defaults. It previously short-circuited when
+``len(field_data_dict) >= len(field_meta_dict)``, using field *count* as a
+proxy for "all schema fields present". That proxy is wrong: a row can have as
+many keys as the schema (or more) while still missing a specific field — for
+example a row written before a new field was added that also carries an extra
+non-schema/internal key. In that case the missing field was silently dropped
+instead of defaulted.
+"""
+
+from openviking.storage.vectordb.utils.validation import fix_fields_data
+
+
+def test_missing_field_is_filled_even_when_counts_match():
+    meta = {
+        "a": {"FieldType": "string", "DefaultValue": None},
+        "b": {"FieldType": "int64", "DefaultValue": None},
+        "vec": {"FieldType": "string", "DefaultValue": None},
+    }
+    # 3 keys == len(meta), but "b" is absent and an extra non-schema key exists.
+    data = {"a": "hello", "vec": "x", "persisted": 5}
+
+    result = fix_fields_data(dict(data), meta)
+
+    assert "b" in result, "missing schema field must be backfilled"
+    assert result["b"] == 0  # int64 type default
+
+
+def test_default_value_is_used_when_present():
+    meta = {
+        "a": {"FieldType": "string", "DefaultValue": None},
+        "status": {"FieldType": "string", "DefaultValue": "pending"},
+        "extra": {"FieldType": "string", "DefaultValue": None},
+    }
+    data = {"a": "hello", "extra": "x", "legacy": "y"}
+
+    result = fix_fields_data(dict(data), meta)
+
+    assert result["status"] == "pending"
+
+
+def test_complete_data_is_returned_unchanged():
+    meta = {
+        "a": {"FieldType": "string", "DefaultValue": None},
+        "b": {"FieldType": "int64", "DefaultValue": None},
+    }
+    data = {"a": "hello", "b": 7}
+
+    result = fix_fields_data(dict(data), meta)
+
+    assert result == {"a": "hello", "b": 7}


### PR DESCRIPTION
## Summary
`fix_fields_data` backfills schema fields absent from a row with their defaults, but short-circuited on a **field-count** check that let missing fields slip through — a "silent data loss" bug.

## Root cause
```python
if len(field_data_dict) >= len(field_meta_dict):
    return field_data_dict          # wrong proxy for "all fields present"
```
`len(data) >= len(meta)` is used as a proxy for "all schema fields present", which is false: a row can have as many keys as the schema (or more) while still missing a specific field. **Schema-evolution trigger**: a row persisted before a field was added, that also carries an extra internal/non-schema key, has `len(data) == len(meta)` but is missing the new field → the fill loop is skipped → the field is silently omitted from the record returned by `fetch_data`.

## Why it matters
This is exactly the failure mode the design guards elsewhere: **never silently drop data**. An incomplete record propagates downstream (missing defaults) with no error.

## Fix
Remove the count guard. The loop already skips present fields, so complete inputs are unchanged; only genuinely missing fields are filled.

## Test plan
Added `tests/vectordb/test_fix_fields_data.py`: missing field is backfilled when key counts match (type default + explicit `DefaultValue`); complete data returned unchanged. Two missing-field tests fail before, pass after; `test_data_processor.py` still 8/8.

---
## 中文说明
### 问题
`fix_fields_data` 用「字段数」当「字段齐全」的判据提前返回,导致缺失字段被静默丢弃。
### 根因
`len(data) >= len(meta)` ≠ 字段齐全:一行可以键数等于/多于 schema 却仍缺某个字段。**schema 演进场景**:字段新增前写入的旧行,又带了一个内部/非 schema 键,`len(data)==len(meta)` 但缺新字段 → 填充循环被跳过 → `fetch_data` 返回不完整记录。
### 影响
正是设计在别处极力避免的失败模式——**绝不静默丢数据**。不完整记录会带着缺失的默认值继续往下游传,且无任何报错。
### 修复
去掉计数守卫。循环本就跳过已存在字段,完整输入原样返回,只填真正缺失的字段。
### 测试
新增 `tests/vectordb/test_fix_fields_data.py`:键数相等时缺失字段被补齐(类型默认值 + 显式 DefaultValue);完整数据原样返回。两个缺失字段用例修复前失败、修复后通过;`test_data_processor.py` 仍 8/8。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)