### PR TITLE
fix(parse): stop routing TypeScript .ts URLs to the video parser (#3266)

### DIFF
--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -23,12 +23,13 @@ from typing import Any, Dict, Mapping, Optional, Tuple, Union
 from urllib.parse import unquote, urlparse
 
 from openviking.parse.base import lazy_import
-from openviking.parse.parsers.constants import CODE_EXTENSIONS
+from openviking.parse.parsers.constants import CODE_EXTENSIONS, TYPESCRIPT_MPEG_TS_EXTENSION
 from openviking.parse.parsers.media.constants import (
     AUDIO_EXTENSIONS,
     IMAGE_EXTENSIONS,
     VIDEO_EXTENSIONS,
 )
+from openviking.parse.parsers.media.utils import is_mpeg_ts
 from openviking.utils import is_code_hosting_blob_url
 from openviking.utils.network_guard import build_httpx_request_validation_hooks
 from openviking_cli.exceptions import PermissionDeniedError
@@ -186,7 +187,15 @@ class URLTypeDetector:
 
         # === Step 1: Check extension from URL path ===
         path_ext = Path(path_lower).suffix
-        if path_ext and path_ext in valid_extensions:
+        # ".ts" is ambiguous (MPEG transport stream video vs TypeScript source).
+        # Do not resolve it from the extension alone; let Content-Type
+        # (video/mp2t) or post-download magic bytes decide so TypeScript files
+        # are not misrouted to the video parser.
+        if (
+            path_ext
+            and path_ext != TYPESCRIPT_MPEG_TS_EXTENSION
+            and path_ext in valid_extensions
+        ):
             for ext, url_type in self.EXTENSION_MAP.items():
                 if path_lower.endswith(ext):
                     meta["detected_by"] = "extension"
@@ -743,6 +752,11 @@ class HTTPAccessor(DataAccessor):
             return URLType.DOWNLOAD_VIDEO, ".mp4"
         if sample.startswith(b"\x1f\x8b"):
             return URLType.UNKNOWN, ".gz"
+        # MPEG transport stream: sync byte 0x47 repeats every 188-byte packet.
+        # ".ts" is ambiguous with TypeScript, so require the packet signature
+        # before routing to the video parser.
+        if is_mpeg_ts(content):
+            return URLType.DOWNLOAD_VIDEO, TYPESCRIPT_MPEG_TS_EXTENSION
         svg_sample = content[:512].lstrip()
         if svg_sample.startswith(b"<svg") or (
             svg_sample.startswith(b"<?xml") and b"<svg" in svg_sample

--- a/tests/parse/test_url_filename_preservation.py
+++ b/tests/parse/test_url_filename_preservation.py
@@ -72,7 +72,10 @@ class TestURLTypeDetectorCodeExtensions:
         assert url_type == URLType.DOWNLOAD_TXT
 
     @pytest.mark.asyncio
-    async def test_ts_extension_defaults_to_video_when_headers_unavailable(self, monkeypatch):
+    async def test_ts_typescript_not_routed_to_video(self, monkeypatch):
+        # ".ts" is ambiguous (TypeScript vs MPEG transport stream). A TypeScript
+        # source served as text/plain must not be classified as video, even
+        # though the URL ends in .ts (issue #3266).
         _patch_httpx_client(
             monkeypatch,
             headers={"content-type": "text/plain"},
@@ -81,9 +84,29 @@ class TestURLTypeDetectorCodeExtensions:
 
         url_type, meta = await self.detector.detect("https://example.com/path/index.ts")
 
+        # ".ts" must not be pinned to video from the extension alone; with no
+        # Content-Type it falls through to the default webpage guess and is
+        # refined only after download (see _download_url tests below).
+        assert url_type != URLType.DOWNLOAD_VIDEO
+        assert meta.get("detected_by") != "extension"
+
+    @pytest.mark.asyncio
+    async def test_ts_mpeg_ts_video_routed_by_content_type(self, monkeypatch):
+        # A real MPEG transport stream served with video/mp2t must still route
+        # to video via Content-Type after the .ts extension shortcut is skipped.
+        _patch_httpx_client(
+            monkeypatch,
+            headers={"content-type": "video/mp2t"},
+            content=b"\x00" * 1880,
+            fail_head=False,
+        )
+
+        url_type, meta = await self.detector.detect(
+            "https://filesamples.com/samples/video/ts/sample_1280x720.ts"
+        )
+
         assert url_type == URLType.DOWNLOAD_VIDEO
-        assert meta["detected_by"] == "extension"
-        assert meta["extension"] == ".ts"
+        assert meta["detected_by"] == "media_type_pattern"
 
     @pytest.mark.asyncio
     async def test_yaml_extension_detected(self):
@@ -367,6 +390,45 @@ class TestHTTPAccessorGetFallback:
         assert temp_path.endswith(expected_ext)
         assert meta["original_filename"] == f"download{expected_ext}"
         assert meta["detected_by"] == "magic_bytes"
+
+    @pytest.mark.asyncio
+    async def test_ts_mpeg_ts_detected_by_magic_bytes(self, monkeypatch):
+        # MPEG transport stream: sync byte 0x47 every 188 bytes. With a generic
+        # Content-Type and a .ts URL, magic bytes must still route it to video
+        # and preserve the .ts extension (issue #3266).
+        mpeg_ts = bytearray(1880)
+        for offset in range(0, len(mpeg_ts), 188):
+            mpeg_ts[offset] = 0x47
+        _patch_httpx_client(
+            monkeypatch,
+            headers={"content-type": "application/octet-stream"},
+            content=bytes(mpeg_ts),
+        )
+
+        accessor = HTTPAccessor()
+        temp_path, url_type, meta = await accessor._download_url(
+            "https://example.com/media/clip.ts"
+        )
+
+        assert url_type == URLType.DOWNLOAD_VIDEO
+        assert temp_path.endswith(".ts")
+        assert meta["detected_by"] == "magic_bytes"
+
+    @pytest.mark.asyncio
+    async def test_ts_typescript_not_routed_to_video_after_download(self, monkeypatch):
+        _patch_httpx_client(
+            monkeypatch,
+            headers={"content-type": "text/plain"},
+            content=b"export const answer: number = 42;\n",
+        )
+
+        accessor = HTTPAccessor()
+        temp_path, url_type, meta = await accessor._download_url(
+            "https://example.com/src/answer.ts"
+        )
+
+        assert url_type != URLType.DOWNLOAD_VIDEO
+        assert temp_path.endswith(".ts")
 
     @pytest.mark.asyncio
     async def test_magic_bytes_recognizes_gzip_without_routing_to_document(self, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #3266.

`.ts` is ambiguous: it means MPEG transport stream for video, but TypeScript source for code. The HTTP URL detector (`URLTypeDetector.detect`) resolved a URL's type from its file extension **first**, and `VIDEO_EXTENSIONS` contains `.ts` (added in #3209). As a result, every URL ending in `.ts` was pinned to `DOWNLOAD_VIDEO` before the `Content-Type` header was consulted, so TypeScript sources served over HTTP were sent to video processing.

Local `.ts` files were already disambiguated by #3574 using MPEG-TS magic-byte sniffing, but the HTTP ingestion path was not covered.

## Changes

- `openviking/parse/accessors/http_accessor.py`
  - Skip the extension-first shortcut for `.ts`; detection falls through to the HEAD request, so a real MPEG-TS stream served as `video/mp2t` (or `video/*`) still resolves to `DOWNLOAD_VIDEO` via Content-Type.
  - Add MPEG transport stream detection to `_detect_from_magic_bytes` (sync byte `0x47` every 188-byte packets, via the existing `is_mpeg_ts`), so a `.ts` download with a generic/missing Content-Type is still routed to video and keeps the `.ts` extension.
- `tests/parse/test_url_filename_preservation.py`
  - Replace the test that asserted the old (buggy) `.ts → video by extension` behavior.
  - Add coverage: TypeScript `.ts` is not routed to video (detect + download); MPEG-TS `.ts` is routed by `Content-Type: video/mp2t`; MPEG-TS `.ts` with `application/octet-stream` is detected by magic bytes and keeps `.ts`.

After download, `MediaProcessor._set_resolved_identity` already sniffs the bytes: TypeScript keeps resolved extension `.ts` (code path), while confirmed MPEG-TS is rewritten to the `mpegts` video alias. This change makes the HTTP layer consistent with that and with `CODE_EXTENSIONS` / `get_resource_content_type`.

## Validation

- `ruff check` and `py_compile` clean on changed files.
- `pytest tests/parse tests/unit/test_accessors_http.py tests/unit/test_web_importer.py tests/misc/test_mpeg_ts_media_utils.py` — **559 passed, 31 skipped**.
- The multimodal `.ts` video matrix case (opt-in live test, `OPENVIKING_RUN_MULTIMODAL_INTEGRATION=1`) continues to resolve to video via `Content-Type: video/mp2t` now that the extension shortcut is skipped.

> Draft while CI runs; I will not self-merge or request promotion.