### PR TITLE
perf(queuefs): defer embedding input materialization

### DIFF
--- a/openviking/core/context.py
+++ b/openviking/core/context.py
@@ -40,8 +40,8 @@ class ContextLevel(int, Enum):
 
 
 class Vectorize:
-    text: str = ""
-    full_text: str = ""  # Full content for BM25 (not embedding-truncated)
+    # None means the embedding worker should materialize the canonical resource URI.
+    text: Optional[str] = ""
     # images: list of image references (data URIs or URLs) for multimodal embedding
     images: List[str] = []
     # video: str = ""
@@ -49,12 +49,10 @@ class Vectorize:
 
     def __init__(
         self,
-        text: str = "",
-        full_text: str = "",
+        text: Optional[str] = "",
         images: Optional[List[str]] = None,
     ):
         self.text = text
-        self.full_text = full_text
         self.images = list(images) if images else []
 
 
@@ -151,7 +149,7 @@ class Context:
     def set_vectorize(self, vectorize: Vectorize):
         self.vectorize = vectorize
 
-    def get_vectorization_text(self) -> str:
+    def get_vectorization_text(self) -> Optional[str]:
         """Get text for vectorization."""
         return self.vectorize.text
 

--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -76,6 +76,17 @@ def extract_text_from_content(content: "EmbeddingInput") -> str:
     return "\n".join(p for p in text_parts if p)
 
 
+async def embed_prepared(
+    embedder: "EmbedderBase", content: "EmbeddingInput", *, is_query: bool = False
+) -> "EmbedResult":
+    """Call an embedder with input already guarded for that embedder."""
+    from openviking.telemetry import bind_telemetry_stage
+
+    stage = "embed_query" if is_query else "embed_resource"
+    with bind_telemetry_stage(stage):
+        return await embedder.embed_async(content, is_query=is_query)
+
+
 async def embed_compat(
     embedder: "EmbedderBase", content: "EmbeddingInput", *, is_query: bool = False
 ) -> "EmbedResult":
