### PR TITLE
fix(search): expand find/search default scope for context_type=skill (#3739)

### DIFF
--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -741,6 +741,7 @@ class LocalClient(BaseClient):
                 filter=resolved_filter,
                 level=level,
                 image_url=image_url,
+                context_type=context_type,
             ),
         )
         return attach_telemetry_payload(
@@ -787,6 +788,7 @@ class LocalClient(BaseClient):
                 filter=resolved_filter,
                 level=level,
                 image_url=image_url,
+                context_type=context_type,
             )
 
         execution = await run_with_telemetry(

--- a/openviking/core/retrieval_targets.py
+++ b/openviking/core/retrieval_targets.py
@@ -14,6 +14,7 @@ from openviking.core.namespace import (
 )
 from openviking.core.peer_id import normalize_peer_id
 from openviking.server.identity import RequestContext, Role
+from openviking.utils.search_filters import resolve_context_types
 from openviking_cli.exceptions import InvalidArgumentError, PermissionDeniedError
 from openviking_cli.retrieve import ContextType
 from openviking_cli.utils.uri import VikingURI
@@ -30,13 +31,14 @@ class ResolvedRetrievalTargets:
 def resolve_retrieval_targets(
     target_uri: Union[str, List[str]],
     ctx: RequestContext,
+    context_type: Optional[Union[str, ContextType, List]] = None,
 ) -> ResolvedRetrievalTargets:
     """Resolve search/find target directories."""
     target_uris = _canonicalize_target_uris(target_uri, ctx)
 
     if not target_uris:
         return ResolvedRetrievalTargets(
-            target_directories=default_target_directories(ctx),
+            target_directories=default_target_directories(ctx, context_type=context_type),
         )
 
     target_directories: List[str] = []
@@ -53,12 +55,34 @@ def resolve_retrieval_targets(
 def default_target_directories(
     ctx: Optional[RequestContext],
     *,
-    context_type: Optional[ContextType] = None,
+    context_type: Optional[Union[str, ContextType, List]] = None,
 ) -> List[str]:
     """Return default retrieval directories for a user context."""
     if not ctx or ctx.role == Role.ROOT:
         return []
 
+    context_types = resolve_context_types(context_type)
+    if not context_types:
+        return _general_default_target_directories(ctx)
+
+    directories: List[str] = []
+    for value in context_types:
+        for directory in _typed_default_target_directories(ctx, ContextType(value)):
+            if directory not in directories:
+                directories.append(directory)
+    return directories
+
+
+def _general_default_target_directories(ctx: RequestContext) -> List[str]:
+    user_root = canonical_user_root(ctx)
+    if ctx.actor_peer_id:
+        return _dedupe(["viking://resources", *_default_user_root_targets(ctx)])
+    return [user_root, "viking://resources"]
+
+
+def _typed_default_target_directories(
+    ctx: RequestContext, context_type: ContextType
+) -> List[str]:
     user_root = canonical_user_root(ctx)
     if context_type == ContextType.MEMORY:
         if ctx.actor_peer_id:
@@ -81,9 +105,7 @@ def default_target_directories(
         return ["viking://resources", user_root]
     if context_type == ContextType.SKILL:
         return _dedupe([*_default_skill_targets(ctx), *_default_agent_skill_targets()])
-    if ctx.actor_peer_id:
-        return _dedupe(["viking://resources", *_default_user_root_targets(ctx)])
-    return [user_root, "viking://resources"]
+    return _general_default_target_directories(ctx)
 
 
 def _canonicalize_target_uris(

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -253,6 +253,7 @@ async def find(
         score_threshold=min_score,
         filter=_resolve_context_type_filter(context_type),
         level=level,
+        context_type=context_type,
     )
     return _format_search_result(result)
 
@@ -284,6 +285,7 @@ async def search(
         score_threshold=min_score,
         filter=_resolve_context_type_filter(context_type),
         level=level,
+        context_type=context_type,
     )
     return _format_search_result(result)
 

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -296,6 +296,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=request.image_url,
+            context_type=request.context_type,
         ),
     )
     result = execution.result
@@ -407,6 +408,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=request.image_url,
+            context_type=request.context_type,
         )
 
     execution = await run_operation(

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -88,6 +88,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -123,6 +124,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result
 
@@ -136,6 +138,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -163,5 +166,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2135,6 +2135,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ):
         """Semantic search.
 
@@ -2158,7 +2159,9 @@ class VikingFS:
         )
 
         real_ctx = self._ctx_or_default(ctx)
-        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx)
+        retrieval_targets = resolve_retrieval_targets(
+            target_uri, real_ctx, context_type=context_type
+        )
 
         for target_dir in retrieval_targets.target_directories:
             self._ensure_access(target_dir, ctx)
@@ -2232,6 +2235,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ):
         """Complex search with session context.
 
@@ -2257,7 +2261,9 @@ class VikingFS:
         )
 
         real_ctx = self._ctx_or_default(ctx)
