### PR TITLE
test(embedder): remove obsolete max_tokens ollama factory tests (#3744)

### DIFF
--- a/tests/unit/test_ollama_embedding_factory.py
+++ b/tests/unit/test_ollama_embedding_factory.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for the ollama embedding factory in EmbeddingConfig._create_embedder.
 
-Regression tests for two bugs fixed in the ollama factory lambda:
-  1. max_tokens was not forwarded to OpenAIDenseEmbedder (so user-configured
-     chunking thresholds were silently ignored for Ollama).
-  2. The api_key placeholder was "ollama" instead of "no-key", inconsistent
-     with the openai factory and the placeholder used inside OpenAIDenseEmbedder.
+Regression tests for the ollama factory lambda:
+  - The api_key placeholder is "no-key", not "ollama", consistent with the
+    openai factory and the placeholder used inside OpenAIDenseEmbedder.
+  - The api_base defaults to the local ollama endpoint and forwards overrides.
 """
 
 from unittest.mock import MagicMock, patch
@@ -26,61 +25,9 @@ def _make_mock_openai_class():
 
 
 def _make_ollama_cfg(**kwargs) -> EmbeddingModelConfig:
-    defaults = dict(provider="ollama", model="nomic-embed-text", dimension=768)
+    defaults = {"provider": "ollama", "model": "nomic-embed-text", "dimension": 768}
     defaults.update(kwargs)
     return EmbeddingModelConfig(**defaults)
-
-
-@patch("openai.OpenAI")
-class TestOllamaFactoryMaxTokens:
-    """max_tokens must be forwarded from config to OpenAIDenseEmbedder."""
-
-    def test_custom_max_tokens_is_forwarded(self, mock_openai_class):
-        """When max_tokens=512, the created embedder should report max_tokens=512."""
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = MagicMock(
-            data=[MagicMock(embedding=[0.1] * 8)], usage=None
-        )
-        mock_openai_class.return_value = mock_client
-
-        cfg = _make_ollama_cfg(max_tokens=512)
-        embedder = EmbeddingConfig(dense=cfg)._create_embedder("ollama", "dense", cfg)
-
-        assert embedder.max_tokens == 512
-
-    def test_none_max_tokens_uses_default(self, mock_openai_class):
-        """When max_tokens is not set (None), the embedder should use its default (8000)."""
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = MagicMock(
-            data=[MagicMock(embedding=[0.1] * 8)], usage=None
-        )
-        mock_openai_class.return_value = mock_client
-
-        cfg = _make_ollama_cfg()  # max_tokens not set -> None
-        assert cfg.max_tokens is None
-
-        embedder = EmbeddingConfig(dense=cfg)._create_embedder("ollama", "dense", cfg)
-
-        assert embedder.max_tokens == 8000  # class-level default
-
-    def test_openai_factory_max_tokens_also_forwarded(self, mock_openai_class):
-        """Sanity: the openai factory also forwards max_tokens (parity check)."""
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = MagicMock(
-            data=[MagicMock(embedding=[0.1] * 8)], usage=None
-        )
-        mock_openai_class.return_value = mock_client
-
-        cfg = EmbeddingModelConfig(
-            provider="openai",
-            model="text-embedding-3-small",
-            api_key="sk-test",
-            dimension=1536,
-            max_tokens=4096,
-        )
-        embedder = EmbeddingConfig(dense=cfg)._create_embedder("openai", "dense", cfg)
-
-        assert embedder.max_tokens == 4096
 
 
 @patch("openai.OpenAI")


### PR DESCRIPTION
## Summary

Closes #3744.

`tests/unit/test_ollama_embedding_factory.py::TestOllamaFactoryMaxTokens` had 3 tests that construct `EmbeddingModelConfig(..., max_tokens=...)`. `EmbeddingModelConfig` no longer has a `max_tokens` field (it uses `extra="forbid"`), so all 3 fail at construction on the `main` baseline with:

```
ValidationError: 1 validation error for EmbeddingModelConfig
  max_tokens
    Extra inputs are not permitted
```

The per-model `max_tokens` concept no longer exists at this layer:
- `EmbeddingModelConfig` has no `max_tokens` field.
- `OpenAIDenseEmbedder.__init__` no longer accepts `max_tokens`.
- Input token limits are configured as `EmbeddingConfig.max_input_tokens` and passed via the embedder runtime `config`.

So these tests assert behavior for a removed field rather than current behavior.

## Changes

- Delete the stale `TestOllamaFactoryMaxTokens` class (3 tests).
- Update the module docstring to describe the still-active coverage (api_key placeholder and api_base forwarding).
- Convert `dict(...)` to a dict literal in `_make_ollama_cfg` so the file passes ruff.

The `TestOllamaFactoryApiKeyPlaceholder` and `TestOllamaFactoryApiBase` classes are unchanged and continue to cover the live factory behavior.

> Note: open PR #2317 also touches this test file but only appends a new class at the end; it does not modify `TestOllamaFactoryMaxTokens`, so there is no conflict. This fix is independent of #2317, as confirmed in the issue.

## Validation

- `ruff check tests/unit/test_ollama_embedding_factory.py` — clean
- `py_compile` — clean
- `pytest -o addopts="" tests/unit/test_ollama_embedding_factory.py` — **5 passed** (was 3 failed + 2 passed)
- The gemini embedder test failures in the broader unit suite are pre-existing on main (missing optional `gemini_embedders` module in this environment) and unrelated to this change.

> Draft while CI runs; I will not self-merge or request promotion.