### PR TITLE
test(config): align RerankConfig default/unknown-provider tests (#3781)

### DIFF
--- a/tests/misc/test_rerank_openai.py
+++ b/tests/misc/test_rerank_openai.py
@@ -268,10 +268,11 @@ class TestRerankConfig:
         with pytest.raises(ValidationError):
             RerankConfig(provider="openai", api_base="https://example.com/rerank")
 
-    def test_default_provider_is_vikingdb(self):
+    def test_default_provider_is_auto_detected(self):
         config = RerankConfig()
-        assert config.provider == "vikingdb"
+        assert config.provider is None
+        assert config.is_available() is False
 
     def test_unknown_provider_raises_value_error(self):
         with pytest.raises(ValueError, match="provider"):
-            RerankConfig(provider="cohere", ak="ak", sk="sk")
+            RerankConfig(provider="unknown")


### PR DESCRIPTION
Fixes #3781.

Two `TestRerankConfig` tests in `tests/misc/test_rerank_openai.py` are stale:

1. `RerankConfig.provider` now defaults to `None` ("Auto-detected from config if omitted") per `openviking_cli/utils/config/rerank_config.py:11`; `_effective_provider()` returns None and `is_available()` is False when no credentials are present. The test asserted the old default `"vikingdb"`.
2. `"cohere"` is now a supported provider (`['vikingdb', 'cohere', 'openai', 'litellm']`), so constructing `RerankConfig(provider="cohere", ...)` no longer raises. The unknown-provider test used this now-valid value.

- Assert `provider is None` and `is_available() is False` for a credential-less config.
- Use a genuinely invalid value (`provider="unknown"`) for the validation-error test.

### Validation
- `pytest tests/misc/test_rerank_openai.py -q` → 24 passed
- `ruff check` clean, `py_compile` clean

Test-only change; no production code modified.