### PR TITLE
fix(server): tighten stdlib detection in profile path sanitizer (#3787)

### DIFF
--- a/openviking/server/profile_middleware.py
+++ b/openviking/server/profile_middleware.py
@@ -110,7 +110,7 @@ def _sanitize_profile_path(path: str) -> str:
                     return "/".join(parts[idx + 1 :])
 
         for idx, part in enumerate(parts):
-            if part.startswith("python") and idx + 1 < len(parts):
+            if part[:6] == "python" and part[6:7].isdigit() and idx + 1 < len(parts):
                 suffix = parts[idx + 1 :]
                 if suffix:
                     return "/".join(suffix)

--- a/tests/server/test_profile_middleware.py
+++ b/tests/server/test_profile_middleware.py
@@ -141,5 +141,14 @@ def test_sanitize_profile_path_prefers_package_root_over_project_root_for_venv_p
     assert _sanitize_profile_path(path) == "starlette/middleware/base.py"
 
 
+def test_sanitize_profile_path_does_not_leak_stdlib_when_ancestor_named_python(tmp_path):
+    path = (
+        "/home/user/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/"
+        "lib/python3.11/asyncio/base_events.py"
+    )
+
+    assert _sanitize_profile_path(path) == "asyncio/base_events.py"
+
+
 def test_profile_default_top_n_is_100():
     assert PROFILE_TOP_N == 100


### PR DESCRIPTION
## Summary

Fixes #3787.

## Root cause
`_sanitize_profile_path()` used `part.startswith("python")` to detect stdlib directories. That also matches ancestor directories literally named `python` (e.g. uv's `~/.local/share/uv/python/`, pyenv's `~/.pyenv/versions/`), leaking absolute interpreter install paths into the profiler frame output and failing `test_profile_query_adds_profile_field_to_json_response` in uv/pyenv-managed environments.

Example (broken):
- input:  `~/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py`
- output: `cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py`
- expected: `asyncio/base_events.py`

## Change
Only treat a path component as the stdlib root when it is versioned (matches `python<digit>`, e.g. `python3.11`, `python311`) rather than any `python*` ancestor.

## Tests
- Added regression test `test_sanitize_profile_path_does_not_leak_stdlib_when_ancestor_named_python` covering the uv/pyenv case.
- All 8 tests in `tests/server/test_profile_middleware.py` pass.