### PR TITLE
test(telemetry): satisfy embedder prepare_embedding_input contract in embedding handler telemetry test

### DIFF
--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -820,12 +820,18 @@ async def test_embedding_handler_binds_registered_operation_telemetry(monkeypatc
     telemetry = MemoryOperationTelemetry(operation="resources.add_resource", enabled=True)
     register_telemetry(telemetry)
 
-    class _TelemetryAwareEmbedder:
+    class _TelemetryAwareEmbedder(DenseEmbedderBase):
+        def __init__(self):
+            super().__init__("telemetry-test", config={"max_input_tokens": None})
+
         def embed(self, text: str, is_query: bool = False) -> EmbedResult:
             assert text == "hello"
             assert is_query is False
             get_current_telemetry().record_token_usage("embedding", 9, 0)
             return EmbedResult(dense_vector=[0.1, 0.2])
+
+        def get_dimension(self) -> int:
+            return 2
 
     class _DummyConfig:
         def __init__(self):


### PR DESCRIPTION
## Problem

`tests/test_telemetry_runtime.py::test_embedding_handler_binds_registered_operation_telemetry` fails with:

```
KeyError: 'tokens'
```

The dummy `_TelemetryAwareEmbedder` in this test is a plain class that only implements `embed()`. `embed_compat` now calls `embedder.prepare_embedding_input(content)` before delegating to `embed_async`. The dummy does not define `prepare_embedding_input`, so `TextEmbeddingHandler.on_dequeue` raises `AttributeError` inside its embed `try/except`, classifies it as a transient/unknown error, trips the circuit breaker, and returns `None` without ever invoking the dummy `embed()`.

As a result `record_token_usage("embedding", 9, 0)` is never called, `tokens.embedding.total` stays 0, and `_prune_zero_metrics` drops the entire `tokens` subtree from the telemetry summary.

The failure log captured in teardown confirms the path:

```
Failed to generate embedding: '_TelemetryAwareEmbedder' object has no attribute 'prepare_embedding_input'
```

## Fix

Make `_TelemetryAwareEmbedder` subclass `DenseEmbedderBase` (already imported in the module), mirroring the sibling test `test_embed_compat_binds_query_stage_for_embedding_tokens`. This inherits the production `prepare_embedding_input` and the default `embed_async` that delegates to `embed()`, so the test double now conforms to the current embedder contract and token usage is recorded inside the bound telemetry context as intended.

## Verification

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/test_telemetry_runtime.py --no-cov -q
26 passed
```

Draft PR — no promotion, merge, or close.
