### PR TITLE
fix(memory): enforce typed and lifecycle-safe updates

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -138,7 +138,7 @@ Once connected, OpenViking exposes 13 tools:
 | `recall` | Type-quota recall assembled server-side into flat `<memory>` blocks that always carry their URI | `query`, `quotas` (optional), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty` (optional), `session_id` (optional), `detail` (optional), `max_tokens` (optional), `rewrite` (optional) |
 | `read` | Read one or more `viking://` URIs | `uris` (single string or array) |
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |
-| `remember` | Store messages into long-term memory (triggers extraction) | `messages` (list of `{role, content}`) |
+| `remember` | Store messages into long-term memory (triggers asynchronous extraction) | `messages` (list of `{role, content}`), `memory_type` (optional: `preferences` or `experiences`) |
 | `add_resource` | Add a local file or URL as a resource (local files trigger a progressive upload flow) | `path`, `temp_file_id` (optional), `description` (optional), `watch_interval` (optional, minutes — auto-refresh cadence for remote URLs), `processing_mode` (optional: `semantic_and_vectors` default, or `vectors_only` to skip VLM semantic understanding and only vectorize current files), `to` (optional, target `viking://resources/...` URI; if omitted when `watch_interval > 0`, the watch auto-binds to the resource's created URI), `args` (optional parser-specific options, including `{"parse_mode":"no_split"}` to parse each source document into one Markdown body, `{"feishu_access_token":"u-..."}` for one-time Feishu user-token imports, or `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}` for Feishu user-token watches) |
 | `list_watches` | List watch tasks (auto-refresh subscriptions) visible to the current agent. Each entry shows target URI, refresh interval (minutes), active/paused status, and next scheduled execution time | none |
 | `cancel_watch` | Cancel (delete) a watch task by its target URI. To change the cadence or pause temporarily, cancel and re-add with a new `watch_interval` | `to_uri` (must match the watch task's `to` value, e.g. `viking://resources/...`) |
@@ -148,6 +148,19 @@ Once connected, OpenViking exposes 13 tools:
 | `health` | Check OpenViking service health | none |
 
 > **Note**: MCP exposes the minimum closure for watch management (`list_watches` + `cancel_watch`). Pause / resume / trigger and the unified `update` verb are intentionally not exposed here — use the REST `/api/v1/watches/*` endpoints or the `ov task watch` CLI for those operations.
+
+When `remember.memory_type` is omitted, extraction keeps the existing policy-driven
+behavior. Setting it to `preferences` constrains the one-shot session to Preference
+memory. Setting it to `experiences` enables the Case → Trajectory → Experience
+pipeline for that session and therefore requires Agent Evolution to be enabled;
+the tool fails explicitly when that prerequisite is disabled instead of silently
+storing the text as another memory type.
+
+Treat typed Experience writes as a trusted-author operation. `remember` accepts
+caller-supplied transcript messages; it does not cryptographically attest that
+the described tool calls or outcomes occurred. Untrusted applications should
+commit a server-recorded session instead of accepting arbitrary text as an
+Experience candidate.
 
 > Feishu/Lark imports without `args.feishu_access_token` keep the existing app/tenant-token behavior and can be watched. Feishu/Lark one-time user-token imports pass only `args.feishu_access_token`; Feishu/Lark user-token watches must also pass `args.feishu_refresh_token` and require the same Feishu app credentials configured on the OpenViking server.
 

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -130,7 +130,7 @@ claude mcp add --transport http openviking \
 | `recall` | 按记忆类别配额召回，服务端组装为带 URI 的扁平 `<memory>` 块 | `query`, `quotas`(可选), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty`(可选), `session_id`(可选), `detail`(可选), `max_tokens`(可选), `rewrite`(可选) |
 | `read` | 读取一个或多个 `viking://` URI 的内容 | `uris`（单个字符串或数组） |
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |
-| `remember` | 存储消息到长期记忆（触发记忆提取） | `messages`（`{role, content}` 列表） |
+| `remember` | 存储消息到长期记忆（触发异步记忆提取） | `messages`（`{role, content}` 列表），`memory_type`（可选：`preferences` 或 `experiences`） |
 | `add_resource` | 添加本地文件或 URL 作为资源(本地文件触发渐进式上传流) | `path`, `temp_file_id`(可选), `description`(可选), `watch_interval`(可选,分钟数 — 远程 URL 的自动刷新周期), `processing_mode`(可选：默认 `semantic_and_vectors`；传 `vectors_only` 时跳过 VLM 语义理解，只向量化当前文件), `to`(可选,目标 `viking://resources/...` URI；`watch_interval > 0` 时若省略 `to`,watch 将自动绑定到本次 add 创建的资源 URI), `args`(可选,特定 parser 参数，包括 `{"parse_mode":"no_split"}` 用于正常解析但每个源文档只生成一个 Markdown 正文、飞书一次性用户 token 导入使用 `{"feishu_access_token":"u-..."}`，或飞书用户 token watch 使用 `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}`) |
 | `list_watches` | 列出当前 Agent 可见的 watch 任务（自动刷新订阅），每行显示目标 URI、刷新间隔（分钟）、active/paused 状态以及下一次调度时间 | 无 |
 | `cancel_watch` | 按目标 URI 取消（删除）watch 任务。若需调整刷新周期或临时暂停，请取消后使用新的 `watch_interval` 重新添加 | `to_uri`（必须匹配 watch 任务的 `to` 值，例如 `viking://resources/...`） |
@@ -140,6 +140,17 @@ claude mcp add --transport http openviking \
 | `health` | 检查 OpenViking 服务健康状态 | 无 |
 
 > **注**：MCP 仅暴露 watch 管理的最小闭包（`list_watches` + `cancel_watch`）。pause / resume / trigger 和统一的 `update` 动作刻意不在此处暴露，请通过 REST `/api/v1/watches/*` 接口或 `ov task watch` CLI 使用上述操作。
+
+省略 `remember.memory_type` 时，系统保持原有的策略驱动提取行为。设为
+`preferences` 时，这个一次性 session 只提取 Preference；设为 `experiences`
+时，则为该 session 启用 Case → Trajectory → Experience 链路，因此要求已开启
+Agent Evolution。若前置条件未满足，工具会明确报错，而不会把内容静默写成其他
+记忆类型。
+
+类型明确的 Experience 写入应只开放给可信调用方。`remember` 接收的是调用方提供
+的 transcript 消息，并不会以密码学方式证明其中描述的工具调用或结果确实发生过。
+不可信应用应提交由服务端实际记录的 session，而不是允许任意文本直接成为
+Experience 候选。
 
 > 未传 `args.feishu_access_token` 的飞书/Lark 导入保持现有应用/tenant token 行为，也支持 watch。飞书/Lark 一次性用户 token 导入只传 `args.feishu_access_token`；飞书/Lark 用户 token watch 还必须传 `args.feishu_refresh_token`，并要求 OpenViking 服务端配置同一个飞书应用凭证。
 

--- a/openviking/retrieve/context_assembler/pipeline.py
+++ b/openviking/retrieve/context_assembler/pipeline.py
@@ -9,7 +9,9 @@ cross-turn dedup from one implementation.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import asyncio
+import json
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from openviking.retrieve.context_assembler.budget import (
     oversized_abstract_needs_body,
@@ -17,11 +19,12 @@ from openviking.retrieve.context_assembler.budget import (
     plan_entries,
 )
 from openviking.retrieve.context_assembler.expansion import expand_queries
-from openviking.retrieve.context_assembler.gather import gather_candidates
+from openviking.retrieve.context_assembler.gather import Candidate, gather_candidates
 from openviking.retrieve.context_assembler.ledger import RecallLedger
 from openviking.retrieve.context_assembler.models import AssembleResult
 from openviking.retrieve.context_assembler.params import (
     AssembleParams,
+    READ_CONCURRENCY,
     normalize_detail,
     normalize_exclude_uris,
     normalize_penalties,
@@ -29,11 +32,115 @@ from openviking.retrieve.context_assembler.params import (
 )
 from openviking.retrieve.context_assembler.render import render_context
 from openviking.retrieve.context_assembler.rewrite import rewrite_context, server_rewrite_enabled
-from openviking.retrieve.context_assembler.tiers import needs_content, prefetch_contents
+from openviking.retrieve.context_assembler.tiers import (
+    content_uri_for,
+    needs_content,
+    prefetch_contents,
+)
 from openviking.server.identity import RequestContext
+from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.session.memory.utils.memory_fields import MEMORY_FIELDS_COMMENT_RE
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_EXCLUDED_EXPERIENCE_STATUSES = frozenset({"deprecated", "archived"})
+
+
+def _decode_raw_memory(raw: Any) -> str:
+    if raw is None:
+        raise ValueError("authoritative memory read returned no content")
+    if isinstance(raw, bytes):
+        decoded = raw.decode("utf-8")
+    elif isinstance(raw, str):
+        decoded = raw
+    else:
+        decoded = str(raw)
+    if not decoded:
+        raise ValueError("authoritative memory read returned empty content")
+    return decoded
+
+
+async def _filter_experience_lifecycle(
+    *,
+    service: Any,
+    candidates: Sequence[Candidate],
+) -> Tuple[List[Candidate], Dict[str, str], Dict[str, Any]]:
+    """Fail closed on non-authoritative Experience lifecycle state.
+
+    Retrieval payloads do not carry policy lifecycle metadata. Every Experience
+    candidate therefore needs one raw file read before it can enter budgeting or
+    rendering. The parsed body is returned as a cache so an explicitly deepened
+    Experience is not read twice.
+    """
+    experience_candidates = [
+        candidate for candidate in candidates if candidate.category == "experiences"
+    ]
+    stats: Dict[str, Any] = {
+        "checked": len(experience_candidates),
+        "kept": 0,
+        "excluded": 0,
+        "read_errors": 0,
+        "excluded_by_status": {"deprecated": 0, "archived": 0},
+    }
+    if not experience_candidates:
+        return list(candidates), {}, stats
+
+    semaphore = asyncio.Semaphore(READ_CONCURRENCY)
+
+    async def inspect(candidate: Candidate) -> Tuple[bool, str, str]:
+        try:
+            async with semaphore:
+                raw = await service.fs.read(candidate.base_uri, ctx=candidate.read_ctx)
+            decoded = _decode_raw_memory(raw)
+            fields_match = MEMORY_FIELDS_COMMENT_RE.search(decoded)
+            if fields_match:
+                fields = json.loads(fields_match.group("fields").strip())
+                if not isinstance(fields, dict):
+                    raise ValueError("authoritative memory fields are not an object")
+            memory_file = MemoryFileUtils.read(
+                decoded,
+                uri=candidate.base_uri,
+            )
+        except Exception as exc:
+            logger.info(
+                "Experience %s excluded because authoritative lifecycle read failed: %s",
+                candidate.base_uri,
+                exc,
+            )
+            return False, "read_error", ""
+
+        status = str((memory_file.extra_fields or {}).get("status") or "").strip().lower()
+        if status in _EXCLUDED_EXPERIENCE_STATUSES:
+            return False, status, memory_file.content
+        # Lifecycle validation already paid for an authoritative read. Use the
+        # same snapshot for the default abstract tier instead of a potentially
+        # stale vector payload.
+        candidate.abstract = memory_file.content
+        return True, status, memory_file.content
+
+    inspections = iter(
+        await asyncio.gather(*(inspect(candidate) for candidate in experience_candidates))
+    )
+    kept: List[Candidate] = []
+    raw_contents: Dict[str, str] = {}
+    for candidate in candidates:
+        if candidate.category != "experiences":
+            kept.append(candidate)
+            continue
+        allowed, reason, content = next(inspections)
+        if allowed:
+            kept.append(candidate)
+            stats["kept"] += 1
+            raw_contents[content_uri_for(candidate)] = content
+            continue
+        stats["excluded"] += 1
+        if reason == "read_error":
+            stats["read_errors"] += 1
+        else:
+            stats["excluded_by_status"][reason] += 1
+
+    return kept, raw_contents, stats
 
 
 async def _load_session(service: Any, ctx: RequestContext, session_id: Optional[str]) -> Any:
@@ -94,6 +201,10 @@ async def assemble_context(
         excluded=excluded,
     )
 
+    candidates, experience_contents, experience_lifecycle_stats = (
+        await _filter_experience_lifecycle(service=service, candidates=candidates)
+    )
+
     # Read only the candidates whose planned tier actually needs a body: with
     # the default tiers that is the events bucket, not every hit.
     pins = normalize_detail(params.detail)
@@ -103,9 +214,10 @@ async def assemble_context(
         for c in candidates
         if needs_content(c, pins.for_category(c.category)) or oversized_abstract_needs_body(c, cap)
     ]
-    contents: Dict[str, str] = {}
-    if readable:
-        contents = await prefetch_contents(service=service, candidates=readable)
+    contents: Dict[str, str] = dict(experience_contents)
+    unread = [candidate for candidate in readable if content_uri_for(candidate) not in contents]
+    if unread:
+        contents.update(await prefetch_contents(service=service, candidates=unread))
 
     plan = plan_entries(
         candidates,
@@ -150,6 +262,7 @@ async def assemble_context(
         "other_peer_penalties": penalties,
         "rewrite": rewrite_status,
         "rewrite_usage": rewrite_usage,
+        "experience_lifecycle": experience_lifecycle_stats,
         "dedup": {
             "turns": params.dedup_turns,
             "status": ledger.status if ledger else "off",

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -46,6 +46,7 @@ from openviking.server.upload_token_store import upload_token_store
 from openviking.telemetry.span_models import update_root_span_identity
 from openviking.utils.search_filters import SearchContextTypeInput, merge_search_filter
 from openviking_cli.exceptions import (
+    FailedPreconditionError,
     InvalidArgumentError,
     PermissionDeniedError,
     UnauthenticatedError,
@@ -424,8 +425,18 @@ class StoreMessage(BaseModel):
 
 
 @mcp.tool()
-async def remember(messages: list[StoreMessage]) -> str:
-    """Store information into OpenViking long-term memory. Use when the user says 'remember this', shares preferences, important facts, or decisions worth persisting."""
+async def remember(
+    messages: list[StoreMessage],
+    memory_type: Optional[Literal["preferences", "experiences"]] = None,
+) -> str:
+    """Store information into OpenViking long-term memory.
+
+    ``memory_type`` is optional for backwards compatibility.  When supplied it
+    constrains extraction to that memory family.  Experience extraction needs
+    Agent Evolution because experiences are trained from cases and
+    trajectories; rejecting that request up front avoids silently storing the
+    same text as an unrelated user preference.
+    """
     import uuid
 
     from openviking.message.part import TextPart
@@ -433,7 +444,28 @@ async def remember(messages: list[StoreMessage]) -> str:
     service = get_service()
     ctx = _get_ctx()
     session_id = f"mcp-store-{uuid.uuid4().hex[:12]}"
-    session = await service.sessions.get(session_id, ctx, auto_create=True)
+    memory_policy = None
+    if memory_type == "preferences":
+        memory_policy = {"memory_types": ["preferences"]}
+    elif memory_type == "experiences":
+        if not await service.sessions.get_agent_evolution_enabled(ctx.account_id):
+            raise FailedPreconditionError(
+                "memory_type='experiences' requires Agent Evolution to be enabled"
+            )
+        # Experiences are produced by the Agent Evolution pipeline from cases
+        # and trajectories, so all three stages must remain eligible.
+        memory_policy = {
+            "memory_types": ["cases", "trajectories", "experiences"],
+        }
+
+    if memory_policy is None:
+        session = await service.sessions.get(session_id, ctx, auto_create=True)
+    else:
+        session = await service.sessions.create(
+            ctx,
+            session_id=session_id,
+            memory_policy=memory_policy,
+        )
     for msg in messages:
         if msg.content:
             add_async = getattr(session, "add_message_async", None)
@@ -441,8 +473,32 @@ async def remember(messages: list[StoreMessage]) -> str:
                 await add_async(msg.role, [TextPart(text=msg.content)])
             else:
                 session.add_message(msg.role, [TextPart(text=msg.content)])
-    await service.sessions.commit_async(session_id, ctx)
-    return f"Stored {len(messages)} message(s) and committed for memory extraction."
+    commit_kwargs = {}
+    if memory_type == "experiences":
+        # Session.commit_async re-reads the account switch for the authoritative
+        # commit snapshot. This closes the hot-config race between the early
+        # validation above and Phase 1 enqueue.
+        commit_kwargs["require_agent_evolution_enabled"] = True
+    commit_result = await service.sessions.commit_async(session_id, ctx, **commit_kwargs)
+
+    if isinstance(commit_result, dict):
+        status = str(commit_result.get("status") or "unknown")
+        task_id = commit_result.get("task_id")
+        if status == "accepted" and task_id:
+            return (
+                f"Stored {len(messages)} message(s). Commit status=accepted; "
+                f"memory extraction queued; task_id={task_id}."
+            )
+        reason = commit_result.get("reason")
+        reason_suffix = f"; reason={reason}" if reason else ""
+        return (
+            f"Stored {len(messages)} message(s). Commit status={status}; "
+            f"memory extraction not queued{reason_suffix}."
+        )
+
+    # Compatibility for custom SessionService implementations that still
+    # return no structured commit result.
+    return f"Stored {len(messages)} message(s). Commit request submitted."
 
 
 # -- add_resource ----------------------------------------------------------

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -368,6 +368,7 @@ class SessionService:
         ctx: RequestContext,
         keep_recent_count: int = 0,
         *,
+        require_agent_evolution_enabled: bool = False,
         retention_mode: Optional[str] = None,
         keep_recent_turn_count: Optional[int] = None,
         retained_message_token_budget: Optional[int] = None,
@@ -381,10 +382,16 @@ class SessionService:
         Args:
             session_id: Session ID to commit
             keep_recent_count: See :meth:`commit_async`.
+            require_agent_evolution_enabled: See :meth:`commit_async`.
 
         Returns:
             Commit result
         """
+        requirement_kwargs = (
+            {"require_agent_evolution_enabled": True}
+            if require_agent_evolution_enabled
+            else {}
+        )
         return await self.commit_async(
             session_id,
             ctx,
@@ -394,6 +401,7 @@ class SessionService:
             retained_message_token_budget=retained_message_token_budget,
             min_raw_tail_steps=min_raw_tail_steps,
             event_tags=event_tags,
+            **requirement_kwargs,
         )
 
     async def commit_async(
@@ -402,6 +410,7 @@ class SessionService:
         ctx: RequestContext,
         keep_recent_count: int = 0,
         *,
+        require_agent_evolution_enabled: bool = False,
         retention_mode: Optional[str] = None,
         keep_recent_turn_count: Optional[int] = None,
         retained_message_token_budget: Optional[int] = None,
@@ -417,6 +426,8 @@ class SessionService:
             session_id: Session ID to commit
             keep_recent_count: Number of most-recent messages to keep in the
                 live session after commit. ``0`` archives everything.
+            require_agent_evolution_enabled: Fail before enqueue when the
+                authoritative commit snapshot has Agent Evolution disabled.
 
         Returns:
             Commit result with keys: session_id, status, task_id,
@@ -425,6 +436,8 @@ class SessionService:
         self._ensure_initialized()
         session = await self.get(session_id, ctx)
         commit_kwargs: Dict[str, Any] = {"keep_recent_count": keep_recent_count}
+        if require_agent_evolution_enabled:
+            commit_kwargs["require_agent_evolution_enabled"] = True
         optional_retention = {
             "retention_mode": retention_mode,
             "keep_recent_turn_count": keep_recent_turn_count,

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -51,7 +51,10 @@ from openviking.session.memory.streaming_memory_updater import (
     merge_link_lists,
 )
 from openviking.session.memory.utils.json_parser import JsonUtils
-from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.session.memory.utils.memory_file_utils import (
+    MemoryFileUtils,
+    memory_files_semantically_equal,
+)
 from openviking.session.memory.utils.uri import generate_uri
 from openviking.session.train import (
     Case,
@@ -1978,14 +1981,7 @@ def _applied_memory_diff(value: Any) -> dict[str, Any] | None:
 
 def _same_memory_file(before: Optional[MemoryFile], after: Optional[MemoryFile]) -> bool:
     """Return whether two parsed memory files represent the same stored memory."""
-    if before is None or after is None:
-        return False
-    # memory_type is commonly known from the operation/URI even when the raw
-    # memory file does not serialize it, so do not treat that metadata-only
-    # representation difference as a real file update.
-    return before.model_dump(exclude={"uri", "memory_type"}) == after.model_dump(
-        exclude={"uri", "memory_type"}
-    )
+    return memory_files_semantically_equal(before, after)
 
 
 def _v3_extraction_response(

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -32,6 +32,7 @@ from openviking.session.memory.utils import (
     pretty_print_messages,
 )
 from openviking.session.memory.utils.json_parser import JsonUtils
+from openviking.session.memory.utils.memory_file_utils import memory_type_from_uri
 from openviking.storage.viking_fs import VikingFS, get_viking_fs
 from openviking.telemetry import bind_telemetry_stage, tracer
 from openviking_cli.utils import get_logger
@@ -45,6 +46,38 @@ _CANNED_REFUSAL_RE = re.compile(
     r"(无法|不能|未能|不给|没有找到|未找到|can't|cannot|unable|won't|not able)",
     re.IGNORECASE,
 )
+
+_IMMUTABLE_IDENTITY_MISMATCH_PREFIX = "Immutable identity mismatch:"
+_INVALID_PAGE_ID_PREFIX = "Invalid page_id:"
+
+
+def _schema_identity_fields(schema: Any) -> set[str]:
+    """Return fields that determine an item's stable identity or URI.
+
+    ``IMMUTABLE`` is the explicit schema contract.  URI template fields are
+    identity-bearing as well even in older/custom schemas that accidentally
+    declared them ``REPLACE``: changing one while reusing an existing page_id
+    would make the metadata disagree with the already-bound URI.
+    """
+    fields = list(getattr(schema, "fields", []) or [])
+    schema_fields = {field.name for field in fields}
+    immutable_fields = {
+        field.name for field in fields if field.merge_op == MergeOp.IMMUTABLE
+    }
+    uri_template = (
+        f"{getattr(schema, 'directory', '') or ''}/"
+        f"{getattr(schema, 'filename_template', '') or ''}"
+    )
+    template_expressions = re.findall(r"\{\{(.*?)\}\}", uri_template, re.DOTALL)
+    template_fields = {
+        field_name
+        for field_name in schema_fields
+        if any(
+            re.search(rf"\b{re.escape(field_name)}\b", expression)
+            for expression in template_expressions
+        )
+    }
+    return immutable_fields | (template_fields & schema_fields)
 
 
 def _looks_like_canned_refusal(content: str) -> bool:
@@ -157,6 +190,7 @@ class ExtractLoop:
         # Reset format retry counter for each run
         self._format_retry_count = 0
         patch_repair_count = 0
+        immutable_identity_repair_count = 0
 
         # 从 provider 获取 schemas（内部自动加载 registry）
         schemas = self.context_provider.get_memory_schemas(self.ctx)
@@ -207,6 +241,7 @@ class ExtractLoop:
 - For existing items, use the page_id shown in read/search results.
 - For new items, assign a unique page_id >= 100.
 - When editing an existing item, reuse its existing page_id.
+- Reuse an existing page_id only when every immutable identity field (for example, topic or name) exactly matches that item. If the identity differs, create a separate item with a new page_id.
 - To delete an existing item, add an entry to `delete_ids` using its page_id.
 - For canonical merges, set `replacement_page_id` to the surviving page that should inherit the deleted page's existing links/backlinks; for pure deletes, set `replacement_page_id` to null.
 """
@@ -293,6 +328,36 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         tracer.info(f"Extended max_iterations to {max_iterations} for refetch")
 
                     continue
+                memory_routing_errors = [
+                    error
+                    for error in final_operations.errors
+                    if error.startswith(
+                        (_IMMUTABLE_IDENTITY_MISMATCH_PREFIX, _INVALID_PAGE_ID_PREFIX)
+                    )
+                ]
+                if memory_routing_errors:
+                    if immutable_identity_repair_count == 0:
+                        immutable_identity_repair_count += 1
+                        max_iterations += 1
+                        self._disable_tools_for_iteration = True
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": self._build_immutable_identity_repair_instruction(
+                                    memory_routing_errors
+                                ),
+                            }
+                        )
+                        tracer.info(
+                            f"Extended max_iterations to {max_iterations} for immutable identity repair",
+                            console=True,
+                        )
+                        continue
+                    # A repeated identity conflict is unsafe to apply. Keep the
+                    # error on the operations object so MemoryUpdater rejects
+                    # the whole batch instead of writing mutable fields into a
+                    # memory with a different identity.
+                    break
                 patch_errors = self._validate_patch_operations(final_operations)
                 if patch_errors and patch_repair_count == 0:
                     patch_repair_count += 1
@@ -359,7 +424,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
         tracer.info(f"final_operations={final_operations.model_dump_json(indent=4)}")
 
         # Resolve links after the loop completes using the URIs already bound in resolve_operations().
-        await self.finalize_operations(final_operations, raw_links)
+        if final_operations is not None and not final_operations.has_errors():
+            await self.finalize_operations(final_operations, raw_links)
 
         return final_operations, tools_used
 
@@ -371,8 +437,15 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         role_scope = self._isolation_handler.get_read_scope()
         page_id_map = getattr(self._extract_context, "page_id_map", None)
+        new_page_ids: set[int] = set()
+        schemas = list(self.context_provider.get_memory_schemas(self.ctx))
+        deletable_memory_types = {
+            schema.memory_type
+            for schema in schemas
+            if getattr(schema, "operation_mode", "upsert") != "add_only"
+        }
 
-        for schema in self.context_provider.get_memory_schemas(self.ctx):
+        for schema in schemas:
             memory_type = schema.memory_type
             value = getattr(operations, memory_type, None)
             if value is None:
@@ -410,45 +483,127 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     page_id=page_id,
                 )
 
-                if page_id is not None and page_id_map is not None:
-                    resolved_uri = page_id_map.resolve(page_id)
+                if page_id is None:
+                    errors.append(
+                        f"{_INVALID_PAGE_ID_PREFIX} memory_type={memory_type} is missing page_id"
+                    )
+                else:
+                    resolved_uri = page_id_map.resolve(page_id) if page_id_map is not None else None
                     if resolved_uri:
-                        resolved_op.uris = [resolved_uri]
                         old_content = self.context_provider.read_file_contents.get(resolved_uri)
+                        uri_memory_type = memory_type_from_uri(resolved_uri)
+                        if uri_memory_type is None:
+                            errors.append(
+                                f"{_INVALID_PAGE_ID_PREFIX} page_id={page_id} is not bound "
+                                "to a canonical memory item"
+                            )
+                            upsert_operations.append(resolved_op)
+                            continue
+                        # Validate every available binding signal.  Trusting a
+                        # stale/inconsistent stored ``memory_type`` ahead of the
+                        # canonical URI path could otherwise let a page_id for
+                        # one schema overwrite a file owned by another schema.
+                        bound_memory_types = {
+                            value
+                            for value in (
+                                old_content.memory_type if old_content is not None else None,
+                                (
+                                    old_content.extra_fields.get("memory_type")
+                                    if old_content is not None
+                                    else None
+                                ),
+                                uri_memory_type,
+                            )
+                            if value
+                        }
+                        mismatched_memory_types = sorted(
+                            value for value in bound_memory_types if value != memory_type
+                        )
+                        if mismatched_memory_types:
+                            bound_summary = ",".join(mismatched_memory_types)
+                            errors.append(
+                                f"{_INVALID_PAGE_ID_PREFIX} page_id={page_id} is bound to "
+                                f"memory_type={bound_summary}, not {memory_type}"
+                            )
+                            upsert_operations.append(resolved_op)
+                            continue
+
+                        resolved_op.uris = [resolved_uri]
                         if old_content is not None:
                             resolved_op.old_memory_file_content = old_content
-                            immutable_fields = {
-                                field.name
-                                for field in schema.fields
-                                if field.merge_op != MergeOp.PATCH
-                            }
-                            for field_name in immutable_fields:
-                                if field_name in old_content.extra_fields:
-                                    resolved_op.memory_fields[field_name] = (
-                                        old_content.extra_fields[field_name]
+                            identity_fields = _schema_identity_fields(schema)
+                            for field_name in identity_fields:
+                                if field_name == "content":
+                                    current_value = old_content.plain_content()
+                                elif field_name in old_content.extra_fields:
+                                    current_value = old_content.extra_fields[field_name]
+                                else:
+                                    continue
+                                proposed_value = resolved_op.memory_fields.get(field_name)
+                                if (
+                                    field_name in resolved_op.memory_fields
+                                    and proposed_value != current_value
+                                ):
+                                    errors.append(
+                                        f"{_IMMUTABLE_IDENTITY_MISMATCH_PREFIX} "
+                                        f"memory_type={memory_type} field={field_name} "
+                                        f"page_id={page_id}; use a new page_id for a distinct identity"
                                     )
+                                # Always pin an existing item's identity value.
+                                # If there was a mismatch, the error above will
+                                # either trigger one repair round or fail closed.
+                                resolved_op.memory_fields[field_name] = current_value
+                    elif page_id < 100:
+                        errors.append(
+                            f"{_INVALID_PAGE_ID_PREFIX} unknown existing page_id={page_id}; "
+                            "new items must use a unique page_id >= 100"
+                        )
+                    elif page_id in new_page_ids:
+                        errors.append(
+                            f"{_INVALID_PAGE_ID_PREFIX} duplicate new page_id={page_id}; "
+                            "each new item must use a unique page_id >= 100"
+                        )
                     else:
+                        new_page_ids.add(page_id)
                         resolved_op.uris = self._isolation_handler.calculate_memory_uris(
                             memory_type_schema=schema,
                             operation=resolved_op,
                             extract_context=self._extract_context,
                         )
-                else:
-                    resolved_op.uris = self._isolation_handler.calculate_memory_uris(
-                        memory_type_schema=schema,
-                        operation=resolved_op,
-                        extract_context=self._extract_context,
-                    )
 
                 upsert_operations.append(resolved_op)
 
         delete_ids = self._normalize_delete_ids(getattr(operations, "delete_ids", []) or [])
         delete_replacements: dict[str, str] = {}
         for delete_id in delete_ids:
-            if delete_id.delete_page_id is None or page_id_map is None:
+            if delete_id.delete_page_id is None:
+                errors.append(f"{_INVALID_PAGE_ID_PREFIX} delete_page_id is missing")
+                continue
+            if page_id_map is None:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} delete_page_id={delete_id.delete_page_id} "
+                    "cannot be resolved"
+                )
                 continue
             delete_uri = page_id_map.resolve(delete_id.delete_page_id)
             if not delete_uri:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} unknown delete_page_id="
+                    f"{delete_id.delete_page_id}"
+                )
+                continue
+            delete_memory_type = memory_type_from_uri(delete_uri)
+            if delete_memory_type is None:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} delete_page_id={delete_id.delete_page_id} "
+                    "is not bound to a canonical memory item"
+                )
+                continue
+            if delete_memory_type not in deletable_memory_types:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} delete_page_id={delete_id.delete_page_id} "
+                    f"has memory_type={delete_memory_type}, which is not writable in this extraction"
+                )
                 continue
             old_content = self.context_provider.read_file_contents.get(delete_uri)
             if not old_content:
