### PR TITLE
fix(retry): admit one half-open circuit probe

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -548,6 +548,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         report_success = False
         report_error_args: Optional[tuple[str, Optional[Dict[str, Any]]]] = None
         request_failed_message: Optional[str] = None
+        probe_token: int | None = None
         try:
             queue_data = json.loads(data["data"])
             # Parse EmbeddingMsg from data
@@ -576,7 +577,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
 
                 # Circuit breaker: if API is known-broken, re-enqueue and wait
                 try:
-                    self._circuit_breaker.check()
+                    probe_token = self._circuit_breaker.check()
                     self._breaker_open_last_log_at = 0.0
                     self._breaker_open_suppressed_count = 0
                 except CircuitBreakerOpen:
@@ -656,7 +657,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
 
                         if error_class == ERROR_CLASS_PERMANENT:
                             logger.critical(error_msg)
-                            self._circuit_breaker.record_failure(embed_err)
+                            self._circuit_breaker.record_failure(embed_err, probe_token)
                             self._merge_request_stats(embedding_msg.telemetry_id, error_count=1)
                             request_failed_message = error_msg
                             report_error_args = (error_msg, data)
@@ -677,7 +678,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
 
                         # Transient or unknown — re-enqueue for retry
                         logger.warning(error_msg)
-                        self._circuit_breaker.record_failure(embed_err)
+                        self._circuit_breaker.record_failure(embed_err, probe_token)
                         if getattr(self._vikingdb, "has_queue_manager", False):
                             try:
                                 await self._vikingdb.enqueue_embedding_msg(embedding_msg)
@@ -816,7 +817,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                 self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
                 self._record_request_success(embedding_msg)
                 report_success = True
-                self._circuit_breaker.record_success()
+                self._circuit_breaker.record_success(probe_token)
                 return inserted_data
 
         except Exception as e:
@@ -834,6 +835,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             report_error_args = (error_msg, data)
             return None
         finally:
+            self._circuit_breaker.record_ignored(probe_token)
             if embedding_msg is not None and request_failed_message is not None:
                 self._record_request_failure(embedding_msg, request_failed_message)
             if embedding_msg and embedding_msg.semantic_msg_id:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -318,6 +318,7 @@ class SemanticProcessor(DequeueHandlerBase):
         """Process dequeued SemanticMsg, recursively process all subdirectories."""
         msg: Optional[SemanticMsg] = None
         collector = None
+        probe_token: int | None = None
         try:
             import json
 
@@ -341,7 +342,7 @@ class SemanticProcessor(DequeueHandlerBase):
                 return None
             # Circuit breaker: if API is known-broken, re-enqueue and wait
             try:
-                self._circuit_breaker.check()
+                probe_token = self._circuit_breaker.check()
             except CircuitBreakerOpen:
                 logger.warning(
                     f"Circuit breaker is open, re-enqueueing semantic message: {msg.uri}"
@@ -462,7 +463,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     self._merge_request_stats(msg.telemetry_id, processed=1)
                     logger.info(f"Completed semantic generation for: {msg.uri}")
                     self.report_success()
-                    self._circuit_breaker.record_success()
+                    self._circuit_breaker.record_success(probe_token)
                     return None
                 finally:
                     reset_root_observability_context(root_context_token)
@@ -475,6 +476,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     e,
                     exc_info=True,
                 )
+                self._circuit_breaker.record_ignored(probe_token)
                 if msg is not None:
                     await self._requeue_semantic_msg_after_error(msg, data, e)
                 else:
@@ -498,7 +500,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     f"Permanent API error processing semantic message, dropping: {e}",
                     exc_info=True,
                 )
-                self._circuit_breaker.record_failure(e)
+                self._circuit_breaker.record_failure(e, probe_token)
                 if msg is not None:
                     self._merge_request_stats(msg.telemetry_id, error_count=1)
                     get_request_wait_tracker().mark_semantic_failed(
@@ -511,12 +513,14 @@ class SemanticProcessor(DequeueHandlerBase):
                     f"Transient API error processing semantic message, re-enqueueing: {e}",
                     exc_info=True,
                 )