-        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx)
+        retrieval_targets = resolve_retrieval_targets(
+            target_uri, real_ctx, context_type=context_type
+        )
         primary_target_uri = retrieval_targets.first_explicit_directory
 
         session_summary = (

--- a/tests/server/test_actor_peer_retrieval_targets.py
+++ b/tests/server/test_actor_peer_retrieval_targets.py
@@ -171,3 +171,56 @@ def test_actor_peer_collection_targets_actor_peer_only():
         "viking://user/support_bot/peers/web-visitor-alice/memories",
         "viking://user/support_bot/peers/web-visitor-alice/resources",
     ]
+
+
+def test_skill_context_type_expands_default_scope_to_agent_skills():
+    targets = resolve_retrieval_targets(
+        "",
+        _ctx(),
+        context_type=ContextType.SKILL,
+    ).target_directories
+
+    assert targets == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_skill_context_type_accepts_string_and_list_values():
+    assert resolve_retrieval_targets(
+        "", _ctx(), context_type="skill"
+    ).target_directories == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+    assert resolve_retrieval_targets(
+        "", _ctx(), context_type=["skill"]
+    ).target_directories == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_multi_context_type_unions_default_scopes():
+    targets = resolve_retrieval_targets(
+        "",
+        _ctx(actor_peer_id="web-visitor-alice"),
+        context_type=["memory", "skill"],
+    ).target_directories
+
+    assert targets == [
+        "viking://user/support_bot/memories",
+        "viking://user/support_bot/peers/web-visitor-alice/memories",
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_explicit_target_uri_overrides_context_type_scope():
+    targets = resolve_retrieval_targets(
+        "viking://user/support_bot/memories",
+        _ctx(),
+        context_type=ContextType.SKILL,
+    ).target_directories
+
+    assert targets == ["viking://user/support_bot/memories"]


### PR DESCRIPTION
## Summary

Fixes #3739.

`ov find "<q>" --context-type skill` and `POST /api/v1/search/find` / `/api/v1/search/search` with `context_type="skill"` (and empty `target_uri`) returned zero results for skills installed under the shared `viking://agent/skills/` namespace, even though `ov skills find` and `ov find -u viking://agent "<q>"` found them.

### Root cause
`context_type` was consumed only as a result-type filter (`merge_search_filter`); it was never forwarded as a *scope* input. When `target_uri` is empty, `resolve_retrieval_targets` unconditionally called `default_target_directories(ctx)` without `context_type`, even though `default_target_directories` already has a correct `ContextType.SKILL` branch that includes `viking://agent/skills`.

### Change
- Thread `context_type` through the HTTP router (`search.py`), local SDK client (`client/local.py`), MCP endpoint (`mcp_endpoint.py`), `SearchService.find/search`, and `VikingFS.find/search` into `resolve_retrieval_targets`.
- `resolve_retrieval_targets` passes `context_type` to `default_target_directories` when `target_uri` is empty.
- `default_target_directories` now accepts the same `str | ContextType | list` input already used by the request model (reusing `resolve_context_types`), unions the type-specific default roots for multi-value input, and preserves prior behavior when `context_type` is omitted.
- Explicit `target_uri` still overrides `context_type` scope (no narrowing of an explicit directory).

This makes generic `find --context-type skill` scope-equivalent to `ov skills find` for the default-root case (user skills + shared agent skills), while the existing result filter continues to restrict returned types.

## Validation
- `ruff check` clean on all changed files; `py_compile` clean.
- Added regression tests in `tests/server/test_actor_peer_retrieval_targets.py`:
  - skill context expands default scope to `viking://user/<id>/skills` + `viking://agent/skills`
  - accepts string and list `context_type`
  - multi-type (`memory,skill`) unions scopes
  - explicit `target_uri` overrides context_type scope
- `pytest tests/server/test_actor_peer_retrieval_targets.py tests/storage/test_viking_vector_scope_filter.py` → 29 passed.
- Stub-based check confirms `context_type` is forwarded end to end through `SearchService`/`VikingFS` and the router call path.

Note: full server/API search tests in this checkout require the compiled `ragfs_python` + x86 vector engine (`PersistStore`) native artifacts, which are not available in this environment; the affected surface is covered by the retrieval-target unit tests and forwarding checks above.

> Draft only — not ready for formal review/merge per contribution workflow.