### PR TITLE
feat(agent-evolution): improve provenance, history, and account settings

### DIFF
--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -530,7 +530,10 @@ This catalog follows the routes actually mounted by the server. Each group headi
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/admin/agent-evolution` | Get the live instance-wide Agent Evolution status |
+| GET | `/api/v1/admin/agent-evolution` | Get the caller account's Agent Evolution status |
+| PUT | `/api/v1/admin/agent-evolution` | Update the caller account's Agent Evolution status |
+| GET | `/api/v1/admin/accounts/{account_id}/settings` | Get effective account settings |
+| PATCH | `/api/v1/admin/accounts/{account_id}/settings` | Update allowlisted account settings |
 | POST | `/api/v1/admin/accounts` | Create an account and its first administrator |
 | GET | `/api/v1/admin/accounts` | List accounts |
 | POST | `/api/v1/admin/migrate` | Migrate legacy identity data |

--- a/docs/en/api/08-admin.md
+++ b/docs/en/api/08-admin.md
@@ -59,8 +59,8 @@ Configure `root_api_key` in `~/.openviking/ovcli.conf`:
 
 ### get_agent_evolution_status
 
-Return the live instance-wide Agent Evolution switch and the configured default
-account ID. The endpoint is ROOT-only.
+Return the effective Agent Evolution switch for the caller's account. ROOT
+operates on the configured default account; ADMIN operates on its own account.
 
 **HTTP API**
 
@@ -86,8 +86,36 @@ curl http://localhost:1933/api/v1/admin/agent-evolution \
 }
 ```
 
-`enabled` is read from the live `server.agent_evolution.enabled` value used by
-session commits. `account_id` is the deployment's configured default account.
+`enabled` is the account override from
+`/local/{account_id}/_system/setting.json`, or
+`server.agent_evolution.enabled` when no override exists. Session commits read
+this effective value without restarting the server.
+
+The existing update endpoint name is unchanged:
+
+```http
+PUT /api/v1/admin/agent-evolution
+Content-Type: application/json
+
+{"enabled": true}
+```
+
+### account_settings
+
+ROOT can manage any account and ADMIN can manage only its own account. The
+generic settings endpoint accepts only explicitly allowlisted fields; currently
+only `agent_evolution.enabled` is writable.
+
+```http
+GET /api/v1/admin/accounts/{account_id}/settings
+PATCH /api/v1/admin/accounts/{account_id}/settings
+Content-Type: application/json
+
+{"agent_evolution": {"enabled": true}}
+```
+
+Before an existing setting is replaced, it is backed up to
+`/local/{account_id}/_system/setting.backup.json`.
 
 ---
 

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -525,7 +525,10 @@ JSON 输出 - 错误：
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/api/v1/admin/agent-evolution` | 获取实例级 Agent 进化开关的实时状态 |
+| GET | `/api/v1/admin/agent-evolution` | 获取调用方 account 的 Agent 进化状态 |
+| PUT | `/api/v1/admin/agent-evolution` | 更新调用方 account 的 Agent 进化状态 |
+| GET | `/api/v1/admin/accounts/{account_id}/settings` | 获取 account 生效配置 |
+| PATCH | `/api/v1/admin/accounts/{account_id}/settings` | 更新白名单内的 account 配置 |
 | POST | `/api/v1/admin/accounts` | 创建账号及首个管理员 |
 | GET | `/api/v1/admin/accounts` | 列出账号 |
 | POST | `/api/v1/admin/migrate` | 迁移旧版身份数据 |

--- a/docs/zh/api/08-admin.md
+++ b/docs/zh/api/08-admin.md
@@ -59,8 +59,8 @@ Admin API 用于多租户环境下的账户和用户管理。包括工作区（a
 
 ### get_agent_evolution_status
 
-返回实例级 Agent 进化开关的实时状态和已配置的默认 account ID。该接口仅限
-ROOT 调用。
+返回调用方所属 account 的 Agent 进化实时状态。ROOT 操作已配置的默认
+account，ADMIN 仅操作自己所属的 account。
 
 **HTTP API**
 
@@ -86,9 +86,34 @@ curl http://localhost:1933/api/v1/admin/agent-evolution \
 }
 ```
 
-`enabled` 来自 session commit 实际使用的
-`server.agent_evolution.enabled` 实时值；`account_id` 是部署配置的默认
-account。
+`enabled` 优先读取
+`/local/{account_id}/_system/setting.json` 中的 account 级覆盖值；未配置时使用
+`server.agent_evolution.enabled`。Session commit 会实时读取生效值，无需重启。
+
+现有更新接口名保持不变：
+
+```http
+PUT /api/v1/admin/agent-evolution
+Content-Type: application/json
+
+{"enabled": true}
+```
+
+### account_settings
+
+ROOT 可管理任意 account，ADMIN 仅可管理自己所属的 account。通用配置接口仅允许
+显式列入白名单的字段；当前只允许修改 `agent_evolution.enabled`。
+
+```http
+GET /api/v1/admin/accounts/{account_id}/settings
+PATCH /api/v1/admin/accounts/{account_id}/settings
+Content-Type: application/json
+
+{"agent_evolution": {"enabled": true}}
+```
+
+覆盖已有配置前，内核会先备份到
+`/local/{account_id}/_system/setting.backup.json`。
 
 ---
 

