### PR TITLE
feat(agent-evolution): persist experience trajectory provenance

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -100,26 +100,31 @@ async def _commit_experience_snapshot(
     ctx: RequestContext,
     experience_uris: list[str],
     archive_uri: str = "",
-) -> None:
+) -> Optional[str]:
     commit = getattr(viking_fs, "commit", None)
     if not callable(commit):
-        return
+        return None
     has_experience_changes = any(
         "/memories/experiences/" in uri and uri.endswith(".md")
         for uri in dict.fromkeys(str(uri or "") for uri in experience_uris)
     )
     if not has_experience_changes:
-        return
+        return None
     paths = [_experience_root_uri(ctx)]
     archive_ref = archive_uri.rstrip("/") if archive_uri else "unknown"
     try:
-        await commit(
+        result = await commit(
             message=f"Update experience memories from session commit {archive_ref}",
             paths=paths,
             ctx=ctx,
         )
+        if not isinstance(result, dict) or result.get("result") != "created":
+            return None
+        commit_oid = str(result.get("commit_oid") or "")
+        return commit_oid or None
     except Exception as exc:
         logger.warning("Failed to commit experience snapshot for %s: %s", paths, exc, exc_info=True)
+        return None
 
 
 class SessionCompressorV3:
@@ -889,8 +894,9 @@ class SessionCompressorV3:
                         viking_fs=viking_fs,
                     )
                 exp_apply_result = getattr(exp_training_result, "apply_result", None)
+                snapshot_commit_id: Optional[str] = None
                 if exp_apply_result is not None:
-                    await _commit_experience_snapshot(
+                    snapshot_commit_id = await _commit_experience_snapshot(
                         viking_fs,
                         ctx=ctx,
                         experience_uris=[
@@ -929,6 +935,7 @@ class SessionCompressorV3:
                         viking_fs=viking_fs,
                         ctx=ctx,
                         archive_uri=archive_uri,
+                        snapshot_commit_id=snapshot_commit_id,
                     )
                     if _memory_diff_has_changes(memory_diff):
                         memory_diffs.append(memory_diff)
@@ -965,6 +972,7 @@ class SessionCompressorV3:
         viking_fs: Any,
         ctx: RequestContext,
         archive_uri: str,
+        snapshot_commit_id: Optional[str] = None,
     ) -> dict[str, Any]:
         adds: list[dict[str, Any]] = []
         updates: list[dict[str, Any]] = []
@@ -997,10 +1005,11 @@ class SessionCompressorV3:
         for item in training_result.plan.items:
             if item.memory_type != "experiences":
                 continue
-            if source_trajectory_uris and not _plan_item_has_source_trajectory(
+            item_source_trajectory_uris = _plan_item_source_trajectory_uris(
                 item,
-                source_trajectory_uris,
-            ):
+                allowed_uris=source_trajectory_uris if source_trajectory_uris else None,
+            )
+            if source_trajectory_uris and not item_source_trajectory_uris:
                 continue
             uri = _experience_plan_item_uri(item, root_uri)
             if not uri:
@@ -1024,8 +1033,19 @@ class SessionCompressorV3:
                 fallback=item.after_content or "",
             )
             before = item.before_content
+            provenance = {
+                "source_trajectory_uris": item_source_trajectory_uris,
+                "snapshot_commit_id": snapshot_commit_id,
+            }
             if before is None:
-                adds.append({"uri": uri, "memory_type": "experiences", "after": after})
+                adds.append(
+                    {
+                        "uri": uri,
+                        "memory_type": "experiences",
+                        "after": after,
+                        **provenance,
+                    }
+                )
             else:
                 # Filter no-op experience updates the same way as user-memory
                 # updates: a patch that re-serializes to identical content should
@@ -1044,6 +1064,7 @@ class SessionCompressorV3:
                         "memory_type": "experiences",
                         "before": before,
                         "after": after,
+                        **provenance,
                     }
                 )
 
