### PR TITLE
fix(storage): fail closed on vector move remap

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -3105,18 +3105,47 @@ class VikingFS:
             return
 
         real_ctx = self._ctx_or_default(ctx)
+        completed_mappings: List[tuple[str, str]] = []
 
         for uri in uris:
+            new_uri = new_base + uri[len(old_base) :]
             try:
-                new_uri = new_base + uri[len(old_base) :]
-                if await vector_store.update_uri_mapping(
+                updated = await vector_store.update_uri_mapping(
                     ctx=real_ctx,
                     uri=uri,
                     new_uri=new_uri,
-                ):
-                    logger.debug(f"[VikingFS] Updated URI: {uri} -> {new_uri}")
-            except Exception as e:
-                logger.warning(f"[VikingFS] Failed to update {uri} in vector store: {e}")
+                )
+                if not updated:
+                    raise RuntimeError(
+                        f"Vector store URI mapping returned false for {uri} -> {new_uri}"
+                    )
+            except Exception as exc:
+                rollback_failures = []
+                for old_uri, mapped_uri in reversed(completed_mappings):
+                    try:
+                        rolled_back = await vector_store.update_uri_mapping(
+                            ctx=real_ctx,
+                            uri=mapped_uri,
+                            new_uri=old_uri,
+                        )
+                        if not rolled_back:
+                            raise RuntimeError(
+                                f"Vector store URI rollback returned false for "
+                                f"{mapped_uri} -> {old_uri}"
+                            )
+                    except Exception as rollback_exc:
+                        rollback_failures.append(f"{mapped_uri} -> {old_uri}: {rollback_exc}")
+
+                logger.warning(f"[VikingFS] Failed to update {uri} in vector store: {exc}")
+                if rollback_failures:
+                    raise RuntimeError(
+                        f"Vector store URI remap failed for {uri} -> {new_uri}; "
+                        f"rollback incomplete: {'; '.join(rollback_failures)}"
+                    ) from exc
+                raise
+
+            completed_mappings.append((uri, new_uri))
+            logger.debug(f"[VikingFS] Updated URI: {uri} -> {new_uri}")
 
     def _get_vector_store(self) -> Optional["VikingVectorIndexBackend"]:
         """Get vector store instance."""

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -3115,6 +3115,9 @@ class VikingFS:
                     uri=uri,
                     new_uri=new_uri,
                 )
+                if updated is None:
+                    logger.debug(f"[VikingFS] No vector URI to update: {uri}")
+                    continue
                 if not updated:
                     raise RuntimeError(
                         f"Vector store URI mapping returned false for {uri} -> {new_uri}"
@@ -3128,7 +3131,7 @@ class VikingFS:
                             uri=mapped_uri,
                             new_uri=old_uri,
                         )
-                        if not rolled_back:
+                        if rolled_back is not True:
                             raise RuntimeError(
                                 f"Vector store URI rollback returned false for "
                                 f"{mapped_uri} -> {old_uri}"

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -68,6 +68,7 @@ URI_REWRITE_OUTPUT_FIELDS = [
     "content",
     "account_id",
 ]
+URI_REWRITE_RECORD_LIMIT = 100_000
 
 VIKINGDB_CONTENT_MAX_SIZE = 1024 * 1024
 
@@ -466,13 +467,17 @@ class _SingleAccountBackend:
 
     async def get(self, ids: List[str]) -> List[Dict[str, Any]]:
         try:
-            records = await self._async_adapter.call("get", ids)
-            if self._bound_account_id:
-                records = [r for r in records if r.get("account_id") == self._bound_account_id]
-            return records
+            return await self.get_strict(ids)
         except Exception as e:
             logger.error("Error getting records: %s", e)
             return []
+
+    async def get_strict(self, ids: List[str]) -> List[Dict[str, Any]]:
+        """Fetch records without converting backend failures into an empty result."""
+        records = await self._async_adapter.call("get", ids)
+        if self._bound_account_id:
+            records = [r for r in records if r.get("account_id") == self._bound_account_id]
+        return records
 
     async def delete(self, ids: List[str]) -> int:
         try:
@@ -528,23 +533,7 @@ class _SingleAccountBackend:
         order_desc: bool = False,
     ) -> List[Dict[str, Any]]:
         try:
