### PR TITLE
fix(storage): treat localfs read ENOENT as NotFound

### DIFF
--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -274,8 +274,8 @@ impl LocalFileSystem {
         Error::plugin(format!("failed to lock for {operation}: {error}"))
     }
 
-    /// Map local file read failures into stable filesystem error categories.
-    fn map_read_error(path: &str, error: std::io::Error) -> Error {
+    /// Map local file failures into stable filesystem error categories.
+    fn map_error(path: &str, error: std::io::Error) -> Error {
         if error.kind() == std::io::ErrorKind::NotFound {
             return Error::NotFound(path.to_string());
         }
@@ -964,7 +964,7 @@ impl FileSystem for LocalFileSystem {
         }
 
         // Read file
-        let data = fs::read(&local_path).map_err(|e| Self::map_read_error(path, e))?;
+        let data = fs::read(&local_path).map_err(|e| Self::map_error(path, e))?;
 
         // Apply offset and size
         let file_size = data.len() as u64;

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -274,6 +274,14 @@ impl LocalFileSystem {
         Error::plugin(format!("failed to lock for {operation}: {error}"))
     }
 
+    /// Map local file read failures into stable filesystem error categories.
+    fn map_read_error(path: &str, error: std::io::Error) -> Error {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Error::NotFound(path.to_string());
+        }
+        Error::plugin(format!("failed to read file: {}", error))
+    }
+
     /// Run blocking local filesystem work on a dedicated thread.
     async fn run_blocking_fs<T, F>(job: F) -> Result<T>
     where
@@ -956,8 +964,7 @@ impl FileSystem for LocalFileSystem {
         }
 
         // Read file
-        let data = fs::read(&local_path)
-            .map_err(|e| Error::plugin(format!("failed to read file: {}", e)))?;
+        let data = fs::read(&local_path).map_err(|e| Self::map_read_error(path, e))?;
 
         // Apply offset and size
         let file_size = data.len() as u64;


### PR DESCRIPTION
## Description

原本read 方法逻辑如下:
1. 先用 metadata() 判断“这个路径存不存在、是不是目录”
2. 这一步如果失败，就明确返回 Error::NotFound
3. 然后再做真正的 fs::read()
4. 这一步如果失败，代码直接统一包成了 Error::Plugin("failed to read file: ...")

但是在并发场景下却并不是原子的， 可能存在如下场景 ，A 线程 metadata()  判断存在，然后 B 线程删除了文件， A 线程再读就会发生ENOENT 报错， 被read()认为是Error::Plugin("failed to read file: ...")，从而阻塞上游任务

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made


- read方法中细分 plugin 错误，认为ENOENT等同于 NotFound
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
