### PR TITLE
fix(auth): reject tenant/user override for USER OAuth tokens (#3801)

### DIFF
--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -155,7 +155,26 @@ class ApiKeyAuthPlugin(AuthPlugin):
                     "please re-authorize the client."
                 )
 
-        # Silently ignore identity assertion headers in api_key mode.
+        # In api_key mode the OAuth token's bound account/user is the sole
+        # authority for caller identity. For USER tokens (the lowest rank,
+        # which cannot legitimately target other tenants) a *mismatched*
+        # assertion header is an impersonation attempt and must fail closed.
+        # Matching headers are harmless. Privileged tokens retain the legacy
+        # silent-strip behavior for backwards compatibility.
+        if role == Role.USER:
+            if x_openviking_account and x_openviking_account != record.account_id:
+                raise PermissionDeniedError(
+                    "OAuth token cannot override its bound account via "
+                    "X-OpenViking-Account."
+                )
+            if x_openviking_user and x_openviking_user != record.user_id:
+                raise PermissionDeniedError(
+                    "OAuth token cannot override its bound user via "
+                    "X-OpenViking-User."
+                )
+
+        # Strip any surviving identity assertion headers so downstream code
+        # never acts on a client-supplied account/user in api_key mode.
         if x_openviking_account:
             _remove_header(request, b"x-openviking-account")
         if x_openviking_user:

--- a/tests/server/oauth/test_auth_integration.py
+++ b/tests/server/oauth/test_auth_integration.py
@@ -227,6 +227,50 @@ async def test_oauth_user_role_rejects_account_override(provider, store):
 
 
 @pytest.mark.asyncio
+async def test_oauth_user_role_rejects_user_override(provider, store):
+    """A USER OAuth token cannot impersonate another user via header."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="user")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(),
+        oauth_provider=provider,
+        extra_headers={"x-openviking-user": "bob"},
+    )
+    with pytest.raises(PermissionDeniedError):
+        await resolve_identity(
+            request,
+            x_api_key=None,
+            authorization=f"Bearer {token}",
+            x_openviking_user="bob",
+        )
+
+
+@pytest.mark.asyncio
+async def test_oauth_user_role_allows_matching_assertion_headers(provider, store):
+    """Headers that match the token's bound identity are accepted, not rejected."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="user")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(),
+        oauth_provider=provider,
+        extra_headers={
+            "x-openviking-account": "tenant-a",
+            "x-openviking-user": "alice",
+        },
+    )
+    identity = await resolve_identity(
+        request,
+        x_api_key=None,
+        authorization=f"Bearer {token}",
+        x_openviking_account="tenant-a",
+        x_openviking_user="alice",
+    )
+    assert identity.account_id == "tenant-a"
+    assert identity.user_id == "alice"
+    assert identity.from_oauth is True
+
+
+@pytest.mark.asyncio
 async def test_oauth_root_can_be_used_without_explicit_tenant_headers(provider, store):
     """ROOT OAuth tokens carry account/user in claims — no header requirement."""
     token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="root")


### PR DESCRIPTION
## Summary

Fixes #3801

In api_key mode, `ApiKeyAuthPlugin._try_resolve_oauth_token` resolves caller identity strictly from the bound OAuth access-token record. Client-supplied `X-OpenViking-Account` / `X-OpenViking-User` headers were silently stripped, so a **USER-role** OAuth token presenting a *mismatched* assertion header (token bound to `tenant-a/alice`, header asserting `tenant-b`) was accepted with no error.

The token's own bound identity was always used, so this was not a direct impersonation — but silently accepting a conflicting tenant/user header masks a client/proxy misconfiguration that can indicate a confused-deputy or impersonation attempt. The OAuth integration test `test_oauth_user_role_rejects_account_override` codifies the stricter fail-closed contract and currently fails.

### Change

For OAuth tokens at the lowest rank (`Role.USER`), raise `PermissionDeniedError` when an assertion header does not match the token's bound `account_id`/`user_id`:

- mismatched `X-OpenViking-Account` → `PermissionDeniedError`
- mismatched `X-OpenViking-User` → `PermissionDeniedError`
- headers that match the bound identity remain accepted (and are still stripped downstream)

Privileged (ROOT/ADMIN) OAuth tokens retain the legacy silent-strip behavior to avoid backwards-compatibility impact, since they may legitimately carry routing headers.

### Tests

- Added `test_oauth_user_role_rejects_user_override` (symmetric user-header case).
- Added `test_oauth_user_role_allows_matching_assertion_headers` (matching headers still accepted).
- Existing `test_oauth_user_role_rejects_account_override` now passes.
- `tests/server/oauth/test_auth_integration.py`: 14 passed.
- `tests/server/test_auth.py`: all collectable tests pass; remaining collection errors are the environmental missing native `ragfs_python` binding (pass in CI).

## Test plan

- [x] `pytest tests/server/oauth/test_auth_integration.py`
- [x] `pytest tests/server/test_auth.py` (environmental ragfs errors only)

---

This is a **Draft PR** opened by the automated LoopX issue-fix lane. It will not be merged or promoted by automation; awaiting CI and maintainer review.
