### PR TITLE
test(service): fix reindex file-lock test fixtures and pathlock fake

### DIFF
--- a/tests/service/conftest.py
+++ b/tests/service/conftest.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Fixtures shared by service tests."""
+
+import uuid
+
+import pytest
+
+from tests.transaction.conftest import MemoryAgfs
+
+
+@pytest.fixture
+def agfs_client():
+    agfs = MemoryAgfs()
+    agfs.mkdir("/local")
+    agfs.mkdir("/local/default")
+    return agfs
+
+
+@pytest.fixture
+def test_dir(agfs_client):
+    path = f"/local/default/transaction-{uuid.uuid4().hex}"
+    agfs_client.mkdir(path)
+    return path

--- a/tests/service/test_reindex_file_lock.py
+++ b/tests/service/test_reindex_file_lock.py
@@ -11,10 +11,28 @@ from openviking.service.reindex_executor import ReindexExecutor
 from openviking_cli.session.user_id import UserIdentifier
 
 
+class _FakePathLockClient:
+    def __init__(self):
+        self.held = False
+
+    async def pathlock_acquire_tree(self, path):
+        del path
+        self.held = True
+        return {"lease_ref": "lock-1"}
+
+    async def pathlock_as_borrowed(self, lease):
+        return {"lease_ref": lease["lease_ref"], "borrowed": True}
+
+    async def pathlock_release(self, lease):
+        assert lease == {"lease_ref": "lock-1"}
+        self.held = False
+
+
 class _FakeVikingFS:
     def __init__(self, uri: str, path: str):
         self._uri = uri
         self._path = path
+        self._async_agfs = _FakePathLockClient()
 
     def _uri_to_path(self, uri: str, ctx=None):
         assert uri == self._uri


### PR DESCRIPTION
## Summary

`tests/service/test_reindex_file_lock.py` is broken on current `main` (674f5e60):

1. **Collection error — missing fixtures.** The test requests `agfs_client` and `test_dir`, but these are only defined in `tests/transaction/conftest.py`. With no `tests/service/conftest.py`, the test errors at setup:
   ```
   fixture 'agfs_client' not found
   ```
2. **Stale fake after the pathlock refactor (#3602).** `ReindexExecutor._run` now acquires a tree lock through `service.viking_fs._async_agfs.pathlock_acquire_tree(path)` / `pathlock_as_borrowed(...)` / `pathlock_release(...)` (`openviking/service/reindex_executor.py:438-504`). The hand-rolled `_FakeVikingFS` has no `_async_agfs`, so once the fixtures resolve it fails with:
   ```
   AttributeError: '_FakeVikingFS' object has no attribute '_async_agfs'
   ```

This is distinct from #3754, which fixes `pathlock` config fakes in two `tests/unit` files and does not touch this test.

## Changes (test-only, no production code change)

- Add `tests/service/conftest.py` exposing `agfs_client` (reusing `MemoryAgfs` from `tests/transaction/conftest.py`) and `test_dir`, so the test is collectable independently of `tests/transaction`.
- Add a minimal `_FakePathLockClient` (async `pathlock_acquire_tree` / `pathlock_as_borrowed` / `pathlock_release`) and attach it as `_async_agfs` on `_FakeVikingFS`, matching the pattern already used in `tests/server/test_content_batch_write.py`.

## Validation

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/service/test_reindex_file_lock.py -p no:cacheprovider --no-cov -q
# 1 passed
```

Full `tests/service` shows only the two pre-existing failures already addressed by #3778; no new regressions.
