### PR TITLE
fix(storage): enumerate all entries when mv copies a directory

### DIFF
--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -977,7 +977,7 @@ class VikingFS:
         """Recursively copy a directory through VikingFS read/write hooks."""
         await self.mkdir(new_uri, exist_ok=True, ctx=ctx, lease_ref=lease_ref)
 
-        entries = await self.ls(old_uri, show_all_hidden=True, ctx=ctx)
+        entries = await self.ls(old_uri, show_all_hidden=True, node_limit=LS_ALL_NODES, ctx=ctx)
         for entry in entries:
             name = entry.get("name", "")
             if not name or name in (".", ".."):

--- a/tests/storage/test_mv_copy_node_limit.py
+++ b/tests/storage/test_mv_copy_node_limit.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression test: mv() must enumerate every entry of a source directory.
+
+``VikingFS._copy_dir_through_vikingfs`` drives the copy phase of ``mv()`` for
+non-temp directories. It must pass ``node_limit=LS_ALL_NODES`` to ``ls()`` —
+the agent-facing default of 1000 would silently truncate larger directories,
+and the subsequent recursive source delete would destroy the uncopied entries.
+"""
+
+import contextvars
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+def _make_viking_fs():
+    """Create a VikingFS instance with mocked AGFS backend."""
+    from openviking.storage.viking_fs import VikingFS
+
+    fs = VikingFS.__new__(VikingFS)
+    fs.agfs = MagicMock()
+    fs._async_agfs = MagicMock()
+    fs._async_agfs.mkdir = AsyncMock(return_value=None)
+    fs.query_embedder = None
+    fs.vector_store = None
+    fs._uri_prefix = "viking://"
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx", default=None)
+    return fs
+
+
+class TestCopyDirThroughVikingFS:
+    """_copy_dir_through_vikingfs must not inherit the agent-facing ls cap."""
+
+    @pytest.mark.asyncio
+    async def test_enumerates_all_entries_with_ls_all_nodes(self):
+        from openviking.storage.viking_fs import LS_ALL_NODES
+
+        fs = _make_viking_fs()
+        fs.mkdir = AsyncMock()
+        fs._copy_file_through_vikingfs = AsyncMock()
+        fs.ls = AsyncMock(
+            return_value=[
+                {"name": "a.md", "isDir": False},
+                {"name": "b.md", "isDir": False},
+            ]
+        )
+
+        await fs._copy_dir_through_vikingfs(
+            "viking://resources/src", "viking://resources/dst"
+        )
+
+        fs.ls.assert_called_once_with(
+            "viking://resources/src",
+            show_all_hidden=True,
+            node_limit=LS_ALL_NODES,
+            ctx=None,
+        )
+        assert fs._copy_file_through_vikingfs.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_subdirectory_recursion_also_enumerates_all_entries(self):
+        from openviking.storage.viking_fs import LS_ALL_NODES
+
+        fs = _make_viking_fs()
+        fs.mkdir = AsyncMock()
+        fs._copy_file_through_vikingfs = AsyncMock()
+        fs.ls = AsyncMock(
+            side_effect=[
+                [{"name": "sub", "isDir": True}],
+                [{"name": "leaf.md", "isDir": False}],
+            ]
+        )
+
+        await fs._copy_dir_through_vikingfs(
+            "viking://resources/src", "viking://resources/dst"
+        )
+
+        assert fs.ls.await_count == 2
+        for call in fs.ls.await_args_list:
+            assert call.kwargs["node_limit"] == LS_ALL_NODES


### PR DESCRIPTION
## Problem

`mv()` of a non-temp directory copies via `_copy_dir_through_vikingfs()`, which enumerates the source with the agent-facing `ls()`:

```python
entries = await self.ls(old_uri, show_all_hidden=True, ctx=ctx)
```

`ls()` defaults to `node_limit=1000`, and `_ls_original` hard-truncates past the cap. After the copy, `mv()` unconditionally deletes the source recursively. So for any directory level containing more than 1000 visible entries (e.g. a resource directory from a bulk ingest):

1. only the first 1000 entries are copied to the destination,
2. the recursive source `rm` destroys the rest,
3. no error is raised.

The vector index makes it worse: URI remapping covers *all* entries via the uncapped `_collect_uris`, so after the move the index points at URIs whose files no longer exist anywhere. Permanent, silent data loss on a plain `mv`.

The module already defines the `LS_ALL_NODES` sentinel precisely for this situation ("internal callers that MUST enumerate an entire directory ... Pass this explicitly at those call sites"), and the same class of bug was previously fixed on the ingest path in #2518 — this call site was missed.

## Fix

```python
entries = await self.ls(old_uri, show_all_hidden=True, node_limit=LS_ALL_NODES, ctx=ctx)
```

## Tests

Added `tests/storage/test_mv_copy_node_limit.py`:

- asserts the copy phase enumerates with `node_limit=LS_ALL_NODES` (fails without the fix),
- asserts subdirectory recursion passes the sentinel at every level.

```
tests/storage/test_mv_copy_node_limit.py: 2 passed (2 failed without the fix)
tests/storage/test_viking_fs_write_locking.py: all passed (mv locking behavior unchanged)
```