### PR TITLE
fix(vectordb): hide removed symbols when engine is unavailable

### DIFF
--- a/openviking/storage/vectordb/engine/__init__.py
+++ b/openviking/storage/vectordb/engine/__init__.py
@@ -31,6 +31,17 @@ _REQUEST_ALIASES = {
 _WINDOWS_DLL_DIR_HANDLES = []
 
 
+class _DummyBackend:
+    def __getattr__(self, name: str):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+
+_ABI3_EXPORT_NAMES = frozenset(build_abi3_exports(_DummyBackend()))
+
+
 def _is_x86_machine(machine: str | None = None) -> bool:
     normalized = (machine or platform.machine() or "").strip().lower()
     # platform.machine() returns empty string on some Windows 11 builds.
@@ -231,14 +242,14 @@ else:
 
 
 def __getattr__(name: str):
-    if _BACKEND is None and _ENGINE_IMPORT_ERROR is not None:
+    if _BACKEND is None and name in _ABI3_EXPORT_NAMES:
         return _MissingBackendSymbol(name, _ENGINE_IMPORT_ERROR)
     raise AttributeError(name)
 
 
 __all__ = tuple(
     sorted(
-        set(_EXPORTED_NAMES).union(
+        (_ABI3_EXPORT_NAMES if _BACKEND is None else set(_EXPORTED_NAMES)).union(
             {
                 "AVAILABLE_ENGINE_VARIANTS",
                 "ENGINE_VARIANT",


### PR DESCRIPTION
## Summary
- Restrict unavailable-engine placeholder attributes to the live ABI3 export surface.
- Keep deferred `ImportError` behavior for valid symbols such as `IndexEngine` when the backend is missing.
- Make removed/unknown symbols such as `FetchDataResult` raise normal `AttributeError`, so `hasattr()` reflects the actual API.

## Validation
- `PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest tests/misc/test_abi3_packaging_config.py tests/misc/test_vectordb_engine_loader.py -p no:cacheprovider --no-cov -q --tb=short` → `19 passed, 4 warnings`
- `PYTHONPATH="$PWD" "$SIBV/bin/python" -m pytest tests/vectordb/test_store_streaming.py tests/misc/test_abi3_packaging_config.py tests/misc/test_vectordb_engine_loader.py -p no:cacheprovider --no-cov -q --tb=short` → `25 passed, 1 skipped, 4 warnings`
- Direct unavailable-backend check confirmed `not hasattr(engine, "FetchDataResult")` and that using `engine.IndexEngine(...)` raises `ImportError`.
- `python -m compileall -q openviking/storage/vectordb/engine/__init__.py`
- `ruff check openviking/storage/vectordb/engine/__init__.py`
- `git diff --check`

Native-dependent `tests/vectordb/test_bytes_row.py` cases fail identically on the untouched baseline in this environment with `No compatible x86 engine backend was packaged in this wheel`; they are not caused by this change.
