### PR TITLE
test(resource): add watch manager fixtures

### DIFF
--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -62,6 +62,20 @@ async def mock_viking_fs(temp_storage: Path) -> MockVikingFS:
     return MockVikingFS(root_path=str(temp_storage))
 
 
+@pytest_asyncio.fixture
+async def watch_manager(mock_viking_fs: MockVikingFS) -> AsyncGenerator[WatchManager, None]:
+    manager = WatchManager(viking_fs=mock_viking_fs)
+    await manager.initialize()
+    yield manager
+
+
+@pytest_asyncio.fixture
+async def watch_manager_no_fs() -> AsyncGenerator[WatchManager, None]:
+    manager = WatchManager(viking_fs=None)
+    await manager.initialize()
+    yield manager
+
+
 class TestWatchTask:
     """Tests for WatchTask data model."""
 


### PR DESCRIPTION
## Summary

- add the missing async `watch_manager` fixture used by `tests/resource/test_watch_manager.py`
- add `watch_manager_no_fs` for tests that explicitly exercise in-memory behavior without persistence
- initialize managers with the existing mock VikingFS so resource watch manager setup errors are resolved

## Validation

```bash
PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest tests/resource/test_watch_manager.py -p no:cacheprovider --no-cov -q
# 37 passed, 4 warnings

PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest tests/resource -p no:cacheprovider --no-cov -q
# 45 passed, 6 warnings

PYTHONPATH="$PWD" "$SIBV/bin/python" -m compileall -q tests/resource/test_watch_manager.py
"$SIBV/bin/ruff" check tests/resource/test_watch_manager.py
# All checks passed!
```

This is a Draft PR for the independent OpenViking issue-fix workflow.
