### PR TITLE
fix(auth): fail closed on legacy agent headers

### DIFF
--- a/openviking/server/auth/__init__.py
+++ b/openviking/server/auth/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Authentication and authorization middleware for OpenViking multi-tenant HTTP Server."""
 
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import Depends, Header, HTTPException, Query, Request
 
@@ -74,6 +74,15 @@ def normalize_actor_peer_header(value: Optional[str]) -> Optional[str]:
         raise InvalidArgumentError(str(exc)) from exc
 
 
+def reject_legacy_agent_header(value: str | list[str] | None) -> None:
+    values = value if isinstance(value, list) else [value]
+    if any(_normalize_header_value(item) is not None for item in values):
+        raise InvalidArgumentError(
+            "X-OpenViking-Agent is no longer supported; "
+            "use X-OpenViking-Actor-Peer instead."
+        )
+
+
 def _explicit_identity_from_request(request: Request) -> tuple[Optional[str], Optional[str]]:
     path_params = getattr(request, "path_params", {}) or {}
     query_params = request.query_params
@@ -130,8 +139,13 @@ async def resolve_identity(
     authorization: Optional[str] = Header(None),
     x_openviking_account: Optional[str] = Header(None, alias="X-OpenViking-Account"),
     x_openviking_user: Optional[str] = Header(None, alias="X-OpenViking-User"),
+    x_openviking_agent: Annotated[
+        Optional[list[str]],
+        Header(alias="X-OpenViking-Agent", include_in_schema=False),
+    ] = None,
 ) -> ResolvedIdentity:
     """Resolve API key to identity via the active auth plugin."""
+    reject_legacy_agent_header(x_openviking_agent)
     x_openviking_account = _normalize_header_value(x_openviking_account)
     x_openviking_user = _normalize_header_value(x_openviking_user)
     api_key = _extract_api_key(x_api_key, authorization)
@@ -183,6 +197,10 @@ async def get_upload_request_context(
     x_openviking_account: Optional[str] = Header(None, alias="X-OpenViking-Account"),
     x_openviking_user: Optional[str] = Header(None, alias="X-OpenViking-User"),
     x_openviking_actor_peer: Optional[str] = Header(None, alias="X-OpenViking-Actor-Peer"),
+    x_openviking_agent: Annotated[
+        Optional[list[str]],
+        Header(alias="X-OpenViking-Agent", include_in_schema=False),
+    ] = None,
 ) -> RequestContext:
     """Two-layer auth for the ``temp_upload`` route: API key first, else a signed token.
 
