### PR TITLE
fix(privacy): avoid redacting skill values in prose

### DIFF
--- a/openviking/privacy/skill_placeholder.py
+++ b/openviking/privacy/skill_placeholder.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Placeholder helpers for skill privacy values."""
 
+import re
 from dataclasses import dataclass, field
 
 
@@ -18,29 +19,18 @@ def build_placeholder(skill_name: str, field_name: str) -> str:
 
 
 def _replace_structured_value(content: str, raw_value: str, placeholder: str) -> tuple[str, bool]:
-    replacements = (
-        (f'"{raw_value}"', f'"{placeholder}"'),
-        (f"'{raw_value}'", f"'{placeholder}'"),
-        (f": {raw_value}\n", f": {placeholder}\n"),
-        (f": {raw_value}\r\n", f": {placeholder}\r\n"),
-        (f":{raw_value}\n", f":{placeholder}\n"),
-        (f":{raw_value}\r\n", f":{placeholder}\r\n"),
-        (f": {raw_value}", f": {placeholder}"),
-        (f":{raw_value}", f":{placeholder}"),
-        (f"= {raw_value}\n", f"= {placeholder}\n"),
-        (f"= {raw_value}\r\n", f"= {placeholder}\r\n"),
-        (f"={raw_value}\n", f"={placeholder}\n"),
-        (f"={raw_value}\r\n", f"={placeholder}\r\n"),
-        (f"= {raw_value}", f"= {placeholder}"),
-        (f"={raw_value}", f"={placeholder}"),
+    sanitized, quoted_replacements = re.subn(
+        rf'(["\']){re.escape(raw_value)}\1',
+        rf"\1{placeholder}\1",
+        content,
     )
-
-    replaced = False
-    for old, new in replacements:
-        if old in content:
-            content = content.replace(old, new)
-            replaced = True
-    return content, replaced
+    sanitized, assignment_replacements = re.subn(
+        rf"([:=])([ \t]*){re.escape(raw_value)}(?=\r?$)",
+        rf"\1\2{placeholder}",
+        sanitized,
+        flags=re.MULTILINE,
+    )
+    return sanitized, quoted_replacements + assignment_replacements > 0
 
 
 def placeholderize_skill_content_with_blocks(

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -104,7 +104,23 @@ async def test_skill_read_restores_placeholder_with_user_shorthand(service):
 
 
 @pytest.mark.asyncio
-async def test_skill_privacy_extraction_returns_content_blocks():
+async def test_skill_privacy_extraction_returns_content_blocks(monkeypatch):
+    async def fake_completion_async(_prompt):
+        return '{"values": {"api_key": "secret-xyz", "base_url": "https://example.com"}}'
+
+    monkeypatch.setattr(
+        "openviking.privacy.skill_extractor.get_openviking_config",
+        lambda: type(
+            "Cfg",
+            (),
+            {
+                "vlm": type(
+                    "VLM", (), {"get_completion_async": staticmethod(fake_completion_async)}
+                )()
+            },
+        )(),
+    )
+
     content = 'api_key: "secret-xyz"\nbase_url: "https://example.com"\n'
     result = await extract_skill_privacy_values(
         skill_name="extract-block-skill",


### PR DESCRIPTION
Closes #3791.

## Problem
`_replace_structured_value` used unterminated substring replacements for `: value` and `= value`. That over-redacted the configured value when it appeared later in prose on the same line, e.g. `text: prod should stay here` when `env=prod` was configured.

The skill privacy extraction block test also instantiated the real VLM, so it failed in environments without `OPENAI_API_KEY`.

## Fix
- Anchor unquoted assignment replacements to end of line with `re.MULTILINE`, preserving separator spacing and CRLF.
- Preserve quoted-value replacement anywhere on a line.
- Mock the VLM completion in the extraction-content-blocks unit test.

## Validation
```text
tests/server/test_privacy_config_service.py::test_skill_privacy_extraction_returns_content_blocks
tests/server/test_privacy_config_service.py::test_placeholderization_only_replaces_structured_values
tests/server/test_privacy_config_service.py::test_placeholderization_replaces_end_of_file_values_without_newline
tests/server/test_privacy_config_service.py::test_placeholderization_replaces_all_structured_occurrences_for_same_value
4 passed
```

Direct prose/assignment/CRLF/quoted regression checks also pass. Other tests in this file that construct a full `OpenVikingService` still require the unavailable native `ragfs_python` binding locally and pass in CI.
