### PR TITLE
fix(watch): avoid tz-aware vs naive datetime comparison crash (fixes #3268)

### DIFF
--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -10,7 +10,7 @@ import asyncio
 import inspect
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -27,6 +27,18 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 _UNSET = object()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc_aware(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _uri_matches_prefix(uri: Optional[str], prefix: str) -> bool:
@@ -82,7 +94,7 @@ class WatchTask(BaseModel):
     auth_state: Optional[Dict[str, Any]] = Field(
         default=None, description="Private authentication state for scheduled re-processing"
     )
-    created_at: datetime = Field(default_factory=datetime.now, description="Task creation time")
+    created_at: datetime = Field(default_factory=_utcnow, description="Task creation time")
     last_execution_time: Optional[datetime] = Field(None, description="Last execution time")
     next_execution_time: Optional[datetime] = Field(None, description="Next execution time")
     is_active: bool = Field(default=True, description="Whether the task is active")
@@ -133,12 +145,14 @@ class WatchTask(BaseModel):
     def from_dict(cls, data: Dict[str, Any]) -> "WatchTask":
         """Create task from dictionary."""
         data = dict(data)
-        if isinstance(data.get("created_at"), str):
-            data["created_at"] = datetime.fromisoformat(data["created_at"])
-        if isinstance(data.get("last_execution_time"), str):
-            data["last_execution_time"] = datetime.fromisoformat(data["last_execution_time"])
-        if isinstance(data.get("next_execution_time"), str):
-            data["next_execution_time"] = datetime.fromisoformat(data["next_execution_time"])
+        for ts_field in ("created_at", "last_execution_time", "next_execution_time"):
+            value = data.get(ts_field)
+            if isinstance(value, str):
+                data[ts_field] = _as_utc_aware(datetime.fromisoformat(value))
+            elif isinstance(value, datetime):
+                data[ts_field] = _as_utc_aware(value)
+            else:
+                data.pop(ts_field, None)
         if data.get("processor_kwargs") is None:
             data["processor_kwargs"] = {}
         if data.get("auth_state") is not None and not isinstance(data.get("auth_state"), dict):
@@ -284,7 +298,7 @@ class WatchManager:
 
             data = {
                 "tasks": [task.to_storage_dict() for task in self._tasks.values()],
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": _utcnow().isoformat(),
             }
 
             content = json.dumps(data, ensure_ascii=False, indent=2)
@@ -849,7 +863,7 @@ class WatchManager:
                 await self._save_tasks()
                 return
 
-            task.last_execution_time = datetime.now()
+            task.last_execution_time = _utcnow()
             task.next_execution_time = task.calculate_next_execution_time()
 
             await self._save_tasks()
@@ -864,7 +878,7 @@ class WatchManager:
             List of tasks that need to be executed
         """
         async with self._lock:
-            now = datetime.now()
+            now = _utcnow()
             due_tasks = []
 
             for task in self._tasks.values():

--- a/openviking/resource/watch_manager.py
+++ b/openviking/resource/watch_manager.py
@@ -37,7 +37,11 @@ def _as_utc_aware(value: Optional[datetime]) -> Optional[datetime]:
     if value is None:
         return None
     if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
+        # `datetime.now()` and older serialization wrote naive wall-clock
+        # times in the host's local timezone. `astimezone(utc)` on a naive
+        # datetime first assumes local time, which preserves the original
+        # instant that the producer recorded.
+        return value.astimezone(timezone.utc)
     return value.astimezone(timezone.utc)
 
 

--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -7,7 +7,7 @@ Provides scheduled task execution for watch tasks.
 """
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Set
 
 from openviking.resource.feishu_watch_auth import (
@@ -167,7 +167,7 @@ class WatchScheduler:
                 if self._watch_manager:
                     next_time = await self._watch_manager.get_next_execution_time()
                     if next_time is not None:
-                        now = datetime.now()
+                        now = datetime.now(timezone.utc)
                         sleep_seconds = min(
                             self._check_interval,
                             max(0.0, (next_time - now).total_seconds()),

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -168,12 +168,18 @@ class TestWatchTask:
         assert task.last_execution_time == now
 
     def test_from_dict_normalizes_naive_and_offset_timestamps_to_utc(self):
-        """Legacy naive and offset-aware timestamps should load as UTC-aware."""
-        naive = datetime(2026, 7, 9, 4, 14, 37)
+        """Legacy naive and offset-aware timestamps should load as UTC-aware.
+
+        Naive wall-clock times must be interpreted in the host's local timezone
+        (matching how the original naive ``datetime.now()`` producer recorded
+        them) and then converted to UTC, rather than being relabeled as UTC.
+        Offset-aware inputs are converted to their equivalent UTC instant.
+        """
+        naive_local = datetime(2026, 7, 9, 4, 14, 37)
         offset = datetime(2026, 7, 9, 4, 14, 37, tzinfo=timezone(timedelta(hours=8)))
         data = {
             "path": "/test/path",
-            "created_at": naive.isoformat(),
+            "created_at": naive_local.isoformat(),
             "next_execution_time": offset.isoformat(),
         }
 
@@ -183,7 +189,22 @@ class TestWatchTask:
         assert task.created_at.utcoffset() == timedelta(0)
         assert task.next_execution_time is not None
         assert task.next_execution_time.utcoffset() == timedelta(0)
+        # naive wall-clock treated as local time -> matching UTC instant
+        assert task.created_at == naive_local.astimezone(timezone.utc)
+        # offset-aware converted to its UTC equivalent
         assert task.next_execution_time == offset.astimezone(timezone.utc)
+
+    def test_from_dict_naive_wall_time_interpreted_as_local_then_utc(self):
+        """A naive datetime must be interpreted in the host's local timezone
+        (matching how the original ``datetime.now()`` producer recorded it)
+        and then converted to UTC, rather than relabeled as UTC directly.
+        """
+        from openviking.resource.watch_manager import _as_utc_aware
+
+        naive = datetime(2026, 7, 9, 18, 40, 0)
+        expected_utc = naive.astimezone(timezone.utc)
+        assert _as_utc_aware(naive) == expected_utc
+        assert _as_utc_aware(naive).utcoffset() == timedelta(0)
 
     def test_from_dict_defaults_legacy_processing_mode(self):
         task = WatchTask.from_dict({"path": "/test/path"})
@@ -305,12 +326,8 @@ class TestWatchManager:
     async def test_uri_index_move_and_deactivate_are_account_scoped(self):
         manager = WatchManager()
         uri = "viking://resources/shared"
-        task_a = await manager.create_task(
-            path="/a", account_id="account-a", to_uri=uri
-        )
-        task_b = await manager.create_task(
-            path="/b", account_id="account-b", to_uri=uri
-        )
+        task_a = await manager.create_task(path="/a", account_id="account-a", to_uri=uri)
+        task_b = await manager.create_task(path="/b", account_id="account-b", to_uri=uri)
         with pytest.raises(ConflictError):
             await manager.create_task(path="/duplicate", account_id="account-a", to_uri=uri)
 
@@ -327,9 +344,7 @@ class TestWatchManager:
         assert task_b.to_uri == uri
         assert task_b.is_active is False
         assert deactivated == [task_b]
-        moved = await manager.get_task_by_uri(
-            f"{uri}-moved", "account-a", "default", "root"
-        )
+        moved = await manager.get_task_by_uri(f"{uri}-moved", "account-a", "default", "root")
         assert moved is task_a
         assert await manager.get_task_by_uri(uri, "account-b", "default", "root") is task_b
 

--- a/tests/resource/test_watch_manager.py
+++ b/tests/resource/test_watch_manager.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock
@@ -140,7 +140,7 @@ class TestWatchTask:
 
     def test_from_dict(self):
         """Test creating task from dictionary."""
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         data = {
             "task_id": "test-id",
             "path": "/test/path",
@@ -166,6 +166,24 @@ class TestWatchTask:
         assert task.is_active is False
         assert task.created_at == now
         assert task.last_execution_time == now
+
+    def test_from_dict_normalizes_naive_and_offset_timestamps_to_utc(self):
+        """Legacy naive and offset-aware timestamps should load as UTC-aware."""
+        naive = datetime(2026, 7, 9, 4, 14, 37)
+        offset = datetime(2026, 7, 9, 4, 14, 37, tzinfo=timezone(timedelta(hours=8)))
+        data = {
+            "path": "/test/path",
+            "created_at": naive.isoformat(),
+            "next_execution_time": offset.isoformat(),
+        }
+
+        task = WatchTask.from_dict(data)
+
+        assert task.created_at.tzinfo is not None
+        assert task.created_at.utcoffset() == timedelta(0)
+        assert task.next_execution_time is not None
+        assert task.next_execution_time.utcoffset() == timedelta(0)
+        assert task.next_execution_time == offset.astimezone(timezone.utc)
 
     def test_from_dict_defaults_legacy_processing_mode(self):
         task = WatchTask.from_dict({"path": "/test/path"})


### PR DESCRIPTION
## Summary

Fixes #3268.

Watch manager/scheduler used naive `datetime.now()`, but persisted watch tasks can contain offset-aware timestamps (e.g. +00:00 from isoformat round-trips). When the scheduler compares these, it raises `TypeError: can't compare offset-naive and offset-aware datetimes`, terminating the background watch scheduler loop and preventing watched resource refreshes.

## Changes

- `openviking/resource/watch_manager.py`:
  - Add `_utcnow()` helper returning `datetime.now(timezone.utc)`.
  - Add `_as_utc_aware()` helper that normalizes naive datetimes to UTC and converts offset-aware datetimes to UTC.
  - `WatchTask.created_at` default factory now uses `_utcnow()`.
  - `WatchTask.from_dict()` normalizes `created_at`, `last_execution_time`, `next_execution_time` to UTC-aware datetimes on load (handles str, datetime, and None).
  - Replace naive `datetime.now()` in storage `updated_at`, `update_execution_time`, and `get_due_tasks` with `_utcnow()`.
- `openviking/resource/watch_scheduler.py`: Replace naive `datetime.now()` in `_run_scheduler` sleep calculation with `datetime.now(timezone.utc)`.
- `tests/resource/test_watch_manager.py`:
  - Update `test_from_dict` to assert UTC-aware `created_at`.
  - Add regression test `test_from_dict_normalizes_naive_and_offset_timestamps_to_utc` covering legacy naive and +08:00 offset timestamps.

## Verification

- `tests/resource/test_watch_manager.py`: 15 passed (23 pre-existing fixture errors unrelated to this change).
- `tests/resource/test_watch_scheduler.py`: 6 passed.