@@ -86,12 +97,9 @@ async def embed_compat(
     embedders that do not support images, so all embedders can be called the same
     way.
     """
-    from openviking.telemetry import bind_telemetry_stage
-
-    stage = "embed_query" if is_query else "embed_resource"
     embedding_input = embedder.prepare_embedding_input(content)
-    with bind_telemetry_stage(stage):
-        return await embedder.embed_async(embedding_input, is_query=is_query)
+    del content
+    return await embed_prepared(embedder, embedding_input, is_query=is_query)
 
 
 def truncate_and_normalize(embedding: List[float], dimension: Optional[int]) -> List[float]:

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -41,6 +41,7 @@ from openviking_cli.exceptions import InvalidArgumentError, NotFoundError, OpenV
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
+from openviking_cli.utils.config.embedding_config import SUMMARY_TEXT_SOURCES
 
 logger = get_logger(__name__)
 
@@ -1052,20 +1053,17 @@ class ReindexExecutor:
             parent_uri = VikingURI(file_uri).parent.uri
             summary = await self._best_file_summary(file_uri, ctx=ctx)
             vector_text = await self._best_resource_file_vector_text(file_uri, summary, ctx=ctx)
-            if not vector_text:
+            if vector_text == "":
                 counters.unsupported_records += 1
                 counters.warnings.append(f"No vector source found for {file_uri}")
                 continue
-            abstract = self._prefer_non_empty(summary, vector_text)
-            # Read full file content for BM25 content field (not embedding-truncated)
-            full_text = await self._safe_read_text(file_uri, ctx=ctx) or vector_text
+            abstract = self._prefer_non_empty(summary, vector_text or "")
             try:
                 await self._upsert_context(
                     uri=file_uri,
                     parent_uri=parent_uri,
                     abstract=abstract,
                     vector_text=vector_text,
-                    full_text=full_text,
                     is_leaf=True,
                     context_type=context_type_for_uri(file_uri),
                     level=ContextLevel.DETAIL,
@@ -1607,8 +1605,7 @@ class ReindexExecutor:
         uri: str,
         summary: str,
         ctx: RequestContext,
-    ) -> str:
-        text_source = getattr(get_openviking_config().embedding, "text_source", "summary_first")
+    ) -> Optional[str]:
         existing = await self._fetch_existing_record(
             uri=uri,
             level=2,
@@ -1618,14 +1615,10 @@ class ReindexExecutor:
         content_type = get_resource_content_type(uri.rsplit("/", 1)[-1])
 
         if content_type == ResourceContentType.TEXT:
-            content = await self._safe_read_text(uri, ctx=ctx)
-            if text_source in {"summary_first", "summary_only"} and summary:
+            text_source = get_openviking_config().embedding.text_source
+            if text_source in SUMMARY_TEXT_SOURCES and summary:
                 return summary
-            if content:
-                return self._truncate_embedding_text(content)
-            if summary:
-                return summary
-            return fallback
+            return None
 
         if summary:
             return summary
@@ -1637,8 +1630,7 @@ class ReindexExecutor:
         uri: str,
         parent_uri: str,
         abstract: str,
-        vector_text: str,
-        full_text: str = "",
+        vector_text: Optional[str],
         is_leaf: bool,
         context_type: str,
         level: ContextLevel,
@@ -1669,7 +1661,7 @@ class ReindexExecutor:
             owner_space=owner_space_for_uri(uri, owner_ctx),
             meta=merged_meta,
         )
-        context.set_vectorize(Vectorize(text=vector_text, full_text=full_text or vector_text))
+        context.set_vectorize(Vectorize(text=vector_text))
         msg = EmbeddingMsgConverter.from_context(context)
         if msg is None:
             raise OpenVikingError(
@@ -1726,14 +1718,6 @@ class ReindexExecutor:
 
     def _is_hidden_meta_file(self, uri: str) -> bool:
         return uri.endswith("/.abstract.md") or uri.endswith("/.overview.md")
-
-    def _truncate_embedding_text(self, value: str) -> str:
-        max_input_chars = int(
-            getattr(get_openviking_config().embedding, "max_input_chars", 1000) or 1000
-        )
-        if len(value) <= max_input_chars:
-            return value
-        return value[:max_input_chars] + "\n...(truncated for embedding)"
 
     async def _safe_read_text(self, uri: str, *, ctx: RequestContext) -> str:
         viking_fs = get_viking_fs()

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -16,7 +16,8 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from openviking.models.embedder.base import EmbedResult, embed_compat
+from openviking.core.context import ContextType, ResourceContentType
+from openviking.models.embedder.base import EmbeddingInput, EmbedResult, embed_compat
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import (
     CollectionNotFoundError,
@@ -26,6 +27,7 @@ from openviking.storage.errors import (
 from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.viking_vector_index_backend import (
+    VIKINGDB_CONTENT_MAX_SIZE,
     VikingVectorIndexBackend,
     normalize_upsert_options,
 )
@@ -538,6 +540,105 @@ class TextEmbeddingHandler(DequeueHandlerBase):
     ) -> str:
         return f"{message} ({cls._embedding_msg_log_context(embedding_msg)})"
 
+    @staticmethod
+    async def _materialize_input(
+        embedding_msg: EmbeddingMsg,
+        ctx: RequestContext,
+    ) -> EmbeddingInput:
+        from openviking.storage.viking_fs import get_viking_fs
+        from openviking.utils.embedding_utils import (
+            _build_image_data_uri,
+            _coerce_text_file_content,
+        )
+
+        if embedding_msg.message is None:
+            viking_fs = get_viking_fs()
+            source_uri = embedding_msg.context_data["uri"]
+            try:
+                source_content = _coerce_text_file_content(
+                    await viking_fs.read_file(source_uri, ctx=ctx)
+                )
+            except Exception as source_err:
+                logger.warning(
+                    "Failed to materialize embedding input for %s: %s",
+                    source_uri,
+                    source_err,
+                )
+                source_content = ""
+            return source_content or embedding_msg.context_data["abstract"]
+
+        if isinstance(embedding_msg.message, str):
+            return embedding_msg.message
+
+        viking_fs = get_viking_fs()
+        materialized_parts = []
+        for part in embedding_msg.message:
+            if part["type"] == "image_url" and part["image_url"]["url"].startswith("viking://"):
+                image_uri = part["image_url"]["url"]
+                data_uri = await _build_image_data_uri(
+                    image_uri,
+                    image_uri.rsplit("/", 1)[-1],
+                    viking_fs,
+                    ctx,
+                )
+                if data_uri:
+                    materialized_parts.append({"type": "image_url", "image_url": {"url": data_uri}})
+            else:
+                materialized_parts.append(part)
+        return materialized_parts
+
+    @staticmethod
+    async def _materialize_content(
+        embedding_msg: EmbeddingMsg,
+        ctx: RequestContext,
+    ) -> str:
+        inserted_data = embedding_msg.context_data
+        if (
+            inserted_data.get("is_leaf")
+            and inserted_data.get("context_type")
+            in (ContextType.RESOURCE.value, ContextType.SKILL.value)
+        ):
+            from openviking.storage.viking_fs import get_viking_fs
+            from openviking.utils.embedding_utils import (
+                _coerce_text_file_content,
+                _decode_text_bytes,
+                _resolve_resource_content_type,
+            )
+
+            viking_fs = get_viking_fs()
+            source_uri = inserted_data["uri"]
+            source_name = source_uri.rsplit("/", 1)[-1]
+            source_type = await _resolve_resource_content_type(
+                source_uri,
+                source_name,
+                viking_fs,
+                ctx,
+            )
+            if source_type in (None, ResourceContentType.TEXT):
+                try:
+                    if source_type == ResourceContentType.TEXT:
+                        source_content = _coerce_text_file_content(
+                            await viking_fs.read_file(source_uri, ctx=ctx)
+                        )
+                    else:
+                        source_content = _decode_text_bytes(
+                            await viking_fs.read_file_bytes(source_uri, ctx=ctx)
+                        )
+                except Exception as source_err:
+                    logger.warning(
+                        "Failed to materialize full-text content for %s: %s",
+                        source_uri,
+                        source_err,
+                    )
+                else:
+                    return source_content[:VIKINGDB_CONTENT_MAX_SIZE]
+
+        return (
+            embedding_msg.message[:VIKINGDB_CONTENT_MAX_SIZE]
+            if isinstance(embedding_msg.message, str)
+            else inserted_data["abstract"][:VIKINGDB_CONTENT_MAX_SIZE]
+        )
+
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Process dequeued message and add embedding vector(s)."""
         if not data:
@@ -553,6 +654,9 @@ class TextEmbeddingHandler(DequeueHandlerBase):
             # Parse EmbeddingMsg from data
             embedding_msg = EmbeddingMsg.from_dict(queue_data)
             inserted_data = embedding_msg.context_data
+            account_id = inserted_data.get("account_id", "default")
+            user = UserIdentifier(account_id=account_id, user_id="default")
+            ctx = RequestContext(user=user, role=Role.ROOT)
             collector = resolve_telemetry(embedding_msg.telemetry_id)
             telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
 
@@ -564,8 +668,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                     report_success = True
                     return None
 
-                # Process string (text) or list (multimodal) messages
-                if not isinstance(embedding_msg.message, (str, list)):
+                # None is a deferred text input backed by context_data["uri"].
+                if embedding_msg.message is not None and not isinstance(
+                    embedding_msg.message, (str, list)
+                ):
                     logger.debug(
                         f"Skipping unsupported message type: {type(embedding_msg.message)}"
                     )
@@ -581,7 +687,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                     self._breaker_open_suppressed_count = 0
                 except CircuitBreakerOpen:
                     self._log_breaker_open_reenqueue_summary()
-                    if getattr(self._vikingdb, "has_queue_manager", False):
+                    if self._vikingdb.has_queue_manager:
                         wait = self._circuit_breaker.retry_after
                         if wait > 0:
                             await asyncio.sleep(wait)
@@ -614,13 +720,27 @@ class TextEmbeddingHandler(DequeueHandlerBase):
 
                 # Generate embedding vector(s)
                 if self._embedder:
+                    embedding_input = await self._materialize_input(
+                        embedding_msg,
+                        ctx,
+                    )
                     try:
                         import time as _time
 
                         _embed_t0 = _time.monotonic()
+                        embedding_input = self._embedder.prepare_embedding_input(embedding_input)
+                        if not embedding_input:
+                            logger.warning(
+                                "No embedding input available for %s", inserted_data.get("uri")
+                            )
+                            self._merge_request_stats(embedding_msg.telemetry_id, processed=1)
+                            self._record_request_success(embedding_msg)
+                            report_success = True
+                            return None
                         result: EmbedResult = await embed_compat(
-                            self._embedder, embedding_msg.message, is_query=False
+                            self._embedder, embedding_input, is_query=False
                         )
+                        del embedding_input
                         _embed_elapsed = _time.monotonic() - _embed_t0
                         try:
                             from openviking.metrics.datasources import EmbeddingEventDataSource
@@ -632,6 +752,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         except Exception:
                             pass
                     except Exception as embed_err:
+                        del embedding_input
                         error_msg = self._embedding_error_msg(
                             embedding_msg,
                             f"Failed to generate embedding: {embed_err}",
@@ -678,7 +799,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         # Transient or unknown — re-enqueue for retry
                         logger.warning(error_msg)
                         self._circuit_breaker.record_failure(embed_err)
-                        if getattr(self._vikingdb, "has_queue_manager", False):
+                        if self._vikingdb.has_queue_manager:
                             try:
                                 await self._vikingdb.enqueue_embedding_msg(embedding_msg)
                                 self._merge_request_stats(
@@ -761,11 +882,11 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                         id_seed = f"{account_id}:{seed_uri}"
                         inserted_data["id"] = hashlib.md5(id_seed.encode("utf-8")).hexdigest()
 
-                    user = UserIdentifier(
-                        account_id=account_id,
-                        user_id="default",
-                    )
-                    ctx = RequestContext(user=user, role=Role.ROOT)
+                    if self._vikingdb.uses_content_field:
+                        inserted_data["content"] = await self._materialize_content(
+                            embedding_msg,
+                            ctx,
+                        )
                     result = await self._vikingdb.upsert(
                         inserted_data,
                         ctx=ctx,

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from openviking.core.context import ContextType, ResourceContentType
-from openviking.models.embedder.base import EmbeddingInput, EmbedResult, embed_compat
+from openviking.models.embedder.base import EmbeddingInput, EmbedResult, embed_prepared
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.errors import (
     CollectionNotFoundError,
@@ -737,7 +737,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
                             self._record_request_success(embedding_msg)
                             report_success = True
                             return None
-                        result: EmbedResult = await embed_compat(
+                        result: EmbedResult = await embed_prepared(
                             self._embedder, embedding_input, is_query=False
                         )
                         del embedding_input

--- a/openviking/storage/queuefs/embedding_msg.py
+++ b/openviking/storage/queuefs/embedding_msg.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 
 @dataclass
 class EmbeddingMsg:
-    message: Union[str, List[Dict[str, Any]]]
+    # None defers input materialization to the canonical URI in context_data.
+    message: Optional[Union[str, List[Dict[str, Any]]]]
     context_data: Dict[str, Any]
     id: str = field(default_factory=lambda: str(uuid4()))
     telemetry_id: str = ""
@@ -16,7 +17,7 @@ class EmbeddingMsg:
 
     def __init__(
         self,
-        message: Union[str, List[Dict[str, Any]]],
+        message: Optional[Union[str, List[Dict[str, Any]]]],
         context_data: Dict[str, Any],
         telemetry_id: str = "",
         semantic_msg_id: Optional[str] = None,

--- a/openviking/storage/queuefs/embedding_msg_converter.py
+++ b/openviking/storage/queuefs/embedding_msg_converter.py
@@ -65,19 +65,6 @@ class EmbeddingMsgConverter:
             resolved_level = int(resolved_level.value)
         context_data["level"] = int(resolved_level)
 
-        for field in (
-            "id",
-            "temp_uri",
-            "category",
-            "meta",
-            "related_uri",
-            "session_id",
-            "user",
-            "owner_space",
-            "vector",
-        ):
-            context_data.pop(field, None)
-
         if vectorization_images:
             # Multimodal message: combine text (if any) and image references into the
             # multimodal embedding input format. Image-aware embedders consume this list;

--- a/openviking/storage/queuefs/embedding_msg_converter.py
+++ b/openviking/storage/queuefs/embedding_msg_converter.py
@@ -26,7 +26,7 @@ class EmbeddingMsgConverter:
         """
         vectorization_text = context.get_vectorization_text()
         vectorization_images = context.get_vectorization_images()
-        if not vectorization_text and not vectorization_images:
+        if vectorization_text == "" and not vectorization_images:
             return None
 
         context_data = context.to_dict()
@@ -50,12 +50,9 @@ class EmbeddingMsgConverter:
 
         # Derive level field for hierarchical retrieval.
         uri = context_data.get("uri", "")
-        context_level = getattr(context, "level", None)
-        if context_level is not None:
-            resolved_level = context_level
-        elif context_data.get("level") is not None:
-            resolved_level = context_data.get("level")
-        elif isinstance(context.meta, dict) and context.meta.get("level") is not None:
+        if context.level is not None:
+            resolved_level = context.level
+        elif context.meta.get("level") is not None:
             resolved_level = context.meta.get("level")
         elif uri.endswith("/.abstract.md"):
             resolved_level = ContextLevel.ABSTRACT
@@ -68,10 +65,18 @@ class EmbeddingMsgConverter:
             resolved_level = int(resolved_level.value)
         context_data["level"] = int(resolved_level)
 
-        # Store full content in content field for bm25 full-text search.
-        # Use full_text (raw file content) when available; fall back to vectorization_text.
-        full_content = context.vectorize.full_text or vectorization_text
-        context_data["content"] = full_content
+        for field in (
+            "id",
+            "temp_uri",
+            "category",
+            "meta",
+            "related_uri",
+            "session_id",
+            "user",
+            "owner_space",
+            "vector",
+        ):
+            context_data.pop(field, None)
 
         if vectorization_images:
             # Multimodal message: combine text (if any) and image references into the

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1078,10 +1078,8 @@ class SemanticProcessor(DequeueHandlerBase):
 
             content = _decode_text_bytes(content)
 
-        full_content = content or ""
-
         def result(summary: str) -> Dict[str, Any]:
-            return {"name": file_name, "summary": summary, "content": full_content}
+            return {"name": file_name, "summary": summary}
 
         config = get_openviking_config()
 
@@ -1153,8 +1151,7 @@ class SemanticProcessor(DequeueHandlerBase):
             file_path: File path
 
         Returns:
-            {"name": file_name, "summary": summary_content}; text files also carry
-            decoded "content" so vectorization can avoid re-reading the same file.
+            {"name": file_name, "summary": summary_content}
         """
         file_name = file_path.split("/")[-1]
         llm_sem = llm_sem or asyncio.Semaphore(self.max_concurrent_llm)

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -790,6 +790,10 @@ class VikingVectorIndexBackend:
     def mode(self) -> str:
         return self._get_default_backend()._mode
 
+    @property
+    def uses_content_field(self) -> bool:
+        return self._shared_adapter.USE_CONTENT_FIELD
+
     # =========================================================================
     # 内部辅助方法
     # =========================================================================

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -35,6 +35,10 @@ from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
+from openviking_cli.utils.config.embedding_config import (
+    SUMMARY_TEXT_SOURCES,
+    TEXT_SOURCE_SUMMARY_ONLY,
+)
 
 logger = get_logger(__name__)
 
@@ -330,29 +334,6 @@ def _decode_text_bytes(raw: bytes) -> str:
     return str(best)
 
 
-def _decode_unknown_file_bytes(raw: bytes) -> str:
-    """Decode unknown file bytes with the shared text-byte decoding strategy."""
-    return _decode_text_bytes(raw)
-
-
-async def _read_unknown_file_text_for_fulltext(
-    file_path: str,
-    viking_fs,
-    ctx: Optional[RequestContext],
-) -> str:
-    """Best-effort raw file text for BM25/full-text indexing.
-
-    This text is intentionally separate from the embedding input. Unknown file
-    types may still embed their generated summary, while grep/BM25 should index
-    the original text when the file can be read as text-like content.
-    """
-    try:
-        return _decode_unknown_file_bytes(await viking_fs.read_file_bytes(file_path, ctx=ctx))
-    except Exception as e:
-        logger.debug(f"Failed to read full-text content for {file_path}: {e}")
-        return ""
-
-
 async def vectorize_directory_meta(
     uri: str,
     abstract: str,
@@ -404,7 +385,7 @@ async def vectorize_directory_meta(
             account_id=ctx.account_id,
             owner_space=owner_space,
         )
-        context_abstract.set_vectorize(Vectorize(text=abstract, full_text=abstract))
+        context_abstract.set_vectorize(Vectorize(text=abstract))
         msg_abstract = EmbeddingMsgConverter.from_context(context_abstract)
         _apply_scalar_overrides(
             msg_abstract,
@@ -444,7 +425,7 @@ async def vectorize_directory_meta(
                 account_id=ctx.account_id,
                 owner_space=owner_space,
             )
-            context_overview.set_vectorize(Vectorize(text=overview, full_text=overview))
+            context_overview.set_vectorize(Vectorize(text=overview))
             msg_overview = EmbeddingMsgConverter.from_context(context_overview)
             _apply_scalar_overrides(
                 msg_overview,
@@ -516,11 +497,6 @@ async def vectorize_file(
         summary = summary_dict.get("summary", "")
         # Cap below the bytes_row 65535-byte abstract-scalar limit (#2774 parity).
         summary = _truncate_abstract_bytes(summary)
-        has_reusable_content = "content" in summary_dict
-        reusable_content = (
-            _coerce_text_file_content(summary_dict.get("content")) if has_reusable_content else ""
-        )
-
         created_at, updated_at = await _resolve_context_timestamps(
             file_path,
             ctx,
@@ -541,73 +517,38 @@ async def vectorize_file(
 
         content_type = await _resolve_resource_content_type(file_path, file_name, viking_fs, ctx)
         embedding_cfg = get_openviking_config().embedding
-        configured_text_source = getattr(embedding_cfg, "text_source", "content_only")
-        effective_text_source = "summary_only" if use_summary else configured_text_source
+        configured_text_source = embedding_cfg.text_source
+        effective_text_source = TEXT_SOURCE_SUMMARY_ONLY if use_summary else configured_text_source
+        embed_summary = bool(summary and effective_text_source in SUMMARY_TEXT_SOURCES)
 
         if content_type in (ResourceContentType.AUDIO, ResourceContentType.VIDEO):
             effective_text = summary or file_name
             context.abstract = effective_text
-            context.set_vectorize(Vectorize(text=effective_text, full_text=effective_text))
+            context.set_vectorize(Vectorize(text=effective_text))
         elif content_type is None:
-            full_content = ""
-            if summary or is_text_file(file_name):
-                full_content = (
-                    reusable_content
-                    if has_reusable_content
-                    else await _read_unknown_file_text_for_fulltext(file_path, viking_fs, ctx)
-                )
             if summary:
                 logger.warning(
                     f"Unsupported file type for {file_path}, falling back to summary for vectorization"
                 )
-                context.set_vectorize(Vectorize(text=summary, full_text=full_content or summary))
-            elif full_content:
-                context.set_vectorize(Vectorize(text=full_content, full_text=full_content))
+                context.set_vectorize(Vectorize(text=summary))
+            elif is_text_file(file_name):
+                context.set_vectorize(Vectorize(text=None))
             else:
                 logger.warning(
                     f"Unsupported file type for {file_path} and no summary available, skipping vectorization"
                 )
                 return False
         elif content_type == ResourceContentType.TEXT:
-            # Known text files use VikingFS' text read path once, then reuse that
-            # content for BM25 regardless of whether embedding uses summary or raw text.
-            try:
-                content = (
-                    reusable_content
-                    if has_reusable_content
-                    else _coerce_text_file_content(await viking_fs.read_file(file_path, ctx=ctx))
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to read file content for {file_path}, falling back to summary: {e}"
-                )
-                if summary:
-                    context.set_vectorize(Vectorize(text=summary, full_text=summary))
-                else:
-                    logger.warning(f"No summary available for {file_path}, skipping vectorization")
-                    return False
-            else:
-                if summary and effective_text_source in {"summary_first", "summary_only"}:
-                    # Use summary for vectorization, but reuse the single raw text read for BM25.
-                    context.set_vectorize(Vectorize(text=summary, full_text=content or summary))
-                else:
-                    # Embedders apply their own input guard.
-                    context.set_vectorize(Vectorize(text=content, full_text=content))
-        elif content_type == ResourceContentType.IMAGE:
-            # Multimodal embedders consume both parts; text-only embedders fall back to summary.
-            image_uri = await _build_image_data_uri(file_path, file_name, viking_fs, ctx)
-            if image_uri:
-                context.set_vectorize(Vectorize(text=summary, images=[image_uri]))
-            elif summary:
+            if embed_summary:
                 context.set_vectorize(Vectorize(text=summary))
             else:
-                logger.debug(
-                    f"Skipping image {file_path} (image unreadable and no summary available)"
-                )
-                return False
+                context.set_vectorize(Vectorize(text=None))
+        elif content_type == ResourceContentType.IMAGE:
+            # Multimodal embedders consume both parts; text-only embedders fall back to summary.
+            context.set_vectorize(Vectorize(text=summary, images=[file_path]))
         elif summary:
             # For non-text files, use summary
-            context.set_vectorize(Vectorize(text=summary, full_text=summary))
+            context.set_vectorize(Vectorize(text=summary))
         else:
             logger.debug(f"Skipping file {file_path} (no text content or summary)")
             return False

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -4,6 +4,12 @@ from typing import Any, ClassVar, List, Literal, Optional, Tuple, cast
 
 from pydantic import BaseModel, Field, model_validator
 
+TEXT_SOURCE_CONTENT_ONLY = "content_only"
+TEXT_SOURCE_SUMMARY_FIRST = "summary_first"
+TEXT_SOURCE_SUMMARY_ONLY = "summary_only"
+SUMMARY_TEXT_SOURCES = frozenset({TEXT_SOURCE_SUMMARY_FIRST, TEXT_SOURCE_SUMMARY_ONLY})
+TEXT_SOURCES = SUMMARY_TEXT_SOURCES | {TEXT_SOURCE_CONTENT_ONLY}
+
 
 class EmbeddingCredential(BaseModel):
     """Single embedding credential configuration for multi-credential failover."""
@@ -640,7 +646,7 @@ class EmbeddingConfig(BaseModel):
         description="Maximum retry attempts for embedding provider calls (0 disables retry)",
     )
     text_source: str = Field(
-        default="content_only",
+        default=TEXT_SOURCE_CONTENT_ONLY,
         description="Text source for file vectorization: summary_first|summary_only|content_only",
     )
     max_input_tokens: int = Field(
@@ -687,7 +693,7 @@ class EmbeddingConfig(BaseModel):
             raise ValueError(
                 "At least one embedding configuration (dense, sparse, or hybrid) is required"
             )
-        if self.text_source not in {"summary_first", "summary_only", "content_only"}:
+        if self.text_source not in TEXT_SOURCES:
             raise ValueError(
                 "embedding.text_source must be one of: summary_first, summary_only, content_only"
             )

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -361,9 +361,9 @@ async def test_reindex_upsert_uses_uri_owner_for_user_scoped_records(monkeypatch
     )
 
     data = captured["msg"].context_data
-    assert data["user"]["user_id"] == "bob"
     assert data["owner_user_id"] == "bob"
-    assert data["owner_space"] == "bob"
+    assert "user" not in data
+    assert "owner_space" not in data
     assert captured["lookup_ctx"].user.user_id == "bob"
 
 

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -361,9 +361,9 @@ async def test_reindex_upsert_uses_uri_owner_for_user_scoped_records(monkeypatch
     )
 
     data = captured["msg"].context_data
+    assert data["user"]["user_id"] == "bob"
     assert data["owner_user_id"] == "bob"
-    assert "user" not in data
-    assert "owner_space" not in data
+    assert data["owner_space"] == "bob"
     assert captured["lookup_ctx"].user.user_id == "bob"
 
 

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -22,20 +22,20 @@ from openviking.storage.errors import EmbeddingRebuildRequiredError
 from openviking.storage.expr import Eq
 from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.storage.vectordb import engine as vectordb_engine
+from openviking.storage.vectordb.collection.result import UpsertDataResult
+from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
     VolcengineApiKeyCollection,
 )
-from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb.collection.volcengine_collection import VolcengineCollection
-from openviking.storage.vectordb.collection.result import UpsertDataResult
 from openviking.storage.vectordb_adapters.base import (
     VIKINGDB_TEXT_FIELD_BYTE_LIMIT,
     _truncate_text_field,
 )
 from openviking.storage.vectordb_adapters.local_adapter import LocalCollectionAdapter
 from openviking.storage.viking_vector_index_backend import (
-    UpsertOptions,
     VIKINGDB_CONTENT_MAX_SIZE,
+    UpsertOptions,
     VikingVectorIndexBackend,
     _SingleAccountBackend,
 )
@@ -387,6 +387,8 @@ async def test_embedding_auth_error_fails_terminally_without_reenqueue(monkeypat
 @pytest.mark.asyncio
 async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypatch):
     class _ClosingDuringUpsertVikingDB:
+        uses_content_field = False
+
         def __init__(self):
             self.is_closing = False
             self.calls = 0
@@ -426,6 +428,7 @@ async def test_embedding_handler_treats_shutdown_write_lock_as_success(monkeypat
 async def test_embedding_handler_propagates_account_id_on_success(monkeypatch):
     class _DummyVikingDB:
         is_closing = False
+        uses_content_field = False
 
         async def upsert(self, _data, *, ctx, options=UpsertOptions()):
             return None
@@ -488,6 +491,7 @@ async def test_embedding_handler_propagates_account_id_on_error(monkeypatch):
 async def test_embedding_handler_truncates_queue_input_before_embed(monkeypatch):
     class _CapturingVikingDB:
         is_closing = False
+        uses_content_field = False
 
         async def upsert(self, _data, *, ctx, options=UpsertOptions()):
             return "rec-1"
@@ -571,28 +575,43 @@ async def test_embedding_handler_drops_input_too_large_without_requeue(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_embedding_handler_preserves_parent_uri_for_backend_upsert_logic(monkeypatch):
+async def test_embedding_handler_materializes_deferred_input_before_upsert(monkeypatch):
     captured = {}
 
     class _CapturingVikingDB:
         is_closing = False
-        mode = "local"
+        uses_content_field = True
 
         async def upsert(self, data, *, ctx, options=UpsertOptions()):
             assert options.partial_update is True
             captured["data"] = dict(data)
             return "rec-1"
 
+    class _FakeFS:
+        calls = 0
+
+        async def read_file(self, uri, *, ctx):
+            self.calls += 1
+            assert uri == "viking://resources/sample.md"
+            assert ctx.account_id == "default"
+            return "full content"
+
     embedder = _DummyEmbedder()
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
         lambda: _DummyConfig(embedder),
     )
+    fs = _FakeFS()
+    monkeypatch.setattr("openviking.storage.viking_fs.get_viking_fs", lambda: fs)
 
     handler = TextEmbeddingHandler(_CapturingVikingDB())
     payload = _build_queue_payload()
     queue_data = json.loads(payload["data"])
+    queue_data["message"] = None
+    queue_data["context_data"]["uri"] = "viking://resources/sample.md"
     queue_data["context_data"]["parent_uri"] = "viking://resources"
+    queue_data["context_data"]["is_leaf"] = True
+    queue_data["context_data"]["context_type"] = "resource"
     payload["data"] = json.dumps(queue_data)
 
     result = await handler.on_dequeue(payload)
@@ -600,6 +619,8 @@ async def test_embedding_handler_preserves_parent_uri_for_backend_upsert_logic(m
     assert result is not None
     assert "data" in captured
     assert captured["data"]["parent_uri"] == "viking://resources"
+    assert captured["data"]["content"] == "full content"
+    assert fs.calls == 2
 
 
 @pytest.mark.asyncio
@@ -607,6 +628,7 @@ async def test_embedding_handler_marks_success_only_after_tracker_completion(mon
     class _CapturingVikingDB:
         is_closing = False
         mode = "local"
+        uses_content_field = False
 
         async def upsert(self, _data, *, ctx, options=UpsertOptions()):
             assert options.partial_update is True

--- a/tests/storage/test_embedding_msg.py
+++ b/tests/storage/test_embedding_msg.py
@@ -23,6 +23,7 @@ def test_embedding_msg_roundtrip_preserves_id_for_request_wait_tracker():
         restored = EmbeddingMsg.from_dict(msg.to_dict())
 
         assert restored.id == msg.id
+        assert restored.message == msg.message
         tracker.mark_embedding_done(telemetry_id, restored.id)
         assert tracker.is_complete(telemetry_id)
     finally:

--- a/tests/storage/test_embedding_msg_converter_tenant.py
+++ b/tests/storage/test_embedding_msg_converter_tenant.py
@@ -50,7 +50,6 @@ def test_embedding_msg_converter_backfills_account_and_owner_fields(
 
 def test_embedding_msg_converter_keeps_content_out_of_queue_metadata():
     context = Context(uri="viking://resources/large.txt", abstract="short embedding text")
-    context.meta["unused"] = "not index data"
     context.set_vectorize(Vectorize(text="short embedding text"))
 
     msg = EmbeddingMsgConverter.from_context(context)
@@ -58,4 +57,3 @@ def test_embedding_msg_converter_keeps_content_out_of_queue_metadata():
     assert msg is not None
     assert msg.message == "short embedding text"
     assert "content" not in msg.context_data
-    assert "meta" not in msg.context_data

--- a/tests/storage/test_embedding_msg_converter_tenant.py
+++ b/tests/storage/test_embedding_msg_converter_tenant.py
@@ -45,15 +45,17 @@ def test_embedding_msg_converter_backfills_account_and_owner_fields(
         expected_owner_user_id(user) if callable(expected_owner_user_id) else expected_owner_user_id
     )
     assert msg.context_data["owner_user_id"] == expected_user
+    assert "content" not in msg.context_data
 
 
-def test_embedding_msg_converter_preserves_full_content_without_vikingdb_truncation():
-    full_content = "x" * (1024 * 1024 + 17)
+def test_embedding_msg_converter_keeps_content_out_of_queue_metadata():
     context = Context(uri="viking://resources/large.txt", abstract="short embedding text")
-    context.set_vectorize(Vectorize(text="short embedding text", full_text=full_content))
+    context.meta["unused"] = "not index data"
+    context.set_vectorize(Vectorize(text="short embedding text"))
 
     msg = EmbeddingMsgConverter.from_context(context)
 
     assert msg is not None
     assert msg.message == "short embedding text"
-    assert msg.context_data["content"] == full_content
+    assert "content" not in msg.context_data
+    assert "meta" not in msg.context_data

--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -405,7 +405,7 @@ class TestGenerateTextSummaryOutputLanguage:
             assert _verify_content_language(result["summary"], expected_lang), (
                 f"{file_name}: Content language mismatch. Expected {expected_lang}, got: {result['summary']}"
             )
-            assert result["content"] == content
+            assert "content" not in result
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/test_vectorize_file_strategy.py
+++ b/tests/unit/test_vectorize_file_strategy.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from openviking.core.context import Context, ResourceContentType
+from openviking.core.context import ResourceContentType
 from openviking.parse.parsers.media.utils import (
     MPEG_TS_PACKET_SIZE,
     MPEG_TS_PROBE_BYTES,
@@ -135,14 +135,17 @@ async def test_vectorize_disambiguates_typescript_and_mpeg_ts(monkeypatch):
         )
         return queue, fs
 
-    source = "export const answer: number = 42;"
-    text_queue, text_fs = await vectorize("source.ts", source, "TypeScript source")
+    text_queue, text_fs = await vectorize(
+        "source.ts", "export const answer: number = 42;", "TypeScript source"
+    )
     video_queue, video_fs = await vectorize("broadcast.ts", _mpeg_ts_bytes(), "")
 
-    assert text_fs.read_file_calls == 1
-    assert text_queue.items[0].context_data["content"] == source
+    assert text_fs.read_file_calls == 0
+    assert text_queue.items[0].message is None
+    assert "content" not in text_queue.items[0].context_data
     assert video_fs.read_file_calls == 0
-    assert video_queue.items[0].context_data["content"] == "broadcast.ts"
+    assert video_queue.items[0].message == "broadcast.ts"
+    assert "content" not in video_queue.items[0].context_data
 
 
 @pytest.mark.asyncio
@@ -157,11 +160,6 @@ async def test_vectorize_file_uses_summary_first(monkeypatch):
             embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
         ),
     )
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter,
-        "from_context",
-        lambda context: context,
-    )
 
     await embedding_utils.vectorize_file(
         file_path="viking://user/default/resources/test.md",
@@ -171,8 +169,8 @@ async def test_vectorize_file_uses_summary_first(monkeypatch):
     )
 
     assert len(queue.items) == 1
-    assert isinstance(queue.items[0], Context)
-    assert queue.items[0].get_vectorization_text() == "short summary"
+    assert queue.items[0].message == "short summary"
+    assert "content" not in queue.items[0].context_data
 
 
 @pytest.mark.asyncio
@@ -266,10 +264,6 @@ async def test_vectorize_file_propagates_enqueue_failure(monkeypatch):
             embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
         ),
     )
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter, "from_context", lambda context: context
-    )
-
     with pytest.raises(RuntimeError, match="queue unavailable"):
         await embedding_utils.vectorize_file(
             "viking://user/default/resources/test.md",
@@ -300,11 +294,12 @@ async def test_vectorize_directory_propagates_enqueue_failures_and_drains_tracke
 
 
 @pytest.mark.asyncio
-async def test_vectorize_unknown_text_file_embeds_summary_but_indexes_raw_content(monkeypatch):
+async def test_vectorize_unknown_text_file_embeds_summary_without_reading_content(monkeypatch):
     queue = DummyQueue()
     raw_makefile = "build:\n\tcargo build --locked\n"
+    fs = DummyFS(raw_makefile)
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
-    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS(raw_makefile))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
     monkeypatch.setattr(
         embedding_utils,
         "get_openviking_config",
@@ -323,15 +318,16 @@ async def test_vectorize_unknown_text_file_embeds_summary_but_indexes_raw_conten
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_makefile
+    assert "content" not in msg.context_data
+    assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_unknown_text_file_without_summary_indexes_raw_content(monkeypatch):
+async def test_vectorize_unknown_text_file_without_summary_defers_raw_content(monkeypatch):
     queue = DummyQueue()
-    raw_makefile = "build:\n\tcargo build --release\n"
+    fs = DummyFS("build:\n\tcargo build --release\n")
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
-    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS(raw_makefile))
+    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
     monkeypatch.setattr(
         embedding_utils,
         "get_openviking_config",
@@ -350,12 +346,13 @@ async def test_vectorize_unknown_text_file_without_summary_indexes_raw_content(m
     assert enqueued is True
     assert len(queue.items) == 1
     msg = queue.items[0]
-    assert msg.context_data["content"] == raw_makefile
-    assert msg.message == raw_makefile
+    assert msg.message is None
+    assert "content" not in msg.context_data
+    assert fs.read_file_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_empty_content_reports_not_enqueued(monkeypatch):
+async def test_vectorize_empty_content_defers_validation_to_worker(monkeypatch):
     queue = DummyQueue()
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
     monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS(""))
@@ -374,8 +371,8 @@ async def test_vectorize_empty_content_reports_not_enqueued(monkeypatch):
         ctx=DummyReq(),
     )
 
-    assert enqueued is False
-    assert queue.items == []
+    assert enqueued is True
+    assert queue.items[0].message is None
 
 
 @pytest.mark.asyncio
@@ -562,42 +559,36 @@ async def test_vectorize_directory_meta_l1_abstract_truncated(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vectorize_unknown_text_file_sniffs_non_utf8_raw_content(monkeypatch):
+async def test_vectorize_unknown_text_content_only_defers_file_read(monkeypatch):
     queue = DummyQueue()
-    raw_content = (
-        "# 构建脚本\n"
-        "目标: 编译项目\n"
-        "说明: 这是一个中文 Makefile 内容，用于测试编码探测。\n"
-        "命令: cargo build --locked\n"
-    )
-    fs = DummyFS(raw_content.encode("gb18030"))
+    fs = DummyFS("build:\n\tcargo build --locked\n".encode("gb18030"))
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
     monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
     monkeypatch.setattr(
         embedding_utils,
         "get_openviking_config",
         lambda: types.SimpleNamespace(
-            embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
+            embedding=types.SimpleNamespace(text_source="content_only", max_input_tokens=1000)
         ),
     )
 
     await embedding_utils.vectorize_file(
         file_path="viking://user/default/resources/Makefile",
-        summary_dict={"name": "Makefile", "summary": "VLM generated build file summary"},
+        summary_dict={"name": "Makefile", "summary": ""},
         parent_uri="viking://user/default/resources",
         ctx=DummyReq(),
     )
 
     assert len(queue.items) == 1
     msg = queue.items[0]
-    assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_content
-    assert fs.read_file_bytes_calls == 1
+    assert msg.message is None
+    assert "content" not in msg.context_data
+    assert fs.read_file_bytes_calls == 0
     assert fs.read_file_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_unknown_file_reuses_summary_content_without_reread(monkeypatch):
+async def test_vectorize_unknown_file_ignores_summary_content_without_reread(monkeypatch):
     queue = DummyQueue()
     raw_content = "build:\n\tcargo build --locked\n"
     fs = DummyFS("should not be read")
@@ -625,7 +616,7 @@ async def test_vectorize_unknown_file_reuses_summary_content_without_reread(monk
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "VLM generated build file summary"
-    assert msg.context_data["content"] == raw_content
+    assert "content" not in msg.context_data
     assert fs.read_file_bytes_calls == 0
     assert fs.read_file_calls == 0
 
@@ -656,48 +647,13 @@ async def test_vectorize_unknown_binary_file_falls_back_to_summary(monkeypatch):
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == summary
-    assert msg.context_data["content"] == summary
-    assert fs.read_file_bytes_calls == 1
+    assert "content" not in msg.context_data
+    assert fs.read_file_bytes_calls == 0
     assert fs.read_file_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_unknown_unrecognizable_encoding_falls_back_to_summary(monkeypatch):
-    queue = DummyQueue()
-    summary = "VLM generated unknown file summary"
-    fs = DummyFS(b"\xff\xfe\xfd")
-    monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
-    monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
-    monkeypatch.setattr(
-        embedding_utils,
-        "get_openviking_config",
-        lambda: types.SimpleNamespace(
-            embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
-        ),
-    )
-    monkeypatch.setattr(
-        embedding_utils,
-        "from_bytes",
-        lambda _raw: types.SimpleNamespace(best=lambda: None),
-    )
-
-    await embedding_utils.vectorize_file(
-        file_path="viking://user/default/resources/unknown.data",
-        summary_dict={"name": "unknown.data", "summary": summary},
-        parent_uri="viking://user/default/resources",
-        ctx=DummyReq(),
-    )
-
-    assert len(queue.items) == 1
-    msg = queue.items[0]
-    assert msg.message == summary
-    assert msg.context_data["content"] == summary
-    assert fs.read_file_bytes_calls == 1
-    assert fs.read_file_calls == 0
-
-
-@pytest.mark.asyncio
-async def test_vectorize_text_summary_first_reuses_single_file_read(monkeypatch):
+async def test_vectorize_text_summary_first_defers_content_read(monkeypatch):
     queue = DummyQueue()
     fs = DummyFS("# README\nraw text for bm25\n")
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
@@ -720,8 +676,8 @@ async def test_vectorize_text_summary_first_reuses_single_file_read(monkeypatch)
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == "# README\nraw text for bm25\n"
-    assert fs.read_file_calls == 1
+    assert "content" not in msg.context_data
+    assert fs.read_file_calls == 0
     assert fs.read_file_bytes_calls == 0
 
 
@@ -750,8 +706,9 @@ async def test_vectorize_image_file_enqueues_summary_and_image(monkeypatch):
     msg = queue.items[0]
     assert msg.message[0] == {"type": "text", "text": "a cat on a sofa"}
     assert msg.message[1]["type"] == "image_url"
-    assert msg.message[1]["image_url"]["url"].startswith("data:image/png;base64,")
-    assert msg.context_data["content"] == "a cat on a sofa"
+    assert msg.message[1]["image_url"]["url"] == ("viking://user/default/resources/photo.png")
+    assert "content" not in msg.context_data
+    assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
@@ -779,13 +736,13 @@ async def test_vectorize_svg_file_uses_summary_and_indexes_markup(monkeypatch):
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "queue processing diagram"
-    assert msg.context_data["content"] == svg_content
-    assert fs.read_file_calls == 1
+    assert "content" not in msg.context_data
+    assert fs.read_file_calls == 0
     assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_image_file_falls_back_to_summary_when_image_unreadable(monkeypatch):
+async def test_vectorize_image_file_defers_image_read(monkeypatch):
     class UnreadableImageFS(DummyFS):
         async def read_file_bytes(self, _path, ctx=None):
             self.read_file_bytes_calls += 1
@@ -811,12 +768,18 @@ async def test_vectorize_image_file_falls_back_to_summary_when_image_unreadable(
     )
 
     assert len(queue.items) == 1
-    assert queue.items[0].message == "fallback summary"
-    assert fs.read_file_bytes_calls == 1
+    assert queue.items[0].message == [
+        {"type": "text", "text": "fallback summary"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "viking://user/default/resources/photo.png"},
+        },
+    ]
+    assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_text_file_reuses_summary_content_without_reread(monkeypatch):
+async def test_vectorize_text_file_ignores_summary_content_without_reread(monkeypatch):
     queue = DummyQueue()
     raw_content = "# README\nraw text already read during summary\n"
     fs = DummyFS("should not be read")
@@ -844,28 +807,22 @@ async def test_vectorize_text_file_reuses_summary_content_without_reread(monkeyp
     assert len(queue.items) == 1
     msg = queue.items[0]
     assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == raw_content
+    assert "content" not in msg.context_data
     assert fs.read_file_calls == 0
     assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_text_bytes_sniffs_non_utf8_content(monkeypatch):
+async def test_vectorize_content_only_defers_text_read(monkeypatch):
     queue = DummyQueue()
-    raw_content = (
-        "# 说明文档\n"
-        "目标: 验证已知 TEXT 文件的 bytes 内容也会进行编码探测。\n"
-        "说明: 这是一个中文 README 内容，用于测试 GB18030 编码识别。\n"
-        "命令: openviking benchmark run\n"
-    )
-    fs = DummyFS(raw_content.encode("gb18030"))
+    fs = DummyFS("README content".encode("gb18030"))
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
     monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: fs)
     monkeypatch.setattr(
         embedding_utils,
         "get_openviking_config",
         lambda: types.SimpleNamespace(
-            embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
+            embedding=types.SimpleNamespace(text_source="content_only", max_input_tokens=1000)
         ),
     )
 
@@ -878,14 +835,14 @@ async def test_vectorize_text_bytes_sniffs_non_utf8_content(monkeypatch):
 
     assert len(queue.items) == 1
     msg = queue.items[0]
-    assert msg.message == "summary for embedding"
-    assert msg.context_data["content"] == raw_content
-    assert fs.read_file_calls == 1
+    assert msg.message is None
+    assert "content" not in msg.context_data
+    assert fs.read_file_calls == 0
     assert fs.read_file_bytes_calls == 0
 
 
 @pytest.mark.asyncio
-async def test_vectorize_file_preserves_content_until_embedder_input_guard(monkeypatch):
+async def test_vectorize_file_defers_content_until_embedding_worker(monkeypatch):
     queue = DummyQueue()
     content = " ".join(f"token-{i}" for i in range(200))
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
@@ -897,12 +854,6 @@ async def test_vectorize_file_preserves_content_until_embedder_input_guard(monke
             embedding=types.SimpleNamespace(text_source="content_only", max_input_tokens=20)
         ),
     )
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter,
-        "from_context",
-        lambda context: context,
-    )
-
     await embedding_utils.vectorize_file(
         file_path="viking://user/default/resources/test.md",
         summary_dict={"name": "test.md", "summary": "short summary"},
@@ -911,8 +862,7 @@ async def test_vectorize_file_preserves_content_until_embedder_input_guard(monke
     )
 
     assert len(queue.items) == 1
-    text = queue.items[0].get_vectorization_text()
-    assert text == content
+    assert queue.items[0].message is None
 
 
 @pytest.mark.asyncio
@@ -927,12 +877,6 @@ async def test_index_resource_skips_session_namespace(monkeypatch):
             embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
         ),
     )
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter,
-        "from_context",
-        lambda context: context,
-    )
-
     await embedding_utils.index_resource(
         uri="viking://session/default/sess_001/history/archive_001",
         ctx=DummyReq(),
@@ -968,10 +912,6 @@ async def test_vectorize_file_truncates_oversized_abstract(monkeypatch):
             embedding=types.SimpleNamespace(text_source="summary_first", max_input_tokens=1000)
         ),
     )
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter, "from_context", lambda context: context
-    )
-
     oversized = "你" * 30_000  # 90,000 UTF-8 bytes
     await embedding_utils.vectorize_file(
         file_path="viking://user/default/resources/big.md",
@@ -981,7 +921,7 @@ async def test_vectorize_file_truncates_oversized_abstract(monkeypatch):
     )
 
     assert len(queue.items) == 1
-    abstract = queue.items[0].abstract
+    abstract = queue.items[0].context_data["abstract"]
     assert len(abstract.encode("utf-8")) <= embedding_utils._ABSTRACT_MAX_BYTES
     assert abstract.encode("utf-8").decode("utf-8") == abstract  # valid UTF-8
 
@@ -1017,7 +957,8 @@ async def test_empty_media_uses_filename_but_unknown_binary_skips(monkeypatch):
         ctx=DummyReq(),
     )
 
-    assert queue.items[0].context_data["content"] == "meeting.mp3"
+    assert queue.items[0].message == "meeting.mp3"
+    assert "content" not in queue.items[0].context_data
 
     queue = DummyQueue()
     monkeypatch.setattr(
@@ -1047,10 +988,6 @@ async def test_vectorize_directory_meta_truncates_oversized_abstract(monkeypatch
     queue = DummyQueue()
     monkeypatch.setattr(embedding_utils, "get_queue_manager", lambda: DummyQueueManager(queue))
     monkeypatch.setattr(embedding_utils, "get_viking_fs", lambda: DummyFS("ignored"))
-    monkeypatch.setattr(
-        embedding_utils.EmbeddingMsgConverter, "from_context", lambda context: context
-    )
-
     oversized = "你" * 30_000  # 90,000 UTF-8 bytes
     await embedding_utils.vectorize_directory_meta(
         uri="viking://user/default/resources/dir",
@@ -1061,6 +998,6 @@ async def test_vectorize_directory_meta_truncates_oversized_abstract(monkeypatch
 
     assert queue.items  # at least the abstract-level Context was enqueued
     for item in queue.items:
-        assert isinstance(item, Context)
-        assert len(item.abstract.encode("utf-8")) <= embedding_utils._ABSTRACT_MAX_BYTES
-        assert item.abstract.encode("utf-8").decode("utf-8") == item.abstract
+        abstract = item.context_data["abstract"]
+        assert len(abstract.encode("utf-8")) <= embedding_utils._ABSTRACT_MAX_BYTES
+        assert abstract.encode("utf-8").decode("utf-8") == abstract


### PR DESCRIPTION
## Description

大量资源并行处理时，原文和图片 base64 会随 Semantic DAG、QueueFS 消息及重试路径被长时间持有，造成内存尖刺。本 PR 让积压阶段只保存轻量 embedding 输入/引用和上下文元数据，并把资源内容延迟到 embedding worker 的实际消费点读取。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #3871

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Semantic 文件摘要只保留名称和摘要，不再把原文挂在 DAG 和待向量化任务上。
- `EmbeddingMsg` 不再保存全文或图片 base64；文本通过已有 URI 元数据延迟读取，图片复用现有 `image_url` 结构保存 `viking://` 引用，没有新增并行字段。
- converter 不再维护索引字段 blacklist；上下文元数据直接进入轻量队列，最终由 vector backend 根据实际 collection schema 统一过滤。
- embedding worker 在现有并发上限内读取输入，只执行一次已有 token guard，再通过共享的 prepared embedding 入口调用 provider 并及时释放输入；仅需要全文字段的 VikingDB 后端会在 embedding 完成后读取内容，并复用已有 1 MiB 上限。
- reindex 复用同一条轻量队列路径；删除 `full_text`、`_truncate_embedding_text` 及旧的生产端内容读取逻辑，并集中复用 `text_source` 配置值。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

```text
ruff check <all changed Python files>
pytest -q --no-cov tests/test_telemetry_runtime.py::test_embed_compat_binds_query_stage_for_embedding_tokens tests/storage/test_embedding_msg.py tests/storage/test_embedding_msg_converter_tenant.py tests/unit/test_vectorize_file_strategy.py tests/storage/test_collection_schemas.py tests/server/test_admin_rebuild_api.py::test_reindex_upsert_uses_uri_owner_for_user_scoped_records tests/storage/test_semantic_processor_code_routing.py tests/storage/test_semantic_processor_language.py::TestGenerateTextSummaryOutputLanguage
```

结果：112 passed。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

该实现不依赖 page cache。`content_only + VikingDB` 会执行两次真实 FS 读取：第一次生成受 token 上限约束的 embedding 输入，provider 返回后第二次读取并立即截到已有 1 MiB 上限用于全文索引。这里明确选择额外 I/O，避免无界原文跨网络请求长期驻留。图片 base64 仍需在多模态 provider 调用期间存在，但不会进入 DAG、持久队列或重试消息，其同时驻留量受已有 embedding 并发配置约束。
