### PR TITLE
fix(search): expand find/search scope for context_type=skill

### DIFF
--- a/openviking/client/local.py
+++ b/openviking/client/local.py
@@ -741,6 +741,7 @@ class LocalClient(BaseClient):
                 filter=resolved_filter,
                 level=level,
                 image_url=image_url,
+                context_type=context_type,
             ),
         )
         return attach_telemetry_payload(
@@ -787,6 +788,7 @@ class LocalClient(BaseClient):
                 filter=resolved_filter,
                 level=level,
                 image_url=image_url,
+                context_type=context_type,
             )
 
         execution = await run_with_telemetry(

--- a/openviking/core/retrieval_targets.py
+++ b/openviking/core/retrieval_targets.py
@@ -14,6 +14,7 @@ from openviking.core.namespace import (
 )
 from openviking.core.peer_id import normalize_peer_id
 from openviking.server.identity import RequestContext, Role
+from openviking.utils.search_filters import resolve_context_types
 from openviking_cli.exceptions import InvalidArgumentError, PermissionDeniedError
 from openviking_cli.retrieve import ContextType
 from openviking_cli.utils.uri import VikingURI
@@ -30,13 +31,14 @@ class ResolvedRetrievalTargets:
 def resolve_retrieval_targets(
     target_uri: Union[str, List[str]],
     ctx: RequestContext,
+    context_type: Optional[Union[str, ContextType, List]] = None,
 ) -> ResolvedRetrievalTargets:
     """Resolve search/find target directories."""
     target_uris = _canonicalize_target_uris(target_uri, ctx)
 
     if not target_uris:
         return ResolvedRetrievalTargets(
-            target_directories=default_target_directories(ctx),
+            target_directories=default_target_directories(ctx, context_type=context_type),
         )
 
     target_directories: List[str] = []
@@ -53,12 +55,34 @@ def resolve_retrieval_targets(
 def default_target_directories(
     ctx: Optional[RequestContext],
     *,
-    context_type: Optional[ContextType] = None,
+    context_type: Optional[Union[str, ContextType, List]] = None,
 ) -> List[str]:
     """Return default retrieval directories for a user context."""
     if not ctx or ctx.role == Role.ROOT:
         return []
 
+    context_types = resolve_context_types(context_type)
+    if not context_types:
+        return _general_default_target_directories(ctx)
+
+    directories: List[str] = []
+    for value in context_types:
+        for directory in _typed_default_target_directories(ctx, ContextType(value)):
+            if directory not in directories:
+                directories.append(directory)
+    return directories
+
+
+def _general_default_target_directories(ctx: RequestContext) -> List[str]:
+    user_root = canonical_user_root(ctx)
+    if ctx.actor_peer_id:
+        return _dedupe(["viking://resources", *_default_user_root_targets(ctx)])
+    return [user_root, "viking://resources"]
+
+
+def _typed_default_target_directories(
+    ctx: RequestContext, context_type: ContextType
+) -> List[str]:
     user_root = canonical_user_root(ctx)
     if context_type == ContextType.MEMORY:
         if ctx.actor_peer_id:
@@ -81,9 +105,7 @@ def default_target_directories(
         return ["viking://resources", user_root]
     if context_type == ContextType.SKILL:
         return _dedupe([*_default_skill_targets(ctx), *_default_agent_skill_targets()])
-    if ctx.actor_peer_id:
-        return _dedupe(["viking://resources", *_default_user_root_targets(ctx)])
-    return [user_root, "viking://resources"]
+    return _general_default_target_directories(ctx)
 
 
 def _canonicalize_target_uris(

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -254,6 +254,7 @@ async def find(
         score_threshold=min_score,
         filter=_resolve_context_type_filter(context_type),
         level=level,
+        context_type=context_type,
     )
     return _format_search_result(result)
 
@@ -285,6 +286,7 @@ async def search(
         score_threshold=min_score,
         filter=_resolve_context_type_filter(context_type),
         level=level,
+        context_type=context_type,
     )
     return _format_search_result(result)
 

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -296,6 +296,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=request.image_url,
+            context_type=request.context_type,
         ),
     )
     result = execution.result
@@ -407,6 +408,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=request.image_url,
+            context_type=request.context_type,
         )
 
     execution = await run_operation(

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -88,6 +88,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -123,6 +124,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result
 
@@ -136,6 +138,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -163,5 +166,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -2136,6 +2136,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ):
         """Semantic search.
 
@@ -2159,7 +2160,9 @@ class VikingFS:
         )
 
         real_ctx = self._ctx_or_default(ctx)
-        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx)
+        retrieval_targets = resolve_retrieval_targets(
+            target_uri, real_ctx, context_type=context_type
+        )
 
         for target_dir in retrieval_targets.target_directories:
             self._ensure_access(target_dir, ctx)
@@ -2233,6 +2236,7 @@ class VikingFS:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Union[str, List[str]]] = None,
     ):
         """Complex search with session context.
 
@@ -2258,7 +2262,9 @@ class VikingFS:
         )
 
         real_ctx = self._ctx_or_default(ctx)
