### PR TITLE
test(vlm): align provider config assertions with normalized credential dict

### DIFF
--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -204,7 +204,8 @@ def test_vlm_config_default_provider_resolves_codex(_mock_auth_available):
     provider_config, provider_name = config.get_provider_config()
 
     assert provider_name == "openai-codex"
-    assert provider_config == {}
+    assert provider_config["api_key"] is None
+    assert provider_config["stream"] is False
 
 
 @patch("openviking.models.vlm.backends.codex_auth.has_codex_auth_available", return_value=True)

--- a/tests/unit/test_kimi_glm_vlm.py
+++ b/tests/unit/test_kimi_glm_vlm.py
@@ -87,7 +87,7 @@ def test_vlm_config_uses_canonical_provider_names():
     assert "kimi" in config.providers
     assert "glm" in config.providers
     assert provider_name == "glm"
-    assert provider_config == {"api_key": "glm-key"}
+    assert provider_config["api_key"] == "glm-key"
 
 
 @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")


### PR DESCRIPTION
## Summary

`VLMConfig` now normalizes legacy `providers`/`default_provider` config into a default `VLMCredential` (`_normalize_credentials`). `get_provider_config()` therefore returns the full credential dict with all seven keys (`api_key`, `api_base`, `api_version`, `forward_api_key`, `extra_headers`, `extra_request_body`, `stream`), using `None`/`False` defaults, instead of the raw provider sub-dict.

Two stale assertions failed:
- `tests/unit/test_codex_vlm.py::test_vlm_config_default_provider_resolves_codex` expected `provider_config == {}` for `openai-codex: {}`.
- `tests/unit/test_kimi_glm_vlm.py::test_vlm_config_uses_canonical_provider_names` expected `provider_config == {"api_key": "glm-key"}`.

The resolved provider name and api_key are correct; only the exact-dict assertions are stale. Assert the meaningful fields (`provider_name`, `api_key`, and `stream` for the codex case) instead. Test-only; production code is unchanged.

## Tests

```
PYTHONPATH=. .venv/bin/python -m pytest tests/unit/test_codex_vlm.py tests/unit/test_kimi_glm_vlm.py -p no:cacheprovider --no-cov -q
26 passed, 4 warnings in 0.33s
```