### PR TITLE
fix(storage): propagate VikingFS.mkdir backend errors instead of swallowing them

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -597,6 +597,7 @@ class VikingFS:
             already_exists = "exist" in message or "already" in message
             if exist_ok and already_exists:
                 return
+            raise
 
     async def rm(
         self,

--- a/tests/misc/test_mkdir.py
+++ b/tests/misc/test_mkdir.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for VikingFS.mkdir() — verifies the target directory is actually created."""
+"""Tests for VikingFS.mkdir() — verifies the target directory is actually created
+and that backend errors are propagated instead of silently swallowed."""
 
 import contextvars
 import os
@@ -19,7 +20,8 @@ def _make_viking_fs():
 
     fs = VikingFS.__new__(VikingFS)
     fs.agfs = MagicMock()
-    fs.agfs.mkdir = MagicMock(return_value=None)
+    fs._async_agfs = MagicMock()
+    fs._async_agfs.mkdir = AsyncMock(return_value=None)
     fs.query_embedder = None
     fs.vector_store = None
     fs._uri_prefix = "viking://"
@@ -35,37 +37,34 @@ class TestMkdir:
         """mkdir() must call agfs.mkdir with the target path."""
         fs = _make_viking_fs()
         fs._ensure_parent_dirs = AsyncMock()
-        fs.stat = AsyncMock(side_effect=Exception("not found"))
 
         await fs.mkdir("viking://resources/new_dir")
 
-        fs.agfs.mkdir.assert_called_once()
-        call_path = fs.agfs.mkdir.call_args[0][0]
+        fs._async_agfs.mkdir.assert_called_once()
+        call_path = fs._async_agfs.mkdir.call_args[0][0]
         assert call_path.endswith("resources/new_dir")
 
     @pytest.mark.asyncio
     async def test_mkdir_exist_ok_true_existing(self):
-        """mkdir(exist_ok=True) should return early if directory exists."""
+        """mkdir(exist_ok=True) should tolerate an already-exists backend error."""
         fs = _make_viking_fs()
         fs._ensure_parent_dirs = AsyncMock()
-        fs.stat = AsyncMock(return_value={"isDir": True})
+        fs._async_agfs.mkdir = AsyncMock(side_effect=Exception("directory already exists"))
 
         await fs.mkdir("viking://resources/existing_dir", exist_ok=True)
 
-        # Should NOT call agfs.mkdir because directory already exists
-        fs.agfs.mkdir.assert_not_called()
+        fs._async_agfs.mkdir.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_mkdir_exist_ok_true_not_existing(self):
         """mkdir(exist_ok=True) should create dir if it does not exist."""
         fs = _make_viking_fs()
         fs._ensure_parent_dirs = AsyncMock()
-        fs.stat = AsyncMock(side_effect=Exception("not found"))
 
         await fs.mkdir("viking://resources/new_dir", exist_ok=True)
 
-        fs.agfs.mkdir.assert_called_once()
-        call_path = fs.agfs.mkdir.call_args[0][0]
+        fs._async_agfs.mkdir.assert_called_once()
+        call_path = fs._async_agfs.mkdir.call_args[0][0]
         assert call_path.endswith("resources/new_dir")
 
     @pytest.mark.asyncio
@@ -76,16 +75,46 @@ class TestMkdir:
 
         await fs.mkdir("viking://resources/another_dir")
 
-        fs.agfs.mkdir.assert_called_once()
+        fs._async_agfs.mkdir.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_mkdir_ensures_parents_first(self):
         """mkdir() must call _ensure_parent_dirs before creating target."""
         fs = _make_viking_fs()
         call_order = []
-        fs._ensure_parent_dirs = AsyncMock(side_effect=lambda p: call_order.append("parents"))
-        fs.agfs.mkdir = MagicMock(side_effect=lambda p: call_order.append("mkdir"))
+        fs._ensure_parent_dirs = AsyncMock(side_effect=lambda *a, **kw: call_order.append("parents"))
+        fs._async_agfs.mkdir = AsyncMock(side_effect=lambda *a, **kw: call_order.append("mkdir"))
 
         await fs.mkdir("viking://a/b/c")
 
         assert call_order == ["parents", "mkdir"]
+
+    @pytest.mark.asyncio
+    async def test_mkdir_propagates_backend_error(self):
+        """mkdir() must not swallow backend errors (permissions, quota, I/O)."""
+        fs = _make_viking_fs()
+        fs._ensure_parent_dirs = AsyncMock()
+        fs._async_agfs.mkdir = AsyncMock(side_effect=Exception("permission denied"))
+
+        with pytest.raises(Exception, match="permission denied"):
+            await fs.mkdir("viking://resources/protected_dir")
+
+    @pytest.mark.asyncio
+    async def test_mkdir_exist_ok_true_propagates_non_exists_error(self):
+        """mkdir(exist_ok=True) only tolerates already-exists errors, not others."""
+        fs = _make_viking_fs()
+        fs._ensure_parent_dirs = AsyncMock()
+        fs._async_agfs.mkdir = AsyncMock(side_effect=Exception("resource exhausted: quota exceeded"))
+
+        with pytest.raises(Exception, match="resource exhausted"):
+            await fs.mkdir("viking://resources/full_dir", exist_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_mkdir_exist_ok_false_raises_on_existing(self):
+        """mkdir(exist_ok=False) surfaces the already-exists error to the caller."""
+        fs = _make_viking_fs()
+        fs._ensure_parent_dirs = AsyncMock()
+        fs._async_agfs.mkdir = AsyncMock(side_effect=Exception("directory already exists"))
+
+        with pytest.raises(Exception, match="already exists"):
+            await fs.mkdir("viking://resources/existing_dir")


### PR DESCRIPTION
## Problem

`VikingFS.mkdir()` (`openviking/storage/viking_fs.py`) catches every exception from the backend `mkdir` call, but the `except` block has no re-raise:

```python
try:
    await self._async_agfs.mkdir(path, fs_ctx=self._pathlock_fs_ctx(ctx, lease_ref))
except Exception as exc:
    message = str(exc).lower()
    already_exists = "exist" in message or "already" in message
    if exist_ok and already_exists:
        return
    # <- anything else falls through and is silently discarded
```

Any failure that is not an already-exists error tolerated by `exist_ok=True` — permission denied, quota/resource-exhausted, I/O errors, lock-lease violations, and even already-exists errors with the default `exist_ok=False` — is silently swallowed, and `mkdir()` returns as if the directory had been created.

`mkdir` is on the write hot path (ovpack import, parsers, session, privacy service, and `mv`'s internal copy). Callers reasonably assume a returned `mkdir` means the directory exists; downstream writes then fail later with confusing secondary errors, and the original, actionable error is lost.

## Fix

Re-raise the original exception unless it is an already-exists error tolerated by `exist_ok=True`:

```python
            if exist_ok and already_exists:
                return
            raise
```

One-line change; no behavior change for the already-exists + `exist_ok=True` path.

## Tests

`tests/misc/test_mkdir.py` was stale: it mocked `fs.agfs.mkdir`, but `mkdir()` goes through the `AsyncAGFSClient` wrapper (`self._async_agfs`). Four of its five tests failed on `main`, and the fifth passed only because the swallowed `AttributeError` from the missing mock made `mkdir()` return early — the very bug this PR fixes.

- Updated the existing tests to mock `_async_agfs.mkdir` and to match the current create-then-tolerate-exists semantics.
- Added regression tests: backend errors propagate with both `exist_ok=False` and `exist_ok=True` (non-exists errors), and `exist_ok=False` surfaces already-exists errors.

```
tests/misc/test_mkdir.py: 8 passed
```

Full `tests/storage`, `tests/misc`, and `tests/service` runs show no new failures versus `main` (the only delta is the 4 previously-failing stale mkdir tests now passing).