### PR TITLE
test(zip_safe): fix cp437 greek literal and no-UTF-8-flag zip setup (#3785)

### DIFF
--- a/tests/misc/test_zip_safe.py
+++ b/tests/misc/test_zip_safe.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import io
 import stat
+import struct
 import zipfile
 from pathlib import Path
 
@@ -85,7 +86,11 @@ class TestContainsCommonMojibake:
     """Verify mojibake pattern detection."""
 
     def test_detects_greek_chars(self) -> None:
-        assert _contains_common_mojibake("Î±Î²") is True  # Greek alpha, beta
+        # UTF-8 bytes of Greek alpha/beta (0xCE 0xB1, 0xCE 0xB2) decoded as cp437
+        # (the encoding zipfile uses when the UTF-8 flag is unset) produce box
+        # drawing characters that the mojibake detector recognizes.
+        greek_mojibake = bytes([0xCE, 0xB1, 0xCE, 0xB2]).decode("cp437")
+        assert _contains_common_mojibake(greek_mojibake) is True
 
     def test_detects_math_operators(self) -> None:
         assert _contains_common_mojibake("\u2200x") is True  # for-all
@@ -133,36 +138,75 @@ class TestNormalizeZipFilenames:
         The zip module reads it via cp437 producing mojibake.
         normalize_zip_filenames should re-decode from cp437 -> UTF-8.
         """
-        # Create a zip with raw bytes: write CJK UTF-8 bytes as the filename
-        # but do NOT set the UTF-8 flag, so Python's zipfile reads it as cp437.
         cjk_name = "测试文件.txt"
         utf8_bytes = cjk_name.encode("utf-8")
 
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w") as zf:
-            info = zipfile.ZipInfo(cjk_name)
-            info.flag_bits = 0  # no UTF-8 flag
-            zf.writestr(info, "content")
-        # Manually patch the raw zip to remove UTF-8 flag
-        # (Python's ZipFile may set it automatically for non-ASCII)
-        # The flag_bits field is at offset 6 in the local file header
-        # This is complex; instead test the logic paths individually
-        # by directly calling with a pre-mangled ZipInfo
-        buf2 = io.BytesIO()
-        with zipfile.ZipFile(buf2, "w") as zf:
-            # Encode filename as cp437 representation of the UTF-8 bytes
-            try:
-                cp437_name = utf8_bytes.decode("cp437")
-            except UnicodeDecodeError:
-                pytest.skip("Cannot represent CJK UTF-8 bytes in cp437")
-            info = zipfile.ZipInfo(cp437_name)
-            info.flag_bits = 0
-            zf.writestr(info, "content")
-        buf2.seek(0)
-        with zipfile.ZipFile(buf2, "r") as zf:
+        # Python's zipfile forces the UTF-8 flag (and re-encodes) when writing
+        # non-ASCII names, so build the archive bytes directly with the flag
+        # cleared and the raw cp437-mojibake filename bytes in place.
+        cp437_name = utf8_bytes.decode("cp437")
+        name_bytes = cp437_name.encode("cp437")
+        content = b"content"
+        crc = zipfile.crc32(content) & 0xFFFFFFFF
+        local_header = (
+            struct.pack(
+                "<IHHHHHIIIHH",
+                0x04034B50,
+                20,
+                0,  # flag_bits: UTF-8 flag intentionally clear
+                0,
+                0,
+                0,
+                crc,
+                len(content),
+                len(content),
+                len(name_bytes),
+                0,
+            )
+            + name_bytes
+            + content
+        )
+        central_header = (
+            struct.pack(
+                "<IHHHHHHIIIHHHHHII",
+                0x02014B50,
+                20,
+                20,
+                0,  # flag_bits: UTF-8 flag intentionally clear
+                0,
+                0,
+                0,
+                crc,
+                len(content),
+                len(content),
+                len(name_bytes),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+            + name_bytes
+        )
+        eocd = struct.pack(
+            "<IHHHHIIH",
+            0x06054B50,
+            0,
+            0,
+            1,
+            1,
+            len(central_header),
+            len(local_header),
+            0,
+        )
+        raw_zip = local_header + central_header + eocd
+
+        with zipfile.ZipFile(io.BytesIO(raw_zip), "r") as zf:
             member = zf.infolist()[0]
             # Before normalization, filename should be the mojibake
             assert member.filename == cp437_name
+            assert member.flag_bits & 0x800 == 0
             normalize_zip_filenames(zf)
             # After normalization, the name should be repaired to CJK
             repaired = zf.infolist()[0]


### PR DESCRIPTION
Fixes #3785.

Two tests in `tests/misc/test_zip_safe.py` fail due to stale test setup, not production code:

1. `test_detects_greek_chars` used the literal `"Î±Î²"`, which is the **latin-1** rendering of bytes `CE B1 CE B2` (Greek α/β UTF-8) and lands in Latin-1 Supplement, so `_contains_common_mojibake` returns False. Under cp437 (the encoding `zipfile` uses when the UTF-8 flag is unset), those bytes decode to box-drawing chars that the detector does match. Build the string as `bytes([0xCE,0xB1,0xCE,0xB2]).decode("cp437")`.

2. `test_repairs_cjk_filename_from_cp437_mojibake` tried to clear the UTF-8 flag by setting `ZipInfo.flag_bits = 0` before `writestr`, but modern Python's `writestr` forces the UTF-8 flag and re-encodes non-ASCII names. The read-back member always had `flag_bits == 0x800`, so `normalize_zip_filenames` early-returned and never repaired the name. Build the archive from raw local/central/EOCD bytes with the flag genuinely clear and the cp437-mojibake filename bytes, and assert the flag is clear before normalization and the CJK name after.

### Validation
- `pytest tests/misc/test_zip_safe.py -q` → 33 passed
- `ruff check` clean, `py_compile` clean

Test-only change; no production code modified.