### PR TITLE
test(session): accept lease_ref in _MemoryVikingFS.write_file fake (#3757)

### DIFF
--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -44,7 +44,7 @@ class _MemoryVikingFS:
             raise FileNotFoundError(uri)
         return self.files[uri]
 
-    async def write_file(self, uri, content, ctx=None):
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
         self.files[uri] = content
 
 


### PR DESCRIPTION
## Problem

`test_resume_queued_commit_fails_terminally_for_unreadable_archive` (all three parametrizations: `None`, `{invalid json`, `{}`) fails on `main`:

```
TypeError: _MemoryVikingFS.write_file() got an unexpected keyword argument 'lease_ref'
  at openviking/session/session.py:2821
```

`Session._persist_terminal_failure` writes the `.failed.json` marker via `self._viking_fs.write_file(..., lease_ref=lease_ref)`. The real `VikingFS.write_file` accepts `lease_ref` (`openviking/storage/viking_fs.py:3235`), but the in-test fake `_MemoryVikingFS.write_file` (`tests/unit/session/test_session_commit_resume.py`) still had the old signature `(self, uri, content, ctx=None)` and rejected the kwarg. The fake was not updated when `lease_ref` was threaded through the write path, so the terminal-failure test crashed before reaching its assertions.

This is a test-only fake mismatch; production behavior is correct.

## Change

- Add `lease_ref=None` to `_MemoryVikingFS.write_file` so it mirrors the real `VikingFS.write_file` signature.

## Verification

- `pytest tests/unit/session/test_session_commit_resume.py -q` → **7 passed** (previously 3 failed, 4 passed).
- `ruff check` clean; `py_compile` clean.

Fixes #3757
