### PR TITLE
fix(memory): offload fuzzy patch work from event loop

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -21,7 +21,7 @@ from openviking.session.memory.dataclass import (
     StoredLink,
 )
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
-from openviking.session.memory.merge_op import MergeOp
+from openviking.session.memory.merge_op import FieldType, MergeOp, PatchOp
 from openviking.session.memory.schema_model_generator import SchemaModelGenerator
 from openviking.session.memory.tools import (
     MEMORY_TOOLS_REGISTRY,
@@ -293,7 +293,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         tracer.info(f"Extended max_iterations to {max_iterations} for refetch")
 
                     continue
-                patch_errors = self._validate_patch_operations(final_operations)
+                patch_errors = await self._validate_patch_operations(final_operations)
                 if patch_errors and patch_repair_count == 0:
                     patch_repair_count += 1
                     max_iterations += 1
@@ -779,11 +779,14 @@ The final output of the model must strictly follow the JSON Schema format shown 
             f"{skeleton}"
         )
 
-    def _validate_patch_operations(self, operations: ResolvedOperations) -> List[Dict[str, Any]]:
+    async def _validate_patch_operations(
+        self,
+        operations: ResolvedOperations,
+    ) -> List[Dict[str, Any]]:
         from openviking.session.memory.merge_op.base import SearchReplaceBlock, StrPatch
-        from openviking.session.memory.merge_op.patch_handler import apply_str_patch
 
         errors = []
+        patch_op = PatchOp(FieldType.STRING)
         read_files = self.context_provider.read_file_contents or {}
         for operation in operations.upsert_operations:
             if operation.old_memory_file_content is None:
@@ -806,7 +809,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     continue
                 patch = StrPatch(blocks=blocks)
                 try:
-                    applied_content = apply_str_patch(current_content, patch)
+                    applied_content = await patch_op.apply(current_content, patch)
                 except Exception:
                     applied_content = current_content
                 if applied_content != current_content:

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -1082,7 +1082,7 @@ class MemoryUpdater:
                     # Use merge_op to process field value
                     merge_op = MergeOpFactory.from_field(field)
                     try:
