### PR TITLE
test(utils): expect auth class for 401/403 in circuit-breaker tests (#3769)

### DIFF
--- a/tests/utils/test_circuit_breaker.py
+++ b/tests/utils/test_circuit_breaker.py
@@ -179,14 +179,17 @@ def test_classify_chained_filesystem_error_as_permanent():
     assert classify_api_error(wrapper) == ERROR_CLASS_PERMANENT
 
 
-def test_classify_permanent_errors():
+def test_classify_auth_errors():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_AUTH, ERROR_CLASS_PERMANENT
 
-    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_PERMANENT
-    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_PERMANENT
+    # 401/403 (including overdue) are credential-level auth errors, distinct
+    # from request-level permanent 4xx such as 400.
+    assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("AccountOverdueError: 403")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("401 Unauthorized")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("Forbidden")) == ERROR_CLASS_AUTH
+    assert classify_api_error(RuntimeError("400 Bad Request")) == ERROR_CLASS_PERMANENT
 
 
 def test_classify_transient_errors():
@@ -212,9 +215,9 @@ def test_classify_unknown_errors():
 
 def test_classify_chained_exception():
     from openviking.utils.circuit_breaker import classify_api_error
-    from openviking.utils.model_retry import ERROR_CLASS_PERMANENT, ERROR_CLASS_TRANSIENT, ERROR_CLASS_UNKNOWN
+    from openviking.utils.model_retry import ERROR_CLASS_AUTH
 
     cause = RuntimeError("403 Forbidden")
     wrapper = RuntimeError("API call failed")
     wrapper.__cause__ = cause
-    assert classify_api_error(wrapper) == ERROR_CLASS_PERMANENT
+    assert classify_api_error(wrapper) == ERROR_CLASS_AUTH


### PR DESCRIPTION
## Problem

Two tests fail on `main`:

- `test_classify_permanent_errors`
- `test_classify_chained_exception`

```
assert classify_api_error(RuntimeError("403 Forbidden")) == ERROR_CLASS_PERMANENT
E  AssertionError: assert 'auth' == 'permanent'
```

The classifier separates credential-level `auth` errors (401/403, including overdue) from request-level `permanent` errors (400) — `openviking/utils/model_retry.py:18-24`. `classify_api_error` returns `"auth"` for 401/403. The tests predate the `auth` class and still assert `permanent`. Stale assertions; production classification is correct.

## Change

- Rename `test_classify_permanent_errors` → `test_classify_auth_errors`.
- Assert `ERROR_CLASS_AUTH` for `403 Forbidden`, `AccountOverdueError: 403`, `401 Unauthorized`, `Forbidden`.
- Add a `400 Bad Request` → `ERROR_CLASS_PERMANENT` case to keep permanent-class coverage.
- Update `test_classify_chained_exception` to follow the 403 cause to `ERROR_CLASS_AUTH`.

## Verification

- `pytest tests/utils/test_circuit_breaker.py -q` → **18 passed** (previously 2 failed, 16 passed).
- `py_compile` clean. (Note: the file has pre-existing ruff isort/F401 nits in adjacent unchanged functions; my edited region adds none and is left untouched per minimal-change discipline.)

Fixes #3769
