### PR TITLE
fix(overview):language fix

### DIFF
--- a/openviking/prompts/templates/semantic/overview_generation.yaml
+++ b/openviking/prompts/templates/semantic/overview_generation.yaml
@@ -56,7 +56,7 @@ template: |
 
   1. **Title** (H1): Directory name
 
-  2. **Brief Description** (plain text paragraph, 50-150 words):
+  2. **{{ "简要描述" if output_language == "zh-CN" else "Brief Description" }}** (plain text paragraph, 50-150 words):
      - Immediately following the title, without any H2 heading
      - Explain what this is, what it's about, what it covers
      - Include core keywords for easy searching


### PR DESCRIPTION
Description

  This PR fixes a language inconsistency in the semantic overview generation prompt template. The "Brief Description" section heading was hardcoded in English, while the surrounding
  section headings ("Quick Navigation", "Detailed Description") already localized based on output_language. This change makes the "Brief Description" label follow the same
  conditional so that when output_language == "zh-CN", it renders as "简要描述", keeping the generated overview fully localized.

  Human Involvement
  <!-- Select exactly one option -->

  - [x] A human participated in the implementation or review loop
  - [ ] This PR was generated entirely by AI agents without human participation in the loop

  Related Issue
  <!-- Link to the related issue (if applicable) -->

  N/A

  Type of Change
  <!-- Mark the relevant option with an "x" -->

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Test update

  Changes Made
  <!-- List the main changes made in this PR -->

  - In openviking/prompts/templates/semantic/overview_generation.yaml, replaced the hardcoded **Brief Description** heading label with the conditional {{ "简要描述" if
    output_language == "zh-CN" else "Brief Description" }}.

  - Aligned the "Brief Description" heading localization behavior with the existing "Quick Navigation" and "Detailed Description" headings.

  Testing
  <!-- Describe how you tested your changes -->

  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] I have tested this on the following platforms:
      - [ ] Linux
      - [x] macOS
      - [ ] Windows

  Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published

  Screenshots (if applicable)
  <!-- Add screenshots to help explain your changes -->

  N/A

  Additional Notes
  <!-- Add any additional notes or context about the PR -->

  This is a one-line template fix. Only the section heading label is affected; the body content generation rules (50–150 word plain-text paragraph, no H2 heading, core keywords,
  target audience) are unchanged.