-                        new_value = merge_op.apply(current_value, patch_value)
+                        new_value = await merge_op.apply(current_value, patch_value)
                     except Exception as e:
                         tracer.info(
                             f"[memory_updater] Skipping field update after merge_op failure: uri={uri}, field={field.name}, error={e}"

--- a/openviking/session/memory/merge_op/base.py
+++ b/openviking/session/memory/merge_op/base.py
@@ -132,7 +132,7 @@ class MergeOpBase(ABC):
         pass
 
     @abstractmethod
-    def apply(self, current_value: Any, patch_value: Any) -> Any:
+    async def apply(self, current_value: Any, patch_value: Any) -> Any:
         """Apply this merge operation.
 
         Args:

--- a/openviking/session/memory/merge_op/immutable.py
+++ b/openviking/session/memory/merge_op/immutable.py
@@ -25,7 +25,7 @@ class ImmutableOp(MergeOpBase):
     def get_output_schema_description(self, field_description: str) -> str:
         return f"Immutable field '{field_description}' - can only be set once, cannot be modified"
 
-    def apply(self, current_value: Any, patch_value: Any) -> Any:
+    async def apply(self, current_value: Any, patch_value: Any) -> Any:
         if current_value is None:
             return patch_value
         # Keep current value if already set

--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -4,6 +4,7 @@
 Patch merge operation - SEARCH/REPLACE for strings, direct replace for others.
 """
 
+import asyncio
 from typing import Any, Type
 
 from openviking.session.memory.merge_op.base import (
@@ -34,7 +35,7 @@ class PatchOp(MergeOpBase):
             return f"PATCH operation for '{field_description}'. Follow the shared SEARCH/REPLACE rules above."
         return f"Replace value for '{field_description}'"
 
-    def apply(self, current_value: Any, patch_value: Any) -> Any:
+    async def apply(self, current_value: Any, patch_value: Any) -> Any:
         """
         Apply patch operation.
 
@@ -69,7 +70,11 @@ class PatchOp(MergeOpBase):
             # against non-empty content), so skip those blocks.
             valid_blocks = [b for b in patch_value.blocks if b.search]
             if valid_blocks:
-                return apply_str_patch(current_str, StrPatch(blocks=valid_blocks))
+                return await asyncio.to_thread(
+                    apply_str_patch,
+                    current_str,
+                    StrPatch(blocks=valid_blocks),
+                )
             # All blocks have empty search → no valid patches, keep original
             return current_value
 
@@ -91,7 +96,11 @@ class PatchOp(MergeOpBase):
                     return str(patch_value) if patch_value is not None else ""
 
                 if converted_patch is not None:
-                    return apply_str_patch(current_str, converted_patch)
+                    return await asyncio.to_thread(
+                        apply_str_patch,
+                        current_str,
+                        converted_patch,
+                    )
                 # All blocks have empty search → keep original
                 return current_value
 

--- a/openviking/session/memory/merge_op/replace.py
+++ b/openviking/session/memory/merge_op/replace.py
@@ -34,7 +34,7 @@ class ReplaceOp(MergeOpBase):
             "You must have read the current content first and incorporate it."
         )
 
-    def apply(self, current_value: Any, patch_value: Any) -> Any:
+    async def apply(self, current_value: Any, patch_value: Any) -> Any:
         if patch_value is None or patch_value == "":
             return current_value
         return patch_value

--- a/openviking/session/memory/merge_op/sum.py
+++ b/openviking/session/memory/merge_op/sum.py
@@ -25,7 +25,7 @@ class SumOp(MergeOpBase):
     def get_output_schema_description(self, field_description: str) -> str:
         return f"add for '{field_description}'"
 
-    def apply(self, current_value: Any, patch_value: Any) -> Any:
+    async def apply(self, current_value: Any, patch_value: Any) -> Any:
         # None 或空值保留原值
         if patch_value is None or patch_value == "":
             return current_value

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -768,7 +768,7 @@ async def merge_one_memory_type_operations(
             delete_replacements={},
         )
 
-    fast_path, fast_path_reason = classify_memory_merge_mode(operations, schema=schema)
+    fast_path, fast_path_reason = await classify_memory_merge_mode(operations, schema=schema)
     if fast_path:
         tracer.info(
             "[streaming_memory_updater] memory_type merge decision "
@@ -815,11 +815,17 @@ async def merge_one_memory_type_operations(
         )
     )
     patches = [
-        operation_to_patch(op, schema=schema, extract_context=extract_context) for op in operations
-    ] + [
+        await operation_to_patch(
+            op=op,
+            schema=schema,
+            extract_context=extract_context,
+        )
+        for op in operations
+    ]
+    patches.extend(
         memory_file_to_delete_patch(df, schema=schema, extract_context=extract_context)
         for df in delete_files
-    ]
+    )
     provider = PatchMergeContextProvider(
         memory_type=memory_type,
         required_file_uris=required_file_uris,
@@ -935,14 +941,14 @@ def memory_file_to_delete_patch(
     )
 
 
-def operation_to_patch(
+async def operation_to_patch(
     op: ResolvedOperation,
     *,
     schema: MemoryTypeSchema,
     extract_context: ExtractContext,
 ) -> PatchMergePatch:
     old_file = getattr(op, "old_memory_file_content", None)
-    after_file = render_operation_after_file(
+    after_file = await render_operation_after_file(
         op,
         schema=schema,
         extract_context=extract_context,
@@ -953,13 +959,13 @@ def operation_to_patch(
     )
 
 
-def render_operation_after_file(
+async def render_operation_after_file(
     op: ResolvedOperation,
     *,
     schema: MemoryTypeSchema,
     extract_context: ExtractContext,
 ) -> MemoryFile:
-    after_content = render_operation_after_file_content(
+    after_content = await render_operation_after_file_content(
         op,
         schema=schema,
         extract_context=extract_context,
@@ -967,7 +973,7 @@ def render_operation_after_file(
     return MemoryFileUtils.read(after_content, uri=_first_uri(getattr(op, "uris", []) or []))
 
 
-def render_operation_after_file_content(
+async def render_operation_after_file_content(
     op: ResolvedOperation,
     *,
     schema: MemoryTypeSchema,
@@ -991,7 +997,7 @@ def render_operation_after_file_content(
         else:
             current_value = old_content.extra_fields.get(field_def.name)
         try:
-            metadata[field_def.name] = MergeOpFactory.from_field(field_def).apply(
+            metadata[field_def.name] = await MergeOpFactory.from_field(field_def).apply(
                 current_value,
                 metadata[field_def.name],
             )
@@ -1026,7 +1032,7 @@ def render_operation_after_file_content(
     )
 
 
-def classify_memory_merge_mode(
+async def classify_memory_merge_mode(
     operations: list[ResolvedOperation],
     *,
     schema: MemoryTypeSchema | None = None,
@@ -1062,7 +1068,7 @@ def classify_memory_merge_mode(
     old_plain_content = old_file.plain_content().strip()
     if schema is not None:
         try:
-            after_content = render_operation_after_file_content(
+            after_content = await render_operation_after_file_content(
                 op,
                 schema=schema,
                 extract_context=ExtractContext([]),

--- a/openviking/session/skill/skill_operation_updater.py
+++ b/openviking/session/skill/skill_operation_updater.py
@@ -96,7 +96,7 @@ class SkillOperationUpdater:
         skill_md_uri = operation.uris[0]
         root_uri = self._root_uri_from_skill_md(skill_md_uri)
         existing_skill = await self._load_existing_skill(skill_md_uri, ctx)
-        merged_skill = self._merge_skill(operation, existing_skill)
+        merged_skill = await self._merge_skill(operation, existing_skill)
 
         if existing_skill is None:
             processor_result = await self._skill_processor.process_skill(
@@ -135,7 +135,7 @@ class SkillOperationUpdater:
             "name": merged_skill["name"],
         }
 
-    def _merge_skill(
+    async def _merge_skill(
         self,
         operation: ResolvedOperation,
         existing_skill: Optional[Dict[str, Any]],
@@ -163,7 +163,7 @@ class SkillOperationUpdater:
             patch_value = operation.memory_fields[schema_field.name]
             target_key = self._target_skill_key(schema_field.name)
             current_value = skill.get(target_key)
-            skill[target_key] = merge_op.apply(current_value, patch_value)
+            skill[target_key] = await merge_op.apply(current_value, patch_value)
 
         if not skill["name"]:
             raise ValueError("Session skill operation is missing skill_name")

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -7,15 +7,15 @@ Tests for memory ExtractLoop orchestrator.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from openviking.session.memory.dataclass import (
     MemoryTypeSchema,
     ResolvedOperations,
 )
-from openviking.session.memory.schema_model_generator import SchemaModelGenerator
-
 from openviking.session.memory.extract_loop import (
     ExtractLoop,
 )
+from openviking.session.memory.schema_model_generator import SchemaModelGenerator
 
 
 class TestPreFetchFileFiltering:
@@ -205,7 +205,7 @@ class TestExtractLoopFinalJsonRetry:
         )
         extract_loop.resolve_operations = AsyncMock(return_value=(resolved, []))
         extract_loop._check_unread_existing_files = AsyncMock(return_value={})
-        extract_loop._validate_patch_operations = MagicMock(return_value=[])
+        extract_loop._validate_patch_operations = AsyncMock(return_value=[])
         extract_loop.finalize_operations = AsyncMock()
 
         await extract_loop.run()

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -1408,9 +1408,9 @@ class TestConsecutivePatchesSameURI:
         updater._get_viking_fs = MagicMock(return_value=mock_viking_fs)
 
         patch_op = MagicMock()
-        patch_op.apply.side_effect = ValueError("patch failed")
+        patch_op.apply = AsyncMock(side_effect=ValueError("patch failed"))
         replace_op = MagicMock()
-        replace_op.apply.return_value = "Updated Title"
+        replace_op.apply = AsyncMock(return_value="Updated Title")
 
         def mock_from_field(field):
             if field.name == "content":

--- a/tests/session/memory/test_merge_ops.py
+++ b/tests/session/memory/test_merge_ops.py
@@ -4,6 +4,9 @@
 Tests for MergeOp architecture - type-safe merge operations.
 """
 
+import asyncio
+import threading
+
 import pytest
 
 from openviking.session.memory.dataclass import (
@@ -76,29 +79,50 @@ class TestPatchOp:
         assert "Replace" in desc
         assert "score" in desc
 
-    def test_apply(self):
+    @pytest.mark.asyncio
+    async def test_apply(self):
         """PatchOp apply should just return the patch value."""
         op_str = PatchOp(FieldType.STRING)
-        assert op_str.apply("old", "new") == "new"
+        assert await op_str.apply("old", "new") == "new"
 
         op_int = PatchOp(FieldType.INT64)
-        assert op_int.apply(100, 200) == 200
+        assert await op_int.apply(100, 200) == 200
 
-    def test_apply_dict_patch(self):
-        """Dict-form string patches should be converted and applied."""
+    @pytest.mark.asyncio
+    async def test_apply_dict_patch(self, monkeypatch):
+        """Dict-form string patches should be applied without blocking the event loop."""
+        from openviking.session.memory.merge_op import patch_handler
+
         op = PatchOp(FieldType.STRING)
+        original_apply = patch_handler.apply_str_patch
+        loop_progressed = threading.Event()
+        merge_observed_progress = None
+
+        def apply_and_observe(current_value, patch_value):
+            nonlocal merge_observed_progress
+            merge_observed_progress = loop_progressed.wait(timeout=0.5)
+            return original_apply(current_value, patch_value)
+
+        monkeypatch.setattr(patch_handler, "apply_str_patch", apply_and_observe)
         patch = {"blocks": [{"search": "hello world", "replace": "hello there"}]}
 
-        assert op.apply("hello world", patch) == "hello there"
+        merge_task = asyncio.create_task(op.apply("hello world", patch))
+        await asyncio.sleep(0)
+        loop_progressed.set()
 
-    def test_apply_invalid_dict_patch_falls_back_to_string_replacement(self):
+        assert await merge_task == "hello there"
+        assert merge_observed_progress is True
+
+    @pytest.mark.asyncio
+    async def test_apply_invalid_dict_patch_falls_back_to_string_replacement(self):
         """Invalid dict-form patches should preserve the compatibility fallback."""
         op = PatchOp(FieldType.STRING)
         patch = {"blocks": [{"search": "hello world"}]}
 
-        assert op.apply("hello world", patch) == str(patch)
+        assert await op.apply("hello world", patch) == str(patch)
 
-    def test_apply_dict_patch_propagates_patch_parse_error(self):
+    @pytest.mark.asyncio
+    async def test_apply_dict_patch_propagates_patch_parse_error(self):
         """Patch errors raised after dict conversion must reach the caller."""
         op = PatchOp(FieldType.STRING)
         patch = {
@@ -106,8 +130,7 @@ class TestPatchOp:
         }
 
         with pytest.raises(PatchParseError, match="matched 2 locations"):
-            op.apply("status: pending\nstatus: pending", patch)
-
+            await op.apply("status: pending\nstatus: pending", patch)
 
 class TestSumOp:
     """Tests for SumOp."""
@@ -124,30 +147,35 @@ class TestSumOp:
         desc = op.get_output_schema_description("打分合")
         assert desc == "add for '打分合'"
 
-    def test_apply_both_int(self):
+    @pytest.mark.asyncio
+    async def test_apply_both_int(self):
         """Sum of two ints."""
         op = SumOp()
-        assert op.apply(10, 5) == 15
+        assert await op.apply(10, 5) == 15
 
-    def test_apply_both_float(self):
+    @pytest.mark.asyncio
+    async def test_apply_both_float(self):
         """Sum of two floats."""
         op = SumOp()
-        assert op.apply(10.5, 3.5) == 14.0
+        assert await op.apply(10.5, 3.5) == 14.0
 
-    def test_apply_mixed(self):
+    @pytest.mark.asyncio
+    async def test_apply_mixed(self):
         """Sum of int and float."""
         op = SumOp()
-        assert op.apply(10, 3.5) == 13.5
+        assert await op.apply(10, 3.5) == 13.5
 
-    def test_apply_current_none(self):
+    @pytest.mark.asyncio
+    async def test_apply_current_none(self):
         """Current is None should return patch."""
         op = SumOp()
-        assert op.apply(None, 10) == 10
+        assert await op.apply(None, 10) == 10
 
-    def test_apply_invalid_values(self):
+    @pytest.mark.asyncio
+    async def test_apply_invalid_values(self):
         """Invalid values should keep current."""
         op = SumOp()
-        assert op.apply("not a number", 10) == "not a number"
+        assert await op.apply("not a number", 10) == "not a number"
 
 
 class TestImmutableOp:
@@ -167,15 +195,17 @@ class TestImmutableOp:
         assert "name" in desc
         assert "can only be set once" in desc
 
-    def test_apply_current_none(self):
+    @pytest.mark.asyncio
+    async def test_apply_current_none(self):
         """Current is None should set to patch."""
         op = ImmutableOp()
-        assert op.apply(None, "new value") == "new value"
+        assert await op.apply(None, "new value") == "new value"
 
-    def test_apply_current_exists(self):
+    @pytest.mark.asyncio
+    async def test_apply_current_exists(self):
         """Current exists should keep current."""
         op = ImmutableOp()
-        assert op.apply("existing", "new value") == "existing"
+        assert await op.apply("existing", "new value") == "existing"
 
 
 class TestMergeOpFactory:

--- a/tests/session/memory/test_streaming_memory_updater.py
+++ b/tests/session/memory/test_streaming_memory_updater.py
@@ -179,7 +179,7 @@ def _peer_note_op(name: str, peer_id: str) -> ResolvedOperation:
     return op
 
 
-def test_operation_to_patch_omits_raw_operation_metadata():
+async def test_operation_to_patch_omits_raw_operation_metadata():
     schema = _registry().get("notes")
     old_file = MemoryFile(
         uri="viking://user/u/memories/notes/note.md",
@@ -199,13 +199,13 @@ def test_operation_to_patch_omits_raw_operation_metadata():
         },
     )
 
-    patch = operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
+    patch = await operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
 
     assert patch.metadata == {}
     assert patch.after_file.content == "new content"
 
 
-def test_operation_to_patch_raises_when_after_file_preview_rendering_fails(monkeypatch):
+async def test_operation_to_patch_raises_when_after_file_preview_rendering_fails(monkeypatch):
     schema = _registry().get("notes")
     op = _note_op("note_render_failure")
 
@@ -218,10 +218,10 @@ def test_operation_to_patch_raises_when_after_file_preview_rendering_fails(monke
     )
 
     with pytest.raises(RuntimeError, match="template render failed"):
-        operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
+        await operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
 
 
-def test_operation_to_patch_skips_failed_field_preview_update():
+async def test_operation_to_patch_skips_failed_field_preview_update():
     schema = MemoryTypeSchema(
         memory_type="notes",
         description="note memory",
@@ -270,7 +270,7 @@ def test_operation_to_patch_skips_failed_field_preview_update():
         },
     )
 
-    patch = operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
+    patch = await operation_to_patch(op, schema=schema, extract_context=ExtractContext([]))
 
     assert patch.after_file.content == "new content"
     assert patch.after_file.extra_fields["summary"] == "old summary"
@@ -877,17 +877,19 @@ async def test_streaming_memory_updater_applies_cross_group_links_after_all_grou
     assert peer_file.backlinks[0]["from_uri"] == self_op.uris[0]
 
 
-def test_classify_memory_merge_mode_forces_cross_extraction_merge():
+async def test_classify_memory_merge_mode_forces_cross_extraction_merge():
     op1 = _note_op_with_source("note_a", "extract_a")
     op2 = _note_op_with_source("note_b", "extract_b")
 
-    fast_path, reason = classify_memory_merge_mode([op1, op2], schema=_registry().get("notes"))
+    fast_path, reason = await classify_memory_merge_mode(
+        [op1, op2], schema=_registry().get("notes")
+    )
 
     assert fast_path is False
     assert reason == "cross_extraction_batch"
 
 
-def test_classify_memory_merge_mode_treats_noop_str_patch_as_unchanged():
+async def test_classify_memory_merge_mode_treats_noop_str_patch_as_unchanged():
     old_file = MemoryFile(
         uri="viking://user/u/memories/notes/note.md",
         content="old content",
@@ -906,13 +908,13 @@ def test_classify_memory_merge_mode_treats_noop_str_patch_as_unchanged():
         },
     )
 
