### PR TITLE
fix(openclaw-plugin): 去掉 SecretRef exec，解除 ArkClaw 安装拦截

### DIFF
--- a/examples/openclaw-plugin/INSTALL-ZH.md
+++ b/examples/openclaw-plugin/INSTALL-ZH.md
@@ -238,7 +238,7 @@ openclaw openviking setup --base-url <OPENVIKING_URL> --api-key <API_KEY> --peer
   | --- | --- | --- |
   | `env` | `{ "source": "env", "id": "OPENVIKING_API_KEY" }` | 启动时读取同名环境变量。 |
   | `file` | `{ "source": "file", "id": "/etc/secrets/openviking.key" }` | 以 UTF-8 读取并去除首尾空白；`~` 可展开，适配 Kubernetes `secretKeyRef` 卷挂载、0600 权限文件。 |
-  | `exec` | `{ "source": "exec", "provider": "op", "id": "op://vault/openviking/credential" }` | 运行 `<provider> <id>`，去除 stdout 首尾空白（1Password `op`、Vault、gopass 等均符合此形态）。 |
+  | `exec` | 打包版插件不支持（应用市场安装扫描会拦截子进程执行） | 改用命令包一层环境变量：`OPENVIKING_API_KEY=$(op read op://vault/openviking/credential)`，然后配 `env`。 |
 
   仍可使用纯字符串形式（含 `${ENV_VAR}` 插值）作为向后兼容路径；此时请限制文件权限或通过受控 Secret 卷提供，并在修改后重启 Gateway、容器或 Pod。
 

--- a/examples/openclaw-plugin/INSTALL.md
+++ b/examples/openclaw-plugin/INSTALL.md
@@ -182,7 +182,7 @@ If the `openclaw` CLI cannot run inside the container, merge the following field
   | --- | --- | --- |
   | `env` | `{ "source": "env", "id": "OPENVIKING_API_KEY" }` | Reads the named env var at plugin load time. |
   | `file` | `{ "source": "file", "id": "/etc/secrets/openviking.key" }` | Reads UTF-8, trims whitespace. `~` is expanded; ideal for Kubernetes `secretKeyRef` volumes and 0600-managed files. |
-  | `exec` | `{ "source": "exec", "provider": "op", "id": "op://vault/openviking/credential" }` | Runs `<provider> <id>` and trims stdout (1Password `op`, Vault, gopass, etc. all match this shape). |
+  | `exec` | not supported in the packaged plugin (marketplace install scanners block subprocess execution) | Wrap the CLI instead: `OPENVIKING_API_KEY=$(op read op://vault/openviking/credential)` and use `env`. |
 
   A plain `string` (including `${ENV_VAR}` interpolation) is still accepted, but only as a backward-compatibility path; in that case, restrict file permissions or provide the file through a managed Secret volume, then restart the Gateway, container, or Pod.
 

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -16,11 +16,11 @@ import { getEnv } from "./runtime-utils.js";
  *                     leading/trailing whitespace trimmed — convenient for
  *                     Kubernetes `secretKeyRef` mount volumes and
  *                     file-permission-only deployments.
- *   source: "exec" -> delegate to host `openclaw` secret resolver when the
- *                     runtime exposes it; today the plugin performs a
- *                     best-effort `provider + id` CLI exec call so that
- *                     1Password / Vault / gopass users can share OpenViking
- *                     credentials with their other providers.
+ *   source: "exec" -> NOT supported in the packaged plugin. Marketplace
+ *                     install scanners (OpenClaw/ArkClaw) block any plugin
+ *                     whose shipped code can spawn subprocesses, so the exec
+ *                     resolver was removed from this build; configuring it
+ *                     fails with a clear error pointing at env/file instead.
  */
 export type OpenVikingSecretRef =
   | { source: "env"; id: string }
