### PR TITLE
fix(server): secure watch task refreshes

### DIFF
--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -294,6 +294,7 @@ class WatchScheduler:
                         summarize=getattr(task, "summarize", False),
                         processing_mode=getattr(task, "processing_mode", "semantic_and_vectors"),
                         watch_interval=task.watch_interval,
+                        enforce_public_remote_targets=True,
                         **processor_kwargs,
                     )
 

--- a/openviking/resource/watch_storage.py
+++ b/openviking/resource/watch_storage.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from openviking.core.namespace import uri_parts
+
 WATCH_TASK_STORAGE_URI = "viking://resources/.watch_tasks.json"
 WATCH_TASK_STORAGE_BAK_URI = "viking://resources/.watch_tasks.json.bak"
 WATCH_TASK_STORAGE_TMP_URI = "viking://resources/.watch_tasks.json.tmp"
@@ -15,11 +17,14 @@ WATCH_TASK_CONTROL_URIS = frozenset(
         WATCH_TASK_STORAGE_TMP_URI,
     }
 )
+_WATCH_TASK_CONTROL_NAMES = frozenset(uri.rsplit("/", 1)[-1] for uri in WATCH_TASK_CONTROL_URIS)
 
 
 def is_watch_task_control_uri(uri: str) -> bool:
     """Return True when a URI points at internal watch-task control state."""
     if not isinstance(uri, str):
         return False
-    normalized = uri.rstrip("/")
-    return normalized in WATCH_TASK_CONTROL_URIS
+
+    # Match the logical URI segments used by storage, not the caller's spelling.
+    parts = uri_parts(uri)
+    return len(parts) == 2 and parts[0] == "resources" and parts[1] in _WATCH_TASK_CONTROL_NAMES

--- a/tests/resource/test_watch_scheduler.py
+++ b/tests/resource/test_watch_scheduler.py
@@ -141,3 +141,4 @@ class TestWatchSchedulerResourceExistence:
 
         assert resource_service.calls
         assert resource_service.calls[0]["processing_mode"] == "vectors_only"
+        assert resource_service.calls[0]["enforce_public_remote_targets"] is True

--- a/tests/server/test_watch_task_acl.py
+++ b/tests/server/test_watch_task_acl.py
@@ -119,3 +119,19 @@ def test_content_write_rejects_watch_task_control_files(uri):
 
     with pytest.raises(InvalidArgumentError, match="watch task control file"):
         coordinator._validate_target_uri(uri)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://resources//.watch_tasks.json",
+        "resources//.watch_tasks.json.bak",
+        "/resources///.watch_tasks.json.tmp/",
+    ],
+)
+def test_redundant_separator_aliases_cannot_bypass_watch_task_acl(bare_viking_fs, user_ctx, uri):
+    assert bare_viking_fs._is_accessible(uri, user_ctx) is False
+
+    coordinator = object.__new__(ContentWriteCoordinator)
+    with pytest.raises(InvalidArgumentError, match="watch task control file"):
+        coordinator._validate_target_uri(uri)


### PR DESCRIPTION
## Description

Secure scheduled watch refreshes against remote-target rebinding and prevent redundant URI separators from bypassing the internal watch-task control-file boundary.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Security report; no public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Enable public remote-target validation for every scheduled resource refresh, including outbound request validation during fetches.
- Match watch-task control files by logical URI segments so redundant separators cannot bypass access checks.
- Add focused regressions for scheduler enforcement and control-file URI aliases.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
.venv/bin/pytest -q --no-cov tests/resource/test_watch_scheduler.py tests/server/test_watch_task_acl.py::test_redundant_separator_aliases_cannot_bypass_watch_task_acl tests/server/test_watch_task_acl.py::test_content_write_rejects_watch_task_control_files
OPENVIKING_CONFIG_FILE=./ov.conf .venv/bin/pytest -q --no-cov tests/service/test_resource_service_watch.py tests/service/test_watch_recovery.py tests/misc/test_network_guard.py tests/unit/test_accessors_http.py tests/parse/accessors/web_crawler/test_middlewares.py
.venv/bin/ruff check openviking/resource/watch_scheduler.py openviking/resource/watch_storage.py tests/resource/test_watch_scheduler.py tests/server/test_watch_task_acl.py
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This fix reuses the existing remote-target guard and URI parsing rules. It adds no watch-task schema, persistence, migration, protocol allowlist, or embedded-mode compatibility branch.
