### PR TITLE
feat(admin): 清理已删除用户数据

### DIFF
--- a/openviking/observability/usage_audit/runtime.py
+++ b/openviking/observability/usage_audit/runtime.py
@@ -36,6 +36,11 @@ class UsageAuditRuntime:
     api_service: UsageAuditQueryService
     shutdown_flush_timeout_seconds: float
 
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
+        """Drain accepted events before purging one user's projections."""
+        await self.worker.flush()
+        return await self.store.delete_user_data(account_id=account_id, user_id=user_id)
+
 
 def _resolve_sqlite_path(config: ServerConfig) -> Path:
     configured = config.observability.usage_audit.sqlite_path

--- a/openviking/observability/usage_audit/sqlite_store.py
+++ b/openviking/observability/usage_audit/sqlite_store.py
@@ -103,6 +103,34 @@ class SQLiteUsageAuditStore:
             self._conn.close()
             self._conn = None
 
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
+        """Delete all usage/audit rows for an account/user pair."""
+        async with self._lock:
+            return await asyncio.to_thread(self._delete_user_data_sync, account_id, user_id)
+
+    def _delete_user_data_sync(self, account_id: str, user_id: str) -> dict[str, int]:
+        assert self._conn is not None
+        tables = (
+            "usage_token_hourly",
+            "usage_retrieval_hourly",
+            "usage_context_write_bucket",
+            "request_audit",
+        )
+        self._conn.execute("BEGIN")
+        try:
+            deleted = {
+                table: self._conn.execute(
+                    f"DELETE FROM {table} WHERE account_id = ? AND user_id = ?",
+                    (account_id, user_id),
+                ).rowcount
+                for table in tables
+            }
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+        return deleted
+
     async def record_batch(self, events: Sequence[ObservabilityEvent]) -> None:
         if not events:
             return

--- a/openviking/observability/usage_audit/store.py
+++ b/openviking/observability/usage_audit/store.py
@@ -26,6 +26,9 @@ class UsageAuditStore(Protocol):
     async def record_batch(self, events: Sequence[ObservabilityEvent]) -> None:
         """Persist a batch of observability events."""
 
+    async def delete_user_data(self, *, account_id: str, user_id: str) -> dict[str, int]:
+        """Delete every persisted usage/audit row owned by one user."""
+
     async def get_today_tokens(
         self,
         *,

--- a/openviking/observability/usage_audit/worker.py
+++ b/openviking/observability/usage_audit/worker.py
@@ -106,6 +106,8 @@ class UsageAuditWorker:
                 )
                 raise
             else:
+                for _ in batch:
+                    self._queue.task_done()
                 self._current_batch = None
 
     async def _flush(self, batch: list[ObservabilityEvent]) -> None:
@@ -119,6 +121,12 @@ class UsageAuditWorker:
                 exc,
                 exc_info=logger.isEnabledFor(logging.DEBUG),
             )
