### PR TITLE
fix(resource): skip full re-embedding on unchanged vectors_only refresh

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -534,6 +534,7 @@ class ResourceProcessor:
             try:
                 sync_deleted_files: list[str] = []
                 sync_deleted_dirs: list[str] = []
+                sync_changed_files: Optional[list[str]] = None
                 if not should_summarize and temp_uri and not source_committed:
                     viking_fs = get_viking_fs()
                     if vectors_only and target_preexisting and not root_is_file:
@@ -545,6 +546,9 @@ class ResourceProcessor:
                         )
                         sync_deleted_files = list(getattr(diff, "deleted_files", []))
                         sync_deleted_dirs = list(getattr(diff, "deleted_dirs", []))
+                        sync_changed_files = list(getattr(diff, "added_files", [])) + list(
+                            getattr(diff, "updated_files", [])
+                        )
                     else:
                         await viking_fs.persist_temp_tree(
                             temp_uri,
@@ -580,9 +584,15 @@ class ResourceProcessor:
                             root_uri, ctx=ctx, ingest_options=ingest_options
                         )
                     elif vectors_only:
-                        await self._vectorize_resource_files(
-                            root_uri, ctx=ctx, ingest_options=ingest_options
-                        )
+                        if target_preexisting and sync_changed_files is not None:
+                            for file_uri in dict.fromkeys(sync_changed_files):
+                                await self._vectorize_resource_file(
+                                    file_uri, ctx=ctx, ingest_options=ingest_options
+                                )
+                        else:
+                            await self._vectorize_resource_files(
+                                root_uri, ctx=ctx, ingest_options=ingest_options
+                            )
             finally:
                 await get_viking_fs()._async_agfs.pathlock_release(resource_lock)
         elif should_refresh_file_parent:

