### PR TITLE
fix(opencode-plugin): serialize saveState to avoid ENOENT rename race

### DIFF
--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -30,6 +30,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   const statePath = path.join(pluginRoot, "openviking-session-state.json")
   const oldSessionMapPath = path.join(pluginRoot, "openviking-session-map.json")
   let saveTimer = null
+  let saveChain = Promise.resolve()
 
   async function init() {
     if (config.autoCapture) await migrateLegacySessionMap()
@@ -67,24 +68,38 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   }
 
   async function saveState() {
+    const persisted = {}
+    for (const [opencodeSessionId, state] of sessions.entries()) {
+      persisted[opencodeSessionId] = serializeSessionState(state)
+    }
+    const tempPath = `${statePath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`
     try {
-      const persisted = {}
-      for (const [opencodeSessionId, state] of sessions.entries()) {
-        persisted[opencodeSessionId] = serializeSessionState(state)
-      }
-      const tempPath = `${statePath}.tmp`
       await fs.promises.writeFile(tempPath, JSON.stringify({ version: 2, sessions: persisted, lastSaved: Date.now() }, null, 2), "utf8")
       await fs.promises.rename(tempPath, statePath)
       log("DEBUG", "persistence", "Session state saved", { count: sessions.size })
     } catch (error) {
       log("ERROR", "persistence", "Failed to save session state", { error: error?.message })
+      try {
+        await fs.promises.unlink(tempPath)
+      } catch {
+        // temp file already renamed or never created
+      }
     }
+  }
+
+  function enqueueSave() {
+    const run = saveChain.then(() => saveState(), (reason) => {
+      log("ERROR", "persistence", "Previous save failed, continuing", { error: reason?.message })
+      return saveState()
+    })
+    saveChain = run.catch(() => {})
+    return run
   }
 
   function debouncedSaveState() {
     if (saveTimer) clearTimeout(saveTimer)
     saveTimer = setTimeout(() => {
-      saveState().catch((error) => {
+      enqueueSave().catch((error) => {
         log("ERROR", "persistence", "Debounced save failed", { error: error?.message })
       })
     }, 300)
@@ -176,7 +191,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     if (!sessionId) return
     await flushSession(sessionId, { commit: true, reason: event.type })
     sessions.delete(sessionId)
-    await saveState()
+    await enqueueSave()
   }
 
   async function handleSessionError(event) {
@@ -253,7 +268,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     for (const sessionId of sessions.keys()) {
       await flushSession(sessionId, { commit, reason: "flushAll" })
     }
-    await saveState()
+    await enqueueSave()
   }
 
   async function flushSession(opencodeSessionId, { commit = false, reason = "manual" } = {}) {
@@ -267,7 +282,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     } else if (added > 0) {
       await maybeCommitByThreshold(state)
     }
-    await saveState()
+    await enqueueSave()
     return true
   }
 

--- a/examples/opencode-plugin/tests/memory-session.test.mjs
+++ b/examples/opencode-plugin/tests/memory-session.test.mjs
@@ -213,3 +213,46 @@ test("assistant messages are captured even when finish is not stop", async () =>
     })
   })
 })
+
+test("concurrent flushAll/debounced saves do not corrupt state file", async () => {
+  await withCaptureServer(async ({ endpoint }) => {
+    await withTempDir("ov-oc-session-", async (dir) => {
+      const manager = createMemorySessionManager({ config: baseConfig(endpoint), pluginRoot: dir })
+      await manager.init()
+
+      for (let i = 0; i < 20; i++) {
+        await manager.handleEvent({ type: "session.created", properties: { info: { id: `oc-session-${i}` } } })
+        await manager.handleEvent({
+          type: "message.updated",
+          properties: { info: { id: `msg-${i}`, sessionID: `oc-session-${i}`, role: "user" } },
+        })
+        await manager.handleEvent({
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: `part-${i}`,
+              messageID: `msg-${i}`,
+              sessionID: `oc-session-${i}`,
+              type: "text",
+              text: `hello from session ${i}`,
+            },
+          },
+        })
+      }
+
+      await Promise.all([
+        manager.flushAll({ commit: false }),
+        manager.flushAll({ commit: false }),
+        manager.flushAll({ commit: false }),
+      ])
+      await manager.flushAll({ commit: false })
+
+      const { readFile } = await import("node:fs/promises")
+      const statePath = `${dir}/openviking-session-state.json`
+      const raw = await readFile(statePath, "utf8")
+      const parsed = JSON.parse(raw)
+      assert.equal(parsed.version, 2)
+      assert.equal(Object.keys(parsed.sessions).length, 20)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #3877.

The OpenCode memory plugin's `saveState()` wrote to a fixed `openviking-session-state.json.tmp` temp file and renamed it onto the real state path, with no serialization across callers. Concurrent invocations from `debouncedSaveState`, `flushAll`, `flushSession`, and `handleSessionDeleted` could race on the shared temp path: one call renamed the file away, and the other's `rename` then failed with `ENOENT`.

## Changes
- Add `enqueueSave()` that serializes all state writes through a promise chain, so concurrent callers don't overlap file I/O.
- Use a unique temp filename per write (`statePath.tmp.<pid>.<ts>.<rand>`) instead of a fixed `.tmp`, as defense-in-depth even if future code paths bypass the queue.
- Best-effort cleanup of the temp file on write/rename failure.
- Route every existing `saveState()` call site (debounced, delete, flushAll, flushSession) through `enqueueSave()`.
- Added a regression test that runs three concurrent `flushAll` calls against a manager with 20 sessions and verifies the on-disk state file is valid JSON containing all sessions.

## Verification
- `npm run check`: all `node --check` syntax checks pass.
- `npm test`: all 24 OpenCode plugin tests pass, including the new concurrency regression test.
- No changes to server/Python code; plugin-only change confined to `examples/opencode-plugin`.