### PR TITLE
fix(task-tracker): delete expired persisted tasks

### DIFF
--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -263,27 +263,65 @@ class TaskTracker:
     async def _evict_expired_on_owner(self) -> None:
         now = time.time()
         with self._lock:
-            expired_ids = []
-            for tid, t in self._tasks.items():
-                if (
-                    t.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED)
-                    and (now - t.updated_at) > self.TTL_COMPLETED
-                ):
-                    expired_ids.append(tid)
-                elif t.status == TaskStatus.FAILED and (now - t.updated_at) > self.TTL_FAILED:
-                    expired_ids.append(tid)
+            expired_ids = [
+                task_id for task_id, task in self._tasks.items() if self._is_expired(task, now)
+            ]
 
-            for tid in expired_ids:
-                self._tasks.pop(tid, None)
+        evicted_count = 0
+        for task_id in expired_ids:
+            evicted_count += await self._delete_expired_task_on_owner(task_id, now)
 
+        with self._lock:
             if len(self._tasks) > self.MAX_TASKS:
                 sorted_tasks = sorted(self._tasks.items(), key=lambda x: x[1].created_at)
                 excess = len(self._tasks) - self.MAX_TASKS
                 for tid, _ in sorted_tasks[:excess]:
                     self._tasks.pop(tid, None)
 
-        if expired_ids:
-            logger.debug("[TaskTracker] Evicted %d expired tasks", len(expired_ids))
+        if evicted_count:
+            logger.debug("[TaskTracker] Evicted %d expired tasks", evicted_count)
+
+    def _is_expired(self, task: TaskRecord, now: float) -> bool:
+        age = now - task.updated_at
+        if task.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED):
+            return age > self.TTL_COMPLETED
+        return task.status == TaskStatus.FAILED and age > self.TTL_FAILED
+
+    async def _delete_expired_task_on_owner(self, task_id: str, now: float) -> bool:
+        async with self._task_locks.acquire(task_id):
+            task = self._cached_task(task_id)
+            if task is None or not self._is_expired(task, now):
+                return False
+            account_id = task.account_id
+            user_id = task.user_id
+            if not account_id or not user_id:
+                logger.warning(
+                    "[TaskTracker] Cannot delete expired ownerless task %s",
+                    task_id,
+                )
+                return False
+            try:
+                await self._store_io.run(
+                    "delete",
+                    lambda: run_to_completion(
+                        lambda: self._store.delete(
+                            task_id,
+                            account_id=account_id,
+                            user_id=user_id,
+                        )
+                    ),
+                )
+            except Exception:
+                logger.warning(
+                    "[TaskTracker] Failed to delete expired task %s",
+                    task_id,
+                    exc_info=True,
+                )
+                return False
+
+            with self._lock:
+                self._tasks.pop(task_id, None)
+            return True
 
     @staticmethod
     def _matches_owner(

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -61,6 +61,7 @@ class _FakeAgfs:
     def __init__(self):
         self.files = {}
         self.dirs = {"/", "/local"}
+        self.fail_rm = False
 
     def mkdir(self, path: str, mode: str = "755"):
         self.dirs.add(path.rstrip("/") or "/")
@@ -100,6 +101,12 @@ class _FakeAgfs:
                 if name and "/" not in file_path[len(prefix) + 1 :]:
                     children[name] = {"name": name, "path": f"{prefix}/{name}", "is_dir": False}
         return list(children.values())
+
+    def rm(self, path: str, recursive: bool = False, force: bool = False):
+        if self.fail_rm:
+            raise OSError("simulated delete failure")
+        self.files.pop(path, None)
+        return {"message": "removed", "recursive": recursive, "force": force}
 
 
 class _FakeAgfsExistingDir(_FakeAgfs):
@@ -397,10 +404,33 @@ async def test_evict_expired_completed(tracker: TaskTracker):
     t = await tracker.create("session_commit", **_owner_kwargs())
     await tracker.start(t.task_id)
     await tracker.complete(t.task_id, {})
+    assert await tracker._store.get(t.task_id, **_owner_kwargs()) is not None
     # Simulate old timestamp (access internal state; get() returns defensive copies)
     tracker._tasks[t.task_id].updated_at = time.time() - tracker.TTL_COMPLETED - 1
     await tracker._evict_expired()
     assert await tracker.get(t.task_id) is None
+    assert await tracker._store.get(t.task_id, **_owner_kwargs()) is None
+
+
+async def test_evict_keeps_cached_task_when_persistent_delete_fails():
+    agfs = _FakeAgfs()
+    tracker = TaskTracker(store=PersistentTaskStore(agfs))
+    t = await tracker.create("session_commit", **_owner_kwargs())
+    await tracker.start(t.task_id)
+    await tracker.complete(t.task_id, {})
+    tracker._tasks[t.task_id].updated_at = time.time() - tracker.TTL_COMPLETED - 1
+    agfs.fail_rm = True
+
+    await tracker._evict_expired()
+
+    assert await tracker.get(t.task_id) is not None
+    assert await tracker._store.get(t.task_id, **_owner_kwargs()) is not None
+
+    agfs.fail_rm = False
+    await tracker._evict_expired()
+
+    assert await tracker.get(t.task_id) is None
+    assert await tracker._store.get(t.task_id, **_owner_kwargs()) is None
 
 
 async def test_evict_keeps_recent_completed(tracker: TaskTracker):


### PR DESCRIPTION
## Summary

- delete persisted task records when terminal tasks expire by TTL
- serialize cleanup with the existing per-task lock and store I/O limiter
- retain the cache entry when deletion fails so the next cleanup cycle can retry
- keep `MAX_TASKS` eviction cache-only to avoid deleting active persisted tasks

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `python -m pytest tests/test_task_tracker.py tests/test_task_tracker_concurrency.py -q` (`79 passed`)
- `ruff check openviking/service/task_tracker.py tests/test_task_tracker.py`
- `ruff format --check openviking/service/task_tracker.py tests/test_task_tracker.py`
- `git diff --check origin/main...HEAD`

## Related Issues

Fixes #3896

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added regression tests for the fix
- [x] New and existing related tests pass locally