### PR TITLE
feat(web-studio): group skills by scope

### DIFF
--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -128,6 +128,7 @@ const workspace = {
       'Could not connect to the OpenViking service. Check the server URL and connection status.',
     connectionSettings: 'Open connection settings',
     detail: 'Details',
+    openPlayground: 'Open in Playground',
     viewDetail: 'View {{name}} details',
     detailLoading: 'Loading skill details...',
     detailLoadFailed: 'Could not load skill details',

--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -119,7 +119,10 @@ const workspace = {
     loading: 'Loading skills...',
     empty: 'No skills available',
     emptyDescription:
-      'User and shared skills will appear here after they are added.',
+      'User and shared skills will appear in separate tabs after they are added.',
+    emptyScope: 'No {{scope}} available',
+    emptyScopeDescription:
+      'Skills in this scope will appear here after they are added.',
     loadFailed: 'Could not load skills',
     networkError:
       'Could not connect to the OpenViking service. Check the server URL and connection status.',
@@ -145,6 +148,11 @@ const workspace = {
     scopes: {
       user: 'User skill',
       agent: 'Shared skill',
+    },
+    tabs: {
+      agent: 'Shared skills',
+      label: 'Skill scope',
+      user: 'User skills',
     },
   },
   tasksPage: {

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -116,7 +116,9 @@ const workspace = {
     refresh: '刷新',
     loading: '正在加载技能...',
     empty: '暂无可用技能',
-    emptyDescription: '添加技能后，会在这里按用户技能和共享技能统一展示。',
+    emptyDescription: '添加技能后，会按用户技能和共享技能分开展示。',
+    emptyScope: '暂无{{scope}}',
+    emptyScopeDescription: '添加对应作用域的技能后，会在这里展示。',
     loadFailed: '技能加载失败',
     networkError: '无法连接 OpenViking 服务，请检查服务地址和连接状态。',
     connectionSettings: '打开连接设置',
@@ -141,6 +143,11 @@ const workspace = {
     scopes: {
       user: '用户技能',
       agent: '共享技能',
+    },
+    tabs: {
+      agent: '共享技能',
+      label: '技能作用域',
+      user: '用户技能',
     },
   },
   tasksPage: {

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -123,6 +123,7 @@ const workspace = {
     networkError: '无法连接 OpenViking 服务，请检查服务地址和连接状态。',
     connectionSettings: '打开连接设置',
     detail: '详情',
+    openPlayground: '在 Playground 打开',
     viewDetail: '查看 {{name}} 详情',
     detailLoading: '正在加载技能详情...',
     detailLoadFailed: '技能详情加载失败',

--- a/web-studio/src/routes/skills/-components/skill-scope-tabs.test.tsx
+++ b/web-studio/src/routes/skills/-components/skill-scope-tabs.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import * as React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SkillScopeTabs, getSkillsForScope } from './skill-scope-tabs'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'tabs.user') return '用户技能'
+      if (key === 'tabs.agent') return '共享技能'
+      return key
+    },
+  }),
+}))
+
+afterEach(cleanup)
+
+describe('SkillScopeTabs', () => {
+  const skills = [
+    { name: 'user-reviewer', scope: 'user' as const },
+    { name: 'shared-planner', scope: 'agent' as const },
+  ]
+
+  it('filters skills by the selected scope', () => {
+    expect(getSkillsForScope(skills, 'user')).toEqual([skills[0]])
+    expect(getSkillsForScope(skills, 'agent')).toEqual([skills[1]])
+  })
+
+  it('shows counts and switches to the selected scope', () => {
+    const onScopeChange = vi.fn()
+
+    render(
+      <SkillScopeTabs
+        activeScope="user"
+        skills={skills}
+        onScopeChange={onScopeChange}
+      />,
+    )
+
+    const userTab = screen.getByRole('tab', { name: /用户技能1/ })
+    const sharedTab = screen.getByRole('tab', { name: /共享技能1/ })
+
+    expect(userTab.getAttribute('aria-selected')).toBe('true')
+    expect(sharedTab.getAttribute('aria-selected')).toBe('false')
+
+    fireEvent.click(sharedTab)
+
+    expect(onScopeChange).toHaveBeenCalledWith('agent')
+  })
+})

