### PR TITLE
fix(packaging): decouple LangChain client from server image

### DIFF
--- a/docs/en/agent-integrations/07-langchain-langgraph.md
+++ b/docs/en/agent-integrations/07-langchain-langgraph.md
@@ -12,9 +12,9 @@ pip install langchain-openviking                 # LangChain adapters
 pip install "langchain-openviking[langgraph]"    # LangGraph middleware support
 ```
 
-Existing applications may continue to use `openviking[langchain]` or
-`openviking[langgraph]`; the full package forwards the legacy import path to
-`langchain-openviking`.
+The integration is released independently from the OpenViking server. The full
+package keeps forwarding the legacy `openviking.integrations.langchain` import
+path to `langchain-openviking` for existing applications.
 
 ## Connection
 

--- a/docs/zh/agent-integrations/07-langchain-langgraph.md
+++ b/docs/zh/agent-integrations/07-langchain-langgraph.md
@@ -11,8 +11,8 @@ pip install langchain-openviking                 # LangChain 适配器
 pip install "langchain-openviking[langgraph]"    # LangGraph middleware
 ```
 
-现有应用仍可使用 `openviking[langchain]` 或 `openviking[langgraph]`。完整包会把旧导入路径
-转发到 `langchain-openviking`。
+该集成独立于 OpenViking server 发布。为兼容现有应用，完整包仍会把旧的
+`openviking.integrations.langchain` 导入路径转发到 `langchain-openviking`。
 
 ## 连接
 

