### PR TITLE
test(session): accept lease_ref in tool-externalization MemoryVikingFS fake

### DIFF
--- a/tests/session/test_tool_result_externalization.py
+++ b/tests/session/test_tool_result_externalization.py
@@ -18,10 +18,12 @@ class MemoryVikingFS:
     def __init__(self):
         self.files = {}
 
-    async def write_file(self, uri, content, *, ctx=None):  # noqa: ANN001
+    async def write_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
+        del lease_ref
         self.files[uri] = content
 
-    async def append_file(self, uri, content, *, ctx=None):  # noqa: ANN001
+    async def append_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
+        del lease_ref
         self.files[uri] = self.files.get(uri, "") + content
 
     async def read_file(self, uri, *, ctx=None):  # noqa: ANN001


### PR DESCRIPTION
## Problem

`tests/session/test_tool_result_externalization.py::test_externalized_tool_output_generates_synopsis_once` fails on `main`:

```
openviking/session/session.py:752: in _save_meta
    await self._viking_fs.write_file(
E   TypeError: MemoryVikingFS.write_file() got an unexpected keyword argument 'lease_ref'
```

`Session._save_meta` now calls `self._viking_fs.write_file(..., lease_ref=lease_ref)` (and the authoritative append path calls `append_file(..., lease_ref=lease)`), matching the real `VikingFS.write_file`/`append_file` signatures which accept `lease_ref`. The in-test `MemoryVikingFS` fake still had the old signatures `(self, uri, content, *, ctx=None)` and rejected the kwarg, so the test crashed during message append before reaching its synopsis assertion.

This is the same class of stale test fake as #3758, but in a different file not covered by that PR. Production behavior is correct.

## Change

- Add `lease_ref=None` to the `MemoryVikingFS.write_file` and `MemoryVikingFS.append_file` fakes so they mirror the real `VikingFS` signatures.

## Verification

- `pytest tests/session/test_tool_result_externalization.py -q` → **2 passed** (previously 1 failed, 1 passed).
- `python -m compileall` clean; `ruff check` clean.

No production code changed.
