### PR TITLE
fix(server): prefer known roots in profile path sanitization

### DIFF
--- a/openviking/server/profile_middleware.py
+++ b/openviking/server/profile_middleware.py
@@ -109,17 +109,17 @@ def _sanitize_profile_path(path: str) -> str:
                 if idx + 1 < len(parts):
                     return "/".join(parts[idx + 1 :])
 
-        for idx, part in enumerate(parts):
-            if part.startswith("python") and idx + 1 < len(parts):
-                suffix = parts[idx + 1 :]
-                if suffix:
-                    return "/".join(suffix)
-
         for root in PROFILE_ROOTS:
             try:
                 return candidate.relative_to(root).as_posix()
             except ValueError:
                 continue
+
+        for idx, part in enumerate(parts):
+            if part.startswith("python") and idx + 1 < len(parts):
+                suffix = parts[idx + 1 :]
+                if suffix:
+                    return "/".join(suffix)
 
     return _infer_module_suffix(raw_path)
 

--- a/tests/server/test_profile_middleware.py
+++ b/tests/server/test_profile_middleware.py
@@ -141,5 +141,14 @@ def test_sanitize_profile_path_prefers_package_root_over_project_root_for_venv_p
     assert _sanitize_profile_path(path) == "starlette/middleware/base.py"
 
 
+def test_sanitize_profile_path_prefers_stdlib_root_over_python_prefix(monkeypatch):
+    from openviking.server import profile_middleware
+
+    stdlib = "/data00/home/me/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11"
+    monkeypatch.setattr(profile_middleware, "PROFILE_ROOTS", (profile_middleware.Path(stdlib),))
+
+    assert _sanitize_profile_path(f"{stdlib}/asyncio/events.py") == "asyncio/events.py"
+
+
 def test_profile_default_top_n_is_100():
     assert PROFILE_TOP_N == 100


### PR DESCRIPTION
## Summary
- prefer configured site/stdlib profile roots before the broad python-prefix fallback
- add regression coverage for uv-managed cpython stdlib paths

## Validation
```text
PYTHONPATH="$PWD" ../../issue-3660-user-deletion-cascade/.venv/bin/python -m pytest tests/server/test_profile_middleware.py -p no:cacheprovider --no-cov -q
8 passed, 4 warnings in 3.04s
```

Draft only for maintainer review; no merge requested by automation.