@@ -232,13 +232,10 @@ function resolvePeerPrefix(configured: unknown): string {
  *     Missing / unreadable files propagate the original node error with an
  *     error prefix that names the OpenViking field, so the user knows which
  *     secretRef failed to load.
- *   * `exec`: shells out `<provider> <id>`. Providers commonly expose this
- *     shape (1Password CLI, gopass, HashiCorp Vault), which matches how
- *     OpenClaw's own `@transmitt0r/openclaw-plugin-onepassword` provider
- *     resolves `{source:"exec", provider:"onepassword", id:"..."}`. Exec is
- *     best-effort; failures surface with an error prefix so users can
- *     distinguish `provider not installed` from `provider configured but id
- *     missing`.
+ *   * `exec`: rejected with a "not supported" error. The subprocess-based
+ *     resolver was removed because marketplace install scanners block plugins
+ *     whose shipped code can spawn processes; wrap the secret-manager CLI
+ *     output into an env var or file instead (`OPENVIKING_API_KEY=$(op ...)`).
  */
 function resolveSecret(
   value: string | OpenVikingSecretRef | undefined | null,
@@ -249,7 +246,7 @@ function resolveSecret(
   if (!value || typeof value !== "object") {
     throw new Error(
       `OpenViking ${label} must be a plain string or a SecretRef object ` +
-        `({source:"env"|"file"|"exec", id})`,
+        `({source:"env"|"file", id})`,
     );
   }
   const obj = value as Record<string, unknown>;
@@ -280,39 +277,18 @@ function resolveSecret(
       }
     }
     case "exec": {
-      const provider = typeof (obj as Record<string, unknown>).provider === "string"
-        ? (obj as Record<string, unknown>).provider as string
-        : "";
-      if (!provider) {
-        throw new Error(
-          `OpenViking ${label} SecretRef exec source requires a "provider" field naming the secret-manager CLI on PATH`,
-        );
-      }
-      try {
-        // Avoid top-level `import "node:child_process"` — this branch is rare
-        // and keeping the require lazy makes startup marginally faster for
-        // the 95% of users who pick env/file.
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
-        const out = execFileSync(provider, [id], {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-          timeout: 15_000,
-          env: process.env,
-        }) as string;
-        return out.trim();
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(
-          `OpenViking ${label} SecretRef exec source: provider "${provider}" failed for id "${id}" (${msg})`,
-        );
-      }
+      throw new Error(
+        `OpenViking ${label} SecretRef exec source is not supported in the packaged plugin ` +
+          `(marketplace install scanners block subprocess execution). Export the secret to an ` +
+          `environment variable ({source:"env"}) or a file ({source:"file"}) instead, e.g. ` +
+          `OPENVIKING_API_KEY=$(op read ${id}).`,
+      );
     }
     default:
       throw new Error(
         `OpenViking ${label} SecretRef has unknown source "${String(
           (obj as Record<string, unknown>).source,
-        )}". Supported: "env" | "file" | "exec".`,
+        )}". Supported: "env" | "file".`,
       );
   }
 }
@@ -816,7 +792,7 @@ export const memoryOpenVikingConfigSchema = {
       placeholder: "${OPENVIKING_API_KEY}",
       help:
         "Optional API key for OpenViking server. Accepts a plain string, " +
-        "${ENV_VAR} interpolation, or a SecretRef object ({source: env/file/exec, id}). " +
+        "${ENV_VAR} interpolation, or a SecretRef object ({source: env/file, id}). " +
         "Prefer the SecretRef shapes so the key never sits as plaintext in openclaw.json.",
     },
     headers: {

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -100,7 +100,7 @@
       "label": "OpenViking API Key",
       "sensitive": true,
       "placeholder": "${OPENVIKING_API_KEY}",
-      "help": "Optional API key for OpenViking server. Accepts a plain string, ${ENV_VAR} interpolation, or a SecretRef object ({source: env/file/exec, id}). Prefer a SecretRef so the key is never stored as plaintext in openclaw.json."
+      "help": "Optional API key for OpenViking server. Accepts a plain string, ${ENV_VAR} interpolation, or a SecretRef object ({source: env/file, id}). Prefer a SecretRef so the key is never stored as plaintext in openclaw.json."
     },
     "headers": {
       "label": "Headers",
@@ -319,18 +319,6 @@
             "properties": {
               "source": { "type": "string", "const": "file" },
               "id": { "type": "string", "description": "Absolute file path or ~/relative path. Example: /etc/secrets/openviking.key." }
-            }
-          },
-          {
-            "type": "object",
-            "title": "SecretRef (exec)",
-            "description": "Read the API key by shelling out to a secret-manager CLI. Matches the shape used by OpenClaw's core provider configs so 1Password, HashiCorp Vault, gopass, etc. can manage the OpenViking key alongside LLM/TTS/MCP credentials.",
-            "additionalProperties": false,
-            "required": ["source", "provider", "id"],
-            "properties": {
-              "source": { "type": "string", "const": "exec" },
-              "provider": { "type": "string", "description": "CLI binary name on PATH. Examples: op, vault, gopass." },
-              "id": { "type": "string", "description": "Argument passed to the provider CLI to select the specific secret, e.g. 'vault kv get -field=key secret/openviking' in plain-arg form; this implementation passes id as a single arg." }
             }
           }
         ]

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -489,30 +489,12 @@ describe("memoryOpenVikingConfigSchema.parse() — apiKey SecretRef (#3522)", ()
     ).toThrow(/file source.*no\/such\/path/);
   });
 
