### PR TITLE
test(watch): fix no-watch-manager e2e mock for deferred ingestion

### DIFF
--- a/tests/integration/test_watch_e2e.py
+++ b/tests/integration/test_watch_e2e.py
@@ -4,6 +4,8 @@
 
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -352,7 +354,11 @@ class TestWatchE2EErrorHandling:
 
         class MockResourceProcessor:
             async def process_resource(self, **kwargs):
-                return {"root_uri": kwargs.get("to", "viking://resources/test")}
+                root_uri = kwargs.get("to", "viking://resources/test")
+                return {
+                    "root_uri": root_uri,
+                    "_post_process": {"root_uri": root_uri},
+                }
 
         class MockSkillProcessor:
             async def process_skill(self, **kwargs):
@@ -364,6 +370,9 @@ class TestWatchE2EErrorHandling:
             resource_processor=MockResourceProcessor(),
             skill_processor=MockSkillProcessor(),
             watch_scheduler=None,
+        )
+        resource_service._enqueue_add_resource_job = AsyncMock(
+            return_value=SimpleNamespace(task_id="test-task")
         )
 
         ctx = RequestContext(


### PR DESCRIPTION
## Background
`tests/integration/test_watch_e2e.py::TestWatchE2EErrorHandling::test_watch_without_watch_manager` fails with:

```
openviking_cli.exceptions.InternalError: Deferred resource processing payload is missing
openviking/service/resource_service.py:1408
```

Since #3645 / the deferred post-processing flow, `ResourceService.add_resource` for non-git paths always goes through `_execute_resource_ingestion(defer_post_processing=True)`, which requires the processor result to carry a `_post_process` dict and then enqueues a job via `_enqueue_add_resource_job`. The e2e mock returned only `{"root_uri": ...}`, so it no longer satisfies the ingestion contract.

## Change
- Mock `process_resource` returns `_post_process` payload.
- Stub `_enqueue_add_resource_job` so the test exercises the no-watch-manager path without requiring QueueFS/native backends.

This mirrors the existing unit test `tests/service/test_resource_service_watch.py::test_resource_added_without_watch_manager` and keeps the integration test's isolation intent.

## Validation
```
SIBV=.../.venv
PYTHONPATH=$PWD $SIBV/bin/python -m pytest   tests/integration/test_watch_e2e.py::TestWatchE2EErrorHandling::test_watch_without_watch_manager   -p no:cacheprovider --no-cov -q
# 1 passed
```

The remaining 9 tests in the file error at `e2e_client` setup due to the unavailable native `ragfs_python` binding in this environment (environmental, not caused by this change).