### PR TITLE
fix(claude-plugin): count recalled memory URIs

### DIFF
--- a/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
+++ b/examples/claude-code-memory-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openviking-memory",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Long-term semantic memory for Claude Code, powered by OpenViking. Auto-recall relevant memories at session start and capture important information during conversations.",
   "author": {
     "name": "OpenViking",

--- a/examples/claude-code-memory-plugin/package-lock.json
+++ b/examples/claude-code-memory-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-openviking-memory",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.3.6"

--- a/examples/claude-code-memory-plugin/package.json
+++ b/examples/claude-code-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-openviking-memory",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "OpenViking memory plugin for Claude Code — semantic long-term memory",
   "type": "module",
   "scripts": {

--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -394,7 +394,7 @@ async function main() {
       return;
     }
     writeRecallState({
-      count: 1,
+      count: new Set(endpointBlock.match(/viking:\/\/[^\s<>"')\]]+/g) || []).size,
       content_items: 1,
       hint_items: 0,
       tokens_used: estimateTokens(endpointBlock),


### PR DESCRIPTION
## Description

Fix the Claude Code statusline recall count so server-assembled context reports the number of unique injected `viking://` references instead of always showing `1`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Count unique `viking://` references in server-assembled recall context.
- Bump the Claude Code memory plugin version to `0.4.4`.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Ran `npm test` in `examples/claude-code-memory-plugin` (6/6 passed), `node --check` on `auto-recall.mjs`, and a focused unique-URI count assertion.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is intentionally a minimal fix: one recall-count expression plus the patch version bump.
