### PR TITLE
fix(retrieval): record first-turn session recalls

### DIFF
--- a/openviking/retrieve/context_assembler/pipeline.py
+++ b/openviking/retrieve/context_assembler/pipeline.py
@@ -40,10 +40,9 @@ async def _load_session(service: Any, ctx: RequestContext, session_id: Optional[
     if not session_id:
         return None
     try:
-        session = service.sessions.session(ctx, session_id)
+        session = await service.sessions.get(session_id, ctx, auto_create=True)
         if not await session.is_materialized():
             return None
-        await session.load()
         return session
     except Exception as exc:
         logger.info("Session %s unavailable for context assembly: %s", session_id, exc)

--- a/tests/retrieve/test_context_assembler_pipeline.py
+++ b/tests/retrieve/test_context_assembler_pipeline.py
@@ -55,10 +55,15 @@ def _service(*, hits, bodies, session=None):
             raise FileNotFoundError(uri)
         return bodies[uri]
 
+    async def fake_get(session_id, ctx, *, auto_create=False):
+        del session_id, ctx
+        assert auto_create is True
+        return session
+
     return SimpleNamespace(
         search=SimpleNamespace(find=fake_find),
         fs=SimpleNamespace(read=fake_read),
-        sessions=SimpleNamespace(session=lambda ctx, session_id: session),
+        sessions=SimpleNamespace(get=fake_get),
         viking_fs=None,
     )
 
@@ -67,7 +72,10 @@ def _fake_session():
     async def load():
         return None
 
-    return SimpleNamespace(load=load)
+    async def is_materialized():
+        return True
+
+    return SimpleNamespace(load=load, is_materialized=is_materialized)
 
 
 def test_render_neutralizes_forged_memory_tags():
@@ -141,11 +149,17 @@ async def test_query_expansion_fans_out_planned_queries(monkeypatch):
         queries_seen.append(kwargs["query"])
         return _FakeFindResult()
 
+    async def fake_get(session_id, ctx, *, auto_create=False):
+        del ctx
+        assert session_id == "s1"
+        assert auto_create is True
+        return _fake_session()
+
     monkeypatch.setattr(pipeline_module, "expand_queries", fake_expand)
     service = SimpleNamespace(
         search=SimpleNamespace(find=fake_find),
         fs=SimpleNamespace(read=None),
-        sessions=SimpleNamespace(session=lambda ctx, sid: _fake_session()),
+        sessions=SimpleNamespace(get=fake_get),
         viking_fs=None,
     )
 
@@ -169,14 +183,14 @@ async def test_disabled_intent_does_not_load_session_or_expand_query():
         assert kwargs["query"] == "raw query"
         return _FakeFindResult()
 
-    def fail_session(*args):
-        del args
+    async def fail_get(*args, **kwargs):
+        del args, kwargs
         raise AssertionError("session must not be loaded when intent is disabled")
 
     service = SimpleNamespace(
         search=SimpleNamespace(find=fake_find, is_intent_enabled=lambda: False),
         fs=SimpleNamespace(read=None),
-        sessions=SimpleNamespace(session=fail_session),
+        sessions=SimpleNamespace(get=fail_get),
         viking_fs=None,
     )
 

--- a/tests/server/test_api_search_context.py
+++ b/tests/server/test_api_search_context.py
@@ -324,7 +324,7 @@ async def test_context_mode_dedup_ledger_round_trips_through_agfs(
     assert second.json()["result"]["stats"]["dedup"]["cooled"] == 1
 
 
-async def test_context_mode_unknown_session_does_not_create_recall_ledger(
+async def test_context_mode_first_recall_materializes_session_and_records_ledger(
     client: httpx.AsyncClient,
     service,
     monkeypatch,
@@ -339,10 +339,74 @@ async def test_context_mode_unknown_session_does_not_create_recall_ledger(
 
     monkeypatch.setattr(service.search, "find", fake_find)
     session_id = "context-before-capture"
+    payload = {
+        "query": "recall before capture",
+        "mode": "context",
+        "session_id": session_id,
+        "dedup_turns": 3,
+        "query_expansion": "off",
+    }
+    first = await client.post(
+        "/api/v1/search/search",
+        json=payload,
+    )
+
+    assert first.status_code == 200
+    assert [entry["uri"] for entry in first.json()["result"]["entries"]] == [file_uri]
+    assert first.json()["result"]["stats"]["dedup"]["status"] == "new"
+
+    session_uri = f"viking://user/default/sessions/{session_id}"
+    ledger_uri = f"{session_uri}/.recall_log.json"
+    assert await service.viking_fs.exists(f"{session_uri}/messages.jsonl", ctx=ctx)
+    assert await service.viking_fs.exists(f"{session_uri}/.meta.json", ctx=ctx)
+    ledger = json.loads(await service.viking_fs.read_file(ledger_uri, ctx=ctx))
+    assert file_uri in ledger["entries"]
+
+    added = await client.post(
+        f"/api/v1/sessions/{session_id}/messages",
+        json={"role": "user", "content": "first captured message"},
+    )
+    assert added.status_code == 200
+    messages = await service.viking_fs.read_file(f"{session_uri}/messages.jsonl", ctx=ctx)
+    assert "first captured message" in messages
+    persisted_ledger = json.loads(await service.viking_fs.read_file(ledger_uri, ctx=ctx))
+    assert file_uri in persisted_ledger["entries"]
+
+    second = await client.post("/api/v1/search/search", json=payload)
+    assert second.status_code == 200
+    assert second.json()["result"]["entries"] == []
+    assert second.json()["result"]["stats"]["dedup"]["cooled"] == 1
+
+
+async def test_context_mode_session_materialization_failure_stays_stateless(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    file_uri = "viking://user/default/memories/events/fail-open.md"
+    session_id = "context-materialization-failure"
+    ctx = RequestContext(user=UserIdentifier.the_default_user("default"), role=Role.ROOT)
+    session_uri = f"viking://user/default/sessions/{session_id}"
+    original_write_file = service.viking_fs.write_file
+    failed_once = False
+
+    async def fail_first_message_file(uri, content, **kwargs):
+        nonlocal failed_once
+        if uri == f"{session_uri}/messages.jsonl" and not failed_once:
+            failed_once = True
+            raise OSError("simulated session materialization failure")
+        return await original_write_file(uri, content, **kwargs)
+
+    async def fake_find(**kwargs):
+        del kwargs
+        return _FakeFindResult([_memory(file_uri, 0.7, "fail-open abstract")])
+
+    monkeypatch.setattr(service.viking_fs, "write_file", fail_first_message_file)
+    monkeypatch.setattr(service.search, "find", fake_find)
     response = await client.post(
         "/api/v1/search/search",
         json={
-            "query": "recall before capture",
+            "query": "recall despite session failure",
             "mode": "context",
             "session_id": session_id,
             "dedup_turns": 3,
@@ -353,7 +417,47 @@ async def test_context_mode_unknown_session_does_not_create_recall_ledger(
     assert response.status_code == 200
     assert [entry["uri"] for entry in response.json()["result"]["entries"]] == [file_uri]
     assert response.json()["result"]["stats"]["dedup"]["status"] == "off"
+    assert await service.viking_fs.exists(session_uri, ctx=ctx)
+    assert not await service.viking_fs.exists(f"{session_uri}/messages.jsonl", ctx=ctx)
+    assert not await service.viking_fs.exists(f"{session_uri}/.recall_log.json", ctx=ctx)
+
+    added = await client.post(
+        f"/api/v1/sessions/{session_id}/messages",
+        json={"role": "user", "content": "capture repairs the partial session"},
+    )
+    assert added.status_code == 200
+    messages = await service.viking_fs.read_file(f"{session_uri}/messages.jsonl", ctx=ctx)
+    assert "capture repairs the partial session" in messages
+    assert not await service.viking_fs.exists(f"{session_uri}/.recall_log.json", ctx=ctx)
+
+
+async def test_context_mode_does_not_materialize_session_when_session_features_are_off(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    session_id = "context-with-session-features-off"
+    ctx = RequestContext(user=UserIdentifier.the_default_user("default"), role=Role.ROOT)
+
+    async def fake_find(**kwargs):
+        del kwargs
+        return _FakeFindResult()
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+    response = await client.post(
+        "/api/v1/search/search",
+        json={
+            "query": "stateless context request",
+            "mode": "context",
+            "session_id": session_id,
+            "dedup_turns": 0,
+            "query_expansion": "off",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["stats"]["dedup"]["status"] == "off"
     assert not await service.viking_fs.exists(
-        f"viking://user/default/sessions/{session_id}/.recall_log.json",
+        f"viking://user/default/sessions/{session_id}",
         ctx=ctx,
     )


### PR DESCRIPTION
## Description

Session-aware context recall currently starts recording served URIs only after a session has a durable `messages.jsonl`. On the first Claude Code prompt, `UserPromptSubmit` runs before the first `Stop` capture, so the session is not materialized yet and the first recall is served without a ledger. The same URI can therefore be served again on the second prompt before cooldown begins.

This gap was introduced when server-side context assembly and the per-session recall ledger landed in #3534. The later partial-session recovery in #3820 correctly made `messages.jsonl` the materialization boundary and prevented recall-only directories from blocking capture, but intentionally disabled ledger writes for unknown sessions. This PR completes that recovery by materializing session-aware context requests through the existing `SessionService.get(..., auto_create=True)` path before loading the ledger.

The resulting first-turn flow is: context recall receives `session_id` → SessionService creates the session root, empty `messages.jsonl`, and metadata → recall records served URIs in the same directory → the first message capture appends to that same `messages.jsonl`. A post-create materialization check remains in place, so interrupted initialization still degrades to stateless recall and cannot recreate a ledger-only session.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Materialize session-aware context requests through the standard SessionService auto-create path before loading query-expansion state or the recall ledger.
- Keep the `messages.jsonl` materialization guard so initialization failures remain fail-open and never write a recall ledger into a partial session.
- Add regressions for first-turn ledger recording, same-session message capture, second-turn cooldown, interrupted initialization recovery, and requests with session features disabled.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `pytest --no-cov -q tests/retrieve/test_context_assembler_pipeline.py tests/server/test_api_search_context.py tests/server/test_api_sessions.py` — 82 passed
- `ruff check openviking/retrieve/context_assembler/pipeline.py tests/retrieve/test_context_assembler_pipeline.py tests/server/test_api_search_context.py`
- `ruff format --check openviking/retrieve/context_assembler/pipeline.py tests/retrieve/test_context_assembler_pipeline.py tests/server/test_api_search_context.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No client or plugin update is required. Any harness that already sends a `session_id` for context recall receives first-turn ledger recording from the server change.
