### PR TITLE
fix(tests): set server logger to INFO in concurrent request-id test

### DIFF
--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -169,6 +169,8 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
 
     handler = _CaptureHandler(records)
     server_logger.addHandler(handler)
+    previous_level = server_logger.level
+    server_logger.setLevel(logging.INFO)
     gate = asyncio.Event()
     arrivals = 0
 
@@ -191,6 +193,7 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
             )
     finally:
         server_logger.removeHandler(handler)
+        server_logger.setLevel(previous_level)
 
     assert first.headers[REQUEST_ID_HEADER] == "request-first"
     assert second.headers[REQUEST_ID_HEADER] == "request-second"


### PR DESCRIPTION
Closes #3789

The concurrent request-id isolation test attached a `_CaptureHandler` to the `openviking` logger but did not set the logger level to INFO. With the default WARNING level, the INFO-level `finished label=%s` business log emitted by the test endpoint was filtered before reaching the handler, so `business_records` was always empty and the assertion always failed.

Save the original logger level, set it to INFO for the test duration, and restore it in the finally block so the captured records contain the expected business log lines.

Validation:
```
pytest tests/server/test_request_id.py -q
5 passed
```