### PR TITLE
test(storage): align semantic processor fakes with pathlock lease and localized overview heading

### DIFF
--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -209,7 +209,8 @@ class TestOverviewGenerationFlow:
         )
         assert f"Output Language: {lang}" in prompt
         assert "Output in Markdown format" in prompt
-        assert "Brief Description" in prompt
+        expected_heading = "简要描述" if lang == "zh-CN" else "Brief Description"
+        assert expected_heading in prompt
         assert "abstract_max_chars" not in prompt
 
     def test_overview_generation_prompt_preserves_repository_hierarchy(self):

--- a/tests/storage/test_semantic_processor_mv_vector_store.py
+++ b/tests/storage/test_semantic_processor_mv_vector_store.py
@@ -13,6 +13,7 @@ async def test_mv_canonicalizes_user_shorthand_before_vector_update(monkeypatch)
     fs = VikingFS.__new__(VikingFS)
     fs._async_agfs = AsyncMock()
     fs._async_agfs.stat.return_value = {"isDir": False}
+    fs._async_agfs.pathlock_acquire_batch.return_value = {"lease_ref": "lease-1"}
     fs._collect_uris = AsyncMock(return_value=[])
     fs._copy_for_mv = AsyncMock()
     fs._update_vector_store_uris = AsyncMock()

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -125,8 +125,8 @@ class _FakeVikingFS:
         del ctx
         return f"/fake/{uri.replace('://', '/').strip('/')}"
 
-    async def write_file(self, uri, content, ctx=None):
-        del ctx
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        del ctx, lease_ref
         self.writes.append((uri, content))
 
 


### PR DESCRIPTION
## Problem

Three stale test doubles/assertions in `tests/storage` fail on main at `674f5e60`:

1. `test_semantic_processor_language.py::test_overview_generation_language_flow[zh-CN]` — the `semantic/overview_generation.yaml` template renders the section heading as `简要描述` for `zh-CN` and `Brief Description` otherwise (template line 59), but the test always asserted `"Brief Description"`, so the `zh-CN` parametrization failed while `en`/`ja` passed.
2. `test_semantic_processor_mv_vector_store.py::test_mv_canonicalizes_user_shorthand_before_vector_update` — `VikingFS.mv` now acquires a pathlock lease via `_async_agfs.pathlock_acquire_batch` and passes the resulting lease dict through `_pathlock_fs_ctx`. The test left that mock auto-returning an `AsyncMock`, which `_pathlock_fs_ctx` rejects with `ValueError: lease_ref must be a non-empty string or lease dictionary`.
3. `test_semantic_queue_memory_dedupe.py::test_stale_memory_semantic_write_is_skipped` — `write_semantic_sidecars` now calls `VikingFS.write_file(..., lease_ref=...)`, but the test's `_FakeVikingFS.write_file` did not accept the kwarg (`TypeError: ... got an unexpected keyword argument 'lease_ref'`).

These are the same stale-test-fake class as already-fixed #3758/#3835/#3839.

## Change

Test-only:

- Assert the language-appropriate overview heading (`简要描述` for `zh-CN`).
- Stub `pathlock_acquire_batch` to return a `{'lease_ref': 'lease-1'}` dict in the mv test.
- Add `lease_ref=None` to `_FakeVikingFS.write_file`.

No product code changed.

## Tests

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest   tests/storage/test_semantic_processor_language.py   tests/storage/test_semantic_processor_mv_vector_store.py   tests/storage/test_semantic_queue_memory_dedupe.py   -p no:cacheprovider --no-cov -q
74 passed, 4 warnings in 0.49s
```

The remaining failures under `tests/storage` are covered by other open Draft PRs (#3807 openGauss update_data, #3808 qdrant caplog, #3813 mock adapter, #3777 volcengine update_data) or are environmental (`bulk_upsert` missing `PersistStore` native symbol).