### PR TITLE
test(storage): align set tags fakes with record results

### DIFF
--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -1397,14 +1397,17 @@ async def test_set_tags_recursive_directory_all_missing_vector_records_returns_z
 ):
     root_uri = "viking://resources/demo"
     file_uri = f"{root_uri}/doc.md"
+    nested_uri = f"{root_uri}/nested/note.md"
     abstract_uri = f"{root_uri}/.abstract.md"
     overview_uri = f"{root_uri}/.overview.md"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
     fake_vfs = _FakeVikingFS(file_uri=file_uri, root_uri=root_uri)
+    fake_vfs.content[nested_uri] = "nested"
     fake_vfs.tree_entries = [
         {"uri": abstract_uri, "isDir": False},
         {"uri": overview_uri, "isDir": False},
         {"uri": file_uri, "isDir": False},
+        {"uri": nested_uri, "isDir": False},
     ]
     coordinator = ContentWriteCoordinator(viking_fs=fake_vfs)
 
@@ -1435,6 +1438,13 @@ async def test_set_tags_recursive_directory_all_missing_vector_records_returns_z
     assert result["failed_count"] == 0
     assert result["updated_uris"] == []
     assert result["tags_updated"] is False
+    assert sorted(fake_store.update_calls) == sorted(
+        [
+            (root_uri, ["env=prod"], "replace", [0, 1]),
+            (file_uri, ["env=prod"], "replace"),
+            (nested_uri, ["env=prod"], "replace"),
+        ]
+    )
 
 
 @pytest.mark.asyncio
@@ -1530,7 +1540,7 @@ async def test_set_tags_does_not_return_write_queue_fields(monkeypatch):
             assert uri == file_uri
             assert list(tags) == ["env=prod"]
             assert mode == "replace"
-            return True
+            return [{"uri": file_uri}]
 
     fake_vfs.vector_store = _FakeVectorStore()
 


### PR DESCRIPTION
## Summary
- Update the recursive set-tags zero-count fixture so its three skipped tag targets match production deduplication of root `.abstract.md`/`.overview.md` into one directory-level update.
- Return a vector record from the queue-field fake because `ContentWriteCoordinator` expects updated records, not a boolean.

## Validation
- `PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/server/test_content_write_service.py -p no:cacheprovider --no-cov -q --deselect ...` -> 34 passed, 12 deselected. The 12 deselected tests require the unavailable ragfs_python native service fixture.
- Target reproduction before the change: `1 failed` with `assert 2 == 3`; after the change: included in the 34 passing tests.