### PR TITLE
fix(benchmark): account for failed evaluations

### DIFF
--- a/benchmark/custom/README.md
+++ b/benchmark/custom/README.md
@@ -137,6 +137,8 @@ ov health
 | `--data-root-uri` | `viking://resources/bench/load_test` | Server 侧压测资源根目录 |
 | `--output-dir` | 自动生成 | 报告输出目录 |
 | `--ov-bin` | `ov` | 真实 CLI 子进程使用的可执行文件 |
+| `--max-failure-rate-percent` | 未启用 | 任一 adapter / operation 总体失败率超过阈值时退出非零 |
+| `--max-success-p95-ms` | 未启用 | 任一 adapter / operation 成功请求 p95 超过阈值时退出非零 |
 
 ## Profile 说明
 
@@ -172,11 +174,26 @@ benchmark/results/openviking_server_load/20260511T120000Z/
 报告会重点展示：
 
 - 总请求量、失败数和成功率。
-- 各接口 p50 / p95 / p99 / max 延迟。
+- 各接口尝试 QPS 和成功 QPS；总体 QPS 使用当前 adapter / operation 自身的活跃时间跨度。
+- 成功请求和失败请求分别统计延迟；兼容字段 `p50_ms` / `p95_ms` / `p99_ms` / `max_ms` 表示成功请求延迟。
 - `retrieval` 阶段到 `mixed` 阶段的检索延迟变化。
 - SDK、CLI HTTP 封装、真实 CLI 子进程之间的差异。
 - commit / add_resource 后台任务是否积压。
 - Top 错误类型和发生位置。
+
+默认情况下请求失败和 SLO 超限只进入报告，不改变退出码，以保持已有用法不变。需要 CI
+门禁时显式传入一个或两个阈值，例如：
+
+```bash
+.venv/bin/python benchmark/custom/session_contention_benchmark.py \
+  --profile smoke \
+  --adapters sdk \
+  --max-failure-rate-percent 1 \
+  --max-success-p95-ms 500
+```
+
+门禁按 `scenario=ALL` 的每个 adapter / operation 分组评估；任一分组超限时，报告仍会
+完整写出，命令随后退出非零。
 
 ## 示例：指定认证信息
 

--- a/benchmark/custom/session_contention_benchmark.py
+++ b/benchmark/custom/session_contention_benchmark.py
@@ -105,6 +105,8 @@ class BenchmarkConfig:
     ov_bin: str
     seed: int
     find_limit: int
+    max_failure_rate_percent: Optional[float]
+    max_success_p95_ms: Optional[float]
 
 
 @dataclass
@@ -478,7 +480,11 @@ class BenchmarkRunner:
                     self.recorder.add_note(f"cleanup_at_end failed: {type(exc).__name__}: {exc}")
             for adapter in self.adapters.values():
                 await adapter.close()
-            self._write_outputs()
+            exit_gate_violations = self._write_outputs()
+            if exit_gate_violations:
+                for violation in exit_gate_violations:
+                    print(f"[exit gate] {violation}", file=sys.stderr)
+                exit_code = 1
             self._print_summary_path()
         return exit_code
 
@@ -1136,13 +1142,16 @@ class BenchmarkRunner:
             )
         self.pending_tasks = []
 
-    def _write_outputs(self) -> None:
+    def _write_outputs(self) -> List[str]:
         output_dir = Path(self.config.output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         summary_rows = build_request_summary_rows(
             events=self.recorder.request_events,
             phases=self.recorder.phases,
         )
+        exit_gate_violations = evaluate_exit_gates(self.config, summary_rows)
+        for violation in exit_gate_violations:
+            self.recorder.add_note(f"exit gate failed: {violation}")
         window_rows = build_request_window_rows(
             events=self.recorder.request_events,
             window_seconds=self.config.request_window_seconds,
@@ -1174,6 +1183,7 @@ class BenchmarkRunner:
                 "task_summary": task_rows,
                 "adapter_comparison": adapter_rows,
                 "errors": error_rows,
+                "exit_gate_violations": exit_gate_violations,
                 "summary_zh": report,
             },
         )
@@ -1185,6 +1195,7 @@ class BenchmarkRunner:
         write_csv(output_dir / "task_summary.csv", task_rows)
         write_csv(output_dir / "adapter_comparison.csv", adapter_rows)
         write_csv(output_dir / "errors.csv", error_rows)
+        return exit_gate_violations
 
     def _print_summary_path(self) -> None:
         summary_path = Path(self.config.output_dir) / "summary_zh.md"
