### PR TITLE
docs: add DeerFlow agent access guide

### DIFF
--- a/docs/images/agents/en/deerflow-mcp.md
+++ b/docs/images/agents/en/deerflow-mcp.md
@@ -1,0 +1,73 @@
+DeerFlow can connect to OpenViking through an MCP Server. MCP integration lets DeerFlow agents actively search, read, and use memories and knowledge from OpenViking while executing tasks.
+
+## Step 1: Configure OpenViking credentials
+
+Set the OpenViking MCP endpoint and API key in the environment that starts DeerFlow:
+
+```bash
+export OPENVIKING_MCP_URL="https://api.vikingdb.cn-beijing.volces.com/openviking/mcp"
+export OPENVIKING_API_KEY="[TODO]your-api-key"
+```
+
+If DeerFlow uses a `.env` file, add the same variables there and confirm that the startup command loads it.
+
+## Step 2: Create an MCP configuration file
+
+Create an MCP configuration file in the DeerFlow project, for example `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "openviking": {
+      "url": "${OPENVIKING_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer ${OPENVIKING_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+If DeerFlow already has a standard MCP config path, merge this server into the existing file.
+
+## Step 3: Configure the OpenViking MCP Server
+
+Enable this MCP Server in the DeerFlow agent or tool configuration, and keep the server name aligned with `openviking` in the MCP config file.
+
+Allow DeerFlow to use OpenViking search, read, browse, and health-check tools to cover common memory retrieval and knowledge lookup scenarios.
+
+## Step 4: Restart DeerFlow
+
+Save the MCP configuration and restart DeerFlow:
+
+```bash
+pnpm dev
+```
+
+After restart, check the logs and confirm that the `openviking` MCP Server is loaded and its tools are available.
+
+## Step 5: Verify MCP tools
+
+Ask DeerFlow to check the OpenViking service status:
+
+```text
+Use the OpenViking MCP tools to check whether the current service is available.
+```
+
+You can also ask DeerFlow to search for an existing memory or resource:
+
+```text
+Search OpenViking for memories related to the current project.
+```
+
+If the agent can call OpenViking MCP tools and return results, MCP integration is working.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| MCP Server is not loaded | Check whether DeerFlow reads the MCP config path and whether the server name is configured consistently |
+| Connection fails or times out | Confirm the runtime can access `api.vikingdb.cn-beijing.volces.com`; configure proxy or network allowlists if needed |
+| OpenViking returns 401 / 403 | Verify `OPENVIKING_API_KEY` and make sure the request header is `Authorization: Bearer <API Key>` |
+| Agent does not call tools | Explicitly allow OpenViking MCP tool usage in the DeerFlow system prompt or tool policy |
+| Search results are empty | Confirm OpenViking already has related memories or knowledge resources, and try broader search keywords |

--- a/docs/images/agents/en/deerflow-memory-manager.md
+++ b/docs/images/agents/en/deerflow-memory-manager.md
@@ -1,0 +1,79 @@
+DeerFlow can use OpenViking as a long-term memory backend through MemoryManager. After the integration is enabled, DeerFlow writes conversation messages to OpenViking, recalls relevant memories before model calls, and injects them into the context.
+
+## Step 1: Configure OpenViking credentials
+
+Set the OpenViking base URL and API key in the environment that starts DeerFlow:
+
+```bash
+export OPENVIKING_BASE_URL="https://api.vikingdb.cn-beijing.volces.com/openviking"
+export OPENVIKING_API_KEY="[TODO]your-api-key"
+```
+
+If you use `.env` or a deployment platform to manage environment variables, add the same variables there and make sure the DeerFlow process can read them at startup.
+
+## Step 2: Update DeerFlow memory configuration
+
+Enable MemoryManager in the DeerFlow configuration and point the provider to OpenViking:
+
+```yaml
+memory:
+  enabled: true
+  provider: openviking
+  openviking:
+    base_url: ${OPENVIKING_BASE_URL}
+    api_key: ${OPENVIKING_API_KEY}
+    auto_write: true
+    auto_recall: true
+    inject_recalled_memory: true
+```
+
+Enable write, recall, and injection together so DeerFlow can persist long-term memory during conversations and reuse relevant memories in later tasks.
+
+## Step 3: Restart DeerFlow
+
+Save the configuration and restart DeerFlow:
+
+```bash
+pnpm dev
+```
+
+If DeerFlow is deployed through Docker, a process manager, or a cloud service, use the corresponding restart flow and verify that the new environment variables are available at runtime.
+
+## Step 4: Verify OpenViking connectivity
+
+After startup, check the DeerFlow logs and confirm that MemoryManager initializes successfully without OpenViking authentication or network errors.
+
+You can also check OpenViking connectivity directly:
+
+```bash
+curl -H "Authorization: Bearer ${OPENVIKING_API_KEY}" \
+  "${OPENVIKING_BASE_URL}/health"
+```
+
+A service status response means OpenViking is reachable.
+
+## Step 5: Verify memory write and recall
+
+Start a DeerFlow conversation with a stable fact, for example:
+
+```text
+Remember that my DeerFlow test project uses OpenViking as the long-term memory backend.
+```
+
+Then start a new conversation and ask:
+
+```text
+What does my DeerFlow test project use as the long-term memory backend?
+```
+
+If DeerFlow answers OpenViking, memory write, recall, and context injection are working.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| MemoryManager fails to initialize | Check `memory.enabled`, `provider`, and whether DeerFlow is loading the expected configuration file |
+| OpenViking returns 401 / 403 | Verify `OPENVIKING_API_KEY`, confirm it has not expired, and make sure requests use the `Bearer` prefix |
+| Memories are not written | Confirm `auto_write` is enabled and check DeerFlow logs for write failures |
+| Memories are not recalled | Confirm `auto_recall` and `inject_recalled_memory` are enabled and OpenViking already has related memories |
+| Works locally but not after deployment | Check whether `OPENVIKING_BASE_URL` and `OPENVIKING_API_KEY` are injected into the deployed runtime |

--- a/docs/images/agents/en/index.json
+++ b/docs/images/agents/en/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-06-02",
+  "updatedAt": "2026-08-12",
   "cdnBaseUrl": "https://docs.openviking.net/",
   "accessMethods": [
     {
@@ -95,6 +95,26 @@
       "logo": "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_sth/ljhwZthlaukjlkulzlp/agent_logo/OpenCode.png",
       "summary": "Provides one unified OpenCode plugin for repository context, memory tools, session sync, and automatic recall.",
       "detailPath": "https://docs.openviking.net/agents/en/opencode.md"
+    },
+    {
+      "id": "deerflow",
+      "name": "DeerFlow",
+      "tags": ["MemoryManager", "MCP"],
+      "logo": "https://raw.githubusercontent.com/bytedance/deer-flow/main/frontend/public/images/deer.svg",
+      "summary": "DeerFlow can connect through MemoryManager and MCP to automatically write, recall, inject, and manage memory. Enable both methods for the full memory experience.",
+      "detailPath": "https://docs.openviking.net/agents/en/deerflow-memory-manager.md",
+      "tabs": [
+        {
+          "id": "memory-manager",
+          "label": "MemoryManager Integration",
+          "detailPath": "https://docs.openviking.net/agents/en/deerflow-memory-manager.md"
+        },
+        {
+          "id": "mcp",
+          "label": "MCP Integration",
+          "detailPath": "https://docs.openviking.net/agents/en/deerflow-mcp.md"
+        }
+      ]
     }
   ]
 }

--- a/docs/images/agents/zh/deerflow-mcp.md
+++ b/docs/images/agents/zh/deerflow-mcp.md
@@ -1,0 +1,73 @@
+DeerFlow 支持通过 MCP Server 接入 OpenViking。MCP 接入的核心价值是打通知识检索能力，让 DeerFlow Agent 能够在任务执行过程中主动搜索、读取和使用 OpenViking 中的记忆与知识。
+
+## 步骤 1：配置 OpenViking 鉴权信息
+
+在启动 DeerFlow 的环境中配置 OpenViking MCP 服务地址和 API Key：
+
+```bash
+export OPENVIKING_MCP_URL="https://api.vikingdb.cn-beijing.volces.com/openviking/mcp"
+export OPENVIKING_API_KEY="[TODO]your-api-key"
+```
+
+如果 DeerFlow 使用 `.env` 文件，请写入同名变量，并确认启动命令会加载该文件。
+
+## 步骤 2：创建 MCP 配置文件
+
+在 DeerFlow 项目中创建 MCP 配置文件，例如 `mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "openviking": {
+      "url": "${OPENVIKING_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer ${OPENVIKING_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+如果 DeerFlow 的 MCP 配置文件路径已有约定，请将以上配置合并到现有文件中。
+
+## 步骤 3：配置 OpenViking MCP Server
+
+在 DeerFlow 的 Agent 或工具配置中启用该 MCP Server，并确保 server 名称与 MCP 配置文件中的 `openviking` 保持一致。
+
+建议允许 DeerFlow 使用 OpenViking 的搜索、读取、目录浏览和健康检查工具，以覆盖常见的记忆检索与知识读取场景。
+
+## 步骤 4：重启 DeerFlow
+
+保存 MCP 配置后重启 DeerFlow：
+
+```bash
+pnpm dev
+```
+
+重启后检查日志，确认 `openviking` MCP Server 已成功加载，且工具列表可以正常获取。
+
+## 步骤 5：验证 MCP 工具是否可用
+
+在 DeerFlow 中发起任务，让 Agent 主动检查 OpenViking 连接状态：
+
+```text
+请使用 OpenViking MCP 工具检查当前服务是否可用。
+```
+
+也可以让 DeerFlow 搜索一条已存在的记忆或资源：
+
+```text
+请从 OpenViking 中搜索和当前项目相关的记忆。
+```
+
+如果 Agent 能够调用 OpenViking MCP 工具并返回结果，说明 MCP 接入成功。
+
+## 故障排查
+
+| 现象 | 处理方式 |
+|------|----------|
+| MCP Server 未加载 | 检查 MCP 配置文件路径是否被 DeerFlow 读取，server 名称是否配置一致 |
+| 连接失败或超时 | 确认网络可访问 `api.vikingdb.cn-beijing.volces.com`，必要时配置代理或网络白名单 |
+| OpenViking 返回 401 / 403 | 检查 `OPENVIKING_API_KEY` 是否正确、是否过期，以及请求头是否为 `Authorization: Bearer <API Key>` |
+| Agent 不主动调用工具 | 在 DeerFlow 的系统提示词或工具策略中明确允许使用 OpenViking MCP 工具 |
+| 搜索结果为空 | 确认 OpenViking 中已有相关记忆或知识资源，并尝试放宽搜索关键词 |

--- a/docs/images/agents/zh/deerflow-memory-manager.md
+++ b/docs/images/agents/zh/deerflow-memory-manager.md
@@ -1,0 +1,79 @@
+DeerFlow 支持通过 MemoryManager 接入 OpenViking 作为长期记忆后端。接入后，DeerFlow 会将对话消息写入 OpenViking，并在模型调用前通过 OpenViking 进行记忆召回，再注入到上下文中。
+
+## 步骤 1：配置 OpenViking 鉴权信息
+
+在启动 DeerFlow 的环境中配置 OpenViking 服务地址和 API Key：
+
+```bash
+export OPENVIKING_BASE_URL="https://api.vikingdb.cn-beijing.volces.com/openviking"
+export OPENVIKING_API_KEY="[TODO]your-api-key"
+```
+
+如果使用 `.env` 或部署平台的环境变量管理能力，请写入同名变量，并确认 DeerFlow 进程启动时能够读取到。
+
+## 步骤 2：修改 DeerFlow 的 memory 配置
+
+在 DeerFlow 的配置文件中启用 MemoryManager，并将 provider 指向 OpenViking：
+
+```yaml
+memory:
+  enabled: true
+  provider: openviking
+  openviking:
+    base_url: ${OPENVIKING_BASE_URL}
+    api_key: ${OPENVIKING_API_KEY}
+    auto_write: true
+    auto_recall: true
+    inject_recalled_memory: true
+```
+
+建议同时开启写入、召回和注入，确保 DeerFlow 能够在对话过程中持续沉淀长期记忆，并在后续任务中自动使用相关记忆。
+
+## 步骤 3：重启 DeerFlow
+
+保存配置后重启 DeerFlow，使新的 memory 配置生效：
+
+```bash
+pnpm dev
+```
+
+如果你通过 Docker、进程管理器或云服务部署 DeerFlow，请使用对应的重启方式，并确认新的环境变量已注入到运行时。
+
+## 步骤 4：验证 OpenViking 是否接入成功
+
+启动后检查 DeerFlow 日志，确认 MemoryManager 初始化成功，且没有出现 OpenViking 鉴权或网络错误。
+
+也可以直接检查 OpenViking 服务连通性：
+
+```bash
+curl -H "Authorization: Bearer ${OPENVIKING_API_KEY}" \
+  "${OPENVIKING_BASE_URL}/health"
+```
+
+返回服务状态信息即表示 OpenViking 服务可访问。
+
+## 步骤 5：验证记忆写入与召回是否正常
+
+在 DeerFlow 中发起一轮包含稳定事实的对话，例如：
+
+```text
+请记住：我的 DeerFlow 测试项目使用 OpenViking 作为长期记忆后端。
+```
+
+随后开启一轮新对话并询问：
+
+```text
+我的 DeerFlow 测试项目使用什么作为长期记忆后端？
+```
+
+如果 DeerFlow 能够回答 OpenViking，说明记忆写入、召回和上下文注入链路已经生效。
+
+## 故障排查
+
+| 现象 | 处理方式 |
+|------|----------|
+| MemoryManager 初始化失败 | 检查 `memory.enabled`、`provider` 和 OpenViking 配置项是否已写入 DeerFlow 实际加载的配置文件 |
+| OpenViking 返回 401 / 403 | 检查 `OPENVIKING_API_KEY` 是否正确、是否过期，以及请求头是否带有 `Bearer` 前缀 |
+| 记忆没有写入 | 确认 `auto_write` 已开启，并检查 DeerFlow 日志中是否有写入失败信息 |
+| 记忆无法召回 | 确认 `auto_recall` 和 `inject_recalled_memory` 已开启，并确保 OpenViking 中已有相关记忆 |
+| 本地可用、部署后不可用 | 检查部署环境是否正确注入 `OPENVIKING_BASE_URL` 和 `OPENVIKING_API_KEY` |

--- a/docs/images/agents/zh/index.json
+++ b/docs/images/agents/zh/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-06-05",
+  "updatedAt": "2026-08-12",
   "cdnBaseUrl": "https://docs.openviking.net/",
   "accessMethods": [
     {
@@ -95,6 +95,26 @@
       "logo": "https://lf3-static.bytednsdoc.com/obj/eden-cn/lm_sth/ljhwZthlaukjlkulzlp/agent_logo/OpenCode.png",
       "summary": "提供一个统一 OpenCode 插件，支持仓库上下文、记忆工具、session 同步与自动 recall",
       "detailPath": "https://docs.openviking.net/agents/zh/opencode.md"
+    },
+    {
+      "id": "deerflow",
+      "name": "DeerFlow",
+      "tags": ["MemoryManager", "MCP"],
+      "logo": "https://raw.githubusercontent.com/bytedance/deer-flow/main/frontend/public/images/deer.svg",
+      "summary": "DeerFlow 支持通过 MemoryManager 和 MCP 接入，实现记忆的自动写入、召回、注入及管理。建议同时启用两种方式，以获得完整的记忆体验。",
+      "detailPath": "https://docs.openviking.net/agents/zh/deerflow-memory-manager.md",
+      "tabs": [
+        {
+          "id": "memory-manager",
+          "label": "MemoryManager 接入",
+          "detailPath": "https://docs.openviking.net/agents/zh/deerflow-memory-manager.md"
+        },
+        {
+          "id": "mcp",
+          "label": "MCP 接入",
+          "detailPath": "https://docs.openviking.net/agents/zh/deerflow-mcp.md"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

新增 DeerFlow 接入 OpenViking 的 Agent 接入文档与 catalog 配置，用于控制台「接入 Agent」页面展示 DeerFlow 卡片及详情页内容。

本次变更包含：

- 在主流 Agent 集成列表中新增 DeerFlow 卡片
- DeerFlow 卡片展示官方图标、标签、简介等信息
- 新增 DeerFlow 的两种接入方式文档：
  - MemoryManager 接入
  - MCP 接入
- 同步补充中英文文档内容

## Changes

- 更新 `docs/images/agents/zh/index.json`
  - 在 OpenCode 后新增 DeerFlow
  - 配置 `MemoryManager`、`MCP` 两个标签
  - 配置 DeerFlow 官方图标
  - 配置 DeerFlow 两个详情 Tab

- 更新 `docs/images/agents/en/index.json`
  - 同步新增英文 DeerFlow catalog 配置

- 新增中文文档：
  - `docs/images/agents/zh/deerflow-memory-manager.md`
  - `docs/images/agents/zh/deerflow-mcp.md`

- 新增英文文档：
  - `docs/images/agents/en/deerflow-memory-manager.md`
  - `docs/images/agents/en/deerflow-mcp.md`

## Validation

已本地验证：

- `npm run docs:build` 构建通过
- 本地预览确认 `agents/zh/index.json` 包含 DeerFlow
- 本地控制台联调确认 DeerFlow 卡片可展示
- DeerFlow 详情页可切换 `MemoryManager 接入` 和 `MCP 接入`

## Notes

该 PR 只包含文档源和 catalog 配置。控制台前端需要支持远程 catalog 的 `tabs` 字段后，才能完整展示 DeerFlow 的多 Tab 详情页。