### PR TITLE
fix(cli): keep Config test fixtures in sync

### DIFF
--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -5022,6 +5022,10 @@ mod tests {
             extra_headers: None,
             profile: false,
             gateway_token: None,
+            auth_mode: None,
+            ldap_username: None,
+            ldap_password: None,
+            oidc_token: None,
         };
 
         let ctx = CliContext::from_config(
@@ -5062,6 +5066,10 @@ mod tests {
             extra_headers: None,
             profile: false,
             gateway_token: None,
+            auth_mode: None,
+            ldap_username: None,
+            ldap_password: None,
+            oidc_token: None,
         };
 
         let ctx = CliContext::from_config(
@@ -5100,6 +5108,10 @@ mod tests {
             upload: Default::default(),
             extra_headers: None,
             gateway_token: None,
+            auth_mode: None,
+            ldap_username: None,
+            ldap_password: None,
+            oidc_token: None,
         };
 
         // Without sudo: use api_key


### PR DESCRIPTION
## Summary

- restore Rust CLI test compilation after the OIDC/LDAP auth fields were added to `Config`
- initialize the new optional auth fields in three CLI context test fixtures

## Root cause

The Rust `Config` struct gained `auth_mode`, `ldap_username`, `ldap_password`, and
`oidc_token`, but three struct literals in the CLI tests were not updated. As a result,
`cargo test -p ov_cli --bin ov` failed to compile with `E0063`, even though the normal CLI
binary still built successfully.

## Impact

The Rust CLI unit test target compiles and runs again. This changes test fixtures only and
does not affect runtime behavior.

## Testing

- `cargo test -p ov_cli --bin ov` — 453 passed
- `cargo fmt -p ov_cli -- --check`
- `git diff --check`
