### PR TITLE
fix(studio): open Markdown links in resource preview (#3723)

### DIFF
--- a/web-studio/src/routes/playground/route.tsx
+++ b/web-studio/src/routes/playground/route.tsx
@@ -596,6 +596,7 @@ function PlaygroundWorkbench() {
               file={selectedFile}
               hideDirectoryHeader
               onClose={() => setSelectedFile(null)}
+              onNavigate={(uri) => void revealResource(uri)}
               showCloseButton={false}
             />
           </div>

--- a/web-studio/src/routes/resources/-components/dir-browser.tsx
+++ b/web-studio/src/routes/resources/-components/dir-browser.tsx
@@ -177,6 +177,7 @@ function DetailPane({
         <LazyFilePreview
           file={detail.file}
           onClose={() => {}}
+          onNavigate={onOpenFile}
           showCloseButton={false}
         />
       )

--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { VikingFsEntry } from '../-types/viking-fm'
+import { FilePreview } from './file-preview'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('#/gen/ov-client/client.gen', () => ({
+  client: {
+    buildUrl: ({ query }: { query: { uri: string } }) =>
+      `/api/v1/content/download?uri=${encodeURIComponent(query.uri)}`,
+  },
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  getContentDownload: vi.fn(),
+  ovClient: { getOptions: () => ({ baseUrl: '' }) },
+}))
+
+vi.mock('../-hooks/viking-fm', () => ({
+  useInvalidateVikingFs: () => ({
+    invalidateList: vi.fn(),
+    invalidatePreview: vi.fn(),
+    invalidateTree: vi.fn(),
+  }),
+  useVikingFilePreview: () => ({
+    canLoadContent: false,
+    isContentLoaded: true,
+    isFetching: false,
+    isLoading: false,
+    preview: {
+      content: '[Target](./target.md)',
+      fileType: 'markdown',
+      shouldAutoRead: true,
+    },
+    refetch: vi.fn(),
+  }),
+  useVikingFsStat: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}))
+
+const file: VikingFsEntry = {
+  abstract: '',
+  isDir: false,
+  modTime: '2026-08-04 12:00',
+  modTimestamp: null,
+  name: 'index.md',
+  overview: '',
+  size: '24 B',
+  sizeBytes: 24,
+  uri: 'viking://resources/wiki/index.md',
+}
+
+describe('FilePreview Markdown links', () => {
+  it('opens internal Markdown links in the resource preview', () => {
+    const onNavigate = vi.fn()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    render(
+      <FilePreview
+        file={file}
+        onClose={vi.fn()}
+        onNavigate={onNavigate}
+        showCloseButton={false}
+      />,
+      { wrapper },
+    )
+
+    const link = screen.getByRole('link', { name: 'Target' })
+    expect(link.getAttribute('href')).toBe('viking://resources/wiki/target.md')
+
+    fireEvent.click(link)
+
+    expect(onNavigate).toHaveBeenCalledOnce()
+    expect(onNavigate).toHaveBeenCalledWith('viking://resources/wiki/target.md')
+  })
+})

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -106,6 +106,7 @@ interface FilePreviewProps {
   file: VikingFsEntry | null
   hideDirectoryHeader?: boolean
   onClose: () => void
+  onNavigate?: (uri: string) => void
   showCloseButton?: boolean
 }
 
@@ -1024,6 +1025,7 @@ export function FilePreview({
   file,
   hideDirectoryHeader = false,
   onClose,
+  onNavigate,
   showCloseButton = true,
 }: FilePreviewProps) {
   const { t } = useTranslation('resources')
@@ -1598,15 +1600,28 @@ export function FilePreview({
                       />
                     ),
                     a: ({ href, children }) => {
-                      const resolvedHref = href
-                        ? resolveMarkdownAssetUrl(String(href), file.uri)
-                        : String(href || '')
+                      const target = href
+                        ? resolveMarkdownAssetTarget(String(href), file.uri)
+                        : null
+                      const isInternal =
+                        target?.kind === 'viking' && Boolean(onNavigate)
+                      const resolvedHref = target
+                        ? isInternal
+                          ? target.value
+                          : resolveMarkdownAssetUrl(target.value, file.uri)
+                        : ''
                       const isExternal = /^(https?:|mailto:|tel:)/i.test(
                         resolvedHref,
                       )
                       return (
                         <a
                           href={resolvedHref}
+                          onClick={(event) => {
+                            if (target?.kind === 'viking' && onNavigate) {
+                              event.preventDefault()
+                              onNavigate(target.value)
+                            }
+                          }}
                           target={isExternal ? '_blank' : undefined}
                           rel={isExternal ? 'noreferrer noopener' : undefined}
                         >

--- a/web-studio/src/routes/resources/-components/find-palette.tsx
+++ b/web-studio/src/routes/resources/-components/find-palette.tsx
@@ -538,6 +538,10 @@ export function FindPalette({
                   <LazyFilePreview
                     file={previewEntry}
                     onClose={() => setIndex(-1)}
+                    onNavigate={(uri) => {
+                      onNavigate(uri)
+                      onClose()
+                    }}
                     showCloseButton={false}
                   />
                 </div>

--- a/web-studio/src/routes/resources/-components/lazy-file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/lazy-file-preview.tsx
@@ -13,11 +13,13 @@ export function LazyFilePreview({
   file,
   hideDirectoryHeader,
   onClose,
+  onNavigate,
   showCloseButton,
 }: {
   file: VikingFsEntry | null
   hideDirectoryHeader?: boolean
   onClose: () => void
+  onNavigate?: (uri: string) => void
   showCloseButton?: boolean
 }) {
   return (
@@ -32,6 +34,7 @@ export function LazyFilePreview({
         file={file}
         hideDirectoryHeader={hideDirectoryHeader}
         onClose={onClose}
+        onNavigate={onNavigate}
         showCloseButton={showCloseButton}
       />
     </Suspense>


### PR DESCRIPTION
## Description

Internal Markdown links rendered by Web Studio's resource preview were rewritten to `/api/v1/content/download`, which forced an attachment download instead of opening the linked resource in the existing preview. This change routes resolved `viking://` links through Web Studio's resource navigator while preserving the download fallback for preview contexts without a navigation callback.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Refs #3723

This addresses the Web Studio navigation symptom. It does not change compile-time relation metadata generation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add an optional internal-resource navigation callback to `FilePreview` and its lazy wrapper.
- Connect the main Playground preview and both search-preview paths to the existing resource navigator.
- Keep complete resolved targets such as `viking://resources/wiki/target.md` instead of replacing them with the attachment download endpoint.
- Add a click regression test that verifies the `.md` target is preserved and the resource navigator receives it.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
NODE_OPTIONS='--localstorage-file=/tmp/openviking-vitest-localstorage' pnpm test
# 31 test files passed, 98 tests passed

pnpm build
# production build succeeded

pnpm exec eslint <six changed files>
pnpm exec prettier --check <six changed files>
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; the regression is covered by the component test.

## Additional Notes

`pnpm exec tsc --noEmit` remains blocked by existing errors in generated SDK files and unrelated components on current `main`; the production Vite build passes.
