### PR TITLE
backport: agent evolution changes to release/0.4.12

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -200,7 +200,8 @@ const apiReferenceSidebar = {
           ['03-filesystem.md', 'File System'],
           ['04-skills.md', 'Skills'],
           ['05-sessions.md', 'Sessions'],
-          ['16-memory.md', 'Memory']
+          ['16-memory.md', 'Memory'],
+          ['19-agent-evolution.md', 'Agent Evolution']
         ]
       },
       {
@@ -259,7 +260,8 @@ const apiReferenceSidebar = {
           ['03-filesystem.md', '文件系统'],
           ['04-skills.md', '技能'],
           ['05-sessions.md', '会话'],
-          ['16-memory.md', '记忆']
+          ['16-memory.md', '记忆'],
+          ['19-agent-evolution.md', 'Agent 进化']
         ]
       },
       {

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -530,7 +530,10 @@ This catalog follows the routes actually mounted by the server. Each group headi
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/admin/agent-evolution` | Get the live instance-wide Agent Evolution status |
+| GET | `/api/v1/admin/agent-evolution` | Get the caller account's Agent Evolution status |
+| PUT | `/api/v1/admin/agent-evolution` | Update the caller account's Agent Evolution status |
+| GET | `/api/v1/admin/accounts/{account_id}/settings` | Get effective account settings |
+| PATCH | `/api/v1/admin/accounts/{account_id}/settings` | Update allowlisted account settings |
 | POST | `/api/v1/admin/accounts` | Create an account and its first administrator |
 | GET | `/api/v1/admin/accounts` | List accounts |
 | POST | `/api/v1/admin/migrate` | Migrate legacy identity data |

--- a/docs/en/api/01-overview.md
+++ b/docs/en/api/01-overview.md
@@ -452,7 +452,7 @@ This catalog follows the routes actually mounted by the server. Each group headi
 | PUT | `/api/v1/skills/{skill_name}` | Update a skill |
 | DELETE | `/api/v1/skills/{skill_name}` | Delete a skill |
 
-### [Sessions](05-sessions.md) and [Memory](16-memory.md)
+### [Sessions](05-sessions.md), [Memory](16-memory.md), and [Agent Evolution](19-agent-evolution.md)
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -471,6 +471,8 @@ This catalog follows the routes actually mounted by the server. Each group headi
 | POST | `/api/v1/sessions/{session_id}/messages/batch` | Add messages in a batch |
 | POST | `/api/v1/sessions/{session_id}/used` | Record context or skills actually used |
 | POST | `/api/v1/search/recall` | Recall memory as injection-ready context |
+| GET | `/api/v1/agent-evolution/experiences/trajectories` | List trajectories that consumed an Experience |
+| GET | `/api/v1/agent-evolution/experiences/outcomes` | Aggregate outcomes of trajectories that consumed an Experience |
 
 ### [Retrieval](06-retrieval.md) and [Relations](13-relations.md)
 

--- a/docs/en/api/08-admin.md
+++ b/docs/en/api/08-admin.md
@@ -59,8 +59,8 @@ Configure `root_api_key` in `~/.openviking/ovcli.conf`:
 
 ### get_agent_evolution_status
 
-Return the live instance-wide Agent Evolution switch and the configured default
-account ID. The endpoint is ROOT-only.
+Return the effective Agent Evolution switch for the caller's account. ROOT
+operates on the configured default account; ADMIN operates on its own account.
 
 **HTTP API**
 
@@ -86,8 +86,36 @@ curl http://localhost:1933/api/v1/admin/agent-evolution \
 }
 ```
 
-`enabled` is read from the live `server.agent_evolution.enabled` value used by
-session commits. `account_id` is the deployment's configured default account.
+`enabled` is the account override from
+`/local/{account_id}/_system/setting.json`, or
+`server.agent_evolution.enabled` when no override exists. Session commits read
+this effective value without restarting the server.
+
+The existing update endpoint name is unchanged:
+
+```http
+PUT /api/v1/admin/agent-evolution
+Content-Type: application/json
+
+{"enabled": true}
+```
+
+### account_settings
+
+ROOT can manage any account and ADMIN can manage only its own account. The
+generic settings endpoint accepts only explicitly allowlisted fields; currently
+only `agent_evolution.enabled` is writable.
+
+```http
+GET /api/v1/admin/accounts/{account_id}/settings
+PATCH /api/v1/admin/accounts/{account_id}/settings
+Content-Type: application/json
+
+{"agent_evolution": {"enabled": true}}
+```
+
+Before an existing setting is replaced, it is backed up to
+`/local/{account_id}/_system/setting.backup.json`.
 
 ---
 

--- a/docs/en/api/19-agent-evolution.md
+++ b/docs/en/api/19-agent-evolution.md
@@ -1,0 +1,114 @@
+# Agent Evolution
+
+The Agent Evolution API reports trajectories that consumed a specific Experience and their outcome distribution. These operations are currently available through HTTP only.
+
+## API Reference
+
+### List Experience application trajectories
+
+Return a paginated list of trajectories that successfully read the specified Experience. The query is restricted to Experiences and trajectories owned by the current user.
+
+**Code Entry Points**:
+
+- `openviking/server/routers/agent_evolution.py:list_experience_trajectories` - HTTP route
+- `openviking/service/agent_evolution_service.py:AgentEvolutionService.list_trajectories_by_experience` - Core implementation
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| experience_uri | string | Yes | - | Experience file URI in the current user space |
+| limit | integer | No | 50 | Page size from 1 through 1000 |
+| offset | integer | No | 0 | Zero-based result offset |
+
+**HTTP API**
+
+```
+GET /api/v1/agent-evolution/experiences/trajectories?experience_uri={experience_uri}&limit=50&offset=0
+```
+
+```bash
+curl -X GET "http://localhost:1933/api/v1/agent-evolution/experiences/trajectories?experience_uri=viking://user/default/memories/experiences/exchange.md&limit=50&offset=0" \
+  -H "X-API-Key: your-key"
+```
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "experience_uri": "viking://user/default/memories/experiences/exchange.md",
+    "items": [
+      {
+        "uri": "viking://user/default/memories/trajectories/exchange_20260805020000.md",
+        "name": "exchange_20260805020000.md",
+        "description": "Handle an exchange request",
+        "created_at": "2026-08-05T02:00:00Z",
+        "updated_at": "2026-08-05T02:00:00Z"
+      }
+    ],
+    "total": 1,
+    "limit": 50,
+    "offset": 0,
+    "has_more": false
+  },
+  "time": 0.01
+}
+```
+
+Each item contains only the indexed fields that are present among `uri`, `name`, `description`, `created_at`, and `updated_at`.
+
+---
+
+### Get Experience outcome distribution
+
+Count trajectories that consumed the specified Experience across the five supported outcomes. The query uses exact scalar-tag aggregation and does not load every trajectory file.
+
+**Code Entry Points**:
+
+- `openviking/server/routers/agent_evolution.py:get_experience_outcome_distribution` - HTTP route
+- `openviking/service/agent_evolution_service.py:AgentEvolutionService.get_experience_outcome_distribution` - Core implementation
+
+**Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| experience_uri | string | Yes | - | Experience file URI in the current user space |
+
+**HTTP API**
+
+```
+GET /api/v1/agent-evolution/experiences/outcomes?experience_uri={experience_uri}
+```
+
+```bash
+curl -X GET "http://localhost:1933/api/v1/agent-evolution/experiences/outcomes?experience_uri=viking://user/default/memories/experiences/exchange.md" \
+  -H "X-API-Key: your-key"
+```
+
+**Response Example**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "experience_uri": "viking://user/default/memories/experiences/exchange.md",
+    "outcome_distribution": [
+      {"outcome": "success", "count": 4},
+      {"outcome": "failure", "count": 1},
+      {"outcome": "partial", "count": 0},
+      {"outcome": "unknown", "count": 0},
+      {"outcome": "unfinished", "count": 0}
+    ]
+  },
+  "time": 0.01
+}
+```
+
+The response always includes `success`, `failure`, `partial`, `unknown`, and `unfinished`. Trajectories created by older versions and not yet re-indexed do not carry outcome tags and are therefore excluded.
+
+## Related Documentation
+
+- [Sessions](05-sessions.md) - Commit sessions and generate Agent Evolution memories
+- [Memory](16-memory.md) - Read and recall memories

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -525,7 +525,10 @@ JSON 输出 - 错误：
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/api/v1/admin/agent-evolution` | 获取实例级 Agent 进化开关的实时状态 |
+| GET | `/api/v1/admin/agent-evolution` | 获取调用方 account 的 Agent 进化状态 |
+| PUT | `/api/v1/admin/agent-evolution` | 更新调用方 account 的 Agent 进化状态 |
+| GET | `/api/v1/admin/accounts/{account_id}/settings` | 获取 account 生效配置 |
+| PATCH | `/api/v1/admin/accounts/{account_id}/settings` | 更新白名单内的 account 配置 |
 | POST | `/api/v1/admin/accounts` | 创建账号及首个管理员 |
 | GET | `/api/v1/admin/accounts` | 列出账号 |
 | POST | `/api/v1/admin/migrate` | 迁移旧版身份数据 |

--- a/docs/zh/api/01-overview.md
+++ b/docs/zh/api/01-overview.md
@@ -447,7 +447,7 @@ JSON 输出 - 错误：
 | PUT | `/api/v1/skills/{skill_name}` | 更新技能 |
 | DELETE | `/api/v1/skills/{skill_name}` | 删除技能 |
 
-### [会话](05-sessions.md)与[记忆](16-memory.md)
+### [会话](05-sessions.md)、[记忆](16-memory.md)与 [Agent 进化](19-agent-evolution.md)
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
@@ -466,6 +466,8 @@ JSON 输出 - 错误：
 | POST | `/api/v1/sessions/{session_id}/messages/batch` | 批量添加消息 |
 | POST | `/api/v1/sessions/{session_id}/used` | 记录实际使用的上下文或技能 |
 | POST | `/api/v1/search/recall` | 召回记忆并返回可直接注入的上下文 |
+| GET | `/api/v1/agent-evolution/experiences/trajectories` | 分页查询应用过指定 Experience 的 Trajectory |
+| GET | `/api/v1/agent-evolution/experiences/outcomes` | 聚合应用过指定 Experience 的 Trajectory 结果分布 |
 
 ### [检索](06-retrieval.md)与[关系](13-relations.md)
 

--- a/docs/zh/api/08-admin.md
+++ b/docs/zh/api/08-admin.md
@@ -59,8 +59,8 @@ Admin API 用于多租户环境下的账户和用户管理。包括工作区（a
 
 ### get_agent_evolution_status
 
-返回实例级 Agent 进化开关的实时状态和已配置的默认 account ID。该接口仅限
-ROOT 调用。
+返回调用方所属 account 的 Agent 进化实时状态。ROOT 操作已配置的默认
+account，ADMIN 仅操作自己所属的 account。
 
 **HTTP API**
 
@@ -86,9 +86,34 @@ curl http://localhost:1933/api/v1/admin/agent-evolution \
 }
 ```
 
-`enabled` 来自 session commit 实际使用的
-`server.agent_evolution.enabled` 实时值；`account_id` 是部署配置的默认
-account。
+`enabled` 优先读取
+`/local/{account_id}/_system/setting.json` 中的 account 级覆盖值；未配置时使用
+`server.agent_evolution.enabled`。Session commit 会实时读取生效值，无需重启。
+
+现有更新接口名保持不变：
+
+```http
+PUT /api/v1/admin/agent-evolution
+Content-Type: application/json
+
+{"enabled": true}
+```
+
+### account_settings
+
+ROOT 可管理任意 account，ADMIN 仅可管理自己所属的 account。通用配置接口仅允许
+显式列入白名单的字段；当前只允许修改 `agent_evolution.enabled`。
+
+```http
+GET /api/v1/admin/accounts/{account_id}/settings
+PATCH /api/v1/admin/accounts/{account_id}/settings
+Content-Type: application/json
+
+{"agent_evolution": {"enabled": true}}
+```
+
+覆盖已有配置前，内核会先备份到
+`/local/{account_id}/_system/setting.backup.json`。
 
 ---
 

--- a/docs/zh/api/19-agent-evolution.md
+++ b/docs/zh/api/19-agent-evolution.md
@@ -1,0 +1,114 @@
+# Agent 进化
+
+Agent Evolution API 用于查询某条 Experience 被实际应用后的 Trajectory 记录及结果分布。当前仅提供 HTTP API。
+
+## API 参考
+
+### 查询 Experience 应用轨迹
+
+分页返回成功读取过指定 Experience 的 Trajectory。查询仅匹配当前调用用户空间内的 Experience 和 Trajectory。
+
+**代码入口**：
+
+- `openviking/server/routers/agent_evolution.py:list_experience_trajectories` - HTTP 路由
+- `openviking/service/agent_evolution_service.py:AgentEvolutionService.list_trajectories_by_experience` - 核心实现
+
+**参数**
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| experience_uri | string | 是 | - | 当前用户空间内的 Experience 文件 URI |
+| limit | integer | 否 | 50 | 单页数量，范围为 1～1000 |
+| offset | integer | 否 | 0 | 从零开始的结果偏移量 |
+
+**HTTP API**
+
+```
+GET /api/v1/agent-evolution/experiences/trajectories?experience_uri={experience_uri}&limit=50&offset=0
+```
+
+```bash
+curl -X GET "http://localhost:1933/api/v1/agent-evolution/experiences/trajectories?experience_uri=viking://user/default/memories/experiences/exchange.md&limit=50&offset=0" \
+  -H "X-API-Key: your-key"
+```
+
+**响应示例**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "experience_uri": "viking://user/default/memories/experiences/exchange.md",
+    "items": [
+      {
+        "uri": "viking://user/default/memories/trajectories/exchange_20260805020000.md",
+        "name": "exchange_20260805020000.md",
+        "description": "处理换货请求",
+        "created_at": "2026-08-05T02:00:00Z",
+        "updated_at": "2026-08-05T02:00:00Z"
+      }
+    ],
+    "total": 1,
+    "limit": 50,
+    "offset": 0,
+    "has_more": false
+  },
+  "time": 0.01
+}
+```
+
+`items` 中仅返回索引记录实际存在的 `uri`、`name`、`description`、`created_at` 和 `updated_at` 字段。
+
+---
+
+### 查询 Experience 应用结果分布
+
+统计应用过指定 Experience 的 Trajectory 在五种结果状态下的数量。该查询使用精确标量标签聚合，不读取全部 Trajectory 文件。
+
+**代码入口**：
+
+- `openviking/server/routers/agent_evolution.py:get_experience_outcome_distribution` - HTTP 路由
+- `openviking/service/agent_evolution_service.py:AgentEvolutionService.get_experience_outcome_distribution` - 核心实现
+
+**参数**
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| experience_uri | string | 是 | - | 当前用户空间内的 Experience 文件 URI |
+
+**HTTP API**
+
+```
+GET /api/v1/agent-evolution/experiences/outcomes?experience_uri={experience_uri}
+```
+
+```bash
+curl -X GET "http://localhost:1933/api/v1/agent-evolution/experiences/outcomes?experience_uri=viking://user/default/memories/experiences/exchange.md" \
+  -H "X-API-Key: your-key"
+```
+
+**响应示例**
+
+```json
+{
+  "status": "ok",
+  "result": {
+    "experience_uri": "viking://user/default/memories/experiences/exchange.md",
+    "outcome_distribution": [
+      {"outcome": "success", "count": 4},
+      {"outcome": "failure", "count": 1},
+      {"outcome": "partial", "count": 0},
+      {"outcome": "unknown", "count": 0},
+      {"outcome": "unfinished", "count": 0}
+    ]
+  },
+  "time": 0.01
+}
+```
+
+结果固定包含 `success`、`failure`、`partial`、`unknown` 和 `unfinished`。旧版创建且尚未重新索引的 Trajectory 没有 outcome 标签，因此不会计入分布。
+
+## 相关文档
+
+- [会话](05-sessions.md) - 提交会话并生成 Agent Evolution 记忆
+- [记忆](16-memory.md) - 记忆读取与召回

--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -46,6 +46,8 @@ Once installed, the plugin provides these agent tools:
 | `ov_read` | Read the full original content of one exact OpenViking URI |
 | `ov_multi_read` | Read the full original content of multiple OpenViking URIs |
 | `ov_list` | List OpenViking directories after search to inspect sibling chunks and overview files |
+| `search_experience` | Search reusable execution experiences for the current OpenViking user |
+| `read_experience` | Read one exact Experience returned by `search_experience` |
 | `openviking_tool_result_read` | Restore the full original content of an externalized tool result |
 | `openviking_tool_result_search` | Search inside an externalized tool result by keyword |
 | `openviking_tool_result_list` | List externalized tool results in the current session |
@@ -248,6 +250,8 @@ Beyond automatic behavior, the plugin exposes these tools directly:
 - `ov_read`: read one exact `viking://` URI returned by `ov_search` or `ov_list`
 - `ov_multi_read`: read multiple exact `viking://` URIs, useful for an overview plus sibling chunks
 - `ov_list`: list a hit's parent directory after `ov_search` to recover sibling chunks, `.overview.md`, and related split-document context
+- `search_experience`: search reusable execution experiences for the current OpenViking user
+- `read_experience`: read one exact Experience returned by `search_experience`
 
 They serve different roles:
 
@@ -261,6 +265,7 @@ They serve different roles:
 - `ov_read` turns a ranked hit into original evidence before answering precise documentation, codebase, configuration, or procedural questions
 - `ov_multi_read` reads overview and sibling chunks together when a split document needs more context than a single hit
 - `ov_list` complements `ov_search` when a ranked hit is only one chunk of a larger procedure or document
+- `search_experience` and `read_experience` provide the exact tool-call contract used by the bundled Experience Memory skill and usage reporting
 
 `ov_archive_expand` is especially important because `assemble()` normally returns archive summaries and indexes, not the full raw transcript.
 

