### PR TITLE
Avoid queueing full content for local vector backends

### DIFF
--- a/openviking/storage/queuefs/embedding_msg_converter.py
+++ b/openviking/storage/queuefs/embedding_msg_converter.py
@@ -16,6 +16,21 @@ from openviking_cli.utils import get_logger
 logger = get_logger(__name__)
 
 
+def _current_backend_uses_content_field() -> bool:
+    """Return whether the configured vector backend needs full content in queue data."""
+    try:
+        from openviking.storage.vectordb_adapters.factory import backend_uses_content_field
+        from openviking_cli.utils.config import get_openviking_config
+
+        config = get_openviking_config()
+        vectordb_config = getattr(getattr(config, "storage", None), "vectordb", None)
+        if vectordb_config is None:
+            return False
+        return backend_uses_content_field(vectordb_config)
+    except Exception:
+        return False
+
+
 class EmbeddingMsgConverter:
     """Converter for Context objects to EmbeddingMsg."""
 
@@ -68,10 +83,11 @@ class EmbeddingMsgConverter:
             resolved_level = int(resolved_level.value)
         context_data["level"] = int(resolved_level)
 
-        # Store full content in content field for bm25 full-text search.
-        # Use full_text (raw file content) when available; fall back to vectorization_text.
+        # Store full content only for backends that actually persist/use it for
+        # server-side full-text search. Local-like backends drop it on upsert, so
+        # carrying it through the queue only amplifies memory usage.
         full_content = context.vectorize.full_text or vectorization_text
-        context_data["content"] = full_content
+        context_data["content"] = full_content if _current_backend_uses_content_field() else ""
 
         if vectorization_images:
             # Multimodal message: combine text (if any) and image references into the

--- a/openviking/storage/vectordb_adapters/factory.py
+++ b/openviking/storage/vectordb_adapters/factory.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
 from .base import CollectionAdapter
 from .http_adapter import HttpCollectionAdapter
@@ -25,9 +26,8 @@ _ADAPTER_REGISTRY: dict[str, type[CollectionAdapter]] = {
 }
 
 
-def create_collection_adapter(config) -> CollectionAdapter:
-    """Unified factory entrypoint for backend-specific collection adapters."""
-    backend = config.backend
+def resolve_collection_adapter_class(backend: str) -> type[CollectionAdapter]:
+    """Resolve adapter class without instantiating the backend."""
     adapter_cls = _ADAPTER_REGISTRY.get(backend)
 
     # If not in registry, try to load dynamically as a class path
@@ -44,7 +44,20 @@ def create_collection_adapter(config) -> CollectionAdapter:
 
     if adapter_cls is None:
         raise ValueError(
-            f"Vector backend {config.backend} is not supported. "
+            f"Vector backend {backend} is not supported. "
             f"Available backends: {sorted(_ADAPTER_REGISTRY)}"
         )
+    return adapter_cls
+
+
+def backend_uses_content_field(config_or_backend: Any) -> bool:
+    """Whether a vector backend stores the full-text content field."""
+    backend = getattr(config_or_backend, "backend", config_or_backend)
+    adapter_cls = resolve_collection_adapter_class(str(backend))
+    return bool(getattr(adapter_cls, "USE_CONTENT_FIELD", False))
+
+
+def create_collection_adapter(config) -> CollectionAdapter:
+    """Unified factory entrypoint for backend-specific collection adapters."""
+    adapter_cls = resolve_collection_adapter_class(config.backend)
     return adapter_cls.from_config(config)

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -31,6 +31,7 @@ from openviking.storage.vectordb_adapters.base import (
     VIKINGDB_TEXT_FIELD_BYTE_LIMIT,
     _truncate_text_field,
 )
+from openviking.storage.vectordb_adapters.factory import backend_uses_content_field
 from openviking.storage.vectordb_adapters.local_adapter import LocalCollectionAdapter
 from openviking.storage.viking_vector_index_backend import (
     VIKINGDB_CONTENT_MAX_SIZE,
@@ -99,6 +100,24 @@ class _DummyConfig:
                 max_reset_timeout=600.0,
             ),
         )
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        ("local", False),
+        ("cuvs", False),
+        ("http", False),
+        ("qdrant", False),
+        ("opengauss", False),
+        ("volcengine", True),
+        ("vikingdb", True),
+    ],
+)
+def test_backend_content_field_capability_matches_adapter_flag(backend, expected):
+    config = SimpleNamespace(backend=backend)
+
+    assert backend_uses_content_field(config) is expected
 
 
 def _build_queue_payload() -> dict:

