### PR TITLE
test(vlm): assert resolved provider fields instead of legacy raw dict (#3763)

### DIFF
--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -204,7 +204,7 @@ def test_vlm_config_default_provider_resolves_codex(_mock_auth_available):
     provider_config, provider_name = config.get_provider_config()
 
     assert provider_name == "openai-codex"
-    assert provider_config == {}
+    assert provider_config.get("api_key") is None
 
 
 @patch("openviking.models.vlm.backends.codex_auth.has_codex_auth_available", return_value=True)

--- a/tests/unit/test_kimi_glm_vlm.py
+++ b/tests/unit/test_kimi_glm_vlm.py
@@ -87,7 +87,7 @@ def test_vlm_config_uses_canonical_provider_names():
     assert "kimi" in config.providers
     assert "glm" in config.providers
     assert provider_name == "glm"
-    assert provider_config == {"api_key": "glm-key"}
+    assert provider_config["api_key"] == "glm-key"
 
 
 @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")


### PR DESCRIPTION
## Problem

Two tests fail on `main`:

- `test_kimi_glm_vlm.py::test_vlm_config_uses_canonical_provider_names`
- `test_codex_vlm.py::test_vlm_config_default_provider_resolves_codex`

Both assert exact dict equality on `VLMConfig.get_provider_config()` against the legacy raw provider dict, but validation now migrates legacy `providers` config into the credentials model (`_normalize_credentials`, `openviking_cli/utils/config/vlm_config.py:299`). `get_provider_config()` returns a credential-shaped dict with unset fields as `None` and `stream` defaulting to `False`. Production consumes it with `.get()`/truthiness (`_build_vlm_config_dict`, `doctor.py`), so the extra keys are intended and harmless; only the assertions are stale.

```
assert {'api_key': 'glm-key', 'api_base': None, ...} == {'api_key': 'glm-key'}
assert {'api_key': None, ...} == {}
```

## Change

- `test_kimi_glm_vlm.py`: assert `provider_config["api_key"] == "glm-key"` instead of full-dict equality.
- `test_codex_vlm.py`: assert `provider_name == "openai-codex"` and `provider_config.get("api_key") is None` (codex relies on OAuth, not an api_key).

## Verification

- `pytest tests/unit/test_kimi_glm_vlm.py tests/unit/test_codex_vlm.py -q` → **26 passed** (previously 2 failed).
- Broader `-k "vlm or codex or kimi or glm"` run: 183 passed; the only 11 failures are `test_stream_config_vlm.py`, already fixed by PR #3756.
- `ruff check` and `py_compile` clean.

Fixes #3763