--- a/tests/storage/test_issue_2383_repro.py
+++ b/tests/storage/test_issue_2383_repro.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+from openviking_cli.session.user_id import UserIdentifier
+
+
+class _FakeAgfs:
+    async def pathlock_acquire_exact_batch(self, _paths):
+        return {"lease_ref": "test"}
+
+    async def pathlock_release(self, _lease):
+        return None
+
+
+class _FakeVikingFS:
+    def __init__(self, contents, entries):
+        self.contents = dict(contents)
+        self.entries = {k: list(v) for k, v in entries.items()}
+        self.mutations = []
+        self.deleted_temp = []
+        self._async_agfs = _FakeAgfs()
+
+    async def exists(self, uri, ctx=None):
+        return uri in self.entries
+
+    async def ls(self, uri, show_all_hidden=False, node_limit=None, ctx=None):
+        out = []
+        for entry in self.entries.get(uri, []):
+            name = entry.get("name", "")
+            if show_all_hidden or not name.startswith("."):
+                out.append(entry)
+        return out
+
+    async def stat(self, uri, ctx=None):
+        content = self.contents.get(uri, "")
+        return {"size": len(content)}
+
+    async def read_file(self, uri, ctx=None):
+        return self.contents.get(uri, "")
+
+    async def rm(self, uri, recursive=False, ctx=None, lease_ref=None):
+        self.mutations.append(("rm", uri, lease_ref))
+        self.contents.pop(uri, None)
+        for parent, items in list(self.entries.items()):
+            self.entries[parent] = [e for e in items if _entry_uri(parent, e) != uri]
+
+    async def mv(self, src, dst, ctx=None, lease_ref=None):
+        self.mutations.append(("mv", src, dst, lease_ref))
+        self.contents[dst] = self.contents.pop(src)
+        src_parent = _parent_uri(src)
+        dst_parent = _parent_uri(dst)
+        name = dst.rsplit("/", 1)[-1]
+        if src_parent in self.entries:
+            self.entries[src_parent] = [e for e in self.entries[src_parent] if e.get("name") != _name(src)]
+        self.entries.setdefault(dst_parent, []).append({"name": name, "isDir": False})
+
+    async def mkdir(self, uri, exist_ok=False, ctx=None, lease_ref=None):
+        self.mutations.append(("mkdir", uri, lease_ref))
+        self.entries.setdefault(uri, [])
+
+    async def delete_temp(self, uri, ctx=None, lease_ref=None):
+        self.mutations.append(("delete_temp", uri, lease_ref))
+        self.deleted_temp.append(uri)
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri.replace("viking://", "/local/")
+
+
+def _name(uri):
+    return uri.rsplit("/", 1)[-1]
+
+
+def _parent_uri(uri):
+    if "/" not in uri.split("://", 1)[-1]:
+        return None
+    return uri.rsplit("/", 1)[0]
+
+
+def _entry_uri(parent, entry):
+    return parent.rstrip("/") + "/" + entry["name"]
+
+
+class _FakeProcessor(SemanticProcessor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.files_summarized = []
+        self.overviews_generated = []
+        self.vectorized_files = []
+        self.vectorized_dirs = []
+
+    async def _generate_single_file_summary(self, file_path, llm_sem=None, ctx=None):
+        self.files_summarized.append(file_path)
+        return {"name": file_path.split("/")[-1], "summary": f"summary:{file_path.split('/')[-1]}"}
+
+    async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.overviews_generated.append(dir_uri)
+        lines = ["FILES:"]
+        for item in file_summaries:
+            lines.append(f"- {item['name']}: {item['summary']}")
+        for item in children_abstracts:
+            lines.append(f"- {item['name']}: {item['abstract']}")
+        return "\n".join(lines)
+
+    def _normalize_overview_generation(self, overview):
+        return overview, "abstract"
+
+    async def _vectorize_single_file(self, parent_uri, context_type, file_path, summary_dict, ctx=None, semantic_msg_id=None, use_summary=False, ingest_options=None):
+        self.vectorized_files.append(file_path)
+
+    async def _vectorize_directory(self, dir_uri, context_type, abstract, overview, ctx=None, semantic_msg_id=None, ingest_options=None):
+        self.vectorized_dirs.append(dir_uri)
+
+    def _parse_overview_md(self, overview_content):
+        import re
+        results = {}
+        for line in overview_content.splitlines():
+            m = re.match(r"^-\s*(?P<name>[^:]+):\s*(?P<summary>.*)$", line.strip())
+            if not m:
+                continue
+            results[m.group("name").strip()] = m.group("summary").strip()
+        return results
+
+    async def _rewrite_target_image_uris(self, root_uri, target_uri, ctx=None, lock=None):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_unchanged_temp_target_refresh_skips_all_embedding_work(monkeypatch):
+    root = "viking://resources/root"
+    temp = "viking://temp/refresh/root"
+    contents = {
+        f"{temp}/a.txt": "A content",
+        f"{temp}/b.txt": "B content",
+        f"{root}/a.txt": "A content",
+        f"{root}/b.txt": "B content",
+        f"{root}/.overview.md": "FILES:\n- a.txt: old-a\n- b.txt: old-b",
+        f"{root}/.abstract.md": "old-abstract",
+    }
+    entries = {
+        temp: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+        ],
+        root: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+            {"name": ".overview.md", "isDir": False},
+            {"name": ".abstract.md", "isDir": False},
+        ],
+    }
+    fs = _FakeVikingFS(contents, entries)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_processor.get_viking_fs", lambda: fs)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.write_semantic_sidecars",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=SimpleNamespace(lock={"lease_ref": "test"}, close=AsyncMock())),
+    )
+
+    processor = _FakeProcessor()
+    processor._default_ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    processor._enqueue_parent_refresh = AsyncMock()
+    msg = SemanticMsg(
+        uri=temp,
+        target_uri=root,
+        context_type="resource",
+        account_id="acc1",
+        user_id="user1",
+        peer_id="user1",
+        role=str(Role.USER),
+    )
+
+    await processor.on_dequeue(msg.to_dict())
+
+    assert processor.files_summarized == [], processor.files_summarized
+    assert processor.overviews_generated == [], processor.overviews_generated
+    assert processor.vectorized_files == [], processor.vectorized_files
+    assert processor.vectorized_dirs == [], processor.vectorized_dirs
+
+
+@pytest.mark.asyncio
+async def test_unchanged_temp_target_sync_skips_semantic_and_embedding_work_end_to_end(monkeypatch):
+    """Reproduces #2383: repeated add_resource where temp tree matches target.
+
+    In the real add_resource flow, the parser produces a fresh viking://temp
+    tree and Summarizer emits SemanticMsg(uri=temp, target_uri=root).
+    SemanticProcessor must sync temp→target via _sync_topdown_recursive,
+    detect zero diff, and run the DAG in incremental mode so no file
+    summaries, overviews or vectors are regenerated for unchanged content.
+    """
+    root = "viking://resources/root"
+    temp = "viking://temp/refresh/root"
+    contents = {
+        f"{temp}/a.txt": "A content",
+        f"{temp}/b.txt": "B content",
+        f"{root}/a.txt": "A content",
+        f"{root}/b.txt": "B content",
+        f"{root}/.overview.md": "FILES:\n- a.txt: old-a\n- b.txt: old-b",
+        f"{root}/.abstract.md": "old-abstract",
+        f"{temp}/.image_mappings.json": "{}",
+    }
+    entries = {
+        temp: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+            {"name": ".image_mappings.json", "isDir": False},
+        ],
+        root: [
+            {"name": "a.txt", "isDir": False},
+            {"name": "b.txt", "isDir": False},
+            {"name": ".overview.md", "isDir": False},
+            {"name": ".abstract.md", "isDir": False},
+        ],
+    }
+    fs = _FakeVikingFS(contents, entries)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_processor.get_viking_fs", lambda: fs)
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.write_semantic_sidecars",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.SemanticLockScope.resolve",
+        AsyncMock(return_value=SimpleNamespace(lock={"lease_ref": "test"}, close=AsyncMock())),
+    )
+
+    processor = _FakeProcessor()
+    processor._default_ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    processor._enqueue_parent_refresh = AsyncMock()
+    processor._rewrite_target_image_uris = AsyncMock()
+    msg = SemanticMsg(
+        uri=temp,
+        target_uri=root,
+        context_type="resource",
+        account_id="acc1",
+        user_id="user1",
+        peer_id="user1",
+        role=str(Role.USER),
+        target_preexisting=True,
+    )
+
+    await processor.on_dequeue(msg.to_dict())
+
+    assert processor.files_summarized == [], processor.files_summarized
+    assert processor.overviews_generated == [], processor.overviews_generated
+    assert processor.vectorized_files == [], processor.vectorized_files
+    assert processor.vectorized_dirs == [], processor.vectorized_dirs
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -421,6 +421,125 @@ async def test_vectors_only_deletes_sync_removed_detail_vectors(monkeypatch, ctx
 
 
 @pytest.mark.asyncio
+async def test_vectors_only_unchanged_preexisting_target_skips_all_vectorization(monkeypatch, ctx):
+    """Regression test for #2383.
+
+    When vectors_only refresh runs against an already-existing target and
+    _sync_topdown_recursive reports zero added/updated/deleted files,
+    no vectorize_file calls should be made (previously the code called
+    _vectorize_resource_files on the entire target root, re-embedding
+    every unchanged file).
+    """
+    from openviking.storage.queuefs.semantic_processor import DiffResult
+
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
+        delete_temp=AsyncMock(),
+    )
+    vectorize_file = AsyncMock()
+    sync = AsyncMock(
+        return_value=DiffResult(
+            added_files=[],
+            updated_files=[],
+            deleted_files=[],
+            added_dirs=[],
+            deleted_dirs=[],
+        )
+    )
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.rewrite_image_uris", AsyncMock())
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr("openviking.utils.resource_processor.SemanticProcessor", Mock())
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.SemanticProcessor.return_value._sync_topdown_recursive",
+        sync,
+    )
+    processor = ResourceProcessor(_FakeVikingDB())
+    processor._delete_removed_resource_vectors = AsyncMock()
+    lock = {"lease_ref": "lock-1"}
+
+    await processor.finish_prepared_resource(
+        {
+            "root_uri": "viking://resources/demo",
+            "temp_uri": "viking://temp/demo",
+            "temp_dir_path": "viking://temp/demo",
+            "source_committed": False,
+            "target_preexisting": True,
+        },
+        ctx=ctx,
+        resource_lock=lock,
+        build_index=True,
+        processing_mode="vectors_only",
+    )
+
+    vectorize_file.assert_not_awaited()
+    processor._delete_removed_resource_vectors.assert_not_awaited()
+    viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
+
+
+@pytest.mark.asyncio
+async def test_vectors_only_partial_change_preexisting_target_vectorizes_only_changed(monkeypatch, ctx):
+    """Only added/updated files should be vectorized after incremental sync.
+
+    Unchanged files must not be re-embedded.
+    """
+    from openviking.storage.queuefs.semantic_processor import DiffResult
+
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
+        delete_temp=AsyncMock(),
+    )
+    vectorize_file = AsyncMock()
+    sync = AsyncMock(
+        return_value=DiffResult(
+            added_files=["viking://resources/demo/new.md"],
+            updated_files=["viking://resources/demo/changed.md"],
+            deleted_files=["viking://resources/demo/gone.md"],
+            added_dirs=[],
+            deleted_dirs=[],
+        )
+    )
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.rewrite_image_uris", AsyncMock())
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr("openviking.utils.resource_processor.SemanticProcessor", Mock())
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.SemanticProcessor.return_value._sync_topdown_recursive",
+        sync,
+    )
+    processor = ResourceProcessor(_FakeVikingDB())
+    processor._delete_removed_resource_vectors = AsyncMock()
+    lock = {"lease_ref": "lock-1"}
+
+    await processor.finish_prepared_resource(
+        {
+            "root_uri": "viking://resources/demo",
+            "temp_uri": "viking://temp/demo",
+            "temp_dir_path": "viking://temp/demo",
+            "source_committed": False,
+            "target_preexisting": True,
+        },
+        ctx=ctx,
+        resource_lock=lock,
+        build_index=True,
+        processing_mode="vectors_only",
+    )
+
+    assert vectorize_file.await_count == 2
+    vectorized_paths = {c.kwargs["file_path"] for c in vectorize_file.await_args_list}
+    assert vectorized_paths == {
+        "viking://resources/demo/new.md",
+        "viking://resources/demo/changed.md",
+    }
+    processor._delete_removed_resource_vectors.assert_awaited_once_with(
+        files=["viking://resources/demo/gone.md"],
+        dirs=[],
+        ctx=ctx,
+    )
+    viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
+
+
+@pytest.mark.asyncio
 async def test_delete_removed_resource_vectors_deletes_detail_records(ctx):
     vikingdb = _RecordingVikingDB()
     processor = ResourceProcessor(vikingdb)


