### PR TITLE
test(content-write): align set-tags mocks with update_search_tags contract

### DIFF
--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1431,7 +1431,9 @@ async def test_set_tags_recursive_directory_all_missing_vector_records_returns_z
     )
 
     assert result["success_count"] == 0
-    assert result["skipped_count"] == 3
+    # The abstract/overview files collapse into a single deduped directory
+    # target (levels [0, 1]) plus the standalone file, so 2 skipped targets.
+    assert result["skipped_count"] == 2
     assert result["failed_count"] == 0
     assert result["updated_uris"] == []
     assert result["tags_updated"] is False
@@ -1496,7 +1498,7 @@ async def test_set_tags_single_uri_missing_vector_record_returns_zero_counts(mon
         async def update_search_tags(self, uri: str, tags, *, mode: str, ctx=None):
             del ctx
             self.update_calls.append((uri, list(tags), mode))
-            return False
+            return []
 
     fake_store = _FakeVectorStore()
     fake_vfs.vector_store = fake_store
@@ -1530,7 +1532,7 @@ async def test_set_tags_does_not_return_write_queue_fields(monkeypatch):
             assert uri == file_uri
             assert list(tags) == ["env=prod"]
             assert mode == "replace"
-            return True
+            return [{"uri": file_uri}]
 
     fake_vfs.vector_store = _FakeVectorStore()
 


### PR DESCRIPTION
## Summary

While running the `tests/server` sweep against `origin/main`, three tests in
`tests/server/test_content_write_service.py` failed because their mocked vector
store did not match the production `update_search_tags` contract:

- `VikingVectorIndexBackend.update_search_tags` always returns
  `List[Dict[str, Any]]` — an empty list when no record is found/updated, or a
  list containing the updated record(s).
- Two tests (`test_set_tags_single_uri_missing_vector_record_returns_zero_counts`,
  `test_set_tags_does_not_return_write_queue_fields`) mocked it as returning
  `False`/`True`. The boolean `True` crashed the coordinator with
  `TypeError: 'bool' object is not iterable` at
  `openviking/storage/content_write.py:1279`.
- `test_set_tags_recursive_directory_all_missing_vector_records_returns_zero_counts`
  expected `skipped_count == 3`, but `_collect_directory_tag_targets` deliberately
  collapses the `.abstract.md`/`.overview.md` files into a single deduped
  directory target (levels `[0, 1]`) plus the standalone file, yielding 2.

These mismatches were introduced together with the production "Set tags"
feature (merged PR #2706, commit `21c58bd8`) and represent stale test mocks, not
a product defect.

## Changes

- Change the missing-record mock return from `False` to `[]`.
- Change the success mock return from `True` to `[{"uri": file_uri}]`.
- Align the recursive `skipped_count` expectation from 3 to 2, with a comment
  explaining the directory-target dedup.

No production code is changed.

## Validation

Commands run from the worktree:

```bash
PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest tests/server/test_content_write_service.py -p no:cacheprovider --no-cov -q
# 34 passed, 12 errors (all 12 errors are the known environmental
# ragfs_python native-library ImportError, unrelated to this change)

PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest \
  tests/server/test_content_write_service.py::test_set_tags_recursive_directory_all_missing_vector_records_returns_zero_counts \
  tests/server/test_content_write_service.py::test_set_tags_single_uri_missing_vector_record_returns_zero_counts \
  tests/server/test_content_write_service.py::test_set_tags_does_not_return_write_queue_fields \
  -p no:cacheprovider --no-cov -q
# 3 passed

PYTHONPATH="$PWD" "$SIBV/bin/python" -m compileall -q tests/server/test_content_write_service.py
"$SIBV/bin/ruff" check tests/server/test_content_write_service.py
# All checks passed!
```
