### PR TITLE
test(server): align request wait tracking fake with write path

### DIFF
--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -47,9 +47,18 @@ class _FakeVikingFS:
         self._file_uri = file_uri
         self._root_uri = root_uri
         self.content = {file_uri: "original"}
+
+        async def _acquire_exact(lock_path):
+            del lock_path
+            return SimpleNamespace(id="lock-1")
+
+        async def _release(lease):
+            del lease
+            return None
+
         self._async_agfs = SimpleNamespace(
-            pathlock_acquire_exact=lambda lock_path: SimpleNamespace(id="lock-1"),
-            pathlock_release=lambda lease: None,
+            pathlock_acquire_exact=_acquire_exact,
+            pathlock_release=_release,
         )
 
     async def stat(self, uri: str, ctx=None):
@@ -63,6 +72,10 @@ class _FakeVikingFS:
     def _uri_to_path(self, uri: str, ctx=None):
         del ctx
         return f"/fake/{uri.replace('://', '/').strip('/')}"
+
+    def _ensure_mutable_access(self, uri: str, ctx=None):
+        del uri, ctx
+        return None
 
     async def delete_temp(self, temp_uri: str, ctx=None):
         del temp_uri, ctx


### PR DESCRIPTION
## Summary

- align the request-wait tracking test fake with the current `ContentWriteCoordinator` write path
- provide a no-op mutable-access check on `_FakeVikingFS`
- make fake pathlock acquire/release methods awaitable, matching the AGFS interface used by production code

These are test-only changes that let the content-write wait tests reach the request tracker assertions instead of failing on stale fake APIs.

## Validation

```bash
PYTHONPATH="$PWD" ../issue-3660-user-deletion-cascade/.venv/bin/python -m pytest \
  tests/server/test_request_wait_tracking.py::test_content_write_wait_uses_request_tracker \
  tests/server/test_request_wait_tracking.py::test_content_write_wait_uses_request_tracker_when_telemetry_disabled \
  -p no:cacheprovider --no-cov -q
```

Result: `2 passed, 4 warnings`.

```bash
PYTHONPATH="$PWD" ../issue-3660-user-deletion-cascade/.venv/bin/python -m compileall -q \
  tests/server/test_request_wait_tracking.py
```