@@ -464,7 +619,26 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     if op.page_id == replacement_page_id and op.uris:
                         replacement_uri = op.uris[0]
                         break
-            if replacement_uri and replacement_uri != delete_uri:
+            if not replacement_uri:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} replacement_page_id={replacement_page_id} "
+                    "does not identify a memory item"
+                )
+                continue
+            replacement_memory_type = memory_type_from_uri(replacement_uri)
+            if replacement_memory_type is None:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} replacement_page_id={replacement_page_id} "
+                    "is not bound to a canonical memory item"
+                )
+                continue
+            if replacement_memory_type != delete_memory_type:
+                errors.append(
+                    f"{_INVALID_PAGE_ID_PREFIX} replacement_page_id={replacement_page_id} "
+                    f"has memory_type={replacement_memory_type}, not {delete_memory_type}"
+                )
+                continue
+            if replacement_uri != delete_uri:
                 delete_replacements[delete_uri] = replacement_uri
 
         raw_links = getattr(operations, "links", None) or []
@@ -847,6 +1021,20 @@ The final output of the model must strictly follow the JSON Schema format shown 
             "Regenerate the complete operations JSON, including previous successful operations and fixed failed operations. "
             "Output ONLY the complete JSON object matching the required schema.\n\n"
             f"Failed patch operations:\n{details}"