-    fast_path, reason = classify_memory_merge_mode([op], schema=_registry().get("notes"))
+    fast_path, reason = await classify_memory_merge_mode([op], schema=_registry().get("notes"))
 
     assert fast_path is True
     assert reason == "single_existing_content_unchanged"
 
 
-def test_classify_memory_merge_mode_detects_changed_str_patch_after_preview():
+async def test_classify_memory_merge_mode_detects_changed_str_patch_after_preview():
     old_file = MemoryFile(
         uri="viking://user/u/memories/notes/note.md",
         content="old content",
@@ -931,7 +933,7 @@ def test_classify_memory_merge_mode_detects_changed_str_patch_after_preview():
         },
     )
 
-    fast_path, reason = classify_memory_merge_mode([op], schema=_registry().get("notes"))
+    fast_path, reason = await classify_memory_merge_mode([op], schema=_registry().get("notes"))
 
     assert fast_path is False
     assert reason == "single_existing_content_changed"
@@ -990,12 +992,12 @@ async def test_streaming_memory_updater_persists_source_extraction_id_trace_id_a
     assert "last_update_trace_id" not in read_result
 
 
-def test_render_operation_after_file_content_persists_source_trace_id():
+async def test_render_operation_after_file_content_persists_source_trace_id():
     schema = _registry().get("notes")
     op = _note_op("note_trace")
     op.source = MemoryOperationSource(extraction_id="extract_2", trace_id="trace_2")
 
