### PR TITLE
fix(memory): keep transient task state out of profiles

### DIFF
--- a/openviking/prompts/templates/memory/profile.yaml
+++ b/openviking/prompts/templates/memory/profile.yaml
@@ -1,15 +1,18 @@
 memory_type: profile
 description: |
   # Task Objective
-  User profile memory - captures an identity summary of who the user is as a person.
-  Extract relatively stable personal attributes that define the user's identity at a high level.
-  Include: profession, experience level, technical background, communication style, work habits, etc.
-  Do NOT include transient conversation content or temporary mood states.
+  User profile memory - captures stable identity, work style, and preferences that describe who the user is as a person.
+  Extract durable or slowly changing personal attributes that remain useful across projects and conversations.
+  Include: profession, experience level, technical background, communication style, recurring work habits, and long-term preferences.
+  Do NOT include transient conversation content, temporary mood states, or project/task state.
 
   # Rules
   - Each item: self-contained, declarative sentence, < 30 words
   - Extract only facts stated/confirmed by user; no guesses
-  - Focus on persistent information, not temporary situations
+  - Focus on persistent personal information, not temporary situations
+  - Exclude repository-specific activity, current project phases, one-off tasks, branches, tickets, local paths, blockers, and deadlines
+  - A date or timestamp does not make transient project/task state eligible for profile memory
+  - Store useful project-specific facts as entities or events instead of profile attributes
   - Forbidden: events, only-assistant content, sensitive/private info, trivial updates
   - Merge similar items; keep latest if conflicting
 
@@ -23,20 +26,16 @@ fields:
     description: |
       User profile content in Markdown format describing "who the user is".
       Use Markdown heading(s) with only the person's name, then bullets only; do not write paragraph bodies.
-      Includes relatively stable personal attributes: profession, experience, tech stack, communication style, etc.
-      Only record objective statuses, do not record events or similar information.
-      [IMPORTANT] For changeable statuses, must include the last updated time in the format: (as of 2023-06-09)
+      Include only relatively stable personal attributes: profession, experience, technical background,
+      communication style, recurring work habits, and long-term preferences.
+      Slowly changing personal attributes such as current occupation may include a last-confirmed date,
+      but only when they describe the person beyond a single project or task.
+      Do not record project/task status even when it has a date. Route useful project-specific state to
+      entity or event memory instead.
       Example:
       # Caroline
-      - Date of birth
-      - Gender: Female
-      - Age: 25 (as of 2023-06-09)
-      - Nickname
-      - Place of origin
-      - Place of residence
-      - Regular city of residence
-      - Current occupation
-      - Relationship status: Single (as of 2023-06-09)
-      - Career plan
-      etc.
+      - Profession: Software engineer
+      - Technical background: Python and distributed systems
+      - Communication style: Prefers concise explanations with concrete examples
+      - Work habits: Uses regression tests when changing established behavior
     merge_op: patch

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -79,10 +79,27 @@ def test_profile_memory_template_includes_stable_identity_work_style_and_prefere
     assert '"who the user is"' in text
     assert "identity, work style, and preferences" in text
     assert "profession, experience level, technical background" in text
-    assert "communication style, work habits" in text
+    assert "communication style, recurring work habits" in text
     assert "Do NOT include transient conversation content" in text
     assert "Each item: self-contained" in text
-    assert "Only record objective statuses" in text
+    assert "Slowly changing personal attributes such as current occupation" in text
+
+
+def test_profile_memory_template_excludes_transient_project_and_task_state():
+    template_path = PromptManager._get_bundled_templates_dir() / "memory" / "profile.yaml"
+    schema = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+    text = "\n".join(
+        [
+            schema["description"],
+            schema["fields"][0]["description"],
+        ]
+    )
+
+    assert "repository-specific activity, current project phases, one-off tasks" in text
+    assert "branches, tickets, local paths, blockers, and deadlines" in text
+    assert "date or timestamp does not make transient project/task state eligible" in text
+    assert "project/task status even when it has a date" in text
+    assert "entities or events instead of profile attributes" in text
 
 
 def test_preferences_memory_template_keeps_topic_specific_preferences():


### PR DESCRIPTION
## Description

Keep transient project and task state out of profile memory while preserving durable or slowly changing personal attributes.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3683

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Define profile memory as stable identity, work style, and long-term preferences.
- Exclude repository activity, project phases, one-off tasks, paths, blockers, and deadlines even when dated.
- Add focused regression coverage for the profile boundary.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Targeted Profile tests pass (2 passed). Ruff, formatting, YAML parsing, and git diff --check pass.

The full tests/test_prompt_manager.py run has one unrelated, pre-existing Preferences template assertion failure; the same failure occurs on origin/main.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The change is limited to the built-in Profile memory prompt and focused regression tests. It does not alter memory schemas, APIs, retrieval, or lifecycle behavior.
