### PR TITLE
test(storage): align stale tests with current storage behavior

### DIFF
--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -209,7 +209,8 @@ class TestOverviewGenerationFlow:
         )
         assert f"Output Language: {lang}" in prompt
         assert "Output in Markdown format" in prompt
-        assert "Brief Description" in prompt
+        expected_heading = "简要描述" if lang == "zh-CN" else "Brief Description"
+        assert expected_heading in prompt
         assert "abstract_max_chars" not in prompt
 
     def test_overview_generation_prompt_preserves_repository_hierarchy(self):

--- a/tests/storage/test_semantic_processor_mv_vector_store.py
+++ b/tests/storage/test_semantic_processor_mv_vector_store.py
@@ -13,6 +13,7 @@ async def test_mv_canonicalizes_user_shorthand_before_vector_update(monkeypatch)
     fs = VikingFS.__new__(VikingFS)
     fs._async_agfs = AsyncMock()
     fs._async_agfs.stat.return_value = {"isDir": False}
+    fs._async_agfs.pathlock_acquire_batch.return_value = {"lease_ref": "mv-lease"}
     fs._collect_uris = AsyncMock(return_value=[])
     fs._copy_for_mv = AsyncMock()
     fs._update_vector_store_uris = AsyncMock()

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -125,8 +125,8 @@ class _FakeVikingFS:
         del ctx
         return f"/fake/{uri.replace('://', '/').strip('/')}"
 
-    async def write_file(self, uri, content, ctx=None):
-        del ctx
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        del ctx, lease_ref
         self.writes.append((uri, content))
 
 

--- a/tests/storage/test_volcengine_clients.py
+++ b/tests/storage/test_volcengine_clients.py
@@ -253,6 +253,7 @@ def test_volcengine_collection_update_data_posts_to_update_endpoint(monkeypatch)
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "name": "updated"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -290,6 +291,7 @@ def test_volcengine_collection_update_data_sanitizes_uri_fields(monkeypatch):
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "uri": "/resources/demo", "parent_uri": "/resources"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -331,6 +333,7 @@ def test_volcengine_api_key_collection_update_data_posts_to_update_endpoint(monk
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "name": "updated"}],
+        "ignore_unknown_fields": True,
     }
 
 
@@ -370,6 +373,7 @@ def test_volcengine_api_key_collection_update_data_sanitizes_uri_fields(monkeypa
         "project": "default",
         "collection_name": "context",
         "data": [{"id": "doc-1", "uri": "/resources/demo", "parent_uri": "/resources"}],
+        "ignore_unknown_fields": True,
     }
 
 


### PR DESCRIPTION
## Summary

Test-only fix aligning four stale storage tests with current production behavior. No production code is changed.

## Changes

1. **`tests/storage/test_volcengine_clients.py`** (4 assertions): `VolcengineCollection.update_data` and `VolcengineApiKeyCollection.update_data` intentionally send `"ignore_unknown_fields": True` in the POST body to `/api/vikingdb/data/update` (see `volcengine_collection.py:383` and the api-key collection). The tests asserted an exact payload without it. Added the field to all four expected payloads.

2. **`tests/storage/test_semantic_queue_memory_dedupe.py`**: `semantic_sidecar._write_sidecars` now calls `viking_fs.write_file(..., lease_ref=lease_ref)`. The `_FakeVikingFS.write_file` fake did not accept that kwarg, raising `TypeError`. Added `lease_ref=None`.

3. **`tests/storage/test_semantic_processor_mv_vector_store.py`**: `VikingFS.mv` passes the acquired pathlock lease through `_pathlock_fs_ctx`, which requires a dict with a `lease_ref` key. The test used a bare `AsyncMock` whose return value was another mock, raising `ValueError: lease_ref must be a non-empty string or lease dictionary`. Set `pathlock_acquire_batch.return_value = {"lease_ref": "mv-lease"}`.

4. **`tests/storage/test_semantic_processor_language.py`**: the overview prompt template localizes headings — it renders `简要描述` for `zh-CN` and `Brief Description` otherwise (`overview_generation.yaml:59`). The test asserted `"Brief Description"` unconditionally, failing for the `zh-CN` parametrization. It now asserts the language-appropriate heading.

## Tests

Targeted files: 99 passed. The remaining `tests/storage` failures on this branch are pre-existing on `origin/main` and are addressed independently: openGauss ABC `update_data` (PR #3807), qdrant `caplog` capture (PR #3808), and one environmental `PersistStore` native-backend failure.
