### PR TITLE
fix(cli): recover from failed log rotation instead of dropping records

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -7,9 +7,11 @@ Logging utilities for OpenViking.
 import atexit
 import contextvars
 import logging
+import os
 import queue
 import sys
 import threading
+import time
 from contextlib import contextmanager
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
@@ -92,13 +94,6 @@ def _reopen_rust_tracing_file() -> None:
         sys.stderr.write(f"Warning: Failed to reopen Rust tracing log file: {exc}\n")
 
 
-class _RustAwareTimedRotatingFileHandler(TimedRotatingFileHandler):
-    """Timed rotating file handler that refreshes the Rust tracing file handle."""
-
-    def doRollover(self) -> None:
-        """Rotate the active Python log file and then refresh the Rust writer."""
-        super().doRollover()
-        _reopen_rust_tracing_file()
 
 
 @contextmanager
@@ -746,6 +741,105 @@ def _add_trace_id_filter(handler: logging.Handler) -> None:
         handler.addFilter(TraceIdLoggingFilter())
 
 
+class _ResilientTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """A rotating file handler that recovers from rollover failures.
+
+    The stdlib TimedRotatingFileHandler.doRollover() closes the active stream
+    and sets self.stream = None *before* performing the rename/remove. If that
+    rename raises (notably Windows sharing/locking violations, or any other
+    filesystem error), the stream is left as None permanently, because the
+    reopen only runs after a successful rotate. emit() swallows the exception
+    via handleError and all subsequent records are silently lost.
+
+    This subclass:
+      - serializes rotation across processes via an advisory file lock, so two
+        uvicorn workers don't race to rename the same file;
+      - on a failed doRollover(), reopens the original log file so the next
+        record is written; and
+      - reschedules the next rollover so the failed rotation is retried on the
+        next record instead of being abandoned forever.
+    """
+
+    def __init__(self, filename: str, *args: Any, **kwargs: Any) -> None:
+        super().__init__(filename, *args, **kwargs)
+        self._rollover_lock_path = Path(filename).with_name(
+            f".{Path(filename).name}.rollover.lock"
+        )
+        self._rollover_thread_lock = threading.Lock()
+
+    @contextmanager
+    def _rollover_lock(self) -> Iterator[None]:
+        lock_fd: Optional[int] = None
+        if os.name != "nt":
+            try:
+                import fcntl  # type: ignore[import-not-found]
+
+                lock_fd = os.open(
+                    self._rollover_lock_path, os.O_CREAT | os.O_RDWR, 0o600
+                )
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            except (ImportError, OSError):
+                lock_fd = None
+        # On Windows fcntl is unavailable. Cross-process rename races are
+        # possible but recoverable: a failed doRollover reopens the original
+        # stream and reschedules, so no records are permanently lost.
+        try:
+            with self._rollover_thread_lock:
+                yield
+        finally:
+            if lock_fd is not None:
+                try:
+                    import fcntl  # type: ignore[import-not-found]
+
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    os.close(lock_fd)
+                except OSError:
+                    pass
+
+    def doRollover(self) -> None:  # noqa: N802 - matches stdlib name
+        # Hold the cross-process lock for the entire close+rename+reopen so two
+        # workers cannot rotate simultaneously.
+        with self._rollover_lock():
+            # Snapshot the currently-open stream; if super().doRollover() fails
+            # partway, we need to know whether a recovery reopen is required.
+            had_stream = self.stream is not None
+            try:
+                super().doRollover()
+                _reopen_rust_tracing_file()
+            except Exception:
+                # super().doRollover() closes self.stream and sets it to None
+                # before renaming. If the rename failed, reopen the original
+                # file so subsequent emits are not silently dropped.
+                if self.stream is None and had_stream:
+                    try:
+                        self.stream = self._open()
+                    except Exception:
+                        # As a last resort, leave stream None; the next emit
+                        # will hit shouldRollover -> doRollover again.
+                        pass
+                # Reschedule rollover so the next record retries instead of
+                # abandoning rotation forever. super().doRollover() already
+                # recomputed rolloverAt on success paths that got far enough;
+                # if it failed early, recompute from now.
+                try:
+                    current_time = int(time.time())
+                    new_rollover_at = self.computeRollover(current_time)
+                    while new_rollover_at <= current_time:
+                        new_rollover_at = new_rollover_at + self.interval
+                    self.rolloverAt = new_rollover_at
+                except Exception:
+                    pass
+                # Do not re-raise: the stdlib caller (BaseRotatingHandler.emit)
+                # treats any exception as an emit failure and calls
+                # handleError, which by default silently drops the record. We
+                # want logging to continue on the reopened stream instead.
+                # Surface a one-line warning so the failure is observable.
+                sys.stderr.write(
+                    f"WARNING: log rotation failed for {self.baseFilename!r}; "
+                    "logging continues on the current file.\n"
+                )
+
+
 def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handler:
     # Prevent creating a file literally named "file"
     if log_output == "file":
