### PR TITLE
fix(memory): preserve all patch blocks when creating a new memory

### DIFF
--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -114,21 +114,28 @@ class PatchOp(MergeOpBase):
         Returns:
             The replace content, or empty string if not available
         """
-        from openviking.session.memory.merge_op.base import StrPatch
-
-        # Case 1: StrPatch object
+        # Case 1: StrPatch object — concatenate ALL blocks' replace content.
+        # The schema instructs the model to split non-adjacent edits into
+        # separate blocks, so a new memory routinely arrives as a multi-block
+        # patch. Taking only blocks[0] would silently drop every subsequent
+        # fact/preference the model extracted.
         if isinstance(patch_value, StrPatch):
-            replace = patch_value.get_first_replace()
-            return replace if replace is not None else ""
+            replaces = [b.replace for b in patch_value.blocks if b.replace is not None]
+            return "\n".join(replaces) if replaces else ""
 
-        # Case 2: dict form
+        # Case 2: dict form (from JSON parsing) — same, collect every block.
         if isinstance(patch_value, dict) and "blocks" in patch_value:
-            blocks = patch_value.get("blocks", [])
-            if blocks:
-                first_block = blocks[0]
-                if isinstance(first_block, dict):
-                    replace = first_block.get("replace")
-                    return replace if replace is not None else ""
+            replaces = []
+            for block in patch_value.get("blocks", []):
+                if isinstance(block, SearchReplaceBlock):
+                    replace = block.replace
+                elif isinstance(block, dict):
+                    replace = block.get("replace")
+                else:
+                    replace = None
+                if replace is not None:
+                    replaces.append(replace)
+            return "\n".join(replaces) if replaces else ""
 
         # Case 3: Simple string - use as is
         if isinstance(patch_value, str):

--- a/tests/unit/session/memory/test_patch_no_original_multiblock.py
+++ b/tests/unit/session/memory/test_patch_no_original_multiblock.py
@@ -1,0 +1,66 @@
+"""Regression tests: all blocks must be preserved when creating a new memory.
+
+When ``current_value is None`` (the memory file does not exist yet),
+``PatchOp._extract_replace_when_no_original`` previously took only the
+first block's replace content — silently discarding every subsequent block.
+
+The schema instructs the LLM to "split non-adjacent edits into separate
+blocks."  A new memory therefore routinely arrives as a multi-block patch
+(e.g. one block per extracted fact or preference).  Dropping all but the
+first block means every fact after the first is silently lost with no log,
+warning, or error visible to the caller.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openviking.session.memory.merge_op.base import FieldType, SearchReplaceBlock, StrPatch
+from openviking.session.memory.merge_op.patch import PatchOp
+
+
+class TestNewMemoryMultiBlockPatch:
+    """PatchOp: all blocks must survive when writing a new memory."""
+
+    def test_strpatch_multiblock_no_silent_loss(self):
+        """All StrPatch blocks are joined when current_value is None."""
+        op = PatchOp(FieldType.STRING)
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(search="", replace="Fact A: user prefers dark mode."),
+                SearchReplaceBlock(search="", replace="Fact B: user is in Tokyo."),
+            ]
+        )
+        result = op.apply(None, patch)
+        assert "Fact A" in result, "block 0 content should be present"
+        assert "Fact B" in result, "block 1 content was silently dropped before the fix"
+
+    def test_dict_form_multiblock_no_silent_loss(self):
+        """dict-form blocks (the actual JSON-parsed LLM path) are all joined."""
+        op = PatchOp(FieldType.STRING)
+        patch_value = {
+            "blocks": [
+                {"search": "", "replace": "Line 1 preference"},
+                {"search": "", "replace": "Line 2 fact"},
+            ]
+        }
+        result = op.apply(None, patch_value)
+        assert "Line 1" in result
+        assert "Line 2" in result, "second dict block was silently dropped before the fix"
+
+    def test_single_block_behaviour_unchanged(self):
+        """The common single-block case is unaffected by this change."""
+        op = PatchOp(FieldType.STRING)
+        patch = StrPatch(blocks=[SearchReplaceBlock(search="", replace="Only fact.")])
+        result = op.apply(None, patch)
+        assert result == "Only fact."
+
+    def test_existing_content_path_unaffected(self):
+        """When current_value is NOT None the existing search/replace path runs."""
+        op = PatchOp(FieldType.STRING)
+        patch = StrPatch(
+            blocks=[SearchReplaceBlock(search="old text", replace="new text")]
+        )
+        result = op.apply("some old text here", patch)
+        assert "new text" in result
+        assert "old text" not in result


