### PR TITLE
feat(tau2): add selector experience loader mode

### DIFF
--- a/benchmark/tau2/train/README.md
+++ b/benchmark/tau2/train/README.md
@@ -249,11 +249,51 @@ Service options:
 | `--config` | `~/.openviking/ov.conf` | ov.conf for VikingBot / OpenViking access |
 | `--rollout-language` | `default` | Rollout response language. Use `zh` for Chinese user-facing replies. |
 | `--rollout-backend` | `vikingbot` | Rollout implementation backend. `native` for fast Python executor, `vikingbot` for full VikingBot AgentLoop. |
-| `--experience-recall-mode` | `case_ann` | Experience recall strategy: `case_ann`, `exp_ann`, or `hybrid_ann`. |
+| `--loader-mode` | `skill` | How experiences reach the agent: `skill`, `selector`, `constraint`, or `direct_experience`. See below. |
+| `--experience-recall-mode` | `case_ann` | Experience recall strategy: `case_ann`, `exp_ann`, or `hybrid_ann`. Applies to `--loader-mode skill` only. |
 | `--native-thread-workers` | `128` | Thread pool size for native rollout executor. |
 | `--rollout-thread-workers` | `200` | Worker threads used to host rollout executions off the uvicorn event loop. Use `0` to disable threaded hosting. |
 | `--max-rollout-concurrency` | `200` | Maximum concurrent rollout executions accepted by the service. |
 | `--no-kill-existing` | off | Don't kill existing process on the same port. |
+
+### Experience loader modes
+
+`--loader-mode` (or `TAU2_EXPERIENCE_LOADER_MODE`) selects how stored experiences
+reach the rollout agent:
+
+| Mode | Tools exposed to the agent | Recall and filtering |
+|------|----------------------------|----------------------|
+| `skill` | `search_experience`, `read_experience` | The agent drives recall itself: it searches, reads candidate names and Situation snippets, then decides what to read in full. Honours `--experience-recall-mode`. |
+| `selector` | `load_relevant_experience` | Recall, full reads, and applicability filtering all run **outside** the main context. One isolated LLM call judges the candidates and at most 2 applicable experiences come back — rejected candidates never enter the rollout context. |
+| `constraint` | none | Experience constraints are injected automatically as reminder messages before tool calls. |
+| `direct_experience` | none | A fixed experience supplied via `direct_experience_content` is injected as an Experience Reminder before the task. Used for A/B testing one specific experience. |
+
+`selector` exists because `skill` mode has a priming channel: candidate names and
+Situation snippets the agent never reads still bias it toward past outcomes —
+most damagingly toward refusing or escalating by analogy with a past case. Moving
+the filter into an isolated call closes that channel, at the cost of one extra
+LLM call per retrieval.
+
+Both `skill` and `selector` install an `experience_loader` skill into the rollout
+sandbox at `skills/experience_loader/SKILL.md` and force-read it before task
+actions; the content differs (`experience_loader_template/SKILL.md` vs
+`SKILL_SELECTOR.md`). Selector recall is intentionally fixed at Case ANN ->
+`## Linked Experiences` -> full experience text, since the judge needs whole
+experiences rather than snippets — so `--experience-recall-mode` does not apply.
+
+Two caveats when comparing `selector` against `skill`:
+
+- Selector does not use the exact-case (`task_signature`) lookup that `case_ann`
+  applies in skill mode, so an exactly-matching experience only becomes a
+  candidate when it also ranks in the semantic top 3. A selector-vs-skill A/B
+  therefore varies recall as well as filtering.
+- The judge is one extra LLM call per retrieval, on the rollout's own model. Its
+  tokens are not currently added to the rollout's `token_usage`, so reports
+  understate selector's cost.
+
+```bash
+bash benchmark/tau2/train/run_service.sh --loader-mode selector
+```
 
 Then run the lower-level Tau2 wrapper:
 

--- a/benchmark/tau2/train/experience_loader_template/SKILL_SELECTOR.md
+++ b/benchmark/tau2/train/experience_loader_template/SKILL_SELECTOR.md
@@ -1,0 +1,11 @@
+---
+name: experience_loader
+description: Load relevant past-task experience memories through an isolated retrieval filter before solving a task.
+---
+
+# experience_loader
+
+1. Before taking task actions, call `load_relevant_experience` once with a natural-language description of the current task: the user's intents, target objects, requested operations, and relevant policy keywords.
+2. The tool returns at most 2 past-task experiences that were judged applicable — or a message that none apply. If none apply, proceed from the current policy and tool results; do not retry with rephrased queries.
+3. If a genuinely NEW user intent emerges later in the conversation that the first call's description did not cover, you may call `load_relevant_experience` once more for that intent.
+4. Returned experiences are guidance from prior tasks. Their `## Situation` states when they apply ("Applies when") and when they do not ("Does not apply when"); `## Reminder` and `## Procedure` describe what to do; `## Anti-pattern` records what went wrong before. Current policy, current tool results, and current user requests always take precedence.

--- a/benchmark/tau2/train/restart_vikingbot_train_eval.sh
+++ b/benchmark/tau2/train/restart_vikingbot_train_eval.sh
@@ -27,6 +27,7 @@ AUTO_COMMIT=false
 TAU2_ROLLOUT_SEED="${TAU2_ROLLOUT_SEED:-300}"
 TAU2_FIRST_USER_CACHE="${TAU2_FIRST_USER_CACHE:-on}"
 EXPERIENCE_RECALL_MODE="case_ann"
+LOADER_MODE_ARG="skill"
 declare -a TRAIN_CLI_ARGS=()
 
 usage() {
@@ -51,6 +52,11 @@ Launcher options:
             Cache and replay each task/trial's first user message. Default: on.
   --experience-recall-mode case_ann|exp_ann|hybrid_ann
             Experience recall strategy. Default: case_ann.
+            Applies to --loader-mode skill only.
+  --loader-mode skill|selector|constraint|direct_experience
+            How experiences reach the agent. Default: skill.
+            selector filters candidates in an isolated context and returns
+            at most 2 applicable experiences.
 
 All remaining args are passed to benchmark/tau2/train/run_batch_train_eval.sh.
 USAGE
@@ -111,6 +117,18 @@ parse_launcher_args() {
         EXPERIENCE_RECALL_MODE="${1#--experience-recall-mode=}"
         shift 1
         ;;
+      --loader-mode)
+        if [[ $# -lt 2 ]]; then
+          echo "[restart-vikingbot-train] ERROR: --loader-mode requires a value" >&2
+          exit 1
+        fi
+        LOADER_MODE_ARG="$2"
+        shift 2
+        ;;
+      --loader-mode=*)
+        LOADER_MODE_ARG="${1#--loader-mode=}"
+        shift 1
+        ;;
       -h|--help)
         usage
         exit 0
@@ -156,11 +174,22 @@ validate_experience_recall_mode() {
   fi
 }
 
+validate_loader_mode() {
+  case "${LOADER_MODE_ARG}" in
+    skill|selector|constraint|direct_experience) ;;
+    *)
+      echo "[restart-vikingbot-train] ERROR: --loader-mode must be skill, selector, constraint, or direct_experience, got: ${LOADER_MODE_ARG}" >&2
+      exit 1
+      ;;
+  esac
+}
+
 parse_launcher_args "$@"
 validate_slot
 validate_seed
 validate_first_user_cache
 validate_experience_recall_mode
