### PR TITLE
feat(retrieval): expose directory metadata in context entries

### DIFF
--- a/openviking/retrieve/context_assembler/budget.py
+++ b/openviking/retrieve/context_assembler/budget.py
@@ -62,6 +62,7 @@ def _make_entry(candidate: Candidate, tier: Tier, text: str) -> AssembledEntry:
         category=candidate.category,
         score=candidate.score,
         detail=tier,
+        is_directory=candidate.is_directory,
         text=text,
         origin=candidate.origin,
     )

--- a/openviking/retrieve/context_assembler/models.py
+++ b/openviking/retrieve/context_assembler/models.py
@@ -21,6 +21,7 @@ class AssembledEntry:
     text: str = ""
     origin: str = ""
     tokens: int = 0
+    is_directory: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {
@@ -28,6 +29,7 @@ class AssembledEntry:
             "category": self.category,
             "score": self.score,
             "detail": self.detail,
+            "is_directory": self.is_directory,
             "text": self.text,
         }
         if self.origin:

--- a/tests/retrieve/test_context_assembler_pipeline.py
+++ b/tests/retrieve/test_context_assembler_pipeline.py
@@ -4,6 +4,7 @@
 import re
 from types import SimpleNamespace
 
+from openviking.retrieve.context_assembler import budget as budget_module
 from openviking.retrieve.context_assembler import pipeline as pipeline_module
 from openviking.retrieve.context_assembler import rewrite as rewrite_module
 from openviking.retrieve.context_assembler.budget import (
@@ -88,6 +89,25 @@ def test_render_neutralizes_forged_memory_tags():
     assert len(re.findall(r"(?i)<(/?)memory[\s/>]", rendered)) == 2
     assert rendered.startswith('<memory uri="viking://real"')
     assert rendered.endswith("</memory>")
+
+
+def test_render_ignores_structured_directory_metadata():
+    kwargs = {
+        "uri": "viking://resources/project",
+        "category": "resources",
+        "score": 0.8,
+        "detail": "overview",
+        "text": "Project overview",
+    }
+
+    legacy_entry = AssembledEntry(**kwargs)
+    file_rendered = render_entry(legacy_entry)
+    directory_rendered = render_entry(AssembledEntry(**kwargs, is_directory=True))
+
+    assert legacy_entry.is_directory is False
+    assert legacy_entry.to_dict()["is_directory"] is False
+    assert directory_rendered == file_rendered
+    assert "is_directory" not in directory_rendered
 
 
 def test_coding_purpose_uses_absolute_cross_domain_quotas():
@@ -461,7 +481,13 @@ async def test_only_candidates_that_can_deepen_are_read():
     }
 
 
