### PR TITLE
fix(memory): preserve list JSON responses and fail schema mismatch

### DIFF
--- a/openviking/session/memory/utils/json_parser.py
+++ b/openviking/session/memory/utils/json_parser.py
@@ -15,6 +15,7 @@ from dataclasses import asdict, is_dataclass
 from types import UnionType
 from typing import (
     Any,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -411,8 +412,25 @@ def parse_json_with_stability(
     # Layer 3: Structure tolerance
     # Handle case where model returns [{"xxx": ...}] instead of {"xxx": ...}
     if isinstance(parsed_data, list) and len(parsed_data) > 0:
-        parsed_data = parsed_data[0]
-        tracer.info("Extracted first item from list response")
+        if not all(isinstance(item, dict) for item in parsed_data):
+            return None, "Expected dict after parsing, got list of non-dict items"
+        merged_data: Dict[str, Any] = {}
+        for item in parsed_data:
+            for key, value in item.items():
+                if key not in merged_data:
+                    merged_data[key] = value
+                    continue
+                current = merged_data[key]
+                if isinstance(current, list) and isinstance(value, list):
+                    merged_data[key] = [*current, *value]
+                elif current is None:
+                    merged_data[key] = value
+                elif value is None or current == value:
+                    continue
+                else:
+                    return None, f"Conflicting values for '{key}' in list response"
+        parsed_data = merged_data
+        tracer.info("Merged object fields from list response")
     elif (
         isinstance(parsed_data, list)
         and len(parsed_data) == 0
@@ -434,6 +452,11 @@ def parse_json_with_stability(
         for k, v in parsed_data.items():
             if k in expected_fields:
                 filtered_data[k] = v
+        if not filtered_data and parsed_data:
+            return None, (
+                "No expected fields found in response; "
+                f"expected one of {expected_fields}, got {list(parsed_data)}"
+            )
         parsed_data = filtered_data
 
     # If no model class, return the raw dict

--- a/tests/session/memory/test_json_stability.py
+++ b/tests/session/memory/test_json_stability.py
@@ -165,6 +165,19 @@ class TestParseJsonWithStability:
         assert error is None
         assert data.reasonning == "test"
 
+    def test_merges_multiple_items_from_list_response(self):
+        content = '[{"tags": ["a"]}, {"tags": ["b"], "reasonning": "test"}]'
+        data, error = parse_json_with_stability(content, model_class=self.TestModel)
+        assert error is None
+        assert data.reasonning == "test"
+        assert data.tags == ["a", "b"]
+
+    def test_reports_conflicting_scalar_values_from_list_response(self):
+        content = '[{"count": 1}, {"count": 2}]'
+        data, error = parse_json_with_stability(content, model_class=self.TestModel)
+        assert data is None
+        assert "Conflicting values" in error
+
     def test_handles_empty_list_for_operations_model(self):
         """A bare [] from the operations model (opted in via _allow_empty_list_response)
         is a valid 'no operations' outcome: mapped to an empty object, not an error."""
@@ -205,6 +218,18 @@ class TestParseJsonWithStability:
         assert error is None
         assert data.reasonning == "test"
         assert data.count == 42
+
+    def test_fails_loud_when_all_fields_are_filtered(self):
+        content = '{"current_status": "test", "memories": [{"content": "x"}]}'
+        data, error = parse_json_with_stability(
+            content,
+            model_class=self.TestModel,
+            expected_fields=["preferences", "entities"],
+        )
+        assert data is None
+        assert "No expected fields found" in error
+        assert "current_status" in error
+        assert "memories" in error
 
     def test_returns_raw_dict_when_no_model_class(self):
         """Test returns dict when no model_class is provided."""


### PR DESCRIPTION
## Summary
- Fixes #3508.
- Merge multi-object root JSON lists instead of silently keeping only the first item, preserving repeated list-valued memory fields.
- Fail parse loudly when a non-empty response contains none of the active ExtractLoop schema fields, instead of validating empty defaults and reporting success.
- Keep existing empty-list opt-in behavior for operations models.

## Validation
- `uv run ruff check openviking/session/memory/utils/json_parser.py tests/session/memory/test_json_stability.py`
- `uv run python -m compileall -q openviking/session/memory/utils/json_parser.py tests/session/memory/test_json_stability.py`
- `PYTHONPATH=. uv run pytest -p pr3508_pytest_plugin tests/session/memory/test_json_stability.py -q --no-cov` → 42 passed

Note: the temporary pytest plugin was only used to work around this machine lacking local llama-cpp/embedding dependencies and was deleted before commit.