--- a/openviking/integrations/langchain/__init__.py
+++ b/openviking/integrations/langchain/__init__.py
@@ -31,8 +31,8 @@ def _missing_standalone_error() -> ImportError:
     return ImportError(
         "The legacy OpenViking LangChain integration requires the standalone "
         "langchain-openviking package. Install it with "
-        '`pip install "openviking[langchain]"` or `pip install langchain-openviking` '
-        '(use the corresponding "langgraph" extra for LangGraph support).'
+        "`pip install langchain-openviking` (or "
+        '`pip install "langchain-openviking[langgraph]"` for LangGraph support).'
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,12 +184,6 @@ benchmark = [
     "datasets>=2.0.0",
     "pandas>=2.0.0",
 ]
-langchain = [
-    "langchain-openviking>=0.1.0",
-]
-langgraph = [
-    "langchain-openviking[langgraph]>=0.1.0",
-]
 local-embed = [
     "llama-cpp-python>=0.3.0",
 ]
@@ -298,6 +292,3 @@ line-ending = "auto"
 dev = [
     "pytest>=9.0.2",
 ]
-
-[tool.uv.sources]
-langchain-openviking = { path = "integrations/langchain" }

--- a/tests/unit/test_langchain_package_boundary.py
+++ b/tests/unit/test_langchain_package_boundary.py
@@ -15,6 +15,14 @@ SOURCE_ROOT = PACKAGE_ROOT / "src"
 SDK_ROOT = PROJECT_ROOT / "sdk" / "python"
 
 
+def test_server_distribution_does_not_depend_on_standalone_integration():
+    root_pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    root_lock = (PROJECT_ROOT / "uv.lock").read_text(encoding="utf-8")
+
+    assert "langchain-openviking" not in root_pyproject
+    assert 'name = "langchain-openviking"' not in root_lock
+
+
 def test_standalone_package_has_no_server_imports_at_module_scope():
     violations: list[str] = []
     for source_file in sorted((SOURCE_ROOT / "langchain_openviking").glob("*.py")):
@@ -137,7 +145,7 @@ try:
 except ImportError as exc:
     message = str(exc)
     assert "langchain-openviking" in message
-    assert "openviking[langchain]" in message
+    assert "openviking[langchain]" not in message
 else:
     raise AssertionError("missing standalone package should produce an installation error")
 
@@ -160,7 +168,7 @@ for submodule in (
         assert not isinstance(exc, ModuleNotFoundError)
         message = str(exc)
         assert "langchain-openviking" in message
-        assert "openviking[langchain]" in message
+        assert "openviking[langchain]" not in message
     else:
         raise AssertionError(f"legacy {submodule} import should produce an installation error")
 """

--- a/uv.lock
+++ b/uv.lock
@@ -2315,37 +2315,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langchain-openviking"
-source = { directory = "integrations/langchain" }
-dependencies = [
-    { name = "langchain-core" },
-    { name = "openviking-sdk" },
-    { name = "pydantic" },
-]
-
-[package.optional-dependencies]
-langgraph = [
-    { name = "langchain" },
-    { name = "langgraph" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.0" },
-    { name = "langchain", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "openviking-sdk", specifier = ">=0.1.1" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-]
-provides-extras = ["langgraph", "test", "dev"]
-
-[[package]]
 name = "langchain-text-splitters"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3791,12 +3760,6 @@ gemini-async = [
     { name = "anyio" },
     { name = "google-genai" },
 ]
-langchain = [
-    { name = "langchain-openviking" },
-]
-langgraph = [
-    { name = "langchain-openviking", extra = ["langgraph"] },
-]
 local-embed = [
     { name = "llama-cpp-python" },
 ]
@@ -3862,8 +3825,6 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'benchmark'", specifier = ">=1.0.0" },
     { name = "langchain-core", marker = "extra == 'benchmark'", specifier = ">=1.0.0" },
     { name = "langchain-openai", marker = "extra == 'benchmark'", specifier = ">=1.0.0" },
-    { name = "langchain-openviking", marker = "extra == 'langchain'", directory = "integrations/langchain" },
-    { name = "langchain-openviking", extras = ["langgraph"], marker = "extra == 'langgraph'", directory = "integrations/langchain" },
     { name = "langfuse", marker = "extra == 'bot'", specifier = ">=3.0.0" },
     { name = "lark-oapi", specifier = ">=1.5.3" },
     { name = "lark-oapi", marker = "extra == 'bot'", specifier = ">=1.0.0" },
@@ -3956,7 +3917,7 @@ requires-dist = [
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xxhash", specifier = ">=3.0.0" },
 ]
-provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "langchain", "langgraph", "local-embed"]
+provides-extras = ["test", "opengauss", "dev", "doc", "eval", "gemini", "gemini-async", "ocr", "build", "bot", "benchmark", "local-embed"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]


### PR DESCRIPTION
## Summary

- remove the `openviking[langchain]` and `openviking[langgraph]` extras from the server distribution
- remove the root uv path source for the independently published `langchain-openviking` package
- keep legacy imports as dependency-free compatibility shims, with installation guidance pointing only to the standalone package
- add a package-boundary regression assertion and update the English/Chinese docs

## Root cause

PR #3685 added `langchain-openviking = { path = "integrations/langchain" }` to the root uv configuration. The Dockerfile intentionally copies only server build inputs, so `uv lock --check` / `uv sync` tried to resolve `/app/integrations/langchain` and failed on both amd64 and arm64.

Copying the client source into the server image would hide the packaging boundary problem. This change instead keeps the server lock independent from the standalone client, which is already published as `langchain-openviking==0.1.0`.

## Validation

All validation completed successfully.

- Local checks:
  - `uv lock --check`
  - Ruff format and lint for changed Python files
  - standalone package boundary suite: `14 passed`
  - targeted Linux/arm64 container build on the Python 3.13 uv base, copying only root `pyproject.toml` + `uv.lock` and intentionally excluding `integrations/langchain`; containerized `uv lock --check` resolved 307 packages
- [PR checks](https://github.com/volcengine/OpenViking/actions/runs/30820026110):
  - LangChain integration tests on Python 3.10 and 3.12
  - source distribution on Python 3.12
  - wheels and smoke tests on Linux x86_64, Linux arm64, macOS arm64, macOS Intel, and Windows
  - plugin checks
- [API & CLI integration tests](https://github.com/volcengine/OpenViking/actions/runs/30820021648) on Ubuntu 24.04
- [Post-merge Docker workflow](https://github.com/volcengine/OpenViking/actions/runs/30820327751): amd64 and arm64 images both built and pushed successfully