### PR TITLE
test(agfs): add pathlock to AGFS config test fakes after #3602 (#3753)

### DIFF
--- a/tests/unit/service/test_core_encryption_startup.py
+++ b/tests/unit/service/test_core_encryption_startup.py
@@ -19,6 +19,12 @@ class _FakeCacheConfig:
         return {"enabled": False, "provider": "memory"}
 
 
+class _FakePathLockConfig:
+    def model_dump(self, mode: str) -> dict:
+        assert mode == "json"
+        return {"provider": "filesystem", "lock_timeout_secs": 0.0, "lock_expire_secs": 1800.0}
+
+
 class _FakeConfig:
     """Minimal config object exposing the service-facing to_dict API."""
 
@@ -27,6 +33,7 @@ class _FakeConfig:
             path="/tmp/ov-test",
             backend="local",
             cache=_FakeCacheConfig(),
+            pathlock=_FakePathLockConfig(),
         ),
         skip_process_lock=False,
     )
@@ -72,6 +79,15 @@ async def test_build_ragfs_binding_config_works_inside_running_event_loop(monkey
         "cache": {
             "enabled": False,
             "provider": "memory",
+        },
+        "pathlock": {
+            "provider": "filesystem",
+            "lock_timeout_secs": 0.0,
+            "lock_expire_secs": 1800.0,
+        },
+        "log": {
+            "level": "INFO",
+            "output": "stdout",
         },
         "encryption": {
             "root_key": b"k" * 32,

--- a/tests/unit/test_create_agfs_client_git.py
+++ b/tests/unit/test_create_agfs_client_git.py
@@ -9,8 +9,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from openviking_cli.utils.config import GitConfig, GitLocalConfig
 from openviking.utils.agfs_utils import RagfsBindingConfig, create_agfs_client
+from openviking_cli.utils.config import GitConfig, GitLocalConfig
 
 
 class _FakeAgfsConfig:
@@ -22,6 +22,8 @@ class _FakeAgfsConfig:
         self.s3 = None
         # cache section consumed by RagfsBindingConfig.to_binding_dict()
         self.cache = SimpleNamespace(model_dump=lambda **kwargs: {})
+        # pathlock section consumed by RagfsBindingConfig.to_binding_dict()
+        self.pathlock = SimpleNamespace(model_dump=lambda **kwargs: {})
         # queuefs default
         self.queuefs = SimpleNamespace(
             backend="sqlite", recover_stale_sec=0, busy_timeout_ms=5000, db_path=None


### PR DESCRIPTION
## Summary

Fixes #3753.

PR #3602 ("refactor(pathlock): using rust implement instead python") added a `pathlock` section to `RagfsBindingConfig.to_binding_dict()` (`openviking/utils/agfs_utils.py:39`) and a required `pathlock: AGFSPathLockConfig` field (with `default_factory`) to the real `AGFSConfig` model, but two unit-test files that construct hand-rolled fake `agfs` config objects were not updated. Their fakes only expose `cache`, so `to_binding_dict()` raises `AttributeError` reading `self.agfs.pathlock`, failing **6 tests on current `main`** (674f5e60):

- `tests/unit/service/test_core_encryption_startup.py::test_build_ragfs_binding_config_works_inside_running_event_loop`
- `tests/unit/test_create_agfs_client_git.py` — all 5 `test_git_*` tests

```
openviking/utils/agfs_utils.py:39: in to_binding_dict
    "pathlock": self.agfs.pathlock.model_dump(mode="json"),
E   AttributeError: ... object has no attribute 'pathlock'
```

## Changes (test-only, no production code change)

1. `tests/unit/service/test_core_encryption_startup.py`
   - Add a `_FakePathLockConfig` double mirroring `AGFSPathLockConfig` defaults (`provider=filesystem`, `lock_timeout_secs=0.0`, `lock_expire_secs=1800.0`).
   - Attach `pathlock` to the `_FakeConfig.storage.agfs` namespace.
   - Update the `to_binding_dict()` assertion to include the `pathlock` dict and the always-present `log` section (which surfaced once the AttributeError was resolved).
2. `tests/unit/test_create_agfs_client_git.py`
   - Add `self.pathlock = SimpleNamespace(model_dump=...)` to `_FakeAgfsConfig`, matching the existing `cache` double.
   - Apply ruff isort to the import block (pre-existing unsorted import in this file; ruff was failing on it).

## Verification

```bash
PYTHONPATH=. .venv/bin/python -m pytest -q \
  tests/unit/service/test_core_encryption_startup.py \
  tests/unit/test_create_agfs_client_git.py \
  tests/misc/test_config_validation.py --no-cov
# 67 passed
```

- `ruff check` passes on both changed files.
- `py_compile` passes.
- The 6 previously failing tests now pass; no production behavior changes.
- The remaining broad-suite unit failures (gemini embedder missing optional dep, process_lock, stream_config_vlm) reproduce identically on clean `main` and are unrelated to this change.

## Notes

This is a test-only fix; production code and the real `AGFSConfig` model are correct. Opening as Draft for CI validation.