### PR TITLE
fix(overview):language fix (#3747)

### DIFF
--- a/openviking/prompts/templates/semantic/overview_generation.yaml
+++ b/openviking/prompts/templates/semantic/overview_generation.yaml
@@ -56,7 +56,7 @@ template: |
 
   1. **Title** (H1): Directory name
 
-  2. **Brief Description** (plain text paragraph, 50-150 words):
+  2. **{{ "简要描述" if output_language == "zh-CN" else "Brief Description" }}** (plain text paragraph, 50-150 words):
      - Immediately following the title, without any H2 heading
      - Explain what this is, what it's about, what it covers
      - Include core keywords for easy searching


### PR DESCRIPTION
  Description

  Backport the overview heading language fix from main to release/0.4.12.

  The overview generation template hardcoded the English heading "Brief Description" in the generated document
  structure, so even when output_language was zh-CN, the section heading stayed in English. This backport applies the
  localized inline-conditional heading to release/0.4.12.

  Source PR:

  - fix(overview): language fix #3747 — localize the "Brief Description" heading in overview_generation.yaml using the
    existing output_language conditional pattern.

  Related Issue

  N/A

  Type of Change

  - [ ] New feature
  - [ ] Documentation update
  - [ ] Test update
  - [x] Bug fix
  - [ ] Breaking change
  - [ ] Refactoring
  - [ ] Performance improvement

  Changes Made

  - Backported the overview heading localization in openviking/prompts/templates/semantic/overview_generation.yaml.
  - Replaced the hardcoded Brief Description heading with the repo's existing inline conditional: {{ "简要描述" if
    output_language == "zh-CN" else "Brief Description" }}, so the generated section heading follows the collection's
    output_language.

  - No new localization mechanism introduced; reused the established output_language templating pattern.

  Testing

  - [x] Changed template file follows the existing output_language conditional pattern used elsewhere in the repo.
  - [x] Change is a single-line, self-contained prompt-template edit (1 file changed, +1/-1).

  Commands run:

  git cherry-pick 15dc82f7fe92c3efbb5792674d337aa32f3fe80c
  git diff release/0.4.12...backport/overview_language

  Checklist

  - [x] The changes are scoped to the requested backport.
  - [x] The change reuses the existing output_language localization pattern rather than introducing a new one.
  - [ ] Source commit recorded with cherry-pick -x.
  - [x] Relevant behavior verified against the existing template convention.
  - [ ] Full repository test suite passes locally.

  Screenshots

  N/A

  Additional Notes

  This is a minimal backport containing a single cherry-picked commit (fix(overview): language fix (#3747)), touching
  only the overview prompt template. No code, API, or dependency changes are involved.

