### PR TITLE
fix(vlm): restore OpenAIVLM streaming support for the stream flag (#3755)

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -216,6 +216,75 @@ class OpenAIVLM(VLMBase):
             )
         return message.content or ""
 
+    def _extract_from_chunk(self, chunk):
+        """Extract content and usage from a single streaming chunk.
+
+        Returns:
+            tuple: (content, prompt_tokens, completion_tokens)
+        """
+        content = None
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        if chunk.choices and chunk.choices[0].delta:
+            content = getattr(chunk.choices[0].delta, "content", None)
+
+        if hasattr(chunk, "usage") and chunk.usage:
+            prompt_tokens = chunk.usage.prompt_tokens or 0
+            completion_tokens = chunk.usage.completion_tokens or 0
+
+        return content, prompt_tokens, completion_tokens
+
+    def _process_streaming_response(self, response):
+        """Process a streaming response and extract content and token usage."""
+        content_parts = []
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        for chunk in response:
+            content, pt, ct = self._extract_from_chunk(chunk)
+            if content:
+                content_parts.append(content)
+            if pt > 0:
+                prompt_tokens = pt
+            if ct > 0:
+                completion_tokens = ct
+
+        if prompt_tokens > 0 or completion_tokens > 0:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+
+        return "".join(content_parts)
+
+    async def _process_streaming_response_async(self, response):
+        """Process an async streaming response and extract content and token usage."""
+        content_parts = []
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        async for chunk in response:
+            content, pt, ct = self._extract_from_chunk(chunk)
+            if content:
+                content_parts.append(content)
+            if pt > 0:
+                prompt_tokens = pt
+            if ct > 0:
+                completion_tokens = ct
+
+        if prompt_tokens > 0 or completion_tokens > 0:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+
+        return "".join(content_parts)
+
     def _build_text_kwargs(
         self,
         prompt: str = "",
@@ -232,6 +301,11 @@ class OpenAIVLM(VLMBase):
             "model": model,
             "messages": kwargs_messages,
         }
+        # Streaming deltas cannot carry structured tool-call messages, so tool
+        # calls always use the non-streaming path; plain text/vision honor the
+        # configured ``stream`` flag.
+        if not tools:
+            kwargs["stream"] = self.stream
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
         else:
@@ -269,6 +343,7 @@ class OpenAIVLM(VLMBase):
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": kwargs_messages,
+            "stream": self.stream,
         }
         if is_reasoning:
             kwargs["reasoning_effort"] = self.reasoning_effort
@@ -283,13 +358,19 @@ class OpenAIVLM(VLMBase):
         return kwargs
 
     def _extract_completion_content(self, response, elapsed: float) -> str:
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        content = self._extract_content_from_response(response)
+        if self.stream:
+            content = self._process_streaming_response(response)
+        else:
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
     async def _extract_completion_content_async(self, response, elapsed: float) -> str:
-        self._update_token_usage_from_response(response, duration_seconds=elapsed)
-        content = self._extract_content_from_response(response)
+        if self.stream:
+            content = await self._process_streaming_response_async(response)
+        else:
+            self._update_token_usage_from_response(response, duration_seconds=elapsed)
+            content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
     def get_completion(


### PR DESCRIPTION
## Summary

Fixes #3755.

The `stream` config flag for the OpenAI-compatible VLM provider is accepted by `VLMBase`/`VLMConfig`, documented (`docs/en|zh/guides/configuration.md`), and advertised in the changelog ("OpenAI VLM streaming"), but `OpenAIVLM` stopped honoring it after PR #1711 removed all streaming handling. This breaks OpenAI-compatible gateways that require `stream=true` to parse SSE responses and leaves **11 unit tests red on `main`** (`tests/unit/test_stream_config_vlm.py`).

## Root cause

#1711 removed, without a replacement:
- `_extract_from_chunk()`
- `_process_streaming_response()` / `_process_streaming_response_async()`
- `"stream": self.stream` from `_build_text_kwargs()` / `_build_vision_kwargs()`
- the `if self.stream:` branch in `_extract_completion_content()` / `_extract_completion_content_async()`

while `VLMBase` still stores `self.stream = config.get("stream", False)`, `VLMConfig` still migrates/forwards it, and `codex_vlm.py` still reads it.

## Changes (`openviking/models/vlm/backends/openai_vlm.py`, test-driven by the existing suite)

1. Restore `_extract_from_chunk()` to read `choices[0].delta.content` and the final chunk `usage`.
2. Restore `_process_streaming_response()` / `_process_streaming_response_async()` to concatenate delta content and record token usage.
3. Add `"stream": self.stream` to `_build_vision_kwargs()` and to `_build_text_kwargs()` **only for non-tool calls**. Tool calls require the structured non-streaming message (`tool_calls`, `finish_reason`), so they intentionally stay non-streaming (this also avoids a latent bug the pre-#1711 code had when `stream=true` was combined with tools).
4. Branch `_extract_completion_content()` / `_extract_completion_content_async()` on `self.stream`.

The default `stream=false` path is byte-for-byte unchanged.

## Verification

```bash
PYTHONPATH=. .venv/bin/python -m pytest -q \
  tests/unit/test_stream_config_vlm.py --no-cov
# 20 passed (11 previously failing + 9 already passing)
```

- 156 VLM-related unit tests pass across `test_stream_config_vlm`, `test_extra_headers_vlm`, `test_openai_embedder`, `test_vlm_failover`, `test_vlm_reasoning_models`, `test_vikingbot_vlm_adapter_retry`, `test_litellm_vlm_provider_detection`, `test_litellm_vlm_gemini_cache`.
- `ruff check` and `py_compile` clean.
- The only remaining failures in the vicinity (`test_codex_vlm::test_vlm_config_default_provider_resolves_codex`, `test_kimi_glm_vlm::test_vlm_config_uses_canonical_provider_names`) reproduce identically on clean `main` and are unrelated config/provider-name tests.

## Notes

Opening as Draft for CI validation. No merge/promote/close.