### PR TITLE
feat(storage): add enable_background_workers switch for read replicas

### DIFF
--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from openviking.core.directories import DirectoryInitializer
 from openviking.core.namespace import canonicalize_uri
 from openviking.privacy import UserPrivacyConfigService
+from openviking.pyagfs.exceptions import AGFSIoError, AGFSPermissionDeniedError
 from openviking.resource.watch_scheduler import WatchScheduler
 from openviking.server.identity import RequestContext, Role
 from openviking.service.debug_service import DebugService
@@ -341,13 +342,37 @@ class OpenVikingService:
         )
         self._directory_initializer = directory_initializer
         default_ctx = RequestContext(user=self._user, role=Role.ROOT)
-        account_count = await directory_initializer.initialize_account_directories(default_ctx)
-        user_count = await directory_initializer.initialize_user_directories(default_ctx)
-        logger.info(
-            "Initialized preset directories account=%d user=%d",
-            account_count,
-            user_count,
-        )
+        if self._config.storage.enable_background_workers:
+            account_count = await directory_initializer.initialize_account_directories(default_ctx)
+            user_count = await directory_initializer.initialize_user_directories(default_ctx)
+            logger.info(
+                "Initialized preset directories account=%d user=%d",
+                account_count,
+                user_count,
+            )
+        else:
+            # Read-only replica: writer owns directory creation; tolerate a read-only workspace.
+            try:
+                account_count = await directory_initializer.initialize_account_directories(
+                    default_ctx
+                )
+                user_count = await directory_initializer.initialize_user_directories(default_ctx)
+                logger.info(
+                    "Verified preset directories account=%d user=%d (read-only replica)",
+                    account_count,
+                    user_count,
+                )
+            except (
+                AGFSPermissionDeniedError,
+                AGFSIoError,
+                PermissionError,
+                OSError,
+            ) as exc:
+                logger.warning(
+                    "Skipping preset directory creation on read-only workspace "
+                    "(storage.enable_background_workers=false): %s",
+                    exc,
+                )
 
         self._privacy_config_service = UserPrivacyConfigService(self._viking_fs)
 
@@ -404,39 +429,47 @@ class OpenVikingService:
             agfs_client=self._agfs_client,
         )
 
-        if self._queue_manager:
-            for queue_name in (
-                self._queue_manager.EXTERNAL_PARSE,
-                self._queue_manager.ADD_RESOURCE,
-            ):
-                self._queue_manager.get_queue(
-                    queue_name,
-                    dequeue_handler=AddResourceProcessor(
-                        self._resource_service,
-                        asyncio.get_running_loop(),
+        # Gate autonomous background write subsystems (QueueFS consumers + WatchScheduler);
+        # read-only replicas set enable_background_workers=false to avoid duplicate writes.
+        if self._config.storage.enable_background_workers:
+            if self._queue_manager:
+                for queue_name in (
+                    self._queue_manager.EXTERNAL_PARSE,
+                    self._queue_manager.ADD_RESOURCE,
+                ):
+                    self._queue_manager.get_queue(
                         queue_name,
-                        self._viking_fs,
+                        dequeue_handler=AddResourceProcessor(
+                            self._resource_service,
+                            asyncio.get_running_loop(),
+                            queue_name,
+                            self._viking_fs,
+                        ),
+                        allow_create=True,
+                    )
+                self._queue_manager.get_queue(
+                    self._queue_manager.SESSION_COMMIT,
+                    dequeue_handler=SessionCommitProcessor(
+                        self._session_service,
+                        asyncio.get_running_loop(),
                     ),
                     allow_create=True,
                 )
-            self._queue_manager.get_queue(
-                self._queue_manager.SESSION_COMMIT,
-                dequeue_handler=SessionCommitProcessor(
-                    self._session_service,
-                    asyncio.get_running_loop(),
-                ),
-                allow_create=True,
+                await self._queue_manager.prepare_task_tracking(get_task_tracker())
+
+            # Do not let watches produce queue work while task ownership is being
+            # rebuilt from QueueFS. Consumers start only after the scheduler is ready.
+            await self._watch_scheduler.start()
+            logger.info("WatchScheduler started")
+
+            if self._queue_manager:
+                self._queue_manager.start()
+                logger.info("QueueManager workers started")
+        else:
+            logger.warning(
+                "storage.enable_background_workers=false: skipping QueueFS consumers and "
+                "WatchScheduler; this process serves reads only."
             )
-            await self._queue_manager.prepare_task_tracking(get_task_tracker())
-
-        # Do not let watches produce queue work while task ownership is being
-        # rebuilt from QueueFS. Consumers start only after the scheduler is ready.
-        await self._watch_scheduler.start()
-        logger.info("WatchScheduler started")
-
-        if self._queue_manager:
-            self._queue_manager.start()
-            logger.info("QueueManager workers started")
 
         # Register as the process-wide service so flows that resolve the
         # service via the dependency global (e.g. background reindex tasks

--- a/openviking_cli/utils/config/storage_config.py
+++ b/openviking_cli/utils/config/storage_config.py
@@ -30,6 +30,14 @@ class StorageConfig(BaseModel):
             "explicitly accept the risk of multi-process storage contention."
         ),
     )
+    enable_background_workers: bool = Field(
+        default=True,
+        description=(
+            "Whether to run autonomous background write subsystems (QueueFS consumer "
+            "workers + WatchScheduler). Set false for a read-only replica sharing the "
+            "workspace with a writer, so it only serves reads and avoids duplicate writes."
+        ),
+    )
 
     agfs: AGFSConfig = Field(default_factory=AGFSConfig, description="AGFS configuration")
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -327,6 +327,45 @@ def test_openviking_config_transaction_redo_recovery_enabled_can_be_disabled(mon
     OpenVikingConfigSingleton.reset_instance()
 
 
+def test_openviking_config_enable_background_workers_defaults_to_true(monkeypatch):
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import (
+        OpenVikingConfig,
+        OpenVikingConfigSingleton,
+    )
+
+    config = OpenVikingConfig.from_dict({})
+
+    assert config.storage.enable_background_workers is True
+
+    OpenVikingConfigSingleton.reset_instance()
+
+
+def test_openviking_config_enable_background_workers_can_be_disabled(monkeypatch):
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")
+
+    from openviking_cli.utils.config.open_viking_config import (
+        OpenVikingConfig,
+        OpenVikingConfigSingleton,
+    )
+
+    config = OpenVikingConfig.from_dict(
+        {
+            "storage": {
+                "enable_background_workers": False,
+                "skip_process_lock": True,
+            }
+        }
+    )
+
+    assert config.storage.enable_background_workers is False
+    assert config.storage.skip_process_lock is True
+
+    OpenVikingConfigSingleton.reset_instance()
+
+
+
 @pytest.mark.parametrize("field_name", ["hotness_alpha", "score_propagation_alpha"])
 def test_openviking_config_retrieval_alpha_validates_range(monkeypatch, field_name):
     monkeypatch.setenv(OPENVIKING_CONFIG_ENV, "/tmp/codex-no-config.json")


### PR DESCRIPTION
Gate QueueFS consumers and WatchScheduler behind a single role-agnostic storage.enable_background_workers switch (default true, backward compatible). Read-only replicas set it false to serve reads only and avoid duplicate queue consumption / reindex, and tolerate a read-only workspace during preset directory init.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
