### PR TITLE
test(core): align session Context owner_user_id with user-scoped namespace resolution

### DIFF
--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -483,7 +483,7 @@ class TestContextWithUser:
         user = UserIdentifier(account_id="account-123", user_id="user-123")
         ctx = Context(uri="viking://session/test/msg/1.md", user=user)
 
-        assert ctx.owner_user_id is None
+        assert ctx.owner_user_id == "user-123"
         assert ctx.owner_space == user.user_id
 
     def test_owner_fields_resource_default(self):


### PR DESCRIPTION
## Why

`TestContextWithUser.test_owner_fields_session` fails:

```
assert ctx.owner_user_id is None
E AssertionError: assert 'user-123' is None
```

When a `UserIdentifier` is supplied, `owner_fields_for_uri` resolves `viking://session/...` through `_resolve_session_uri` to the user-scoped canonical URI (`viking://user/<user_id>/sessions/...`) and returns `owner_user_id=ctx.user.user_id`. The assertion expecting `None` predates that user-scoped session resolution.

## What

Update the assertion to `ctx.owner_user_id == "user-123"`, matching the resolved owner. No product code changed.

## Validation

```
PYTHONPATH="$PWD" python -m pytest tests/unit/test_context.py -p no:cacheprovider --no-cov -q
56 passed, 4 warnings in 0.38s
```

Draft PR only.