### PR TITLE
fix(parse): markdown YAML frontmatter 被静默丢弃

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -177,12 +177,15 @@ class MarkdownParser(BaseParser):
         Initialize the enhanced markdown parser.
 
         Args:
-            extract_frontmatter: Whether to extract YAML frontmatter. When None, uses config.
+            extract_frontmatter: Whether to REMOVE YAML frontmatter from the stored
+                document body. Frontmatter is parsed into the parse result metadata
+                either way. Defaults to False (lossless ingestion); when None, uses
+                config.
             config: Parser configuration (uses default if None)
         """
         self.config = config or ParserConfig()
         if extract_frontmatter is None:
-            extract_frontmatter = getattr(self.config, "extract_frontmatter", True)
+            extract_frontmatter = getattr(self.config, "extract_frontmatter", False)
         self.extract_frontmatter = extract_frontmatter
 
         # Compile regex patterns for better performance
@@ -369,11 +372,16 @@ class MarkdownParser(BaseParser):
         meta: Dict[str, Any] = {}
         warnings: List[str] = []
 
-        # Extract frontmatter if present
+        # Frontmatter is ALWAYS parsed into ``meta`` (it drives doc_title below), but
+        # it is only removed from the stored body when explicitly configured.
+        # ``meta`` is transient — it is returned in the parse result and never written
+        # to VikingFS — so stripping by default silently destroyed the frontmatter of
+        # every ingested markdown file with no way to read those fields back.
+        stripped_content, frontmatter = self._extract_frontmatter(content)
+        if frontmatter:
+            meta["frontmatter"] = frontmatter
         if self.extract_frontmatter:
-            content, frontmatter = self._extract_frontmatter(content)
-            if frontmatter:
-                meta["frontmatter"] = frontmatter
+            content = stripped_content
 
         explicit_name = kwargs.get("resource_name")
         if not explicit_name and kwargs.get("source_name"):

--- a/openviking_cli/utils/config/parser_config.py
+++ b/openviking_cli/utils/config/parser_config.py
@@ -439,13 +439,16 @@ class MarkdownConfig(ParserConfig):
 
     Attributes:
         preserve_links: Whether to preserve hyperlinks in output
-        extract_frontmatter: Whether to extract YAML frontmatter
+        extract_frontmatter: Whether to REMOVE YAML frontmatter from the stored
+            document body. Frontmatter is parsed into the parse result metadata
+            regardless. Off by default: the parsed metadata is never persisted, so
+            removing the block would silently lose those fields.
         include_metadata: Whether to include file metadata
         max_heading_depth: Maximum heading depth to include in structure
     """
 
     preserve_links: bool = True
-    extract_frontmatter: bool = True
+    extract_frontmatter: bool = False
     include_metadata: bool = True
     max_heading_depth: int = 3
 

