### PR TITLE
test(server): set openviking logger to INFO in concurrent request-id test

### DIFF
--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -169,6 +169,8 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
 
     handler = _CaptureHandler(records)
     server_logger.addHandler(handler)
+    previous_level = server_logger.level
+    server_logger.setLevel(logging.INFO)
     gate = asyncio.Event()
     arrivals = 0
 
@@ -191,6 +193,7 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
             )
     finally:
         server_logger.removeHandler(handler)
+        server_logger.setLevel(previous_level)
 
     assert first.headers[REQUEST_ID_HEADER] == "request-first"
     assert second.headers[REQUEST_ID_HEADER] == "request-second"


### PR DESCRIPTION
Closes #3789.

## Problem
`test_concurrent_requests_do_not_mix_or_leak_request_ids` asserts on a business log emitted at INFO, but the test attaches its capture handler to the `openviking` logger without setting its level. The logger inherits the root WARNING level, so the INFO business record is filtered out and `business_records` is empty:

```
E   AssertionError: assert {} == {'first': 'request-first', 'second': 'request-second'}
```

## Fix
Temporarily set the `openviking` logger to INFO for the duration of the test, restoring the previous level in `finally`. Test-only change; no production behavior change.

## Tests
`tests/server/test_request_id.py`: 5 passed (including the previously failing concurrent test).