### PR TITLE
fix(openclaw-plugin): 修复 apiKey 类型导致的 release 构建失败

### DIFF
--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -127,8 +127,10 @@ export type MemoryOpenVikingConfig = {
 
 /** Runtime config after memoryOpenVikingConfigSchema.parse() has applied defaults. */
 export type ParsedMemoryOpenVikingConfig = Required<
-  Omit<MemoryOpenVikingConfig, "agentExperience" | "recallTargetTypes">
+  Omit<MemoryOpenVikingConfig, "agentExperience" | "recallTargetTypes" | "apiKey">
 > & {
+  /** parse() resolves SecretRef values, so the runtime shape is always a plain string. */
+  apiKey: string;
   agentExperience: Required<NonNullable<MemoryOpenVikingConfig["agentExperience"]>>;
   recallTargetTypes: Array<"resource" | "user" | "agent">;
 };


### PR DESCRIPTION
## 出了什么事

今天手动触发 OpenClaw plugin release workflow（run 31082903295）发布 #3827 合入的新版插件，Prepare 阶段 `npm pack` 的 prepack build 直接挂了：

```
index.ts(194,8): error TS2322: Type 'ParsedMemoryOpenVikingConfig' is not assignable to type 'ClientRuntimeConfig'.
  Types of property 'apiKey' are incompatible.
    Type 'string | OpenVikingSecretRef' is not assignable to type 'string'.
```

NPM 和 ClawHub 两个发布 job 全部 skip，这版插件发不出去。

## 根因

#3618（7-30 合入）给 `config.apiKey` 加了 SecretRef 支持，输入类型变成 `string | OpenVikingSecretRef`。但 `ParsedMemoryOpenVikingConfig` 是用 `Required<Omit<...>>` 从输入类型直接派生的，把这个联合类型也继承了下来。

实际上 `parse()` 里已经调用 `resolveSecret()` 把 SecretRef 解析成纯字符串再返回（config.ts:645），运行时永远是 string，是类型声明和运行时行为脱节了。

CI 的 plugin-tests 只跑 vitest 不跑 `tsc -p tsconfig.build.json`，所以 main 上这个编译错误潜伏了一周，直到今天 release 的 prepack 才炸出来。跟 #3827 无关，它只是触发了这次发布。

## 怎么修的

在 `ParsedMemoryOpenVikingConfig` 里把 `apiKey` 从 `Required<Omit<...>>` 派生中排除，显式声明为 `string`，和 `parse()` 的真实返回一致。一处类型声明，无运行时改动。

## 测试

- `tsc -p tsconfig.build.json`：修复前稳定复现上述错误，修复后通过
- vitest：755 个用例 750 过；失败的 5 个（architecture-boundaries 4 个 + manifest icon 1 个）在未改动的 main 上同样失败，属于存量问题，与本改动无关

## Follow-up 建议

给 openclaw-plugin-tests CI 加一步 `tsc -p tsconfig.build.json`，让编译错误在 PR 阶段就暴露，而不是等到 release。