### PR TITLE
fix(server): sanitize versioned stdlib paths in profile output

### DIFF
--- a/openviking/server/profile_middleware.py
+++ b/openviking/server/profile_middleware.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import cProfile
 import json
+import re
 import site
 import sysconfig
 from pathlib import Path
@@ -21,6 +22,10 @@ PROFILE_SORT_BY = "cumulative"
 PROFILE_TOP_N = 100
 PROFILE_MAX_CHARS = 16 * 1024
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Matches versioned stdlib parent directories such as ``python3.11`` while
+# rejecting an ancestor literally named ``python`` (e.g. ``.../uv/python``).
+_STD_LIB_PARENT_RE = re.compile(r"python\d")
 
 
 def _build_profile_roots() -> tuple[Path, ...]:
@@ -110,7 +115,7 @@ def _sanitize_profile_path(path: str) -> str:
                     return "/".join(parts[idx + 1 :])
 
         for idx, part in enumerate(parts):
-            if part.startswith("python") and idx + 1 < len(parts):
+            if _STD_LIB_PARENT_RE.fullmatch(part) and idx + 1 < len(parts):
                 suffix = parts[idx + 1 :]
                 if suffix:
                     return "/".join(suffix)

--- a/tests/server/test_profile_middleware.py
+++ b/tests/server/test_profile_middleware.py
@@ -141,5 +141,14 @@ def test_sanitize_profile_path_prefers_package_root_over_project_root_for_venv_p
     assert _sanitize_profile_path(path) == "starlette/middleware/base.py"
 
 
+def test_sanitize_profile_path_matches_versioned_stdlib_dir_not_python_ancestor():
+    path = (
+        "/data00/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/"
+        "lib/python3.11/asyncio/base_events.py"
+    )
+
+    assert _sanitize_profile_path(path) == "asyncio/base_events.py"
+
+
 def test_profile_default_top_n_is_100():
     assert PROFILE_TOP_N == 100


### PR DESCRIPTION
Closes #3787.

## Problem
`_sanitize_profile_path` detected the stdlib directory by matching the first path part starting with `"python"`. With interpreters installed under an ancestor literally named `python` (uv: `~/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/...`), it matched the wrong directory and leaked `cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/...` into the JSON `profile` field, breaking the `/lib/python` privacy assertion.

## Fix
Match only versioned stdlib parent directories (`python3`, `python3.11`) via a `python[0-9]` pattern, not any part starting with `python`.

## Tests
- Added `test_sanitize_profile_path_matches_versioned_stdlib_dir_not_python_ancestor` regression test.
- `tests/server/test_profile_middleware.py`: 8 passed (including the previously failing `test_profile_query_adds_profile_field_to_json_response`).