### PR TITLE
fix(resource): preserve synchronous ingestion errors

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1038,6 +1038,8 @@ class ResourceService:
         get_current_telemetry().set("resource.flags.wait", wait)
         if not wait:
             return result
+        if result.get("status") == "error":
+            return result
         from openviking.service.task_tracker import TaskStatus, get_task_tracker
 
         task_id = result["task_id"]

--- a/tests/server/test_api_resources.py
+++ b/tests/server/test_api_resources.py
@@ -352,14 +352,18 @@ async def test_add_resource_business_error_uses_error_envelope(
     service,
     monkeypatch,
 ):
-    async def fake_add_resource(**kwargs):
+    async def fail_during_ingestion(**kwargs):
         return {
             "status": "error",
             "errors": ["Parse error: boom"],
             "source_path": kwargs["path"],
         }
 
-    monkeypatch.setattr(service.resources, "add_resource", fake_add_resource)
+    monkeypatch.setattr(
+        service.resources,
+        "_execute_resource_ingestion",
+        fail_during_ingestion,
+    )
 
     resp = await client.post(
         "/api/v1/resources",


### PR DESCRIPTION
## Description

`wait=true` 时保留同步资源解析错误，避免无条件读取不存在的 `task_id`，导致原始解析失败被 `KeyError` 遮蔽。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 在进入任务等待前直接返回同步解析错误结果。
- 调整现有 HTTP 业务错误契约测试，使其覆盖真实的 Service 提交路径。

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已执行：

- `tests/server/test_api_resources.py::test_add_resource_success`
- `tests/server/test_api_resources.py::test_add_resource_with_wait`
- `tests/server/test_api_resources.py::test_add_resource_business_error_uses_error_envelope`
- `ruff check openviking/service/resource_service.py tests/server/test_api_resources.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A

## Additional Notes

HTTP 边界仍返回现有的 `PROCESSING_ERROR` 错误封装；本次修改只恢复原始解析错误信息，不再将其替换为通用的 `KeyError` 异常。
