### PR TITLE
feat(agent-evolution): apply global switch immediately

### DIFF
--- a/openviking/server/agent_evolution_config.py
+++ b/openviking/server/agent_evolution_config.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
 from openviking.server.config import ServerConfig
@@ -30,14 +31,29 @@ class AgentEvolutionConfigProvider:
     ) -> None:
         self._last_valid_enabled = bool(default_enabled)
         self._config_path = Path(config_path).expanduser() if config_path else None
+        self._runtime_override: Optional[tuple[bool, str]] = None
+        self._lock = Lock()
 
     def set_default_enabled(self, enabled: bool) -> None:
-        self._last_valid_enabled = bool(enabled)
+        with self._lock:
+            self._last_valid_enabled = bool(enabled)
+
+    def set_runtime_override(self, enabled: bool, revision: str) -> None:
+        """Use a value immediately until the projected config catches up."""
+        with self._lock:
+            self._runtime_override = (bool(enabled), revision)
+            self._last_valid_enabled = bool(enabled)
+
+    def _fallback_enabled(self) -> bool:
+        with self._lock:
+            if self._runtime_override is not None:
+                return self._runtime_override[0]
+            return self._last_valid_enabled
 
     def is_enabled(self) -> bool:
         config_path = self._config_path
         if config_path is None:
-            return self._last_valid_enabled
+            return self._fallback_enabled()
 
         try:
             payload = load_json_config(config_path)
@@ -48,21 +64,30 @@ class AgentEvolutionConfigProvider:
                 server_config = {}
             if not isinstance(server_config, dict):
                 raise ValueError("server must be an object")
