### PR TITLE
fix(retrieve): store L1 overview in abstract scalar so Rerank sees L1 text

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -35,7 +35,7 @@ from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
-from openviking.utils.embedding_utils import get_resource_content_type
+from openviking.utils.embedding_utils import _truncate_abstract_bytes, get_resource_content_type
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError, OpenVikingError
 from openviking_cli.session.user_id import UserIdentifier
@@ -1034,7 +1034,8 @@ class ReindexExecutor:
                     await self._upsert_context(
                         uri=directory_uri,
                         parent_uri=VikingURI(directory_uri).parent.uri,
-                        abstract=abstract,
+                        # L1 abstract scalar carries the overview for Rerank.
+                        abstract=_truncate_abstract_bytes(overview),
                         vector_text=overview,
                         is_leaf=False,
                         context_type=context_type_for_uri(directory_uri),
@@ -1105,6 +1106,10 @@ class ReindexExecutor:
             if not vector_text:
                 await self.delete_uri_level(uri=dir_uri, level=level, ctx=ctx)
                 return
+
+            # L1 abstract scalar carries the overview for Rerank.
+            if level == ContextLevel.OVERVIEW:
+                abstract = _truncate_abstract_bytes(vector_text)
 
             await self._upsert_context(
                 uri=dir_uri,
@@ -1357,7 +1362,8 @@ class ReindexExecutor:
                 await self._upsert_context(
                     uri=uri,
                     parent_uri=parent_uri,
-                    abstract=abstract,
+                    # L1 abstract scalar carries the overview for Rerank.
+                    abstract=_truncate_abstract_bytes(overview),
                     vector_text=overview,
                     is_leaf=False,
                     context_type=ContextType.SKILL.value,
@@ -1521,7 +1527,8 @@ class ReindexExecutor:
                     await self._upsert_context(
                         uri=directory_uri,
                         parent_uri=parent_uri,
-                        abstract=abstract,
+                        # L1 abstract scalar carries the overview for Rerank.
+                        abstract=_truncate_abstract_bytes(overview),
                         vector_text=overview,
                         is_leaf=False,
                         context_type=ContextType.MEMORY.value,

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -428,11 +428,13 @@ async def vectorize_directory_meta(
 
         if include_overview:
             # Vectorize L1: .overview.md (overview)
+            # Store the overview itself in the abstract scalar so Rerank sees
+            # L1 text instead of the L0 abstract (see 03-context-layers.md).
             context_overview = Context(
                 uri=uri,
                 parent_uri=parent_uri,
                 is_leaf=False,
-                abstract=abstract,
+                abstract=_truncate_abstract_bytes(overview),
                 context_type=context_type,
                 level=ContextLevel.OVERVIEW,
                 created_at=created_at,

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -465,6 +465,51 @@ async def test_vectorize_directory_meta_appends_search_tags_by_level(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_vectorize_directory_meta_l1_abstract_is_overview(monkeypatch):
+    """L1 records must carry the overview in the abstract scalar so Rerank
+    sees L1 text instead of the L0 abstract."""
+    queue = DummyQueue()
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS("ignored"))
+
+    overview = "# Overview\n\n" + ("section detail. " * 50)
+    await embedding_utils.vectorize_directory_meta(
+        uri="viking://user/default/resources/demo",
+        abstract="demo abstract",
+        overview=overview,
+        ctx=DummyReq(),
+    )
+
+    assert len(queue.items) == 2
+    l0, l1 = queue.items
+    assert l0.context_data["level"] == 0
+    assert l0.context_data["abstract"] == "demo abstract"
+    assert l1.context_data["level"] == 1
+    assert l1.context_data["abstract"] == overview
+    assert l1.message == overview
+
+
+@pytest.mark.asyncio
+async def test_vectorize_directory_meta_l1_abstract_truncated(monkeypatch):
+    """Oversized overviews are capped below the scalar byte limit."""
+    queue = DummyQueue()
+    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS("ignored"))
+
+    oversized = "长" * 80_000
+    await embedding_utils.vectorize_directory_meta(
+        uri="viking://user/default/resources/demo",
+        abstract="demo abstract",
+        overview=oversized,
+        ctx=DummyReq(),
+    )
+
+    l1 = queue.items[1]
+    assert l1.context_data["level"] == 1
+    assert len(l1.context_data["abstract"].encode("utf-8")) <= 50_000
+
+
+@pytest.mark.asyncio
 async def test_vectorize_unknown_text_file_sniffs_non_utf8_raw_content(monkeypatch):
     queue = DummyQueue()
     raw_content = (


### PR DESCRIPTION
## Problem

`HierarchicalRetriever` reads the `abstract` field to build Rerank documents, but L1 records were written with the L0 abstract in that field — the overview text was only used for the vector embedding. As a result, Rerank saw the same ~100-token L0 abstract as L0 records and could not leverage the richer ~2k-token L1 overview, defeating the design intent documented in `03-context-layers.md` ("L1: Rerank 精排").

| Level | Rerank sees | Vector search uses | Gap |
|-------|------------|-------------------|-----|
| L0 | L0 abstract (~100 tokens) | L0 abstract | None |
| L1 | L0 abstract (~100 tokens) | L1 overview (~2k tokens) | Rerank loses L1 info |

## Fix

On the write side, store the (byte-capped) overview in the `abstract` scalar of L1 records. The retriever is unchanged — it now naturally reads L1 text for Rerank.

Changed write paths:
- `embedding_utils.vectorize_directory_meta()` — entry point for all live indexing (SemanticProcessor / fs_service / ovpack)
- `reindex_executor`: resource directory rebuild, skill rebuild, memory directory rebuild, and `reindex_directory_marker()`

`_truncate_abstract_bytes()` (50 KB byte cap) is applied consistently with the L0 path to stay below the VikingDB scalar byte limit (regression guard for #2774).

## Compatibility

- No schema change, no retrieval-side change; purely additive write behavior.
- Existing records are unaffected (they keep old behavior until reindexed).
- Only deployments with Rerank configured in THINKING mode see improved ranking.

## Tests

Added to `test_vectorize_file_strategy.py`:
- L1 `abstract` field equals the overview (and L0 unchanged)
- Oversized overview is byte-capped