### PR TITLE
feat(search): expose tags in find/search results and drop empty fields

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -615,6 +615,7 @@ class HierarchicalRetriever:
                     category=c.get("category", ""),
                     score=final_score,
                     relations=relations,
+                    search_tags=list(c.get("search_tags") or []),
                 )
             )
 

--- a/openviking_cli/retrieve/types.py
+++ b/openviking_cli/retrieve/types.py
@@ -293,6 +293,7 @@ class MatchedContext:
     match_reason: str = ""
 
     relations: List[RelatedContext] = field(default_factory=list)
+    search_tags: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -373,17 +374,19 @@ class FindResult:
         return result
 
     def _context_to_dict(self, ctx: MatchedContext) -> Dict[str, Any]:
-        """Convert MatchedContext to dict."""
+        """Convert MatchedContext to dict.
+
+        Only fields the retrieval pipeline actually populates are exposed.
+        ``search_tags`` is surfaced under the ``tags`` key to match the
+        ``tags`` filter parameter accepted by find/search.
+        """
         return {
             "context_type": ctx.context_type.value,
             "uri": ctx.uri,
             "level": ctx.level,
             "score": ctx.score,
-            "category": ctx.category,
-            "match_reason": ctx.match_reason,
-            "relations": [{"uri": r.uri, "abstract": r.abstract} for r in ctx.relations],
             "abstract": ctx.abstract,
-            "overview": ctx.overview,
+            "tags": ctx.search_tags,
         }
 
     def _query_to_dict(self, q: TypedQuery) -> Dict[str, Any]:
@@ -431,6 +434,7 @@ class FindResult:
                     RelatedContext(uri=r.get("uri", ""), abstract=r.get("abstract", ""))
                     for r in d.get("relations", [])
                 ],
+                search_tags=list(d.get("tags") or d.get("search_tags") or []),
             )
 
         return cls(

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -637,3 +637,42 @@ async def test_convert_to_matched_contexts_returns_empty_relations():
     )
 
     assert result[0].relations == []
+
+
+@pytest.mark.asyncio
+async def test_convert_to_matched_contexts_propagates_search_tags():
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=None,
+        rerank_config=None,
+    )
+
+    result = await retriever._convert_to_matched_contexts(
+        [
+            _result(
+                "viking://resources/file-a",
+                1.0,
+                abstract="child A",
+                search_tags=["team=infra", "project=viking"],
+            )
+        ],
+        ctx=_ctx(),
+    )
+
+    assert result[0].search_tags == ["team=infra", "project=viking"]
+
+
+@pytest.mark.asyncio
+async def test_convert_to_matched_contexts_defaults_empty_search_tags():
+    retriever = HierarchicalRetriever(
+        storage=DummyStorage(),
+        embedder=None,
+        rerank_config=None,
+    )
+
+    result = await retriever._convert_to_matched_contexts(
+        [_result("viking://resources/file-a", 1.0, abstract="child A")],
+        ctx=_ctx(),
+    )
+
+    assert result[0].search_tags == []

--- a/tests/retrieve/test_provenance.py
+++ b/tests/retrieve/test_provenance.py
@@ -92,3 +92,68 @@ class TestFindResultProvenance:
         assert d_without["resources"] == d_with["resources"]
         assert d_without["skills"] == d_with["skills"]
         assert d_without["total"] == d_with["total"]
+
+
+class TestMatchedContextSearchTags:
+    def test_context_to_dict_exposes_search_tags_as_tags(self):
+        ctx = MatchedContext(
+            uri="viking://resources/docs/arch.md",
+            context_type=ContextType.RESOURCE,
+            level=2,
+            search_tags=["team=infra", "project=viking"],
+        )
+        result = FindResult(memories=[], resources=[ctx], skills=[])
+        d = result.to_dict()
+        assert d["resources"][0]["tags"] == ["team=infra", "project=viking"]
+        assert "search_tags" not in d["resources"][0]
+
+    def test_context_to_dict_defaults_empty_tags(self):
+        ctx = MatchedContext(
+            uri="viking://resources/docs/arch.md",
+            context_type=ContextType.RESOURCE,
+            level=2,
+        )
+        result = FindResult(memories=[], resources=[ctx], skills=[])
+        d = result.to_dict()
+        assert d["resources"][0]["tags"] == []
+
+    def test_context_to_dict_drops_always_empty_fields(self):
+        ctx = MatchedContext(
+            uri="viking://resources/docs/arch.md",
+            context_type=ContextType.RESOURCE,
+            level=2,
+        )
+        result = FindResult(memories=[], resources=[ctx], skills=[])
+        item = result.to_dict()["resources"][0]
+        for dropped in ("category", "match_reason", "relations", "overview"):
+            assert dropped not in item
+
+    def test_context_to_dict_keeps_useful_fields(self):
+        ctx = MatchedContext(
+            uri="viking://resources/docs/arch.md",
+            context_type=ContextType.RESOURCE,
+            level=2,
+            abstract="Architecture doc",
+            score=0.5,
+        )
+        result = FindResult(memories=[], resources=[ctx], skills=[])
+        item = result.to_dict()["resources"][0]
+        assert item["uri"] == "viking://resources/docs/arch.md"
+        assert item["context_type"] == "resource"
+        assert item["level"] == 2
+        assert item["score"] == 0.5
+        assert item["abstract"] == "Architecture doc"
+
+    def test_from_dict_round_trips_tags(self):
+        payload = {
+            "resources": [
+                {
+                    "uri": "viking://resources/docs/arch.md",
+                    "context_type": "resource",
+                    "level": 2,
+                    "tags": ["team=infra"],
+                }
+            ]
+        }
+        result = FindResult.from_dict(payload)
+        assert result.resources[0].search_tags == ["team=infra"]


### PR DESCRIPTION
Surface the vector store's search_tags on each matched context (returned under the "tags" key to match the tags filter param) and remove the result fields the retrieval pipeline never populates (category, match_reason, relations, overview).

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