--- a/tests/storage/test_embedding_msg_converter_tenant.py
+++ b/tests/storage/test_embedding_msg_converter_tenant.py
@@ -6,6 +6,7 @@
 import pytest
 
 from openviking.core.context import Context, Vectorize
+import openviking.storage.queuefs.embedding_msg_converter as converter_module
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -47,7 +48,20 @@ def test_embedding_msg_converter_backfills_account_and_owner_fields(
     assert msg.context_data["owner_user_id"] == expected_user
 
 
-def test_embedding_msg_converter_preserves_full_content_without_vikingdb_truncation():
+def test_embedding_msg_converter_omits_full_content_for_default_local_backend():
+    full_content = "x" * (1024 * 1024 + 17)
+    context = Context(uri="viking://resources/large.txt", abstract="short embedding text")
+    context.set_vectorize(Vectorize(text="short embedding text", full_text=full_content))
+
+    msg = EmbeddingMsgConverter.from_context(context)
+
+    assert msg is not None
+    assert msg.message == "short embedding text"
+    assert msg.context_data["content"] == ""
+
+
+def test_embedding_msg_converter_preserves_full_content_when_backend_needs_it(monkeypatch):
+    monkeypatch.setattr(converter_module, "_current_backend_uses_content_field", lambda: True)
     full_content = "x" * (1024 * 1024 + 17)
     context = Context(uri="viking://resources/large.txt", abstract="short embedding text")
     context.set_vectorize(Vectorize(text="short embedding text", full_text=full_content))

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -241,7 +241,7 @@ async def test_vectorize_unknown_text_file_embeds_summary_but_indexes_raw_conten
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_makefile
+    assert msg.context_data["content"] == ""
 
 
 @pytest.mark.asyncio
@@ -423,7 +423,7 @@ async def test_vectorize_unknown_text_file_sniffs_non_utf8_raw_content(monkeypat
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_content
+    assert msg.context_data["content"] == ""
     assert fs.read_file_bytes_calls == 1
     assert fs.read_file_calls == 0
 
@@ -457,7 +457,7 @@ async def test_vectorize_unknown_file_reuses_summary_content_without_reread(monk
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_content
+    assert msg.context_data["content"] == ""
     assert fs.read_file_bytes_calls == 0
     assert fs.read_file_calls == 0
 
@@ -488,7 +488,7 @@ async def test_vectorize_unknown_binary_file_falls_back_to_summary(monkeypatch):
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == summary
-    assert msg.context_data["content"] == summary
+    assert msg.context_data["content"] == ""
     assert fs.read_file_bytes_calls == 1
     assert fs.read_file_calls == 0
 
@@ -523,7 +523,7 @@ async def test_vectorize_unknown_unrecognizable_encoding_falls_back_to_summary(m
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == summary
-    assert msg.context_data["content"] == summary
+    assert msg.context_data["content"] == ""
     assert fs.read_file_bytes_calls == 1
     assert fs.read_file_calls == 0
 
@@ -552,7 +552,7 @@ async def test_vectorize_text_summary_first_reuses_single_file_read(monkeypatch)
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == "# README\nraw text for bm25\n"
+    assert msg.context_data["content"] == ""
     assert fs.read_file_calls == 1
     assert fs.read_file_bytes_calls == 0
 
@@ -583,7 +583,7 @@ async def test_vectorize_image_file_enqueues_summary_and_image(monkeypatch):
     assert msg.message[0] == {"type": "text", "text": "a cat on a sofa"}
     assert msg.message[1]["type"] == "image_url"
     assert msg.message[1]["image_url"]["url"].startswith("data:image/png;base64,")
-    assert msg.context_data["content"] == "a cat on a sofa"
+    assert msg.context_data["content"] == ""
 
 
 @pytest.mark.asyncio
@@ -611,7 +611,7 @@ async def test_vectorize_svg_file_uses_summary_and_indexes_markup(monkeypatch):
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "queue processing diagram"
-    assert msg.context_data["content"] == svg_content
+    assert msg.context_data["content"] == ""
     assert fs.read_file_calls == 1
     assert fs.read_file_bytes_calls == 0
 
@@ -676,7 +676,7 @@ async def test_vectorize_text_file_reuses_summary_content_without_reread(monkeyp
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == raw_content
+    assert msg.context_data["content"] == ""
     assert fs.read_file_calls == 0
     assert fs.read_file_bytes_calls == 0
 
@@ -711,7 +711,7 @@ async def test_vectorize_text_bytes_sniffs_non_utf8_content(monkeypatch):
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == raw_content
+    assert msg.context_data["content"] == ""
     assert fs.read_file_calls == 1
     assert fs.read_file_bytes_calls == 0
 


### PR DESCRIPTION
## Description

本 PR 修复本地等非全文检索向量后端在 embedding queue 阶段仍携带 full content 的问题。

此前 `EmbeddingMsgConverter` 会无条件把 `context.vectorize.full_text` 写入 `context_data["content"]`。对于 `local` / `cuvs` / `http` / `qdrant` / `opengauss` 等后端，upsert 阶段本来就会根据 `CollectionAdapter.USE_CONTENT_FIELD=False` 丢弃 `content`，但 queue 阶段仍会序列化、反序列化并传递大字段，导致导入大仓库时出现明显内存尖峰。

本次改动将同一后端能力判断前移到入队阶段：只有 `USE_CONTENT_FIELD=True` 的后端才保留 full content，其余后端入队时将 `content` 置为空字符串。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Added `resolve_collection_adapter_class()` and `backend_uses_content_field()` to reuse adapter-level `USE_CONTENT_FIELD` without instantiating the backend.
- Updated `EmbeddingMsgConverter` so full content is only queued for backends that actually store/use the `content` field.
- Updated converter/vectorization tests to assert local/default backends no longer carry full content in `EmbeddingMsg.context_data["content"]`, while `USE_CONTENT_FIELD=True` backends still preserve it.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证命令：

```bash
.venv/bin/python -m py_compile \
  openviking/storage/queuefs/embedding_msg_converter.py \
  openviking/storage/vectordb_adapters/factory.py \
  tests/storage/test_embedding_msg_converter_tenant.py \
  tests/storage/test_collection_schemas.py \
  tests/unit/test_vectorize_file_strategy.py
```

```bash
git diff --check -- \
  openviking/storage/queuefs/embedding_msg_converter.py \
  openviking/storage/vectordb_adapters/factory.py \
  tests/storage/test_embedding_msg_converter_tenant.py \
  tests/storage/test_collection_schemas.py \
  tests/unit/test_vectorize_file_strategy.py
```

```bash
.venv/bin/python -m pytest \
  tests/storage/test_embedding_msg_converter_tenant.py \
  tests/unit/test_vectorize_file_strategy.py \
  tests/storage/test_collection_schemas.py \
  -k "backend_content_field_capability or single_account_backend_drops_content_for_non_vikingdb_backend or single_account_backend_truncates_content_only_at_vector_write" \
  -q
```

结果：

- `py_compile` passed
- `git diff --check` passed
- focused pytest: `9 passed, 96 deselected`

补充说明：完整目标测试曾出现 `2 failed, 103 passed`，失败用例为本地环境 native VectorDB engine 不支持 bounded store scans，错误为 `The native VectorDB engine does not support bounded store scans`，与本次 queue content 改动无关。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
导入https://github.com/bojieli/ai-agent-book 仓库的测试对比
<img width="753" height="439" alt="image" src="https://github.com/user-attachments/assets/2ad9126e-5b13-4e47-89a4-3183c21775bf" />

N/A

## Additional Notes

本地向量库不应写入 full content。已有 upsert 层逻辑已经通过 `CollectionAdapter.USE_CONTENT_FIELD` 对非 VikingDB-backed 后端丢弃 `content`；本 PR 只是将同一判断提前到 embedding queue 阶段，避免无效的大字段在队列链路中被反复复制。

当前内置后端中：

- `volcengine` / `vikingdb`: `USE_CONTENT_FIELD=True`，继续保留 full content。
- `local` / `cuvs` / `http` / `qdrant` / `opengauss`: 默认 `False`，入队时不携带 full content。