--- a/examples/openclaw-plugin/README_CN.md
+++ b/examples/openclaw-plugin/README_CN.md
@@ -78,6 +78,8 @@ Agent 会自动完成安装 → 配置 → 重启 → 验证。详见 [INSTALL-A
 | `ov_read` | 读取 `ov_search` / trace 返回的 `viking://...` OpenViking 虚拟 URI 完整内容 |
 | `ov_multi_read` | 一次读取多个精确 `viking://...` URI，适合同时读取 overview 和同级切片 |
 | `ov_list` | 在检索后列出 OpenViking 目录，补查同级切片和 `.overview.md` 文件 |
+| `search_experience` | 检索当前 OpenViking 用户的可复用执行经验 |
+| `read_experience` | 读取 `search_experience` 返回的单条 Experience 全文 |
 | `openviking_tool_result_list` | 列出当前 session 中被外置的大工具输出 |
 | `openviking_tool_result_search` | 在外置工具输出中按关键词搜索 |
 | `openviking_tool_result_read` | 通过 `viking://session/.../tool-results/...` ref 分页读取外置工具输出 |
@@ -263,7 +265,7 @@ preflight 阶段的 `assemble()` 并不是简单地把旧聊天记录塞回来�
 
 ## 工具层与可展开能力
 
-这套插件除了自动行为，默认直接暴露 12 个工具；当 `enableAddResourceTool=true` 时才额外暴露 opt-in 的 `add_resource` 导入工具。Agent 可见工具可以通过 `enabledTools` 和 `disabledTools` 灵活裁剪：
+这套插件除了自动行为，还会直接暴露一组 Agent 工具；当 `enableAddResourceTool=true` 时才额外暴露 opt-in 的 `add_resource` 导入工具。Agent 可见工具可以通过 `enabledTools` 和 `disabledTools` 灵活裁剪：
 
 - `memory_recall`：在 memory/resource 目标上显式语义召回
 - `memory_store`：把明确的长期事实写入 OpenViking session 并触发阻塞 commit/抽取
@@ -276,11 +278,13 @@ preflight 阶段的 `assemble()` 并不是简单地把旧聊天记录塞回来�
 - `ov_read`：读取 `ov_search` 或 recall trace 返回的 `viking://...` OpenViking 虚拟 URI 完整内容
 - `ov_multi_read`：读取多个精确 `viking://...` URI，适合同时读取 overview 和同级切片
 - `ov_list`：在 `ov_search` 命中后列出父目录，用来补齐同级切片、`.overview.md` 和同源文档上下文
+- `search_experience`：检索当前 OpenViking 用户的可复用执行经验
+- `read_experience`：读取 `search_experience` 返回的单条 Experience 全文
 - `openviking_tool_result_list`：列出当前 session 中被外置的大工具输出
 - `openviking_tool_result_search`：在外置工具输出中按关键词搜索
 - `openviking_tool_result_read`：通过 ref 和 offset/limit 分页读取外置工具输出
 
-工具选择器支持精确工具名，也支持分组：`default`、`all`、`memory`、`resource_query`、`import`、`recall_trace`、`archive`、`tool_result`。例如，禁用记忆并只保留资源查询工具：
+工具选择器支持精确工具名，也支持分组：`default`、`all`、`memory`、`resource_query`、`experience`、`import`、`recall_trace`、`archive`、`tool_result`。例如，禁用记忆并只保留资源查询工具：
 
 ```json
 {

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -168,6 +168,8 @@ export const OPENVIKING_DEFAULT_ENABLED_TOOL_NAMES = [
   "ov_read",
   "ov_multi_read",
   "ov_list",
+  "search_experience",
+  "read_experience",
   "memory_recall",
   "ov_recall_trace",
   "memory_store",
@@ -188,6 +190,7 @@ export const OPENVIKING_TOOL_GROUPS: Record<string, readonly OpenVikingToolName[
   default: OPENVIKING_DEFAULT_ENABLED_TOOL_NAMES,
   memory: ["memory_recall", "memory_store", "memory_forget"],
   resource_query: ["ov_search", "ov_read", "ov_multi_read", "ov_list"],
+  experience: ["search_experience", "read_experience"],
   import: ["add_resource", "add_skill"],
   recall_trace: ["ov_recall_trace"],
   archive: ["ov_archive_search", "ov_archive_expand"],
@@ -970,7 +973,7 @@ export const memoryOpenVikingConfigSchema = {
     enabledTools: {
       label: "Enabled Tools",
       placeholder: "default",
-      help: "Agent-visible tool allowlist. Accepts tool names or groups: default, all, memory, resource_query, import, recall_trace, archive, tool_result. add_resource also requires enableAddResourceTool=true.",
+      help: "Agent-visible tool allowlist. Accepts tool names or groups: default, all, memory, resource_query, experience, import, recall_trace, archive, tool_result. add_resource also requires enableAddResourceTool=true.",
       advanced: true,
     },
     disabledTools: {

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -19,6 +19,7 @@ import { registerOpenVikingCommands } from "./plugin/command-registration.js";
 import { registerRecallTraceRoutes as registerRecallTraceRouteAdapters } from "./plugin/recall-trace-routes.js";
 import { createOpenVikingService } from "./plugin/openviking-services.js";
 import { registerOpenVikingArchiveTools } from "./plugin/openviking-archive-tools.js";
+import { registerOpenVikingExperienceTools } from "./plugin/openviking-experience-tools.js";
 import { createOpenVikingImportRuntime } from "./plugin/openviking-import-runtime.js";
 import { registerOpenVikingImportTools } from "./plugin/openviking-import-tools.js";
 import { registerOpenVikingLifecycleHooks } from "./plugin/openviking-lifecycle-hooks.js";
@@ -278,6 +279,15 @@ const contextEnginePlugin = {
       resolvePluginSessionRouting,
       isBypassedSession,
       makeBypassedToolResult,
+    });
+
+    registerOpenVikingExperienceTools({
+      registerTool: registerOpenVikingTool,
+      getClient,
+      resolvePluginSessionRouting,
+      isBypassedSession,
+      makeBypassedToolResult,
+      userId: cfg.userId,
     });
 
     registerOpenVikingMemoryRecallTools({

--- a/examples/openclaw-plugin/install-manifest.json
+++ b/examples/openclaw-plugin/install-manifest.json
@@ -41,6 +41,7 @@
       ".gitignore",
       "skills/install-openviking-memory/SKILL.md",
       "skills/openviking-context-database/SKILL.md",
+      "skills/ov-experience-memory/SKILL.md",
       "INSTALL-AGENT.md"
     ]
   },

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -19,6 +19,8 @@
       "ov_read",
       "ov_multi_read",
       "ov_list",
+      "search_experience",
+      "read_experience",
       "memory_recall",
       "ov_recall_trace",
       "memory_store",
@@ -252,7 +254,7 @@
     "enabledTools": {
       "label": "Enabled Tools",
       "placeholder": "default",
-      "help": "Agent-visible tool allowlist. Accepts tool names or groups: default, all, memory, resource_query, import, recall_trace, archive, tool_result. add_resource also requires enableAddResourceTool=true.",
+      "help": "Agent-visible tool allowlist. Accepts tool names or groups: default, all, memory, resource_query, experience, import, recall_trace, archive, tool_result. add_resource also requires enableAddResourceTool=true.",
       "advanced": true
     },
     "disabledTools": {

--- a/examples/openclaw-plugin/plugin/openviking-experience-tools.ts
+++ b/examples/openclaw-plugin/plugin/openviking-experience-tools.ts
@@ -1,0 +1,160 @@
+import { Type } from "@sinclair/typebox";
+
+import type { FindResult } from "../client.js";
+
+const EXPERIENCE_TARGET_URI = "viking://user/memories/experiences/";
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+const EXPERIENCE_SIDECAR_FILENAMES = new Set([".abstract.md", ".overview.md", ".relations.json"]);
+
+export type OpenVikingExperienceToolContext = {
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  senderId?: string;
+  requesterSenderId?: string;
+};
+
+export type OpenVikingExperienceSession = {
+  sessionId?: string;
+  sessionKey?: string;
+  ovSessionId?: string;
+  agentId: string;
+  actorPeerId?: string;
+};
+
+type OpenVikingExperienceClient = {
+  find: (
+    query: string,
+    options: { targetUri: string; limit: number; scoreThreshold?: number },
+    actorPeerId?: string,
+  ) => Promise<FindResult>;
+  read: (uri: string, actorPeerId?: string) => Promise<unknown>;
+};
+
+export type OpenVikingExperienceToolsDeps = {
+  registerTool: (toolOrFactory: unknown, opts: { name: string }) => void;
+  getClient: () => Promise<OpenVikingExperienceClient>;
+  resolvePluginSessionRouting: (ctx?: OpenVikingExperienceToolContext) => OpenVikingExperienceSession;
+  isBypassedSession: (ctx?: OpenVikingExperienceToolContext) => boolean;
+  makeBypassedToolResult: (toolName: string) => unknown;
+  userId?: string;
+};
+
+function clampLimit(value: unknown): number {
+  const parsed = Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, parsed));
+}
+
+function experienceRelativePath(uri: string): string {
+  return uri.match(/^viking:\/\/user\/[^/]+\/memories\/experiences\/(.+)$/)?.[1] ?? "";
+}
+
+export function isCanonicalExperienceUri(uri: unknown, expectedUserId?: string): uri is string {
+  const value = typeof uri === "string" ? uri.trim() : "";
+  if (!value || value.includes("?") || value.includes("#")) {
+    return false;
+  }
+  const owner = value.match(/^viking:\/\/user\/([^/]+)\//)?.[1] ?? "";
+  if (expectedUserId?.trim() && owner !== expectedUserId.trim()) {
+    return false;
+  }
+  const relative = experienceRelativePath(value);
+  const segments = relative.split("/");
+  const basename = segments.at(-1) ?? "";
+  return Boolean(
+    relative
+    && segments.every((segment) => segment && segment !== "." && segment !== "..")
+    && !EXPERIENCE_SIDECAR_FILENAMES.has(basename)
+  );
+}
+
+function titleFromUri(uri: string): string {
+  const basename = uri.split("/").at(-1) ?? uri;
+  const title = basename.replace(/\.md$/i, "");
+  try {
+    return decodeURIComponent(title);
+  } catch {
+    return title;
+  }
+}
+
+function jsonToolResult(payload: Record<string, unknown>): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+  };
+}
+
+export function registerOpenVikingExperienceTools(deps: OpenVikingExperienceToolsDeps): void {
+  deps.registerTool(
+    (ctx: OpenVikingExperienceToolContext) => ({
+      name: "search_experience",
+      label: "Search Experience (OpenViking)",
+      description:
+        "Search reusable task-execution experiences for the current OpenViking user. " +
+        "Use before executing operational or multi-step tasks, then call read_experience for selected results.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Current task, situation, or execution problem to search for" }),
+        limit: Type.Optional(Type.Integer({
+          description: `Maximum results to return. Default: ${DEFAULT_LIMIT}; maximum: ${MAX_LIMIT}`,
+          minimum: 1,
+          maximum: MAX_LIMIT,
+        })),
+      }, { additionalProperties: false }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("search_experience");
+        }
+        const query = typeof params.query === "string" ? params.query.trim() : "";
+        if (!query) {
+          throw new Error("query is required");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const client = await deps.getClient();
+        const result = await client.find(query, {
+          targetUri: EXPERIENCE_TARGET_URI,
+          limit: clampLimit(params.limit),
+        }, session.actorPeerId);
+        const results = (result.memories ?? [])
+          .filter((item) => isCanonicalExperienceUri(item.uri, deps.userId))
+          .map((item) => ({
+            uri: item.uri,
+            title: titleFromUri(item.uri),
+            score: typeof item.score === "number" ? item.score : 0,
+            snippet: item.abstract || item.overview || "",
+          }));
+        return jsonToolResult({ results });
+      },
+    }),
+    { name: "search_experience" },
+  );
+
+  deps.registerTool(
+    (ctx: OpenVikingExperienceToolContext) => ({
+      name: "read_experience",
+      label: "Read Experience (OpenViking)",
+      description:
+        "Read the complete Markdown body of one Experience returned by search_experience and use it as execution guidance.",
+      parameters: Type.Object({
+        uri: Type.String({ description: "Exact canonical Experience URI returned by search_experience" }),
+      }, { additionalProperties: false }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        if (deps.isBypassedSession(ctx)) {
+          return deps.makeBypassedToolResult("read_experience");
+        }
+        const uri = typeof params.uri === "string" ? params.uri.trim() : "";
+        if (!isCanonicalExperienceUri(uri, deps.userId)) {
+          throw new Error("uri must be a canonical OpenViking Experience URI returned by search_experience");
+        }
+        const session = deps.resolvePluginSessionRouting(ctx);
+        const client = await deps.getClient();
+        const content = await client.read(uri, session.actorPeerId);
+        const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+        return jsonToolResult({ uri, content: text });
+      },
+    }),
+    { name: "read_experience" },
+  );
+}

--- a/examples/openclaw-plugin/registries/openviking-tools.ts
+++ b/examples/openclaw-plugin/registries/openviking-tools.ts
@@ -1,6 +1,7 @@
 export type OpenVikingToolGroup =
   | "memory"
   | "resource_query"
+  | "experience"
   | "import"
   | "recall_trace"
   | "archive"
@@ -13,6 +14,8 @@ export type OpenVikingToolName =
   | "ov_read"
   | "ov_multi_read"
   | "ov_list"
+  | "search_experience"
+  | "read_experience"
   | "memory_recall"
   | "ov_recall_trace"
   | "memory_store"
@@ -44,6 +47,8 @@ export const OPENVIKING_TOOL_SPECS = [
   { name: "ov_read", group: "resource_query", defaultEnabled: true },
   { name: "ov_multi_read", group: "resource_query", defaultEnabled: true },
   { name: "ov_list", group: "resource_query", defaultEnabled: true },
+  { name: "search_experience", group: "experience", defaultEnabled: true },
+  { name: "read_experience", group: "experience", defaultEnabled: true },
   { name: "memory_recall", group: "memory", defaultEnabled: true },
   { name: "ov_recall_trace", group: "recall_trace", defaultEnabled: true },
   { name: "memory_store", group: "memory", defaultEnabled: true },
@@ -64,6 +69,7 @@ export const OPENVIKING_DEFAULT_ENABLED_TOOL_NAMES = OPENVIKING_TOOL_SPECS
 const OPENVIKING_TOOL_GROUP_ORDER: readonly OpenVikingToolGroup[] = [
   "memory",
   "resource_query",
+  "experience",
   "import",
   "recall_trace",
   "archive",

--- a/examples/openclaw-plugin/setup-helper/install.js
+++ b/examples/openclaw-plugin/setup-helper/install.js
@@ -78,6 +78,7 @@ const FALLBACK_CURRENT = {
     "session-transcript-repair.ts",
     "runtime-utils.ts",
     "commands/setup.ts",
+    "skills/ov-experience-memory/SKILL.md",
     "tsconfig.json",
     "package-lock.json",
     ".gitignore",

--- a/examples/openclaw-plugin/skills/ov-experience-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/ov-experience-memory/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: ov-experience-memory
+description: >
+  Use OpenViking experience memories during task execution. Search relevant
+  experiences with search_experience, read selected experiences with
+  read_experience, and leave standard tool parts in the committed session so
+  OpenViking can report recall and injection usage.
+version: 2026.7.9
+tags:
+  - openviking
+  - experience-memory
+  - agent-memory
+  - usage-reporting
+---
+
+# OpenViking Experience Memory
+
+Use this skill when the current user request starts or continues an executable
+task, especially tasks involving tools, files, code changes, data operations,
+workflow decisions, or multi-step actions.
+
+Do not use this skill for casual chat, pure explanation, or one-off factual Q&A
+that does not require operational guidance.
+
+## Runtime Contract
+
+The agent runtime must expose two tools with these exact names:
+
+- `search_experience`
+- `read_experience`
+
+OpenViking usage reporting recognizes only completed tool parts with these exact
+tool names. Calls to generic `find`, `search`, `read`, `ov_search`, or `ov_read`
+do not count as experience recall or injection events.
+
+## Tool: search_experience
+
+Purpose: search reusable execution experiences from the OpenViking experience
+library before assembling task context.
+
+Input schema:
+
+```json
+{
+  "query": "string",
+  "limit": 5
+}
+```
+
+Output schema:
+
+```json
+{
+  "results": [
+    {
+      "uri": "viking://user/<current_user_id>/memories/experiences/example.md",
+      "title": "example",
+      "score": 0.82,
+      "snippet": "Short summary or matched situation"
+    }
+  ]
+}
+```
+
+Implementation:
+
+The runtime tool calls OpenViking `POST /api/v1/search/find` with `target_uri`
+fixed to the current-user shorthand `viking://user/memories/experiences/`.
+Callers provide only `query` and optional `limit`; they cannot override or pass
+`target_uri`. OpenViking resolves the fixed shorthand against the authenticated
+request user. Return only canonical experience memory URIs for that user; never
+hardcode `default` or another user ID.
+
+Usage reporting:
+
+A completed `search_experience` tool part is counted as an experience recall
+event for every `results[].uri` value.
+
+## Tool: read_experience
+
+Purpose: read the full Markdown body of a selected experience and inject it into
+the agent prompt as task execution guidance.
+
+Input schema:
+
+```json
+{
+  "uri": "viking://user/<current_user_id>/memories/experiences/example.md"
+}
+```
+
+Output schema:
+
+```json
+{
+  "uri": "viking://user/<current_user_id>/memories/experiences/example.md",
+  "content": "Experience Markdown body"
+}
+```
+
+Implementation:
+
+Call OpenViking `GET /api/v1/content/read?uri=<encoded_uri>` for the selected
+experience URI. Always pass the canonical URI returned by `search_experience`;
+do not construct a URI with a hardcoded user ID. The returned content should be
+inserted into the prompt as operational guidance, not as user profile facts.
+
+Usage reporting:
+
+A completed `read_experience` tool part is counted as an experience injection
+event for `tool_input.uri` or `tool_output.uri`. In this design, reading an
+experience through `read_experience` means the experience was injected into the
+prompt.
+
+## Recommended Flow
+
+1. When a task begins, build a short query from the latest user instruction,
+   current plan, active skill name, and important tool/environment context.
+2. Call `search_experience` before final prompt assembly.
+3. Review returned titles/snippets and select only experiences likely to affect
+   execution.
+4. Call `read_experience` for selected experience URIs.
+5. Inject the returned Markdown into the prompt under an explicit experience
+   section.
+6. Continue task execution.
+7. Commit the session normally. The committed session must include the
+   `search_experience` and `read_experience` tool parts so OpenViking can report
+   usage.
+
+## Prompt Injection Format
+
+Use a compact and explicit block:
+
+```text
+<openviking-experience-memory>
+The following guidance was retrieved from prior task execution experience.
+Use it as operational guidance. Do not treat it as user identity or preference.
+
+<experience uri="viking://user/<current_user_id>/memories/experiences/example.md">
+...experience markdown...
+</experience>
+</openviking-experience-memory>
+```
+
+## Commit Requirements
+
+The session committed to OpenViking must preserve tool parts with:
+
+- `tool_name`
+- `tool_status`
+- `tool_input`
+- `tool_output`
+- `tool_id`
+
+Only `tool_status == "completed"` is counted. Failed, cancelled, or skipped tool
+parts are ignored by usage reporting.

--- a/examples/openclaw-plugin/tests/ut/openviking-experience-tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/openviking-experience-tools.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isCanonicalExperienceUri,
+  registerOpenVikingExperienceTools,
+} from "../../plugin/openviking-experience-tools.js";
+
+type RegisteredTool = {
+  name: string;
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+function createHarness(options: { bypassed?: boolean; userId?: string } = {}) {
+  const factories = new Map<string, (ctx: Record<string, unknown>) => RegisteredTool>();
+  const client = {
+    find: vi.fn(),
+    read: vi.fn(),
+  };
+  registerOpenVikingExperienceTools({
+    registerTool(factory, registration) {
+      factories.set(registration.name, factory as (ctx: Record<string, unknown>) => RegisteredTool);
+    },
+    getClient: vi.fn().mockResolvedValue(client),
+    resolvePluginSessionRouting: vi.fn().mockReturnValue({
+      agentId: "agent-main",
+      actorPeerId: "peer-main",
+    }),
+    isBypassedSession: vi.fn().mockReturnValue(options.bypassed ?? false),
+    makeBypassedToolResult: (toolName) => ({ bypassed: toolName }),
+    userId: options.userId,
+  });
+  const tool = (name: string): RegisteredTool => {
+    const factory = factories.get(name);
+    if (!factory) throw new Error(`tool ${name} was not registered`);
+    return factory({ sessionId: "session-1" });
+  };
+  return { client, factories, tool };
+}
+
+function parseTextResult(value: unknown): Record<string, unknown> {
+  const result = value as { content: Array<{ type: string; text: string }> };
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+describe("OpenViking Experience tools", () => {
+  it("registers the two standard Experience tool names", () => {
+    const { factories } = createHarness();
+    expect([...factories.keys()]).toEqual(["search_experience", "read_experience"]);
+  });
+
+  it("searches only the current-user Experience directory and returns canonical results", async () => {
+    const { client, tool } = createHarness();
+    client.find.mockResolvedValue({
+      memories: [
+        {
+          uri: "viking://user/test/memories/experiences/无订单号换货处理.md",
+          score: 0.86,
+          abstract: "先确认用户身份，再定位订单。",
+        },
+        {
+          uri: "viking://user/test/memories/experiences/.overview.md",
+          score: 0.9,
+        },
+        {
+          uri: "viking://user/test/memories/preferences/换货偏好.md",
+          score: 0.8,
+        },
+      ],
+      resources: [],
+      skills: [],
+      total: 3,
+    });
+
+    const output = await tool("search_experience").execute("call-search", {
+      query: "没有订单号时如何换货",
+      limit: 7,
+    });
+
+    expect(client.find).toHaveBeenCalledWith(
+      "没有订单号时如何换货",
+      {
+        targetUri: "viking://user/memories/experiences/",
+        limit: 7,
+      },
+      "peer-main",
+    );
+    expect(parseTextResult(output)).toEqual({
+      results: [
+        {
+          uri: "viking://user/test/memories/experiences/无订单号换货处理.md",
+          title: "无订单号换货处理",
+          score: 0.86,
+          snippet: "先确认用户身份，再定位订单。",
+        },
+      ],
+    });
+  });
+
+  it("reads a canonical Experience and preserves its URI in the tool result", async () => {
+    const { client, tool } = createHarness();
+    const uri = "viking://user/test/memories/experiences/无订单号换货处理.md";
+    client.read.mockResolvedValue("# 无订单号换货处理\n\n先验证用户身份。");
+
+    const output = await tool("read_experience").execute("call-read", { uri });
+
+    expect(client.read).toHaveBeenCalledWith(uri, "peer-main");
+    expect(parseTextResult(output)).toEqual({
+      uri,
+      content: "# 无订单号换货处理\n\n先验证用户身份。",
+    });
+  });
+
+  it("rejects non-Experience and noncanonical URIs before reading", async () => {
+    const { client, tool } = createHarness();
+    const readTool = tool("read_experience");
+
+    await expect(readTool.execute("call-read", {
+      uri: "viking://user/test/memories/preferences/换货偏好.md",
+    })).rejects.toThrow("canonical OpenViking Experience URI");
+    await expect(readTool.execute("call-read", {
+      uri: "viking://user/test/memories/experiences/a.md#approach",
+    })).rejects.toThrow("canonical OpenViking Experience URI");
+    expect(client.read).not.toHaveBeenCalled();
+  });
+
+  it("rejects another user's Experience when userId is explicitly configured", async () => {
+    const { client, tool } = createHarness({ userId: "current-user" });
+
+    await expect(tool("read_experience").execute("call-read", {
+      uri: "viking://user/other-user/memories/experiences/a.md",
+    })).rejects.toThrow("canonical OpenViking Experience URI");
+    expect(client.read).not.toHaveBeenCalled();
+  });
+
+  it("uses the standard bypass result without calling OpenViking", async () => {
+    const { client, tool } = createHarness({ bypassed: true });
+
+    await expect(tool("search_experience").execute("call-search", { query: "换货" }))
+      .resolves.toEqual({ bypassed: "search_experience" });
+    await expect(tool("read_experience").execute("call-read", {
+      uri: "viking://user/test/memories/experiences/a.md",
+    })).resolves.toEqual({ bypassed: "read_experience" });
+    expect(client.find).not.toHaveBeenCalled();
+    expect(client.read).not.toHaveBeenCalled();
+  });
+});
+
+describe("isCanonicalExperienceUri", () => {
+  it("accepts Experience files and rejects sidecars or URI aliases", () => {
+    expect(isCanonicalExperienceUri("viking://user/test/memories/experiences/a.md")).toBe(true);
+    expect(isCanonicalExperienceUri("viking://user/test/memories/experiences/.overview.md")).toBe(false);
+    expect(isCanonicalExperienceUri("viking://user/test/memories/experiences/a.md?version=1")).toBe(false);
+    expect(isCanonicalExperienceUri("viking://user/test/memories/experiences/../a.md")).toBe(false);
+  });
+});

--- a/examples/openclaw-plugin/tests/ut/openviking-tools-registry.test.ts
+++ b/examples/openclaw-plugin/tests/ut/openviking-tools-registry.test.ts
@@ -15,6 +15,8 @@ const DEFAULT_TOOL_NAMES = [
   "ov_read",
   "ov_multi_read",
   "ov_list",
+  "search_experience",
+  "read_experience",
   "memory_recall",
   "ov_recall_trace",
   "memory_store",
@@ -44,6 +46,7 @@ describe("openviking tool registry", () => {
       default: DEFAULT_TOOL_NAMES,
       memory: ["memory_recall", "memory_store", "memory_forget"],
       resource_query: ["ov_search", "ov_read", "ov_multi_read", "ov_list"],
+      experience: ["search_experience", "read_experience"],
       import: ["add_resource", "add_skill"],
       recall_trace: ["ov_recall_trace"],
       archive: ["ov_archive_search", "ov_archive_expand"],
@@ -63,5 +66,12 @@ describe("openviking tool registry", () => {
 
     expect(memoryOpenVikingConfigSchema.parse({}).enabledTools).not.toContain("add_resource");
     expect(memoryOpenVikingConfigSchema.parse({ enableAddResourceTool: true }).enabledTools).toContain("add_resource");
+  });
+
+  it("allows both Experience tools to be disabled as one group", () => {
+    const config = memoryOpenVikingConfigSchema.parse({ disabledTools: ["experience"] });
+
+    expect(config.enabledTools).not.toContain("search_experience");
+    expect(config.enabledTools).not.toContain("read_experience");
   });
 });

--- a/examples/openclaw-plugin/tests/ut/package-install-contract.test.ts
+++ b/examples/openclaw-plugin/tests/ut/package-install-contract.test.ts
@@ -84,6 +84,15 @@ describe("OpenClaw plugin package and install contract", () => {
     ]));
   });
 
