### PR TITLE
test(api): import create_test_file from build_test_helpers to avoid conftest shadowing

### DIFF
--- a/tests/api_test/scenarios/resources_retrieval/test_delete_sync.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_delete_sync.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestDeleteSync:

--- a/tests/api_test/scenarios/resources_retrieval/test_grep_validation.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_grep_validation.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestGrepValidation:

--- a/tests/api_test/scenarios/resources_retrieval/test_intent_extended_search.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_intent_extended_search.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestIntentExtendedSearch:

--- a/tests/api_test/scenarios/resources_retrieval/test_pack_consistency.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_pack_consistency.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestPackConsistency:

--- a/tests/api_test/scenarios/resources_retrieval/test_relation_link.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_relation_link.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestRelationLink:

--- a/tests/api_test/scenarios/resources_retrieval/test_resource_swap.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_resource_swap.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestResourceSwap:

--- a/tests/api_test/scenarios/resources_retrieval/test_semantic_retrieval.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_semantic_retrieval.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestSemanticRetrieval:

--- a/tests/api_test/scenarios/resources_retrieval/test_watch_update.py
+++ b/tests/api_test/scenarios/resources_retrieval/test_watch_update.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestWatchUpdate:

--- a/tests/api_test/scenarios/stability_error/test_account_isolation.py
+++ b/tests/api_test/scenarios/stability_error/test_account_isolation.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestAccountIsolation:

--- a/tests/api_test/scenarios/stability_error/test_concurrent_write.py
+++ b/tests/api_test/scenarios/stability_error/test_concurrent_write.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import uuid
 
-from conftest import create_test_file
+from build_test_helpers import create_test_file
 
 
 class TestConcurrentWrite:


### PR DESCRIPTION
## Problem

Scenario subdirectories under `tests/api_test` insert their own directory onto `sys.path` and contain a local `conftest.py`. Under pytest's default (prepend) import mode, those local files get registered as the top-level `conftest` module, so test files doing

```python
from conftest import create_test_file
```

resolve to the *local* conftest (which does not define the helper) instead of `scenarios/conftest.py`. This produces import-order-dependent collection errors:

```
ImportError: cannot import name 'create_test_file' from 'conftest'
  (.../tests/api_test/scenarios/resources_retrieval_slow/conftest.py)
```

Collecting `scenarios/resources_retrieval` alone succeeds, but collecting it together with `scenarios/resources_retrieval_slow` (which lacks `__init__.py`) breaks the retrieval tests, confirming the shadowing.

## Fix

Import `create_test_file` from `build_test_helpers`, the unambiguous top-level module that already defines it (both root `tests/api_test/build_test_helpers.py` and the local per-scenario `build_test_helpers.py` expose the same helper with an identical signature).

This changes 10 test files in `scenarios/resources_retrieval` and `scenarios/stability_error`:

```diff
-from conftest import create_test_file
+from build_test_helpers import create_test_file
```

## Validation

- Combined collection of the three affected scenario dirs: `64 tests collected`, no import errors.
- Full `tests/api_test` collection (with the container-only `tools/tests/test_app_state.py` ignored, which requires `/app`): `532 tests collected`, no `create_test_file` import/collection errors.
- Runtime import check confirms `create_test_file.__module__ == 'build_test_helpers'` for previously-broken modules, even with `resources_retrieval_slow` on `sys.path`.
- Functional execution of `test_relation_link.py`/`test_grep_validation.py` only fails on connection to a live API server (`127.0.0.1:1933` connection refused), which is an environment requirement and unrelated to this change.

## Notes

- Test-only change; no product code modified.
- `psutil` was installed into the shared test virtualenv to unblock local collection (it is imported unconditionally by `tests/api_test/conftest.py` and `services/service_manager.py`); that is an environment dependency, not a repo change.
- Opened as a Draft PR.