@@ -1685,18 +1706,31 @@ def _case_experience_links_via_trajectories(
 
 
 def _plan_item_has_source_trajectory(item: PolicyPlanItem, trajectory_uris: set[str]) -> bool:
+    return bool(_plan_item_source_trajectory_uris(item, allowed_uris=trajectory_uris))
+
+
+def _plan_item_source_trajectory_uris(
+    item: PolicyPlanItem,
+    *,
+    allowed_uris: Optional[set[str]] = None,
+) -> list[str]:
+    uris: list[str] = []
+    seen: set[str] = set()
     for link in getattr(item, "links", []) or []:
         try:
             stored = link if isinstance(link, StoredLink) else StoredLink(**dict(link))
         except Exception:
             continue
-        if (
-            stored.link_type == "derived_from"
-            and stored.to_uri in trajectory_uris
-            and "/memories/trajectories/" in str(stored.to_uri or "")
-        ):
-            return True
-    return False
+        uri = str(stored.to_uri or "")
+        if stored.link_type != "derived_from" or "/memories/trajectories/" not in uri:
+            continue
+        if allowed_uris is not None and uri not in allowed_uris:
+            continue
+        if uri in seen:
+            continue
+        seen.add(uri)
+        uris.append(uri)
+    return uris
 
 
 def _stored_link(

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -11,7 +11,11 @@ import pytest
 from openviking.message import Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
-from openviking.session.compressor_v3 import SessionCompressorV3, _experience_root_uri
+from openviking.session.compressor_v3 import (
+    SessionCompressorV3,
+    _commit_experience_snapshot,
+    _experience_root_uri,
+)
 from openviking.session.memory.dataclass import (
     MemoryFile,
     ResolvedOperation,
@@ -1117,6 +1121,7 @@ async def test_v3_fast_path_writes_final_memory_diff_with_case_traj_and_exp(monk
 @pytest.mark.asyncio
 async def test_v3_builds_training_memory_diff_from_streaming_result(monkeypatch):
     archive_uri = "viking://user/u/sessions/s1/history/archive_001"
+    snapshot_commit_id = "a" * 40
 
     class FakeFS:
         async def read_file(self, uri, ctx=None):
@@ -1181,6 +1186,7 @@ async def test_v3_builds_training_memory_diff_from_streaming_result(monkeypatch)
         viking_fs=FakeFS(),
         ctx=_ctx(),
         archive_uri=archive_uri,
+        snapshot_commit_id=snapshot_commit_id,
     )
 
     assert diff["summary"] == {"total_adds": 1, "total_updates": 1, "total_deletes": 0}
@@ -1189,6 +1195,10 @@ async def test_v3_builds_training_memory_diff_from_streaming_result(monkeypatch)
     assert update["memory_type"] == "experiences"
     assert update["before"] == "old exp content"
     assert update["after"] == "new exp content"
+    assert update["source_trajectory_uris"] == [
+        "viking://user/u/memories/trajectories/duplicate_booking.md"
+    ]
+    assert update["snapshot_commit_id"] == snapshot_commit_id
 
 
 @pytest.mark.asyncio
@@ -1278,10 +1288,44 @@ async def test_v3_training_memory_diff_filters_batch_items_by_current_analysis_t
         viking_fs=FakeFS(),
         ctx=_ctx(),
         archive_uri=archive_uri,
+        snapshot_commit_id="b" * 40,
     )
 
     assert diff["summary"] == {"total_adds": 2, "total_updates": 0, "total_deletes": 0}
     assert [op["uri"] for op in diff["operations"]["adds"]] == [traj_a, exp_a]
+    experience_add = diff["operations"]["adds"][1]
+    assert experience_add["source_trajectory_uris"] == [traj_a]
+    assert experience_add["snapshot_commit_id"] == "b" * 40
+
+
+@pytest.mark.asyncio
+async def test_v3_experience_snapshot_returns_only_created_commit_oid():
+    experience_uri = "viking://user/u/memories/experiences/exp.md"
+    commit_oid = "c" * 40
+
+    created_fs = SimpleNamespace(
+        commit=AsyncMock(return_value={"result": "created", "commit_oid": commit_oid, "changed": 1})
+    )
+    result = await _commit_experience_snapshot(
+        created_fs,
+        ctx=_ctx(),
+        experience_uris=[experience_uri],
+        archive_uri="viking://user/u/sessions/s1/history/archive_001",
+    )
+
+    assert result == commit_oid
+
+    noop_fs = SimpleNamespace(
+        commit=AsyncMock(return_value={"result": "noop", "commit_oid": "d" * 40})
+    )
+    result = await _commit_experience_snapshot(
+        noop_fs,
+        ctx=_ctx(),
+        experience_uris=[experience_uri],
+        archive_uri="viking://user/u/sessions/s1/history/archive_001",
+    )
+
+    assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Persist exact trajectory provenance for each experience snapshot update so downstream APIs can associate an experience commit with the trajectories that produced it.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Return the created snapshot commit ID from the experience snapshot commit helper.
- Add `source_trajectory_uris` and `snapshot_commit_id` to experience add/update operations in `memory_diff.json`.
- Derive trajectory provenance from the exact `derived_from` links on each experience update plan item.
- Keep snapshot scope limited to the current user's `memories/experiences` directory.

## Testing

- `uv run ruff format --check openviking/session/compressor_v3.py tests/session/test_compressor_v3.py`
- `uv run ruff check openviking/session/compressor_v3.py tests/session/test_compressor_v3.py`
- `python -m py_compile openviking/session/compressor_v3.py tests/session/test_compressor_v3.py`
- Executed the three added/updated targeted test functions directly; all assertions passed. The repository's `tests/session` autouse fixture currently fails while initializing the unrelated full local AGFS client before pytest reaches these unit tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation

## Screenshots

N/A

## Additional Notes

Consumers should match an experience operation by both its `uri` and `snapshot_commit_id`. Older memory-diff records remain readable and simply do not contain the new optional provenance fields.
