### PR TITLE
test(prompt): align memory template assertions with current wording (#3771)

### DIFF
--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -77,7 +77,8 @@ def test_profile_memory_template_includes_stable_identity_work_style_and_prefere
     )
 
     assert '"who the user is"' in text
-    assert "identity, work style, and preferences" in text
+    assert "identity summary" in text
+    assert "stable personal attributes" in text
     assert "profession, experience level, technical background" in text
     assert "communication style, work habits" in text
     assert "Do NOT include transient conversation content" in text
@@ -101,7 +102,7 @@ def test_preferences_memory_template_keeps_topic_specific_preferences():
     assert "specific topic" in text
     assert "code style, communication style, tools, workflow" in text
     assert "Store different topics as separate memory files" in text
-    assert "do not mix unrelated preferences" in text
+    assert "do NOT mix unrelated preferences" in text
 
 
 def test_prompt_manager_prefers_env_templates_dir_over_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

Two tests fail on `main`:

- `test_profile_memory_template_includes_stable_identity_work_style_and_preferences`
- `test_preferences_memory_template_keeps_topic_specific_preferences`

```
assert 'identity, work style, and preferences' in '...identity summary...stable personal attributes...'
assert 'do not mix unrelated preferences' in '...do NOT mix unrelated preferences...'
```

The bundled memory templates (`openviking/prompts/templates/memory/profile.yaml`, `preferences.yaml`) were reworded but the tests pin exact substrings. The semantic content is preserved:
- profile: "identity summary" + "stable personal attributes" + "communication style, work habits" (replaces the single phrase "identity, work style, and preferences").
- preferences: "do NOT mix unrelated preferences" (emphasis capitalization).

Stale, brittle exact-substring assertions; the template is the source of truth.

## Change

- profile test: assert `"identity summary"` and `"stable personal attributes"` instead of the removed phrase.
- preferences test: assert `"do NOT mix unrelated preferences"` to match current capitalization.

## Verification

- `pytest tests/test_prompt_manager.py -q` → **10 passed** (previously 2 failed, 8 passed).
- `ruff check` and `py_compile` clean.

Fixes #3771
