### PR TITLE
test(client): align rebuild_clients tests with current SDK behavior (#3805)

### DIFF
--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -63,8 +63,7 @@ def test_async_http_client_zip_directory_warns_when_archive_is_empty(tmp_path):
         pytest.skip(f"symlinks are not available in this environment: {exc}")
 
     client = AsyncHTTPClient(url="http://localhost:1933")
-    with patch.object(http_module.logger, "warning") as mock_warning:
-        zip_path = Path(client._zip_directory(str(root)))
+    zip_path = Path(client._zip_directory(str(root)))
     try:
         with zipfile.ZipFile(zip_path) as zipf:
             names = sorted(zipf.namelist())
@@ -72,10 +71,6 @@ def test_async_http_client_zip_directory_warns_when_archive_is_empty(tmp_path):
         zip_path.unlink(missing_ok=True)
 
     assert names == []
-    mock_warning.assert_called_once_with(
-        "Created empty directory upload archive for %s",
-        root,
-    )
 
 
 async def test_async_openviking_reindex_forwards_to_local_client(tmp_path):
@@ -294,6 +289,9 @@ async def test_local_client_batch_add_messages_forwards_to_session():
             assert auto_create is True
             return fake_session
 
+        async def maybe_schedule_auto_commit(self, *args, **kwargs):
+            return None
+
     client = LocalClient.__new__(LocalClient)
     client._service = SimpleNamespace(sessions=FakeSessions())
     client._ctx = SimpleNamespace(user=SimpleNamespace(user_id="user-1"))
@@ -352,6 +350,9 @@ async def test_local_client_add_message_accepts_image_parts():
             assert ctx is client._ctx
             assert auto_create is True
             return fake_session
+
+        async def maybe_schedule_auto_commit(self, *args, **kwargs):
+            return None
 
     client = LocalClient.__new__(LocalClient)
     client._service = SimpleNamespace(sessions=FakeSessions())
@@ -498,17 +499,18 @@ def test_sync_http_client_batch_add_messages_forwards_to_async_client():
     with patch.object(
         client._async_client,
         "batch_add_messages",
+        new_callable=Mock,
         return_value={"session_id": "batch-session", "message_count": 2, "added": 2},
     ) as mock_batch:
         with patch(
-            "openviking_cli.client.sync_http.run_async",
-            return_value={"session_id": "batch-session", "message_count": 2, "added": 2},
+            "openviking_sdk.client.run_async",
+            side_effect=lambda coro: coro,
         ) as mock_run:
             result = client.batch_add_messages("batch-session", messages)
 
     assert result == {"session_id": "batch-session", "message_count": 2, "added": 2}
     assert mock_run.called
-    mock_batch.assert_called_once_with("batch-session", messages, False)
+    mock_batch.assert_called_once_with("batch-session", messages)
 
 
 def test_run_async_from_foreign_event_loop_uses_shared_background_loop():


### PR DESCRIPTION
## Description

Updates four stale tests in `tests/client/test_rebuild_clients.py` that fail against current `main` due to SDK changes.

Fixes #3805.

## Changes

- `test_async_http_client_zip_directory_warns_when_archive_is_empty`: drop assertion on removed `http_module.logger.warning` call; `AsyncHTTPClient._zip_directory` in `sdk/python/openviking_sdk/client.py` no longer logs on empty archives (symlinks and root-escape entries are silently skipped).
- `test_local_client_batch_add_messages_forwards_to_session` / `test_local_client_add_message_accepts_image_parts`: add `async maybe_schedule_auto_commit` no-op to the `FakeSessions` fakes; `LocalClient.add_message` / `batch_add_messages` now call `self._service.sessions.maybe_schedule_auto_commit(...)` after session writes.
- `test_sync_http_client_batch_add_messages_forwards_to_async_client`: patch `openviking_sdk.client.run_async` (the compat shim `openviking_cli.client.sync_http` no longer exposes `run_async`) and expect the default 2-arg form (`batch_add_messages(session_id, messages)`) rather than the stale 3-arg call.

The remaining three failures in the file (`test_async_openviking_reindex_forwards_to_local_client`, `test_async_openviking_forwards_turn_retention_and_message_semantics`, `test_sync_openviking_reindex_forwards_to_async_client`) construct a real embedded client requiring the native `ragfs_python` binding that is not available in this environment; they are pre-existing environmental issues unrelated to these test staleness defects and pass in CI.

## Testing

```
PYTHONPATH="$PWD:$PWD/bot" pytest tests/client/test_rebuild_clients.py \
  -k 'test_async_http_client_zip_directory_warns_when_archive_is_empty
      or test_local_client_batch_add_messages_forwards_to_session
      or test_local_client_add_message_accepts_image_parts
      or test_sync_http_client_batch_add_messages_forwards_to_async_client'
# 4 passed
```

## Type of Change

- [x] Test update (fixes stale tests against current SDK)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement