### PR TITLE
test(server): set openviking logger to INFO in concurrent request id test

### DIFF
--- a/tests/server/test_request_id.py
+++ b/tests/server/test_request_id.py
@@ -169,6 +169,8 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
 
     handler = _CaptureHandler(records)
     server_logger.addHandler(handler)
+    previous_level = server_logger.level
+    server_logger.setLevel(logging.INFO)
     gate = asyncio.Event()
     arrivals = 0
 
@@ -191,6 +193,7 @@ async def test_concurrent_requests_do_not_mix_or_leak_request_ids() -> None:
             )
     finally:
         server_logger.removeHandler(handler)
+        server_logger.setLevel(previous_level)
 
     assert first.headers[REQUEST_ID_HEADER] == "request-first"
     assert second.headers[REQUEST_ID_HEADER] == "request-second"


### PR DESCRIPTION
## Description

Closes #3789.

`test_concurrent_requests_do_not_mix_or_leak_request_ids` asserts on INFO business records captured through the `openviking` logger, but the test did not set that logger's level. Under the default WARNING root level, the expected INFO record could be filtered before reaching the capture handler, causing an empty `business_records` assertion.

## Type of Change

- [x] Test update / bug fix for flaky or environment-dependent test behavior
- [ ] Production behavior change

## Changes Made

- Set the `openviking` logger to `INFO` for the duration of the concurrent request-id test.
- Restore the previous logger level in `finally`.

## Testing

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest tests/server/test_request_id.py -q -p no:cacheprovider --no-cov
```

Result: `5 passed`.

`ruff check tests/server/test_request_id.py` and `py_compile` also pass.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Risk

Test-only change; no runtime behavior is modified.
