### PR TITLE
test(service): allow embedding/rerank on ObserverService config mocks (#3780)

### DIFF
--- a/tests/misc/test_debug_service.py
+++ b/tests/misc/test_debug_service.py
@@ -178,9 +178,11 @@ class TestObserverService:
     @patch("openviking.service.debug_service.ModelsObserver")
     def test_models_property(self, mock_observer_cls):
         """Test models property returns ComponentStatus."""
-        mock_config = MagicMock(spec=["vlm"])  # Only allow vlm attribute
+        mock_config = MagicMock(spec=["vlm", "embedding", "rerank"])
         mock_vlm_instance = MagicMock()
         mock_config.vlm.get_vlm_instance.return_value = mock_vlm_instance
+        mock_config.embedding = None
+        mock_config.rerank = None
 
         mock_observer = MagicMock()
         mock_observer.is_healthy.return_value = True
@@ -243,8 +245,10 @@ class TestObserverService:
             "conflicts": [],
         }
 
-        mock_config = MagicMock(spec=["vlm"])  # Only allow vlm attribute
+        mock_config = MagicMock(spec=["vlm", "embedding", "rerank"])  # Only allow known attributes
         mock_config.vlm.get_vlm_instance.return_value = MagicMock()
+        mock_config.embedding = None
+        mock_config.rerank = None
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
         status = service.system()
 
@@ -310,8 +314,10 @@ class TestObserverService:
             "conflicts": [],
         }
 
-        mock_config = MagicMock(spec=["vlm"])  # Only allow vlm attribute
+        mock_config = MagicMock(spec=["vlm", "embedding", "rerank"])  # Only allow known attributes
         mock_config.vlm.get_vlm_instance.return_value = MagicMock()
+        mock_config.embedding = None
+        mock_config.rerank = None
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
         status = service.system()
 
@@ -354,8 +360,10 @@ class TestObserverService:
             "conflicts": [],
         }
 
-        mock_config = MagicMock(spec=["vlm"])
+        mock_config = MagicMock(spec=["vlm", "embedding", "rerank"])
         mock_config.vlm.get_vlm_instance.return_value = MagicMock()
+        mock_config.embedding = None
+        mock_config.rerank = None
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
         status = service.system()
         assert all(c.is_healthy for name, c in status.components.items() if name != "transaction")
@@ -415,8 +423,10 @@ class TestObserverService:
             mock_observer.get_status_table.return_value = "OK"
             mock_cls.return_value = mock_observer
 
-        mock_config = MagicMock(spec=["vlm"])  # Only allow vlm attribute
+        mock_config = MagicMock(spec=["vlm", "embedding", "rerank"])  # Only allow known attributes
         mock_config.vlm.get_vlm_instance.return_value = MagicMock()
+        mock_config.embedding = None
+        mock_config.rerank = None
         service = ObserverService(vikingdb=MagicMock(), config=mock_config)
         assert service.is_healthy() is False
 


### PR DESCRIPTION
Fixes #3780.

Since #1191, `ObserverService.models` reads `self._config.embedding` and `self._config.rerank` in addition to `.vlm` (`openviking/service/debug_service.py:145-151`). Five tests in `tests/misc/test_debug_service.py` construct `MagicMock(spec=["vlm"])`, which forbids the new attributes and raises `AttributeError: Mock object has no attribute 'embedding'`.

Widen the config mock spec to `["vlm", "embedding", "rerank"]` and explicitly set `embedding`/`rerank` to `None`, preserving the existing assertion that the models observer is built with `embedding_instance=None, rerank_instance=None`.

### Validation
- `pytest tests/misc/test_debug_service.py -q` → 25 passed
- `ruff check` clean, `py_compile` clean

Test-only change; no production code modified.