### PR TITLE
feat(opencode): add hook-only installation mode

### DIFF
--- a/examples/opencode-plugin/INSTALL-ZH.md
+++ b/examples/opencode-plugin/INSTALL-ZH.md
@@ -92,6 +92,7 @@ export { OpenVikingPlugin, default } from "./openviking/index.mjs"
 ```json
 {
   "enabled": true,
+  "mcp": { "enabled": true },
   "timeoutMs": 30000,
   "repoContext": { "enabled": true, "cacheTtlMs": 60000 },
   "autoRecall": {
@@ -126,6 +127,19 @@ user/admin API key 的 API_KEY mode 时应留空。
 优先级高于 `openviking-config.json` 里的同名配置。
 
 高级场景可以用 `OPENVIKING_PLUGIN_CONFIG` 指向其他配置文件路径。
+
+### 仅 Hooks 模式
+
+如果其他 MCP server 已经提供 OpenViking，可以关闭本插件附带的 MCP 注册，同时保留生命周期 hooks：
+
+```json
+{
+  "mcp": { "enabled": false }
+}
+```
+
+repository context、自动 recall、消息 capture 和生命周期 commit 会继续工作，也不会添加或覆盖
+OpenCode 的 `mcp.openviking` 配置。
 
 ## 验证
 

--- a/examples/opencode-plugin/INSTALL.md
+++ b/examples/opencode-plugin/INSTALL.md
@@ -92,6 +92,7 @@ Example configuration:
 ```json
 {
   "enabled": true,
+  "mcp": { "enabled": true },
   "timeoutMs": 30000,
   "repoContext": { "enabled": true, "cacheTtlMs": 60000 },
   "autoRecall": {
@@ -121,6 +122,20 @@ API keys are resolved from environment variables or `~/.openviking/ovcli.conf` a
 `OPENVIKING_API_KEY`, `OPENVIKING_ACCOUNT`, `OPENVIKING_USER`, and `OPENVIKING_PEER_ID` take precedence over the corresponding values in `openviking-config.json`.
 
 For advanced setups, use `OPENVIKING_PLUGIN_CONFIG` to point to another configuration file path.
+
+### Hook-only mode
+
+If another MCP server already exposes OpenViking, set the bundled MCP registration to `false` while
+keeping this plugin's lifecycle hooks active:
+
+```json
+{
+  "mcp": { "enabled": false }
+}
+```
+
+Repository context, automatic recall, message capture, and lifecycle commits remain enabled. This
+does not add or overwrite OpenCode's `mcp.openviking` entry.
 
 ## Verify
 

--- a/examples/opencode-plugin/README.md
+++ b/examples/opencode-plugin/README.md
@@ -114,6 +114,7 @@ Create `~/.config/opencode/openviking-config.json`:
 ```json
 {
   "enabled": true,
+  "mcp": { "enabled": true },
   "timeoutMs": 30000,
   "repoContext": { "enabled": true, "cacheTtlMs": 60000 },
   "autoRecall": {
@@ -157,6 +158,20 @@ another person's session.
 and `OPENVIKING_PEER_ID` take precedence over values in this file.
 
 For advanced setups, `OPENVIKING_PLUGIN_CONFIG` can point to another config file path.
+
+### Hook-only mode
+
+When OpenViking is already exposed through another MCP server, retain the lifecycle hooks while
+skipping this plugin's bundled MCP registration:
+
+```json
+{
+  "mcp": { "enabled": false }
+}
+```
+
+This leaves repository context, automatic recall, message capture, and lifecycle commits enabled.
+It does not add or overwrite OpenCode's `mcp.openviking` entry.
 
 OpenCode's local `read`, `glob`, and `grep` tools cannot read `viking://` URIs.
 When the agent accidentally tries that, the plugin blocks the filesystem tool

--- a/examples/opencode-plugin/index.mjs
+++ b/examples/opencode-plugin/index.mjs
@@ -44,8 +44,15 @@ export async function OpenVikingPlugin({ client, directory }) {
 
   return {
     config: async (opencodeConfig) => {
-      const injected = injectOpenVikingMcpConfig(opencodeConfig, pluginRoot)
-      log(injected ? "INFO" : "WARN", "mcp", injected ? "Registered OpenViking MCP server" : "OpenViking MCP server was not registered")
+      const injected = injectOpenVikingMcpConfig(opencodeConfig, pluginRoot, config.mcp.enabled)
+      const hookOnly = !config.mcp.enabled
+      log(
+        injected || hookOnly ? "INFO" : "WARN",
+        "mcp",
+        injected ? "Registered OpenViking MCP server" :
+          hookOnly ? "Skipped bundled MCP registration in hook-only mode" :
+            "OpenViking MCP server was not registered",
+      )
     },
 
     event: async ({ event }) => {

--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -18,6 +18,9 @@ const DEFAULT_CONFIG = {
   workspacePeer: true,
   recallPeerScope: "all",
   enabled: true,
+  mcp: {
+    enabled: true,
+  },
   timeoutMs: 30000,
   runtime: {
     dataDir: "",
@@ -117,6 +120,12 @@ function applyLegacyConnection(config, fileConfig) {
 
 function applyBehaviorConfig(config, fileConfig = {}) {
   if (fileConfig.enabled !== undefined) config.enabled = fileConfig.enabled !== false
+  const mcp = fileConfig.mcp && typeof fileConfig.mcp === "object" ? fileConfig.mcp : {}
+  config.mcp = {
+    ...DEFAULT_CONFIG.mcp,
+    ...mcp,
+    enabled: mcp.enabled !== false,
+  }
   if (fileConfig.timeoutMs !== undefined) config.timeoutMs = fileConfig.timeoutMs
   config.runtime = {
     ...DEFAULT_CONFIG.runtime,

--- a/examples/opencode-plugin/lib/mcp-config.mjs
+++ b/examples/opencode-plugin/lib/mcp-config.mjs
@@ -11,8 +11,9 @@ export function createOpenVikingMcpConfig(pluginRoot) {
   }
 }
 
-export function injectOpenVikingMcpConfig(config, pluginRoot) {
+export function injectOpenVikingMcpConfig(config, pluginRoot, enabled = true) {
   if (!config || typeof config !== "object") return false
+  if (!enabled) return false
   config.mcp = config.mcp && typeof config.mcp === "object" ? config.mcp : {}
   const current = config.mcp[OPENCODE_MCP_NAME]
   if (current?.enabled === false) return false

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -1,9 +1,11 @@
 import test from "node:test"
 import assert from "node:assert/strict"
+import { createServer } from "node:http"
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { loadConfig } from "../lib/config.mjs"
+import { OpenVikingPlugin } from "../index.mjs"
 
 async function withTempDir(prefix, fn) {
   const dir = await mkdtemp(join(tmpdir(), prefix))
@@ -11,6 +13,25 @@ async function withTempDir(prefix, fn) {
     return await fn(dir)
   } finally {
     await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function withHealthServer(fn) {
+  const server = createServer((request, response) => {
+    response.setHeader("Content-Type", "application/json")
+    if (request.url === "/health") {
+      response.end(JSON.stringify({ status: "ok" }))
+      return
+    }
+    response.statusCode = 404
+    response.end(JSON.stringify({ status: "error" }))
+  })
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+  try {
+    const { port } = server.address()
+    return await fn(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
   }
 }
 
@@ -161,6 +182,43 @@ test("loadConfig supports hook-only mode without registering the bundled MCP ser
     } finally {
       restoreOpenVikingEnv(snapshot)
     }
+  })
+})
+
+test("OpenVikingPlugin keeps lifecycle hooks without mutating MCP config in hook-only mode", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-hook-only-runtime-", async (dir) => {
+    await withHealthServer(async (endpoint) => {
+      try {
+        for (const key of Object.keys(process.env)) {
+          if (key.startsWith("OPENVIKING_")) delete process.env[key]
+        }
+        const configPath = join(dir, "openviking-config.json")
+        await writeFile(configPath, JSON.stringify({
+          mcp: { enabled: false },
+          runtime: { dataDir: join(dir, "runtime") },
+          repoContext: { enabled: false },
+          autoRecall: { enabled: false },
+          autoCapture: false,
+        }))
+        process.env.OPENVIKING_PLUGIN_CONFIG = configPath
+        process.env.OPENVIKING_URL = endpoint
+
+        const plugin = await OpenVikingPlugin({ client: {}, directory: dir })
+        assert.equal(typeof plugin.event, "function")
+        assert.equal(typeof plugin["chat.message"], "function")
+        assert.equal(typeof plugin.dispose, "function")
+
+        const opencodeConfig = { mcp: { external: { type: "remote", url: "https://example.com/mcp" } } }
+        await plugin.config(opencodeConfig)
+        assert.deepEqual(opencodeConfig, {
+          mcp: { external: { type: "remote", url: "https://example.com/mcp" } },
+        })
+        await plugin.dispose()
+      } finally {
+        restoreOpenVikingEnv(snapshot)
+      }
+    })
   })
 })
 

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -142,6 +142,28 @@ test("loadConfig can disable workspace peer", async () => {
   })
 })
 
+test("loadConfig supports hook-only mode without registering the bundled MCP server", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-hook-only-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const project = join(dir, "project")
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        mcp: { enabled: false },
+      }))
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.enabled, true)
+      assert.equal(cfg.mcp.enabled, false)
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})
+
 test("loadConfig preserves an explicit zero commit keep recent count", async () => {
   const snapshot = { ...process.env }
   await withTempDir("ov-oc-keep-recent-zero-", async (dir) => {

--- a/examples/opencode-plugin/tests/mcp-config.test.mjs
+++ b/examples/opencode-plugin/tests/mcp-config.test.mjs
@@ -26,10 +26,20 @@ test("injectOpenVikingMcpConfig respects explicit disabled MCP server", () => {
   assert.deepEqual(config.mcp.openviking, { enabled: false })
 })
 
+test("injectOpenVikingMcpConfig leaves OpenCode MCP config untouched in hook-only mode", () => {
+  const config = { mcp: { external: { type: "remote", url: "https://example.com/mcp" } } }
+
+  assert.equal(injectOpenVikingMcpConfig(config, "/tmp/openviking-plugin", false), false)
+  assert.deepEqual(config, {
+    mcp: { external: { type: "remote", url: "https://example.com/mcp" } },
+  })
+})
+
 test("OpenCode plugin keeps tools on MCP rather than native tool hook", async () => {
   const source = await readFile(join(testDir, "../index.mjs"), "utf8")
 
   assert.match(source, /injectOpenVikingMcpConfig/)
+  assert.match(source, /injectOpenVikingMcpConfig\(opencodeConfig, pluginRoot, config\.mcp\.enabled\)/)
   assert.doesNotMatch(source, /createMemoryTools/)
   assert.doesNotMatch(source, /createCodeTools/)
   assert.doesNotMatch(source, /\btool:\s*\{/)


### PR DESCRIPTION
## Description

Adds an opt-in hook-only mode for the OpenCode plugin. The default remains unchanged: the plugin registers its bundled stdio MCP proxy.

Set `mcp.enabled` to `false` in `openviking-config.json` to retain repository context, automatic recall, message capture, and lifecycle commits without adding or overwriting OpenCode's `mcp.openviking` entry.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3690

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `mcp.enabled`, defaulting to `true`, to the OpenCode plugin configuration.
- Skip bundled MCP registration without mutating existing OpenCode MCP configuration when hook-only mode is enabled.
- Document the option in English and Chinese installation guides, with configuration, injection, and plugin-entrypoint regression tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Validated with `npm test` (23 passing tests) and `npm run check` in `examples/opencode-plugin`.
