### PR TITLE
fix(opencode-plugin): serialize saveState to prevent ENOENT rename race

### DIFF
--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -30,6 +30,20 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   const statePath = path.join(pluginRoot, "openviking-session-state.json")
   const oldSessionMapPath = path.join(pluginRoot, "openviking-session-map.json")
   let saveTimer = null
+  // Serialize saves: concurrent saveState() calls (a debounced save racing
+  // with flushAll / flushSession / session deletion) all share the same
+  // `${statePath}.tmp` temp file, so one rename can fail with ENOENT after
+  // another already moved it. Chaining through a promise queue keeps at most
+  // one write+rename in flight. Each queued save re-serializes the in-memory
+  // `sessions` map at execution time, so the last save always persists the
+  // latest state.
+  let saveChain = Promise.resolve()
+
+  function enqueueSave() {
+    const run = saveChain.then(() => saveState())
+    saveChain = run.catch(() => {})
+    return run
+  }
 
   async function init() {
     if (config.autoCapture) await migrateLegacySessionMap()
@@ -84,7 +98,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   function debouncedSaveState() {
     if (saveTimer) clearTimeout(saveTimer)
     saveTimer = setTimeout(() => {
-      saveState().catch((error) => {
+      enqueueSave().catch((error) => {
         log("ERROR", "persistence", "Debounced save failed", { error: error?.message })
       })
     }, 300)
@@ -176,7 +190,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     if (!sessionId) return
     await flushSession(sessionId, { commit: true, reason: event.type })
     sessions.delete(sessionId)
-    await saveState()
+    await enqueueSave()
   }
 
   async function handleSessionError(event) {
@@ -253,7 +267,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     for (const sessionId of sessions.keys()) {
       await flushSession(sessionId, { commit, reason: "flushAll" })
     }
-    await saveState()
+    await enqueueSave()
   }
 
   async function flushSession(opencodeSessionId, { commit = false, reason = "manual" } = {}) {
@@ -267,7 +281,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     } else if (added > 0) {
       await maybeCommitByThreshold(state)
     }
-    await saveState()
+    await enqueueSave()
     return true
   }
 

--- a/examples/opencode-plugin/tests/memory-session.test.mjs
+++ b/examples/opencode-plugin/tests/memory-session.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test"
 import assert from "node:assert/strict"
 import { createServer } from "node:http"
+import fs from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -211,5 +212,75 @@ test("assistant messages are captured even when finish is not stop", async () =>
       assert.match(body.messages[0].content, /Partial assistant output/)
       await manager.flushAll({ commit: false })
     })
+  })
+})
+
+test("concurrent saves never race the shared state file (#3877)", async (t) => {
+  // Widen the race window: concurrent saveState() calls share the same
+  // `${statePath}.tmp` temp file. A slow writeFile keeps the shared .tmp
+  // alive while a second writer arrives, and a slow rename lets a second
+  // rename observe the file already moved — the exact ENOENT from #3877.
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+  const origWriteFile = fs.promises.writeFile
+  const origRename = fs.promises.rename
+  let raceDetected = false
+
+  t.mock.method(fs.promises, "writeFile", async (...args) => {
+    await delay(20)
+    return origWriteFile.call(fs.promises, ...args)
+  })
+  t.mock.method(fs.promises, "rename", async (from, to) => {
+    await delay(5)
+    if (!fs.existsSync(from)) {
+      // The shared .tmp was already moved by another concurrent save.
+      raceDetected = true
+      const err = new Error(
+        `ENOENT: no such file or directory, rename '${from}' -> '${to}'`,
+      )
+      err.code = "ENOENT"
+      throw err
+    }
+    return origRename.call(fs.promises, from, to)
+  })
+
+  await withTempDir("ov-oc-session-", async (dir) => {
+    const manager = createMemorySessionManager({
+      // autoCapture=false keeps the test fully offline (flushSession skips
+      // the network); the endpoint is unreachable so health probes fail fast.
+      config: { ...baseConfig("http://127.0.0.1:1"), autoCapture: false },
+      pluginRoot: dir,
+    })
+
+    await manager.handleEvent({ type: "session.created", properties: { info: { id: "sess-a" } } })
+    await manager.handleEvent({ type: "session.created", properties: { info: { id: "sess-b" } } })
+    await manager.handleEvent({ type: "session.created", properties: { info: { id: "sess-c" } } })
+
+    // Fire several flushAll() calls concurrently — each one calls saveState()
+    // against the same shared `.tmp` file, racing the debounced saves above.
+    const racing = Promise.all([
+      manager.flushAll(),
+      manager.flushAll(),
+      manager.flushAll(),
+    ])
+
+    // Mutate in-memory state while the racing saves are in flight: with the
+    // race, whichever rename runs first moves the shared .tmp away and the
+    // others fail with ENOENT, leaving a stale snapshot on disk. With
+    // serialized saves the final save is the newest snapshot.
+    await delay(30)
+    await manager.handleEvent({ type: "session.created", properties: { info: { id: "sess-d" } } })
+    await racing
+    await manager.flushAll() // final serialized save, includes sess-d
+
+    const statePath = join(dir, "openviking-session-state.json")
+    const data = JSON.parse(await fs.promises.readFile(statePath, "utf8"))
+    assert.equal(data.version, 2)
+    assert.deepEqual(
+      Object.keys(data.sessions).sort(),
+      ["sess-a", "sess-b", "sess-c", "sess-d"],
+    )
+    // Core assertion: concurrent saves must never race each other off the
+    // shared `.tmp` file. With serialized saves no ENOENT can occur.
+    assert.equal(raceDetected, false)
   })
 })


### PR DESCRIPTION
## What

Fixes #3877. Concurrent `saveState()` calls in the OpenCode memory plugin
share the same `${statePath}.tmp` temp file with no serialization, so one
`rename` can fail with `ENOENT` after another already moved the file —
observed as frequent `Failed to save session state` errors during
`dispose`/`flushAll`, where debounced saves race batch flushes.

## Why it matters

The failure is swallowed inside `saveState`, leaving a **stale snapshot** on
disk. If the process exits between a failed save and the next successful one,
the last pending messages lose their local recovery record (server-side
commit is unaffected). The bigger the state file, the easier the race hits.

## How

Serialize saves through a promise chain (`enqueueSave()`); at most one
write+rename runs at a time. Each queued save re-serializes the in-memory
`sessions` map at execution time, so the tail save always persists the
latest state — no update is lost. All four save entry points
(`debouncedSaveState`, `flushAll`, `flushSession`, `handleSessionDeleted`)
now go through the chain.

## Test

New test `concurrent saves never race the shared state file (#3877)` in
`tests/memory-session.test.mjs`: slows `writeFile`/`rename` via
`t.mock.method` (shared CJS `fs.promises` singleton) to widen the race
window, fires concurrent `flushAll()` calls while a session is created
mid-flight, and asserts (1) the final state file contains all sessions and
(2) rename never observed a missing source (`raceDetected === false`).

- Before: the new test fails with `raceDetected: true` (reproduces #3877)
- After: `npm test` → 24/24 pass, `npm run check` → 0 errors
