### PR TITLE
test(session): accept lease_ref in tool-result externalization VFS fake

### DIFF
--- a/tests/session/test_tool_result_externalization.py
+++ b/tests/session/test_tool_result_externalization.py
@@ -18,10 +18,10 @@ class MemoryVikingFS:
     def __init__(self):
         self.files = {}
 
-    async def write_file(self, uri, content, *, ctx=None):  # noqa: ANN001
+    async def write_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
         self.files[uri] = content
 
-    async def append_file(self, uri, content, *, ctx=None):  # noqa: ANN001
+    async def append_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
         self.files[uri] = self.files.get(uri, "") + content
 
     async def read_file(self, uri, *, ctx=None):  # noqa: ANN001


### PR DESCRIPTION
## Summary

`tests/session/test_tool_result_externalization.py::test_externalized_tool_output_generates_synopsis_once` fails on current `main` (674f5e60):

```
openviking/session/session.py:752: in _save_meta
    await self._viking_fs.write_file(
        uri=...,
        content=...,
        ctx=self.ctx,
        lease_ref=lease_ref,
    )
E   TypeError: MemoryVikingFS.write_file() got an unexpected keyword argument 'lease_ref'
```

After the PathLock work, `Session._save_meta` calls `write_file(..., lease_ref=...)` (`openviking/session/session.py:747-756`) and the authoritative append path calls `append_file(..., lease_ref=...)` (`session.py:1195-1201`). The local `MemoryVikingFS` fake in this test file predates that change and does not accept `lease_ref`, so the test errors during `add_message`.

This is the same class of stale fake fixed for `tests/unit/session/test_session_commit_resume.py` in #3758, but #3758 does not touch this test file or its separate fake.

## Changes (test-only, no production code change)

- Add `lease_ref=None` keyword to `MemoryVikingFS.write_file` and `MemoryVikingFS.append_file` in `tests/session/test_tool_result_externalization.py`.

## Validation

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/session/test_tool_result_externalization.py -p no:cacheprovider --no-cov -q
# 2 passed
```
