### PR TITLE
fix(privacy): avoid replacing bare values in prose

### DIFF
--- a/openviking/privacy/skill_placeholder.py
+++ b/openviking/privacy/skill_placeholder.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Placeholder helpers for skill privacy values."""
 
+import re
 from dataclasses import dataclass, field
 
 
@@ -21,18 +22,6 @@ def _replace_structured_value(content: str, raw_value: str, placeholder: str) ->
     replacements = (
         (f'"{raw_value}"', f'"{placeholder}"'),
         (f"'{raw_value}'", f"'{placeholder}'"),
-        (f": {raw_value}\n", f": {placeholder}\n"),
-        (f": {raw_value}\r\n", f": {placeholder}\r\n"),
-        (f":{raw_value}\n", f":{placeholder}\n"),
-        (f":{raw_value}\r\n", f":{placeholder}\r\n"),
-        (f": {raw_value}", f": {placeholder}"),
-        (f":{raw_value}", f":{placeholder}"),
-        (f"= {raw_value}\n", f"= {placeholder}\n"),
-        (f"= {raw_value}\r\n", f"= {placeholder}\r\n"),
-        (f"={raw_value}\n", f"={placeholder}\n"),
-        (f"={raw_value}\r\n", f"={placeholder}\r\n"),
-        (f"= {raw_value}", f"= {placeholder}"),
-        (f"={raw_value}", f"={placeholder}"),
     )
 
     replaced = False
@@ -40,7 +29,20 @@ def _replace_structured_value(content: str, raw_value: str, placeholder: str) ->
         if old in content:
             content = content.replace(old, new)
             replaced = True
-    return content, replaced
+
+    bare_value_pattern = re.compile(
+        rf"(?P<separator>[:=])(?P<leading>[ \t]*){re.escape(raw_value)}"
+        r"(?P<trailing>[ \t]*)(?=\r?$)",
+        re.MULTILINE,
+    )
+    content, bare_replacement_count = bare_value_pattern.subn(
+        lambda match: (
+            f"{match.group('separator')}{match.group('leading')}"
+            f"{placeholder}{match.group('trailing')}"
+        ),
+        content,
+    )
+    return content, replaced or bare_replacement_count > 0
 
 
 def placeholderize_skill_content_with_blocks(

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -280,3 +280,29 @@ def test_placeholderization_replaces_all_structured_occurrences_for_same_value()
         'api_key: "{{ov_privacy:skill:multi-hit-skill:api_key}}"\n'
         "backup={{ov_privacy:skill:multi-hit-skill:api_key}}\n"
     )
+
+
+def test_placeholderization_preserves_crlf_spacing_and_regex_special_values():
+    result = placeholderize_skill_content_with_blocks(
+        "token:\ta.b+c?[x]  \r\ntext: a.b+c?[x] should stay here\r\n",
+        "regex-skill",
+        {"token": "a.b+c?[x]"},
+    )
+
+    assert result.replaced_values == {"token": "a.b+c?[x]"}
+    assert result.sanitized_content == (
+        "token:\t{{ov_privacy:skill:regex-skill:token}}  \r\ntext: a.b+c?[x] should stay here\r\n"
+    )
+
+
+def test_placeholderization_preserves_quoted_value_matching():
+    result = placeholderize_skill_content_with_blocks(
+        'note: use "secret" in prose\n',
+        "quoted-skill",
+        {"api_key": "secret"},
+    )
+
+    assert result.replaced_values == {"api_key": "secret"}
+    assert result.sanitized_content == (
+        'note: use "{{ov_privacy:skill:quoted-skill:api_key}}" in prose\n'
+    )


### PR DESCRIPTION
## Description

Prevent skill privacy placeholderization from rewriting configured bare values
that merely appear at the start of ordinary prose after a colon or equals sign.
Bare assignments now match only when the configured value is followed by
optional horizontal whitespace and then LF, CRLF, or end of input. Quoted-value
replacement behavior and the placeholder format remain unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3791

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Anchor unquoted colon/equal assignment values to line boundaries with an escaped pattern.
- Preserve separators, leading/trailing horizontal whitespace, and LF/CRLF endings.
- Add regression coverage for prose, CRLF, regex-special values, and quoted-value compatibility.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands run:

```text
python -m pytest -o addopts='' tests/server/test_privacy_config_service.py -k placeholderization -q
python -m ruff format --check openviking/privacy/skill_placeholder.py tests/server/test_privacy_config_service.py
python -m ruff check openviking/privacy/skill_placeholder.py tests/server/test_privacy_config_service.py
python -m mypy --follow-imports=skip --ignore-missing-imports openviking/privacy/skill_placeholder.py
python -m compileall -q openviking/privacy/skill_placeholder.py tests/server/test_privacy_config_service.py
git diff --check upstream/main...HEAD
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The focused helper tests report 5 passed with four pre-existing Pydantic
deprecation warnings. The complete privacy service module was attempted, but
service-level cases require the unavailable `ragfs_python` native binding and
one existing extraction case invokes configured VLM I/O. `make check-deps`
stops because CMake is absent on this host. No native code is changed by this PR.