-            enabled = ServerConfig.model_validate(server_config).agent_evolution.enabled
+            agent_evolution = ServerConfig.model_validate(server_config).agent_evolution
+            enabled = agent_evolution.enabled
+            revision = agent_evolution.revision
         except OSError as exc:
             logger.warning(
                 "Failed to access Agent Evolution config file %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return self._fallback_enabled()
         except (KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Failed to read Agent Evolution config from %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return self._fallback_enabled()
 
-        self._last_valid_enabled = enabled
-        return enabled
+        with self._lock:
+            if self._runtime_override is not None:
+                override_enabled, override_revision = self._runtime_override
+                if enabled == override_enabled and revision == override_revision:
+                    self._runtime_override = None
+                else:
+                    return override_enabled
+            self._last_valid_enabled = enabled
+            return enabled

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -85,6 +85,7 @@ class AgentEvolutionConfig(BaseModel):
     """Server-wide Agent Evolution production switch."""
 
     enabled: bool = False
+    revision: Optional[str] = None
 
     model_config = {"extra": "forbid"}
 

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -5,7 +5,7 @@
 import asyncio
 
 from fastapi import APIRouter, Body, Depends, Path, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from openviking.server.api_keys.models import validate_account_user_role
 from openviking.server.auth import (
@@ -68,6 +68,11 @@ class MigrateLegacyDataRequest(BaseModel):
     action: str = "migrate"
 
 
+class SetAgentEvolutionRequest(BaseModel):
+    enabled: bool
+    revision: str = Field(min_length=1, max_length=128)
+
+
 @router.get("/agent-evolution")
 @require_auth_root
 async def get_agent_evolution_status(
@@ -81,6 +86,27 @@ async def get_agent_evolution_status(
         status="ok",
         result={
             "enabled": get_service().sessions.get_agent_evolution_enabled(),
+            "account_id": get_openviking_config().default_account,
+        },
+    )
+
+
+@router.put("/agent-evolution")
+@require_auth_root
+async def set_agent_evolution_status(
+    body: SetAgentEvolutionRequest,
+    request: Request,
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Apply the instance-wide Agent Evolution switch immediately."""
+    del request
+    del ctx
+    sessions = get_service().sessions
+    sessions.set_agent_evolution_runtime_enabled(body.enabled, body.revision)
+    return Response(
+        status="ok",
+        result={
+            "enabled": sessions.get_agent_evolution_enabled(),
             "account_id": get_openviking_config().default_account,
         },
     )

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -87,6 +87,12 @@ class SessionService:
             else None
         )
 
+    def set_agent_evolution_runtime_enabled(self, enabled: bool, revision: str) -> None:
+        """Apply an instance-wide value before the projected config refreshes."""
+        self._agent_evolution_enabled = bool(enabled)
+        if self._agent_evolution_config_provider is not None:
+            self._agent_evolution_config_provider.set_runtime_override(enabled, revision)
+
     def get_agent_evolution_enabled(self) -> bool:
         """Return the live instance-wide Agent Evolution switch."""
         if self._agent_evolution_config_provider is None:

--- a/tests/server/test_agent_evolution_global_setting.py
+++ b/tests/server/test_agent_evolution_global_setting.py
@@ -96,6 +96,105 @@ def test_agent_evolution_provider_reloads_config_file(tmp_path):
     assert provider.is_enabled() is True
 
 
+def test_agent_evolution_runtime_override_waits_for_projected_config(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    provider = AgentEvolutionConfigProvider(
+        default_enabled=False,
+        config_path=config_path,
+    )
+
+    provider.set_runtime_override(True, "revision-1")
+
+    assert provider.is_enabled() is True
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-1",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is True
+
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-3",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is True
+
+
+def test_agent_evolution_runtime_override_uses_latest_rapid_update(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    provider = AgentEvolutionConfigProvider(
+        default_enabled=False,
+        config_path=config_path,
+    )
+
+    provider.set_runtime_override(True, "revision-1")
+    provider.set_runtime_override(False, "revision-2")
+
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": True,
+                        "revision": "revision-1",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "agent_evolution": {
+                        "enabled": False,
+                        "revision": "revision-2",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert provider.is_enabled() is False
+
+
 def test_session_service_reloads_from_resolved_server_config_path(tmp_path):
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
@@ -241,6 +340,27 @@ async def test_agent_evolution_admin_endpoint_returns_runtime_value(
         "enabled": True,
         "account_id": "default",
     }
+
+
+async def test_agent_evolution_admin_endpoint_sets_runtime_value(
+    service,
+    client: httpx.AsyncClient,
+):
+    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+
+    response = await client.put(
+        "/api/v1/admin/agent-evolution",
+        json={"enabled": True, "revision": "revision-1"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["result"] == {
+        "enabled": True,
+        "account_id": "default",
+    }
+    status = await client.get("/api/v1/admin/agent-evolution")
+    assert status.status_code == 200, status.text
+    assert status.json()["result"]["enabled"] is True
 
 
 async def test_manual_extract_respects_disabled_agent_evolution(


### PR DESCRIPTION
## Description

Apply the instance-wide Agent Evolution switch immediately after the control plane persists the desired value, without waiting for Kubernetes Secret projection or restarting the OpenViking Pod.

The runtime override remains active until the mounted `ov.conf` exposes the same revision, so delayed or out-of-order Secret projections cannot revert a newer switch operation.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test update

## Changes Made

- Add a Root API Key-protected `PUT /api/v1/admin/agent-evolution` endpoint that applies the global switch to the running instance.
- Add an optional `server.agent_evolution.revision` value to correlate the runtime update with the persisted `ov.conf`.
- Keep the runtime value authoritative until both `enabled` and `revision` in the mounted config match the requested update.
- Make runtime access thread-safe.
- Ensure rapid updates such as enable followed immediately by disable ignore stale intermediate Secret projections.
- Preserve existing live config reload behavior after the matching revision has arrived.
- Add provider and admin endpoint coverage for immediate and rapid switch updates.

## Testing

- `uv run ruff format --check openviking/server/config.py openviking/server/agent_evolution_config.py openviking/server/routers/admin.py openviking/service/session_service.py tests/server/test_agent_evolution_global_setting.py`
- `uv run ruff check openviking/server/config.py openviking/server/agent_evolution_config.py openviking/server/routers/admin.py openviking/service/session_service.py tests/server/test_agent_evolution_global_setting.py`
- `uv run python -m py_compile openviking/server/config.py openviking/server/agent_evolution_config.py openviking/server/routers/admin.py openviking/service/session_service.py`
- `uv run pytest -q tests/server/test_agent_evolution_global_setting.py -k 'provider' --disable-warnings` — 5 passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the fix is effective
- [x] Targeted unit tests pass locally with my changes
- [ ] I have made corresponding changes to user-facing documentation

## Screenshots

N/A

## Additional Notes

- The control plane must persist the same revision into `ov.conf` and send it with the PUT request.
- Rollout order: deploy this OpenViking kernel version before deploying the Serverless version that calls the new PUT endpoint.
- The full HTTP fixture in this local checkout is currently blocked during unrelated AGFS queue snapshot initialization (`AGFSInvalidOperationError: no operation specified`); provider-level tests, formatting, lint, and syntax checks pass.
