### PR TITLE
test(server): align watch-task ACL tests with PermissionDeniedError and _list_read_path_items

### DIFF
--- a/tests/server/test_watch_task_acl.py
+++ b/tests/server/test_watch_task_acl.py
@@ -15,7 +15,7 @@ from openviking.resource.watch_storage import (
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.exceptions import InvalidArgumentError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -48,7 +48,7 @@ def test_watch_task_control_files_are_root_only(bare_viking_fs, root_ctx, user_c
     assert bare_viking_fs._is_accessible(uri, root_ctx) is True
     assert bare_viking_fs._is_accessible(uri, user_ctx) is False
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionDeniedError):
         bare_viking_fs._ensure_access(uri, user_ctx)
 
 
@@ -56,9 +56,8 @@ def test_watch_task_control_files_are_root_only(bare_viking_fs, root_ctx, user_c
 async def test_hidden_listing_filters_watch_task_control_files_for_non_root(
     bare_viking_fs, root_ctx, user_ctx
 ):
-    bare_viking_fs._uri_to_path = lambda uri, ctx=None: "/fake/resources"
     bare_viking_fs._ctx_or_default = lambda ctx=None: ctx
-    bare_viking_fs._ls_entries = lambda path: [
+    entries = [
         {
             "name": ".watch_tasks.json",
             "isDir": False,
@@ -79,7 +78,12 @@ async def test_hidden_listing_filters_watch_task_control_files_for_non_root(
         },
         {"name": "public.txt", "isDir": False, "size": 5, "modTime": "2026-01-01T00:00:00+00:00"},
     ]
-    bare_viking_fs._path_to_uri = lambda path, ctx=None: f"viking://resources/{path.split('/')[-1]}"
+
+    async def fake_list_read_path_items(uri, ctx=None):
+        del uri, ctx
+        return [(entry, f"viking://resources/{entry['name']}") for entry in entries]
+
+    bare_viking_fs._list_read_path_items = fake_list_read_path_items
 
     root_entries = await bare_viking_fs._ls_original(
         "viking://resources",


### PR DESCRIPTION
Closes #3797.

## Problem
Two stale failures in `tests/server/test_watch_task_acl.py`:
1. `test_watch_task_control_files_are_root_only` expects built-in `PermissionError`, but `VikingFS._ensure_access` raises the domain `PermissionDeniedError` (not a subclass of `PermissionError`).
2. `test_hidden_listing_filters_watch_task_control_files_for_non_root` stubs `_ls_entries`/`_path_to_uri`, but `_ls_original` now consumes `(entry, uri)` tuples from `_list_read_path_items`; with the old stubs the bare `VikingFS` falls through to real path access and raises `NotFoundError`.

## Fix (test-only)
- Import and expect `PermissionDeniedError`.
- Stub `_list_read_path_items` to return `(entry, uri)` tuples directly.

## Tests
`tests/server/test_watch_task_acl.py`: 7 passed.
