### PR TITLE
fix(vectordb): coerce range_out filter values like range does

### DIFF
--- a/openviking/storage/vectordb_adapters/opengauss_adapter.py
+++ b/openviking/storage/vectordb_adapters/opengauss_adapter.py
@@ -609,10 +609,10 @@ class OpenGaussCollection(ICollection):
             params = []
             if payload.get("gte") is not None:
                 clauses.append(f"{_quote_ident(field)} < %s")
-                params.append(payload["gte"])
+                params.append(_coerce_sql_value(payload["gte"], self._field_types.get(field)))
             if payload.get("lte") is not None:
                 clauses.append(f"{_quote_ident(field)} > %s")
-                params.append(payload["lte"])
+                params.append(_coerce_sql_value(payload["lte"], self._field_types.get(field)))
             return " OR ".join(clauses), params
         if op == "contains":
             field = str(payload.get("field") or "")

--- a/openviking/storage/vectordb_adapters/qdrant_adapter.py
+++ b/openviking/storage/vectordb_adapters/qdrant_adapter.py
@@ -316,9 +316,13 @@ class QdrantCollectionAdapter(CollectionAdapter):
             field = payload.get("field")
             branches: List[Dict[str, Any]] = []
             if payload.get("gte") is not None:
-                branches.append({"must": [self._range_condition(field, {"lt": payload["gte"]})]})
+                branches.append(
+                    {"must": [self._range_condition(field, {"lt": self._coerce_datetime_value(payload["gte"])})]}
+                )
             if payload.get("lte") is not None:
-                branches.append({"must": [self._range_condition(field, {"gt": payload["lte"]})]})
+                branches.append(
+                    {"must": [self._range_condition(field, {"gt": self._coerce_datetime_value(payload["lte"])})]}
+                )
             return self._should_clause(*branches)
         if op == "contains":
             return {

--- a/tests/storage/test_opengauss_adapter.py
+++ b/tests/storage/test_opengauss_adapter.py
@@ -95,6 +95,24 @@ def test_collection_filter_to_sql_for_path_scope():
     ]
 
 
+def test_range_out_coerces_values_like_range():
+    # range_out must coerce filter values by field type, exactly like range /
+    # time_range do. Without coercion an int64 bound passed as a string reaches
+    # the SQL layer un-typed, producing an inconsistent (and potentially wrong)
+    # comparison versus the same bound expressed via `range`.
+    collection = object.__new__(OpenGaussCollection)
+    collection._field_types = {"score": "int64"}
+
+    clause, params = collection._compile_filter(
+        {"op": "range_out", "field": "score", "gte": "10", "lte": "20"}
+    )
+
+    assert '"score" < %s' in clause
+    assert '"score" > %s' in clause
+    # coerced to int, not left as the raw "10" / "20" strings
+    assert params == [10, 20]
+
+
 def test_vector_literal_and_identifier_safety():
     assert _vector_literal([1, 2.5, float("nan")]) == "[1,2.5,0]"
 


### PR DESCRIPTION
## Summary
The `range` / `time_range` filter ops coerce their bound values by field type before handing them to the backend, but the sibling `range_out` op passed **raw** values through — in **both** the openGauss and Qdrant adapters.

## Root cause
openGauss `_compile_filter`: `range` uses `_coerce_sql_value(payload[key], field_type)`; `range_out` appended `payload["gte"]` raw. Qdrant: `range`/`time_range` wrap bounds in `self._coerce_datetime_value(...)`; `range_out` did not.

`_coerce_sql_value` / `_coerce_datetime_value` are **not** no-ops for non-string inputs: `int64`/`float` coerce `"10"` → `10`; `date_time` coerces a `date` → a UTC `datetime`. So an **exclusion** filter (`range_out`) on the same field as an **inclusion** filter (`range`) binds a differently-typed value at the query layer — e.g. `"10"` instead of `10` — producing a different, potentially wrong comparison. `range_out` is a first-class op emitted by the filter DSL (`data_processor._convert_filter_node`).

## Fix
Apply the same per-field-type coercion to `range_out` bounds in both adapters, symmetric with the existing `range` branch.

## Test plan
Added `test_range_out_coerces_values_like_range` (openGauss): an `int64` `range_out` bound must be coerced to `int` (`[10, 20]`), not left as `["10","20"]`. Verified end-to-end via a concrete subclass (before `['10','20']` → after `[10,20]`). Both adapters import cleanly.
> The new test mirrors the existing `object.__new__(OpenGaussCollection)` pattern in that file (works on CI Python 3.10; both fail identically only under 3.12 due to an unrelated `object.__new__`-on-ABC change).

---
## 中文说明
### 问题
`range`/`time_range` 会按字段类型归一 bound 值,但兄弟算子 `range_out` 在 openGauss 和 Qdrant 两个 adapter 里都直接透传原值。
### 根因
openGauss:`range` 用 `_coerce_sql_value(..., field_type)`,`range_out` 直接 append 原值;Qdrant:`range` 包了 `_coerce_datetime_value`,`range_out` 没包。这两个 coerce 对非字符串输入**不是** no-op:int64/float 把 `"10"`→`10`,date_time 把 `date`→UTC `datetime`。于是同一字段上,排除过滤(range_out)绑定的值类型和包含过滤(range)不一致——比如绑成字符串 `"10"` 而非整数 `10`——比较结果可能出错。`range_out` 是 filter DSL 的一等算子(由 `data_processor._convert_filter_node` 产生)。
### 修复
两个 adapter 的 `range_out` bound 套用与 `range` 相同的按字段类型归一。
### 测试
新增 `test_range_out_coerces_values_like_range`(openGauss):int64 的 range_out bound 必须归一成 int(`[10,20]`)而非 `["10","20"]`。用具体子类端到端验证(修复前 `['10','20']` → 修复后 `[10,20]`)。两个 adapter 均可正常 import。
> 新测试沿用该文件已有的 `object.__new__` 模式(在 CI 的 py3.10 通过;仅在 py3.12 因无关的 `object.__new__`-on-ABC 变化而与现有同类测试一起失败)。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)