### PR TITLE
fix(cli): correct Rust CLI license metadata

### DIFF
--- a/crates/ov_cli/Cargo.toml
+++ b/crates/ov_cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.91.1"
 authors = ["OpenViking Contributors"]
 description = "Rust CLI client for OpenViking"
-license = "MIT"
+license = "Apache-2.0"
 
 [[bin]]
 name = "ov"


### PR DESCRIPTION
## Description

Align the Rust CLI package metadata with the component's authoritative Apache-2.0 license. `crates/LICENSE` and the root README already identify `crates/ov_cli` as Apache-2.0, while its Cargo manifest incorrectly declared MIT.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3689

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Change the `ov_cli` package license expression from `MIT` to `Apache-2.0`.
- Keep the existing Apache-2.0 license text and README license table unchanged.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Validation performed:

- Parsed `crates/ov_cli/Cargo.toml` with Python `tomllib` and asserted `package.license == "Apache-2.0"`.
- Confirmed `crates/LICENSE` contains Apache License 2.0 and the README already documents `crates/ov_cli` as Apache 2.0.
- Confirmed the diff contains only `crates/ov_cli/Cargo.toml` and passes `git diff --check`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable: no code changed)
- [x] I have made corresponding changes to the documentation (not applicable: existing documentation is already correct)
- [ ] My changes generate no new warnings (Cargo validation was not available locally)
- [x] Any dependent changes have been merged and published (not applicable: no dependencies)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

`cargo metadata` and Rust tests were not run locally because Cargo is unavailable in the current environment. This is a metadata-only, one-line SPDX correction with no runtime behavior change.
