### PR TITLE
fix(session): bound _wait_for_previous_archive_done to prevent permanent SessionCommit queue stall

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Literal, Optional
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ARCHIVE_WAIT_POLL_SECONDS = 0.1
+_ARCHIVE_WAIT_TIMEOUT_SECONDS = 1800.0
 _PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS = 1800.0
 _MEMORY_EXTRACTION_MAX_RETRIES = 3
 _MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS = 1.0
@@ -3743,11 +3745,32 @@ class Session:
             raise ValueError(f"Invalid archive URI: {archive_uri}")
         return int(match.group(1))
 
-    async def _wait_for_previous_archive_done(self, archive_index: int) -> bool:
-        """Wait until every earlier archive reaches a terminal state."""
+    async def _wait_for_previous_archive_done(
+        self,
+        archive_index: int,
+        timeout: float = _ARCHIVE_WAIT_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Wait until every earlier archive reaches a terminal state.
+
+        The wait is bounded: an earlier archive can stay pending forever when
+        its Phase 1 completed (``phase1.status=ready``) but the matching queue
+        item was lost (process crash, upgrade, or a historical enqueue bug).
+        Such an orphan is invisible from here, so after ``timeout`` seconds of
+        polling the still-pending predecessors are marked terminally failed and
+        a ``TimeoutError`` is raised. The caller's failure path then writes the
+        current archive's ``.failed.json`` and fails the task, so the worker
+        slot is released instead of being wedged forever; the next commit
+        replays the raw messages of every failed archive through the existing
+        ``_prepare_phase2_archive_messages`` roll-forward, so no data is lost.
+
+        Raises:
+            TimeoutError: earlier archives were still pending after ``timeout``
+                seconds; they have been marked failed for later raw replay.
+        """
         if archive_index <= 1 or not self._viking_fs:
             return True
 
+        deadline = time.monotonic() + timeout
         while True:
             earlier_states = [
                 state for state in await self._scan_archive_states() if state.index < archive_index
@@ -3775,6 +3798,32 @@ class Session:
                 reconciled = True
             if reconciled:
                 continue
+            if time.monotonic() >= deadline:
+                stuck_ids = [state.archive_id for state in pending_states]
+                for state in pending_states:
+                    logger.error(
+                        "Archive %s stayed pending for over %.0fs while blocking "
+                        "archive_%03d Phase 2; its queue item is presumed lost. "
+                        "Marking it failed so its raw messages replay into a "
+                        "later commit.",
+                        state.archive_id,
+                        timeout,
+                        archive_index,
+                    )
+                    await self._write_failed_marker(
+                        state.archive_uri,
+                        stage="phase2_wait_timeout",
+                        error=(
+                            f"Archive stayed pending for over {timeout:.0f}s; "
+                            "its Phase 2 queue item is presumed lost"
+                        ),
+                    )
+                raise TimeoutError(
+                    f"Timed out after {timeout:.0f}s waiting for earlier archives "
+                    f"{stuck_ids} to finish before archive_{archive_index:03d} "
+                    "Phase 2; they were marked failed for raw replay by a later "
+                    "commit"
+                )
             await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
 
     async def _prepare_phase2_archive_messages(

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -357,6 +357,45 @@ async def test_phase2_waits_for_all_earlier_pending_archives(
     assert await asyncio.wait_for(waiter, timeout=0.5)
 
 
+async def test_phase2_wait_times_out_and_fails_orphaned_pending_archive(
+    client: AsyncOpenViking,
+    monkeypatch,
+):
+    """A pending predecessor whose queue item was lost must not stall forever.
+
+    After the bounded wait expires, the orphan is marked terminally failed for
+    raw replay and the current commit fails cleanly instead of wedging its
+    worker slot (see #3396).
+    """
+    session = client.session(session_id="phase2_wait_timeout_orphan_test")
+    await session.ensure_exists()
+    first_uri = await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "orphaned pending one")],
+    )
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
+
+    with pytest.raises(TimeoutError, match="archive_001"):
+        await asyncio.wait_for(
+            session._wait_for_previous_archive_done(2, timeout=0.05),
+            timeout=2.0,
+        )
+
+    failed = json.loads(
+        await session._viking_fs.read_file(f"{first_uri}/.failed.json", ctx=session.ctx)
+    )
+    assert failed["stage"] == "phase2_wait_timeout"
+    states = {state.archive_id: state.state for state in await session._scan_archive_states()}
+    assert states["archive_001"] == "failed"
+
+    # The next commit's wait now sees only terminal predecessors and proceeds.
+    assert await asyncio.wait_for(
+        session._wait_for_previous_archive_done(2, timeout=0.05),
+        timeout=2.0,
+    )
+
+
 async def test_missing_previous_archive_directory_does_not_block_phase2(
     client: AsyncOpenViking,
 ):


### PR DESCRIPTION
## 出了什么事

线上一台 OpenViking（0.4.12.dev86）的 SessionCommit 队列整个冻住了 10 天以上：860 条任务全部 pending，4 条 in-progress（正好是 worker 并发上限），0 条完成，0 条报错。查询、检索都正常，只有会话记忆提取完全停摆。

## 根因

#3380（0ab85f45，7-24 合入）给 commit 加了一个"等同一 session 更早的 archive 先完成"的循环（`_wait_for_previous_archive_done`），但这个循环没有超时。

如果某个 archive 的队列消息丢了（进程崩溃、升级、老版本存量数据都可能造成），它永远不会完成，等它的 commit 就永远卡住。卡住时占着 worker 的并发槽，4 个槽占满后整个队列不再消费任何任务——一个脏 session 就能冻住所有 session。v0.4.12 是第一个带这个问题的 release。

## 怎么修的

- 等待加上 30 分钟上限（`_ARCHIVE_WAIT_TIMEOUT_SECONDS`，风格对齐现有的 `_PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS`），循环内原有的轮询 reconcile 保留，作为重试。
- 超时后不再等：给卡住的前置 archive 写 `.failed.json` 并打 error 日志，当前任务抛 `TimeoutError`，走既有异常路径落成 failed（tracker.fail + 消息 ack + 释放槽位）。任务只会变 failed，不会再卡 pending。
- 数据不丢：标记 failed 的前置 archive，其内容会被后续 commit 的 roll-forward 机制回放。

## 测试

新增 `test_phase2_wait_times_out_and_fails_orphaned_pending_archive`：构造一个永不完成的前置 archive，验证不挂死、前置落 failed、后续 commit 立即通过。已通过。存量失败用例与未改动的 main 完全一致（均为依赖真实 VLM 端点的环境问题），无回归。本地用的 PyPI 预编译 native 库，建议以 CI 完整结果为准。

## Follow-up（本 PR 不改）

- `queue_manager.py` 的错误路径不 ack、不 tracker.fail，消息会滞留 'processing'。注释显示 no-ack 像是有意设计，建议单独讨论（相关：#3396）。
- 重启后没有任务对账，孤儿任务不会自愈（相关：#3023）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
