### PR TITLE
fix(session): bound archive state polling and recovery

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -8,7 +8,10 @@ Session as Context: Sessions integrated into L0/L1/L2 system.
 import asyncio
 import inspect
 import json
+import random
 import re
+import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Literal, Optional
@@ -68,7 +71,13 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_ARCHIVE_WAIT_POLL_SECONDS = 0.1
+_ARCHIVE_WAIT_POLL_SECONDS = 0.2
+_ARCHIVE_WAIT_MAX_POLL_SECONDS = 2.0
+_ARCHIVE_WAIT_JITTER_RATIO = 0.1
+_ARCHIVE_WAIT_TIMEOUT_SECONDS = 1800.0
+_ARCHIVE_RECOVERY_SCAN_CACHE_SECONDS = 1.0
+_ARCHIVE_RECOVERY_SCAN_ITEM_DELAY_SECONDS = 0.1
+_ARCHIVE_RECOVERY_UNPACED_ITEMS = 4
 _PHASE2_QUEUE_WAIT_TIMEOUT_SECONDS = 1800.0
 _MEMORY_EXTRACTION_MAX_RETRIES = 3
 _MEMORY_EXTRACTION_RETRY_BASE_DELAY_SECONDS = 1.0
@@ -77,6 +86,7 @@ _AGENT_TRAINING_REQUIRED_MEMORY_TYPES = frozenset({"cases", "trajectories"})
 _SESSION_PHASE1_LOCK_TIMEOUT_SECONDS = 30.0
 _MEMORY_STEP_NAMES = ("long_term", "execution")
 _CUMULATIVE_CHECKPOINT_VERSION = 2
+_ARCHIVE_PREDECESSOR_BARRIER_VERSION = 1
 
 
 class _ArchiveMessagesCorruptError(ValueError):
@@ -431,6 +441,29 @@ class ArchiveState:
             if match:
                 return int(match.group(1))
         return self.index
+
+
+@dataclass(frozen=True)
+class _Phase2PredecessorPlan:
+    """Bounded predecessor state needed to prepare one Phase-2 archive."""
+
+    replay_states: tuple[ArchiveState, ...] = ()
+    latest_completed: Optional[ArchiveState] = None
+    used_recovery_scan: bool = False
+
+
+# SessionCommit workers create a fresh ``Session`` object per queue item. Keep
+# process-local coordination at module scope so concurrent items for the same
+# session can share terminal notifications and exceptional recovery scans.
+_ARCHIVE_COORDINATION_GUARD = threading.Lock()
+_ARCHIVE_TERMINAL_EVENTS: Dict[
+    tuple[int, str], tuple[asyncio.AbstractEventLoop, asyncio.Event]
+] = {}
+_ARCHIVE_RECOVERY_SCAN_TASKS: Dict[tuple[int, str], asyncio.Task] = {}
+_ARCHIVE_RECOVERY_SCAN_CACHE: Dict[
+    tuple[int, str], tuple[float, int, tuple[ArchiveState, ...]]
+] = {}
+_ARCHIVE_RECOVERY_SCAN_SEMAPHORES: Dict[int, asyncio.Semaphore] = {}
 
 
 @dataclass
@@ -2363,14 +2396,18 @@ class Session:
         archive_index = self._archive_index_from_uri(archive_uri)
 
         try:
-            await self._wait_for_previous_archive_done(archive_index)
+            predecessor_plan = await self._resolve_phase2_predecessors(archive_index)
             (
                 messages,
                 coverage_start_archive,
                 coverage_end_archive,
                 covered_failed_archives,
                 completed_memory_steps,
-            ) = await self._prepare_phase2_archive_messages(archive_uri, messages)
+            ) = await self._prepare_phase2_archive_messages(
+                archive_uri,
+                messages,
+                predecessor_plan=predecessor_plan,
+            )
             if not messages:
                 raise ValueError("session commit archive has no recoverable messages")
             first_message_id = messages[0].id
@@ -2393,6 +2430,7 @@ class Session:
                             archive_uri,
                             covered_failed_archives,
                             messages,
+                            previous_completed=predecessor_plan.latest_completed,
                         )
                         if working_memory_enabled
                         else []
@@ -2401,6 +2439,7 @@ class Session:
                         await self._get_latest_completed_archive_overview(
                             exclude_archive_uri=archive_uri,
                             before_archive_index=archive_index,
+                            preferred_completed=predecessor_plan.latest_completed,
                         )
                         if working_memory_enabled
                         else ""
@@ -2858,6 +2897,7 @@ class Session:
                 "starting_message_id": first_message_id,
                 "ending_message_id": last_message_id,
                 "working_memory_enabled": working_memory_enabled,
+                "predecessor_barrier_version": _ARCHIVE_PREDECESSOR_BARRIER_VERSION,
                 "coverage_start_archive": coverage_start_archive or archive_id,
                 "coverage_end_archive": coverage_end_archive or archive_id,
                 "covered_failed_archives": list(covered_failed_archives or []),
@@ -2870,6 +2910,7 @@ class Session:
             content=content,
             ctx=self.ctx,
         )
+        self._notify_archive_terminal(archive_uri)
 
     async def _write_failed_marker(
         self,
@@ -2899,6 +2940,7 @@ class Session:
             ctx=self.ctx,
             lease_ref=lease_ref,
         )
+        self._notify_archive_terminal(archive_uri)
 
     async def get_session_context(self, token_budget: int = 128_000) -> Dict[str, Any]:
         """Get assembled session context with the latest summary archive and merged messages."""
@@ -3029,9 +3071,9 @@ class Session:
         ``failed`` archive no longer replays its raw messages. Cumulative v2
         checkpoints are restored from the terminal archive alone; only a
         terminal legacy v1 delta checkpoint invokes an older-history compatibility
-        scan. Phase 2 coverage bookkeeping is unaffected because it keeps using
-        the full ``_scan_archive_states()`` scan. Public
-        ``pre_archive_abstracts`` stay empty; abstracts are not read.
+        scan. Phase 2 resolves current-format predecessor coverage incrementally;
+        only legacy or malformed marker recovery uses a protected full scan.
+        Public ``pre_archive_abstracts`` stay empty; abstracts are not read.
         """
         archive_refs = await self._list_archive_refs()
         newer_pending: List[Dict[str, Any]] = []
@@ -3143,100 +3185,143 @@ class Session:
 
         return sorted(refs, key=lambda item: item["index"], reverse=True)
 
-    async def _scan_archive_states(self) -> List[ArchiveState]:
-        """Derive every archive state exclusively from its directory markers."""
-        states: List[ArchiveState] = []
-        refs = sorted(await self._list_archive_refs(), key=lambda item: item["index"])
-        for archive in refs:
-            done_uri = f"{archive['archive_uri']}/.done"
-            try:
-                done_exists = await self._viking_fs.exists(done_uri, ctx=self.ctx)
-            except Exception:
-                done_exists = False
-            done: Dict[str, Any] = {}
-            if done_exists:
+    @staticmethod
+    def _archive_ref(session_uri: str, index: int) -> Dict[str, Any]:
+        archive_id = f"archive_{index:03d}"
+        return {
+            "archive_id": archive_id,
+            "archive_uri": f"{session_uri}/history/{archive_id}",
+            "index": index,
+        }
+
+    async def _read_archive_state(
+        self,
+        archive: Dict[str, Any],
+        *,
+        verify_directory: bool = False,
+    ) -> Optional[ArchiveState]:
+        """Read one archive state without listing or touching sibling archives."""
+        done_uri = f"{archive['archive_uri']}/.done"
+        done: Dict[str, Any] = {}
+        done_exists = False
+        try:
+            raw_done = await self._viking_fs.read_file(done_uri, ctx=self.ctx)
+            done_exists = True
+            parsed_done = json.loads(raw_done or "{}")
+            if isinstance(parsed_done, dict):
+                done = parsed_done
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                # Preserve the established rule that an existing but unreadable
+                # marker is terminal, while keeping the healthy path to one
+                # read instead of an exists+read pair.
                 try:
-                    raw_done = await self._viking_fs.read_file(done_uri, ctx=self.ctx)
-                    parsed_done = json.loads(raw_done or "{}")
-                    if isinstance(parsed_done, dict):
-                        done = parsed_done
-                except Exception as exc:
-                    # Marker existence still means completion, but unreadable
-                    # contents cannot extend coverage to earlier archives.
-                    logger.warning(
-                        "Unreadable archive done marker %s: %s", archive["archive_uri"], exc
-                    )
-
+                    done_exists = await self._viking_fs.exists(done_uri, ctx=self.ctx)
+                except Exception:
+                    done_exists = False
             if done_exists:
-                # Only validate overview when Working Memory required one.
-                # Otherwise leave overview empty here and let context assembly
-                # lazy-load the newest terminal completed archive's overview.
-                overview = ""
-                if done.get("working_memory_enabled") is True:
-                    overview = await self._read_archive_overview(archive["archive_uri"])
-                    if not overview.strip():
-                        # New markers distinguish an intentionally overview-less
-                        # working_memory=false commit from a missing/corrupt
-                        # required overview. The latter remains logically live and
-                        # can be rolled forward by a later successful archive.
-                        logger.warning(
-                            "Completed archive has no readable required overview: %s",
-                            archive["archive_uri"],
-                        )
-                        states.append(
-                            ArchiveState(
-                                archive_id=archive["archive_id"],
-                                archive_uri=archive["archive_uri"],
-                                index=archive["index"],
-                                state="failed",
-                                done=done,
-                                failed={
-                                    "stage": "archive_overview",
-                                    "error": "required overview is missing or unreadable",
-                                },
-                            )
-                        )
-                        continue
+                logger.warning("Unreadable archive done marker %s: %s", archive["archive_uri"], exc)
 
-                # working_memory=false legitimately writes .done without an
-                # overview. Legacy markers lack the explicit flag, so retain
-                # their established completed semantics for compatibility.
-                states.append(
-                    ArchiveState(
+        if done_exists:
+            # Only validate overview when Working Memory required one.
+            overview = ""
+            if done.get("working_memory_enabled") is True:
+                overview = await self._read_archive_overview(archive["archive_uri"])
+                if not overview.strip():
+                    # A required but unreadable overview keeps the raw archive
+                    # recoverable even though the physical .done marker exists.
+                    logger.warning(
+                        "Completed archive has no readable required overview: %s",
+                        archive["archive_uri"],
+                    )
+                    return ArchiveState(
                         archive_id=archive["archive_id"],
                         archive_uri=archive["archive_uri"],
                         index=archive["index"],
-                        state="completed",
-                        overview=overview,
+                        state="failed",
                         done=done,
+                        failed={
+                            "stage": "archive_overview",
+                            "error": "required overview is missing or unreadable",
+                        },
                     )
-                )
-                continue
 
-            failed: Dict[str, Any] = {}
-            failed_uri = f"{archive['archive_uri']}/.failed.json"
-            try:
-                failed_exists = await self._viking_fs.exists(failed_uri, ctx=self.ctx)
-            except Exception:
-                failed_exists = False
-            if failed_exists:
-                try:
-                    parsed_failed = json.loads(
-                        await self._viking_fs.read_file(failed_uri, ctx=self.ctx) or "{}"
-                    )
-                    if isinstance(parsed_failed, dict):
-                        failed = parsed_failed
-                except Exception as exc:
-                    logger.warning("Unreadable archive failed marker %s: %s", failed_uri, exc)
-            states.append(
-                ArchiveState(
-                    archive_id=archive["archive_id"],
-                    archive_uri=archive["archive_uri"],
-                    index=archive["index"],
-                    state="failed" if failed_exists else "pending",
-                    failed=failed,
-                )
+            # working_memory=false legitimately writes .done without an
+            # overview. Legacy markers lack the explicit flag and retain their
+            # established completed semantics.
+            return ArchiveState(
+                archive_id=archive["archive_id"],
+                archive_uri=archive["archive_uri"],
+                index=archive["index"],
+                state="completed",
+                overview=overview,
+                done=done,
             )
+
+        failed_uri = f"{archive['archive_uri']}/.failed.json"
+        failed: Dict[str, Any] = {}
+        failed_exists = False
+        try:
+            raw_failed = await self._viking_fs.read_file(failed_uri, ctx=self.ctx)
+            failed_exists = True
+            parsed_failed = json.loads(raw_failed or "{}")
+            if isinstance(parsed_failed, dict):
+                failed = parsed_failed
+        except Exception as exc:
+            if not _is_storage_not_found(exc):
+                try:
+                    failed_exists = await self._viking_fs.exists(failed_uri, ctx=self.ctx)
+                except Exception:
+                    failed_exists = False
+            if failed_exists:
+                logger.warning("Unreadable archive failed marker %s: %s", failed_uri, exc)
+
+        if failed_exists:
+            return ArchiveState(
+                archive_id=archive["archive_id"],
+                archive_uri=archive["archive_uri"],
+                index=archive["index"],
+                state="failed",
+                failed=failed,
+            )
+
+        if verify_directory:
+            try:
+                if not await self._viking_fs.exists(archive["archive_uri"], ctx=self.ctx):
+                    return None
+            except Exception:
+                return None
+
+        return ArchiveState(
+            archive_id=archive["archive_id"],
+            archive_uri=archive["archive_uri"],
+            index=archive["index"],
+            state="pending",
+        )
+
+    async def _scan_archive_states(
+        self,
+        *,
+        per_archive_delay: float = 0.0,
+    ) -> List[ArchiveState]:
+        """Derive every archive state exclusively from its directory markers."""
+        states: List[ArchiveState] = []
+        refs = sorted(await self._list_archive_refs(), key=lambda item: item["index"])
+        for offset, archive in enumerate(refs):
+            state = await self._read_archive_state(archive)
+            if state is not None:
+                states.append(state)
+            if per_archive_delay > 0 and offset + 1 < len(refs):
+                # Recovery scans can start together after a fleet restart. A
+                # small jitter keeps different processes from issuing their
+                # next metadata burst on the same fixed cadence.
+                await asyncio.sleep(
+                    per_archive_delay
+                    * random.uniform(
+                        1.0 - _ARCHIVE_WAIT_JITTER_RATIO,
+                        1.0 + _ARCHIVE_WAIT_JITTER_RATIO,
+                    )
+                )
         return states
 
     @staticmethod
@@ -3392,11 +3477,15 @@ class Session:
         exclude_archive_uri: Optional[str] = None,
         before_archive_index: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Return the newest readable completed archive summary."""
