### PR TITLE
test(resource): define missing watch_manager fixtures and complete MockVikingFS

### DIFF
--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -41,6 +41,15 @@ class MockVikingFS:
         path = self._uri_to_path(uri)
         self.agfs.write(path, content.encode("utf-8"))
 
+    async def exists(self, uri: str, ctx=None) -> bool:
+        return self.agfs.exists(self._uri_to_path(uri), ctx=ctx)
+
+    async def rm(self, uri: str, ctx=None) -> None:
+        self.agfs.rm(self._uri_to_path(uri), ctx=ctx)
+
+    async def mv(self, src: str, dst: str, ctx=None) -> None:
+        self.agfs.mv(self._uri_to_path(src), self._uri_to_path(dst), ctx=ctx)
+
     def _uri_to_path(self, uri: str) -> str:
         """Convert URI to path."""
         if uri.startswith("viking://"):
@@ -60,6 +69,20 @@ async def temp_storage(tmp_path: Path) -> AsyncGenerator[Path, None]:
 async def mock_viking_fs(temp_storage: Path) -> MockVikingFS:
     """Create mock VikingFS instance."""
     return MockVikingFS(root_path=str(temp_storage))
+
+
+@pytest_asyncio.fixture
+async def watch_manager(mock_viking_fs: MockVikingFS) -> AsyncGenerator[WatchManager, None]:
+    manager = WatchManager(viking_fs=mock_viking_fs)
+    await manager.initialize()
+    yield manager
+
+
+@pytest_asyncio.fixture
+async def watch_manager_no_fs() -> AsyncGenerator[WatchManager, None]:
+    manager = WatchManager(viking_fs=None)
+    await manager.initialize()
+    yield manager
 
 
 class TestWatchTask:


### PR DESCRIPTION
## Problem

On main (`674f5e6`), `tests/resource/test_watch_manager.py` produces **23 errors**: the `TestWatchManager`, `TestWatchManagerPersistence`, and `TestWatchManagerConcurrency` classes reference fixtures named `watch_manager` and `watch_manager_no_fs` that are never defined in the file or any conftest:

```
fixture 'watch_manager' not found
fixture 'watch_manager_no_fs' not found
```

Additionally, the file-local `MockVikingFS` only implements `read_file`/`write_file`, but `WatchManager._save_tasks` checks for an atomic-write path requiring `exists`/`rm`/`mv`. Without those it falls into the non-atomic branch (which silently logs and returns), so persistence-round-trip tests would not exercise the real save path.

## Change

Test-only:

- Add a `watch_manager` fixture (`WatchManager(viking_fs=mock_viking_fs)`, initialized).
- Add a `watch_manager_no_fs` fixture (`WatchManager(viking_fs=None)`, initialized).
- Add `exists`/`rm`/`mv` to `MockVikingFS`, delegating to the existing `MockLocalAGFS` (which already implements them).

The fixtures follow the same construction used in `tests/service/test_resource_service_watch.py`.

## Tests

```
PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/resource/test_watch_manager.py -p no:cacheprovider --no-cov -q
37 passed, 4 warnings in 0.68s

PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/resource -p no:cacheprovider --no-cov -q
45 passed, 6 warnings in 5.06s
```