### PR TITLE
fix(auth): reject mismatched identity headers for USER OAuth tokens (#3801)

### DIFF
--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -155,11 +155,22 @@ class ApiKeyAuthPlugin(AuthPlugin):
                     "please re-authorize the client."
                 )
 
-        # Silently ignore identity assertion headers in api_key mode.
-        if x_openviking_account:
-            _remove_header(request, b"x-openviking-account")
-        if x_openviking_user:
-            _remove_header(request, b"x-openviking-user")
+        if role in (Role.ROOT, Role.ADMIN):
+            # Privileged OAuth tokens keep the legacy silent-strip behavior so
+            # operator tooling can omit or override tenant context.
+            if x_openviking_account:
+                _remove_header(request, b"x-openviking-account")
+            if x_openviking_user:
+                _remove_header(request, b"x-openviking-user")
+        else:
+            if x_openviking_account and x_openviking_account != record.account_id:
+                raise PermissionDeniedError(
+                    "OAuth token does not match the requested X-OpenViking-Account"
+                )
+            if x_openviking_user and x_openviking_user != record.user_id:
+                raise PermissionDeniedError(
+                    "OAuth token does not match the requested X-OpenViking-User"
+                )
 
         return ResolvedIdentity(
             role=role,

--- a/tests/server/oauth/test_auth_integration.py
+++ b/tests/server/oauth/test_auth_integration.py
@@ -227,6 +227,67 @@ async def test_oauth_user_role_rejects_account_override(provider, store):
 
 
 @pytest.mark.asyncio
+async def test_oauth_user_role_rejects_user_override(provider, store):
+    """A USER OAuth token cannot impersonate another user via header."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="user")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(),
+        oauth_provider=provider,
+        extra_headers={"x-openviking-user": "bob"},
+    )
+    with pytest.raises(PermissionDeniedError):
+        await resolve_identity(
+            request,
+            x_api_key=None,
+            authorization=f"Bearer {token}",
+            x_openviking_user="bob",
+        )
+
+
+@pytest.mark.asyncio
+async def test_oauth_user_role_accepts_matching_identity_headers(provider, store):
+    """Identity headers matching the bound token remain accepted."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="user")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(),
+        oauth_provider=provider,
+        extra_headers={"x-openviking-account": "tenant-a", "x-openviking-user": "alice"},
+    )
+    identity = await resolve_identity(
+        request,
+        x_api_key=None,
+        authorization=f"Bearer {token}",
+        x_openviking_account="tenant-a",
+        x_openviking_user="alice",
+    )
+    assert identity.role == Role.USER
+    assert identity.account_id == "tenant-a"
+    assert identity.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_oauth_admin_keeps_legacy_silent_strip_on_override(provider, store):
+    """ADMIN OAuth tokens retain the legacy silent-strip behavior."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="admin")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(default_role=Role.ADMIN),
+        oauth_provider=provider,
+        extra_headers={"x-openviking-account": "tenant-b"},
+    )
+    identity = await resolve_identity(
+        request,
+        x_api_key=None,
+        authorization=f"Bearer {token}",
+        x_openviking_account="tenant-b",
+    )
+    assert identity.role == Role.ADMIN
+    assert identity.account_id == "tenant-a"
+
+
+@pytest.mark.asyncio
 async def test_oauth_root_can_be_used_without_explicit_tenant_headers(provider, store):
     """ROOT OAuth tokens carry account/user in claims — no header requirement."""
     token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="root")


### PR DESCRIPTION
## Summary

Fixes #3801.

This replaces the earlier closed PR #3802, which cannot be reopened after its head branch was reset to a clean current-main version. The issue still reproduces on main: `tests/server/oauth/test_auth_integration.py::test_oauth_user_role_rejects_account_override` fails because api_key OAuth resolution strips mismatched `X-OpenViking-Account` / `X-OpenViking-User` headers instead of rejecting them.

For USER OAuth tokens, the token's bound account/user is the sole identity authority. A mismatched assertion header is now rejected with `PermissionDeniedError`. Matching headers remain accepted, and ROOT/ADMIN tokens keep the legacy silent-strip behavior to avoid breaking privileged routing tooling.

## Tests

- `pytest tests/server/oauth/test_auth_integration.py -q` → 15 passed
- `ruff check openviking/server/auth/plugins/api_key.py tests/server/oauth/test_auth_integration.py` → passed
- `python -m py_compile ...` → passed