### PR TITLE
test(client): align gateway_token config test with host-bound challenge-only design (#3803)

### DIFF
--- a/tests/client/test_http_client_config.py
+++ b/tests/client/test_http_client_config.py
@@ -49,17 +49,43 @@ def test_async_http_client_loads_missing_fields_from_ovcli_config(tmp_path, monk
     )
     monkeypatch.setenv(OPENVIKING_CLI_CONFIG_ENV, str(config_path))
 
+    # Explicit url wins over the configured url. The gateway token is a secret
+    # bound to its configured host, so it must NOT follow the client across a
+    # host mismatch (no token leakage to another endpoint). It is also sent
+    # only on a WWW-Authenticate challenge, never eagerly in _extra_headers.
     client = AsyncHTTPClient(url="http://explicit-host:1933")
 
     assert client._url == "http://explicit-host:1933"
     assert client._api_key == "config-key"
-    assert client._gateway_token == "gateway-secret"
-    assert client._extra_headers["X-Gateway-Token"] == "gateway-secret"
+    assert client._gateway_token is None
+    assert "X-Gateway-Token" not in client._extra_headers
     assert client._account == "config-account"
     assert client._user_id == "config-user"
     assert client._actor_peer_id == "config-actor"
     assert client._timeout == 12.5
     assert client._profile_enabled is True
+
+
+def test_async_http_client_loads_gateway_token_for_matching_config_url(tmp_path, monkeypatch):
+    """Gateway token loads from ovcli config when the effective URL matches the configured host."""
+    config_path = tmp_path / "ovcli.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "url": "http://config-host:1933",
+                "api_key": "config-key",
+                "gateway_token": "gateway-secret",
+            }
+        )
+    )
+    monkeypatch.setenv(OPENVIKING_CLI_CONFIG_ENV, str(config_path))
+
+    client = AsyncHTTPClient()
+
+    assert client._url == "http://config-host:1933"
+    assert client._gateway_token == "gateway-secret"
+    # Challenge-only: the token is not attached to default headers.
+    assert "X-Gateway-Token" not in client._extra_headers
 
 
 def test_async_http_client_explicit_values_override_ovcli_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #3803

`tests/client/test_http_client_config.py::test_async_http_client_loads_missing_fields_from_ovcli_config` fails on `origin/main`. The test wrote an ovcli config with `url=http://config-host:1933` and `gateway_token=gateway-secret`, constructed `AsyncHTTPClient(url="http://explicit-host:1933")` (a **different host**), and asserted:

```python
assert client._gateway_token == "gateway-secret"
assert client._extra_headers["X-Gateway-Token"] == "gateway-secret"
```

Both assertions contradict the hardened design introduced in the same commit (`cbfb387dc`, #3119):

1. `resolve_client_config` resolves `gateway_token` **only when the effective URL matches the configured URL** — a secret must not follow the client across a host mismatch. With the explicit `explicit-host` URL, `_gateway_token` is correctly `None`.
2. The gateway token is sent **only on a 401 `WWW-Authenticate` challenge** (set in `_request`'s retry/multipart-probe paths), never eagerly attached to `_extra_headers`. Eagerly placing it there would leak the secret on every request.

### Change (test-only)

- In the host-mismatch scenario, assert `_gateway_token is None` and `X-Gateway-Token` absent from `_extra_headers`, documenting why (host-bound secret, challenge-only).
- Added `test_async_http_client_loads_gateway_token_for_matching_config_url`: when no explicit URL overrides the configured host, the gateway token loads onto `_gateway_token` and remains absent from default headers (challenge-only).

### Tests

- `tests/client/test_http_client_config.py`: 23 passed.
- The unrelated pre-existing `sdk/python/tests/test_async_client_behaviors.py::test_glob_normalizes_scope_uri` failure (extra `node_limit: 256` field) reproduces on clean `origin/main` and is not touched here.

## Test plan

- [x] `pytest tests/client/test_http_client_config.py`

---

This is a **Draft PR** opened by the automated LoopX issue-fix lane. It will not be merged or promoted by automation; awaiting CI and maintainer review.
