### PR TITLE
feat(queuefs): add bounded redis startup stale-recovery sweeps

### DIFF
--- a/crates/ragfs/src/plugins/queuefs/redis_backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/redis_backend.rs
@@ -12,11 +12,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const HEARTBEAT_TTL_SECS: u64 = 30;
 const HEARTBEAT_INTERVAL_SECS: u64 = 10;
+const STARTUP_RECOVERY_SWEEPS: usize = 3;
 const REDIS_POOL_MAX_SIZE: u32 = 2;
 const REDIS_POOL_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(5);
 const SENTINEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -538,7 +539,6 @@ impl RedisQueueBackend {
             heartbeat_thread: None,
         };
         backend.start_heartbeat(heartbeat_key);
-        backend.recover_stale()?;
         Ok(backend)
     }
 
@@ -555,9 +555,21 @@ impl RedisQueueBackend {
     fn start_heartbeat(&mut self, key: String) {
         let (sender, receiver) = mpsc::channel();
         let pool = self.pool.clone();
+        let key_prefix = self.key_prefix.clone();
         self.heartbeat_stop = Some(sender);
         self.heartbeat_thread = Some(std::thread::spawn(move || {
+            // ponytail: run only three startup sweeps; upgrade
+            // to continuous recovery if shared multi-replica consumers need steady-state handoff.
+            let mut startup_recovery_sweeps_left = STARTUP_RECOVERY_SWEEPS;
+            let mut next_startup_recovery_at =
+                Instant::now() + Duration::from_secs(HEARTBEAT_TTL_SECS);
             loop {
+                Self::run_startup_recovery_sweep(
+                    &pool,
+                    &key_prefix,
+                    &mut startup_recovery_sweeps_left,
+                    &mut next_startup_recovery_at,
+                );
                 if let Err(error) = refresh_heartbeat(&pool, &key) {
                     tracing::warn!("queuefs redis heartbeat failed: {error}");
                 }
@@ -569,19 +581,46 @@ impl RedisQueueBackend {
         }));
     }
 
+    /// Run at most one scheduled startup recovery sweep and update the next deadline.
+    fn run_startup_recovery_sweep(
+        pool: &RedisPool,
+        key_prefix: &str,
+        startup_recovery_sweeps_left: &mut usize,
+        next_startup_recovery_at: &mut Instant,
+    ) {
+        if *startup_recovery_sweeps_left == 0
+            || (*startup_recovery_sweeps_left != STARTUP_RECOVERY_SWEEPS
+                && Instant::now() < *next_startup_recovery_at)
+        {
+            return;
+        }
+        match Self::recover_stale(pool, key_prefix) {
+            Ok(recovered) => {
+                if recovered > 0 {
+                    tracing::info!("queuefs redis recovered {recovered} stale message(s)");
+                }
+            }
+            Err(error) => tracing::warn!("queuefs redis startup recover_stale failed: {error}"),
+        }
+        *startup_recovery_sweeps_left -= 1;
+        if *startup_recovery_sweeps_left > 0 {
+            *next_startup_recovery_at += Duration::from_secs(HEARTBEAT_TTL_SECS);
+        }
+    }
+
     /// Recover processing messages whose owning instance heartbeat has expired.
-    fn recover_stale(&self) -> Result<usize> {
-        let queue_names_key = queue_names_key(&self.key_prefix);
-        let instance_key_prefix = instance_key_prefix(&self.key_prefix);
-        let queues = self.with_connection("recover_stale list queues", |connection| {
+    fn recover_stale(pool: &RedisPool, key_prefix: &str) -> Result<usize> {
+        let queue_names_key = queue_names_key(key_prefix);
+        let instance_key_prefix = instance_key_prefix(key_prefix);
+        let queues = pool.execute("recover_stale list queues", |connection| {
             redis::cmd("SMEMBERS")
                 .arg(&queue_names_key)
                 .query::<Vec<String>>(connection)
         })?;
         let mut recovered = 0;
         for queue in queues {
-            let keys = QueueKeys::new(&self.key_prefix, &queue);
-            recovered += self.with_connection("recover_stale", |connection| {
+            let keys = QueueKeys::new(key_prefix, &queue);
+            recovered += pool.execute("recover_stale", |connection| {
                 redis::Script::new(RECOVER_STALE_SCRIPT)
                     .key(&keys.processing)
                     .key(&keys.pending)

--- a/crates/ragfs/src/plugins/queuefs/redis_backend.rs
+++ b/crates/ragfs/src/plugins/queuefs/redis_backend.rs
@@ -521,6 +521,8 @@ pub(super) struct RedisQueueBackend {
     instance_id: String,
     heartbeat_stop: Option<Sender<()>>,
     heartbeat_thread: Option<JoinHandle<()>>,
+    startup_recovery_stop: Option<Sender<()>>,
+    startup_recovery_thread: Option<JoinHandle<()>>,
 }
 
 impl RedisQueueBackend {
@@ -537,8 +539,11 @@ impl RedisQueueBackend {
             instance_id,
             heartbeat_stop: None,
             heartbeat_thread: None,
+            startup_recovery_stop: None,
+            startup_recovery_thread: None,
         };
         backend.start_heartbeat(heartbeat_key);
+        backend.start_startup_recovery();
         Ok(backend)
     }
 
@@ -552,24 +557,14 @@ impl RedisQueueBackend {
     }
 
     /// Start the heartbeat thread using a separate pool checkout for every renewal.
+    /// `key` is this instance's heartbeat key in Redis.
+    /// Returns no value; the spawned thread is stored on `self`.
     fn start_heartbeat(&mut self, key: String) {
         let (sender, receiver) = mpsc::channel();
         let pool = self.pool.clone();
-        let key_prefix = self.key_prefix.clone();
         self.heartbeat_stop = Some(sender);
         self.heartbeat_thread = Some(std::thread::spawn(move || {
-            // ponytail: run only three startup sweeps; upgrade
-            // to continuous recovery if shared multi-replica consumers need steady-state handoff.
-            let mut startup_recovery_sweeps_left = STARTUP_RECOVERY_SWEEPS;
-            let mut next_startup_recovery_at =
-                Instant::now() + Duration::from_secs(HEARTBEAT_TTL_SECS);
             loop {
-                Self::run_startup_recovery_sweep(
-                    &pool,
-                    &key_prefix,
-                    &mut startup_recovery_sweeps_left,
-                    &mut next_startup_recovery_at,
-                );
                 if let Err(error) = refresh_heartbeat(&pool, &key) {
                     tracing::warn!("queuefs redis heartbeat failed: {error}");
                 }
@@ -581,19 +576,46 @@ impl RedisQueueBackend {
         }));
     }
 
-    /// Run at most one scheduled startup recovery sweep and update the next deadline.
-    fn run_startup_recovery_sweep(
-        pool: &RedisPool,
-        key_prefix: &str,
-        startup_recovery_sweeps_left: &mut usize,
-        next_startup_recovery_at: &mut Instant,
-    ) {
-        if *startup_recovery_sweeps_left == 0
-            || (*startup_recovery_sweeps_left != STARTUP_RECOVERY_SWEEPS
-                && Instant::now() < *next_startup_recovery_at)
-        {
-            return;
-        }
+    /// Start a bounded startup recovery thread.
+    /// The thread runs at offsets 0, 30, and 60 seconds from startup unless stopped early.
+    /// Returns no value; the spawned thread is stored on `self`.
+    fn start_startup_recovery(&mut self) {
+        let (sender, receiver) = mpsc::channel();
+        let pool = self.pool.clone();
+        let key_prefix = self.key_prefix.clone();
+        self.startup_recovery_stop = Some(sender);
+        self.startup_recovery_thread = Some(std::thread::spawn(move || {
+            // ponytail: keep startup recovery bounded to the restart TTL window;
+            // upgrade to steady-state scanning only if deployments need long-lived handoff.
+            let started_at = Instant::now();
+            for sweep_index in 0..STARTUP_RECOVERY_SWEEPS {
+                let deadline = started_at + Self::startup_recovery_delay_before_sweep(sweep_index);
+                loop {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    match receiver.recv_timeout(deadline.saturating_duration_since(now)) {
+                        Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+                        Err(RecvTimeoutError::Timeout) => {}
+                    }
+                }
+                Self::run_startup_recovery_sweep(&pool, &key_prefix);
+            }
+        }));
+    }
+
+    /// Return the delay before one bounded startup recovery sweep.
+    /// `sweep_index` is zero-based and maps to the documented 0/30/60-second schedule.
+    /// Returns the sweep offset from startup.
+    fn startup_recovery_delay_before_sweep(sweep_index: usize) -> Duration {
+        Duration::from_secs(HEARTBEAT_TTL_SECS * sweep_index as u64)
+    }
+
+    /// Run one startup recovery sweep.
+    /// `pool` provides Redis connections and `key_prefix` selects the queue namespace.
+    /// Returns no value; recovery results are emitted through logs.
+    fn run_startup_recovery_sweep(pool: &RedisPool, key_prefix: &str) {
         match Self::recover_stale(pool, key_prefix) {
             Ok(recovered) => {
                 if recovered > 0 {
@@ -601,10 +623,6 @@ impl RedisQueueBackend {
                 }
             }
             Err(error) => tracing::warn!("queuefs redis startup recover_stale failed: {error}"),
-        }
-        *startup_recovery_sweeps_left -= 1;
-        if *startup_recovery_sweeps_left > 0 {
-            *next_startup_recovery_at += Duration::from_secs(HEARTBEAT_TTL_SECS);
         }
     }
 
@@ -668,7 +686,13 @@ impl Drop for RedisQueueBackend {
         if let Some(sender) = self.heartbeat_stop.take() {
             let _ = sender.send(());
         }
+        if let Some(sender) = self.startup_recovery_stop.take() {
+            let _ = sender.send(());
+        }
         if let Some(thread) = self.heartbeat_thread.take() {
+            let _ = thread.join();
+        }
+        if let Some(thread) = self.startup_recovery_thread.take() {
             let _ = thread.join();
         }
         let _ = self.pool.try_execute(|connection| {

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1129,7 +1129,7 @@ Notes:
 - QueueFS defaults to `sqlite` even if the main AGFS storage backend is `local`, `s3`, or `memory`.
 - `mode=shared` keeps the historical global queue namespace at `/queue`; `mode=worker` isolates each worker under `/queue/worker-<index|pid>`.
 - `db_path` is only used when QueueFS backend is `sqlite` or `sqlite3`.
-- Redis backend runs `recover_stale` in the heartbeat thread immediately after startup, then once more at 30 seconds and 60 seconds to cover the heartbeat-expiry window after a container restart; it does not run long-lived periodic recovery.
+- Redis backend runs three bounded `recover_stale` sweeps in a dedicated startup recovery thread at startup, 30 seconds, and 60 seconds to cover the heartbeat-expiry window after a container restart; it does not run long-lived periodic recovery.
 - If both `storage.agfs.queuefs.db_path` and legacy `storage.agfs.queue_db_path` are set, `storage.agfs.queuefs.db_path` wins.
 - If QueueFS backend is `memory`, any `db_path` or legacy `queue_db_path` is ignored.
 

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1129,6 +1129,7 @@ Notes:
 - QueueFS defaults to `sqlite` even if the main AGFS storage backend is `local`, `s3`, or `memory`.
 - `mode=shared` keeps the historical global queue namespace at `/queue`; `mode=worker` isolates each worker under `/queue/worker-<index|pid>`.
 - `db_path` is only used when QueueFS backend is `sqlite` or `sqlite3`.
+- Redis backend runs `recover_stale` in the heartbeat thread immediately after startup, then once more at 30 seconds and 60 seconds to cover the heartbeat-expiry window after a container restart; it does not run long-lived periodic recovery.
 - If both `storage.agfs.queuefs.db_path` and legacy `storage.agfs.queue_db_path` are set, `storage.agfs.queuefs.db_path` wins.
 - If QueueFS backend is `memory`, any `db_path` or legacy `queue_db_path` is ignored.
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1125,7 +1125,7 @@ QueueFS Redis 参数：
 - `username` 和 `password` 用于 Redis 数据节点；`sentinel_username` 和 `sentinel_password` 仅用于 Sentinel 节点。
 - Redis backend 使用 `{key_prefix}:ov:*` key；连接同一 Redis database 的不同业务必须配置不同的 `key_prefix`。
 - Redis backend 的实例心跳 TTL 为 30 秒，每 10 秒续约一次。
-- Redis backend 会在 heartbeat 线程启动后立即按实例心跳状态执行一次 `recover_stale`，并在之后第 30 秒和第 60 秒各补跑一次，用于覆盖容器异常退出后旧实例心跳尚未过期的恢复窗口；运行期间不做长期周期恢复。
+- Redis backend 会在独立的 startup recovery 线程中按实例心跳状态执行三次有界 `recover_stale` 扫描，时间点分别为启动后立即、30 秒和 60 秒，用于覆盖容器异常退出后旧实例心跳尚未过期的恢复窗口；运行期间不做长期周期恢复。
 - `tls_insecure_skip_verify=true` 时必须同时设置 `tls_enabled=true`。
 - 如果同时设置了 `storage.agfs.queuefs.db_path` 和旧字段 `storage.agfs.queue_db_path`，以前者为准。
 - 如果 QueueFS backend 为 `memory`，则 `db_path` 和旧字段 `queue_db_path` 都会被忽略。

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1125,7 +1125,7 @@ QueueFS Redis 参数：
 - `username` 和 `password` 用于 Redis 数据节点；`sentinel_username` 和 `sentinel_password` 仅用于 Sentinel 节点。
 - Redis backend 使用 `{key_prefix}:ov:*` key；连接同一 Redis database 的不同业务必须配置不同的 `key_prefix`。
 - Redis backend 的实例心跳 TTL 为 30 秒，每 10 秒续约一次。
-- Redis backend 仅在启动时按实例心跳状态执行一次 `recover_stale`，运行期间不周期恢复。
+- Redis backend 会在 heartbeat 线程启动后立即按实例心跳状态执行一次 `recover_stale`，并在之后第 30 秒和第 60 秒各补跑一次，用于覆盖容器异常退出后旧实例心跳尚未过期的恢复窗口；运行期间不做长期周期恢复。
 - `tls_insecure_skip_verify=true` 时必须同时设置 `tls_enabled=true`。
 - 如果同时设置了 `storage.agfs.queuefs.db_path` 和旧字段 `storage.agfs.queue_db_path`，以前者为准。
 - 如果 QueueFS backend 为 `memory`，则 `db_path` 和旧字段 `queue_db_path` 都会被忽略。


### PR DESCRIPTION
## Description

Add bounded Redis `recover_stale` startup retries for QueueFS and document the behavior.

This PR intentionally does **not** add long-lived periodic scanning. Instead, it performs a small, bounded number of startup recovery sweeps in the heartbeat thread:

- immediate sweep after the heartbeat thread starts
- one more sweep at `+30s`
- one more sweep at `+60s`

This design matches our actual deployment model and failure mode better than continuous background scanning.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Fixes #(issue number) -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add bounded Redis startup stale-recovery sweeps in QueueFS: immediate, `+30s`, `+60s`
- Keep `recover_stale` logic on the existing method path and invoke it from the heartbeat-thread startup flow
- Update Chinese and English configuration docs to describe the new Redis recovery behavior

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Verification run locally:

- `cargo check -p ragfs`
- `git diff --check -- docs/zh/guides/01-configuration.md docs/en/guides/01-configuration.md`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR deliberately chooses a bounded startup strategy over a generic always-on background scanner.

The key design choice is: **pay cost only in the startup recovery window where we actually need it**, instead of introducing permanent periodic scans for a failure mode that is currently concentrated around orchestrated restart behavior.



Why bounded sweeps instead of periodic scanning:

- We suggest deployment model is containerized / Kubernetes-based. The practical failure mode is:
  1. old instance exits unexpectedly
  2. orchestrator restarts the service quickly
  3. old Redis heartbeat key may still be alive for up to `30s`
  4. stale `processing` messages are not recoverable on the very first check
- In this model, the recovery window is concentrated around **startup**, not during long-lived steady state
- Bounded sweeps cover the needed window without paying a permanent scanning cost

Why we do **not** use periodic scanning:

- `recover_stale` is not free: it lists queues and scans each queue's `processing` set
- Running it forever every `30s` means paying a constant background cost even when the system is healthy
- That cost is not justified for our current workload and deployment assumptions
- Long-lived periodic scanning also complicates behavior and makes the Redis backend less intentionally bounded

Scenarios covered by this PR:

- **Crash -> immediate restart**  
  First sweep may miss stale work because the old heartbeat has not expired yet; the `+30s` sweep recovers it
- **Crash -> restart with short Redis / scheduling jitter**  
  If the exact `30s` boundary is missed or delayed slightly, the `+60s` sweep still covers the recovery window
- **Already-stale orphaned processing on startup**  
  Immediate sweep recovers messages whose owner heartbeat has already expired before the new instance starts

Scenarios intentionally not optimized by this PR:

- Long-running multi-replica steady-state cross-instance orphan scanning
- Continuous background stale recovery during healthy runtime

if the deployment model or observed production behavior requires them. suggest add cli/http recover ability rather than redis Routine scanning