### PR TITLE
test(session): accept lease_ref in tool-result externalization MemoryVikingFS double

### DIFF
--- a/tests/session/test_tool_result_externalization.py
+++ b/tests/session/test_tool_result_externalization.py
@@ -18,7 +18,7 @@ class MemoryVikingFS:
     def __init__(self):
         self.files = {}
 
-    async def write_file(self, uri, content, *, ctx=None):  # noqa: ANN001
+    async def write_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
         self.files[uri] = content
 
     async def append_file(self, uri, content, *, ctx=None):  # noqa: ANN001


### PR DESCRIPTION
## Why

`test_externalized_tool_output_generates_synopsis_once` fails:

```
TypeError: MemoryVikingFS.write_file() got an unexpected keyword argument 'lease_ref'
```

`Session._save_meta` calls `self._viking_fs.write_file(..., lease_ref=lease_ref)` (the real `VikingFS.write_file` in `openviking/storage/viking_fs.py` accepts `lease_ref`). The in-test `MemoryVikingFS` double's `write_file` signature only accepts `ctx`, so persisting `.meta.json` raises `TypeError`.

This is a stale test double: `Session._save_meta` was extended to pass `lease_ref` but this local double was not updated.

## What

Add `lease_ref=None` keyword parameter to `MemoryVikingFS.write_file` in `tests/session/test_tool_result_externalization.py`. No product code changed.

## Validation

```
PYTHONPATH="$PWD" python -m pytest tests/session/test_tool_result_externalization.py -p no:cacheprovider --no-cov -q
2 passed, 4 warnings in 0.03s
```

Draft PR only.