### PR TITLE
fix(privacy): anchor skill placeholder replacement to line ends

### DIFF
--- a/openviking/privacy/skill_placeholder.py
+++ b/openviking/privacy/skill_placeholder.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Placeholder helpers for skill privacy values."""
 
+import re
 from dataclasses import dataclass, field
 
 
@@ -18,27 +19,21 @@ def build_placeholder(skill_name: str, field_name: str) -> str:
 
 
 def _replace_structured_value(content: str, raw_value: str, placeholder: str) -> tuple[str, bool]:
-    replacements = (
-        (f'"{raw_value}"', f'"{placeholder}"'),
-        (f"'{raw_value}'", f"'{placeholder}'"),
-        (f": {raw_value}\n", f": {placeholder}\n"),
-        (f": {raw_value}\r\n", f": {placeholder}\r\n"),
-        (f":{raw_value}\n", f":{placeholder}\n"),
-        (f":{raw_value}\r\n", f":{placeholder}\r\n"),
-        (f": {raw_value}", f": {placeholder}"),
-        (f":{raw_value}", f":{placeholder}"),
-        (f"= {raw_value}\n", f"= {placeholder}\n"),
-        (f"= {raw_value}\r\n", f"= {placeholder}\r\n"),
-        (f"={raw_value}\n", f"={placeholder}\n"),
-        (f"={raw_value}\r\n", f"={placeholder}\r\n"),
-        (f"= {raw_value}", f"= {placeholder}"),
-        (f"={raw_value}", f"={placeholder}"),
+    escaped = re.escape(raw_value)
+    # A bare assignment (``key: value`` or ``key=value``) is only treated as
+    # structured when the value runs to end of line, so prose occurrences such
+    # as ``text: prod should stay here`` are not over-redacted. The original
+    # separator and spacing are preserved.
+    patterns = (
+        (f'"{escaped}"', f'"{placeholder}"'),
+        (f"'{escaped}'", f"'{placeholder}'"),
+        (rf"(:|=)([ \t]*){escaped}$", rf"\1\g<2>{placeholder}"),
     )
 
     replaced = False
-    for old, new in replacements:
-        if old in content:
-            content = content.replace(old, new)
+    for pattern, replacement in patterns:
+        content, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+        if count:
             replaced = True
     return content, replaced
 

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -280,3 +280,19 @@ def test_placeholderization_replaces_all_structured_occurrences_for_same_value()
         'api_key: "{{ov_privacy:skill:multi-hit-skill:api_key}}"\n'
         "backup={{ov_privacy:skill:multi-hit-skill:api_key}}\n"
     )
+
+
+def test_placeholderization_does_not_replace_value_in_prose():
+    result = placeholderize_skill_content_with_blocks(
+        "region: cn\nnotes: region is cn in docs\ndefault_env=prod\ntext: prod stays here\n",
+        "prose-skill",
+        {"region": "cn", "env": "prod"},
+    )
+
+    assert result.replaced_values == {"region": "cn", "env": "prod"}
+    assert result.sanitized_content == (
+        "region: {{ov_privacy:skill:prose-skill:region}}\n"
+        "notes: region is cn in docs\n"
+        "default_env={{ov_privacy:skill:prose-skill:env}}\n"
+        "text: prod stays here\n"
+    )


### PR DESCRIPTION
Closes #3791.

## Problem
`_replace_structured_value` matched `: value`/`=value` without a trailing line terminator, so a value occurring in prose after a colon was over-redacted. E.g. with `env=prod`:

```
default_env=prod            -> default_env={{placeholder}}
text: prod should stay here -> text: {{placeholder}} should stay here   # wrong
```

This rewrites/corrupts ordinary skill text and is caught by `test_placeholderization_only_replaces_structured_values`.

## Fix
Replace bare assignments with a multiline regex anchored to end of line (`(:|=)([ \t]*)value$`), preserving the original separator/spacing (`=prod` stays `={{...}}`, not `= {{...}}`). Quoted values (`"value""/`'value'`) are still replaced anywhere. The old explicit `\n`/`\r\n` tuples are subsumed by `re.MULTILINE`, and end-of-file values without a trailing newline still match.

## Tests
- Existing `test_placeholderization_only_replaces_structured_values` now passes.
- Added `test_placeholderization_does_not_replace_value_in_prose`.
- All 4 placeholderization unit tests pass (CRLF, no-trailing-newline, multi-occurrence, prose). Other failures in the file are pre-existing native `ragfs_python` setup errors unrelated to this change.