-        for archive in await self._get_completed_archive_refs(
-            exclude_archive_uri,
-            before_archive_index,
-        ):
+        """Return the newest readable completed summary without a full state scan."""
+        exclude = exclude_archive_uri.rstrip("/") if exclude_archive_uri else None
+        for archive in await self._list_archive_refs():  # newest → oldest
+            if exclude and archive["archive_uri"] == exclude:
+                continue
+            if before_archive_index is not None and archive["index"] >= before_archive_index:
+                continue
+            if await self._archive_terminal_state(archive["archive_uri"]) != "completed":
+                continue
             overview = await self._read_archive_overview(archive["archive_uri"])
             if not overview:
                 continue
@@ -3417,8 +3506,24 @@ class Session:
         self,
         exclude_archive_uri: Optional[str] = None,
         before_archive_index: Optional[int] = None,
+        preferred_completed: Optional[ArchiveState] = None,
     ) -> str:
         """Return the newest completed archive overview, skipping incomplete archives."""
+        if (
+            preferred_completed is not None
+            and preferred_completed.state == "completed"
+            and (before_archive_index is None or preferred_completed.index < before_archive_index)
+            and (
+                not exclude_archive_uri
+                or preferred_completed.archive_uri != exclude_archive_uri.rstrip("/")
+            )
+        ):
+            overview = preferred_completed.overview or await self._read_archive_overview(
+                preferred_completed.archive_uri
+            )
+            if overview:
+                return overview
+
         summary = await self._get_latest_completed_archive_summary(
             exclude_archive_uri,
             before_archive_index,
@@ -3478,6 +3583,7 @@ class Session:
         anchor_ids: set[str],
         *,
         before_archive_index: Optional[int] = None,
+        preferred_completed: Optional[ArchiveState] = None,
     ) -> Dict[str, _CheckpointSnapshot]:
         """Resolve completed checkpoint history for the requested retained Turns.
 
@@ -3498,13 +3604,13 @@ class Session:
             }
             for anchor_id in anchor_ids
         }
-        refs = await self._get_completed_archive_refs(before_archive_index=before_archive_index)
-        for archive in refs:  # newest → oldest
+
+        async def ingest_archive(archive: Dict[str, Any]) -> None:
             unresolved = {
                 anchor_id for anchor_id, history in histories.items() if not history["resolved"]
             }
             if not unresolved:
-                break
+                return
             grouped = self._checkpoint_records_for_anchors(
                 await self._read_archive_meta(archive["archive_uri"]),
                 unresolved,
@@ -3541,6 +3647,37 @@ class Session:
                         "archive_uri": archive["archive_uri"],
                     }
                 )
+
+        preferred_uri = ""
+        if (
+            preferred_completed is not None
+            and preferred_completed.state == "completed"
+            and (before_archive_index is None or preferred_completed.index < before_archive_index)
+        ):
+            preferred_uri = preferred_completed.archive_uri
+            await ingest_archive(
+                {
+                    "archive_id": preferred_completed.archive_id,
+                    "archive_uri": preferred_completed.archive_uri,
+                    "index": preferred_completed.index,
+                }
+            )
+
+        unresolved = {
+            anchor_id for anchor_id, history in histories.items() if not history["resolved"]
+        }
+        if unresolved:
+            for archive in await self._list_archive_refs():  # newest → oldest
+                if before_archive_index is not None and archive["index"] >= before_archive_index:
+                    continue
+                if archive["archive_uri"] == preferred_uri:
+                    continue
+                state = await self._read_archive_state(archive)
+                if state is None or state.state != "completed":
+                    continue
+                await ingest_archive(archive)
+                if all(history["resolved"] for history in histories.values()):
+                    break
 
         snapshots: Dict[str, _CheckpointSnapshot] = {}
         for anchor_id, history in histories.items():
@@ -3579,6 +3716,8 @@ class Session:
         archive_uri: str,
         covered_failed_archives: List[str],
         messages: List[Message],
+        *,
+        previous_completed: Optional[ArchiveState] = None,
     ) -> List[_CheckpointRequest]:
         """Collect and validate partial-Turn checkpoint work owned by this Phase 2.
 
