### PR TITLE
fix(server): read attrs tags by exact URI and level

### DIFF
--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -17,6 +17,7 @@ from openviking.server.identity import RequestContext
 from openviking.server.models import Response
 from openviking.server.routers.content import SetTagsRequest
 from openviking.server.routers.content import set_tags as content_set_tags
+from openviking.storage.expr import And, Eq, In
 from openviking.storage.vikingdb_manager import VikingDBManagerProxy
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
 
@@ -35,14 +36,22 @@ def _clean_memory_attrs(raw: str) -> dict[str, Any]:
     return attrs
 
 
-async def _tags_attr(service: Any, uri: str, ctx: RequestContext) -> list[str]:
+async def _tags_attr(
+    service: Any, uri: str, ctx: RequestContext, *, is_dir: bool
+) -> list[str]:
     vikingdb_manager = getattr(service, "vikingdb_manager", None)
     if not vikingdb_manager:
         return []
 
+    # Tags are written per level (see ContentWriteCoordinator.set_tags): a
+    # directory carries them on its L0/L1 summary records, while a file carries
+    # them on its L2 content record. Mirror that here so the exact node's tags
+    # are read back instead of unrelated records. Eq("uri", ...) compiles to an
+    # exact path match (-d=0), avoiding prefix/subtree matches over the path field.
+    levels = [0, 1] if is_dir else [2]
     proxy = VikingDBManagerProxy(vikingdb_manager, ctx)
     records = await proxy.filter(
-        filter={"op": "must", "field": "uri", "conds": [uri]},
+        filter=And([Eq("uri", uri), In("level", levels)]),
         limit=10,
         output_fields=_ATTR_INDEX_FIELDS,
     )
@@ -181,7 +190,9 @@ async def attrs(
             "uri": canonical_uri,
             "context_type": context_type_for_uri(canonical_uri),
             "attrs": {
-                "tags": await _tags_attr(service, canonical_uri, _ctx),
+                "tags": await _tags_attr(
+                    service, canonical_uri, _ctx, is_dir=stat_result.get("isDir", False)
+                ),
             },
         }
         if result["context_type"] == "memory" and not stat_result.get("isDir", False):


### PR DESCRIPTION
GET /api/v1/fs/attrs read search tags with a bare `uri` equality filter and no level constraint. Over a path-typed `uri` field this does not pin an exact node, and it merged tags across all levels, so a directory whose tags live on its L0/L1 summary records could read back tags from an unrelated record instead of its own.

Mirror how ContentWriteCoordinator.set_tags writes tags: a directory carries them on its L0/L1 records and a file on its L2 record. Query with And([Eq("uri", uri), In("level", levels)]) so Eq compiles to an exact path match (-d=0) and the level set matches the node kind.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
