### PR TITLE
test(server): fix filesystem attrs fake for And filter object and memory version

### DIFF
--- a/tests/server/test_filesystem_router.py
+++ b/tests/server/test_filesystem_router.py
@@ -55,7 +55,7 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         async def filter(self, **kwargs):
             return [
                 {
-                    "uri": kwargs["filter"]["conds"][0],
+                    "uri": "viking://user/alice/memories/preferences/theme.md",
                     "level": 2,
                     "search_tags": ["team=search"],
                 }
@@ -81,5 +81,6 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         "fields": {"topic": "theme"},
         "resource_refs": ["viking://resources/docs/api.md"],
         "memory_type": "preferences",
+        "version": 1,
     }
     assert attrs["tags"] == ["team=search"]


### PR DESCRIPTION
## Summary

Test-only fix for `tests/server/test_filesystem_router.py::test_attrs_returns_memory_fields_and_tags`, which fails on main with `TypeError: 'And' object is not subscriptable`.

Two stale test assumptions:

1. The `FakeVectorManager.filter` fake subscribed the filter as a dict (`kwargs["filter"]["conds"][0]`), but production (`_tags_attr` in `openviking/server/routers/filesystem.py`) passes an `And` filter-expression object via `VikingDBManagerProxy.filter`, which forwards it unchanged. The fake now returns the queried URI directly instead of introspecting the filter AST.
2. The expected memory metadata dict omitted the `version` field. `MemoryFileUtils.to_metadata()` now includes `"version": 1` (default from `memory_version_from_fields`), so the assertion is updated to expect it.

## Verification

```
tests/server/test_filesystem_router.py: 2 passed, 4 warnings in 0.04s
```