@@ -3692,6 +3831,7 @@ class Session:
         previous_by_anchor = await self._get_effective_completed_checkpoints(
             {request.turn_anchor_message_id for request in requests},
             before_archive_index=self._archive_index_from_uri(archive_uri),
+            preferred_completed=previous_completed,
         )
         return [
             _CheckpointRequest(
@@ -3884,44 +4024,382 @@ class Session:
             raise ValueError(f"Invalid archive URI: {archive_uri}")
         return int(match.group(1))
 
-    async def _wait_for_previous_archive_done(self, archive_index: int) -> bool:
-        """Wait until every earlier archive reaches a terminal state."""
-        if archive_index <= 1 or not self._viking_fs:
-            return True
+    @staticmethod
+    def _has_authoritative_coverage(state: ArchiveState) -> bool:
+        """Whether a completed marker can terminate a predecessor walk."""
+        if state.state != "completed":
+            return False
+        try:
+            barrier_version = int(state.done.get("predecessor_barrier_version", 0) or 0)
+        except (TypeError, ValueError):
+            return False
+        if barrier_version < _ARCHIVE_PREDECESSOR_BARRIER_VERSION:
+            return False
+        start = state.done.get("coverage_start_archive")
+        end = state.done.get("coverage_end_archive")
+        covered_failed = state.done.get("covered_failed_archives")
+        if not isinstance(start, str) or not isinstance(end, str):
+            return False
+        start_match = re.fullmatch(r"archive_(\d+)", start)
+        end_match = re.fullmatch(r"archive_(\d+)", end)
+        if not start_match or not end_match or not isinstance(covered_failed, list):
+            return False
+        start_index = int(start_match.group(1))
+        end_index = int(end_match.group(1))
+        return 1 <= start_index <= end_index == state.index
+
+    def _get_archive_terminal_event(
+        self,
+        archive_uri: str,
+    ) -> tuple[tuple[int, str], asyncio.Event]:
+        loop = asyncio.get_running_loop()
+        key = (id(loop), archive_uri)
+        with _ARCHIVE_COORDINATION_GUARD:
+            registered = _ARCHIVE_TERMINAL_EVENTS.get(key)
+            if registered is None:
+                event = asyncio.Event()
+                _ARCHIVE_TERMINAL_EVENTS[key] = (loop, event)
+            else:
+                event = registered[1]
+        return key, event
+
+    @staticmethod
+    def _release_archive_terminal_event(key: tuple[int, str], event: asyncio.Event) -> None:
+        with _ARCHIVE_COORDINATION_GUARD:
+            registered = _ARCHIVE_TERMINAL_EVENTS.get(key)
+            if registered is not None and registered[1] is event:
+                _ARCHIVE_TERMINAL_EVENTS.pop(key, None)
+
+    @staticmethod
+    def _notify_archive_terminal(archive_uri: str) -> None:
+        notifications: List[tuple[asyncio.AbstractEventLoop, asyncio.Event]] = []
+        with _ARCHIVE_COORDINATION_GUARD:
+            for key, registered in list(_ARCHIVE_TERMINAL_EVENTS.items()):
+                if key[1] != archive_uri:
+                    continue
+                _ARCHIVE_TERMINAL_EVENTS.pop(key, None)
+                notifications.append(registered)
+            for key in list(_ARCHIVE_RECOVERY_SCAN_CACHE):
+                if key[1] == archive_uri.rsplit("/history/", 1)[0]:
+                    _ARCHIVE_RECOVERY_SCAN_CACHE.pop(key, None)
+
+        for loop, event in notifications:
+            if loop.is_closed():
+                continue
+            try:
+                loop.call_soon_threadsafe(event.set)
+            except RuntimeError:
+                continue
+
+    def _invalidate_archive_recovery_cache(self) -> None:
+        with _ARCHIVE_COORDINATION_GUARD:
+            for key in list(_ARCHIVE_RECOVERY_SCAN_CACHE):
+                if key[1] == self._session_uri:
+                    _ARCHIVE_RECOVERY_SCAN_CACHE.pop(key, None)
+
+    @staticmethod
+    async def _pace_archive_recovery(processed_items: int) -> None:
+        """Smooth large exceptional walks without delaying the common short tail."""
+        if processed_items <= _ARCHIVE_RECOVERY_UNPACED_ITEMS:
+            return
+        await asyncio.sleep(
+            _ARCHIVE_RECOVERY_SCAN_ITEM_DELAY_SECONDS
+            * random.uniform(
+                1.0 - _ARCHIVE_WAIT_JITTER_RATIO,
+                1.0 + _ARCHIVE_WAIT_JITTER_RATIO,
+            )
+        )
+
+    async def _scan_archive_states_for_recovery(
+        self,
+        archive_index: int,
+    ) -> List[ArchiveState]:
+        """Singleflight and rate-limit the exceptional full-history scan."""
+        loop = asyncio.get_running_loop()
+        loop_id = id(loop)
+        key = (loop_id, self._session_uri)
+        required_generation = archive_index - 1
+        generation_retried = False
 
         while True:
-            earlier_states = [
-                state for state in await self._scan_archive_states() if state.index < archive_index
-            ]
-            pending_states = [state for state in earlier_states if state.state == "pending"]
-            if not pending_states:
-                non_completed = [state for state in earlier_states if state.state == "failed"]
-                if non_completed:
-                    logger.info(
-                        "Earlier archives reached terminal non-completed states; "
-                        "continuing with raw replay: %s",
-                        [state.archive_id for state in non_completed],
-                    )
-                return True
+            now = time.monotonic()
+            with _ARCHIVE_COORDINATION_GUARD:
+                cached = _ARCHIVE_RECOVERY_SCAN_CACHE.get(key)
+                if (
+                    cached is not None
+                    and cached[0] > now
+                    and cached[1] >= required_generation
+                ):
+                    return list(cached[2])
 
-            # A new-format intent without ready status may be left by a
-            # process interruption. Reconcile it under the session lock rather
-            # than waiting forever for a queue item that may never have existed.
-            reconciled = False
-            for state in pending_states:
+                task = _ARCHIVE_RECOVERY_SCAN_TASKS.get(key)
+                if task is None:
+                    semaphore = _ARCHIVE_RECOVERY_SCAN_SEMAPHORES.get(loop_id)
+                    if semaphore is None:
+                        # One exceptional scan per process event loop keeps corrupt
+                        # or legacy sessions from forming a metadata-read stampede.
+                        semaphore = asyncio.Semaphore(1)
+                        _ARCHIVE_RECOVERY_SCAN_SEMAPHORES[loop_id] = semaphore
+
+                    async def run_scan(
+                        scan_semaphore: asyncio.Semaphore,
+                    ) -> List[ArchiveState]:
+                        async with scan_semaphore:
+                            states = await self._scan_archive_states(
+                                per_archive_delay=_ARCHIVE_RECOVERY_SCAN_ITEM_DELAY_SECONDS
+                            )
+                        max_index = max((state.index for state in states), default=0)
+                        with _ARCHIVE_COORDINATION_GUARD:
+                            _ARCHIVE_RECOVERY_SCAN_CACHE[key] = (
+                                time.monotonic() + _ARCHIVE_RECOVERY_SCAN_CACHE_SECONDS,
+                                max_index,
+                                tuple(states),
+                            )
+                        return states
+
+                    task = loop.create_task(run_scan(semaphore))
+                    _ARCHIVE_RECOVERY_SCAN_TASKS[key] = task
+
+                    def clear_finished_scan(finished: asyncio.Task) -> None:
+                        with _ARCHIVE_COORDINATION_GUARD:
+                            if _ARCHIVE_RECOVERY_SCAN_TASKS.get(key) is finished:
+                                _ARCHIVE_RECOVERY_SCAN_TASKS.pop(key, None)
+
+                    task.add_done_callback(clear_finished_scan)
+
+            states = list(await asyncio.shield(task))
+            if max((state.index for state in states), default=0) >= required_generation:
+                return states
+
+            # The listing may have raced creation/publication of the immediate
+            # predecessor. Retry one paced scan, but never spin on a stale or
+            # unhealthy ``ls`` response: after that, directly probe the one
+            # predecessor required by this caller and return the bounded result.
+            if generation_retried:
+                self._invalidate_archive_recovery_cache()
+                predecessor = await self._read_archive_state(
+                    self._archive_ref(self._session_uri, required_generation),
+                    verify_directory=True,
+                )
+                if predecessor is not None and all(
+                    state.index != predecessor.index for state in states
+                ):
+                    states.append(predecessor)
+                    states.sort(key=lambda state: state.index)
+                return states
+
+            generation_retried = True
+            self._invalidate_archive_recovery_cache()
+            with _ARCHIVE_COORDINATION_GUARD:
+                if _ARCHIVE_RECOVERY_SCAN_TASKS.get(key) is task:
+                    _ARCHIVE_RECOVERY_SCAN_TASKS.pop(key, None)
+            await asyncio.sleep(
+                _ARCHIVE_WAIT_POLL_SECONDS
+                * random.uniform(
+                    1.0 - _ARCHIVE_WAIT_JITTER_RATIO,
+                    1.0 + _ARCHIVE_WAIT_JITTER_RATIO,
+                )
+            )
+
+    async def _wait_for_archive_terminal(
+        self,
+        archive: Dict[str, Any],
+        *,
+        deadline: float,
+        timeout: float,
+        blocked_archive_index: int,
+    ) -> Optional[ArchiveState]:
+        """Wait on one blocker, then fail a presumed orphan after the deadline."""
+        event_key, event = self._get_archive_terminal_event(archive["archive_uri"])
+        delay = max(0.0, _ARCHIVE_WAIT_POLL_SECONDS)
+        try:
+            while True:
+                # The caller already established that the archive directory
+                # exists. Steady-state polling only needs the two terminal
+                # markers; avoid a third directory stat on every interval.
+                state = await self._read_archive_state(archive)
+                if state.state != "pending":
+                    return state
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    # Re-read immediately before publishing the terminal marker;
+                    # a predecessor may have completed at the timeout boundary.
+                    state = await self._read_archive_state(archive, verify_directory=True)
+                    if state is None or state.state != "pending":
+                        return state
+                    logger.error(
+                        "Archive %s stayed pending for over %.0fs while blocking "
+                        "archive_%03d Phase 2; its queue item is presumed lost. "
+                        "Marking it failed so its raw messages can be replayed.",
+                        archive["archive_id"],
+                        timeout,
+                        blocked_archive_index,
+                    )
+                    await self._write_failed_marker(
+                        archive["archive_uri"],
+                        stage="phase2_wait_timeout",
+                        error=(
+                            f"Archive stayed pending for over {timeout:.0f}s; "
+                            "its Phase 2 queue item is presumed lost"
+                        ),
+                        blocked_by=f"archive_{blocked_archive_index:03d}",
+                    )
+                    raise TimeoutError(
+                        f"Timed out after {timeout:.0f}s waiting for "
+                        f"{archive['archive_id']} to finish before "
+                        f"archive_{blocked_archive_index:03d} Phase 2; it was "
+                        "marked failed for raw replay by a later commit"
+                    )
+
+                jitter = 1.0 + random.uniform(
+                    -_ARCHIVE_WAIT_JITTER_RATIO,
+                    _ARCHIVE_WAIT_JITTER_RATIO,
+                )
+                poll_timeout = min(remaining, max(0.001, delay * jitter))
+                try:
+                    await asyncio.wait_for(event.wait(), timeout=poll_timeout)
+                except TimeoutError:
+                    pass
+                else:
+                    # Event.set() is level-triggered. Consume this notification
+                    # so a temporarily stale cross-layer marker read cannot turn
+                    # the next iterations into a no-sleep metadata hot loop.
+                    event.clear()
+                delay = min(
+                    _ARCHIVE_WAIT_MAX_POLL_SECONDS,
+                    max(_ARCHIVE_WAIT_POLL_SECONDS, delay * 2),
+                )
+        finally:
+            self._release_archive_terminal_event(event_key, event)
+
+    async def _resolve_phase2_predecessors_from_scan(
+        self,
+        archive_index: int,
+        *,
+        timeout: float,
+    ) -> _Phase2PredecessorPlan:
+        """Compatibility recovery for legacy, missing, or malformed marker chains."""
+        states = await self._scan_archive_states_for_recovery(archive_index)
+        earlier_by_index = {
+            state.index: state for state in states if state.index < archive_index
+        }
+        pending_states = sorted(
+            (state for state in earlier_by_index.values() if state.state == "pending"),
+            key=lambda state: state.index,
+        )
+
+        # The exceptional scan is a snapshot. Resolve each blocker directly
+        # from that snapshot instead of rescanning all history after every
+        # terminal transition. A blocker that already finished is a one-read
+        # fast path; a real pending blocker uses the bounded event/backoff wait.
+        for blocker in pending_states:
+            phase1 = await self._read_phase1_meta(blocker.archive_uri)
+            if phase1 and phase1.get("status") != "ready":
+                await self._ensure_phase1_ready(blocker.archive_uri)
+            terminal = await self._wait_for_archive_terminal(
+                self._archive_ref(self._session_uri, blocker.index),
+                # Time spent behind the recovery-scan throttle, or waiting for
+                # an older blocker, must not age this blocker into an orphan.
+                deadline=time.monotonic() + timeout,
+                timeout=timeout,
+                blocked_archive_index=archive_index,
+            )
+            if terminal is None:
+                earlier_by_index.pop(blocker.index, None)
+            else:
+                earlier_by_index[blocker.index] = terminal
+
+        earlier_states = [earlier_by_index[index] for index in sorted(earlier_by_index)]
+        covered = self._covered_archive_ids(earlier_states)
+        replay_states = tuple(
+            state
+            for state in earlier_states
+            if state.state == "failed" and state.archive_id not in covered
+        )
+        completed = [state for state in earlier_states if state.state == "completed"]
+        return _Phase2PredecessorPlan(
+            replay_states=replay_states,
+            latest_completed=max(completed, key=lambda state: state.index, default=None),
+            used_recovery_scan=True,
+        )
+
+    async def _resolve_phase2_predecessors(
+        self,
+        archive_index: int,
+        timeout: float = _ARCHIVE_WAIT_TIMEOUT_SECONDS,
+    ) -> _Phase2PredecessorPlan:
+        """Resolve only the predecessor chain needed by the current Phase 2.
+
+        A current-format completed marker has authoritative transitive coverage,
+        so the normal path is O(1). Failed predecessors are walked backward and
+        replayed. Only a legacy marker or a directory gap enters the protected
+        full-history compatibility path.
+        """
+        if archive_index <= 1 or not self._viking_fs:
+            return _Phase2PredecessorPlan()
+
+        timeout = max(0.0, float(timeout))
+        deadline = time.monotonic() + timeout
+        failed_newest_first: List[ArchiveState] = []
+        previous_index = archive_index - 1
+        while previous_index >= 1:
+            archive = self._archive_ref(self._session_uri, previous_index)
+            state = await self._read_archive_state(archive, verify_directory=True)
+            if state is None:
+                return await self._resolve_phase2_predecessors_from_scan(
+                    archive_index,
+                    timeout=timeout,
+                )
+
+            if state.state == "pending":
                 phase1 = await self._read_phase1_meta(state.archive_uri)
-                if not phase1 or phase1.get("status") == "ready":
-                    continue
-                await self._ensure_phase1_ready(state.archive_uri)
-                reconciled = True
-            if reconciled:
+                if phase1 and phase1.get("status") != "ready":
+                    await self._ensure_phase1_ready(state.archive_uri)
+                await self._wait_for_archive_terminal(
+                    archive,
+                    deadline=deadline,
+                    timeout=timeout,
+                    blocked_archive_index=archive_index,
+                )
                 continue
-            await asyncio.sleep(_ARCHIVE_WAIT_POLL_SECONDS)
+
+            if state.state == "failed":
+                failed_newest_first.append(state)
+                await self._pace_archive_recovery(len(failed_newest_first))
+                previous_index -= 1
+                continue
+
+            if not self._has_authoritative_coverage(state):
+                return await self._resolve_phase2_predecessors_from_scan(
+                    archive_index,
+                    timeout=timeout,
+                )
+
+            return _Phase2PredecessorPlan(
+                replay_states=tuple(reversed(failed_newest_first)),
+                latest_completed=state,
+            )
+
+        return _Phase2PredecessorPlan(
+            replay_states=tuple(reversed(failed_newest_first)),
+        )
+
+    async def _wait_for_previous_archive_done(
+        self,
+        archive_index: int,
+        timeout: float = _ARCHIVE_WAIT_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Compatibility wrapper around bounded predecessor resolution."""
+        await self._resolve_phase2_predecessors(archive_index, timeout=timeout)
+        return True
 
     async def _prepare_phase2_archive_messages(
         self,
         archive_uri: str,
         current_messages: List[Message],
+        *,
+        predecessor_plan: Optional[_Phase2PredecessorPlan] = None,
     ) -> tuple[List[Message], str, str, List[str], Dict[str, set[str]]]:
         """Roll earlier failed raw archives into current Phase 2 input.
 
@@ -3930,19 +4408,25 @@ class Session:
         reached a terminal state.
         """
         current_index = self._archive_index_from_uri(archive_uri)
-        states = await self._scan_archive_states()
-        covered = self._covered_archive_ids(states)
-        replay_states = [
-            state
-            for state in states
-            if state.index < current_index
-            and state.archive_id not in covered
-            and state.state == "failed"
-        ]
+        if predecessor_plan is None:
+            # Keep direct internal callers compatible; the production Phase-2
+            # path supplies the already-resolved plan and performs no rescan.
+            states = await self._scan_archive_states()
+            covered = self._covered_archive_ids(states)
+            replay_states = [
+                state
+                for state in states
+                if state.index < current_index
+                and state.archive_id not in covered
+                and state.state == "failed"
+            ]
+        else:
+            replay_states = list(predecessor_plan.replay_states)
 
         combined: List[Message] = []
         completed_memory_steps: Dict[str, set[str]] = {}
-        for state in replay_states:
+        for position, state in enumerate(replay_states, start=1):
+            await self._pace_archive_recovery(position)
             # A terminally-failed earlier archive can have a missing or corrupt
             # messages.jsonl (legacy "no messages" data, or #3417's own
             # archive_read terminal path). Tolerate that exactly like

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -74,7 +74,9 @@ logger = get_logger(__name__)
 _ARCHIVE_WAIT_POLL_SECONDS = 0.2
 _ARCHIVE_WAIT_MAX_POLL_SECONDS = 2.0
 _ARCHIVE_WAIT_JITTER_RATIO = 0.1
+# Reaching this age triggers a liveness check; it is not a hard task timeout.
 _ARCHIVE_WAIT_TIMEOUT_SECONDS = 1800.0
+_ARCHIVE_QUEUE_SNAPSHOT_CACHE_SECONDS = 1.0
 _ARCHIVE_RECOVERY_SCAN_CACHE_SECONDS = 1.0
 _ARCHIVE_RECOVERY_SCAN_ITEM_DELAY_SECONDS = 0.1
 _ARCHIVE_RECOVERY_UNPACED_ITEMS = 4
@@ -452,6 +454,24 @@ class _Phase2PredecessorPlan:
     used_recovery_scan: bool = False
 
 
+@dataclass(frozen=True)
+class _SessionCommitQueueSnapshot:
+    """One durable view of unacknowledged SessionCommit work."""
+
+    task_ids: frozenset[str]
+    archive_uris: frozenset[str]
+    mount_point: str
+
+
+@dataclass(frozen=True)
+class _ArchiveQueueLiveness:
+    """Best-effort liveness verdict for one pending archive's Phase-2 task."""
+
+    state: Literal["active", "missing", "unknown"]
+    task_id: str = ""
+    reason: str = ""
+
+
 # SessionCommit workers create a fresh ``Session`` object per queue item. Keep
 # process-local coordination at module scope so concurrent items for the same
 # session can share terminal notifications and exceptional recovery scans.
@@ -464,6 +484,8 @@ _ARCHIVE_RECOVERY_SCAN_CACHE: Dict[
     tuple[int, str], tuple[float, int, tuple[ArchiveState, ...]]
 ] = {}
 _ARCHIVE_RECOVERY_SCAN_SEMAPHORES: Dict[int, asyncio.Semaphore] = {}
+_ARCHIVE_QUEUE_SNAPSHOT_TASKS: Dict[tuple[int, str], asyncio.Task[_SessionCommitQueueSnapshot]] = {}
+_ARCHIVE_QUEUE_SNAPSHOT_CACHE: Dict[tuple[int, str], tuple[float, _SessionCommitQueueSnapshot]] = {}
 
 
 @dataclass
@@ -1629,6 +1651,7 @@ class Session:
         keep_recent_turn_count: int,
         retained_message_token_budget: int,
         min_raw_tail_steps: int,
+        queue_mount_point: str = "",
         agent_evolution_enabled: bool = True,
         agent_memory_skip_reason: Optional[str] = None,
         lease_ref: Optional[Any] = None,
@@ -1648,6 +1671,8 @@ class Session:
             "retained_message_token_budget": retained_message_token_budget,
             "min_raw_tail_steps": min_raw_tail_steps,
         }
+        if queue_mount_point:
+            payload["queue_mount_point"] = queue_mount_point
         await self._merge_archive_meta(
             archive_uri,
             {
@@ -1850,6 +1875,7 @@ class Session:
         from openviking.service.task_tracker import get_task_tracker
         from openviking.storage.queuefs import QueueManager, get_queue_manager
         from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+        from openviking.utils.agfs_utils import resolve_queuefs_mount_point
 
         trace_id = tracer.get_trace_id()
         keep_recent_count = max(0, int(keep_recent_count or 0))
@@ -2083,6 +2109,7 @@ class Session:
                     keep_recent_turn_count=effective_keep_turns if turn_mode else 0,
                     retained_message_token_budget=effective_token_budget if turn_mode else 0,
                     min_raw_tail_steps=effective_min_tail,
+                    queue_mount_point=resolve_queuefs_mount_point(),
                     agent_evolution_enabled=agent_evolution_enabled,
                     agent_memory_skip_reason=agent_memory_skip_reason,
                     lease_ref=lease,
@@ -4209,7 +4236,7 @@ class Session:
         timeout: float,
         blocked_archive_index: int,
     ) -> Optional[ArchiveState]:
-        """Wait on one blocker, then fail a presumed orphan after the deadline."""
+        """Wait on one blocker and only fail it after confirmed QueueFS loss."""
         event_key, event = self._get_archive_terminal_event(archive["archive_uri"])
         delay = max(0.0, _ARCHIVE_WAIT_POLL_SECONDS)
         try:
@@ -4223,34 +4250,66 @@ class Session:
 
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    # Re-read immediately before publishing the terminal marker;
-                    # a predecessor may have completed at the timeout boundary.
+                    # Time alone does not prove that a long-running Phase 2 is
+                    # orphaned. Re-read its marker, then consult local task work
+                    # and the durable QueueFS message before replaying raw data.
                     state = await self._read_archive_state(archive, verify_directory=True)
                     if state is None or state.state != "pending":
                         return state
-                    logger.error(
-                        "Archive %s stayed pending for over %.0fs while blocking "
-                        "archive_%03d Phase 2; its queue item is presumed lost. "
-                        "Marking it failed so its raw messages can be replayed.",
+                    liveness = await self._check_archive_queue_liveness(archive["archive_uri"])
+                    if liveness.state == "missing":
+                        # The liveness check performs I/O. Close the race with a
+                        # predecessor that became terminal while it was in flight.
+                        state = await self._read_archive_state(archive, verify_directory=True)
+                        if state is None or state.state != "pending":
+                            return state
+                        logger.error(
+                            "Archive %s stayed pending for over %.0fs while blocking "
+                            "archive_%03d Phase 2, and its QueueFS task %s is no "
+                            "longer recoverable (%s). Marking it failed so its raw "
+                            "messages can be replayed.",
+                            archive["archive_id"],
+                            timeout,
+                            blocked_archive_index,
+                            liveness.task_id or "<unknown>",
+                            liveness.reason or "missing queue work",
+                        )
+                        await self._write_failed_marker(
+                            archive["archive_uri"],
+                            stage="phase2_orphan_recovery",
+                            error=(
+                                f"Archive stayed pending for over {timeout:.0f}s and "
+                                "its Phase 2 QueueFS work is no longer recoverable: "
+                                f"{liveness.reason or 'missing queue work'}"
+                            ),
+                            blocked_by=f"archive_{blocked_archive_index:03d}",
+                        )
+                        raise TimeoutError(
+                            f"Timed out after {timeout:.0f}s waiting for "
+                            f"{archive['archive_id']} to finish before "
+                            f"archive_{blocked_archive_index:03d} Phase 2; QueueFS "
+                            "confirmed it was orphaned, so it was marked failed "
+                            "for raw replay by a later commit"
+                        )
+
+                    logger.warning(
+                        "Archive %s is still pending after %.0fs while blocking "
+                        "archive_%03d Phase 2; continuing low-frequency wait because "
+                        "its QueueFS task is %s (%s).",
                         archive["archive_id"],
                         timeout,
                         blocked_archive_index,
+                        liveness.state,
+                        liveness.reason or "no conclusive liveness signal",
                     )
-                    await self._write_failed_marker(
-                        archive["archive_uri"],
-                        stage="phase2_wait_timeout",
-                        error=(
-                            f"Archive stayed pending for over {timeout:.0f}s; "
-                            "its Phase 2 queue item is presumed lost"
-                        ),
-                        blocked_by=f"archive_{blocked_archive_index:03d}",
+                    # Marker polling remains exponentially backed off. Do not
+                    # repeat the extra liveness lookup until another full window.
+                    deadline = time.monotonic() + max(
+                        timeout,
+                        _ARCHIVE_WAIT_MAX_POLL_SECONDS,
+                        0.001,
                     )
-                    raise TimeoutError(
-                        f"Timed out after {timeout:.0f}s waiting for "
-                        f"{archive['archive_id']} to finish before "
-                        f"archive_{blocked_archive_index:03d} Phase 2; it was "
-                        "marked failed for raw replay by a later commit"
-                    )
+                    remaining = deadline - time.monotonic()
 
                 jitter = 1.0 + random.uniform(
                     -_ARCHIVE_WAIT_JITTER_RATIO,
@@ -4272,6 +4331,222 @@ class Session:
                 )
         finally:
             self._release_archive_terminal_event(event_key, event)
+
+    async def _get_session_commit_queue_snapshot(
+        self,
+    ) -> _SessionCommitQueueSnapshot:
+        """Read unacknowledged SessionCommit work with cache and singleflight.
+
+        This path only runs after a predecessor has already waited for the full
+        liveness window, so a one-second cached view necessarily postdates the
+        archive's Phase 1 publication and is safe to share across waiters.
+        """
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+
+        manager = get_queue_manager()
+        mount_point = str(getattr(manager, "mount_point", "") or "").rstrip("/")
+        loop = asyncio.get_running_loop()
+        key = (id(loop), mount_point)
+        now = time.monotonic()
+        with _ARCHIVE_COORDINATION_GUARD:
+            cached = _ARCHIVE_QUEUE_SNAPSHOT_CACHE.get(key)
+            if cached is not None and cached[0] > now:
+                return cached[1]
+
+            task = _ARCHIVE_QUEUE_SNAPSHOT_TASKS.get(key)
+            if task is None:
+                queue = manager.get_queue(QueueManager.SESSION_COMMIT)
+
+                async def read_snapshot() -> _SessionCommitQueueSnapshot:
+                    task_ids: set[str] = set()
+                    archive_uris: set[str] = set()
+                    for message in await queue.snapshot():
+                        payload: Any = message
+                        if isinstance(message, dict) and "data" in message:
+                            payload = message.get("data")
+                        if isinstance(payload, str):
+                            try:
+                                payload = json.loads(payload)
+                            except (TypeError, ValueError):
+                                continue
+                        if not isinstance(payload, dict):
+                            continue
+                        task_id = payload.get("task_id")
+                        archive_uri = payload.get("archive_uri")
+                        if isinstance(task_id, str) and task_id:
+                            task_ids.add(task_id)
+                        if isinstance(archive_uri, str) and archive_uri:
+                            archive_uris.add(archive_uri.rstrip("/"))
+
+                    snapshot = _SessionCommitQueueSnapshot(
+                        task_ids=frozenset(task_ids),
+                        archive_uris=frozenset(archive_uris),
+                        mount_point=mount_point,
+                    )
+                    with _ARCHIVE_COORDINATION_GUARD:
+                        _ARCHIVE_QUEUE_SNAPSHOT_CACHE[key] = (
+                            time.monotonic() + _ARCHIVE_QUEUE_SNAPSHOT_CACHE_SECONDS,
+                            snapshot,
+                        )
+                    return snapshot
+
+                task = loop.create_task(read_snapshot())
+                _ARCHIVE_QUEUE_SNAPSHOT_TASKS[key] = task
+
+                def clear_finished_snapshot(finished: asyncio.Task) -> None:
+                    with _ARCHIVE_COORDINATION_GUARD:
+                        if _ARCHIVE_QUEUE_SNAPSHOT_TASKS.get(key) is finished:
+                            _ARCHIVE_QUEUE_SNAPSHOT_TASKS.pop(key, None)
+
+                task.add_done_callback(clear_finished_snapshot)
+
+        return await asyncio.shield(task)
+
+    async def _check_archive_queue_liveness(
+        self,
+        archive_uri: str,
+    ) -> _ArchiveQueueLiveness:
+        """Check local work first, then use QueueFS only when it is inconclusive."""
+        try:
+            phase1 = await self._read_phase1_meta(archive_uri)
+        except Exception as exc:
+            logger.warning(
+                "Could not read Phase 1 task metadata for archive %s: %s",
+                archive_uri,
+                exc,
+            )
+            return _ArchiveQueueLiveness(
+                state="unknown",
+                reason="archive Phase 1 task metadata is unavailable",
+            )
+
+        queue_message = phase1.get("queue_message") if isinstance(phase1, dict) else None
+        task_id = queue_message.get("task_id") if isinstance(queue_message, dict) else None
+        task_id = task_id if isinstance(task_id, str) else ""
+        expected_mount = str(phase1.get("queue_mount_point") or "").rstrip("/")
+        normalized_archive_uri = archive_uri.rstrip("/")
+
+        manager = None
+        current_mount = ""
+        try:
+            from openviking.storage.queuefs import get_queue_manager
+
+            manager = get_queue_manager()
+            current_mount = str(getattr(manager, "mount_point", "") or "").rstrip("/")
+            has_task_work = getattr(manager, "has_task_work", None)
+            if task_id and callable(has_task_work) and has_task_work(task_id):
+                return _ArchiveQueueLiveness(
+                    state="active",
+                    task_id=task_id,
+                    reason="process-local task work is still active",
+                )
+        except Exception as exc:
+            logger.warning(
+                "Could not inspect local QueueFS task work for archive %s: %s",
+                archive_uri,
+                exc,
+            )
+
+        snapshot_available = False
+        snapshot_authoritative = False
+        durable_absent = False
+        # A stored worker mount is only queryable by the same worker. Shared
+        # queues and legacy archives without this field can use the current view.
+        can_query_current_queue = not expected_mount or expected_mount == current_mount
+        if manager is not None and can_query_current_queue:
+            try:
+                snapshot = await self._get_session_commit_queue_snapshot()
+                snapshot_available = True
+                snapshot_authoritative = (
+                    expected_mount == snapshot.mount_point
+                    if expected_mount
+                    else snapshot.mount_point == "/queue"
+                )
+
+                def snapshot_contains_work(
+                    candidate: _SessionCommitQueueSnapshot,
+                ) -> bool:
+                    return bool(
+                        (task_id and task_id in candidate.task_ids)
+                        or normalized_archive_uri in candidate.archive_uris
+                    )
+
+                if snapshot_contains_work(snapshot):
+                    return _ArchiveQueueLiveness(
+                        state="active",
+                        task_id=task_id,
+                        reason="durable QueueFS work is still unacknowledged",
+                    )
+
+                durable_absent = snapshot_authoritative
+            except Exception as exc:
+                logger.warning(
+                    "Could not inspect durable SessionCommit QueueFS work for archive %s: %s",
+                    archive_uri,
+                    exc,
+                )
+
+        task = None
+        tracker_available = False
+        if task_id:
+            try:
+                from openviking.service.task_tracker import get_task_tracker
+
+                task = await get_task_tracker().get(
+                    task_id,
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
+                )
+                tracker_available = True
+            except Exception as exc:
+                logger.warning(
+                    "Could not inspect task tracker state for archive %s task %s: %s",
+                    archive_uri,
+                    task_id,
+                    exc,
+                )
+
+        task_status = getattr(getattr(task, "status", None), "value", "")
+        if task_status == "completed":
+            # Phase 2 writes .done before completing its task. Missing .done is
+            # an integrity/visibility ambiguity, not permission to replay raw.
+            return _ArchiveQueueLiveness(
+                state="unknown",
+                task_id=task_id,
+                reason="task completed but its .done marker is not visible",
+            )
+        if task_status in {"failed", "cancelled"}:
+            return _ArchiveQueueLiveness(
+                state="missing",
+                task_id=task_id,
+                reason=f"task tracker is already terminal ({task_status})",
+            )
+        if task_status in {"pending", "running", "cancelling"} and not durable_absent:
+            return _ArchiveQueueLiveness(
+                state="active",
+                task_id=task_id,
+                reason=(
+                    f"task tracker is still {task_status}; the current QueueFS "
+                    "view cannot authoritatively disprove remote work"
+                ),
+            )
+        if durable_absent:
+            return _ArchiveQueueLiveness(
+                state="missing",
+                task_id=task_id,
+                reason="task is absent from its authoritative durable QueueFS",
+            )
+        if snapshot_available and tracker_available and task is None:
+            return _ArchiveQueueLiveness(
+                state="missing",
+                task_id=task_id,
+                reason="task is absent from both QueueFS and the task tracker",
+            )
+        return _ArchiveQueueLiveness(
+            state="unknown",
+            task_id=task_id,
+            reason="QueueFS/task-tracker state could not be confirmed",
+        )
 
     async def _resolve_phase2_predecessors_from_scan(
         self,
@@ -4390,7 +4665,11 @@ class Session:
         archive_index: int,
         timeout: float = _ARCHIVE_WAIT_TIMEOUT_SECONDS,
     ) -> bool:
-        """Compatibility wrapper around bounded predecessor resolution."""
+        """Compatibility wrapper around predecessor resolution.
+
+        ``timeout`` controls when to check QueueFS liveness; valid work may run
+        longer and continues with low-frequency marker polling.
+        """
         await self._resolve_phase2_predecessors(archive_index, timeout=timeout)
         return True
 

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -330,6 +330,10 @@ class QueueManager:
         """Check if QueueManager is running."""
         return self._started
 
+    def has_task_work(self, task_id: str) -> bool:
+        """Check the process-local work index without querying QueueFS."""
+        return self._task_work_index.has_work(task_id)
+
     def get_queue(
         self,
         name: str,

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -12,7 +12,12 @@ from openviking.message import Message, TextPart, ToolPart
 from openviking.models.vlm.base import ToolCall, VLMResponse
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
-from openviking.session.session import Session, _ArchiveSummaryResult, _CheckpointRequest
+from openviking.session.session import (
+    ArchiveState,
+    Session,
+    _ArchiveSummaryResult,
+    _CheckpointRequest,
+)
 
 
 async def _write_archive(
@@ -340,9 +345,26 @@ async def test_phase2_waits_for_all_earlier_pending_archives(
         2,
         [_text_message("u2", "user", "completed two")],
         overview="# Summary\n\ncomplete",
-        done={"starting_message_id": "u2", "ending_message_id": "u2"},
+        done={
+            "starting_message_id": "u2",
+            "ending_message_id": "u2",
+            # Coverage written by an older build is not enough to prove that
+            # every predecessor crossed the new sequencing barrier.
+            "coverage_start_archive": "archive_001",
+            "coverage_end_archive": "archive_002",
+            "covered_failed_archives": ["archive_001"],
+        },
     )
     monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
+    original_scan = session._scan_archive_states
+    scan_calls = 0
+
+    async def counted_scan(*, per_archive_delay=0.0):
+        nonlocal scan_calls
+        scan_calls += 1
+        return await original_scan(per_archive_delay=0.0)
+
+    monkeypatch.setattr(session, "_scan_archive_states", counted_scan)
 
     waiter = asyncio.create_task(session._wait_for_previous_archive_done(3))
     await asyncio.sleep(0.03)
@@ -354,6 +376,7 @@ async def test_phase2_waits_for_all_earlier_pending_archives(
         ctx=session.ctx,
     )
     assert await asyncio.wait_for(waiter, timeout=0.5)
+    assert scan_calls == 1
 
 
 async def test_missing_previous_archive_directory_does_not_block_phase2(
@@ -371,6 +394,366 @@ async def test_missing_previous_archive_directory_does_not_block_phase2(
         session._wait_for_previous_archive_done(2),
         timeout=0.5,
     )
+
+
+async def test_current_coverage_predecessor_avoids_full_history_scan(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_bounded_predecessor_test")
+    await session.ensure_exists()
+    await _write_archive(
+        session,
+        99,
+        [_text_message("u99", "user", "completed predecessor")],
+        done={
+            "starting_message_id": "u99",
+            "ending_message_id": "u99",
+            "working_memory_enabled": False,
+            "predecessor_barrier_version": 1,
+            "coverage_start_archive": "archive_099",
+            "coverage_end_archive": "archive_099",
+            "covered_failed_archives": [],
+        },
+    )
+
+    async def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("current-format predecessor must not scan archive history")
+
+    original_read_file = session._viking_fs.read_file
+    marker_reads: list[str] = []
+
+    async def counted_read_file(uri, *args, **kwargs):
+        if uri.endswith("/.done") or uri.endswith("/.failed.json"):
+            marker_reads.append(uri)
+        return await original_read_file(uri, *args, **kwargs)
+
+    monkeypatch.setattr(session, "_scan_archive_states", unexpected_full_scan)
+    monkeypatch.setattr(session, "_list_archive_refs", unexpected_full_scan)
+    monkeypatch.setattr(session._viking_fs, "read_file", counted_read_file)
+
+    plan = await session._resolve_phase2_predecessors(100)
+
+    assert plan.latest_completed is not None
+    assert plan.latest_completed.archive_id == "archive_099"
+    assert plan.replay_states == ()
+    assert not plan.used_recovery_scan
+    assert marker_reads == [f"{plan.latest_completed.archive_uri}/.done"]
+
+
+async def test_predecessor_plan_reuses_overview_and_cumulative_checkpoint(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_predecessor_compression_reuse_test")
+    await session.ensure_exists()
+    anchor = _text_message("u1", "user", "investigate the outage")
+    previous_uri = await _write_archive(
+        session,
+        1,
+        [anchor, _text_message("a1", "assistant", "first archived step")],
+        overview="# Working Memory\n\nPool saturation was confirmed.",
+        meta={
+            "checkpoints": [
+                {
+                    "checkpoint_version": 2,
+                    "turn_anchor_message_id": "u1",
+                    "source_message_ids": ["a1"],
+                    "abstract": "Pool saturation was confirmed.",
+                }
+            ]
+        },
+        done={
+            "starting_message_id": "u1",
+            "ending_message_id": "a1",
+            "working_memory_enabled": True,
+            "predecessor_barrier_version": 1,
+            "coverage_start_archive": "archive_001",
+            "coverage_end_archive": "archive_001",
+            "covered_failed_archives": [],
+        },
+    )
+    current_source = _text_message("a2", "assistant", "second archived step")
+    current_uri = await _write_archive(
+        session,
+        2,
+        [anchor, current_source],
+        meta={
+            "retention_plan": {
+                "partial_turn": True,
+                "turn_anchor_message_id": "u1",
+                "checkpoint_source_message_ids": ["a2"],
+                "retained_message_token_budget": 6000,
+                "estimated_active_tokens": 100,
+            }
+        },
+    )
+
+    plan = await session._resolve_phase2_predecessors(2)
+
+    async def unexpected_history_list(*_args, **_kwargs):
+        raise AssertionError("preferred compression state must not list archive history")
+
+    monkeypatch.setattr(session, "_list_archive_refs", unexpected_history_list)
+    requests = await session._collect_checkpoint_requests_for_phase2(
+        current_uri,
+        [],
+        [anchor, current_source],
+        previous_completed=plan.latest_completed,
+    )
+    overview = await session._get_latest_completed_archive_overview(
+        before_archive_index=2,
+        preferred_completed=plan.latest_completed,
+    )
+
+    assert plan.latest_completed is not None
+    assert plan.latest_completed.archive_uri == previous_uri
+    assert requests[0].previous_checkpoint_source_message_ids == ("a1",)
+    assert requests[0].previous_checkpoint_abstract == "Pool saturation was confirmed."
+    assert overview == "# Working Memory\n\nPool saturation was confirmed."
+
+
+async def test_predecessor_walk_replays_only_contiguous_failed_chain(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_failed_predecessor_chain_test")
+    await session.ensure_exists()
+    await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "completed base")],
+        done={
+            "starting_message_id": "u1",
+            "ending_message_id": "u1",
+            "working_memory_enabled": False,
+            "predecessor_barrier_version": 1,
+            "coverage_start_archive": "archive_001",
+            "coverage_end_archive": "archive_001",
+            "covered_failed_archives": [],
+        },
+    )
+    await _write_archive(
+        session,
+        2,
+        [_text_message("u2", "user", "failed two")],
+        failed=True,
+    )
+    await _write_archive(
+        session,
+        3,
+        [_text_message("u3", "user", "failed three")],
+        failed=True,
+    )
+    current = _text_message("u4", "user", "current four")
+    current_uri = await _write_archive(session, 4, [current], meta={})
+
+    async def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("bounded failed chain must not scan archive history")
+
+    monkeypatch.setattr(session, "_scan_archive_states", unexpected_full_scan)
+    monkeypatch.setattr(session, "_list_archive_refs", unexpected_full_scan)
+
+    plan = await session._resolve_phase2_predecessors(4)
+    messages, start, end, failed, _steps = await session._prepare_phase2_archive_messages(
+        current_uri,
+        [current],
+        predecessor_plan=plan,
+    )
+
+    assert [state.archive_id for state in plan.replay_states] == [
+        "archive_002",
+        "archive_003",
+    ]
+    assert [message.id for message in messages] == ["u2", "u3", "u4"]
+    assert start == "archive_002"
+    assert end == "archive_004"
+    assert failed == ["archive_002", "archive_003"]
+
+
+async def test_pending_predecessor_uses_terminal_notification_without_full_scan(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_predecessor_notification_test")
+    await session.ensure_exists()
+    await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "completed base")],
+        done={
+            "starting_message_id": "u1",
+            "ending_message_id": "u1",
+            "working_memory_enabled": False,
+            "predecessor_barrier_version": 1,
+            "coverage_start_archive": "archive_001",
+            "coverage_end_archive": "archive_001",
+            "covered_failed_archives": [],
+        },
+    )
+    pending_uri = await _write_archive(
+        session,
+        2,
+        [_text_message("u2", "user", "pending predecessor")],
+    )
+
+    async def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("pending predecessor polling must stay O(1)")
+
+    monkeypatch.setattr(session, "_scan_archive_states", unexpected_full_scan)
+    monkeypatch.setattr(session, "_list_archive_refs", unexpected_full_scan)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 10.0)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_MAX_POLL_SECONDS", 10.0)
+
+    waiter = asyncio.create_task(session._resolve_phase2_predecessors(3))
+    await asyncio.sleep(0.02)
+    assert not waiter.done()
+
+    await session._write_failed_marker(
+        pending_uri,
+        stage="synthetic",
+        error="wake the direct successor",
+    )
+    plan = await asyncio.wait_for(waiter, timeout=0.5)
+
+    assert [state.archive_id for state in plan.replay_states] == ["archive_002"]
+    assert plan.latest_completed is not None
+    assert plan.latest_completed.archive_id == "archive_001"
+
+
+async def test_pending_predecessor_timeout_marks_orphan_failed_for_raw_replay(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_predecessor_orphan_timeout_test")
+    await session.ensure_exists()
+    orphan_uri = await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "orphaned pending predecessor")],
+    )
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_MAX_POLL_SECONDS", 0.02)
+
+    with pytest.raises(TimeoutError, match="archive_001"):
+        await asyncio.wait_for(
+            session._wait_for_previous_archive_done(2, timeout=0.05),
+            timeout=1.0,
+        )
+
+    failed = json.loads(
+        await session._viking_fs.read_file(f"{orphan_uri}/.failed.json", ctx=session.ctx)
+    )
+    assert failed["stage"] == "phase2_wait_timeout"
+    assert failed["blocked_by"] == "archive_002"
+
+    plan = await session._resolve_phase2_predecessors(2, timeout=0.05)
+    assert [state.archive_id for state in plan.replay_states] == ["archive_001"]
+
+
+async def test_terminal_notification_does_not_hot_loop_on_stale_marker_read(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_terminal_notification_stale_read_test")
+    await session.ensure_exists()
+    archive = session._archive_ref(session.uri, 1)
+    read_calls = 0
+
+    async def temporarily_stale_state(*_args, **_kwargs):
+        nonlocal read_calls
+        read_calls += 1
+        return ArchiveState(
+            archive_id=archive["archive_id"],
+            archive_uri=archive["archive_uri"],
+            index=archive["index"],
+            state="pending" if read_calls <= 2 else "failed",
+        )
+
+    monkeypatch.setattr(session, "_read_archive_state", temporarily_stale_state)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.05)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_MAX_POLL_SECONDS", 0.05)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_JITTER_RATIO", 0.0)
+
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    waiter = asyncio.create_task(
+        session._wait_for_archive_terminal(
+            archive,
+            deadline=loop.time() + 1.0,
+            timeout=1.0,
+            blocked_archive_index=2,
+        )
+    )
+    await asyncio.sleep(0.01)
+    session._notify_archive_terminal(archive["archive_uri"])
+    state = await asyncio.wait_for(waiter, timeout=0.5)
+
+    assert state is not None and state.state == "failed"
+    assert read_calls == 3
+    assert loop.time() - started_at >= 0.04
+
+
+async def test_legacy_recovery_scan_is_singleflight_per_session(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_recovery_scan_singleflight_test")
+    await session.ensure_exists()
+    await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "legacy predecessor")],
+        done={"starting_message_id": "u1", "ending_message_id": "u1"},
+    )
+
+    original_scan = session._scan_archive_states
+    scan_started = asyncio.Event()
+    allow_scan = asyncio.Event()
+    scan_calls = 0
+
+    async def delayed_scan(*, per_archive_delay=0.0):
+        nonlocal scan_calls
+        scan_calls += 1
+        scan_started.set()
+        await allow_scan.wait()
+        return await original_scan(per_archive_delay=0.0)
+
+    monkeypatch.setattr(session, "_scan_archive_states", delayed_scan)
+    first = asyncio.create_task(session._resolve_phase2_predecessors(2))
+    second = asyncio.create_task(session._resolve_phase2_predecessors(2))
+    await asyncio.wait_for(scan_started.wait(), timeout=0.5)
+    allow_scan.set()
+    first_plan, second_plan = await asyncio.gather(first, second)
+
+    assert scan_calls == 1
+    assert first_plan.used_recovery_scan
+    assert second_plan.used_recovery_scan
+
+
+async def test_stale_recovery_listing_has_only_one_bounded_rescan(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_stale_recovery_listing_test")
+    await session.ensure_exists()
+    scan_calls = 0
+
+    async def stale_scan(*, per_archive_delay=0.0):
+        nonlocal scan_calls
+        scan_calls += 1
+        return []
+
+    monkeypatch.setattr(session, "_scan_archive_states", stale_scan)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.0)
+
+    states = await asyncio.wait_for(
+        session._scan_archive_states_for_recovery(2),
+        timeout=0.5,
+    )
+
+    assert states == []
+    assert scan_calls == 2
 
 
 async def test_phase2_roll_forward_writes_coverage_and_calls_existing_summary_once(
@@ -436,6 +819,7 @@ async def test_phase2_roll_forward_writes_coverage_and_calls_existing_summary_on
     assert done["coverage_start_archive"] == "archive_001"
     assert done["coverage_end_archive"] == "archive_002"
     assert done["covered_failed_archives"] == ["archive_001"]
+    assert done["predecessor_barrier_version"] == 1
     assert context["latest_archive_overview"].endswith("Both rounds are covered.")
     assert context["messages"] == []
 

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -15,8 +15,10 @@ from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
 from openviking.session.session import (
     ArchiveState,
     Session,
+    _ArchiveQueueLiveness,
     _ArchiveSummaryResult,
     _CheckpointRequest,
+    _SessionCommitQueueSnapshot,
 )
 
 
@@ -621,7 +623,57 @@ async def test_pending_predecessor_uses_terminal_notification_without_full_scan(
     assert plan.latest_completed.archive_id == "archive_001"
 
 
-async def test_pending_predecessor_timeout_marks_orphan_failed_for_raw_replay(
+@pytest.mark.parametrize("liveness_state", ["active", "unknown"])
+async def test_pending_predecessor_timeout_keeps_unconfirmed_work_pending(
+    client,
+    monkeypatch,
+    liveness_state,
+):
+    session = client(session_id=f"phase2_predecessor_{liveness_state}_timeout_test")
+    await session.ensure_exists()
+    pending_uri = await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "long-running pending predecessor")],
+        meta={
+            "phase1": {
+                "status": "ready",
+                "queue_message": {"task_id": f"task-{liveness_state}"},
+            }
+        },
+    )
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_MAX_POLL_SECONDS", 0.02)
+    checked = asyncio.Event()
+
+    async def liveness(_archive_uri):
+        checked.set()
+        return _ArchiveQueueLiveness(
+            state=liveness_state,
+            task_id=f"task-{liveness_state}",
+            reason="synthetic non-terminal task state",
+        )
+
+    monkeypatch.setattr(session, "_check_archive_queue_liveness", liveness)
+    waiter = asyncio.create_task(session._resolve_phase2_predecessors(2, timeout=0.05))
+    await asyncio.wait_for(checked.wait(), timeout=0.5)
+    assert not waiter.done()
+
+    await session._write_failed_marker(
+        pending_uri,
+        stage="synthetic_terminal",
+        error="finish the test wait without orphan recovery",
+    )
+    plan = await asyncio.wait_for(waiter, timeout=0.5)
+
+    failed = json.loads(
+        await session._viking_fs.read_file(f"{pending_uri}/.failed.json", ctx=session.ctx)
+    )
+    assert failed["stage"] == "synthetic_terminal"
+    assert [state.archive_id for state in plan.replay_states] == ["archive_001"]
+
+
+async def test_pending_predecessor_timeout_marks_confirmed_orphan_failed_for_raw_replay(
     client,
     monkeypatch,
 ):
