### PR TITLE
feat(reindex): support tag updates

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -459,13 +459,22 @@ impl HttpClient {
         mode: &str,
         wait: bool,
         dry_run: bool,
+        tags: Vec<String>,
+        tag_mode: &str,
     ) -> Result<serde_json::Value> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "uri": uri,
             "mode": mode,
             "wait": wait,
             "dry_run": dry_run,
         });
+        if !tags.is_empty() {
+            let obj = body
+                .as_object_mut()
+                .expect("reindex request body must be an object");
+            obj.insert("tags".to_string(), serde_json::json!(tags));
+            obj.insert("tag_mode".to_string(), serde_json::json!(tag_mode));
+        }
         self.post("/api/v1/content/reindex", &body).await
     }
 

--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -75,10 +75,14 @@ pub async fn reindex(
     mode: &str,
     wait: bool,
     dry_run: bool,
+    tags: Vec<String>,
+    tag_mode: &str,
     output_format: OutputFormat,
     compact: bool,
 ) -> Result<()> {
-    let result = client.reindex(uri, mode, wait, dry_run).await?;
+    let result = client
+        .reindex(uri, mode, wait, dry_run, tags, tag_mode)
+        .await?;
     crate::output::output_success(result, output_format, compact);
     Ok(())
 }

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -1384,6 +1384,8 @@ pub async fn handle_reindex(
     mode: String,
     wait: bool,
     dry_run: bool,
+    tags: Vec<String>,
+    tag_mode: String,
     ctx: CliContext,
 ) -> Result<()> {
     let client = ctx.get_client();
@@ -1393,6 +1395,8 @@ pub async fn handle_reindex(
         &mode,
         wait,
         dry_run,
+        tags,
+        &tag_mode,
         ctx.output_format,
         ctx.compact,
     )

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1176,6 +1176,17 @@ enum Commands {
         /// Preview prune_orphans deletions without mutating vectors
         #[arg(long, help_heading = "Common options")]
         dry_run: bool,
+        /// Explicit k=v retrieval tag for rebuilt vector records. Can be repeated.
+        #[arg(long = "tag", value_name = "k=v", help_heading = "Common options")]
+        tags: Vec<String>,
+        /// Tag update mode when --tag is provided
+        #[arg(
+            long = "tag-mode",
+            default_value = "replace",
+            value_parser = ["replace", "append"],
+            help_heading = "Common options"
+        )]
+        tag_mode: String,
     },
 }
 
@@ -3532,7 +3543,9 @@ async fn main() {
             mode,
             wait,
             dry_run,
-        } => handlers::handle_reindex(uri, mode, wait, dry_run, ctx).await,
+            tags,
+            tag_mode,
+        } => handlers::handle_reindex(uri, mode, wait, dry_run, tags, tag_mode, ctx).await,
         Commands::Get { uri, local_path } => handlers::handle_get(uri, local_path, ctx).await,
         Commands::Find {
             query,
@@ -5385,9 +5398,20 @@ mod tests {
             "prune_orphans",
             "--wait=false",
             "--dry-run",
+            "--tag",
+            "team=search",
+            "--tag-mode",
+            "append",
         ]);
 
-        assert!(result.is_ok(), "reindex command should parse");
+        let cli = result.expect("reindex command should parse");
+        match cli.command {
+            Commands::Reindex { tags, tag_mode, .. } => {
+                assert_eq!(tags, vec!["team=search"]);
+                assert_eq!(tag_mode, "append");
+            }
+            _ => panic!("expected reindex command"),
+        }
     }
 
     #[test]