+  it("ships the Experience Memory skill with source installs", () => {
+    const installManifest = readJson("install-manifest.json");
+    const installHelper = readFileSync(join(rootDir, "setup-helper/install.js"), "utf8");
+
+    expect(installManifest.files.optional).toContain("skills/ov-experience-memory/SKILL.md");
+    expect(existsSync(join(rootDir, "skills/ov-experience-memory/SKILL.md"))).toBe(true);
+    expect(installHelper).toContain('"skills/ov-experience-memory/SKILL.md"');
+  });
+
   it("keeps runtime dependencies and overrides available for installed plugin loading", () => {
     const packageJson = readJson("package.json");
 

--- a/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-registration.test.ts
@@ -98,4 +98,14 @@ describe("plugin registration", () => {
       expect.any(Function),
     );
   });
+
+  it("registers the standard Experience tools by default", () => {
+    const api = createPluginApi({});
+
+    contextEnginePlugin.register(api as any);
+
+    const registeredNames = api.registerTool.mock.calls.map((call) => call[1]?.name);
+    expect(registeredNames).toContain("search_experience");
+    expect(registeredNames).toContain("read_experience");
+  });
 });

--- a/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tool-round-trip.test.ts
@@ -39,6 +39,43 @@ describe("extractNewTurnMessages: toolCallId propagation", () => {
     }
   });
 