--- a/openviking/server/account_settings.py
+++ b/openviking/server/account_settings.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Persistent, account-scoped runtime settings."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from openviking.pyagfs import AGFSAlreadyExistsError, AGFSNotFoundError, AsyncAGFSClient
+from openviking.pyagfs.async_client import fs_ctx_from_agfs_path
+from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.session.user_id import validate_account_id
+from openviking_cli.utils.logger import get_logger
+
+ACCOUNT_SETTINGS_PATH_TEMPLATE = "/local/{account_id}/_system/setting.json"
+ACCOUNT_SETTINGS_BACKUP_PATH_TEMPLATE = "/local/{account_id}/_system/setting.backup.json"
+
+logger = get_logger(__name__)
+
+
+class AccountAgentEvolutionSettings(BaseModel):
+    """Account-scoped Agent Evolution override."""
+
+    enabled: bool
+
+    model_config = {"extra": "forbid"}
+
+
+class AccountSettings(BaseModel):
+    """Persisted account overrides.
+
+    Only explicitly allowlisted hot-reloadable settings belong in this model.
+    """
+
+    agent_evolution: Optional[AccountAgentEvolutionSettings] = None
+
+    model_config = {"extra": "forbid"}
+
+
+class AccountSettingsPatch(BaseModel):
+    """Allowlisted account settings accepted by the update API."""
+
+    agent_evolution: Optional[AccountAgentEvolutionSettings] = None
+
+    model_config = {"extra": "forbid"}
+
+
+def account_settings_path(account_id: str) -> str:
+    _validate_account_id(account_id)
+    return ACCOUNT_SETTINGS_PATH_TEMPLATE.format(account_id=account_id)
+
+
+def account_settings_backup_path(account_id: str) -> str:
+    _validate_account_id(account_id)
+    return ACCOUNT_SETTINGS_BACKUP_PATH_TEMPLATE.format(account_id=account_id)
+
+
+def _validate_account_id(account_id: str) -> None:
+    error = validate_account_id(account_id)
+    if error:
+        raise InvalidArgumentError(error)
+
+
+def _decode_read_result(result: Any) -> bytes:
+    if isinstance(result, bytes):
+        return result
+    content = getattr(result, "content", None)
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, str):
+        return content.encode("utf-8")
+    if isinstance(result, str):
+        return result.encode("utf-8")
+    raise InvalidArgumentError("account settings content must be JSON text")
+
+
+def _parse_account_settings(raw: bytes) -> AccountSettings:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidArgumentError(f"Invalid account settings JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise InvalidArgumentError("account settings must be an object")
+    try:
+        return AccountSettings.model_validate(payload)
+    except Exception as exc:
+        raise InvalidArgumentError(str(exc)) from exc
+
+
+async def _read_raw(client: AsyncAGFSClient, path: str) -> Optional[bytes]:
+    try:
+        return _decode_read_result(await client.read(path))
+    except AGFSNotFoundError:
+        return None
+
+
+async def read_account_settings(viking_fs: VikingFS, account_id: str) -> AccountSettings:
+    """Read the persisted overrides for one account."""
+    path = account_settings_path(account_id)
+    raw = await _read_raw(AsyncAGFSClient(viking_fs.agfs), path)
+    return AccountSettings() if raw is None else _parse_account_settings(raw)
+
+
+def effective_agent_evolution_enabled(
+    settings: AccountSettings,
+    *,
+    default_enabled: bool,
+) -> bool:
+    if settings.agent_evolution is None:
+        return bool(default_enabled)
+    return settings.agent_evolution.enabled
+
+
+async def update_account_settings(
+    viking_fs: VikingFS,
+    account_id: str,
+    patch: AccountSettingsPatch,
+) -> AccountSettings:
+    """Apply a locked, backed-up update to one account's settings."""
+    path = account_settings_path(account_id)
+    backup_path = account_settings_backup_path(account_id)
+    client = AsyncAGFSClient(viking_fs.agfs)
+    try:
+        lease = await client.pathlock_acquire_exact(path, timeout_secs=10.0)
+    except LockAcquisitionError as exc:
+        raise ResourceBusyError(
+            "Another account settings update is in progress. Please retry.",
+            uri=path,
+            conflict_type="account_settings_busy",
+        ) from exc
+
+    fs_ctx = fs_ctx_from_agfs_path(path)
+    lease_ref = getattr(lease, "lease_ref", None) or getattr(lease, "id", None)
+    if isinstance(lease, dict):
+        lease_ref = lease.get("lease_ref", lease_ref)
+    if isinstance(lease_ref, str) and lease_ref:
+        fs_ctx["lease_ref"] = lease_ref
+
+    try:
+        current_raw = await _read_raw(client, path)
+        current = AccountSettings() if current_raw is None else _parse_account_settings(current_raw)
+        updated = current.model_copy(deep=True)
+        if patch.agent_evolution is not None:
+            updated.agent_evolution = patch.agent_evolution.model_copy(deep=True)
+        if updated == current:
+            return current
+
+        encoded = json.dumps(
+            updated.model_dump(exclude_none=True),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            await client.ensure_parent_dirs(path)
+        except AGFSAlreadyExistsError:
+            pass
+
+        if current_raw is not None:
+            await client.write(backup_path, current_raw)
+
+        try:
+            await client.write(path, encoded, fs_ctx=fs_ctx)
+        except Exception:
+            try:
+                if current_raw is not None:
+                    await client.write(path, current_raw, fs_ctx=fs_ctx)
+                else:
+                    await client.rm(path, fs_ctx=fs_ctx)
+            except AGFSNotFoundError:
+                pass
+            except Exception:
+                logger.exception(
+                    "Failed to roll back account settings for account %s",
+                    account_id,
+                )
+            raise
+        return updated
+    finally:
+        await client.pathlock_release(lease)

--- a/openviking/server/agent_evolution_config.py
+++ b/openviking/server/agent_evolution_config.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
 from openviking.server.config import ServerConfig
@@ -30,14 +31,29 @@ class AgentEvolutionConfigProvider:
     ) -> None:
         self._last_valid_enabled = bool(default_enabled)
         self._config_path = Path(config_path).expanduser() if config_path else None
+        self._runtime_override: Optional[tuple[bool, str]] = None
+        self._lock = Lock()
 
     def set_default_enabled(self, enabled: bool) -> None:
-        self._last_valid_enabled = bool(enabled)
+        with self._lock:
+            self._last_valid_enabled = bool(enabled)
+
+    def set_runtime_override(self, enabled: bool, revision: str) -> None:
+        """Use a value immediately until the projected config catches up."""
+        with self._lock:
+            self._runtime_override = (bool(enabled), revision)
+            self._last_valid_enabled = bool(enabled)
+
+    def _fallback_enabled(self) -> bool:
+        with self._lock:
+            if self._runtime_override is not None:
+                return self._runtime_override[0]
+            return self._last_valid_enabled
 
     def is_enabled(self) -> bool:
         config_path = self._config_path
         if config_path is None:
-            return self._last_valid_enabled
+            return self._fallback_enabled()
 
         try:
             payload = load_json_config(config_path)
@@ -48,21 +64,30 @@ class AgentEvolutionConfigProvider:
                 server_config = {}
             if not isinstance(server_config, dict):
                 raise ValueError("server must be an object")
-            enabled = ServerConfig.model_validate(server_config).agent_evolution.enabled
+            agent_evolution = ServerConfig.model_validate(server_config).agent_evolution
+            enabled = agent_evolution.enabled
+            revision = agent_evolution.revision
         except OSError as exc:
             logger.warning(
                 "Failed to access Agent Evolution config file %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return self._fallback_enabled()
         except (KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Failed to read Agent Evolution config from %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return self._fallback_enabled()
 
-        self._last_valid_enabled = enabled
-        return enabled
+        with self._lock:
+            if self._runtime_override is not None:
+                override_enabled, override_revision = self._runtime_override
+                if enabled == override_enabled and revision == override_revision:
+                    self._runtime_override = None
+                else:
+                    return override_enabled
+            self._last_valid_enabled = enabled
+            return enabled

--- a/openviking/server/agent_evolution_config.py
+++ b/openviking/server/agent_evolution_config.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Live access to the instance-wide Agent Evolution switch."""
+"""Live access to account-scoped Agent Evolution settings."""
 
 from __future__ import annotations
 
@@ -8,7 +8,12 @@ from pathlib import Path
 from threading import Lock
 from typing import Optional
 
+from openviking.server.account_settings import (
+    effective_agent_evolution_enabled,
+    read_account_settings,
+)
 from openviking.server.config import ServerConfig
+from openviking.storage.viking_fs import VikingFS
 from openviking_cli.utils.config import load_json_config
 from openviking_cli.utils.logger import get_logger
 
@@ -16,44 +21,32 @@ logger = get_logger(__name__)
 
 
 class AgentEvolutionConfigProvider:
-    """Read the live Agent Evolution value from the configured ov.conf.
-
-    Kubernetes projects Secret updates into the mounted config directory
-    atomically. Reading the file at commit time lets already-created sessions
-    observe the new value without restarting the server.
-    """
+    """Resolve ov.conf defaults with persistent account overrides."""
 
     def __init__(
         self,
         *,
         default_enabled: bool,
+        viking_fs: VikingFS,
         config_path: Optional[str | Path] = None,
     ) -> None:
         self._last_valid_enabled = bool(default_enabled)
+        self._last_valid_account_overrides: dict[str, Optional[bool]] = {}
+        self._viking_fs = viking_fs
         self._config_path = Path(config_path).expanduser() if config_path else None
-        self._runtime_override: Optional[tuple[bool, str]] = None
         self._lock = Lock()
 
     def set_default_enabled(self, enabled: bool) -> None:
         with self._lock:
             self._last_valid_enabled = bool(enabled)
 
-    def set_runtime_override(self, enabled: bool, revision: str) -> None:
-        """Use a value immediately until the projected config catches up."""
+    def _default_enabled(self) -> bool:
         with self._lock:
-            self._runtime_override = (bool(enabled), revision)
-            self._last_valid_enabled = bool(enabled)
+            fallback = self._last_valid_enabled
 
-    def _fallback_enabled(self) -> bool:
-        with self._lock:
-            if self._runtime_override is not None:
-                return self._runtime_override[0]
-            return self._last_valid_enabled
-
-    def is_enabled(self) -> bool:
         config_path = self._config_path
         if config_path is None:
-            return self._fallback_enabled()
+            return fallback
 
         try:
             payload = load_json_config(config_path)
@@ -66,28 +59,45 @@ class AgentEvolutionConfigProvider:
                 raise ValueError("server must be an object")
             agent_evolution = ServerConfig.model_validate(server_config).agent_evolution
             enabled = agent_evolution.enabled
-            revision = agent_evolution.revision
         except OSError as exc:
             logger.warning(
                 "Failed to access Agent Evolution config file %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._fallback_enabled()
+            return fallback
         except (KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Failed to read Agent Evolution config from %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._fallback_enabled()
+            return fallback
 
         with self._lock:
-            if self._runtime_override is not None:
-                override_enabled, override_revision = self._runtime_override
-                if enabled == override_enabled and revision == override_revision:
-                    self._runtime_override = None
-                else:
-                    return override_enabled
             self._last_valid_enabled = enabled
             return enabled
+
+    async def is_enabled(self, account_id: str) -> bool:
+        default_enabled = self._default_enabled()
+        try:
+            settings = await read_account_settings(self._viking_fs, account_id)
+            enabled = effective_agent_evolution_enabled(
+                settings,
+                default_enabled=default_enabled,
+            )
+            override = (
+                settings.agent_evolution.enabled if settings.agent_evolution is not None else None
+            )
+            with self._lock:
+                self._last_valid_account_overrides[account_id] = override
+            return enabled
+        except Exception as exc:
+            logger.warning(
+                "Failed to read Agent Evolution settings for account %s, using last valid value: %s",
+                account_id,
+                exc,
+            )
+            with self._lock:
+                override = self._last_valid_account_overrides.get(account_id)
+            return default_enabled if override is None else override

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -85,6 +85,7 @@ class AgentEvolutionConfig(BaseModel):
     """Server-wide Agent Evolution production switch."""
 
     enabled: bool = False
+    revision: Optional[str] = None
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -82,10 +82,9 @@ class AddTargetsConfig(BaseModel):
 
 
 class AgentEvolutionConfig(BaseModel):
-    """Server-wide Agent Evolution production switch."""
+    """Default Agent Evolution setting for accounts without an override."""
 
     enabled: bool = False
-    revision: Optional[str] = None
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -5,7 +5,7 @@
 import asyncio
 
 from fastapi import APIRouter, Body, Depends, Path, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from openviking.server.api_keys.models import validate_account_user_role
 from openviking.server.auth import (
@@ -68,6 +68,11 @@ class MigrateLegacyDataRequest(BaseModel):
     action: str = "migrate"
 
 
+class SetAgentEvolutionRequest(BaseModel):
+    enabled: bool
+    revision: str = Field(min_length=1, max_length=128)
+
+
 @router.get("/agent-evolution")
 @require_auth_root
 async def get_agent_evolution_status(
@@ -81,6 +86,27 @@ async def get_agent_evolution_status(
         status="ok",
         result={
             "enabled": get_service().sessions.get_agent_evolution_enabled(),
+            "account_id": get_openviking_config().default_account,
+        },
+    )
+
+
+@router.put("/agent-evolution")
+@require_auth_root
+async def set_agent_evolution_status(
+    body: SetAgentEvolutionRequest,
+    request: Request,
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Apply the instance-wide Agent Evolution switch immediately."""
+    del request
+    del ctx
+    sessions = get_service().sessions
+    sessions.set_agent_evolution_runtime_enabled(body.enabled, body.revision)
+    return Response(
+        status="ok",
+        result={
+            "enabled": sessions.get_agent_evolution_enabled(),
             "account_id": get_openviking_config().default_account,
         },
     )

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -5,8 +5,15 @@
 import asyncio
 
 from fastapi import APIRouter, Body, Depends, Path, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
+from openviking.server.account_settings import (
+    AccountAgentEvolutionSettings,
+    AccountSettings,
+    AccountSettingsPatch,
+    read_account_settings,
+    update_account_settings,
+)
 from openviking.server.api_keys.models import validate_account_user_role
 from openviking.server.auth import (
     get_api_key_manager_or_raise,
@@ -31,6 +38,7 @@ from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     InvalidArgumentError,
+    NotFoundError,
     PermissionDeniedError,
 )
 from openviking_cli.session.user_id import UserIdentifier
@@ -70,45 +78,52 @@ class MigrateLegacyDataRequest(BaseModel):
 
 class SetAgentEvolutionRequest(BaseModel):
     enabled: bool
-    revision: str = Field(min_length=1, max_length=128)
+
+
+def _agent_evolution_account_id(ctx: RequestContext) -> str:
+    if ctx.role == Role.ROOT:
+        return get_openviking_config().default_account
+    return ctx.account_id
 
 
 @router.get("/agent-evolution")
-@require_auth_root
+@require_auth_root_or_admin
 async def get_agent_evolution_status(
     request: Request,
     ctx: RequestContext = Depends(get_request_context),
 ):
-    """Return the live instance-wide Agent Evolution switch."""
-    del request
-    del ctx
+    """Return the effective Agent Evolution switch for the caller's account."""
+    account_id = _agent_evolution_account_id(ctx)
+    _check_account_exists(request, account_id)
+    enabled = await get_service().sessions.get_agent_evolution_enabled(account_id)
     return Response(
         status="ok",
-        result={
-            "enabled": get_service().sessions.get_agent_evolution_enabled(),
-            "account_id": get_openviking_config().default_account,
-        },
+        result={"enabled": enabled, "account_id": account_id},
     )
 
 
 @router.put("/agent-evolution")
-@require_auth_root
+@require_auth_root_or_admin
 async def set_agent_evolution_status(
     body: SetAgentEvolutionRequest,
     request: Request,
     ctx: RequestContext = Depends(get_request_context),
 ):
-    """Apply the instance-wide Agent Evolution switch immediately."""
-    del request
-    del ctx
-    sessions = get_service().sessions
-    sessions.set_agent_evolution_runtime_enabled(body.enabled, body.revision)
+    """Persist and hot-reload Agent Evolution for the caller's account."""
+    account_id = _agent_evolution_account_id(ctx)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    await update_account_settings(
+        service.viking_fs,
+        account_id,
+        AccountSettingsPatch(agent_evolution=AccountAgentEvolutionSettings(enabled=body.enabled)),
+    )
+    enabled = await service.sessions.get_agent_evolution_enabled(account_id)
     return Response(
         status="ok",
-        result={
-            "enabled": sessions.get_agent_evolution_enabled(),
-            "account_id": get_openviking_config().default_account,
-        },
+        result={"enabled": enabled, "account_id": account_id},
     )
 
 
@@ -128,6 +143,31 @@ def _check_account_access(ctx: RequestContext, account_id: str) -> None:
     """ADMIN can only operate on their own account."""
     if ctx.role == Role.ADMIN and ctx.account_id != account_id:
         raise PermissionDeniedError(f"ADMIN can only manage account: {ctx.account_id}")
+
+
+def _check_account_exists(request: Request, account_id: str) -> None:
+    manager = getattr(request.app.state, "api_key_manager", None)
+    if manager is None:
+        return
+    accounts = manager.get_accounts()
+    if not any(item.get("account_id") == account_id for item in accounts):
+        raise NotFoundError(account_id, "account")
+
+
+async def _account_settings_result(
+    account_id: str,
+    settings: AccountSettings,
+) -> dict:
+    enabled = await get_service().sessions.get_agent_evolution_enabled(account_id)
+    return {
+        "account_id": account_id,
+        "settings": {
+            "agent_evolution": {
+                "enabled": enabled,
+            }
+        },
+        "overrides": settings.model_dump(exclude_none=True),
+    }
 
 
 def _has_add_targets(user_config: UserConfig | None) -> bool:
@@ -325,6 +365,47 @@ async def delete_account(
     # Finally delete the account metadata
     await manager.delete_account(account_id)
     return Response(status="ok", result={"deleted": True})
+
+
+@router.get("/accounts/{account_id}/settings")
+@require_auth_root_or_admin
+async def get_account_settings(
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Return effective and explicitly overridden settings for one account."""
+    _check_account_access(ctx, account_id)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    settings = await read_account_settings(service.viking_fs, account_id)
+    return Response(
+        status="ok",
+        result=await _account_settings_result(account_id, settings),
+    )
+
+
+@router.patch("/accounts/{account_id}/settings")
+@require_auth_root_or_admin
+async def patch_account_settings(
+    body: AccountSettingsPatch,
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Update allowlisted hot-reloadable settings for one account."""
+    _check_account_access(ctx, account_id)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    settings = await update_account_settings(service.viking_fs, account_id, body)
+    return Response(
+        status="ok",
+        result=await _account_settings_result(account_id, settings),
+    )
 
 
 # ---- User endpoints ----

--- a/openviking/server/routers/snapshot.py
+++ b/openviking/server/routers/snapshot.py
@@ -22,7 +22,12 @@ from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
-from openviking_cli.exceptions import InternalError, NotFoundError, OpenVikingError
+from openviking_cli.exceptions import (
+    InternalError,
+    InvalidArgumentError,
+    NotFoundError,
+    OpenVikingError,
+)
 
 router = APIRouter(prefix="/api/v1/snapshot", tags=["snapshot"])
 
@@ -158,6 +163,7 @@ async def restore(
 async def show(
     target_ref: str = Query(..., description="Commit oid, branch, or tag"),
     path: Optional[str] = Query(None, description="Optional viking:// URI for a single blob"),
+    raw: bool = Query(True, description="Return raw stored content with memory fields"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Without ``path``: commit metadata JSON. With ``path``: raw blob bytes + X-Snapshot-* headers."""
@@ -177,12 +183,23 @@ async def show(
             raise mapped from e
         raise
 
+    content = blob["bytes"]
+    if not raw:
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise InvalidArgumentError("raw=false requires UTF-8 snapshot content") from exc
+
+        from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+        content = MemoryFileUtils.read(text, uri=path).content.encode("utf-8")
+
     return FastAPIResponse(
-        content=blob["bytes"],
+        content=content,
         media_type="application/octet-stream",
         headers={
             "X-Snapshot-Oid": str(blob["oid"]),
-            "X-Snapshot-Size": str(blob["size"]),
+            "X-Snapshot-Size": str(len(content)),
         },
     )
 
@@ -196,6 +213,7 @@ async def diff(
         description="Base commit oid, branch, or tag; omit to compare against an empty file",
     ),
     to_ref: str = Query(..., alias="to", description="Target commit oid, branch, or tag"),
+    raw: bool = Query(True, description="Compare raw stored content with memory fields"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Return a unified text diff for one path between two snapshots."""
@@ -205,6 +223,7 @@ async def diff(
             path=path,
             from_ref=from_ref,
             to_ref=to_ref,
+            raw=raw,
             ctx=_ctx,
         )
     except (AGFSClientError, ValueError) as exc:

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -692,12 +692,19 @@ class FSService:
         path: str,
         from_ref: Optional[str],
         to_ref: str,
+        raw: bool = True,
         ctx: RequestContext,
     ) -> Dict[str, Any]:
         """Return a unified text diff for one path between two snapshots."""
         viking_fs = self._ensure_initialized()
         path = validate_viking_uri(path, field_name="path")
-        return await viking_fs.diff(path=path, from_ref=from_ref, to_ref=to_ref, ctx=ctx)
+        return await viking_fs.diff(
+            path=path,
+            from_ref=from_ref,
+            to_ref=to_ref,
+            raw=raw,
+            ctx=ctx,
+        )
 
     async def log(
         self,

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -87,6 +87,12 @@ class SessionService:
             else None
         )
 
+    def set_agent_evolution_runtime_enabled(self, enabled: bool, revision: str) -> None:
+        """Apply an instance-wide value before the projected config refreshes."""
+        self._agent_evolution_enabled = bool(enabled)
+        if self._agent_evolution_config_provider is not None:
+            self._agent_evolution_config_provider.set_runtime_override(enabled, revision)
+
     def get_agent_evolution_enabled(self) -> bool:
         """Return the live instance-wide Agent Evolution switch."""
         if self._agent_evolution_config_provider is None:

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -51,6 +51,7 @@ class SessionService:
         # server.agent_evolution during app setup.
         self._agent_evolution_enabled = True
         self._agent_evolution_config_provider: Optional[AgentEvolutionConfigProvider] = None
+        self._agent_evolution_config_path: Optional[str] = None
         self._usage_reporter: Optional["UsageReporter"] = None
 
     def set_dependencies(
@@ -63,6 +64,7 @@ class SessionService:
         self._vikingdb = vikingdb
         self._viking_fs = viking_fs
         self._session_compressor = session_compressor
+        self._configure_agent_evolution_provider()
 
     def set_tool_output_externalization_config(
         self, config: ToolOutputExternalizationConfig
@@ -71,33 +73,31 @@ class SessionService:
         self._tool_output_externalization_config = config.model_copy(deep=True)
 
     def set_agent_evolution_config(self, config: AgentEvolutionConfig) -> None:
-        """Set the instance-wide Agent Evolution switch."""
+        """Set the default used when an account has no persisted override."""
         self._agent_evolution_enabled = config.enabled
         if self._agent_evolution_config_provider is not None:
             self._agent_evolution_config_provider.set_default_enabled(config.enabled)
 
     def set_agent_evolution_config_path(self, config_path: Optional[str]) -> None:
-        """Enable live reload from the HTTP server's resolved ov.conf path."""
-        self._agent_evolution_config_provider = (
-            AgentEvolutionConfigProvider(
-                default_enabled=self._agent_evolution_enabled,
-                config_path=config_path,
-            )
-            if config_path
-            else None
+        """Enable account settings layered over the resolved ov.conf."""
+        self._agent_evolution_config_path = config_path
+        self._configure_agent_evolution_provider()
+
+    def _configure_agent_evolution_provider(self) -> None:
+        if self._viking_fs is None:
+            self._agent_evolution_config_provider = None
+            return
+        self._agent_evolution_config_provider = AgentEvolutionConfigProvider(
+            default_enabled=self._agent_evolution_enabled,
+            viking_fs=self._viking_fs,
+            config_path=self._agent_evolution_config_path,
         )
 
-    def set_agent_evolution_runtime_enabled(self, enabled: bool, revision: str) -> None:
-        """Apply an instance-wide value before the projected config refreshes."""
-        self._agent_evolution_enabled = bool(enabled)
-        if self._agent_evolution_config_provider is not None:
-            self._agent_evolution_config_provider.set_runtime_override(enabled, revision)
-
-    def get_agent_evolution_enabled(self) -> bool:
-        """Return the live instance-wide Agent Evolution switch."""
+    async def get_agent_evolution_enabled(self, account_id: str) -> bool:
+        """Return the effective Agent Evolution switch for one account."""
         if self._agent_evolution_config_provider is None:
             return self._agent_evolution_enabled
-        return self._agent_evolution_config_provider.is_enabled()
+        return await self._agent_evolution_config_provider.is_enabled(account_id)
 
     def set_usage_reporter(self, usage_reporter: Optional["UsageReporter"]) -> None:
         """Set the usage reporter for newly created sessions."""
@@ -163,8 +163,10 @@ class SessionService:
             session_id=session_id,
             session_uri=session_uri,
             tool_output_externalization_config=self._tool_output_externalization_config,
-            agent_evolution_enabled=self.get_agent_evolution_enabled(),
-            agent_evolution_enabled_provider=self.get_agent_evolution_enabled,
+            agent_evolution_enabled=self._agent_evolution_enabled,
+            agent_evolution_enabled_provider=lambda: self.get_agent_evolution_enabled(
+                ctx.account_id
+            ),
             usage_reporter=self._usage_reporter,
         )
 
@@ -407,7 +409,7 @@ class SessionService:
             session_id=session_id,
             ctx=ctx,
             archive_uri=archive_uri,
-            agent_evolution_enabled=self.get_agent_evolution_enabled(),
+            agent_evolution_enabled=await self.get_agent_evolution_enabled(ctx.account_id),
         )
         self._record_lifecycle_metric("extract", "ok")
         return memories

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -903,21 +903,22 @@ class SessionCompressorV3:
                     )
                 exp_apply_result = getattr(exp_training_result, "apply_result", None)
                 if exp_apply_result is not None:
-                    experience_trajectory_map = _experience_trajectory_map(
-                        plan=exp_training_result.plan,
-                        apply_result=exp_apply_result,
-                        trajectory_uris={
-                            str(getattr(trajectory, "uri", "") or "")
-                            for trajectory in analysis.trajectories
-                            if str(getattr(trajectory, "uri", "") or "")
-                        },
+                    snapshot_apply_result, experience_trajectory_map = (
+                        _experience_snapshot_provenance(
+                            exp_training_result,
+                            fallback_trajectory_uris={
+                                uri
+                                for trajectory in analysis.trajectories
+                                if (uri := str(getattr(trajectory, "uri", "") or ""))
+                            },
+                        )
                     )
                     await _commit_experience_snapshot(
                         viking_fs,
                         ctx=ctx,
                         experience_uris=[
-                            *list(getattr(exp_apply_result, "written_uris", []) or []),
-                            *list(getattr(exp_apply_result, "deleted_uris", []) or []),
+                            *list(getattr(snapshot_apply_result, "written_uris", []) or []),
+                            *list(getattr(snapshot_apply_result, "deleted_uris", []) or []),
                         ],
                         archive_uri=archive_uri,
                         experience_trajectory_map=experience_trajectory_map,
@@ -1757,6 +1758,36 @@ def _experience_trajectory_map(
         existing = result.setdefault(experience_uri, [])
         existing.extend(uri for uri in source_uris if uri not in existing)
     return result
+
+
+def _experience_snapshot_provenance(
+    training_result: Any,
+    *,
+    fallback_trajectory_uris: Optional[set[str]] = None,
+) -> tuple[PolicyApplyResult, dict[str, list[str]]]:
+    """Return provenance for the complete update that reached storage.
+
+    Concurrent submitters can share one streaming trainer flush. Their
+    top-level result is scoped to one submitter, while ``batch_result`` owns
+    the complete plan and apply result that were written atomically. Snapshot
+    history must describe that complete persisted update, regardless of which
+    waiter reaches the snapshot commit first.
+    """
+    persisted_result = getattr(training_result, "batch_result", None) or training_result
+    apply_result = persisted_result.apply_result
+    trajectory_uris = {
+        uri
+        for analysis in getattr(persisted_result, "analyses", []) or []
+        for trajectory in getattr(analysis, "trajectories", []) or []
+        if (uri := str(getattr(trajectory, "uri", "") or ""))
+    }
+    if not trajectory_uris:
+        trajectory_uris = set(fallback_trajectory_uris or set())
+    return apply_result, _experience_trajectory_map(
+        plan=persisted_result.plan,
+        apply_result=apply_result,
+        trajectory_uris=trajectory_uris,
+    )
 
 
 def _stored_link(

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -887,10 +887,39 @@ class SessionCompressorV3:
                     policy_set=exp_trainer.policy_set,
                 )
                 if exp_gradients:
+                    fallback_trajectory_uris = {
+                        uri
+                        for trajectory in analysis.trajectories
+                        if (uri := str(getattr(trajectory, "uri", "") or ""))
+                    }
+
+                    async def commit_experience_batch(
+                        batch_result: RolloutTrainingResult,
+                        *,
+                        _fallback_trajectory_uris: set[str] = fallback_trajectory_uris,
+                    ) -> None:
+                        snapshot_apply_result, experience_trajectory_map = (
+                            _experience_snapshot_provenance(
+                                batch_result,
+                                fallback_trajectory_uris=_fallback_trajectory_uris,
+                            )
+                        )
+                        await _commit_experience_snapshot(
+                            viking_fs,
+                            ctx=ctx,
+                            experience_uris=[
+                                *list(getattr(snapshot_apply_result, "written_uris", []) or []),
+                                *list(getattr(snapshot_apply_result, "deleted_uris", []) or []),
+                            ],
+                            archive_uri=archive_uri,
+                            experience_trajectory_map=experience_trajectory_map,
+                        )
+
                     exp_training_result = await exp_trainer.submit_gradients(
                         exp_gradients,
                         analysis=analysis,
                         rollout=rollout,
+                        batch_finalizer=commit_experience_batch,
                     )
                 if case_uri:
                     await self._link_case_to_training_outputs(
@@ -900,28 +929,6 @@ class SessionCompressorV3:
                         apply_result=exp_training_result.apply_result,
                         ctx=ctx,
                         viking_fs=viking_fs,
-                    )
-                exp_apply_result = getattr(exp_training_result, "apply_result", None)
-                if exp_apply_result is not None:
-                    snapshot_apply_result, experience_trajectory_map = (
-                        _experience_snapshot_provenance(
-                            exp_training_result,
-                            fallback_trajectory_uris={
-                                uri
-                                for trajectory in analysis.trajectories
-                                if (uri := str(getattr(trajectory, "uri", "") or ""))
-                            },
-                        )
-                    )
-                    await _commit_experience_snapshot(
-                        viking_fs,
-                        ctx=ctx,
-                        experience_uris=[
-                            *list(getattr(snapshot_apply_result, "written_uris", []) or []),
-                            *list(getattr(snapshot_apply_result, "deleted_uris", []) or []),
-                        ],
-                        archive_uri=archive_uri,
-                        experience_trajectory_map=experience_trajectory_map,
                     )
                 # Skill path: co-extracted skill gradients go directly to skill trainer
                 if skill_trainer is not None and analysis.gradients:

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -92,6 +92,7 @@ _TRAINING_CASE_SPEC_PROTOCOL = "openviking.batch_train.case_spec.v1"
 _TRAINING_CASE_SPEC_HEADER = "# OpenViking Batch Training CaseSpec v1"
 _TRAINING_FAST_PATH_MEMORY_TYPES = frozenset({"cases", "trajectories", "experiences"})
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+_EXPERIENCE_TRAJECTORY_MAP_PREFIX = "OpenViking-Experience-Trajectory-Map: "
 
 
 async def _commit_experience_snapshot(
@@ -100,6 +101,7 @@ async def _commit_experience_snapshot(
     ctx: RequestContext,
     experience_uris: list[str],
     archive_uri: str = "",
+    experience_trajectory_map: Optional[dict[str, list[str]]] = None,
 ) -> None:
     commit = getattr(viking_fs, "commit", None)
     if not callable(commit):
@@ -112,9 +114,20 @@ async def _commit_experience_snapshot(
         return
     paths = [_experience_root_uri(ctx)]
     archive_ref = archive_uri.rstrip("/") if archive_uri else "unknown"
+    changed_experience_uris = set(dict.fromkeys(str(uri or "") for uri in experience_uris))
+    trajectory_map = {
+        experience_uri: list(dict.fromkeys(trajectory_uris))
+        for experience_uri, trajectory_uris in (experience_trajectory_map or {}).items()
+        if experience_uri in changed_experience_uris
+    }
+    message = (
+        f"Update experience memories from session commit {archive_ref}\n"
+        f"{_EXPERIENCE_TRAJECTORY_MAP_PREFIX}"
+        f"{json.dumps(trajectory_map, ensure_ascii=False, sort_keys=True, separators=(',', ':'))}"
+    )
     try:
         await commit(
-            message=f"Update experience memories from session commit {archive_ref}",
+            message=message,
             paths=paths,
             ctx=ctx,
         )
@@ -890,6 +903,15 @@ class SessionCompressorV3:
                     )
                 exp_apply_result = getattr(exp_training_result, "apply_result", None)
                 if exp_apply_result is not None:
+                    experience_trajectory_map = _experience_trajectory_map(
+                        plan=exp_training_result.plan,
+                        apply_result=exp_apply_result,
+                        trajectory_uris={
+                            str(getattr(trajectory, "uri", "") or "")
+                            for trajectory in analysis.trajectories
+                            if str(getattr(trajectory, "uri", "") or "")
+                        },
+                    )
                     await _commit_experience_snapshot(
                         viking_fs,
                         ctx=ctx,
@@ -898,6 +920,7 @@ class SessionCompressorV3:
                             *list(getattr(exp_apply_result, "deleted_uris", []) or []),
                         ],
                         archive_uri=archive_uri,
+                        experience_trajectory_map=experience_trajectory_map,
                     )
                 # Skill path: co-extracted skill gradients go directly to skill trainer
                 if skill_trainer is not None and analysis.gradients:
@@ -1685,6 +1708,15 @@ def _case_experience_links_via_trajectories(
 
 
 def _plan_item_has_source_trajectory(item: PolicyPlanItem, trajectory_uris: set[str]) -> bool:
+    return bool(_plan_item_source_trajectory_uris(item, trajectory_uris))
+
+
+def _plan_item_source_trajectory_uris(
+    item: PolicyPlanItem,
+    trajectory_uris: set[str],
+) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
     for link in getattr(item, "links", []) or []:
         try:
             stored = link if isinstance(link, StoredLink) else StoredLink(**dict(link))
@@ -1695,8 +1727,36 @@ def _plan_item_has_source_trajectory(item: PolicyPlanItem, trajectory_uris: set[
             and stored.to_uri in trajectory_uris
             and "/memories/trajectories/" in str(stored.to_uri or "")
         ):
-            return True
-    return False
+            uri = str(stored.to_uri)
+            if uri not in seen:
+                seen.add(uri)
+                result.append(uri)
+    return result
+
+
+def _experience_trajectory_map(
+    *,
+    plan: PolicyUpdatePlan,
+    apply_result: PolicyApplyResult,
+    trajectory_uris: set[str],
+) -> dict[str, list[str]]:
+    root_uri = getattr(getattr(apply_result, "updated_policy_set", None), "root_uri", "")
+    if not root_uri:
+        return {}
+    written_uris = set(getattr(apply_result, "written_uris", []) or [])
+    result: dict[str, list[str]] = {}
+    for item in getattr(plan, "items", []) or []:
+        if item.memory_type != "experiences" or item.kind != "upsert":
+            continue
+        experience_uri = _experience_plan_item_uri(item, root_uri)
+        if not experience_uri or experience_uri not in written_uris:
+            continue
+        source_uris = _plan_item_source_trajectory_uris(item, trajectory_uris)
+        if not source_uris:
+            continue
+        existing = result.setdefault(experience_uri, [])
+        existing.extend(uri for uri in source_uris if uri not in existing)
+    return result
 
 
 def _stored_link(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -6,6 +6,7 @@ Session as Context: Sessions integrated into L0/L1/L2 system.
 """
 
 import asyncio
+import inspect
 import json
 import re
 from dataclasses import dataclass, field
@@ -559,7 +560,7 @@ class Session:
         tool_output_externalization_config: Optional[ToolOutputExternalizationConfig] = None,
         agent_evolution_enabled: bool = True,
         usage_reporter: Optional["UsageReporter"] = None,
-        agent_evolution_enabled_provider: Optional[Callable[[], bool]] = None,
+        agent_evolution_enabled_provider: Optional[Callable[[], bool | Awaitable[bool]]] = None,
     ):
         self._viking_fs = viking_fs
         self._vikingdb_manager = vikingdb_manager
@@ -1736,11 +1737,14 @@ class Session:
             memory_policy if memory_policy is not None else self._meta.memory_policy
         )
         _validate_memory_policy_types(effective_policy)
-        agent_evolution_enabled = (
-            self._agent_evolution_enabled_provider()
-            if self._agent_evolution_enabled_provider is not None
-            else self._agent_evolution_enabled
-        )
+        agent_evolution_enabled = self._agent_evolution_enabled
+        if self._agent_evolution_enabled_provider is not None:
+            provided_enabled = self._agent_evolution_enabled_provider()
+            agent_evolution_enabled = (
+                await provided_enabled
+                if inspect.isawaitable(provided_enabled)
+                else provided_enabled
+            )
         effective_policy = _apply_agent_evolution_setting(
             effective_policy,
             agent_evolution_enabled=agent_evolution_enabled,

--- a/openviking/session/train/components/policy_trainer.py
+++ b/openviking/session/train/components/policy_trainer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, Hashable
 
@@ -250,6 +251,7 @@ class StreamingPolicyTrainer:
         *,
         analysis: RolloutAnalysis | None = None,
         rollout: Rollout | None = None,
+        batch_finalizer: Callable[[RolloutTrainingResult], Awaitable[None]] | None = None,
     ) -> RolloutTrainingResult | ScopedRolloutTrainingResult:
         """Submit pre-computed gradients directly to the streaming trainer.
 
@@ -283,6 +285,7 @@ class StreamingPolicyTrainer:
             gradients=list(gradients),
             analysis=analysis,
             rollout=rollout,
+            batch_finalizer=batch_finalizer,
         )
         result = await self._batcher.submit(buffered)
         self._last_apply_result = result.apply_result
@@ -376,6 +379,16 @@ class StreamingPolicyTrainer:
                 "flush_reason": reason,
             },
         )
+        # Finalize the persisted batch before StreamingBatcher releases its
+        # flush lock and starts another batch. All submitters in this flush
+        # share the same complete result, so one finalizer is sufficient.
+        # This keeps snapshot creation ordered with the writes it describes.
+        batch_finalizer = next(
+            (item.batch_finalizer for item in items if item.batch_finalizer is not None),
+            None,
+        )
+        if batch_finalizer is not None:
+            await batch_finalizer(result)
         tracer.info(
             "StreamingPolicyTrainer flush finished "
             f"reason={reason} "
@@ -594,6 +607,7 @@ class _BufferedRolloutTraining:
     gradients: list[SemanticGradient]
     analysis: RolloutAnalysis | None = None
     rollout: Rollout | None = None
+    batch_finalizer: Callable[[RolloutTrainingResult], Awaitable[None]] | None = None
 
 
 @dataclass(slots=True)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -4195,6 +4195,7 @@ class VikingFS:
         path: str,
         from_ref: Optional[str],
         to_ref: str,
+        raw: bool = True,
         ctx: Optional[RequestContext] = None,
     ) -> Dict[str, Any]:
         """Return a unified text diff for one path between two snapshots."""
@@ -4247,6 +4248,21 @@ class VikingFS:
                     f"snapshot diff file size limit exceeded ({SNAPSHOT_DIFF_MAX_FILE_BYTES} bytes)",
                     details={"limit_bytes": SNAPSHOT_DIFF_MAX_FILE_BYTES, "path": path},
                 )
+
+        if not raw:
+            from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+            def visible_content(value: Optional[bytes]) -> Optional[bytes]:
+                if value is None:
+                    return None
+                try:
+                    text = value.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise InvalidArgumentError("raw=false requires UTF-8 snapshot content") from exc
+                return MemoryFileUtils.read(text, uri=path).content.encode("utf-8")
+
+            before_bytes = visible_content(before_bytes)
+            after_bytes = visible_content(after_bytes)
 
         change_type, before, after = await asyncio.to_thread(
             _prepare_snapshot_diff,

--- a/tests/server/test_agent_evolution_global_setting.py
+++ b/tests/server/test_agent_evolution_global_setting.py
@@ -6,52 +6,114 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
+import pytest
+import pytest_asyncio
 
+from openviking.pyagfs import AGFSNotFoundError
+from openviking.server.account_settings import (
+    AccountAgentEvolutionSettings,
+    AccountSettingsPatch,
+    account_settings_backup_path,
+    account_settings_path,
+    read_account_settings,
+    update_account_settings,
+)
 from openviking.server.agent_evolution_config import AgentEvolutionConfigProvider
 from openviking.server.app import create_app
+from openviking.server.auth.plugins import DevAuthPlugin
 from openviking.server.config import AgentEvolutionConfig, ServerConfig, UserConfig
+from openviking.server.dependencies import set_service
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
 from openviking.session import Session
 from openviking_cli.session.user_id import UserIdentifier
-from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
+
+
+class _FakeAGFS:
+    def __init__(self):
+        self.files: dict[str, bytes] = {}
+
+    def read(self, path, ctx=None):
+        del ctx
+        if path not in self.files:
+            raise AGFSNotFoundError(path)
+        return self.files[path]
+
+    def write(self, path, data, ctx=None):
+        del ctx
+        self.files[path] = bytes(data)
+        return path
+
+    def ensure_parent_dirs(self, path, ctx=None):
+        del path
+        del ctx
+        return {}
+
+    def rm(self, path, ctx=None):
+        del ctx
+        self.files.pop(path, None)
+        return {}
+
+    def pathlock_acquire_exact(self, ctx, path, timeout_secs, owner_lease_ref):
+        del ctx
+        del path
+        del timeout_secs
+        del owner_lease_ref
+        return {"lease_ref": "test-lease"}
+
+    def pathlock_release(self, ctx, lease):
+        del ctx
+        del lease
+
+
+@pytest.fixture
+def fake_viking_fs():
+    return SimpleNamespace(agfs=_FakeAGFS())
+
+
+@pytest_asyncio.fixture
+async def settings_http(fake_viking_fs):
+    sessions = SessionService(viking_fs=fake_viking_fs)
+    service = SimpleNamespace(sessions=sessions, viking_fs=fake_viking_fs)
+    app = create_app(config=ServerConfig(), service=service)
+    set_service(service)
+    app.state.auth_plugin = DevAuthPlugin()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client, service
+
+
+def _patch(enabled: bool) -> AccountSettingsPatch:
+    return AccountSettingsPatch(agent_evolution=AccountAgentEvolutionSettings(enabled=enabled))
 
 
 def test_agent_evolution_is_disabled_by_default():
     assert ServerConfig().agent_evolution.enabled is False
 
 
-def test_agent_evolution_can_be_enabled_for_the_server():
+def test_agent_evolution_can_be_enabled_as_account_default():
     config = ServerConfig.model_validate({"agent_evolution": {"enabled": True}})
 
     assert config.agent_evolution.enabled is True
 
 
-def test_embedded_session_service_preserves_agent_evolution_default(
-    tmp_path,
-    monkeypatch,
-):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
-
+async def test_embedded_session_service_preserves_agent_evolution_default():
     service = SessionService()
 
-    assert service.get_agent_evolution_enabled() is True
+    assert await service.get_agent_evolution_enabled("default") is True
 
 
-def test_existing_session_observes_updated_runtime_value():
-    service = SessionService(viking_fs=object())
+async def test_existing_session_observes_updated_account_value(fake_viking_fs):
+    service = SessionService(viking_fs=fake_viking_fs)
+    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+    service.set_agent_evolution_config_path(None)
     session = service.session(
         RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
     )
 
-    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
 
-    assert session._agent_evolution_enabled_provider() is False
+    assert await session._agent_evolution_enabled_provider() is True
 
 
 def test_session_positional_usage_reporter_remains_compatible():
@@ -75,7 +137,7 @@ def test_session_positional_usage_reporter_remains_compatible():
     assert session._agent_evolution_enabled_provider is None
 
 
-def test_agent_evolution_provider_reloads_config_file(tmp_path):
+async def test_provider_reloads_ov_conf_and_account_override(fake_viking_fs, tmp_path):
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
         json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
@@ -83,233 +145,101 @@ def test_agent_evolution_provider_reloads_config_file(tmp_path):
     )
     provider = AgentEvolutionConfigProvider(
         default_enabled=True,
+        viking_fs=fake_viking_fs,
         config_path=config_path,
     )
 
-    assert provider.is_enabled() is False
+    assert await provider.is_enabled("default") is False
 
     config_path.write_text(
         json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
         encoding="utf-8",
     )
+    assert await provider.is_enabled("default") is True
 
-    assert provider.is_enabled() is True
+    await update_account_settings(fake_viking_fs, "default", _patch(False))
+    assert await provider.is_enabled("default") is False
 
 
-def test_agent_evolution_runtime_override_waits_for_projected_config(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
+async def test_account_overrides_are_isolated(fake_viking_fs):
     provider = AgentEvolutionConfigProvider(
         default_enabled=False,
-        config_path=config_path,
+        viking_fs=fake_viking_fs,
+    )
+    await update_account_settings(fake_viking_fs, "account-a", _patch(True))
+
+    assert await provider.is_enabled("account-a") is True
+    assert await provider.is_enabled("account-b") is False
+
+
+async def test_account_settings_update_backs_up_previous_file(fake_viking_fs):
+    await update_account_settings(fake_viking_fs, "default", _patch(False))
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
+
+    current = fake_viking_fs.agfs.files[account_settings_path("default")]
+    backup = fake_viking_fs.agfs.files[account_settings_backup_path("default")]
+    current_payload = json.loads(current.decode("utf-8"))
+    backup_payload = json.loads(backup.decode("utf-8"))
+
+    assert current_payload["agent_evolution"]["enabled"] is True
+    assert backup_payload["agent_evolution"]["enabled"] is False
+
+
+async def test_account_settings_admin_api_reads_and_updates_effective_value(
+    settings_http,
+):
+    client, service = settings_http
+    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+
+    initial = await client.get("/api/v1/admin/accounts/default/settings")
+    assert initial.status_code == 200, initial.text
+    assert initial.json()["result"] == {
+        "account_id": "default",
+        "settings": {"agent_evolution": {"enabled": False}},
+        "overrides": {},
+    }
+
+    updated = await client.patch(
+        "/api/v1/admin/accounts/default/settings",
+        json={"agent_evolution": {"enabled": True}},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["result"]["settings"]["agent_evolution"]["enabled"] is True
+    assert updated.json()["result"]["overrides"] == {"agent_evolution": {"enabled": True}}
+    assert (await read_account_settings(service.viking_fs, "default")).agent_evolution.enabled
+
+
+async def test_account_settings_admin_api_rejects_non_allowlisted_fields(
+    settings_http,
+):
+    client, _ = settings_http
+    response = await client.patch(
+        "/api/v1/admin/accounts/default/settings",
+        json={"root_api_key": "not-allowed"},
     )
 
-    provider.set_runtime_override(True, "revision-1")
+    assert response.status_code == 400
 
-    assert provider.is_enabled() is True
 
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "agent_evolution": {
-                        "enabled": True,
-                        "revision": "revision-1",
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
+async def test_agent_evolution_endpoint_keeps_name_and_uses_account_settings(
+    settings_http,
+):
+    client, service = settings_http
+    updated = await client.put(
+        "/api/v1/admin/agent-evolution",
+        json={"enabled": True},
     )
-    assert provider.is_enabled() is True
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["result"] == {
+        "enabled": True,
+        "account_id": "default",
+    }
 
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    assert provider.is_enabled() is False
+    response = await client.get("/api/v1/admin/agent-evolution")
 
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "agent_evolution": {
-                        "enabled": True,
-                        "revision": "revision-3",
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    assert provider.is_enabled() is True
-
-
-def test_agent_evolution_runtime_override_uses_latest_rapid_update(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-
-    provider.set_runtime_override(True, "revision-1")
-    provider.set_runtime_override(False, "revision-2")
-
-    assert provider.is_enabled() is False
-
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "agent_evolution": {
-                        "enabled": True,
-                        "revision": "revision-1",
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    assert provider.is_enabled() is False
-
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "agent_evolution": {
-                        "enabled": False,
-                        "revision": "revision-2",
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    assert provider.is_enabled() is False
-
-
-def test_session_service_reloads_from_resolved_server_config_path(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    service = SessionService()
-    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-    service.set_agent_evolution_config_path(str(config_path))
-
-    assert service.get_agent_evolution_enabled() is False
-
-
-def test_http_app_wires_resolved_server_config_path(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    sessions = SessionService()
-
-    create_app(
-        config=ServerConfig(agent_evolution=AgentEvolutionConfig(enabled=True)),
-        service=SimpleNamespace(sessions=sessions),
-        config_path=str(config_path),
-    )
-
-    assert sessions.get_agent_evolution_enabled() is False
-
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-
-    assert sessions.get_agent_evolution_enabled() is True
-
-
-def test_agent_evolution_provider_applies_missing_section_default(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-    assert provider.is_enabled() is True
-
-    config_path.write_text(json.dumps({"server": {}}), encoding="utf-8")
-
-    assert provider.is_enabled() is False
-
-
-def test_agent_evolution_provider_uses_standard_config_loading(tmp_path, monkeypatch):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        '\ufeff{"server": {"agent_evolution": {"enabled": ${AGENT_EVOLUTION_ENABLED}}}}',
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("AGENT_EVOLUTION_ENABLED", "true")
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-
-    assert provider.is_enabled() is True
-
-
-def test_agent_evolution_provider_keeps_last_valid_value(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-    assert provider.is_enabled() is True
-
-    config_path.write_text("{", encoding="utf-8")
-
-    assert provider.is_enabled() is True
-
-    config_path.write_text("[]", encoding="utf-8")
-
-    assert provider.is_enabled() is True
-
-
-def test_agent_evolution_provider_rejects_invalid_unrelated_server_config(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-    assert provider.is_enabled() is True
-
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "port": "not-an-integer",
-                    "agent_evolution": {"enabled": False},
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    assert provider.is_enabled() is True
+    assert response.status_code == 200, response.text
+    assert response.json()["result"]["enabled"] is True
+    assert (await read_account_settings(service.viking_fs, "default")).agent_evolution.enabled
 
 
 def test_deprecated_user_agent_evolution_config_is_not_persisted():
@@ -319,88 +249,21 @@ def test_deprecated_user_agent_evolution_config_is_not_persisted():
     assert "agent_evolution" not in config.model_dump(exclude_none=True)
 
 
-async def test_agent_evolution_user_endpoint_is_not_registered(
-    client: httpx.AsyncClient,
-):
-    response = await client.get("/api/v1/user-settings/memory")
-
-    assert response.status_code == 404
-
-
-async def test_agent_evolution_admin_endpoint_returns_runtime_value(
-    service,
-    client: httpx.AsyncClient,
-):
-    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-
-    response = await client.get("/api/v1/admin/agent-evolution")
-
-    assert response.status_code == 200, response.text
-    assert response.json()["result"] == {
-        "enabled": True,
-        "account_id": "default",
-    }
-
-
-async def test_agent_evolution_admin_endpoint_sets_runtime_value(
-    service,
-    client: httpx.AsyncClient,
-):
-    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
-
-    response = await client.put(
-        "/api/v1/admin/agent-evolution",
-        json={"enabled": True, "revision": "revision-1"},
-    )
-
-    assert response.status_code == 200, response.text
-    assert response.json()["result"] == {
-        "enabled": True,
-        "account_id": "default",
-    }
-    status = await client.get("/api/v1/admin/agent-evolution")
-    assert status.status_code == 200, status.text
-    assert status.json()["result"]["enabled"] is True
-
-
-async def test_manual_extract_respects_disabled_agent_evolution(
-    service,
-    client: httpx.AsyncClient,
-):
-    create_response = await client.post("/api/v1/sessions", json={})
-    session_id = create_response.json()["result"]["session_id"]
-    add_response = await client.post(
-        f"/api/v1/sessions/{session_id}/messages",
-        json={"role": "user", "content": "请处理一次换货任务"},
-    )
-    assert add_response.status_code == 200, add_response.text
-
+async def test_manual_extract_respects_account_setting(fake_viking_fs):
     extract = AsyncMock(return_value=[])
-    service.sessions._session_compressor.extract_long_term_memories = extract
-
-    response = await client.post(f"/api/v1/sessions/{session_id}/extract")
-
-    assert response.status_code == 200, response.text
-    assert extract.await_args.kwargs["agent_evolution_enabled"] is False
-
-
-async def test_manual_extract_respects_enabled_agent_evolution(
-    service,
-    client: httpx.AsyncClient,
-):
-    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-    create_response = await client.post("/api/v1/sessions", json={})
-    session_id = create_response.json()["result"]["session_id"]
-    add_response = await client.post(
-        f"/api/v1/sessions/{session_id}/messages",
-        json={"role": "user", "content": "请处理一次换货任务"},
+    compressor = SimpleNamespace(extract_long_term_memories=extract)
+    service = SessionService(
+        viking_fs=fake_viking_fs,
+        session_compressor=compressor,
     )
-    assert add_response.status_code == 200, add_response.text
+    session = SimpleNamespace(
+        uri="viking://user/default/sessions/test-session",
+        messages=[],
+    )
+    service.get = AsyncMock(return_value=session)
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
 
-    extract = AsyncMock(return_value=[])
-    service.sessions._session_compressor.extract_long_term_memories = extract
+    await service.extract("test-session", ctx)
 
-    response = await client.post(f"/api/v1/sessions/{session_id}/extract")
-
-    assert response.status_code == 200, response.text
     assert extract.await_args.kwargs["agent_evolution_enabled"] is True

--- a/tests/server/test_agent_evolution_global_setting.py
+++ b/tests/server/test_agent_evolution_global_setting.py
@@ -96,6 +96,105 @@ def test_agent_evolution_provider_reloads_config_file(tmp_path):
     assert provider.is_enabled() is True
 
 
+def test_agent_evolution_runtime_override_waits_for_projected_config(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    provider = AgentEvolutionConfigProvider(
+        default_enabled=False,
+        config_path=config_path,
+    )
+
+    provider.set_runtime_override(True, "revision-1")
+
+    assert provider.is_enabled() is True
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-1",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is True
+
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-3",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is True
+
+
+def test_agent_evolution_runtime_override_uses_latest_rapid_update(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    provider = AgentEvolutionConfigProvider(
+        default_enabled=False,
+        config_path=config_path,
+    )
+
+    provider.set_runtime_override(True, "revision-1")
+    provider.set_runtime_override(False, "revision-2")
+
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-1",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": False,
+                        "revision": "revision-2",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+
 def test_session_service_reloads_from_resolved_server_config_path(tmp_path):
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
@@ -241,6 +340,27 @@ async def test_agent_evolution_admin_endpoint_returns_runtime_value(
         "enabled": True,
         "account_id": "default",
     }
+
+
+async def test_agent_evolution_admin_endpoint_sets_runtime_value(
+    service,
+    client: httpx.AsyncClient,
+):
+    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+
+    response = await client.put(
+        "/api/v1/admin/agent-evolution",
+        json={"enabled": True, "revision": "revision-1"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["result"] == {
+        "enabled": True,
+        "account_id": "default",
+    }
+    status = await client.get("/api/v1/admin/agent-evolution")
+    assert status.status_code == 200, status.text
+    assert status.json()["result"]["enabled"] is True
 
 
 async def test_manual_extract_respects_disabled_agent_evolution(

--- a/tests/server/test_api_snapshot.py
+++ b/tests/server/test_api_snapshot.py
@@ -236,6 +236,31 @@ async def test_show_blob_returns_binary_with_headers(client_with_resource_and_bl
     assert resp.content == expected_bytes
 
 
+async def test_show_blob_can_hide_memory_fields(snapshot_router_client, monkeypatch):
+    from openviking.server.routers import snapshot
+
+    stored = b'visible content\n\n<!-- MEMORY_FIELDS\n{"version": 2}\n-->'
+    show_mock = AsyncMock(return_value={"oid": "a" * 40, "size": len(stored), "bytes": stored})
+    monkeypatch.setattr(
+        snapshot,
+        "get_service",
+        lambda: SimpleNamespace(fs=SimpleNamespace(show_blob_raw=show_mock)),
+    )
+
+    response = await snapshot_router_client.get(
+        "/api/v1/snapshot/show",
+        params={
+            "target_ref": "a" * 40,
+            "path": "viking://user/default/memories/experiences/example.md",
+            "raw": "false",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"visible content"
+    assert response.headers["x-snapshot-size"] == str(len(response.content))
+
+
 async def test_show_path_not_found_returns_404(client_with_resource):
     client, _ = client_with_resource
     commit = (await client.post("/api/v1/snapshot/commit", json={"message": "for 404"})).json()["result"]

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -14,6 +14,7 @@ from openviking.session import create_session_compressor
 from openviking.session.compressor_v3 import (
     SessionCompressorV3,
     _experience_root_uri,
+    _experience_snapshot_provenance,
     _experience_trajectory_map,
 )
 from openviking.session.memory.dataclass import (
@@ -1342,6 +1343,61 @@ def test_v3_maps_each_written_experience_to_its_source_trajectories():
         apply_result=apply_result,
         trajectory_uris={traj_a, traj_b},
     ) == {
+        exp_a: [traj_a],
+        exp_b: [traj_b],
+    }
+
+
+def test_v3_snapshot_provenance_uses_complete_shared_batch_result():
+    traj_a = "viking://user/u/memories/trajectories/traj_a.md"
+    traj_b = "viking://user/u/memories/trajectories/traj_b.md"
+    exp_a = "viking://user/u/memories/experiences/exp_a.md"
+    exp_b = "viking://user/u/memories/experiences/exp_b.md"
+
+    def plan_item(experience_uri: str, trajectory_uri: str) -> PolicyPlanItem:
+        return PolicyPlanItem(
+            kind="upsert",
+            memory_type="experiences",
+            target_name=experience_uri.rsplit("/", 1)[-1].removesuffix(".md"),
+            target_uri=experience_uri,
+            before_content=None,
+            after_content="updated",
+            links=[
+                StoredLink(
+                    from_uri=experience_uri,
+                    to_uri=trajectory_uri,
+                    link_type="derived_from",
+                    weight=1.0,
+                )
+            ],
+        )
+
+    root = "viking://user/u/memories/experiences"
+    batch_result = SimpleNamespace(
+        analyses=[
+            SimpleNamespace(trajectories=[SimpleNamespace(uri=traj_a)]),
+            SimpleNamespace(trajectories=[SimpleNamespace(uri=traj_b)]),
+        ],
+        plan=PolicyUpdatePlan(items=[plan_item(exp_a, traj_a), plan_item(exp_b, traj_b)]),
+        apply_result=PolicyApplyResult(
+            updated_policy_set=ExperienceSet(root_uri=root, policies=[]),
+            written_uris=[exp_a, exp_b],
+        ),
+    )
+    scoped_result = SimpleNamespace(
+        analyses=[batch_result.analyses[0]],
+        plan=PolicyUpdatePlan(items=[batch_result.plan.items[0]]),
+        apply_result=PolicyApplyResult(
+            updated_policy_set=ExperienceSet(root_uri=root, policies=[]),
+            written_uris=[exp_a],
+        ),
+        batch_result=batch_result,
+    )
+
+    apply_result, trajectory_map = _experience_snapshot_provenance(scoped_result)
+
+    assert apply_result is batch_result.apply_result
+    assert trajectory_map == {
         exp_a: [traj_a],
         exp_b: [traj_b],
     }

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -1484,7 +1484,14 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
     class FakeTrainer:
         policy_set = ExperienceSet(root_uri="viking://user/u/memories/experiences", policies=[])
 
-        async def submit_gradients(self, gradients, *, analysis=None, rollout=None):
+        async def submit_gradients(
+            self,
+            gradients,
+            *,
+            analysis=None,
+            rollout=None,
+            batch_finalizer=None,
+        ):
             del gradients, analysis, rollout
             plan = PolicyUpdatePlan(
                 items=[
@@ -1508,7 +1515,7 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                     )
                 ]
             )
-            return RolloutTrainingResult(
+            result = RolloutTrainingResult(
                 analyses=[],
                 gradients=[],
                 plan=plan,
@@ -1523,6 +1530,9 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                 ),
                 metadata={},
             )
+            if batch_finalizer is not None:
+                await batch_finalizer(result)
+            return result
 
     class FakeAnalyzer:
         async def analyze(self, rollout, context):

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -11,7 +11,11 @@ import pytest
 from openviking.message import Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
-from openviking.session.compressor_v3 import SessionCompressorV3, _experience_root_uri
+from openviking.session.compressor_v3 import (
+    SessionCompressorV3,
+    _experience_root_uri,
+    _experience_trajectory_map,
+)
 from openviking.session.memory.dataclass import (
     MemoryFile,
     ResolvedOperation,
@@ -1284,6 +1288,65 @@ async def test_v3_training_memory_diff_filters_batch_items_by_current_analysis_t
     assert [op["uri"] for op in diff["operations"]["adds"]] == [traj_a, exp_a]
 
 
+def test_v3_maps_each_written_experience_to_its_source_trajectories():
+    traj_a = "viking://user/u/memories/trajectories/traj_a.md"
+    traj_b = "viking://user/u/memories/trajectories/traj_b.md"
+    exp_a = "viking://user/u/memories/experiences/exp_a.md"
+    exp_b = "viking://user/u/memories/experiences/exp_b.md"
+    plan = PolicyUpdatePlan(
+        items=[
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="exp_a",
+                target_uri=exp_a,
+                before_content=None,
+                after_content="exp a",
+                links=[
+                    StoredLink(
+                        from_uri=exp_a,
+                        to_uri=traj_a,
+                        link_type="derived_from",
+                        weight=1.0,
+                    )
+                ],
+            ),
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="exp_b",
+                target_uri=exp_b,
+                before_content=None,
+                after_content="exp b",
+                links=[
+                    StoredLink(
+                        from_uri=exp_b,
+                        to_uri=traj_b,
+                        link_type="derived_from",
+                        weight=1.0,
+                    )
+                ],
+            ),
+        ]
+    )
+    apply_result = PolicyApplyResult(
+        updated_policy_set=ExperienceSet(
+            root_uri="viking://user/u/memories/experiences",
+            policies=[],
+        ),
+        written_uris=[exp_a, exp_b],
+    )
+
+    assert _experience_trajectory_map(
+        plan=plan,
+        apply_result=apply_result,
+        trajectory_uris={traj_a, traj_b},
+    ) == {
+        exp_a: [traj_a],
+        exp_b: [traj_b],
+    }
+
+
 @pytest.mark.asyncio
 async def test_v3_training_links_case_to_trajectory_and_experience_via_trajectory(monkeypatch):
     case_uri = "viking://user/u/memories/cases/duplicate_booking.md"
@@ -1351,8 +1414,8 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
             del ctx
             return self.files[uri]
 
-        async def write_file(self, uri, content, ctx=None):
-            del ctx
+        async def write_file(self, uri, content, ctx=None, lease_ref=None):
+            del ctx, lease_ref
             self.files[uri] = content
 
         async def ls(self, uri, output="original", ctx=None):
@@ -1497,7 +1560,10 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
         {
             "message": (
                 "Update experience memories from session commit "
-                "viking://user/u/sessions/session-1/history/archive_001"
+                "viking://user/u/sessions/session-1/history/archive_001\n"
+                "OpenViking-Experience-Trajectory-Map: "
+                '{"viking://user/u/memories/experiences/booking_duplicate_handling.md":'
+                '["viking://user/u/memories/trajectories/duplicate_booking.md"]}'
             ),
             "paths": ["viking://user/u/memories/experiences"],
             "ctx": _ctx(),

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -79,7 +79,10 @@ class TestCommit:
     async def test_commit_default_disables_agent_memory_but_keeps_archive(
         self, session_with_messages: Session
     ):
-        session_with_messages._agent_evolution_enabled_provider = lambda: False
+        async def account_setting_provider() -> bool:
+            return False
+
+        session_with_messages._agent_evolution_enabled_provider = account_setting_provider
         session_with_messages._session_compressor.extract_long_term_memories = AsyncMock(
             return_value=[]
         )

--- a/tests/session/train/test_train_framework.py
+++ b/tests/session/train/test_train_framework.py
@@ -873,6 +873,92 @@ async def test_streaming_policy_trainer_scopes_concurrent_submit_results_by_sour
 
 
 @pytest.mark.asyncio
+async def test_streaming_policy_trainer_finalizes_snapshot_before_next_flush_writes():
+    from openviking.session.train import StreamingPolicyTrainer, StreamingPolicyTrainerConfig
+
+    writes: list[str] = []
+    snapshots: list[tuple[str, list[str], list[str]]] = []
+    first_finalizer_started = asyncio.Event()
+    release_first_finalizer = asyncio.Event()
+
+    class RecordingCore:
+        async def plan_and_apply(self, *, gradients, policy_set, ctx):
+            del ctx
+            uris = [gradient.target_uri for gradient in gradients]
+            writes.extend(uris)
+            return (
+                PolicyUpdatePlan(metadata={"uris": uris}),
+                PolicyApplyResult(updated_policy_set=policy_set, written_uris=uris),
+            )
+
+    trainer = StreamingPolicyTrainer(
+        policy_set=_policy_set(),
+        rollout_analyzer=DummyAnalyzer(),
+        gradient_estimator=DummyEstimator(),
+        policy_optimizer=DummyOptimizer(),
+        policy_updater=DummyUpdater(),
+        context=PipelineContext(),
+        config=StreamingPolicyTrainerConfig(
+            max_gradients_per_update=1,
+            max_wait_seconds=60.0,
+            timer_check_interval_seconds=60.0,
+        ),
+    )
+    trainer._core = RecordingCore()
+
+    async def finalize_first(result):
+        first_finalizer_started.set()
+        await release_first_finalizer.wait()
+        snapshots.append(("first", list(writes), list(result.apply_result.written_uris)))
+
+    async def finalize_second(result):
+        snapshots.append(("second", list(writes), list(result.apply_result.written_uris)))
+
+    def gradient(name: str) -> DummyGradient:
+        uri = f"viking://user/u/memories/experiences/{name}.md"
+        return DummyGradient(
+            target_name=name,
+            target_uri=uri,
+            base_version=None,
+            rationale="test",
+            links=[],
+            confidence=1.0,
+        )
+
+    first_task = asyncio.create_task(
+        trainer.submit_gradients([gradient("exp_a")], batch_finalizer=finalize_first)
+    )
+    await first_finalizer_started.wait()
+    second_task = asyncio.create_task(
+        trainer.submit_gradients([gradient("exp_b")], batch_finalizer=finalize_second)
+    )
+    await asyncio.sleep(0)
+
+    assert writes == ["viking://user/u/memories/experiences/exp_a.md"]
+
+    release_first_finalizer.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert snapshots == [
+        (
+            "first",
+            ["viking://user/u/memories/experiences/exp_a.md"],
+            ["viking://user/u/memories/experiences/exp_a.md"],
+        ),
+        (
+            "second",
+            [
+                "viking://user/u/memories/experiences/exp_a.md",
+                "viking://user/u/memories/experiences/exp_b.md",
+            ],
+            ["viking://user/u/memories/experiences/exp_b.md"],
+        ),
+    ]
+
+    assert await trainer.close() is None
+
+
+@pytest.mark.asyncio
 async def test_streaming_policy_trainer_splits_flush_by_gradient_count():
     from openviking.session.train import StreamingPolicyTrainer, StreamingPolicyTrainerConfig
 

--- a/tests/storage/test_viking_fs_git.py
+++ b/tests/storage/test_viking_fs_git.py
@@ -108,6 +108,26 @@ async def test_diff_reads_blobs_from_resolved_commit_oids():
     assert "+new content" in result["diff_text"]
 
 
+async def test_diff_can_hide_memory_fields():
+    before = b'old content\n\n<!-- MEMORY_FIELDS\n{"version": 1}\n-->'
+    after = b'new content\n\n<!-- MEMORY_FIELDS\n{"version": 2}\n-->'
+    vfs = _DiffVikingFS(before, after)
+
+    result = await VikingFS.diff(
+        vfs,
+        path="viking://user/user/memories/experiences/example.md",
+        from_ref="from",
+        to_ref="to",
+        raw=False,
+        ctx=_request_context(),
+    )
+
+    assert "-old content" in result["diff_text"]
+    assert "+new content" in result["diff_text"]
+    assert "MEMORY_FIELDS" not in result["diff_text"]
+    assert "version" not in result["diff_text"]
+
+
 class _DiffVikingFS:
     def __init__(self, before: bytes, after: bytes):
         self._before = before


### PR DESCRIPTION
## Description

Improve Agent Evolution provenance, history, and runtime configuration:

1. Record the exact experience-to-trajectory relationship in each experience snapshot commit so history consumers can associate an experience update with the trajectories that produced it.
2. Move the Agent Evolution switch from an instance-wide runtime override to persistent account-scoped settings that take effect without restarting OpenViking.
3. Let history consumers read and diff user-visible experience content without exposing internal `MEMORY_FIELDS`, while preserving raw snapshot behavior by default.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test update

## Changes Made

### Experience provenance

- Add a deterministic `OpenViking-Experience-Trajectory-Map` JSON line to experience snapshot commit messages.
- Build the mapping from successfully written experience plan items and their exact `derived_from` trajectory links.
- Use the complete shared streaming batch result so concurrent session commits cannot omit another submitter's persisted trajectory provenance.
- Keep mappings for multiple experience files independent and deduplicate trajectory URIs.
- Preserve the existing archive URI first line and experience-directory snapshot scope.
- Do not change `memory_diff.json` or experience file metadata.

### Account-scoped Agent Evolution settings

- Keep the existing `GET/PUT /api/v1/admin/agent-evolution` endpoint names.
- Persist each account's override at `/local/{account_id}/_system/setting.json`.
- Back up the previous file to `/local/{account_id}/_system/setting.backup.json` before replacing it.
- Add generic `GET/PATCH /api/v1/admin/accounts/{account_id}/settings` endpoints with an explicit writable allowlist; currently only `agent_evolution.enabled` is accepted.
- Use `server.agent_evolution.enabled` from `ov.conf` as the default when an account has no override.
- Resolve the account setting at session commit and manual extraction time so existing sessions observe updates without a process restart.
- Restrict ADMIN callers to their own account while allowing ROOT to manage explicit accounts through the generic endpoint.
- Remove the revision-based in-memory override mechanism.

### User-visible snapshot history

- Add an optional `raw` query parameter to snapshot show and diff; it defaults to `true` to preserve existing API and SDK behavior.
- With `raw=false`, snapshot show parses the historical memory file and returns only its user-visible content.
- With `raw=false`, snapshot diff strips `MEMORY_FIELDS` from both historical blobs before generating the unified diff.
- Keep raw blob size and diff safety limits enforced before parsing user-visible content.
- Reject `raw=false` for non-UTF-8 snapshot content instead of attempting to parse binary data.

## Testing

- `uv run ruff check openviking/server/account_settings.py openviking/server/agent_evolution_config.py openviking/server/config.py openviking/server/routers/admin.py openviking/service/session_service.py openviking/session/session.py tests/server/test_agent_evolution_global_setting.py` — passed.
- `uv run pytest --no-cov -q tests/server/test_agent_evolution_global_setting.py tests/unit/session/test_agent_evolution_policy.py` — 17 passed.
- `uv run python -m compileall -q openviking/server/account_settings.py openviking/server/agent_evolution_config.py openviking/server/config.py openviking/server/routers/admin.py openviking/service/session_service.py openviking/session/session.py` — passed.
- `node docs/scripts/check-api-reference.mjs` — passed; all mounted routes remain covered.
- Snapshot show/diff targeted tests for hiding memory fields — passed.
- Targeted trajectory mapping, shared-batch provenance, and compressor tests — passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the fixes and feature behavior
- [x] Targeted unit tests pass locally with my changes
- [ ] All existing test suites pass locally
- [x] I have made corresponding changes to user-facing documentation

## Screenshots

N/A

## Additional Notes

- A session can contain multiple archives, and one archive can produce multiple snapshot commits. Each snapshot commit carries its own experience-to-trajectory mapping.
- Account settings are read from shared AGFS storage for each relevant operation, so updates are visible across workers without relying on process-local state.
- The Serverless control plane should call the unchanged Agent Evolution admin endpoint directly and no longer persist this switch by rewriting the Kubernetes Secret.
- The Serverless Experience Version and Diff calls must explicitly request `raw=false`; generic snapshot callers remain raw by default.
- The repository's full HTTP/session fixture is currently blocked during unrelated local AGFS initialization before the affected session assertion runs.
