### PR TITLE
test(storage): align set_tags tests with directory-level grouping and list contract

### DIFF
--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1431,10 +1431,15 @@ async def test_set_tags_recursive_directory_all_missing_vector_records_returns_z
     )
 
     assert result["success_count"] == 0
-    assert result["skipped_count"] == 3
+    assert result["skipped_count"] == 2
     assert result["failed_count"] == 0
     assert result["updated_uris"] == []
     assert result["tags_updated"] is False
+    # The .abstract.md/.overview.md entries collapse into the parent directory's
+    # L0/L1 target, leaving one directory target plus the standalone file target.
+    assert sorted(call[0] for call in fake_store.update_calls) == sorted(
+        [file_uri, root_uri]
+    )
 
 
 @pytest.mark.asyncio
@@ -1530,7 +1535,7 @@ async def test_set_tags_does_not_return_write_queue_fields(monkeypatch):
             assert uri == file_uri
             assert list(tags) == ["env=prod"]
             assert mode == "replace"
-            return True
+            return [{"uri": uri}]
 
     fake_vfs.vector_store = _FakeVectorStore()
 


### PR DESCRIPTION
Closes #3795.

## Problem
Two `set_tags` tests were stale:
1. `test_set_tags_recursive_directory_all_missing_vector_records_returns_zero_counts` expected `skipped_count == 3`, but `_collect_directory_tag_targets` now folds `.abstract.md`/`.overview.md` into the parent directory's L0/L1 target, so there are two upsert targets (the directory root + the standalone file) and `skipped_count == 2`.
2. `test_set_tags_does_not_return_write_queue_fields` had `_FakeVectorStore.update_search_tags` return `True`, but the production contract is `List[Dict]`; `_upsert_uri_tags` iterates the result and raised `TypeError: 'bool' object is not iterable`.

## Fix (test-only)
- Expect `skipped_count == 2` and assert the upsert targets are the file and directory root.
- Return `[{"uri": uri}]` from the single-file fake to match the real store.

## Tests
All 11 `set_tags`/tag tests in `tests/server/test_content_write_service.py` pass.