+  it("preserves standard Experience calls as completed ToolParts", () => {
+    const uri = "viking://user/test/memories/experiences/无订单号换货处理.md";
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_experience_search",
+            name: "search_experience",
+            arguments: { query: "没有订单号时如何换货", limit: 5 },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_experience_search",
+        toolName: "search_experience",
+        content: [{ type: "text", text: JSON.stringify({ results: [{ uri }] }) }],
+      },
+    ];
+
+    const { messages: extracted } = extractNewTurnMessages(messages, 0);
+    const toolPart = extracted.flatMap((message) => message.parts).find((part) => part.type === "tool");
+
+    expect(toolPart).toMatchObject({
+      type: "tool",
+      toolCallId: "call_experience_search",
+      toolName: "search_experience",
+      toolInput: { query: "没有订单号时如何换货", limit: 5 },
+      toolStatus: "completed",
+    });
+    if (toolPart?.type === "tool") {
+      expect(JSON.parse(toolPart.toolOutput)).toEqual({ results: [{ uri }] });
+    }
+  });
+
   it("sets toolCallId to undefined when original message has no toolCallId", () => {
     const messages = [
       {

--- a/examples/openclaw-plugin/tests/ut/tools.test.ts
+++ b/examples/openclaw-plugin/tests/ut/tools.test.ts
@@ -1988,10 +1988,10 @@ describe("Tool: ov_recall_trace", () => {
 });
 
 describe("Plugin registration", () => {
-  it("registers all 14 default tools", () => {
+  it("registers all 16 default tools", () => {
     const { api } = setupPlugin();
     contextEnginePlugin.register(api as any);
-    expect(api.registerTool).toHaveBeenCalledTimes(14);
+    expect(api.registerTool).toHaveBeenCalledTimes(16);
   });
 
   it("registers only resource query tools when enabledTools is resource_query", () => {

--- a/openviking/server/account_settings.py
+++ b/openviking/server/account_settings.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Persistent, account-scoped runtime settings."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from openviking.pyagfs import AGFSAlreadyExistsError, AGFSNotFoundError, AsyncAGFSClient
+from openviking.pyagfs.async_client import fs_ctx_from_agfs_path
+from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.session.user_id import validate_account_id
+from openviking_cli.utils.logger import get_logger
+
+ACCOUNT_SETTINGS_PATH_TEMPLATE = "/local/{account_id}/_system/setting.json"
+ACCOUNT_SETTINGS_BACKUP_PATH_TEMPLATE = "/local/{account_id}/_system/setting.backup.json"
+
+logger = get_logger(__name__)
+
+
+class AccountAgentEvolutionSettings(BaseModel):
+    """Account-scoped Agent Evolution override."""
+
+    enabled: bool
+
+    model_config = {"extra": "forbid"}
+
+
+class AccountSettings(BaseModel):
+    """Persisted account overrides.
+
+    Only explicitly allowlisted hot-reloadable settings belong in this model.
+    """
+
+    agent_evolution: Optional[AccountAgentEvolutionSettings] = None
+
+    model_config = {"extra": "forbid"}
+
+
+class AccountSettingsPatch(BaseModel):
+    """Allowlisted account settings accepted by the update API."""
+
+    agent_evolution: Optional[AccountAgentEvolutionSettings] = None
+
+    model_config = {"extra": "forbid"}
+
+
+def account_settings_path(account_id: str) -> str:
+    _validate_account_id(account_id)
+    return ACCOUNT_SETTINGS_PATH_TEMPLATE.format(account_id=account_id)
+
+
+def account_settings_backup_path(account_id: str) -> str:
+    _validate_account_id(account_id)
+    return ACCOUNT_SETTINGS_BACKUP_PATH_TEMPLATE.format(account_id=account_id)
+
+
+def _validate_account_id(account_id: str) -> None:
+    error = validate_account_id(account_id)
+    if error:
+        raise InvalidArgumentError(error)
+
+
+def _decode_read_result(result: Any) -> bytes:
+    if isinstance(result, bytes):
+        return result
+    content = getattr(result, "content", None)
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, str):
+        return content.encode("utf-8")
+    if isinstance(result, str):
+        return result.encode("utf-8")
+    raise InvalidArgumentError("account settings content must be JSON text")
+
+
+def _parse_account_settings(raw: bytes) -> AccountSettings:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidArgumentError(f"Invalid account settings JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise InvalidArgumentError("account settings must be an object")
+    try:
+        return AccountSettings.model_validate(payload)
+    except Exception as exc:
+        raise InvalidArgumentError(str(exc)) from exc
+
+
+async def _read_raw(client: AsyncAGFSClient, path: str) -> Optional[bytes]:
+    try:
+        return _decode_read_result(await client.read(path))
+    except AGFSNotFoundError:
+        return None
+
+
+async def read_account_settings(viking_fs: VikingFS, account_id: str) -> AccountSettings:
+    """Read the persisted overrides for one account."""
+    path = account_settings_path(account_id)
+    raw = await _read_raw(AsyncAGFSClient(viking_fs.agfs), path)
+    return AccountSettings() if raw is None else _parse_account_settings(raw)
+
+
+def effective_agent_evolution_enabled(
+    settings: AccountSettings,
+    *,
+    default_enabled: bool,
+) -> bool:
+    if settings.agent_evolution is None:
+        return bool(default_enabled)
+    return settings.agent_evolution.enabled
+
+
+async def update_account_settings(
+    viking_fs: VikingFS,
+    account_id: str,
+    patch: AccountSettingsPatch,
+) -> AccountSettings:
+    """Apply a locked, backed-up update to one account's settings."""
+    path = account_settings_path(account_id)
+    backup_path = account_settings_backup_path(account_id)
+    client = AsyncAGFSClient(viking_fs.agfs)
+    try:
+        lease = await client.pathlock_acquire_exact(path, timeout_secs=10.0)
+    except LockAcquisitionError as exc:
+        raise ResourceBusyError(
+            "Another account settings update is in progress. Please retry.",
+            uri=path,
+            conflict_type="account_settings_busy",
+        ) from exc
+
+    fs_ctx = fs_ctx_from_agfs_path(path)
+    lease_ref = getattr(lease, "lease_ref", None) or getattr(lease, "id", None)
+    if isinstance(lease, dict):
+        lease_ref = lease.get("lease_ref", lease_ref)
+    if isinstance(lease_ref, str) and lease_ref:
+        fs_ctx["lease_ref"] = lease_ref
+
+    try:
+        current_raw = await _read_raw(client, path)
+        current = AccountSettings() if current_raw is None else _parse_account_settings(current_raw)
+        updated = current.model_copy(deep=True)
+        if patch.agent_evolution is not None:
+            updated.agent_evolution = patch.agent_evolution.model_copy(deep=True)
+        if updated == current:
+            return current
+
+        encoded = json.dumps(
+            updated.model_dump(exclude_none=True),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            await client.ensure_parent_dirs(path)
+        except AGFSAlreadyExistsError:
+            pass
+
+        if current_raw is not None:
+            await client.write(backup_path, current_raw)
+
+        try:
+            await client.write(path, encoded, fs_ctx=fs_ctx)
+        except Exception:
+            try:
+                if current_raw is not None:
+                    await client.write(path, current_raw, fs_ctx=fs_ctx)
+                else:
+                    await client.rm(path, fs_ctx=fs_ctx)
+            except AGFSNotFoundError:
+                pass
+            except Exception:
+                logger.exception(
+                    "Failed to roll back account settings for account %s",
+                    account_id,
+                )
+            raise
+        return updated
+    finally:
+        await client.pathlock_release(lease)

--- a/openviking/server/agent_evolution_config.py
+++ b/openviking/server/agent_evolution_config.py
@@ -1,13 +1,19 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Live access to the instance-wide Agent Evolution switch."""
+"""Live access to account-scoped Agent Evolution settings."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
+from openviking.server.account_settings import (
+    effective_agent_evolution_enabled,
+    read_account_settings,
+)
 from openviking.server.config import ServerConfig
+from openviking.storage.viking_fs import VikingFS
 from openviking_cli.utils.config import load_json_config
 from openviking_cli.utils.logger import get_logger
 
@@ -15,29 +21,32 @@ logger = get_logger(__name__)
 
 
 class AgentEvolutionConfigProvider:
-    """Read the live Agent Evolution value from the configured ov.conf.
-
-    Kubernetes projects Secret updates into the mounted config directory
-    atomically. Reading the file at commit time lets already-created sessions
-    observe the new value without restarting the server.
-    """
+    """Resolve ov.conf defaults with persistent account overrides."""
 
     def __init__(
         self,
         *,
         default_enabled: bool,
+        viking_fs: VikingFS,
         config_path: Optional[str | Path] = None,
     ) -> None:
         self._last_valid_enabled = bool(default_enabled)
+        self._last_valid_account_overrides: dict[str, Optional[bool]] = {}
+        self._viking_fs = viking_fs
         self._config_path = Path(config_path).expanduser() if config_path else None
+        self._lock = Lock()
 
     def set_default_enabled(self, enabled: bool) -> None:
-        self._last_valid_enabled = bool(enabled)
+        with self._lock:
+            self._last_valid_enabled = bool(enabled)
 
-    def is_enabled(self) -> bool:
+    def _default_enabled(self) -> bool:
+        with self._lock:
+            fallback = self._last_valid_enabled
+
         config_path = self._config_path
         if config_path is None:
-            return self._last_valid_enabled
+            return fallback
 
         try:
             payload = load_json_config(config_path)
@@ -48,21 +57,47 @@ class AgentEvolutionConfigProvider:
                 server_config = {}
             if not isinstance(server_config, dict):
                 raise ValueError("server must be an object")
-            enabled = ServerConfig.model_validate(server_config).agent_evolution.enabled
+            agent_evolution = ServerConfig.model_validate(server_config).agent_evolution
+            enabled = agent_evolution.enabled
         except OSError as exc:
             logger.warning(
                 "Failed to access Agent Evolution config file %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return fallback
         except (KeyError, TypeError, ValueError) as exc:
             logger.warning(
                 "Failed to read Agent Evolution config from %s, using last valid value: %s",
                 config_path,
                 exc,
             )
-            return self._last_valid_enabled
+            return fallback
 
-        self._last_valid_enabled = enabled
-        return enabled
+        with self._lock:
+            self._last_valid_enabled = enabled
+            return enabled
+
+    async def is_enabled(self, account_id: str) -> bool:
+        default_enabled = self._default_enabled()
+        try:
+            settings = await read_account_settings(self._viking_fs, account_id)
+            enabled = effective_agent_evolution_enabled(
+                settings,
+                default_enabled=default_enabled,
+            )
+            override = (
+                settings.agent_evolution.enabled if settings.agent_evolution is not None else None
+            )
+            with self._lock:
+                self._last_valid_account_overrides[account_id] = override
+            return enabled
+        except Exception as exc:
+            logger.warning(
+                "Failed to read Agent Evolution settings for account %s, using last valid value: %s",
+                account_id,
+                exc,
+            )
+            with self._lock:
+                override = self._last_valid_account_overrides.get(account_id)
+            return default_enabled if override is None else override

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -31,6 +31,7 @@ from openviking.server.profile_middleware import create_profile_http_middleware
 from openviking.server.request_id import REQUEST_ID_HEADER, RequestIdMiddleware
 from openviking.server.routers import (
     admin_router,
+    agent_evolution_router,
     bot_router,
     console_router,
     content_router,
@@ -88,6 +89,7 @@ def create_worker_app() -> FastAPI:
     if bot_api_url is not None:
         config.bot_api_url = bot_api_url
     return create_app(config, config_path=config_path)
+
 
 async def _initialize_auth_plugin(
     app: FastAPI,
@@ -572,6 +574,7 @@ def create_app(
     # Register routers
     app.include_router(system_router)
     app.include_router(admin_router)
+    app.include_router(agent_evolution_router)
     app.include_router(resources_router)
     app.include_router(filesystem_router)
     app.include_router(content_router)

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -82,7 +82,7 @@ class AddTargetsConfig(BaseModel):
 
 
 class AgentEvolutionConfig(BaseModel):
-    """Server-wide Agent Evolution production switch."""
+    """Default Agent Evolution setting for accounts without an override."""
 
     enabled: bool = False
 

--- a/openviking/server/routers/__init__.py
+++ b/openviking/server/routers/__init__.py
@@ -3,6 +3,7 @@
 """OpenViking HTTP Server routers."""
 
 from openviking.server.routers.admin import router as admin_router
+from openviking.server.routers.agent_evolution import router as agent_evolution_router
 from openviking.server.routers.bot import router as bot_router
 from openviking.server.routers.console import router as console_router
 from openviking.server.routers.content import router as content_router
@@ -28,6 +29,7 @@ from openviking.server.routers.webdav import router as webdav_router
 
 __all__ = [
     "admin_router",
+    "agent_evolution_router",
     "bot_router",
     "system_router",
     "resources_router",

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -7,6 +7,13 @@ import asyncio
 from fastapi import APIRouter, Body, Depends, Path, Request
 from pydantic import BaseModel
 
+from openviking.server.account_settings import (
+    AccountAgentEvolutionSettings,
+    AccountSettings,
+    AccountSettingsPatch,
+    read_account_settings,
+    update_account_settings,
+)
 from openviking.server.api_keys.models import validate_account_user_role
 from openviking.server.auth import (
     get_api_key_manager_or_raise,
@@ -31,6 +38,7 @@ from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     InvalidArgumentError,
+    NotFoundError,
     PermissionDeniedError,
 )
 from openviking_cli.session.user_id import UserIdentifier
@@ -68,21 +76,54 @@ class MigrateLegacyDataRequest(BaseModel):
     action: str = "migrate"
 
 
+class SetAgentEvolutionRequest(BaseModel):
+    enabled: bool
+
+
+def _agent_evolution_account_id(ctx: RequestContext) -> str:
+    if ctx.role == Role.ROOT:
+        return get_openviking_config().default_account
+    return ctx.account_id
+
+
 @router.get("/agent-evolution")
-@require_auth_root
+@require_auth_root_or_admin
 async def get_agent_evolution_status(
     request: Request,
     ctx: RequestContext = Depends(get_request_context),
 ):
-    """Return the live instance-wide Agent Evolution switch."""
-    del request
-    del ctx
+    """Return the effective Agent Evolution switch for the caller's account."""
+    account_id = _agent_evolution_account_id(ctx)
+    _check_account_exists(request, account_id)
+    enabled = await get_service().sessions.get_agent_evolution_enabled(account_id)
     return Response(
         status="ok",
-        result={
-            "enabled": get_service().sessions.get_agent_evolution_enabled(),
-            "account_id": get_openviking_config().default_account,
-        },
+        result={"enabled": enabled, "account_id": account_id},
+    )
+
+
+@router.put("/agent-evolution")
+@require_auth_root_or_admin
+async def set_agent_evolution_status(
+    body: SetAgentEvolutionRequest,
+    request: Request,
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Persist and hot-reload Agent Evolution for the caller's account."""
+    account_id = _agent_evolution_account_id(ctx)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    await update_account_settings(
+        service.viking_fs,
+        account_id,
+        AccountSettingsPatch(agent_evolution=AccountAgentEvolutionSettings(enabled=body.enabled)),
+    )
+    enabled = await service.sessions.get_agent_evolution_enabled(account_id)
+    return Response(
+        status="ok",
+        result={"enabled": enabled, "account_id": account_id},
     )
 
 
@@ -102,6 +143,31 @@ def _check_account_access(ctx: RequestContext, account_id: str) -> None:
     """ADMIN can only operate on their own account."""
     if ctx.role == Role.ADMIN and ctx.account_id != account_id:
         raise PermissionDeniedError(f"ADMIN can only manage account: {ctx.account_id}")
+
+
+def _check_account_exists(request: Request, account_id: str) -> None:
+    manager = getattr(request.app.state, "api_key_manager", None)
+    if manager is None:
+        return
+    accounts = manager.get_accounts()
+    if not any(item.get("account_id") == account_id for item in accounts):
+        raise NotFoundError(account_id, "account")
+
+
+async def _account_settings_result(
+    account_id: str,
+    settings: AccountSettings,
+) -> dict:
+    enabled = await get_service().sessions.get_agent_evolution_enabled(account_id)
+    return {
+        "account_id": account_id,
+        "settings": {
+            "agent_evolution": {
+                "enabled": enabled,
+            }
+        },
+        "overrides": settings.model_dump(exclude_none=True),
+    }
 
 
 def _has_add_targets(user_config: UserConfig | None) -> bool:
@@ -299,6 +365,47 @@ async def delete_account(
     # Finally delete the account metadata
     await manager.delete_account(account_id)
     return Response(status="ok", result={"deleted": True})
+
+
+@router.get("/accounts/{account_id}/settings")
+@require_auth_root_or_admin
+async def get_account_settings(
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Return effective and explicitly overridden settings for one account."""
+    _check_account_access(ctx, account_id)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    settings = await read_account_settings(service.viking_fs, account_id)
+    return Response(
+        status="ok",
+        result=await _account_settings_result(account_id, settings),
+    )
+
+
+@router.patch("/accounts/{account_id}/settings")
+@require_auth_root_or_admin
+async def patch_account_settings(
+    body: AccountSettingsPatch,
+    request: Request,
+    account_id: str = Path(..., description="Account ID"),
+    ctx: RequestContext = Depends(get_request_context),
+):
+    """Update allowlisted hot-reloadable settings for one account."""
+    _check_account_access(ctx, account_id)
+    _check_account_exists(request, account_id)
+    service = get_service()
+    if service.viking_fs is None:
+        raise FailedPreconditionError("OpenViking service is not initialized.")
+    settings = await update_account_settings(service.viking_fs, account_id, body)
+    return Response(
+        status="ok",
+        result=await _account_settings_result(account_id, settings),
+    )
 
 
 # ---- User endpoints ----

--- a/openviking/server/routers/agent_evolution.py
+++ b/openviking/server/routers/agent_evolution.py
@@ -36,3 +36,17 @@ async def list_experience_trajectories(
         offset=offset,
     )
     return Response(status="ok", result=result)
+
+
+@router.get("/experiences/outcomes")
+async def get_experience_outcome_distribution(
+    experience_uri: str = Query(..., description="Experience file URI"),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Count application trajectories by outcome for an Experience."""
+    service = get_service()
+    result = await service.agent_evolution.get_experience_outcome_distribution(
+        experience_uri=experience_uri,
+        ctx=_ctx,
+    )
+    return Response(status="ok", result=result)

--- a/openviking/server/routers/agent_evolution.py
+++ b/openviking/server/routers/agent_evolution.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Agent Evolution endpoints."""
+
+from fastapi import APIRouter, Depends, Query
+
+from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
+from openviking.server.identity import RequestContext
+from openviking.server.models import Response
+from openviking.service.agent_evolution_service import (
+    DEFAULT_TRAJECTORY_PAGE_LIMIT,
+    MAX_TRAJECTORY_PAGE_LIMIT,
+)
+
+router = APIRouter(prefix="/api/v1/agent-evolution", tags=["agent-evolution"])
+
+
+@router.get("/experiences/trajectories")
+async def list_experience_trajectories(
+    experience_uri: str = Query(..., description="Experience file URI"),
+    limit: int = Query(
+        DEFAULT_TRAJECTORY_PAGE_LIMIT,
+        ge=1,
+        le=MAX_TRAJECTORY_PAGE_LIMIT,
+    ),
+    offset: int = Query(0, ge=0),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """List trajectories produced by commits that read an Experience."""
+    service = get_service()
+    result = await service.agent_evolution.list_trajectories_by_experience(
+        experience_uri=experience_uri,
+        ctx=_ctx,
+        limit=limit,
+        offset=offset,
+    )
+    return Response(status="ok", result=result)

--- a/openviking/server/routers/snapshot.py
+++ b/openviking/server/routers/snapshot.py
@@ -22,7 +22,12 @@ from openviking.server.dependencies import get_service
 from openviking.server.error_mapping import map_exception
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
-from openviking_cli.exceptions import InternalError, NotFoundError, OpenVikingError
+from openviking_cli.exceptions import (
+    InternalError,
+    InvalidArgumentError,
+    NotFoundError,
+    OpenVikingError,
+)
 
 router = APIRouter(prefix="/api/v1/snapshot", tags=["snapshot"])
 
@@ -158,6 +163,7 @@ async def restore(
 async def show(
     target_ref: str = Query(..., description="Commit oid, branch, or tag"),
     path: Optional[str] = Query(None, description="Optional viking:// URI for a single blob"),
+    raw: bool = Query(True, description="Return raw stored content with memory fields"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Without ``path``: commit metadata JSON. With ``path``: raw blob bytes + X-Snapshot-* headers."""
@@ -177,12 +183,23 @@ async def show(
             raise mapped from e
         raise
 
+    content = blob["bytes"]
+    if not raw:
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise InvalidArgumentError("raw=false requires UTF-8 snapshot content") from exc
+
+        from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+        content = MemoryFileUtils.read(text, uri=path).content.encode("utf-8")
+
     return FastAPIResponse(
-        content=blob["bytes"],
+        content=content,
         media_type="application/octet-stream",
         headers={
             "X-Snapshot-Oid": str(blob["oid"]),
-            "X-Snapshot-Size": str(blob["size"]),
+            "X-Snapshot-Size": str(len(content)),
         },
     )
 
@@ -196,6 +213,7 @@ async def diff(
         description="Base commit oid, branch, or tag; omit to compare against an empty file",
     ),
     to_ref: str = Query(..., alias="to", description="Target commit oid, branch, or tag"),
+    raw: bool = Query(True, description="Compare raw stored content with memory fields"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Return a unified text diff for one path between two snapshots."""
@@ -205,6 +223,7 @@ async def diff(
             path=path,
             from_ref=from_ref,
             to_ref=to_ref,
+            raw=raw,
             ctx=_ctx,
         )
     except (AGFSClientError, ValueError) as exc:

--- a/openviking/service/agent_evolution_service.py
+++ b/openviking/service/agent_evolution_service.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Agent Evolution product queries."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Optional
+
+from openviking.core.namespace import canonicalize_uri
+from openviking.server.identity import RequestContext
+from openviking.session.memory.experience_lineage import (
+    canonical_experience_uri,
+    experience_source_tag,
+)
+from openviking.storage.expr import And, Eq, PathScope
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
+
+if TYPE_CHECKING:
+    from openviking.storage.vikingdb_manager import VikingDBManager
+
+DEFAULT_TRAJECTORY_PAGE_LIMIT = 50
+MAX_TRAJECTORY_PAGE_LIMIT = 1000
+
+_TRAJECTORY_OUTPUT_FIELDS = [
+    "uri",
+    "name",
+    "description",
+    "created_at",
+    "updated_at",
+]
+
+
+class AgentEvolutionService:
+    """Serve exact, non-semantic Agent Evolution lineage queries."""
+
+    def __init__(
+        self,
+        viking_fs: Optional[VikingFS] = None,
+        vikingdb: Optional[VikingDBManager] = None,
+    ):
+        self._viking_fs = viking_fs
+        self._vikingdb = vikingdb
+
+    def set_dependencies(self, *, viking_fs: VikingFS, vikingdb: VikingDBManager) -> None:
+        self._viking_fs = viking_fs
+        self._vikingdb = vikingdb
+
+    def _ensure_initialized(self) -> VikingFS:
+        if self._viking_fs is None:
+            raise NotInitializedError("VikingFS")
+        return self._viking_fs
+
+    async def list_trajectories_by_experience(
+        self,
+        *,
+        experience_uri: str,
+        ctx: RequestContext,
+        limit: int = DEFAULT_TRAJECTORY_PAGE_LIMIT,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List trajectories produced by commits that read an Experience."""
+        if limit < 1 or limit > MAX_TRAJECTORY_PAGE_LIMIT:
+            raise InvalidArgumentError(f"limit must be between 1 and {MAX_TRAJECTORY_PAGE_LIMIT}")
+        if offset < 0:
+            raise InvalidArgumentError("offset must be greater than or equal to 0")
+
+        canonical_uri = canonical_experience_uri(experience_uri, ctx)
+        if canonical_uri is None:
+            raise InvalidArgumentError(
+                "experience_uri must identify an Experience owned by the current user"
+            )
+
+        viking_fs = self._ensure_initialized()
+        stat = await viking_fs.stat(canonical_uri, ctx=ctx, skip_count=True)
+        if stat.get("isDir", False):
+            raise InvalidArgumentError("experience_uri must identify an Experience file")
+
+        if self._vikingdb is None:
+            raise NotInitializedError("VikingDB")
+
+        trajectory_root = canonicalize_uri(
+            f"viking://user/{ctx.user.user_id}/memories/trajectories",
+            ctx,
+        )
+        lineage_filter = And(
+            [
+                PathScope("uri", trajectory_root, depth=1),
+                Eq("context_type", "memory"),
+                Eq("level", 2),
+                Eq("search_tags", experience_source_tag(canonical_uri)),
+            ]
+        )
+        records, total = await asyncio.gather(
+            self._vikingdb.filter(
+                filter=lineage_filter,
+                limit=limit,
+                offset=offset,
+                output_fields=_TRAJECTORY_OUTPUT_FIELDS,
+                order_by="updated_at",
+                order_desc=True,
+                ctx=ctx,
+            ),
+            self._vikingdb.count(filter=lineage_filter, ctx=ctx),
+        )
+        items = [
+            {field: record.get(field) for field in _TRAJECTORY_OUTPUT_FIELDS if field in record}
+            for record in records
+        ]
+        return {
+            "experience_uri": canonical_uri,
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + len(items) < total,
+        }

--- a/openviking/service/agent_evolution_service.py
+++ b/openviking/service/agent_evolution_service.py
@@ -10,8 +10,10 @@ from typing import TYPE_CHECKING, Any, Optional
 from openviking.core.namespace import canonicalize_uri
 from openviking.server.identity import RequestContext
 from openviking.session.memory.experience_lineage import (
+    TRAJECTORY_OUTCOMES,
     canonical_experience_uri,
     experience_source_tag,
+    trajectory_outcome_tag,
 )
 from openviking.storage.expr import And, Eq, PathScope
 from openviking.storage.viking_fs import VikingFS
@@ -52,20 +54,12 @@ class AgentEvolutionService:
             raise NotInitializedError("VikingFS")
         return self._viking_fs
 
-    async def list_trajectories_by_experience(
+    async def _prepare_experience_query(
         self,
         *,
         experience_uri: str,
         ctx: RequestContext,
-        limit: int = DEFAULT_TRAJECTORY_PAGE_LIMIT,
-        offset: int = 0,
-    ) -> dict[str, Any]:
-        """List trajectories produced by commits that read an Experience."""
-        if limit < 1 or limit > MAX_TRAJECTORY_PAGE_LIMIT:
-            raise InvalidArgumentError(f"limit must be between 1 and {MAX_TRAJECTORY_PAGE_LIMIT}")
-        if offset < 0:
-            raise InvalidArgumentError("offset must be greater than or equal to 0")
-
+    ) -> tuple[str, str, VikingDBManager]:
         canonical_uri = canonical_experience_uri(experience_uri, ctx)
         if canonical_uri is None:
             raise InvalidArgumentError(
@@ -84,6 +78,26 @@ class AgentEvolutionService:
             f"viking://user/{ctx.user.user_id}/memories/trajectories",
             ctx,
         )
+        return canonical_uri, trajectory_root, self._vikingdb
+
+    async def list_trajectories_by_experience(
+        self,
+        *,
+        experience_uri: str,
+        ctx: RequestContext,
+        limit: int = DEFAULT_TRAJECTORY_PAGE_LIMIT,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List trajectories produced by commits that read an Experience."""
+        if limit < 1 or limit > MAX_TRAJECTORY_PAGE_LIMIT:
+            raise InvalidArgumentError(f"limit must be between 1 and {MAX_TRAJECTORY_PAGE_LIMIT}")
+        if offset < 0:
+            raise InvalidArgumentError("offset must be greater than or equal to 0")
+
+        canonical_uri, trajectory_root, vikingdb = await self._prepare_experience_query(
+            experience_uri=experience_uri,
+            ctx=ctx,
+        )
         lineage_filter = And(
             [
                 PathScope("uri", trajectory_root, depth=1),
@@ -93,7 +107,7 @@ class AgentEvolutionService:
             ]
         )
         records, total = await asyncio.gather(
-            self._vikingdb.filter(
+            vikingdb.filter(
                 filter=lineage_filter,
                 limit=limit,
                 offset=offset,
@@ -102,7 +116,7 @@ class AgentEvolutionService:
                 order_desc=True,
                 ctx=ctx,
             ),
-            self._vikingdb.count(filter=lineage_filter, ctx=ctx),
+            vikingdb.count(filter=lineage_filter, ctx=ctx),
         )
         items = [
             {field: record.get(field) for field in _TRAJECTORY_OUTPUT_FIELDS if field in record}
@@ -115,4 +129,43 @@ class AgentEvolutionService:
             "limit": limit,
             "offset": offset,
             "has_more": offset + len(items) < total,
+        }
+
+    async def get_experience_outcome_distribution(
+        self,
+        *,
+        experience_uri: str,
+        ctx: RequestContext,
+    ) -> dict[str, Any]:
+        """Count application trajectories by outcome for an Experience."""
+        canonical_uri, trajectory_root, vikingdb = await self._prepare_experience_query(
+            experience_uri=experience_uri,
+            ctx=ctx,
+        )
+        base_conditions = [
+            PathScope("uri", trajectory_root, depth=1),
+            Eq("context_type", "memory"),
+            Eq("level", 2),
+            Eq("search_tags", experience_source_tag(canonical_uri)),
+        ]
+        counts = await asyncio.gather(
+            *[
+                vikingdb.count(
+                    filter=And(
+                        [
+                            *base_conditions,
+                            Eq("search_tags", trajectory_outcome_tag(outcome)),
+                        ]
+                    ),
+                    ctx=ctx,
+                )
+                for outcome in TRAJECTORY_OUTCOMES
+            ]
+        )
+        return {
+            "experience_uri": canonical_uri,
+            "outcome_distribution": [
+                {"outcome": outcome, "count": count}
+                for outcome, count in zip(TRAJECTORY_OUTCOMES, counts, strict=True)
+            ],
         }

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -15,6 +15,7 @@ from openviking.core.namespace import canonicalize_uri
 from openviking.privacy import UserPrivacyConfigService
 from openviking.resource.watch_scheduler import WatchScheduler
 from openviking.server.identity import RequestContext, Role
+from openviking.service.agent_evolution_service import AgentEvolutionService
 from openviking.service.debug_service import DebugService
 from openviking.service.fs_service import FSService
 from openviking.service.pack_service import PackService
@@ -104,6 +105,7 @@ class OpenVikingService:
         self._resource_service = ResourceService()
         self._session_service = SessionService()
         self._debug_service = DebugService()
+        self._agent_evolution_service = AgentEvolutionService()
 
         # State
         self._initialized = False
@@ -277,6 +279,11 @@ class OpenVikingService:
         """Get DebugService instance."""
         return self._debug_service
 
+    @property
+    def agent_evolution(self) -> AgentEvolutionService:
+        """Get Agent Evolution query service."""
+        return self._agent_evolution_service
+
     async def initialize(self) -> None:
         """Initialize OpenViking storage and indexes."""
         if self._initialized:
@@ -402,6 +409,10 @@ class OpenVikingService:
             vikingdb=self._vikingdb_manager,
             config=self._config,
             agfs_client=self._agfs_client,
+        )
+        self._agent_evolution_service.set_dependencies(
+            vikingdb=self._vikingdb_manager,
+            viking_fs=self._viking_fs,
         )
 
         if self._queue_manager:

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -26,13 +26,13 @@ from openviking.service.search_service import SearchService
 from openviking.service.session_service import SessionService
 from openviking.service.task_tracker import get_task_tracker, set_task_tracker
 from openviking.session import create_session_compressor
-from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.collection_schemas import init_context_collection
 from openviking.storage.index_consistency import check_index_consistency
 from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor
 from openviking.storage.queuefs.queue_manager import QueueManager, init_queue_manager
 from openviking.storage.queuefs.session_commit_processor import SessionCommitProcessor
 from openviking.storage.viking_fs import VikingFS, init_viking_fs
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.utils.agfs_utils import (
     build_runtime_ragfs_binding_config,
     resolve_queuefs_mount_point,

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -692,12 +692,19 @@ class FSService:
         path: str,
         from_ref: Optional[str],
         to_ref: str,
+        raw: bool = True,
         ctx: RequestContext,
     ) -> Dict[str, Any]:
         """Return a unified text diff for one path between two snapshots."""
         viking_fs = self._ensure_initialized()
         path = validate_viking_uri(path, field_name="path")
-        return await viking_fs.diff(path=path, from_ref=from_ref, to_ref=to_ref, ctx=ctx)
+        return await viking_fs.diff(
+            path=path,
+            from_ref=from_ref,
+            to_ref=to_ref,
+            raw=raw,
+            ctx=ctx,
+        )
 
     async def log(
         self,

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -51,6 +51,7 @@ class SessionService:
         # server.agent_evolution during app setup.
         self._agent_evolution_enabled = True
         self._agent_evolution_config_provider: Optional[AgentEvolutionConfigProvider] = None
+        self._agent_evolution_config_path: Optional[str] = None
         self._usage_reporter: Optional["UsageReporter"] = None
 
     def set_dependencies(
@@ -63,6 +64,7 @@ class SessionService:
         self._vikingdb = vikingdb
         self._viking_fs = viking_fs
         self._session_compressor = session_compressor
+        self._configure_agent_evolution_provider()
 
     def set_tool_output_externalization_config(
         self, config: ToolOutputExternalizationConfig
@@ -71,27 +73,31 @@ class SessionService:
         self._tool_output_externalization_config = config.model_copy(deep=True)
 
     def set_agent_evolution_config(self, config: AgentEvolutionConfig) -> None:
-        """Set the instance-wide Agent Evolution switch."""
+        """Set the default used when an account has no persisted override."""
         self._agent_evolution_enabled = config.enabled
         if self._agent_evolution_config_provider is not None:
             self._agent_evolution_config_provider.set_default_enabled(config.enabled)
 
     def set_agent_evolution_config_path(self, config_path: Optional[str]) -> None:
-        """Enable live reload from the HTTP server's resolved ov.conf path."""
-        self._agent_evolution_config_provider = (
-            AgentEvolutionConfigProvider(
-                default_enabled=self._agent_evolution_enabled,
-                config_path=config_path,
-            )
-            if config_path
-            else None
+        """Enable account settings layered over the resolved ov.conf."""
+        self._agent_evolution_config_path = config_path
+        self._configure_agent_evolution_provider()
+
+    def _configure_agent_evolution_provider(self) -> None:
+        if self._viking_fs is None:
+            self._agent_evolution_config_provider = None
+            return
+        self._agent_evolution_config_provider = AgentEvolutionConfigProvider(
+            default_enabled=self._agent_evolution_enabled,
+            viking_fs=self._viking_fs,
+            config_path=self._agent_evolution_config_path,
         )
 
-    def get_agent_evolution_enabled(self) -> bool:
-        """Return the live instance-wide Agent Evolution switch."""
+    async def get_agent_evolution_enabled(self, account_id: str) -> bool:
+        """Return the effective Agent Evolution switch for one account."""
         if self._agent_evolution_config_provider is None:
             return self._agent_evolution_enabled
-        return self._agent_evolution_config_provider.is_enabled()
+        return await self._agent_evolution_config_provider.is_enabled(account_id)
 
     def set_usage_reporter(self, usage_reporter: Optional["UsageReporter"]) -> None:
         """Set the usage reporter for newly created sessions."""
@@ -157,8 +163,10 @@ class SessionService:
             session_id=session_id,
             session_uri=session_uri,
             tool_output_externalization_config=self._tool_output_externalization_config,
-            agent_evolution_enabled=self.get_agent_evolution_enabled(),
-            agent_evolution_enabled_provider=self.get_agent_evolution_enabled,
+            agent_evolution_enabled=self._agent_evolution_enabled,
+            agent_evolution_enabled_provider=lambda: self.get_agent_evolution_enabled(
+                ctx.account_id
+            ),
             usage_reporter=self._usage_reporter,
         )
 
@@ -401,7 +409,7 @@ class SessionService:
             session_id=session_id,
             ctx=ctx,
             archive_uri=archive_uri,
-            agent_evolution_enabled=self.get_agent_evolution_enabled(),
+            agent_evolution_enabled=await self.get_agent_evolution_enabled(ctx.account_id),
         )
         self._record_lifecycle_metric("extract", "ok")
         return memories

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -106,15 +106,15 @@ async def _commit_experience_snapshot(
     commit = getattr(viking_fs, "commit", None)
     if not callable(commit):
         return
-    has_experience_changes = any(
-        "/memories/experiences/" in uri and uri.endswith(".md")
+    paths = [
+        uri
         for uri in dict.fromkeys(str(uri or "") for uri in experience_uris)
-    )
-    if not has_experience_changes:
+        if "/memories/experiences/" in uri and uri.endswith(".md")
+    ]
+    if not paths:
         return
-    paths = [_experience_root_uri(ctx)]
     archive_ref = archive_uri.rstrip("/") if archive_uri else "unknown"
-    changed_experience_uris = set(dict.fromkeys(str(uri or "") for uri in experience_uris))
+    changed_experience_uris = set(paths)
     trajectory_map = {
         experience_uri: list(dict.fromkeys(trajectory_uris))
         for experience_uri, trajectory_uris in (experience_trajectory_map or {}).items()
@@ -898,6 +898,9 @@ class SessionCompressorV3:
                         *,
                         _fallback_trajectory_uris: set[str] = fallback_trajectory_uris,
                     ) -> None:
+                        persisted_result = (
+                            getattr(batch_result, "batch_result", None) or batch_result
+                        )
                         snapshot_apply_result, experience_trajectory_map = (
                             _experience_snapshot_provenance(
                                 batch_result,
@@ -907,10 +910,10 @@ class SessionCompressorV3:
                         await _commit_experience_snapshot(
                             viking_fs,
                             ctx=ctx,
-                            experience_uris=[
-                                *list(getattr(snapshot_apply_result, "written_uris", []) or []),
-                                *list(getattr(snapshot_apply_result, "deleted_uris", []) or []),
-                            ],
+                            experience_uris=_visible_experience_snapshot_uris(
+                                plan=persisted_result.plan,
+                                apply_result=snapshot_apply_result,
+                            ),
                             archive_uri=archive_uri,
                             experience_trajectory_map=experience_trajectory_map,
                         )
@@ -1764,6 +1767,42 @@ def _experience_trajectory_map(
             continue
         existing = result.setdefault(experience_uri, [])
         existing.extend(uri for uri in source_uris if uri not in existing)
+    return result
+
+
+def _visible_experience_snapshot_uris(
+    *,
+    plan: PolicyUpdatePlan,
+    apply_result: PolicyApplyResult,
+) -> list[str]:
+    """Return successfully applied Experience paths whose visible content changed."""
+    root_uri = getattr(getattr(apply_result, "updated_policy_set", None), "root_uri", "")
+    written_uris = set(getattr(apply_result, "written_uris", []) or [])
+    deleted_uris = set(getattr(apply_result, "deleted_uris", []) or [])
+    result: list[str] = []
+    seen: set[str] = set()
+
+    for item in getattr(plan, "items", []) or []:
+        if item.memory_type != _EXPERIENCES_MEMORY_TYPE:
+            continue
+        if item.before_content == item.after_content:
+            continue
+
+        uri = _experience_plan_item_uri(item, root_uri)
+        if not uri or uri in seen:
+            continue
+        if item.kind == "upsert":
+            applied = uri in written_uris
+        elif item.kind == "delete":
+            applied = uri in deleted_uris
+        else:
+            applied = False
+        if not applied:
+            continue
+
+        seen.add(uri)
+        result.append(uri)
+
     return result
 
 

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -92,6 +92,7 @@ _TRAINING_CASE_SPEC_PROTOCOL = "openviking.batch_train.case_spec.v1"
 _TRAINING_CASE_SPEC_HEADER = "# OpenViking Batch Training CaseSpec v1"
 _TRAINING_FAST_PATH_MEMORY_TYPES = frozenset({"cases", "trajectories", "experiences"})
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+_EXPERIENCE_TRAJECTORY_MAP_PREFIX = "OpenViking-Experience-Trajectory-Map: "
 
 
 async def _commit_experience_snapshot(
@@ -100,6 +101,7 @@ async def _commit_experience_snapshot(
     ctx: RequestContext,
     experience_uris: list[str],
     archive_uri: str = "",
+    experience_trajectory_map: Optional[dict[str, list[str]]] = None,
 ) -> None:
     commit = getattr(viking_fs, "commit", None)
     if not callable(commit):
@@ -112,9 +114,20 @@ async def _commit_experience_snapshot(
         return
     paths = [_experience_root_uri(ctx)]
     archive_ref = archive_uri.rstrip("/") if archive_uri else "unknown"
+    changed_experience_uris = set(dict.fromkeys(str(uri or "") for uri in experience_uris))
+    trajectory_map = {
+        experience_uri: list(dict.fromkeys(trajectory_uris))
+        for experience_uri, trajectory_uris in (experience_trajectory_map or {}).items()
+        if experience_uri in changed_experience_uris
+    }
+    message = (
+        f"Update experience memories from session commit {archive_ref}\n"
+        f"{_EXPERIENCE_TRAJECTORY_MAP_PREFIX}"
+        f"{json.dumps(trajectory_map, ensure_ascii=False, sort_keys=True, separators=(',', ':'))}"
+    )
     try:
         await commit(
-            message=f"Update experience memories from session commit {archive_ref}",
+            message=message,
             paths=paths,
             ctx=ctx,
         )
@@ -874,10 +887,39 @@ class SessionCompressorV3:
                     policy_set=exp_trainer.policy_set,
                 )
                 if exp_gradients:
+                    fallback_trajectory_uris = {
+                        uri
+                        for trajectory in analysis.trajectories
+                        if (uri := str(getattr(trajectory, "uri", "") or ""))
+                    }
+
+                    async def commit_experience_batch(
+                        batch_result: RolloutTrainingResult,
+                        *,
+                        _fallback_trajectory_uris: set[str] = fallback_trajectory_uris,
+                    ) -> None:
+                        snapshot_apply_result, experience_trajectory_map = (
+                            _experience_snapshot_provenance(
+                                batch_result,
+                                fallback_trajectory_uris=_fallback_trajectory_uris,
+                            )
+                        )
+                        await _commit_experience_snapshot(
+                            viking_fs,
+                            ctx=ctx,
+                            experience_uris=[
+                                *list(getattr(snapshot_apply_result, "written_uris", []) or []),
+                                *list(getattr(snapshot_apply_result, "deleted_uris", []) or []),
+                            ],
+                            archive_uri=archive_uri,
+                            experience_trajectory_map=experience_trajectory_map,
+                        )
+
                     exp_training_result = await exp_trainer.submit_gradients(
                         exp_gradients,
                         analysis=analysis,
                         rollout=rollout,
+                        batch_finalizer=commit_experience_batch,
                     )
                 if case_uri:
                     await self._link_case_to_training_outputs(
@@ -887,17 +929,6 @@ class SessionCompressorV3:
                         apply_result=exp_training_result.apply_result,
                         ctx=ctx,
                         viking_fs=viking_fs,
-                    )
-                exp_apply_result = getattr(exp_training_result, "apply_result", None)
-                if exp_apply_result is not None:
-                    await _commit_experience_snapshot(
-                        viking_fs,
-                        ctx=ctx,
-                        experience_uris=[
-                            *list(getattr(exp_apply_result, "written_uris", []) or []),
-                            *list(getattr(exp_apply_result, "deleted_uris", []) or []),
-                        ],
-                        archive_uri=archive_uri,
                     )
                 # Skill path: co-extracted skill gradients go directly to skill trainer
                 if skill_trainer is not None and analysis.gradients:
@@ -1685,6 +1716,15 @@ def _case_experience_links_via_trajectories(
 
 
 def _plan_item_has_source_trajectory(item: PolicyPlanItem, trajectory_uris: set[str]) -> bool:
+    return bool(_plan_item_source_trajectory_uris(item, trajectory_uris))
+
+
+def _plan_item_source_trajectory_uris(
+    item: PolicyPlanItem,
+    trajectory_uris: set[str],
+) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
     for link in getattr(item, "links", []) or []:
         try:
             stored = link if isinstance(link, StoredLink) else StoredLink(**dict(link))
@@ -1695,8 +1735,66 @@ def _plan_item_has_source_trajectory(item: PolicyPlanItem, trajectory_uris: set[
             and stored.to_uri in trajectory_uris
             and "/memories/trajectories/" in str(stored.to_uri or "")
         ):
-            return True
-    return False
+            uri = str(stored.to_uri)
+            if uri not in seen:
+                seen.add(uri)
+                result.append(uri)
+    return result
+
+
+def _experience_trajectory_map(
+    *,
+    plan: PolicyUpdatePlan,
+    apply_result: PolicyApplyResult,
+    trajectory_uris: set[str],
+) -> dict[str, list[str]]:
+    root_uri = getattr(getattr(apply_result, "updated_policy_set", None), "root_uri", "")
+    if not root_uri:
+        return {}
+    written_uris = set(getattr(apply_result, "written_uris", []) or [])
+    result: dict[str, list[str]] = {}
+    for item in getattr(plan, "items", []) or []:
+        if item.memory_type != "experiences" or item.kind != "upsert":
+            continue
+        experience_uri = _experience_plan_item_uri(item, root_uri)
+        if not experience_uri or experience_uri not in written_uris:
+            continue
+        source_uris = _plan_item_source_trajectory_uris(item, trajectory_uris)
+        if not source_uris:
+            continue
+        existing = result.setdefault(experience_uri, [])
+        existing.extend(uri for uri in source_uris if uri not in existing)
+    return result
+
+
+def _experience_snapshot_provenance(
+    training_result: Any,
+    *,
+    fallback_trajectory_uris: Optional[set[str]] = None,
+) -> tuple[PolicyApplyResult, dict[str, list[str]]]:
+    """Return provenance for the complete update that reached storage.
+
+    Concurrent submitters can share one streaming trainer flush. Their
+    top-level result is scoped to one submitter, while ``batch_result`` owns
+    the complete plan and apply result that were written atomically. Snapshot
+    history must describe that complete persisted update, regardless of which
+    waiter reaches the snapshot commit first.
+    """
+    persisted_result = getattr(training_result, "batch_result", None) or training_result
+    apply_result = persisted_result.apply_result
+    trajectory_uris = {
+        uri
+        for analysis in getattr(persisted_result, "analyses", []) or []
+        for trajectory in getattr(analysis, "trajectories", []) or []
+        if (uri := str(getattr(trajectory, "uri", "") or ""))
+    }
+    if not trajectory_uris:
+        trajectory_uris = set(fallback_trajectory_uris or set())
+    return apply_result, _experience_trajectory_map(
+        plan=persisted_result.plan,
+        apply_result=apply_result,
+        trajectory_uris=trajectory_uris,
+    )
 
 
 def _stored_link(

--- a/openviking/session/memory/experience_lineage.py
+++ b/openviking/session/memory/experience_lineage.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Experience-to-trajectory lineage helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from openviking.core.namespace import canonicalize_uri, uri_parts
+from openviking.message import Message, ToolPart
+from openviking.server.identity import RequestContext
+from openviking.utils.tags import normalize_search_tag
+
+_EXPERIENCE_SIDECAR_FILENAMES = {".abstract.md", ".overview.md", ".relations.json"}
+
+
+def is_experience_uri_for_user(uri: str, user_id: str) -> bool:
+    """Return whether ``uri`` identifies an Experience owned by ``user_id``."""
+    if not uri or "?" in uri or "#" in uri:
+        return False
+    parts = uri_parts(uri)
+    if len(parts) < 5 or parts[:4] != ["user", user_id, "memories", "experiences"]:
+        return False
+    relative_parts = parts[4:]
+    if any(not segment or segment in {".", ".."} for segment in relative_parts):
+        return False
+    return relative_parts[-1] not in _EXPERIENCE_SIDECAR_FILENAMES
+
+
+def canonical_experience_uri(uri: str, ctx: RequestContext) -> str | None:
+    """Canonicalize an Experience URI and enforce current-user ownership."""
+    try:
+        canonical_uri = canonicalize_uri(str(uri or "").strip(), ctx)
+    except (TypeError, ValueError):
+        return None
+    if not is_experience_uri_for_user(canonical_uri, ctx.user.user_id):
+        return None
+    return canonical_uri
+
+
+def experience_source_tag(experience_uri: str) -> str:
+    """Build the exact retrieval tag used for Experience lineage filtering."""
+    uri_key = _escape_search_tag_key(str(experience_uri or "").strip())
+    return normalize_search_tag(f"{uri_key}=1")
+
+
+def _escape_search_tag_key(value: str) -> str:
+    """Preserve URI identity through lowercase-only strict k=v tag normalization."""
+    escaped: list[str] = []
+    for character in value:
+        if character in {"%", "="} or character.lower() != character:
+            escaped.extend(f"%{byte:02x}" for byte in character.encode("utf-8"))
+        else:
+            escaped.append(character)
+    return "".join(escaped)
+
+
+def experience_source_tags(experience_uris: Iterable[str] | None) -> list[str]:
+    """Build stable, de-duplicated lineage tags for Experience URIs."""
+    if isinstance(experience_uris, str):
+        experience_uris = [experience_uris]
+    tags: list[str] = []
+    seen: set[str] = set()
+    for uri in experience_uris or []:
+        normalized = str(uri or "").strip()
+        if not normalized:
+            continue
+        tag = experience_source_tag(normalized)
+        if tag in seen:
+            continue
+        seen.add(tag)
+        tags.append(tag)
+    return tags
+
+
+def collect_read_experience_uris(
+    messages: Iterable[Message] | None,
+    *,
+    ctx: RequestContext,
+) -> list[str]:
+    """Collect Experiences successfully read in a committed session message set."""
+    message_list = list(messages or [])
+    tool_inputs: dict[tuple[str, str], dict[str, Any]] = {}
+    for message in message_list:
+        for part in message.parts:
+            if (
+                isinstance(part, ToolPart)
+                and part.tool_id
+                and isinstance(part.tool_input, dict)
+                and part.tool_input
+            ):
+                tool_inputs[(part.tool_id, part.tool_name)] = part.tool_input
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for message in message_list:
+        for part in message.parts:
+            if not isinstance(part, ToolPart):
+                continue
+            if part.tool_name != "read_experience" or part.tool_status != "completed":
+                continue
+            tool_input = part.tool_input if isinstance(part.tool_input, dict) else {}
+            if not tool_input and part.tool_id:
+                tool_input = tool_inputs.get((part.tool_id, part.tool_name), {})
+            output = _load_mapping(part.tool_output)
+            uri = tool_input.get("uri") or output.get("uri")
+            canonical_uri = canonical_experience_uri(str(uri or ""), ctx)
+            if not canonical_uri or canonical_uri in seen:
+                continue
+            seen.add(canonical_uri)
+            result.append(canonical_uri)
+    return result
+
+
+def _load_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}

--- a/openviking/session/memory/experience_lineage.py
+++ b/openviking/session/memory/experience_lineage.py
@@ -13,6 +13,7 @@ from openviking.server.identity import RequestContext
 from openviking.utils.tags import normalize_search_tag
 
 _EXPERIENCE_SIDECAR_FILENAMES = {".abstract.md", ".overview.md", ".relations.json"}
+TRAJECTORY_OUTCOMES = ("success", "failure", "partial", "unknown", "unfinished")
 
 
 def is_experience_uri_for_user(uri: str, user_id: str) -> bool:
@@ -72,6 +73,19 @@ def experience_source_tags(experience_uris: Iterable[str] | None) -> list[str]:
         seen.add(tag)
         tags.append(tag)
     return tags
+
+
+def normalize_trajectory_outcome(outcome: Any) -> str:
+    """Normalize trajectory outcome values used by scalar lineage aggregation."""
+    normalized = str(outcome or "").strip().lower()
+    if normalized not in TRAJECTORY_OUTCOMES:
+        return "unknown"
+    return normalized
+
+
+def trajectory_outcome_tag(outcome: Any) -> str:
+    """Build the exact scalar tag used for trajectory outcome aggregation."""
+    return normalize_search_tag(f"trajectory_outcome={normalize_trajectory_outcome(outcome)}")
 
 
 def collect_read_experience_uris(

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -806,6 +806,7 @@ class MemoryUpdater:
         ctx: RequestContext,
         extract_context: ExtractContext = None,
         isolation_handler: MemoryIsolationHandler = None,
+        search_tags_by_uri: Dict[str, List[str]] = None,
     ) -> MemoryUpdateResult:
         result = MemoryUpdateResult()
         viking_fs = self._get_viking_fs()
@@ -925,6 +926,7 @@ class MemoryUpdater:
             ctx,
             extract_context=extract_context,
             uri_memory_type_map=uri_memory_type_map,
+            search_tags_by_uri=search_tags_by_uri,
         )
 
         # Apply links to endpoint files not covered by upsert_operations
@@ -1291,6 +1293,7 @@ class MemoryUpdater:
         ctx: RequestContext,
         extract_context: Any = None,
         uri_memory_type_map: Dict[str, str] = None,
+        search_tags_by_uri: Dict[str, List[str]] = None,
     ) -> int:
         """Vectorize written and edited memory files.
 
@@ -1299,12 +1302,14 @@ class MemoryUpdater:
             ctx: Request context
             extract_context: Extract context for embedding template rendering
             uri_memory_type_map: Mapping from URI to memory_type
+            search_tags_by_uri: Transient search tags to attach while indexing each URI
         """
         if not self._vikingdb:
             logger.debug("VikingDB not available, skipping vectorization")
             return 0
 
         uri_memory_type_map = uri_memory_type_map or {}
+        search_tags_by_uri = search_tags_by_uri or {}
         viking_fs = self._get_viking_fs()
         request_wait_tracker = get_request_wait_tracker()
         attempted_count = 0
@@ -1385,6 +1390,12 @@ class MemoryUpdater:
                 # Convert to embedding msg and enqueue
                 embedding_msg = EmbeddingMsgConverter.from_context(memory_context)
                 if embedding_msg:
+                    transient_tags = search_tags_by_uri.get(uri)
+                    if transient_tags:
+                        embedding_msg.context_data["search_tags"] = list(transient_tags)
+                        embedding_msg.context_data["_upsert_options"] = {
+                            "search_tag_mode": "append"
+                        }
                     if embedding_msg.telemetry_id:
                         request_wait_tracker.register_embedding_root(
                             embedding_msg.telemetry_id, embedding_msg.id

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -6,6 +6,7 @@ Session as Context: Sessions integrated into L0/L1/L2 system.
 """
 
 import asyncio
+import inspect
 import json
 import re
 from dataclasses import dataclass, field
@@ -559,7 +560,7 @@ class Session:
         tool_output_externalization_config: Optional[ToolOutputExternalizationConfig] = None,
         agent_evolution_enabled: bool = True,
         usage_reporter: Optional["UsageReporter"] = None,
-        agent_evolution_enabled_provider: Optional[Callable[[], bool]] = None,
+        agent_evolution_enabled_provider: Optional[Callable[[], bool | Awaitable[bool]]] = None,
     ):
         self._viking_fs = viking_fs
         self._vikingdb_manager = vikingdb_manager
@@ -1736,11 +1737,14 @@ class Session:
             memory_policy if memory_policy is not None else self._meta.memory_policy
         )
         _validate_memory_policy_types(effective_policy)
-        agent_evolution_enabled = (
-            self._agent_evolution_enabled_provider()
-            if self._agent_evolution_enabled_provider is not None
-            else self._agent_evolution_enabled
-        )
+        agent_evolution_enabled = self._agent_evolution_enabled
+        if self._agent_evolution_enabled_provider is not None:
+            provided_enabled = self._agent_evolution_enabled_provider()
+            agent_evolution_enabled = (
+                await provided_enabled
+                if inspect.isawaitable(provided_enabled)
+                else provided_enabled
+            )
         effective_policy = _apply_agent_evolution_setting(
             effective_policy,
             agent_evolution_enabled=agent_evolution_enabled,

--- a/openviking/session/train/components/policy_trainer.py
+++ b/openviking/session/train/components/policy_trainer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, Hashable
 
@@ -250,6 +251,7 @@ class StreamingPolicyTrainer:
         *,
         analysis: RolloutAnalysis | None = None,
         rollout: Rollout | None = None,
+        batch_finalizer: Callable[[RolloutTrainingResult], Awaitable[None]] | None = None,
     ) -> RolloutTrainingResult | ScopedRolloutTrainingResult:
         """Submit pre-computed gradients directly to the streaming trainer.
 
@@ -283,6 +285,7 @@ class StreamingPolicyTrainer:
             gradients=list(gradients),
             analysis=analysis,
             rollout=rollout,
+            batch_finalizer=batch_finalizer,
         )
         result = await self._batcher.submit(buffered)
         self._last_apply_result = result.apply_result
@@ -376,6 +379,16 @@ class StreamingPolicyTrainer:
                 "flush_reason": reason,
             },
         )
+        # Finalize the persisted batch before StreamingBatcher releases its
+        # flush lock and starts another batch. All submitters in this flush
+        # share the same complete result, so one finalizer is sufficient.
+        # This keeps snapshot creation ordered with the writes it describes.
+        batch_finalizer = next(
+            (item.batch_finalizer for item in items if item.batch_finalizer is not None),
+            None,
+        )
+        if batch_finalizer is not None:
+            await batch_finalizer(result)
         tracer.info(
             "StreamingPolicyTrainer flush finished "
             f"reason={reason} "
@@ -594,6 +607,7 @@ class _BufferedRolloutTraining:
     gradients: list[SemanticGradient]
     analysis: RolloutAnalysis | None = None
     rollout: Rollout | None = None
+    batch_finalizer: Callable[[RolloutTrainingResult], Awaitable[None]] | None = None
 
 
 @dataclass(slots=True)

--- a/openviking/session/train/components/trajectory_analyzer.py
+++ b/openviking/session/train/components/trajectory_analyzer.py
@@ -19,6 +19,10 @@ from openviking.session.memory.dataclass import (
     ResolvedOperations,
     StoredLink,
 )
+from openviking.session.memory.experience_lineage import (
+    collect_read_experience_uris,
+    experience_source_tags,
+)
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import ExtractContext, MemoryUpdateResult
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
@@ -164,6 +168,7 @@ class TrajectoryRolloutAnalyzer:
             include_trajectories=include_trajectories,
             include_session_skills=include_session_skills,
         )
+        consumed_experience_uris = collect_read_experience_uris(messages, ctx=ctx)
         phase_result = await self._run_trajectory_extract_phase(
             provider=provider,
             messages=messages,
@@ -173,6 +178,7 @@ class TrajectoryRolloutAnalyzer:
             include_session_skills=include_session_skills,
             case_name=case_name,
             source_archive_uri=source_archive_uri,
+            consumed_experience_uris=consumed_experience_uris,
         )
         if phase_result is None:
             return empty_result
@@ -191,6 +197,7 @@ class TrajectoryRolloutAnalyzer:
         include_session_skills: bool = False,
         case_name: str = "",
         source_archive_uri: str = "",
+        consumed_experience_uris: list[str] | None = None,
     ) -> tuple[list[str], list[str], list[Context], list[PatchSemanticGradient]] | None:
         config = get_openviking_config()
         vlm = self.vlm or config.vlm.get_vlm_instance()
@@ -257,6 +264,7 @@ class TrajectoryRolloutAnalyzer:
                     ctx=ctx,
                     extract_context=extract_context,
                     isolation_handler=isolation_handler,
+                    consumed_experience_uris=consumed_experience_uris,
                 )
             tracer.info(
                 "[trajectory] Applied memory ops: "
@@ -286,6 +294,7 @@ class TrajectoryRolloutAnalyzer:
         ctx: RequestContext,
         extract_context: ExtractContext,
         isolation_handler: MemoryIsolationHandler,
+        consumed_experience_uris: list[str] | None = None,
     ) -> MemoryUpdateResult:
         updater = MemoryUpdater(
             registry=provider._get_registry(),
@@ -298,6 +307,10 @@ class TrajectoryRolloutAnalyzer:
             ctx,
             extract_context=extract_context,
             isolation_handler=isolation_handler,
+            search_tags_by_uri=_trajectory_search_tags_by_uri(
+                operations,
+                consumed_experience_uris,
+            ),
         )
 
     @tracer(
@@ -408,6 +421,23 @@ def _apply_trajectory_source_archive_uri(
         if not isinstance(fields, dict):
             continue
         fields["source_archive_uri"] = source_archive_uri
+
+
+def _trajectory_search_tags_by_uri(
+    operations: ResolvedOperations,
+    consumed_experience_uris: list[str] | None,
+) -> dict[str, list[str]]:
+    tags = experience_source_tags(consumed_experience_uris)
+    if not tags:
+        return {}
+    result: dict[str, list[str]] = {}
+    for op in getattr(operations, "upsert_operations", []) or []:
+        if getattr(op, "memory_type", None) != _TRAJECTORY_MEMORY_TYPE:
+            continue
+        for uri in getattr(op, "uris", []) or []:
+            if uri:
+                result[uri] = list(tags)
+    return result
 
 
 def _messages_with_evaluation_feedback(

--- a/openviking/session/train/components/trajectory_analyzer.py
+++ b/openviking/session/train/components/trajectory_analyzer.py
@@ -22,6 +22,7 @@ from openviking.session.memory.dataclass import (
 from openviking.session.memory.experience_lineage import (
     collect_read_experience_uris,
     experience_source_tags,
+    trajectory_outcome_tag,
 )
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import ExtractContext, MemoryUpdateResult
@@ -427,13 +428,14 @@ def _trajectory_search_tags_by_uri(
     operations: ResolvedOperations,
     consumed_experience_uris: list[str] | None,
 ) -> dict[str, list[str]]:
-    tags = experience_source_tags(consumed_experience_uris)
-    if not tags:
-        return {}
+    source_tags = experience_source_tags(consumed_experience_uris)
     result: dict[str, list[str]] = {}
     for op in getattr(operations, "upsert_operations", []) or []:
         if getattr(op, "memory_type", None) != _TRAJECTORY_MEMORY_TYPE:
             continue
+        fields = getattr(op, "memory_fields", None)
+        outcome = fields.get("outcome") if isinstance(fields, dict) else None
+        tags = [*source_tags, trajectory_outcome_tag(outcome)]
         for uri in getattr(op, "uris", []) or []:
             if uri:
                 result[uri] = list(tags)

--- a/openviking/storage/vectordb_adapters/base.py
+++ b/openviking/storage/vectordb_adapters/base.py
@@ -77,6 +77,13 @@ def _normalize_collection_names(raw_collections: Iterable[Any]) -> list[str]:
     return names
 
 
+def _normalize_result_score(value: Any) -> float:
+    """Return a finite numeric score; scalar sort values may be strings or datetimes."""
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return float(value)
+    return 0.0
+
+
 class CollectionAdapter(ABC):
     """Backend-specific adapter for single-collection operations.
 
@@ -512,10 +519,7 @@ class CollectionAdapter(ABC):
         for item in result.data:
             record = dict(item.fields) if item.fields else {}
             record["id"] = item.id
-            raw_score = item.score if item.score is not None else 0.0
-            if not math.isfinite(raw_score):
-                raw_score = 0.0
-            record["_score"] = raw_score
+            record["_score"] = _normalize_result_score(item.score)
             record = self._normalize_record_for_read(record)
             records.append(record)
         return records

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -4195,6 +4195,7 @@ class VikingFS:
         path: str,
         from_ref: Optional[str],
         to_ref: str,
+        raw: bool = True,
         ctx: Optional[RequestContext] = None,
     ) -> Dict[str, Any]:
         """Return a unified text diff for one path between two snapshots."""
@@ -4247,6 +4248,21 @@ class VikingFS:
                     f"snapshot diff file size limit exceeded ({SNAPSHOT_DIFF_MAX_FILE_BYTES} bytes)",
                     details={"limit_bytes": SNAPSHOT_DIFF_MAX_FILE_BYTES, "path": path},
                 )
+
+        if not raw:
+            from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+
+            def visible_content(value: Optional[bytes]) -> Optional[bytes]:
+                if value is None:
+                    return None
+                try:
+                    text = value.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise InvalidArgumentError("raw=false requires UTF-8 snapshot content") from exc
+                return MemoryFileUtils.read(text, uri=path).content.encode("utf-8")
+
+            before_bytes = visible_content(before_bytes)
+            after_bytes = visible_content(after_bytes)
 
         change_type, before, after = await asyncio.to_thread(
             _prepare_snapshot_diff,

--- a/tests/server/test_agent_evolution_global_setting.py
+++ b/tests/server/test_agent_evolution_global_setting.py
@@ -6,52 +6,114 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
+import pytest
+import pytest_asyncio
 
+from openviking.pyagfs import AGFSNotFoundError
+from openviking.server.account_settings import (
+    AccountAgentEvolutionSettings,
+    AccountSettingsPatch,
+    account_settings_backup_path,
+    account_settings_path,
+    read_account_settings,
+    update_account_settings,
+)
 from openviking.server.agent_evolution_config import AgentEvolutionConfigProvider
 from openviking.server.app import create_app
+from openviking.server.auth.plugins import DevAuthPlugin
 from openviking.server.config import AgentEvolutionConfig, ServerConfig, UserConfig
+from openviking.server.dependencies import set_service
 from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
 from openviking.session import Session
 from openviking_cli.session.user_id import UserIdentifier
-from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
+
+
+class _FakeAGFS:
+    def __init__(self):
+        self.files: dict[str, bytes] = {}
+
+    def read(self, path, ctx=None):
+        del ctx
+        if path not in self.files:
+            raise AGFSNotFoundError(path)
+        return self.files[path]
+
+    def write(self, path, data, ctx=None):
+        del ctx
+        self.files[path] = bytes(data)
+        return path
+
+    def ensure_parent_dirs(self, path, ctx=None):
+        del path
+        del ctx
+        return {}
+
+    def rm(self, path, ctx=None):
+        del ctx
+        self.files.pop(path, None)
+        return {}
+
+    def pathlock_acquire_exact(self, ctx, path, timeout_secs, owner_lease_ref):
+        del ctx
+        del path
+        del timeout_secs
+        del owner_lease_ref
+        return {"lease_ref": "test-lease"}
+
+    def pathlock_release(self, ctx, lease):
+        del ctx
+        del lease
+
+
+@pytest.fixture
+def fake_viking_fs():
+    return SimpleNamespace(agfs=_FakeAGFS())
+
+
+@pytest_asyncio.fixture
+async def settings_http(fake_viking_fs):
+    sessions = SessionService(viking_fs=fake_viking_fs)
+    service = SimpleNamespace(sessions=sessions, viking_fs=fake_viking_fs)
+    app = create_app(config=ServerConfig(), service=service)
+    set_service(service)
+    app.state.auth_plugin = DevAuthPlugin()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client, service
+
+
+def _patch(enabled: bool) -> AccountSettingsPatch:
+    return AccountSettingsPatch(agent_evolution=AccountAgentEvolutionSettings(enabled=enabled))
 
 
 def test_agent_evolution_is_disabled_by_default():
     assert ServerConfig().agent_evolution.enabled is False
 
 
-def test_agent_evolution_can_be_enabled_for_the_server():
+def test_agent_evolution_can_be_enabled_as_account_default():
     config = ServerConfig.model_validate({"agent_evolution": {"enabled": True}})
 
     assert config.agent_evolution.enabled is True
 
 
-def test_embedded_session_service_preserves_agent_evolution_default(
-    tmp_path,
-    monkeypatch,
-):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
-
+async def test_embedded_session_service_preserves_agent_evolution_default():
     service = SessionService()
 
-    assert service.get_agent_evolution_enabled() is True
+    assert await service.get_agent_evolution_enabled("default") is True
 
 
-def test_existing_session_observes_updated_runtime_value():
-    service = SessionService(viking_fs=object())
+async def test_existing_session_observes_updated_account_value(fake_viking_fs):
+    service = SessionService(viking_fs=fake_viking_fs)
+    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+    service.set_agent_evolution_config_path(None)
     session = service.session(
         RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
     )
 
-    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
 
-    assert session._agent_evolution_enabled_provider() is False
+    assert await session._agent_evolution_enabled_provider() is True
 
 
 def test_session_positional_usage_reporter_remains_compatible():
@@ -75,7 +137,7 @@ def test_session_positional_usage_reporter_remains_compatible():
     assert session._agent_evolution_enabled_provider is None
 
 
-def test_agent_evolution_provider_reloads_config_file(tmp_path):
+async def test_provider_reloads_ov_conf_and_account_override(fake_viking_fs, tmp_path):
     config_path = tmp_path / "ov.conf"
     config_path.write_text(
         json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
@@ -83,134 +145,101 @@ def test_agent_evolution_provider_reloads_config_file(tmp_path):
     )
     provider = AgentEvolutionConfigProvider(
         default_enabled=True,
+        viking_fs=fake_viking_fs,
         config_path=config_path,
     )
 
-    assert provider.is_enabled() is False
+    assert await provider.is_enabled("default") is False
 
     config_path.write_text(
         json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
         encoding="utf-8",
     )
+    assert await provider.is_enabled("default") is True
 
-    assert provider.is_enabled() is True
-
-
-def test_session_service_reloads_from_resolved_server_config_path(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    service = SessionService()
-    service.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-    service.set_agent_evolution_config_path(str(config_path))
-
-    assert service.get_agent_evolution_enabled() is False
+    await update_account_settings(fake_viking_fs, "default", _patch(False))
+    assert await provider.is_enabled("default") is False
 
 
-def test_http_app_wires_resolved_server_config_path(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": False}}}),
-        encoding="utf-8",
-    )
-    sessions = SessionService()
-
-    create_app(
-        config=ServerConfig(agent_evolution=AgentEvolutionConfig(enabled=True)),
-        service=SimpleNamespace(sessions=sessions),
-        config_path=str(config_path),
-    )
-
-    assert sessions.get_agent_evolution_enabled() is False
-
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-
-    assert sessions.get_agent_evolution_enabled() is True
-
-
-def test_agent_evolution_provider_applies_missing_section_default(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
+async def test_account_overrides_are_isolated(fake_viking_fs):
     provider = AgentEvolutionConfigProvider(
         default_enabled=False,
-        config_path=config_path,
+        viking_fs=fake_viking_fs,
     )
-    assert provider.is_enabled() is True
+    await update_account_settings(fake_viking_fs, "account-a", _patch(True))
 
-    config_path.write_text(json.dumps({"server": {}}), encoding="utf-8")
+    assert await provider.is_enabled("account-a") is True
+    assert await provider.is_enabled("account-b") is False
 
-    assert provider.is_enabled() is False
+
+async def test_account_settings_update_backs_up_previous_file(fake_viking_fs):
+    await update_account_settings(fake_viking_fs, "default", _patch(False))
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
+
+    current = fake_viking_fs.agfs.files[account_settings_path("default")]
+    backup = fake_viking_fs.agfs.files[account_settings_backup_path("default")]
+    current_payload = json.loads(current.decode("utf-8"))
+    backup_payload = json.loads(backup.decode("utf-8"))
+
+    assert current_payload["agent_evolution"]["enabled"] is True
+    assert backup_payload["agent_evolution"]["enabled"] is False
 
 
-def test_agent_evolution_provider_uses_standard_config_loading(tmp_path, monkeypatch):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        '\ufeff{"server": {"agent_evolution": {"enabled": ${AGENT_EVOLUTION_ENABLED}}}}',
-        encoding="utf-8",
+async def test_account_settings_admin_api_reads_and_updates_effective_value(
+    settings_http,
+):
+    client, service = settings_http
+    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=False))
+
+    initial = await client.get("/api/v1/admin/accounts/default/settings")
+    assert initial.status_code == 200, initial.text
+    assert initial.json()["result"] == {
+        "account_id": "default",
+        "settings": {"agent_evolution": {"enabled": False}},
+        "overrides": {},
+    }
+
+    updated = await client.patch(
+        "/api/v1/admin/accounts/default/settings",
+        json={"agent_evolution": {"enabled": True}},
     )
-    monkeypatch.setenv("AGENT_EVOLUTION_ENABLED", "true")
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-
-    assert provider.is_enabled() is True
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["result"]["settings"]["agent_evolution"]["enabled"] is True
+    assert updated.json()["result"]["overrides"] == {"agent_evolution": {"enabled": True}}
+    assert (await read_account_settings(service.viking_fs, "default")).agent_evolution.enabled
 
 
-def test_agent_evolution_provider_keeps_last_valid_value(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-    assert provider.is_enabled() is True
-
-    config_path.write_text("{", encoding="utf-8")
-
-    assert provider.is_enabled() is True
-
-    config_path.write_text("[]", encoding="utf-8")
-
-    assert provider.is_enabled() is True
-
-
-def test_agent_evolution_provider_rejects_invalid_unrelated_server_config(tmp_path):
-    config_path = tmp_path / "ov.conf"
-    config_path.write_text(
-        json.dumps({"server": {"agent_evolution": {"enabled": True}}}),
-        encoding="utf-8",
-    )
-    provider = AgentEvolutionConfigProvider(
-        default_enabled=False,
-        config_path=config_path,
-    )
-    assert provider.is_enabled() is True
-
-    config_path.write_text(
-        json.dumps(
-            {
-                "server": {
-                    "port": "not-an-integer",
-                    "agent_evolution": {"enabled": False},
-                }
-            }
-        ),
-        encoding="utf-8",
+async def test_account_settings_admin_api_rejects_non_allowlisted_fields(
+    settings_http,
+):
+    client, _ = settings_http
+    response = await client.patch(
+        "/api/v1/admin/accounts/default/settings",
+        json={"root_api_key": "not-allowed"},
     )
 
-    assert provider.is_enabled() is True
+    assert response.status_code == 400
+
+
+async def test_agent_evolution_endpoint_keeps_name_and_uses_account_settings(
+    settings_http,
+):
+    client, service = settings_http
+    updated = await client.put(
+        "/api/v1/admin/agent-evolution",
+        json={"enabled": True},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["result"] == {
+        "enabled": True,
+        "account_id": "default",
+    }
+
+    response = await client.get("/api/v1/admin/agent-evolution")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["result"]["enabled"] is True
+    assert (await read_account_settings(service.viking_fs, "default")).agent_evolution.enabled
 
 
 def test_deprecated_user_agent_evolution_config_is_not_persisted():
@@ -220,67 +249,21 @@ def test_deprecated_user_agent_evolution_config_is_not_persisted():
     assert "agent_evolution" not in config.model_dump(exclude_none=True)
 
 
-async def test_agent_evolution_user_endpoint_is_not_registered(
-    client: httpx.AsyncClient,
-):
-    response = await client.get("/api/v1/user-settings/memory")
-
-    assert response.status_code == 404
-
-
-async def test_agent_evolution_admin_endpoint_returns_runtime_value(
-    service,
-    client: httpx.AsyncClient,
-):
-    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-
-    response = await client.get("/api/v1/admin/agent-evolution")
-
-    assert response.status_code == 200, response.text
-    assert response.json()["result"] == {
-        "enabled": True,
-        "account_id": "default",
-    }
-
-
-async def test_manual_extract_respects_disabled_agent_evolution(
-    service,
-    client: httpx.AsyncClient,
-):
-    create_response = await client.post("/api/v1/sessions", json={})
-    session_id = create_response.json()["result"]["session_id"]
-    add_response = await client.post(
-        f"/api/v1/sessions/{session_id}/messages",
-        json={"role": "user", "content": "请处理一次换货任务"},
-    )
-    assert add_response.status_code == 200, add_response.text
-
+async def test_manual_extract_respects_account_setting(fake_viking_fs):
     extract = AsyncMock(return_value=[])
-    service.sessions._session_compressor.extract_long_term_memories = extract
-
-    response = await client.post(f"/api/v1/sessions/{session_id}/extract")
-
-    assert response.status_code == 200, response.text
-    assert extract.await_args.kwargs["agent_evolution_enabled"] is False
-
-
-async def test_manual_extract_respects_enabled_agent_evolution(
-    service,
-    client: httpx.AsyncClient,
-):
-    service.sessions.set_agent_evolution_config(AgentEvolutionConfig(enabled=True))
-    create_response = await client.post("/api/v1/sessions", json={})
-    session_id = create_response.json()["result"]["session_id"]
-    add_response = await client.post(
-        f"/api/v1/sessions/{session_id}/messages",
-        json={"role": "user", "content": "请处理一次换货任务"},
+    compressor = SimpleNamespace(extract_long_term_memories=extract)
+    service = SessionService(
+        viking_fs=fake_viking_fs,
+        session_compressor=compressor,
     )
-    assert add_response.status_code == 200, add_response.text
+    session = SimpleNamespace(
+        uri="viking://user/default/sessions/test-session",
+        messages=[],
+    )
+    service.get = AsyncMock(return_value=session)
+    await update_account_settings(fake_viking_fs, "default", _patch(True))
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
 
-    extract = AsyncMock(return_value=[])
-    service.sessions._session_compressor.extract_long_term_memories = extract
+    await service.extract("test-session", ctx)
 
-    response = await client.post(f"/api/v1/sessions/{session_id}/extract")
-
-    assert response.status_code == 200, response.text
     assert extract.await_args.kwargs["agent_evolution_enabled"] is True

--- a/tests/server/test_api_agent_evolution.py
+++ b/tests/server/test_api_agent_evolution.py
@@ -58,3 +58,37 @@ async def test_list_experience_trajectories_rejects_limit_above_1000(
     )
 
     assert response.status_code == 400
+
+
+async def test_get_experience_outcome_distribution(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    captured = {}
+
+    async def fake_get(*, experience_uri, ctx):
+        captured.update(experience_uri=experience_uri, ctx=ctx)
+        return {
+            "experience_uri": experience_uri,
+            "outcome_distribution": [{"outcome": "success", "count": 2}],
+        }
+
+    monkeypatch.setattr(
+        service.agent_evolution,
+        "get_experience_outcome_distribution",
+        fake_get,
+    )
+    uri = "viking://user/default/memories/experiences/exchange.md"
+
+    response = await client.get(
+        "/api/v1/agent-evolution/experiences/outcomes",
+        params={"experience_uri": uri},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {
+        "experience_uri": uri,
+        "outcome_distribution": [{"outcome": "success", "count": 2}],
+    }
+    assert captured["experience_uri"] == uri

--- a/tests/server/test_api_agent_evolution.py
+++ b/tests/server/test_api_agent_evolution.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import httpx
+
+
+async def test_list_experience_trajectories_uses_default_pagination(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    captured = {}
+
+    async def fake_list(*, experience_uri, ctx, limit, offset):
+        captured.update(
+            experience_uri=experience_uri,
+            ctx=ctx,
+            limit=limit,
+            offset=offset,
+        )
+        return {
+            "experience_uri": experience_uri,
+            "items": [],
+            "total": 0,
+            "limit": limit,
+            "offset": offset,
+            "has_more": False,
+        }
+
+    monkeypatch.setattr(
+        service.agent_evolution,
+        "list_trajectories_by_experience",
+        fake_list,
+    )
+    uri = "viking://user/default/memories/experiences/exchange.md"
+
+    response = await client.get(
+        "/api/v1/agent-evolution/experiences/trajectories",
+        params={"experience_uri": uri},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["limit"] == 50
+    assert captured["experience_uri"] == uri
+    assert captured["limit"] == 50
+    assert captured["offset"] == 0
+
+
+async def test_list_experience_trajectories_rejects_limit_above_1000(
+    client: httpx.AsyncClient,
+):
+    response = await client.get(
+        "/api/v1/agent-evolution/experiences/trajectories",
+        params={
+            "experience_uri": "viking://user/default/memories/experiences/exchange.md",
+            "limit": 1001,
+        },
+    )
+
+    assert response.status_code == 400

--- a/tests/server/test_api_snapshot.py
+++ b/tests/server/test_api_snapshot.py
@@ -9,8 +9,8 @@ import httpx
 import pytest
 import pytest_asyncio
 
-from openviking.server.auth import get_request_context
 from openviking.server.app import create_app
+from openviking.server.auth import get_request_context
 from openviking.server.config import ServerConfig
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.exceptions import InvalidArgumentError, InvalidURIError
@@ -536,9 +536,9 @@ async def test_restore_apply_triggers_reindex_hook(client_with_resource_and_blob
     """Verify the HTTP restore path actually invokes the vector-reindex
     scheduler — protects the chain router -> viking_fs.restore -> _schedule_vector_rebuild.
     """
+    import openviking.service.reindex_executor as reindex_mod
     from openviking.server.identity import RequestContext, Role
     from openviking_cli.session.user_id import UserIdentifier
-    import openviking.service.reindex_executor as reindex_mod
 
     client, c1_oid, blob_uri, _v1 = client_with_resource_and_blob
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
@@ -583,9 +583,9 @@ async def test_restore_delete_removes_orphaned_vectors(client_with_resource_and_
     viking_fs.restore must route deleted source paths to the executor's
     level-precise delete (DETAIL).
     """
+    import openviking.service.reindex_executor as reindex_mod
     from openviking.server.identity import RequestContext, Role
     from openviking_cli.session.user_id import UserIdentifier
-    import openviking.service.reindex_executor as reindex_mod
 
     client, c1_oid, _blob_uri, _v1 = client_with_resource_and_blob
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)

--- a/tests/server/test_api_snapshot.py
+++ b/tests/server/test_api_snapshot.py
@@ -236,6 +236,31 @@ async def test_show_blob_returns_binary_with_headers(client_with_resource_and_bl
     assert resp.content == expected_bytes
 
 
+async def test_show_blob_can_hide_memory_fields(snapshot_router_client, monkeypatch):
+    from openviking.server.routers import snapshot
+
+    stored = b'visible content\n\n<!-- MEMORY_FIELDS\n{"version": 2}\n-->'
+    show_mock = AsyncMock(return_value={"oid": "a" * 40, "size": len(stored), "bytes": stored})
+    monkeypatch.setattr(
+        snapshot,
+        "get_service",
+        lambda: SimpleNamespace(fs=SimpleNamespace(show_blob_raw=show_mock)),
+    )
+
+    response = await snapshot_router_client.get(
+        "/api/v1/snapshot/show",
+        params={
+            "target_ref": "a" * 40,
+            "path": "viking://user/default/memories/experiences/example.md",
+            "raw": "false",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"visible content"
+    assert response.headers["x-snapshot-size"] == str(len(response.content))
+
+
 async def test_show_path_not_found_returns_404(client_with_resource):
     client, _ = client_with_resource
     commit = (await client.post("/api/v1/snapshot/commit", json={"message": "for 404"})).json()["result"]

--- a/tests/service/test_agent_evolution_service.py
+++ b/tests/service/test_agent_evolution_service.py
@@ -7,7 +7,11 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.service.agent_evolution_service import AgentEvolutionService
-from openviking.session.memory.experience_lineage import experience_source_tag
+from openviking.session.memory.experience_lineage import (
+    TRAJECTORY_OUTCOMES,
+    experience_source_tag,
+    trajectory_outcome_tag,
+)
 from openviking.storage.expr import And, Eq, PathScope
 from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.session.user_id import UserIdentifier
@@ -135,3 +139,55 @@ async def test_list_trajectories_by_experience_accepts_1000_and_paginates_all_re
     assert second_page["items"] == [{"uri": "viking://user/alice/memories/trajectories/1000.md"}]
     assert second_page["has_more"] is False
     assert [call.kwargs["offset"] for call in vikingdb.filter.await_args_list] == [0, 1000]
+
+
+@pytest.mark.asyncio
+async def test_get_experience_outcome_distribution_counts_two_tags_on_same_list_field():
+    experience_uri = "viking://user/alice/memories/experiences/exchange.md"
+    viking_fs = Mock()
+    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    vikingdb = Mock()
+    vikingdb.count = AsyncMock(side_effect=[4, 2, 1, 0, 3])
+    service = AgentEvolutionService(viking_fs=viking_fs, vikingdb=vikingdb)
+
+    result = await service.get_experience_outcome_distribution(
+        experience_uri=experience_uri,
+        ctx=_ctx(),
+    )
+
+    assert result == {
+        "experience_uri": experience_uri,
+        "outcome_distribution": [
+            {"outcome": "success", "count": 4},
+            {"outcome": "failure", "count": 2},
+            {"outcome": "partial", "count": 1},
+            {"outcome": "unknown", "count": 0},
+            {"outcome": "unfinished", "count": 3},
+        ],
+    }
+    assert vikingdb.count.await_count == len(TRAJECTORY_OUTCOMES)
+    for call, outcome in zip(vikingdb.count.await_args_list, TRAJECTORY_OUTCOMES, strict=True):
+        assert call.kwargs["filter"] == And(
+            [
+                PathScope(
+                    "uri",
+                    "viking://user/alice/memories/trajectories",
+                    depth=1,
+                ),
+                Eq("context_type", "memory"),
+                Eq("level", 2),
+                Eq("search_tags", experience_source_tag(experience_uri)),
+                Eq("search_tags", trajectory_outcome_tag(outcome)),
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_experience_outcome_distribution_rejects_other_user_uri():
+    service = AgentEvolutionService(viking_fs=Mock(), vikingdb=Mock())
+
+    with pytest.raises(InvalidArgumentError):
+        await service.get_experience_outcome_distribution(
+            experience_uri="viking://user/bob/memories/experiences/exchange.md",
+            ctx=_ctx(),
+        )

--- a/tests/service/test_agent_evolution_service.py
+++ b/tests/service/test_agent_evolution_service.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.service.agent_evolution_service import AgentEvolutionService
+from openviking.session.memory.experience_lineage import experience_source_tag
+from openviking.storage.expr import And, Eq, PathScope
+from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("account", "alice"), role=Role.USER)
+
+
+@pytest.mark.asyncio
+async def test_list_trajectories_by_experience_uses_exact_scalar_filter_and_pagination():
+    experience_uri = "viking://user/alice/memories/experiences/exchange.md"
+    viking_fs = Mock()
+    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    vikingdb = Mock()
+    vikingdb.filter = AsyncMock(
+        return_value=[
+            {
+                "uri": "viking://user/alice/memories/trajectories/exchange-2.md",
+                "name": "exchange-2.md",
+                "updated_at": "2026-08-03T12:00:00Z",
+                "_score": 1,
+            }
+        ]
+    )
+    vikingdb.count = AsyncMock(return_value=3)
+    service = AgentEvolutionService(viking_fs=viking_fs, vikingdb=vikingdb)
+
+    result = await service.list_trajectories_by_experience(
+        experience_uri=experience_uri,
+        ctx=_ctx(),
+        limit=1,
+        offset=1,
+    )
+
+    assert result == {
+        "experience_uri": experience_uri,
+        "items": [
+            {
+                "uri": "viking://user/alice/memories/trajectories/exchange-2.md",
+                "name": "exchange-2.md",
+                "updated_at": "2026-08-03T12:00:00Z",
+            }
+        ],
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+        "has_more": True,
+    }
+    expected_filter = And(
+        [
+            PathScope(
+                "uri",
+                "viking://user/alice/memories/trajectories",
+                depth=1,
+            ),
+            Eq("context_type", "memory"),
+            Eq("level", 2),
+            Eq("search_tags", experience_source_tag(experience_uri)),
+        ]
+    )
+    assert vikingdb.filter.await_args.kwargs["filter"] == expected_filter
+    assert vikingdb.filter.await_args.kwargs["limit"] == 1
+    assert vikingdb.filter.await_args.kwargs["offset"] == 1
+    assert vikingdb.filter.await_args.kwargs["order_by"] == "updated_at"
+    assert vikingdb.filter.await_args.kwargs["order_desc"] is True
+    assert vikingdb.count.await_args.kwargs["filter"] == expected_filter
+
+
+@pytest.mark.asyncio
+async def test_list_trajectories_by_experience_rejects_other_user_uri():
+    service = AgentEvolutionService(viking_fs=Mock(), vikingdb=Mock())
+
+    with pytest.raises(InvalidArgumentError):
+        await service.list_trajectories_by_experience(
+            experience_uri="viking://user/bob/memories/experiences/exchange.md",
+            ctx=_ctx(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_trajectories_by_experience_rejects_limit_above_1000():
+    service = AgentEvolutionService(viking_fs=Mock(), vikingdb=Mock())
+
+    with pytest.raises(InvalidArgumentError):
+        await service.list_trajectories_by_experience(
+            experience_uri="viking://user/alice/memories/experiences/exchange.md",
+            ctx=_ctx(),
+            limit=1001,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_trajectories_by_experience_accepts_1000_and_paginates_all_results():
+    experience_uri = "viking://user/alice/memories/experiences/exchange.md"
+    viking_fs = Mock()
+    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    vikingdb = Mock()
+    vikingdb.filter = AsyncMock(
+        side_effect=[
+            [
+                {"uri": f"viking://user/alice/memories/trajectories/{index}.md"}
+                for index in range(1000)
+            ],
+            [{"uri": "viking://user/alice/memories/trajectories/1000.md"}],
+        ]
+    )
+    vikingdb.count = AsyncMock(side_effect=[1001, 1001])
+    service = AgentEvolutionService(viking_fs=viking_fs, vikingdb=vikingdb)
+
+    first_page = await service.list_trajectories_by_experience(
+        experience_uri=experience_uri,
+        ctx=_ctx(),
+        limit=1000,
+    )
+    second_page = await service.list_trajectories_by_experience(
+        experience_uri=experience_uri,
+        ctx=_ctx(),
+        limit=1000,
+        offset=1000,
+    )
+
+    assert len(first_page["items"]) == 1000
+    assert first_page["has_more"] is True
+    assert second_page["items"] == [{"uri": "viking://user/alice/memories/trajectories/1000.md"}]
+    assert second_page["has_more"] is False
+    assert [call.kwargs["offset"] for call in vikingdb.filter.await_args_list] == [0, 1000]

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -11,7 +11,12 @@ import pytest
 from openviking.message import Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
-from openviking.session.compressor_v3 import SessionCompressorV3, _experience_root_uri
+from openviking.session.compressor_v3 import (
+    SessionCompressorV3,
+    _experience_root_uri,
+    _experience_snapshot_provenance,
+    _experience_trajectory_map,
+)
 from openviking.session.memory.dataclass import (
     MemoryFile,
     ResolvedOperation,
@@ -1284,6 +1289,120 @@ async def test_v3_training_memory_diff_filters_batch_items_by_current_analysis_t
     assert [op["uri"] for op in diff["operations"]["adds"]] == [traj_a, exp_a]
 
 
+def test_v3_maps_each_written_experience_to_its_source_trajectories():
+    traj_a = "viking://user/u/memories/trajectories/traj_a.md"
+    traj_b = "viking://user/u/memories/trajectories/traj_b.md"
+    exp_a = "viking://user/u/memories/experiences/exp_a.md"
+    exp_b = "viking://user/u/memories/experiences/exp_b.md"
+    plan = PolicyUpdatePlan(
+        items=[
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="exp_a",
+                target_uri=exp_a,
+                before_content=None,
+                after_content="exp a",
+                links=[
+                    StoredLink(
+                        from_uri=exp_a,
+                        to_uri=traj_a,
+                        link_type="derived_from",
+                        weight=1.0,
+                    )
+                ],
+            ),
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="exp_b",
+                target_uri=exp_b,
+                before_content=None,
+                after_content="exp b",
+                links=[
+                    StoredLink(
+                        from_uri=exp_b,
+                        to_uri=traj_b,
+                        link_type="derived_from",
+                        weight=1.0,
+                    )
+                ],
+            ),
+        ]
+    )
+    apply_result = PolicyApplyResult(
+        updated_policy_set=ExperienceSet(
+            root_uri="viking://user/u/memories/experiences",
+            policies=[],
+        ),
+        written_uris=[exp_a, exp_b],
+    )
+
+    assert _experience_trajectory_map(
+        plan=plan,
+        apply_result=apply_result,
+        trajectory_uris={traj_a, traj_b},
+    ) == {
+        exp_a: [traj_a],
+        exp_b: [traj_b],
+    }
+
+
+def test_v3_snapshot_provenance_uses_complete_shared_batch_result():
+    traj_a = "viking://user/u/memories/trajectories/traj_a.md"
+    traj_b = "viking://user/u/memories/trajectories/traj_b.md"
+    exp_a = "viking://user/u/memories/experiences/exp_a.md"
+    exp_b = "viking://user/u/memories/experiences/exp_b.md"
+
+    def plan_item(experience_uri: str, trajectory_uri: str) -> PolicyPlanItem:
+        return PolicyPlanItem(
+            kind="upsert",
+            memory_type="experiences",
+            target_name=experience_uri.rsplit("/", 1)[-1].removesuffix(".md"),
+            target_uri=experience_uri,
+            before_content=None,
+            after_content="updated",
+            links=[
+                StoredLink(
+                    from_uri=experience_uri,
+                    to_uri=trajectory_uri,
+                    link_type="derived_from",
+                    weight=1.0,
+                )
+            ],
+        )
+
+    root = "viking://user/u/memories/experiences"
+    batch_result = SimpleNamespace(
+        analyses=[
+            SimpleNamespace(trajectories=[SimpleNamespace(uri=traj_a)]),
+            SimpleNamespace(trajectories=[SimpleNamespace(uri=traj_b)]),
+        ],
+        plan=PolicyUpdatePlan(items=[plan_item(exp_a, traj_a), plan_item(exp_b, traj_b)]),
+        apply_result=PolicyApplyResult(
+            updated_policy_set=ExperienceSet(root_uri=root, policies=[]),
+            written_uris=[exp_a, exp_b],
+        ),
+    )
+    scoped_result = SimpleNamespace(
+        analyses=[batch_result.analyses[0]],
+        plan=PolicyUpdatePlan(items=[batch_result.plan.items[0]]),
+        apply_result=PolicyApplyResult(
+            updated_policy_set=ExperienceSet(root_uri=root, policies=[]),
+            written_uris=[exp_a],
+        ),
+        batch_result=batch_result,
+    )
+
+    apply_result, trajectory_map = _experience_snapshot_provenance(scoped_result)
+
+    assert apply_result is batch_result.apply_result
+    assert trajectory_map == {
+        exp_a: [traj_a],
+        exp_b: [traj_b],
+    }
+
+
 @pytest.mark.asyncio
 async def test_v3_training_links_case_to_trajectory_and_experience_via_trajectory(monkeypatch):
     case_uri = "viking://user/u/memories/cases/duplicate_booking.md"
@@ -1351,8 +1470,8 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
             del ctx
             return self.files[uri]
 
-        async def write_file(self, uri, content, ctx=None):
-            del ctx
+        async def write_file(self, uri, content, ctx=None, lease_ref=None):
+            del ctx, lease_ref
             self.files[uri] = content
 
         async def ls(self, uri, output="original", ctx=None):
@@ -1365,7 +1484,14 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
     class FakeTrainer:
         policy_set = ExperienceSet(root_uri="viking://user/u/memories/experiences", policies=[])
 
-        async def submit_gradients(self, gradients, *, analysis=None, rollout=None):
+        async def submit_gradients(
+            self,
+            gradients,
+            *,
+            analysis=None,
+            rollout=None,
+            batch_finalizer=None,
+        ):
             del gradients, analysis, rollout
             plan = PolicyUpdatePlan(
                 items=[
@@ -1389,7 +1515,7 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                     )
                 ]
             )
-            return RolloutTrainingResult(
+            result = RolloutTrainingResult(
                 analyses=[],
                 gradients=[],
                 plan=plan,
@@ -1404,6 +1530,9 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                 ),
                 metadata={},
             )
+            if batch_finalizer is not None:
+                await batch_finalizer(result)
+            return result
 
     class FakeAnalyzer:
         async def analyze(self, rollout, context):
@@ -1497,7 +1626,10 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
         {
             "message": (
                 "Update experience memories from session commit "
-                "viking://user/u/sessions/session-1/history/archive_001"
+                "viking://user/u/sessions/session-1/history/archive_001\n"
+                "OpenViking-Experience-Trajectory-Map: "
+                '{"viking://user/u/memories/experiences/booking_duplicate_handling.md":'
+                '["viking://user/u/memories/trajectories/duplicate_booking.md"]}'
             ),
             "paths": ["viking://user/u/memories/experiences"],
             "ctx": _ctx(),

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -13,9 +13,11 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
 from openviking.session.compressor_v3 import (
     SessionCompressorV3,
+    _commit_experience_snapshot,
     _experience_root_uri,
     _experience_snapshot_provenance,
     _experience_trajectory_map,
+    _visible_experience_snapshot_uris,
 )
 from openviking.session.memory.dataclass import (
     MemoryFile,
@@ -1403,6 +1405,75 @@ def test_v3_snapshot_provenance_uses_complete_shared_batch_result():
     }
 
 
+def test_visible_experience_snapshot_uris_only_returns_applied_body_changes():
+    root = "viking://user/u/memories/experiences"
+    changed_uri = f"{root}/changed.md"
+    metadata_only_uri = f"{root}/metadata_only.md"
+    failed_uri = f"{root}/failed.md"
+    deleted_uri = f"{root}/deleted.md"
+    content_write_uri = f"{root}/content_write.md"
+    plan = PolicyUpdatePlan(
+        items=[
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="changed",
+                target_uri=changed_uri,
+                before_content="before",
+                after_content="after",
+            ),
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="metadata_only",
+                target_uri=metadata_only_uri,
+                before_content="unchanged",
+                after_content="unchanged",
+            ),
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="experiences",
+                target_name="failed",
+                target_uri=failed_uri,
+                before_content="before",
+                after_content="after",
+            ),
+            PolicyPlanItem(
+                kind="delete",
+                memory_type="experiences",
+                target_name="deleted",
+                target_uri=deleted_uri,
+                before_content="old content",
+                after_content=None,
+            ),
+        ]
+    )
+    apply_result = PolicyApplyResult(
+        updated_policy_set=ExperienceSet(root_uri=root, policies=[]),
+        written_uris=[changed_uri, metadata_only_uri, content_write_uri],
+        deleted_uris=[deleted_uri],
+    )
+
+    assert _visible_experience_snapshot_uris(
+        plan=plan,
+        apply_result=apply_result,
+    ) == [changed_uri, deleted_uri]
+
+
+@pytest.mark.asyncio
+async def test_commit_experience_snapshot_skips_when_no_visible_content_changed():
+    viking_fs = SimpleNamespace(commit=AsyncMock())
+
+    await _commit_experience_snapshot(
+        viking_fs,
+        ctx=_ctx(),
+        experience_uris=[],
+        archive_uri="viking://user/u/sessions/session-1/history/archive_001",
+    )
+
+    viking_fs.commit.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_v3_training_links_case_to_trajectory_and_experience_via_trajectory(monkeypatch):
     case_uri = "viking://user/u/memories/cases/duplicate_booking.md"
@@ -1512,7 +1583,15 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                                 description="",
                             )
                         ],
-                    )
+                    ),
+                    PolicyPlanItem(
+                        kind="delete",
+                        memory_type="experiences",
+                        target_name="legacy_booking_handling",
+                        target_uri=deleted_exp_uri,
+                        before_content="legacy exp content",
+                        after_content=None,
+                    ),
                 ]
             )
             result = RolloutTrainingResult(
@@ -1631,7 +1710,7 @@ async def test_v3_training_links_case_to_trajectory_and_experience_via_trajector
                 '{"viking://user/u/memories/experiences/booking_duplicate_handling.md":'
                 '["viking://user/u/memories/trajectories/duplicate_booking.md"]}'
             ),
-            "paths": ["viking://user/u/memories/experiences"],
+            "paths": [exp_uri, deleted_exp_uri],
             "ctx": _ctx(),
         }
     ]

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -79,7 +79,10 @@ class TestCommit:
     async def test_commit_default_disables_agent_memory_but_keeps_archive(
         self, session_with_messages: Session
     ):
-        session_with_messages._agent_evolution_enabled_provider = lambda: False
+        async def account_setting_provider() -> bool:
+            return False
+
+        session_with_messages._agent_evolution_enabled_provider = account_setting_provider
         session_with_messages._session_compressor.extract_long_term_memories = AsyncMock(
             return_value=[]
         )

--- a/tests/session/train/test_train_framework.py
+++ b/tests/session/train/test_train_framework.py
@@ -873,6 +873,92 @@ async def test_streaming_policy_trainer_scopes_concurrent_submit_results_by_sour
 
 
 @pytest.mark.asyncio
+async def test_streaming_policy_trainer_finalizes_snapshot_before_next_flush_writes():
+    from openviking.session.train import StreamingPolicyTrainer, StreamingPolicyTrainerConfig
+
+    writes: list[str] = []
+    snapshots: list[tuple[str, list[str], list[str]]] = []
+    first_finalizer_started = asyncio.Event()
+    release_first_finalizer = asyncio.Event()
+
+    class RecordingCore:
+        async def plan_and_apply(self, *, gradients, policy_set, ctx):
+            del ctx
+            uris = [gradient.target_uri for gradient in gradients]
+            writes.extend(uris)
+            return (
+                PolicyUpdatePlan(metadata={"uris": uris}),
+                PolicyApplyResult(updated_policy_set=policy_set, written_uris=uris),
+            )
+
+    trainer = StreamingPolicyTrainer(
+        policy_set=_policy_set(),
+        rollout_analyzer=DummyAnalyzer(),
+        gradient_estimator=DummyEstimator(),
+        policy_optimizer=DummyOptimizer(),
+        policy_updater=DummyUpdater(),
+        context=PipelineContext(),
+        config=StreamingPolicyTrainerConfig(
+            max_gradients_per_update=1,
+            max_wait_seconds=60.0,
+            timer_check_interval_seconds=60.0,
+        ),
+    )
+    trainer._core = RecordingCore()
+
+    async def finalize_first(result):
+        first_finalizer_started.set()
+        await release_first_finalizer.wait()
+        snapshots.append(("first", list(writes), list(result.apply_result.written_uris)))
+
+    async def finalize_second(result):
+        snapshots.append(("second", list(writes), list(result.apply_result.written_uris)))
+
+    def gradient(name: str) -> DummyGradient:
+        uri = f"viking://user/u/memories/experiences/{name}.md"
+        return DummyGradient(
+            target_name=name,
+            target_uri=uri,
+            base_version=None,
+            rationale="test",
+            links=[],
+            confidence=1.0,
+        )
+
+    first_task = asyncio.create_task(
+        trainer.submit_gradients([gradient("exp_a")], batch_finalizer=finalize_first)
+    )
+    await first_finalizer_started.wait()
+    second_task = asyncio.create_task(
+        trainer.submit_gradients([gradient("exp_b")], batch_finalizer=finalize_second)
+    )
+    await asyncio.sleep(0)
+
+    assert writes == ["viking://user/u/memories/experiences/exp_a.md"]
+
+    release_first_finalizer.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert snapshots == [
+        (
+            "first",
+            ["viking://user/u/memories/experiences/exp_a.md"],
+            ["viking://user/u/memories/experiences/exp_a.md"],
+        ),
+        (
+            "second",
+            [
+                "viking://user/u/memories/experiences/exp_a.md",
+                "viking://user/u/memories/experiences/exp_b.md",
+            ],
+            ["viking://user/u/memories/experiences/exp_b.md"],
+        ),
+    ]
+
+    assert await trainer.close() is None
+
+
+@pytest.mark.asyncio
 async def test_streaming_policy_trainer_splits_flush_by_gradient_count():
     from openviking.session.train import StreamingPolicyTrainer, StreamingPolicyTrainerConfig
 

--- a/tests/session/train/test_trajectory_analyzer_component.py
+++ b/tests/session/train/test_trajectory_analyzer_component.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from openviking.message import Message, TextPart
+from openviking.message import Message, TextPart, ToolPart
 from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOperations
 from openviking.session.train import (
     Case,
@@ -90,8 +90,8 @@ class FakeVikingFS:
     async def read_file(self, uri, ctx=None):
         return self.files[uri]
 
-    async def write_file(self, uri, content, ctx=None, lock_handle=None):
-        del lock_handle
+    async def write_file(self, uri, content, ctx=None, lock_handle=None, lease_ref=None):
+        del lock_handle, lease_ref
         self.files[uri] = content
         self.writes.append((uri, content, ctx))
 
@@ -157,7 +157,24 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
         source_archive_uri="viking://user/u/sessions/s1/history/archive_001",
     )
 
-    analysis = await analyzer.analyze(_rollout(), context)
+    rollout = _rollout()
+    rollout.messages.append(
+        Message(
+            id="tool-result",
+            role="user",
+            parts=[
+                ToolPart(
+                    tool_id="read-1",
+                    tool_name="read_experience",
+                    tool_input={"uri": "viking://user/u/memories/experiences/exchange.md"},
+                    tool_output="experience body",
+                    tool_status="completed",
+                )
+            ],
+        )
+    )
+
+    analysis = await analyzer.analyze(rollout, context)
 
     assert FakeExtractLoop.created
     created_loop = FakeExtractLoop.created[0]
@@ -173,6 +190,7 @@ async def test_trajectory_rollout_analyzer_extracts_and_persists_trajectory(monk
     assert (
         '"source_archive_uri": "viking://user/u/sessions/s1/history/archive_001"' in fs.writes[0][1]
     )
+    assert '"source_experience_uris"' not in fs.writes[0][1]
     assert '"source_session_id"' not in fs.writes[0][1]
     assert '"source_messages_uri"' not in fs.writes[0][1]
     assert '"source_task_id"' not in fs.writes[0][1]

--- a/tests/storage/test_vectordb_adapter_scores.py
+++ b/tests/storage/test_vectordb_adapter_scores.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from datetime import datetime, timezone
+
+from openviking.storage.vectordb_adapters.base import _normalize_result_score
+
+
+def test_normalize_result_score_keeps_finite_numeric_scores():
+    assert _normalize_result_score(0.75) == 0.75
+    assert _normalize_result_score(float("nan")) == 0.0
+    assert _normalize_result_score(float("inf")) == 0.0
+
+
+def test_normalize_result_score_ignores_scalar_sort_values():
+    assert _normalize_result_score("viking://user/alice/memories/trajectories/a.md") == 0.0
+    assert _normalize_result_score(datetime.now(timezone.utc)) == 0.0

--- a/tests/storage/test_viking_fs_git.py
+++ b/tests/storage/test_viking_fs_git.py
@@ -108,6 +108,26 @@ async def test_diff_reads_blobs_from_resolved_commit_oids():
     assert "+new content" in result["diff_text"]
 
 
+async def test_diff_can_hide_memory_fields():
+    before = b'old content\n\n<!-- MEMORY_FIELDS\n{"version": 1}\n-->'
+    after = b'new content\n\n<!-- MEMORY_FIELDS\n{"version": 2}\n-->'
+    vfs = _DiffVikingFS(before, after)
+
+    result = await VikingFS.diff(
+        vfs,
+        path="viking://user/user/memories/experiences/example.md",
+        from_ref="from",
+        to_ref="to",
+        raw=False,
+        ctx=_request_context(),
+    )
+
+    assert "-old content" in result["diff_text"]
+    assert "+new content" in result["diff_text"]
+    assert "MEMORY_FIELDS" not in result["diff_text"]
+    assert "version" not in result["diff_text"]
+
+
 class _DiffVikingFS:
     def __init__(self, before: bytes, after: bytes):
         self._before = before

--- a/tests/unit/session/memory/test_embedding_template.py
+++ b/tests/unit/session/memory/test_embedding_template.py
@@ -8,6 +8,7 @@ import pytest
 
 from openviking.prompts.manager import PromptManager
 from openviking.session.memory.dataclass import MemoryField, MemoryFile
+from openviking.session.memory.experience_lineage import experience_source_tag
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.memory_updater import MemoryUpdater, MemoryUpdateResult
 from openviking.session.memory.merge_op.base import FieldType
@@ -92,6 +93,53 @@ class TestContentTemplateRendering:
 
 
 class TestEmbeddingTextConstruction:
+    @pytest.mark.asyncio
+    async def test_trajectory_vectorization_adds_source_experience_search_tags(self):
+        registry = MemoryTypeRegistry(load_schemas=False)
+        memory_dir = PromptManager._get_bundled_templates_dir() / "memory"
+        registry.load_from_yaml(str(memory_dir / "trajectories.yaml"))
+        experience_uri = "viking://user/alice/memories/experiences/exchange.md"
+        trajectory_uri = "viking://user/alice/memories/trajectories/exchange.md"
+        updater = MemoryUpdater(registry=registry, vikingdb=Mock())
+        updater._viking_fs = Mock()
+        updater._viking_fs.read_file = AsyncMock(
+            return_value=MemoryFileUtils.write(
+                MemoryFile(
+                    uri=trajectory_uri,
+                    memory_type="trajectories",
+                    content="# exchange\nbody",
+                    extra_fields={
+                        "trajectory_name": "exchange",
+                        "retrieval_anchor": "Stage: final",
+                    },
+                )
+            )
+        )
+        updater._vikingdb.enqueue_embedding_msg = AsyncMock(return_value=True)
+        result = MemoryUpdateResult()
+        result.add_written(trajectory_uri)
+        ctx = SimpleNamespace(user=None, account_id="default")
+
+        with patch.object(EmbeddingMsgConverter, "from_context") as mock_from_context:
+            mock_from_context.side_effect = lambda context: SimpleNamespace(
+                telemetry_id=None,
+                id="msg-1",
+                message=context.get_vectorization_text(),
+                context_data={},
+            )
+            await updater._vectorize_memories(
+                result,
+                ctx,
+                uri_memory_type_map={trajectory_uri: "trajectories"},
+                search_tags_by_uri={
+                    trajectory_uri: [experience_source_tag(experience_uri)],
+                },
+            )
+
+        embedding_msg = updater._vikingdb.enqueue_embedding_msg.await_args.args[0]
+        assert embedding_msg.context_data["search_tags"] == [experience_source_tag(experience_uri)]
+        assert embedding_msg.context_data["_upsert_options"] == {"search_tag_mode": "append"}
+
     @pytest.mark.asyncio
     async def test_logs_final_embedding_text_before_vectorization(self):
         registry = MemoryTypeRegistry(load_schemas=False)

--- a/tests/unit/session/memory/test_experience_lineage.py
+++ b/tests/unit/session/memory/test_experience_lineage.py
@@ -7,6 +7,8 @@ from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOpera
 from openviking.session.memory.experience_lineage import (
     collect_read_experience_uris,
     experience_source_tag,
+    normalize_trajectory_outcome,
+    trajectory_outcome_tag,
 )
 from openviking.session.train.components.trajectory_analyzer import (
     _trajectory_search_tags_by_uri,
@@ -85,9 +87,7 @@ def test_experience_source_tag_preserves_case_and_escapes_equals_without_collisi
     uppercase_tag = experience_source_tag(uppercase_uri)
     lowercase_tag = experience_source_tag(lowercase_uri)
 
-    assert uppercase_tag == (
-        "viking://user/%41lice/memories/experiences/%45xchange%3d%46low.md=1"
-    )
+    assert uppercase_tag == ("viking://user/%41lice/memories/experiences/%45xchange%3d%46low.md=1")
     assert lowercase_tag == "viking://user/alice/memories/experiences/exchange%3dflow.md=1"
     assert uppercase_tag != lowercase_tag
     assert uppercase_tag.count("=") == 1
@@ -100,12 +100,12 @@ def test_source_experiences_create_transient_tags_for_every_generated_trajectory
     operations = ResolvedOperations(
         upsert_operations=[
             ResolvedOperation(
-                memory_fields={"trajectory_name": "exchange"},
+                memory_fields={"trajectory_name": "exchange", "outcome": "success"},
                 memory_type="trajectories",
                 uris=["viking://user/alice/memories/trajectories/exchange.md"],
             ),
             ResolvedOperation(
-                memory_fields={"trajectory_name": "refund"},
+                memory_fields={"trajectory_name": "refund", "outcome": "failure"},
                 memory_type="trajectories",
                 uris=["viking://user/alice/memories/trajectories/refund.md"],
             ),
@@ -119,10 +119,23 @@ def test_source_experiences_create_transient_tags_for_every_generated_trajectory
         [first_uri, second_uri, first_uri],
     )
 
-    expected_tags = [experience_source_tag(first_uri), experience_source_tag(second_uri)]
     assert tags_by_uri == {
-        "viking://user/alice/memories/trajectories/exchange.md": expected_tags,
-        "viking://user/alice/memories/trajectories/refund.md": expected_tags,
+        "viking://user/alice/memories/trajectories/exchange.md": [
+            experience_source_tag(first_uri),
+            experience_source_tag(second_uri),
+            "trajectory_outcome=success",
+        ],
+        "viking://user/alice/memories/trajectories/refund.md": [
+            experience_source_tag(first_uri),
+            experience_source_tag(second_uri),
+            "trajectory_outcome=failure",
+        ],
     }
     for operation in operations.upsert_operations:
         assert "source_experience_uris" not in operation.memory_fields
+
+
+def test_trajectory_outcome_tag_normalizes_unknown_values():
+    assert trajectory_outcome_tag(" SUCCESS ") == "trajectory_outcome=success"
+    assert trajectory_outcome_tag("unexpected") == "trajectory_outcome=unknown"
+    assert normalize_trajectory_outcome(None) == "unknown"

--- a/tests/unit/session/memory/test_experience_lineage.py
+++ b/tests/unit/session/memory/test_experience_lineage.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.message import Message, ToolPart
+from openviking.server.identity import RequestContext, Role
+from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOperations
+from openviking.session.memory.experience_lineage import (
+    collect_read_experience_uris,
+    experience_source_tag,
+)
+from openviking.session.train.components.trajectory_analyzer import (
+    _trajectory_search_tags_by_uri,
+)
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("account", "alice"), role=Role.USER)
+
+
+def test_collect_read_experience_uris_only_keeps_completed_current_user_reads():
+    uri = "viking://user/alice/memories/experiences/order-exchange.md"
+    messages = [
+        Message(
+            id="call",
+            role="assistant",
+            parts=[
+                ToolPart(
+                    tool_id="read-1",
+                    tool_name="read_experience",
+                    tool_input={"uri": uri},
+                    tool_status="pending",
+                ),
+                ToolPart(
+                    tool_id="search-1",
+                    tool_name="search_experience",
+                    tool_input={"query": "exchange"},
+                    tool_status="completed",
+                    tool_output='{"results":[{"uri":"%s"}]}' % uri,
+                ),
+            ],
+        ),
+        Message(
+            id="result",
+            role="user",
+            parts=[
+                ToolPart(
+                    tool_id="read-1",
+                    tool_name="read_experience",
+                    tool_status="completed",
+                    tool_output='{"uri":"%s"}' % uri,
+                ),
+                ToolPart(
+                    tool_id="read-2",
+                    tool_name="read_experience",
+                    tool_input={"uri": "viking://user/bob/memories/experiences/other.md"},
+                    tool_status="completed",
+                ),
+                ToolPart(
+                    tool_id="read-3",
+                    tool_name="read_experience",
+                    tool_input={"uri": uri},
+                    tool_status="error",
+                ),
+            ],
+        ),
+    ]
+
+    assert collect_read_experience_uris(messages, ctx=_ctx()) == [uri]
+
+
+def test_experience_source_tag_uses_experience_uri_as_key():
+    uri = "viking://user/alice/memories/experiences/无订单号换货处理.md"
+
+    tag = experience_source_tag(uri)
+
+    assert tag == f"{uri}=1"
+    assert tag.count("=") == 1
+
+
+def test_experience_source_tag_preserves_case_and_escapes_equals_without_collisions():
+    uppercase_uri = "viking://user/Alice/memories/experiences/Exchange=Flow.md"
+    lowercase_uri = "viking://user/alice/memories/experiences/exchange=flow.md"
+
+    uppercase_tag = experience_source_tag(uppercase_uri)
+    lowercase_tag = experience_source_tag(lowercase_uri)
+
+    assert uppercase_tag == (
+        "viking://user/%41lice/memories/experiences/%45xchange%3d%46low.md=1"
+    )
+    assert lowercase_tag == "viking://user/alice/memories/experiences/exchange%3dflow.md=1"
+    assert uppercase_tag != lowercase_tag
+    assert uppercase_tag.count("=") == 1
+    assert lowercase_tag.count("=") == 1
+
+
+def test_source_experiences_create_transient_tags_for_every_generated_trajectory():
+    first_uri = "viking://user/alice/memories/experiences/exchange.md"
+    second_uri = "viking://user/alice/memories/experiences/refund.md"
+    operations = ResolvedOperations(
+        upsert_operations=[
+            ResolvedOperation(
+                memory_fields={"trajectory_name": "exchange"},
+                memory_type="trajectories",
+                uris=["viking://user/alice/memories/trajectories/exchange.md"],
+            ),
+            ResolvedOperation(
+                memory_fields={"trajectory_name": "refund"},
+                memory_type="trajectories",
+                uris=["viking://user/alice/memories/trajectories/refund.md"],
+            ),
+        ],
+        delete_file_contents=[],
+        errors=[],
+    )
+
+    tags_by_uri = _trajectory_search_tags_by_uri(
+        operations,
+        [first_uri, second_uri, first_uri],
+    )
+
+    expected_tags = [experience_source_tag(first_uri), experience_source_tag(second_uri)]
+    assert tags_by_uri == {
+        "viking://user/alice/memories/trajectories/exchange.md": expected_tags,
+        "viking://user/alice/memories/trajectories/refund.md": expected_tags,
+    }
+    for operation in operations.upsert_operations:
+        assert "source_experience_uris" not in operation.memory_fields


### PR DESCRIPTION
## Description

Backport this week's merged Agent Evolution changes from `main` to `release/0.4.12`.

Source PRs:
- #3695: improve Agent Evolution provenance, history, and account settings
- #3727: track Experience-to-Trajectory lineage
- #3742: aggregate trajectory outcomes and refine Experience snapshots
- #3827: add Experience Memory tools to the OpenClaw plugin

## Related Issue

N/A

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test update
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Performance improvement

## Changes Made

- Backported Agent Evolution account settings, provenance, snapshot, lineage, and outcome APIs.
- Backported Experience-to-Trajectory tracking and related metadata handling.
- Backported OpenClaw `search_experience` and `read_experience` tools and the bundled Experience Memory skill.
- Preserved the `release/0.4.12` behavior description for `/api/v1/search/recall` while adding the Agent Evolution endpoints to the API catalog.
- Applied release-branch import ordering required by Ruff.

## Testing

- [x] Changed Python files compile successfully.
- [x] Ruff passes for all changed Python files.
- [x] Targeted Python tests: 59 passed, 1 skipped.
- [x] OpenClaw targeted tests: 117 passed.

Commands run:

```bash
.venv/bin/ruff check <changed-python-files>
.venv/bin/python -m pytest -q \
  tests/server/test_agent_evolution_global_setting.py \
  tests/service/test_agent_evolution_service.py \
  tests/storage/test_vectordb_adapter_scores.py \
  tests/storage/test_viking_fs_git.py \
  tests/unit/session/memory/test_embedding_template.py \
  tests/unit/session/memory/test_experience_lineage.py

cd examples/openclaw-plugin
npm test -- --run \
  tests/ut/openviking-experience-tools.test.ts \
  tests/ut/openviking-tools-registry.test.ts \
  tests/ut/package-install-contract.test.ts \
  tests/ut/plugin-registration.test.ts \
  tests/ut/tool-round-trip.test.ts \
  tests/ut/tools.test.ts
```

## Checklist

- [x] The changes are scoped to the requested backport.
- [x] Source commits are recorded with `cherry-pick -x`.
- [x] Documentation was updated with the backported APIs.
- [x] Relevant focused tests pass locally.
- [ ] Full repository test suite passes locally.

## Screenshots

N/A

## Additional Notes

The broader changed-test run collected 173 tests. Tests requiring full OpenViking service initialization could not run in the local environment because the installed AGFS native extension failed during fixture setup with `AGFSInvalidOperationError: invalid operation: no operation specified`. No affected test reached its assertions in those cases; release CI should provide the authoritative service-initialization result.
