### PR TITLE
fix(server): make account deletion cleanup complete

### DIFF
--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -27,7 +27,6 @@ from openviking.service.task_store import (
 from openviking.service.task_tracker import (
     get_task_tracker,
 )
-from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     InvalidArgumentError,
@@ -275,26 +274,15 @@ async def delete_account(
         role=Role.ROOT,
     )
 
-    # Cascade: remove AGFS data for the account
-    viking_fs = get_viking_fs()
-    account_prefixes = [
-        "viking://user/",
-        "viking://resources/",
-    ]
-    for prefix in account_prefixes:
-        try:
-            await viking_fs.rm(prefix, recursive=True, ctx=cleanup_ctx)
-        except Exception as e:
-            logger.warning(f"AGFS cleanup for {prefix} in account {account_id}: {e}")
-
-    # Cascade: remove VectorDB records for the account
-    try:
-        storage = viking_fs._get_vector_store()
-        if storage:
-            deleted = await storage.delete_account_data(account_id)
-            logger.info(f"VectorDB cascade delete for account {account_id}: {deleted} records")
-    except Exception as e:
-        logger.warning(f"VectorDB cleanup for account {account_id}: {e}")
+    # Remove all account-owned storage before revoking its credentials. Cleanup
+    # errors intentionally abort the request so orphaned data is not hidden
+    # behind a successful response and the operation can be retried.
+    service = get_service()
+    viking_fs = service.viking_fs
+    if viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    cleanup_result = await viking_fs.delete_account_data(ctx=cleanup_ctx)
+    logger.info("Account storage cleanup for %s: %s", account_id, cleanup_result)
 
     # Finally delete the account metadata
     await manager.delete_account(account_id)

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -708,6 +708,75 @@ class VikingFS:
             if lease_ref is None:
                 await self._async_agfs.pathlock_release(lease)
 
+    async def delete_account_data(self, *, ctx: RequestContext) -> Dict[str, Any]:
+        """Delete all filesystem and vector-index data owned by an account.
+
+        Account roots are deliberately not removable through :meth:`rm`, whose
+        URI-facing safety checks protect callers from erasing an entire tenant.
+        Administrative account teardown uses this explicit root-only operation
+        instead.  The account is resolved exclusively from ``ctx`` so the
+        filesystem path and vector-index filter cannot target different tenants.
+
+        The operation is idempotent.  A missing filesystem root still triggers
+        vector cleanup so a previously interrupted deletion can be retried.
+        """
+        from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+
+        if ctx.role != Role.ROOT:
+            raise PermissionDeniedError("Only ROOT can delete account storage.")
+
+        account_id = ctx.account_id
+        account_path = self._uri_to_path("viking://", ctx=ctx)
+        vector_store = self._get_vector_store()
+
+        try:
+            lease = await self._async_agfs.pathlock_acquire_tree(account_path)
+        except LockAcquisitionError as exc:
+            raise ResourceBusyError(
+                f"Account storage is busy and cannot be deleted: {account_id}",
+                uri=account_path,
+            ) from exc
+
+        try:
+            deleted_vector_records = 0
+            if vector_store is not None:
+                deleted_vector_records = await vector_store.delete_account_data(
+                    account_id,
+                    ctx=ctx,
+                )
+
+            try:
+                stat = await self._async_agfs.stat(account_path)
+            except Exception as exc:
+                if is_not_found_error(exc):
+                    return {
+                        "deleted_filesystem": False,
+                        "deleted_vector_records": deleted_vector_records,
+                    }
+                mapped = map_exception(exc, resource=account_path)
+                if mapped is not None:
+                    raise mapped from exc
+                raise
+
+            if isinstance(stat, dict) and not stat.get("isDir", False):
+                raise FailedPreconditionError(
+                    f"Account storage root is not a directory: {account_path}",
+                    details={"resource": account_path},
+                )
+
+            await self._async_agfs.rm(
+                account_path,
+                recursive=True,
+                fs_ctx=self._pathlock_fs_ctx(ctx, lease),
+            )
+        finally:
+            await self._async_agfs.pathlock_release(lease)
+
+        return {
+            "deleted_filesystem": True,
+            "deleted_vector_records": deleted_vector_records,
+        }
+
     async def mv(
         self,
         old_uri: str,

--- a/tests/misc/test_vikingfs_uri_guard.py
+++ b/tests/misc/test_vikingfs_uri_guard.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from openviking.pyagfs.exceptions import AGFSInvalidOperationError
+from openviking.pyagfs.exceptions import AGFSInvalidOperationError, AGFSNotFoundError
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import PermissionDeniedError
@@ -32,6 +32,13 @@ def _user_ctx(account_id: str = "acct1", user_id: str = "alice") -> RequestConte
     return RequestContext(
         user=UserIdentifier(account_id=account_id, user_id=user_id),
         role=Role.USER,
+    )
+
+
+def _root_ctx(account_id: str = "acct1") -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id=account_id, user_id="system"),
+        role=Role.ROOT,
     )
 
 
