### PR TITLE
feat(server): make HTTP keep-alive idle timeout configurable

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -222,6 +222,7 @@ Remote backends also require endpoint, bucket/collection, credentials, and timeo
 | `host` | IP / hostname | `"127.0.0.1"` | Listen address |
 | `port` | integer | `1933` | Listen port |
 | `workers` | integer | `1` | Worker process count |
+| `timeout_keep_alive` | integer (seconds) | `5` | Idle HTTP keep-alive timeout; raise it above the upstream's idle-connection lifetime |
 | `auth_mode` | `dev`, `api_key`, `trusted` / `null` | `null` | Auth mode; null is inferred from `root_api_key` |
 | `root_api_key` | string / `null` | `null` | Root key; setting it defaults auth to `api_key` |
 | `cors_origins` | string[] | `["*"]` | Allowed origins |

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -222,6 +222,7 @@ Search 和 Find 请求的默认 `limit` 为 `10`，可以在每次 API 或 SDK �
 | `host` | IP / hostname | `"127.0.0.1"` | HTTP 监听地址 |
 | `port` | integer | `1933` | HTTP 监听端口 |
 | `workers` | integer | `1` | 服务进程数量 |
+| `timeout_keep_alive` | integer（秒） | `5` | 空闲 HTTP keep-alive 超时；应调大到超过上游空闲连接寿命 |
 | `auth_mode` | `dev`、`api_key`、`trusted` / `null` | `null` | 鉴权模式；空值根据 `root_api_key` 自动判断 |
 | `root_api_key` | string / `null` | `null` | Root API Key；配置后默认启用 `api_key` 模式 |
 | `cors_origins` | string[] | `["*"]` | 允许的跨域来源 |

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -2,6 +2,7 @@
     "server": {
         "host": "0.0.0.0",
         "port": 1933,
+        "timeout_keep_alive": 5,
         "root_api_key": null,
         "cors_origins": ["*"],
         "agent_evolution": {

--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -308,10 +308,17 @@ def main():
                 host=config.host,
                 port=config.port,
                 workers=workers,
+                timeout_keep_alive=config.timeout_keep_alive,
                 log_config=None,
             )
         else:
-            uvicorn.run(app, host=config.host, port=config.port, log_config=None)
+            uvicorn.run(
+                app,
+                host=config.host,
+                port=config.port,
+                timeout_keep_alive=config.timeout_keep_alive,
+                log_config=None,
+            )
     finally:
         # Cleanup vikingbot process on shutdown
         if bot_process is not None:

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -268,6 +268,15 @@ class ServerConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = 1933
     workers: int = 1
+    # Seconds an idle HTTP keep-alive connection is kept open before the server
+    # closes it. Defaults to 5 to match uvicorn's built-in default and preserve
+    # the existing service behavior. Raise it above the idle-connection lifetime
+    # of any upstream client or load balancer that reuses connections (e.g. the
+    # serverless VKE forwarder keeps idle connections for up to 60s via
+    # WithMaxIdleConnDuration(1*time.Minute)); otherwise the server may close
+    # connections the client still believes are reusable, causing sporadic
+    # connection-reset / EOF errors.
+    timeout_keep_alive: int = 5
     auth_mode: Optional[str] = None  # If None, auto-detect based on root_api_key
     root_api_key: Optional[str] = None
     profile_enabled: bool = False

--- a/tests/test_server_config_loader.py
+++ b/tests/test_server_config_loader.py
@@ -61,6 +61,7 @@ def test_load_server_config_preserves_supported_fields(tmp_path):
                     "host": "0.0.0.0",
                     "port": 1944,
                     "workers": 2,
+                    "timeout_keep_alive": 120,
                     "auth_mode": "trusted",
                     "with_bot": True,
                     "bot_api_url": "http://localhost:19999",
@@ -77,11 +78,21 @@ def test_load_server_config_preserves_supported_fields(tmp_path):
     assert config.host == "0.0.0.0"
     assert config.port == 1944
     assert config.workers == 2
+    assert config.timeout_keep_alive == 120
     assert config.auth_mode == "trusted"
     assert config.with_bot is True
     assert config.bot_api_url == "http://localhost:19999"
     assert config.observability.metrics.exporters.prometheus.enabled is True
     assert config.encryption_enabled is True
+
+
+def test_load_server_config_defaults_timeout_keep_alive(tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(json.dumps({"server": {"host": "0.0.0.0"}}))
+
+    config = load_server_config(str(config_path))
+
+    assert config.timeout_keep_alive == 5
 
 
 def test_load_server_config_rejects_legacy_queuefs_scope(tmp_path):


### PR DESCRIPTION
Add `server.timeout_keep_alive` to ServerConfig and pass it to uvicorn.run in both single- and multi-worker paths. Defaults to 5s to match uvicorn's built-in default, so the service's default behavior is unchanged.

This lets deployments raise the server-side idle keep-alive timeout above an upstream client / load balancer's idle-connection lifetime (e.g. the serverless VKE forwarder keeps idle connections for up to 60s), avoiding sporadic connection-reset / EOF errors caused by the server closing connections the client still considers reusable.

Also document the field (en/zh), add it to ov.conf.example, and cover the default and override behavior in tests.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
