### PR TITLE
test(service): align resource memory link tests with current behavior (#3776)

### DIFF
--- a/tests/service/test_resource_memory_link_service.py
+++ b/tests/service/test_resource_memory_link_service.py
@@ -377,7 +377,7 @@ async def test_on_resource_deleted_bridges_through_fixed_session(request_context
     assert "## Resource Deletion" in message_text
     assert resource_uri in message_text
     assert memory_uri in message_text
-    assert "Do not create a new event" in message_text
+    assert "Update existing mutable memories that mention or depend on this resource." in message_text
 
 
 @pytest.mark.asyncio
@@ -615,7 +615,8 @@ async def test_unlink_memory_reference_keeps_visible_text_and_no_schema_metadata
     assert result.edited_uris == [memory_uri]
     mf = MemoryFileUtils.read(store[memory_uri], uri=memory_uri)
     assert mf.content == "今天是清明节。用户保存了一张不二周助的照片"
-    assert mf.extra_fields == {}
+    assert mf.extra_fields == {"version": 1}
+    assert "resource_refs" not in mf.extra_fields
     assert mf.memory_type is None
 
 


### PR DESCRIPTION
Fixes #3776.

Two stale assertions in `tests/service/test_resource_memory_link_service.py` no longer match production behavior:

1. `test_on_resource_deleted_bridges_through_fixed_session` expected the substring "Do not create a new event", but `ResourceMemoryLinkService._build_resource_deletion_message` has emitted "Update existing mutable memories that mention or depend on this resource." since #2678.
2. `test_unlink_memory_reference_keeps_visible_text_and_no_schema_metadata` expected `mf.extra_fields == {}` after a write/read round trip, but `MemoryFile.to_metadata()` always sets `version` (default 1), so the round-tripped extra_fields are `{"version": 1}`. The `resource_refs` key is still correctly removed.

Update both assertions to match current behavior, and add an explicit `resource_refs not in mf.extra_fields` check to preserve the original intent of the second test.

### Validation
- `pytest tests/service/test_resource_memory_link_service.py -q` → 16 passed
- `ruff check` clean, `py_compile` clean

Test-only change; no production code modified.