@@ -631,9 +683,24 @@ async def test_pending_predecessor_timeout_marks_orphan_failed_for_raw_replay(
         session,
         1,
         [_text_message("u1", "user", "orphaned pending predecessor")],
+        meta={
+            "phase1": {
+                "status": "ready",
+                "queue_message": {"task_id": "task-orphan"},
+            }
+        },
     )
     monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
     monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_MAX_POLL_SECONDS", 0.02)
+
+    async def missing_liveness(_archive_uri):
+        return _ArchiveQueueLiveness(
+            state="missing",
+            task_id="task-orphan",
+            reason="synthetic durable queue miss",
+        )
+
+    monkeypatch.setattr(session, "_check_archive_queue_liveness", missing_liveness)
 
     with pytest.raises(TimeoutError, match="archive_001"):
         await asyncio.wait_for(
@@ -644,11 +711,252 @@ async def test_pending_predecessor_timeout_marks_orphan_failed_for_raw_replay(
     failed = json.loads(
         await session._viking_fs.read_file(f"{orphan_uri}/.failed.json", ctx=session.ctx)
     )
-    assert failed["stage"] == "phase2_wait_timeout"
+    assert failed["stage"] == "phase2_orphan_recovery"
     assert failed["blocked_by"] == "archive_002"
 
     plan = await session._resolve_phase2_predecessors(2, timeout=0.05)
     assert [state.archive_id for state in plan.replay_states] == ["archive_001"]
+
+
+async def test_pending_predecessor_rechecks_terminal_after_orphan_lookup(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="phase2_predecessor_orphan_race_test")
+    await session.ensure_exists()
+    pending_uri = await _write_archive(
+        session,
+        1,
+        [_text_message("u1", "user", "finishes during orphan lookup")],
+    )
+    monkeypatch.setattr("openviking.session.session._ARCHIVE_WAIT_POLL_SECONDS", 0.01)
+
+    async def completes_during_lookup(_archive_uri):
+        await session._viking_fs.write_file(
+            f"{pending_uri}/.done",
+            json.dumps(
+                {
+                    "predecessor_barrier_version": 1,
+                    "coverage_start_archive": "archive_001",
+                    "coverage_end_archive": "archive_001",
+                    "covered_failed_archives": [],
+                }
+            ),
+            ctx=session.ctx,
+        )
+        return _ArchiveQueueLiveness(state="missing", reason="stale absence")
+
+    monkeypatch.setattr(
+        session,
+        "_check_archive_queue_liveness",
+        completes_during_lookup,
+    )
+
+    plan = await session._resolve_phase2_predecessors(2, timeout=0.01)
+
+    assert plan.latest_completed is not None
+    assert plan.latest_completed.archive_id == "archive_001"
+    assert not await session._archive_file_exists(pending_uri, ".failed.json")
+
+
+async def test_archive_queue_liveness_uses_local_index_without_snapshot(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="archive_queue_local_index_test")
+
+    async def phase1(_archive_uri):
+        return {
+            "queue_message": {"task_id": "task-local"},
+            "queue_mount_point": "/queue",
+        }
+
+    class FakeManager:
+        mount_point = "/queue"
+
+        @staticmethod
+        def has_task_work(task_id):
+            return task_id == "task-local"
+
+    async def unexpected_snapshot(*_args, **_kwargs):
+        raise AssertionError("local active work must not query durable QueueFS")
+
+    monkeypatch.setattr(session, "_read_phase1_meta", phase1)
+    monkeypatch.setattr(session, "_get_session_commit_queue_snapshot", unexpected_snapshot)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: FakeManager(),
+    )
+
+    liveness = await session._check_archive_queue_liveness("archive-uri")
+
+    assert liveness.state == "active"
+    assert "process-local" in liveness.reason
+
+
+async def test_legacy_archive_liveness_matches_durable_work_by_archive_uri(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="legacy_archive_queue_uri_match_test")
+    archive_uri = f"{session.uri}/history/archive_001"
+
+    async def phase1(_archive_uri):
+        return {}
+
+    class FakeManager:
+        mount_point = "/queue"
+
+        @staticmethod
+        def has_task_work(_task_id):
+            return False
+
+    async def snapshot():
+        return _SessionCommitQueueSnapshot(
+            task_ids=frozenset({"legacy-task"}),
+            archive_uris=frozenset({archive_uri}),
+            mount_point="/queue",
+        )
+
+    monkeypatch.setattr(session, "_read_phase1_meta", phase1)
+    monkeypatch.setattr(session, "_get_session_commit_queue_snapshot", snapshot)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: FakeManager(),
+    )
+
+    liveness = await session._check_archive_queue_liveness(archive_uri)
+
+    assert liveness.state == "active"
+    assert "durable QueueFS" in liveness.reason
+
+
+@pytest.mark.parametrize(
+    (
+        "expected_mount",
+        "current_mount",
+        "task_status",
+        "expected_state",
+        "expected_snapshot_calls",
+    ),
+    [
+        ("/queue", "/queue", "running", "missing", 1),
+        ("/queue/worker-1", "/queue/worker-1", "running", "missing", 1),
+        ("/queue/worker-1", "/queue/worker-2", "running", "active", 0),
+        ("", "/queue/worker-2", "running", "active", 1),
+        ("/queue", "/queue", "completed", "unknown", 1),
+    ],
+)
+async def test_archive_queue_liveness_respects_worker_authority(
+    client,
+    monkeypatch,
+    expected_mount,
+    current_mount,
+    task_status,
+    expected_state,
+    expected_snapshot_calls,
+):
+    session = client(session_id=f"archive_queue_liveness_{uuid4()}")
+    snapshot_calls = 0
+
+    async def phase1(_archive_uri):
+        return {
+            "queue_message": {"task_id": "task-check"},
+            "queue_mount_point": expected_mount,
+        }
+
+    class FakeManager:
+        mount_point = current_mount
+
+        @staticmethod
+        def has_task_work(_task_id):
+            return False
+
+    async def snapshot():
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        return _SessionCommitQueueSnapshot(
+            task_ids=frozenset(),
+            archive_uris=frozenset(),
+            mount_point=current_mount,
+        )
+
+    class FakeTracker:
+        async def get(self, *_args, **_kwargs):
+            return SimpleNamespace(status=SimpleNamespace(value=task_status))
+
+    monkeypatch.setattr(session, "_read_phase1_meta", phase1)
+    monkeypatch.setattr(session, "_get_session_commit_queue_snapshot", snapshot)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: FakeManager(),
+    )
+    monkeypatch.setattr(
+        "openviking.service.task_tracker.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+
+    liveness = await session._check_archive_queue_liveness("archive-uri")
+
+    assert liveness.state == expected_state
+    assert snapshot_calls == expected_snapshot_calls
+
+
+async def test_session_commit_queue_snapshot_is_singleflight_and_cached(
+    client,
+    monkeypatch,
+):
+    session = client(session_id="archive_queue_snapshot_singleflight_test")
+    snapshot_started = asyncio.Event()
+    release_snapshot = asyncio.Event()
+    snapshot_calls = 0
+    mount_point = f"/queue/test-{uuid4()}"
+
+    class FakeQueue:
+        async def snapshot(self):
+            nonlocal snapshot_calls
+            snapshot_calls += 1
+            snapshot_started.set()
+            await release_snapshot.wait()
+            return [
+                {
+                    "id": "queue-message-1",
+                    "data": json.dumps(
+                        {
+                            "task_id": "task-1",
+                            "archive_uri": "viking://session/s1/history/archive_001",
+                        }
+                    ),
+                }
+            ]
+
+    class FakeManager:
+        def __init__(self):
+            self.mount_point = mount_point
+            self.queue = FakeQueue()
+
+        def get_queue(self, _queue_name):
+            return self.queue
+
+    manager = FakeManager()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: manager,
+    )
+
+    first = asyncio.create_task(session._get_session_commit_queue_snapshot())
+    second = asyncio.create_task(session._get_session_commit_queue_snapshot())
+    await asyncio.wait_for(snapshot_started.wait(), timeout=0.5)
+    release_snapshot.set()
+    first_result, second_result = await asyncio.gather(first, second)
+    cached_result = await session._get_session_commit_queue_snapshot()
+
+    assert snapshot_calls == 1
+    assert first_result == second_result == cached_result
+    assert first_result.task_ids == frozenset({"task-1"})
+    assert first_result.archive_uris == frozenset(
+        {"viking://session/s1/history/archive_001"}
+    )
 
 
 async def test_terminal_notification_does_not_hot_loop_on_stale_marker_read(
@@ -2201,6 +2509,8 @@ async def test_phase1_enqueues_before_root_rewrite_and_publishes_ready_last(
     observations: list[tuple[list[str], str]] = []
 
     class InspectingQueueManager:
+        mount_point = "/queue/test-worker"
+
         async def enqueue(self, _queue_name, data):
             root = await session._read_live_messages_strict()
             archive_uri = data["archive_uri"]
@@ -2215,11 +2525,17 @@ async def test_phase1_enqueues_before_root_rewrite_and_publishes_ready_last(
         "openviking.storage.queuefs.get_queue_manager",
         lambda: InspectingQueueManager(),
     )
+    monkeypatch.setattr(
+        "openviking.utils.agfs_utils.resolve_queuefs_mount_point",
+        lambda: "/queue/test-worker",
+    )
 
     result = await session.commit_async()
 
     assert observations == [(["archive me"], "preparing")]
-    assert (await session._read_phase1_meta(result["archive_uri"]))["status"] == "ready"
+    phase1 = await session._read_phase1_meta(result["archive_uri"])
+    assert phase1["status"] == "ready"
+    assert phase1["queue_mount_point"] == "/queue/test-worker"
     assert await session._read_live_messages_strict() == []
 
 

--- a/tests/storage/test_queue_manager.py
+++ b/tests/storage/test_queue_manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Focused tests for QueueManager concurrency selection."""
 
+from openviking.service.task_work_index import QueueTaskMetadata
 from openviking.storage.queuefs.queue_manager import QueueManager
 
 
@@ -16,3 +17,12 @@ def test_queue_concurrency_uses_separate_configured_values() -> None:
     assert manager._max_concurrent_for_queue(manager.EXTERNAL_PARSE) == 9
     assert manager._max_concurrent_for_queue(manager.ADD_RESOURCE) == 7
     assert manager._max_concurrent_for_queue(manager.SESSION_COMMIT) == 5
+
+
+def test_has_task_work_uses_runtime_index_without_queue_io() -> None:
+    manager = QueueManager(agfs=object())
+    metadata = QueueTaskMetadata(task_id="task-1", work_id="work-1")
+
+    assert not manager.has_task_work("task-1")
+    assert manager._task_work_index.register(manager.SESSION_COMMIT, metadata)
+    assert manager.has_task_work("task-1")

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -44,7 +44,8 @@ class _MemoryVikingFS:
             raise FileNotFoundError(uri)
         return self.files[uri]
 
-    async def write_file(self, uri, content, ctx=None):
+    async def write_file(self, uri, content, ctx=None, lease_ref=None):
+        del lease_ref
         self.files[uri] = content
 
 


### PR DESCRIPTION
## 背景

Session Phase 2 等待历史 archive 进入终态时，旧路径会每 100ms 扫描整个 `history/`，并逐个检查 `.done`、`.failed.json` 和 overview。archive 数量和并发 worker 增长后，元数据访问会被按 `worker × archive × polling frequency` 放大，可能冲击 EFS 元数据 QPS。

另一方面，异常退出可能留下没有 `.done`、也没有 `.failed.json` 的 pending archive。它需要被恢复，但仅凭“等待超过 30 分钟”不能证明任务已经丢失：合法的长任务也可能运行超过 30 分钟。

## 修改内容

### 1. 正常链路改为 O(1) 前驱解析

- Phase 2 只读取直接前驱 archive，不再周期性全量扫描历史。
- 新 `.done` 增加向后兼容字段 `predecessor_barrier_version`，用于证明此前 archive 已完成终态处理。
- 连续 failed archive 沿前驱链向前读取，并按原顺序回放 raw messages。
- 复用已解析前驱的 overview 和累计 checkpoint，避免下游再次扫描历史。
- marker 状态读取从 `exists + read` 优化为正常路径单次 `read`。

### 2. pending 使用通知与指数退避

- 同进程写入 `.done` 或 `.failed.json` 后立即通知等待者。
- 跨进程或通知丢失时，marker 轮询采用 `200ms → 400ms → 800ms → 1.6s → 2s` 的指数退避，并加入 jitter。
- 每轮只检查实际 blocker 的终态 marker，不扫描所有 archive。
- 等待期间不持有 session PathLock。

### 3. 30 分钟后判活，而不是直接判失败

30 分钟现在是一次存活检查窗口，不再是任务硬超时：

1. 先查询 `TaskWorkIndex` 进程内索引。任务仍在本进程排队或处理中时直接继续等待，不访问 QueueFS。
2. 本地索引无法确认时，再读取一次 `SessionCommit/messages` durable snapshot，检查对应 `task_id` 或 `archive_uri` 是否仍未 ACK。
3. 多个并发等待者共享同一个 snapshot 请求，并复用 1 秒缓存，避免并发放大。
4. Phase 1 记录 `queue_mount_point`，只有当前进程能够权威观察对应 queue 时，才用“snapshot 中不存在”判定任务丢失；worker 隔离场景使用 TaskTracker 保守兜底。
5. 只有确认 QueueFS work 已丢失或 TaskTracker 已失败/取消，才写入 `.failed.json`，让后续 commit 按原有语义回放 raw messages。
6. 若任务仍 active 或状态无法可靠确认，则继续低频等待；下一次额外判活仍在另一个完整窗口之后。
7. 判定丢失后会再次读取 terminal marker，避免任务恰好在判活期间完成而被误写 failed。

### 4. legacy 和异常状态采用受控恢复扫描

- 旧 marker、目录缺失或 marker 异常时才执行完整历史扫描。
- 同 session 扫描在进程内 singleflight；每个事件循环同时最多执行一个恢复扫描。
- 扫描按约 100ms/archive 节流并加入 jitter，避免服务集中重启时形成固定节奏的元数据突发。
- 一次扫描后直接处理快照中的 pending blocker，不在每次 terminal 变化后重复扫描全历史。
- EFS listing 持续滞后时最多重试一次，之后直接检查所需前驱。
- 连续 failed archive 超过 4 个后，对 marker 和 raw replay 读取进行 pacing，限制短时峰值。

## QPS 影响

| 场景 | 修改后行为 |
|---|---|
| 当前格式前驱已完成 | O(1)，只读取直接前驱 marker；不执行 `ls history` |
| 前驱 pending | marker 轮询稳定后约每 2 秒一次；同进程完成可由事件立即唤醒 |
| 任务运行未满 30 分钟 | 不执行额外 QueueFS 存活查询 |
| 超过 30 分钟，本进程任务仍 active | 查询内存索引，新增存储请求为 0 |
| 超过 30 分钟，本地无法确认 | 每个进程/queue 的并发请求合并为一次 QueueFS snapshot，并缓存 1 秒 |
| 长任务仍 active 或状态未知 | 继续低频等待，下一次额外判活在 30 分钟后 |
| legacy/异常恢复 | 受控、限速、singleflight 的历史扫描，不进入 100ms 全量重扫 |

这里的 snapshot 是 QueueFS 的单个队列视图请求，不是对 session archive 目录逐项 `ls/exists/read`。

## 锁与并发

- 未新增 VikingFS PathLock、`.path.ovlock` 或分布式文件锁。
- 复用 `TaskWorkIndex` 已有线程锁查询本地任务状态。
- snapshot singleflight/cache 复用已有进程内协调锁；临界区内没有 `await`、文件访问或 PathLock。
- `asyncio.Semaphore` 只用于异常恢复扫描限流，不参与正常 commit。
- Phase 1、append 和 metadata merge 的既有 PathLock 获取顺序不变。

## 兼容性

- session 目录结构、`messages.jsonl`、overview、checkpoint 和公开 API 保持不变。
- `.done` 与 Phase 1 metadata 只新增可忽略字段，旧消费者不受影响。
- 旧 archive 没有 `queue_mount_point` 时仍兼容：共享队列可权威判断；worker 隔离场景采用保守策略，避免误回放 raw。
- 不新增 LLM 调用，不改变 Working Memory、累计 checkpoint 或 failed raw replay 的生成语义。

## 验证

- Session retention/context/commit/concurrency、QueueManager、TaskTracker 定向回归：`107 passed`
- 覆盖长任务、确认孤儿、terminal race、legacy archive、worker 隔离、snapshot singleflight/cache
- `ruff check`、`compileall`、`git diff --check` 通过
