### PR TITLE
fix(vectordb): enforce the UINT16 length contract for list<string> elements

### DIFF
--- a/openviking/storage/vectordb/store/bytes_row.py
+++ b/openviking/storage/vectordb/store/bytes_row.py
@@ -199,6 +199,10 @@ class _PyBytesRow:
                 for item in value:
                     bytes_item = item.encode("utf-8")
                     bytes_item_len = len(bytes_item)
+                    if bytes_item_len > STRING_MAX_UINT16_LENGTH:
+                        raise ValueError(
+                            f"string element in list field '{field_meta.name}' exceeds 65535 bytes"
+                        )
                     var_fmt_list.append("H")
                     var_val_list.append(bytes_item_len)
                     var_fmt_list.append(f"{bytes_item_len}s")

--- a/tests/vectordb/test_bytes_row.py
+++ b/tests/vectordb/test_bytes_row.py
@@ -125,6 +125,22 @@ class TestBytesRow(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "text.*exceeds 65535 bytes"):
             py_row.serialize({"text": text})
 
+    def test_oversized_list_string_element_serialization_raises(self):
+        # A list<string> element uses the same UINT16 length prefix as a scalar
+        # string, so it must reject >65535-byte elements with the same clean,
+        # field-attributed ValueError — not a raw struct.error from deep inside
+        # struct.pack_into.
+        py_schema = _PySchema(
+            [{"name": "tags", "data_type": _PyFieldType.list_string, "id": 0}]
+        )
+        py_row = _PyBytesRow(py_schema)
+        with self.assertRaisesRegex(ValueError, "tags.*exceeds 65535 bytes"):
+            py_row.serialize({"tags": ["x" * 65536, "ok"]})
+
+        # A list of in-bounds strings (including multibyte) still round-trips.
+        blob = py_row.serialize({"tags": ["hello", "世界"]})
+        self.assertEqual(py_row.deserialize_field(blob, "tags"), ["hello", "世界"])
+
     def test_binary_data(self):
         @serializable
         @dataclass


### PR DESCRIPTION
## Summary

The row serializer (`_PyBytesRow.serialize`) encodes every string's byte length as a **UINT16** prefix. The scalar `string` field guards that contract; the `list<string>` element path — which uses the *identical* UINT16 prefix — did not. An oversized list element therefore escaped as a raw, opaque `struct.error` instead of the clean, field-named `ValueError` the scalar path guarantees.

### Root cause

`openviking/storage/vectordb/store/bytes_row.py`. Scalar `string` (guarded):
```python
if bytes_item_len > STRING_MAX_UINT16_LENGTH:
    raise ValueError(f"string field '{field_meta.name}' exceeds 65535 bytes")
var_fmt_list.append("H")   # UINT16
```
`list<string>` element loop (before this PR — no guard):
```python
for item in value:
    bytes_item = item.encode("utf-8")
    bytes_item_len = len(bytes_item)
    var_fmt_list.append("H")            # same UINT16 prefix, unchecked
    var_val_list.append(bytes_item_len)
```

### Why it matters

This is a **type-checked-contract integrity** gap. The serializer's UINT16 length prefix is a hard invariant; the scalar path upholds it, the list path silently does not. Concretely:

- **X:** `serialize({"tags": ["x"*70000, "y"]})` where `tags` is `list<string>`.
- **Before:** `struct.error: 'H' format requires 0 <= number <= 65535` — raised deep inside `struct.pack_into`, a *different exception type* that names *no field*. Callers catching `ValueError` (per the scalar contract) won't catch it, and the message gives no clue which field/element overflowed.
- **After:** `ValueError: string element in list field 'tags' exceeds 65535 bytes` — symmetric with the scalar guarantee.

### Fix

Add the same `STRING_MAX_UINT16_LENGTH` bounds check inside the `list<string>` element loop. Bounded, and mirrors an invariant the code already commits to for scalar strings.

> Follow-up (out of scope here): the list *element count* is also written as UINT16 (`list_int64`/`list_float32`/`list_string`); a list with >65535 elements hits the same raw `struct.error`. Higher threshold and far less likely than a single oversized string element, so left for a separate guard.

## Test plan

- Added `test_oversized_list_string_element_serialization_raises` alongside the existing scalar `test_oversized_string_serialization_raises`: asserts the clean field-attributed `ValueError`, and that an in-bounds list (incl. multibyte `"世界"`) still round-trips.
- Fails before the fix (raw `struct.error`), passes after.
- No regressions: `tests/vectordb/test_bytes_row.py` has the same 5 pre-existing C++-engine-dependent failures on `main` and on this branch; the branch adds 1 passing test.

---

## 中文说明

### 问题
行序列化器把每个字符串的字节长度写成 **UINT16** 前缀。标量 `string` 字段对这个契约做了校验;但 `list<string>` 的元素路径用的是**完全相同**的 UINT16 前缀,却没有校验。于是超长的 list 元素不是抛出标量路径那种干净、带字段名的 `ValueError`,而是抛出一个原始、晦涩的 `struct.error`。

### 根因
`bytes_row.py`:标量 `string` 有 `if bytes_item_len > STRING_MAX_UINT16_LENGTH: raise ValueError(...)` 守卫;`list<string>` 元素循环没有,直接把 `bytes_item_len` 塞进 `"H"`(UINT16)。

### 影响(类型契约完整性)
序列化器的 UINT16 长度前缀是硬不变量。标量路径守住了,list 路径静默没守:
- **输入:** `serialize({"tags": ["x"*70000, "y"]})`(`tags` 为 `list<string>`)
- **修复前:** `struct.error: 'H' format requires 0 <= number <= 65535` —— 从 `struct.pack_into` 深处抛出,**异常类型不同、且不含字段名**。按标量契约 `catch ValueError` 的调用方接不住,也无从知道是哪个字段/元素溢出。
- **修复后:** `ValueError: string element in list field 'tags' exceeds 65535 bytes` —— 与标量路径对称。

### 修复
在 `list<string>` 元素循环内加同样的 `STRING_MAX_UINT16_LENGTH` 校验。改动有界,且只是补齐代码在标量路径已承诺的不变量。

> 后续(本 PR 不含):list 的**元素个数**也写成 UINT16(`list_int64`/`list_float32`/`list_string`),>65535 个元素会触发同样的原始 `struct.error`。阈值更高、比单个超长字符串元素罕见得多,留作单独守卫。

### 测试
在现有标量 `test_oversized_string_serialization_raises` 旁新增 `test_oversized_list_string_element_serialization_raises`:断言干净的带字段名 `ValueError`,并验证界内 list(含多字节 `"世界"`)仍能正确 round-trip。修复前(原始 struct.error)失败,修复后通过。无回归:`test_bytes_row.py` 在 main 和本分支有相同的 5 个预存(依赖 C++ 引擎)失败,本分支多 1 个通过的测试。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)