### PR TITLE
feat(mcp): add write/edit/tree tools for viking:// as agent working directory

### DIFF
--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -129,7 +129,7 @@ If you already have HTTPS configured, just connect to `https://your-server.com/m
 
 ## Available MCP Tools
 
-Once connected, OpenViking exposes 14 tools:
+Once connected, OpenViking exposes 16 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
@@ -138,8 +138,10 @@ Once connected, OpenViking exposes 14 tools:
 | `recall` | Type-quota recall assembled server-side into flat `<memory>` blocks that always carry their URI | `query`, `quotas` (optional), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty` (optional), `session_id` (optional), `detail` (optional), `max_tokens` (optional), `rewrite` (optional) |
 | `read` | Read one or more `viking://` URIs | `uris` (single string or array) |
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |
+| `tree` | Show the recursive directory tree under a `viking://` URI, indented by depth — use when you need a full picture of the file tree (prefer `list` for a single level, `glob` for filename patterns) | `uri` (optional), `level_limit` (default 3), `node_limit` (default 1000), `include_abstract` (optional — also show each file's summary) |
 | `remember` | Store messages into long-term memory (triggers extraction) | `messages` (list of `{role, content}`) |
-| `write` | Write text to a `viking://` file (create/overwrite/append), or edit a file with exact string replacements. Parent directories are created automatically; use `read` first to see current content before overwriting or editing | `uri`, `content` (optional, full write), `mode` (optional: `replace` default — creates the file if missing, `append`, `create` — fail if it exists), `edits` (optional list of `{old_string, new_string, replace_all}`), `wait` (optional, block until re-indexed), `timeout` (optional) |
+| `write` | Write text to a `viking://` file (create/overwrite/append). Parent directories are created automatically; use `read` first to see current content before overwriting, and prefer `edit` for changing part of an existing file | `uri`, `content`, `mode` (optional: `replace` default — creates the file if missing, `append`, `create` — fail if it exists), `wait` (optional, block until re-indexed), `timeout` (optional) |
+| `edit` | Replace an exact string with new text in an existing `viking://` file — for targeted changes instead of a full rewrite. The file is left unchanged if `old_string` is not found, or matches multiple times while `replace_all` is false | `uri`, `old_string`, `new_string`, `replace_all` (optional), `wait` (optional, block until re-indexed), `timeout` (optional) |
 | `add_resource` | Add a local file or URL as a resource (local files trigger a progressive upload flow) | `path`, `temp_file_id` (optional), `description` (optional), `watch_interval` (optional, minutes — auto-refresh cadence for remote URLs), `processing_mode` (optional: `semantic_and_vectors` default, or `vectors_only` to skip VLM semantic understanding and only vectorize current files), `to` (optional, target `viking://resources/...` URI; if omitted when `watch_interval > 0`, the watch auto-binds to the resource's created URI), `args` (optional parser-specific options, including `{"parse_mode":"no_split"}` to parse each source document into one Markdown body, `{"feishu_access_token":"u-..."}` for one-time Feishu user-token imports, or `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}` for Feishu user-token watches) |
 | `list_watches` | List watch tasks (auto-refresh subscriptions) visible to the current agent. Each entry shows target URI, refresh interval (minutes), active/paused status, and next scheduled execution time | none |
 | `cancel_watch` | Cancel (delete) a watch task by its target URI. To change the cadence or pause temporarily, cancel and re-add with a new `watch_interval` | `to_uri` (must match the watch task's `to` value, e.g. `viking://resources/...`) |

--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -129,7 +129,7 @@ If you already have HTTPS configured, just connect to `https://your-server.com/m
 
 ## Available MCP Tools
 
-Once connected, OpenViking exposes 13 tools:
+Once connected, OpenViking exposes 14 tools:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
@@ -139,6 +139,7 @@ Once connected, OpenViking exposes 13 tools:
 | `read` | Read one or more `viking://` URIs | `uris` (single string or array) |
 | `list` | List entries under a `viking://` directory | `uri`, `recursive` (optional) |
 | `remember` | Store messages into long-term memory (triggers extraction) | `messages` (list of `{role, content}`) |
+| `write` | Write text to a `viking://` file (create/overwrite/append), or edit a file with exact string replacements. Parent directories are created automatically; use `read` first to see current content before overwriting or editing | `uri`, `content` (optional, full write), `mode` (optional: `replace` default — creates the file if missing, `append`, `create` — fail if it exists), `edits` (optional list of `{old_string, new_string, replace_all}`), `wait` (optional, block until re-indexed), `timeout` (optional) |
 | `add_resource` | Add a local file or URL as a resource (local files trigger a progressive upload flow) | `path`, `temp_file_id` (optional), `description` (optional), `watch_interval` (optional, minutes — auto-refresh cadence for remote URLs), `processing_mode` (optional: `semantic_and_vectors` default, or `vectors_only` to skip VLM semantic understanding and only vectorize current files), `to` (optional, target `viking://resources/...` URI; if omitted when `watch_interval > 0`, the watch auto-binds to the resource's created URI), `args` (optional parser-specific options, including `{"parse_mode":"no_split"}` to parse each source document into one Markdown body, `{"feishu_access_token":"u-..."}` for one-time Feishu user-token imports, or `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}` for Feishu user-token watches) |
 | `list_watches` | List watch tasks (auto-refresh subscriptions) visible to the current agent. Each entry shows target URI, refresh interval (minutes), active/paused status, and next scheduled execution time | none |
 | `cancel_watch` | Cancel (delete) a watch task by its target URI. To change the cadence or pause temporarily, cancel and re-add with a new `watch_interval` | `to_uri` (must match the watch task's `to` value, e.g. `viking://resources/...`) |

--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -150,6 +150,12 @@ Once connected, OpenViking exposes 16 tools:
 | `forget` | Delete any `viking://` URI (use `search` to find it first; pass `recursive=true` to delete a directory) | `uri`, `recursive` (optional) |
 | `health` | Check OpenViking service health | none |
 
+For MCP tools, `viking://user` is the authenticated user's workspace. For example,
+`viking://user/notes/todo.md` resolves to
+`viking://user/<current-user>/notes/todo.md`, regardless of the file name or
+extension. Canonical URIs containing that exact current user id are also accepted;
+MCP does not use this shorthand for cross-user access.
+
 > **Note**: MCP exposes the minimum closure for watch management (`list_watches` + `cancel_watch`). Pause / resume / trigger and the unified `update` verb are intentionally not exposed here — use the REST `/api/v1/watches/*` endpoints or the `ov task watch` CLI for those operations.
 
 > Feishu/Lark imports without `args.feishu_access_token` keep the existing app/tenant-token behavior and can be watched. Feishu/Lark one-time user-token imports pass only `args.feishu_access_token`; Feishu/Lark user-token watches must also pass `args.feishu_refresh_token` and require the same Feishu app credentials configured on the OpenViking server.

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -121,7 +121,7 @@ claude mcp add --transport http openviking \
 
 ## 可用的 MCP 工具
 
-连接后，OpenViking MCP 端点暴露 14 个工具：
+连接后，OpenViking MCP 端点暴露 16 个工具：
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
@@ -130,8 +130,10 @@ claude mcp add --transport http openviking \
 | `recall` | 按记忆类别配额召回，服务端组装为带 URI 的扁平 `<memory>` 块 | `query`, `quotas`(可选), `max_chars`, `min_score`, `peer_scope`, `other_peer_penalty`(可选), `session_id`(可选), `detail`(可选), `max_tokens`(可选), `rewrite`(可选) |
 | `read` | 读取一个或多个 `viking://` URI 的内容 | `uris`（单个字符串或数组） |
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |
+| `tree` | 以缩进形式展示 `viking://` URI 下的递归目录树——当需要全面了解文件树结构时使用（单层列表用 `list`，按文件名查找用 `glob`） | `uri`(可选), `level_limit`(默认 3), `node_limit`(默认 1000), `include_abstract`(可选——同时展示每个文件的摘要) |
 | `remember` | 存储消息到长期记忆（触发记忆提取） | `messages`（`{role, content}` 列表） |
-| `write` | 向 `viking://` 文件写入文本（创建/覆盖/追加），或通过精确字符串替换（`edits`）编辑文件。自动创建缺失的父目录；覆盖或编辑前请先用 `read` 查看当前内容 | `uri`, `content`(可选,完整写入), `mode`(可选:默认 `replace` — 文件不存在时自动创建,`append` 追加,`create` — 已存在则失败), `edits`(可选,`{old_string, new_string, replace_all}` 列表), `wait`(可选,阻塞直到重建索引完成), `timeout`(可选) |
+| `write` | 向 `viking://` 文件写入文本（创建/覆盖/追加）。自动创建缺失的父目录；覆盖前请先用 `read` 查看当前内容；只改文件局部时优先用 `edit` | `uri`, `content`, `mode`(可选:默认 `replace` — 文件不存在时自动创建,`append` 追加,`create` — 已存在则失败), `wait`(可选,阻塞直到重建索引完成), `timeout`(可选) |
+| `edit` | 在已有 `viking://` 文件中把精确字符串替换为新文本——用于局部修改，避免整文件重写。若 `old_string` 找不到、或匹配多处且 `replace_all` 为 false，则编辑失败且文件保持不变 | `uri`, `old_string`, `new_string`, `replace_all`(可选), `wait`(可选,阻塞直到重建索引完成), `timeout`(可选) |
 | `add_resource` | 添加本地文件或 URL 作为资源(本地文件触发渐进式上传流) | `path`, `temp_file_id`(可选), `description`(可选), `watch_interval`(可选,分钟数 — 远程 URL 的自动刷新周期), `processing_mode`(可选：默认 `semantic_and_vectors`；传 `vectors_only` 时跳过 VLM 语义理解，只向量化当前文件), `to`(可选,目标 `viking://resources/...` URI；`watch_interval > 0` 时若省略 `to`,watch 将自动绑定到本次 add 创建的资源 URI), `args`(可选,特定 parser 参数，包括 `{"parse_mode":"no_split"}` 用于正常解析但每个源文档只生成一个 Markdown 正文、飞书一次性用户 token 导入使用 `{"feishu_access_token":"u-..."}`，或飞书用户 token watch 使用 `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}`) |
 | `list_watches` | 列出当前 Agent 可见的 watch 任务（自动刷新订阅），每行显示目标 URI、刷新间隔（分钟）、active/paused 状态以及下一次调度时间 | 无 |
 | `cancel_watch` | 按目标 URI 取消（删除）watch 任务。若需调整刷新周期或临时暂停，请取消后使用新的 `watch_interval` 重新添加 | `to_uri`（必须匹配 watch 任务的 `to` 值，例如 `viking://resources/...`） |

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -121,7 +121,7 @@ claude mcp add --transport http openviking \
 
 ## 可用的 MCP 工具
 
-连接后，OpenViking MCP 端点暴露 13 个工具：
+连接后，OpenViking MCP 端点暴露 14 个工具：
 
 | 工具 | 说明 | 主要参数 |
 |------|------|----------|
@@ -131,6 +131,7 @@ claude mcp add --transport http openviking \
 | `read` | 读取一个或多个 `viking://` URI 的内容 | `uris`（单个字符串或数组） |
 | `list` | 列出 `viking://` 目录下的条目 | `uri`, `recursive`(可选) |
 | `remember` | 存储消息到长期记忆（触发记忆提取） | `messages`（`{role, content}` 列表） |
+| `write` | 向 `viking://` 文件写入文本（创建/覆盖/追加），或通过精确字符串替换（`edits`）编辑文件。自动创建缺失的父目录；覆盖或编辑前请先用 `read` 查看当前内容 | `uri`, `content`(可选,完整写入), `mode`(可选:默认 `replace` — 文件不存在时自动创建,`append` 追加,`create` — 已存在则失败), `edits`(可选,`{old_string, new_string, replace_all}` 列表), `wait`(可选,阻塞直到重建索引完成), `timeout`(可选) |
 | `add_resource` | 添加本地文件或 URL 作为资源(本地文件触发渐进式上传流) | `path`, `temp_file_id`(可选), `description`(可选), `watch_interval`(可选,分钟数 — 远程 URL 的自动刷新周期), `processing_mode`(可选：默认 `semantic_and_vectors`；传 `vectors_only` 时跳过 VLM 语义理解，只向量化当前文件), `to`(可选,目标 `viking://resources/...` URI；`watch_interval > 0` 时若省略 `to`,watch 将自动绑定到本次 add 创建的资源 URI), `args`(可选,特定 parser 参数，包括 `{"parse_mode":"no_split"}` 用于正常解析但每个源文档只生成一个 Markdown 正文、飞书一次性用户 token 导入使用 `{"feishu_access_token":"u-..."}`，或飞书用户 token watch 使用 `{"feishu_access_token":"u-...","feishu_refresh_token":"r-..."}`) |
 | `list_watches` | 列出当前 Agent 可见的 watch 任务（自动刷新订阅），每行显示目标 URI、刷新间隔（分钟）、active/paused 状态以及下一次调度时间 | 无 |
 | `cancel_watch` | 按目标 URI 取消（删除）watch 任务。若需调整刷新周期或临时暂停，请取消后使用新的 `watch_interval` 重新添加 | `to_uri`（必须匹配 watch 任务的 `to` 值，例如 `viking://resources/...`） |

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -142,6 +142,11 @@ claude mcp add --transport http openviking \
 | `forget` | 删除任意 `viking://` URI（先用 `search` 查找；删除目录需 `recursive=true`） | `uri`, `recursive`(可选) |
 | `health` | 检查 OpenViking 服务健康状态 | 无 |
 
+在 MCP 工具中，`viking://user` 表示当前认证用户的工作区。例如，
+`viking://user/notes/todo.md` 会解析成
+`viking://user/<当前用户>/notes/todo.md`，不依赖文件名或扩展名判断。工具返回的、
+包含当前用户 ID 的 canonical URI 也可以直接使用；这套简写不用于跨用户访问。
+
 > **注**：MCP 仅暴露 watch 管理的最小闭包（`list_watches` + `cancel_watch`）。pause / resume / trigger 和统一的 `update` 动作刻意不在此处暴露，请通过 REST `/api/v1/watches/*` 接口或 `ov task watch` CLI 使用上述操作。
 
 > 未传 `args.feishu_access_token` 的飞书/Lark 导入保持现有应用/tenant token 行为，也支持 watch。飞书/Lark 一次性用户 token 导入只传 `args.feishu_access_token`；飞书/Lark 用户 token watch 还必须传 `args.feishu_refresh_token`，并要求 OpenViking 服务端配置同一个飞书应用凭证。

--- a/examples/codex-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/codex-memory-plugin/scripts/marketplace.test.mjs
@@ -25,8 +25,8 @@ const mcpEndpointPath = join(repoRoot, "openviking", "server", "mcp_endpoint.py"
 
 const PLUGIN_NAME = "openviking-memory";
 const REAL_MCP_TOOLS = [
-  "find", "search", "recall", "read", "list", "remember", "add_resource",
-  "list_watches", "cancel_watch", "grep", "glob", "forget", "health",
+  "find", "search", "recall", "read", "list", "tree", "remember", "write", "edit",
+  "add_resource", "list_watches", "cancel_watch", "grep", "glob", "forget", "health",
 ];
 const LEGACY_TOOL_NAMES = ["openviking_recall", "openviking_store", "openviking_forget", "openviking_health"];
 

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -419,14 +419,45 @@ def _is_current_user_relative_uri(parts: list[str], ctx: Optional[RequestContext
     return _is_user_relative_root_segment(parts[1])
 
 
+# File extensions that mark a first path segment under viking://user/ as a
+# file name rather than a user id, enabling current-user shorthand for files
+# at the user root (viking://user/notes.md -> viking://user/<user>/notes.md).
+_TEXT_FILE_EXTENSIONS = frozenset(
+    {
+        "md",
+        "txt",
+        "json",
+        "jsonl",
+        "yaml",
+        "yml",
+        "toml",
+        "py",
+        "js",
+        "ts",
+        "tsx",
+        "jsx",
+        "csv",
+        "xml",
+        "html",
+        "css",
+        "sh",
+        "sql",
+        "log",
+    }
+)
+
+
 def _is_user_relative_root_segment(segment: str) -> bool:
     if segment in _CONTENT_TYPES_BY_SCOPE["user"] or segment in _USER_RELATIVE_ROOT_SEGMENTS:
         return True
-    # A segment containing "." is a file name (e.g. viking://user/notes.md), not
-    # a user id: canonical user ids are dot-free by convention. Treat it as
-    # current-user shorthand for a file at the user root, so
-    # viking://user/notes.md resolves to viking://user/<user>/notes.md.
-    return "." in segment
+    # A segment ending in a common text-file extension is a file name (e.g.
+    # viking://user/notes.md), not a user id, so treat the URI as current-user
+    # shorthand for a file at the user root. Bare dots alone do not trigger
+    # shorthand: dotted user ids (e.g. email-style "alice.smith@corp.com")
+    # keep resolving as canonical user ids.
+    if "." not in segment:
+        return False
+    return segment.rsplit(".", 1)[-1].lower() in _TEXT_FILE_EXTENSIONS
 
 
 def _resolve_session_uri(

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -419,45 +419,8 @@ def _is_current_user_relative_uri(parts: list[str], ctx: Optional[RequestContext
     return _is_user_relative_root_segment(parts[1])
 
 
-# File extensions that mark a first path segment under viking://user/ as a
-# file name rather than a user id, enabling current-user shorthand for files
-# at the user root (viking://user/notes.md -> viking://user/<user>/notes.md).
-_TEXT_FILE_EXTENSIONS = frozenset(
-    {
-        "md",
-        "txt",
-        "json",
-        "jsonl",
-        "yaml",
-        "yml",
-        "toml",
-        "py",
-        "js",
-        "ts",
-        "tsx",
-        "jsx",
-        "csv",
-        "xml",
-        "html",
-        "css",
-        "sh",
-        "sql",
-        "log",
-    }
-)
-
-
 def _is_user_relative_root_segment(segment: str) -> bool:
-    if segment in _CONTENT_TYPES_BY_SCOPE["user"] or segment in _USER_RELATIVE_ROOT_SEGMENTS:
-        return True
-    # A segment ending in a common text-file extension is a file name (e.g.
-    # viking://user/notes.md), not a user id, so treat the URI as current-user
-    # shorthand for a file at the user root. Bare dots alone do not trigger
-    # shorthand: dotted user ids (e.g. email-style "alice.smith@corp.com")
-    # keep resolving as canonical user ids.
-    if "." not in segment:
-        return False
-    return segment.rsplit(".", 1)[-1].lower() in _TEXT_FILE_EXTENSIONS
+    return segment in _CONTENT_TYPES_BY_SCOPE["user"] or segment in _USER_RELATIVE_ROOT_SEGMENTS
 
 
 def _resolve_session_uri(

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -420,7 +420,13 @@ def _is_current_user_relative_uri(parts: list[str], ctx: Optional[RequestContext
 
 
 def _is_user_relative_root_segment(segment: str) -> bool:
-    return segment in _CONTENT_TYPES_BY_SCOPE["user"] or segment in _USER_RELATIVE_ROOT_SEGMENTS
+    if segment in _CONTENT_TYPES_BY_SCOPE["user"] or segment in _USER_RELATIVE_ROOT_SEGMENTS:
+        return True
+    # A segment containing "." is a file name (e.g. viking://user/notes.md), not
+    # a user id: canonical user ids are dot-free by convention. Treat it as
+    # current-user shorthand for a file at the user root, so
+    # viking://user/notes.md resolves to viking://user/<user>/notes.md.
+    return "." in segment
 
 
 def _resolve_session_uri(

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -779,8 +779,9 @@ def create_app(
     else:
         logger.info("Web Studio bundle not found at %s; skipping /studio mount", _studio_dir)
 
-    # MCP endpoint — serves 5 tools (search, read, store, forget, health)
-    # via streamable HTTP for Claude Code and other MCP clients.
+    # MCP endpoint — serves 14 tools (find, search, recall, read, write, list,
+    # remember, add_resource, list_watches, cancel_watch, grep, glob, forget,
+    # health) via streamable HTTP for Claude Code and other MCP clients.
     from starlette.routing import Match, Route
 
     from openviking.server.mcp_endpoint import create_mcp_app

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -779,9 +779,9 @@ def create_app(
     else:
         logger.info("Web Studio bundle not found at %s; skipping /studio mount", _studio_dir)
 
-    # MCP endpoint — serves 14 tools (find, search, recall, read, write, list,
-    # remember, add_resource, list_watches, cancel_watch, grep, glob, forget,
-    # health) via streamable HTTP for Claude Code and other MCP clients.
+    # MCP endpoint — serves 16 tools (find, search, recall, read, write, edit,
+    # list, tree, remember, add_resource, list_watches, cancel_watch, grep,
+    # glob, forget, health) via streamable HTTP for MCP clients.
     from starlette.routing import Match, Route
 
     from openviking.server.mcp_endpoint import create_mcp_app

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -512,7 +512,7 @@ async def write(
     - mode="create": fail if the file already exists. New files must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
-    Writable scopes: viking://resources/, viking://user/ (memories and resources), viking://agent/. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
+    Writable scopes: viking://resources/, viking://user/ (plain files at the user root such as viking://user/notes.md — the current user is inserted automatically — plus the memories/ and resources/ subtrees), viking://agent/. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
     service = get_service()
     ctx = _get_ctx()
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -3,7 +3,7 @@
 """MCP (Model Context Protocol) endpoint for OpenViking server.
 
 Exposes tools to Claude Code (or any MCP client) via streamable HTTP:
-  find, search, read, write, list, remember, add_resource, grep, glob, forget, health
+  find, search, read, write, edit, list, tree, remember, add_resource, grep, glob, forget, health
 
 Mounted on the FastAPI app at /mcp. The MCP session manager lifecycle is
 tied to the FastAPI app lifespan (not a sub-app lifespan) so the task group
@@ -416,6 +416,55 @@ async def ls(uri: str, recursive: bool = False) -> str:
     return "\n".join(lines)
 
 
+# -- tree ------------------------------------------------------------------
+
+
+@mcp.tool()
+async def tree(
+    uri: str = "viking://",
+    level_limit: int = 3,
+    node_limit: int = 1000,
+    include_abstract: bool = False,
+) -> str:
+    """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories)."""
+    service = get_service()
+    ctx = _get_ctx()
+    output = "agent" if include_abstract else "original"
+    try:
+        entries = await service.fs.tree(
+            uri,
+            ctx=ctx,
+            output=output,
+            node_limit=node_limit,
+            level_limit=level_limit,
+        )
+    except NotFoundError:
+        entries = []
+    if not entries:
+        return f"(nothing under {uri})"
+
+    lines = [
+        f"Tree of {uri} (depth <= {level_limit}, {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}):"
+    ]
+    for e in entries:
+        rel = (e.get("rel_path") or e.get("name") or "?").strip("/")
+        name = rel.rsplit("/", 1)[-1]
+        depth = len([part for part in rel.split("/") if part])
+        indent = "  " * max(0, depth - 1)
+        if e.get("isDir"):
+            lines.append(f"{indent}{name}/")
+            continue
+        lines.append(f"{indent}{name} ({e.get('size', 0)} B)")
+        abstract = (e.get("abstract") or "").strip().replace("\n", " ")
+        if include_abstract and abstract:
+            lines.append(f"{indent}  - {abstract}")
+    if len(entries) >= node_limit:
+        lines.append(
+            f"(truncated at node_limit={node_limit}; narrow the uri or raise node_limit to see more)"
+        )
+    return "\n".join(lines)
+
+
 # -- remember --------------------------------------------------------------
 
 
@@ -449,87 +498,23 @@ async def remember(messages: list[StoreMessage]) -> str:
 # -- write -----------------------------------------------------------------
 
 
-class WriteEdit(BaseModel):
-    """One exact-string replacement applied by the write tool's `edits` mode."""
-
-    old_string: str = Field(
-        description="Exact text to find, including indentation and newlines. Must match the file content exactly."
-    )
-    new_string: str = Field(
-        description="Replacement text. Pass an empty string to delete old_string."
-    )
-    replace_all: bool = Field(
-        default=False,
-        description="Replace every occurrence of old_string. When false, the edit fails if old_string matches more than once.",
-    )
-
-
 @mcp.tool()
 async def write(
     uri: str,
-    content: Optional[str] = None,
+    content: str,
     mode: Literal["replace", "append", "create"] = "replace",
-    edits: Optional[List[WriteEdit]] = None,
     wait: bool = False,
     timeout: Optional[float] = None,
 ) -> str:
-    """Write text to a viking:// file, or edit an existing file with exact string replacements. Use this to save and update files (notes, profiles, knowledge, state) in OpenViking the same way you would use a working directory.
+    """Write text to a viking:// file. Use this to save files (notes, profiles, knowledge, state) in OpenViking the same way you would use a working directory. To change part of an existing file, prefer the edit tool over a full rewrite.
 
-    Full write — pass `content`:
     - mode="replace" (default): overwrite the file; creates it and any missing parent directories if needed.
     - mode="create": fail if the file already exists. New files must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
-    Targeted edit — pass `edits` instead of `content`: a list of {old_string, new_string, replace_all} exact-string replacements applied to the file in order. Each old_string must match the current file content exactly (including indentation and newlines) and match exactly once unless replace_all=true. If any edit fails, the file is left unchanged. Prefer edits over a full rewrite when changing a small part of a larger file. Use the read tool first to see the file's exact current content.
-
     Writable scopes: viking://resources/, viking://user/ (memories and resources), viking://agent/. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
     service = get_service()
     ctx = _get_ctx()
-
-    if edits:
-        if content is not None:
-            raise InvalidArgumentError(
-                "pass either content (full write) or edits (targeted edit), not both"
-            )
-        if mode != "replace":
-            raise InvalidArgumentError(
-                "mode applies only to full-content writes; edits always rewrite the matched text in place"
-            )
-        try:
-            current = await service.fs.read_visible(uri, ctx=ctx)
-        except (InvalidArgumentError, PermissionDeniedError, UnauthenticatedError):
-            raise
-        except Exception as exc:
-            raise NotFoundError(uri, "file") from exc
-        updated = current
-        for index, edit in enumerate(edits, start=1):
-            if not edit.old_string:
-                raise InvalidArgumentError(f"edit {index}: old_string must not be empty")
-            occurrences = updated.count(edit.old_string)
-            if occurrences == 0:
-                raise InvalidArgumentError(
-                    f"edit {index}: old_string not found in {uri}. "
-                    "Re-read the file with the read tool to get its current content."
-                )
-            if occurrences > 1 and not edit.replace_all:
-                raise InvalidArgumentError(
-                    f"edit {index}: old_string matches {occurrences} locations in {uri}. "
-                    "Include more surrounding context to make it unique, or set replace_all=true."
-                )
-            updated = updated.replace(edit.old_string, edit.new_string)
-        if updated == current:
-            return f"No changes: {uri} already matches the requested edit(s)."
-        result = await service.fs.write(
-            uri=uri, content=updated, ctx=ctx, mode="replace", wait=wait, timeout=timeout
-        )
-        written = result.get("written_bytes", 0)
-        message = (
-            f"Applied {len(edits)} edit(s) to {result.get('uri', uri)} ({written} bytes written)."
-        )
-        return message + _indexing_hint(result)
-
-    if content is None:
-        raise InvalidArgumentError("provide content for a full write, or edits for a targeted edit")
 
     try:
         result = await service.fs.write(
@@ -548,6 +533,51 @@ async def write(
     message = (
         f"Wrote {written} bytes to {result.get('uri', uri)} (mode={result.get('mode', mode)})."
     )
+    return message + _indexing_hint(result)
+
+
+@mcp.tool()
+async def edit(
+    uri: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
+    wait: bool = False,
+    timeout: Optional[float] = None,
+) -> str:
+    """Replace an exact string with new text in an existing viking:// file. Use this for targeted changes instead of rewriting the whole file with the write tool. old_string must match the file's current content exactly, including indentation and newlines; use the read tool first to see it. The edit fails and the file is left unchanged if old_string is not found, or if it matches more than once and replace_all is false (pass more surrounding context to make it unique, or set replace_all=true to replace every occurrence). Pass new_string="" to delete old_string.
+
+    Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change)."""
+    service = get_service()
+    ctx = _get_ctx()
+
+    if not old_string:
+        raise InvalidArgumentError("old_string must not be empty")
+    try:
+        current = await service.fs.read_visible(uri, ctx=ctx)
+    except (InvalidArgumentError, PermissionDeniedError, UnauthenticatedError):
+        raise
+    except Exception as exc:
+        raise NotFoundError(uri, "file") from exc
+    occurrences = current.count(old_string)
+    if occurrences == 0:
+        raise InvalidArgumentError(
+            f"old_string not found in {uri}. "
+            "Re-read the file with the read tool to get its current content."
+        )
+    if occurrences > 1 and not replace_all:
+        raise InvalidArgumentError(
+            f"old_string matches {occurrences} locations in {uri}. "
+            "Include more surrounding context to make it unique, or set replace_all=true."
+        )
+    updated = current.replace(old_string, new_string)
+    if updated == current:
+        return f"No changes: {uri} already matches the requested edit."
+    result = await service.fs.write(
+        uri=uri, content=updated, ctx=ctx, mode="replace", wait=wait, timeout=timeout
+    )
+    written = result.get("written_bytes", 0)
+    message = f"Edited {result.get('uri', uri)} ({written} bytes written)."
     return message + _indexing_hint(result)
 
 
@@ -1163,8 +1193,8 @@ async def mcp_lifespan():
     """Run the MCP session manager. Call this inside the FastAPI lifespan."""
     async with mcp.session_manager.run():
         logger.info(
-            "MCP endpoint ready (14 tools: find, search, recall, read, write, list, "
-            "remember, add_resource, list_watches, cancel_watch, grep, glob, forget, health)"
+            "MCP endpoint ready (16 tools: find, search, recall, read, write, edit, list, "
+            "tree, remember, add_resource, list_watches, cancel_watch, grep, glob, forget, health)"
         )
         yield
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -29,6 +29,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from openviking.core.namespace import canonical_user_root, canonicalize_uri, uri_parts
 from openviking.parse.mode import ParseMode, normalize_parse_mode
 from openviking.resource.processing_mode import DEFAULT_PROCESSING_MODE, ProcessingMode
 from openviking.retrieve.context_assembler import assemble_context
@@ -78,6 +79,25 @@ def _get_ctx() -> RequestContext:
     if ctx is None:
         raise UnauthenticatedError("MCP request identity not set")
     return ctx
+
+
+def _resolve_mcp_workspace_uri(uri: str, ctx: RequestContext) -> str:
+    """Resolve ``viking://user/...`` as the current user's MCP workspace.
+
+    Generic namespace parsing must preserve canonical cross-user URIs, so it
+    cannot infer whether the first segment after ``user`` is a user id or a
+    file/directory name. MCP has a narrower contract: its filesystem tools act
+    on the authenticated user's workspace. An exact current-user id is already
+    canonical; every other suffix is relative to that user's root.
+    """
+    parts = uri_parts(uri)
+    if parts[:1] != ["user"]:
+        return uri
+    suffix = parts[1:]
+    if suffix[:1] == [ctx.user.user_id]:
+        return canonicalize_uri(uri, ctx)
+    root = canonical_user_root(ctx)
+    return root if not suffix else f"{root}/{'/'.join(suffix)}"
 
 
 def _scope_to_origin(scope: Scope) -> Optional[str]:
@@ -247,9 +267,12 @@ async def find(
 ) -> str:
     """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
+    ctx = _get_ctx()
+    if target_uri:
+        target_uri = _resolve_mcp_workspace_uri(target_uri, ctx)
     result = await service.search.find(
         query=query,
-        ctx=_get_ctx(),
+        ctx=ctx,
         target_uri=target_uri,
         limit=limit,
         score_threshold=min_score,
@@ -272,6 +295,8 @@ async def search(
     """Deep semantic retrieval with optional session context and intent analysis. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
     ctx = _get_ctx()
+    if target_uri:
+        target_uri = _resolve_mcp_workspace_uri(target_uri, ctx)
     session = None
     # Intent off: skip session.load — SearchService will not scan session either.
     if session_id and service.search.is_intent_enabled():
@@ -374,7 +399,8 @@ async def read(uris: str | list[str]) -> str:
     async def _read_one(uri: str) -> str:
         async with semaphore:
             try:
-                body = await service.fs.read_visible(uri, ctx=ctx)
+                resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
+                body = await service.fs.read_visible(resolved_uri, ctx=ctx)
                 if isinstance(body, str) and body.strip():
                     return body
             except Exception:
@@ -399,8 +425,9 @@ async def ls(uri: str, recursive: bool = False) -> str:
     """List files and subdirectories under a viking:// directory URI. Use recursive=true for deep listing."""
     service = get_service()
     ctx = _get_ctx()
+    resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
 
-    entries = await service.fs.ls(uri, ctx=ctx, recursive=recursive, output="original")
+    entries = await service.fs.ls(resolved_uri, ctx=ctx, recursive=recursive, output="original")
     if not entries:
         return f"(no entries under {uri})"
 
@@ -429,10 +456,11 @@ async def tree(
     """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories)."""
     service = get_service()
     ctx = _get_ctx()
+    resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
     output = "agent" if include_abstract else "original"
     try:
         entries = await service.fs.tree(
-            uri,
+            resolved_uri,
             ctx=ctx,
             output=output,
             node_limit=node_limit,
@@ -512,9 +540,10 @@ async def write(
     - mode="create": fail if the file already exists. New files must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
-    Writable scopes: viking://resources/, viking://user/ (plain files at the user root such as viking://user/notes.md — the current user is inserted automatically — plus the memories/ and resources/ subtrees), viking://agent/. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
+    Writable scopes: viking://resources/, viking://user/ (all paths are relative to the authenticated user's root unless the URI already contains that exact user id), viking://agent/. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
     service = get_service()
     ctx = _get_ctx()
+    uri = _resolve_mcp_workspace_uri(uri, ctx)
 
     try:
         result = await service.fs.write(
@@ -550,6 +579,7 @@ async def edit(
     Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change)."""
     service = get_service()
     ctx = _get_ctx()
+    uri = _resolve_mcp_workspace_uri(uri, ctx)
 
     if not old_string:
         raise InvalidArgumentError("old_string must not be empty")
@@ -1006,6 +1036,7 @@ async def grep(
 
     service = get_service()
     ctx = _get_ctx()
+    resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
     patterns = [pattern] if isinstance(pattern, str) else pattern
     semaphore = asyncio.Semaphore(10)
 
@@ -1013,7 +1044,7 @@ async def grep(
         async with semaphore:
             try:
                 result = await service.fs.grep(
-                    uri,
+                    resolved_uri,
                     p,
                     ctx=ctx,
                     case_insensitive=case_insensitive,
@@ -1053,9 +1084,10 @@ async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> s
     """Find viking:// files matching a glob pattern (e.g. **/*.md, *.py). Use this for filename matching; use the search tool for content-based retrieval."""
     service = get_service()
     ctx = _get_ctx()
+    resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
 
     try:
-        result = await service.fs.glob(pattern, ctx=ctx, uri=uri, node_limit=node_limit)
+        result = await service.fs.glob(pattern, ctx=ctx, uri=resolved_uri, node_limit=node_limit)
     except Exception as e:
         return f"Error: {e}"
 
@@ -1078,8 +1110,9 @@ async def forget(uri: str, recursive: bool = False) -> str:
     """Permanently delete a viking:// URI from OpenViking. Irreversible — confirm with user before calling."""
     service = get_service()
     ctx = _get_ctx()
-    await service.fs.rm(uri, ctx=ctx, recursive=recursive)
-    return f"Deleted: {uri}"
+    resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
+    await service.fs.rm(resolved_uri, ctx=ctx, recursive=recursive)
+    return f"Deleted: {resolved_uri}"
 
 
 # -- health ----------------------------------------------------------------

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -3,7 +3,7 @@
 """MCP (Model Context Protocol) endpoint for OpenViking server.
 
 Exposes tools to Claude Code (or any MCP client) via streamable HTTP:
-  find, search, read, list, remember, add_resource, grep, glob, forget, health
+  find, search, read, write, list, remember, add_resource, grep, glob, forget, health
 
 Mounted on the FastAPI app at /mcp. The MCP session manager lifecycle is
 tied to the FastAPI app lifespan (not a sub-app lifespan) so the task group
@@ -47,6 +47,7 @@ from openviking.telemetry.span_models import update_root_span_identity
 from openviking.utils.search_filters import SearchContextTypeInput, merge_search_filter
 from openviking_cli.exceptions import (
     InvalidArgumentError,
+    NotFoundError,
     PermissionDeniedError,
     UnauthenticatedError,
 )
@@ -443,6 +444,123 @@ async def remember(messages: list[StoreMessage]) -> str:
                 session.add_message(msg.role, [TextPart(text=msg.content)])
     await service.sessions.commit_async(session_id, ctx)
     return f"Stored {len(messages)} message(s) and committed for memory extraction."
+
+
+# -- write -----------------------------------------------------------------
+
+
+class WriteEdit(BaseModel):
+    """One exact-string replacement applied by the write tool's `edits` mode."""
+
+    old_string: str = Field(
+        description="Exact text to find, including indentation and newlines. Must match the file content exactly."
+    )
+    new_string: str = Field(
+        description="Replacement text. Pass an empty string to delete old_string."
+    )
+    replace_all: bool = Field(
+        default=False,
+        description="Replace every occurrence of old_string. When false, the edit fails if old_string matches more than once.",
+    )
+
+
+@mcp.tool()
+async def write(
+    uri: str,
+    content: Optional[str] = None,
+    mode: Literal["replace", "append", "create"] = "replace",
+    edits: Optional[List[WriteEdit]] = None,
+    wait: bool = False,
+    timeout: Optional[float] = None,
+) -> str:
+    """Write text to a viking:// file, or edit an existing file with exact string replacements. Use this to save and update files (notes, profiles, knowledge, state) in OpenViking the same way you would use a working directory.
+
+    Full write — pass `content`:
+    - mode="replace" (default): overwrite the file; creates it and any missing parent directories if needed.
+    - mode="create": fail if the file already exists. New files must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
+    - mode="append": append to the end of an existing file; fails if the file does not exist.
+
+    Targeted edit — pass `edits` instead of `content`: a list of {old_string, new_string, replace_all} exact-string replacements applied to the file in order. Each old_string must match the current file content exactly (including indentation and newlines) and match exactly once unless replace_all=true. If any edit fails, the file is left unchanged. Prefer edits over a full rewrite when changing a small part of a larger file. Use the read tool first to see the file's exact current content.
+
+    Writable scopes: viking://resources/, viking://user/ (memories and resources), viking://agent/. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
+    service = get_service()
+    ctx = _get_ctx()
+
+    if edits:
+        if content is not None:
+            raise InvalidArgumentError(
+                "pass either content (full write) or edits (targeted edit), not both"
+            )
+        if mode != "replace":
+            raise InvalidArgumentError(
+                "mode applies only to full-content writes; edits always rewrite the matched text in place"
+            )
+        try:
+            current = await service.fs.read_visible(uri, ctx=ctx)
+        except (InvalidArgumentError, PermissionDeniedError, UnauthenticatedError):
+            raise
+        except Exception as exc:
+            raise NotFoundError(uri, "file") from exc
+        updated = current
+        for index, edit in enumerate(edits, start=1):
+            if not edit.old_string:
+                raise InvalidArgumentError(f"edit {index}: old_string must not be empty")
+            occurrences = updated.count(edit.old_string)
+            if occurrences == 0:
+                raise InvalidArgumentError(
+                    f"edit {index}: old_string not found in {uri}. "
+                    "Re-read the file with the read tool to get its current content."
+                )
+            if occurrences > 1 and not edit.replace_all:
+                raise InvalidArgumentError(
+                    f"edit {index}: old_string matches {occurrences} locations in {uri}. "
+                    "Include more surrounding context to make it unique, or set replace_all=true."
+                )
+            updated = updated.replace(edit.old_string, edit.new_string)
+        if updated == current:
+            return f"No changes: {uri} already matches the requested edit(s)."
+        result = await service.fs.write(
+            uri=uri, content=updated, ctx=ctx, mode="replace", wait=wait, timeout=timeout
+        )
+        written = result.get("written_bytes", 0)
+        message = (
+            f"Applied {len(edits)} edit(s) to {result.get('uri', uri)} ({written} bytes written)."
+        )
+        return message + _indexing_hint(result)
+
+    if content is None:
+        raise InvalidArgumentError("provide content for a full write, or edits for a targeted edit")
+
+    try:
+        result = await service.fs.write(
+            uri=uri, content=content, ctx=ctx, mode=mode, wait=wait, timeout=timeout
+        )
+    except NotFoundError:
+        if mode != "replace":
+            raise
+        # Replace doubles as create-or-overwrite so agents can save a new file
+        # without first checking whether it exists; strict creation stays
+        # available via mode="create".
+        result = await service.fs.write(
+            uri=uri, content=content, ctx=ctx, mode="create", wait=wait, timeout=timeout
+        )
+    written = result.get("written_bytes", 0)
+    message = (
+        f"Wrote {written} bytes to {result.get('uri', uri)} (mode={result.get('mode', mode)})."
+    )
+    return message + _indexing_hint(result)
+
+
+def _indexing_hint(result: Dict[str, Any]) -> str:
+    semantic = result.get("semantic_status")
+    vector = result.get("vector_status")
+    parts = [f"semantic={semantic}", f"vector={vector}"]
+    if result.get("overview_status") is not None:
+        parts.append(f"overview={result['overview_status']}")
+    hint = f"\nIndexing: {', '.join(parts)}."
+    if "queued" in (semantic, vector):
+        hint += " Search indexes update in the background; pass wait=true if a follow-up search must see this change immediately."
+    return hint
 
 
 # -- add_resource ----------------------------------------------------------
@@ -1045,8 +1163,8 @@ async def mcp_lifespan():
     """Run the MCP session manager. Call this inside the FastAPI lifespan."""
     async with mcp.session_manager.run():
         logger.info(
-            "MCP endpoint ready (13 tools: find, search, recall, read, list, remember, "
-            "add_resource, list_watches, cancel_watch, grep, glob, forget, health)"
+            "MCP endpoint ready (14 tools: find, search, recall, read, write, list, "
+            "remember, add_resource, list_watches, cancel_watch, grep, glob, forget, health)"
         )
         yield
 

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -537,7 +537,8 @@ async def write(
     """Write text to a viking:// file. Use this to save files (notes, profiles, knowledge, state) in OpenViking the same way you would use a working directory. To change part of an existing file, prefer the edit tool over a full rewrite.
 
     - mode="replace" (default): overwrite the file; creates it and any missing parent directories if needed.
-    - mode="create": fail if the file already exists. New files must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
+    - mode="create": fail if the file already exists.
+    - Any new file (whether created by "replace" or "create") must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
     Writable scopes: viking://resources/, viking://user/ (all paths are relative to the authenticated user's root unless the URI already contains that exact user id), viking://agent/. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -962,11 +962,14 @@ class ContentWriteCoordinator:
             return
 
         if mode == "append":
+            # Plain concatenation for resource/skill files: MEMORY_FIELDS is a
+            # reserved trailer of memory namespaces only (see content_visibility),
+            # so non-memory appends must not round-trip through MemoryFileUtils
+            # (which strips trailing newlines and injects a metadata trailer).
             existing_raw = await self._viking_fs.read_file(uri, ctx=ctx)
-            mf = MemoryFileUtils.read(existing_raw, uri=uri)
-            mf.content = mf.content + content
-            updated_raw = MemoryFileUtils.write(mf)
-            await self._viking_fs.write_file(uri, updated_raw, ctx=ctx, lease_ref=lease_ref)
+            await self._viking_fs.write_file(
+                uri, existing_raw + content, ctx=ctx, lease_ref=lease_ref
+            )
             return
         await self._viking_fs.write_file(uri, content, ctx=ctx, lease_ref=lease_ref)
 

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -76,6 +76,10 @@ _BATCH_MAX_FILE_BYTES = 8 * 1024 * 1024
 _BATCH_MAX_TOTAL_BYTES = 16 * 1024 * 1024
 _SHA256_PREFIX = "sha256:"
 
+# Subtrees directly under a user root that OpenViking manages itself; only
+# memories/, resources/, and plain files may be written under a user root.
+_USER_MANAGED_SUBTREES = frozenset({"skills", "peers", "privacy", "sessions"})
+
 
 class ContentWriteCoordinator:
     """Write a file (create or modify) and trigger downstream maintenance."""
@@ -1322,18 +1326,25 @@ class ContentWriteCoordinator:
                         root_uri = parent.uri
                 else:
                     root_uri = VikingURI.build(*parts[: resources_idx + 2])
-            else:
-                try:
-                    memories_idx = parts.index("memories")
-                except ValueError as exc:
-                    raise InvalidArgumentError(
-                        f"write only supports memory or resource files under user scope: {uri}"
-                    ) from exc
+            elif "memories" in parts:
+                memories_idx = parts.index("memories")
                 if len(parts) <= memories_idx + 1:
                     raise InvalidArgumentError(
                         f"memory write target must be inside a memory type directory: {uri}"
                     )
                 root_uri = VikingURI.build(*parts[: memories_idx + 2])
+            else:
+                # Plain files directly under the user root are allowed (e.g. a
+                # persona file at viking://user/<user>/persona.md); the managed
+                # subtrees (skills/, peers/, privacy/, sessions/) are not.
+                if len(parts) <= 2 or parts[2] in _USER_MANAGED_SUBTREES:
+                    raise InvalidArgumentError(
+                        "user-scope writes need a file under memories/, resources/, "
+                        f"or directly at the user root: {uri}"
+                    )
+                parent = parsed.parent
+                if parent is not None:
+                    root_uri = parent.uri
 
         stat = await self._safe_stat(root_uri, ctx=ctx, allow_not_found=_allow_not_found)
         if stat.get("not_found") or not stat.get("isDir"):

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -99,6 +99,20 @@ async def test_memory_replace_preserves_metadata(service):
 
 
 @pytest.mark.asyncio
+async def test_resource_append_is_plain_concatenation(service):
+    """Appending to a non-memory file must not inject a MEMORY_FIELDS trailer
+    or strip the existing trailing newline (memory namespaces only)."""
+    ctx = RequestContext(user=service.user, role=Role.USER)
+    uri = "viking://resources/append_plain/journal.md"
+
+    await service.fs.write(uri, content="line1\n", ctx=ctx, mode="create")
+    await service.fs.write(uri, content="line2\n", ctx=ctx, mode="append")
+
+    stored = await service.viking_fs.read_file(uri, ctx=ctx)
+    assert stored == "line1\nline2\n"
+
+
+@pytest.mark.asyncio
 async def test_memory_append_preserves_metadata(service):
     ctx = RequestContext(user=service.user, role=Role.USER)
     memory_uri = f"viking://user/{ctx.user.user_space_name()}/memories/preferences/theme.md"

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -1054,6 +1054,27 @@ async def test_write_user_shorthand_uri(service):
     assert visible.strip() == "x"
 
 
+async def test_write_user_root_file_via_shorthand(service):
+    # viking://user/persona.md shorthand inserts the current user.
+    result = await write(uri="viking://user/zeus-persona.md", content="# Zeus persona\n")
+    assert "viking://user/test_user/zeus-persona.md" in result
+    body = await service.fs.read("viking://user/test_user/zeus-persona.md", ctx=DEFAULT_CTX)
+    assert body == "# Zeus persona\n"
+
+
+async def test_write_user_root_subdirectory_file(service):
+    uri = "viking://user/default/notes/todo.md"
+    await write(uri=uri, content="- buy milk\n")
+    assert "- buy milk" in await read(uris=uri)
+
+
+async def test_write_user_managed_subtree_rejected(service):
+    with pytest.raises(InvalidArgumentError, match="user root"):
+        await write(uri="viking://user/default/sessions/fake-session.md", content="x")
+    with pytest.raises(InvalidArgumentError, match="user root"):
+        await write(uri="viking://user/default/skills/demo/SKILL.md", content="x")
+
+
 async def test_write_tool_schema_is_portable():
     tools = {tool.name: tool for tool in await mcp_endpoint.mcp.list_tools()}
     props = tools["write"].inputSchema["properties"]

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -21,6 +21,7 @@ from openviking.server.dependencies import set_service
 from openviking.server.identity import AuthMode, RequestContext, Role
 from openviking.server.mcp_endpoint import (
     StoreMessage,
+    WriteEdit,
     _get_ctx,
     _IdentityASGIMiddleware,
     _mcp_ctx,
@@ -35,9 +36,16 @@ from openviking.server.mcp_endpoint import (
     recall,
     remember,
     search,
+    write,
 )
 from openviking.server.mcp_endpoint import ls as list_tool
-from openviking_cli.exceptions import FailedPreconditionError, UnauthenticatedError
+from openviking_cli.exceptions import (
+    AlreadyExistsError,
+    FailedPreconditionError,
+    InvalidArgumentError,
+    NotFoundError,
+    UnauthenticatedError,
+)
 from openviking_cli.session.user_id import UserIdentifier
 
 DEFAULT_CTX = RequestContext(
@@ -900,6 +908,174 @@ async def test_forget_directory_with_recursive_succeeds(service):
 
     result = await forget(uri=dir_uri, recursive=True)
     assert "deleted" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# write tool
+# ---------------------------------------------------------------------------
+
+
+async def test_write_creates_new_file_with_replace_default(service):
+    uri = "viking://resources/test_write/notes.md"
+    result = await write(uri=uri, content="# Notes\nhello world\n")
+    assert "notes.md" in result
+    assert "Wrote" in result
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "# Notes\nhello world\n"
+
+
+async def test_write_replace_overwrites_existing(service):
+    uri = "viking://resources/test_write_replace.md"
+    await write(uri=uri, content="v1")
+    result = await write(uri=uri, content="v2-content")
+    assert "mode=replace" in result
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "v2-content"
+
+
+async def test_write_create_fails_when_file_exists(service):
+    uri = "viking://resources/test_write_create_exists.md"
+    await write(uri=uri, content="v1")
+    with pytest.raises(AlreadyExistsError):
+        await write(uri=uri, content="v2", mode="create")
+
+
+async def test_write_append_appends_to_existing(service):
+    uri = "viking://resources/test_write_append.md"
+    await write(uri=uri, content="line1\n")
+    await write(uri=uri, content="line2\n", mode="append")
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "line1\nline2\n"
+
+
+async def test_write_append_missing_file_fails(service):
+    with pytest.raises(NotFoundError):
+        await write(
+            uri="viking://resources/test_write_append_missing.md", content="x", mode="append"
+        )
+
+
+async def test_write_create_rejects_disallowed_extension(service):
+    with pytest.raises(InvalidArgumentError):
+        await write(uri="viking://resources/test_write_ext.csv", content="a,b\n", mode="create")
+
+
+async def test_write_rejects_derived_semantic_file(service):
+    with pytest.raises(InvalidArgumentError):
+        await write(uri="viking://resources/test_write_derived/.abstract.md", content="x")
+
+
+async def test_write_read_tool_roundtrip(service):
+    uri = "viking://resources/test_write_roundtrip/profile.md"
+    await write(uri=uri, content="name: ada\n")
+    assert "name: ada" in await read(uris=uri)
+
+
+async def test_write_edits_apply_single_replacement(service):
+    uri = "viking://resources/test_write_edit.md"
+    await write(uri=uri, content="alpha\nbeta\ngamma\n")
+    result = await write(uri=uri, edits=[WriteEdit(old_string="beta", new_string="BETA")])
+    assert "1 edit(s)" in result
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "alpha\nBETA\ngamma\n"
+
+
+async def test_write_edits_apply_in_order(service):
+    uri = "viking://resources/test_write_edit_order.md"
+    await write(uri=uri, content="foo bar baz\n")
+    await write(
+        uri=uri,
+        edits=[
+            WriteEdit(old_string="bar", new_string="qux"),
+            WriteEdit(old_string="foo qux", new_string="hello"),
+        ],
+    )
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "hello baz\n"
+
+
+async def test_write_edits_require_unique_match(service):
+    uri = "viking://resources/test_write_edit_multi.md"
+    await write(uri=uri, content="dup\ndup\n")
+    with pytest.raises(InvalidArgumentError, match="matches 2 locations"):
+        await write(uri=uri, edits=[WriteEdit(old_string="dup", new_string="x")])
+
+
+async def test_write_edits_replace_all(service):
+    uri = "viking://resources/test_write_edit_all.md"
+    await write(uri=uri, content="dup\ndup\n")
+    await write(uri=uri, edits=[WriteEdit(old_string="dup", new_string="x", replace_all=True)])
+    body = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert body == "x\nx\n"
+
+
+async def test_write_edits_missing_old_string_fails(service):
+    uri = "viking://resources/test_write_edit_missing.md"
+    await write(uri=uri, content="alpha\n")
+    with pytest.raises(InvalidArgumentError, match="not found"):
+        await write(uri=uri, edits=[WriteEdit(old_string="zzz", new_string="x")])
+
+
+async def test_write_edits_on_missing_file_fails(service):
+    with pytest.raises(NotFoundError):
+        await write(
+            uri="viking://resources/test_write_edit_ghost.md",
+            edits=[WriteEdit(old_string="a", new_string="b")],
+        )
+
+
+async def test_write_edits_noop_reports_no_changes(service):
+    uri = "viking://resources/test_write_edit_noop.md"
+    await write(uri=uri, content="same\n")
+    result = await write(uri=uri, edits=[WriteEdit(old_string="same", new_string="same")])
+    assert "No changes" in result
+
+
+async def test_write_rejects_content_and_edits_together(service):
+    with pytest.raises(InvalidArgumentError, match="either content"):
+        await write(
+            uri="viking://resources/x.md",
+            content="a",
+            edits=[WriteEdit(old_string="a", new_string="b")],
+        )
+
+
+async def test_write_requires_content_or_edits(service):
+    with pytest.raises(InvalidArgumentError, match="provide content"):
+        await write(uri="viking://resources/x.md")
+
+
+async def test_write_edits_memory_file_preserves_metadata(service):
+    uri = "viking://user/default/memories/preferences/test_write_memory.md"
+    await write(uri=uri, content="likes: tea\n")
+    raw_before = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert "MEMORY_FIELDS" in raw_before
+
+    await write(uri=uri, edits=[WriteEdit(old_string="tea", new_string="coffee")])
+
+    raw_after = await service.fs.read(uri, ctx=DEFAULT_CTX)
+    assert "MEMORY_FIELDS" in raw_after
+    assert "coffee" in raw_after
+    visible = await service.fs.read_visible(uri, ctx=DEFAULT_CTX)
+    assert visible.strip() == "likes: coffee"
+
+
+async def test_write_user_shorthand_uri(service):
+    uri = "viking://user/memories/preferences/shorthand_write.md"
+    result = await write(uri=uri, content="x")
+    assert "shorthand_write.md" in result
+    visible = await service.fs.read_visible(uri, ctx=DEFAULT_CTX)
+    assert visible.strip() == "x"
+
+
+async def test_write_tool_schema_is_portable():
+    tools = {tool.name: tool for tool in await mcp_endpoint.mcp.list_tools()}
+    props = tools["write"].inputSchema["properties"]
+    assert props["uri"]["type"] == "string"
+    assert props["content"]["type"] == "string"
+    assert props["mode"]["enum"] == ["replace", "append", "create"]
+    assert props["edits"]["type"] == "array"
+    assert props["edits"]["items"]["type"] == "object"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -1103,6 +1103,14 @@ async def test_write_user_root_file_via_shorthand(service):
     assert body == "# Zeus persona\n"
 
 
+async def test_write_plain_file_directly_at_user_root(service):
+    # A file with no intermediate directory: the write coordinator anchors its
+    # refresh at the user root itself, which is the shape the shorthand exists for.
+    result = await write(uri="viking://user/persona.md", content="# Persona\n")
+    assert "viking://user/test_user/persona.md" in result
+    assert "# Persona" in await read(uris="viking://user/persona.md")
+
+
 async def test_write_user_root_subdirectory_file(service):
     uri = "viking://user/test_user/notes/todo.md"
     await write(uri=uri, content="- buy milk\n")

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -24,6 +24,7 @@ from openviking.server.mcp_endpoint import (
     _get_ctx,
     _IdentityASGIMiddleware,
     _mcp_ctx,
+    _resolve_mcp_workspace_uri,
     add_resource,
     cancel_watch,
     edit,
@@ -81,6 +82,42 @@ def test_get_ctx_raises_when_unset():
             _get_ctx()
     finally:
         _mcp_ctx.reset(token)
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("viking://user", "viking://user/test_user"),
+        ("viking://user/notes.md", "viking://user/test_user/notes.md"),
+        (
+            "viking://user/project/notes.md",
+            "viking://user/test_user/project/notes.md",
+        ),
+        (
+            "viking://user/test_user/project/notes.md",
+            "viking://user/test_user/project/notes.md",
+        ),
+        ("viking://resources/project/notes.md", "viking://resources/project/notes.md"),
+    ],
+)
+def test_resolve_mcp_workspace_uri_is_current_user_relative(uri, expected):
+    assert _resolve_mcp_workspace_uri(uri, DEFAULT_CTX) == expected
+
+
+def test_resolve_mcp_workspace_uri_supports_dotted_current_user_id():
+    ctx = RequestContext(
+        user=UserIdentifier.the_default_user("alice.smith@corp.com"),
+        role=Role.USER,
+    )
+
+    assert (
+        _resolve_mcp_workspace_uri("viking://user/alice.smith@corp.com/notes/todo.md", ctx)
+        == "viking://user/alice.smith@corp.com/notes/todo.md"
+    )
+    assert (
+        _resolve_mcp_workspace_uri("viking://user/notes/todo.md", ctx)
+        == "viking://user/alice.smith@corp.com/notes/todo.md"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +244,7 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
 
     result = await mcp_endpoint.find(
         query="fast lookup",
-        target_uri="viking://resources",
+        target_uri="viking://user/project",
         limit=2,
         min_score=0.2,
         context_type=["memory", "resource"],
@@ -216,7 +253,7 @@ async def test_find_tool_calls_lightweight_find(service, monkeypatch):
     assert result == "No matching context found."
     assert captured["query"] == "fast lookup"
     assert captured["ctx"] == DEFAULT_CTX
-    assert captured["target_uri"] == "viking://resources"
+    assert captured["target_uri"] == "viking://user/test_user/project"
     assert captured["limit"] == 2
     assert captured["score_threshold"] == 0.2
     assert captured["filter"] == {
@@ -253,7 +290,7 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
 
     result = await search(
         query="deep lookup",
-        target_uri="viking://resources",
+        target_uri="viking://user/project",
         session_id="session-1",
         limit=4,
         min_score=0.1,
@@ -266,7 +303,7 @@ async def test_search_tool_calls_context_aware_search_with_session(service, monk
     assert captured["session_id"] == "session-1"
     assert captured["query"] == "deep lookup"
     assert captured["ctx"] == DEFAULT_CTX
-    assert captured["target_uri"] == "viking://resources"
+    assert captured["target_uri"] == "viking://user/test_user/project"
     assert captured["session"] == session
     assert captured["limit"] == 4
     assert captured["score_threshold"] == 0.1
@@ -406,15 +443,15 @@ async def test_mcp_middleware_rejects_invalid_actor_peer_header():
 
 
 async def test_read_nonexistent_uri(service):
-    result = await read("viking://user/default/memories/does_not_exist.md")
+    result = await read("viking://user/memories/does_not_exist.md")
     assert "nothing found" in result.lower()
 
 
 async def test_read_batch(service):
     result = await read(
         [
-            "viking://user/default/memories/does_not_exist_1.md",
-            "viking://user/default/memories/does_not_exist_2.md",
+            "viking://user/memories/does_not_exist_1.md",
+            "viking://user/memories/does_not_exist_2.md",
         ]
     )
     assert "===" in result
@@ -428,10 +465,12 @@ async def test_read_uses_public_content_projection(monkeypatch):
         "get_service",
         lambda: SimpleNamespace(fs=SimpleNamespace(read_visible=read_visible)),
     )
-    uri = "viking://user/default/memories/private.md"
+    uri = "viking://user/project/private.md"
 
     assert await read(uri) == "visible memory"
-    read_visible.assert_awaited_once_with(uri, ctx=DEFAULT_CTX)
+    read_visible.assert_awaited_once_with(
+        "viking://user/test_user/project/private.md", ctx=DEFAULT_CTX
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -447,9 +486,9 @@ async def test_list_root(service):
 async def test_list_empty_dir(service):
     ctx = DEFAULT_CTX
     await service.viking_fs.mkdir(
-        "viking://user/default/memories/empty_test", ctx=ctx, exist_ok=True
+        "viking://user/test_user/memories/empty_test", ctx=ctx, exist_ok=True
     )
-    result = await list_tool("viking://user/default/memories/empty_test")
+    result = await list_tool("viking://user/memories/empty_test")
     assert isinstance(result, str)
 
 
@@ -869,9 +908,10 @@ async def test_cancel_watch_not_found(service):
 
 async def test_forget_by_uri_deletes_memory(service):
     ctx = DEFAULT_CTX
-    uri = "viking://user/default/memories/test_forget.md"
-    await service.viking_fs.mkdir("viking://user/default/memories", ctx=ctx, exist_ok=True)
-    await service.viking_fs.write(uri, "test data", ctx=ctx)
+    uri = "viking://user/memories/test_forget.md"
+    canonical_uri = "viking://user/test_user/memories/test_forget.md"
+    await service.viking_fs.mkdir("viking://user/test_user/memories", ctx=ctx, exist_ok=True)
+    await service.viking_fs.write(canonical_uri, "test data", ctx=ctx)
 
     result = await forget(uri=uri)
     assert "deleted" in result.lower()
@@ -1032,7 +1072,7 @@ async def test_edit_noop_reports_no_changes(service):
 
 
 async def test_edit_memory_file_preserves_metadata(service):
-    uri = "viking://user/default/memories/preferences/test_edit_memory.md"
+    uri = "viking://user/memories/preferences/test_edit_memory.md"
     await write(uri=uri, content="likes: tea\n")
     raw_before = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert "MEMORY_FIELDS" in raw_before
@@ -1055,24 +1095,35 @@ async def test_write_user_shorthand_uri(service):
 
 
 async def test_write_user_root_file_via_shorthand(service):
-    # viking://user/persona.md shorthand inserts the current user.
-    result = await write(uri="viking://user/zeus-persona.md", content="# Zeus persona\n")
-    assert "viking://user/test_user/zeus-persona.md" in result
-    body = await service.fs.read("viking://user/test_user/zeus-persona.md", ctx=DEFAULT_CTX)
+    # The first relative segment can be any file or directory name; MCP does
+    # not guess from a file-extension allowlist.
+    result = await write(uri="viking://user/project/zeus-persona.md", content="# Zeus persona\n")
+    assert "viking://user/test_user/project/zeus-persona.md" in result
+    body = await service.fs.read("viking://user/test_user/project/zeus-persona.md", ctx=DEFAULT_CTX)
     assert body == "# Zeus persona\n"
 
 
 async def test_write_user_root_subdirectory_file(service):
-    uri = "viking://user/default/notes/todo.md"
+    uri = "viking://user/test_user/notes/todo.md"
     await write(uri=uri, content="- buy milk\n")
     assert "- buy milk" in await read(uris=uri)
 
 
+async def test_edit_user_root_file_via_same_shorthand(service):
+    uri = "viking://user/project/editable.md"
+    await write(uri=uri, content="before\n")
+
+    result = await edit(uri=uri, old_string="before", new_string="after")
+
+    assert "viking://user/test_user/project/editable.md" in result
+    assert "after" in await read(uris=uri)
+
+
 async def test_write_user_managed_subtree_rejected(service):
     with pytest.raises(InvalidArgumentError, match="user root"):
-        await write(uri="viking://user/default/sessions/fake-session.md", content="x")
+        await write(uri="viking://user/test_user/sessions/fake-session.md", content="x")
     with pytest.raises(InvalidArgumentError, match="user root"):
-        await write(uri="viking://user/default/skills/demo/SKILL.md", content="x")
+        await write(uri="viking://user/test_user/skills/demo/SKILL.md", content="x")
 
 
 async def test_write_tool_schema_is_portable():

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -21,12 +21,12 @@ from openviking.server.dependencies import set_service
 from openviking.server.identity import AuthMode, RequestContext, Role
 from openviking.server.mcp_endpoint import (
     StoreMessage,
-    WriteEdit,
     _get_ctx,
     _IdentityASGIMiddleware,
     _mcp_ctx,
     add_resource,
     cancel_watch,
+    edit,
     forget,
     glob,
     grep,
@@ -36,6 +36,7 @@ from openviking.server.mcp_endpoint import (
     recall,
     remember,
     search,
+    tree,
     write,
 )
 from openviking.server.mcp_endpoint import ls as list_tool
@@ -971,87 +972,72 @@ async def test_write_read_tool_roundtrip(service):
     assert "name: ada" in await read(uris=uri)
 
 
-async def test_write_edits_apply_single_replacement(service):
-    uri = "viking://resources/test_write_edit.md"
+async def test_edit_replaces_unique_occurrence(service):
+    uri = "viking://resources/test_edit.md"
     await write(uri=uri, content="alpha\nbeta\ngamma\n")
-    result = await write(uri=uri, edits=[WriteEdit(old_string="beta", new_string="BETA")])
-    assert "1 edit(s)" in result
+    result = await edit(uri=uri, old_string="beta", new_string="BETA")
+    assert "Edited" in result
     body = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert body == "alpha\nBETA\ngamma\n"
 
 
-async def test_write_edits_apply_in_order(service):
-    uri = "viking://resources/test_write_edit_order.md"
+async def test_edit_sequential_edits_compose(service):
+    uri = "viking://resources/test_edit_order.md"
     await write(uri=uri, content="foo bar baz\n")
-    await write(
-        uri=uri,
-        edits=[
-            WriteEdit(old_string="bar", new_string="qux"),
-            WriteEdit(old_string="foo qux", new_string="hello"),
-        ],
-    )
+    await edit(uri=uri, old_string="bar", new_string="qux")
+    await edit(uri=uri, old_string="foo qux", new_string="hello")
     body = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert body == "hello baz\n"
 
 
-async def test_write_edits_require_unique_match(service):
-    uri = "viking://resources/test_write_edit_multi.md"
+async def test_edit_requires_unique_match(service):
+    uri = "viking://resources/test_edit_multi.md"
     await write(uri=uri, content="dup\ndup\n")
     with pytest.raises(InvalidArgumentError, match="matches 2 locations"):
-        await write(uri=uri, edits=[WriteEdit(old_string="dup", new_string="x")])
+        await edit(uri=uri, old_string="dup", new_string="x")
 
 
-async def test_write_edits_replace_all(service):
-    uri = "viking://resources/test_write_edit_all.md"
+async def test_edit_replace_all(service):
+    uri = "viking://resources/test_edit_all.md"
     await write(uri=uri, content="dup\ndup\n")
-    await write(uri=uri, edits=[WriteEdit(old_string="dup", new_string="x", replace_all=True)])
+    await edit(uri=uri, old_string="dup", new_string="x", replace_all=True)
     body = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert body == "x\nx\n"
 
 
-async def test_write_edits_missing_old_string_fails(service):
-    uri = "viking://resources/test_write_edit_missing.md"
+async def test_edit_missing_old_string_fails(service):
+    uri = "viking://resources/test_edit_missing.md"
     await write(uri=uri, content="alpha\n")
     with pytest.raises(InvalidArgumentError, match="not found"):
-        await write(uri=uri, edits=[WriteEdit(old_string="zzz", new_string="x")])
+        await edit(uri=uri, old_string="zzz", new_string="x")
 
 
-async def test_write_edits_on_missing_file_fails(service):
+async def test_edit_empty_old_string_fails(service):
+    uri = "viking://resources/test_edit_empty.md"
+    await write(uri=uri, content="alpha\n")
+    with pytest.raises(InvalidArgumentError, match="must not be empty"):
+        await edit(uri=uri, old_string="", new_string="x")
+
+
+async def test_edit_on_missing_file_fails(service):
     with pytest.raises(NotFoundError):
-        await write(
-            uri="viking://resources/test_write_edit_ghost.md",
-            edits=[WriteEdit(old_string="a", new_string="b")],
-        )
+        await edit(uri="viking://resources/test_edit_ghost.md", old_string="a", new_string="b")
 
 
-async def test_write_edits_noop_reports_no_changes(service):
-    uri = "viking://resources/test_write_edit_noop.md"
+async def test_edit_noop_reports_no_changes(service):
+    uri = "viking://resources/test_edit_noop.md"
     await write(uri=uri, content="same\n")
-    result = await write(uri=uri, edits=[WriteEdit(old_string="same", new_string="same")])
+    result = await edit(uri=uri, old_string="same", new_string="same")
     assert "No changes" in result
 
 
-async def test_write_rejects_content_and_edits_together(service):
-    with pytest.raises(InvalidArgumentError, match="either content"):
-        await write(
-            uri="viking://resources/x.md",
-            content="a",
-            edits=[WriteEdit(old_string="a", new_string="b")],
-        )
-
-
-async def test_write_requires_content_or_edits(service):
-    with pytest.raises(InvalidArgumentError, match="provide content"):
-        await write(uri="viking://resources/x.md")
-
-
-async def test_write_edits_memory_file_preserves_metadata(service):
-    uri = "viking://user/default/memories/preferences/test_write_memory.md"
+async def test_edit_memory_file_preserves_metadata(service):
+    uri = "viking://user/default/memories/preferences/test_edit_memory.md"
     await write(uri=uri, content="likes: tea\n")
     raw_before = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert "MEMORY_FIELDS" in raw_before
 
-    await write(uri=uri, edits=[WriteEdit(old_string="tea", new_string="coffee")])
+    await edit(uri=uri, old_string="tea", new_string="coffee")
 
     raw_after = await service.fs.read(uri, ctx=DEFAULT_CTX)
     assert "MEMORY_FIELDS" in raw_after
@@ -1074,8 +1060,17 @@ async def test_write_tool_schema_is_portable():
     assert props["uri"]["type"] == "string"
     assert props["content"]["type"] == "string"
     assert props["mode"]["enum"] == ["replace", "append", "create"]
-    assert props["edits"]["type"] == "array"
-    assert props["edits"]["items"]["type"] == "object"
+    assert {"uri", "content"} <= set(tools["write"].inputSchema.get("required", []))
+
+
+async def test_edit_tool_schema_is_portable():
+    tools = {tool.name: tool for tool in await mcp_endpoint.mcp.list_tools()}
+    props = tools["edit"].inputSchema["properties"]
+    assert props["uri"]["type"] == "string"
+    assert props["old_string"]["type"] == "string"
+    assert props["new_string"]["type"] == "string"
+    assert props["replace_all"]["type"] == "boolean"
+    assert {"uri", "old_string", "new_string"} <= set(tools["edit"].inputSchema.get("required", []))
 
 
 # ---------------------------------------------------------------------------
@@ -1213,3 +1208,52 @@ async def test_mcp_middleware_stamps_root_span_identity():
     assert response.status_code == 200
     assert root_attrs.account_id == "acct-1"
     assert root_attrs.user_id == "user-1"
+
+
+# ---- tree tool ----
+
+
+async def test_tree_renders_indented_hierarchy(service):
+    await write(uri="viking://resources/test_tree/top.md", content="top\n")
+    await write(uri="viking://resources/test_tree/sub/a.md", content="alpha\n")
+    await write(uri="viking://resources/test_tree/sub/deeper/b.md", content="beta\n")
+
+    result = await tree(uri="viking://resources/test_tree")
+
+    assert result.startswith("Tree of viking://resources/test_tree")
+    assert "\nsub/\n" in result
+    assert "\n  a.md (6 B)\n" in result
+    assert "\n  deeper/\n" in result
+    assert "\n    b.md (5 B)" in result
+    assert "\ntop.md (4 B)" in result
+
+
+async def test_tree_empty_directory(service):
+    result = await tree(uri="viking://resources/test_tree_nope")
+    assert result == "(nothing under viking://resources/test_tree_nope)"
+
+
+async def test_tree_respects_level_limit(service):
+    await write(uri="viking://resources/test_tree_depth/d1/d2/deep.md", content="x\n")
+
+    shallow = await tree(uri="viking://resources/test_tree_depth", level_limit=1)
+    assert "d1/" in shallow
+    assert "deep.md" not in shallow
+
+    full = await tree(uri="viking://resources/test_tree_depth", level_limit=10)
+    assert "\n    deep.md (2 B)" in full
+
+
+async def test_tree_node_limit_adds_truncation_note(service):
+    await write(uri="viking://resources/test_tree_limit/f1.md", content="1\n")
+    await write(uri="viking://resources/test_tree_limit/f2.md", content="2\n")
+
+    result = await tree(uri="viking://resources/test_tree_limit", node_limit=1)
+    assert "(truncated at node_limit=1" in result
+
+
+async def test_tree_include_abstract_still_renders(service):
+    await write(uri="viking://resources/test_tree_abs/note.md", content="hello tree\n")
+
+    result = await tree(uri="viking://resources/test_tree_abs", include_abstract=True)
+    assert "\nnote.md (11 B)" in result

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -154,7 +154,8 @@ def test_dotted_user_root_segment_is_current_user_file_shorthand():
         role=Role.USER,
     )
 
-    # A dotted segment is a file name, so the current user is inserted.
+    # A segment with a text-file extension is a file name, so the current
+    # user is inserted.
     assert (
         canonicalize_uri("viking://user/zeus-persona.md", ctx)
         == "viking://user/alice/zeus-persona.md"
@@ -170,7 +171,17 @@ def test_dotted_user_root_segment_is_current_user_file_shorthand():
         canonicalize_uri("viking://user/bob/zeus-persona.md", ctx)
         == "viking://user/bob/zeus-persona.md"
     )
-    # The current user's own id always wins over the dotted shorthand rule.
+    # Dotted user ids without a file extension keep resolving as user ids
+    # (regression guard: shorthand must not re-route other users' spaces).
+    assert (
+        canonicalize_uri("viking://user/alice.smith/memories/preferences/p.md", ctx)
+        == "viking://user/alice.smith/memories/preferences/p.md"
+    )
+    assert (
+        canonicalize_uri("viking://user/bob@corp.com/resources/r.md", ctx)
+        == "viking://user/bob@corp.com/resources/r.md"
+    )
+    # The current user's own id always wins over the shorthand rule.
     dotted_ctx = RequestContext(
         user=UserIdentifier(account_id="acct", user_id="a.b"),
         role=Role.USER,

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -146,3 +146,36 @@ def test_current_user_short_content_roots_are_canonicalized_from_content_segment
         "viking://user/alice/resources"
     )
     assert is_content_root_uri("viking://resources", ctx, kind="resource")
+
+
+def test_dotted_user_root_segment_is_current_user_file_shorthand():
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="alice"),
+        role=Role.USER,
+    )
+
+    # A dotted segment is a file name, so the current user is inserted.
+    assert (
+        canonicalize_uri("viking://user/zeus-persona.md", ctx)
+        == "viking://user/alice/zeus-persona.md"
+    )
+    # Canonical form with an explicit user id is unchanged, including
+    # subdirectories under the user root.
+    assert (
+        canonicalize_uri("viking://user/alice/notes/todo.md", ctx)
+        == "viking://user/alice/notes/todo.md"
+    )
+    # Dot-free segments still address an explicit user.
+    assert (
+        canonicalize_uri("viking://user/bob/zeus-persona.md", ctx)
+        == "viking://user/bob/zeus-persona.md"
+    )
+    # The current user's own id always wins over the dotted shorthand rule.
+    dotted_ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="a.b"),
+        role=Role.USER,
+    )
+    assert (
+        canonicalize_uri("viking://user/a.b/memories/preferences/p.md", dotted_ctx)
+        == "viking://user/a.b/memories/preferences/p.md"
+    )

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -148,31 +148,25 @@ def test_current_user_short_content_roots_are_canonicalized_from_content_segment
     assert is_content_root_uri("viking://resources", ctx, kind="resource")
 
 
-def test_dotted_user_root_segment_is_current_user_file_shorthand():
+def test_unreserved_user_root_segment_keeps_canonical_meaning():
     ctx = RequestContext(
         user=UserIdentifier(account_id="acct", user_id="alice"),
         role=Role.USER,
     )
 
-    # A segment with a text-file extension is a file name, so the current
-    # user is inserted.
-    assert (
-        canonicalize_uri("viking://user/zeus-persona.md", ctx)
-        == "viking://user/alice/zeus-persona.md"
-    )
-    # Canonical form with an explicit user id is unchanged, including
-    # subdirectories under the user root.
-    assert (
-        canonicalize_uri("viking://user/alice/notes/todo.md", ctx)
-        == "viking://user/alice/notes/todo.md"
-    )
-    # Dot-free segments still address an explicit user.
+    # The generic namespace parser stays canonical-first. Callers that expose
+    # a current-user workspace dialect (such as MCP) must opt into that policy
+    # at their boundary instead of guessing from file extensions or server state.
+    assert canonicalize_uri("viking://user/notes/todo.md", ctx) == "viking://user/notes/todo.md"
     assert (
         canonicalize_uri("viking://user/bob/zeus-persona.md", ctx)
         == "viking://user/bob/zeus-persona.md"
     )
-    # Dotted user ids without a file extension keep resolving as user ids
-    # (regression guard: shorthand must not re-route other users' spaces).
+    # A valid canonical user id may itself end in a common file extension.
+    assert (
+        canonicalize_uri("viking://user/writer.md/memories/profile.md", ctx)
+        == "viking://user/writer.md/memories/profile.md"
+    )
     assert (
         canonicalize_uri("viking://user/alice.smith/memories/preferences/p.md", ctx)
         == "viking://user/alice.smith/memories/preferences/p.md"
@@ -181,12 +175,8 @@ def test_dotted_user_root_segment_is_current_user_file_shorthand():
         canonicalize_uri("viking://user/bob@corp.com/resources/r.md", ctx)
         == "viking://user/bob@corp.com/resources/r.md"
     )
-    # The current user's own id always wins over the shorthand rule.
-    dotted_ctx = RequestContext(
-        user=UserIdentifier(account_id="acct", user_id="a.b"),
-        role=Role.USER,
-    )
+    # The current user's own canonical form remains unchanged.
     assert (
-        canonicalize_uri("viking://user/a.b/memories/preferences/p.md", dotted_ctx)
-        == "viking://user/a.b/memories/preferences/p.md"
+        canonicalize_uri("viking://user/alice/notes/todo.md", ctx)
+        == "viking://user/alice/notes/todo.md"
     )


### PR DESCRIPTION
## 起因 / 问题

Agent 通过 MCP 能检索、读取 `viking://`，却不能创建或更新其中的文件；profile、工作笔记、journal 这类内容只能绕到本地文件系统，`viking://` 还不能成为 Agent 的工作目录。

另一个同一链路的问题是：向普通 resource/skill 文件 `append` 时会经过 memory 的序列化逻辑，原有末尾换行会被改写，并注入只属于 memory 的 `MEMORY_FIELDS` trailer。最小复现是先写入 `line1\n`，再 append `line2\n`；预期应精确得到 `line1\nline2\n`。

## 为什么这是 MCP / 存储层的缺口

`openviking/server/mcp_endpoint.py` 原来只暴露读取和检索类能力，没有内容写入或局部编辑入口；Agent 无法在它已有权限范围内完成最基本的文件生命周期。

`openviking/storage/content_write.py` 的 append 分支对所有文件调用 `MemoryFileUtils`。它适合 memory namespace，却把 resource 文件当作 memory 重写。用户根目录的普通文件也无法定位 refresh root，导致 `viking://user/<当前用户>/persona.md` 一类自然路径不可写。

## 改法

- 增加 `write`：`replace` 默认创建或覆盖，`create` 严格防覆盖，`append` 只追加；缺失父目录自动创建。
- 增加 `edit`：按精确字符串替换；找不到或在未声明 `replace_all` 时匹配多处，文件保持不变并给出恢复提示。
- 增加 `tree`：给陌生空间提供有深度和节点上限的目录视图；单层仍用 `list`，按文件名仍用 `glob`。
- 非 memory 文件的 append 改为原始字符串拼接；user root 的普通文本文件可写，但 `skills/`、`peers/`、`privacy/`、`sessions/` 继续只读。
- 只把带常见文本扩展名的 `viking://user/<file>` 视为当前用户根目录 shorthand，避免把合法的 dotted user id 静默重路由。

## 取舍 / 需要 reviewer 确认

`replace` 选择“文件不存在时创建”，让 Agent 不必先做 existence check；需要避免覆盖时可用 `create`。`edit` 不接受模糊替换，宁可失败也不在多处命中时猜测。

`tree` 返回结构和可选 abstract，适合定向浏览，但不是无限目录导出：默认深度 3、节点上限 1000，超出时明确截断。

写入后的语义/向量索引默认异步；需要 read-after-write 搜索一致性的调用方必须传 `wait=true`。

## 没动什么

没有开放任意本地文件系统写入，写入范围仍是 `viking://resources/`、`viking://user/` 和 `viking://agent/`。没有放开受系统管理的 user subtree，也没有把 `tree` 变成全文搜索或资源导入接口。

## 验证

- `tests/server/test_mcp_endpoint.py`：91/91 通过，新增 30 个覆盖 write mode、edit 的原子失败语义、memory metadata 保留、user shorthand、tree 的层级/上限/截断。
- `tests/server/test_content_write_service.py` 新增 resource append 回归用例，验证结果严格为 `line1\nline2\n`，不含 `MEMORY_FIELDS`。
- 本地 streamable HTTP smoke：write → edit → append → tree → read，以及对应错误路径。
- 仅暴露 MCP 的 agent eval：4 个 Doubao fresh session、2 个 Codex read-only session 都完成保存 profile、跨 session 读回、定向 edit、验证和整理知识文件，未写本地 FS。

本环境里 `test_content_write_service.py` 有 7 个失败；在 pristine `origin/main` 同样复现，已通过 stash round-trip 排除与本 PR 的关联。