--- a/docs/en/api/12-content.md
+++ b/docs/en/api/12-content.md
@@ -660,6 +660,9 @@ console.log(await client.reindex("viking://resources/docs/", {
 
 **Go SDK**
 
+When passing a non-`nil` `ReindexOptions`, set `Wait` explicitly. Go's zero
+value is `false`; only `opts=nil` applies the SDK default `wait=true`.
+
 ```go
 result, err := client.Reindex(ctx, "viking://resources", &openviking.ReindexOptions{
     Mode: "vectors_only",

--- a/docs/en/api/12-content.md
+++ b/docs/en/api/12-content.md
@@ -582,6 +582,8 @@ This API operates on existing `viking://...` content. It does not import new fil
 | mode | str | No | `vectors_only` | Reindex mode: `vectors_only`, `semantic_and_vectors`, or `prune_orphans` |
 | wait | bool | No | `true` | Whether to wait for completion |
 | dry_run | bool | No | `false` | Only valid with `mode="prune_orphans"`; report orphan vector records without deleting them |
+| tags | list[str] | No | `null` | Write tags to every successfully rebuilt vector record. Omit to preserve existing tags; an empty list with `replace` clears them |
+| tag_mode | str | No | `replace` | Tag write mode: `replace` or `append` |
 
 The HTTP request body rejects unknown fields. `uri` may use OpenViking path variables accepted by other content APIs; it is resolved before validation.
 
@@ -612,6 +614,10 @@ For `semantic_and_vectors`, semantic generation and vector rebuilding are sequen
 
 For `prune_orphans`, source existence is checked against the filesystem. If an entire directory is missing, vector records for files and semantic sidecars below that directory, such as `.abstract.md` and `.overview.md`, are pruned together. `dry_run` is rejected for other modes.
 
+When `tags` is provided, tags are included in the same upsert as each vector record produced by reindex; reindex does not call `set_tags` afterwards. Directory and namespace reindex operations apply tags to successfully rebuilt directory L0/L1 and leaf L2 records. `replace` overwrites existing tags, while `append` merges by key. When `tags` is omitted, `tag_mode` is ignored and existing tags remain unchanged. `prune_orphans` produces no vectors and ignores both fields.
+
+Subtree reindex is not transactional. Records skipped because no semantic source is available, or records whose embedding fails, do not receive the new tags.
+
 **Python SDK**
 
 ```python
@@ -619,6 +625,8 @@ result = client.reindex(
     uri="viking://resources",
     mode="vectors_only",
     wait=True,
+    tags=["team=search", "env=prod"],
+    tag_mode="replace",
 )
 print(result)
 ```
@@ -644,7 +652,10 @@ print(result["would_delete_records"])
 **TypeScript SDK**
 
 ```typescript
-console.log(await client.reindex("viking://resources/docs/"));
+console.log(await client.reindex("viking://resources/docs/", {
+  tags: ["team=search"],
+  tagMode: "append",
+}));
 ```
 
 **Go SDK**
@@ -653,6 +664,8 @@ console.log(await client.reindex("viking://resources/docs/"));
 result, err := client.Reindex(ctx, "viking://resources", &openviking.ReindexOptions{
     Mode: "vectors_only",
     Wait: true,
+    Tags: []string{"team=search"},
+    TagMode: "replace",
 })
 if err != nil {
     return err
@@ -687,17 +700,21 @@ curl -X POST http://localhost:1933/api/v1/content/reindex \
   -H "X-OpenViking-Account: default" \
   -d '{
     "uri": "viking://resources",
-    "mode": "prune_orphans",
+    "mode": "vectors_only",
     "wait": true,
-    "dry_run": true
+    "tags": ["team=search", "env=prod"],
+    "tag_mode": "replace"
   }'
 ```
 
 **CLI**
 
 ```bash
-openviking reindex viking://resources --mode vectors_only
+openviking reindex viking://resources --mode vectors_only \
+  --tag team=search --tag env=prod --tag-mode replace
 ```
+
+The CLI sends tag fields only when at least one `--tag` is provided. Use HTTP or an SDK to clear tags with `tags: []`.
 
 ```bash
 openviking reindex viking://user/default/skills --mode semantic_and_vectors --wait false

--- a/docs/zh/api/12-content.md
+++ b/docs/zh/api/12-content.md
@@ -660,6 +660,9 @@ console.log(await client.reindex("viking://resources/docs/", {
 
 **Go SDK**
 
+传入非 `nil` 的 `ReindexOptions` 时，需要显式设置 `Wait`。Go 的布尔零值为
+`false`；只有 `opts=nil` 时 SDK 才会应用 `wait=true` 的默认值。
+
 ```go
 result, err := client.Reindex(ctx, "viking://resources", &openviking.ReindexOptions{
     Mode: "vectors_only",

--- a/docs/zh/api/12-content.md
+++ b/docs/zh/api/12-content.md
@@ -582,6 +582,8 @@ ov set-tags viking://resources/project/ \
 | mode | str | 否 | `vectors_only` | 重建模式：`vectors_only`、`semantic_and_vectors` 或 `prune_orphans` |
 | wait | bool | 否 | `true` | 是否等待任务完成 |
 | dry_run | bool | 否 | `false` | 仅适用于 `mode="prune_orphans"`；只报告 orphan 向量记录，不实际删除 |
+| tags | list[str] | 否 | `null` | 写入本次成功重建的全部向量记录。省略时保留已有 tags；空数组配合 `replace` 可清空 |
+| tag_mode | str | 否 | `replace` | `tags` 的写入模式：`replace` 或 `append` |
 
 HTTP 请求体不接受未知字段。`uri` 可以使用其他 content API 支持的 OpenViking 路径变量，服务端会先解析再校验。
 
@@ -612,6 +614,10 @@ session 子树会被跳过。
 
 对于 `prune_orphans`，源文件是否存在以当前文件系统为准。如果整个目录已经不存在，该目录下的正文文件向量和语义 sidecar 向量（例如 `.abstract.md`、`.overview.md`）会一起清理。`dry_run` 用在其他模式时会被拒绝。
 
+传入 `tags` 时，标签会随 reindex 生成的向量记录在同一次 upsert 中写入，不会在完成后额外调用 `set_tags`。目录或 namespace reindex 会把标签应用到本次成功重建的目录 L0/L1 和叶子 L2 记录。`replace` 覆盖已有标签，`append` 按 key 合并；省略 `tags` 时不校验 `tag_mode` 且不修改已有标签。`prune_orphans` 不生成向量，因此会忽略 `tags` 和 `tag_mode`。
+
+子树 reindex 不是事务性操作。如果部分记录因缺少语义来源或 embedding 失败而未重建，只有成功写入的记录会更新标签。
+
 **Python SDK**
 
 ```python
@@ -619,6 +625,8 @@ result = client.reindex(
     uri="viking://resources",
     mode="vectors_only",
     wait=True,
+    tags=["team=search", "env=prod"],
+    tag_mode="replace",
 )
 print(result)
 ```
@@ -644,7 +652,10 @@ print(result["would_delete_records"])
 **TypeScript SDK**
 
 ```typescript
-console.log(await client.reindex("viking://resources/docs/"));
+console.log(await client.reindex("viking://resources/docs/", {
+  tags: ["team=search"],
+  tagMode: "append",
+}));
 ```
 
 **Go SDK**
@@ -653,6 +664,8 @@ console.log(await client.reindex("viking://resources/docs/"));
 result, err := client.Reindex(ctx, "viking://resources", &openviking.ReindexOptions{
     Mode: "vectors_only",
     Wait: true,
+    Tags: []string{"team=search"},
+    TagMode: "replace",
 })
 if err != nil {
     return err
@@ -687,17 +700,21 @@ curl -X POST http://localhost:1933/api/v1/content/reindex \
   -H "X-OpenViking-Account: default" \
   -d '{
     "uri": "viking://resources",
-    "mode": "prune_orphans",
+    "mode": "vectors_only",
     "wait": true,
-    "dry_run": true
+    "tags": ["team=search", "env=prod"],
+    "tag_mode": "replace"
   }'
 ```
 
 **CLI**
 
 ```bash
-openviking reindex viking://resources --mode vectors_only
+openviking reindex viking://resources --mode vectors_only \
+  --tag team=search --tag env=prod --tag-mode replace
 ```
+
+CLI 仅在至少传入一个 `--tag` 时发送标签字段；如需用 `tags: []` 清空标签，请使用 HTTP 或 SDK。
 
 ```bash
 openviking reindex viking://user/default/skills --mode semantic_and_vectors --wait false

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -108,6 +108,8 @@ class ReindexRequest(BaseModel):
     mode: str = "vectors_only"
     wait: bool = True
     dry_run: bool = False
+    tags: list[str] | None = None
+    tag_mode: str = "replace"
 
 
 router = APIRouter(prefix="/api/v1/content", tags=["content"])
@@ -336,11 +338,17 @@ async def reindex(
     uri = _validate_reindex_uri(uri)
     uri = _authorize_reindex_uri(uri, ctx)
     service = get_service()
+    reindex_kwargs = {
+        "uri": uri,
+        "mode": body.mode,
+        "wait": body.wait,
+        "dry_run": body.dry_run,
+        "ctx": ctx,
+    }
+    if body.tags is not None:
+        reindex_kwargs["tags"] = body.tags
+        reindex_kwargs["tag_mode"] = body.tag_mode
     result = await service.reindex(
-        uri=uri,
-        mode=body.mode,
-        wait=body.wait,
-        dry_run=body.dry_run,
-        ctx=ctx,
+        **reindex_kwargs,
     )
     return Response(status="ok", result=result)

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -556,6 +556,8 @@ class OpenVikingService:
         mode: str = "vectors_only",
         wait: bool = True,
         dry_run: bool = False,
+        tags: list[str] | None = None,
+        tag_mode: str = "replace",
         ctx: RequestContext | None = None,
     ) -> dict[str, Any]:
         """Reindex semantic/vector artifacts for a URI."""
@@ -566,13 +568,17 @@ class OpenVikingService:
         canonical_uri = canonicalize_uri(uri, effective_ctx)
         from openviking.service.reindex_executor import get_reindex_executor
 
-        return await get_reindex_executor().execute(
-            uri=canonical_uri,
-            mode=mode,
-            wait=wait,
-            dry_run=dry_run,
-            ctx=effective_ctx,
-        )
+        execute_kwargs = {
+            "uri": canonical_uri,
+            "mode": mode,
+            "wait": wait,
+            "dry_run": dry_run,
+            "ctx": effective_ctx,
+        }
+        if tags is not None:
+            execute_kwargs["tags"] = tags
+            execute_kwargs["tag_mode"] = tag_mode
+        return await get_reindex_executor().execute(**execute_kwargs)
 
     async def check_consistency(
         self,

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -475,7 +475,12 @@ class ReindexExecutor:
         if telemetry_id:
             wait_tracker.register_request(telemetry_id)
 
-        lease = await service.viking_fs._async_agfs.pathlock_acquire_tree(path)
+        acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_tree
+        if mode != "prune_orphans":
+            stat = await service.viking_fs.stat(uri, ctx=ctx)
+            if not stat.get("isDir", stat.get("is_dir")):
+                acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_exact
+        lease = await acquire_lock(path)
         try:
             borrowed = await service.viking_fs._async_agfs.pathlock_as_borrowed(lease)
             run = _ReindexRunContext(

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -476,7 +476,7 @@ class ReindexExecutor:
             wait_tracker.register_request(telemetry_id)
 
         acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_tree
-        if mode != "prune_orphans":
+        if mode != "prune_orphans" or await service.viking_fs.exists(uri, ctx=ctx):
             stat = await service.viking_fs.stat(uri, ctx=ctx)
             if not stat.get("isDir", stat.get("is_dir")):
                 acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_exact

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -36,7 +36,12 @@ from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.embedding_input import truncate_embedding_input
-from openviking.utils.embedding_utils import _truncate_abstract_bytes, get_resource_content_type
+from openviking.utils.embedding_utils import (
+    _apply_ingest_options,
+    _truncate_abstract_bytes,
+    get_resource_content_type,
+)
+from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError, OpenVikingError
 from openviking_cli.session.user_id import UserIdentifier
@@ -101,6 +106,7 @@ class _ReindexRunContext:
     ctx: RequestContext
     counters: _ReindexCounters
     lock: dict | None = None
+    ingest_options: IngestOptions | None = None
 
 
 @dataclass
@@ -146,12 +152,19 @@ class ReindexExecutor:
         mode: str,
         wait: bool,
         dry_run: bool = False,
+        tags: list[str] | None = None,
+        tag_mode: str = "replace",
         ctx: RequestContext,
     ) -> dict[str, Any]:
         object_type = self._infer_target_type(uri)
         self._validate_mode(object_type, mode)
         if dry_run and mode != "prune_orphans":
             raise InvalidArgumentError("dry_run is only supported for prune_orphans reindex mode.")
+        ingest_options = self._resolve_ingest_options(
+            mode=mode,
+            tags=tags,
+            tag_mode=tag_mode,
+        )
 
         tracker = get_task_tracker()
         if wait:
@@ -171,6 +184,7 @@ class ReindexExecutor:
                 object_type=object_type,
                 mode=mode,
                 dry_run=dry_run,
+                ingest_options=ingest_options,
                 ctx=ctx,
             )
 
@@ -194,6 +208,7 @@ class ReindexExecutor:
                 object_type=object_type,
                 mode=mode,
                 dry_run=dry_run,
+                ingest_options=ingest_options,
                 ctx=ctx,
             )
         )
@@ -204,6 +219,28 @@ class ReindexExecutor:
             "object_type": object_type,
             "mode": mode,
         }
+
+    @staticmethod
+    def _resolve_ingest_options(
+        *,
+        mode: str,
+        tags: list[str] | None,
+        tag_mode: str,
+    ) -> IngestOptions | None:
+        if mode == "prune_orphans" or tags is None:
+            return None
+        if tag_mode not in {"replace", "append"}:
+            raise InvalidArgumentError(f"unsupported tag mode: {tag_mode}")
+        return IngestOptions.from_search_tags(tags, mode=tag_mode)
+
+    @staticmethod
+    def _with_ingest_options(
+        kwargs: dict[str, Any],
+        ingest_options: IngestOptions | None,
+    ) -> dict[str, Any]:
+        if ingest_options is not None:
+            kwargs["ingest_options"] = ingest_options
+        return kwargs
 
     def _infer_target_type(self, uri: str) -> str:
         if not uri.startswith("viking://"):
@@ -417,6 +454,7 @@ class ReindexExecutor:
         object_type: str,
         mode: str,
         dry_run: bool = False,
+        ingest_options: IngestOptions | None = None,
         ctx: RequestContext,
     ) -> dict[str, Any]:
         service = get_service()
@@ -444,6 +482,7 @@ class ReindexExecutor:
                 ctx=ctx,
                 counters=counters,
                 lock=borrowed,
+                ingest_options=ingest_options,
             )
             if mode == "prune_orphans":
                 await self._prune_orphan_vectors(
@@ -530,6 +569,7 @@ class ReindexExecutor:
         object_type: str,
         mode: str,
         dry_run: bool = False,
+        ingest_options: IngestOptions | None = None,
         ctx: RequestContext,
     ) -> None:
         tracker = get_task_tracker()
@@ -542,6 +582,7 @@ class ReindexExecutor:
                     object_type=object_type,
                     mode=mode,
                     dry_run=dry_run,
+                    ingest_options=ingest_options,
                     ctx=ctx,
                 )
             await tracker.complete(
@@ -874,9 +915,19 @@ class ReindexExecutor:
                 ctx=ctx,
                 lock=run.lock,
             )
-            await self._reindex_resource_vectors(uri=uri, counters=counters, ctx=ctx)
+            await self._reindex_resource_vectors(
+                **self._with_ingest_options(
+                    {"uri": uri, "counters": counters, "ctx": ctx},
+                    run.ingest_options,
+                )
+            )
             return
-        await self._reindex_resource_vectors(uri=uri, counters=counters, ctx=ctx)
+        await self._reindex_resource_vectors(
+            **self._with_ingest_options(
+                {"uri": uri, "counters": counters, "ctx": ctx},
+                run.ingest_options,
+            )
+        )
 
     async def _reindex_skill(
         self,
@@ -889,7 +940,12 @@ class ReindexExecutor:
         ctx = run.ctx
         if mode == "semantic_and_vectors":
             await self._regenerate_skill_semantics(uri=uri, ctx=ctx)
-        await self._reindex_skill_vectors(uri=uri, counters=counters, ctx=ctx)
+        await self._reindex_skill_vectors(
+            **self._with_ingest_options(
+                {"uri": uri, "counters": counters, "ctx": ctx},
+                run.ingest_options,
+            )
+        )
 
     async def _reindex_memory(
         self,
@@ -909,9 +965,19 @@ class ReindexExecutor:
                     ctx=ctx,
                     lock=run.lock,
                 )
-            await self._reindex_memory_vectors(uri=uri, counters=counters, ctx=ctx)
+            await self._reindex_memory_vectors(
+                **self._with_ingest_options(
+                    {"uri": uri, "counters": counters, "ctx": ctx},
+                    run.ingest_options,
+                )
+            )
             return
-        await self._reindex_memory_vectors(uri=uri, counters=counters, ctx=ctx)
+        await self._reindex_memory_vectors(
+            **self._with_ingest_options(
+                {"uri": uri, "counters": counters, "ctx": ctx},
+                run.ingest_options,
+            )
+        )
 
     async def _run_semantic_processor(
         self,
@@ -943,6 +1009,7 @@ class ReindexExecutor:
         uri: str,
         counters: _ReindexCounters,
         ctx: RequestContext,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         viking_fs = get_viking_fs()
         try:
@@ -973,11 +1040,16 @@ class ReindexExecutor:
             files = [uri]
 
         await self._reindex_resource_vectors_from_entries(
-            root_uri=uri,
-            directories=directories,
-            files=files,
-            counters=counters,
-            ctx=ctx,
+            **self._with_ingest_options(
+                {
+                    "root_uri": uri,
+                    "directories": directories,
+                    "files": files,
+                    "counters": counters,
+                    "ctx": ctx,
+                },
+                ingest_options,
+            )
         )
 
     async def _reindex_resource_vectors_from_entries(
@@ -988,6 +1060,7 @@ class ReindexExecutor:
         files: Iterable[str],
         counters: _ReindexCounters,
         ctx: RequestContext,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         deduped_directories = []
         seen_directories = set()
@@ -1026,6 +1099,7 @@ class ReindexExecutor:
                         context_type=context_type_for_uri(directory_uri),
                         level=ContextLevel.ABSTRACT,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1043,6 +1117,7 @@ class ReindexExecutor:
                         context_type=context_type_for_uri(directory_uri),
                         level=ContextLevel.OVERVIEW,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1069,6 +1144,7 @@ class ReindexExecutor:
                     context_type=context_type_for_uri(file_uri),
                     level=ContextLevel.DETAIL,
                     ctx=ctx,
+                    ingest_options=ingest_options,
                 )
                 counters.rebuilt_records += 1
             except Exception as exc:
@@ -1233,11 +1309,16 @@ class ReindexExecutor:
             )
 
         await self._reindex_resource_vectors_from_entries(
-            root_uri=target_root,
-            directories=resource_directories,
-            files=resource_files,
-            counters=counters,
-            ctx=ctx,
+            **self._with_ingest_options(
+                {
+                    "root_uri": target_root,
+                    "directories": resource_directories,
+                    "files": resource_files,
+                    "counters": counters,
+                    "ctx": ctx,
+                },
+                run.ingest_options,
+            )
         )
 
     async def _reindex_global_namespace(
@@ -1299,11 +1380,16 @@ class ReindexExecutor:
             )
 
         await self._reindex_resource_vectors_from_entries(
-            root_uri=target_root,
-            directories=resource_directories,
-            files=resource_files,
-            counters=counters,
-            ctx=ctx,
+            **self._with_ingest_options(
+                {
+                    "root_uri": target_root,
+                    "directories": resource_directories,
+                    "files": resource_files,
+                    "counters": counters,
+                    "ctx": ctx,
+                },
+                run.ingest_options,
+            )
         )
 
     async def _reindex_skill_vectors(
@@ -1312,6 +1398,7 @@ class ReindexExecutor:
         uri: str,
         counters: _ReindexCounters,
         ctx: RequestContext,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         viking_fs = get_viking_fs()
         counters.scanned_records += 1
@@ -1351,6 +1438,7 @@ class ReindexExecutor:
                     level=ContextLevel.ABSTRACT,
                     meta=await self._skill_meta(uri=uri, abstract=abstract, ctx=ctx),
                     ctx=ctx,
+                    ingest_options=ingest_options,
                 )
                 counters.rebuilt_records += 1
             except Exception as exc:
@@ -1369,6 +1457,7 @@ class ReindexExecutor:
                     level=ContextLevel.OVERVIEW,
                     meta=await self._skill_meta(uri=uri, abstract=abstract, ctx=ctx),
                     ctx=ctx,
+                    ingest_options=ingest_options,
                 )
                 counters.rebuilt_records += 1
             except Exception as exc:
@@ -1391,6 +1480,7 @@ class ReindexExecutor:
                         context_type=ContextType.SKILL.value,
                         level=ContextLevel.DETAIL,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1403,6 +1493,7 @@ class ReindexExecutor:
         uri: str,
         counters: _ReindexCounters,
         ctx: RequestContext,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         viking_fs = get_viking_fs()
         if await viking_fs.exists(uri, ctx=ctx):
@@ -1415,9 +1506,14 @@ class ReindexExecutor:
                     if entry_uri and entry.get("isDir"):
                         directory_uris.add(entry_uri)
                 await self._reindex_memory_directory_chain(
-                    directory_uris=sorted(directory_uris),
-                    counters=counters,
-                    ctx=ctx,
+                    **self._with_ingest_options(
+                        {
+                            "directory_uris": sorted(directory_uris),
+                            "counters": counters,
+                            "ctx": ctx,
+                        },
+                        ingest_options,
+                    )
                 )
                 file_uris = [entry["uri"] for entry in entries if not entry.get("isDir")]
             else:
@@ -1463,6 +1559,7 @@ class ReindexExecutor:
                         context_type=ContextType.MEMORY.value,
                         level=ContextLevel.DETAIL,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1481,6 +1578,7 @@ class ReindexExecutor:
                     context_type=ContextType.MEMORY.value,
                     level=ContextLevel.DETAIL,
                     ctx=ctx,
+                    ingest_options=ingest_options,
                 )
                 counters.rebuilt_records += 1
                 counters.warnings.append(
@@ -1496,6 +1594,7 @@ class ReindexExecutor:
         directory_uris: Iterable[str],
         counters: _ReindexCounters,
         ctx: RequestContext,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         for directory_uri in directory_uris:
             counters.scanned_records += 1
@@ -1516,6 +1615,7 @@ class ReindexExecutor:
                         context_type=ContextType.MEMORY.value,
                         level=ContextLevel.ABSTRACT,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1533,6 +1633,7 @@ class ReindexExecutor:
                         context_type=ContextType.MEMORY.value,
                         level=ContextLevel.OVERVIEW,
                         ctx=ctx,
+                        ingest_options=ingest_options,
                     )
                     counters.rebuilt_records += 1
                 except Exception as exc:
@@ -1641,18 +1742,12 @@ class ReindexExecutor:
         level: ContextLevel,
         ctx: RequestContext,
         meta: Optional[dict[str, Any]] = None,
+        ingest_options: IngestOptions | None = None,
     ) -> None:
         service = get_service()
         assert service.vikingdb_manager is not None
         merged_meta = dict(meta or {})
         owner_ctx = self._content_owner_ctx(uri, ctx)
-        existing = await self._fetch_existing_record(uri=uri, level=int(level), ctx=owner_ctx)
-        if (
-            existing
-            and existing.get("search_tags") is not None
-            and "search_tags" not in merged_meta
-        ):
-            merged_meta["search_tags"] = existing.get("search_tags")
 
         context = Context(
             uri=uri,
@@ -1668,6 +1763,7 @@ class ReindexExecutor:
         )
         context.set_vectorize(Vectorize(text=vector_text))
         msg = EmbeddingMsgConverter.from_context(context)
+        _apply_ingest_options(msg, ingest_options)
         if msg is None:
             raise OpenVikingError(
                 f"No vector text generated for {uri}",

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -268,6 +268,28 @@ func TestReindexSendsDryRun(t *testing.T) {
 	}
 }
 
+func TestReindexSendsExplicitEmptyTags(t *testing.T) {
+	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readJSONBody(t, r)
+		tags, ok := body["tags"].([]any)
+		if !ok || len(tags) != 0 {
+			t.Fatalf("tags = %#v", body["tags"])
+		}
+		if got := body["tag_mode"]; got != "replace" {
+			t.Fatalf("tag_mode = %#v", got)
+		}
+		writeOK(t, w, map[string]any{"status": "completed"})
+	}))
+	defer closeServer()
+
+	if _, err := client.Reindex(context.Background(), "resources/demo", &ReindexOptions{
+		Tags:    []string{},
+		TagMode: "replace",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAdminCreatePathsAcceptInitialUserConfig(t *testing.T) {
 	var seen []map[string]any
 	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/filesystem.go
+++ b/sdk/go/filesystem.go
@@ -209,6 +209,14 @@ func (c *Client) Reindex(ctx context.Context, uri string, opts *ReindexOptions) 
 		"wait":    opts.Wait,
 		"dry_run": opts.DryRun,
 	}
+	if opts.Tags != nil {
+		payload["tags"] = opts.Tags
+		tagMode := opts.TagMode
+		if tagMode == "" {
+			tagMode = "replace"
+		}
+		payload["tag_mode"] = tagMode
+	}
 	var result map[string]any
 	err := c.doJSON(ctx, http.MethodPost, "/api/v1/content/reindex", nil, payload, &result)
 	return result, err

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -185,6 +185,8 @@ type SetTagsOptions struct {
 }
 
 // ReindexOptions controls Reindex.
+// Wait is used as-is when options are provided; set it explicitly to true
+// when adding optional fields such as Tags and synchronous behavior is desired.
 type ReindexOptions struct {
 	Mode    string
 	Wait    bool

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -186,9 +186,11 @@ type SetTagsOptions struct {
 
 // ReindexOptions controls Reindex.
 type ReindexOptions struct {
-	Mode   string
-	Wait   bool
-	DryRun bool
+	Mode    string
+	Wait    bool
+	DryRun  bool
+	Tags    []string
+	TagMode string
 }
 
 // FindOptions controls Find.

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -1647,11 +1647,17 @@ class AsyncHTTPClient:
         mode: str = "vectors_only",
         wait: bool = True,
         dry_run: bool = False,
+        tags: Optional[List[str]] = None,
+        tag_mode: str = "replace",
     ) -> Dict[str, Any]:
+        payload = {"uri": uri, "mode": mode, "wait": wait, "dry_run": dry_run}
+        if tags is not None:
+            payload["tags"] = tags
+            payload["tag_mode"] = tag_mode
         response = await self._request(
             "POST",
             "/api/v1/content/reindex",
-            json={"uri": uri, "mode": mode, "wait": wait, "dry_run": dry_run},
+            json=payload,
         )
         return self._handle_response(response)
 
@@ -2597,8 +2603,19 @@ class SyncHTTPClient:
         mode: str = "vectors_only",
         wait: bool = True,
         dry_run: bool = False,
+        tags: Optional[List[str]] = None,
+        tag_mode: str = "replace",
     ) -> Dict[str, Any]:
-        return run_async(self._async_client.reindex(uri=uri, mode=mode, wait=wait, dry_run=dry_run))
+        kwargs = {
+            "uri": uri,
+            "mode": mode,
+            "wait": wait,
+            "dry_run": dry_run,
+        }
+        if tags is not None:
+            kwargs["tags"] = tags
+            kwargs["tag_mode"] = tag_mode
+        return run_async(self._async_client.reindex(**kwargs))
 
     def admin_create_account(
         self,

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -205,6 +205,23 @@ async def test_async_http_client_reindex_posts_content_reindex():
 
 
 @pytest.mark.asyncio
+async def test_async_http_client_reindex_sends_explicit_empty_tags():
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    fake_http = SimpleNamespace(post=AsyncMock(return_value=object()))
+    client._http = fake_http
+    client._handle_response = lambda _response: {"status": "completed"}
+
+    await client.reindex(
+        "viking://resources/demo",
+        tags=[],
+        tag_mode="replace",
+    )
+
+    assert fake_http.post.await_args.kwargs["json"]["tags"] == []
+    assert fake_http.post.await_args.kwargs["json"]["tag_mode"] == "replace"
+
+
+@pytest.mark.asyncio
 async def test_async_http_client_write_forwards_processing_mode():
     client = AsyncHTTPClient(url="http://localhost:1933")
     fake_http = SimpleNamespace(post=AsyncMock(return_value=object()))

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -537,15 +537,23 @@ export class OpenVikingClient {
   /** Rebuild indexes for a URI. */
   reindex(
     uri: string,
-    options: { mode?: string; wait?: boolean; dryRun?: boolean } = {},
+    options: {
+      mode?: string;
+      wait?: boolean;
+      dryRun?: boolean;
+      tags?: string[];
+      tagMode?: "replace" | "append";
+    } = {},
   ): Promise<JsonObject> {
     return this.request("POST", "/api/v1/content/reindex", {
-      body: {
+      body: compact({
         uri: normalizeURI(uri),
         mode: options.mode ?? "vectors_only",
         wait: options.wait ?? true,
         dry_run: options.dryRun ?? false,
-      },
+        tags: options.tags,
+        tag_mode: options.tags === undefined ? undefined : options.tagMode ?? "replace",
+      }),
     });
   }
 

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -99,6 +99,26 @@ describe("OpenVikingClient", () => {
     });
   });
 
+  it("sends explicit empty tags for reindex requests", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(ok({ status: "completed" }));
+    const client = new OpenVikingClient({
+      baseUrl: "https://example.com",
+      fetch: fetcher,
+    });
+
+    await client.reindex("resources", {
+      tags: [],
+      tagMode: "replace",
+    });
+
+    expect(JSON.parse(String(fetcher.mock.calls[0]![1]?.body))).toMatchObject({
+      tags: [],
+      tag_mode: "replace",
+    });
+  });
+
   it("sends processing_mode for addResource requests", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok({}));
     const client = new OpenVikingClient({

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -476,6 +476,138 @@ async def test_reindex_file_target_uses_exact_lock(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reindex_prune_existing_file_uses_exact_lock(monkeypatch):
+    from types import SimpleNamespace
+
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    calls = []
+
+    class FakeAGFS:
+        async def pathlock_acquire_exact(self, path):
+            calls.append(("exact", path))
+            return {"id": "lease-1"}
+
+        async def pathlock_acquire_tree(self, path):
+            calls.append(("tree", path))
+            raise AssertionError("existing file target must not acquire a tree lock")
+
+        async def pathlock_as_borrowed(self, lease):
+            return lease
+
+        async def pathlock_release(self, lease):
+            calls.append(("release", lease["id"]))
+
+    class FakeFS:
+        _async_agfs = FakeAGFS()
+
+        def _uri_to_path(self, uri, ctx):
+            return "/local/default/resources/demo.md"
+
+        async def exists(self, uri, ctx):
+            return True
+
+        async def stat(self, uri, ctx):
+            return {"isDir": False}
+
+    executor = ReindexExecutor()
+
+    async def fake_prune_orphan_vectors(**kwargs):
+        return None
+
+    monkeypatch.setattr(executor, "_prune_orphan_vectors", fake_prune_orphan_vectors)
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: SimpleNamespace(
+            viking_fs=FakeFS(),
+            vikingdb_manager=SimpleNamespace(has_queue_manager=True),
+        ),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    result = await executor._run(
+        uri="viking://resources/demo.md",
+        object_type="resource",
+        mode="prune_orphans",
+        dry_run=True,
+        ctx=ctx,
+    )
+
+    assert result["status"] == "completed"
+    assert calls == [
+        ("exact", "/local/default/resources/demo.md"),
+        ("release", "lease-1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reindex_prune_missing_target_keeps_tree_lock(monkeypatch):
+    from types import SimpleNamespace
+
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    calls = []
+
+    class FakeAGFS:
+        async def pathlock_acquire_exact(self, path):
+            raise AssertionError("missing target must retain tree lock scope")
+
+        async def pathlock_acquire_tree(self, path):
+            calls.append(("tree", path))
+            return {"id": "lease-1"}
+
+        async def pathlock_as_borrowed(self, lease):
+            return lease
+
+        async def pathlock_release(self, lease):
+            calls.append(("release", lease["id"]))
+
+    class FakeFS:
+        _async_agfs = FakeAGFS()
+
+        def _uri_to_path(self, uri, ctx):
+            return "/local/default/resources/missing"
+
+        async def exists(self, uri, ctx):
+            return False
+
+    executor = ReindexExecutor()
+
+    async def fake_prune_orphan_vectors(**kwargs):
+        return None
+
+    monkeypatch.setattr(executor, "_prune_orphan_vectors", fake_prune_orphan_vectors)
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: SimpleNamespace(
+            viking_fs=FakeFS(),
+            vikingdb_manager=SimpleNamespace(has_queue_manager=True),
+        ),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    result = await executor._run(
+        uri="viking://resources/missing",
+        object_type="resource",
+        mode="prune_orphans",
+        dry_run=True,
+        ctx=ctx,
+    )
+
+    assert result["status"] == "completed"
+    assert calls == [
+        ("tree", "/local/default/resources/missing"),
+        ("release", "lease-1"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_reindex_executor_passes_tags_to_background_run(monkeypatch):
     import asyncio
 

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -164,11 +164,23 @@ async def test_reindex_resource_vectors_only_wait_true(monkeypatch):
     seen = {}
 
     class FakeService:
-        async def reindex(self, *, uri, mode, wait, ctx, dry_run=False):
+        async def reindex(
+            self,
+            *,
+            uri,
+            mode,
+            wait,
+            ctx,
+            dry_run=False,
+            tags=None,
+            tag_mode="replace",
+        ):
             seen["uri"] = uri
             seen["mode"] = mode
             seen["wait"] = wait
             seen["ctx"] = ctx
+            seen["tags"] = tags
+            seen["tag_mode"] = tag_mode
             return {
                 "status": "completed",
                 "uri": uri,
@@ -186,7 +198,13 @@ async def test_reindex_resource_vectors_only_wait_true(monkeypatch):
         user=UserIdentifier(account_id="test", user_id="alice"),
         role=Role.ROOT,
     )
-    request = ReindexRequest(uri="viking://resources/demo", mode="vectors_only", wait=True)
+    request = ReindexRequest(
+        uri="viking://resources/demo",
+        mode="vectors_only",
+        wait=True,
+        tags=["Team=Search", "env=prod"],
+        tag_mode="append",
+    )
 
     monkeypatch.setattr("openviking.server.routers.content.get_service", lambda: FakeService())
     response = await reindex(body=request, ctx=ctx)
@@ -199,6 +217,8 @@ async def test_reindex_resource_vectors_only_wait_true(monkeypatch):
     assert seen["mode"] == "vectors_only"
     assert seen["wait"] is True
     assert seen["ctx"] == ctx
+    assert seen["tags"] == ["Team=Search", "env=prod"]
+    assert seen["tag_mode"] == "append"
     assert "reason" not in response.result
 
 
@@ -326,16 +346,163 @@ async def test_reindex_executor_rejects_dry_run_for_non_prune_mode_direct():
 
 
 @pytest.mark.asyncio
+async def test_reindex_executor_validates_tags_before_creating_background_task(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    class FakeTracker:
+        async def create_if_no_running(self, *args, **kwargs):
+            raise AssertionError("task must not be created for invalid tags")
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    with pytest.raises(OpenVikingError, match="expected strict k=v"):
+        await ReindexExecutor().execute(
+            uri="viking://resources/demo",
+            mode="vectors_only",
+            wait=False,
+            tags=["invalid"],
+            tag_mode="replace",
+            ctx=ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_reindex_executor_ignores_tags_for_prune_orphans(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    executor = ReindexExecutor()
+    seen = {}
+
+    async def fake_run(**kwargs):
+        seen.update(kwargs)
+        return {"status": "completed"}
+
+    class FakeTracker:
+        async def has_running(self, *args, **kwargs):
+            return False
+
+    monkeypatch.setattr(executor, "_run", fake_run)
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    result = await executor.execute(
+        uri="viking://resources/demo",
+        mode="prune_orphans",
+        wait=True,
+        tags=["invalid"],
+        tag_mode="invalid",
+        ctx=ctx,
+    )
+
+    assert result == {"status": "completed"}
+    assert seen["ingest_options"] is None
+
+
+@pytest.mark.asyncio
+async def test_reindex_executor_passes_tags_to_background_run(monkeypatch):
+    import asyncio
+
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    seen = {}
+
+    class FakeTask:
+        task_id = "task-1"
+
+    class FakeTracker:
+        async def create_if_no_running(self, *args, **kwargs):
+            return FakeTask()
+
+    executor = ReindexExecutor()
+
+    async def fake_run_tracked(task_id, **kwargs):
+        seen["task_id"] = task_id
+        seen.update(kwargs)
+
+    monkeypatch.setattr(executor, "_run_tracked", fake_run_tracked)
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_task_tracker",
+        lambda: FakeTracker(),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    result = await executor.execute(
+        uri="viking://resources/demo",
+        mode="vectors_only",
+        wait=False,
+        tags=["Team=Search"],
+        tag_mode="append",
+        ctx=ctx,
+    )
+    await asyncio.sleep(0)
+
+    assert result["status"] == "accepted"
+    assert seen["task_id"] == "task-1"
+    assert seen["ingest_options"].search_tags == ["team=search"]
+    assert seen["ingest_options"].search_tag_mode == "append"
+
+
+@pytest.mark.asyncio
+async def test_reindex_resource_passes_run_tags_to_vector_rebuild(monkeypatch):
+    from openviking.service.reindex_executor import (
+        ReindexExecutor,
+        _ReindexCounters,
+        _ReindexRunContext,
+    )
+    from openviking.utils.ingest_options import IngestOptions
+
+    seen = {}
+
+    async def fake_reindex_resource_vectors(self, **kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(
+        ReindexExecutor,
+        "_reindex_resource_vectors",
+        fake_reindex_resource_vectors,
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+    ingest_options = IngestOptions.from_search_tags(["team=search"], mode="replace")
+
+    await ReindexExecutor()._reindex_resource(
+        uri="viking://resources/demo",
+        mode="vectors_only",
+        run=_ReindexRunContext(
+            ctx=ctx,
+            counters=_ReindexCounters(),
+            ingest_options=ingest_options,
+        ),
+    )
+
+    assert seen["ingest_options"] is ingest_options
+
+
+@pytest.mark.asyncio
 async def test_reindex_upsert_uses_uri_owner_for_user_scoped_records(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor
 
     captured = {}
 
     class FakeVikingDB:
-        async def get_context_by_uri(self, uri, owner_space=None, level=None, limit=1, *, ctx=None):
-            captured["lookup_ctx"] = ctx
-            return []
-
         async def enqueue_embedding_msg(self, msg):
             captured["msg"] = msg
             return True
@@ -364,7 +531,6 @@ async def test_reindex_upsert_uses_uri_owner_for_user_scoped_records(monkeypatch
     assert data["user"]["user_id"] == "bob"
     assert data["owner_user_id"] == "bob"
     assert data["owner_space"] == "bob"
-    assert captured["lookup_ctx"].user.user_id == "bob"
 
 
 @pytest.mark.asyncio
@@ -1441,23 +1607,12 @@ async def test_reindex_fetch_existing_record_uses_get_context_by_uri(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_reindex_upsert_context_preserves_existing_search_tags(monkeypatch):
+async def test_reindex_upsert_context_omits_search_tags_without_ingest_options(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor
 
     captured = {}
 
     class FakeVikingDB:
-        async def get_context_by_uri(self, uri, owner_space=None, level=None, limit=1, *, ctx=None):
-            del owner_space, limit, ctx
-            return [
-                {
-                    "uri": uri,
-                    "level": level,
-                    "abstract": "existing",
-                    "search_tags": ["team-a", "project-x"],
-                }
-            ]
-
         async def enqueue_embedding_msg(self, msg):
             captured["msg"] = msg
             return True
@@ -1469,6 +1624,7 @@ async def test_reindex_upsert_context_preserves_existing_search_tags(monkeypatch
         def __init__(self):
             self.telemetry_id = ""
             self.id = "msg-1"
+            self.context_data = {}
 
     def fake_from_context(context):
         captured["meta"] = dict(context.meta or {})
@@ -1496,7 +1652,8 @@ async def test_reindex_upsert_context_preserves_existing_search_tags(monkeypatch
         ctx=ctx,
     )
 
-    assert captured["meta"]["search_tags"] == ["team-a", "project-x"]
+    assert "search_tags" not in captured["meta"]
+    assert "search_tags" not in captured["msg"].context_data
 
 
 @pytest.mark.asyncio
@@ -2446,6 +2603,49 @@ async def test_reindex_skill_l2_falls_back_to_skill_content_when_abstract_missin
     )
 
     assert seen["viking://user/skills/my_skill/SKILL.md"]["abstract"] == "skill abstract"
+
+
+@pytest.mark.asyncio
+async def test_reindex_upsert_applies_empty_replace_tags_to_embedding_message(monkeypatch):
+    from types import SimpleNamespace
+
+    from openviking.service.reindex_executor import ReindexExecutor
+    from openviking.utils.ingest_options import IngestOptions
+
+    queued = []
+
+    class FakeVikingDB:
+        async def enqueue_embedding_msg(self, msg):
+            queued.append(msg)
+            return True
+
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: SimpleNamespace(vikingdb_manager=FakeVikingDB()),
+    )
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_request_wait_tracker",
+        lambda: SimpleNamespace(register_embedding_root=lambda *args: None),
+    )
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+    await ReindexExecutor()._upsert_context(
+        uri="viking://resources/demo.md",
+        parent_uri="viking://resources",
+        abstract="demo",
+        vector_text="demo",
+        is_leaf=True,
+        context_type="resource",
+        level=ContextLevel.DETAIL,
+        ctx=ctx,
+        ingest_options=IngestOptions.from_search_tags([], mode="replace"),
+    )
+
+    assert queued[0].context_data["search_tags"] == []
+    assert queued[0].context_data["_upsert_options"] == {"search_tag_mode": "replace"}
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -412,6 +412,70 @@ async def test_reindex_executor_ignores_tags_for_prune_orphans(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reindex_file_target_uses_exact_lock(monkeypatch):
+    from types import SimpleNamespace
+
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    calls = []
+
+    class FakeAGFS:
+        async def pathlock_acquire_exact(self, path):
+            calls.append(("exact", path))
+            return {"id": "lease-1"}
+
+        async def pathlock_acquire_tree(self, path):
+            calls.append(("tree", path))
+            raise AssertionError("file target must not acquire a tree lock")
+
+        async def pathlock_as_borrowed(self, lease):
+            return lease
+
+        async def pathlock_release(self, lease):
+            calls.append(("release", lease["id"]))
+
+    class FakeFS:
+        _async_agfs = FakeAGFS()
+
+        def _uri_to_path(self, uri, ctx):
+            return "/local/default/resources/demo.md"
+
+        async def stat(self, uri, ctx):
+            return {"isDir": False}
+
+    executor = ReindexExecutor()
+
+    async def fake_reindex_resource(*, uri, mode, run):
+        return None
+
+    monkeypatch.setattr(executor, "_reindex_resource", fake_reindex_resource)
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_service",
+        lambda: SimpleNamespace(
+            viking_fs=FakeFS(),
+            vikingdb_manager=SimpleNamespace(has_queue_manager=True),
+        ),
+    )
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    result = await executor._run(
+        uri="viking://resources/demo.md",
+        object_type="resource",
+        mode="vectors_only",
+        ctx=ctx,
+    )
+
+    assert result["status"] == "completed"
+    assert calls == [
+        ("exact", "/local/default/resources/demo.md"),
+        ("release", "lease-1"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_reindex_executor_passes_tags_to_background_run(monkeypatch):
     import asyncio
 


### PR DESCRIPTION
 ## 变更概述

  为 reindex 增加显式设置 tags 的能力，并让 tags 随每条重建向量记录的首次 upsert 一起写入。

  - 在 reindex HTTP API 中新增 `tags` 和 `tag_mode`。
  - 支持 `replace` 和 `append` 两种写入模式。
  - 覆盖 resource、memory、skill 及 namespace 级 reindex。
  - 未传 `tags` 时保留已有 tags。
  - 支持通过 `tags: []` 和 `tag_mode: "replace"` 清空 tags。
  - 同步支持 `wait=true` 和 `wait=false` 后台任务。
  - 对齐 Python、TypeScript、Go SDK 和 Rust CLI。
  - 修复单文件 reindex 和 prune 错误使用 tree lock 的问题。

  ## 行为说明

  ### 覆盖 tags

  ```json
  {
    "uri": "viking://resources/docs",
    "mode": "vectors_only",
    "tags": ["team=search", "env=prod"],
    "tag_mode": "replace"
  }
  ```

  本次 reindex 成功重建的所有向量记录都会使用传入的 tags。

  对于目录或 namespace reindex，tags 会作用于成功重建的目录 L0/L1 和叶子 L2 记录。

  追加 tags

  {
    "uri": "viking://resources/docs",
    "mode": "vectors_only",
    "tags": ["region=cn"],
    "tag_mode": "append"
  }

  已有的其他 tag key 会被保留；如果传入 tags 中包含相同 key，则使用新的值覆盖旧值。

  省略与空数组

  - 省略 tags：保留已有 tags。
  - tags: [] + append：不修改已有 tags。
  - tags: [] + replace：清空 tags。
  - mode="prune_orphans"：忽略 tags 和 tag_mode。

  tags 继续复用已有的严格 k=v 校验和标准化逻辑，包括转小写和重复 key 处理。

  tags 会在 EmbeddingMsg 入队前写入，不会在 reindex 完成后额外调用一次 set_tags。

  接口示例

  Python SDK

  client.reindex(
      "viking://resources/docs",
      tags=["team=search"],
      tag_mode="append",
  )

  TypeScript SDK

  await client.reindex("viking://resources/docs", {
    tags: ["team=search"],
    tagMode: "append",
  });

  Go SDK

  client.Reindex(ctx, "viking://resources/docs", &openviking.ReindexOptions{
      Wait:    true,
      Tags:    []string{"team=search"},
      TagMode: "append",
  })

  Go 调用方传入非 nil 的 ReindexOptions 时，需要显式设置 Wait。Go 的布尔零值为 false，只有 opts=nil 时才会使用 SDK 默认的 wait=true。

  CLI

  ov reindex viking://resources/docs \
    --tag team=search \
    --tag env=prod \
    --tag-mode append

  --tag 可以重复传入。

  CLI 只有在至少传入一个 --tag 时才会发送 tags 字段。通过空数组清空 tags 的能力目前只在 HTTP API 和 SDK 中提供。

  文件锁修复

  此前 reindex 会对单文件目标使用 tree lock，导致 AGFS 把文件当作目录扫描，并返回 not a directory。

  本次调整后：

  - 已存在的文件目标使用 exact lock。
  - 目录目标继续使用 tree lock。
  - prune_orphans 遇到已存在的文件目标时使用 exact lock。
  - prune_orphans 遇到已经不存在的目标时继续使用 tree lock，以便扫描和清理该路径下残留的历史向量记录。

  兼容性

  - 未传 tags 的现有调用保持原有行为。
  - 不修改向量库 schema。
  - 不修改持久化数据格式，无需数据迁移。
  - 继续依赖 partial_update=True 保留 reindex 未显式提供的字段。
  - 不重新引入 main 分支已经删除的 Python embedded client。

  测试

  - [x] 服务端 reindex 与 IngestOptions 测试：63 passed
  - [x] Python SDK reindex 测试
  - [x] TypeScript reindex 测试及 tsc --noEmit
  - [x] Go SDK reindex 测试
  - [x] Rust CLI 参数解析和编译测试
  - [x] 本地持久化 AGFS + VectorDB 端到端测试：22 个断言
  - [x] 目录 tags 递归传播
  - [x] replace 覆盖
  - [x] append 合并及同 key 替换
  - [x] 大小写与重复 key 标准化
  - [x] 空数组清空和空数组 append
  - [x] 省略 tags 时保留已有值
  - [x] wait=false 后台任务 tags 传播
  - [x] 非法 tag 和非法 tag_mode 校验
  - [x] 单文件 reindex 与 prune 锁行为
  - [x] 服务重启后 tags 持久化