### PR TITLE
test(fs): expect raw=True in diff forwarder assertion (#3761)

### DIFF
--- a/tests/unit/test_fs_service_git_forwarders.py
+++ b/tests/unit/test_fs_service_git_forwarders.py
@@ -137,6 +137,7 @@ async def test_diff_forwards_validated_path_and_refs(svc, viking_fs_mock):
         path="viking://resources/a.md",
         from_ref=None,
         to_ref="main",
+        raw=True,
         ctx=ctx,
     )
     assert out["change_type"] == "added"


### PR DESCRIPTION
## Problem

`test_diff_forwards_validated_path_and_refs` fails on `main`:

```
AssertionError: expected await not found.
Expected: diff(path=..., from_ref=None, to_ref='main', ctx=...)
  Actual: diff(path=..., from_ref=None, to_ref='main', raw=True, ctx=...)
```

`FsService.diff` (`openviking/service/fs_service.py:718`) has `raw: bool = True` and forwards `raw=raw` to `VikingFS.diff` (`openviking/storage/viking_fs.py:4221`, also default `True`). The test's `assert_awaited_once_with` predates the `raw` parameter and omits it. Stale test assertion; production correctly forwards the parameter.

## Change

- Add `raw=True` to the expected forwarded call.

## Verification

- `pytest tests/unit/test_fs_service_git_forwarders.py -q` → **10 passed** (previously 1 failed, 9 passed).
- `ruff check` clean; `py_compile` clean.

Fixes #3761
