### PR TITLE
test(core): expect user owner for session URI in Context owner test (#3765)

### DIFF
--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -483,7 +483,7 @@ class TestContextWithUser:
         user = UserIdentifier(account_id="account-123", user_id="user-123")
         ctx = Context(uri="viking://session/test/msg/1.md", user=user)
 
-        assert ctx.owner_user_id is None
+        assert ctx.owner_user_id == user.user_id
         assert ctx.owner_space == user.user_id
 
     def test_owner_fields_resource_default(self):


### PR DESCRIPTION
## Problem

`TestContextWithUser::test_owner_fields_session` fails on `main`:

```
AssertionError: assert 'user-123' is None
```

`Context.__init__` derives `owner_user_id` from `owner_fields_for_uri(uri, user=...)`. For a `viking://session/...` URI with a user, the namespace resolver now treats session URIs as user-scoped and returns `owner_user_id=ctx.user.user_id` (`openviking/core/namespace.py::_resolve_session_uri`). The test still asserts `is None`, predating that change; the sibling `owner_space == user.user_id` assertion already reflects user-scoped semantics. Stale assertion; production is correct.

## Change

- Assert `owner_user_id == user.user_id` for the session URI, consistent with `owner_space` and the resolver.

## Verification

- `pytest tests/unit/test_context.py -q` → **56 passed** (previously 1 failed, 55 passed).
- `ruff check` and `py_compile` clean.

Fixes #3765