--- a/web-studio/src/routes/skills/-components/skill-scope-tabs.tsx
+++ b/web-studio/src/routes/skills/-components/skill-scope-tabs.tsx
@@ -7,6 +7,11 @@ export type SkillScope = 'agent' | 'user'
 
 const SKILL_SCOPES: SkillScope[] = ['user', 'agent']
 
+export const SKILL_SCOPE_ICONS = {
+  agent: UsersRoundIcon,
+  user: UserRoundIcon,
+} satisfies Record<SkillScope, typeof UserRoundIcon>
+
 export function getSkillsForScope<T extends { scope: SkillScope }>(
   skills: T[],
   scope: SkillScope,
@@ -32,7 +37,7 @@ export function SkillScopeTabs({
       role="tablist"
     >
       {SKILL_SCOPES.map((scope) => {
-        const ScopeIcon = scope === 'user' ? UserRoundIcon : UsersRoundIcon
+        const ScopeIcon = SKILL_SCOPE_ICONS[scope]
 
         return (
           <Button

--- a/web-studio/src/routes/skills/-components/skill-scope-tabs.tsx
+++ b/web-studio/src/routes/skills/-components/skill-scope-tabs.tsx
@@ -1,0 +1,61 @@
+import { UserRoundIcon, UsersRoundIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '#/components/ui/button'
+
+export type SkillScope = 'agent' | 'user'
+
+const SKILL_SCOPES: SkillScope[] = ['user', 'agent']
+
+export function getSkillsForScope<T extends { scope: SkillScope }>(
+  skills: T[],
+  scope: SkillScope,
+): T[] {
+  return skills.filter((skill) => skill.scope === scope)
+}
+
+export function SkillScopeTabs({
+  activeScope,
+  onScopeChange,
+  skills,
+}: {
+  activeScope: SkillScope
+  onScopeChange: (scope: SkillScope) => void
+  skills: { scope: SkillScope }[]
+}) {
+  const { t } = useTranslation('skillsPage')
+
+  return (
+    <div
+      aria-label={t('tabs.label')}
+      className="inline-flex w-fit gap-1 rounded-lg border bg-muted/30 p-1"
+      role="tablist"
+    >
+      {SKILL_SCOPES.map((scope) => {
+        const ScopeIcon = scope === 'user' ? UserRoundIcon : UsersRoundIcon
+
+        return (
+          <Button
+            key={scope}
+            id={`skills-${scope}-tab`}
+            type="button"
+            role="tab"
+            size="sm"
+            variant={activeScope === scope ? 'secondary' : 'ghost'}
+            aria-controls={`skills-${scope}-panel`}
+            aria-selected={activeScope === scope}
+            tabIndex={activeScope === scope ? 0 : -1}
+            className="min-w-28 gap-1.5"
+            onClick={() => onScopeChange(scope)}
+          >
+            <ScopeIcon />
+            {t(`tabs.${scope}`)}
+            <span className="text-xs text-muted-foreground">
+              {getSkillsForScope(skills, scope).length}
+            </span>
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web-studio/src/routes/skills/route.tsx
+++ b/web-studio/src/routes/skills/route.tsx
@@ -31,11 +31,15 @@ import {
 import { useAppConnection } from '#/hooks/use-app-connection'
 import { getOvResult, isOvClientError, ovClient } from '#/lib/ov-client'
 
+import {
+  SkillScopeTabs,
+  getSkillsForScope,
+} from './-components/skill-scope-tabs'
+import type { SkillScope } from './-components/skill-scope-tabs'
+
 export const Route = createFileRoute('/skills')({
   component: SkillsRoute,
 })
-
-type SkillScope = 'agent' | 'user'
 
 type SkillItem = {
   description: string
@@ -104,7 +108,10 @@ function stringArray(value: unknown): string[] {
     : []
 }
 
-function normalizeSkillDetail(value: unknown, fallback: SkillItem): SkillDetail {
+function normalizeSkillDetail(
+  value: unknown,
+  fallback: SkillItem,
+): SkillDetail {
   const detail = asRecord(value)
   const files = Array.isArray(detail?.files) ? detail.files : []
 
@@ -185,6 +192,11 @@ function SkillsRoute() {
     staleTime: 30_000,
   })
   const skills = skillsQuery.data ?? []
+  const [activeScope, setActiveScope] = React.useState<SkillScope>('user')
+  const visibleSkills = React.useMemo(
+    () => getSkillsForScope(skills, activeScope),
+    [activeScope, skills],
+  )
   const connectionUnavailable =
     isOvClientError(skillsQuery.error) &&
     skillsQuery.error.code === 'NETWORK_ERROR'
@@ -262,57 +274,94 @@ function SkillsRoute() {
           </div>
         </Card>
       ) : (
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {skills.map((skill) => {
-            const ScopeIcon =
-              skill.scope === 'user' ? UserRoundIcon : UsersRoundIcon
+        <div className="grid gap-4">
+          <SkillScopeTabs
+            activeScope={activeScope}
+            skills={skills}
+            onScopeChange={setActiveScope}
+          />
 
-            return (
-              <button
-                key={`${skill.scope}:${skill.uri}`}
-                type="button"
-                className="min-w-0 rounded-xl text-left outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
-                aria-label={t('viewDetail', { name: skill.name })}
-                onClick={() => setSelectedSkill(skill)}
-              >
-                <Card
-                  size="sm"
-                  className="h-full transition-colors hover:bg-muted/35"
-                >
-                  <CardHeader>
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex min-w-0 items-center gap-2.5">
-                        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                          <SparklesIcon className="size-4" />
-                        </div>
-                        <CardTitle className="truncate">{skill.name}</CardTitle>
-                      </div>
-                      <Badge variant="outline" className="gap-1 font-normal">
-                        <ScopeIcon />
-                        {t(`scopes.${skill.scope}`)}
-                      </Badge>
-                    </div>
-                    {skill.description ? (
-                      <CardDescription className="line-clamp-2 pt-1 leading-5">
-                        {skill.description}
-                      </CardDescription>
-                    ) : null}
-                  </CardHeader>
-                  <CardContent className="mt-auto">
-                    <div className="flex items-center justify-between gap-3">
-                      <code className="min-w-0 truncate text-xs text-muted-foreground">
-                        {skill.uri}
-                      </code>
-                      <span className="flex shrink-0 items-center gap-0.5 text-xs font-medium text-primary">
-                        {t('detail')}
-                        <ChevronRightIcon className="size-3.5" />
-                      </span>
-                    </div>
-                  </CardContent>
-                </Card>
-              </button>
-            )
-          })}
+          <div
+            id={`skills-${activeScope}-panel`}
+            aria-labelledby={`skills-${activeScope}-tab`}
+            role="tabpanel"
+          >
+            {visibleSkills.length === 0 ? (
+              <Card className="min-h-56 items-center justify-center px-6 text-center">
+                <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <SparklesIcon className="size-5" />
+                </div>
+                <div className="grid max-w-md gap-1">
+                  <p className="font-medium">
+                    {t('emptyScope', {
+                      scope: t(`scopes.${activeScope}`),
+                    })}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {t('emptyScopeDescription')}
+                  </p>
+                </div>
+              </Card>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {visibleSkills.map((skill) => {
+                  const ScopeIcon =
+                    skill.scope === 'user' ? UserRoundIcon : UsersRoundIcon
+
+                  return (
+                    <button
+                      key={`${skill.scope}:${skill.uri}`}
+                      type="button"
+                      className="min-w-0 rounded-xl text-left outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+                      aria-label={t('viewDetail', { name: skill.name })}
+                      onClick={() => setSelectedSkill(skill)}
+                    >
+                      <Card
+                        size="sm"
+                        className="h-full transition-colors hover:bg-muted/35"
+                      >
+                        <CardHeader>
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="flex min-w-0 items-center gap-2.5">
+                              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                                <SparklesIcon className="size-4" />
+                              </div>
+                              <CardTitle className="truncate">
+                                {skill.name}
+                              </CardTitle>
+                            </div>
+                            <Badge
+                              variant="outline"
+                              className="gap-1 font-normal"
+                            >
+                              <ScopeIcon />
+                              {t(`scopes.${skill.scope}`)}
+                            </Badge>
+                          </div>
+                          {skill.description ? (
+                            <CardDescription className="line-clamp-2 pt-1 leading-5">
+                              {skill.description}
+                            </CardDescription>
+                          ) : null}
+                        </CardHeader>
+                        <CardContent className="mt-auto">
+                          <div className="flex items-center justify-between gap-3">
+                            <code className="min-w-0 truncate text-xs text-muted-foreground">
+                              {skill.uri}
+                            </code>
+                            <span className="flex shrink-0 items-center gap-0.5 text-xs font-medium text-primary">
+                              {t('detail')}
+                              <ChevronRightIcon className="size-3.5" />
+                            </span>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
         </div>
       )}
 
@@ -322,7 +371,7 @@ function SkillsRoute() {
           if (!open) setSelectedSkill(null)
         }}
       >
-        <SheetContent className="gap-0 sm:max-w-2xl">
+        <SheetContent className="gap-0 data-[side=right]:sm:max-w-3xl">
           <SheetHeader className="border-b px-6 py-5">
             <div className="flex items-center gap-2 pr-10">
               <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">

--- a/web-studio/src/routes/skills/route.tsx
+++ b/web-studio/src/routes/skills/route.tsx
@@ -3,12 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import { Link, createFileRoute } from '@tanstack/react-router'
 import {
   ChevronRightIcon,
+  ExternalLinkIcon,
   FileCode2Icon,
   LoaderCircleIcon,
   RefreshCwIcon,
   SparklesIcon,
   UserRoundIcon,
-  UsersRoundIcon,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -32,6 +32,7 @@ import { useAppConnection } from '#/hooks/use-app-connection'
 import { getOvResult, isOvClientError, ovClient } from '#/lib/ov-client'
 
 import {
+  SKILL_SCOPE_ICONS,
   SkillScopeTabs,
   getSkillsForScope,
 } from './-components/skill-scope-tabs'
@@ -305,8 +306,7 @@ function SkillsRoute() {
             ) : (
               <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                 {visibleSkills.map((skill) => {
-                  const ScopeIcon =
-                    skill.scope === 'user' ? UserRoundIcon : UsersRoundIcon
+                  const ScopeIcon = SKILL_SCOPE_ICONS[skill.scope]
 
                   return (
                     <button
@@ -381,9 +381,29 @@ function SkillsRoute() {
                 {selectedSkill?.name}
               </SheetTitle>
             </div>
-            <SheetDescription className="truncate font-mono text-xs">
-              {selectedSkill?.uri}
-            </SheetDescription>
+            <div className="flex items-center gap-2 pr-10">
+              <SheetDescription className="min-w-0 flex-1 truncate font-mono text-xs">
+                {selectedSkill?.uri}
+              </SheetDescription>
+              {selectedSkill ? (
+                <Button
+                  render={
+                    <Link
+                      rel="noreferrer noopener"
+                      search={{ uri: selectedSkill.uri }}
+                      target="_blank"
+                      to="/playground"
+                    />
+                  }
+                  nativeButton={false}
+                  size="xs"
+                  variant="outline"
+                >
+                  {t('openPlayground')}
+                  <ExternalLinkIcon />
+                </Button>
+              ) : null}
+            </div>
           </SheetHeader>
 
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">


### PR DESCRIPTION
## Description

Separate user and shared skills in Web Studio so skills with the same name are no longer mixed in one list. The skill detail drawer is also aligned with other detail drawers and can open the selected skill directly in Playground.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add user/shared skill tabs with per-scope counts, filtering, and empty states.
- Match the skill detail drawer width with other Web Studio detail drawers.
- Add an Open in Playground action and centralize skill-scope icon metadata.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `pnpm test` (40 files, 129 tests passed)
- `pnpm lint`
- `pnpm build`
- Browser verification at `http://127.0.0.1:3000/skills`: opened a skill detail, clicked Open in Playground, and confirmed the new tab targeted the selected skill URI with no console errors.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

UI behavior was verified locally in Web Studio; screenshots are not attached to this PR.

## Additional Notes

- No documentation update is required for this UI-only change.
- No dependent changes are required.
- The existing Vite chunk-size warning remains unchanged.
