### PR TITLE
test(embedder): match Gemini param validation error wording (#3767)

### DIFF
--- a/tests/unit/test_embedding_config_gemini.py
+++ b/tests/unit/test_embedding_config_gemini.py
@@ -73,11 +73,11 @@ class TestGeminiConfigValidation:
             EmbeddingModelConfig(model="gemini-embedding-2-preview", provider="gemini")
 
     def test_invalid_query_param_raises(self):
-        with pytest.raises(ValueError, match="Invalid query_param"):
+        with pytest.raises(ValueError, match="invalid query_param"):
             _gcfg(query_param="NOT_A_VALID_TYPE")
 
     def test_invalid_document_param_raises(self):
-        with pytest.raises(ValueError, match="Invalid document_param"):
+        with pytest.raises(ValueError, match="invalid document_param"):
             _gcfg(document_param="ALSO_INVALID")
 
     def test_query_document_param_case_normalized(self):


### PR DESCRIPTION
## Problem

Two `TestGeminiConfigValidation` tests fail on `main`:

- `test_invalid_query_param_raises`
- `test_invalid_document_param_raises`

```
AssertionError: Regex pattern did not match.
Expected: 'Invalid query_param'
Actual:   "Embedding: invalid query_param 'NOT_A_VALID_TYPE' for Gemini. Valid task_types: ..."
```

Gemini validation (`openviking_cli/utils/config/embedding_config.py:319`) raises `f"{label}: invalid {field_name} '{value}' for Gemini. Valid task_types: ..."` with `label="Embedding"` — lowercase, prefixed. The tests match the old `"Invalid query_param"`/`"Invalid document_param"` wording. Stale assertions; production message is correct.

(The other failures in this file — `TestGeminiDimension` and `TestGeminiContextRouting` — come from the optional `google-genai` dep being absent locally and pass in CI; not touched here.)

## Change

- Update the two `match=` strings to `invalid query_param` / `invalid document_param`.

## Verification

- `pytest tests/unit/test_embedding_config_gemini.py::TestGeminiConfigValidation -q` → **4 passed** (previously 2 failed, 2 passed).
- `ruff check` and `py_compile` clean.

Fixes #3767
