### PR TITLE
fix(mcp): enable stateless HTTP for multi-instance deployments

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -219,6 +219,7 @@ class _IdentityASGIMiddleware:
 mcp = FastMCP(
     "openviking",
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    stateless_http=True,
 )
 
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the MCP endpoint may fail in multi-instance deployments behind a load balancer.

FastMCP's Streamable HTTP session manager stores sessions in an in-process dictionary. When multiple OpenViking instances are deployed, an `initialize` request handled by one instance creates a session that is not available to subsequent requests routed to another instance, causing intermittent `404 "Session not found"` errors.

This resulted in MCP tool discovery failures (for example, OpenCode reporting "Failed to get tools") and repeated 404 errors in server logs.

OpenViking MCP tools do not rely on FastMCP session state. The MCP tool flow creates and manages its own OpenViking session state where needed, so enabling stateless Streamable HTTP mode is safe and allows the MCP endpoint to work correctly in load-balanced deployments.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Enabled `stateless_http=True` for the OpenViking MCP server.
- Removed the dependency on FastMCP in-process session state for Streamable HTTP requests.
- Improved MCP endpoint compatibility with multi-instance deployments and load-balanced environments.

## Testing

Tested MCP functionality with multiple OpenViking instances behind a load balancer.

Validation steps:

- Started multiple OpenViking instances.
- Connected OpenCode to the MCP endpoint.
- Verified MCP initialization and tool discovery succeed consistently.
- Confirmed that repeated MCP requests no longer produce intermittent `404 "Session not found"` errors.

Test environment:

- [x] Linux
- [ ] macOS
- [ ] Windows

Tests:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

This is the bug screenshots.

<img width="356" height="98" alt="opencode" src="https://github.com/user-attachments/assets/c880d182-c53c-4ce8-b502-fabd77b17b4e" />


## Additional Notes

The root cause is that FastMCP's default Streamable HTTP session handling relies on process-local state, which is not suitable for stateless load-balanced deployments.

This change keeps the MCP endpoint stateless instead of requiring session affinity or shared session storage.