+validate_loader_mode
 
 if [[ "${SLOT}" == "0" ]]; then
   DEFAULT_OPENVIKING_PORT="1933"
@@ -189,7 +218,7 @@ OPENVIKING_BOT_PORT="${DEFAULT_OPENVIKING_BOT_PORT}"
 TAU2_SERVICE_HOST="127.0.0.1"
 TAU2_SERVICE_PORT="${DEFAULT_TAU2_SERVICE_PORT}"
 TAU2_ROLLOUT_BACKEND="vikingbot"
-TAU2_EXPERIENCE_LOADER_MODE="skill"
+TAU2_EXPERIENCE_LOADER_MODE="${LOADER_MODE_ARG}"
 TAU2_MAX_ROLLOUT_CONCURRENCY="150"
 TAU2_ROLLOUT_THREAD_WORKERS="${TAU2_MAX_ROLLOUT_CONCURRENCY}"
 WAIT_TIMEOUT_SECONDS="180"

--- a/benchmark/tau2/train/rollout_executor_vikingbot.py
+++ b/benchmark/tau2/train/rollout_executor_vikingbot.py
@@ -40,7 +40,7 @@ from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
-Tau2ExperienceLoaderMode = Literal["skill", "constraint", "direct_experience"]
+Tau2ExperienceLoaderMode = Literal["skill", "selector", "constraint", "direct_experience"]
 Tau2ExperienceRecallMode = Literal["case_ann", "exp_ann", "hybrid_ann"]
 VikingBotSystemPromptProfile = Literal["full", "minimal"]
 DEFAULT_TAU2_EXPERIENCE_LOADER_MODE: Tau2ExperienceLoaderMode = "skill"
@@ -49,6 +49,15 @@ DEFAULT_SYSTEM_PROMPT_PROFILE: VikingBotSystemPromptProfile = "minimal"
 _EXPERIENCE_RECALL_RRF_K = 60
 _SEMANTIC_CASE_PRIOR_WEIGHT = 0.25
 _EXACT_CASE_BOOST = 1.0