### PR DESCRIPTION
## Summary

When writing a memory that has **no existing content** (`current_value is None`), `PatchOp` returned only the **first** block's replace text and silently discarded every subsequent block. Because the `StrPatch` schema tells the model to split non-adjacent edits into separate blocks, a brand-new memory routinely arrives as a multi-block patch — so facts/preferences extracted from the session were being dropped with no signal.

### Root cause

`openviking/session/memory/merge_op/patch.py` → `_extract_replace_when_no_original`:

```python
# StrPatch object
replace = patch_value.get_first_replace()   # only blocks[0]
return replace if replace is not None else ""
# dict form
first_block = blocks[0]                      # only blocks[0]
return first_block.get("replace") ...
```

The **existing-content** path (`apply_str_patch`) already iterates *all* blocks. The no-original branch was an asymmetric omission, not a deliberate choice.

### Concrete loss scenario

The model is instructed to split edits into separate blocks. Writing a new memory, it emits e.g.:
- block 0 → `"Fact A: user prefers dark mode."`
- block 1 → `"Fact B: user is in Tokyo."`

`apply(None, patch)` returns only `"Fact A: user prefers dark mode."`. **`Fact B` is gone** — no log, no warning, no telemetry, no caller-visible signal. This is silent context loss in the session→memory path, precisely the failure mode a memory layer must not have.

### Fix

Concatenate every block's `replace` (joined by newline) in both the `StrPatch` and dict forms. The common single-block case is unchanged (`"\n".join([x]) == x`); the existing-content path is untouched.

> Note: `StrPatch.get_first_replace()` in `base.py` now has no remaining caller. Left in place to keep this PR focused; can be removed in a follow-up.

## Test plan

- Added `tests/unit/session/memory/test_patch_no_original_multiblock.py`:
  - multi-block `StrPatch` and multi-block **dict form** → all blocks preserved (both **fail before** the fix)
  - single-block and existing-content paths → behaviour pinned unchanged
- Before fix: the 2 multi-block tests fail (second block missing); after fix: all 4 pass.

---

## 中文说明

### 问题
写入一条**尚无内容**的 memory 时(`current_value is None`),`PatchOp` 只返回**第一个** block 的 replace,静默丢弃其余所有 block。由于 `StrPatch` 的 schema 要求模型把不相邻的编辑拆成多个 block,新建 memory 常常就是多 block patch——于是从会话里抽取出的事实/偏好被丢掉。

### 根因
`patch.py` 的 `_extract_replace_when_no_original`:StrPatch 走 `get_first_replace()`(只取 blocks[0]),dict 形式取 `blocks[0]`。而**有内容**的路径(`apply_str_patch`)本就遍历所有 block——no-original 分支是不对称的遗漏。

### 具体丢失场景
模型被要求把编辑拆成多个 block。新建 memory 时它产出:block0=`"Fact A: 偏好深色模式"`、block1=`"Fact B: 在东京"`。`apply(None, patch)` 只返回 `"Fact A..."`,**`Fact B` 直接消失**——无日志、无告警、无 telemetry、调用方完全无感。这正是 session→memory 路径上的静默上下文丢失,记忆层绝不该有的失败模式。

### 修复
StrPatch 与 dict 两种形式都拼接**所有** block 的 replace(换行连接)。常见单 block 场景不变(`"\n".join([x]) == x`);有内容路径不受影响。

> 注:`base.py` 的 `StrPatch.get_first_replace()` 修复后已无调用方。为保持本 PR 聚焦,暂予保留,可在后续 PR 移除。

### 测试
新增 `tests/unit/session/memory/test_patch_no_original_multiblock.py`:多 block StrPatch、多 block dict 形式 → 全部 block 保留(修复前均失败);单 block、有内容路径 → 行为不变。修复前 2 个多 block 用例失败,修复后 4 个全通过。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)