### PR TITLE
test(storage): expect ignore_unknown_fields in volcengine update_data bodies (#3775)

### DIFF
--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -253,6 +253,7 @@ def test_volcengine_collection_update_data_posts_to_update_endpoint(monkeypatch)
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "name": "updated"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -290,6 +291,7 @@ def test_volcengine_collection_update_data_sanitizes_uri_fields(monkeypatch):
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "uri": "/resources/demo", "parent_uri": "/resources"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -331,6 +333,7 @@ def test_volcengine_api_key_collection_update_data_posts_to_update_endpoint(monk
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "name": "updated"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -370,6 +373,7 @@ def test_volcengine_api_key_collection_update_data_sanitizes_uri_fields(monkeypa
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "uri": "/resources/demo", "parent_uri": "/resources"}],
+        "ignore_unknown_fields": True,
     }
 
 


### PR DESCRIPTION
Fixes #3775.

Since #2981 (`34c191a0`, "fix(vikingdb): trust OpenViking schema for volcengine api_key mode"), `VolcengineCollection.update_data` and `VolcengineApiKeyCollection.update_data` always post `"ignore_unknown_fields": True` to `/api/vikingdb/data/update`. Four tests in `tests/storage/test_volcengine_clients.py` asserted the legacy exact request body and fail with `Left contains 1 more item: {'ignore_unknown_fields': True}`.

Add `"ignore_unknown_fields": True` to the four expected request dicts.

### Validation
- `pytest tests/storage/test_volcengine_clients.py -q` → 25 passed
- `ruff check` clean, `py_compile` clean

Test-only change; no production code modified.