+_SELECTOR_CANDIDATE_CASE_LIMIT = 3
+_SELECTOR_CANDIDATE_LIMIT = 6
+_SELECTOR_CANDIDATE_CHARS = 6000
+_SELECTOR_MAX_SELECTED = 2
+# The judge only has to emit `{"selected": [...]}`, but this budget is also spent on
+# reasoning tokens, so it is sized for reasoning models rather than for the answer.
+# It is a ceiling, not an allocation: a model that answers in 10 tokens still costs 10.
+# Only honoured on the LiteLLMProvider path — VLMProviderAdapter drops it (see _selector_judge).
+_SELECTOR_JUDGE_MAX_TOKENS = 2048
 DEFAULT_FIRST_USER_CACHE_DIR = (
     Path(__file__).resolve().parents[3]
     / "result"
@@ -68,8 +77,10 @@ def normalize_system_prompt_profile(value: Any) -> VikingBotSystemPromptProfile:
 
 def normalize_tau2_experience_loader_mode(value: Any) -> Tau2ExperienceLoaderMode:
     mode = str(value or DEFAULT_TAU2_EXPERIENCE_LOADER_MODE).strip().lower()
-    if mode not in {"skill", "constraint", "direct_experience"}:
-        raise ValueError("loader_mode must be 'skill', 'constraint', or 'direct_experience'")
+    if mode not in {"skill", "selector", "constraint", "direct_experience"}:
+        raise ValueError(
+            "loader_mode must be 'skill', 'selector', 'constraint', or 'direct_experience'"
+        )
     return mode  # type: ignore[return-value]
 
 
@@ -620,6 +631,23 @@ def _trace_experience_recall(
     tracer.info(json.dumps(payload, ensure_ascii=False))
 
 
+def _format_loaded_experience(uri: str, content: str) -> str:
+    """Render one experience as the `# Loaded Experience` block the agent sees.
+
+    Shared by `read_experience` (skill mode) and the selector, so both modes present
+    experiences identically no matter which path loaded them.
+    """
+    return "\n".join(
+        [
+            "# Loaded Experience",
+            "",
+            f"Experience URI: `{uri}`",
+            "",
+            content.rstrip(),
+        ]
+    ).rstrip()
+
+
 def _make_read_experience_tool():
     Tool = _vikingbot_imports()["Tool"]
 
@@ -657,20 +685,10 @@ def _make_read_experience_tool():
                     return f"Error: URI is not an experience memory: {experience_uri}"
                 content = await client.read_content(experience_uri, level="read")
                 if not content:
-                    return (
-                        "# Loaded Experience\n\n"
-                        f"Experience URI: `{experience_uri}`\n\n"
-                        "Error: experience content not found."
+                    return _format_loaded_experience(
+                        experience_uri, "Error: experience content not found."
                     )
-                return "\n".join(
-                    [
-                        "# Loaded Experience",
-                        "",
-                        f"Experience URI: `{experience_uri}`",
-                        "",
-                        content.rstrip(),
-                    ]
-                ).rstrip()
+                return _format_loaded_experience(experience_uri, content)
             except Exception as exc:
                 logger.warning("read_experience failed: %s", exc)
                 return f"Error reading experience memory: {exc}"
@@ -679,6 +697,294 @@ def _make_read_experience_tool():
                     await client.close()
 
     return ReadExperienceTool()
+
+
+_SELECTOR_NO_EXPERIENCE = (
+    "No stored experience is applicable to this task. "
+    "Proceed from the current policy, tool results, and user requests."
+)
+
+_SELECTOR_SYSTEM_PROMPT = """\
+You are a memory-retrieval filter for an autonomous agent. You receive the agent's \
+current task description and a numbered list of candidate experience memories written \
+after past tasks. Decide which candidates are genuinely applicable to the current task.
+
+Selection rules:
+- A candidate is applicable only if its `## Situation` matches the current task AND none \
+of its exclusions match it. Exclusions are written as "Does not apply when" (or the \
+equivalent in the run's language, e.g. "不适用于").
+- The candidates describe how PAST tasks were handled. That a past task ended in refusal, \
+denial, or escalation is not evidence the current task ends that way — judge only whether \
+the described situation matches, not whether the outcome sounds plausible.
+- When unsure, do not select. A partially matching experience misleads the agent more than \
+no experience at all.
+- Select at most 2 candidates.
+
+Respond with strict JSON only, no prose: {"selected": [<candidate numbers>]} \
+Use {"selected": []} if none apply."""
+
+
+async def _selector_collect_candidates(client: Any, query: str) -> list[tuple[str, str]]:
+    """Search cases, resolve linked experiences, read their full content.
+
+    Selector recall is deliberately independent of ``experience_recall_mode``: it always
+    goes Case ANN -> ``## Linked Experiences`` -> full experience text, because the judge
+    needs whole experiences (Situation plus exclusions) rather than the snippet-shaped
+    candidates the ``search_experience`` recall modes produce.
+
+    Known gap: unlike ``skill`` mode this does not consult ``_find_exact_case_item``, so a
+    task_signature-exact case only contributes candidates when it also ranks in the
+    semantic top-``_SELECTOR_CANDIDATE_CASE_LIMIT``. Feeding exact-case links in first is
+    a plausible improvement, but it changes which candidates the judge sees and so needs
+    its own A/B run rather than being folded in silently.
+    """
+    target_uri = _current_cases_uri(client)
+    result = await client.search(query, target_uri=target_uri, limit=_SELECTOR_CANDIDATE_CASE_LIMIT)
+    memories = result.get("memories", []) if isinstance(result, dict) else []
+    case_uris = [uri for uri in (_case_uri(item) for item in memories) if uri]
+    case_contents = await asyncio.gather(
+        *(_selector_read(client, uri) for uri in case_uris),
+    )
+
+    # Case rank drives candidate order, so keep the search order while de-duplicating:
+    # the same experience is routinely linked from several cases.
+    exp_uris: list[str] = []
+    for case_uri, case_content in zip(case_uris, case_contents, strict=True):
+        if not case_content:
+            continue
+        for uri in _linked_experience_uris(case_content, source_uri=case_uri):
+            if uri not in exp_uris:
+                exp_uris.append(uri)
+
+    exp_uris = exp_uris[:_SELECTOR_CANDIDATE_LIMIT]
+    exp_contents = await asyncio.gather(
+        *(_selector_read(client, uri) for uri in exp_uris),
+    )
+    return [
+        (uri, _truncate_candidate(content.strip()))
+        for uri, content in zip(exp_uris, exp_contents, strict=True)
+        if content and content.strip()
+    ]
+
+
+def _truncate_candidate(content: str) -> str:
+    """Bound one candidate's contribution to the judge prompt.
+
+    The selected text is handed to the agent verbatim, so a silent cut would make selector
+    mode deliver a different (shorter) experience than `read_experience` does for the same
+    URI. Mark the cut instead of hiding it.
+    """
+    if len(content) <= _SELECTOR_CANDIDATE_CHARS:
+        return content
+    return content[:_SELECTOR_CANDIDATE_CHARS].rstrip() + "\n\n[... experience truncated ...]"
+
+
+async def _selector_read(client: Any, uri: str) -> str | None:
+    """Read one memory, treating an unreadable entry as absent rather than fatal."""
+    try:
+        return await client.read_content(uri, level="read")
+    except Exception as exc:
+        logger.warning("selector could not read %s: %s", uri, exc)
+        return None
+
+
+async def _selector_judge(
+    provider: Any,
+    model: str | None,
+    task_description: str,
+    candidates: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """One isolated LLM call deciding which candidates genuinely apply (at most 2).
+
+    The call carries only the task description and the candidate texts — never the
+    rollout conversation — so rejected candidates leave no trace in the main context.
+    """
+    parts = [f"## Current task\n{task_description.strip()}", "## Candidates"]
+    for idx, (_uri, content) in enumerate(candidates, start=1):
+        parts.append(f"### Candidate {idx}\n{content}")
+    response = await provider.chat(
+        messages=[
+            {"role": "system", "content": _SELECTOR_SYSTEM_PROMPT},
+            {"role": "user", "content": "\n\n".join(parts)},
+        ],
+        model=model,
+        # NOTE: `VLMProviderAdapter.chat` accepts these two and then drops them — it calls
+        # `get_completion_async`, whose signature has neither. They only take effect on the
+        # `LiteLLMProvider` path. So the judge runs at the VLM's own temperature and token
+        # ceiling whenever `bot.agents.provider` is configured; do not rely on them for
+        # determinism, and do not tell operators to tune them.
+        max_tokens=_SELECTOR_JUDGE_MAX_TOKENS,
+        temperature=0.0,
+    )
+    finish_reason = str(getattr(response, "finish_reason", "") or "")
+    raw = str(getattr(response, "content", "") or "")
+
+    # `VLMProviderAdapter.chat` never raises: it returns finish_reason="error" with the
+    # exception text as content. Without this branch a rate-limited or timed-out judge is
+    # indistinguishable from a judge that carefully decided nothing applies — the whole
+    # mode would degrade to the no-memory baseline while the report claims it ran.
+    if finish_reason == "error":
+        logger.error("experience selector judge call failed: %s", raw[:300])
+        return []
+    if finish_reason == "length":
+        logger.warning(
+            "experience selector reply was truncated before it emitted JSON: %r", raw[:200]
+        )
+        return []
+
+    parsed = _parse_selector_reply(raw)
+    if parsed is None:
+        logger.warning("experience selector returned no usable JSON object: %r", raw[:200])
+        return []
+
+    selected = parsed.get("selected")
+    if not isinstance(selected, list):
+        # A bare `{"selected": 1}` would otherwise raise TypeError and surface as a
+        # retrieval failure, hiding the fact that the judge answered in the wrong shape.
+        if selected is not None:
+            logger.warning("experience selector 'selected' is not a list: %r", selected)
+        return []
+
+    picked: list[tuple[str, str]] = []
+    seen: set[int] = set()
+    for value in selected:
+        # bool is an int subclass; `[true]` must not silently mean candidate 1.
+        if isinstance(value, bool) or not isinstance(value, int | str):
+            continue
+        try:
+            idx = int(value)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= idx <= len(candidates) and idx not in seen:
+            seen.add(idx)
+            picked.append(candidates[idx - 1])
+    return picked[:_SELECTOR_MAX_SELECTED]
+
+
+def _parse_selector_reply(raw: str) -> dict[str, Any] | None:
+    """Extract the judge's JSON object from a reply that may carry prose around it.
+
+    A greedy ``\\{.*\\}`` scan breaks on any stray brace in that prose — and because an
+    empty selection is indistinguishable from "nothing applies", such a miss silently
+    discards a correct answer. Try the whole reply first, then each balanced ``{...}``
+    span, preferring one that actually carries ``selected``.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    def _as_obj(text: str) -> dict[str, Any] | None:
+        try:
+            value = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    direct = _as_obj(raw)
+    if direct is not None:
+        return direct
+
+    fallback: dict[str, Any] | None = None
+    for start, char in enumerate(raw):
+        if char != "{":
+            continue
+        depth = 0
+        for end in range(start, len(raw)):
+            if raw[end] == "{":
+                depth += 1
+            elif raw[end] == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = _as_obj(raw[start : end + 1])
+                    if candidate is not None:
+                        if "selected" in candidate:
+                            return candidate
+                        fallback = fallback if fallback is not None else candidate
+                    break
+    return fallback
+
+
+def _format_selected_experiences(selected: list[tuple[str, str]]) -> str:
+    return "\n\n---\n\n".join(_format_loaded_experience(uri, content) for uri, content in selected)
+
+
+def _make_load_relevant_experience_tool(judge_provider: Any, judge_model: str | None = None):
+    """Selector-mode experience retrieval: search, read, and applicability filtering all
+    happen outside the main context; only the selected experiences (or nothing) return.
+
+    This removes the priming channel that ``skill`` mode exposes, where unread candidate
+    names and Situation snippets in ``search_experience`` output bias the agent toward
+    past outcomes — most damagingly toward refusing or escalating by analogy.
+
+    The judge runs on ``judge_provider``/``judge_model``, which today is the rollout
+    agent's own provider and model. They are passed explicitly so the filter can later
+    be pointed at a cheaper model without reaching into the agent.
+    """
+    Tool = _vikingbot_imports()["Tool"]
+
+    class LoadRelevantExperienceTool(Tool):
+        @property
+        def name(self) -> str:
+            return "load_relevant_experience"
+
+        @property
+        def description(self) -> str:
+            return (
+                "Retrieve past experience memories relevant to the current task. "
+                "Searches the memory store and filters candidates for applicability in an "
+                "isolated context; returns at most 2 applicable experiences, or a message "
+                "that none apply. Call once with a full description of the task."
+            )
+
+        @property
+        def parameters(self) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "properties": {
+                    "task_description": {
+                        "type": "string",
+                        "description": (
+                            "Natural-language description of the current task: user "
+                            "intents, target objects, requested operations, policy keywords."
+                        ),
+                    },
+                },
+                "required": ["task_description"],
+            }
+
+        async def execute(self, tool_context: Any, task_description: str, **kwargs: Any) -> str:
+            del tool_context, kwargs
+            client = None
+            try:
+                from vikingbot.openviking_mount.ov_server import VikingClient
+
+                client = await VikingClient.create()
+                try:
+                    candidates = await _selector_collect_candidates(client, task_description)
+                finally:
+                    # Release the OV connection pool before the judge call: rollouts run at
+                    # concurrency ~200 and the provider retries rate limits without bound,
+                    # so holding it across the LLM call would pin ~200 idle pools for as
+                    # long as that takes.
+                    await client.close()
+                    client = None
+                if not candidates:
+                    return _SELECTOR_NO_EXPERIENCE
+                selected = await _selector_judge(
+                    judge_provider, judge_model, task_description, candidates
+                )
+                if not selected:
+                    return _SELECTOR_NO_EXPERIENCE
+                return _format_selected_experiences(selected)
+            except Exception as exc:
+                # Memory is best-effort: a retrieval failure must never fail the rollout.
+                logger.warning("load_relevant_experience failed: %s", exc)
+                return _SELECTOR_NO_EXPERIENCE
+            finally:
+                if client is not None:
+                    await client.close()
+
+    return LoadRelevantExperienceTool()
 
 
 def _current_cases_uri(client: Any) -> str:
@@ -1459,6 +1765,11 @@ def _configure_tools(
             )
         )
         agent.tools.register(_make_read_experience_tool())
+    elif loader_mode == "selector":
+        # Single tool: recall and applicability filtering run outside the main context.
+        # agent.model, not a None fallback: falling back would silently judge with the
+        # provider's default model rather than the rollout's own.
+        agent.tools.register(_make_load_relevant_experience_tool(agent.provider, agent.model))
     tool_lock = _AsyncRWLock()
     write_tool_names = _classify_write_tools(provider)
     for schema in provider.list_openai_tools():
@@ -1551,6 +1862,14 @@ def _classify_write_tools(provider: Any) -> set[str]:
     return write_names
 
 
+_EXPERIENCE_PRECEDENCE_CAVEAT = (
+    "Loaded experiences are guidance from prior training runs. "
+    "Use them only when their situation and applicability boundaries match the current "
+    "task; current policy, current tool results, and current user facts override prior "
+    "experience."
+)
+
+
 def _build_system_prompt(
     policy: str,
     *,
@@ -1564,20 +1883,23 @@ def _build_system_prompt(
     if policy:
         instructions.append(policy)
     instructions.append("Use the provided tools to interact with the environment.")
-    if loader_mode == "skill":
-        instructions.append(
-            "Before taking task actions, you MUST use the required `experience_loader` skill. "
-            "It explains how to search OpenViking case memories with the `search_experience` "
-            "tool, use exact-case experiences that are auto-loaded inline, and use Situation "
-            "snippets only as filters before reading semantic-search candidates with the "
-            "`read_experience` tool."
-        )
-        instructions.append(
-            "Loaded experiences are guidance from prior training runs. "
-            "Use them only when their situation and applicability boundaries match the current "
-            "task; current policy, current tool results, and current user facts override prior "
-            "experience."
-        )
+    if loader_mode in {"skill", "selector"}:
+        if loader_mode == "skill":
+            instructions.append(
+                "Before taking task actions, you MUST use the required `experience_loader` "
+                "skill. It explains how to search OpenViking case memories with the "
+                "`search_experience` tool, use exact-case experiences that are auto-loaded "
+                "inline, and use Situation snippets only as filters before reading "
+                "semantic-search candidates with the `read_experience` tool."
+            )
+        else:
+            instructions.append(
+                "Before taking task actions, you MUST use the required `experience_loader` "
+                "skill. It explains how to retrieve applicable past experiences with the "
+                "`load_relevant_experience` tool, which searches and filters candidates in an "
+                "isolated context and returns only experiences judged applicable."
+            )
+        instructions.append(_EXPERIENCE_PRECEDENCE_CAVEAT)
     elif loader_mode == "direct_experience":
         instructions.append(
             "A direct experimental experience will be injected as an Experience Reminder before "
@@ -1622,11 +1944,16 @@ async def _prepare_experience_loader_skill(
     agent: Any,
     session_key: Any,
     system_prompt_profile: VikingBotSystemPromptProfile = DEFAULT_SYSTEM_PROMPT_PROFILE,
+    template_filename: str = "SKILL.md",
 ) -> Any:
     """Install the generic experience_loader skill into the rollout sandbox.
 
-    The loader does not contain per-task memory. It instructs the LLM to use the
-    tau2-only `search_experience` and `read_experience` tools to search case-linked experiences and load selected experience memories.
+    The loader does not contain per-task memory. ``SKILL.md`` (loader_mode='skill')
+    instructs the LLM to use the tau2-only `search_experience` and `read_experience`
+    tools to search case-linked experiences and load selected experience memories.
+    ``SKILL_SELECTOR.md`` (loader_mode='selector') instead points at the single
+    `load_relevant_experience` tool. Either way the skill is installed at the same
+    sandbox path, so the required-read step is identical.
     """
 
     imports = _vikingbot_imports()
@@ -1636,7 +1963,7 @@ async def _prepare_experience_loader_skill(
         if sandbox_manager
         else agent.context.workspace
     )
-    skill_content = _read_experience_loader_template_file("SKILL.md")
+    skill_content = _read_experience_loader_template_file(template_filename)
     await asyncio.to_thread(_EXPERIENCE_LOADER_SKILL_LOCK.acquire)
     try:
         await _install_experience_loader_skill(
@@ -1819,12 +2146,15 @@ async def _run_agent(
     system_prompt_profile = normalize_system_prompt_profile(system_prompt_profile)
     message_context = agent.context
     experience_loader_skill = None
-    if loader_mode == "skill":
-        system_prompt = _append_runtime_case_context(system_prompt, case_lookup)
+    if loader_mode in {"skill", "selector"}:
+        if loader_mode == "skill":
+            # Selector mode has no `search_experience` tool to pass a task_signature to.
+            system_prompt = _append_runtime_case_context(system_prompt, case_lookup)
         message_context = await _prepare_experience_loader_skill(
             agent=agent,
             session_key=session_key,
             system_prompt_profile=system_prompt_profile,
+            template_filename="SKILL_SELECTOR.md" if loader_mode == "selector" else "SKILL.md",
         )
         experience_loader_skill = getattr(
             message_context,
@@ -2150,10 +2480,16 @@ def _case_memory_context_from_tools(tools_used: list[dict] | None) -> str:
         if tool.get("tool_name") == "search_experience":
             blocks.extend(_exact_case_experience_blocks(tool.get("result")))
             continue
-        if tool.get("tool_name") != "read_experience":
+        tool_name = tool.get("tool_name")
+        if tool_name not in {"read_experience", "load_relevant_experience"}:
             continue
         result = str(tool.get("result") or "").strip()
         if not result:
+            continue
+        # Selector mode reports "nothing applied" through a sentinel rather than an empty
+        # result; recording it as loaded memory would tell failure analysis the rollout had
+        # experience context when it had none.
+        if tool_name == "load_relevant_experience" and result == _SELECTOR_NO_EXPERIENCE:
             continue
         args = tool.get("args")
         blocks.append(
@@ -2161,7 +2497,7 @@ def _case_memory_context_from_tools(tools_used: list[dict] | None) -> str:
                 [
                     "## Loaded Experience",
                     "",
-                    "Tool: `read_experience`",
+                    f"Tool: `{tool_name}`",
                     "",
                     "Args:",
                     "```json",

--- a/benchmark/tau2/train/run_service.sh
+++ b/benchmark/tau2/train/run_service.sh
@@ -83,7 +83,7 @@ Options:
                      Rollout response language. Use zh for Chinese user-facing replies.
   --rollout-backend native|vikingbot
                      Rollout implementation backend. Default: vikingbot.
-  --loader-mode skill|constraint|direct_experience
+  --loader-mode skill|selector|constraint|direct_experience
                      VikingBot experience loading mode. Default: skill.
   --experience-recall-mode case_ann|exp_ann|hybrid_ann
                      VikingBot experience recall strategy. Default: case_ann.
@@ -123,8 +123,8 @@ if [[ "${ROLLOUT_BACKEND}" != "native" && "${ROLLOUT_BACKEND}" != "vikingbot" ]]
   exit 1
 fi
 
-if [[ "${LOADER_MODE}" != "skill" && "${LOADER_MODE}" != "constraint" && "${LOADER_MODE}" != "direct_experience" ]]; then
-  echo "[tau2-service] invalid --loader-mode: ${LOADER_MODE}. Expected skill, constraint, or direct_experience" >&2
+if [[ "${LOADER_MODE}" != "skill" && "${LOADER_MODE}" != "selector" && "${LOADER_MODE}" != "constraint" && "${LOADER_MODE}" != "direct_experience" ]]; then
+  echo "[tau2-service] invalid --loader-mode: ${LOADER_MODE}. Expected skill, selector, constraint, or direct_experience" >&2
   exit 1
 fi
 

--- a/benchmark/tau2/train/service_app.py
+++ b/benchmark/tau2/train/service_app.py
@@ -177,7 +177,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--loader-mode",
-        choices=["skill", "constraint", "direct_experience"],
+        choices=["skill", "selector", "constraint", "direct_experience"],
         default=os.getenv("TAU2_EXPERIENCE_LOADER_MODE", DEFAULT_TAU2_EXPERIENCE_LOADER_MODE),
         help="Experience loading mode for vikingbot rollouts (default: skill).",
     )

--- a/openviking/session/train/components/gradient_estimator.py
+++ b/openviking/session/train/components/gradient_estimator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
@@ -572,6 +573,18 @@ def _loaded_experience_uris(analysis: RolloutAnalysis) -> list[str]:
                 )
                 loaded_uris.extend(_exact_case_search_loaded_experience_uris(tool_output))
                 continue
+            if tool_name == "load_relevant_experience":
+                # Selector-mode retrieval names the experiences it loaded only in its
+                # output; its input is a task description. Without this the estimator can
+                # never target an existing experience for update, so selector rollouts
+                # could only ever create new ones.
+                tool_output = (
+                    part.get("tool_output", "")
+                    if isinstance(part, dict)
+                    else getattr(part, "tool_output", "")
+                )
+                loaded_uris.extend(_loaded_experience_block_uris(tool_output))
+                continue
             if tool_name != "read_experience":
                 continue
             tool_input = tool_input or {}
@@ -581,6 +594,17 @@ def _loaded_experience_uris(analysis: RolloutAnalysis) -> list[str]:
             if uri:
                 loaded_uris.append(uri)
     return list(dict.fromkeys(loaded_uris))
+
+
+def _loaded_experience_block_uris(tool_output: Any) -> list[str]:
+    """Pull experience URIs out of rendered ``# Loaded Experience`` blocks."""
+    if not isinstance(tool_output, str):
+        return []
+    return [
+        uri
+        for uri in re.findall(r"^Experience URI: `([^`]+)`", tool_output, re.MULTILINE)
+        if uri.strip()
+    ]
 
 
 def _exact_case_search_loaded_experience_uris(tool_output: Any) -> list[str]:

--- a/tests/session/train/test_rollout_executor_component.py
+++ b/tests/session/train/test_rollout_executor_component.py
@@ -2650,3 +2650,567 @@ def test_tau2_rollout_messages_preserve_runtime_user_constraint_reminder():
     ]
     assert tool_parts[0].tool_name == "get_reservation_details"
     assert tool_parts[0].tool_input == {"reservation_id": "XEHM4B"}
+
+
+def _selector_client_factory(*, cases, contents, observed=None):
+    """Build a FakeClient class serving one case search plus memory reads."""
+
+    class FakeClient:
+        @classmethod
+        async def create(cls):
+            return cls()
+
+        def _memory_target_uri(self, uri):
+            assert uri is None
+            return "viking://user/u/memories"
+
+        async def search(self, query, *, target_uri, limit):
+            if observed is not None:
+                observed.update(query=query, target_uri=target_uri, limit=limit)
+            return {"memories": cases}
+
+        async def read_content(self, uri, *, level=None):
+            if uri not in contents:
+                raise FileNotFoundError(uri)
+            return contents[uri]
+
+        async def close(self):
+            if observed is not None:
+                observed["closed"] = True
+
+    return FakeClient
+
+
+def _selector_provider(reply, *, observed=None, finish_reason="stop"):
+    class FakeProvider:
+        async def chat(self, messages, *, model=None, max_tokens=None, temperature=None, **kwargs):
+            if observed is not None:
+                observed["judge_messages"] = messages
+                observed["judge_model"] = model
+                observed["judge_max_tokens"] = max_tokens
+                observed["judge_temperature"] = temperature
+            return SimpleNamespace(content=reply, finish_reason=finish_reason)
+
+    return FakeProvider()
+
+
+def test_tau2_experience_loader_mode_accepts_selector():
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        DEFAULT_TAU2_EXPERIENCE_LOADER_MODE,
+        VikingBotTau2RolloutExecutor,
+        normalize_tau2_experience_loader_mode,
+    )
+
+    assert DEFAULT_TAU2_EXPERIENCE_LOADER_MODE == "skill"
+    assert VikingBotTau2RolloutExecutor(loader_mode="selector").loader_mode == "selector"
+    assert normalize_tau2_experience_loader_mode(" SELECTOR ") == "selector"
+    with pytest.raises(ValueError, match="loader_mode"):
+        normalize_tau2_experience_loader_mode("selecter")
+
+
+def test_tau2_selector_mode_registers_only_the_isolated_retrieval_tool():
+    """Selector mode must not expose search_experience: its snippets are the priming
+    channel selector exists to remove."""
+    import benchmark.tau2.train.rollout_executor_vikingbot as module
+
+    registered = []
+
+    class FakeTools:
+        tool_names = []
+
+        def unregister(self, name):
+            raise AssertionError(f"unexpected unregister: {name}")
+
+        def register(self, tool):
+            registered.append(tool.name)
+
+    class FakeProvider:
+        def list_openai_tools(self):
+            return []
+
+    agent = SimpleNamespace(tools=FakeTools(), provider=FakeProvider(), model="m")
+    module._configure_tools(agent, agent.provider, keep_default_tools=True, loader_mode="selector")
+
+    assert registered == ["load_relevant_experience"]
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_returns_only_judge_selected_experiences(monkeypatch):
+    """The tool output carries the selected experience only — rejected candidates and
+    the candidate list itself never reach the rollout context."""
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _make_load_relevant_experience_tool,
+    )
+
+    observed = {}
+    monkeypatch.setattr(
+        ov_server,
+        "VikingClient",
+        _selector_client_factory(
+            cases=[{"uri": "viking://user/u/memories/cases/case1.md", "score": 0.9}],
+            contents={
+                "viking://user/u/memories/cases/case1.md": (
+                    "## Linked Experiences\n\n"
+                    "- [refund](../experiences/refund.md)\n"
+                    "- [upgrade](../experiences/upgrade.md)\n"
+                ),
+                "viking://user/u/memories/experiences/refund.md": "## Situation\nRefund request.",
+                "viking://user/u/memories/experiences/upgrade.md": "## Situation\nCabin upgrade.",
+            },
+            observed=observed,
+        ),
+    )
+
+    tool = _make_load_relevant_experience_tool(
+        _selector_provider('{"selected": [2]}', observed=observed), "judge-model"
+    )
+    result = await tool.execute(None, task_description="user wants a cabin upgrade")
+
+    assert observed["target_uri"] == "viking://user/u/memories/cases"
+    assert observed["closed"] is True
+    assert observed["judge_model"] == "judge-model"
+
+    # The judge call is isolated: system prompt plus one user turn, no rollout history.
+    assert [m["role"] for m in observed["judge_messages"]] == ["system", "user"]
+
+    assert "Experience URI: `viking://user/u/memories/experiences/upgrade.md`" in result
+    assert "Cabin upgrade." in result
+    assert "refund.md" not in result
+    assert "Refund request." not in result
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_reports_no_experience_when_judge_selects_nothing(monkeypatch):
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _SELECTOR_NO_EXPERIENCE,
+        _make_load_relevant_experience_tool,
+    )
+
+    monkeypatch.setattr(
+        ov_server,
+        "VikingClient",
+        _selector_client_factory(
+            cases=[{"uri": "viking://user/u/memories/cases/case1.md", "score": 0.9}],
+            contents={
+                "viking://user/u/memories/cases/case1.md": (
+                    "## Linked Experiences\n\n- [refund](../experiences/refund.md)\n"
+                ),
+                "viking://user/u/memories/experiences/refund.md": "## Situation\nRefund request.",
+            },
+        ),
+    )
+
+    tool = _make_load_relevant_experience_tool(_selector_provider('{"selected": []}'))
+    assert await tool.execute(None, task_description="unrelated") == _SELECTOR_NO_EXPERIENCE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reply",
+    ["no json here", "{not valid json}", '{"selected": [99]}', '{"selected": ["x"]}', "[]"],
+)
+async def test_tau2_selector_degrades_to_no_experience_on_bad_judge_output(monkeypatch, reply):
+    """Memory is best-effort: a malformed judge reply must never fail the rollout."""
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _SELECTOR_NO_EXPERIENCE,
+        _make_load_relevant_experience_tool,
+    )
+
+    monkeypatch.setattr(
+        ov_server,
+        "VikingClient",
+        _selector_client_factory(
+            cases=[{"uri": "viking://user/u/memories/cases/case1.md", "score": 0.9}],
+            contents={
+                "viking://user/u/memories/cases/case1.md": (
+                    "## Linked Experiences\n\n- [refund](../experiences/refund.md)\n"
+                ),
+                "viking://user/u/memories/experiences/refund.md": "## Situation\nRefund request.",
+            },
+        ),
+    )
+
+    tool = _make_load_relevant_experience_tool(_selector_provider(reply))
+    assert await tool.execute(None, task_description="anything") == _SELECTOR_NO_EXPERIENCE
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_caps_selection_and_keeps_case_rank_order(monkeypatch):
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import _selector_collect_candidates
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _selector_judge as judge,
+    )
+
+    contents = {
+        "viking://user/u/memories/cases/case1.md": (
+            "## Linked Experiences\n\n- [a](../experiences/a.md)\n- [b](../experiences/b.md)\n"
+        ),
+        # case2 re-links a.md: de-duplication must keep the first (higher-ranked) position.
+        "viking://user/u/memories/cases/case2.md": (
+            "## Linked Experiences\n\n- [a](../experiences/a.md)\n- [c](../experiences/c.md)\n"
+        ),
+    }
+    for name in "abc":
+        contents[f"viking://user/u/memories/experiences/{name}.md"] = f"## Situation\n{name}"
+
+    monkeypatch.setattr(
+        ov_server,
+        "VikingClient",
+        _selector_client_factory(
+            cases=[
+                {"uri": "viking://user/u/memories/cases/case1.md", "score": 0.9},
+                {"uri": "viking://user/u/memories/cases/case2.md", "score": 0.5},
+            ],
+            contents=contents,
+        ),
+    )
+    client = await ov_server.VikingClient.create()
+
+    candidates = await _selector_collect_candidates(client, "q")
+    assert [uri.rsplit("/", 1)[-1] for uri, _ in candidates] == ["a.md", "b.md", "c.md"]
+
+    picked = await judge(_selector_provider('{"selected": [1, 2, 3]}'), None, "q", candidates)
+    assert len(picked) == 2
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_skips_unreadable_memories(monkeypatch):
+    """An unreadable case or experience drops that entry instead of failing recall."""
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import _selector_collect_candidates
+
+    monkeypatch.setattr(
+        ov_server,
+        "VikingClient",
+        _selector_client_factory(
+            cases=[
+                {"uri": "viking://user/u/memories/cases/missing.md", "score": 0.9},
+                {"uri": "viking://user/u/memories/cases/case2.md", "score": 0.5},
+            ],
+            contents={
+                "viking://user/u/memories/cases/case2.md": (
+                    "## Linked Experiences\n\n"
+                    "- [gone](../experiences/gone.md)\n"
+                    "- [ok](../experiences/ok.md)\n"
+                ),
+                "viking://user/u/memories/experiences/ok.md": "## Situation\nfine",
+            },
+        ),
+    )
+    client = await ov_server.VikingClient.create()
+
+    candidates = await _selector_collect_candidates(client, "q")
+    assert [uri.rsplit("/", 1)[-1] for uri, _ in candidates] == ["ok.md"]
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_tool_survives_unavailable_memory_service(monkeypatch):
+    import vikingbot.openviking_mount.ov_server as ov_server
+
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _SELECTOR_NO_EXPERIENCE,
+        _make_load_relevant_experience_tool,
+    )
+
+    class UnavailableClient:
+        @classmethod
+        async def create(cls):
+            raise ConnectionError("memory service down")
+
+    monkeypatch.setattr(ov_server, "VikingClient", UnavailableClient)
+
+    tool = _make_load_relevant_experience_tool(_selector_provider('{"selected": [1]}'))
+    assert await tool.execute(None, task_description="anything") == _SELECTOR_NO_EXPERIENCE
+
+
+def test_tau2_selector_system_prompt_directs_agent_to_isolated_tool():
+    from benchmark.tau2.train.rollout_executor_vikingbot import _build_system_prompt
+
+    prompt = _build_system_prompt(
+        "POLICY", keep_default_tools=True, rollout_language="default", loader_mode="selector"
+    )
+    assert "load_relevant_experience" in prompt
+    assert "search_experience" not in prompt
+    assert "read_experience" not in prompt
+
+
+def test_tau2_loaded_experience_format_is_shared_by_both_load_paths():
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _format_loaded_experience,
+        _format_selected_experiences,
+    )
+
+    one = _format_loaded_experience("viking://u/memories/experiences/a.md", "## Situation\nbody\n")
+    assert one.startswith("# Loaded Experience")
+    assert "Experience URI: `viking://u/memories/experiences/a.md`" in one
+    assert one.endswith("body")
+
+    both = _format_selected_experiences(
+        [
+            ("viking://u/memories/experiences/a.md", "## Situation\nfirst"),
+            ("viking://u/memories/experiences/b.md", "## Situation\nsecond"),
+        ]
+    )
+    assert both.count("# Loaded Experience") == 2
+    assert "\n\n---\n\n" in both
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_judge_call_failure_is_logged_as_an_error(monkeypatch):
+    """VLMProviderAdapter.chat never raises — it returns finish_reason='error' with the
+    exception text as content. Without this branch a rate-limited judge is
+    indistinguishable from one that decided nothing applies, and a whole run silently
+    degrades to the no-memory baseline."""
+    import benchmark.tau2.train.rollout_executor_vikingbot as module
+
+    errors: list[str] = []
+    monkeypatch.setattr(
+        module.logger, "error", lambda msg, *args: errors.append(str(msg) % args if args else msg)
+    )
+    candidates = [("viking://u/memories/experiences/a.md", "## Situation\na")]
+
+    # An adapter error whose text embeds JSON would otherwise parse as a valid reply.
+    picked = await module._selector_judge(
+        _selector_provider(
+            'Error calling LLM in VLM Adapter: {"error": {"code": "RateLimit"}}',
+            finish_reason="error",
+        ),
+        "m",
+        "task",
+        candidates,
+    )
+    assert picked == []
+    assert errors and "RateLimit" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_distinguishes_truncation_from_a_disobedient_reply(monkeypatch):
+    """Both degrade to 'select nothing', so the logs are the only way to tell a broken
+    judge from an empty verdict."""
+    import benchmark.tau2.train.rollout_executor_vikingbot as module
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        module.logger,
+        "warning",
+        lambda msg, *args: warnings.append(str(msg) % args if args else msg),
+    )
+    candidates = [("viking://u/memories/experiences/a.md", "## Situation\na")]
+
+    picked = await module._selector_judge(
+        _selector_provider("I need to consider whether", finish_reason="length"),
+        "m",
+        "task",
+        candidates,
+    )
+    assert picked == []
+    assert any("truncated" in w for w in warnings), warnings
+
+    warnings.clear()
+    picked = await module._selector_judge(
+        _selector_provider("nope, no json", finish_reason="stop"), "m", "task", candidates
+    )
+    assert picked == []
+    assert warnings and not any("truncated" in w for w in warnings), warnings
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reply",
+    [
+        '{"selected": [1]}',
+        '```json\n{"selected": [1]}\n```',
+        # Prose containing braces used to defeat a greedy {.*} scan, silently discarding
+        # a correct selection.
+        '{"selected": [1]}\n\nCandidate 1 matches the {situation} described.',
+        'Thinking: the {task} is a refund.\n{"selected": [1]}',
+        '{"reasoning": "candidate {1} fits"}\n{"selected": [1]}',
+    ],
+)
+async def test_tau2_selector_finds_the_verdict_despite_surrounding_prose(reply):
+    from benchmark.tau2.train.rollout_executor_vikingbot import _selector_judge
+
+    candidates = [
+        ("viking://u/memories/experiences/a.md", "## Situation\na"),
+        ("viking://u/memories/experiences/b.md", "## Situation\nb"),
+    ]
+    picked = await _selector_judge(_selector_provider(reply), "m", "task", candidates)
+    assert [uri.rsplit("/", 1)[-1] for uri, _ in picked] == ["a.md"], reply
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [
+        # Wrong shape must not raise: a TypeError here surfaces as "retrieval failed",
+        # hiding that the judge answered badly.
+        ('{"selected": 1}', []),
+        ('{"selected": null}', []),
+        ('{"selected": "1"}', []),
+        # Duplicates would emit the same experience twice and burn the 2-slot budget.
+        ('{"selected": [1, 1, 2]}', ["a.md", "b.md"]),
+        # bool is an int subclass; `true` must not mean candidate 1.
+        ('{"selected": [true]}', []),
+        ('{"selected": [2, 1]}', ["b.md", "a.md"]),
+    ],
+)
+async def test_tau2_selector_handles_malformed_selection_values(reply, expected):
+    from benchmark.tau2.train.rollout_executor_vikingbot import _selector_judge
+
+    candidates = [
+        ("viking://u/memories/experiences/a.md", "## Situation\na"),
+        ("viking://u/memories/experiences/b.md", "## Situation\nb"),
+    ]
+    picked = await _selector_judge(_selector_provider(reply), "m", "task", candidates)
+    assert [uri.rsplit("/", 1)[-1] for uri, _ in picked] == expected, reply
+
+
+def test_tau2_skill_and_selector_share_one_experience_precedence_caveat():
+    """Both modes end with the same precedence caveat; it is defined once so the two
+    cannot drift apart."""
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _EXPERIENCE_PRECEDENCE_CAVEAT,
+        _build_system_prompt,
+    )
+
+    prompts = {
+        mode: _build_system_prompt(
+            "POLICY", keep_default_tools=True, rollout_language="default", loader_mode=mode
+        )
+        for mode in ("skill", "selector")
+    }
+    for mode, prompt in prompts.items():
+        assert prompt.count(_EXPERIENCE_PRECEDENCE_CAVEAT) == 1, mode
+
+    # Only the tool-specific sentence differs between the two modes.
+    assert "search_experience" in prompts["skill"]
+    assert "load_relevant_experience" in prompts["selector"]
+
+
+@pytest.mark.asyncio
+async def test_tau2_selector_installs_the_selector_skill_template(tmp_path, monkeypatch):
+    """This one line decides whether the agent is told to call a tool that exists. Getting
+    it wrong instructs the agent to use search_experience, which selector never registers
+    — a degraded rollout with no crash."""
+    import benchmark.tau2.train.rollout_executor_vikingbot as module
+
+    class StubContextBuilder:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    real_imports = module._vikingbot_imports
+    monkeypatch.setattr(
+        module,
+        "_vikingbot_imports",
+        lambda: {**real_imports(), "ContextBuilder": StubContextBuilder},
+    )
+    agent = SimpleNamespace(context=SimpleNamespace(workspace=tmp_path), sandbox_manager=None)
+
+    installed = {}
+    for mode, template in (("skill", "SKILL.md"), ("selector", "SKILL_SELECTOR.md")):
+        builder = await module._prepare_experience_loader_skill(
+            agent=agent, session_key=None, template_filename=template
+        )
+        written = (tmp_path / module.EXPERIENCE_LOADER_SKILL_PATH).read_text(encoding="utf-8")
+        assert written == module._read_experience_loader_template_file(template)
+        assert builder.latest_experience_loader_skill_content == written
+        installed[mode] = written
+
+    # Both land at the same path; only the tool they name differs.
+    assert "load_relevant_experience" in installed["selector"]
+    assert "search_experience" not in installed["selector"]
+    assert "search_experience" in installed["skill"]
+
+
+def test_tau2_selector_output_reaches_the_train_loop_memory_context():
+    """metadata['memory'] feeds failure analysis and the memory_context ratio in reports.
+    Keying only on search_experience/read_experience would report every selector rollout
+    as having had no memory at all."""
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _SELECTOR_NO_EXPERIENCE,
+        _case_memory_context_from_tools,
+    )
+
+    loaded = _case_memory_context_from_tools(
+        [
+            {
+                "tool_name": "load_relevant_experience",
+                "args": '{"task_description": "refund"}',
+                "result": (
+                    "# Loaded Experience\n\n"
+                    "Experience URI: `viking://u/memories/experiences/refund.md`\n\n"
+                    "## Situation\nRefund request."
+                ),
+            }
+        ]
+    )
+    assert "load_relevant_experience" in loaded
+    assert "Refund request." in loaded
+
+    # The "nothing applied" sentinel is not memory context.
+    assert (
+        _case_memory_context_from_tools(
+            [{"tool_name": "load_relevant_experience", "result": _SELECTOR_NO_EXPERIENCE}]
+        )
+        == ""
+    )
+
+
+def test_tau2_selector_loaded_uris_are_visible_to_the_gradient_estimator():
+    """Without this the estimator can never target the experience that caused a failure,
+    so selector rollouts could only ever create new experiences, never patch one."""
+    from openviking.session.train.components.gradient_estimator import _loaded_experience_uris
+
+    analysis = SimpleNamespace(
+        metadata={
+            "rollout_messages": [
+                {
+                    "parts": [
+                        {
+                            "tool_name": "load_relevant_experience",
+                            "tool_status": "completed",
+                            "tool_input": {"task_description": "refund"},
+                            "tool_output": (
+                                "# Loaded Experience\n\n"
+                                "Experience URI: `viking://u/memories/experiences/a.md`\n\n"
+                                "## Situation\na\n\n---\n\n"
+                                "# Loaded Experience\n\n"
+                                "Experience URI: `viking://u/memories/experiences/b.md`\n\n"
+                                "## Situation\nb"
+                            ),
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+    assert _loaded_experience_uris(analysis) == [
+        "viking://u/memories/experiences/a.md",
+        "viking://u/memories/experiences/b.md",
+    ]
+
+
+def test_tau2_selector_marks_truncated_candidates():
+    """Selected text goes to the agent verbatim, so an unmarked cut would silently deliver
+    a shorter experience than read_experience returns for the same URI."""
+    from benchmark.tau2.train.rollout_executor_vikingbot import (
+        _SELECTOR_CANDIDATE_CHARS,
+        _truncate_candidate,
+    )
+
+    short = "## Situation\nfits"
+    assert _truncate_candidate(short) == short
+
+    long_content = "x" * (_SELECTOR_CANDIDATE_CHARS + 500)
+    truncated = _truncate_candidate(long_content)
+    assert truncated.endswith("[... experience truncated ...]")
+    assert len(truncated) < len(long_content)


### PR DESCRIPTION
## 背景

`skill` 模式存在一条 priming 通道：`search_experience` 返回的候选名和 Situation 摘要，即使 agent 从未 `read_experience` 读取全文，也会对它产生影响——最有害的表现是**按类比拒绝或转人工**（过去某个 case 以拒绝收场，当前任务就倾向于同样收场）。

## 改动

新增第四种 loader mode：`selector`，与 `skill` / `constraint` / `direct_experience` 并列。

```bash
bash benchmark/tau2/train/restart_vikingbot_train_eval.sh --loader-mode selector
```

它把召回、全文读取、适用性筛选全部移出主上下文：单个 `load_relevant_experience` 工具执行 Case ANN → `## Linked Experiences` → 完整 experience 正文，然后**一次独立的 LLM 调用**判定适用性，最多返回 2 条。被判定不适用的候选完全不进入 rollout 上下文。

judge 调用只携带任务描述和候选正文，不带 rollout 对话历史。

## 设计取舍

**selector 不接 `--experience-recall-mode`。** 三种 recall 模式产出的是 snippet 形状的候选，而 judge 需要完整 experience（Situation 加排除条件）才能判定适用性，因此 selector 的召回固定为 Case ANN → Linked Experiences → 全文。

**`--loader-mode` 走 CLI 参数而非环境变量。** `restart_vikingbot_train_eval.sh` 中 loader mode 所在的赋值块有意不继承环境变量（保持 `--slot N` 的隔离性），因此按现有 `--experience-recall-mode` 的模式新增 CLI 参数，未破坏 slot 隔离。

**skill 与 selector 共用同一套 skill 安装链路**，装到相同的 sandbox 路径并在任务动作前强制读取，只有模板内容不同（`SKILL.md` vs 新增的 `SKILL_SELECTOR.md`）。`_append_runtime_case_context` 只在 `skill` 模式下追加——selector 没有 `search_experience` 工具可以接收 `task_signature`。

**judge 的 provider/model 显式传入**而非传整个 agent，依赖关系可见，后续也便于把筛选指向更便宜的模型。

**召回全程 best-effort**：搜索失败、judge 输出畸形、VikingClient 不可达，一律降级为"无适用经验"，绝不使 rollout 失败；单条 memory 读取失败会记日志并跳过该条，而非中断整次召回。

## 已知差距

`_selector_collect_candidates` 不查 `_find_exact_case_item`，因此 task_signature 精确命中的 case 只有在同时进入语义 top-3 时才会贡献候选。把 exact-case 链接优先喂给 judge 是合理的改进方向，但它会改变 judge 看到的候选集合，需要独立的 A/B 验证，故本 PR 不静默夹带。代码内已注明。

## 验证

`tests/session/train/test_rollout_executor_component.py` 新增 14 个测试，沿用该文件既有的 `monkeypatch VikingClient` 风格：

- mode 校验与默认值不变（不传 `--loader-mode` 仍为 `skill`）
- 工具注册：selector 只注册 `load_relevant_experience`，**不**注册 `search_experience` / `read_experience`
- judge 调用形态：system + 单条 user，无 rollout 历史
- 输出只含被选中的 experience，被拒候选的 URI 与正文均不出现
- 选择数量上限为 2
- 同一 experience 被多个 case 链接时按 case 排名去重保序
- 不可读的 case / experience 跳过而非中断召回
- 5 种畸形 judge 输出（非 JSON、坏 JSON、越界序号、非数字序号、非 dict）全部降级为"无适用经验"
- memory service 不可达时同样降级
- `read_experience` 与 selector 的 `# Loaded Experience` 渲染一致

另：`ruff check` / `ruff format` 通过；两个 shell 脚本 `bash -n` 通过；非法 `--loader-mode` 在服务启动前被拒。

注：`tests/session/` 下的测试依赖 `tests/session/conftest.py` 的 autouse fixture（经 `client` 需要 native engine wheel），在未编译 native 绑定的环境中整个目录都会 error——该现象在本 PR 的 base commit 上完全一致。上述 14 个测试是在不受该 conftest 影响的位置实跑通过后，再落到正式位置的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)