### PR TITLE
feat(queuefs): support redis as queufs backend ,redis mode support singleton 、cluster 、 sentinel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -178,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +191,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -216,6 +222,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,7 +240,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -949,6 +966,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,7 +1058,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1213,6 +1241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1276,12 @@ dependencies = [
  "regex",
  "rustversion",
 ]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -1308,7 +1351,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strict",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1478,7 +1521,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1489,7 +1532,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1549,7 +1592,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1571,7 +1614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1615,7 +1658,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1727,7 +1770,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1771,6 +1814,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1980,7 +2033,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2058,6 +2111,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2835,7 +2889,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2846,7 +2900,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2955,7 +3009,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3200,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -3320,7 +3374,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3638,7 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3680,7 +3734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3714,7 +3768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3768,7 +3822,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3781,7 +3835,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3876,6 +3930,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,8 +3982,10 @@ dependencies = [
  "lru",
  "mime_guess",
  "path-clean",
+ "r2d2",
  "radix_trie",
  "rand 0.8.5",
+ "redis 1.5.0",
  "regex",
  "rusqlite",
  "serde",
@@ -3942,7 +4009,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "ragfs",
- "redis",
+ "redis 0.32.7",
  "thiserror 1.0.69",
  "tokio",
  "url",
@@ -3989,6 +4056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +4103,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -4137,6 +4221,38 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "redis"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
+dependencies = [
+ "arcstr",
+ "async-lock",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "crc16",
+ "futures-util",
+ "itoa",
+ "log",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "r2d2",
+ "rand 0.10.2",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4476,6 +4592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4561,7 +4686,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4619,7 +4744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4636,7 +4761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4851,7 +4976,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4874,7 +4999,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -5036,7 +5161,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5063,6 +5188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,7 +5215,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5152,7 +5288,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5163,7 +5299,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5259,9 +5395,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5276,13 +5412,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5453,7 +5589,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5793,7 +5929,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5937,7 +6073,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5948,7 +6084,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6265,7 +6401,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6281,7 +6417,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6336,6 +6472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6369,7 +6511,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6390,7 +6532,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6410,7 +6552,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6431,7 +6573,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6464,7 +6606,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/ragfs/Cargo.toml
+++ b/crates/ragfs/Cargo.toml
@@ -68,6 +68,8 @@ bytes = "1.5"
 
 # Database
 rusqlite = { version = "0.32", features = ["bundled"] }
+redis = { version = "1.5.0", features = ["cluster", "r2d2", "sentinel", "tls-rustls-insecure", "tokio-rustls-comp"] }
+r2d2 = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "mysql"], optional = true }
 
 # AWS S3

