### PR TITLE
test(server): fix attrs tags fake for And filter and version metadata

### DIFF
--- a/tests/server/test_filesystem_router.py
+++ b/tests/server/test_filesystem_router.py
@@ -55,7 +55,7 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         async def filter(self, **kwargs):
             return [
                 {
-                    "uri": kwargs["filter"]["conds"][0],
+                    "uri": "viking://user/alice/memories/preferences/theme.md",
                     "level": 2,
                     "search_tags": ["team=search"],
                 }
@@ -81,5 +81,6 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         "fields": {"topic": "theme"},
         "resource_refs": ["viking://resources/docs/api.md"],
         "memory_type": "preferences",
+        "version": 1,
     }
     assert attrs["tags"] == ["team=search"]


### PR DESCRIPTION
Closes #3793.

## Problem
`test_attrs_returns_memory_fields_and_tags` failed two ways:
1. Its `FakeVectorManager.filter` subscripted `kwargs['filter']['conds'][0]`, but `_tags_attr` now passes an `And([Eq(...), In(...)])` filter object → `TypeError: 'And' object is not subscriptable`.
2. The expected memory metadata omitted `"version": 1`, which `MemoryFile.to_metadata()` now always sets (same metadata change as #3778).

## Fix (test-only)
- Return a fixed record from the fake rather than introspecting the filter.
- Add `"version": 1` to the expected dict.

## Tests
`tests/server/test_filesystem_router.py`: 2 passed.