### PR DESCRIPTION
## Summary

`add_resource(..., processing_mode='vectors_only', to=<existing_uri>)` on an unchanged directory reported a full Embedding queue on every refresh (issue #2383).

## Root cause

In `ResourceProcessor.finish_prepared_resource`, when `vectors_only=True`, `target_preexisting=True`, and the target is a directory, `_sync_topdown_recursive` is already called to reconcile the temp tree into the target and computes a precise `DiffResult` (added/updated/deleted files & dirs). However, after the sync and deleted-vector cleanup, the code unconditionally called `_vectorize_resource_files(root_uri, ...)`, which walks **every non-hidden file under the target root** and enqueues an embedding task for each.

The non-vectors_only (semantic DAG) path already threads the diff through `SemanticDagExecutor(changes=..., incremental_update=True)` and only re-summarizes/re-vectorizes changed paths, so the bug was isolated to the vectors_only branch. `preserve_structure` does not affect this path.

## Fix

- Collect `added_files + updated_files` from the sync `DiffResult` into `sync_changed_files`.
- In the vectors_only post-sync branch, when `target_preexisting` is true and a diff was computed, call `_vectorize_resource_file` only for those changed URIs (deduped, preserving order).
- Keep the existing deleted-files/dirs vector cleanup intact.
- First-time ingest (`target_preexisting=False`), single-file vectorization, and non-vectors_only flows are unchanged.

## Why not the earlier approaches

Closes #2383. Supersedes the previously closed attempts that used a sidecar `.embedding_cache.json` (#2659) or parsed `.overview.md` to detect unchanged files (#2790), per maintainer guidance to keep the fix minimal pending a future structured auxiliary-file refactor. This fix reuses the diff `_sync_topdown_recursive` already computes and adds ~10 lines of production code.

## Tests

- Adds `test_vectors_only_unchanged_preexisting_target_skips_all_vectorization`: empty diff → zero `vectorize_file` calls, zero delete calls.
- Adds `test_vectors_only_partial_change_preexisting_target_vectorizes_only_changed`: diff with added/updated/deleted → only added+updated files vectorized, deleted vectors cleaned up.
- Existing `tests/storage/test_issue_2383_repro.py` covers the non-vectors_only (semantic DAG) incremental path (2 tests).
- `tests/utils/test_resource_processor_processing_mode.py`: all 11 tests pass (9 pre-existing + 2 new).
- Related storage / semantic / resource processor tests: 140 pass; the 2 pre-existing failures (`test_overview_generation_language_flow[zh-CN-...]`, `test_mv_canonicalizes_user_shorthand_before_vector_update`) reproduce on `origin/main` unmodified and are unrelated to this change.