### PR TITLE
fix: normalize non-string intent reasoning

### DIFF
--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -91,6 +91,10 @@ class IntentAnalyzer:
         if not parsed:
             raise ValueError("Failed to parse intent analysis response")
 
+        reasoning = parsed.get("reasoning", "")
+        if not isinstance(reasoning, str):
+            reasoning = str(reasoning)
+
         # Build QueryPlan
         queries = []
         for q in parsed.get("queries", []):
@@ -113,12 +117,12 @@ class IntentAnalyzer:
             logger.info(
                 f'  [{i + 1}] type={q.context_type.value}, priority={q.priority}, query="{q.query}"'
             )
-        logger.debug(f"[IntentAnalyzer] Reasoning: {parsed.get('reasoning', '')[:200]}...")
+        logger.debug(f"[IntentAnalyzer] Reasoning: {reasoning[:200]}...")
 
         return QueryPlan(
             queries=queries,
             session_context=self._summarize_context(compression_summary, current_message),
-            reasoning=parsed.get("reasoning", ""),
+            reasoning=reasoning,
         )
 
     def _build_context_prompt(

--- a/tests/retrieve/test_intent_analyzer_query_planner.py
+++ b/tests/retrieve/test_intent_analyzer_query_planner.py
@@ -107,6 +107,35 @@ async def test_intent_analyzer_uses_query_planner_when_configured(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_intent_analyzer_normalizes_non_string_reasoning(monkeypatch):
+    planner = RecordingModel(
+        """{
+          "reasoning": {"cause": "malformed output"},
+          "queries": [
+            {
+              "query": "planned query",
+              "context_type": "memory",
+              "intent": "test intent",
+              "priority": 1
+            }
+          ]
+        }"""
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert result.reasoning == "{'cause': 'malformed output'}"
+
+
+@pytest.mark.asyncio
 async def test_intent_analyzer_uses_model_specific_prompt(monkeypatch):
     planner = RecordingModel(
         _query_plan_response("planned query"),


### PR DESCRIPTION
## Summary

- normalize non-string query-planner `reasoning` before slicing
- reuse the normalized value for logging and `QueryPlan`
- add regression coverage for object-shaped `reasoning`

## Testing

- `pytest -q -o addopts='' tests/retrieve/test_intent_analyzer_query_planner.py` — 9 passed
- `ruff check openviking/retrieve/intent_analyzer.py tests/retrieve/test_intent_analyzer_query_planner.py`
- `ruff format --check openviking/retrieve/intent_analyzer.py tests/retrieve/test_intent_analyzer_query_planner.py`

Fixes #3859
