### PR TITLE
test(service): align memory link assertions with persisted schema version and deletion message

### DIFF
--- a/tests/service/test_resource_memory_link_service.py
+++ b/tests/service/test_resource_memory_link_service.py
@@ -377,7 +377,7 @@ async def test_on_resource_deleted_bridges_through_fixed_session(request_context
     assert "## Resource Deletion" in message_text
     assert resource_uri in message_text
     assert memory_uri in message_text
-    assert "Do not create a new event" in message_text
+    assert "Update existing mutable memories that mention or depend on this resource." in message_text
 
 
 @pytest.mark.asyncio
@@ -615,7 +615,7 @@ async def test_unlink_memory_reference_keeps_visible_text_and_no_schema_metadata
     assert result.edited_uris == [memory_uri]
     mf = MemoryFileUtils.read(store[memory_uri], uri=memory_uri)
     assert mf.content == "今天是清明节。用户保存了一张不二周助的照片"
-    assert mf.extra_fields == {}
+    assert "resource_refs" not in mf.extra_fields
     assert mf.memory_type is None
 
 


### PR DESCRIPTION
## Why

Two tests in `tests/service/test_resource_memory_link_service.py` assert outdated behavior.

1. `test_unlink_memory_reference_keeps_visible_text_and_no_schema_metadata` asserts `mf.extra_fields == {}`, but `MemoryFile.to_metadata()` persists `metadata.setdefault("version", 1)` (added in commit fd73dcf23) so after re-reading, `extra_fields` is `{'version': 1}`. The test's intent is that `resource_refs` is removed, not that metadata is empty.

2. `test_on_resource_deleted_bridges_through_fixed_session` asserts the literal `"Do not create a new event"`, but `ResourceMemoryLinkService._build_resource_deletion_message` ends with `"Update existing mutable memories that mention or depend on this resource."`. The `"Do not create a new event..."` instruction lives separately in `session_extract_context_provider.py` and is not part of this service's message.

## What

- Replace `assert mf.extra_fields == {}` with `assert "resource_refs" not in mf.extra_fields`, keeping the visible-content assertion.
- Assert the actual deletion-bridge message fields: `## Resource Deletion` heading, the resource and memory URIs, and the `Update existing mutable memories...` instruction.

## Validation

```
PYTHONPATH="$PWD" python -m pytest tests/service/test_resource_memory_link_service.py -p no:cacheprovider --no-cov -q
16 passed, 4 warnings in 0.09s
```

Draft PR only; no product code changed.