### PR TITLE
fix(ovpack): restore protected scope roots

### DIFF
--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -116,9 +116,43 @@ async def _ensure_parent_exists(viking_fs, parent: str, ctx: RequestContext) -> 
         await viking_fs.mkdir(parent, ctx=ctx)
 
 
+_PROTECTED_SCOPE_ROOTS = frozenset({"viking://agent", "viking://user"})
+
+
+def _is_protected_scope_root(uri: str) -> bool:
+    return uri.rstrip("/") in _PROTECTED_SCOPE_ROOTS
+
+
+async def _clear_protected_root(viking_fs, root_uri: str, ctx: RequestContext) -> None:
+    """Remove a protected namespace's children while preserving its virtual root."""
+    while True:
+        try:
+            entries = await viking_fs.ls(root_uri, show_all_hidden=True, ctx=ctx)
+        except (NotFoundError, FileNotFoundError):
+            return
+        if not entries:
+            return
+
+        children: list[str] = []
+        prefix = f"{root_uri.rstrip('/')}/"
+        for entry in entries:
+            child_uri = entry.get("uri") if isinstance(entry, dict) else None
+            if not isinstance(child_uri, str) or not child_uri.startswith(prefix):
+                raise InvalidArgumentError(
+                    "Protected scope listing returned an invalid child",
+                    details={"root": root_uri, "child": child_uri},
+                )
+            children.append(child_uri)
+        for child_uri in children:
+            await viking_fs.rm(child_uri, recursive=True, ctx=ctx)
+
+
 async def _remove_existing_root(viking_fs, root_uri: str, ctx: RequestContext) -> None:
     if not hasattr(viking_fs, "rm"):
         logger.warning(f"[ovpack] Cannot remove existing resource without rm(): {root_uri}")
+        return
+    if _is_protected_scope_root(root_uri):
+        await _clear_protected_root(viking_fs, root_uri, ctx)
         return
     try:
         await viking_fs.rm(root_uri, recursive=True, ctx=ctx)
@@ -679,7 +713,9 @@ async def restore_ovpack(
             if kind in {"manifest", "internal"} or rel_path == "":
                 continue
             if kind == "directory":
-                await viking_fs.mkdir(join_uri(root_uri, rel_path), exist_ok=True, ctx=ctx)
+                target_uri = join_uri(root_uri, rel_path)
+                if not _is_protected_scope_root(target_uri):
+                    await viking_fs.mkdir(target_uri, exist_ok=True, ctx=ctx)
                 continue
 
             data = zf.read(safe_zip_path)

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -54,6 +54,33 @@ class FakeVikingFS:
         raise FileNotFoundError(uri)
 
 
+class FakeInitializedRestoreVikingFS(FakeVikingFS):
+    """Model the public roots and protected user namespace of an initialized server."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.removed: list[str] = []
+        self.children = {
+            "viking://resources": [{"uri": "viking://resources/old.md"}],
+            "viking://user": [{"uri": "viking://user/old-user"}],
+        }
+
+    async def ls(self, uri: str, show_all_hidden: bool = False, ctx=None):
+        if uri in self.children:
+            return list(self.children[uri])
+        raise NotFoundError(uri, "file")
+
+    async def mkdir(self, uri: str, exist_ok: bool = False, ctx=None):
+        assert uri != "viking://user"
+        await super().mkdir(uri, exist_ok=exist_ok, ctx=ctx)
+
+    async def rm(self, uri: str, recursive: bool = False, ctx=None):
+        assert uri != "viking://user"
+        self.removed.append(uri)
+        for entries in self.children.values():
+            entries[:] = [entry for entry in entries if entry["uri"] != uri]
+
+
 class FakeExportVikingFS:
     def __init__(self) -> None:
         self.binary_files = {
@@ -619,6 +646,30 @@ async def test_backup_restore_contract(temp_ovpack_path: Path, request_ctx: Requ
         "viking://user/alice/sessions/sess_1/.meta.json",
     ]
     assert fake_fs.tree_calls == ["viking://resources", "viking://user"]
+
+
+@pytest.mark.asyncio
+async def test_backup_restore_overwrites_initialized_protected_scope(
+    temp_ovpack_path: Path, request_ctx: RequestContext
+):
+    await backup_ovpack(FakeBackupVikingFS(), str(temp_ovpack_path), ctx=request_ctx)
+    fake_fs = FakeInitializedRestoreVikingFS()
+
+    assert (
+        await restore_ovpack(
+            fake_fs,
+            str(temp_ovpack_path),
+            request_ctx,
+            on_conflict="overwrite",
+        )
+        == "viking://"
+    )
+    assert fake_fs.removed == ["viking://resources", "viking://user/old-user"]
+    assert "viking://user" not in fake_fs.created_dirs
+    assert fake_fs.written_files == [
+        "viking://resources/README.md",
+        "viking://user/alice/sessions/sess_1/.meta.json",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the full-backup overwrite restore path for initialized servers by treating protected namespace roots as structural containers:

- clear children of `viking://user` / `viking://agent` instead of deleting the protected root;
- skip replaying the synthetic protected-root directory entry itself;
- retain normal replacement behavior for unprotected roots such as `viking://resources`.

Closes #3875.

This supersedes the approach in the closed #3876: clearing children alone still leaves restore failing when archive extraction calls `mkdir("viking://user")` (`PERMISSION_DENIED`). This change covers both phases.

## Type of Change

- [x] Bug fix

## Testing

- [x] `ruff check` passes for changed files.
- [x] `ruff format --check` passes for changed files.
- [x] All 19 tests in `tests/misc/test_ovpack_import_policy.py` pass.
- [x] Added regression coverage for an initialized target with existing `resources` and protected `user` roots.
- [x] End-to-end validated with the v0.4.13 Docker image: created an isolated encrypted server and account, uploaded a real restore-only OVPack through `/api/v1/resources/temp_upload`, restored through `/api/v1/pack/restore` with `on_conflict=overwrite`, and read the restored resource tree. The isolated container and data were removed afterward.

## Safety properties

- The OVPack manifest, members, hashes, and vector payload are fully validated before any existing root is mutated (existing restore ordering is preserved).
- Invalid child records abort rather than deleting an unverified URI.
- A child deletion error propagates; restore never reports success with known stale content.

## Related Issues

- Fixes #3875
- Supersedes closed PR #3876
