### PR TITLE
fix(memory-plugin): preserve commit payload on retry

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/ov-session.mjs
@@ -134,7 +134,7 @@ export async function commitSession(fetchJSON, sessionId, payload = {}) {
   });
   if (!res.ok) {
     if (isRetryableFailure(res)) {
-      const queued = await enqueuePendingDirectly("commitSession", sessionId, {});
+      const queued = await enqueuePendingDirectly("commitSession", sessionId, payload || {});
       if (queued.ok) res.pendingQueued = true;
       else res.pendingEnqueueFailed = true;
     } else {

--- a/examples/claude-code-memory-plugin/scripts/lib/pending-queue.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/pending-queue.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { addMessage } from "./ov-session.mjs";
+import { addMessage, commitSession } from "./ov-session.mjs";
 import {
   claimForReplay,
   enqueue,
@@ -108,6 +108,40 @@ test("addMessage queues conflicts only when the server marks them retryable", as
     );
     assert.equal(terminal.pendingQueued, undefined);
     assert.equal((await listPending()).length, 1);
+  });
+});
+
+test("commitSession preserves retention payload across retry and replay", async () => {
+  await withPendingDir(async () => {
+    const payload = { keep_recent_count: 10 };
+    const res = await commitSession(
+      async () => ({
+        ok: false,
+        status: 409,
+        error: {
+          code: "CONFLICT",
+          details: { conflict_type: "path_busy", retryable: true },
+        },
+      }),
+      "cc-retryable-commit",
+      payload,
+    );
+
+    assert.equal(res.pendingQueued, true);
+    const pending = await listPending();
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].entry.type, "commitSession");
+    assert.deepEqual(pending[0].entry.payload, payload);
+
+    const calls = [];
+    const result = await replayPending(async (path, init) => {
+      calls.push({ path, init });
+      return { ok: true };
+    }, () => {});
+
+    assert.deepEqual(result, { replayed: 1, failed: 0, skipped: 0, deferred: 0 });
+    assert.equal(calls[0].path, "/api/v1/sessions/cc-retryable-commit/commit");
+    assert.deepEqual(JSON.parse(calls[0].init.body), payload);
   });
 });
 


### PR DESCRIPTION
## Description

Preserve Claude Code commit retention options when a retryable storage conflict queues the commit for replay. This is a follow-up to #3820.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Follow-up to #3820

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Queue the original `commitSession` payload after retryable failures instead of replacing it with `{}`.
- Preserve fields such as `keep_recent_count` when pending commits are replayed.
- Add a regression test covering retryable HTTP 409 enqueue and replay.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`cd examples/claude-code-memory-plugin && npm test` (8 passed)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The regression test uses an isolated temporary `OPENVIKING_PENDING_DIR`; it does not read or modify an existing OpenViking configuration or data directory.