-            logger.debug(
-                f"[_SingleAccountBackend.query] Called with bound_account_id={self._bound_account_id}, filter={filter}"
-            )
-            if self._bound_account_id:
-                account_filter = Eq("account_id", self._bound_account_id)
-                if filter:
-                    if isinstance(filter, dict):
-                        filter = RawDSL(filter)
-                    filter = And([account_filter, filter])
-                else:
-                    filter = account_filter
-                logger.debug(
-                    f"[_SingleAccountBackend.query] Applied account filter, final filter={filter}"
-                )
-
-            return await self._async_adapter.call(
-                "query",
+            return await self.query_strict(
                 query_vector=query_vector,
                 sparse_query_vector=sparse_query_vector,
                 filter=filter,
@@ -557,6 +546,50 @@ class _SingleAccountBackend:
         except Exception as e:
             logger.error("Error querying collection: %s", e, exc_info=True)
             return []
+
+    async def query_strict(
+        self,
+        query_vector: Optional[List[float]] = None,
+        sparse_query_vector: Optional[Dict[str, float]] = None,
+        filter: Optional[Dict[str, Any] | FilterExpr] = None,
+        limit: int = 10,
+        offset: int = 0,
+        output_fields: Optional[List[str]] = None,
+        order_by: Optional[str] = None,
+        order_desc: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Query without converting backend failures into an empty result."""
+        logger.debug(
+            "[_SingleAccountBackend.query_strict] Called with "
+            "bound_account_id=%s, filter=%s",
+            self._bound_account_id,
+            filter,
+        )
+        if self._bound_account_id:
+            account_filter = Eq("account_id", self._bound_account_id)
+            if filter:
+                if isinstance(filter, dict):
+                    filter = RawDSL(filter)
+                filter = And([account_filter, filter])
+            else:
+                filter = account_filter
+            logger.debug(
+                "[_SingleAccountBackend.query_strict] Applied account filter, "
+                "final filter=%s",
+                filter,
+            )
+
+        return await self._async_adapter.call(
+            "query",
+            query_vector=query_vector,
+            sparse_query_vector=sparse_query_vector,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            output_fields=output_fields,
+            order_by=order_by,
+            order_desc=order_desc,
+        )
 
     async def search(
         self,
@@ -653,19 +686,26 @@ class _SingleAccountBackend:
 
     async def count(self, filter: Optional[Dict[str, Any] | FilterExpr] = None) -> int:
         try:
-            if self._bound_account_id:
-                account_filter = Eq("account_id", self._bound_account_id)
-                if filter:
-                    if isinstance(filter, dict):
-                        filter = RawDSL(filter)
-                    filter = And([account_filter, filter])
-                else:
-                    filter = account_filter
-
-            return await self._async_adapter.call("count", filter=filter)
+            return await self.count_strict(filter=filter)
         except Exception as e:
             logger.error("Error counting records: %s", e)
             return 0
+
+    async def count_strict(
+        self,
+        filter: Optional[Dict[str, Any] | FilterExpr] = None,
+    ) -> int:
+        """Count records without converting backend failures into zero."""
+        if self._bound_account_id:
+            account_filter = Eq("account_id", self._bound_account_id)
+            if filter:
+                if isinstance(filter, dict):
+                    filter = RawDSL(filter)
+                filter = And([account_filter, filter])
+            else:
+                filter = account_filter
+
+        return await self._async_adapter.call("count", filter=filter)
 
     async def clear(self) -> bool:
         try:
@@ -1401,34 +1441,66 @@ class VikingVectorIndexBackend:
         conds: List[FilterExpr] = [Eq("uri", canonical_uri), Eq("account_id", ctx.account_id)]
         if levels:
             conds.append(In("level", levels))
+        rewrite_filter = And(conds)
+        backend = self._get_backend_for_context(ctx)
 
-        records = await self.filter(
-            filter=And(conds),
-            limit=100,
-            output_fields=URI_REWRITE_OUTPUT_FIELDS,
-            ctx=ctx,
-        )
-        if not records:
+        record_count = await backend.count_strict(filter=rewrite_filter)
+        if record_count == 0:
             return None
-        record_ids = [str(record["id"]) for record in records if record.get("id")]
-        if not record_ids:
+        if record_count > URI_REWRITE_RECORD_LIMIT:
             logger.warning(
-                "update_uri_mapping found records without ids: uri=%s new_uri=%s account_id=%s",
+                "update_uri_mapping exceeded the safe record limit: uri=%s "
+                "new_uri=%s account_id=%s count=%s limit=%s",
+                canonical_uri,
+                canonical_new_uri,
+                ctx.account_id,
+                record_count,
+                URI_REWRITE_RECORD_LIMIT,
+            )
+            return False
+        records = await backend.query_strict(
+            filter=rewrite_filter,
+            limit=record_count,
+            output_fields=URI_REWRITE_OUTPUT_FIELDS,
+        )
+        if len(records) != record_count:
+            logger.warning(
+                "update_uri_mapping fetched an incomplete record set: uri=%s "
+                "new_uri=%s account_id=%s expected=%s actual=%s",
+                canonical_uri,
+                canonical_new_uri,
+                ctx.account_id,
+                record_count,
+                len(records),
+            )
+            return False
+        record_ids = [str(record["id"]) for record in records if record.get("id")]
+        if len(record_ids) != record_count or len(set(record_ids)) != record_count:
+            logger.warning(
+                "update_uri_mapping found records with missing or duplicate ids: "
+                "uri=%s new_uri=%s account_id=%s",
                 canonical_uri,
                 canonical_new_uri,
                 ctx.account_id,
             )
             return False
-        full_records = await self.get(record_ids, ctx=ctx)
-        if not full_records:
+        full_records = await backend.get_strict(record_ids)
+        full_records_by_id = {
+            str(record["id"]): record for record in full_records if record.get("id")
+        }
+        if len(full_records_by_id) != record_count or any(
+            record_id not in full_records_by_id for record_id in record_ids
+        ):
             logger.warning(
-                "update_uri_mapping failed to fetch full records: uri=%s new_uri=%s account_id=%s ids=%s",
+                "update_uri_mapping failed to fetch every full record: "
+                "uri=%s new_uri=%s account_id=%s ids=%s",
                 canonical_uri,
                 canonical_new_uri,
                 ctx.account_id,
                 record_ids,
             )
             return False
+        ordered_records = [full_records_by_id[record_id] for record_id in record_ids]
 
         def _seed_uri_for_id(uri: str, level: int) -> str:
             if level == 0:
@@ -1437,11 +1509,8 @@ class VikingVectorIndexBackend:
                 return uri if uri.endswith("/.overview.md") else f"{uri}/.overview.md"
             return uri
 
-        success = False
-        ids_to_delete: List[str] = []
-        for record in full_records:
-            if "id" not in record:
-                continue
+        rewritten_records: List[Dict[str, Any]] = []
+        for record in ordered_records:
             raw_level = record.get("level", 2)
             try:
                 level = int(raw_level)
@@ -1460,25 +1529,147 @@ class VikingVectorIndexBackend:
             vector = updated.get("vector")
             if not vector:
                 logger.warning(
-                    "update_uri_mapping skipped record without dense vector: old_uri=%s new_uri=%s level=%s account_id=%s id=%s",
+                    "update_uri_mapping cannot rewrite record without dense vector: "
+                    "old_uri=%s new_uri=%s level=%s account_id=%s id=%s",
                     canonical_uri,
                     canonical_new_uri,
                     level,
                     ctx.account_id,
                     record.get("id"),
                 )
-                continue
-            result = await self.upsert(updated, ctx=ctx)
-            if result:
-                success = True
-                old_id = record.get("id")
-                if old_id and old_id != new_id:
-                    ids_to_delete.append(old_id)
+                return False
+            rewritten_records.append(updated)
 
-        if ids_to_delete:
-            await self.delete(list(set(ids_to_delete)), ctx=ctx)
+        new_ids = [str(record["id"]) for record in rewritten_records]
+        if len(set(new_ids)) != len(new_ids):
+            logger.warning(
+                "update_uri_mapping generated duplicate destination ids: "
+                "old_uri=%s new_uri=%s account_id=%s ids=%s",
+                canonical_uri,
+                canonical_new_uri,
+                ctx.account_id,
+                new_ids,
+            )
+            return False
 
-        return success
+        destination_records = await backend.get_strict(new_ids)
+        destination_records_by_id = {
+            str(record["id"]): record
+            for record in destination_records
+            if record.get("id")
+        }
+        attempted_ids: List[str] = []
+
+        async def _restore_after_failure(*, restore_source: bool) -> List[str]:
+            rollback_failures: List[str] = []
+            if restore_source:
+                for source_record in ordered_records:
+                    try:
+                        restored_id = await self.upsert(source_record, ctx=ctx)
+                        expected_id = str(source_record["id"])
+                        if str(restored_id) != expected_id:
+                            raise RuntimeError(
+                                f"source upsert returned {restored_id!r}, "
+                                f"expected {expected_id!r}"
+                            )
+                    except Exception as exc:
+                        rollback_failures.append(
+                            f"restore source {source_record.get('id')}: {exc}"
+                        )
+
+            current_destination_ids: set[str] = set()
+            if attempted_ids:
+                try:
+                    current_destination_ids = {
+                        str(record["id"])
+                        for record in await backend.get_strict(attempted_ids)
+                        if record.get("id")
+                    }
+                except Exception as exc:
+                    rollback_failures.append(
+                        f"inspect destination records {attempted_ids}: {exc}"
+                    )
+
+            destination_ids_to_delete: List[str] = []
+            for attempted_id in attempted_ids:
+                previous = destination_records_by_id.get(attempted_id)
+                if previous is not None:
+                    try:
+                        restored_id = await self.upsert(previous, ctx=ctx)
+                        expected_id = str(previous["id"])
+                        if str(restored_id) != expected_id:
+                            raise RuntimeError(
+                                f"destination restore returned {restored_id!r}, "
+                                f"expected {expected_id!r}"
+                            )
+                    except Exception as exc:
+                        rollback_failures.append(
+                            f"restore destination {attempted_id}: {exc}"
+                        )
+                elif attempted_id in current_destination_ids:
+                    destination_ids_to_delete.append(attempted_id)
+
+            if destination_ids_to_delete:
+                try:
+                    deleted = await self.delete(
+                        destination_ids_to_delete,
+                        ctx=ctx,
+                    )
+                    if deleted != len(destination_ids_to_delete):
+                        raise RuntimeError(
+                            f"deleted {deleted} of "
+                            f"{len(destination_ids_to_delete)} destination records"
+                        )
+                except Exception as exc:
+                    rollback_failures.append(
+                        f"delete destination records {destination_ids_to_delete}: {exc}"
+                    )
+            return rollback_failures
+
+        source_delete_attempted = False
+        try:
+            for rewritten in rewritten_records:
+                expected_id = str(rewritten["id"])
+                attempted_ids.append(expected_id)
+                result = await self.upsert(rewritten, ctx=ctx)
+                if str(result) != expected_id:
+                    raise RuntimeError(
+                        f"Vector store URI upsert returned {result!r}, "
+                        f"expected {expected_id!r}"
+                    )
+
+            old_ids_to_delete = list(
+                dict.fromkeys(
+                    str(source_record["id"])
+                    for source_record, rewritten in zip(
+                        ordered_records,
+                        rewritten_records,
+                        strict=True,
+                    )
+                    if str(source_record["id"]) != str(rewritten["id"])
+                )
+            )
+            if old_ids_to_delete:
+                source_delete_attempted = True
+                deleted = await self.delete(old_ids_to_delete, ctx=ctx)
+                if deleted != len(old_ids_to_delete):
+                    raise RuntimeError(
+                        f"Vector store URI rewrite deleted {deleted} of "
+                        f"{len(old_ids_to_delete)} source records"
+                    )
+        except Exception as exc:
+            rollback_failures = await _restore_after_failure(
+                restore_source=source_delete_attempted
+            )
+            if rollback_failures:
+                raise RuntimeError(
+                    f"Vector store URI remap failed for {canonical_uri} -> "
+                    f"{canonical_new_uri}; rollback incomplete: "
+                    f"{'; '.join(rollback_failures)}"
+                ) from exc
+            raise
+
+        return True
 
     async def increment_active_count(self, ctx: RequestContext, uris: List[str]) -> int:
         updated = 0

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1392,7 +1392,8 @@ class VikingVectorIndexBackend:
         uri: str,
         new_uri: str,
         levels: Optional[List[int]] = None,
-    ) -> bool:
+    ) -> Optional[bool]:
+        """Return True when remapped, None when absent, or False on invalid records."""
         import hashlib
 
         canonical_uri = canonicalize_uri(uri, ctx)
@@ -1408,7 +1409,7 @@ class VikingVectorIndexBackend:
             ctx=ctx,
         )
         if not records:
-            return False
+            return None
         record_ids = [str(record["id"]) for record in records if record.get("id")]
         if not record_ids:
             logger.warning(

--- a/openviking/storage/vikingdb_manager.py
+++ b/openviking/storage/vikingdb_manager.py
@@ -505,7 +505,8 @@ class VikingDBManagerProxy:
         self,
         uri: str,
         new_uri: str,
-    ) -> bool:
+    ) -> Optional[bool]:
+        """Return True when remapped, None when absent, or False on invalid records."""
         return await self._manager.update_uri_mapping(
             self._ctx,
             uri=uri,

--- a/tests/storage/test_semantic_processor_mv_vector_store.py
+++ b/tests/storage/test_semantic_processor_mv_vector_store.py
@@ -4,6 +4,7 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
+from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -122,6 +123,35 @@ async def test_update_vector_store_uris_raises_false_result():
 
 
 @pytest.mark.asyncio
+async def test_update_vector_store_uris_allows_missing_vector_record():
+    ctx = _ctx()
+    fs = VikingFS.__new__(VikingFS)
+    fs.vector_store = AsyncMock()
+    fs.vector_store.update_uri_mapping.return_value = None
+
+    await fs._update_vector_store_uris(
+        ["viking://resources/unindexed"],
+        "viking://resources/unindexed",
+        "viking://resources/moved",
+        ctx=ctx,
+    )
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_distinguishes_missing_record_from_failure():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    backend.filter = AsyncMock(return_value=[])
+
+    result = await backend.update_uri_mapping(
+        ctx=_ctx(),
+        uri="viking://resources/unindexed",
+        new_uri="viking://resources/moved",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_update_vector_store_uris_rolls_back_partial_batch():
     ctx = _ctx()
     old_base = "viking://resources/source"
@@ -194,6 +224,23 @@ async def test_mv_vector_remap_failure_keeps_source_and_cleans_destination(
 @pytest.mark.asyncio
 async def test_mv_complete_vector_remap_deletes_source(monkeypatch, source_is_dir):
     vector_results = [True, True] if source_is_dir else [True]
+    fs, agfs, _, source_uri, target_uri, source_path, _ = _move_fs(
+        monkeypatch,
+        source_is_dir=source_is_dir,
+        vector_results=vector_results,
+    )
+
+    await fs.mv(source_uri, target_uri, ctx=_ctx())
+
+    assert [(path, recursive) for path, recursive, _ in agfs.rm_calls] == [
+        (source_path, source_is_dir)
+    ]
+
+
+@pytest.mark.parametrize("source_is_dir", [False, True], ids=["file", "directory"])
+@pytest.mark.asyncio
+async def test_mv_without_vector_record_deletes_source(monkeypatch, source_is_dir):
+    vector_results = [None, None] if source_is_dir else [None]
     fs, agfs, _, source_uri, target_uri, source_path, _ = _move_fs(
         monkeypatch,
         source_is_dir=source_is_dir,

--- a/tests/storage/test_semantic_processor_mv_vector_store.py
+++ b/tests/storage/test_semantic_processor_mv_vector_store.py
@@ -1,10 +1,14 @@
-from unittest.mock import AsyncMock, call
+import hashlib
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
-from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
+from openviking.storage.viking_vector_index_backend import (
+    URI_REWRITE_RECORD_LIMIT,
+    VikingVectorIndexBackend,
+)
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -137,10 +141,20 @@ async def test_update_vector_store_uris_allows_missing_vector_record():
     )
 
 
+def _attach_strict_backend(backend):
+    strict_backend = Mock()
+    strict_backend.count_strict = AsyncMock()
+    strict_backend.query_strict = AsyncMock()
+    strict_backend.get_strict = AsyncMock()
+    backend._get_backend_for_context = Mock(return_value=strict_backend)
+    return strict_backend
+
+
 @pytest.mark.asyncio
 async def test_vector_backend_distinguishes_missing_record_from_failure():
     backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
-    backend.filter = AsyncMock(return_value=[])
+    strict_backend = _attach_strict_backend(backend)
+    strict_backend.count_strict.return_value = 0
 
     result = await backend.update_uri_mapping(
         ctx=_ctx(),
@@ -149,6 +163,243 @@ async def test_vector_backend_distinguishes_missing_record_from_failure():
     )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_propagates_record_lookup_failures():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    strict_backend.count_strict.side_effect = RuntimeError("vector unavailable")
+
+    with pytest.raises(RuntimeError, match="vector unavailable"):
+        await backend.update_uri_mapping(
+            ctx=_ctx(),
+            uri="viking://resources/source.md",
+            new_uri="viking://resources/target.md",
+        )
+
+    strict_backend.query_strict.assert_not_awaited()
+
+
+def _vector_record(record_id, *, level, vector):
+    return {
+        "id": record_id,
+        "uri": "viking://resources/source.md",
+        "level": level,
+        "vector": vector,
+        "account_id": "acc",
+    }
+
+
+def _destination_record_id(level):
+    suffix = "/.abstract.md" if level == 0 else "/.overview.md" if level == 1 else ""
+    seed = f"acc:viking://resources/target.md{suffix}"
+    return hashlib.md5(seed.encode("utf-8")).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_rejects_incomplete_record_rewrite():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    records = [
+        _vector_record("old-l0", level=0, vector=[0.1]),
+        _vector_record("old-l1", level=1, vector=[]),
+    ]
+    strict_backend.count_strict.return_value = len(records)
+    strict_backend.query_strict.return_value = [
+        {"id": record["id"]} for record in records
+    ]
+    strict_backend.get_strict.return_value = records
+    backend.upsert = AsyncMock(return_value=True)
+    backend.delete = AsyncMock(return_value=1)
+
+    result = await backend.update_uri_mapping(
+        ctx=_ctx(),
+        uri="viking://resources/source.md",
+        new_uri="viking://resources/target.md",
+    )
+
+    assert result is False
+    backend.upsert.assert_not_awaited()
+    backend.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_rolls_back_destination_records_after_upsert_failure():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    records = [
+        _vector_record("old-l0", level=0, vector=[0.1]),
+        _vector_record("old-l1", level=1, vector=[0.2]),
+    ]
+    strict_backend.count_strict.return_value = len(records)
+    strict_backend.query_strict.return_value = [
+        {"id": record["id"]} for record in records
+    ]
+    first_new_id = _destination_record_id(0)
+    second_new_id = _destination_record_id(1)
+    strict_backend.get_strict.side_effect = [
+        records,
+        [],
+        [{"id": first_new_id}, {"id": second_new_id}],
+    ]
+    backend.upsert = AsyncMock(
+        side_effect=[first_new_id, RuntimeError("second upsert failed")]
+    )
+    backend.delete = AsyncMock(return_value=2)
+
+    with pytest.raises(RuntimeError, match="second upsert failed"):
+        await backend.update_uri_mapping(
+            ctx=_ctx(),
+            uri="viking://resources/source.md",
+            new_uri="viking://resources/target.md",
+        )
+
+    backend.delete.assert_awaited_once_with(
+        [first_new_id, second_new_id],
+        ctx=_ctx(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_restores_old_records_after_delete_failure():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    records = [
+        _vector_record("old-l0", level=0, vector=[0.1]),
+        _vector_record("old-l1", level=1, vector=[0.2]),
+    ]
+    strict_backend.count_strict.return_value = len(records)
+    strict_backend.query_strict.return_value = [
+        {"id": record["id"]} for record in records
+    ]
+    strict_backend.get_strict.side_effect = [
+        records,
+        [],
+        [
+            {"id": _destination_record_id(0)},
+            {"id": _destination_record_id(1)},
+        ],
+    ]
+    backend.upsert = AsyncMock(
+        side_effect=[
+            _destination_record_id(0),
+            _destination_record_id(1),
+            "old-l0",
+            "old-l1",
+        ]
+    )
+    backend.delete = AsyncMock(
+        side_effect=[RuntimeError("old delete failed"), 2]
+    )
+
+    with pytest.raises(RuntimeError, match="old delete failed"):
+        await backend.update_uri_mapping(
+            ctx=_ctx(),
+            uri="viking://resources/source.md",
+            new_uri="viking://resources/target.md",
+        )
+
+    assert backend.upsert.await_count == 4
+    assert [call.args[0]["id"] for call in backend.upsert.await_args_list[-2:]] == [
+        "old-l0",
+        "old-l1",
+    ]
+    assert backend.delete.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_restores_preexisting_destination_after_failure():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    records = [
+        _vector_record("old-l0", level=0, vector=[0.1]),
+        _vector_record("old-l1", level=1, vector=[0.2]),
+    ]
+    first_new_id = _destination_record_id(0)
+    previous_destination = {
+        "id": first_new_id,
+        "uri": "viking://resources/target.md",
+        "level": 0,
+        "vector": [9.9],
+        "account_id": "acc",
+    }
+    strict_backend.count_strict.return_value = len(records)
+    strict_backend.query_strict.return_value = [
+        {"id": record["id"]} for record in records
+    ]
+    strict_backend.get_strict.side_effect = [
+        records,
+        [previous_destination],
+        [previous_destination],
+    ]
+    backend.upsert = AsyncMock(
+        side_effect=[
+            first_new_id,
+            RuntimeError("second upsert failed"),
+            first_new_id,
+        ]
+    )
+    backend.delete = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="second upsert failed"):
+        await backend.update_uri_mapping(
+            ctx=_ctx(),
+            uri="viking://resources/source.md",
+            new_uri="viking://resources/target.md",
+        )
+
+    assert backend.upsert.await_args_list[-1].args[0] == previous_destination
+    backend.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_requests_the_complete_uri_record_set():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    records = [
+        _vector_record("old-l0", level=0, vector=[0.1]),
+        _vector_record("old-l1", level=1, vector=[0.2]),
+    ]
+    strict_backend.count_strict.return_value = len(records)
+    strict_backend.query_strict.return_value = [
+        {"id": record["id"]} for record in records
+    ]
+    strict_backend.get_strict.side_effect = [records, []]
+    backend.upsert = AsyncMock(
+        side_effect=[_destination_record_id(0), _destination_record_id(1)]
+    )
+    backend.delete = AsyncMock(return_value=2)
+
+    result = await backend.update_uri_mapping(
+        ctx=_ctx(),
+        uri="viking://resources/source.md",
+        new_uri="viking://resources/target.md",
+    )
+
+    assert result is True
+    assert strict_backend.query_strict.await_args.kwargs["limit"] == len(records)
+
+
+@pytest.mark.asyncio
+async def test_vector_backend_rejects_record_sets_above_safe_limit():
+    backend = VikingVectorIndexBackend.__new__(VikingVectorIndexBackend)
+    strict_backend = _attach_strict_backend(backend)
+    strict_backend.count_strict.return_value = URI_REWRITE_RECORD_LIMIT + 1
+    backend.upsert = AsyncMock()
+    backend.delete = AsyncMock()
+
+    result = await backend.update_uri_mapping(
+        ctx=_ctx(),
+        uri="viking://resources/source.md",
+        new_uri="viking://resources/target.md",
+    )
+
+    assert result is False
+    strict_backend.query_strict.assert_not_awaited()
+    strict_backend.get_strict.assert_not_awaited()
+    backend.upsert.assert_not_awaited()
+    backend.delete.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_semantic_processor_mv_vector_store.py
+++ b/tests/storage/test_semantic_processor_mv_vector_store.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -7,12 +7,69 @@ from openviking.storage.viking_fs import VikingFS
 from openviking_cli.session.user_id import UserIdentifier
 
 
+class _MoveAGFS:
+    def __init__(self, *, source_path: str, source_is_dir: bool):
+        self.source_path = source_path
+        self.source_is_dir = source_is_dir
+        self.rm_calls = []
+        self.release_calls = []
+
+    async def stat(self, path):
+        if path == self.source_path:
+            return {"isDir": self.source_is_dir}
+        raise FileNotFoundError(path)
+
+    async def pathlock_acquire_batch(self, requests, owner_lease_ref=None):
+        return {"lease_ref": "operation"}
+
+    async def pathlock_acquire_tree(self, path, owner_lease_ref=None):
+        return {"lease_ref": "cleanup"}
+
+    async def pathlock_release(self, lease):
+        self.release_calls.append(lease)
+
+    async def rm(self, path, recursive=False, fs_ctx=None):
+        self.rm_calls.append((path, recursive, fs_ctx))
+        return {}
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("acc", "default"), role=Role.ROOT)
+
+
+def _move_fs(monkeypatch, *, source_is_dir: bool, vector_results):
+    source_uri = "viking://resources/source"
+    target_uri = "viking://resources/target"
+    source_path = "/local/acc/resources/source"
+    target_path = "/local/acc/resources/target"
+    agfs = _MoveAGFS(source_path=source_path, source_is_dir=source_is_dir)
+    vector_store = AsyncMock()
+    vector_store.update_uri_mapping.side_effect = vector_results
+    fs = VikingFS.__new__(VikingFS)
+    fs._async_agfs = agfs
+    fs.vector_store = vector_store
+
+    monkeypatch.setattr(fs, "_ensure_mutable_access", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(fs, "_ensure_delete_access", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(fs, "_copy_for_mv", AsyncMock())
+    monkeypatch.setattr(
+        fs,
+        "_collect_uris",
+        AsyncMock(
+            return_value=[f"{source_uri}/child.md"] if source_is_dir else [],
+        ),
+    )
+
+    return fs, agfs, vector_store, source_uri, target_uri, source_path, target_path
+
+
 @pytest.mark.asyncio
 async def test_mv_canonicalizes_user_shorthand_before_vector_update(monkeypatch):
-    ctx = RequestContext(user=UserIdentifier("acc", "default"), role=Role.ROOT)
+    ctx = _ctx()
     fs = VikingFS.__new__(VikingFS)
     fs._async_agfs = AsyncMock()
     fs._async_agfs.stat.return_value = {"isDir": False}
+    fs._async_agfs.pathlock_acquire_batch.return_value = {"lease_ref": "operation"}
     fs._collect_uris = AsyncMock(return_value=[])
     fs._copy_for_mv = AsyncMock()
     fs._update_vector_store_uris = AsyncMock()
@@ -32,16 +89,119 @@ async def test_mv_canonicalizes_user_shorthand_before_vector_update(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_update_vector_store_uris_swallows_update_failure():
-    ctx = RequestContext(user=UserIdentifier("acc", "default"), role=Role.ROOT)
+async def test_update_vector_store_uris_raises_update_exception():
+    ctx = _ctx()
     fs = VikingFS.__new__(VikingFS)
     fs.vector_store = AsyncMock()
     fs.vector_store.update_uri_mapping.side_effect = RuntimeError("vector unavailable")
 
-    await fs._update_vector_store_uris(
-        ["viking://user/default/source.md"],
-        "viking://user/default/source.md",
-        "viking://user/default/target.md",
-        ctx=ctx,
-    )
+    with pytest.raises(RuntimeError, match="vector unavailable"):
+        await fs._update_vector_store_uris(
+            ["viking://user/default/source.md"],
+            "viking://user/default/source.md",
+            "viking://user/default/target.md",
+            ctx=ctx,
+        )
     fs.vector_store.update_uri_mapping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_vector_store_uris_raises_false_result():
+    ctx = _ctx()
+    fs = VikingFS.__new__(VikingFS)
+    fs.vector_store = AsyncMock()
+    fs.vector_store.update_uri_mapping.return_value = False
+
+    with pytest.raises(RuntimeError, match="source.md"):
+        await fs._update_vector_store_uris(
+            ["viking://user/default/source.md"],
+            "viking://user/default/source.md",
+            "viking://user/default/target.md",
+            ctx=ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_vector_store_uris_rolls_back_partial_batch():
+    ctx = _ctx()
+    old_base = "viking://resources/source"
+    new_base = "viking://resources/target"
+    first_uri = f"{old_base}/first.md"
+    second_uri = f"{old_base}/second.md"
+    first_target = f"{new_base}/first.md"
+    fs = VikingFS.__new__(VikingFS)
+    fs.vector_store = AsyncMock()
+    fs.vector_store.update_uri_mapping.side_effect = [True, False, True]
+
+    with pytest.raises(RuntimeError, match="second.md"):
+        await fs._update_vector_store_uris(
+            [first_uri, second_uri],
+            old_base,
+            new_base,
+            ctx=ctx,
+        )
+
+    assert fs.vector_store.update_uri_mapping.await_args_list == [
+        call(ctx=ctx, uri=first_uri, new_uri=first_target),
+        call(ctx=ctx, uri=second_uri, new_uri=f"{new_base}/second.md"),
+        call(ctx=ctx, uri=first_target, new_uri=first_uri),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_vector_store_uris_succeeds_for_complete_batch():
+    ctx = _ctx()
+    old_base = "viking://resources/source"
+    new_base = "viking://resources/target"
+    uris = [old_base, f"{old_base}/child.md"]
+    fs = VikingFS.__new__(VikingFS)
+    fs.vector_store = AsyncMock()
+    fs.vector_store.update_uri_mapping.side_effect = [True, True]
+
+    await fs._update_vector_store_uris(uris, old_base, new_base, ctx=ctx)
+
+    assert fs.vector_store.update_uri_mapping.await_args_list == [
+        call(ctx=ctx, uri=old_base, new_uri=new_base),
+        call(
+            ctx=ctx,
+            uri=f"{old_base}/child.md",
+            new_uri=f"{new_base}/child.md",
+        ),
+    ]
+
+
+@pytest.mark.parametrize("source_is_dir", [False, True], ids=["file", "directory"])
+@pytest.mark.asyncio
+async def test_mv_vector_remap_failure_keeps_source_and_cleans_destination(
+    monkeypatch, source_is_dir
+):
+    fs, agfs, _, source_uri, target_uri, source_path, target_path = _move_fs(
+        monkeypatch,
+        source_is_dir=source_is_dir,
+        vector_results=[False],
+    )
+
+    with pytest.raises(RuntimeError):
+        await fs.mv(source_uri, target_uri, ctx=_ctx())
+
+    assert not any(path == source_path for path, _, _ in agfs.rm_calls)
+    assert [(path, recursive) for path, recursive, _ in agfs.rm_calls] == [
+        (target_path, source_is_dir)
+    ]
+
+
+@pytest.mark.parametrize("source_is_dir", [False, True], ids=["file", "directory"])
+@pytest.mark.asyncio
+async def test_mv_complete_vector_remap_deletes_source(monkeypatch, source_is_dir):
+    vector_results = [True, True] if source_is_dir else [True]
+    fs, agfs, _, source_uri, target_uri, source_path, _ = _move_fs(
+        monkeypatch,
+        source_is_dir=source_is_dir,
+        vector_results=vector_results,
+    )
+
+    await fs.mv(source_uri, target_uri, ctx=_ctx())
+
+    assert [(path, recursive) for path, recursive, _ in agfs.rm_calls] == [
+        (source_path, source_is_dir)
+    ]


### PR DESCRIPTION
## Description

Make `VikingFS.mv()` fail closed when vector URI remapping is incomplete, without rejecting legitimate moves that have no vector rows.

Previously `_update_vector_store_uris()` logged per-record exceptions, so a filesystem move could delete the source while vector records still referenced old or partially moved URIs. The remap now propagates real failures, compensates earlier successful mappings in reverse order, and lets the existing move rollback remove the copied destination while preserving the source.

The vector backend now distinguishes three outcomes: `True` means records were remapped, `None` means no matching vector record exists, and `False` means records existed but could not be safely rewritten. This preserves empty-directory and unindexed-file moves while still failing closed on malformed, partial, or exceptional remaps.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Found during a source-first reliability audit; no existing issue or open PR directly covered move-time vector remapping.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Propagate vector backend exceptions and invalid (`False`) mapping results as move failures.
- Treat absent (`None`) vector rows as a successful no-op for unindexed files and empty directories.
- Compensate already-remapped records in reverse order and report incomplete compensation explicitly.
- Preflight the complete record set with strict reads so lookup failures cannot look like absent rows.
- Reject missing vectors, duplicate IDs, incomplete fetches, and oversized rewrites before any write.
- Restore source records and pre-existing destination records, and remove newly inserted destination records, when any per-record step fails.
- Add file/directory fault-injection coverage for exceptions, invalid results, missing rows, partial batches, rollback, and success.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```text
PYTHONPATH=. python -m pytest -o addopts='' -q \
  tests/storage/test_semantic_processor_mv_vector_store.py
# 20 passed

PYTHONPATH=. python -m pytest -o addopts='' -q \
  tests/storage/test_semantic_processor_mv_vector_store.py \
  tests/storage/test_viking_fs_write_locking.py \
  tests/misc/test_vikingfs_uri_guard.py \
  tests/storage/test_viking_vector_scope_filter.py \
  tests/storage/test_collection_schemas.py
# 135 passed, 2 skipped

ruff check \
  openviking/storage/viking_vector_index_backend.py \
  tests/storage/test_semantic_processor_mv_vector_store.py

git diff --check
# passed
```

A live isolated HTTP server loaded from this branch also reproduced the CI endpoint sequence for an unindexed empty directory:

```text
POST /api/v1/fs/mkdir -> status: ok
POST /api/v1/fs/mv    -> status: ok
GET destination       -> status: ok
GET source            -> NOT_FOUND
```

Local artifact: `/tmp/openviking-vector-move-ci/http-move-result.json`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The first API integration run caught the empty-directory ambiguity because the old boolean API used `False` for both “no row” and “unsafe rewrite.” Commit `20906205` separates those outcomes and adds regression coverage.

Review follow-up commit `b1097b4c` closes the per-URI partial-write gaps: strict reads distinguish backend failure from absence, incomplete record sets fail before writes, and compensation now covers writes that took effect before raising as well as pre-existing destination records. If compensation itself fails, the operation remains failed closed and reports `rollback incomplete`; the source filesystem entry remains intact for operator recovery.

