### PR TITLE
fix(observer): ignore historical lock diagnostics in health

### DIFF
--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -180,17 +180,17 @@ class ObserverService:
         waiting = snapshot.get("waiting_locks", 0)
         stale = snapshot.get("stale_locks_removed", 0)
         conflicts = snapshot.get("conflicts", [])
-        has_errors = bool(conflicts) or stale > 0
         lines = [
             f"Active locks: {active}",
             f"Waiting locks: {waiting}",
             f"Stale locks removed: {stale}",
             f"Conflicts: {len(conflicts)}",
         ]
+        # Conflicts and stale removals are retained diagnostics, not current failures.
         return ComponentStatus(
             name="lock",
-            is_healthy=not has_errors,
-            has_errors=has_errors,
+            is_healthy=True,
+            has_errors=False,
             status="\n".join(lines),
         )
 


### PR DESCRIPTION
## Description

Prevent historical lock conflict and stale-cleanup diagnostics from permanently marking the lock observer and overall system as unhealthy.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Closes #3897

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Keep conflict and stale-lock cleanup counts visible as diagnostic information.
- Stop treating those retained historical values as current lock failures.
- Preserve the existing unhealthy result when the lock observer cannot be initialized.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Manual verification covered a snapshot with non-zero conflict and stale-removal history, confirming that the component remains healthy while the diagnostic counts remain visible.

- `ruff format --check openviking/service/debug_service.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

No lock lifecycle, CLI, SDK, or public response schema changes are included.