+        )
+
+    def _build_immutable_identity_repair_instruction(self, errors: List[str]) -> str:
+        details = json.dumps(errors, ensure_ascii=False, indent=2)
+        return (
+            "An operation used an invalid page_id or reused an existing page_id while changing an immutable identity field. "
+            "Immutable fields such as topic or name define which memory an item represents. "
+            "Reuse an existing page_id only when all immutable identity fields exactly match the existing item. "
+            "Existing page_ids must belong to the same memory type. "
+            "For a new item, assign a page_id >= 100 that is unique within the complete operations JSON. "
+            "If the information belongs to a different identity, create a separate item with a new page_id. "
+            "Regenerate the complete operations JSON, including all previous valid operations and the repaired operation. "
+            "Output ONLY the complete JSON object matching the required schema.\n\n"
+            f"Conflicts (values intentionally omitted):\n{details}"
         )
 
     async def _add_refetch_results_to_messages(

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -31,6 +31,8 @@ from openviking.session.memory.page_id_map import PageIdMap
 from openviking.session.memory.utils.memory_file_utils import (
     MemoryFileUtils,
     bump_memory_version,
+    memory_type_from_uri as parse_memory_type_from_uri,
+    memory_files_semantically_equal,
     next_memory_version,
 )
 from openviking.session.memory.utils.resource_refs import (
@@ -45,7 +47,7 @@ from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.tracer import get_trace_id
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.exceptions import NotFoundError
-from openviking_cli.utils import VikingURI, get_logger
+from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
 
@@ -816,14 +818,7 @@ class MemoryUpdater:
 
     @staticmethod
     def memory_type_from_uri(uri: str) -> Optional[str]:
-        parts = [part for part in VikingURI(uri).full_path.split("/") if part]
-        try:
-            memories_idx = parts.index("memories")
-        except ValueError:
-            return None
-        if len(parts) <= memories_idx + 1:
-            return None
-        return parts[memories_idx + 1]
+        return parse_memory_type_from_uri(uri)
 
     @tracer()
     async def apply_operations(
@@ -871,22 +866,35 @@ class MemoryUpdater:
         # Distribute resolved_links to corresponding upsert operations
         self._distribute_links_to_operations(operations)
 
-        # Apply unified operations - _apply_edit returns True if edited, False if written
+        # Track every successfully processed target, including semantic no-ops.
+        # A no-op still protects a same-URI replacement from the batch's delete
+        # phase and remains an endpoint owned by the upsert phase.
+        successful_upsert_uris: set[str] = set()
+        semantic_noop_uris: set[str] = set()
+
         for resolved_op in applicable_upserts:
             try:
-                await self._apply_upsert(
+                changed_uris = await self._apply_upsert(
                     resolved_op,
                     ctx,
                     extract_context=extract_context,
                     lease_ref=self._transaction_handle,
                 )
-                # Add all uris to result (uris is List[str])
+                successful_upsert_uris.update(resolved_op.uris)
+                # Preserve compatibility with custom/test implementations of
+                # _apply_upsert that predate its changed-URI return value.
+                if not isinstance(changed_uris, set):
+                    changed_uris = set(resolved_op.uris)
+                else:
+                    semantic_noop_uris.update(set(resolved_op.uris) - changed_uris)
                 if resolved_op.is_edit():
                     for uri in resolved_op.uris:
-                        result.add_edited(uri)
+                        if uri in changed_uris:
+                            result.add_edited(uri)
                 else:
                     for uri in resolved_op.uris:
-                        result.add_written(uri)
+                        if uri in changed_uris:
+                            result.add_written(uri)
             except Exception as e:
                 tracer.error(
                     f"Failed to apply operation: op_type={type(resolved_op).__name__}, uris={resolved_op.uris}",
@@ -910,7 +918,7 @@ class MemoryUpdater:
         # Skip deletes whose URI was just written in the same batch — this happens when the
         # LLM issues a Replace with the same experience_name (delete old + create same-name new),
         # which is semantically an Update. Executing the delete would remove the just-written file.
-        upserted_uris = set(result.written_uris + result.edited_uris)
+        upserted_uris = set(successful_upsert_uris)
         upserted_uri_keys = {_same_batch_delete_conflict_key(uri) for uri in upserted_uris}
         for file_content in operations.delete_file_contents:
             delete_uri = file_content.uri
@@ -940,7 +948,12 @@ class MemoryUpdater:
                 tracer.error(f"Failed to delete memory {delete_uri}", e)
                 result.add_error(delete_uri, e)
 
-        await self._sync_resource_refs_for_result(result, ctx, lease_ref=self._transaction_handle)
+        await self._sync_resource_refs_for_result(
+            result,
+            ctx,
+            additional_uris=semantic_noop_uris,
+            lease_ref=self._transaction_handle,
+        )
 
         # Vectorize written and edited memories
         uri_memory_type_map = {}
@@ -952,13 +965,15 @@ class MemoryUpdater:
         effective_search_tags_by_uri = _collect_search_tags_by_uri(
             operations, search_tags_by_uri
         )
-        await self._vectorize_memories(
-            result,
-            ctx,
-            extract_context=extract_context,
-            uri_memory_type_map=uri_memory_type_map,
-            search_tags_by_uri=effective_search_tags_by_uri,
-        )
+        if result.written_uris or result.edited_uris or semantic_noop_uris:
+            await self._vectorize_memories(
+                result,
+                ctx,
+                extract_context=extract_context,
+                uri_memory_type_map=uri_memory_type_map,
+                search_tags_by_uri=effective_search_tags_by_uri,
+                additional_uris=semantic_noop_uris,
+            )
 
         # Apply links to endpoint files not covered by upsert_operations
         if operations.resolved_links:
@@ -967,6 +982,7 @@ class MemoryUpdater:
                 result,
                 ctx,
                 deleted_uris=set(result.deleted_uris),
+                upserted_uris=successful_upsert_uris,
                 lease_ref=self._transaction_handle,
             )
 
@@ -977,6 +993,11 @@ class MemoryUpdater:
         dirs = {}
         for operation in operations.upsert_operations:
             for uri_str in operation.uris:
+                # Derived overview writes have no durable completion marker.
+                # Retry them after a semantic no-op as well, so an earlier
+                # overview failure can recover without rewriting this memory.
+                if uri_str not in successful_upsert_uris:
+                    continue
                 dir_path = "/".join(uri_str.split("/")[:-1])
                 dirs[dir_path] = operation.memory_type
         for file_content in operations.delete_file_contents:
@@ -1002,12 +1023,18 @@ class MemoryUpdater:
         self,
         result: MemoryUpdateResult,
         ctx: RequestContext,
+        additional_uris: Optional[set[str]] = None,
         lease_ref: Any = None,
     ) -> None:
         """Synchronize resource refs for memory files touched by session extraction."""
         viking_fs = self._get_viking_fs()
         deleted_uris = set(result.deleted_uris)
-        for uri in dict.fromkeys(result.written_uris + result.edited_uris):
+        candidate_uris = [
+            *result.written_uris,
+            *result.edited_uris,
+            *(additional_uris or ()),
+        ]
+        for uri in dict.fromkeys(candidate_uris):
             if (
                 uri in deleted_uris
                 or uri.endswith("/.overview.md")
@@ -1037,27 +1064,36 @@ class MemoryUpdater:
         ctx: RequestContext,
         extract_context: Any = None,
         lease_ref: Any = None,
-    ):
-        """Apply upsert operation from a flat model."""
+    ) -> set[str]:
+        """Apply an upsert and return only URIs with semantic changes."""
         viking_fs = self._get_viking_fs()
 
         memory_type = resolved_op.memory_type
         schema = self._registry.get(memory_type)
+        changed_uris: set[str] = set()
         # Process each URI independently
         for uri in resolved_op.uris:
             # Always read from disk first to get the latest content,
             # so consecutive patches to the same URI see each other's changes.
-            old_content: Optional[MemoryFile] = None
+            prefetched_content = resolved_op.old_memory_file_content
             try:
                 content = await viking_fs.read_file(uri, ctx=ctx)
-                if content:
-                    old_content = MemoryFileUtils.read(content, uri=uri)
-            except Exception:
-                # File doesn't exist yet, that's okay
-                pass
-            # Fall back to pre-fetched content if disk read failed
-            if old_content is None:
-                old_content = resolved_op.old_memory_file_content
+            except (NotFoundError, FileNotFoundError):
+                # A missing authoritative file is valid only for an operation
+                # that was already classified as new.  If prefetch saw a file,
+                # a concurrent delete must fail closed instead of resurrecting
+                # stale content or reporting a false semantic no-op.
+                if prefetched_content is not None:
+                    raise
+                old_content: Optional[MemoryFile] = None
+            else:
+                if content is None:
+                    raise RuntimeError(
+                        f"Authoritative memory read returned no content for {uri}"
+                    )
+                # Empty files are still existing files and must not be
+                # mistaken for a missing/new target.
+                old_content = MemoryFileUtils.read(content, uri=uri)
 
             metadata: Dict[str, Any] = dict(resolved_op.memory_fields)
             source = getattr(resolved_op, "source", None)
@@ -1104,8 +1140,6 @@ class MemoryUpdater:
                     if key not in schema_field_names and key not in metadata and val is not None:
                         metadata[key] = val
 
-            metadata["version"] = next_memory_version(old_content)
-
             # Handle links/backlinks fields: merge with existing
             incoming_links_by_uri = getattr(resolved_op, "_incoming_links_by_uri", {})
             incoming_backlinks_by_uri = getattr(resolved_op, "_incoming_backlinks_by_uri", {})
@@ -1142,7 +1176,18 @@ class MemoryUpdater:
                 elif existing_backlinks:
                     metadata["backlinks"] = existing_backlinks
 
-            mf = MemoryFile.from_parsed(uri=uri, parsed=metadata)
+            mf = MemoryFile.from_parsed(uri=uri, parsed=dict(metadata))
+            candidate_content = MemoryFileUtils.write(
+                mf,
+                content_template=schema.content_template,
+                extract_context=extract_context,
+            )
+            candidate_file = MemoryFileUtils.read(candidate_content, uri=uri)
+            if memory_files_semantically_equal(old_content, candidate_file):
+                tracer.info(f"[memory_updater] Skipping semantic no-op upsert: uri={uri}")
+                continue
+
+            mf.extra_fields["version"] = next_memory_version(old_content)
             new_full_content = MemoryFileUtils.write(
                 mf,
                 content_template=schema.content_template,
@@ -1154,6 +1199,9 @@ class MemoryUpdater:
                 ctx=ctx,
                 lease_ref=lease_ref,
             )
+            changed_uris.add(uri)
+
+        return changed_uris
 
     def _distribute_links_to_operations(self, operations: ResolvedOperations) -> None:
         """Distribute resolved_links to corresponding upsert operations by URI.
@@ -1189,6 +1237,7 @@ class MemoryUpdater:
         result: MemoryUpdateResult,
         ctx: RequestContext,
         deleted_uris: Optional[set[str]] = None,
+        upserted_uris: Optional[set[str]] = None,
         lease_ref: Any = None,
     ) -> None:
         """Apply links to endpoint files that are NOT in the current upsert batch."""
@@ -1197,7 +1246,9 @@ class MemoryUpdater:
             return
         from openviking.core.namespace import context_type_for_uri
 
-        upserted_uris = set(result.written_uris + result.edited_uris)
+        upserted_uris = set(upserted_uris or ()) | set(
+            result.written_uris + result.edited_uris
+        )
         non_memory_endpoints = {
             uri
             for link in resolved_links
@@ -1325,6 +1376,7 @@ class MemoryUpdater:
         extract_context: Any = None,
         uri_memory_type_map: Dict[str, str] = None,
         search_tags_by_uri: Dict[str, List[str]] = None,
+        additional_uris: Optional[set[str]] = None,
     ) -> int:
         """Vectorize written and edited memory files.
 
@@ -1334,6 +1386,8 @@ class MemoryUpdater:
             extract_context: Extract context for embedding template rendering
             uri_memory_type_map: Mapping from URI to memory_type
             search_tags_by_uri: Transient search tags to attach while indexing each URI
+            additional_uris: Semantic no-op URIs whose derived vector/tag
+                state still needs an idempotent repair attempt.
         """
         if not self._vikingdb:
             logger.debug("VikingDB not available, skipping vectorization")
@@ -1349,7 +1403,12 @@ class MemoryUpdater:
         # Also skip URIs that were deleted in the same batch
         uris_to_vectorize = []
         deleted_set = set(result.deleted_uris)
-        for uri in result.written_uris + result.edited_uris:
+        candidate_uris = [
+            *result.written_uris,
+            *result.edited_uris,
+            *(additional_uris or ()),
+        ]
+        for uri in dict.fromkeys(candidate_uris):
             if uri in deleted_set:
                 continue
             if not uri.endswith("/.overview.md") and not uri.endswith("/.abstract.md"):

--- a/openviking/session/memory/page_id_map.py
+++ b/openviking/session/memory/page_id_map.py
@@ -28,11 +28,25 @@ class PageIdMap:
         self._next_id: int = 1
         self._id_to_uri: Dict[int, str] = {}
         self._uri_to_id: Dict[str, int] = {}
+        self._existing_namespace_exhausted_warned = False
 
-    def get_page_id(self, uri: str) -> int:
-        """Register an existing page (from prefetch/read). Returns page_id in 1-99 range."""
+    def get_page_id(self, uri: str) -> Optional[int]:
+        """Register an existing page, returning ``None`` after IDs 1-99 are full.
+
+        Previously registered URIs keep their original ID even after the
+        existing-page namespace is exhausted.  Unseen URIs are left entirely
+        unregistered so IDs >=100 remain reserved for model-declared new pages.
+        """
         if uri in self._uri_to_id:
             return self._uri_to_id[uri]
+        if self._next_id >= 100:
+            if not self._existing_namespace_exhausted_warned:
+                logger.warning(
+                    "Existing-page ID namespace 1..99 is full; "
+                    "additional read results will omit page_id"
+                )
+                self._existing_namespace_exhausted_warned = True
+            return None
         page_id = self._next_id
         self._next_id += 1
         self._id_to_uri[page_id] = uri

--- a/openviking/session/memory/utils/memory_file_utils.py
+++ b/openviking/session/memory/utils/memory_file_utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 from datetime import datetime
 from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
 
 from openviking.session.memory.dataclass import MemoryFile
 from openviking.session.memory.utils.link_renderer import LinkRenderer
@@ -40,6 +41,119 @@ def bump_memory_version(memory_file: MemoryFile) -> None:
     memory_file.extra_fields["version"] = memory_version_from_fields(
         memory_file.extra_fields, default=1
     ) + 1
+
+
+_NON_SEMANTIC_MEMORY_FIELDS = {
+    "version",
+    "source_extraction_id",
+    "source_extraction_ids",
+    "last_update_trace_id",
+    # These isolation/serialization fields do not describe the memory itself.
+    "user_id",
+    "user_ids",
+    "_uri",
+    "memory_type",
+}
+
+
+def memory_type_from_uri(uri: str) -> Optional[str]:
+    """Return the memory type from a canonical OpenViking memory URI.
+
+    Locate the memory root from the namespace grammar instead of searching for
+    the first segment named ``memories``.  The latter is ambiguous when a user
+    ID or a deeper category is itself named ``memories``.
+    """
+    raw_uri = str(uri or "")
+    parsed = urlsplit(raw_uri)
+    if parsed.scheme and parsed.netloc:
+        parts = [parsed.netloc, *[part for part in parsed.path.split("/") if part]]
+    else:
+        parts = [part for part in raw_uri.split("/") if part]
+
+    memory_root_index: Optional[int] = None
+    if parts and parts[0] == "user":
+        # Canonical peer memory: user/<uid>/peers/<peer>/memories/<type>/...
+        if len(parts) > 5 and parts[2] == "peers" and parts[4] == "memories":
+            memory_root_index = 4
+        # Canonical user memory: user/<uid>/memories/<type>/...
+        elif len(parts) > 3 and parts[2] == "memories":
+            memory_root_index = 2
+        # Legacy peer memory without an explicit user ID.
+        elif len(parts) > 4 and parts[1] == "peers" and parts[3] == "memories":
+            memory_root_index = 3
+        # Legacy user memory: user/memories/<type>/...
+        elif len(parts) > 2 and parts[1] == "memories":
+            memory_root_index = 1
+    elif (
+        len(parts) > 3
+        and parts[0] == "agent"
+        and parts[2] == "memories"
+    ):
+        # Preserve the corresponding agent namespace accepted by VikingURI.
+        memory_root_index = 2
+
+    if memory_root_index is None or memory_root_index + 1 >= len(parts):
+        return None
+    memory_type = parts[memory_root_index + 1].removesuffix(".md")
+    return memory_type or None
+
+
+def _known_memory_types(memory_file: MemoryFile) -> set[str]:
+    """Collect explicit and URI-derived schema ownership signals.
+
+    Legacy memory files do not always serialize ``memory_type``.  Their URI is
+    still authoritative, so a missing explicit value must not turn every
+    otherwise-identical legacy update into a change.  Conversely, retaining
+    all available signals catches both a real type change and an inconsistent
+    file whose embedded type disagrees with its canonical path.
+    """
+    known = {
+        str(value)
+        for value in (
+            memory_file.memory_type,
+            (memory_file.extra_fields or {}).get("memory_type"),
+        )
+        if value
+    }
+    uri_memory_type = memory_type_from_uri(str(memory_file.uri or ""))
+    if uri_memory_type:
+        known.add(uri_memory_type)
+    return known
+
+
+def memory_files_semantically_equal(
+    before: Optional[MemoryFile], after: Optional[MemoryFile]
+) -> bool:
+    """Return whether two files carry the same user-visible memory.
+
+    Version and extraction provenance are write bookkeeping.  Comparing them
+    as content makes an otherwise identical extraction look like a real edit,
+    which in turn bumps the version, rewrites the vector, and regenerates the
+    overview.  Stored content is compared verbatim: ``plain_content`` strips
+    every relative Markdown target, including user-authored links that are not
+    represented by ``links`` metadata, and could therefore hide a real edit.
+    """
+    if before is None or after is None:
+        return False
+
+    def _semantic_fields(memory_file: MemoryFile) -> Dict[str, Any]:
+        return {
+            key: value
+            for key, value in dict(memory_file.extra_fields or {}).items()
+            if key not in _NON_SEMANTIC_MEMORY_FIELDS
+        }
+
+    before_memory_types = _known_memory_types(before)
+    after_memory_types = _known_memory_types(after)
+    same_memory_type = before_memory_types == after_memory_types
+
+    return (
+        same_memory_type
+        and before.content == after.content
+        and before.links == after.links
+        and before.backlinks == after.backlinks
+        and _semantic_fields(before) == _semantic_fields(after)
+    )
 
 
 def _serialize_datetime(obj: Any) -> Any:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1791,6 +1791,7 @@ class Session:
         keep_recent_count: int = 0,
         *,
         memory_policy: Optional[Dict[str, Any]] = None,
+        require_agent_evolution_enabled: bool = False,
         retention_mode: Optional[str] = None,
         keep_recent_turn_count: Optional[int] = None,
         retained_message_token_budget: Optional[int] = None,
@@ -1801,6 +1802,7 @@ class Session:
             self.commit_async(
                 keep_recent_count=keep_recent_count,
                 memory_policy=memory_policy,
+                require_agent_evolution_enabled=require_agent_evolution_enabled,
                 retention_mode=retention_mode,
                 keep_recent_turn_count=keep_recent_turn_count,
                 retained_message_token_budget=retained_message_token_budget,
@@ -1814,6 +1816,7 @@ class Session:
         keep_recent_count: int = 0,
         *,
         memory_policy: Optional[Dict[str, Any]] = None,
+        require_agent_evolution_enabled: bool = False,
         retention_mode: Optional[str] = None,
         keep_recent_turn_count: Optional[int] = None,
         retained_message_token_budget: Optional[int] = None,
@@ -1837,6 +1840,10 @@ class Session:
                 behavior of archiving everything. The plugin's afterTurn path
                 typically passes its configured value (default 10); the compact
                 path passes ``0``.
+            require_agent_evolution_enabled: Reject the commit before Phase 1
+                when its authoritative Agent Evolution snapshot is disabled.
+                Used by explicitly typed experience writes so they never
+                degrade into a silently filtered commit.
             persist_keep_recent_count: When ``True`` (default), ``keep_recent_count``
                 is remembered in meta for subsequent add_message() accounting.
                 The idle full-commit path passes ``False`` with
@@ -1894,6 +1901,11 @@ class Session:
                 await provided_enabled
                 if inspect.isawaitable(provided_enabled)
                 else provided_enabled
+            )
+        if require_agent_evolution_enabled and not agent_evolution_enabled:
+            raise FailedPreconditionError(
+                "Agent Evolution was disabled before the commit snapshot; "
+                "experience extraction was not queued"
             )
         effective_policy = _apply_agent_evolution_setting(
             effective_policy,

--- a/tests/retrieve/test_context_assembler_pipeline.py
+++ b/tests/retrieve/test_context_assembler_pipeline.py
@@ -138,6 +138,75 @@ async def test_assembly_returns_readable_entries_within_budget():
     assert result.rendered.count("<memory ") == 3
 
 
+async def test_experience_lifecycle_reads_raw_status_and_fails_closed():
+    statuses = {
+        "draft": "draft",
+        "staging": "staging",
+        "production": "production",
+        "missing": None,
+        "deprecated": "deprecated",
+        "archived": "ARCHIVED",
+        "read-error": "production",
+        "empty-read": "production",
+        "malformed": "production",
+    }
+    hits = [
+        {
+            "uri": f"{USER_ROOT}/memories/experiences/{name}.md",
+            "score": 0.9 - index * 0.01,
+            "abstract": f"abstract {name}",
+        }
+        for index, name in enumerate(statuses)
+    ]
+    bodies = {
+        f"{USER_ROOT}/memories/experiences/{name}.md": (
+            f"body {name}"
+            if status is None
+            else (
+                f"body {name}\n\n<!-- MEMORY_FIELDS\n"
+                f'{{"status": "{status}", "version": 1}}\n-->'
+            )
+        )
+        for name, status in statuses.items()
+        if name != "read-error"
+    }
+    bodies[f"{USER_ROOT}/memories/experiences/empty-read.md"] = ""
+    bodies[f"{USER_ROOT}/memories/experiences/malformed.md"] = (
+        "body malformed\n\n<!-- MEMORY_FIELDS\n{not-json}\n-->"
+    )
+
+    result = await assemble_context(
+        service=_service(hits=hits, bodies=bodies),
+        ctx=_ctx(),
+        params=AssembleParams(
+            query="lifecycle",
+            quotas={"experiences": len(hits)},
+            peer_scope="actor",
+            max_tokens=1600,
+        ),
+    )
+
+    assert [entry.uri.rsplit("/", 1)[-1] for entry in result.entries] == [
+        "draft.md",
+        "staging.md",
+        "production.md",
+        "missing.md",
+    ]
+    assert [entry.text for entry in result.entries] == [
+        "body draft",
+        "body staging",
+        "body production",
+        "body missing",
+    ]
+    assert result.stats["experience_lifecycle"] == {
+        "checked": 9,
+        "kept": 4,
+        "excluded": 5,
+        "read_errors": 3,
+        "excluded_by_status": {"deprecated": 1, "archived": 1},
+    }
+
+
 async def test_query_expansion_fans_out_planned_queries(monkeypatch):
     queries_seen = []
 

--- a/tests/server/test_api_search_context.py
+++ b/tests/server/test_api_search_context.py
@@ -62,6 +62,52 @@ async def test_context_mode_returns_flat_entries_within_budget(
     assert result["stats"]["used_tokens"] <= 1200
 
 
+async def test_context_mode_filters_deprecated_experiences_from_raw_status(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    production_uri = "viking://user/default/memories/experiences/production.md"
+    deprecated_uri = "viking://user/default/memories/experiences/deprecated.md"
+
+    async def fake_find(**kwargs):
+        del kwargs
+        return _FakeFindResult(
+            [
+                _memory(production_uri, 0.8, "production experience"),
+                _memory(deprecated_uri, 0.9, "deprecated experience"),
+            ]
+        )
+
+    async def fake_read(uri, **kwargs):
+        del kwargs
+        status = "deprecated" if uri == deprecated_uri else "production"
+        return f'body\n\n<!-- MEMORY_FIELDS\n{{"status":"{status}"}}\n-->'
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+    monkeypatch.setattr(service.fs, "read", fake_read)
+    response = await client.post(
+        "/api/v1/search/search",
+        json={
+            "query": "safe experience",
+            "mode": "context",
+            "quotas": {"experiences": 2},
+            "peer_scope": "actor",
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert [entry["uri"] for entry in result["entries"]] == [production_uri]
+    assert result["stats"]["experience_lifecycle"] == {
+        "checked": 2,
+        "kept": 1,
+        "excluded": 1,
+        "read_errors": 0,
+        "excluded_by_status": {"deprecated": 1, "archived": 0},
+    }
+
+
 async def test_context_mode_quotas_use_category_ownership_roots(
     client: httpx.AsyncClient,
     service,

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -521,6 +521,82 @@ async def test_store_skips_empty_message_content(service, monkeypatch):
     service.sessions.commit_async.assert_awaited_once()
 
 
+async def test_store_preferences_constrains_memory_policy(service, monkeypatch):
+    class FakeSession:
+        add_message_async = AsyncMock()
+
+    fake_session = FakeSession()
+    create = AsyncMock(return_value=fake_session)
+    get = AsyncMock()
+    commit = AsyncMock(return_value={"status": "accepted", "task_id": "task-123"})
+    monkeypatch.setattr(service.sessions, "create", create)
+    monkeypatch.setattr(service.sessions, "get", get)
+    monkeypatch.setattr(service.sessions, "commit_async", commit)
+
+    result = await remember(
+        messages=[StoreMessage(role="user", content="Prefer concise updates")],
+        memory_type="preferences",
+    )
+
+    get.assert_not_awaited()
+    create.assert_awaited_once()
+    assert create.await_args.args == (DEFAULT_CTX,)
+    session_id = create.await_args.kwargs["session_id"]
+    assert session_id.startswith("mcp-store-")
+    assert create.await_args.kwargs["memory_policy"] == {
+        "memory_types": ["preferences"]
+    }
+    commit.assert_awaited_once_with(session_id, DEFAULT_CTX)
+    assert "status=accepted" in result
+    assert "memory extraction queued" in result
+    assert "task_id=task-123" in result
+
+
+async def test_store_experiences_fails_when_agent_evolution_disabled(service, monkeypatch):
+    enabled = AsyncMock(return_value=False)
+    create = AsyncMock()
+    commit = AsyncMock()
+    monkeypatch.setattr(service.sessions, "get_agent_evolution_enabled", enabled)
+    monkeypatch.setattr(service.sessions, "create", create)
+    monkeypatch.setattr(service.sessions, "commit_async", commit)
+
+    with pytest.raises(FailedPreconditionError, match="Agent Evolution"):
+        await remember(
+            messages=[StoreMessage(role="user", content="Reusable operational lesson")],
+            memory_type="experiences",
+        )
+
+    enabled.assert_awaited_once_with(DEFAULT_CTX.account_id)
+    create.assert_not_awaited()
+    commit.assert_not_awaited()
+
+
+async def test_store_experiences_enables_training_dependencies(service, monkeypatch):
+    class FakeSession:
+        add_message_async = AsyncMock()
+
+    enabled = AsyncMock(return_value=True)
+    create = AsyncMock(return_value=FakeSession())
+    commit = AsyncMock()
+    monkeypatch.setattr(service.sessions, "get_agent_evolution_enabled", enabled)
+    monkeypatch.setattr(service.sessions, "create", create)
+    monkeypatch.setattr(service.sessions, "commit_async", commit)
+
+    await remember(
+        messages=[StoreMessage(role="user", content="Reusable operational lesson")],
+        memory_type="experiences",
+    )
+
+    assert create.await_args.kwargs["memory_policy"] == {
+        "memory_types": ["cases", "trajectories", "experiences"]
+    }
+    commit.assert_awaited_once_with(
+        create.await_args.kwargs["session_id"],
+        DEFAULT_CTX,
+        require_agent_evolution_enabled=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # add_resource tool
 # ---------------------------------------------------------------------------

--- a/tests/server/test_recall_endpoint.py
+++ b/tests/server/test_recall_endpoint.py
@@ -147,6 +147,60 @@ async def test_recall_endpoint_assembles_context_and_signals_deprecation(
     }
 
 
+async def test_recall_endpoint_filters_archived_experience_and_failed_raw_read(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    draft_uri = "viking://user/default/memories/experiences/draft.md"
+    archived_uri = "viking://user/default/memories/experiences/archived.md"
+    unreadable_uri = "viking://user/default/memories/experiences/unreadable.md"
+
+    async def fake_find(**kwargs):
+        del kwargs
+        return _FakeFindResult(
+            [
+                _memory(archived_uri, 0.9, "archived experience"),
+                _memory(unreadable_uri, 0.85, "unreadable experience"),
+                _memory(draft_uri, 0.8, "draft experience"),
+            ]
+        )
+
+    async def fake_read(uri, **kwargs):
+        del kwargs
+        if uri == unreadable_uri:
+            raise OSError("raw read unavailable")
+        status = "archived" if uri == archived_uri else "draft"
+        return f'body\n\n<!-- MEMORY_FIELDS\n{{"status":"{status}"}}\n-->'
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+    monkeypatch.setattr(service.fs, "read", fake_read)
+    response = await client.post(
+        "/api/v1/search/recall",
+        json={
+            "query": "safe experience",
+            "quotas": {
+                "events": 0,
+                "entities": 0,
+                "preferences": 0,
+                "experiences": 3,
+            },
+            "peer_scope": "actor",
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert [entry["uri"] for entry in result["entries"]] == [draft_uri]
+    assert result["stats"]["experience_lifecycle"] == {
+        "checked": 3,
+        "kept": 1,
+        "excluded": 2,
+        "read_errors": 1,
+        "excluded_by_status": {"deprecated": 0, "archived": 1},
+    }
+
+
 async def test_recall_excludes_profile_and_duplicate_hits(
     client: httpx.AsyncClient,
     service,

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -69,6 +69,32 @@ async def test_commit_async_keeps_working_when_session_metrics_fail(
 
 
 @pytest.mark.asyncio
+async def test_commit_forwards_explicit_agent_evolution_requirement():
+    service = SessionService(viking_fs=Mock())
+    ctx = _make_ctx()
+    service.commit_async = AsyncMock(return_value={"status": "queued"})
+
+    result = await service.commit(
+        "sess-1",
+        ctx,
+        require_agent_evolution_enabled=True,
+    )
+
+    assert result == {"status": "queued"}
+    service.commit_async.assert_awaited_once_with(
+        "sess-1",
+        ctx,
+        keep_recent_count=0,
+        require_agent_evolution_enabled=True,
+        retention_mode=None,
+        keep_recent_turn_count=None,
+        retained_message_token_budget=None,
+        min_raw_tail_steps=None,
+        event_tags=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_sessions_returns_empty_and_logs_when_storage_listing_fails(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/session/memory/test_immutable_identity.py
+++ b/tests/session/memory/test_immutable_identity.py
@@ -1,0 +1,428 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for immutable memory identity routing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openviking.session.memory.dataclass import MemoryField, MemoryFile, MemoryTypeSchema
+from openviking.session.memory.extract_loop import ExtractLoop, _schema_identity_fields
+from openviking.session.memory.memory_isolation_handler import RoleScope
+from openviking.session.memory.memory_updater import ExtractContext
+from openviking.session.memory.merge_op import FieldType, MergeOp
+
+
+_OLD_URI = "viking://user/default/memories/preferences/workflow.md"
+
+
+def _preference_schema() -> MemoryTypeSchema:
+    return MemoryTypeSchema(
+        memory_type="preferences",
+        description="User preferences",
+        directory="viking://user/{{ user_space }}/memories/preferences",
+        filename_template="{{ topic }}.md",
+        fields=[
+            MemoryField(
+                name="topic",
+                field_type=FieldType.STRING,
+                merge_op=MergeOp.IMMUTABLE,
+            ),
+            MemoryField(
+                name="content",
+                field_type=FieldType.STRING,
+                merge_op=MergeOp.REPLACE,
+            ),
+        ],
+    )
+
+
+def test_uri_template_filters_still_mark_schema_fields_as_identity():
+    schema = MemoryTypeSchema(
+        memory_type="custom",
+        directory="viking://user/{{ user_space }}/memories/custom/{{ tenant | lower }}",
+        filename_template="{{ slug(name) }}.md",
+        fields=[
+            MemoryField(
+                name="tenant",
+                field_type=FieldType.STRING,
+                merge_op=MergeOp.REPLACE,
+            ),
+            MemoryField(
+                name="name",
+                field_type=FieldType.STRING,
+                merge_op=MergeOp.REPLACE,
+            ),
+            MemoryField(
+                name="content",
+                field_type=FieldType.STRING,
+                merge_op=MergeOp.REPLACE,
+            ),
+        ],
+    )
+
+    assert _schema_identity_fields(schema) == {"tenant", "name"}
+
+
+def _make_loop(
+    responses: list[str],
+    *,
+    old_uri: str = _OLD_URI,
+    old_file: MemoryFile | None = None,
+    read_files: dict[str, MemoryFile] | None = None,
+) -> tuple[ExtractLoop, object]:
+    schema = _preference_schema()
+    old_file = old_file or MemoryFile(
+        uri=old_uri,
+        content="Prefers concise status updates.",
+        extra_fields={"topic": "workflow", "memory_type": "preferences"},
+    )
+
+    class DummyProvider:
+        def __init__(self):
+            self.extract_context = ExtractContext([])
+            self.read_file_contents = dict(read_files or {old_uri: old_file})
+
+        def get_memory_schemas(self, _ctx):
+            return [schema]
+
+        def get_output_language(self):
+            return "English"
+
+        def get_tools(self):
+            return []
+
+        def instruction(self):
+            return "Extract preference memories."
+
+        async def prefetch(self):
+            return []
+
+        def get_extract_context(self):
+            return self.extract_context
+
+    class DummyIsolationHandler:
+        def get_read_scope(self):
+            return RoleScope(user_ids=["default"])
+
+        def fill_identity_fields(self, item_dict, role_scope):
+            del role_scope
+
+        def calculate_memory_uris(self, memory_type_schema, operation, extract_context):
+            del memory_type_schema, extract_context
+            return [
+                "viking://user/default/memories/preferences/"
+                f"{operation.memory_fields['topic']}.md"
+            ]
+
+    class DummyVLM:
+        model = "dummy"
+
+        def __init__(self):
+            self.responses = list(responses)
+            self.messages = []
+
+        async def get_completion_async(
+            self, messages, tools=None, tool_choice=None, thinking=False
+        ):
+            del tools, tool_choice, thinking
+            self.messages.append(list(messages))
+            return self.responses.pop(0)
+
+    vlm = DummyVLM()
+    loop = ExtractLoop(
+        vlm=vlm,
+        viking_fs=MagicMock(),
+        max_iterations=1,
+        context_provider=DummyProvider(),
+        isolation_handler=DummyIsolationHandler(),
+    )
+    return loop, vlm
+
+
+@pytest.mark.asyncio
+async def test_immutable_topic_mismatch_gets_one_safe_repair_round():
+    loop, vlm = _make_loop(
+        [
+            '{"preferences":[{"page_id":1,"topic":"private_food_topic",'
+            '"content":"Prefers noodles."}],"delete_ids":[]}',
+            '{"preferences":[{"page_id":100,"topic":"private_food_topic",'
+            '"content":"Prefers noodles."}],"delete_ids":[]}',
+        ]
+    )
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 2
+    repair_prompt = "\n".join(message["content"] for message in vlm.messages[1])
+    assert "immutable identity field" in repair_prompt
+    assert "page_id >= 100" in repair_prompt
+    # Conflict diagnostics describe the schema boundary without echoing either
+    # the stored or newly proposed identity value.
+    assert "private_food_topic" not in repair_prompt
+    assert "workflow" not in repair_prompt
+    assert operations.errors == []
+    assert operations.upsert_operations[0].page_id == 100
+    assert operations.upsert_operations[0].uris == [
+        "viking://user/default/memories/preferences/private_food_topic.md"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_repeated_immutable_topic_mismatch_fails_closed():
+    mismatch = (
+        '{"preferences":[{"page_id":1,"topic":"another_topic",'
+        '"content":"Must not overwrite workflow."}],"delete_ids":[]}'
+    )
+    loop, vlm = _make_loop([mismatch, mismatch])
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 2
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Immutable identity mismatch:")
+    assert "another_topic" not in operations.errors[0]
+    assert "workflow" not in operations.errors[0]
+    # Resolution pins the stored identity as a second line of defense; the
+    # batch-level error prevents the mutable content from being applied.
+    assert operations.upsert_operations[0].memory_fields["topic"] == "workflow"
+
+
+@pytest.mark.asyncio
+async def test_replace_field_on_matching_identity_is_not_treated_as_immutable():
+    loop, vlm = _make_loop(
+        [
+            '{"preferences":[{"page_id":1,"topic":"workflow",'
+            '"content":"Prefers detailed status updates."}],"delete_ids":[]}'
+        ]
+    )
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 1
+    assert operations.errors == []
+    assert (
+        operations.upsert_operations[0].memory_fields["content"]
+        == "Prefers detailed status updates."
+    )
+
+
+@pytest.mark.asyncio
+async def test_page_id_bound_to_another_memory_type_fails_closed():
+    entity_uri = "viking://user/default/memories/entities/person/alice.md"
+    entity_file = MemoryFile(
+        uri=entity_uri,
+        content="Alice profile",
+        memory_type="entities",
+        extra_fields={"name": "alice"},
+    )
+    mismatch = (
+        '{"preferences":[{"page_id":1,"topic":"workflow",'
+        '"content":"Must not overwrite an entity."}],"delete_ids":[]}'
+    )
+    loop, _ = _make_loop(
+        [mismatch, mismatch],
+        old_uri=entity_uri,
+        old_file=entity_file,
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Invalid page_id:")
+    assert "memory_type=entities, not preferences" in operations.errors[0]
+    assert entity_uri not in operations.errors[0]
+    assert operations.upsert_operations[0].uris == []
+
+
+@pytest.mark.asyncio
+async def test_page_id_uri_type_mismatch_cannot_be_hidden_by_stored_type():
+    entity_uri = "viking://user/default/memories/entities/person/alice.md"
+    inconsistent_file = MemoryFile(
+        uri=entity_uri,
+        content="Alice profile",
+        memory_type="preferences",
+        extra_fields={"memory_type": "preferences", "topic": "workflow"},
+    )
+    mismatch = (
+        '{"preferences":[{"page_id":1,"topic":"workflow",'
+        '"content":"Must not overwrite an entity path."}],"delete_ids":[]}'
+    )
+    loop, _ = _make_loop(
+        [mismatch, mismatch],
+        old_uri=entity_uri,
+        old_file=inconsistent_file,
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert "memory_type=entities, not preferences" in operations.errors[0]
+    assert operations.upsert_operations[0].uris == []
+
+
+@pytest.mark.asyncio
+async def test_page_id_bound_to_resource_cannot_be_used_for_memory_upsert():
+    resource_uri = "viking://user/default/resources/private-notes.md"
+    resource_file = MemoryFile(uri=resource_uri, content="Private resource body")
+    invalid = (
+        '{"preferences":[{"page_id":1,"topic":"workflow",'
+        '"content":"Must not overwrite a resource."}],"delete_ids":[]}'
+    )
+    loop, _ = _make_loop(
+        [invalid, invalid],
+        old_uri=resource_uri,
+        old_file=resource_file,
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Invalid page_id:")
+    assert "not bound to a canonical memory item" in operations.errors[0]
+    assert resource_uri not in operations.errors[0]
+    assert operations.upsert_operations[0].uris == []
+
+
+@pytest.mark.asyncio
+async def test_resource_page_id_cannot_be_deleted_by_memory_operations():
+    resource_uri = "viking://user/default/resources/private-notes.md"
+    resource_file = MemoryFile(uri=resource_uri, content="Private resource body")
+    invalid = (
+        '{"preferences":[],"delete_ids":['
+        '{"delete_page_id":1,"replacement_page_id":null}]}'
+    )
+    loop, _ = _make_loop(
+        [invalid, invalid],
+        old_uri=resource_uri,
+        old_file=resource_file,
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Invalid page_id:")
+    assert "not bound to a canonical memory item" in operations.errors[0]
+    assert resource_uri not in operations.errors[0]
+    assert operations.delete_file_contents == []
+
+
+@pytest.mark.asyncio
+async def test_delete_page_id_must_belong_to_effective_memory_schemas():
+    entity_uri = "viking://user/default/memories/entities/person/alice.md"
+    entity_file = MemoryFile(
+        uri=entity_uri,
+        content="Alice profile",
+        memory_type="entities",
+        extra_fields={"name": "alice", "memory_type": "entities"},
+    )
+    invalid = (
+        '{"preferences":[],"delete_ids":['
+        '{"delete_page_id":1,"replacement_page_id":null}]}'
+    )
+    loop, _ = _make_loop(
+        [invalid, invalid],
+        old_uri=entity_uri,
+        old_file=entity_file,
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Invalid page_id:")
+    assert "memory_type=entities" in operations.errors[0]
+    assert "not writable in this extraction" in operations.errors[0]
+    assert entity_uri not in operations.errors[0]
+    assert operations.delete_file_contents == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_delete_page_id_gets_one_repair_round():
+    loop, vlm = _make_loop(
+        [
+            '{"preferences":[],"delete_ids":['
+            '{"delete_page_id":42,"replacement_page_id":null}]}',
+            '{"preferences":[],"delete_ids":[]}',
+        ]
+    )
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 2
+    assert operations.errors == []
+    assert operations.delete_file_contents == []
+
+
+@pytest.mark.asyncio
+async def test_resource_page_id_cannot_be_a_delete_replacement():
+    resource_uri = "viking://user/default/resources/private-notes.md"
+    preference_file = MemoryFile(
+        uri=_OLD_URI,
+        content="Prefers concise status updates.",
+        memory_type="preferences",
+        extra_fields={"topic": "workflow", "memory_type": "preferences"},
+    )
+    resource_file = MemoryFile(uri=resource_uri, content="Private resource body")
+    invalid = (
+        '{"preferences":[],"delete_ids":['
+        '{"delete_page_id":1,"replacement_page_id":2}]}'
+    )
+    loop, _ = _make_loop(
+        [invalid, invalid],
+        read_files={_OLD_URI: preference_file, resource_uri: resource_file},
+    )
+
+    operations, _ = await loop.run()
+
+    assert operations.has_errors()
+    assert operations.errors[0].startswith("Invalid page_id:")
+    assert "not bound to a canonical memory item" in operations.errors[0]
+    assert resource_uri not in operations.errors[0]
+    assert operations.delete_replacements == {}
+
+
+@pytest.mark.asyncio
+async def test_unknown_low_page_id_repairs_to_new_page_id():
+    loop, vlm = _make_loop(
+        [
+            '{"preferences":[{"page_id":42,"topic":"food",'
+            '"content":"Prefers noodles."}],"delete_ids":[]}',
+            '{"preferences":[{"page_id":100,"topic":"food",'
+            '"content":"Prefers noodles."}],"delete_ids":[]}',
+        ]
+    )
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 2
+    assert operations.errors == []
+    assert operations.upsert_operations[0].page_id == 100
+    assert operations.upsert_operations[0].uris == [
+        "viking://user/default/memories/preferences/food.md"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_new_page_ids_get_one_repair_round():
+    loop, vlm = _make_loop(
+        [
+            '{"preferences":['
+            '{"page_id":100,"topic":"food","content":"Prefers noodles."},'
+            '{"page_id":100,"topic":"travel","content":"Prefers trains."}'
+            '],"delete_ids":[]}',
+            '{"preferences":['
+            '{"page_id":100,"topic":"food","content":"Prefers noodles."},'
+            '{"page_id":101,"topic":"travel","content":"Prefers trains."}'
+            '],"delete_ids":[]}',
+        ]
+    )
+
+    operations, _ = await loop.run()
+
+    assert len(vlm.messages) == 2
+    assert operations.errors == []
+    assert [operation.page_id for operation in operations.upsert_operations] == [100, 101]
+    assert [operation.uris[0] for operation in operations.upsert_operations] == [
+        "viking://user/default/memories/preferences/food.md",
+        "viking://user/default/memories/preferences/travel.md",
+    ]

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -808,7 +808,9 @@ class TestMemoryUpdater:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -877,7 +879,9 @@ class TestMemoryUpdater:
         async def mock_read_file(uri, **kwargs):
             if uri == resource_uri:
                 raise AssertionError("resource target should not be read as a memory file")
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             if uri == resource_uri:
@@ -944,7 +948,9 @@ class TestMemoryUpdater:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1014,7 +1020,9 @@ class TestMemoryUpdater:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1286,7 +1294,9 @@ class TestConsecutivePatchesSameURI:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1325,6 +1335,215 @@ class TestConsecutivePatchesSameURI:
         assert parsed["content"] == "Step B"
         assert parsed["version"] == 2
 
+    @staticmethod
+    def _registry():
+        schema = MemoryTypeSchema(
+            memory_type="preferences",
+            description="User preferences",
+            fields=[
+                MemoryField(
+                    name="topic",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.IMMUTABLE,
+                ),
+                MemoryField(
+                    name="content",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.REPLACE,
+                ),
+            ],
+        )
+        registry = MagicMock()
+        registry.get.return_value = schema
+        return registry
+
+    @pytest.mark.asyncio
+    async def test_no_op_keeps_version_but_retries_derived_state(self):
+        uri = "viking://user/default/memories/preferences/workflow.md"
+        old_file = MemoryFile(
+            uri=uri,
+            content="Prefers concise updates.",
+            extra_fields={
+                "topic": "workflow",
+                "version": 7,
+                "source_extraction_id": "old-extraction",
+                "last_update_trace_id": "old-trace",
+            },
+        )
+        original_raw = MemoryFileUtils.write(old_file)
+
+        mock_viking_fs = MagicMock()
+        mock_viking_fs.read_file = AsyncMock(return_value=original_raw)
+        mock_viking_fs.write_file = AsyncMock()
+
+        updater = MemoryUpdater(registry=self._registry(), vikingdb=MagicMock())
+        updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
+        updater._sync_resource_refs_for_result = AsyncMock()
+        updater._vectorize_memories = AsyncMock()
+        updater.generate_overview = AsyncMock()
+
+        operation = ResolvedOperation(
+            old_memory_file_content=old_file,
+            memory_fields={
+                "topic": "workflow",
+                "content": "Prefers concise updates.",
+            },
+            memory_type="preferences",
+            uris=[uri],
+            source=MemoryOperationSource(
+                extraction_id="new-extraction",
+                trace_id="new-trace",
+            ),
+            search_tags=["scope=important"],
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[operation],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        ctx = MagicMock()
+        result = await updater.apply_operations(operations, ctx)
+
+        assert result.written_uris == []
+        assert result.edited_uris == []
+        mock_viking_fs.write_file.assert_not_awaited()
+        updater._sync_resource_refs_for_result.assert_awaited_once_with(
+            result,
+            ctx,
+            additional_uris={uri},
+            lease_ref=None,
+        )
+        assert updater._vectorize_memories.await_args.kwargs["additional_uris"] == {uri}
+        assert updater._vectorize_memories.await_args.kwargs["search_tags_by_uri"] == {
+            uri: ["scope=important"]
+        }
+        updater.generate_overview.assert_awaited_once()
+        assert updater.generate_overview.await_args.args[:2] == (
+            "preferences",
+            "viking://user/default/memories/preferences",
+        )
+        assert MemoryFileUtils.read(original_raw).extra_fields["version"] == 7
+
+    @pytest.mark.asyncio
+    async def test_real_content_change_writes_and_increments_version_once(self):
+        uri = "viking://user/default/memories/preferences/workflow.md"
+        old_file = MemoryFile(
+            uri=uri,
+            content="Prefers concise updates.",
+            extra_fields={"topic": "workflow", "version": 7},
+        )
+        original_raw = MemoryFileUtils.write(old_file)
+        written: list[str] = []
+
+        mock_viking_fs = MagicMock()
+        mock_viking_fs.read_file = AsyncMock(return_value=original_raw)
+
+        async def write_file(_uri, content, **_kwargs):
+            written.append(content)
+
+        mock_viking_fs.write_file = AsyncMock(side_effect=write_file)
+        updater = MemoryUpdater(registry=self._registry())
+        updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
+        operation = ResolvedOperation(
+            old_memory_file_content=old_file,
+            memory_fields={
+                "topic": "workflow",
+                "content": "Prefers detailed updates.",
+            },
+            memory_type="preferences",
+            uris=[uri],
+        )
+
+        changed_uris = await updater._apply_upsert(operation, MagicMock())
+
+        assert changed_uris == {uri}
+        assert len(written) == 1
+        parsed = MemoryFileUtils.read(written[0])
+        assert parsed.content == "Prefers detailed updates."
+        assert parsed.extra_fields["version"] == 8
+
+    @pytest.mark.asyncio
+    async def test_authoritative_permission_error_never_uses_prefetched_content(self):
+        uri = "viking://user/default/memories/preferences/workflow.md"
+        old_file = MemoryFile(
+            uri=uri,
+            content="Prefers concise updates.",
+            extra_fields={"topic": "workflow", "version": 7},
+        )
+        mock_viking_fs = MagicMock()
+        mock_viking_fs.read_file = AsyncMock(side_effect=PermissionError("denied"))
+        mock_viking_fs.write_file = AsyncMock()
+        updater = MemoryUpdater(registry=self._registry())
+        updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
+        operation = ResolvedOperation(
+            old_memory_file_content=old_file,
+            memory_fields={"topic": "workflow", "content": old_file.content},
+            memory_type="preferences",
+            uris=[uri],
+        )
+
+        with pytest.raises(PermissionError, match="denied"):
+            await updater._apply_upsert(operation, MagicMock())
+
+        mock_viking_fs.write_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_authoritative_not_found_for_prefetched_file_fails_closed(self):
+        uri = "viking://user/default/memories/preferences/workflow.md"
+        old_file = MemoryFile(
+            uri=uri,
+            content="Prefers concise updates.",
+            extra_fields={"topic": "workflow", "version": 7},
+        )
+        mock_viking_fs = MagicMock()
+        mock_viking_fs.read_file = AsyncMock(
+            side_effect=NotFoundError(uri, "memory")
+        )
+        mock_viking_fs.write_file = AsyncMock()
+        updater = MemoryUpdater(registry=self._registry())
+        updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
+        operation = ResolvedOperation(
+            old_memory_file_content=old_file,
+            memory_fields={"topic": "workflow", "content": old_file.content},
+            memory_type="preferences",
+            uris=[uri],
+        )
+
+        with pytest.raises(NotFoundError):
+            await updater._apply_upsert(operation, MagicMock())
+
+        mock_viking_fs.write_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_authoritative_not_found_for_new_file_still_creates_it(self):
+        uri = "viking://user/default/memories/preferences/workflow.md"
+        written: list[str] = []
+        mock_viking_fs = MagicMock()
+        mock_viking_fs.read_file = AsyncMock(side_effect=FileNotFoundError(uri))
+
+        async def write_file(_uri, content, **_kwargs):
+            written.append(content)
+
+        mock_viking_fs.write_file = AsyncMock(side_effect=write_file)
+        updater = MemoryUpdater(registry=self._registry())
+        updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={
+                "topic": "workflow",
+                "content": "Prefers concise updates.",
+            },
+            memory_type="preferences",
+            uris=[uri],
+        )
+
+        changed_uris = await updater._apply_upsert(operation, MagicMock())
+
+        assert changed_uris == {uri}
+        assert len(written) == 1
+        assert MemoryFileUtils.read(written[0]).extra_fields["version"] == 1
+
     @pytest.mark.asyncio
     async def test_apply_upsert_strips_user_id_and_sets_version(self):
         memory_type = "notes"
@@ -1347,7 +1566,9 @@ class TestConsecutivePatchesSameURI:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1392,11 +1613,18 @@ class TestConsecutivePatchesSameURI:
         registry = MemoryTypeRegistry()
         registry.register(schema)
 
-        store: dict[str, str] = {}
+        old_file = MemoryFile(
+            uri=uri,
+            content="Original body",
+            extra_fields={"title": "Original Title"},
+        )
+        store: dict[str, str] = {uri: MemoryFileUtils.write(old_file)}
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1427,11 +1655,7 @@ class TestConsecutivePatchesSameURI:
         monkeypatch.setattr("openviking.session.memory.memory_updater.tracer.info", trace_info)
 
         op = ResolvedOperation(
-            old_memory_file_content=MemoryFile(
-                uri=uri,
-                content="Original body",
-                extra_fields={"title": "Original Title"},
-            ),
+            old_memory_file_content=old_file,
             memory_fields={
                 "title": "Updated Title",
                 "content": StrPatch(blocks=[SearchReplaceBlock(search="old", replace="new")]),
@@ -1468,7 +1692,9 @@ class TestConsecutivePatchesSameURI:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content
@@ -1539,7 +1765,9 @@ class TestConsecutivePatchesSameURI:
         mock_viking_fs = MagicMock()
 
         async def mock_read_file(uri, **kwargs):
-            return store.get(uri)
+            if uri not in store:
+                raise FileNotFoundError(uri)
+            return store[uri]
 
         async def mock_write_file(uri, content, **kwargs):
             store[uri] = content

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -17,6 +17,7 @@ from openviking.session.compressor_v3 import (
     _experience_root_uri,
     _experience_snapshot_provenance,
     _experience_trajectory_map,
+    _same_memory_file,
     _visible_experience_snapshot_uris,
 )
 from openviking.session.memory.dataclass import (
@@ -93,6 +94,74 @@ def test_factory_ignores_deprecated_memory_version():
         create_session_compressor(vikingdb=None, memory_version="unsupported"),
         SessionCompressorV3,
     )
+
+
+def test_same_memory_file_ignores_only_bookkeeping_metadata():
+    link = {
+        "from_uri": "viking://user/u/memories/preferences/workflow.md",
+        "to_uri": "viking://resources/guide",
+    }
+    before = MemoryFile(
+        uri="viking://user/u/memories/preferences/workflow.md",
+        content="Prefers concise updates.",
+        links=[link],
+        memory_type="preferences",
+        extra_fields={
+            "topic": "workflow",
+            "version": 3,
+            "source_extraction_id": "extract-old",
+            "source_extraction_ids": ["extract-old"],
+            "last_update_trace_id": "trace-old",
+        },
+    )
+    bookkeeping_only = before.model_copy(deep=True)
+    bookkeeping_only.extra_fields.update(
+        {
+            "version": 4,
+            "source_extraction_id": "extract-new",
+            "source_extraction_ids": ["extract-old", "extract-new"],
+            "last_update_trace_id": "trace-new",
+        }
+    )
+
+    assert _same_memory_file(before, bookkeeping_only) is True
+
+    memory_type_change = bookkeeping_only.model_copy(deep=True)
+    memory_type_change.memory_type = "entities"
+    assert _same_memory_file(before, memory_type_change) is False
+
+    # Legacy files may omit the serialized field.  Their canonical URI still
+    # supplies the same schema ownership and should not manufacture an update.
+    missing_explicit_memory_type = bookkeeping_only.model_copy(deep=True)
+    missing_explicit_memory_type.memory_type = None
+    assert _same_memory_file(before, missing_explicit_memory_type) is True
+
+    typed_without_uri = MemoryFile(content="same", memory_type="preferences")
+    untyped_without_uri = MemoryFile(content="same")
+    assert _same_memory_file(typed_without_uri, untyped_without_uri) is False
+
+    inconsistent_extra_memory_type = bookkeeping_only.model_copy(deep=True)
+    inconsistent_extra_memory_type.extra_fields["memory_type"] = "entities"
+    assert _same_memory_file(before, inconsistent_extra_memory_type) is False
+
+    content_change = bookkeeping_only.model_copy(deep=True)
+    content_change.content = "Prefers detailed updates."
+    assert _same_memory_file(before, content_change) is False
+
+    relative_link_target_change = bookkeeping_only.model_copy(deep=True)
+    relative_link_target_change.content = "Prefers [guide](./new-guide.md)."
+    before_with_user_link = before.model_copy(
+        update={"content": "Prefers [guide](./old-guide.md)."}, deep=True
+    )
+    assert _same_memory_file(before_with_user_link, relative_link_target_change) is False
+
+    link_change = bookkeeping_only.model_copy(deep=True)
+    link_change.links = []
+    assert _same_memory_file(before, link_change) is False
+
+    business_field_change = bookkeeping_only.model_copy(deep=True)
+    business_field_change.extra_fields["topic"] = "communication"
+    assert _same_memory_file(before, business_field_change) is False
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -8,11 +8,14 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from openviking import AsyncOpenViking
 from openviking.client.session import Session as ClientSession
 from openviking.message import TextPart
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
+from openviking_cli.exceptions import FailedPreconditionError
 
 
 async def _wait_for_task(task_id: str, timeout: float = 30.0) -> dict:
@@ -104,6 +107,23 @@ class TestCommit:
         assert "cases" not in call_kwargs["allowed_memory_types"]
         assert "trajectories" not in call_kwargs["allowed_memory_types"]
         assert "experiences" not in call_kwargs["allowed_memory_types"]
+
+    async def test_explicit_agent_evolution_requirement_fails_before_enqueue(
+        self, session_with_messages: Session
+    ):
+        session_with_messages._agent_evolution_enabled_provider = lambda: False
+        message_count = len(session_with_messages.messages)
+
+        with pytest.raises(FailedPreconditionError, match="not queued"):
+            await session_with_messages.commit_async(
+                memory_policy={
+                    "memory_types": ["cases", "trajectories", "experiences"]
+                },
+                require_agent_evolution_enabled=True,
+            )
+
+        # Failure happens before Phase 1 archives or removes live messages.
+        assert len(session_with_messages.messages) == message_count
 
     async def test_commit_uses_global_setting_and_enables_agent_memory(
         self, session_with_messages: Session

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -74,6 +74,9 @@ class TestResolveOperations:
         assert operation.old_memory_file_content is old_file
         assert operation.memory_fields["name"] == "Melanie"
         assert operation.memory_fields["content"] == "new content"
+        assert operations.errors[0].startswith("Immutable identity mismatch:")
+        assert "WrongName" not in operations.errors[0]
+        assert "Melanie" not in operations.errors[0]
         isolation_handler.calculate_memory_uris.assert_not_called()
 
     def test_unresolved_page_ids_are_ignored(self):

--- a/tests/unit/session/memory/test_memory_type_uri.py
+++ b/tests/unit/session/memory/test_memory_type_uri.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.session.memory.memory_updater import MemoryUpdater
+from openviking.session.memory.utils.memory_file_utils import memory_type_from_uri
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        (
+            "viking://user/memories/memories/preferences/topic.md",
+            "preferences",
+        ),
+        (
+            "viking://user/alice/peers/support/memories/experiences/case.md",
+            "experiences",
+        ),
+        ("viking://user/memories/preferences/topic.md", "preferences"),
+        ("viking://user/alice/memories/profile.md", "profile"),
+        (
+            "viking://user/alice/memories/entities/memories/topic.md",
+            "entities",
+        ),
+        (
+            "viking://user/peers/support/memories/preferences/topic.md",
+            "preferences",
+        ),
+        ("viking://agent/code-agent/memories/facts/project.md", "facts"),
+        ("viking://user/alice/resources/memories/topic.md", None),
+    ],
+)
+def test_memory_type_from_uri_uses_namespace_grammar(uri, expected):
+    assert memory_type_from_uri(uri) == expected
+    assert MemoryUpdater.memory_type_from_uri(uri) == expected

--- a/tests/unit/session/memory/test_page_id_map.py
+++ b/tests/unit/session/memory/test_page_id_map.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+from unittest.mock import patch
+
 from openviking.session.memory.page_id_map import PageIdMap
 
 
@@ -57,3 +59,35 @@ class TestPageIdMap:
         assert pim.get_page_id("viking://profile.md") == existing_id
         assert pim.resolve(existing_id) == "viking://profile.md"
         assert pim.resolve(100) == "viking://profile.md"
+
+    def test_existing_page_namespace_stops_at_99_without_registering_overflow(self):
+        pim = PageIdMap()
+        uris = [f"viking://existing/{index}.md" for index in range(1, 101)]
+
+        assigned = [pim.get_page_id(uri) for uri in uris]
+
+        assert assigned[:99] == list(range(1, 100))
+        assert assigned[99] is None
+        assert pim.resolve(100) is None
+        assert uris[99] not in pim._uri_to_id
+
+    def test_existing_page_duplicate_keeps_id_after_namespace_is_full(self):
+        pim = PageIdMap()
+        uris = [f"viking://existing/{index}.md" for index in range(1, 100)]
+        for uri in uris:
+            pim.get_page_id(uri)
+
+        assert pim.get_page_id(uris[-1]) == 99
+        assert pim.get_page_id("viking://existing/overflow.md") is None
+        assert pim.get_page_id(uris[0]) == 1
+
+    def test_existing_page_namespace_overflow_warns_only_once(self):
+        pim = PageIdMap()
+        for index in range(1, 100):
+            pim.get_page_id(f"viking://existing/{index}.md")
+
+        with patch("openviking.session.memory.page_id_map.logger.warning") as warning:
+            assert pim.get_page_id("viking://existing/overflow-a.md") is None
+            assert pim.get_page_id("viking://existing/overflow-b.md") is None
+
+        warning.assert_called_once()


### PR DESCRIPTION
## Summary

- Add an optional `memory_type` to MCP `remember` for explicit Preference or Experience extraction while preserving the existing untyped behavior.
- Require Agent Evolution for typed Experience writes at both request validation and the authoritative commit snapshot, avoiding silent coercion into another memory type.
- Harden memory updates around immutable identity, canonical memory-type ownership, page-ID namespaces, delete/replacement targets, and semantic no-op versioning.
- Hydrate Experience lifecycle metadata authoritatively during server-side context assembly and exclude deprecated, archived, unreadable, empty, or malformed entries.

## Why

The generic `remember` path could accept an explicit Experience intent while Agent Evolution was disabled and silently update an unrelated Preference. LLM-generated update operations could also bind an existing page ID to the wrong schema or rewrite immutable identity fields. Separately, recalled Experience candidates were not checked against their authoritative lifecycle metadata.

This change makes those boundaries explicit and fail-closed while keeping existing untyped callers and legacy Experience documents without lifecycle metadata compatible.

## User impact

- `remember(messages=...)` keeps its current behavior.
- `remember(..., memory_type="preferences")` constrains extraction to Preferences.
- `remember(..., memory_type="experiences")` queues the Case → Trajectory → Experience pipeline and returns an explicit precondition error when Agent Evolution is disabled.
- Semantic no-op updates no longer bump the primary memory version, but derived indexes and metadata are still retried.
- Deprecated and archived Experiences are no longer returned by server-assembled context or legacy recall.

Typed Experience writes accept caller-supplied transcripts and are documented as a trusted-author operation.

## Validation

- 53 focused memory, MCP, session, URI, page-ID, and service tests passed.
- 18 context-assembler pipeline tests passed.
- `git diff --check` and Python compilation passed.
- Full HTTP fixture execution was not available locally because the isolated test environment lacks the native RAGFS binding; endpoint regressions are included for upstream CI.
- The upstream API and CLI integration workflow passed, including API tests, CLI compatibility, and CLI integration.

## CI note

The Docs workflow currently reports an API-reference baseline failure: the route `PATCH /api/v1/sessions/{session_id}/config` is mounted on `main`, while the existing English and Chinese API reference still says runtime session-config updates are unavailable. This PR does not change that route or those API-reference pages; its MCP guide changes merely trigger the repository-wide API-reference check.

## Related

The independent Codex memory-plugin reliability changes are in #3917. Neither PR contains the other's commit.

---

## 中文说明

### 改动概述

- 为 MCP `remember` 增加可选的 `memory_type`，支持显式提取 Preference 或 Experience，同时保持原有未指定类型时的行为不变。
- typed Experience 写入会在请求校验和最终 commit 快照两个阶段确认 Agent Evolution 已开启，避免内容被静默写成其他 memory 类型。
- 加固 memory 更新边界，包括 immutable identity、canonical memory type、page ID 命名空间、删除与替换目标，以及语义 no-op 的版本处理。
- 服务端组装检索上下文时会读取 Experience 的权威 lifecycle metadata，并排除 deprecated、archived、无法读取、空内容或 metadata 损坏的条目。

### 问题背景

此前，调用者即使明确希望保存 Experience，在 Agent Evolution 关闭时，通用 `remember` 路径仍可能接受请求并把内容更新到不相关的 Preference。LLM 生成的更新操作也可能将已有 page ID 绑定到错误的 schema，或者改写本应不可变的 identity 字段。此外，召回 Experience 时没有根据源文件中的权威 lifecycle metadata 做最终校验。

本 PR 将这些边界改为显式、fail-closed 的行为，同时兼容现有未指定 `memory_type` 的调用，以及没有 lifecycle metadata 的历史 Experience 文档。

### 用户影响

- `remember(messages=...)` 保持现有行为。
- `remember(..., memory_type="preferences")` 只允许提取 Preference。
- `remember(..., memory_type="experiences")` 会进入 Case → Trajectory → Experience 流水线；Agent Evolution 未开启时返回明确的前置条件错误。
- 语义没有变化的更新不再增加主 memory 版本，但仍会重试派生索引和 metadata 的同步。
- deprecated 和 archived Experience 不再出现在服务端组装的 context 或 legacy recall 结果中。

Typed Experience 接受调用者提供的 transcript，因此文档中明确将它定义为可信写入方接口；不可信应用应提交由服务端实际记录的 session。

### 验证结果

- 53 项 memory、MCP、session、URI、page ID 与 service 聚焦测试通过。
- 18 项 context assembler pipeline 测试通过。
- `git diff --check` 与 Python 编译检查通过。
- 本地隔离环境缺少原生 RAGFS binding，因此未执行完整 HTTP fixture；对应 endpoint 回归测试已经加入，交由上游 CI 执行。
- 上游 API 与 CLI 集成 workflow 已通过，包括 API tests、CLI compatibility 和 CLI integration。

### CI 说明

Docs workflow 当前命中了上游 API reference 的既有缺口：`main` 已挂载 `PATCH /api/v1/sessions/{session_id}/config`，但现有中英文 API 文档仍声明运行时 session config 不可更新。本 PR 没有修改该路由或对应 API reference，只是 MCP guide 的改动触发了全仓 API reference 检查。

### 相关 PR

Codex memory plugin 的独立可靠性修复位于 #3917；两个 PR 均不包含对方的提交。
