### PR TITLE
refactor(vectordb): unify random recall via client-generated vector

### DIFF
--- a/openviking/storage/vectordb/collection/collection.py
+++ b/openviking/storage/vectordb/collection/collection.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 import importlib
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, Dict, List, Optional, Type
 
 from openviking.storage.vectordb.collection.result import AggregateResult, SearchResult
 from openviking.storage.vectordb.index.index import IIndex
@@ -475,7 +475,6 @@ class Collection:
         offset: int = 0,
         filters: Optional[Dict[str, Any]] = None,
         output_fields: Optional[List[str]] = None,
-        raise_on_error: bool = False,
     ):
         """Retrieve random documents from the index.
 
@@ -486,7 +485,6 @@ class Collection:
             filters (Optional[Dict[str, Any]]): Query filters to narrow down results. Defaults to None.
             output_fields (Optional[List[str]]): List of field names to include in results.
                 If None, returns all fields. Defaults to None.
-            raise_on_error (bool): Propagate HTTP errors for deletion lookups. Defaults to False.
 
         Returns:
             SearchResult: Random documents from the index with field values (scores are not meaningful).
@@ -496,15 +494,6 @@ class Collection:
         """
         if self.__collection is None:
             raise RuntimeError("Collection is closed")
-        if raise_on_error:
-            return cast(Any, self.__collection).search_by_random(
-                index_name,
-                limit,
-                offset,
-                filters,
-                output_fields,
-                raise_on_error=True,
-            )
         return self.__collection.search_by_random(index_name, limit, offset, filters, output_fields)
 
     def search_by_scalar(

--- a/openviking/storage/vectordb/collection/http_collection.py
+++ b/openviking/storage/vectordb/collection/http_collection.py
@@ -523,7 +523,6 @@ class HttpCollection(ICollection):
         offset: int = 0,
         filters: Optional[Dict[str, Any]] = None,
         output_fields: Optional[List[str]] = None,
-        raise_on_error: bool = False,
     ) -> SearchResult:
         url = self.url_prefix + "api/vikingdb/data/search/random"
         response = requests.post(
@@ -541,12 +540,9 @@ class HttpCollection(ICollection):
             timeout=DEFAULT_TIMEOUT,
         )
         # logger.info(f"SearchByRandom response: {response.text}")
-        if raise_on_error:
-            payload = _parse_success_response(response, "query data for deletion")
-        else:
-            if response.status_code != 200:
-                return SearchResult()
-            payload = json.loads(response.text)
+        if response.status_code != 200:
+            return SearchResult()
+        payload = json.loads(response.text)
 
         data = payload.get("data", {})
         result = SearchResult()

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import math
+import random
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Optional
@@ -27,6 +28,7 @@ from openviking.storage.expr import (
 from openviking.storage.vectordb.collection.collection import Collection
 from openviking.storage.vectordb.collection.result import FetchDataInCollectionResult
 from openviking_cli.utils import get_logger
+from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.config.vectordb_config import DEFAULT_INDEX_NAME
 
 logger = get_logger(__name__)
@@ -464,7 +466,6 @@ class CollectionAdapter(ABC):
         output_fields: Optional[list[str]] = None,
         order_by: Optional[str] = None,
         order_desc: bool = False,
-        raise_on_error: bool = False,
     ) -> list[Dict[str, Any]]:
         coll = self.get_collection()
         vectordb_filter = self._compile_filter(filter)
@@ -490,23 +491,18 @@ class CollectionAdapter(ABC):
                 output_fields=output_fields,
             )
         else:
-            if raise_on_error:
-                result = coll.search_by_random(
-                    index_name=self._index_name,
-                    limit=limit,
-                    offset=offset,
-                    filters=vectordb_filter,
-                    output_fields=output_fields,
-                    raise_on_error=True,
-                )
-            else:
-                result = coll.search_by_random(
-                    index_name=self._index_name,
-                    limit=limit,
-                    offset=offset,
-                    filters=vectordb_filter,
-                    output_fields=output_fields,
-                )
+            # Approximate random sampling with a client-generated random
+            # vector so every backend behaves consistently.
+            dim = get_openviking_config().embedding.dimension
+            random_vector = [random.uniform(-1, 1) for _ in range(dim)]
+            result = coll.search_by_vector(
+                index_name=self._index_name,
+                dense_vector=random_vector,
+                limit=limit,
+                offset=offset,
+                filters=vectordb_filter,
+                output_fields=output_fields,
+            )
 
         records: list[Dict[str, Any]] = []
         for item in result.data:
@@ -534,7 +530,6 @@ class CollectionAdapter(ABC):
                 filter=filter,
                 limit=limit,
                 output_fields=["id"],
-                raise_on_error=self.mode == "http",
             )
             delete_ids = [record["id"] for record in matched if record.get("id")]
 


### PR DESCRIPTION
Route the query() random-sampling branch through search_by_vector with a client-generated random vector (config.embedding.dimension) so every backend behaves consistently, instead of each backend's server-side search_by_random. This also makes Qdrant/OpenGauss truly random rather than a deterministic scroll/scan.

Drop the raise_on_error path entirely per request: query(), the Collection wrapper, and HttpCollection.search_by_random no longer take raise_on_error, and delete() no longer requests it. As a result, HTTP filter-based deletion id lookups now return empty on non-200 instead of raising.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
