### PR TITLE
feat(ci): openclaw plugin 合入 main 自动发包

### DIFF
--- a/.github/workflows/clawhub-dev-release.yml
+++ b/.github/workflows/clawhub-dev-release.yml
@@ -7,6 +7,11 @@ name: OpenViking OpenClaw plugin release
 # until ClawHub legacy /download hashes are compatible with npm-pack releases.
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "examples/openclaw-plugin/**"
   workflow_dispatch:
     inputs:
       version:
@@ -39,6 +44,12 @@ on:
         required: false
         type: boolean
         default: true
+
+# Serialize releases so back-to-back merges don't race the auto-generated
+# YYYY.M.D / YYYY.M.D-N version resolution.
+concurrency:
+  group: openclaw-plugin-release
+  cancel-in-progress: false
 
 permissions:
   actions: read
@@ -326,7 +337,7 @@ jobs:
 
   publish-clawhub:
     name: Publish to ClawHub
-    if: ${{ inputs.publish_clawhub }}
+    if: ${{ github.event_name == 'push' || inputs.publish_clawhub }}
     needs:
       - guard
       - prepare-package-source
@@ -488,9 +499,24 @@ jobs:
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
           set -euo pipefail
-          node "$CLAWHUB_BIN" package inspect "@openviking/openclaw-plugin" \
-            --version "$VERSION" \
-            --json | tee "$RUNNER_TEMP/clawhub-package-inspect.json"
+          # ClawHub version lookup is not read-after-write consistent and the
+          # API rate-limit window can return "Version not found" seconds after
+          # a successful publish. Retry with backoff before failing the job.
+          attempts=6
+          delay=30
+          for i in $(seq 1 "$attempts"); do
+            if node "$CLAWHUB_BIN" package inspect "@openviking/openclaw-plugin" \
+              --version "$VERSION" \
+              --json | tee "$RUNNER_TEMP/clawhub-package-inspect.json"; then
+              break
+            fi
+            if [ "$i" -eq "$attempts" ]; then
+              echo "::error title=ClawHub verify failed::Version $VERSION still not visible after $attempts attempts."
+              exit 1
+            fi
+            echo "ClawHub version $VERSION not visible yet (attempt $i/$attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
           python3 - <<'PY'
           import json
@@ -519,7 +545,7 @@ jobs:
 
   publish-npm:
     name: Publish to npm
-    if: ${{ inputs.publish_npm }}
+    if: ${{ github.event_name == 'push' || inputs.publish_npm }}
     needs:
       - guard
       - prepare-package-source


### PR DESCRIPTION
## 出了什么事

现在 openclaw plugin 的发布 workflow 只有 workflow_dispatch，每次合了插件改动都要有人记得手动去触发。今天 #3827 合入后就是手动触发才发现构建被 #3618 破了一周（#3832 已修）。顺带，重跑时 ClawHub 发布成功但 verify 步骤 4 秒后查版本撞上 rate limit / 读写延迟窗口，返回 Version not found 把 job 标红，实际包已经发出去了。

## 改了什么

1. **push 触发**：合入 main 且改动涉及 `examples/openclaw-plugin/**` 时自动跑发布。channel 走 auto（官方仓库 → latest）、版本自动生成、NPM 和 ClawHub 都发，跟手动触发默认参数完全一致
2. **publish 条件适配 push**：`inputs.publish_*` 在 push 事件里是空值，原来的 `if: ${{ inputs.publish_clawhub }}` 会让两个发布 job 直接 skip，改成 push 事件默认发
3. **并发串行化**：加 concurrency group，连续合入不会并发跑，避免自动版本号（YYYY.M.D-N）竞态
4. **verify 重试**：ClawHub 版本查询不是读写一致的，publish 成功后立刻 inspect 可能报 Version not found（今天 run 31083894161 实锤）。加了 6 次 × 30s 退避重试，重试穷尽才失败

## 测试

- YAML 语法校验通过
- guard 的 channel/版本解析逻辑全部用的 `github.event.inputs.x || 默认值` 写法，push 事件下取默认值，与手动触发默认参数等价，逐处核对过
- 真实效果需要合入后由下一次插件改动验证，或者合入后手动 dispatch 一次确认无回归

## 备注

手动 workflow_dispatch 完全保留，参数行为不变；fork 上的 push 会被 guard 的仓库白名单拦住，不会误发 latest。