-    rendered = render_operation_after_file_content(
+    rendered = await render_operation_after_file_content(
         op,
         schema=schema,
         extract_context=ExtractContext([]),


### PR DESCRIPTION
## Description

Session Commit 的记忆更新虽是异步任务，但字符串 PATCH 原本仍在 Server 事件循环线程执行。当精确 SEARCH 失败并进入 Levenshtein 模糊匹配时，CPU 计算会阻塞事件循环，导致其他请求超时。

本 PR 将 MergeOp 统一为异步接口，并在 `PatchOp` 内用 `asyncio.to_thread` 执行字符串 PATCH。调用方只需统一 `await`，无需各自判断是否切换线程。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 将 `MergeOpBase.apply` 及各实现改为异步接口。
- `PatchOp` 通过 `asyncio.to_thread` 执行 `apply_str_patch`。
- 更新 MemoryUpdater、ExtractLoop、StreamingMemoryUpdater 和 SkillOperationUpdater 的调用链及现有测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

### Session Commit A/B

使用相同火山配置、单 worker Server 和 244 行记忆，改前/改后各执行 3 次真实 Session Commit。测试通过零宽字符差异稳定触发非精确 SEARCH；每轮均确认目标记忆实际更新。

| 版本 | 有效更新 | 健康检查超时 | 最大延迟 | 任务轮询错误 |
| --- | ---: | ---: | ---: | ---: |
| 修改前 | 3/3 | 21 次 | ≥ 2002 ms | 4 次 |
| 修改后 | 3/3 | 0 次 | 205 ms | 0 次 |

自然情况下火山模型通常生成精确 SEARCH，不会进入该慢路径，因此自然样本不能用于验证本修复。

### 自动化测试

- 聚焦测试：`53 passed`
- Ruff、`git diff --check`：通过
- 相关四个测试文件：`88 passed, 14 failed`；失败均为现有 Fake/InMemory VikingFS 与 `lease_ref` 参数不匹配，本 PR 未修改该接口。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

`asyncio.to_thread` 解决的是事件循环阻塞，不会减少模糊匹配本身的 CPU 消耗。