@@ -1429,7 +1440,15 @@ def build_request_summary_rows(
     for event in events:
         overall.setdefault((event.adapter, event.operation), []).append(event)
     for (adapter, operation), group_events in sorted(overall.items()):
-        rows.append(build_summary_row(adapter, "ALL", operation, group_events, total_span(events)))
+        rows.append(
+            build_summary_row(
+                adapter,
+                "ALL",
+                operation,
+                group_events,
+                estimate_event_span_seconds(group_events),
+            )
+        )
     return rows
 
 
@@ -1440,9 +1459,12 @@ def build_summary_row(
     events: List[RequestEvent],
     duration_seconds: float,
 ) -> Dict[str, Any]:
-    latencies = [event.latency_ms for event in events]
-    successes = sum(1 for event in events if event.success)
-    failures = len(events) - successes
+    attempt_latencies = [event.latency_ms for event in events]
+    success_latencies = [event.latency_ms for event in events if event.success]
+    failure_latencies = [event.latency_ms for event in events if not event.success]
+    successes = len(success_latencies)
+    failures = len(failure_latencies)
+    measurement_span_seconds = max(duration_seconds, 1e-9)
     status_counts: Dict[str, int] = {}
     for event in events:
         key = (
@@ -1459,16 +1481,66 @@ def build_summary_row(
         "successes": successes,
         "failures": failures,
         "success_rate": round((successes / len(events)) * 100.0, 4) if events else 0.0,
-        "qps": round(len(events) / max(duration_seconds, 1e-9), 4),
-        "avg_ms": round_optional(sum(latencies) / len(latencies) if latencies else None),
-        "p50_ms": round_optional(percentile(latencies, 50)),
-        "p90_ms": round_optional(percentile(latencies, 90)),
-        "p95_ms": round_optional(percentile(latencies, 95)),
-        "p99_ms": round_optional(percentile(latencies, 99)),
-        "max_ms": round_optional(max(latencies) if latencies else None),
-        "slow_gt_1s": sum(1 for latency in latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[0]),
-        "slow_gt_3s": sum(1 for latency in latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[1]),
-        "slow_gt_5s": sum(1 for latency in latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[2]),
+        "qps_span_seconds": round(measurement_span_seconds, 6),
+        "qps": round(len(events) / measurement_span_seconds, 4),
+        "successful_qps": round(successes / measurement_span_seconds, 4),
+        "avg_ms": round_optional(
+            sum(success_latencies) / len(success_latencies) if success_latencies else None
+        ),
+        "p50_ms": round_optional(percentile(success_latencies, 50)),
+        "p90_ms": round_optional(percentile(success_latencies, 90)),
+        "p95_ms": round_optional(percentile(success_latencies, 95)),
+        "p99_ms": round_optional(percentile(success_latencies, 99)),
+        "max_ms": round_optional(max(success_latencies) if success_latencies else None),
+        "avg_attempt_ms": round_optional(
+            sum(attempt_latencies) / len(attempt_latencies) if attempt_latencies else None
+        ),
+        "p95_attempt_ms": round_optional(percentile(attempt_latencies, 95)),
+        "p99_attempt_ms": round_optional(percentile(attempt_latencies, 99)),
+        "max_attempt_ms": round_optional(max(attempt_latencies) if attempt_latencies else None),
+        "avg_success_ms": round_optional(
+            sum(success_latencies) / len(success_latencies) if success_latencies else None
+        ),
+        "p50_success_ms": round_optional(percentile(success_latencies, 50)),
+        "p90_success_ms": round_optional(percentile(success_latencies, 90)),
+        "p95_success_ms": round_optional(percentile(success_latencies, 95)),
+        "p99_success_ms": round_optional(percentile(success_latencies, 99)),
+        "max_success_ms": round_optional(max(success_latencies) if success_latencies else None),
+        "avg_failure_ms": round_optional(
+            sum(failure_latencies) / len(failure_latencies) if failure_latencies else None
+        ),
+        "p50_failure_ms": round_optional(percentile(failure_latencies, 50)),
+        "p90_failure_ms": round_optional(percentile(failure_latencies, 90)),
+        "p95_failure_ms": round_optional(percentile(failure_latencies, 95)),
+        "p99_failure_ms": round_optional(percentile(failure_latencies, 99)),
+        "max_failure_ms": round_optional(max(failure_latencies) if failure_latencies else None),
+        "slow_gt_1s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[0]
+        ),
+        "slow_gt_3s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[1]
+        ),
+        "slow_gt_5s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[2]
+        ),
+        "slow_success_gt_1s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[0]
+        ),
+        "slow_success_gt_3s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[1]
+        ),
+        "slow_success_gt_5s": sum(
+            1 for latency in success_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[2]
+        ),
+        "slow_failure_gt_1s": sum(
+            1 for latency in failure_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[0]
+        ),
+        "slow_failure_gt_3s": sum(
+            1 for latency in failure_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[1]
+        ),
+        "slow_failure_gt_5s": sum(
+            1 for latency in failure_latencies if latency > DEFAULT_SLOW_THRESHOLDS_MS[2]
+        ),
         "status_codes": json.dumps(status_counts, sort_keys=True),
     }
 
@@ -1484,8 +1556,10 @@ def build_request_window_rows(
         ).append(event)
     rows: List[Dict[str, Any]] = []
     for (window_index, adapter, scenario, operation), window_events in sorted(groups.items()):