@@ -166,6 +173,83 @@ class TestVikingFSURITraversalGuard:
         fs._delete_from_vector_store.assert_not_called()
         fs.agfs.stat.assert_not_called()
         fs.agfs.rm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_account_data_removes_physical_root_and_vectors(self) -> None:
+        fs = _make_viking_fs()
+        fs.agfs.stat = AsyncMock(return_value={"isDir": True})
+        fs.agfs.pathlock_acquire_tree = AsyncMock(return_value={"lease_ref": "account-lock"})
+        fs.agfs.pathlock_release = AsyncMock()
+        vector_store = MagicMock()
+        vector_store.delete_account_data = AsyncMock(return_value=7)
+        fs.vector_store = vector_store
+        ctx = _root_ctx("tenant-a")
+
+        result = await fs.delete_account_data(ctx=ctx)
+
+        assert result == {
+            "deleted_filesystem": True,
+            "deleted_vector_records": 7,
+        }
+        vector_store.delete_account_data.assert_awaited_once_with("tenant-a", ctx=ctx)
+        fs.agfs.stat.assert_awaited_once_with("/local/tenant-a")
+        fs.agfs.pathlock_acquire_tree.assert_awaited_once_with("/local/tenant-a")
+        fs.agfs.rm.assert_awaited_once_with(
+            "/local/tenant-a",
+            recursive=True,
+            fs_ctx={"account_id": "tenant-a", "lease_ref": "account-lock"},
+        )
+        fs.agfs.pathlock_release.assert_awaited_once_with({"lease_ref": "account-lock"})
+
+    @pytest.mark.asyncio
+    async def test_delete_account_data_requires_root_role(self) -> None:
+        fs = _make_viking_fs()
+
+        with pytest.raises(PermissionDeniedError, match="Only ROOT"):
+            await fs.delete_account_data(ctx=_user_ctx())
+
+        fs.agfs.stat.assert_not_called()
+        fs.agfs.rm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_account_data_cleans_orphan_vectors_when_root_is_missing(self) -> None:
+        fs = _make_viking_fs()
+        fs.agfs.stat = AsyncMock(side_effect=AGFSNotFoundError("/local/tenant-a"))
+        fs.agfs.pathlock_acquire_tree = AsyncMock(return_value={"lease_ref": "account-lock"})
+        fs.agfs.pathlock_release = AsyncMock()
+        vector_store = MagicMock()
+        vector_store.delete_account_data = AsyncMock(return_value=3)
+        fs.vector_store = vector_store
+        ctx = _root_ctx("tenant-a")
+
+        result = await fs.delete_account_data(ctx=ctx)
+
+        assert result == {
+            "deleted_filesystem": False,
+            "deleted_vector_records": 3,
+        }
+        vector_store.delete_account_data.assert_awaited_once_with("tenant-a", ctx=ctx)
+        fs.agfs.rm.assert_not_called()
+        fs.agfs.pathlock_release.assert_awaited_once_with({"lease_ref": "account-lock"})
+
+    @pytest.mark.asyncio
+    async def test_delete_account_data_releases_lock_when_vector_cleanup_fails(self) -> None:
+        fs = _make_viking_fs()
+        fs.agfs.pathlock_acquire_tree = AsyncMock(return_value={"lease_ref": "account-lock"})
+        fs.agfs.pathlock_release = AsyncMock()
+        vector_store = MagicMock()
+        vector_store.delete_account_data = AsyncMock(
+            side_effect=RuntimeError("vector cleanup failed")
+        )
+        fs.vector_store = vector_store
+        ctx = _root_ctx("tenant-a")
+
+        with pytest.raises(RuntimeError, match="vector cleanup failed"):
+            await fs.delete_account_data(ctx=ctx)
+
+        fs.agfs.stat.assert_not_called()
+        fs.agfs.rm.assert_not_called()
+        fs.agfs.pathlock_release.assert_awaited_once_with({"lease_ref": "account-lock"})
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -80,6 +80,8 @@ class _FakeVikingFS:
     def __init__(self):
         self.agfs = _FakeAGFS()
         self.files = {}
+        self.account_cleanup_contexts = []
+        self.account_cleanup_error = None
 
     async def read_file(self, uri, **_kwargs):
         if uri not in self.files:
@@ -91,6 +93,12 @@ class _FakeVikingFS:
 
     async def rm(self, uri, **_kwargs):
         self.files.pop(uri, None)
+
+    async def delete_account_data(self, *, ctx):
+        if self.account_cleanup_error is not None:
+            raise self.account_cleanup_error
+        self.account_cleanup_contexts.append(ctx)
+        return {"deleted_filesystem": True, "deleted_vector_records": 0}
 
 
 class _FakeService:
@@ -376,8 +384,11 @@ async def test_list_accounts(admin_client: httpx.AsyncClient):
     assert acct in account_ids
 
 
-async def test_delete_account(admin_client: httpx.AsyncClient):
-    """ROOT can delete an account."""
+async def test_delete_account(
+    admin_client: httpx.AsyncClient,
+    admin_service: OpenVikingService,
+):
+    """ROOT can delete an account together with all account-owned filesystem data."""
     acct = _uid()
     resp = await admin_client.post(
         "/api/v1/admin/accounts",
@@ -385,10 +396,18 @@ async def test_delete_account(admin_client: httpx.AsyncClient):
         headers=root_headers(),
     )
     user_key = resp.json()["result"]["user_key"]
