### PR TITLE
fix(storage): implement update_data for openGauss backend

### DIFF
--- a/openviking/storage/vectordb_adapters/opengauss_adapter.py
+++ b/openviking/storage/vectordb_adapters/opengauss_adapter.py
@@ -1083,6 +1083,30 @@ class OpenGaussCollection(ICollection):
             ids.append(record_id)
         return ids
 
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        if not data_list:
+            return []
+        primary_keys = []
+        for record in data_list:
+            record_id = record.get("id")
+            if record_id is None or record_id == "":
+                raise ValueError("openGauss vector record requires id")
+            primary_keys.append(record_id)
+
+        existing = self.fetch_data(primary_keys)
+        existing_map = {str(item.id): item.fields for item in existing.items}
+        missing_ids = [key for key in primary_keys if str(key) not in existing_map]
+        if missing_ids:
+            raise ValueError(f"record not found for primary key(s): {missing_ids}")
+
+        merged_list = []
+        for record in data_list:
+            existing_fields = existing_map[str(record["id"])] or {}
+            merged = dict(existing_fields)
+            merged.update(record)
+            merged_list.append(merged)
+        return self.upsert_data(merged_list)
+
     def _upsert_row(self, columns: List[str], values: List[Any]) -> None:
         id_index = columns.index("id")
         update_columns = [column for column in columns if column != "id"]
@@ -1510,6 +1534,17 @@ class OpenGaussCollectionAdapter(CollectionAdapter):
             current_parts.append(part)
             roots.append("/" + "/".join(current_parts))
         return roots
+
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        normalized = [self._normalize_record_for_write(record) for record in data_list]
+        collection = self.get_collection()
+        result = collection.update_data(normalized)
+        if isinstance(result, list):
+            return [str(item) for item in result if item is not None]
+        fallback_ids = [
+            record.get("id") for record in normalized if record.get("id") is not None
+        ]
+        return [str(item) for item in fallback_ids]
 
     def _normalize_record_for_write(self, record: Dict[str, Any]) -> Dict[str, Any]:
         normalized = dict(super()._normalize_record_for_write(record))

--- a/tests/storage/mock_backend.py
+++ b/tests/storage/mock_backend.py
@@ -179,6 +179,9 @@ class MockCollection(ICollection):
     def upsert_data(self, data_list: List[Dict[str, Any]], ttl=0):
         raise NotImplementedError("MockCollection.upsert_data is not supported")
 
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        raise NotImplementedError("MockCollection.update_data is not supported")
+
     def fetch_data(self, primary_keys: List[Any]):
         raise NotImplementedError("MockCollection.fetch_data is not supported")
 

--- a/tests/storage/test_opengauss_adapter.py
+++ b/tests/storage/test_opengauss_adapter.py
@@ -8,7 +8,11 @@ import uuid
 
 import pytest
 
