### PR TITLE
fix(vlm): honor configured stream flag in OpenAIVLM text and vision calls

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -216,6 +216,55 @@ class OpenAIVLM(VLMBase):
             )
         return message.content or ""
 
+    @staticmethod
+    def _extract_from_chunk(chunk) -> str:
+        """Extract text content from a single streaming chunk."""
+        choices = getattr(chunk, "choices", None) or []
+        if not choices:
+            return ""
+        delta = getattr(choices[0], "delta", None)
+        if delta is None:
+            return ""
+        return getattr(delta, "content", None) or ""
+
+    def _process_streaming_response(self, chunks) -> str:
+        """Concatenate streaming chunks and record token usage from the final chunk."""
+        parts: List[str] = []
+        usage_seen = None
+        for chunk in chunks:
+            content = self._extract_from_chunk(chunk)
+            if content:
+                parts.append(content)
+            if not usage_seen and getattr(chunk, "usage", None):
+                usage_seen = chunk.usage
+        if usage_seen:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=getattr(usage_seen, "prompt_tokens", 0) or 0,
+                completion_tokens=getattr(usage_seen, "completion_tokens", 0) or 0,
+            )
+        return "".join(parts)
+
+    async def _process_streaming_response_async(self, chunks) -> str:
+        """Async counterpart of _process_streaming_response."""
+        parts: List[str] = []
+        usage_seen = None
+        async for chunk in chunks:
+            content = self._extract_from_chunk(chunk)
+            if content:
+                parts.append(content)
+            if not usage_seen and getattr(chunk, "usage", None):
+                usage_seen = chunk.usage
+        if usage_seen:
+            self.update_token_usage(
+                model_name=self.model or "gpt-4o-mini",
+                provider=self.provider,
+                prompt_tokens=getattr(usage_seen, "prompt_tokens", 0) or 0,
+                completion_tokens=getattr(usage_seen, "completion_tokens", 0) or 0,
+            )
+        return "".join(parts)
+
     def _build_text_kwargs(
         self,
         prompt: str = "",
@@ -242,6 +291,8 @@ class OpenAIVLM(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        else:
+            kwargs["stream"] = bool(self.stream)
         return kwargs
 
     def _build_vision_kwargs(
@@ -280,14 +331,22 @@ class OpenAIVLM(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        else:
+            kwargs["stream"] = bool(self.stream)
         return kwargs
 
     def _extract_completion_content(self, response, elapsed: float) -> str:
+        if self.stream:
+            content = self._process_streaming_response(response)
+            return self._clean_response(content)
         self._update_token_usage_from_response(response, duration_seconds=elapsed)
         content = self._extract_content_from_response(response)
         return self._clean_response(content)
 
     async def _extract_completion_content_async(self, response, elapsed: float) -> str:
+        if self.stream:
+            content = await self._process_streaming_response_async(response)
+            return self._clean_response(content)
         self._update_token_usage_from_response(response, duration_seconds=elapsed)
         content = self._extract_content_from_response(response)
         return self._clean_response(content)


### PR DESCRIPTION
## Problem

`OpenAIVLM` no longer honors the documented `stream` config flag. PR #1711 (memory isolation / group-chat support) removed the streaming helpers (`_extract_from_chunk`, `_process_streaming_response`, `_process_streaming_response_async`), the `stream` kwarg from `_build_text_kwargs`/`_build_vision_kwargs`, and the `if self.stream` branch in `_extract_completion_content`/`_extract_completion_content_async`. The base class, `VLMConfig` migration, the documented feature (\u201cOpenAI VLM streaming\u201d / \u201cOpenAI SDK needs `stream=true` to parse SSE\u201d), and the `codex_vlm` backend (which still reads `self.stream`) all still treat streaming as supported, so OpenAI-compatible gateways that force SSE responses silently break and token usage is lost on streaming calls.

Refs #3755.

## Evidence

`tests/unit/test_stream_config_vlm.py` encodes the contract and fails 11/20 on current `main` (`674f5e60`) because:
- `_build_text_kwargs`/`_build_vision_kwargs` don\u2019t pass `stream`, so `call_kwargs.get('stream')` is `None` instead of `False`/`True`.
- `get_completion*()` always hands the response to the non-streaming parser, which can\u2019t iterate chunks.
- `_process_streaming_response` / `_process_streaming_response_async` no longer exist.

## Fix

Restore streaming support in `openviking/models/vlm/backends/openai_vlm.py`:

1. Add back `_extract_from_chunk()`, `_process_streaming_response()`, and `_process_streaming_response_async()`. These concatenate `choices[0].delta.content` pieces across chunks and call `update_token_usage` with the final chunk\u2019s `usage` when present (matching the existing test contract).
2. Emit `"stream": bool(self.stream)` from `_build_text_kwargs()` and `_build_vision_kwargs()` for non-tool calls; tool-call invocations keep using the structured non-streaming response (they require `message.tool_calls`, which isn\u2019t delivered in delta chunks).
3. Branch `_extract_completion_content()` and `_extract_completion_content_async()` on `self.stream`: streaming responses go through `_process_streaming_response(_async)`, non-streaming responses are unchanged.

Default behavior for `stream: false` (the default) is byte-for-byte unchanged.

## Verification

- `tests/unit/test_stream_config_vlm.py`: **20/20 pass** (was 11 failed, 9 passed).
- `tests/unit/ tests/models/`: 1571 passed; remaining failures are pre-existing environmental issues (missing `google.genai` module, live-process `test_process_lock` PID assumptions, ollama factory max_tokens checks) unrelated to streaming.