+    account_root = f"/local/{acct}"
+    await _agfs_write(
+        admin_service,
+        f"{account_root}/resources/private.txt",
+        "account-owned data",
+    )
+    assert await _agfs_exists(admin_service, account_root)
 
     resp = await admin_client.delete(f"/api/v1/admin/accounts/{acct}", headers=root_headers())
     assert resp.status_code == 200
     assert resp.json()["result"]["deleted"] is True
+    assert not await _agfs_exists(admin_service, account_root)
 
     # User key should now be invalid
     resp = await admin_client.get(
@@ -396,6 +415,56 @@ async def test_delete_account(admin_client: httpx.AsyncClient):
         headers={"X-API-Key": user_key},
     )
     assert resp.status_code == 401
+
+
+async def test_delete_account_delegates_complete_storage_cleanup(
+    lightweight_admin_client: httpx.AsyncClient,
+    lightweight_admin_app: FastAPI,
+):
+    """The router passes one account-scoped ROOT context to the storage boundary."""
+    acct = _uid()
+    await lightweight_admin_client.post(
+        "/api/v1/admin/accounts",
+        json={"account_id": acct, "admin_user_id": "alice"},
+        headers=root_headers(),
+    )
+
+    response = await lightweight_admin_client.delete(
+        f"/api/v1/admin/accounts/{acct}", headers=root_headers()
+    )
+
+    assert response.status_code == 200
+    cleanup_contexts = lightweight_admin_app.state.fake_service.viking_fs.account_cleanup_contexts
+    assert len(cleanup_contexts) == 1
+    cleanup_ctx = cleanup_contexts[0]
+    assert cleanup_ctx.account_id == acct
+    assert cleanup_ctx.role == Role.ROOT
+
+
+async def test_delete_account_keeps_metadata_when_storage_cleanup_fails(
+    lightweight_admin_client: httpx.AsyncClient,
+    lightweight_admin_app: FastAPI,
+):
+    """A cleanup failure must not be reported as successful account deletion."""
+    acct = _uid()
+    await lightweight_admin_client.post(
+        "/api/v1/admin/accounts",
+        json={"account_id": acct, "admin_user_id": "alice"},
+        headers=root_headers(),
+    )
+    lightweight_admin_app.state.fake_service.viking_fs.account_cleanup_error = RuntimeError(
+        "storage cleanup failed"
+    )
+
+    with pytest.raises(RuntimeError, match="storage cleanup failed"):
+        await lightweight_admin_client.delete(
+            f"/api/v1/admin/accounts/{acct}", headers=root_headers()
+        )
+
+    accounts_response = await lightweight_admin_client.get(
+        "/api/v1/admin/accounts", headers=root_headers()
+    )
+    assert acct in {account["account_id"] for account in accounts_response.json()["result"]}
 
 
 async def test_create_duplicate_account_fails(admin_client: httpx.AsyncClient):


### PR DESCRIPTION
## Summary

Account deletion could return `200 OK` while leaving account-owned data behind. The router attempted to remove two public URI prefixes, called the vector backend without its required request context, and logged cleanup failures without failing the request.

This change moves complete account teardown behind a single storage-owned operation:

- delete the account's full physical AGFS root, covering every account-owned namespace
- delete vector records using the same account-scoped ROOT context
- serialize teardown with an account-root tree lock
- keep cleanup idempotent so interrupted deletions can be retried
- delete account metadata and revoke credentials only after storage cleanup succeeds

The successful HTTP response remains unchanged. Cleanup failures now propagate instead of being reported as successful deletion.

## Root cause

The account router owned storage-specific cleanup logic:

1. `viking://user/` is a protected namespace root and cannot be removed through the normal URI-facing `rm()` API.
2. Cleaning only `viking://user/` and `viking://resources/` did not cover sessions, temporary data, internal account files, or legacy namespaces.
3. The direct vector-store call omitted the required `ctx` argument.
4. Broad exception handlers converted all three failures into warnings, then deleted account metadata and returned success.

## Design

`VikingFS.delete_account_data()` is an explicit ROOT-only administrative boundary. It derives the filesystem path and vector account filter from one `RequestContext`, preventing the two stores from targeting different tenants. It locks `/local/{account_id}`, deletes vector records, removes the complete account directory recursively, and always releases the lease.

If a previous attempt already removed the filesystem root, a retry still removes orphaned vector records. If either cleanup step fails, the account metadata remains available so the operator can retry rather than losing the only supported deletion path.

## Verification

- 4 account-storage unit tests passed, covering complete cleanup, ROOT authorization, missing filesystem roots, and lock release on vector cleanup failure
- 3 account-deletion API tests passed, including a real embedded OpenViking service that verifies the physical account root is removed and the user key is revoked
- 46 API-key manager and directory-initialization regression tests passed
- `ruff check` passed for all changed files
- `git diff --check` passed

The broader admin module run produced 75 passes and one unrelated existing legacy-migration assertion failure. The failing migration code and assertion are unchanged by this branch.
