### PR TITLE
test(server): capture concurrent request ID info logs

### DIFF
--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -169,6 +169,8 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
 
     handler = _CaptureHandler(records)
     server_logger.addHandler(handler)
+    old_level = server_logger.level
+    server_logger.setLevel(logging.INFO)
     gate = asyncio.Event()
     arrivals = 0
 
@@ -191,6 +193,7 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
             )
     finally:
         server_logger.removeHandler(handler)
+        server_logger.setLevel(old_level)
 
     assert first.headers[REQUEST_ID_HEADER] == "request-first"
     assert second.headers[REQUEST_ID_HEADER] == "request-second"


### PR DESCRIPTION
## Summary
- enable the managed `openviking` logger at INFO for the concurrent request-id test so the `finished label=%s` business log reaches the capture handler
- restore the previous logger level during cleanup
- keep request-id concurrency assertions unchanged

## Validation
```bash
PYTHONPATH="$PWD" /data00/home/huangruiteng/code-reading/openviking-worktrees/issue-3660-user-deletion-cascade/.venv/bin/python -m pytest tests/server/test_request_id.py -p no:cacheprovider --no-cov -q
```
```text
5 passed, 4 warnings in 1.00s
```