### PR TITLE
fix(ovpack): restore --on-conflict overwrite clears protected scope roots via children

### DIFF
--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -116,9 +116,52 @@ async def _ensure_parent_exists(viking_fs, parent: str, ctx: RequestContext) -> 
         await viking_fs.mkdir(parent, ctx=ctx)
 
 
+_PROTECTED_SCOPE_ROOTS = frozenset({"viking://user", "viking://agent"})
+
+
+def _is_protected_scope_root(root_uri: str) -> bool:
+    return root_uri.rstrip("/") in _PROTECTED_SCOPE_ROOTS
+
+
+async def _clear_protected_root_children(viking_fs, root_uri: str, ctx: RequestContext) -> None:
+    """Clear the children of a protected scope root without deleting the root itself.
+
+    viking://user and viking://agent are namespace containers that VikingFS
+    forbids removing directly; restore-overwrite must wipe their contents so
+    the backup can repopulate them, while keeping the container in place for
+    the server's public-scope invariants.
+    """
+    ls_fn = getattr(viking_fs, "ls", None)
+    if ls_fn is None:
+        logger.warning(f"[ovpack] Cannot clear protected root without ls(): {root_uri}")
+        return
+    try:
+        entries = await ls_fn(root_uri, ctx=ctx)
+    except NotFoundError:
+        return
+    except FileNotFoundError:
+        return
+    for entry in entries or []:
+        child_uri = entry.get("uri") if isinstance(entry, dict) else None
+        if not child_uri:
+            continue
+        if not hasattr(viking_fs, "rm"):
+            logger.warning(f"[ovpack] Cannot remove protected-root child without rm(): {child_uri}")
+            continue
+        try:
+            await viking_fs.rm(child_uri, recursive=True, ctx=ctx)
+        except NotFoundError:
+            continue
+        except FileNotFoundError:
+            continue
+
+
 async def _remove_existing_root(viking_fs, root_uri: str, ctx: RequestContext) -> None:
     if not hasattr(viking_fs, "rm"):
         logger.warning(f"[ovpack] Cannot remove existing resource without rm(): {root_uri}")
+        return
+    if _is_protected_scope_root(root_uri):
+        await _clear_protected_root_children(viking_fs, root_uri, ctx=ctx)
         return
     try:
         await viking_fs.rm(root_uri, recursive=True, ctx=ctx)

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -258,6 +258,14 @@ class MissingSidecarBackupVikingFS(FakeBackupVikingFS):
         )
 
 
+class PermissionDeniedError(Exception):
+    """Minimal stand-in mirroring storage.errors.PermissionDeniedError."""
+
+    def __init__(self, message: str, resource: str | None = None) -> None:
+        super().__init__(message)
+        self.resource = resource
+
+
 class FakeRestoreVectorVikingFS(FakeVikingFS):
     async def tree(self, uri: str, node_limit=None, level_limit=None, ctx=None):
         self.tree_calls.append(uri)
@@ -619,6 +627,70 @@ async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: Requ
         "viking://user/alice/sessions/sess_1/.meta.json",
     ]
     assert fake_fs.tree_calls == ["viking://resources", "viking://user"]
+
+
+class FakeInitializedVikingFS(FakeVikingFS):
+    """Simulates a freshly initialized server: resources + user roots exist and
+    rm() rejects deleting the protected viking://user / viking://agent containers,
+    mirroring VikingFS._ensure_supported_delete_namespace.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.rm_calls: list[str] = []
+        # Pre-existing children under the protected user root.
+        self._children: dict[str, list[dict[str, object]]] = {
+            "viking://resources": [
+                {"uri": "viking://resources/old.md", "isDir": False},
+            ],
+            "viking://user": [
+                {"uri": "viking://user/old-user", "isDir": True},
+                {"uri": "viking://user/legacy-session", "isDir": False},
+            ],
+        }
+
+    async def ls(self, uri: str, ctx=None):
+        if uri in self._children:
+            return list(self._children[uri])
+        raise NotFoundError(uri, "file")
+
+    async def rm(self, uri: str, recursive: bool = False, ctx=None):
+        if uri in {"viking://user", "viking://agent", "viking://"}:
+            raise PermissionDeniedError(
+                f"Deleting {uri} is not supported",
+                resource=uri,
+            )
+        self.rm_calls.append(uri)
+        return {"estimated_deleted_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_restore_overwrite_clears_protected_user_root(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    """overwrite mode must not try to rm() viking://user itself; it should clear
+    children so backup content can be restored into the initialized server.
+    Regression for #3875.
+    """
+    await backup_ovpack(
+        FakeBackupVikingFS(),
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    fake_fs = FakeInitializedVikingFS()
+    assert (
+        await restore_ovpack(fake_fs, str(temp_ovpack_path), request_ctx, on_conflict="overwrite")
+        == "viking://"
+    )
+    assert "viking://user" not in fake_fs.rm_calls
+    assert "viking://user/old-user" in fake_fs.rm_calls
+    assert "viking://user/legacy-session" in fake_fs.rm_calls
+    assert "viking://resources" in fake_fs.rm_calls
+    assert fake_fs.written_files == [
+        "viking://resources/README.md",
+        "viking://user/alice/sessions/sess_1/.meta.json",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issue

Closes #3875.

Running `ov restore <backup.ovpack> --on-conflict overwrite` failed with:

```
PERMISSION_DENIED: Deleting viking://user is not supported; use an explicit user namespace or current-user content path instead.
```

## Root Cause

`restore_ovpack()` calls `_remove_existing_root()` which does a recursive `rm()` on the target namespace root. Since #2628 (commit `23a76f9`), VikingFS blocks deletion of the protected scope roots `viking://user` and `viking://agent` via `_ensure_supported_delete_namespace`, so overwrite restores onto a freshly-initialized server crash.

## Fix

- Add a protected-scope-root helper that detects `viking://user` and `viking://agent`.
- For those roots, list their children and delete each child individually instead of `rm`ing the root itself.
- Non-protected roots (e.g. `viking://resources`) continue to use the existing recursive `rm`.

## Testing

- Added regression test `test_restore_overwrite_clears_protected_user_root` in `tests/misc/test_ovpack_import_policy.py` using a fake FS that raises `PermissionDeniedError` on protected-root deletes.
- All 19 tests in `tests/misc/test_ovpack_import_policy.py` pass.
- `ruff check` clean; `ruff format` applied.