-def _resource_candidate(abstract, category="resources", uri=f"{USER_ROOT}/resources/creds.md"):
+def _resource_candidate(
+    abstract,
+    category="resources",
+    uri=f"{USER_ROOT}/resources/creds.md",
+    *,
+    is_directory=False,
+):
     return Candidate(
         uri=uri,
         base_uri=uri,
@@ -471,9 +497,62 @@ def _resource_candidate(abstract, category="resources", uri=f"{USER_ROOT}/resour
         level=2,
         abstract=abstract,
         origin="actor_peer",
-        is_directory=False,
+        is_directory=is_directory,
         read_ctx=_ctx(),
     )
+
+
+def test_directory_metadata_survives_initial_upgrade_and_fallback_tiers():
+    directory_uri = f"{USER_ROOT}/resources/project"
+    directory = _resource_candidate(
+        "",
+        uri=directory_uri,
+        is_directory=True,
+    )
+    directory_contents = {f"{directory_uri}/.overview.md": "Project overview"}
+
+    initial = plan_entries([directory], directory_contents, max_tokens=1600)
+    assert [(entry.detail, entry.is_directory) for entry in initial.entries] == [
+        ("overview", True)
+    ]
+
+    oversized_contents = {f"{directory_uri}/.overview.md": "overview " * 500}
+    fallback = plan_entries([directory], oversized_contents, max_tokens=80)
+    assert [(entry.detail, entry.is_directory) for entry in fallback.entries] == [("uri", True)]
+
+    file_uri = f"{USER_ROOT}/memories/events/launch.md"
+    file_candidate = _resource_candidate(
+        "Launch summary",
+        category="events",
+        uri=file_uri,
+    )
+    upgraded = plan_entries(
+        [file_candidate],
+        {file_uri: "# Summary\nLaunch summary\n\n# Detail\nFull launch details."},
+        max_tokens=1600,
+    )
+    assert [(entry.detail, entry.is_directory) for entry in upgraded.entries] == [
+        ("full", False)
+    ]
+    assert initial.entries[0].to_dict()["is_directory"] is True
+    assert upgraded.entries[0].to_dict()["is_directory"] is False
+
+
+def test_directory_metadata_survives_upgrade_replacement(monkeypatch):
+    directory_uri = f"{USER_ROOT}/resources/project"
+    directory = _resource_candidate("", uri=directory_uri, is_directory=True)
+    monkeypatch.setattr(budget_module, "tier_window", lambda candidate, pin: ("uri", "overview"))
+
+    plan = plan_entries(
+        [directory],
+        {f"{directory_uri}/.overview.md": "Project overview"},
+        max_tokens=1600,
+    )
+
+    assert plan.stats["fill"]["overview_upgrades"] == 1
+    assert [(entry.detail, entry.is_directory) for entry in plan.entries] == [
+        ("overview", True)
+    ]
 
 
 def test_resource_without_abstract_never_substitutes_its_body():

--- a/tests/server/test_api_search_context.py
+++ b/tests/server/test_api_search_context.py
@@ -284,8 +284,11 @@ async def test_context_mode_reads_real_agfs_content_and_sidecars(
     by_uri = {entry["uri"]: entry for entry in response.json()["result"]["entries"]}
     assert "Shipped the stdio MCP proxy." in by_uri[file_uri]["text"]
     assert "MEMORY_FIELDS" not in by_uri[file_uri]["text"]
+    assert by_uri[file_uri]["is_directory"] is False
     assert by_uri[directory_uri]["detail"] == "overview"
+    assert by_uri[directory_uri]["is_directory"] is True
     assert by_uri[directory_uri]["text"] == "Entities directory: projects, people and software."
+    assert "is_directory" not in response.json()["result"]["rendered"]
 
 
 async def test_context_mode_dedup_ledger_round_trips_through_agfs(


### PR DESCRIPTION
## Description

Expose retrieval-backed directory identity in structured context assembly entries. Every `entries[]` item returned by `/search` with `mode: "context"` and the deprecated `/recall` preset now includes a stable boolean `is_directory` field sourced directly from `Candidate.is_directory`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Propagate `Candidate.is_directory` through the context budget planner's single `AssembledEntry` construction path, including initial placement, tier fallback, and upgrade replacement.
- Serialize `is_directory` as a required boolean in `AssembledEntry.to_dict()` while retaining a default of `False` for compatibility with existing explicit dataclass constructors.
- Keep XML/text rendering byte-compatible by leaving `render_entry()` unchanged and limiting the extension to structured entries.
- Add focused coverage for directory and file values, initial/fallback/upgrade tiers, API serialization, `/recall` reuse, and unchanged rendered output.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```text
.venv/bin/pytest -q --no-cov tests/retrieve/test_context_assembler_pipeline.py
.venv/bin/pytest -q --no-cov tests/server/test_api_search_context.py tests/server/test_recall_endpoint.py
.venv/bin/ruff check openviking/retrieve/context_assembler/models.py openviking/retrieve/context_assembler/budget.py tests/retrieve/test_context_assembler_pipeline.py tests/server/test_api_search_context.py
git diff --check
```

Results: 35 targeted tests passed. The server tests used the repository's `MockLocalAGFS` test backend and an existing local ABI3 vector engine artifact because this isolated worktree does not contain built native extensions.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This is an additive structured-response change. Existing rendered context remains unchanged, and no directory inference is performed from URI suffixes or file extensions.