-        latencies = [event.latency_ms for event in window_events]
-        successes = sum(1 for event in window_events if event.success)
+        attempt_latencies = [event.latency_ms for event in window_events]
+        success_latencies = [event.latency_ms for event in window_events if event.success]
+        failure_latencies = [event.latency_ms for event in window_events if not event.success]
+        successes = len(success_latencies)
         rows.append(
             {
                 "window_index": window_index,
@@ -1499,9 +1573,25 @@ def build_request_window_rows(
                 "failures": len(window_events) - successes,
                 "success_rate": round((successes / len(window_events)) * 100.0, 4),
                 "qps": round(len(window_events) / max(window_seconds, 1e-9), 4),
-                "p95_ms": round_optional(percentile(latencies, 95)),
-                "p99_ms": round_optional(percentile(latencies, 99)),
-                "max_ms": round_optional(max(latencies) if latencies else None),
+                "successful_qps": round(successes / max(window_seconds, 1e-9), 4),
+                "p95_ms": round_optional(percentile(success_latencies, 95)),
+                "p99_ms": round_optional(percentile(success_latencies, 99)),
+                "max_ms": round_optional(max(success_latencies) if success_latencies else None),
+                "p95_attempt_ms": round_optional(percentile(attempt_latencies, 95)),
+                "p99_attempt_ms": round_optional(percentile(attempt_latencies, 99)),
+                "max_attempt_ms": round_optional(
+                    max(attempt_latencies) if attempt_latencies else None
+                ),
+                "p95_success_ms": round_optional(percentile(success_latencies, 95)),
+                "p99_success_ms": round_optional(percentile(success_latencies, 99)),
+                "max_success_ms": round_optional(
+                    max(success_latencies) if success_latencies else None
+                ),
+                "p95_failure_ms": round_optional(percentile(failure_latencies, 95)),
+                "p99_failure_ms": round_optional(percentile(failure_latencies, 99)),
+                "max_failure_ms": round_optional(
+                    max(failure_latencies) if failure_latencies else None
+                ),
             }
         )
     return rows
@@ -1548,6 +1638,39 @@ def build_adapter_comparison_rows(summary_rows: List[Dict[str, Any]]) -> List[Di
         and row["operation"] in {"add_resource", "find", "search", "add_message", "commit_session"}
     ]
     return sorted(rows, key=lambda row: (row["operation"], row["adapter"]))
+
+
+def evaluate_exit_gates(config: BenchmarkConfig, summary_rows: List[Dict[str, Any]]) -> List[str]:
+    if config.max_failure_rate_percent is None and config.max_success_p95_ms is None:
+        return []
+
+    violations: List[str] = []
+    overall_rows = [row for row in summary_rows if row["scenario"] == "ALL"]
+    for row in sorted(overall_rows, key=lambda item: (item["adapter"], item["operation"])):
+        label = f"{row['adapter']}/{row['operation']}"
+        requests = int(row.get("requests", 0))
+        failures = int(row.get("failures", 0))
+        failure_rate = failures / requests * 100.0 if requests else 0.0
+        if (
+            config.max_failure_rate_percent is not None
+            and failure_rate > config.max_failure_rate_percent
+        ):
+            violations.append(
+                f"{label} failure rate {failure_rate:.4f}% exceeds "
+                f"{config.max_failure_rate_percent:.4f}%"
+            )
+
+        if config.max_success_p95_ms is None or not requests:
+            continue
+        success_p95 = to_float(row.get("p95_success_ms"))
+        if success_p95 is None:
+            violations.append(f"{label} successful p95 is unavailable")
+        elif success_p95 > config.max_success_p95_ms:
+            violations.append(
+                f"{label} successful p95 {success_p95:.4f}ms exceeds "
+                f"{config.max_success_p95_ms:.4f}ms"
+            )
+    return violations
 
 
 def build_error_rows(events: List[RequestEvent]) -> List[Dict[str, Any]]:
@@ -1619,9 +1742,10 @@ def render_report_zh(
         if mixed_find and retrieval_find:
             lines.append(
                 "- "
-                f"`{adapter}` find p95: retrieval {fmt_ms(retrieval_find['p95_ms'])} -> "
-                f"mixed {fmt_ms(mixed_find['p95_ms'])}，变化 "
-                f"{fmt_delta_percent(percent_change(retrieval_find['p95_ms'], mixed_find['p95_ms']))}。"
+                f"`{adapter}` find 成功请求 p95: retrieval "
+                f"{fmt_ms(retrieval_find['p95_success_ms'])} -> "
+                f"mixed {fmt_ms(mixed_find['p95_success_ms'])}，变化 "
+                f"{fmt_delta_percent(percent_change(retrieval_find['p95_success_ms'], mixed_find['p95_success_ms']))}。"
             )
     incomplete = [row for row in task_rows if row["status"] == "incomplete"]
     if incomplete:
@@ -1650,10 +1774,11 @@ def render_report_zh(
                         "requests",
                         "success_rate",
                         "qps",
-                        "p50_ms",
-                        "p95_ms",
-                        "p99_ms",
-                        "max_ms",
+                        "successful_qps",
+                        "p50_success_ms",
+                        "p95_success_ms",
+                        "p99_success_ms",
+                        "p95_failure_ms",
                     ],
                 )
                 for row in summary_rows
@@ -1668,7 +1793,17 @@ def render_report_zh(
             [
                 pick(
                     row,
-                    ["adapter", "operation", "requests", "success_rate", "qps", "p95_ms", "p99_ms"],
+                    [
+                        "adapter",
+                        "operation",
+                        "requests",
+                        "success_rate",
+                        "qps",
+                        "successful_qps",
+                        "p95_success_ms",
+                        "p99_success_ms",
+                        "p95_failure_ms",
+                    ],
                 )
                 for row in adapter_rows
             ]
@@ -1731,14 +1866,6 @@ def find_summary(
 
 
 def estimate_event_span_seconds(events: List[RequestEvent]) -> float:
-    if len(events) < 2:
-        return 1e-9
-    starts = [event.elapsed_ms_since_run_start for event in events]
-    ends = [event.elapsed_ms_since_run_start + event.latency_ms for event in events]
-    return max((max(ends) - min(starts)) / 1000.0, 1e-9)
-
-
-def total_span(events: List[RequestEvent]) -> float:
     if not events:
         return 1e-9
     starts = [event.elapsed_ms_since_run_start for event in events]
@@ -1883,6 +2010,22 @@ def parse_args(argv: Optional[List[str]] = None) -> BenchmarkConfig:
     parser.add_argument("--ov-bin", default=os.getenv("OV_BIN", "ov"))
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--find-limit", type=int, default=10)
+    parser.add_argument(
+        "--max-failure-rate-percent",
+        type=float,
+        help=(
+            "Exit non-zero if any adapter/operation overall failure rate exceeds this "
+            "percentage. Disabled by default."
+        ),
+    )
+    parser.add_argument(
+        "--max-success-p95-ms",
+        type=float,
+        help=(
+            "Exit non-zero if any adapter/operation successful-request p95 exceeds this "
+            "latency. Disabled by default."
+        ),
+    )
     args = parser.parse_args(argv)
 
     profile = PROFILE_DEFAULTS[args.profile]
@@ -1904,6 +2047,12 @@ def parse_args(argv: Optional[List[str]] = None) -> BenchmarkConfig:
         parser.error(f"Unsupported adapters: {', '.join(invalid)}")
     if not adapters:
         parser.error("--adapters must not be empty")
+    if args.max_failure_rate_percent is not None and not (
+        0.0 <= args.max_failure_rate_percent <= 100.0
+    ):
+        parser.error("--max-failure-rate-percent must be between 0 and 100")
+    if args.max_success_p95_ms is not None and args.max_success_p95_ms < 0:
+        parser.error("--max-success-p95-ms must be >= 0")
 
     return BenchmarkConfig(
         server_url=args.server_url.rstrip("/"),
@@ -1936,6 +2085,8 @@ def parse_args(argv: Optional[List[str]] = None) -> BenchmarkConfig:
         ov_bin=args.ov_bin,
         seed=args.seed,
         find_limit=max(1, args.find_limit),
+        max_failure_rate_percent=args.max_failure_rate_percent,
+        max_success_p95_ms=args.max_success_p95_ms,
     )
 
 

--- a/benchmark/locomo/openviking/README.md
+++ b/benchmark/locomo/openviking/README.md
@@ -84,6 +84,11 @@ python benchmark/locomo/openviking/run_eval.py "$DATA" \
 Set `--single-search-rerank-limit 0` to disable rerank. Set
 `--single-search-max-context-chars 0` to disable the character budget.
 
+Every planned non-adversarial QA is written with an explicit `status`:
+`completed` for a generated response or `failed` with an `error` message. The
+command exits non-zero if any planned QA failed or if planned and recorded QA
+identities/counts do not match.
+
 ## Judge And Stat
 
 ```bash
@@ -98,5 +103,8 @@ python benchmark/locomo/openviking/stat_judge_result.py \
 The judge writes `result` values back into the same CSV. Use `--force` to
 re-grade rows that already have a result. Use `--strict-prompt` when you want the
 stricter LoCoMo judge prompt instead of the default lenient prompt.
+Rows with `status=failed` are not sent to the judge. Statistics report expected,
+failed, ungraded, correct, and wrong rows separately, including both accuracy
+among graded rows and accuracy over the expected-row denominator.
 
 Category 5 adversarial questions are skipped by the LoCoMo judge/stat flow.

--- a/benchmark/locomo/openviking/judge.py
+++ b/benchmark/locomo/openviking/judge.py
@@ -159,6 +159,8 @@ def get_ungraded_rows(rows: list[dict], force: bool = False) -> list[int]:
     for i, row in enumerate(rows):
         if str(row.get("category", "")).strip() == "5":
             continue
+        if str(row.get("status", "")).strip().lower() == "failed":
+            continue
         if force:
             row["result"] = ""
             row["reasoning"] = ""
@@ -302,10 +304,23 @@ async def main():
     tasks = [process_row(idx) for idx in ungraded]
     await asyncio.gather(*tasks)
 
-    correct = sum(1 for row in rows if row.get("result") == "CORRECT")
-    total_graded = sum(1 for row in rows if row.get("result"))
-    accuracy = correct / total_graded if total_graded > 0 else 0.0
-    print(f"\nGrading completed: {correct}/{total_graded} correct, accuracy: {accuracy:.2%}")
+    expected_rows = [row for row in rows if str(row.get("category", "")).strip() != "5"]
+    correct = sum(1 for row in expected_rows if row.get("result") == "CORRECT")
+    wrong = sum(1 for row in expected_rows if row.get("result") == "WRONG")
+    failed = sum(
+        1 for row in expected_rows if str(row.get("status", "")).strip().lower() == "failed"
+    )
+    total_graded = correct + wrong
+    ungraded = len(expected_rows) - total_graded - failed
+    graded_accuracy = correct / total_graded if total_graded > 0 else 0.0
+    expected_accuracy = correct / len(expected_rows) if expected_rows else 0.0
+    print(
+        "\nGrading completed: "
+        f"expected={len(expected_rows)}, graded={total_graded}, failed={failed}, "
+        f"ungraded={ungraded}, correct={correct}, wrong={wrong}, "
+        f"graded accuracy={graded_accuracy:.2%}, "
+        f"expected-denominator accuracy={expected_accuracy:.2%}"
+    )
     print(f"All results saved to {args.input}")
 
 

--- a/benchmark/locomo/openviking/run_eval.py
+++ b/benchmark/locomo/openviking/run_eval.py
@@ -648,6 +648,60 @@ def result_row_key(row: dict[str, Any]) -> str:
     return f"question:{str(row.get('question', '') or '').strip()}"
 
 
+class ResultIntegrityError(RuntimeError):
+    pass
+
+
+def validate_result_integrity(
+    planned_rows: list[dict[str, Any]], recorded_rows: list[dict[str, Any]]
+) -> None:
+    planned_keys = [result_row_key(row) for row in planned_rows]
+    recorded_keys = [result_row_key(row) for row in recorded_rows]
+    planned_key_set = set(planned_keys)
+    recorded_key_set = set(recorded_keys)
+    duplicate_planned = sorted(key for key in planned_key_set if planned_keys.count(key) > 1)
+    duplicate_recorded = sorted(key for key in recorded_key_set if recorded_keys.count(key) > 1)
+    missing = sorted(planned_key_set - recorded_key_set)
+    unexpected = sorted(recorded_key_set - planned_key_set)
+    completed = sum(1 for row in recorded_rows if str(row.get("status", "")).strip() == "completed")
+    failed = sum(1 for row in recorded_rows if str(row.get("status", "")).strip() == "failed")
+    invalid_status = sorted(
+        result_row_key(row)
+        for row in recorded_rows
+        if str(row.get("status", "")).strip() not in {"completed", "failed"}
+    )
+
+    if (
+        len(planned_rows) == len(recorded_rows)
+        and completed == len(planned_rows)
+        and not failed
+        and not duplicate_planned
+        and not duplicate_recorded
+        and not missing
+        and not unexpected
+        and not invalid_status
+    ):
+        return
+
+    details = [
+        f"planned={len(planned_rows)}",
+        f"recorded={len(recorded_rows)}",
+        f"completed={completed}",
+        f"failed={failed}",
+    ]
+    if missing:
+        details.append(f"missing={missing}")
+    if unexpected:
+        details.append(f"unexpected={unexpected}")
+    if duplicate_planned:
+        details.append(f"duplicate_planned={duplicate_planned}")
+    if duplicate_recorded:
+        details.append(f"duplicate_recorded={duplicate_recorded}")
+    if invalid_status:
+        details.append(f"invalid_status={invalid_status}")
+    raise ResultIntegrityError("LoCoMo result integrity check failed: " + ", ".join(details))
+
+
 def parse_sample_indices(
     raw_samples: str | None, dataset_size: int | None = None
 ) -> list[int] | None:
@@ -806,10 +860,9 @@ def main():
         invalid_questions=invalid_questions,
         sample_indices=parse_sample_indices(args.samples),
     )
-    total = len(qa_list)
-
     # 过滤掉 category=5 的问题
     qa_list = [qa for qa in qa_list if str(qa.get("category")) != "5"]
+    total = len(qa_list)
     print(f"Filtered to {len(qa_list)} questions after removing category=5")
 
     # 加载已处理的问题
@@ -823,6 +876,8 @@ def main():
         "sample_id",
         "question_id",
         "question_index",
+        "status",
+        "error",
         "result",
         "is_invalid",
         "question",
@@ -878,41 +933,17 @@ def main():
         f"Starting evaluation with {args.threads} concurrent threads, {remaining_count} questions to process"
     )
 
-    def process_qa(qa_item, idx, total_count):
-        """单个QA处理函数，供多线程调用"""
+    def build_base_row(qa_item):
         question = qa_item["question"]
         answer = qa_item["answer"]
         question_time = qa_item.get("question_time")
-        # 使用 question_id 作为 session_id，实现完全独立并行
-        sample_id = qa_item.get("sample_id")
         question_id = qa_item.get("question_id")
-        print(f"Processing {idx}/{total_count}: {question[:60]}...")
-        if question_time:
-            print(f"  [time context: {question_time}]")
-
-        (
-            response,
-            token_usage,
-            time_cost,
-            iteration,
-            tools_used_names,
-            retrieved_uris_by_iteration,
-            model_input_prompt,
-        ) = run_vikingbot_chat(
-            question=question,
-            question_time=question_time,
-            sample_id=sample_id,
-            question_id=question_id,
-            openviking_url=args.openviking_url,
-            single_search_context_limit=args.single_search_context_limit,
-            single_search_rerank_limit=args.single_search_rerank_limit,
-            single_search_max_context_chars=args.single_search_max_context_chars,
-        )
-
-        row = {
+        return {
             "sample_id": qa_item["sample_id"],
             "question_id": question_id,
             "question_index": qa_item.get("question_index", ""),
+            "status": "",
+            "error": "",
             "result": "",
             "question": question,
             "answer": answer,
@@ -920,55 +951,132 @@ def main():
             "question_time": question_time or "",
             "evidence": json.dumps(qa_item.get("evidence", [])),
             "evidence_text": json.dumps(qa_item.get("evidence_text", [])),
-            "response": response,
-            "model_input_prompt": model_input_prompt if args.debug_print_model_input else "",
-            "token_usage": json.dumps(token_usage, ensure_ascii=False),
-            "memory_prompt_tokens": token_usage.get("memory_prompt_tokens", 0),
-            "memory_chars": token_usage.get("memory_chars", 0),
-            "memory_tokenizer": token_usage.get("memory_tokenizer", ""),
-            "time_cost": round(time_cost, 2),
-            "iteration": iteration,
-            "tools_used_names": json.dumps(tools_used_names, ensure_ascii=False),
-            "retrieved_uris_by_iteration": json.dumps(
-                retrieved_uris_by_iteration, ensure_ascii=False
-            )
-            if args.debug_print_model_input
-            else "",
+            "response": "",
+            "model_input_prompt": "",
+            "token_usage": "{}",
+            "memory_prompt_tokens": 0,
+            "memory_chars": 0,
+            "memory_tokenizer": "",
+            "time_cost": 0,
+            "iteration": 0,
+            "tools_used_names": "[]",
+            "retrieved_uris_by_iteration": "",
             "is_invalid": qa_item.get("is_invalid", False),
         }
 
-        # 线程安全的结果收集
+    def record_row(row, total_count):
+        nonlocal processed_count
+        row_key = result_row_key(row)
         with write_lock:
-            nonlocal processed_count
-            new_rows.append(row)
-            row_key = result_row_key(row)
-            found = False
+            for new_row in new_rows:
+                if result_row_key(new_row) == row_key:
+                    new_row.update(row)
+                    break
+            else:
+                new_rows.append(row)
+
             for existing_row in existing_rows:
                 if result_row_key(existing_row) == row_key:
                     existing_row.update(row)
-                    found = True
                     break
-            if not found:
+            else:
                 existing_rows.append(row)
+
             processed_questions.add(row_key)
-            processed_count += 1
+            processed_count = len(new_rows)
             save_results_locked()
-            print(f"Completed {processed_count}/{total_count}, time cost: {round(time_cost, 2)}s")
-        return True
+            print(
+                f"Recorded {processed_count}/{total_count}: "
+                f"{row['status']}, time cost: {row['time_cost']}s"
+            )
+
+    def process_qa(qa_item, idx, total_count):
+        """单个QA处理函数，供多线程调用"""
+        row = build_base_row(qa_item)
+        question = qa_item["question"]
+        question_time = qa_item.get("question_time")
+        sample_id = qa_item.get("sample_id")
+        question_id = qa_item.get("question_id")
+        print(f"Processing {idx}/{total_count}: {question[:60]}...")
+        if question_time:
+            print(f"  [time context: {question_time}]")
+
+        started = time.perf_counter()
+        try:
+            (
+                response,
+                token_usage,
+                time_cost,
+                iteration,
+                tools_used_names,
+                retrieved_uris_by_iteration,
+                model_input_prompt,
+            ) = run_vikingbot_chat(
+                question=question,
+                question_time=question_time,
+                sample_id=sample_id,
+                question_id=question_id,
+                openviking_url=args.openviking_url,
+                single_search_context_limit=args.single_search_context_limit,
+                single_search_rerank_limit=args.single_search_rerank_limit,
+                single_search_max_context_chars=args.single_search_max_context_chars,
+            )
+            row.update(
+                {
+                    "status": "completed",
+                    "response": response,
+                    "model_input_prompt": (
+                        model_input_prompt if args.debug_print_model_input else ""
+                    ),
+                    "token_usage": json.dumps(token_usage, ensure_ascii=False),
+                    "memory_prompt_tokens": token_usage.get("memory_prompt_tokens", 0),
+                    "memory_chars": token_usage.get("memory_chars", 0),
+                    "memory_tokenizer": token_usage.get("memory_tokenizer", ""),
+                    "time_cost": round(time_cost, 2),
+                    "iteration": iteration,
+                    "tools_used_names": json.dumps(tools_used_names, ensure_ascii=False),
+                    "retrieved_uris_by_iteration": (
+                        json.dumps(retrieved_uris_by_iteration, ensure_ascii=False)
+                        if args.debug_print_model_input
+                        else ""
+                    ),
+                }
+            )
+        except Exception as exc:
+            row.update(
+                {
+                    "status": "failed",
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "time_cost": round(time.perf_counter() - started, 2),
+                }
+            )
+        record_row(row, total_count)
+        return row
 
     # 使用线程池处理：全局并行，每个 question 独立 session
     with ThreadPoolExecutor(max_workers=args.threads) as executor:
         # 提交所有任务
-        futures = []
+        futures = {}
         for idx, qa_item in enumerate(remaining_qa, 1):
-            futures.append(executor.submit(process_qa, qa_item, idx, remaining_count))
+            future = executor.submit(process_qa, qa_item, idx, remaining_count)
+            futures[future] = qa_item
 
         # 等待所有任务完成
         for future in as_completed(futures):
             try:
                 future.result()
             except Exception as e:
-                print(f"Error processing QA item: {str(e)}")
+                qa_item = futures[future]
+                row = build_base_row(qa_item)
+                row.update(
+                    {
+                        "status": "failed",
+                        "error": f"{type(e).__name__}: {e}",
+                    }
+                )
+                record_row(row, remaining_count)
+
+    validate_result_integrity(remaining_qa, new_rows)
 
     if args.update_mode:
         print(f"Updated {len(new_rows)} rows in {args.output}")

--- a/benchmark/locomo/openviking/stat_judge_result.py
+++ b/benchmark/locomo/openviking/stat_judge_result.py
@@ -40,6 +40,8 @@ def main():
     # 统计所有题目 (排除 category=5)
     correct = 0
     wrong = 0
+    failed = 0
+    ungraded = 0
     total_time = 0.0
     total_prompt_tokens = 0
     total_memory_prompt_tokens = 0
@@ -49,12 +51,14 @@ def main():
     valid_rows = 0
     total_iteration = 0
     by_category: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"CORRECT": 0, "WRONG": 0, "OTHER": 0}
+        lambda: {"CORRECT": 0, "WRONG": 0, "FAILED": 0, "UNGRADED": 0}
     )
 
     # 统计 is_valid=True 的题目 (排除 category=5)
     valid_only_correct = 0
     valid_only_wrong = 0
+    valid_only_failed = 0
+    valid_only_ungraded = 0
     valid_only_total_time = 0.0
     valid_only_total_prompt_tokens = 0
     valid_only_total_memory_prompt_tokens = 0
@@ -80,8 +84,14 @@ def main():
 
             # 统计结果
             result = row.get("result", "").strip().upper()
+            status = row.get("status", "").strip().lower()
             category_key = category_label(category)
-            if result == "CORRECT":
+            if status == "failed":
+                failed += 1
+                by_category[category_key]["FAILED"] += 1
+                if is_valid:
+                    valid_only_failed += 1
+            elif result == "CORRECT":
                 correct += 1
                 by_category[category_key]["CORRECT"] += 1
                 if is_valid:
@@ -92,7 +102,10 @@ def main():
                 if is_valid:
                     valid_only_wrong += 1
             else:
-                by_category[category_key]["OTHER"] += 1
+                ungraded += 1
+                by_category[category_key]["UNGRADED"] += 1
+                if is_valid:
+                    valid_only_ungraded += 1
 
             total_iteration += int(row.get("iteration", "0"))
             if is_valid:
@@ -135,13 +148,17 @@ def main():
                 valid_only_rows += 1
 
     total_graded = correct + wrong
-    accuracy = correct / total_graded if total_graded > 0 else 0.0
+    graded_accuracy = correct / total_graded if total_graded > 0 else 0.0
+    expected_accuracy = correct / valid_rows if valid_rows > 0 else 0.0
     avg_time = total_time / valid_rows if valid_rows > 0 else 0.0
 
     # is_valid=True 题目的统计 (排除 category=5)
     valid_only_total_graded = valid_only_correct + valid_only_wrong
-    valid_only_accuracy = (
+    valid_only_graded_accuracy = (
         valid_only_correct / valid_only_total_graded if valid_only_total_graded > 0 else 0.0
+    )
+    valid_only_expected_accuracy = (
+        valid_only_correct / valid_only_rows if valid_only_rows > 0 else 0.0
     )
     valid_only_avg_time = valid_only_total_time / valid_only_rows if valid_only_rows > 0 else 0.0
 
@@ -170,11 +187,14 @@ def main():
 
     output_lines = [
         "=== Judge Result Statistics (excluding category=5) ===",
-        f"Total rows: {valid_rows}",
+        f"Expected rows: {valid_rows}",
         f"Graded rows: {total_graded}",
+        f"Failed rows: {failed}",
+        f"Ungraded rows: {ungraded}",
         f"Correct: {correct}",
         f"Wrong: {wrong}",
-        f"Accuracy: {accuracy:.2%}",
+        f"Graded accuracy: {graded_accuracy:.2%}",
+        f"Accuracy (expected denominator): {expected_accuracy:.2%}",
         f"\nAverage time cost: {avg_time:.2f}s",
         f"\nAverage iteration: {total_iteration / valid_rows if valid_rows > 0 else 0.0:.2f}",
         "\nToken usage:",
@@ -190,19 +210,28 @@ def main():
         f"  Avg total tokens: {avg_total_tokens:.2f}",
         "",
         "By category:",
-        f"{'category':<28} {'correct':>8} {'wrong':>8} {'other':>8} {'graded':>8} {'total':>8} {'accuracy':>10}",
+        f"{'category':<28} {'correct':>8} {'wrong':>8} {'failed':>8} "
+        f"{'ungraded':>8} {'graded':>8} {'expected':>8} {'graded acc':>11} {'expected acc':>12}",
     ]
 
     for category in sorted(by_category):
         category_correct = by_category[category]["CORRECT"]
         category_wrong = by_category[category]["WRONG"]
-        category_other = by_category[category]["OTHER"]
+        category_failed = by_category[category]["FAILED"]
+        category_ungraded = by_category[category]["UNGRADED"]
         category_graded = category_correct + category_wrong
-        category_total = category_graded + category_other
-        category_accuracy = category_correct / category_graded if category_graded > 0 else 0.0
+        category_expected = category_graded + category_failed + category_ungraded
+        category_graded_accuracy = (
+            category_correct / category_graded if category_graded > 0 else 0.0
+        )
+        category_expected_accuracy = (
+            category_correct / category_expected if category_expected > 0 else 0.0
+        )
         output_lines.append(
-            f"{category:<28} {category_correct:>8} {category_wrong:>8} {category_other:>8} "
-            f"{category_graded:>8} {category_total:>8} {category_accuracy:>9.2%}"
+            f"{category:<28} {category_correct:>8} {category_wrong:>8} "
+            f"{category_failed:>8} {category_ungraded:>8} {category_graded:>8} "
+            f"{category_expected:>8} {category_graded_accuracy:>10.2%} "
+            f"{category_expected_accuracy:>11.2%}"
         )
 
     valid_only_matches_overall = (
@@ -210,6 +239,8 @@ def main():
         and valid_only_total_graded == total_graded
         and valid_only_correct == correct
         and valid_only_wrong == wrong
+        and valid_only_failed == failed
+        and valid_only_ungraded == ungraded
         and valid_only_total_time == total_time
         and valid_only_total_iteration == total_iteration
         and valid_only_total_prompt_tokens == total_prompt_tokens
@@ -223,11 +254,14 @@ def main():
             [
                 "",
                 "=== Valid Questions Only (is_valid=True, excluding category=5) ===",
-                f"Valid rows: {valid_only_rows}",
+                f"Valid expected rows: {valid_only_rows}",
                 f"Valid graded rows: {valid_only_total_graded}",
+                f"Valid failed rows: {valid_only_failed}",
+                f"Valid ungraded rows: {valid_only_ungraded}",
                 f"Valid correct: {valid_only_correct}",
                 f"Valid wrong: {valid_only_wrong}",
-                f"Valid accuracy: {valid_only_accuracy:.2%}",
+                f"Valid graded accuracy: {valid_only_graded_accuracy:.2%}",
+                (f"Valid accuracy (expected denominator): {valid_only_expected_accuracy:.2%}"),
                 f"\nAverage time cost: {valid_only_avg_time:.2f}s",
                 f"\nAverage iteration: {valid_only_total_iteration / valid_only_rows if valid_only_rows > 0 else 0.0:.2f}",
                 "\nToken usage:",

--- a/tests/benchmark/test_locomo_benchmark_integrity.py
+++ b/tests/benchmark/test_locomo_benchmark_integrity.py
@@ -1,0 +1,154 @@
+import csv
+import sys
+
+import pytest
+
+from benchmark.locomo.openviking import judge, run_eval, stat_judge_result
+
+
+def _qa_item(question_id: str) -> dict:
+    return {
+        "sample_id": "sample_0",
+        "question_id": question_id,
+        "question_index": 0,
+        "question": "What happened?",
+        "answer": "A benchmark answer",
+        "category": "1",
+        "question_time": "2026-01-01",
+        "evidence": [],
+        "evidence_text": [],
+        "is_invalid": False,
+    }
+
+
+def test_run_eval_writes_explicit_failed_row_for_worker_exception(tmp_path, monkeypatch):
+    output_path = tmp_path / "result.csv"
+    monkeypatch.setattr(run_eval, "load_locomo_qa", lambda *_args, **_kwargs: [_qa_item("q-1")])
+
+    def fail_worker(**_kwargs):
+        raise RuntimeError("deterministic worker failure")
+
+    monkeypatch.setattr(run_eval, "run_vikingbot_chat", fail_worker)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_eval.py",
+            "unused.json",
+            "--output",
+            str(output_path),
+            "--errors",
+            str(tmp_path / "missing-errors.json"),
+            "--threads",
+            "1",
+        ],
+    )
+
+    with pytest.raises(
+        run_eval.ResultIntegrityError,
+        match=r"planned=1, recorded=1, completed=0, failed=1",
+    ):
+        run_eval.main()
+
+    with output_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 1
+    assert rows[0]["question_id"] == "q-1"
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error"] == "RuntimeError: deterministic worker failure"
+    assert rows[0]["result"] == ""
+
+
+def test_validate_result_integrity_rejects_missing_planned_row():
+    planned = [_qa_item("q-1"), _qa_item("q-2")]
+    completed = [
+        {
+            **_qa_item("q-1"),
+            "status": "completed",
+            "error": "",
+        }
+    ]
+
+    with pytest.raises(
+        run_eval.ResultIntegrityError,
+        match=r"planned=2, recorded=1.*missing=.*question_id:q-2",
+    ):
+        run_eval.validate_result_integrity(planned, completed)
+
+
+def test_statistics_report_expected_failed_and_ungraded_denominators(tmp_path, monkeypatch, capsys):
+    input_path = tmp_path / "judge-results.csv"
+    fieldnames = ["question_id", "category", "is_invalid", "status", "error", "result"]
+    rows = [
+        {
+            "question_id": "correct",
+            "category": "1",
+            "is_invalid": "false",
+            "status": "completed",
+            "error": "",
+            "result": "CORRECT",
+        },
+        {
+            "question_id": "wrong",
+            "category": "1",
+            "is_invalid": "false",
+            "status": "completed",
+            "error": "",
+            "result": "WRONG",
+        },
+        {
+            "question_id": "ungraded",
+            "category": "1",
+            "is_invalid": "false",
+            "status": "completed",
+            "error": "",
+            "result": "",
+        },
+        {
+            "question_id": "failed",
+            "category": "1",
+            "is_invalid": "false",
+            "status": "failed",
+            "error": "RuntimeError: failed",
+            "result": "",
+        },
+        {
+            "question_id": "adversarial",
+            "category": "5",
+            "is_invalid": "false",
+            "status": "completed",
+            "error": "",
+            "result": "CORRECT",
+        },
+    ]
+    with input_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    monkeypatch.setattr(sys, "argv", ["stat_judge_result.py", "--input", str(input_path)])
+
+    stat_judge_result.main()
+
+    output = capsys.readouterr().out
+    assert "Expected rows: 4" in output
+    assert "Failed rows: 1" in output
+    assert "Ungraded rows: 1" in output
+    assert "Graded accuracy: 50.00%" in output
+    assert "Accuracy (expected denominator): 25.00%" in output
+    assert (
+        (tmp_path / "summary.txt")
+        .read_text(encoding="utf-8")
+        .startswith("=== Judge Result Statistics")
+    )
+
+
+def test_judge_does_not_grade_failed_execution_rows():
+    rows = [
+        {"category": "1", "status": "failed", "result": ""},
+        {"category": "1", "status": "completed", "result": ""},
+        {"category": "1", "result": ""},
+        {"category": "5", "status": "completed", "result": ""},
+    ]
+
+    assert judge.get_ungraded_rows(rows) == [1, 2]
+    assert judge.get_ungraded_rows(rows, force=True) == [1, 2]

--- a/tests/benchmark/test_session_contention_benchmark.py
+++ b/tests/benchmark/test_session_contention_benchmark.py
@@ -1,0 +1,171 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "benchmark" / "custom" / "session_contention_benchmark.py"
+)
+SPEC = importlib.util.spec_from_file_location("session_contention_benchmark", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = benchmark
+SPEC.loader.exec_module(benchmark)
+
+
+def _event(
+    *,
+    adapter: str = "sdk",
+    scenario: str = "retrieval",
+    operation: str = "find",
+    started_ms: float,
+    latency_ms: float,
+    success: bool = True,
+):
+    return benchmark.RequestEvent(
+        adapter=adapter,
+        scenario=scenario,
+        operation=operation,
+        started_at="2026-01-01T00:00:00Z",
+        ended_at="2026-01-01T00:00:01Z",
+        elapsed_ms_since_run_start=started_ms,
+        latency_ms=latency_ms,
+        success=success,
+        status_code=200 if success else 500,
+        exception_type=None if success else "RuntimeError",
+        error_message=None if success else "failed",
+    )
+
+
+def test_overall_qps_uses_adapter_operation_active_span():
+    events = [
+        _event(started_ms=0, latency_ms=100),
+        _event(started_ms=900, latency_ms=100),
+        _event(
+            adapter="cli-http",
+            operation="search",
+            started_ms=10_000,
+            latency_ms=1_000,
+        ),
+    ]
+
+    rows = benchmark.build_request_summary_rows(events=events, phases=[])
+    overall = benchmark.find_summary(rows, adapter="sdk", scenario="ALL", operation="find")
+
+    assert overall is not None
+    assert overall["qps_span_seconds"] == pytest.approx(1.0)
+    assert overall["qps"] == pytest.approx(2.0)
+    assert overall["successful_qps"] == pytest.approx(2.0)
+
+
+def test_summary_separates_success_and_failure_latency():
+    events = [
+        _event(started_ms=0, latency_ms=100, success=True),
+        _event(started_ms=100, latency_ms=300, success=True),
+        _event(started_ms=200, latency_ms=5_000, success=False),
+    ]
+
+    row = benchmark.build_summary_row("sdk", "mixed", "find", events, 2.0)
+
+    assert row["qps"] == pytest.approx(1.5)
+    assert row["successful_qps"] == pytest.approx(1.0)
+    assert row["p50_success_ms"] == pytest.approx(200.0)
+    assert row["p95_success_ms"] == pytest.approx(290.0)
+    assert row["p50_failure_ms"] == pytest.approx(5_000.0)
+    assert row["p95_failure_ms"] == pytest.approx(5_000.0)
+    assert row["p95_ms"] == pytest.approx(290.0)
+    assert row["slow_success_gt_1s"] == 0
+    assert row["slow_failure_gt_1s"] == 1
+
+
+def test_slo_gates_are_disabled_by_default():
+    config = benchmark.parse_args(["--profile", "smoke", "--adapters", "sdk"])
+    summary_rows = [
+        {
+            "adapter": "sdk",
+            "scenario": "ALL",
+            "operation": "find",
+            "requests": 10,
+            "failures": 10,
+            "success_rate": 0.0,
+            "p95_success_ms": None,
+        }
+    ]
+
+    assert config.max_failure_rate_percent is None
+    assert config.max_success_p95_ms is None
+    assert benchmark.evaluate_exit_gates(config, summary_rows) == []
+
+
+def test_opt_in_slo_gates_report_failure_rate_and_success_latency():
+    config = benchmark.parse_args(
+        [
+            "--profile",
+            "smoke",
+            "--adapters",
+            "sdk",
+            "--max-failure-rate-percent",
+            "5",
+            "--max-success-p95-ms",
+            "250",
+        ]
+    )
+    summary_rows = [
+        {
+            "adapter": "sdk",
+            "scenario": "ALL",
+            "operation": "find",
+            "requests": 100,
+            "failures": 10,
+            "success_rate": 90.0,
+            "p95_success_ms": 300.0,
+        },
+        {
+            "adapter": "sdk",
+            "scenario": "retrieval",
+            "operation": "find",
+            "requests": 100,
+            "failures": 10,
+            "success_rate": 90.0,
+            "p95_success_ms": 300.0,
+        },
+    ]
+
+    violations = benchmark.evaluate_exit_gates(config, summary_rows)
+
+    assert violations == [
+        "sdk/find failure rate 10.0000% exceeds 5.0000%",
+        "sdk/find successful p95 300.0000ms exceeds 250.0000ms",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_returns_nonzero_when_opt_in_gate_fails(tmp_path, monkeypatch):
+    config = benchmark.parse_args(
+        [
+            "--profile",
+            "smoke",
+            "--adapters",
+            "sdk",
+            "--output-dir",
+            str(tmp_path),
+            "--max-failure-rate-percent",
+            "0",
+        ]
+    )
+    runner = benchmark.BenchmarkRunner(config)
+
+    async def no_op():
+        return None
+
+    async def create_no_adapters():
+        return {}
+
+    monkeypatch.setattr(runner, "_prepare_filesystem", no_op)
+    monkeypatch.setattr(runner, "_prepare_remote_state", no_op)
+    monkeypatch.setattr(runner, "_create_adapters", create_no_adapters)
+    monkeypatch.setattr(runner, "_write_outputs", lambda: ["sdk/find gate failed"])
+    monkeypatch.setattr(runner, "_print_summary_path", lambda: None)
+
+    assert await runner.run() == 1


### PR DESCRIPTION
## Description

Make OpenViking benchmark results failure-inclusive and suitable for opt-in CI gating.

LoCoMo worker failures now persist explicit failed rows and the runner verifies planned versus recorded identities/counts. Judge/stat output separates expected, failed, ungraded, correct, and wrong rows and reports both graded-only and expected-denominator accuracy.

The session contention benchmark now calculates each adapter/operation overall QPS from its own active span, reports successful QPS, separates successful and failed latency, and offers default-off failure-rate and successful-p95 exit gates.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Found during a source-first benchmark audit; no existing issue or open PR covered the denominator and aggregation defects together.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Persist explicit LoCoMo `completed`/`failed` status and errors for every planned QA row.
- Verify planned/recorded result integrity and expose expected-denominator accuracy.
- Correct per-adapter/operation QPS spans and separate attempt/success/failure latency.
- Add default-off `--max-failure-rate-percent` and `--max-success-p95-ms` gates.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```text
pytest -q tests/benchmark/test_locomo_benchmark_integrity.py \
  tests/benchmark/test_session_contention_benchmark.py
# 9 passed

ruff check benchmark/custom/session_contention_benchmark.py \
  benchmark/locomo/openviking/judge.py \
  benchmark/locomo/openviking/run_eval.py \
  benchmark/locomo/openviking/stat_judge_result.py \
  tests/benchmark/test_locomo_benchmark_integrity.py \
  tests/benchmark/test_session_contention_benchmark.py
ruff format --check <same Python files>
git diff --check
# passed
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The new contention SLO gates are disabled by default, preserving existing command exit behavior unless thresholds are explicitly supplied. No live server load run was used as proof; deterministic tests cover persistence, denominator, aggregation, and exit-gate semantics.