@@ -768,7 +862,7 @@ def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handl
                         when = log_rotation_interval
                         interval = 1
 
-                    return _RustAwareTimedRotatingFileHandler(
+                    return _ResilientTimedRotatingFileHandler(
                         log_output,
                         when=when,
                         interval=interval,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for the resilient TimedRotatingFileHandler used by CLI logging."""
+
+import logging
+import os
+import sys
+import time
+
+import pytest
+
+from openviking_cli.utils.logger import _ResilientTimedRotatingFileHandler
+
+
+@pytest.fixture(autouse=True)
+def _isolated_logger():
+    """Ensure handlers do not leak into the root logger between tests."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    for h in saved_handlers:
+        root.removeHandler(h)
+    yield
+    for h in list(root.handlers):
+        root.removeHandler(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def _make_handler(tmp_path, when="S", interval=1):
+    log_file = tmp_path / "server.log"
+    handler = _ResilientTimedRotatingFileHandler(
+        str(log_file),
+        when=when,
+        interval=interval,
+        backupCount=3,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.INFO)
+    return log_file, handler
+
+
+def test_successful_rollover_rotates_file(tmp_path):
+    log_file, handler = _make_handler(tmp_path, when="S", interval=1)
+    logger = logging.getLogger("test_rollover_ok")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    logger.info("before rollover")
+    handler.flush()
+    assert log_file.exists()
+
+    # Force the next emit to cross the per-second rollover boundary.
+    time.sleep(1.05)
+    logger.info("after rollover")
+    handler.flush()
+
+    rotated = [
+        p for p in tmp_path.iterdir()
+        if p.name.startswith("server.log.") and p.is_file()
+    ]
+    assert rotated, "a dated backup should exist after a successful rollover"
+    assert log_file.exists()
+
+
+def test_failed_rollover_reopens_stream(tmp_path, monkeypatch):
+    log_file, handler = _make_handler(tmp_path)
+    logger = logging.getLogger("test_stream_recovery")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    logger.info("prime")
+    handler.flush()
+    assert handler.stream is not None
+
+    # Simulate a filesystem failure during the rename step of doRollover.
+    # At that point stdlib has already closed and nulled self.stream.
+    def _fail_rename(src, dst, *args, **kwargs):
+        raise PermissionError("simulated locked destination")
+
+    monkeypatch.setattr(os, "rename", _fail_rename)
+    # Also block the Windows-specific path so the failure reproduces there.
+    if hasattr(os, "replace"):
+        monkeypatch.setattr(os, "replace", _fail_rename)
+
+    time.sleep(1.05)
+    logger.info("trigger failed rollover")
+    handler.flush()
+
+    assert handler.stream is not None, (
+        "stream must be reopened so subsequent writes are not silently lost"
+    )
+    # The original file must still accept writes.
+    logger.info("post failure")
+    handler.flush()
+    assert "post failure" in log_file.read_text(encoding="utf-8")
+
+
+def test_failed_rollover_warns_to_stderr(tmp_path, monkeypatch, capsys):
+    log_file, handler = _make_handler(tmp_path)
+    logger = logging.getLogger("test_stderr_warning")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("prime")
+    handler.flush()
+
+    def _fail_rename(src, dst, *args, **kwargs):
+        raise OSError("simulated IO error")
+
+    monkeypatch.setattr(os, "rename", _fail_rename)
+    if hasattr(os, "replace"):
+        monkeypatch.setattr(os, "replace", _fail_rename)
+
+    time.sleep(1.05)
+    logger.info("trigger")
+    handler.flush()
+
+    captured = capsys.readouterr()
+    assert "log rotation failed" in captured.err
+    assert log_file.name in captured.err
+
+
+def test_rollover_is_retried_after_failure(tmp_path, monkeypatch):
+    log_file, handler = _make_handler(tmp_path)
+    logger = logging.getLogger("test_retry")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("prime")
+    handler.flush()
+
+    failures = {"count": 0}
+
+    def _flaky_rename(src, dst, *args, **kwargs):
+        failures["count"] += 1
+        if failures["count"] == 1:
+            raise PermissionError("temporary lock")
+        # Second attempt delegates to the real implementation.
+        monkeypatch.undo()
+        return os.rename(src, dst)
+
+    monkeypatch.setattr(os, "rename", _flaky_rename)
+    if hasattr(os, "replace"):
+        monkeypatch.setattr(os, "replace", _flaky_rename)
+
+    time.sleep(1.05)
+    logger.info("first attempt fails")
+    handler.flush()
+    assert handler.stream is not None
+    # rolloverAt must have been pushed into the future so we can try again.
+    assert handler.rolloverAt > time.time()
+
+    time.sleep(1.05)
+    logger.info("second attempt succeeds")
+    handler.flush()
+
+    rotated = [
+        p for p in tmp_path.iterdir()
+        if p.name.startswith("server.log.") and p.is_file()
+    ]
+    assert rotated, "a later successful emit should complete the rollover"
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="fcntl is POSIX-only")
+def test_rollover_lock_is_held_during_rollover(tmp_path, monkeypatch):
+    import fcntl
+
+    log_file, handler = _make_handler(tmp_path)
+    observed: dict[str, "bool | None"] = {"lock_present_during": None}
+
+    from logging.handlers import TimedRotatingFileHandler
+
+    real_do_rollover = TimedRotatingFileHandler.doRollover
+
+    def _check_lock_during_rollover(self):
+        lock_fd = os.open(str(self._rollover_lock_path), os.O_RDWR)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            observed["lock_present_during"] = False
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except BlockingIOError:
+            observed["lock_present_during"] = True
+        finally:
+            os.close(lock_fd)
+        return real_do_rollover(self)
+
+    monkeypatch.setattr(
+        TimedRotatingFileHandler, "doRollover", _check_lock_during_rollover
+    )
+
+    logger = logging.getLogger("test_lock_held")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("prime")
+    handler.flush()
+    time.sleep(1.05)
+    logger.info("trigger rollover")
+    handler.flush()
+
+    assert observed["lock_present_during"] is True, (
+        "an exclusive advisory lock must be held for the duration of doRollover"
+    )
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="fcntl is POSIX-only")
+def test_rollover_proceeds_when_lock_file_unwritable(tmp_path):
+    # If the advisory lock file cannot be opened (e.g. an unexpected entry
+    # already exists at that path), the handler must silently fall back to
+    # in-process locking instead of breaking rotation. The log directory itself
+    # is valid; only the lock-side open fails.
+    log_file, handler = _make_handler(tmp_path)
+    # A directory at the lock path makes os.open(O_CREAT | O_RDWR) raise EISDIR.
+    handler._rollover_lock_path.mkdir()
+
+    logger = logging.getLogger("test_lock_fallback")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("before rollover")
+    handler.flush()
+
+    time.sleep(1.05)
+    logger.info("after rollover")
+    handler.flush()
+
+    rotated = [
+        p for p in tmp_path.iterdir()
+        if p.name.startswith("server.log.") and p.is_file()
+    ]
+    assert rotated, (
+        "rollover must still succeed when the cross-process lock is unavailable"
+    )
+    assert log_file.exists()
+    assert handler.stream is not None


### PR DESCRIPTION
## Summary

Fixes #3669.

On Windows (Python 3.11.15, OpenViking v0.4.11), the first midnight log
rollover can silently kill `server.log`: no dated backup is produced and all
subsequent log records are lost, with no exception surfaced.

### Root cause

`logging.handlers.TimedRotatingFileHandler.doRollover()` closes the active
stream and sets `self.stream = None` *before* it performs the
rename/remove of the old log file. If that rename raises (a Windows
sharing/locking violation such as `WinError 32`, or any other filesystem
error), the stream is left as `None` permanently because the reopen only runs
after a successful rotate. `BaseRotatingHandler.emit()` swallows the exception
through `handleError`, so every later record is silently dropped.

The same failure mode leaves `rolloverAt` stale, so the failed rotation is
never retried. This also affects the related report in #2939.

### Fix

Introduce `_ResilientTimedRotatingFileHandler`, a thin subclass used only when
`config.log.rotation` is enabled:

- Wrap `doRollover()` so that on any exception it reopens the original log
  file (when the stream was previously open), recomputes and advances
  `rolloverAt` so the failed rotation is retried on the next record, and
  writes a one-line `WARNING: ...` to `sys.stderr` instead of re-raising
  (re-raising would only cause `emit()` to drop the record via
  `handleError`).
- Serialize rotation across processes with an advisory `fcntl.flock` lock on
  POSIX (`.server.log.rollover.lock` next to the log file) plus a per-instance
  thread lock, so multiple uvicorn workers cannot race to rename the same
  file. On Windows the thread lock is used and cross-process races remain
  recoverable through the reopen/retry path. If the lock file cannot be
  opened, the handler falls back to in-process locking rather than failing.

No new third-party dependency is introduced (the competing #2950 adds
`concurrent-log-handler` but does not recover the nulled stream).

### Files

- `openviking_cli/utils/logger.py` — add `_ResilientTimedRotatingFileHandler`
  and return it from `_create_log_handler()` when rotation is enabled.
- `tests/test_logger.py` — six focused tests covering successful rotation,
  stream recovery after a failed rename, the stderr warning, retry after a
  flaky failure, that the advisory lock is held during `doRollover`, and
  fallback when the lock file is unwritable.

### Validation

- `uv run ruff check openviking_cli/utils/logger.py tests/test_logger.py` — pass
- `uv run mypy openviking_cli/utils/logger.py tests/test_logger.py` — pass
  (pre-existing errors elsewhere in the tree are unrelated)
- `uv run pytest tests/test_logger.py -v --no-cov` — 6/6 pass

### Release note

```release-note
CLI logging now recovers from failed log rotation instead of silently
stopping writes to server.log.
```