-                self._circuit_breaker.record_failure(e)
+                self._circuit_breaker.record_failure(e, probe_token)
                 if msg is not None:
                     await self._requeue_semantic_msg_after_error(msg, data, e)
                 else:
                     self.report_error(str(e), data)
             return None
+        finally:
+            self._circuit_breaker.record_ignored(probe_token)
 
     async def on_cancelled(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Release a queued semantic lock before cancelled work is ACKed."""

--- a/openviking/utils/circuit_breaker.py
+++ b/openviking/utils/circuit_breaker.py
@@ -54,18 +54,29 @@ class CircuitBreaker:
         self._state = _STATE_CLOSED
         self._failure_count = 0
         self._last_failure_time: float = 0
+        self._probe_started_at: float = 0
 
     def check(self) -> None:
         """Allow the request through, or raise ``CircuitBreakerOpen``."""
         with self._lock:
             if self._state == _STATE_CLOSED:
                 return
+            now = time.monotonic()
             if self._state == _STATE_HALF_OPEN:
-                return  # allow probe request
+                elapsed = now - self._probe_started_at
+                if elapsed >= self._current_reset_timeout:
+                    self._probe_started_at = now
+                    logger.info("Circuit breaker replacing timed-out HALF_OPEN probe")
+                    return
+                raise CircuitBreakerOpen(
+                    "Circuit breaker is HALF_OPEN with a probe in progress, "
+                    f"retry after {self._current_reset_timeout - elapsed:.0f}s"
+                )
             # OPEN — check if timeout elapsed
-            elapsed = time.monotonic() - self._last_failure_time
+            elapsed = now - self._last_failure_time
             if elapsed >= self._current_reset_timeout:
                 self._state = _STATE_HALF_OPEN
+                self._probe_started_at = now
                 logger.info("Circuit breaker transitioning OPEN -> HALF_OPEN (timeout elapsed)")
                 return
             raise CircuitBreakerOpen(
@@ -92,6 +103,7 @@ class CircuitBreaker:
             self._failure_count = 0
             self._state = _STATE_CLOSED
             self._current_reset_timeout = self._base_reset_timeout
+            self._probe_started_at = 0
 
     def record_failure(self, error: Exception) -> None:
         """Record a failed API call. May trip the breaker."""
@@ -106,6 +118,7 @@ class CircuitBreaker:
 
             if self._state == _STATE_HALF_OPEN:
                 self._state = _STATE_OPEN
+                self._probe_started_at = 0
                 self._current_reset_timeout = min(
                     self._current_reset_timeout * 2,
                     self._max_reset_timeout,

--- a/openviking/utils/circuit_breaker.py
+++ b/openviking/utils/circuit_breaker.py
@@ -24,6 +24,7 @@ logger = get_logger(__name__)
 _STATE_CLOSED = "CLOSED"
 _STATE_OPEN = "OPEN"
 _STATE_HALF_OPEN = "HALF_OPEN"
+_PROBE_UNSET = object()
 
 
 class CircuitBreakerOpen(Exception):
@@ -55,19 +56,28 @@ class CircuitBreaker:
         self._failure_count = 0
         self._last_failure_time: float = 0
         self._probe_started_at: float = 0
+        self._probe_token = 0
+        self._active_probe_token: int | None = None
 
-    def check(self) -> None:
-        """Allow the request through, or raise ``CircuitBreakerOpen``."""
+    def _start_probe(self, now: float) -> int:
+        self._probe_token += 1
+        self._active_probe_token = self._probe_token
+        self._probe_started_at = now
+        return self._probe_token
+
+    def check(self) -> int | None:
+        """Allow the request through and return its HALF_OPEN probe token."""
         with self._lock:
             if self._state == _STATE_CLOSED:
-                return
+                return None
             now = time.monotonic()
             if self._state == _STATE_HALF_OPEN:
+                if self._active_probe_token is None:
+                    return self._start_probe(now)
                 elapsed = now - self._probe_started_at
                 if elapsed >= self._current_reset_timeout:
-                    self._probe_started_at = now
                     logger.info("Circuit breaker replacing timed-out HALF_OPEN probe")
-                    return
+                    return self._start_probe(now)
                 raise CircuitBreakerOpen(
                     "Circuit breaker is HALF_OPEN with a probe in progress, "
                     f"retry after {self._current_reset_timeout - elapsed:.0f}s"
@@ -76,9 +86,8 @@ class CircuitBreaker:
             elapsed = now - self._last_failure_time
             if elapsed >= self._current_reset_timeout:
                 self._state = _STATE_HALF_OPEN
-                self._probe_started_at = now
                 logger.info("Circuit breaker transitioning OPEN -> HALF_OPEN (timeout elapsed)")
-                return
+                return self._start_probe(now)
             raise CircuitBreakerOpen(
                 f"Circuit breaker is OPEN, retry after {self._current_reset_timeout - elapsed:.0f}s"
             )
@@ -87,38 +96,93 @@ class CircuitBreaker:
     def retry_after(self) -> float:
         """Seconds until the breaker may transition to HALF_OPEN, capped at 30s.
 
-        Returns 0 if the breaker is CLOSED or HALF_OPEN.
+        Returns 0 if the breaker is CLOSED or no HALF_OPEN probe is active.
         """
         with self._lock:
-            if self._state != _STATE_OPEN:
+            if self._state == _STATE_CLOSED:
                 return 0
-            remaining = self._current_reset_timeout - (time.monotonic() - self._last_failure_time)
+            if self._state == _STATE_HALF_OPEN:
+                if self._active_probe_token is None:
+                    return 0
+                elapsed = time.monotonic() - self._probe_started_at
+            else:
+                elapsed = time.monotonic() - self._last_failure_time
+            remaining = self._current_reset_timeout - elapsed
             return min(max(remaining, 0), 30)
 
-    def record_success(self) -> None:
+    def record_success(self, probe_token: int | None | object = _PROBE_UNSET) -> None:
         """Record a successful API call. Resets failure count."""
         with self._lock:
+            explicit_token = probe_token is not _PROBE_UNSET
             if self._state == _STATE_HALF_OPEN:
+                effective_token = (
+                    self._active_probe_token if not explicit_token else probe_token
+                )
+                if effective_token != self._active_probe_token:
+                    logger.debug("Ignoring completion from a stale HALF_OPEN probe")
+                    return
                 logger.info("Circuit breaker transitioning HALF_OPEN -> CLOSED (probe succeeded)")
+            elif self._state == _STATE_OPEN or (
+                explicit_token and probe_token is not None
+            ):
+                logger.debug("Ignoring success from a request admitted before the current state")
+                return
             self._failure_count = 0
             self._state = _STATE_CLOSED
             self._current_reset_timeout = self._base_reset_timeout
             self._probe_started_at = 0
+            self._active_probe_token = None
 
-    def record_failure(self, error: Exception) -> None:
+    def record_ignored(self, probe_token: int | None | object = _PROBE_UNSET) -> None:
+        """Release a probe whose outcome does not describe provider health."""
+        with self._lock:
+            explicit_token = probe_token is not _PROBE_UNSET
+            effective_token = (
+                self._active_probe_token if not explicit_token else probe_token
+            )
+            if (
+                self._state == _STATE_HALF_OPEN
+                and effective_token is not None
+                and effective_token == self._active_probe_token
+            ):
+                self._probe_started_at = 0
+                self._active_probe_token = None
+
+    def record_failure(
+        self,
+        error: Exception,
+        probe_token: int | None | object = _PROBE_UNSET,
+    ) -> None:
         """Record a failed API call. May trip the breaker."""
         error_class = classify_api_error(error)
         if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
             logger.info(f"Circuit breaker ignoring row-specific input error: {error}")
+            self.record_ignored(probe_token)
             return
 
         with self._lock:
+            explicit_token = probe_token is not _PROBE_UNSET
+            effective_token = (
+                self._active_probe_token if not explicit_token else probe_token
+            )
+            if explicit_token:
+                if probe_token is None:
+                    if self._state != _STATE_CLOSED:
+                        logger.debug("Ignoring failure from a request admitted before the current state")
+                        return
+                elif (
+                    self._state != _STATE_HALF_OPEN
+                    or effective_token != self._active_probe_token
+                ):
+                    logger.debug("Ignoring failure from a stale HALF_OPEN probe")
+                    return
             self._failure_count += 1
             self._last_failure_time = time.monotonic()
 
             if self._state == _STATE_HALF_OPEN:
                 self._state = _STATE_OPEN
                 self._probe_started_at = 0
+                self._active_probe_token = None
                 self._current_reset_timeout = min(
                     self._current_reset_timeout * 2,
                     self._max_reset_timeout,

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -369,7 +369,11 @@ async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypat
         "openviking_cli.utils.config.get_openviking_config",
         lambda: _DummyConfig(_AuthErrorEmbedder()),
     )
+    from openviking.utils.circuit_breaker import CircuitBreaker
+
     handler = TextEmbeddingHandler(vikingdb)
+    handler._circuit_breaker = CircuitBreaker(failure_threshold=1, reset_timeout=0)
+    handler._circuit_breaker.record_failure(RuntimeError("500 Internal Server Error"))
     status = {"success": 0, "requeue": 0, "error": 0}
     handler.set_callbacks(
         on_success=lambda: status.__setitem__("success", status["success"] + 1),
@@ -382,7 +386,8 @@ async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypat
     assert result is None
     assert vikingdb.enqueued == []  # terminal: not re-enqueued
     assert status == {"success": 0, "requeue": 0, "error": 1}
-    handler._circuit_breaker.check()  # breaker not tripped (would raise if open)
+    assert handler._circuit_breaker._state == "HALF_OPEN"
+    assert handler._circuit_breaker._probe_started_at == 0
 
 
 @pytest.mark.asyncio
@@ -555,7 +560,11 @@ async def test_embedding_handler_drops_input_too_large_without_requeue(monkeypat
         lambda: _DummyConfig(_OversizedInputEmbedder()),
     )
 
+    from openviking.utils.circuit_breaker import CircuitBreaker
+
     handler = TextEmbeddingHandler(vikingdb)
+    handler._circuit_breaker = CircuitBreaker(failure_threshold=1, reset_timeout=0)
+    handler._circuit_breaker.record_failure(RuntimeError("500 Internal Server Error"))
     status = {"success": 0, "requeue": 0, "error": 0}
     handler.set_callbacks(
         on_success=lambda: status.__setitem__("success", status["success"] + 1),
@@ -568,7 +577,9 @@ async def test_embedding_handler_drops_input_too_large_without_requeue(monkeypat
     assert result is None
     assert vikingdb.enqueued == []
     assert status == {"success": 0, "requeue": 0, "error": 1}
-    assert handler._circuit_breaker._failure_count == 0
+    assert handler._circuit_breaker._failure_count == 1
+    assert handler._circuit_breaker._state == "HALF_OPEN"
+    assert handler._circuit_breaker._probe_started_at == 0
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_memory_semantic_stall.py
+++ b/tests/storage/test_memory_semantic_stall.py
@@ -11,8 +11,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
 from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking.utils.circuit_breaker import CircuitBreaker
 
 
 def _make_msg(uri="viking://user/memories", context_type="memory", **kwargs):
@@ -183,6 +185,47 @@ async def test_memory_ls_transient_error_requeues():
     assert success_called, "report_success() must fire after successful re-enqueue"
     assert not error_called, "report_error() must NOT fire for transient errors"
     reenqueue_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lock_error_releases_half_open_probe():
+    processor = SemanticProcessor()
+    processor._circuit_breaker = CircuitBreaker(failure_threshold=1, reset_timeout=0)
+    processor._circuit_breaker.record_failure(RuntimeError("500 Internal Server Error"))
+    probe_state_during_requeue = []
+
+    async def requeue(*_args):
+        probe_state_during_requeue.append(
+            (
+                processor._circuit_breaker._state,
+                processor._circuit_breaker._probe_started_at,
+            )
+        )
+
+    requeue_mock = AsyncMock(side_effect=requeue)
+    msg = _make_msg()
+
+    with (
+        patch(
+            "openviking.storage.queuefs.semantic_processor.resolve_telemetry",
+            return_value=None,
+        ),
+        patch(
+            "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+            new=AsyncMock(side_effect=LockAcquisitionError("busy")),
+        ),
+        patch.object(
+            processor,
+            "_requeue_semantic_msg_after_error",
+            new=requeue_mock,
+        ),
+    ):
+        await processor.on_dequeue(_build_data(msg))
+
+    requeue_mock.assert_awaited_once()
+    assert probe_state_during_requeue == [("HALF_OPEN", 0)]
+    assert processor._circuit_breaker._state == "HALF_OPEN"
+    assert processor._circuit_breaker._probe_started_at == 0
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -3,8 +3,61 @@
 
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _run_concurrent_checks(circuit_breaker, worker_count):
+    from openviking.utils.circuit_breaker import CircuitBreakerOpen
+
+    barrier = threading.Barrier(worker_count + 1)
+    outcomes = []
+    outcomes_lock = threading.Lock()
+
+    def check():
+        barrier.wait()
+        try:
+            circuit_breaker.check()
+            outcome = "admitted"
+        except CircuitBreakerOpen:
+            outcome = "blocked"
+        with outcomes_lock:
+            outcomes.append(outcome)
+
+    threads = [threading.Thread(target=check) for _ in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    return outcomes
+
+
+@pytest.fixture
+def circuit_breaker_clock(monkeypatch):
+    import openviking.utils.circuit_breaker as circuit_breaker_module
+
+    clock = _Clock()
+    monkeypatch.setattr(
+        circuit_breaker_module,
+        "time",
+        SimpleNamespace(monotonic=clock.monotonic),
+    )
+    return clock
 
 
 def test_circuit_breaker_starts_closed():
@@ -109,6 +162,98 @@ def test_half_open_success_resets_backoff(monkeypatch):
     cb.record_success()
 
     assert cb._current_reset_timeout == 60
+
+
+def test_half_open_concurrent_checks_admit_exactly_one_probe(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+
+    outcomes = _run_concurrent_checks(cb, worker_count=8)
+
+    assert outcomes.count("admitted") == 1
+    assert outcomes.count("blocked") == 7
+
+
+def test_half_open_probe_success_closes_for_waiting_callers(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+
+    cb.check()
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+    assert cb.retry_after == 0
+
+    cb.record_success()
+
+    assert _run_concurrent_checks(cb, worker_count=4) == ["admitted"] * 4
+
+
+def test_half_open_probe_failure_reopens_for_waiting_callers(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10, max_reset_timeout=40)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    cb.check()
+
+    cb.record_failure(RuntimeError("500 again"))
+
+    assert cb._current_reset_timeout == 20
+    assert cb.retry_after == 20
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+
+
+def test_half_open_probe_success_resets_failure_state(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(failure_threshold=2, reset_timeout=10, max_reset_timeout=40)
+    cb.record_failure(RuntimeError("500"))
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    cb.check()
+    cb.record_failure(RuntimeError("500 again"))
+    circuit_breaker_clock.advance(20)
+    cb.check()
+
+    cb.record_success()
+
+    assert cb._failure_count == 0
+    assert cb._current_reset_timeout == 10
+    cb.record_failure(RuntimeError("500"))
+    cb.check()
+    cb.record_failure(RuntimeError("500"))
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+
+
+def test_half_open_abandoned_probe_allows_one_replacement_after_timeout(
+    circuit_breaker_clock,
+):
+    from openviking.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    cb.check()
+
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+    circuit_breaker_clock.advance(9)
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+    circuit_breaker_clock.advance(1)
+
+    outcomes = _run_concurrent_checks(cb, worker_count=8)
+
+    assert outcomes.count("admitted") == 1
+    assert outcomes.count("blocked") == 7
 
 
 def test_permanent_error_trips_immediately():

--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -187,11 +187,45 @@ def test_half_open_probe_success_closes_for_waiting_callers(circuit_breaker_cloc
     cb.check()
     with pytest.raises(CircuitBreakerOpen):
         cb.check()
-    assert cb.retry_after == 0
+    assert cb.retry_after == 10
+    circuit_breaker_clock.advance(4)
+    assert cb.retry_after == 6
 
     cb.record_success()
 
     assert _run_concurrent_checks(cb, worker_count=4) == ["admitted"] * 4
+
+
+def test_half_open_ignored_probe_allows_one_immediate_replacement(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    cb.check()
+
+    cb.record_ignored()
+
+    outcomes = _run_concurrent_checks(cb, worker_count=8)
+
+    assert outcomes.count("admitted") == 1
+    assert outcomes.count("blocked") == 7
+
+
+def test_half_open_input_error_releases_probe(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    cb.check()
+
+    cb.record_failure(RuntimeError("maximum context length exceeded"))
+
+    outcomes = _run_concurrent_checks(cb, worker_count=8)
+
+    assert outcomes.count("admitted") == 1
+    assert outcomes.count("blocked") == 7
 
 
 def test_half_open_probe_failure_reopens_for_waiting_callers(circuit_breaker_clock):
@@ -254,6 +288,26 @@ def test_half_open_abandoned_probe_allows_one_replacement_after_timeout(
 
     assert outcomes.count("admitted") == 1
     assert outcomes.count("blocked") == 7
+
+
+def test_replaced_probe_cannot_complete_the_current_probe(circuit_breaker_clock):
+    from openviking.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(failure_threshold=1, reset_timeout=10)
+    cb.record_failure(RuntimeError("500"))
+    circuit_breaker_clock.advance(10)
+    first_probe = cb.check()
+    circuit_breaker_clock.advance(10)
+    replacement_probe = cb.check()
+
+    cb.record_failure(RuntimeError("late failure"), first_probe)
+    cb.record_success(first_probe)
+
+    with pytest.raises(CircuitBreakerOpen):
+        cb.check()
+
+    cb.record_success(replacement_probe)
+    cb.check()
 
 
 def test_permanent_error_trips_immediately():


### PR DESCRIPTION
## Description

Serialize circuit-breaker recovery probes so a half-open circuit admits exactly one caller.

Previously every caller observing `HALF_OPEN` was allowed through, which could stampede a recovering provider. The breaker now holds one implicit probe lease under its existing lock, blocks followers, and admits one replacement if the probe is abandoned for the current reset timeout.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Found during a source-first reliability audit; no existing issue or open PR directly covered the half-open probe race.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Admit one atomic half-open probe and block concurrent followers.
- Reset the probe lease on success/failure while preserving existing backoff behavior.
- Return a real retry delay while a half-open probe is active so blocked queue work is throttled.
- Release neutral outcomes such as input-size, authentication, and lock errors without treating them as provider failures.
- Tag probes with ownership tokens so a timed-out probe cannot settle its replacement.
- Allow exactly one replacement after an abandoned probe exceeds the current reset timeout.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```text
PYTHONPATH=. python -m pytest -o addopts='' -q \
  tests/utils/test_circuit_breaker.py \
  tests/storage/test_collection_schemas.py \
  tests/storage/test_memory_semantic_stall.py \
  -k 'half_open or replaced_probe or auth_error or input_too_large or lock_error_releases'
# 16 passed, 78 deselected

PYTHONPATH=. python -m pytest -o addopts='' -q \
  tests/utils/test_circuit_breaker.py \
  tests/unit/test_circuit_breaker.py \
  tests/storage/test_collection_schemas.py \
  tests/storage/test_memory_semantic_stall.py
# 130 passed, 2 skipped, 2 known baseline failures

ruff check \
  openviking/utils/circuit_breaker.py \
  openviking/storage/collection_schemas.py \
  openviking/storage/queuefs/semantic_processor.py \
  tests/storage/test_memory_semantic_stall.py

git diff --check
# passed
```

The two deselected baseline utility assertions expect `403 -> permanent`, while the current shared `model_retry` contract returns the more specific `auth` classification. This PR does not change classifier semantics.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Review follow-up commit `ee78e534` makes probe ownership explicit at the two queue callers. Every admitted half-open request carries a token through success, failure, or neutral completion; stale completions are ignored, and a `finally` safety release prevents future early-return paths from stranding the probe. `retry_after` now reports the active probe delay, so blocked queue work sleeps instead of cycling immediately.