-  it("SecretRef exec source runs <provider> <id> and trims stdout", () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const cp = require("node:child_process") as typeof import("node:child_process");
-    const spy = vi
-      .spyOn(cp, "execFileSync")
-      .mockImplementation(((cmd: string, args: readonly string[]): unknown => {
-        expect(cmd).toBe("my-vault");
-        expect(args).toEqual(["secret/openviking/apiKey"]);
-        return "  provider-returned-key  \n";
-      }) as typeof cp.execFileSync);
-
-    const cfg = memoryOpenVikingConfigSchema.parse({
-      apiKey: { source: "exec", provider: "my-vault", id: "secret/openviking/apiKey" },
-    });
-    expect(cfg.apiKey).toBe("provider-returned-key");
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it("SecretRef exec source errors without a provider field", () => {
+  it("SecretRef exec source is rejected with a not-supported error", () => {
     expect(() =>
       memoryOpenVikingConfigSchema.parse({
-        apiKey: { source: "exec", id: "some-id" } as unknown as { source: "exec"; provider: string; id: string },
+        apiKey: { source: "exec", provider: "my-vault", id: "secret/openviking/apiKey" },
       }),
-    ).toThrow(/exec source requires a "provider" field/);
+    ).toThrow(/exec source is not supported in the packaged plugin/);
   });
 
   it("SecretRef validates required fields (unknown source, missing id)", () => {


### PR DESCRIPTION
## 出了什么事

今天发的 2026.8.6（翱翔修 experience 工具缺陷的版本）在 ArkClaw 上安装被拦：安装扫描检测到 dist/config.js 里有 child_process，直接 block。实测官方 OpenClaw 2026.7.1-2 安装同版本完全正常，这是 ArkClaw 自有的安全策略；ArkClaw 侧确认策略推不动，智恒拍板回滚该功能。

## 根因

#3618（7-30 合入）给 apiKey 加了 SecretRef 支持，其中 exec source 会 execFileSync 调本机密钥 CLI（1Password/vault 等），编译产物里因此带上 child_process。2026.8.6 是第一个把它发出去的版本。

## 怎么改的

只去 exec，保留 env / file 两种 SecretRef（它们是无子进程的安全实现，不受影响）：

- config.ts：exec 分支改为抛明确错误，提示改用 env/file（例：`OPENVIKING_API_KEY=$(op read ...)`），child_process require 彻底移除
- openclaw.plugin.json：删掉 SecretRef (exec) 的 schema 变体和帮助文案
- INSTALL.md / INSTALL-ZH.md：exec 行改为「不支持 + 替代写法」
- 类型 OpenVikingSecretRef 保留 exec 变体，配置了会在 resolve 时报清晰错误而不是 unknown source

setup-helper/install.js 也有 child_process，但它不在 package.json files 里、不进 npm 包，不受扫描影响，未动。

## 测试

- 全部 shipped 文件（dist/、根 *.ts、plugin/ 等）grep child_process 为零
- tsc -p tsconfig.build.json 通过
- config.test.ts 59/59 绿（exec 用例改为断言 not-supported 错误）

## 合入后

需要再 dispatch 一次 release workflow 出 2026.8.6-1（或等 #3836 的自动发包合入）。