-from openviking.storage.vectordb.collection.result import SearchResult
+from openviking.storage.vectordb.collection.result import (
+    DataItem,
+    FetchDataInCollectionResult,
+    SearchResult,
+)
 from openviking.storage.vectordb_adapters.factory import create_collection_adapter
 from openviking.storage.vectordb_adapters.opengauss_adapter import (
     OpenGaussCollection,
@@ -258,6 +262,73 @@ def test_vector_search_binds_vector_before_filter_params():
 
     assert captured["fetch"] is True
     assert captured["params"] == ["[0.1,0.2]", "%\n/a\n%", "[0.1,0.2]", 10, 0]
+
+
+def test_update_data_merges_existing_fields_and_upserts():
+    collection = object.__new__(OpenGaussCollection)
+    existing = {"uri": "/a", "text": "old", "account_id": "acct"}
+    upserted = {}
+
+    collection.fetch_data = lambda primary_keys: FetchDataInCollectionResult(
+        items=[DataItem(id="row-1", fields=dict(existing))]
+    )
+
+    def fake_upsert(data_list, ttl=0):
+        upserted["data"] = data_list
+        return ["row-1"]
+
+    collection.upsert_data = fake_upsert
+
+    result = collection.update_data([{"id": "row-1", "text": "new"}])
+
+    assert result == ["row-1"]
+    assert upserted["data"] == [
+        {"id": "row-1", "uri": "/a", "text": "new", "account_id": "acct"}
+    ]
+
+
+def test_update_data_rejects_missing_primary_key():
+    collection = object.__new__(OpenGaussCollection)
+
+    with pytest.raises(ValueError, match="requires id"):
+        collection.update_data([{"text": "no id"}])
+
+
+def test_update_data_rejects_unknown_record():
+    collection = object.__new__(OpenGaussCollection)
+    collection.fetch_data = lambda primary_keys: FetchDataInCollectionResult(items=[])
+
+    with pytest.raises(ValueError, match="record not found"):
+        collection.update_data([{"id": "missing", "text": "x"}])
+
+
+def test_update_data_empty_list_returns_empty():
+    collection = object.__new__(OpenGaussCollection)
+    assert collection.update_data([]) == []
+
+
+def test_adapter_update_data_normalizes_and_returns_ids(monkeypatch):
+    adapter = object.__new__(OpenGaussCollectionAdapter)
+    adapter._collection_name = "context"
+    adapter._index_name = "default"
+    captured = {}
+
+    class FakeCollection:
+        def update_data(self, data_list):
+            captured["data"] = data_list
+            return ["row-1"]
+
+    monkeypatch.setattr(adapter, "get_collection", lambda: FakeCollection())
+    monkeypatch.setattr(
+        adapter,
+        "_normalize_record_for_write",
+        lambda record: {**record, "uri": "/a/b/"},
+    )
+
+    result = adapter.update_data([{"id": "row-1", "uri": "/a/b/", "text": "new"}])
+
+    assert result == ["row-1"]
+    assert captured["data"] == [{"id": "row-1", "uri": "/a/b/", "text": "new"}]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

Implements `update_data` for the openGauss vector backend, which was missing despite being an `@abstractmethod` on `ICollection`.

## Why

`OpenGaussCollection(ICollection)` implemented `upsert_data`, `fetch_data`, `delete_data`, and `delete_all_data`, but never implemented `update_data`. Since `update_data` is abstract, `OpenGaussCollection` could not be instantiated at all (`TypeError: Can't instantiate abstract class OpenGaussCollection with abstract method update_data`), and the `data/update` path through the adapter (`self._async_adapter.call("update_data", ...)`) had no backend implementation for openGauss.

This also broke the dynamically loaded `MockCollection` test backend and 7 unit tests in `tests/storage/test_opengauss_adapter.py` plus `tests/storage/test_vectordb_adaptor.py`.

## Change

- `OpenGaussCollection.update_data`: partial-update semantics consistent with `LocalCollection`/`QdrantCollection` — require non-empty `id`, fetch existing rows, raise `ValueError` for missing primary keys, merge existing fields with the provided partial fields, then `upsert_data` the merged rows.
- `OpenGaussCollectionAdapter.update_data`: normalize each record via `_normalize_record_for_write` (so uri/parent_uri/scope_roots are populated), delegate to the collection, and return stringified ids.
- `tests/storage/mock_backend.py`: implement the abstract `update_data` stub on `MockCollection`.
- Tests: add regression coverage for merge-and-upsert, missing-id rejection, unknown-record rejection, empty input, and adapter normalization/id return.

## Verification

- `tests/storage/test_opengauss_adapter.py`: 18 passed, 1 skipped (the skipped test is the gated openGauss live integration smoke test).
- `tests/storage/test_vectordb_adaptor.py`: passes (dynamic MockCollection loading now succeeds).
- Full `tests/storage`: 410 passed, up from 398; the 8 `update_data`/ABC-instantiation failures are resolved. Remaining failures in this bucket (qdrant logging, semantic processor, volcengine payload shape, bulk_upsert native `PersistStore`) are unrelated and tracked separately.

No merge/promotion — Draft only.
