### PR TITLE
feat(agent-evolution): add rerunnable task query to trajectories

### DIFF
--- a/openviking/prompts/templates/memory/trajectories.yaml
+++ b/openviking/prompts/templates/memory/trajectories.yaml
@@ -35,6 +35,20 @@ fields:
       Use exactly one of: success, failure, partial, unfinished, unknown.
     merge_op: immutable
 
+  - name: task_query
+    type: string
+    description: |
+      Write a self-contained user task that can be copied and rerun to reproduce the intent represented by this trajectory.
+
+      Rules:
+      - Reconstruct the complete task from the relevant conversation context instead of copying unrelated turns or the whole session.
+      - Preserve the user's objective, target, constraints, requested output, and acceptance criteria that are necessary to execute the task independently.
+      - Preserve non-secret concrete inputs such as the requested topic, time range, and target object when they are required to rerun the task. Never include credentials, tokens, or authentication secrets.
+      - Remove conversational references such as "above", "continue", or "why did it stop" by resolving them into explicit task context.
+      - Do not include the assistant's solution, tool results, execution outcome, trajectory analysis, or any experience-memory content.
+      - Write in the user's voice and in {{ language }}. Use concise sentences, but include all information required to rerun the task.
+    merge_op: immutable
+
   - name: retrieval_anchor
     type: string
     description: |

--- a/tests/unit/session/memory/test_embedding_template.py
+++ b/tests/unit/session/memory/test_embedding_template.py
@@ -11,6 +11,7 @@ from openviking.session.memory.dataclass import MemoryField, MemoryFile
 from openviking.session.memory.experience_lineage import experience_source_tag
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.memory_updater import MemoryUpdater, MemoryUpdateResult
+from openviking.session.memory.merge_op import MergeOp
 from openviking.session.memory.merge_op.base import FieldType
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
@@ -50,6 +51,13 @@ class TestEmbeddingTemplateYamlParsing:
     def test_trajectories_exposes_retrieval_anchor_template(self):
         schema = self.registry.get("trajectories")
         assert schema.embedding_template == "{{ trajectory_name }}\n\n{{ retrieval_anchor }}"
+
+    def test_trajectories_exposes_immutable_task_query(self):
+        schema = self.registry.get("trajectories")
+        fields = {field.name: field for field in schema.fields}
+
+        assert "task_query" in fields
+        assert fields["task_query"].merge_op == MergeOp.IMMUTABLE
 
 
 class TestContentTemplateRendering:


### PR DESCRIPTION
## Description

Add a hidden, immutable task_query field to Agent Evolution trajectories. The field reconstructs a self-contained user task from the relevant conversation context so downstream Experience testing can present a runnable query without copying the whole archived session.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add task_query to the trajectory memory schema with immutable merge semantics.
- Define extraction rules that preserve runnable task context while excluding secrets, assistant solutions, tool results, outcomes, and experience content.
- Add a unit test covering field registration and immutable merge behavior.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Command:

    uv run --frozen pytest tests/unit/session/memory/test_embedding_template.py -q --no-cov

Result: 16 passed.

Additional checks:

    uv run --frozen ruff check --fix tests/unit/session/memory/test_embedding_template.py
    uv run --frozen ruff format --check tests/unit/session/memory/test_embedding_template.py
    git diff --check

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR only adds trajectory schema and extraction support. The Serverless Experience Test Messages API consumes task_query separately and is not included in this PR.