@@ -193,6 +211,7 @@ async def get_upload_request_context(
     any spoofed ``X-OpenViking-Account/User`` headers are ignored. The consumed token is
     stashed on ``request.state.signed_upload`` so the handler can finish ingestion.
     """
+    reject_legacy_agent_header(x_openviking_agent)
     api_key = _extract_api_key(x_api_key, authorization)
     if token and not api_key:
         try:

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -36,7 +36,11 @@ from openviking.retrieve.type_quota_recall import (
     DEFAULT_QUOTAS,
     search_type_quota_recall,
 )
-from openviking.server.auth import _extract_api_key, normalize_actor_peer_header, resolve_identity
+from openviking.server.auth import (
+    _extract_api_key,
+    normalize_actor_peer_header,
+    resolve_identity,
+)
 from openviking.server.dependencies import get_server_config, get_service
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import (
@@ -149,6 +153,7 @@ class _IdentityASGIMiddleware:
                 authorization=authorization,
                 x_openviking_account=request.headers.get("x-openviking-account"),
                 x_openviking_user=request.headers.get("x-openviking-user"),
+                x_openviking_agent=request.headers.getlist("x-openviking-agent"),
             )
             actor_peer_id = normalize_actor_peer_header(
                 request.headers.get("x-openviking-actor-peer")

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -781,6 +781,78 @@ async def test_actor_peer_header_rejects_path_separators():
         await get_request_context(request, identity, "bad/peer")
 
 
+async def test_legacy_agent_header_is_rejected():
+    request = _make_request("/api/v1/search/find", auth_enabled=True)
+    request.app.state.auth_plugin = None
+
+    with pytest.raises(InvalidArgumentError, match="X-OpenViking-Actor-Peer"):
+        await resolve_identity(request, x_openviking_agent="legacy-agent")
+
+
+async def test_blank_legacy_agent_header_is_treated_as_absent():
+    request = _make_request("/api/v1/search/find", auth_enabled=False)
+
+    identity = await resolve_identity(request, x_openviking_agent="   ")
+
+    assert identity is not None
+
+
+async def test_direct_resolve_identity_defaults_legacy_header_to_none():
+    request = _make_request("/api/v1/search/find", auth_enabled=False)
+
+    identity = await resolve_identity(request)
+
+    assert identity is not None
+
+
+async def test_legacy_agent_header_returns_400_via_rest_dependency():
+    app = _build_auth_http_test_app(identity=None, auth_enabled=False)
+    app.state.auth_plugin = None
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(
+            "/api/v1/fs/ls",
+            headers={"X-OpenViking-Agent": "legacy-agent"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+    assert "X-OpenViking-Actor-Peer" in response.json()["error"]["message"]
+
+
+async def test_duplicate_legacy_agent_headers_reject_any_nonempty_value():
+    app = _build_auth_http_test_app(identity=None, auth_enabled=False)
+    app.state.auth_plugin = None
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(
+            "/api/v1/fs/ls",
+            headers=[
+                ("X-OpenViking-Agent", ""),
+                ("X-OpenViking-Agent", "legacy-agent"),
+            ],
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+def test_legacy_agent_header_is_hidden_from_openapi():
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(_ctx=Depends(get_request_context)):
+        return {}
+
+    parameters = app.openapi()["paths"]["/probe"]["get"].get("parameters", [])
+    header_names = {parameter["name"] for parameter in parameters}
+
+    assert "X-OpenViking-Agent" not in header_names
+    assert "X-OpenViking-Actor-Peer" in header_names
+
+
 async def test_root_monitoring_requests_allow_implicit_default_identity():
     """Observer/debug endpoints keep the existing ROOT monitoring flow."""
     observer_request = _make_request("/api/v1/observer/system", auth_enabled=True)

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -388,6 +388,51 @@ async def test_mcp_middleware_rejects_invalid_actor_peer_header():
     assert "path separators" in response.text
 
 
+async def test_mcp_middleware_rejects_legacy_agent_header():
+    async def downstream(scope, receive, send):
+        raise AssertionError("legacy agent header should not reach downstream app")
+
+    app = FastAPI()
+    app.state.config = SimpleNamespace(get_effective_auth_mode=lambda: AuthMode.DEV)
+    app.state.auth_plugin = DevAuthPlugin()
+    app.routes.append(Route("/mcp", endpoint=_IdentityASGIMiddleware(downstream), methods=["POST"]))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ov.test") as client:
+        response = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers={"X-OpenViking-Agent": "legacy-agent"},
+        )
+
+    assert response.status_code == 400
+    assert "X-OpenViking-Actor-Peer" in response.text
+
+
+async def test_mcp_middleware_rejects_nonempty_duplicate_legacy_agent_header():
+    async def downstream(scope, receive, send):
+        raise AssertionError("duplicate legacy agent header should not reach downstream app")
+
+    app = FastAPI()
+    app.state.config = SimpleNamespace(get_effective_auth_mode=lambda: AuthMode.DEV)
+    app.state.auth_plugin = DevAuthPlugin()
+    app.routes.append(Route("/mcp", endpoint=_IdentityASGIMiddleware(downstream), methods=["POST"]))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://ov.test") as client:
+        response = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers=[
+                ("X-OpenViking-Agent", ""),
+                ("X-OpenViking-Agent", "legacy-agent"),
+            ],
+        )
+
+    assert response.status_code == 400
+    assert "X-OpenViking-Actor-Peer" in response.text
+
+
 # ---------------------------------------------------------------------------
 # read tool
 # ---------------------------------------------------------------------------

--- a/tests/server/test_resources_temp_upload_token.py
+++ b/tests/server/test_resources_temp_upload_token.py
@@ -226,3 +226,48 @@ async def test_apikey_temp_upload_returns_temp_file_id(
     assert resp.status_code == 200, resp.text
     tfid = resp.json()["result"]["temp_file_id"]
     assert (upload_temp_dir / tfid).is_file()
+
+
+async def test_apikey_temp_upload_rejects_legacy_agent_header(
+    client: httpx.AsyncClient,
+):
+    resp = await client.post(
+        "/api/v1/resources/temp_upload",
+        files={"file": ("legacy.md", b"legacy", "text/plain")},
+        headers={
+            "X-API-Key": "dev-api-key",
+            "X-OpenViking-Agent": "legacy-agent",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "X-OpenViking-Actor-Peer" in resp.text
+
+
+async def test_signed_token_upload_rejects_legacy_agent_header_before_consuming_token(
+    client: httpx.AsyncClient,
+    service,
+    upload_temp_dir: Path,
+    monkeypatch,
+):
+    _stub_ingest(service, monkeypatch)
+    token = _issue(actor_peer_id="token-peer")
+
+    rejected = await client.post(
+        "/api/v1/resources/temp_upload",
+        params={"token": token},
+        files={"file": ("legacy.md", b"legacy", "text/plain")},
+        headers=[
+            ("X-OpenViking-Agent", ""),
+            ("X-OpenViking-Agent", "legacy-agent"),
+        ],
+    )
+    assert rejected.status_code == 400
+    assert "X-OpenViking-Actor-Peer" in rejected.text
+
+    accepted = await client.post(
+        "/api/v1/resources/temp_upload",
+        params={"token": token},
+        files={"file": ("clean.md", b"clean", "text/plain")},
+    )
+    assert accepted.status_code == 200, accepted.text


### PR DESCRIPTION
## Description

Fail closed when a request still sends a non-empty `X-OpenViking-Agent` header after #3661 removed that compatibility path.

Without an explicit guard, FastAPI and the independent MCP middleware silently ignore the removed header. A legacy client can then reach peer-scoped reads with `actor_peer_id=None`, broadening the request from one peer view to the whole user view. This follow-up chooses an actionable HTTP 400 instead of restoring the legacy mapping, preserving #3661's intentional breaking change and actor-free Session lifecycle.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Follow-up to #3661 and the reviewer-confirmed fail-open findings at the
[REST ingress](https://github.com/volcengine/OpenViking/pull/3661#discussion_r3690193535)
and [MCP ingress](https://github.com/volcengine/OpenViking/pull/3661#discussion_r3690193539).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Declare the removed header as a hidden multi-value FastAPI dependency and reject when any duplicate value is non-empty.
- Reject before auth-plugin resolution, API-key handling, or signed upload-token consumption; blank-only values remain equivalent to an absent peer selector.
- Apply the same all-values check at MCP ingress while leaving `X-OpenViking-Actor-Peer` behavior unchanged.
- Add REST, OpenAPI, API-key upload, signed-token upload, MCP, duplicate-header, and direct-call regression coverage.

## Testing

- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed on a sparse five-file materialization of current main `c4d2b27c`:

- `python3 -m py_compile` on all five changed files
- `ruff check --ignore I001` on all five changed files
  - sparse package discovery reports the same six pre-existing `I001` findings on unmodified main
- isolated FastAPI/Starlette behavior harnesses covering REST/OpenAPI, API-key and signed-token ordering, MCP, direct defaults, and duplicate values (31 assertions)
- trailing-whitespace and current-main blob checks
- dual adversarial review: reworked positional compatibility, OpenAPI exposure, auth ordering, and duplicate-header findings; final verdict `approve`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- A rejected signed-token upload does not consume the token; retrying without the removed header remains valid.
- Session routes remain user-scoped and actor-free as introduced by #3661.
- Commit authorship is r266-tech only.