--- a/crates/ragfs/src/plugins/queuefs/backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/backend.rs
@@ -36,7 +36,7 @@ impl Message {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct StoredMessage {
+pub(super) struct StoredMessage {
     id: String,
     #[serde(deserialize_with = "deserialize_stored_message_data")]
     data: Vec<u8>,
@@ -45,7 +45,7 @@ struct StoredMessage {
 }
 
 impl StoredMessage {
-    fn from_message(msg: &Message) -> Self {
+    pub(super) fn from_message(msg: &Message) -> Self {
         Self {
             id: msg.id.clone(),
             data: msg.data.clone(),
@@ -54,7 +54,7 @@ impl StoredMessage {
         }
     }
 
-    fn into_message(self) -> Message {
+    pub(super) fn into_message(self) -> Message {
         Message {
             id: self.id,
             data: self.data,

--- a/crates/ragfs/src/plugins/queuefs/mod.rs
+++ b/crates/ragfs/src/plugins/queuefs/mod.rs
@@ -11,6 +11,7 @@
 //! - `/queue_name/ack` - Write message ID to this file to acknowledge and delete it
 
 mod backend;
+mod redis_backend;
 
 use crate::core::{
     errors::{Error, Result},
@@ -20,7 +21,8 @@ use crate::core::{
 };
 use async_trait::async_trait;
 use backend::{MemoryBackend, Message, QueueBackend, SQLiteQueueBackend, SQLiteQueueOptions};
-use serde::Serialize;
+use redis_backend::RedisQueueBackend;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
@@ -74,6 +76,7 @@ struct QueueMessage {
 enum BackendKind {
     Memory,
     Sqlite,
+    Redis,
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +84,162 @@ struct ParsedBackendConfig {
     kind: BackendKind,
     sqlite_db_path: Option<String>,
     sqlite_options: SQLiteQueueOptions,
+    redis_options: Option<RedisQueueOptions>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum RedisMode {
+    #[default]
+    Singleton,
+    Cluster,
+    Sentinel,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RedisQueueOptions {
+    mode: RedisMode,
+    endpoints: Vec<String>,
+    master_name: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+    sentinel_username: Option<String>,
+    sentinel_password: Option<String>,
+    db: i64,
+    connect_timeout_ms: u64,
+    command_timeout_ms: u64,
+    key_prefix: String,
+    tls_enabled: bool,
+    tls_insecure_skip_verify: bool,
+}
+
+impl std::fmt::Debug for RedisQueueOptions {
+    /// Format Redis settings without exposing the configured password.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RedisQueueOptions")
+            .field("mode", &self.mode)
+            .field("endpoints", &self.endpoints)
+            .field("master_name", &self.master_name)
+            .field("username", &self.username)
+            .field("password_configured", &self.password.is_some())
+            .field(
+                "sentinel_username_configured",
+                &self.sentinel_username.is_some(),
+            )
+            .field(
+                "sentinel_password_configured",
+                &self.sentinel_password.is_some(),
+            )
+            .field("db", &self.db)
+            .field("connect_timeout_ms", &self.connect_timeout_ms)
+            .field("command_timeout_ms", &self.command_timeout_ms)
+            .field("key_prefix", &self.key_prefix)
+            .field("tls_enabled", &self.tls_enabled)
+            .field(
+                "tls_insecure_skip_verify",
+                &self.tls_insecure_skip_verify,
+            )
+            .finish()
+    }
+}
+
+impl Default for RedisQueueOptions {
+    /// Return the default standalone Redis connection settings.
+    fn default() -> Self {
+        Self {
+            mode: RedisMode::Singleton,
+            endpoints: vec!["redis://127.0.0.1:6379".to_string()],
+            master_name: None,
+            username: None,
+            password: None,
+            sentinel_username: None,
+            sentinel_password: None,
+            db: 0,
+            connect_timeout_ms: 3_000,
+            command_timeout_ms: 3_000,
+            key_prefix: "default".to_string(),
+            tls_enabled: false,
+            tls_insecure_skip_verify: false,
+        }
+    }
+}
+
+impl RedisQueueOptions {
+    /// Validate Redis endpoint and timeout settings.
+    fn validate(&self) -> Result<()> {
+        if self.endpoints.is_empty() || self.endpoints.iter().any(|value| value.trim().is_empty()) {
+            return Err(Error::config(
+                "queuefs redis endpoints must not be empty".to_string(),
+            ));
+        }
+        for value in &self.endpoints {
+            if !value.starts_with("redis://") && !value.starts_with("rediss://") {
+                return Err(Error::config(
+                    "queuefs redis endpoints must use valid redis:// or rediss:// URLs".to_string(),
+                ));
+            }
+            let info = redis::IntoConnectionInfo::into_connection_info(value.as_str()).map_err(|_| {
+                Error::config("queuefs redis endpoints must use valid redis:// or rediss:// URLs".to_string())
+            })?;
+            if matches!(
+                info.addr(),
+                redis::ConnectionAddr::Tcp(_, 0) | redis::ConnectionAddr::TcpTls { port: 0, .. }
+            ) {
+                return Err(Error::config("queuefs redis endpoint port is invalid".to_string()));
+            }
+        }
+        if self.mode == RedisMode::Singleton && self.endpoints.len() != 1 {
+            return Err(Error::config(
+                "queuefs redis singleton mode requires exactly one endpoint".to_string(),
+            ));
+        }
+        if self.mode == RedisMode::Cluster && self.db != 0 {
+            return Err(Error::config(
+                "queuefs redis cluster mode requires db=0".to_string(),
+            ));
+        }
+        if self.mode == RedisMode::Sentinel
+            && self
+                .master_name
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(Error::config(
+                "queuefs redis sentinel mode requires master_name".to_string(),
+            ));
+        }
+        if self.db < 0 {
+            return Err(Error::config("queuefs redis db must be >= 0".to_string()));
+        }
+        if self.connect_timeout_ms == 0 {
+            return Err(Error::config(
+                "queuefs redis connect_timeout_ms must be > 0".to_string(),
+            ));
+        }
+        if self.command_timeout_ms == 0 {
+            return Err(Error::config(
+                "queuefs redis command_timeout_ms must be > 0".to_string(),
+            ));
+        }
+        if self.key_prefix.trim().is_empty() {
+            return Err(Error::config(
+                "queuefs redis key_prefix must not be empty".to_string(),
+            ));
+        }
+        if self.key_prefix.contains(['{', '}']) {
+            return Err(Error::config(
+                "queuefs redis key_prefix must not contain '{' or '}'".to_string(),
+            ));
+        }
+        if self.tls_insecure_skip_verify && !self.tls_enabled {
+            return Err(Error::config(
+                "queuefs redis tls_insecure_skip_verify requires tls_enabled=true".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Parsed path information
@@ -488,7 +647,7 @@ impl QueueFSPlugin {
                     "backend",
                     "string",
                     "memory",
-                    "Queue backend (memory, sqlite, sqlite3)",
+                    "Queue backend (memory, sqlite, sqlite3, redis)",
                 ),
                 ConfigParameter::optional(
                     "db_path",
@@ -508,6 +667,12 @@ impl QueueFSPlugin {
                     "5000",
                     "SQLite busy timeout in milliseconds",
                 ),
+                ConfigParameter::optional(
+                    "redis",
+                    "json",
+                    "{}",
+                    "Redis connection settings when backend=redis",
+                ),
             ],
         }
     }
@@ -522,7 +687,7 @@ impl QueueFSPlugin {
 
     fn parse_backend_config(config: &PluginConfig) -> Result<ParsedBackendConfig> {
         let backend_name = Self::get_string_param(config, "backend").unwrap_or("memory");
-        let valid_backends = ["memory", "sqlite", "sqlite3"];
+        let valid_backends = ["memory", "sqlite", "sqlite3", "redis"];
         if !valid_backends.contains(&backend_name) {
             return Err(Error::config(format!(
                 "unsupported queue backend: {} (valid: {})",
@@ -534,6 +699,7 @@ impl QueueFSPlugin {
         let kind = match backend_name {
             "memory" => BackendKind::Memory,
             "sqlite" | "sqlite3" => BackendKind::Sqlite,
+            "redis" => BackendKind::Redis,
             _ => {
                 return Err(Error::config(format!(
                     "unsupported queue backend: {}",
@@ -560,7 +726,7 @@ impl QueueFSPlugin {
         }
 
         let sqlite_db_path = match kind {
-            BackendKind::Memory => None,
+            BackendKind::Memory | BackendKind::Redis => None,
             BackendKind::Sqlite => {
                 let db_path = Self::get_string_param(config, "db_path").unwrap_or("");
                 if db_path.trim().is_empty() {
@@ -572,6 +738,27 @@ impl QueueFSPlugin {
                 Some(db_path.to_string())
             }
         };
+        let redis_options = match kind {
+            BackendKind::Redis => {
+                let value = config.params.get("redis").ok_or_else(|| {
+                    Error::config("queuefs redis config is required when backend=redis".to_string())
+                })?;
+                let value = match value {
+                    crate::core::types::ConfigValue::Json(value) => value.clone(),
+                    _ => {
+                        return Err(Error::config(
+                            "queuefs redis config must be a JSON object".to_string(),
+                        ))
+                    }
+                };
+                let options: RedisQueueOptions = serde_json::from_value(value).map_err(|error| {
+                    Error::config(format!("invalid queuefs redis config: {error}"))
+                })?;
+                options.validate()?;
+                Some(options)
+            }
+            BackendKind::Memory | BackendKind::Sqlite => None,
+        };
 
         Ok(ParsedBackendConfig {
             kind,
@@ -580,6 +767,7 @@ impl QueueFSPlugin {
                 recover_stale_sec,
                 busy_timeout_ms,
             },
+            redis_options,
         })
     }
 }
@@ -651,6 +839,13 @@ impl ServicePlugin for QueueFSPlugin {
                     .expect("sqlite db_path is validated"),
                 parsed.sqlite_options,
             )?),
+            BackendKind::Redis => {
+                Box::new(RedisQueueBackend::open(
+                    parsed
+                        .redis_options
+                        .expect("redis options are validated for redis backend"),
+                )?)
+            }
         };
 
         Ok(Box::new(QueueFileSystem::with_backend(backend)))
@@ -671,6 +866,20 @@ mod tests {
     struct TestQueueMessage {
         id: String,
         data: String,
+    }
+
+    /// Build a QueueFS plugin config containing a nested Redis object.
+    fn redis_plugin_config(redis: serde_json::Value) -> PluginConfig {
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "backend".to_string(),
+            crate::core::types::ConfigValue::String("redis".to_string()),
+        );
+        params.insert(
+            "redis".to_string(),
+            crate::core::types::ConfigValue::Json(redis),
+        );
+        PluginConfig::single_backend("queuefs", "/queue", params)
     }
 
     /// Create a queue filesystem with one initialized queue.
@@ -895,7 +1104,7 @@ mod tests {
 
         assert_eq!(plugin.name(), "queuefs");
         assert!(!plugin.readme().is_empty());
-        assert_eq!(plugin.config_params().len(), 4);
+        assert_eq!(plugin.config_params().len(), 5);
 
         let config =
             PluginConfig::single_backend("queuefs", "/queue", std::collections::HashMap::new());
@@ -910,6 +1119,192 @@ mod tests {
         enqueue(fs.as_ref(), "test", b"test").await;
         let msg = dequeue_msg(fs.as_ref(), "test").await;
         assert_eq!(msg.data, "test");
+    }
+
+    #[test]
+    fn test_parse_redis_backend_config() {
+        let parsed = QueueFSPlugin::parse_backend_config(&redis_plugin_config(
+            serde_json::json!({
+                "mode": "singleton",
+                "endpoints": ["redis://127.0.0.1:6379"],
+                "master_name": null,
+                "username": "queue-user",
+                "password": "secret",
+                "sentinel_username": null,
+                "sentinel_password": null,
+                "db": 2,
+                "connect_timeout_ms": 1500,
+                "command_timeout_ms": 2500,
+                "key_prefix": "tenant-a",
+                "tls_enabled": false,
+                "tls_insecure_skip_verify": false
+            }),
+        ))
+        .unwrap();
+
+        assert!(matches!(parsed.kind, BackendKind::Redis));
+        let options = parsed.redis_options.unwrap();
+        assert_eq!(options.endpoints, vec!["redis://127.0.0.1:6379"]);
+        assert_eq!(options.username.as_deref(), Some("queue-user"));
+        assert_eq!(options.password.as_deref(), Some("secret"));
+        assert_eq!(options.db, 2);
+        assert_eq!(options.connect_timeout_ms, 1500);
+        assert_eq!(options.command_timeout_ms, 2500);
+        assert_eq!(options.key_prefix, "tenant-a");
+    }
+
+    #[test]
+    /// Accept valid Cluster and Sentinel topology configurations.
+    fn test_parse_redis_backend_config_accepts_high_availability_modes() {
+        let cluster = QueueFSPlugin::parse_backend_config(&redis_plugin_config(
+            serde_json::json!({
+                "mode": "cluster",
+                "endpoints": ["redis://cluster-1:6379", "redis://cluster-2:6379"],
+                "db": 0
+            }),
+        ));
+        assert!(cluster.is_ok());
+
+        let sentinel = QueueFSPlugin::parse_backend_config(&redis_plugin_config(
+            serde_json::json!({
+                "mode": "sentinel",
+                "endpoints": ["redis://sentinel-1:26379", "redis://sentinel-2:26379"],
+                "master_name": "mymaster"
+            }),
+        ));
+        assert!(sentinel.is_ok());
+    }
+
+    #[test]
+    /// Reject topology settings that violate the selected Redis mode.
+    fn test_parse_redis_backend_config_rejects_invalid_mode_settings() {
+        let cases = [
+            (serde_json::json!({"mode": "invalid"}), "invalid"),
+            (
+                serde_json::json!({
+                    "mode": "singleton",
+                    "endpoints": ["redis://redis-1:6379", "redis://redis-2:6379"]
+                }),
+                "singleton",
+            ),
+            (
+                serde_json::json!({"mode": "cluster", "endpoints": []}),
+                "endpoints",
+            ),
+            (serde_json::json!({"mode": "cluster", "db": 1}), "db"),
+            (
+                serde_json::json!({
+                    "mode": "sentinel",
+                    "endpoints": [],
+                    "master_name": "mymaster"
+                }),
+                "endpoints",
+            ),
+            (
+                serde_json::json!({"mode": "sentinel", "master_name": ""}),
+                "master_name",
+            ),
+            (
+                serde_json::json!({"key_prefix": "invalid{tag}"}),
+                "key_prefix",
+            ),
+        ];
+
+        for (redis, expected) in cases {
+            let error = QueueFSPlugin::parse_backend_config(&redis_plugin_config(redis))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(expected),
+                "expected {expected:?} in {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_redis_backend_config_rejects_empty_endpoints() {
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "backend".to_string(),
+            crate::core::types::ConfigValue::String("redis".to_string()),
+        );
+        params.insert(
+            "redis".to_string(),
+            crate::core::types::ConfigValue::Json(serde_json::json!({
+                "endpoints": []
+            })),
+        );
+        let config = PluginConfig::single_backend("queuefs", "/queue", params);
+
+        assert!(QueueFSPlugin::parse_backend_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("endpoints"));
+    }
+
+    #[test]
+    fn test_parse_redis_backend_config_rejects_invalid_endpoint() {
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "backend".to_string(),
+            crate::core::types::ConfigValue::String("redis".to_string()),
+        );
+        params.insert(
+            "redis".to_string(),
+            crate::core::types::ConfigValue::Json(serde_json::json!({
+                "endpoints": ["http://127.0.0.1:6379"]
+            })),
+        );
+        let config = PluginConfig::single_backend("queuefs", "/queue", params);
+
+        assert!(QueueFSPlugin::parse_backend_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("redis:// or rediss://"));
+    }
+
+    #[test]
+    /// Reject an empty Redis namespace prefix.
+    fn test_parse_redis_backend_config_rejects_empty_key_prefix() {
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "backend".to_string(),
+            crate::core::types::ConfigValue::String("redis".to_string()),
+        );
+        params.insert(
+            "redis".to_string(),
+            crate::core::types::ConfigValue::Json(serde_json::json!({
+                "key_prefix": ""
+            })),
+        );
+        let config = PluginConfig::single_backend("queuefs", "/queue", params);
+
+        assert!(QueueFSPlugin::parse_backend_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("key_prefix"));
+    }
+
+    #[test]
+    /// Reject the removed Redis connection pool setting.
+    fn test_parse_redis_backend_config_rejects_removed_pool_max_size() {
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "backend".to_string(),
+            crate::core::types::ConfigValue::String("redis".to_string()),
+        );
+        params.insert(
+            "redis".to_string(),
+            crate::core::types::ConfigValue::Json(serde_json::json!({
+                "pool_max_size": 16
+            })),
+        );
+        let config = PluginConfig::single_backend("queuefs", "/queue", params);
+
+        assert!(QueueFSPlugin::parse_backend_config(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("pool_max_size"));
     }
 
     #[tokio::test]

--- a/crates/ragfs/src/plugins/queuefs/mod.rs
+++ b/crates/ragfs/src/plugins/queuefs/mod.rs
@@ -183,6 +183,20 @@ impl RedisQueueOptions {
             let info = redis::IntoConnectionInfo::into_connection_info(value.as_str()).map_err(|_| {
                 Error::config("queuefs redis endpoints must use valid redis:// or rediss:// URLs".to_string())
             })?;
+            let endpoint = value
+                .split_once("://")
+                .map(|(_, endpoint)| endpoint)
+                .unwrap_or_default();
+            let options_start = endpoint
+                .find(|character| matches!(character, '/' | '?' | '#'))
+                .unwrap_or(endpoint.len());
+            if endpoint[..options_start].contains('@')
+                || !matches!(&endpoint[options_start..], "" | "/")
+            {
+                return Err(Error::config(
+                    "queuefs redis endpoints must not include credentials, database paths, query parameters, or fragments; use dedicated redis fields".to_string(),
+                ));
+            }
             if matches!(
                 info.addr(),
                 redis::ConnectionAddr::Tcp(_, 0) | redis::ConnectionAddr::TcpTls { port: 0, .. }
@@ -740,20 +754,19 @@ impl QueueFSPlugin {
         };
         let redis_options = match kind {
             BackendKind::Redis => {
-                let value = config.params.get("redis").ok_or_else(|| {
-                    Error::config("queuefs redis config is required when backend=redis".to_string())
-                })?;
-                let value = match value {
-                    crate::core::types::ConfigValue::Json(value) => value.clone(),
-                    _ => {
+                let options = match config.params.get("redis") {
+                    Some(crate::core::types::ConfigValue::Json(value)) => {
+                        serde_json::from_value(value.clone()).map_err(|error| {
+                            Error::config(format!("invalid queuefs redis config: {error}"))
+                        })?
+                    }
+                    Some(_) => {
                         return Err(Error::config(
                             "queuefs redis config must be a JSON object".to_string(),
                         ))
                     }
+                    None => RedisQueueOptions::default(),
                 };
-                let options: RedisQueueOptions = serde_json::from_value(value).map_err(|error| {
-                    Error::config(format!("invalid queuefs redis config: {error}"))
-                })?;
                 options.validate()?;
                 Some(options)
             }

--- a/crates/ragfs/src/plugins/queuefs/redis_backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/redis_backend.rs
@@ -19,6 +19,7 @@ const HEARTBEAT_TTL_SECS: u64 = 30;
 const HEARTBEAT_INTERVAL_SECS: u64 = 10;
 const REDIS_POOL_MAX_SIZE: u32 = 2;
 const REDIS_POOL_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(5);
+const SENTINEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 const CREATE_QUEUE_SCRIPT: &str = r#"
 if redis.call('SADD', KEYS[1], ARGV[1]) == 0 then
@@ -279,20 +280,26 @@ impl ManageConnection for SingletonPoolManager {
 
 struct SentinelPoolManager {
     client: Mutex<SentinelClient>,
+    discovery_runtime: tokio::runtime::Runtime,
     connect_timeout: Duration,
     command_timeout: Duration,
     generation: ConnectionGeneration,
 }
 
 impl SentinelPoolManager {
-    /// Build a Sentinel manager that rediscovers the master for every new connection.
-    fn new(client: SentinelClient, options: &RedisQueueOptions) -> Self {
-        Self {
+    /// Build a Sentinel manager from `client` and `options`, returning an initialization error.
+    fn new(client: SentinelClient, options: &RedisQueueOptions) -> RedisResult<Self> {
+        let discovery_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(RedisError::from)?;
+        Ok(Self {
             client: Mutex::new(client),
+            discovery_runtime,
             connect_timeout: Duration::from_millis(options.connect_timeout_ms),
             command_timeout: Duration::from_millis(options.command_timeout_ms),
             generation: ConnectionGeneration::default(),
-        }
+        })
     }
 }
 
@@ -302,16 +309,28 @@ impl ManageConnection for SentinelPoolManager {
 
     /// Discover the current Sentinel master and open one data connection.
     fn connect(&self) -> RedisResult<Self::Connection> {
-        let client = self
-            .client
-            .lock()
-            .map_err(|_| {
+        let client = {
+            let mut sentinel = self.client.lock().map_err(|_| {
                 RedisError::from((
                     redis::ErrorKind::Client,
                     "redis sentinel client lock poisoned",
                 ))
-            })?
-            .get_client()?;
+            })?;
+            self.discovery_runtime.block_on(async {
+                match tokio::time::timeout(
+                    SENTINEL_DISCOVERY_TIMEOUT,
+                    sentinel.async_get_client(),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "redis sentinel discovery timed out",
+                    ))),
+                }
+            })
+        }?;
         let connection = client.get_connection_with_timeout(self.connect_timeout)?;
         configure_connection(&connection, self.command_timeout)?;
         Ok(SentinelConnection::new(
@@ -365,6 +384,7 @@ impl RedisPool {
                     .collect::<RedisResult<Vec<_>>>()
                     .map_err(config_error)?;
                 let mut builder = ClusterClient::builder(nodes)
+                    .retries(0)
                     .connection_timeout(Duration::from_millis(options.connect_timeout_ms))
                     .response_timeout(Duration::from_millis(options.command_timeout_ms));
                 if let Some(username) = &options.username {
@@ -416,7 +436,8 @@ impl RedisPool {
                         .set_client_to_sentinel_tls_mode(mode);
                 }
                 let client = builder.build().map_err(config_error)?;
-                build_pool(SentinelPoolManager::new(client, options)).map(Self::Sentinel)
+                let manager = SentinelPoolManager::new(client, options).map_err(config_error)?;
+                build_pool(manager).map(Self::Sentinel)
             }
         }
     }

--- a/crates/ragfs/src/plugins/queuefs/redis_backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/redis_backend.rs
@@ -537,8 +537,8 @@ impl RedisQueueBackend {
             heartbeat_stop: None,
             heartbeat_thread: None,
         };
-        backend.recover_stale()?;
         backend.start_heartbeat(heartbeat_key);
+        backend.recover_stale()?;
         Ok(backend)
     }
 
@@ -558,12 +558,12 @@ impl RedisQueueBackend {
         self.heartbeat_stop = Some(sender);
         self.heartbeat_thread = Some(std::thread::spawn(move || {
             loop {
+                if let Err(error) = refresh_heartbeat(&pool, &key) {
+                    tracing::warn!("queuefs redis heartbeat failed: {error}");
+                }
                 match receiver.recv_timeout(Duration::from_secs(HEARTBEAT_INTERVAL_SECS)) {
                     Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
                     Err(RecvTimeoutError::Timeout) => {}
-                }
-                if let Err(error) = refresh_heartbeat(&pool, &key) {
-                    tracing::warn!("queuefs redis heartbeat failed: {error}");
                 }
             }
         }));

--- a/crates/ragfs/src/plugins/queuefs/redis_backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/redis_backend.rs
@@ -1,0 +1,1435 @@
+use super::backend::{Message, QueueBackend, StoredMessage};
+use super::{RedisMode, RedisQueueOptions};
+use crate::core::errors::{Error, Result};
+use redis::cluster::ClusterClient;
+use redis::sentinel::{SentinelClient, SentinelClientBuilder, SentinelServerType};
+use redis::{
+    Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo, RedisError,
+    RedisConnectionInfo, RedisResult, ServerErrorKind, TlsMode,
+};
+use r2d2::{ManageConnection, Pool};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+const HEARTBEAT_TTL_SECS: u64 = 30;
+const HEARTBEAT_INTERVAL_SECS: u64 = 10;
+const REDIS_POOL_MAX_SIZE: u32 = 2;
+const REDIS_POOL_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(5);
+
+const CREATE_QUEUE_SCRIPT: &str = r#"
+if redis.call('SADD', KEYS[1], ARGV[1]) == 0 then
+    return 0
+end
+redis.call('HSET', KEYS[2], 'created_at', ARGV[2], 'last_updated', ARGV[2])
+return 1
+"#;
+
+const REMOVE_QUEUE_SCRIPT: &str = r#"
+local removed = 0
+local queues = redis.call('SMEMBERS', KEYS[1])
+for _, queue in ipairs(queues) do
+    if queue == ARGV[1] or string.sub(queue, 1, string.len(ARGV[1]) + 1) == ARGV[1] .. '/' then
+        local prefix = ARGV[2] .. queue
+        local pending_key = prefix .. ':pending'
+        local processing_key = prefix .. ':processing'
+        local message_prefix = prefix .. ':msg:'
+        local pending = redis.call('LRANGE', pending_key, 0, -1)
+        for _, id in ipairs(pending) do
+            redis.call('DEL', message_prefix .. id)
+        end
+        local processing = redis.call('ZRANGE', processing_key, 0, -1)
+        for _, member in ipairs(processing) do
+            local separator = string.find(member, '|', 1, true)
+            if separator then
+                redis.call('DEL', message_prefix .. string.sub(member, 1, separator - 1))
+            end
+        end
+        redis.call('DEL', prefix .. ':meta', pending_key, processing_key)
+        redis.call('SREM', KEYS[1], queue)
+        removed = removed + 1
+    end
+end
+return removed
+"#;
+
+const ENQUEUE_SCRIPT: &str = r#"
+if redis.call('SISMEMBER', KEYS[1], ARGV[1]) == 0 then
+    return 0
+end
+redis.call('SET', KEYS[2], ARGV[3])
+redis.call('RPUSH', KEYS[3], ARGV[2])
+redis.call('HSET', KEYS[4], 'last_updated', ARGV[4])
+return 1
+"#;
+
+const DEQUEUE_SCRIPT: &str = r#"
+local id = redis.call('LPOP', KEYS[1])
+if not id then
+    return nil
+end
+local payload = redis.call('GET', ARGV[1] .. id)
+if not payload then
+    redis.call('LPUSH', KEYS[1], id)
+    return redis.error_reply('queuefs payload missing for message ' .. id)
+end
+redis.call('ZADD', KEYS[2], ARGV[3], id .. '|' .. ARGV[2])
+return {id, payload}
+"#;
+
+const PEEK_SCRIPT: &str = r#"
+local id = redis.call('LINDEX', KEYS[1], 0)
+if not id then
+    return nil
+end
+local payload = redis.call('GET', ARGV[1] .. id)
+if not payload then
+    return redis.error_reply('queuefs payload missing for message ' .. id)
+end
+return payload
+"#;
+
+const LIST_UNACKED_SCRIPT: &str = r#"
+local result = {}
+local pending = redis.call('LRANGE', KEYS[1], 0, -1)
+for _, id in ipairs(pending) do
+    local payload = redis.call('GET', ARGV[1] .. id)
+    if not payload then
+        return redis.error_reply('queuefs payload missing for message ' .. id)
+    end
+    table.insert(result, payload)
+end
+local processing = redis.call('ZRANGE', KEYS[2], 0, -1)
+for _, member in ipairs(processing) do
+    local separator = string.find(member, '|', 1, true)
+    if separator then
+        local id = string.sub(member, 1, separator - 1)
+        local payload = redis.call('GET', ARGV[1] .. id)
+        if not payload then
+            return redis.error_reply('queuefs payload missing for message ' .. id)
+        end
+        table.insert(result, payload)
+    end
+end
+return result
+"#;
+
+const ACK_SCRIPT: &str = r#"
+local members = redis.call('ZRANGE', KEYS[1], 0, -1)
+for _, member in ipairs(members) do
+    if string.sub(member, 1, string.len(ARGV[1]) + 1) == ARGV[1] .. '|' then
+        redis.call('ZREM', KEYS[1], member)
+        redis.call('DEL', KEYS[2])
+        return 1
+    end
+end
+return 0
+"#;
+
+const CLEAR_SCRIPT: &str = r#"
+local pending = redis.call('LRANGE', KEYS[1], 0, -1)
+for _, id in ipairs(pending) do
+    redis.call('DEL', ARGV[1] .. id)
+end
+local processing = redis.call('ZRANGE', KEYS[2], 0, -1)
+for _, member in ipairs(processing) do
+    local separator = string.find(member, '|', 1, true)
+    if separator then
+        redis.call('DEL', ARGV[1] .. string.sub(member, 1, separator - 1))
+    end
+end
+redis.call('DEL', KEYS[1], KEYS[2])
+return #pending + #processing
+"#;
+
+const RECOVER_STALE_SCRIPT: &str = r#"
+local recovered = 0
+local members = redis.call('ZRANGE', KEYS[1], 0, -1)
+for _, member in ipairs(members) do
+    local separator = string.find(member, '|', 1, true)
+    if separator then
+        local id = string.sub(member, 1, separator - 1)
+        local instance = string.sub(member, separator + 1)
+        if redis.call('EXISTS', ARGV[1] .. instance .. ':alive') == 0 then
+            redis.call('ZREM', KEYS[1], member)
+            redis.call('RPUSH', KEYS[2], id)
+            recovered = recovered + 1
+        end
+    end
+end
+return recovered
+"#;
+
+struct QueueKeys {
+    meta: String,
+    pending: String,
+    processing: String,
+    message_prefix: String,
+}
+
+impl QueueKeys {
+    /// Build all Redis keys owned by one queue.
+    fn new(key_prefix: &str, queue: &str) -> Self {
+        let prefix = format!("{}{queue}", queue_key_prefix(key_prefix));
+        Self {
+            meta: format!("{prefix}:meta"),
+            pending: format!("{prefix}:pending"),
+            processing: format!("{prefix}:processing"),
+            message_prefix: format!("{prefix}:msg:"),
+        }
+    }
+
+    /// Build the payload key for one message.
+    fn message(&self, message_id: &str) -> String {
+        format!("{}{message_id}", self.message_prefix)
+    }
+}
+
+struct SentinelConnection {
+    connection: Connection,
+    generation: ConnectionGeneration,
+    snapshot: u64,
+}
+
+impl SentinelConnection {
+    /// Wrap one Sentinel connection with the current topology generation.
+    fn new(connection: Connection, generation: ConnectionGeneration) -> Self {
+        let snapshot = generation.snapshot();
+        Self {
+            connection,
+            generation,
+            snapshot,
+        }
+    }
+
+    /// Invalidate this and every other connection from the same Sentinel generation.
+    fn invalidate_topology(&self) {
+        self.generation.invalidate();
+    }
+
+    /// Return whether this connection belongs to the current Sentinel topology.
+    fn is_current(&self) -> bool {
+        self.generation.is_current(self.snapshot)
+    }
+}
+
+#[derive(Clone, Default)]
+struct ConnectionGeneration(Arc<AtomicU64>);
+
+impl ConnectionGeneration {
+    /// Capture the generation assigned to a newly created connection.
+    fn snapshot(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// Advance the generation after a Sentinel topology error.
+    fn invalidate(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Return whether a connection belongs to the current generation.
+    fn is_current(&self, snapshot: u64) -> bool {
+        self.snapshot() == snapshot
+    }
+}
+
+struct SingletonPoolManager {
+    client: redis::Client,
+    connect_timeout: Duration,
+    command_timeout: Duration,
+}
+
+impl SingletonPoolManager {
+    /// Build a Singleton manager with physical connect and command timeouts.
+    fn new(client: redis::Client, options: &RedisQueueOptions) -> Self {
+        Self {
+            client,
+            connect_timeout: Duration::from_millis(options.connect_timeout_ms),
+            command_timeout: Duration::from_millis(options.command_timeout_ms),
+        }
+    }
+}
+
+impl ManageConnection for SingletonPoolManager {
+    type Connection = Connection;
+    type Error = RedisError;
+
+    /// Open one Singleton connection with the configured physical connect timeout.
+    fn connect(&self) -> RedisResult<Self::Connection> {
+        let connection = self
+            .client
+            .get_connection_with_timeout(self.connect_timeout)?;
+        configure_connection(&connection, self.command_timeout)?;
+        Ok(connection)
+    }
+
+    /// Validate one checked-out Singleton connection.
+    fn is_valid(&self, connection: &mut Self::Connection) -> RedisResult<()> {
+        validate_connection(connection)
+    }
+
+    /// Return whether r2d2 must discard this Singleton connection.
+    fn has_broken(&self, connection: &mut Self::Connection) -> bool {
+        !connection.is_open()
+    }
+}
+
+struct SentinelPoolManager {
+    client: Mutex<SentinelClient>,
+    connect_timeout: Duration,
+    command_timeout: Duration,
+    generation: ConnectionGeneration,
+}
+
+impl SentinelPoolManager {
+    /// Build a Sentinel manager that rediscovers the master for every new connection.
+    fn new(client: SentinelClient, options: &RedisQueueOptions) -> Self {
+        Self {
+            client: Mutex::new(client),
+            connect_timeout: Duration::from_millis(options.connect_timeout_ms),
+            command_timeout: Duration::from_millis(options.command_timeout_ms),
+            generation: ConnectionGeneration::default(),
+        }
+    }
+}
+
+impl ManageConnection for SentinelPoolManager {
+    type Connection = SentinelConnection;
+    type Error = RedisError;
+
+    /// Discover the current Sentinel master and open one data connection.
+    fn connect(&self) -> RedisResult<Self::Connection> {
+        let client = self
+            .client
+            .lock()
+            .map_err(|_| {
+                RedisError::from((
+                    redis::ErrorKind::Client,
+                    "redis sentinel client lock poisoned",
+                ))
+            })?
+            .get_client()?;
+        let connection = client.get_connection_with_timeout(self.connect_timeout)?;
+        configure_connection(&connection, self.command_timeout)?;
+        Ok(SentinelConnection::new(
+            connection,
+            self.generation.clone(),
+        ))
+    }
+
+    /// Validate one checked-out Sentinel data connection.
+    fn is_valid(&self, connection: &mut Self::Connection) -> RedisResult<()> {
+        if !connection.is_current() {
+            return Err(RedisError::from((
+                redis::ErrorKind::Io,
+                "redis sentinel topology changed",
+            )));
+        }
+        validate_connection(&mut connection.connection)
+    }
+
+    /// Return whether r2d2 must discard this Sentinel data connection.
+    fn has_broken(&self, connection: &mut Self::Connection) -> bool {
+        !connection.is_current() || !connection.connection.is_open()
+    }
+}
+
+#[derive(Clone)]
+enum RedisPool {
+    Singleton(Pool<SingletonPoolManager>),
+    Cluster(Pool<ClusterClient>),
+    Sentinel(Pool<SentinelPoolManager>),
+}
+
+impl RedisPool {
+    /// Build and initialize the configured topology pool.
+    fn open(options: &RedisQueueOptions) -> Result<Self> {
+        let config_error = |error| {
+            Error::config(format!("invalid queuefs redis client configuration: {error}"))
+        };
+        match options.mode {
+            RedisMode::Singleton => {
+                let info = endpoint_connection_info(&options.endpoints[0], options)
+                    .map_err(config_error)?;
+                let client = redis::Client::open(info).map_err(config_error)?;
+                build_pool(SingletonPoolManager::new(client, options)).map(Self::Singleton)
+            }
+            RedisMode::Cluster => {
+                let nodes = options
+                    .endpoints
+                    .iter()
+                    .map(|endpoint| endpoint_connection_info(endpoint, options))
+                    .collect::<RedisResult<Vec<_>>>()
+                    .map_err(config_error)?;
+                let mut builder = ClusterClient::builder(nodes)
+                    .connection_timeout(Duration::from_millis(options.connect_timeout_ms))
+                    .response_timeout(Duration::from_millis(options.command_timeout_ms));
+                if let Some(username) = &options.username {
+                    builder = builder.username(username.clone());
+                }
+                if let Some(password) = &options.password {
+                    builder = builder.password(password.clone());
+                }
+                if options.tls_enabled {
+                    builder = builder
+                        .tls(tls_mode(options))
+                        .danger_accept_invalid_hostnames(options.tls_insecure_skip_verify);
+                }
+                build_pool(builder.build().map_err(config_error)?).map(Self::Cluster)
+            }
+            RedisMode::Sentinel => {
+                let sentinels = options
+                    .endpoints
+                    .iter()
+                    .map(|endpoint| sentinel_addr(endpoint, options))
+                    .collect::<RedisResult<Vec<_>>>()
+                    .map_err(config_error)?;
+                let mut builder = SentinelClientBuilder::new(
+                    sentinels,
+                    options
+                        .master_name
+                        .clone()
+                        .expect("sentinel master_name is validated"),
+                    SentinelServerType::Master,
+                )
+                .map_err(config_error)?
+                .set_client_to_redis_db(options.db);
+                if let Some(username) = &options.username {
+                    builder = builder.set_client_to_redis_username(username.clone());
+                }
+                if let Some(password) = &options.password {
+                    builder = builder.set_client_to_redis_password(password.clone());
+                }
+                if let Some(username) = &options.sentinel_username {
+                    builder = builder.set_client_to_sentinel_username(username.clone());
+                }
+                if let Some(password) = &options.sentinel_password {
+                    builder = builder.set_client_to_sentinel_password(password.clone());
+                }
+                if options.tls_enabled {
+                    let mode = tls_mode(options);
+                    builder = builder
+                        .set_client_to_redis_tls_mode(mode)
+                        .set_client_to_sentinel_tls_mode(mode);
+                }
+                let client = builder.build().map_err(config_error)?;
+                build_pool(SentinelPoolManager::new(client, options)).map(Self::Sentinel)
+            }
+        }
+    }
+
+    /// Checkout one pooled connection and execute one command without replaying failures.
+    fn execute<T>(
+        &self,
+        operation: &str,
+        call: impl FnOnce(&mut dyn ConnectionLike) -> RedisResult<T>,
+    ) -> Result<T> {
+        match self {
+            Self::Singleton(pool) => execute_pool(pool, operation, call),
+            Self::Cluster(pool) => execute_pool(pool, operation, call),
+            Self::Sentinel(pool) => {
+                let mut connection = pool.get().map_err(|error| pool_error(operation, error))?;
+                let result = call(&mut connection.connection);
+                if let Err(error) = &result {
+                    if is_sentinel_topology_error(error) {
+                        connection.invalidate_topology();
+                    }
+                }
+                result.map_err(|error| redis_error(operation, error))
+            }
+        }
+    }
+
+    /// Execute one best-effort command only when an idle pooled connection is available.
+    fn try_execute<T>(
+        &self,
+        call: impl FnOnce(&mut dyn ConnectionLike) -> RedisResult<T>,
+    ) -> Option<RedisResult<T>> {
+        match self {
+            Self::Singleton(pool) => try_execute_pool(pool, call),
+            Self::Cluster(pool) => try_execute_pool(pool, call),
+            Self::Sentinel(pool) => {
+                let mut connection = pool.try_get()?;
+                let result = call(&mut connection.connection);
+                if let Err(error) = &result {
+                    if is_sentinel_topology_error(error) {
+                        connection.invalidate_topology();
+                    }
+                }
+                Some(result)
+            }
+        }
+    }
+}
+
+/// Execute one command through a pool backed by a redis-rs native manager.
+fn execute_pool<M, T>(
+    pool: &Pool<M>,
+    operation: &str,
+    call: impl FnOnce(&mut dyn ConnectionLike) -> RedisResult<T>,
+) -> Result<T>
+where
+    M: ManageConnection,
+    M::Connection: ConnectionLike,
+{
+    let mut connection = pool.get().map_err(|error| pool_error(operation, error))?;
+    call(&mut *connection).map_err(|error| redis_error(operation, error))
+}
+
+/// Execute one best-effort command through an available native pooled connection.
+fn try_execute_pool<M, T>(
+    pool: &Pool<M>,
+    call: impl FnOnce(&mut dyn ConnectionLike) -> RedisResult<T>,
+) -> Option<RedisResult<T>>
+where
+    M: ManageConnection,
+    M::Connection: ConnectionLike,
+{
+    let mut connection = pool.try_get()?;
+    Some(call(&mut *connection))
+}
+
+/// Redis-backed QueueFS implementation.
+pub(super) struct RedisQueueBackend {
+    pool: RedisPool,
+    key_prefix: String,
+    instance_id: String,
+    heartbeat_stop: Option<Sender<()>>,
+    heartbeat_thread: Option<JoinHandle<()>>,
+}
+
+impl RedisQueueBackend {
+    /// Connect to Redis, register this instance, recover stale work, and start heartbeats.
+    pub(super) fn open(options: RedisQueueOptions) -> Result<Self> {
+        let pool = RedisPool::open(&options)?;
+        let key_prefix = options.key_prefix;
+        let instance_id = Uuid::new_v4().to_string();
+        let heartbeat_key = heartbeat_key(&key_prefix, &instance_id);
+        refresh_heartbeat(&pool, &heartbeat_key)?;
+        let mut backend = Self {
+            pool,
+            key_prefix,
+            instance_id,
+            heartbeat_stop: None,
+            heartbeat_thread: None,
+        };
+        backend.recover_stale()?;
+        backend.start_heartbeat(heartbeat_key);
+        Ok(backend)
+    }
+
+    /// Execute a Redis operation using one checked-out pooled connection.
+    fn with_connection<T>(
+        &self,
+        operation: &str,
+        call: impl FnOnce(&mut dyn ConnectionLike) -> redis::RedisResult<T>,
+    ) -> Result<T> {
+        self.pool.execute(operation, call)
+    }
+
+    /// Start the heartbeat thread using a separate pool checkout for every renewal.
+    fn start_heartbeat(&mut self, key: String) {
+        let (sender, receiver) = mpsc::channel();
+        let pool = self.pool.clone();
+        self.heartbeat_stop = Some(sender);
+        self.heartbeat_thread = Some(std::thread::spawn(move || {
+            loop {
+                match receiver.recv_timeout(Duration::from_secs(HEARTBEAT_INTERVAL_SECS)) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
+                    Err(RecvTimeoutError::Timeout) => {}
+                }
+                if let Err(error) = refresh_heartbeat(&pool, &key) {
+                    tracing::warn!("queuefs redis heartbeat failed: {error}");
+                }
+            }
+        }));
+    }
+
+    /// Recover processing messages whose owning instance heartbeat has expired.
+    fn recover_stale(&self) -> Result<usize> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        let instance_key_prefix = instance_key_prefix(&self.key_prefix);
+        let queues = self.with_connection("recover_stale list queues", |connection| {
+            redis::cmd("SMEMBERS")
+                .arg(&queue_names_key)
+                .query::<Vec<String>>(connection)
+        })?;
+        let mut recovered = 0;
+        for queue in queues {
+            let keys = QueueKeys::new(&self.key_prefix, &queue);
+            recovered += self.with_connection("recover_stale", |connection| {
+                redis::Script::new(RECOVER_STALE_SCRIPT)
+                    .key(&keys.processing)
+                    .key(&keys.pending)
+                    .arg(&instance_key_prefix)
+                    .invoke::<usize>(connection)
+            })?;
+        }
+        Ok(recovered)
+    }
+
+    /// Deserialize one stored Redis payload.
+    fn decode_message(payload: &str) -> Result<Message> {
+        serde_json::from_str::<StoredMessage>(payload)
+            .map(StoredMessage::into_message)
+            .map_err(|error| Error::Serialization(format!("invalid queue payload: {error}")))
+    }
+
+    /// Require that a queue is registered.
+    fn require_queue(&self, queue_name: &str) -> Result<()> {
+        if self.queue_exists_result(queue_name)? {
+            Ok(())
+        } else {
+            Err(Error::NotFound(format!(
+                "queue '{}' not found",
+                queue_name
+            )))
+        }
+    }
+
+    /// Return whether a queue is registered while preserving Redis failures.
+    fn queue_exists_result(&self, queue_name: &str) -> Result<bool> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        self.with_connection("queue_exists", |connection| {
+            redis::cmd("SISMEMBER")
+                .arg(&queue_names_key)
+                .arg(queue_name)
+                .query::<bool>(connection)
+        })
+    }
+}
+
+impl Drop for RedisQueueBackend {
+    /// Stop and join the heartbeat thread without waiting for its next interval.
+    fn drop(&mut self) {
+        if let Some(sender) = self.heartbeat_stop.take() {
+            let _ = sender.send(());
+        }
+        if let Some(thread) = self.heartbeat_thread.take() {
+            let _ = thread.join();
+        }
+        let _ = self.pool.try_execute(|connection| {
+            redis::cmd("DEL")
+                .arg(heartbeat_key(&self.key_prefix, &self.instance_id))
+                .query::<()>(connection)
+        });
+    }
+}
+
+impl QueueBackend for RedisQueueBackend {
+    /// Create a queue and its metadata atomically.
+    fn create_queue(&mut self, name: &str) -> Result<()> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        let keys = QueueKeys::new(&self.key_prefix, name);
+        let created = self.with_connection("create_queue", |connection| {
+            redis::Script::new(CREATE_QUEUE_SCRIPT)
+                .key(&queue_names_key)
+                .key(&keys.meta)
+                .arg(name)
+                .arg(unix_secs(SystemTime::now()))
+                .invoke::<i64>(connection)
+        })?;
+        if created == 0 {
+            return Err(Error::AlreadyExists(format!(
+                "queue '{}' already exists",
+                name
+            )));
+        }
+        Ok(())
+    }
+
+    /// Remove a queue and all of its Redis keys atomically.
+    fn remove_queue(&mut self, name: &str) -> Result<()> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        let queue_key_prefix = queue_key_prefix(&self.key_prefix);
+        let removed = self.with_connection("remove_queue", |connection| {
+            redis::Script::new(REMOVE_QUEUE_SCRIPT)
+                .key(&queue_names_key)
+                .arg(name)
+                .arg(&queue_key_prefix)
+                .invoke::<i64>(connection)
+        })?;
+        if removed == 0 {
+            return Err(Error::NotFound(format!("queue '{}' not found", name)));
+        }
+        Ok(())
+    }
+
+    /// Return whether a queue is registered.
+    fn queue_exists(&self, name: &str) -> bool {
+        match self.queue_exists_result(name) {
+            Ok(exists) => exists,
+            Err(error) => {
+                tracing::error!(
+                    queue = name,
+                    error = %error,
+                    "queuefs redis queue_exists failed; returning false"
+                );
+                false
+            }
+        }
+    }
+
+    /// List registered queues matching the requested prefix.
+    fn list_queues(&self, prefix: &str) -> Vec<String> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        let mut queues = match self.with_connection("list_queues", |connection| {
+            redis::cmd("SMEMBERS")
+                .arg(&queue_names_key)
+                .query::<Vec<String>>(connection)
+        }) {
+            Ok(queues) => queues,
+            Err(error) => {
+                tracing::error!(
+                    prefix,
+                    error = %error,
+                    "queuefs redis list_queues failed; returning an empty list"
+                );
+                return Vec::new();
+            }
+        };
+        queues.retain(|queue| queue.starts_with(prefix));
+        queues.sort();
+        queues
+    }
+
+    /// Store a payload and append its ID to the pending list atomically.
+    fn enqueue(&mut self, queue_name: &str, msg: Message) -> Result<()> {
+        let queue_names_key = queue_names_key(&self.key_prefix);
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        let payload = serde_json::to_string(&StoredMessage::from_message(&msg))?;
+        let enqueued = self.with_connection("enqueue", |connection| {
+            redis::Script::new(ENQUEUE_SCRIPT)
+                .key(&queue_names_key)
+                .key(keys.message(&msg.id))
+                .key(&keys.pending)
+                .key(&keys.meta)
+                .arg(queue_name)
+                .arg(&msg.id)
+                .arg(&payload)
+                .arg(unix_secs(SystemTime::now()))
+                .invoke::<i64>(connection)
+        })?;
+        if enqueued == 0 {
+            return Err(Error::NotFound(format!(
+                "queue '{}' not found",
+                queue_name
+            )));
+        }
+        Ok(())
+    }
+
+    /// Move the oldest pending message to processing and return its payload atomically.
+    fn dequeue(&mut self, queue_name: &str) -> Result<Option<Message>> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        let result = self.with_connection("dequeue", |connection| {
+            redis::Script::new(DEQUEUE_SCRIPT)
+                .key(&keys.pending)
+                .key(&keys.processing)
+                .arg(&keys.message_prefix)
+                .arg(&self.instance_id)
+                .arg(unix_secs(SystemTime::now()))
+                .invoke::<Option<Vec<String>>>(connection)
+        })?;
+        result
+            .map(|values| {
+                values
+                    .get(1)
+                    .ok_or_else(|| Error::internal("redis dequeue returned no payload"))
+                    .and_then(|payload| Self::decode_message(payload))
+            })
+            .transpose()
+    }
+
+    /// Read the oldest pending payload without changing queue state.
+    fn peek(&self, queue_name: &str) -> Result<Option<Message>> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        self.with_connection("peek", |connection| {
+            redis::Script::new(PEEK_SCRIPT)
+                .key(&keys.pending)
+                .arg(&keys.message_prefix)
+                .invoke::<Option<String>>(connection)
+        })?
+        .map(|payload| Self::decode_message(&payload))
+        .transpose()
+    }
+
+    /// Return the number of pending messages.
+    fn size(&self, queue_name: &str) -> Result<usize> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        self.with_connection("size", |connection| {
+            redis::cmd("LLEN")
+                .arg(&keys.pending)
+                .query::<usize>(connection)
+        })
+    }
+
+    /// Return all pending and processing messages without changing their state.
+    fn list_unacked(&self, queue_name: &str) -> Result<Vec<Message>> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        let payloads = self.with_connection("list_unacked", |connection| {
+            redis::Script::new(LIST_UNACKED_SCRIPT)
+                .key(&keys.pending)
+                .key(&keys.processing)
+                .arg(&keys.message_prefix)
+                .invoke::<Vec<String>>(connection)
+        })?;
+        payloads
+            .iter()
+            .map(|payload| Self::decode_message(payload))
+            .collect()
+    }
+
+    /// Delete all pending, processing, and payload keys for one queue atomically.
+    fn clear(&mut self, queue_name: &str) -> Result<()> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        self.with_connection("clear", |connection| {
+            redis::Script::new(CLEAR_SCRIPT)
+                .key(&keys.pending)
+                .key(&keys.processing)
+                .arg(&keys.message_prefix)
+                .invoke::<usize>(connection)
+        })?;
+        Ok(())
+    }
+
+    /// Return the latest timestamp among the current pending messages.
+    fn get_last_enqueue_time(&self, queue_name: &str) -> Result<SystemTime> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        let pending_ids = self.with_connection("get_last_enqueue_time list pending", |connection| {
+            redis::cmd("LRANGE")
+                .arg(&keys.pending)
+                .arg(0)
+                .arg(-1)
+                .query::<Vec<String>>(connection)
+        })?;
+        if pending_ids.is_empty() {
+            return Ok(UNIX_EPOCH);
+        }
+        let payloads = self.with_connection("get_last_enqueue_time load payloads", |connection| {
+            let mut command = redis::cmd("MGET");
+            for id in &pending_ids {
+                command.arg(keys.message(id));
+            }
+            command.query::<Vec<Option<String>>>(connection)
+        })?;
+        let payloads = payloads
+            .into_iter()
+            .enumerate()
+            .map(|(index, payload)| {
+                payload.ok_or_else(|| {
+                    Error::internal(format!(
+                        "redis get_last_enqueue_time missing payload for message {}",
+                        pending_ids[index]
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // ponytail: scan current pending payloads on demand; if this becomes hot, add a dedicated pending timestamp index.
+        last_enqueue_time_from_pending_payloads(&payloads)
+    }
+
+    /// Remove a processing record and its payload atomically.
+    fn ack(&mut self, queue_name: &str, msg_id: &str) -> Result<bool> {
+        self.require_queue(queue_name)?;
+        let keys = QueueKeys::new(&self.key_prefix, queue_name);
+        self.with_connection("ack", |connection| {
+            redis::Script::new(ACK_SCRIPT)
+                .key(&keys.processing)
+                .key(keys.message(msg_id))
+                .arg(msg_id)
+                .invoke::<bool>(connection)
+        })
+    }
+}
+
+/// Return the queue registry key for one namespace.
+fn queue_names_key(key_prefix: &str) -> String {
+    format!("{}names", queue_key_prefix(key_prefix))
+}
+
+/// Return the queue key prefix for one namespace.
+fn queue_key_prefix(key_prefix: &str) -> String {
+    format!("{{{key_prefix}}}:ov:queue:")
+}
+
+/// Return the instance key prefix for one namespace.
+fn instance_key_prefix(key_prefix: &str) -> String {
+    format!("{}instance:", queue_key_prefix(key_prefix))
+}
+
+/// Return the heartbeat key for one instance.
+fn heartbeat_key(key_prefix: &str, instance_id: &str) -> String {
+    format!("{}{instance_id}:alive", instance_key_prefix(key_prefix))
+}
+
+/// Return Unix seconds for Redis scores and metadata.
+fn unix_secs(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+/// Return the latest timestamp among the current pending payloads.
+fn last_enqueue_time_from_pending_payloads(payloads: &[String]) -> Result<SystemTime> {
+    payloads.iter().try_fold(UNIX_EPOCH, |latest, payload| {
+        let timestamp = serde_json::from_str::<StoredMessage>(payload)
+            .map(StoredMessage::into_message)
+            .map(|message| message.timestamp)
+            .map_err(|error| Error::Serialization(format!("invalid queue payload: {error}")))?;
+        Ok(if timestamp > latest { timestamp } else { latest })
+    })
+}
+
+/// Build one data-node connection descriptor with authentication, database, and TLS.
+fn endpoint_connection_info(
+    endpoint: &str,
+    options: &RedisQueueOptions,
+) -> redis::RedisResult<ConnectionInfo> {
+    let info = endpoint.into_connection_info()?;
+    let mut redis_settings = RedisConnectionInfo::default()
+        .set_db(options.db)
+        .set_protocol(info.redis_settings().protocol());
+    if let Some(username) = &options.username {
+        redis_settings = redis_settings.set_username(username);
+    }
+    if let Some(password) = &options.password {
+        redis_settings = redis_settings.set_password(password);
+    }
+    let address = if options.tls_enabled {
+        force_tls(info.addr().clone(), options.tls_insecure_skip_verify)
+    } else {
+        info.addr().clone()
+    };
+    Ok(info
+        .set_redis_settings(redis_settings)
+        .set_addr(address))
+}
+
+/// Build one Sentinel node address with the configured transport security.
+fn sentinel_addr(
+    endpoint: &str,
+    options: &RedisQueueOptions,
+) -> redis::RedisResult<ConnectionAddr> {
+    let info = endpoint.into_connection_info()?;
+    Ok(if options.tls_enabled {
+        force_tls(info.addr().clone(), options.tls_insecure_skip_verify)
+    } else {
+        info.addr().clone()
+    })
+}
+
+/// Convert a TCP address into its TLS form while preserving non-TCP transports.
+fn force_tls(address: ConnectionAddr, insecure: bool) -> ConnectionAddr {
+    match address {
+        ConnectionAddr::Tcp(host, port) | ConnectionAddr::TcpTls { host, port, .. } => {
+            ConnectionAddr::TcpTls {
+                host,
+                port,
+                insecure,
+                tls_params: None,
+            }
+        }
+        address => address,
+    }
+}
+
+/// Return the redis-rs TLS mode represented by QueueFS settings.
+fn tls_mode(options: &RedisQueueOptions) -> TlsMode {
+    if options.tls_insecure_skip_verify {
+        TlsMode::Insecure
+    } else {
+        TlsMode::Secure
+    }
+}
+
+/// Apply QueueFS command timeouts to one direct Redis connection.
+fn configure_connection(
+    connection: &Connection,
+    command_timeout: Duration,
+) -> redis::RedisResult<()> {
+    let timeout = Some(command_timeout);
+    connection.set_read_timeout(timeout)?;
+    connection.set_write_timeout(timeout)?;
+    Ok(())
+}
+
+/// Validate that one direct Redis connection is still usable.
+fn validate_connection(connection: &mut Connection) -> RedisResult<()> {
+    if connection.check_connection() {
+        Ok(())
+    } else {
+        Err(RedisError::from((
+            redis::ErrorKind::Io,
+            "redis connection closed",
+        )))
+    }
+}
+
+/// Return whether one Sentinel response means the connected master is no longer writable.
+fn is_sentinel_topology_error(error: &RedisError) -> bool {
+    matches!(
+        error.kind(),
+        redis::ErrorKind::Server(ServerErrorKind::ReadOnly | ServerErrorKind::MasterDown)
+    )
+}
+
+/// Build one initialized r2d2 pool with the QueueFS capacity and checkout timeout.
+fn build_pool<M>(manager: M) -> Result<Pool<M>>
+where
+    M: ManageConnection,
+{
+    Pool::builder()
+        .max_size(REDIS_POOL_MAX_SIZE)
+        .connection_timeout(REDIS_POOL_CHECKOUT_TIMEOUT)
+        .build(manager)
+        .map_err(|error| pool_error("connect", error))
+}
+
+/// Map r2d2 initialization and checkout failures into a QueueFS network error.
+fn pool_error(operation: &str, error: r2d2::Error) -> Error {
+    Error::Network(format!("redis {operation} pool error: {error}"))
+}
+
+/// Refresh one instance heartbeat through one pooled logical connection.
+fn refresh_heartbeat(pool: &RedisPool, key: &str) -> Result<()> {
+    pool.execute("heartbeat", |connection| {
+        redis::cmd("SET")
+            .arg(key)
+            .arg("1")
+            .arg("EX")
+            .arg(HEARTBEAT_TTL_SECS)
+            .query::<()>(connection)
+    })
+}
+
+/// Map redis-rs failures into the QueueFS error categories.
+fn redis_error(operation: &str, error: redis::RedisError) -> Error {
+    if error.is_timeout() {
+        Error::Timeout(format!("redis {operation} error: {error}"))
+    } else if error.is_io_error() || error.is_connection_dropped() {
+        Error::Network(format!("redis {operation} error: {error}"))
+    } else {
+        Error::internal(format!("redis {operation} error: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant, UNIX_EPOCH};
+
+    /// Exercise one complete QueueFS message lifecycle.
+    fn assert_queue_flow(mut backend: RedisQueueBackend) {
+        let queue = format!("queuefs-test-{}", Uuid::new_v4());
+        backend.create_queue(&queue).unwrap();
+        let message = Message::new(b"topology".to_vec());
+        let message_id = message.id.clone();
+        backend.enqueue(&queue, message).unwrap();
+        assert_eq!(backend.peek(&queue).unwrap().unwrap().id, message_id);
+        assert_eq!(backend.dequeue(&queue).unwrap().unwrap().id, message_id);
+        assert!(backend.ack(&queue, &message_id).unwrap());
+        backend.remove_queue(&queue).unwrap();
+    }
+
+    #[test]
+    /// Build queue keys under the configured namespace.
+    fn queue_keys_use_the_documented_layout() {
+        let keys = QueueKeys::new("tenant-a", "Semantic");
+
+        assert_eq!(queue_names_key("tenant-a"), "{tenant-a}:ov:queue:names");
+        assert_eq!(keys.meta, "{tenant-a}:ov:queue:Semantic:meta");
+        assert_eq!(keys.pending, "{tenant-a}:ov:queue:Semantic:pending");
+        assert_eq!(
+            keys.processing,
+            "{tenant-a}:ov:queue:Semantic:processing"
+        );
+        assert_eq!(
+            keys.message("message-id"),
+            "{tenant-a}:ov:queue:Semantic:msg:message-id"
+        );
+        assert_eq!(
+            heartbeat_key("tenant-a", "instance-id"),
+            "{tenant-a}:ov:queue:instance:instance-id:alive"
+        );
+    }
+
+    #[test]
+    /// Derive the last enqueue time from the latest pending message timestamp.
+    fn last_enqueue_time_comes_from_pending_messages() {
+        let mut first = Message::new(b"first".to_vec());
+        first.timestamp = UNIX_EPOCH + Duration::from_secs(10);
+        let mut second = Message::new(b"second".to_vec());
+        second.timestamp = UNIX_EPOCH + Duration::from_secs(20);
+        let payloads = vec![
+            serde_json::to_string(&StoredMessage::from_message(&first)).unwrap(),
+            serde_json::to_string(&StoredMessage::from_message(&second)).unwrap(),
+        ];
+
+        assert_eq!(
+            last_enqueue_time_from_pending_payloads(&payloads).unwrap(),
+            UNIX_EPOCH + Duration::from_secs(20)
+        );
+    }
+
+    #[test]
+    /// Discard Sentinel connections only for errors that indicate a stale master.
+    fn sentinel_topology_errors_invalidate_the_connection() {
+        assert!(is_sentinel_topology_error(&redis::RedisError::from((
+            redis::ErrorKind::Server(ServerErrorKind::ReadOnly),
+            "old master is read-only",
+        ))));
+        assert!(is_sentinel_topology_error(&redis::RedisError::from((
+            redis::ErrorKind::Server(ServerErrorKind::MasterDown),
+            "master is down",
+        ))));
+        assert!(!is_sentinel_topology_error(&redis::RedisError::from((
+            redis::ErrorKind::Server(ServerErrorKind::ResponseError),
+            "ordinary command error",
+        ))));
+    }
+
+    #[test]
+    /// Invalidate every pooled Sentinel connection created before a topology change.
+    fn sentinel_topology_generation_invalidates_all_old_connections() {
+        let generation = ConnectionGeneration::default();
+        let first = generation.snapshot();
+        let second = generation.snapshot();
+        assert!(generation.is_current(first));
+        assert!(generation.is_current(second));
+
+        generation.invalidate();
+
+        assert!(!generation.is_current(first));
+        assert!(!generation.is_current(second));
+        assert!(generation.is_current(generation.snapshot()));
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Replace a dead Singleton connection before use without replaying command failures.
+    fn redis_backend_reconnects_singleton_after_disconnect() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let mut backend = RedisQueueBackend::open(RedisQueueOptions {
+            endpoints: vec![endpoint.clone()],
+            key_prefix: format!("queuefs-test-{}", Uuid::new_v4()),
+            ..RedisQueueOptions::default()
+        })
+        .unwrap();
+        backend.create_queue("reconnect").unwrap();
+        let client_id = backend
+            .with_connection("test client id", |connection| {
+                redis::cmd("CLIENT").arg("ID").query::<i64>(connection)
+            })
+            .unwrap();
+        let mut control = redis::Client::open(endpoint)
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        redis::cmd("CLIENT")
+            .arg("KILL")
+            .arg("ID")
+            .arg(client_id)
+            .query::<usize>(&mut control)
+            .unwrap();
+
+        assert_eq!(backend.size("reconnect").unwrap(), 0);
+
+        let mut command_calls = 0;
+        let result = backend.with_connection("test command failure", |_connection| {
+            command_calls += 1;
+            RedisResult::<()>::Err(redis::RedisError::from((
+                redis::ErrorKind::Server(ServerErrorKind::ResponseError),
+                "test command failure",
+            )))
+        });
+        assert!(result.is_err());
+        assert_eq!(command_calls, 1);
+
+        backend.remove_queue("reconnect").unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_CLUSTER_TEST_URLS"]
+    /// Execute QueueFS Lua scripts through a real Redis Cluster connection.
+    fn redis_backend_cluster_executes_queue_flow() {
+        let endpoints = std::env::var("QUEUEFS_REDIS_CLUSTER_TEST_URLS")
+            .expect("QUEUEFS_REDIS_CLUSTER_TEST_URLS is required");
+        let options = RedisQueueOptions {
+            mode: RedisMode::Cluster,
+            endpoints: endpoints.split(',').map(str::to_string).collect(),
+            key_prefix: format!("queuefs-test-{}", Uuid::new_v4()),
+            ..RedisQueueOptions::default()
+        };
+
+        assert_queue_flow(RedisQueueBackend::open(options).unwrap());
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_SENTINEL_TEST_URLS"]
+    /// Execute QueueFS operations through Sentinel master discovery.
+    fn redis_backend_sentinel_executes_queue_flow() {
+        let endpoints = std::env::var("QUEUEFS_REDIS_SENTINEL_TEST_URLS")
+            .expect("QUEUEFS_REDIS_SENTINEL_TEST_URLS is required");
+        let options = RedisQueueOptions {
+            mode: RedisMode::Sentinel,
+            endpoints: endpoints.split(',').map(str::to_string).collect(),
+            master_name: Some(
+                std::env::var("QUEUEFS_REDIS_SENTINEL_MASTER")
+                    .unwrap_or_else(|_| "mymaster".to_string()),
+            ),
+            key_prefix: format!("queuefs-test-{}", Uuid::new_v4()),
+            ..RedisQueueOptions::default()
+        };
+
+        assert_queue_flow(RedisQueueBackend::open(options).unwrap());
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_SENTINEL_TEST_URLS and a replica"]
+    /// Rediscover the Sentinel master after the connected master is demoted.
+    fn redis_backend_sentinel_reconnects_after_failover() {
+        let endpoints = std::env::var("QUEUEFS_REDIS_SENTINEL_TEST_URLS")
+            .expect("QUEUEFS_REDIS_SENTINEL_TEST_URLS is required");
+        let master_name = std::env::var("QUEUEFS_REDIS_SENTINEL_MASTER")
+            .unwrap_or_else(|_| "mymaster".to_string());
+        let sentinel_endpoint = endpoints.split(',').next().unwrap();
+        let mut sentinel = redis::Client::open(sentinel_endpoint)
+            .unwrap()
+            .get_connection()
+            .unwrap();
+        let original_master = redis::cmd("SENTINEL")
+            .arg("GET-MASTER-ADDR-BY-NAME")
+            .arg(&master_name)
+            .query::<Vec<String>>(&mut sentinel)
+            .unwrap();
+        let original_master_client = redis::Client::open(format!(
+            "redis://{}:{}",
+            original_master[0], original_master[1]
+        ))
+        .unwrap();
+        let mut backend = RedisQueueBackend::open(RedisQueueOptions {
+            mode: RedisMode::Sentinel,
+            endpoints: endpoints.split(',').map(str::to_string).collect(),
+            master_name: Some(master_name.clone()),
+            key_prefix: format!("queuefs-test-{}", Uuid::new_v4()),
+            ..RedisQueueOptions::default()
+        })
+        .unwrap();
+        backend.create_queue("failover").unwrap();
+
+        redis::cmd("SENTINEL")
+            .arg("FAILOVER")
+            .arg(&master_name)
+            .query::<()>(&mut sentinel)
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let current_master = redis::cmd("SENTINEL")
+                .arg("GET-MASTER-ADDR-BY-NAME")
+                .arg(&master_name)
+                .query::<Vec<String>>(&mut sentinel)
+                .unwrap();
+            let original_is_replica = original_master_client
+                .get_connection()
+                .and_then(|mut connection| {
+                    redis::cmd("INFO")
+                        .arg("replication")
+                        .query::<String>(&mut connection)
+                })
+                .is_ok_and(|replication| replication.contains("role:slave"));
+            if current_master != original_master && original_is_replica {
+                break;
+            }
+            assert!(Instant::now() < deadline, "Sentinel failover timed out");
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        if backend
+            .enqueue("failover", Message::new(b"first".to_vec()))
+            .is_err()
+        {
+            backend
+                .enqueue("failover", Message::new(b"second".to_vec()))
+                .unwrap();
+        }
+        assert!(backend.size("failover").unwrap() > 0);
+        backend.remove_queue("failover").unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Reject an unregistered queue inside the enqueue script before writing any keys.
+    fn enqueue_script_rejects_unregistered_queue_atomically() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let options = RedisQueueOptions {
+            endpoints: vec![endpoint],
+            key_prefix: format!("queuefs-test-{}", Uuid::new_v4()),
+            ..RedisQueueOptions::default()
+        };
+        let mut backend = RedisQueueBackend::open(options).unwrap();
+        let queue = "removed";
+        let queue_names_key = queue_names_key(&backend.key_prefix);
+        let keys = QueueKeys::new(&backend.key_prefix, queue);
+        let message = Message::new(b"orphan".to_vec());
+        let message_key = keys.message(&message.id);
+
+        assert!(backend.enqueue(queue, message).is_err());
+        let existing_keys = backend
+            .with_connection("test_enqueue_missing_queue keys", |connection| {
+                redis::cmd("EXISTS")
+                    .arg(&queue_names_key)
+                    .arg(&message_key)
+                    .arg(&keys.pending)
+                    .arg(&keys.meta)
+                    .query::<usize>(connection)
+            })
+            .unwrap();
+        assert_eq!(existing_keys, 0);
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Remove a queue tree without deleting a same-prefix sibling queue.
+    fn redis_backend_removes_nested_queues_recursively() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let key_prefix = format!("queuefs-test-{}", Uuid::new_v4());
+        let options = RedisQueueOptions {
+            endpoints: vec![endpoint],
+            key_prefix,
+            ..RedisQueueOptions::default()
+        };
+        let mut backend = RedisQueueBackend::open(options).unwrap();
+        backend.create_queue("worker-0").unwrap();
+        backend.create_queue("worker-0/Embedding").unwrap();
+        backend.create_queue("worker-01").unwrap();
+        backend
+            .enqueue("worker-0/Embedding", Message::new(b"nested".to_vec()))
+            .unwrap();
+        backend
+            .enqueue("worker-01", Message::new(b"sibling".to_vec()))
+            .unwrap();
+
+        backend.remove_queue("worker-0").unwrap();
+
+        assert!(!backend.queue_exists("worker-0"));
+        assert!(!backend.queue_exists("worker-0/Embedding"));
+        assert!(backend.queue_exists("worker-01"));
+        assert_eq!(backend.size("worker-01").unwrap(), 1);
+        backend.remove_queue("worker-01").unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Isolate queue state between independent Redis key prefixes.
+    fn redis_backend_isolates_key_prefixes() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let suffix = Uuid::new_v4();
+        let mut first = RedisQueueBackend::open(RedisQueueOptions {
+            endpoints: vec![endpoint.clone()],
+            key_prefix: format!("queuefs-test-a-{suffix}"),
+            ..RedisQueueOptions::default()
+        })
+        .unwrap();
+        let mut second = RedisQueueBackend::open(RedisQueueOptions {
+            endpoints: vec![endpoint],
+            key_prefix: format!("queuefs-test-b-{suffix}"),
+            ..RedisQueueOptions::default()
+        })
+        .unwrap();
+
+        first.create_queue("Semantic").unwrap();
+        assert!(!second.queue_exists("Semantic"));
+        second.create_queue("Semantic").unwrap();
+        first
+            .enqueue("Semantic", Message::new(b"first".to_vec()))
+            .unwrap();
+
+        assert_eq!(first.size("Semantic").unwrap(), 1);
+        assert_eq!(second.size("Semantic").unwrap(), 0);
+        first.remove_queue("Semantic").unwrap();
+        second.remove_queue("Semantic").unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Recover processing messages owned by instances without a heartbeat.
+    fn redis_backend_recovers_messages_owned_by_dead_instances() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let options = RedisQueueOptions {
+            endpoints: vec![endpoint],
+            ..RedisQueueOptions::default()
+        };
+        let queue = format!("queuefs-test-{}", Uuid::new_v4());
+        let mut backend = RedisQueueBackend::open(options.clone()).unwrap();
+        backend.create_queue(&queue).unwrap();
+        let message = Message::new(b"payload".to_vec());
+        let message_id = message.id.clone();
+        backend.enqueue(&queue, message).unwrap();
+
+        let keys = QueueKeys::new(&options.key_prefix, &queue);
+        backend
+            .with_connection("test_dead_owner", |connection| {
+                redis::Script::new(
+                    r#"
+local id = redis.call('LPOP', KEYS[1])
+redis.call('ZADD', KEYS[2], ARGV[1], id .. '|dead-instance')
+return id
+"#,
+                )
+                .key(&keys.pending)
+                .key(&keys.processing)
+                .arg(unix_secs(SystemTime::now()))
+                .invoke::<String>(connection)
+            })
+            .unwrap();
+        drop(backend);
+
+        let mut recovered = RedisQueueBackend::open(options).unwrap();
+        let dequeued = recovered.dequeue(&queue).unwrap().unwrap();
+        assert_eq!(dequeued.id, message_id);
+        assert_eq!(dequeued.data, b"payload");
+        assert!(recovered.ack(&queue, &message_id).unwrap());
+        recovered.remove_queue(&queue).unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires QUEUEFS_REDIS_TEST_URL"]
+    /// Recover this instance's processing messages after a graceful restart.
+    fn redis_backend_graceful_restart_recovers_processing_messages() {
+        let endpoint =
+            std::env::var("QUEUEFS_REDIS_TEST_URL").expect("QUEUEFS_REDIS_TEST_URL is required");
+        let options = RedisQueueOptions {
+            endpoints: vec![endpoint],
+            ..RedisQueueOptions::default()
+        };
+        let queue = format!("queuefs-test-{}", Uuid::new_v4());
+        let mut backend = RedisQueueBackend::open(options.clone()).unwrap();
+        backend.create_queue(&queue).unwrap();
+        let message = Message::new(b"payload".to_vec());
+        let message_id = message.id.clone();
+        backend.enqueue(&queue, message).unwrap();
+        assert_eq!(backend.dequeue(&queue).unwrap().unwrap().id, message_id);
+        drop(backend);
+
+        let mut restarted = RedisQueueBackend::open(options).unwrap();
+        assert_eq!(
+            restarted.dequeue(&queue).unwrap().unwrap().id,
+            message_id
+        );
+        assert!(restarted.ack(&queue, &message_id).unwrap());
+        restarted.remove_queue(&queue).unwrap();
+    }
+}

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1077,16 +1077,45 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
 | `mode` | str | QueueFS 命名空间模式：`"shared"` 使用 `/queue`；`"worker"` 为每个 worker 隔离到 `/queue/worker-<index\|pid>` | `"shared"` |
-| `backend` | str | QueueFS 后端：`"memory"`、`"sqlite"` 或 `"sqlite3"` | `"sqlite"` |
+| `backend` | str | QueueFS 后端：`"memory"`、`"sqlite"`、`"sqlite3"` 或 `"redis"` | `"sqlite"` |
 | `db_path` | str（可选） | 当 backend 为 `"sqlite"` 或 `"sqlite3"` 时使用的 QueueFS sqlite 数据库路径 | `null` |
 | `recover_stale_sec` | int | 启动时恢复超过该秒数的 `processing` 队列消息；`0` 表示恢复全部 stale processing 消息 | `0` |
 | `busy_timeout_ms` | int | QueueFS sqlite 的 busy timeout，单位毫秒 | `5000` |
+| `redis` | object | 当 backend 为 `"redis"` 时使用的连接参数 | 见下表 |
+
+QueueFS Redis 参数：
+
+| 参数 | 类型 | 说明 | 默认值 |
+|------|------|------|--------|
+| `mode` | str | Redis 拓扑模式：`"singleton"`、`"cluster"` 或 `"sentinel"` | `"singleton"` |
+| `endpoints` | array[str] | Singleton 的唯一数据节点、Cluster 初始节点或 Sentinel 节点 | `["redis://127.0.0.1:6379"]` |
+| `master_name` | str（可选） | Sentinel master 名称；Sentinel 模式必须配置 | `null` |
+| `username` | str（可选） | Redis ACL 用户名 | `null` |
+| `password` | str（可选） | Redis ACL 密码 | `null` |
+| `sentinel_username` | str（可选） | Sentinel ACL 用户名 | `null` |
+| `sentinel_password` | str（可选） | Sentinel ACL 密码 | `null` |
+| `db` | int | Redis database 编号 | `0` |
+| `connect_timeout_ms` | int | Redis 数据节点物理建连超时，单位毫秒 | `3000` |
+| `command_timeout_ms` | int | 命令读写超时，单位毫秒 | `3000` |
+| `key_prefix` | str | Redis key 隔离前缀，不能为空；所有 QueueFS key 使用 `{key_prefix}:ov:*` | `"default"` |
+| `tls_enabled` | bool | 对 `redis://` endpoint 强制启用 TLS | `false` |
+| `tls_insecure_skip_verify` | bool | 跳过 TLS 证书校验，仅用于受控测试环境 | `false` |
 
 说明：
 
 - 即使主 AGFS 存储后端是 `local`、`s3` 或 `memory`，QueueFS 默认仍使用 `sqlite`。
 - `mode=shared` 会继续使用历史上的全局队列命名空间 `/queue`；`mode=worker` 会为每个 worker 隔离到 `/queue/worker-<index|pid>`。
 - `db_path` 仅在 QueueFS backend 为 `sqlite` 或 `sqlite3` 时生效。
+- `recover_stale_sec` 和 `busy_timeout_ms` 仅在 QueueFS backend 为 `sqlite` 或 `sqlite3` 时生效。
+- Redis Singleton 模式必须且只能配置一个 endpoint。
+- Redis Cluster 模式的 endpoints 是初始节点，且必须配置 `db=0`；slot 路由、`MOVED`/`ASK` 处理和节点重连由 redis-rs 完成。
+- Redis Sentinel 模式的 endpoints 是 Sentinel 节点，并且必须配置非空 `master_name`；master 发现和故障切换后的重连由 redis-rs 完成。
+- Redis Sentinel 模式下，`connect_timeout_ms` 作用于发现 Master 后的数据节点连接；redis-rs 同步 Sentinel discovery 不暴露物理建连 timeout，该阶段由内部固定 5 秒的 pool checkout timeout 限制调用方等待。
+- `username` 和 `password` 用于 Redis 数据节点；`sentinel_username` 和 `sentinel_password` 仅用于 Sentinel 节点。
+- Redis backend 使用 `{key_prefix}:ov:*` key；连接同一 Redis database 的不同业务必须配置不同的 `key_prefix`。
+- Redis backend 的实例心跳 TTL 为 30 秒，每 10 秒续约一次。
+- Redis backend 仅在启动时按实例心跳状态执行一次 `recover_stale`，运行期间不周期恢复。
+- `tls_insecure_skip_verify=true` 时必须同时设置 `tls_enabled=true`。
 - 如果同时设置了 `storage.agfs.queuefs.db_path` 和旧字段 `storage.agfs.queue_db_path`，以前者为准。
 - 如果 QueueFS backend 为 `memory`，则 `db_path` 和旧字段 `queue_db_path` 都会被忽略。
 
@@ -1102,6 +1131,95 @@ RAGFS 默认使用 Rust binding 模式，通过 Rust 实现直接访问文件系
         "mode": "shared",
         "backend": "sqlite",
         "db_path": "./data/_system/queue/custom-queue.db"
+      }
+    }
+  }
+}
+```
+
+Redis QueueFS 配置示例：
+
+```json
+{
+  "storage": {
+    "workspace": "./data",
+    "agfs": {
+      "backend": "local",
+      "queuefs": {
+        "mode": "shared",
+        "backend": "redis",
+        "redis": {
+          "mode": "singleton",
+          "endpoints": ["redis://127.0.0.1:6379"],
+          "master_name": null,
+          "username": null,
+          "password": null,
+          "sentinel_username": null,
+          "sentinel_password": null,
+          "db": 0,
+          "connect_timeout_ms": 3000,
+          "command_timeout_ms": 3000,
+          "key_prefix": "default",
+          "tls_enabled": false,
+          "tls_insecure_skip_verify": false
+        }
+      }
+    }
+  }
+}
+```
+
+Redis Cluster 只需配置可用于发现拓扑的初始节点：
+
+```json
+{
+  "storage": {
+    "workspace": "./data",
+    "agfs": {
+      "backend": "local",
+      "queuefs": {
+        "mode": "shared",
+        "backend": "redis",
+        "redis": {
+          "mode": "cluster",
+          "endpoints": [
+            "redis://redis-cluster-0:6379",
+            "redis://redis-cluster-1:6379"
+          ],
+          "db": 0,
+          "key_prefix": "default"
+        }
+      }
+    }
+  }
+}
+```
+
+Redis Sentinel 分别配置数据节点和 Sentinel 的 ACL：
+
+```json
+{
+  "storage": {
+    "workspace": "./data",
+    "agfs": {
+      "backend": "local",
+      "queuefs": {
+        "mode": "shared",
+        "backend": "redis",
+        "redis": {
+          "mode": "sentinel",
+          "endpoints": [
+            "redis://redis-sentinel-0:26379",
+            "redis://redis-sentinel-1:26379"
+          ],
+          "master_name": "mymaster",
+          "username": "queue-user",
+          "password": "queue-password",
+          "sentinel_username": "sentinel-user",
+          "sentinel_password": "sentinel-password",
+          "db": 0,
+          "key_prefix": "default"
+        }
       }
     }
   }

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1088,7 +1088,7 @@ QueueFS Redis 参数：
 | 参数 | 类型 | 说明 | 默认值 |
 |------|------|------|--------|
 | `mode` | str | Redis 拓扑模式：`"singleton"`、`"cluster"` 或 `"sentinel"` | `"singleton"` |
-| `endpoints` | array[str] | Singleton 的唯一数据节点、Cluster 初始节点或 Sentinel 节点 | `["redis://127.0.0.1:6379"]` |
+| `endpoints` | array[str] | Singleton 的唯一数据节点、Cluster 初始节点或 Sentinel 节点；仅允许协议、主机和端口，认证与 DB 使用独立字段 | `["redis://127.0.0.1:6379"]` |
 | `master_name` | str（可选） | Sentinel master 名称；Sentinel 模式必须配置 | `null` |
 | `username` | str（可选） | Redis ACL 用户名 | `null` |
 | `password` | str（可选） | Redis ACL 密码 | `null` |

--- a/openviking/utils/agfs_utils.py
+++ b/openviking/utils/agfs_utils.py
@@ -175,13 +175,11 @@ def _build_queuefs_plugin_config(agfs_config: Any, data_path: Path) -> Dict[str,
     queuefs_config = getattr(agfs_config, "queuefs", None)
 
     backend = getattr(queuefs_config, "backend", "sqlite") if queuefs_config else "sqlite"
-    plugin_config: Dict[str, Any] = {
-        "backend": backend,
-        "recover_stale_sec": getattr(queuefs_config, "recover_stale_sec", 0),
-        "busy_timeout_ms": getattr(queuefs_config, "busy_timeout_ms", 5000),
-    }
+    plugin_config: Dict[str, Any] = {"backend": backend}
 
     if backend in {"sqlite", "sqlite3"}:
+        plugin_config["recover_stale_sec"] = getattr(queuefs_config, "recover_stale_sec", 0)
+        plugin_config["busy_timeout_ms"] = getattr(queuefs_config, "busy_timeout_ms", 5000)
         configured_queue_db_path = None
         if queuefs_config is not None:
             configured_queue_db_path = getattr(queuefs_config, "db_path", None)
@@ -194,6 +192,9 @@ def _build_queuefs_plugin_config(agfs_config: Any, data_path: Path) -> Dict[str,
             queue_db_path = str(default_queue_db_path)
 
         plugin_config["db_path"] = queue_db_path
+
+    if backend == "redis":
+        plugin_config["redis"] = queuefs_config.redis.model_dump()
 
     return plugin_config
 

--- a/openviking_cli/utils/config/agfs_config.py
+++ b/openviking_cli/utils/config/agfs_config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -107,6 +108,70 @@ class S3Config(BaseModel):
         return self
 
 
+class QueueFSRedisConfig(BaseModel):
+    """Configuration for the QueueFS Redis backend."""
+
+    mode: Literal["singleton", "cluster", "sentinel"] = Field(
+        default="singleton",
+        description="Redis topology mode.",
+    )
+    endpoints: list[str] = Field(
+        default_factory=lambda: ["redis://127.0.0.1:6379"],
+        description="Redis endpoints interpreted by the selected topology mode.",
+    )
+    master_name: Optional[str] = Field(default=None, description="Sentinel master name")
+    username: Optional[str] = Field(default=None, description="Redis ACL username")
+    password: Optional[str] = Field(default=None, description="Redis ACL password")
+    sentinel_username: Optional[str] = Field(default=None, description="Sentinel ACL username")
+    sentinel_password: Optional[str] = Field(default=None, description="Sentinel ACL password")
+    db: int = Field(default=0, description="Redis database number")
+    connect_timeout_ms: int = Field(default=3000, description="Redis connect timeout")
+    command_timeout_ms: int = Field(default=3000, description="Redis command timeout")
+    key_prefix: str = Field(default="default", description="Redis QueueFS key prefix")
+    tls_enabled: bool = Field(default=False, description="Enable Redis TLS")
+    tls_insecure_skip_verify: bool = Field(
+        default=False,
+        description="Skip Redis TLS certificate verification",
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_config(self):
+        """Validate Redis topology, endpoints, and numeric limits."""
+        if not self.endpoints:
+            raise ValueError("queuefs redis endpoints must not be empty")
+        for endpoint in self.endpoints:
+            parsed = urlparse(endpoint)
+            if parsed.scheme not in {"redis", "rediss"} or not parsed.hostname:
+                raise ValueError("queuefs redis endpoints must use redis:// or rediss:// URLs")
+            try:
+                port = parsed.port
+            except ValueError as error:
+                raise ValueError("queuefs redis endpoint port is invalid") from error
+            if port == 0:
+                raise ValueError("queuefs redis endpoint port is invalid")
+        if self.mode == "singleton" and len(self.endpoints) != 1:
+            raise ValueError("queuefs redis singleton mode requires exactly one endpoint")
+        if self.mode == "cluster" and self.db != 0:
+            raise ValueError("queuefs redis cluster mode requires db=0")
+        if self.mode == "sentinel" and not (self.master_name or "").strip():
+            raise ValueError("queuefs redis sentinel mode requires master_name")
+        if self.db < 0:
+            raise ValueError("queuefs redis db must be >= 0")
+        if self.connect_timeout_ms <= 0:
+            raise ValueError("queuefs redis connect_timeout_ms must be > 0")
+        if self.command_timeout_ms <= 0:
+            raise ValueError("queuefs redis command_timeout_ms must be > 0")
+        if not self.key_prefix.strip():
+            raise ValueError("queuefs redis key_prefix must not be empty")
+        if "{" in self.key_prefix or "}" in self.key_prefix:
+            raise ValueError("queuefs redis key_prefix must not contain '{' or '}'")
+        if self.tls_insecure_skip_verify and not self.tls_enabled:
+            raise ValueError("queuefs redis tls_insecure_skip_verify requires tls_enabled=true")
+        return self
+
+
 class QueueFSConfig(BaseModel):
     """Configuration for QueueFS backend."""
 
@@ -117,7 +182,7 @@ class QueueFSConfig(BaseModel):
 
     backend: str = Field(
         default="sqlite",
-        description="QueueFS backend: 'memory' | 'sqlite' | 'sqlite3'",
+        description="QueueFS backend: 'memory' | 'sqlite' | 'sqlite3' | 'redis'",
     )
 
     db_path: Optional[str] = Field(
@@ -135,6 +200,8 @@ class QueueFSConfig(BaseModel):
         description="SQLite busy timeout for QueueFS in milliseconds.",
     )
 
+    redis: QueueFSRedisConfig = Field(default_factory=QueueFSRedisConfig)
+
     model_config = {"extra": "forbid"}
 
     @model_validator(mode="after")
@@ -143,9 +210,11 @@ class QueueFSConfig(BaseModel):
         if self.mode not in valid_modes:
             raise ValueError("queuefs mode must be one of: 'shared', 'worker'")
 
-        valid_backends = {"memory", "sqlite", "sqlite3"}
+        valid_backends = {"memory", "sqlite", "sqlite3", "redis"}
         if self.backend not in valid_backends:
-            raise ValueError("queuefs backend must be one of: 'memory', 'sqlite', 'sqlite3'")
+            raise ValueError(
+                "queuefs backend must be one of: 'memory', 'sqlite', 'sqlite3', 'redis'"
+            )
         if self.recover_stale_sec < 0:
             raise ValueError("queuefs recover_stale_sec must be >= 0")
         if self.busy_timeout_ms < 0:

--- a/openviking_cli/utils/config/agfs_config.py
+++ b/openviking_cli/utils/config/agfs_config.py
@@ -151,6 +151,17 @@ class QueueFSRedisConfig(BaseModel):
                 raise ValueError("queuefs redis endpoint port is invalid") from error
             if port == 0:
                 raise ValueError("queuefs redis endpoint port is invalid")
+            if (
+                parsed.username is not None
+                or parsed.password is not None
+                or parsed.path not in {"", "/"}
+                or parsed.query
+                or parsed.fragment
+            ):
+                raise ValueError(
+                    "queuefs redis endpoints must not include credentials, database paths, "
+                    "query parameters, or fragments; use dedicated redis fields"
+                )
         if self.mode == "singleton" and len(self.endpoints) != 1:
             raise ValueError("queuefs redis singleton mode requires exactly one endpoint")
         if self.mode == "cluster" and self.db != 0:

--- a/tests/misc/test_config_validation.py
+++ b/tests/misc/test_config_validation.py
@@ -180,6 +180,7 @@ def test_agfs_queuefs_validation_accepts_supported_shapes(queuefs, expected):
         ({"backend": "bogus"}, "queuefs"),
         ({"busy_timeout_ms": -1}, "busy_timeout_ms"),
         ({"recover_stale_sec": -1}, "recover_stale_sec"),
+        ({"backend": "redis", "redis": {"key_prefix": ""}}, "key_prefix"),
     ],
 )
 def test_agfs_queuefs_validation_rejects_invalid_shapes(queuefs, match):
@@ -340,6 +341,149 @@ def test_generate_plugin_config_forwards_queuefs_runtime_options():
     assert plugins["queuefs"]["config"]["backend"] == "sqlite3"
     assert plugins["queuefs"]["config"]["recover_stale_sec"] == 17
     assert plugins["queuefs"]["config"]["busy_timeout_ms"] == 1234
+
+
+def test_agfs_queuefs_accepts_redis_config():
+    """Validate the QueueFS Redis configuration model."""
+    config = AGFSConfig(
+        path="/tmp/ov-test",
+        backend="local",
+        queuefs={
+            "backend": "redis",
+            "redis": {
+                "mode": "singleton",
+                "endpoints": ["redis://redis.example.com:6379"],
+                "master_name": None,
+                "username": "queue-user",
+                "password": "secret",
+                "sentinel_username": None,
+                "sentinel_password": None,
+                "db": 2,
+                "connect_timeout_ms": 3000,
+                "command_timeout_ms": 4000,
+                "key_prefix": "tenant-a",
+                "tls_enabled": False,
+                "tls_insecure_skip_verify": False,
+            },
+        },
+    )
+
+    assert config.queuefs.backend == "redis"
+    assert config.queuefs.redis.mode == "singleton"
+    assert config.queuefs.redis.endpoints == ["redis://redis.example.com:6379"]
+    assert config.queuefs.redis.db == 2
+    assert config.queuefs.redis.key_prefix == "tenant-a"
+
+
+def test_agfs_queuefs_redis_defaults_singleton_mode_and_key_prefix():
+    """Use the documented Redis mode and key prefix defaults."""
+    config = AGFSConfig(
+        path="/tmp/ov-test",
+        backend="local",
+        queuefs={"backend": "redis"},
+    )
+
+    assert config.queuefs.redis.mode == "singleton"
+    assert config.queuefs.redis.key_prefix == "default"
+
+
+@pytest.mark.parametrize(
+    ("redis_config", "match"),
+    [
+        ({"mode": "invalid"}, "mode"),
+        (
+            {
+                "mode": "singleton",
+                "endpoints": ["redis://redis-1:6379", "redis://redis-2:6379"],
+            },
+            "singleton",
+        ),
+        ({"mode": "cluster", "endpoints": []}, "endpoints"),
+        ({"mode": "cluster", "db": 1}, "db"),
+        ({"mode": "sentinel", "endpoints": [], "master_name": "mymaster"}, "endpoints"),
+        ({"mode": "sentinel", "master_name": ""}, "master_name"),
+        ({"key_prefix": "invalid{tag}"}, "key_prefix"),
+    ],
+)
+def test_agfs_queuefs_redis_rejects_invalid_mode_config(redis_config, match):
+    """Reject Redis topology settings that violate the selected mode."""
+    with pytest.raises(ValueError, match=match):
+        AGFSConfig(
+            path="/tmp/ov-test",
+            backend="local",
+            queuefs={"backend": "redis", "redis": redis_config},
+        )
+
+
+@pytest.mark.parametrize(
+    "redis_config",
+    [
+        {
+            "mode": "cluster",
+            "endpoints": ["redis://cluster-1:6379", "redis://cluster-2:6379"],
+            "db": 0,
+        },
+        {
+            "mode": "sentinel",
+            "endpoints": ["redis://sentinel-1:26379", "redis://sentinel-2:26379"],
+            "master_name": "mymaster",
+        },
+    ],
+)
+def test_agfs_queuefs_redis_accepts_high_availability_modes(redis_config):
+    """Accept valid Cluster and Sentinel QueueFS configurations."""
+    config = AGFSConfig(
+        path="/tmp/ov-test",
+        backend="local",
+        queuefs={"backend": "redis", "redis": redis_config},
+    )
+
+    assert config.queuefs.redis.mode == redis_config["mode"]
+    assert config.queuefs.redis.endpoints == redis_config["endpoints"]
+
+
+def test_agfs_queuefs_redis_rejects_removed_pool_max_size():
+    """Reject the removed Redis connection pool setting."""
+    with pytest.raises(ValueError, match="pool_max_size"):
+        AGFSConfig(
+            path="/tmp/ov-test",
+            backend="local",
+            queuefs={
+                "backend": "redis",
+                "redis": {"pool_max_size": 16},
+            },
+        )
+
+
+def test_generate_plugin_config_forwards_queuefs_redis_config():
+    """Forward the complete Redis child object to the QueueFS plugin."""
+    redis_config = {
+        "mode": "singleton",
+        "endpoints": ["rediss://redis.example.com:6380"],
+        "master_name": None,
+        "username": "queue-user",
+        "password": "secret",
+        "sentinel_username": None,
+        "sentinel_password": None,
+        "db": 3,
+        "connect_timeout_ms": 1500,
+        "command_timeout_ms": 2500,
+        "key_prefix": "tenant-b",
+        "tls_enabled": True,
+        "tls_insecure_skip_verify": False,
+    }
+    config = AGFSConfig(
+        path="/tmp/ov-test",
+        backend="local",
+        queuefs={"backend": "redis", "redis": redis_config},
+    )
+
+    plugins = _generate_plugin_config(config, Path("/tmp/ov-test"))
+
+    assert plugins["queuefs"]["config"] == {
+        "backend": "redis",
+        "redis": redis_config,
+    }
 
 
 def test_agfs_redirects_require_backups():


### PR DESCRIPTION

## Description

<!-- Provide a brief description of the changes in this PR -->

Add Redis as a persistent QueueFS backend while preserving the existing SQLite-style `pending -> processing -> ack -> recover_stale` lifecycle. The implementation supports Singleton, Cluster, and Sentinel deployments, keeps the Python worker flow unchanged, and uses Redis Lua scripts for atomic queue state transitions.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

https://github.com/volcengine/OpenViking/issues/3740

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Added a Redis QueueFS backend with Lua-based `create_queue`, `enqueue`, `dequeue`, `peek`, `ack`, `clear`, recursive `remove_queue`, and startup stale-message recovery while retaining at-least-once delivery semantics.
- Added Singleton, Cluster, and Sentinel connection modes with ACL/TLS support, Cluster hash-tagged keys, fixed-size synchronous connection pooling, heartbeat-based instance ownership, and Sentinel topology invalidation after failover.
- Added Python and Rust configuration validation, AGFS plugin configuration passthrough, Chinese configuration documentation, and unit/integration test coverage for Redis topology, key isolation, reconnect, recovery, and queue lifecycle behavior.

## Testing

<!-- Describe how you tested your changes -->

- `.venv/bin/python -m pytest -o addopts='' tests/misc/test_config_validation.py -q`
  - Result: `55 passed, 4 warnings`
- `cargo test -p ragfs queuefs --lib`
  - Result: `41 passed, 0 failed, 9 ignored`
  - The ignored tests require external Singleton, Cluster, or Sentinel Redis environments.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

Not applicable.

## Additional Notes

<!-- Add any additional notes or context about the PR -->

- Redis keys use `{key_prefix}:ov:*`; the hash tag keeps all QueueFS keys for one prefix in the same Redis Cluster slot.
- Heartbeats use a 30-second TTL with a 10-second refresh interval. Stale recovery runs once when the backend starts and does not run periodically.
- Normal enqueue/dequeue remains FIFO. Recovered processing messages are appended after existing pending messages, so strict FIFO ordering is not guaranteed after recovery.
- Redis connection failures do not automatically replay write commands with unknown outcomes, avoiding duplicate execution of `enqueue`, `dequeue`, or `ack`.