+
+    async def flush(self) -> None:
+        """Wait until every event already accepted by this worker is handled."""
+        if self._queue is None or self._task is None or self._closed:
+            raise RuntimeError("Usage/Audit worker is not running")
+        await self._queue.join()
 
     async def close(self, *, timeout_seconds: float = 3.0) -> None:
         """Stop the worker and flush remaining queued events."""

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -26,6 +26,7 @@ from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
 from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import (
     AlreadyExistsError,
+    FailedPreconditionError,
     InvalidArgumentError,
     NotFoundError,
     UnauthenticatedError,
@@ -84,6 +85,7 @@ class LegacyAPIKeyManager:
         self._prefix_index: Dict[str, list[UserKeyEntry]] = {}
         # Serializes reload() so overlapping refreshes can't interleave.
         self._reload_lock = asyncio.Lock()
+        self._user_deletion_lock = asyncio.Lock()
 
     def _discard_account_state(self, account_id: str) -> None:
         """Remove an account and its key index entries from in-memory state."""
@@ -419,35 +421,128 @@ class LegacyAPIKeyManager:
         await self._save_users_json(account_id)
         return key
 
-    async def remove_user(self, account_id: str, user_id: str) -> None:
-        """Remove a user from an account."""
+    async def begin_user_deletion(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        task_id: str,
+        owner_account_id: str,
+        owner_user_id: str,
+    ) -> tuple[dict, bool]:
+        """Revoke the user key and persist the deletion task fence."""
+        async with self._reload_lock, self._user_deletion_lock:
+            account = self._accounts.get(account_id)
+            if account is None:
+                raise NotFoundError(account_id, "account")
+            user_info = account.users.get(user_id)
+            if user_info is None:
+                raise NotFoundError(user_id, "user")
+
+            existing = user_info.get("deletion")
+            if isinstance(existing, dict) and existing.get("task_id"):
+                return dict(existing), False
+
+            if user_info.get("role") == Role.ADMIN:
+                active_admins = sum(
+                    info.get("role") == Role.ADMIN and not info.get("deletion")
+                    for info in account.users.values()
+                )
+                if active_admins <= 1:
+                    raise FailedPreconditionError("Cannot delete the last active account admin")
+
+            original = dict(user_info)
+            deletion = {
+                "task_id": task_id,
+                "owner_account_id": owner_account_id,
+                "owner_user_id": owner_user_id,
+            }
+            user_info["deletion"] = deletion
+            user_info["key"] = ""
+            user_info.pop("key_prefix", None)
+            try:
+                await self._save_users_json(account_id)
+            except Exception:
+                account.users[user_id] = original
+                raise
+            self._remove_key_index_entry(account_id, user_id, original)
+            return dict(deletion), True
+
+    async def replace_user_deletion_task(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        expected_task_id: str,
+        task_id: str,
+        owner_account_id: str,
+        owner_user_id: str,
+    ) -> dict:
+        """Replace the task that owns an existing deletion fence."""
+        async with self._reload_lock, self._user_deletion_lock:
+            account = self._accounts.get(account_id)
+            if account is None:
+                raise NotFoundError(account_id, "account")
+            user_info = account.users.get(user_id)
+            if user_info is None:
+                raise NotFoundError(user_id, "user")
+            current = user_info.get("deletion")
+            if not isinstance(current, dict) or current.get("task_id") != expected_task_id:
+                return dict(current) if isinstance(current, dict) else {}
+
+            replacement = {
+                "task_id": task_id,
+                "owner_account_id": owner_account_id,
+                "owner_user_id": owner_user_id,
+            }
+            user_info["deletion"] = replacement
+            try:
+                await self._save_users_json(account_id)
+            except Exception:
+                user_info["deletion"] = current
+                raise
+            return dict(replacement)
+
+    async def finish_user_deletion(self, account_id: str, user_id: str, task_id: str) -> bool:
+        """Remove the user only when this task still owns the deletion fence."""
+        async with self._reload_lock, self._user_deletion_lock:
+            account = self._accounts.get(account_id)
+            if account is None:
+                return False
+            user_info = account.users.get(user_id)
+            if user_info is None:
+                return False
+            deletion = user_info.get("deletion")
+            if not isinstance(deletion, dict) or deletion.get("task_id") != task_id:
+                return False
+
+            account.users.pop(user_id)
+            try:
+                await self._save_users_json(account_id)
+            except Exception:
+                account.users[user_id] = user_info
+                raise
+            return True
+
+    def get_user_deletion(self, account_id: str, user_id: str) -> Optional[dict]:
         account = self._accounts.get(account_id)
         if account is None:
-            raise NotFoundError(account_id, "account")
-        if user_id not in account.users:
-            raise NotFoundError(user_id, "user")
+            return None
+        user_info = account.users.get(user_id)
+        deletion = user_info.get("deletion") if user_info else None
+        return dict(deletion) if isinstance(deletion, dict) else None
 
-        user_info = account.users.pop(user_id)
-        key_or_hash = user_info.get("key", "")
+    def iter_user_deletions(self) -> list[tuple[str, str, dict]]:
+        return [
+            (account_id, user_id, dict(deletion))
+            for account_id, account in self._accounts.items()
+            for user_id, user_info in account.users.items()
+            if isinstance((deletion := user_info.get("deletion")), dict)
+            and deletion.get("task_id")
+        ]
 
-        if key_or_hash:
-            # Get key_prefix - if not in user_info, compute from key
-            key_prefix = user_info.get("key_prefix", "")
-            if not key_prefix:
-                key_prefix = self._get_key_prefix(key_or_hash)
-
-            # Remove from prefix index
-            if key_prefix in self._prefix_index:
-                self._prefix_index[key_prefix] = [
-                    entry
-                    for entry in self._prefix_index[key_prefix]
-                    if not (entry.account_id == account_id and entry.user_id == user_id)
-                ]
-                # Remove prefix if index is empty
-                if not self._prefix_index[key_prefix]:
-                    del self._prefix_index[key_prefix]
-
-        await self._save_users_json(account_id)
+    def is_user_deleting(self, account_id: str, user_id: str) -> bool:
+        return self.get_user_deletion(account_id, user_id) is not None
 
     async def regenerate_key(
         self, account_id: str, user_id: str, seed: Optional[str] = None
@@ -458,6 +553,8 @@ class LegacyAPIKeyManager:
             raise NotFoundError(account_id, "account")
         if user_id not in account.users:
             raise NotFoundError(user_id, "user")
+        if account.users[user_id].get("deletion"):
+            raise FailedPreconditionError("User deletion is in progress")
 
         old_user_info = account.users[user_id]
         old_key_or_hash = old_user_info.get("key", "")
@@ -527,6 +624,8 @@ class LegacyAPIKeyManager:
             raise NotFoundError(account_id, "account")
         if user_id not in account.users:
             raise NotFoundError(user_id, "user")
+        if account.users[user_id].get("deletion"):
+            raise FailedPreconditionError("User deletion is in progress")
 
         account.users[user_id]["role"] = resolved_role
 
@@ -659,6 +758,21 @@ class LegacyAPIKeyManager:
         return hashlib.sha256(stored.encode("utf-8")).hexdigest()
 
     # ---- internal helpers ----
+
+    def _remove_key_index_entry(self, account_id: str, user_id: str, user_info: dict) -> None:
+        key_or_hash = user_info.get("key", "")
+        if not key_or_hash:
+            return
+        key_prefix = user_info.get("key_prefix", "") or self._get_key_prefix(key_or_hash)
+        if key_prefix not in self._prefix_index:
+            return
+        self._prefix_index[key_prefix] = [
+            entry
+            for entry in self._prefix_index[key_prefix]
+            if not (entry.account_id == account_id and entry.user_id == user_id)
+        ]
+        if not self._prefix_index[key_prefix]:
+            del self._prefix_index[key_prefix]
 
     def _generate_api_key(self) -> str:
         """Generate new API Key (legacy format - hex)."""

--- a/openviking/server/api_keys/new.py
+++ b/openviking/server/api_keys/new.py
@@ -22,7 +22,11 @@ from openviking.server.api_keys.models import (
 )
 from openviking.server.identity import ResolvedIdentity, Role
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.exceptions import InvalidArgumentError, UnauthenticatedError
+from openviking_cli.exceptions import (
+    FailedPreconditionError,
+    InvalidArgumentError,
+    UnauthenticatedError,
+)
 from openviking_cli.session.user_id import validate_account_id, validate_user_id
 from openviking_cli.utils import get_logger
 
@@ -318,9 +322,53 @@ class NewAPIKeyManager:
         await self._legacy._save_users_json(account_id)
         return key
 
-    async def remove_user(self, account_id: str, user_id: str) -> None:
-        """Remove a user from an account."""
-        await self._legacy.remove_user(account_id, user_id)
+    async def begin_user_deletion(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        task_id: str,
+        owner_account_id: str,
+        owner_user_id: str,
+    ) -> tuple[dict, bool]:
+        return await self._legacy.begin_user_deletion(
+            account_id,
+            user_id,
+            task_id=task_id,
+            owner_account_id=owner_account_id,
+            owner_user_id=owner_user_id,
+        )
+
+    async def replace_user_deletion_task(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        expected_task_id: str,
+        task_id: str,
+        owner_account_id: str,
+        owner_user_id: str,
+    ) -> dict:
+        return await self._legacy.replace_user_deletion_task(
+            account_id,
+            user_id,
+            expected_task_id=expected_task_id,
+            task_id=task_id,
+            owner_account_id=owner_account_id,
+            owner_user_id=owner_user_id,
+        )
+
+    async def finish_user_deletion(self, account_id: str, user_id: str, task_id: str) -> bool:
+        return await self._legacy.finish_user_deletion(account_id, user_id, task_id)
+
+    def get_user_deletion(self, account_id: str, user_id: str) -> Optional[dict]:
+        return self._legacy.get_user_deletion(account_id, user_id)
+
+    def iter_user_deletions(self) -> list[tuple[str, str, dict]]:
+        return self._legacy.iter_user_deletions()
+
+    def is_user_deleting(self, account_id: str, user_id: str) -> bool:
+        return self._legacy.is_user_deleting(account_id, user_id)
 
     async def regenerate_key(
         self,
@@ -342,6 +390,8 @@ class NewAPIKeyManager:
             from openviking_cli.exceptions import NotFoundError
 
             raise NotFoundError(user_id, "user")
+        if account.users[user_id].get("deletion"):
+            raise FailedPreconditionError("User deletion is in progress")
 
         old_user_info = account.users[user_id]
         old_key_or_hash = old_user_info.get("key", "")

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -139,6 +139,15 @@ async def _initialize_runtime_state(
     """Initialize service and auth dependencies before traffic is accepted."""
     await service.initialize()
     await _initialize_auth_plugin(app, service, config)
+    from openviking.service.user_deletion import setup_user_deletion
+
+    app.state.user_deletion_service = await setup_user_deletion(
+        service=service,
+        manager=app.state.api_key_manager,
+        shared_upload_prefix=config.temp_upload.shared_prefix,
+        oauth_store=getattr(app.state, "oauth_store", None),
+        usage_audit_runtime=getattr(app.state, "usage_audit_runtime", None),
+    )
     logger.info("OpenVikingService initialization complete")
 
 
@@ -384,6 +393,7 @@ def create_app(
 
     app.state.config = config
     app.state.api_key_manager = None
+    app.state.user_deletion_service = None
     set_server_config(config)
 
     # Body dump middleware must be registered BEFORE observability so it ends up

--- a/openviking/server/auth/__init__.py
+++ b/openviking/server/auth/__init__.py
@@ -16,6 +16,7 @@ from openviking.server.identity import (
 from openviking.server.upload_token_store import UploadTokenError, upload_token_store
 from openviking.telemetry.span_models import update_root_span_identity
 from openviking_cli.exceptions import (
+    FailedPreconditionError,
     InvalidArgumentError,
     PermissionDeniedError,
     UnauthenticatedError,
@@ -116,6 +117,18 @@ def _build_request_context(
         from_oauth=identity.from_oauth,
         api_key=api_key,
     )
+    manager = getattr(request.app.state, "api_key_manager", None)
+    is_user_deleting = getattr(manager, "is_user_deleting", None)
+    if (
+        ctx.role != Role.ROOT
+        and callable(is_user_deleting)
+        and is_user_deleting(ctx.account_id, ctx.user.user_id)
+    ):
+        deletion = manager.get_user_deletion(ctx.account_id, ctx.user.user_id) or {}
+        raise FailedPreconditionError(
+            "User deletion is in progress",
+            details={"task_id": deletion.get("task_id")},
+        )
     update_root_span_identity(
         request_state=request.state,
         account_id=identity.account_id,

--- a/openviking/server/oauth/storage.py
+++ b/openviking/server/oauth/storage.py
@@ -593,10 +593,16 @@ class OAuthStore:
                 "UPDATE oauth_codes SET used = 1 WHERE account_id = ? AND user_id = ? AND used = 0",
                 (account_id, user_id),
             ).rowcount
+            pending = self._conn.execute(
+                "DELETE FROM oauth_pending_authorizations "
+                "WHERE verified_account_id = ? AND verified_user_id = ?",
+                (account_id, user_id),
+            ).rowcount
             return {
                 "access_tokens_revoked": access,
                 "refresh_tokens_revoked": refresh,
                 "codes_revoked": codes,
+                "pending_authorizations_revoked": pending,
             }
 
         async with self._lock:

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -466,7 +466,7 @@ async def list_users(
     return Response(status="ok", result=users)
 
 
-@router.delete("/accounts/{account_id}/users/{user_id}")
+@router.delete("/accounts/{account_id}/users/{user_id}", status_code=202)
 @require_auth_root_or_admin
 async def remove_user(
     request: Request,
@@ -474,11 +474,13 @@ async def remove_user(
     user_id: str = Path(..., description="User ID"),
     ctx: RequestContext = Depends(get_request_context),
 ):
-    """Remove a user from an account."""
+    """Revoke a user and start durable cleanup of their owned data."""
     _check_account_access(ctx, account_id)
-    manager = _get_api_key_manager(request)
-    await manager.remove_user(account_id, user_id)
-    return Response(status="ok", result={"deleted": True})
+    deletion_service = request.app.state.user_deletion_service
+    if deletion_service is None:
+        raise FailedPreconditionError("User deletion service is not initialized.")
+    result = await deletion_service.delete_user(account_id, user_id, actor=ctx)
+    return Response(status="ok", result=result)
 
 
 @router.put("/accounts/{account_id}/users/{user_id}/role")

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -467,6 +467,13 @@ class OpenVikingService:
                 ),
                 allow_create=True,
             )
+            # Auth state is initialized by the HTTP server after the core service.
+            # Register the durable queue now so task tracking can rebuild its work;
+            # the user-deletion service binds the handler once auth is ready.
+            self._queue_manager.get_queue(
+                self._queue_manager.USER_DELETION,
+                allow_create=True,
+            )
             await self._queue_manager.prepare_task_tracking(get_task_tracker())
 
         if self._config.enable_watch_scheduler:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -740,6 +740,53 @@ class TaskTracker:
             return await _poll()
         return await asyncio.wait_for(_poll(), timeout)
 
+    async def delete_user_tasks(self, account_id: str, user_id: str) -> int:
+        """Delete terminal task records for one user from storage and cache."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._delete_user_tasks_on_owner(account_id, user_id)
+        )
+
+    async def _delete_user_tasks_on_owner(self, account_id: str, user_id: str) -> int:
+        self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        tasks = [
+            task
+            for task in self._cache_snapshot()
+            if self._matches_owner(task, account_id, user_id)
+        ]
+        active = [task for task in tasks if task.status in _ACTIVE_STATUSES]
+        if active:
+            raise RuntimeError(
+                "Cannot delete active task records: "
+                + ", ".join(f"{task.task_id}({task.task_type})" for task in active)
+            )
+
+        deleted = 0
+        for task in tasks:
+            async with self._task_locks.acquire(task.task_id):
+                current = self._cached_task(task.task_id)
+                if current is None or not self._matches_owner(current, account_id, user_id):
+                    continue
+                if current.status in _ACTIVE_STATUSES or self._work_index.has_work(task.task_id):
+                    raise RuntimeError(
+                        f"Cannot delete active task record: {task.task_id}({task.task_type})"
+                    )
+                await self._store_io.run(
+                    "delete",
+                    lambda task_id=task.task_id: run_to_completion(
+                        lambda: self._store.delete(
+                            task_id,
+                            account_id=account_id,
+                            user_id=user_id,
+                        )
+                    ),
+                )
+                with self._lock:
+                    self._tasks.pop(task.task_id, None)
+                self._work_index.clear_failure(task.task_id)
+                deleted += 1
+        return deleted
+
     async def wait_for_descendants(self, task_id: str, current_work_id: str) -> None:
         """Wait on the same durable work index used by completion and cancellation."""
         while self._work_index.has_work(task_id, exclude_work_id=current_work_id):

--- a/openviking/service/user_deletion.py
+++ b/openviking/service/user_deletion.py
@@ -24,7 +24,7 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 TASK_TYPE = "user_delete"
-_CANCEL_WAIT_SECONDS = 30.0
+_CANCEL_WAIT_SECONDS = 10 * 60
 _ACTIVE_TASK_STATUSES = (
     TaskStatus.PENDING,
     TaskStatus.RUNNING,

--- a/openviking/service/user_deletion.py
+++ b/openviking/service/user_deletion.py
@@ -286,6 +286,10 @@ class UserDeletionService:
         )
         steps: list[tuple[str, Callable[[], Awaitable[Any]]]] = [
             (
+                "task_records",
+                lambda: tracker.delete_user_tasks(target_account_id, target_user_id),
+            ),
+            (
                 "agfs",
                 lambda: self._service.viking_fs.rm(
                     canonical_user_root(cleanup_ctx),

--- a/openviking/service/user_deletion.py
+++ b/openviking/service/user_deletion.py
@@ -1,0 +1,535 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Durable, idempotent deletion of one user and their owned data."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any, Awaitable, Callable, Optional
+from uuid import uuid4
+
+from openviking.core.namespace import canonical_user_root
+from openviking.server.identity import RequestContext, Role
+from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
+from openviking.service.task_tracker import TaskStatus, get_task_tracker
+from openviking.service.task_work_index import extract_task_metadata
+from openviking.storage.queuefs.named_queue import DequeueHandlerBase
+from openviking.storage.viking_fs import LS_ALL_NODES
+from openviking_cli.exceptions import NotFoundError
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+TASK_TYPE = "user_delete"
+_CANCEL_WAIT_SECONDS = 30.0
+_ACTIVE_TASK_STATUSES = (
+    TaskStatus.PENDING,
+    TaskStatus.RUNNING,
+    TaskStatus.CANCELLING,
+)
+_TERMINAL_TASK_STATUSES = (
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+)
+
+
+def _deletion_message(
+    *,
+    task_id: str,
+    owner_account_id: str,
+    owner_user_id: str,
+    target_account_id: str,
+    target_user_id: str,
+) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "account_id": owner_account_id,
+        "user_id": owner_user_id,
+        "target": {
+            "account_id": target_account_id,
+            "user_id": target_user_id,
+        },
+    }
+
+
+class UserDeletionService:
+    """Own the deletion fence, tracked task, durable work, and cleanup pipeline."""
+
+    def __init__(
+        self,
+        *,
+        service: Any,
+        manager: Any,
+        service_loop: asyncio.AbstractEventLoop,
+        shared_upload_prefix: str,
+        oauth_store: Any = None,
+        usage_audit_runtime: Any = None,
+    ) -> None:
+        self._service = service
+        self._manager = manager
+        self._service_loop = service_loop
+        self._shared_upload_prefix = shared_upload_prefix.rstrip("/")
+        self._oauth_store = oauth_store
+        self._usage_audit_runtime = usage_audit_runtime
+        self._request_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Bind the queue consumer and reconcile persisted deletion fences."""
+        self._service.viking_fs.set_user_deletion_guard(self._manager.is_user_deleting)
+        queue_manager = self._service._queue_manager
+        queue = queue_manager.get_queue(queue_manager.USER_DELETION)
+        queued_task_ids = {
+            metadata.task_id
+            for message in await queue.snapshot()
+            if (metadata := extract_task_metadata(message)) is not None
+        }
+        queue_manager.get_queue(
+            queue_manager.USER_DELETION,
+            dequeue_handler=_UserDeletionProcessor(self, self._service_loop),
+        )
+
+        tracker = get_task_tracker()
+        for account_id, user_id, deletion in self._manager.iter_user_deletions():
+            task_id = deletion.get("task_id")
+            owner_account_id = deletion.get("owner_account_id")
+            owner_user_id = deletion.get("owner_user_id")
+            if not task_id or not owner_account_id or not owner_user_id:
+                continue
+            task = await tracker.get(
+                task_id,
+                account_id=owner_account_id,
+                user_id=owner_user_id,
+            )
+            if task is None:
+                task = await tracker.create(
+                    TASK_TYPE,
+                    resource_id=f"{account_id}/{user_id}",
+                    task_id=task_id,
+                    account_id=owner_account_id,
+                    user_id=owner_user_id,
+                )
+            if task.status in (TaskStatus.PENDING, TaskStatus.RUNNING) and task_id not in (
+                queued_task_ids
+            ):
+                await queue.enqueue(
+                    _deletion_message(
+                        task_id=task_id,
+                        owner_account_id=owner_account_id,
+                        owner_user_id=owner_user_id,
+                        target_account_id=account_id,
+                        target_user_id=user_id,
+                    )
+                )
+                queued_task_ids.add(task_id)
+
+    async def delete_user(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        actor: RequestContext,
+    ) -> dict[str, str]:
+        """Revoke the user immediately and ensure one durable cleanup task exists."""
+        if actor.role == Role.ROOT or (
+            actor.account_id == account_id and actor.user.user_id == user_id
+        ):
+            request_owner_account_id = SYSTEM_TASK_ACCOUNT_ID
+            request_owner_user_id = SYSTEM_TASK_USER_ID
+        else:
+            request_owner_account_id = actor.account_id
+            request_owner_user_id = actor.user.user_id
+
+        async with self._request_lock:
+            task_id = str(uuid4())
+            deletion, created = await self._manager.begin_user_deletion(
+                account_id,
+                user_id,
+                task_id=task_id,
+                owner_account_id=request_owner_account_id,
+                owner_user_id=request_owner_user_id,
+            )
+            if not created:
+                task_id = deletion["task_id"]
+                owner_account_id = deletion["owner_account_id"]
+                owner_user_id = deletion["owner_user_id"]
+                existing = await get_task_tracker().get(
+                    task_id,
+                    account_id=owner_account_id,
+                    user_id=owner_user_id,
+                )
+                if existing is not None and existing.status in _TERMINAL_TASK_STATUSES:
+                    deletion = await self._manager.replace_user_deletion_task(
+                        account_id,
+                        user_id,
+                        expected_task_id=task_id,
+                        task_id=str(uuid4()),
+                        owner_account_id=request_owner_account_id,
+                        owner_user_id=request_owner_user_id,
+                    )
+                    if not deletion:
+                        raise NotFoundError(user_id, "user")
+
+            task_id = deletion["task_id"]
+            owner_account_id = deletion["owner_account_id"]
+            owner_user_id = deletion["owner_user_id"]
+            await get_task_tracker().create(
+                TASK_TYPE,
+                resource_id=f"{account_id}/{user_id}",
+                task_id=task_id,
+                account_id=owner_account_id,
+                user_id=owner_user_id,
+            )
+            await self._enqueue_if_missing(
+                task_id=task_id,
+                owner_account_id=owner_account_id,
+                owner_user_id=owner_user_id,
+                target_account_id=account_id,
+                target_user_id=user_id,
+            )
+
+        return {
+            "account_id": account_id,
+            "user_id": user_id,
+            "status": "deleting",
+            "task_id": task_id,
+        }
+
+    async def _enqueue_if_missing(
+        self,
+        *,
+        task_id: str,
+        owner_account_id: str,
+        owner_user_id: str,
+        target_account_id: str,
+        target_user_id: str,
+    ) -> None:
+        queue_manager = self._service._queue_manager
+        queue = queue_manager.get_queue(queue_manager.USER_DELETION)
+        for message in await queue.snapshot():
+            metadata = extract_task_metadata(message)
+            if metadata is not None and metadata.task_id == task_id:
+                return
+        await queue.enqueue(
+            _deletion_message(
+                task_id=task_id,
+                owner_account_id=owner_account_id,
+                owner_user_id=owner_user_id,
+                target_account_id=target_account_id,
+                target_user_id=target_user_id,
+            )
+        )
+
+    async def _process(self, message: dict[str, Any]) -> Optional[str]:
+        task_id = message["task_id"]
+        owner_account_id = message["account_id"]
+        owner_user_id = message["user_id"]
+        target_account_id = message["target"]["account_id"]
+        target_user_id = message["target"]["user_id"]
+        tracker = get_task_tracker()
+        task = await tracker.create(
+            TASK_TYPE,
+            resource_id=f"{target_account_id}/{target_user_id}",
+            task_id=task_id,
+            account_id=owner_account_id,
+            user_id=owner_user_id,
+        )
+        owner = {
+            "account_id": owner_account_id,
+            "user_id": owner_user_id,
+        }
+        if task.status in _TERMINAL_TASK_STATUSES:
+            return None
+
+        deletion = self._manager.get_user_deletion(target_account_id, target_user_id)
+        if deletion is None or deletion.get("task_id") != task_id:
+            deleted = not self._manager.has_user(target_account_id, target_user_id)
+            await tracker.complete(
+                task_id,
+                {"deleted": deleted, "stale": True},
+                **owner,
+            )
+            return None
+
+        try:
+            await tracker.start(task_id, stage="stopping_watches", **owner)
+            await self._stop_watches(target_account_id, target_user_id)
+        except Exception:
+            logger.exception(
+                "Failed to stop watches for user %s/%s",
+                target_account_id,
+                target_user_id,
+            )
+            error = "User cleanup failed at stages: watches"
+            await tracker.fail(task_id, error, **owner)
+            return error
+
+        try:
+            await tracker.update_stage(task_id, "cancelling_tasks", **owner)
+            await self._cancel_user_tasks(target_account_id, target_user_id)
+        except Exception:
+            logger.exception(
+                "Failed to settle tasks for user %s/%s",
+                target_account_id,
+                target_user_id,
+            )
+            error = "User cleanup failed at stages: tasks"
+            await tracker.fail(task_id, error, **owner)
+            return error
+
+        cleanup_ctx = RequestContext(
+            user=UserIdentifier(target_account_id, target_user_id),
+            role=Role.ROOT,
+        )
+        steps: list[tuple[str, Callable[[], Awaitable[Any]]]] = [
+            (
+                "agfs",
+                lambda: self._service.viking_fs.rm(
+                    canonical_user_root(cleanup_ctx),
+                    recursive=True,
+                    ctx=cleanup_ctx,
+                ),
+            ),
+            (
+                "uploads",
+                lambda: self._delete_uploads(cleanup_ctx),
+            ),
+        ]
+        vector_store = self._service.viking_fs.vector_store
+        if vector_store is not None:
+            steps.insert(
+                1,
+                (
+                    "vectordb",
+                    lambda: vector_store.delete_user_data(
+                        target_account_id,
+                        target_user_id,
+                        ctx=cleanup_ctx,
+                    ),
+                ),
+            )
+        if self._oauth_store is not None:
+            steps.append(
+                (
+                    "oauth",
+                    lambda: self._oauth_store.revoke_user_tokens(
+                        account_id=target_account_id,
+                        user_id=target_user_id,
+                    ),
+                )
+            )
+        if self._usage_audit_runtime is not None:
+            steps.append(
+                (
+                    "usage_audit",
+                    lambda: self._usage_audit_runtime.delete_user_data(
+                        account_id=target_account_id,
+                        user_id=target_user_id,
+                    ),
+                )
+            )
+
+        failed_stages: list[str] = []
+        for stage, cleanup in steps:
+            await tracker.update_stage(task_id, f"cleaning_{stage}", **owner)
+            try:
+                await cleanup()
+            except Exception:
+                failed_stages.append(stage)
+                logger.exception(
+                    "User cleanup stage %s failed for %s/%s",
+                    stage,
+                    target_account_id,
+                    target_user_id,
+                )
+
+        if failed_stages:
+            error = "User cleanup failed at stages: " + ", ".join(failed_stages)
+            await tracker.fail(task_id, error, **owner)
+            return error
+
+        await tracker.update_stage(task_id, "removing_user", **owner)
+        try:
+            removed = await self._manager.finish_user_deletion(
+                target_account_id,
+                target_user_id,
+                task_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to remove user registry entry for %s/%s",
+                target_account_id,
+                target_user_id,
+            )
+            error = "User cleanup failed at stages: registry"
+            await tracker.fail(task_id, error, **owner)
+            return error
+
+        await tracker.complete(
+            task_id,
+            {"deleted": removed, "stale": not removed},
+            **owner,
+        )
+        return None
+
+    async def _stop_watches(self, account_id: str, user_id: str) -> None:
+        scheduler = self._service.watch_scheduler
+        manager = scheduler.watch_manager if scheduler is not None else None
+        if manager is None:
+            return
+        for task in await manager.get_all_tasks(account_id, user_id, Role.USER):
+            await manager.delete_task(task.task_id, account_id, user_id, Role.USER)
+
+    async def _cancel_user_tasks(self, account_id: str, user_id: str) -> None:
+        tracker = get_task_tracker()
+        active = [
+            task
+            for task in await tracker.list_tasks(
+                account_id=account_id,
+                user_id=user_id,
+                limit=10_000,
+            )
+            if task.status in _ACTIVE_TASK_STATUSES
+        ]
+        blockers: list[str] = []
+        waiting: list[str] = []
+        for task in active:
+            try:
+                await tracker.cancel(
+                    task.task_id,
+                    account_id=account_id,
+                    user_id=user_id,
+                )
+                waiting.append(task.task_id)
+            except ValueError:
+                current = await tracker.get(
+                    task.task_id,
+                    account_id=account_id,
+                    user_id=user_id,
+                )
+                if current is not None and current.status in _ACTIVE_TASK_STATUSES:
+                    blockers.append(f"{current.task_id}({current.task_type})")
+        if blockers:
+            raise RuntimeError("Active tasks do not support cancellation: " + ", ".join(blockers))
+
+        deadline = time.monotonic() + _CANCEL_WAIT_SECONDS
+        for task_id in waiting:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for user tasks to stop")
+            await tracker.wait(
+                task_id,
+                account_id=account_id,
+                user_id=user_id,
+                timeout=remaining,
+            )
+
+    async def _delete_uploads(self, ctx: RequestContext) -> None:
+        viking_fs = self._service.viking_fs
+        try:
+            uploads = await viking_fs.ls(
+                self._shared_upload_prefix,
+                show_all_hidden=True,
+                node_limit=LS_ALL_NODES,
+                ctx=ctx,
+            )
+        except NotFoundError:
+            return
+
+        for upload in uploads:
+            uri = upload.get("uri") or f"{self._shared_upload_prefix}/{upload.get('name', '')}"
+            uri = uri.rstrip("/")
+            if not uri or uri == self._shared_upload_prefix:
+                continue
+            try:
+                meta = json.loads(await viking_fs.read_file(f"{uri}/meta.json", ctx=ctx))
+            except Exception:
+                logger.warning("Skipping shared upload with unreadable metadata: %s", uri)
+                continue
+            if meta.get("account") == ctx.account_id and meta.get("user") == ctx.user.user_id:
+                await viking_fs.rm(uri, recursive=True, ctx=ctx)
+
+
+class _UserDeletionProcessor(DequeueHandlerBase):
+    def __init__(
+        self,
+        deletion_service: UserDeletionService,
+        service_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._deletion_service = deletion_service
+        self._service_loop = service_loop
+
+    @staticmethod
+    def _parse_message(data: dict[str, Any]) -> dict[str, Any]:
+        payload = data.get("data", data)
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            raise ValueError("Invalid user deletion message")
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            raise ValueError("Invalid user deletion target")
+        required = ("task_id", "account_id", "user_id")
+        if any(not payload.get(field) for field in required):
+            raise ValueError("Invalid user deletion owner")
+        if not target.get("account_id") or not target.get("user_id"):
+            raise ValueError("Invalid user deletion target")
+        return {
+            "task_id": str(payload["task_id"]),
+            "account_id": str(payload["account_id"]),
+            "user_id": str(payload["user_id"]),
+            "target": {
+                "account_id": str(target["account_id"]),
+                "user_id": str(target["user_id"]),
+            },
+        }
+
+    async def on_dequeue(self, data: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not data:
+            return None
+        try:
+            message = self._parse_message(data)
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            self.report_error(str(exc), data)
+            return None
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._deletion_service._process(message),
+            self._service_loop,
+        )
+        try:
+            error = await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
+        if error is None:
+            self.report_success()
+        else:
+            self.report_error(error, data)
+        return None
+
+
+async def setup_user_deletion(
+    *,
+    service: Any,
+    manager: Any,
+    shared_upload_prefix: str,
+    oauth_store: Any = None,
+    usage_audit_runtime: Any = None,
+) -> Optional[UserDeletionService]:
+    """Create the deletion service after storage and authentication are ready."""
+    if manager is None or service.viking_fs is None or service._queue_manager is None:
+        return None
+    deletion_service = UserDeletionService(
+        service=service,
+        manager=manager,
+        service_loop=asyncio.get_running_loop(),
+        shared_upload_prefix=shared_upload_prefix,
+        oauth_store=oauth_store,
+        usage_audit_runtime=usage_audit_runtime,
+    )
+    await deletion_service.initialize()
+    return deletion_service

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -143,11 +143,16 @@ class NamedQueue:
 
         # Inject callbacks to handler
         if self._dequeue_handler:
-            self._dequeue_handler.set_callbacks(
-                on_success=self._on_process_success,
-                on_requeue=self._on_process_requeue,
-                on_error=self._on_process_error,
-            )
+            self.set_dequeue_handler(self._dequeue_handler)
+
+    def set_dequeue_handler(self, handler: DequeueHandlerBase) -> None:
+        """Bind the consumer after its runtime dependencies are initialized."""
+        self._dequeue_handler = handler
+        handler.set_callbacks(
+            on_success=self._on_process_success,
+            on_requeue=self._on_process_requeue,
+            on_error=self._on_process_error,
+        )
 
     def _on_dequeue_start(self) -> None:
         """Called on dequeue."""

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -77,6 +77,7 @@ class QueueManager:
     EXTERNAL_PARSE = "ExternalParse"
     ADD_RESOURCE = "AddResource"
     SESSION_COMMIT = "SessionCommit"
+    USER_DELETION = "UserDeletion"
 
     def __init__(
         self,
@@ -182,6 +183,8 @@ class QueueManager:
 
     def _max_concurrent_for_queue(self, queue_name: str) -> int:
         """Return the worker concurrency limit for a named queue."""
+        if queue_name == self.USER_DELETION:
+            return 1
         if queue_name == self.EMBEDDING:
             return self._max_concurrent_embedding
         if queue_name == self.EXTERNAL_PARSE:
@@ -357,9 +360,12 @@ class QueueManager:
                 )
             if self._started:
                 self._start_queue_worker(self._queues[name])
-        elif self._started:
-            # Ensure existing queue has a worker running
-            self._start_queue_worker(self._queues[name])
+        else:
+            if dequeue_handler is not None:
+                self._queues[name].set_dequeue_handler(dequeue_handler)
+            if self._started:
+                # Ensure existing queue has a worker running
+                self._start_queue_worker(self._queues[name])
         return self._queues[name]
 
     # ========== Compatibility convenience methods ==========

--- a/openviking/storage/viking_fs.py
+++ b/openviking/storage/viking_fs.py
@@ -317,6 +317,9 @@ class VikingFS:
     Uses Rust binding mode: Use RAGFSBindingClient to directly use RAGFS implementation
     """
 
+    def set_user_deletion_guard(self, guard: Optional[Callable[[str, str], bool]]) -> None:
+        self._user_deletion_guard = guard
+
     def __init__(
         self,
         agfs: Any,
@@ -343,6 +346,7 @@ class VikingFS:
             "vikingfs_bound_ctx", default=None
         )
         self._background_tasks: set = set()
+        self._user_deletion_guard: Optional[Callable[[str, str], bool]] = None
 
     @staticmethod
     def _default_ctx() -> RequestContext:
@@ -428,6 +432,7 @@ class VikingFS:
     def _ensure_mutable_access(self, uri: str, ctx: Optional[RequestContext]) -> None:
         self._ensure_access(uri, ctx)
         real_ctx = self._ctx_or_default(ctx)
+        self._ensure_user_not_deleting(real_ctx)
         normalized_uri, _ = self._normalized_uri_parts(uri)
         if is_hidden_by_actor_peer_view(normalized_uri, real_ctx) or may_include_hidden_actor_peers(
             normalized_uri, real_ctx
@@ -443,6 +448,7 @@ class VikingFS:
     def _ensure_delete_access(self, uri: str, ctx: Optional[RequestContext]) -> None:
         self._ensure_access(uri, ctx)
         real_ctx = self._ctx_or_default(ctx)
+        self._ensure_user_not_deleting(real_ctx)
         normalized_uri, _ = self._normalized_uri_parts(uri)
         if is_hidden_by_actor_peer_view(normalized_uri, real_ctx) or may_include_hidden_actor_peers(
             normalized_uri, real_ctx
@@ -454,6 +460,14 @@ class VikingFS:
                 "Temp root is read-only for non-root users",
                 resource=normalized_uri,
             )
+
+    def _ensure_user_not_deleting(self, ctx: RequestContext) -> None:
+        if (
+            ctx.role != Role.ROOT
+            and self._user_deletion_guard is not None
+            and self._user_deletion_guard(ctx.account_id, ctx.user.user_id)
+        ):
+            raise FailedPreconditionError("User deletion is in progress")
 
     def _ensure_supported_delete_namespace(self, normalized_uri: str) -> None:
         parts = [p for p in normalized_uri[len("viking://") :].strip("/").split("/") if p]

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -1375,6 +1375,20 @@ class VikingVectorIndexBackend:
         root_backend = self._get_root_backend()
         return await root_backend.delete_by_filter(Eq("account_id", account_id))
 
+    async def delete_user_data(
+        self,
+        account_id: str,
+        user_id: str,
+        *,
+        ctx: RequestContext,
+    ) -> int:
+        """Delete every vector record owned by one user as ROOT."""
+        self._check_root_role(ctx)
+        root_backend = self._get_root_backend()
+        return await root_backend.delete_by_filter(
+            And([Eq("account_id", account_id), Eq("owner_user_id", user_id)])
+        )
+
     async def delete_uris(self, ctx: RequestContext, uris: List[str]) -> None:
         for uri in uris:
             canonical_uri = canonicalize_uri(uri, ctx)

--- a/tests/server/oauth/test_storage.py
+++ b/tests/server/oauth/test_storage.py
@@ -337,16 +337,53 @@ async def test_revoke_user_tokens_cascades(store):
         ttl_seconds=3600,
     )
     await _insert_code(store, "code-alice", account_id="acct", user_id="alice")
+    alice_pending = await store.create_pending_authorization(
+        client_id="cx",
+        redirect_uri="https://example/cb",
+        redirect_uri_provided_explicitly=True,
+        code_challenge="chal",
+        scopes=None,
+        resource=None,
+        state=None,
+        display_code="ALICE-1",
+    )
+    assert await store.mark_pending_verified(
+        pending_id=alice_pending,
+        account_id="acct",
+        user_id="alice",
+        role="user",
+        verified_key_fp=_FP,
+    )
+    bob_pending = await store.create_pending_authorization(
+        client_id="cx",
+        redirect_uri="https://example/cb",
+        redirect_uri_provided_explicitly=True,
+        code_challenge="chal",
+        scopes=None,
+        resource=None,
+        state=None,
+        display_code="BOB-1",
+    )
+    assert await store.mark_pending_verified(
+        pending_id=bob_pending,
+        account_id="acct",
+        user_id="bob",
+        role="user",
+        verified_key_fp=_FP_OTHER,
+    )
 
     counts = await store.revoke_user_tokens(account_id="acct", user_id="alice")
     assert counts["access_tokens_revoked"] == 1
     assert counts["refresh_tokens_revoked"] == 1
     assert counts["codes_revoked"] == 1
+    assert counts["pending_authorizations_revoked"] == 1
 
     # Alice's everything dead, Bob's untouched.
     assert await store.load_access("at-1") is None
     assert await store.load_access("at-other") is not None
     assert await store.consume_auth_code("code-alice") is None
+    assert await store.load_pending_authorization(alice_pending) is None
+    assert await store.load_pending_authorization(bob_pending) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -28,6 +28,7 @@ from openviking.service.task_store import (
     SYSTEM_TASK_ACCOUNT_ID,
     SYSTEM_TASK_USER_ID,
 )
+from openviking.service.task_tracker import get_task_tracker
 from openviking.service.user_deletion import setup_user_deletion
 from openviking_cli.exceptions import OpenVikingError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
@@ -640,7 +641,7 @@ async def test_remove_user(
     admin_service: OpenVikingService,
     admin_app: FastAPI,
 ):
-    """Deletion revokes the user, settles their work, and removes private data."""
+    """Deletion revokes the user and removes their private data and task records."""
     acct = _uid()
     await admin_client.post(
         "/api/v1/admin/accounts",
@@ -656,6 +657,12 @@ async def test_remove_user(
     bob_ctx = RequestContext(user=UserIdentifier(acct, "bob"), role=Role.USER)
     private_uri = "viking://user/bob/memories/private.md"
     await admin_service.viking_fs.write_file(private_uri, "private", ctx=bob_ctx)
+    bob_task = await get_task_tracker().create(
+        "session_commit",
+        resource_id="bob-session",
+        account_id=acct,
+        user_id="bob",
+    )
     resp = await admin_client.delete(
         f"/api/v1/admin/accounts/{acct}/users/bob", headers=root_headers()
     )
@@ -673,6 +680,14 @@ async def test_remove_user(
     assert deletion_task["status"] == "completed"
     assert not await admin_service.viking_fs.exists(private_uri, ctx=bob_ctx)
     assert not admin_app.state.api_key_manager.has_user(acct, "bob")
+    assert (
+        await get_task_tracker().get(
+            bob_task.task_id,
+            account_id=acct,
+            user_id="bob",
+        )
+        is None
+    )
 
     missing = await admin_client.delete(
         f"/api/v1/admin/accounts/{acct}/users/bob",

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -28,6 +28,7 @@ from openviking.service.task_store import (
     SYSTEM_TASK_ACCOUNT_ID,
     SYSTEM_TASK_USER_ID,
 )
+from openviking.service.user_deletion import setup_user_deletion
 from openviking_cli.exceptions import OpenVikingError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -175,6 +176,11 @@ async def admin_app(admin_service):
     manager = APIKeyManager(root_key=ROOT_KEY, viking_fs=admin_service.viking_fs)
     await manager.load()
     app.state.api_key_manager = manager
+    app.state.user_deletion_service = await setup_user_deletion(
+        service=admin_service,
+        manager=manager,
+        shared_upload_prefix=config.temp_upload.shared_prefix,
+    )
 
     # Set auth plugin (lifespan not triggered in ASGI tests)
     registry = get_registry()
@@ -629,8 +635,12 @@ async def test_list_users(admin_client: httpx.AsyncClient):
     assert user_ids == {"alice", "bob"}
 
 
-async def test_remove_user(admin_client: httpx.AsyncClient):
-    """ROOT can remove a user."""
+async def test_remove_user(
+    admin_client: httpx.AsyncClient,
+    admin_service: OpenVikingService,
+    admin_app: FastAPI,
+):
+    """Deletion revokes the user, settles their work, and removes private data."""
     acct = _uid()
     await admin_client.post(
         "/api/v1/admin/accounts",
@@ -643,18 +653,32 @@ async def test_remove_user(admin_client: httpx.AsyncClient):
         headers=root_headers(),
     )
     bob_key = resp.json()["result"]["user_key"]
-
+    bob_ctx = RequestContext(user=UserIdentifier(acct, "bob"), role=Role.USER)
+    private_uri = "viking://user/bob/memories/private.md"
+    await admin_service.viking_fs.write_file(private_uri, "private", ctx=bob_ctx)
     resp = await admin_client.delete(
         f"/api/v1/admin/accounts/{acct}/users/bob", headers=root_headers()
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 202
+    task_id = resp.json()["result"]["task_id"]
 
-    # Bob's key should be invalid now
+    # The fence invalidates Bob before background cleanup finishes.
     resp = await admin_client.get(
         "/api/v1/fs/ls?uri=viking://",
         headers={"X-API-Key": bob_key},
     )
     assert resp.status_code == 401
+
+    deletion_task = await _wait_for_task(admin_client, task_id)
+    assert deletion_task["status"] == "completed"
+    assert not await admin_service.viking_fs.exists(private_uri, ctx=bob_ctx)
+    assert not admin_app.state.api_key_manager.has_user(acct, "bob")
+
+    missing = await admin_client.delete(
+        f"/api/v1/admin/accounts/{acct}/users/bob",
+        headers=root_headers(),
+    )
+    assert missing.status_code == 404
 
 
 # ---- Role management ----

--- a/tests/server/test_api_key_manager.py
+++ b/tests/server/test_api_key_manager.py
@@ -234,20 +234,36 @@ async def test_register_user_in_nonexistent_account_raises(manager: APIKeyManage
         await manager.register_user("nonexistent", "bob", "user")
 
 
-async def test_remove_user(manager: APIKeyManager):
-    """Removing user should invalidate their key."""
+async def test_user_deletion_fence_revokes_key_and_rejects_stale_finish(
+    manager: APIKeyManager,
+):
     acct = _uid()
     await manager.create_account(acct, "alice")
     bob_key = await manager.register_user(acct, "bob", "user")
 
-    identity = manager.resolve(bob_key)
-    assert identity.user_id == "bob"
+    deletion, created = await manager.begin_user_deletion(
+        acct,
+        "bob",
+        task_id="delete-1",
+        owner_account_id=acct,
+        owner_user_id="alice",
+    )
 
-    await manager.remove_user(acct, "bob")
+    assert created is True
+    assert deletion["task_id"] == "delete-1"
+    assert manager.is_user_deleting(acct, "bob")
     with pytest.raises(UnauthenticatedError):
         manager.resolve(bob_key)
+    with pytest.raises(AlreadyExistsError):
+        await manager.register_user(acct, "bob", "user")
+    assert await manager.finish_user_deletion(acct, "bob", "stale") is False
+    assert manager.has_user(acct, "bob")
+    assert await manager.finish_user_deletion(acct, "bob", "delete-1") is True
+    assert not manager.has_user(acct, "bob")
 
-
+    new_key = await manager.register_user(acct, "bob", "user")
+    assert await manager.finish_user_deletion(acct, "bob", "delete-1") is False
+    assert manager.resolve(new_key).user_id == "bob"
 async def test_regenerate_key(manager: APIKeyManager):
     """Regenerating key should invalidate old key and return new valid key."""
     acct = _uid()
@@ -286,8 +302,14 @@ async def test_get_user_key_fingerprint_changes_on_rotation(manager: APIKeyManag
     assert fp2 is not None
     assert fp2 != fp1
 
-    # Removal → no fp at all.
-    await manager.remove_user(acct, "bob")
+    # Deletion fence immediately removes the fingerprint.
+    await manager.begin_user_deletion(
+        acct,
+        "bob",
+        task_id="delete-1",
+        owner_account_id=acct,
+        owner_user_id="alice",
+    )
     assert manager.get_user_key_fingerprint(acct, "bob") is None
 
 
@@ -941,7 +963,14 @@ async def test_reload_reflects_removed_user(manager_service):
     # Reader accepts bob at first.
     assert reader.resolve(user_key).user_id == "bob"
 
-    await writer.remove_user(acct, "bob")
+    await writer.begin_user_deletion(
+        acct,
+        "bob",
+        task_id="delete-1",
+        owner_account_id=acct,
+        owner_user_id="alice",
+    )
+    await writer.finish_user_deletion(acct, "bob", "delete-1")
     await reader.reload()
 
     with pytest.raises(UnauthenticatedError):


### PR DESCRIPTION
## Description

删除用户接口改为先同步撤销身份，再通过单并发持久队列异步清理用户数据。实现直接复用当前 `main` 已有的 TaskTracker 取消、等待和 QueueFS 工作索引，不引入新的任务取消机制。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3660

替代已关闭的 #3578。

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 持久化用户删除栅栏并立即撤销认证凭据；重复删除、失败重试和服务重启均复用或恢复对应清理任务。
- 停止用户 Watch，使用现有 TaskTracker 取消并等待用户任务，删除对应任务记录，然后清理 AGFS、孤立向量记录、共享上传、OAuth 及 Usage/Audit 数据，最后删除用户注册信息。
- 在认证与 VikingFS 写入边界阻止删除中的用户继续访问或产生数据；仅改写已有测试，没有新增测试文件、测试函数或参数化 Case。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已验证：

- 改写后的 5 个既有用户删除、API Key 和 OAuth 契约测试，以及 44 个既有 TaskTracker 测试通过。
- `check_no_new_tests.py --base origin/main` 通过，测试函数与静态 Case 数未增加。
- Ruff、Python `compileall` 和 `git diff --check` 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本 PR 基于当前 `main` 重新实现用户删除与数据清理，不包含旧 PR 中已经被主干重构替代的任务取消代码。
