### PR TITLE
test(storage): implement update_data in mock adapter

### DIFF
--- a/tests/storage/mock_backend.py
+++ b/tests/storage/mock_backend.py
@@ -179,6 +179,9 @@ class MockCollection(ICollection):
     def upsert_data(self, data_list: List[Dict[str, Any]], ttl=0):
         raise NotImplementedError("MockCollection.upsert_data is not supported")
 
+    def update_data(self, data_list: List[Dict[str, Any]]):
+        raise NotImplementedError("MockCollection.update_data is not supported")
+
     def fetch_data(self, primary_keys: List[Any]):
         raise NotImplementedError("MockCollection.fetch_data is not supported")
 


### PR DESCRIPTION
## Summary

- implement `ICollection.update_data` in the storage test `MockCollection`
- keep the mock's unsupported-operation behavior consistent with adjacent methods
- allow the dynamic mock adapter loading test to instantiate after the abstract collection interface gained `update_data`

## Validation

- `PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/storage/test_vectordb_adaptor.py -p no:cacheprovider --no-cov -q`
- `PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/storage/test_vectordb_adaptor.py tests/storage -k 'mock_adapter or adapter_loading or dynamic_loading' -p no:cacheprovider --no-cov -q`
- `PYTHONPATH="$PWD" .venv/bin/python -m compileall -q tests/storage/mock_backend.py tests/storage/test_vectordb_adaptor.py`
- `.venv/bin/ruff check tests/storage/mock_backend.py tests/storage/test_vectordb_adaptor.py`

## Notes

This is a test-only fix for local/CI adapter instantiation. The production mock remains unsupported for data mutation methods.
