### PR TITLE
test(server): align request wait and watch ACL fakes with async pathlocks and PermissionDeniedError

### DIFF
--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -4,6 +4,7 @@
 """Tests for request-scoped wait behavior on write APIs."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -48,8 +49,8 @@ class _FakeVikingFS:
         self._root_uri = root_uri
         self.content = {file_uri: "original"}
         self._async_agfs = SimpleNamespace(
-            pathlock_acquire_exact=lambda lock_path: SimpleNamespace(id="lock-1"),
-            pathlock_release=lambda lease: None,
+            pathlock_acquire_exact=AsyncMock(return_value=SimpleNamespace(id="lock-1")),
+            pathlock_release=AsyncMock(),
         )
 
     async def stat(self, uri: str, ctx=None):
@@ -79,6 +80,9 @@ class _FakeVikingFS:
     async def rm(self, uri: str, ctx=None, lock_handle=None, lease_ref=None):
         del ctx, lock_handle, lease_ref
         self.content.pop(uri, None)
+
+    def _ensure_mutable_access(self, uri, ctx=None):
+        del uri, ctx
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_watch_task_acl.py
+++ b/tests/server/test_watch_task_acl.py
@@ -4,6 +4,7 @@
 """Regression tests for watch-task control file access boundaries."""
 
 import contextvars
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -15,7 +16,7 @@ from openviking.resource.watch_storage import (
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.exceptions import InvalidArgumentError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -48,7 +49,7 @@ def test_watch_task_control_files_are_root_only(bare_viking_fs, root_ctx, user_c
     assert bare_viking_fs._is_accessible(uri, root_ctx) is True
     assert bare_viking_fs._is_accessible(uri, user_ctx) is False
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionDeniedError):
         bare_viking_fs._ensure_access(uri, user_ctx)
 
 
@@ -58,27 +59,29 @@ async def test_hidden_listing_filters_watch_task_control_files_for_non_root(
 ):
     bare_viking_fs._uri_to_path = lambda uri, ctx=None: "/fake/resources"
     bare_viking_fs._ctx_or_default = lambda ctx=None: ctx
-    bare_viking_fs._ls_entries = lambda path: [
-        {
-            "name": ".watch_tasks.json",
-            "isDir": False,
-            "size": 10,
-            "modTime": "2026-01-01T00:00:00+00:00",
-        },
-        {
-            "name": ".watch_tasks.json.bak",
-            "isDir": False,
-            "size": 10,
-            "modTime": "2026-01-01T00:00:00+00:00",
-        },
-        {
-            "name": ".watch_tasks.json.tmp",
-            "isDir": False,
-            "size": 10,
-            "modTime": "2026-01-01T00:00:00+00:00",
-        },
-        {"name": "public.txt", "isDir": False, "size": 5, "modTime": "2026-01-01T00:00:00+00:00"},
-    ]
+    bare_viking_fs._ls_entries = AsyncMock(
+        return_value=[
+            {
+                "name": ".watch_tasks.json",
+                "isDir": False,
+                "size": 10,
+                "modTime": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "name": ".watch_tasks.json.bak",
+                "isDir": False,
+                "size": 10,
+                "modTime": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "name": ".watch_tasks.json.tmp",
+                "isDir": False,
+                "size": 10,
+                "modTime": "2026-01-01T00:00:00+00:00",
+            },
+            {"name": "public.txt", "isDir": False, "size": 5, "modTime": "2026-01-01T00:00:00+00:00"},
+        ]
+    )
     bare_viking_fs._path_to_uri = lambda path, ctx=None: f"viking://resources/{path.split('/')[-1]}"
 
     root_entries = await bare_viking_fs._ls_original(


### PR DESCRIPTION
## Summary

Test-only fixes aligning stale test fakes in two `tests/server` files with current production interfaces.

### `tests/server/test_request_wait_tracking.py`
- `_FakeVikingFS` mocked pathlock methods as sync lambdas, but `ContentWriteCoordinator` now `await`s them. Replaced with `AsyncMock` so the content-write wait-tracking tests exercise the real async path.
- Added a no-op `_ensure_mutable_access` to the fake, which the production write path now invokes.

### `tests/server/test_watch_task_acl.py`
- `_ensure_access` now raises `openviking_cli.exceptions.PermissionDeniedError` (not the built-in `PermissionError`); updated the `pytest.raises` expectation and import.
- `_ls_original` now `await`s `_ls_entries`; replaced the sync lambda with an `AsyncMock` returning the same entries.

## Verification

```
tests/server/test_request_wait_tracking.py tests/server/test_watch_task_acl.py
9 passed, 4 warnings, 2 errors
```

The 2 errors (`test_add_skill_wait_uses_request_tracker*`) are pre-existing environmental failures: those tests construct a real `OpenVikingService`, which requires the `ragfs_python` native binding (`ImportError: Rust binding not available`) that is not installed in this environment. They are unrelated to the fakes changed here.

The 7 tests exercising the fixed fakes all pass, including the 4 watch-task ACL tests and the 3 content-write wait-tracking tests.