-        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx)
+        retrieval_targets = resolve_retrieval_targets(
+            target_uri, real_ctx, context_type=context_type
+        )
         primary_target_uri = retrieval_targets.first_explicit_directory
 
         session_summary = (

--- a/tests/server/test_actor_peer_retrieval_targets.py
+++ b/tests/server/test_actor_peer_retrieval_targets.py
@@ -171,3 +171,56 @@ def test_actor_peer_collection_targets_actor_peer_only():
         "viking://user/support_bot/peers/web-visitor-alice/memories",
         "viking://user/support_bot/peers/web-visitor-alice/resources",
     ]
+
+
+def test_skill_context_type_expands_default_scope_to_agent_skills():
+    targets = resolve_retrieval_targets(
+        "",
+        _ctx(),
+        context_type=ContextType.SKILL,
+    ).target_directories
+
+    assert targets == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_skill_context_type_accepts_string_and_list_values():
+    assert resolve_retrieval_targets(
+        "", _ctx(), context_type="skill"
+    ).target_directories == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+    assert resolve_retrieval_targets(
+        "", _ctx(), context_type=["skill"]
+    ).target_directories == [
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_multi_context_type_unions_default_scopes():
+    targets = resolve_retrieval_targets(
+        "",
+        _ctx(actor_peer_id="web-visitor-alice"),
+        context_type=["memory", "skill"],
+    ).target_directories
+
+    assert targets == [
+        "viking://user/support_bot/memories",
+        "viking://user/support_bot/peers/web-visitor-alice/memories",
+        "viking://user/support_bot/skills",
+        "viking://agent/skills",
+    ]
+
+
+def test_explicit_target_uri_overrides_context_type_scope():
+    targets = resolve_retrieval_targets(
+        "viking://user/support_bot/memories",
+        _ctx(),
+        context_type=ContextType.SKILL,
+    ).target_directories
+
+    assert targets == ["viking://user/support_bot/memories"]


### PR DESCRIPTION
## Summary

Fixes #3739.

When `target_uri` is empty, `ov find --context-type skill` (and the equivalent `/api/v1/search/find` and MCP `find`/`search`) now expands the default retrieval scope to include `viking://agent/skills` in addition to the user skill root, matching the behavior of `ov skills find` and `ov find -u viking://agent`.

Previously, `context_type` was threaded only into the result filter, so the shared agent-skill namespace was never queried and skill searches silently returned zero results.

## Changes

- Thread `context_type` from the HTTP router (`openviking/server/routers/search.py`), MCP endpoint (`openviking/server/mcp_endpoint.py`), and local client (`openviking/client/local.py`) through `SearchService` and `VikingFS` into `resolve_retrieval_targets`.
- `default_target_directories` now accepts the same string/`ContextType`/list input as the public API and unions the type-specific default directories, so an empty `target_uri` expands to the correct roots for each requested context type (e.g. `memory`, `resource`, `skill`, or a comma/list combination).
- Explicit `target_uri` continues to override the default scope; `context_type` is only applied when no target is supplied.
- Add unit tests in `tests/server/test_actor_peer_retrieval_targets.py` covering skill default expansion, string/list inputs, multi-type unions, and the explicit-`target_uri` override.

## Validation

- `pytest tests/server/test_actor_peer_retrieval_targets.py` → 20 passed.
- Manual import check of `resolve_retrieval_targets`, `SearchService`, and `VikingFS` succeeds.

No user-facing docs change required: the documented behavior of `ov find --context-type skill` is now the actual behavior.