### PR TITLE
fix(session): validate archive names when loading history

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -664,13 +664,15 @@ class Session:
         # Restore compression_index (scan history directory)
         try:
             history_items = await self._viking_fs.ls(f"{self._session_uri}/history", ctx=self.ctx)
-            archives = [
-                item["name"] for item in history_items if item["name"].startswith("archive_")
+            archive_indices = [
+                int(match.group(1))
+                for item in history_items
+                if (match := re.fullmatch(r"archive_(\d+)", item["name"]))
             ]
-            if archives:
-                max_index = max(int(a.split("_")[1]) for a in archives)
+            if archive_indices:
+                max_index = max(archive_indices)
                 self._compression.compression_index = max_index
-                self._stats.compression_count = len(archives)
+                self._stats.compression_count = len(archive_indices)
                 logger.debug(f"Restored compression_index: {max_index}")
         except Exception as exc:
             if not _is_storage_not_found(exc):

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -67,6 +67,21 @@ class TestSessionLoad:
         # Nonexistent session should be empty after loading
         assert len(session.messages) == 0
 
+    async def test_load_ignores_non_archive_history_entries(self, client: AsyncOpenViking):
+        session = client.session(session_id="archive_name_validation_test")
+        for name in ("archive_001", "archive_002", "archive_001.bak.20260628"):
+            await session._viking_fs.mkdir(
+                f"{session.uri}/history/{name}",
+                exist_ok=True,
+                ctx=session.ctx,
+            )
+
+        loaded = client.session(session_id=session.session_id)
+        await loaded.load()
+
+        assert loaded.compression.compression_index == 2
+        assert loaded.stats.compression_count == 2
+
     async def test_session_properties(self, session: Session):
         """Test session properties"""
         assert hasattr(session, "uri")


### PR DESCRIPTION
## Description

Fix session history loading when backup-like directory names such as
`archive_001.bak.20260628` are present.

Previously, `Session.load()` treated every entry starting with `archive_` as a
valid archive and attempted to convert the remaining string to an integer.
This raised a `ValueError` and caused the current resource reason memory linking
attempt to be skipped.

The loader now only recognizes directory names that fully match
`archive_<digits>`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3899

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Validate session archive directory names using an exact `archive_<digits>` match.
- Ignore backup or malformed history entries when restoring compression state.
- Add a regression test covering valid archives alongside `archive_001.bak.20260628`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Tests and checks performed:

- `.venv/bin/pytest -q tests/session/test_session_lifecycle.py` — 14 passed
- `.venv/bin/ruff check openviking/session/session.py tests/session/test_session_lifecycle.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Non-canonical history entries are ignored but not modified or deleted. No
changes were made to the ResourceService linking flow, and no new dependencies
were introduced.