### PR TITLE
test(memory): expose model_fields in mocked operations model (#3759)

### DIFF
--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -219,7 +219,7 @@ class TestPageIdInstruction:
             ) as mock_create_model,
         ):
             mock_config.return_value = SimpleNamespace(memory=SimpleNamespace(link_enabled=False))
-            mock_create_model.return_value = SimpleNamespace(model_json_schema=lambda: {})
+            mock_create_model.return_value = SimpleNamespace(model_fields={}, model_json_schema=lambda: {})
 
             await loop.run()
 
@@ -298,7 +298,7 @@ class TestPageIdInstruction:
             ) as mock_create_model,
         ):
             mock_config.return_value = SimpleNamespace(memory=SimpleNamespace(link_enabled=True))
-            mock_create_model.return_value = SimpleNamespace(model_json_schema=lambda: {})
+            mock_create_model.return_value = SimpleNamespace(model_fields={}, model_json_schema=lambda: {})
 
             await loop.run()
 
@@ -364,7 +364,7 @@ class TestFinalOperationsHydration:
             patch("openviking.session.memory.extract_loop.tracer.info") as mock_tracer_info,
         ):
             mock_config.return_value = SimpleNamespace(memory=SimpleNamespace(link_enabled=False))
-            mock_create_model.return_value = SimpleNamespace(model_json_schema=lambda: {})
+            mock_create_model.return_value = SimpleNamespace(model_fields={}, model_json_schema=lambda: {})
 
             final_operations, _ = await loop.run()
 


### PR DESCRIPTION
## Problem

Three tests in `tests/unit/session/memory/test_extract_loop_match_text.py` fail on `main`:

- `TestPageIdInstruction::test_run_always_includes_page_id_rules_when_links_disabled`
- `TestPageIdInstruction::test_run_includes_link_page_id_rule_when_links_enabled`
- `TestFinalOperationsHydration::test_run_logs_final_operations_after_old_memory_file_is_hydrated`

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'model_fields'
  at openviking/session/memory/extract_loop.py:197
```

`ExtractLoop.run` builds the stability parser allowlist from the generated operations model:

```python
self._expected_fields = list(self._operations_model.model_fields)
```

The real model is a Pydantic model with `model_fields`. The three tests patch `create_structured_operations_model` to return `SimpleNamespace(model_json_schema=lambda: {})`, which lacks `model_fields`, so the test crashes before exercising the code under test. The mock was not updated when `_expected_fields` was introduced. Test-only mismatch; production is correct.

## Change

- Add `model_fields={}` to the mocked operations model in all three tests so it mirrors the real Pydantic model surface.

## Verification

- `pytest tests/unit/session/memory/test_extract_loop_match_text.py -q` → **7 passed** (previously 3 failed, 4 passed).
- `ruff check` clean; `py_compile` clean.

Fixes #3759