--- a/tests/parse/test_markdown_frontmatter.py
+++ b/tests/parse/test_markdown_frontmatter.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for YAML frontmatter handling in MarkdownParser.
+
+Frontmatter is parsed into ``ParseResult.meta`` but that metadata is never written
+to VikingFS, so removing the block from the stored body loses the fields for good.
+These tests pin the contract: parse always, remove only when explicitly configured.
+"""
+
+import pytest
+
+from openviking.parse.parsers.markdown import MarkdownParser
+from openviking_cli.utils.config.parser_config import MarkdownConfig, ParserConfig
+
+FRONTMATTER = """---
+id: stuck-pr-watch
+name: PR watch
+---
+"""
+
+BODY = """
+# Guide
+
+body text
+"""
+
+DOCUMENT = FRONTMATTER + BODY
+
+
+def _written(layout) -> list[str]:
+    return [op.content for op in layout.ops if op.kind == "write"]
+
+
+@pytest.mark.asyncio
+async def test_frontmatter_is_kept_in_stored_body_by_default() -> None:
+    layout = await MarkdownParser()._compute_layout(
+        DOCUMENT, "viking://temp/test", source_path="/tmp/stuck-pr-watch.md"
+    )
+
+    assert _written(layout) == [DOCUMENT]
+    assert layout.meta["frontmatter"] == {"id": "stuck-pr-watch", "name": "PR watch"}
+
+
+@pytest.mark.asyncio
+async def test_frontmatter_is_kept_when_config_omits_the_option() -> None:
+    # The registry passes a bare ParserConfig when no [parsers.markdown] section
+    # exists; that must not silently enable removal.
+    layout = await MarkdownParser(config=ParserConfig())._compute_layout(
+        DOCUMENT, "viking://temp/test", source_path="/tmp/stuck-pr-watch.md"
+    )
+
+    assert _written(layout) == [DOCUMENT]
+    assert layout.meta["frontmatter"] == {"id": "stuck-pr-watch", "name": "PR watch"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "parser",
+    [
+        MarkdownParser(extract_frontmatter=True),
+        MarkdownParser(config=MarkdownConfig(extract_frontmatter=True)),
+    ],
+)
+async def test_frontmatter_is_removed_only_when_explicitly_requested(
+    parser: MarkdownParser,
+) -> None:
+    layout = await parser._compute_layout(
+        DOCUMENT, "viking://temp/test", source_path="/tmp/stuck-pr-watch.md"
+    )
+
+    assert _written(layout) == [BODY]
+    assert layout.meta["frontmatter"] == {"id": "stuck-pr-watch", "name": "PR watch"}
+
+
+@pytest.mark.asyncio
+async def test_frontmatter_title_still_names_the_document_when_kept() -> None:
+    document = "---\ntitle: Release Notes\n---\n\n# Guide\n\nbody text\n"
+
+    layout = await MarkdownParser()._compute_layout(
+        document, "viking://temp/test", source_path="/tmp/whatever.md"
+    )
+
+    assert layout.doc_title == "Release Notes"
+    assert _written(layout) == [document]


### PR DESCRIPTION
## 问题

导入任何带 YAML frontmatter 的 markdown，`---` 块会被整块删掉，而且删掉之后没有任何地方能读回那些字段。

复现（v0.4.11，对着 main 31e01c58 也一样）：

```bash
printf -- '---\nid: demo\nwindow:\n  timezone: Asia/Shanghai\n---\n\n# 指引\n\nbody text here\n' > demo.md
ov add-resource ./demo.md --to viking://demo.md --wait
ov get viking://demo.md ./roundtrip.md
```

120 字节进去，22 字节出来。`ov read` 和 `ov get` 拿到的正文是 `\n# 指引\n\nbody text here\n`，frontmatter 没了。

## 为什么是数据丢失而不是「CLI 少个入口」

frontmatter 确实被解析进了 `meta["frontmatter"]`，但 `meta` 只活在 parse result 里，从来没写进 VikingFS：

- `openviking/parse/parsers/markdown.py:372-379` 用剥掉 frontmatter 的 `content` 去生成写入操作
- `openviking/utils/resource_processor.py:223` 把 `meta` 放进结果，但 `275-285` 做 finalize 时只传 `parse_result.temp_dir_path`，`meta` 没有落盘
- `openviking_cli/` 里没有任何地方读 `result["meta"]`
- 目录导入更彻底：`openviking/parse/parsers/directory.py:383-404` 只用每个子文件的 `temp_dir_path`，frontmatter 连 API 响应都到不了

唯一用到解析结果的是 `markdown.py:383` 拿 `title` 决定资源名。也就是说除了 `title:`，其他字段解析完就丢。

## 改法

把「解析」和「从正文里删掉」拆开：frontmatter 永远解析进 `meta`（`title:` 命名的行为不变），只有显式配置时才从存储正文里删除，且这个删除默认关闭。

- `markdown.py:372-383` 拆分解析与剥离
- `markdown.py:186` 构造函数默认值 `True` → `False`
- `parser_config.py:448` `MarkdownConfig.extract_frontmatter` 默认 `True` → `False`，docstring 写清楚这个开关的含义是「从正文里移除」，不是「是否解析」

#3475 已经把这个开关从写死改成读配置，这里接着把默认值改成不丢数据的那一侧，语义和那个 PR 描述里「`extract_frontmatter = false` 用来保留正文里的 frontmatter」是一致的。

## 取舍，请 maintainer 定夺

改默认值意味着以后所有 markdown 导入，frontmatter 会留在正文里，也就会进向量文本。这是无损导入想要的结果，但确实是行为变更。

另一条路是保留剥离、另外做一个能持久化的 metadata 面（`ov stat` 目前只有 name/size/mode/modTime/isDir/isLocked，VikingFS 也没有 per-resource metadata 存储），改动面大得多。要是你们更倾向那条路，这个 PR 可以只留测试，实现我按你们的方向重做。

`_extract_frontmatter` 里那个按 `line.split(":", 1)` 的朴素解析我没动：正文保住之后它的扁平化不再丢东西，换成 `yaml.safe_load` 会扩大 diff、也会改变 `meta` 的形状。

## 测试

新增 `tests/parse/test_markdown_frontmatter.py`，仿 `tests/parse/test_markdown_no_split.py` 的写法直接驱动 `_compute_layout` 断言写入操作，四个用例：默认保留、裸 `ParserConfig`（registry 里没有 `[parsers.markdown]` 段的路径）也保留、显式 `extract_frontmatter=True` 时才移除且 `meta["frontmatter"]` 始终有值、保留时 `title:` 仍然决定文档名。

在改动前的代码上这些用例会按预期失败。