### PR TITLE
Fix Web Studio terminal panel crash

### DIFF
--- a/web-studio/src/routes/playground/-components/terminal-panel.test.tsx
+++ b/web-studio/src/routes/playground/-components/terminal-panel.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TerminalHistoryItem } from './terminal-panel'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TerminalHistoryItem', () => {
+  it('renders command entries with their terminal icon', () => {
+    const { container } = render(
+      <TerminalHistoryItem
+        entry={{ id: 'command-1', kind: 'command', title: '/ls' }}
+        onOpenResource={vi.fn()}
+        openingUri={null}
+      />,
+    )
+
+    expect(screen.getByText('/ls')).not.toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/web-studio/src/routes/playground/-components/terminal-panel.tsx
+++ b/web-studio/src/routes/playground/-components/terminal-panel.tsx
@@ -8,6 +8,7 @@ import {
   Loader2Icon,
   SendIcon,
   SparklesIcon,
+  TerminalIcon,
   TrashIcon,
   XCircleIcon,
 } from 'lucide-react'


### PR DESCRIPTION
## Description

Fix the Web Studio Playground crash that occurred when opening the Terminal panel with command history entries.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Import TerminalIcon in the terminal panel component.
- Add a regression test that renders a command history entry and its icon.
- Prevent the Terminal panel from throwing a TerminalIcon is not defined runtime error.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- npm run lint
- npm test (31 test files, 98 tests)
- npm run build -- --base=/studio/
- git diff --check

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Documentation and dependent changes are not required for this fix.

## Screenshots (if applicable)

Not applicable. This restores the existing Terminal panel behavior without visual changes.

## Additional Notes

The crash was caused by a missing lucide-react import. Vite transpiles TypeScript without type checking, so the undefined JSX component reached runtime; the new regression test directly exercises that render path.
