### PR TITLE
test(prompts): align memory template assertions with reworded profile/preferences templates

### DIFF
--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -77,7 +77,8 @@ def test_profile_memory_template_includes_stable_identity_work_style_and_prefere
     )
 
     assert '"who the user is"' in text
-    assert "identity, work style, and preferences" in text
+    assert "identity summary of who the user is as a person" in text
+    assert "define the user's identity at a high level" in text
     assert "profession, experience level, technical background" in text
     assert "communication style, work habits" in text
     assert "Do NOT include transient conversation content" in text
@@ -101,7 +102,7 @@ def test_preferences_memory_template_keeps_topic_specific_preferences():
     assert "specific topic" in text
     assert "code style, communication style, tools, workflow" in text
     assert "Store different topics as separate memory files" in text
-    assert "do not mix unrelated preferences" in text
+    assert "do NOT mix unrelated preferences" in text
 
 
 def test_prompt_manager_prefers_env_templates_dir_over_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

Two tests in `tests/test_prompt_manager.py` fail against the current bundled memory templates:

- `test_profile_memory_template_includes_stable_identity_work_style_and_preferences`
  asserts `"identity, work style, and preferences"` is present.
- `test_preferences_memory_template_keeps_topic_specific_preferences`
  asserts `"do not mix unrelated preferences"` (lowercase) is present.

PR #3242 (模板优化) intentionally reworded both templates without updating these exact-string assertions:

- `profile.yaml` description now reads:
  - `User profile memory - captures an identity summary of who the user is as a person.`
  - `Extract relatively stable personal attributes that define the user's identity at a high level.`
- `preferences.yaml` description already reads `Store different topics as separate memory files, do NOT mix unrelated preferences.` (uppercase `NOT`).

The conceptual guidance is unchanged; only the exact wording/casing changed.

## Fix

Update the two assertions to match the current templates:
- assert `"identity summary of who the user is as a person"` and `"define the user's identity at a high level"` (profile);
- assert `"do NOT mix unrelated preferences"` (preferences, actual casing).

No product/template content is changed — this only realigns the tests with #3242.

## Verification

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/test_prompt_manager.py --no-cov -q
10 passed
```

Draft PR — no promotion, merge, or close.
