### PR TITLE
test(telemetry): update embedder fake for embed_compat protocol (#3773)

### DIFF
--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -827,6 +827,12 @@ async def test_embedding_handler_binds_registered_operation_telemetry(monkeypatc
             get_current_telemetry().record_token_usage("embedding", 9, 0)
             return EmbedResult(dense_vector=[0.1, 0.2])
 
+        def prepare_embedding_input(self, content):
+            return content
+
+        async def embed_async(self, content, is_query: bool = False) -> EmbedResult:
+            return self.embed(content, is_query=is_query)
+
     class _DummyConfig:
         def __init__(self):
             self.storage = SimpleNamespace(vectordb=SimpleNamespace(name="context"))


### PR DESCRIPTION
Fixes #3773.

`TextEmbeddingHandler.on_dequeue` now routes embeds through `embed_compat(self._embedder, ...)`, which calls `embedder.prepare_embedding_input(content)` before `await embedder.embed_async(...)`. The `_TelemetryAwareEmbedder` fake in `tests/test_telemetry_runtime.py` only defined a sync `embed()`, so `embed_compat` crashed (`'_TelemetryAwareEmbedder' object has no attribute 'prepare_embedding_input'`) before `record_token_usage("embedding", 9, 0)` ran. The swallowed embed error left no token summary, causing `KeyError: 'tokens'` at the `summary["tokens"]["embedding"]` assertion.

Add `prepare_embedding_input()` (returns content) and an async `embed_async()` that delegates to the existing sync `embed()`.

### Validation
- `pytest tests/test_telemetry_runtime.py -q` → 26 passed
- `ruff check tests/test_telemetry_runtime.py` → All checks passed
- `py_compile` clean

Pure test-only change, no production code modified.