### PR TITLE
feat(keyword): add local FTS5 keyword retrieval

### DIFF
--- a/docs/design/local-keyword-fts5-sidecar-design.md
+++ b/docs/design/local-keyword-fts5-sidecar-design.md
@@ -1,0 +1,352 @@
+# 本地关键词检索（SQLite FTS5 sidecar + search-time BM25）实现计划
+
+| 项目 | 信息 |
+| --- | --- |
+| 状态 | 已实现（MVP 落地，M1–M4 主体完成） |
+| 目标版本 | v0.5 |
+| 更新日期 | 2026-08-13 |
+| 关联 | 上游 PR #1857（被关闭）、Issue #2850/#2900（远程 BM25 grep 回退）、#2144（grep 接入 VikingDB BM25） |
+
+> **实现状态（2026-08-13）**：M1（grep local_then_fs + 引擎解析 + 配置）、M2（KeywordQueue/
+> KeywordProcessor + 与 EmbeddingMsg 同生产点共发 + rm/mv/restore 一致性 + wait_processed）、
+> M3（HybridKeywordRecaller RRF/weighted 融合 + find/search/HTTP hybrid 字段）、M4（observer
+> /observer/keyword + 文档 + 单测）均已完成。落地代码见 `openviking/storage/keywordfs/`、
+> `openviking/retrieve/hybrid_keyword.py`，测试见 `tests/storage/keywordfs/`、
+> `tests/retrieve/test_hybrid_keyword.py`、`tests/service/test_observer_keyword.py`。
+> 未实现（后续）：`ov reindex --mode keyword` 全量重建 CLI 接线、git.tuning 级观测指标。
+
+> 本文是 B2「本地 BM25 / 关键词检索」的实现计划。方向遵循上游维护者在 PR #1857 中的明确指引：
+> **“keyword recall comes from backend-owned search-time BM25 over a local SQLite FTS5 sidecar”，而不是预计算稀疏向量。**
+> 对应 PR #1857 的关闭结论：本季度倾向更长期的检索层关键词方案，暂不合并 local_bm25（稀疏向量 + 重建）。
+
+---
+
+## 1. 背景与动机
+
+### 1.1 问题
+
+OpenViking 的 `grep` 与 `find`/`search` 目前的关键词能力依赖远程 VikingDB 的 BM25：
+
+- `grep`：`engine="auto"` 时 `_resolve_grep_engine` 只有 `backend_type in ("volcengine", "vikingdb")` 才走 `_grep_vikingdb_then_fs`（远程 BM25 召回 + 本地精确匹配）；**本地后端（`local` 向量索引）直接退化为全量文件扫描** `_grep_fs`。
+- `find`/`search`：`HierarchicalRetriever` 只做 dense 向量检索，**没有任何关键词召回**；对代码名、缩写、ticker、版本号这类“必须精确命中”的短查询，dense 检索不稳定（这也是 #1857 作者的核心痛点）。
+- 远程 BM25 在 `local` 后端下不可用 → **纯本地部署没有可用的关键词召回，只能全量 grep 扫描**。
+
+### 1.2 现状接线（已核实，main @ dcca2936）
+
+| 位置 | 现状 |
+|---|---|
+| `viking_fs.grep()` | `engine: auto\|fs`；`auto` 解析为 `fs` 或 `vikingdb_then_fs` |
+| `viking_fs._grep_vikingdb_then_fs()` | 远程 BM25 召回候选 URI → `_grep_in_files` 精确匹配（**最终匹配永远基于磁盘原文**） |
+| `viking_fs._grep_fs()` | `_grep_with_agfs`（原生 grep）/ `_grep_encrypted`（解密扫描） |
+| 向量异步管线 | `EmbeddingMsg` → `EmbeddingQueue` → `SemanticProcessor._vectorize_single_file/_vectorize_directory`；`wait_processed` 可等待 |
+| 写入路径 | `viking_fs.write_file/write_file_bytes/rm/mv/move_file/mkdir`；snapshot restore 走 `_schedule_vector_rebuild` |
+| 系统 SQLite 惯例 | `<workspace>/_system/queue/queue.db`、`<workspace>/_system/usage_audit/usage_audit.sqlite3`、`ingest/cursor_store.py`（SQLite 状态库范式） |
+| 配置 | `OpenVikingConfig.grep: GrepConfig{engine, switch_to_remote_threshold}`、`retrieval: RetrievalConfig`；`ServerConfig` 不承载，走 ov.conf |
+| CLI | `ov reindex`（`crates/ov_cli/src/commands/content.rs`） |
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 为**本地/离线部署**提供后端自有（backend-owned）的 search-time BM25 关键词召回，使 `grep` 不再退化为全量扫描。
+2. 提供可选的 **hybrid 检索**：`find`/`search` 融合 dense + 关键词结果，解决短查询/精确 token 召回。
+3. 与现有异步管线、权限模型、`wait_processed`、`ov reindex`、observer/metrics 一致，维护成本可接受。
+4. 默认关闭（off-by-default），显式开启，符合项目一贯的隐私/最小侵入风格（同 `ingest`、`experimental_memory_switch`）。
+
+### 2.2 非目标（避免踩 #1857 被否的坑）
+
+- **不做**预计算稀疏向量 + 全文重建的方案（被维护者明确否定：BM25 stats 一致性 + reindex 复杂度）。
+- **不替换**远程 VikingDB BM25：当 `vikingdb` 后端可用且数据量达到阈值时，仍优先远程（避免与现有能力重叠、造成用户选择困惑）。
+- **不修改**向量索引格式与 `search_by_keywords` 远程接口。
+- **不做**自动 commit hook / 强一致同步：关键词索引是**召回加速器**，非事实来源；缺失/过期时优雅回退 fs 扫描（与现有 `_grep_vikingdb_then_fs` 的 Step 2 回退语义一致）。
+
+---
+
+## 3. 总体架构
+
+```text
+写入路径 (write/rm/mv/restore/reindex/语义管线)
+        │  发 KeywordMsg（与 EmbeddingMsg 同生产点，可独立等待）
+        ▼
+KeywordQueue (queuefs 持久化) ──► KeywordProcessor（异步）
+                                      │  tokenize + upsert
+                                      ▼
+                  SQLite FTS5 sidecar   <workspace>/_system/keyword/<account_id>.sqlite3
+                                      ▲
+查询路径 grep / find / search          │  search-time bm25() 召回候选 URI
+        └──► KeywordFS.lookup() ───────┘
+                  │
+                  ├── grep: 候选 URI → _grep_in_files 精确匹配（复用现有）
+                  └── find/search(hybrid): 候选 URI + bm25 score → RRF 融合 dense
+```
+
+核心原则：
+
+- **FTS5 负责存储与 search-time BM25**（`ORDER BY bm25(kf)` 由 SQLite 用索引内统计即时计算），无需维护 corpus stats 表。
+- **FTS 只做召回**，最终匹配/排序决策仍走现有代码（grep 用 `_grep_in_files`；dense 用 `HierarchicalRetriever`）。
+- **sidecar 是本地加速器**，天然支持回退：sidecar 缺失/未就绪 → `fs` 扫描或纯 dense。
+
+---
+
+## 4. 核心设计决策
+
+| 决策 | 方案 | 备选被否原因 |
+|---|---|---|
+| 存储载体 | 每账号一个 SQLite FTS5 库，`<workspace>/_system/keyword/<account_id>.sqlite3` | 单一全局库无法隔离多租户重建；`_system` 已有 queue/usage_audit 先例 |
+| 召回方式 | FTS5 内置 `bm25()`（search-time），不预计算稀疏向量 | #1857 的稀疏向量方案被维护者否决（stats 一致性 + 重建复杂度） |
+| 索引内容 | 复用 `embedding.text_source`（默认 `content_only` 叶子原文）+ L1 overview（可选） | 与向量索引覆盖一致，避免两套内容源漂移 |
+| 构建管线 | 独立 `KeywordMsg`/`KeywordQueue`/`KeywordProcessor`，**与 `EmbeddingMsg` 同生产点共发** | 独立队列使关键词不依赖 embedding 健康；同生产点保证覆盖一致 |
+| 一致性 | 异步 + 回退：FTS 缺失/过期 → fs 扫描；`wait_processed` 可等待 | 强同步会侵入写链路，违反项目“索引异步重建”一贯模型 |
+| CJK 分词 | Python 预归一化：默认拉丁按词、CJK 按字切分；`jieba` 可选增强（按字→按词） | FTS5 `unicode61` 原生不切 CJK（#1857 同款批评）；`trigram` 无位置信息、`bm25()` 排名弱 |
+| 加密共存 | `keyword.respect_encryption=true` 时跳过索引 | 明文 sidecar 与加密保证冲突；`_grep_encrypted` 查询期解密扫描已覆盖加密场景 |
+| 多副本 | sidecar 本地化，副本上 `keyword.enabled=false`（同 `enable_watch_scheduler` 只读副本开关） | 共享 s3 后端时本地 sidecar 无法随写者同步，加速器语义天然可降级 |
+
+---
+
+## 5. 数据模型与 Schema
+
+文件：`<workspace>/_system/keyword/<account_id>.sqlite3`（`account_id` 需做白名单校验，防 `../`）。
+
+```sql
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+-- 索引内容表（FTS5，外部内容表模式便于增量替换单行）
+CREATE VIRTUAL TABLE kf USING fts5(
+    account_id,            -- 索引列：用于 MATCH 租户限定
+    scope,                 -- 索引列：context_type（memory/resource/skill），用于 MATCH 过滤
+    uri,                   -- UNINDEXED：精确候选 URI
+    content,               -- 索引列：归一化后的可检索文本
+    tokenize='unicode61'
+);
+
+-- 状态/元数据（供增量同步、重建、健康检查）
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,          -- schema_version / tokenizer_version / built_at / last_seq
+    value TEXT NOT NULL
+);
+
+-- 可选：索引内容到 URI 的映射（count、一致性核对用）
+CREATE TABLE uri_map (
+    rowid INTEGER PRIMARY KEY,       -- = kf.rowid
+    uri TEXT NOT NULL,               -- 规范化 viking URI（含 owner 字段）
+    level INTEGER NOT NULL,          -- 0/1/2
+    context_type TEXT NOT NULL,
+    owner_user_id TEXT NOT NULL,
+    byte_len INTEGER NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(uri)
+);
+```
+
+要点：
+
+- **租户限定走 MATCH 列过滤**：`WHERE kf MATCH 'account_id: "acct" AND content: "foo"'`，让 FTS 内部扫描按账号收敛，而不是对全库结果做后置过滤。
+- **scope/level/owner_user_id 不进 FTS 全文列**（`UNINDEXED`），只做候选后置过滤；必要时把 `context_type` 也提为索引列（见上 `scope`）。
+- **单行替换**：外部内容表模式下，`INSERT INTO kf(kf, account_id, scope, uri, content) VALUES('delete', ...)` + `'rebuild'` 可精确替换单 URI，配合 `uri_map` 记录已建行，实现增量 upsert/delete。
+- **bm25 即 search-time**：`SELECT uri FROM kf WHERE kf MATCH ? ORDER BY bm25(kf, 1.2, 0.75) LIMIT ?`。
+
+---
+
+## 6. 配置
+
+扩展 `OpenVikingConfig`，新增顶层 `keyword` 段 + `grep.engine` 增补 `"local"`：
+
+```jsonc
+{
+  "grep": {
+    "engine": "auto",                 // auto | fs | local | vikingdb
+    "switch_to_remote_threshold": 10000
+  },
+  "keyword": {
+    "enabled": false,                 // off-by-default
+    "tokenizer": "auto",              // auto | char | jieba
+    "content_source": "content",      // content | summary | both（对齐 embedding.text_source）
+    "max_doc_bytes": 65536,           // 跳过超大原文（对齐 #3006 的 verbatim 顾虑）
+    "respect_encryption": true,       // encryption.enabled 时自动禁用索引
+    "cjk_mode": "char"                // char | bigram（CJK 归一化粒度）
+  },
+  "retrieval": {
+    "hybrid": {
+      "enabled": false,               // find/search 是否融合关键词
+      "fusion": "rrf",                // rrf | weighted
+      "rrf_k": 60,
+      "keyword_weight": 0.3,          // weighted 模式的权重
+      "min_token_query_len": 2        // 低于该长度的查询跳过关键词（避免噪音）
+    }
+  }
+}
+```
+
+引擎解析顺序（`_resolve_grep_engine` 扩展）：
+
+```text
+engine == "fs"            → fs
+engine == "local"         → local_then_fs（要求 keyword.enabled 且 sidecar 就绪，否则 fs）
+engine == "vikingdb"      → vikingdb_then_fs
+engine == "auto":
+   1. vikingdb 可用 && count >= switch_to_remote_threshold → vikingdb_then_fs
+   2. keyword.enabled && sidecar 就绪                       → local_then_fs
+   3. 否则                                                  → fs
+```
+
+---
+
+## 7. 组件拆解（新增模块）
+
+新增 `openviking/storage/keywordfs/`（对齐 `queuefs/` 命名与结构）：
+
+| 文件 | 职责 |
+|---|---|
+| `keyword_fs.py` | `KeywordFS`：打开/建库/迁移、`upsert(uri, level, context_type, owner, text)`、`delete(uri)`、`move(old_uri,new_uri)`、`lookup(query, scope, exclude, limit) -> list[(uri, score)]`、`rebuild(scope)`、`health()` |
+| `keyword_msg.py` | `KeywordMsg`：`{kind: upsert|delete|move, uri, old_uri?, level?, context_type?, owner?, text?}`（复用 `EmbeddingMsg` 的 dataclass 风格） |
+| `keyword_queue.py` | `KeywordQueue(NamedQueue)` + `KeywordMsgConverter` |
+| `keyword_processor.py` | `KeywordProcessor(DequeueHandlerBase)`：消费消息 → `KeywordFS` upsert/delete/move；失败重试入队（复用 `SemanticProcessor` 的重试模式） |
+| `tokenizer.py` | `tokenize(text, cfg) -> str`：拉丁按词、CJK 按字/大词（`jieba` 可选）；归一化、小写化 |
+| `config.py` | `KeywordConfig` / `HybridRetrievalConfig`（pydantic，`extra=forbid`） |
+| `builder.py` | 全量重建：临时库建好 → 原子替换（`VACUUM INTO` + rename），避免半成品可见 |
+
+改动点（存量文件，均为小侵入）：
+
+| 文件 | 改动 |
+|---|---|
+| `openviking_cli/utils/config/open_viking_config.py` | 挂载 `keyword`、`retrieval.hybrid` 段 |
+| `openviking_cli/utils/config/grep_config.py` | `GrepEngine` 增 `"local"`/`"vikingdb"` |
+| `openviking/storage/viking_fs.py` | `_resolve_grep_engine` 增 `local_then_fs` 分支；`_grep_local_then_fs`；`rm/mv` 发 delete/move 消息；`write_file_bytes` 可选直发（内容写入场景） |
+| `openviking/storage/queuefs/semantic_processor.py` | 在 `_vectorize_single_file/_vectorize_directory` 成功点**共发** `KeywordMsg`（复用已读取的 content/level/owner） |
+| `openviking/service/reindex_executor.py` | reindex 时同时调度关键词重建；snapshot restore 的 `_schedule_vector_rebuild` 同步触发 `_schedule_keyword_rebuild` |
+| `openviking/service/core.py` | 组装 `KeywordFS` + `KeywordProcessor`，注册队列与 `wait_processed` 等待 |
+| `openviking/server/routers/system.py` | `wait_processed` 覆盖 keyword 队列；`consistency` 增加 keyword 核对项 |
+| `openviking/server/routers/observer.py` | 新增 `observer_keyword`（sidecar 状态/行数/落后数） |
+| `crates/ov_cli/src/commands/content.rs` | `ov reindex --mode keyword`；`ov doctor` 检查 keyword 健康 |
+
+---
+
+## 8. 索引构建与一致性
+
+### 8.1 增量构建
+
+1. `SemanticProcessor` 在 embedding 成功点共发 `KeywordMsg{kind=upsert, ...}`（内容来源与 `text_source` 一致）。
+2. `KeywordProcessor` 消费 → `tokenize` → `KeywordFS.upsert`（`INSERT OR REPLACE` 单行）。
+3. `viking_fs.rm/mv` 在向量删除点共发 `delete`/`move` 消息。
+4. `snapshot restore` → `_schedule_keyword_rebuild(written, deleted)`（复用 `_schedule_vector_rebuild` 的精确路径调度）。
+5. 服务重启后消息从持久化队列恢复（同 embedding 语义）。
+
+### 8.2 全量重建
+
+- 命令：`ov reindex <uri> --mode keyword --wait`，走 `reindex_executor`。
+- 流程：临时库 `*.sqlite3.tmp` 边扫边写 → 完成 `VACUUM INTO` 目标库 → 原子 rename → 更新 `meta.built_at`/`tokenizer_version`。
+- tokenizer 版本变更时自动触发全量重建（`meta.tokenizer_version` 比对）。
+
+### 8.3 一致性语义
+
+- **不强一致**：新写入到可召回存在异步窗口（与 embedding 一致）；`wait_processed` 可等待收敛。
+- **回退保证正确性**：grep 的最终匹配始终基于磁盘原文（`_grep_in_files`）；FTS 召回为空 → 直接返回空（与远程 BM25 空召回语义一致，见 #2850 结论——索引确认无匹配）或按配置回退 fs 扫描。
+- `content_transform`（projection）存在时强制走 `fs`（与现有远程路径一致，FTS 无法安全做投影）。
+
+---
+
+## 9. 检索接入
+
+### 9.1 Phase 1 —— grep（低风险、独立合入）
+
+`_grep_local_then_fs`（镜像 `_grep_vikingdb_then_fs`）：
+
+```python
+async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive, node_limit, level_limit, ctx):
+    query = " ".join(kw.strip() for kw in pattern.split("|") if kw.strip())   # 同现有
+    candidates = await self._keyword_fs.lookup(
+        query, scope=uri, exclude=exclude_uri, limit=min(node_limit*5, 100000), ctx=ctx)
+    if not candidates:
+        return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+    return await self._grep_in_files(candidates, pattern, case_insensitive, node_limit, ctx)
+```
+
+- 复用 `_grep_in_files`（精确匹配），API/CLI 无变化。
+- `engine=local` 显式开启；`auto` 在无 vikingdb 时落到 `local_then_fs`。
+
+### 9.2 Phase 2 —— find/search hybrid（独立合入）
+
+在 `HierarchicalRetriever` 前加轻量 `HybridKeywordRecaller`：
+
+1. 满足 `retrieval.hybrid.enabled && len(query tokens) >= min_token_query_len` 时，`KeywordFS.lookup` 取候选 URI + bm25 score。
+2. dense 结果与关键词候选用 **RRF** 融合（默认）：`score = Σ 1/(k + rank)`；`weighted` 模式用 `kw_norm = (bm25 - min)/(max - min)` 加权。
+3. 重复 URI 去重合并（`max` 或 RRF 求和）。
+4. 结果仍走现有 `_convert_to_matched_contexts` 与 rerank（关键词候选可选择性跳过 rerank 或一并参与，默认跳过以省成本）。
+5. 暴露：`find(query, hybrid=True)` / `search(..., hybrid=True)`，CLI `ov find --hybrid`；HTTP 加 `hybrid` 字段（`extra` 逃生舱已支持 SDK 透传）。
+
+---
+
+## 10. 多租户与权限
+
+- **存储隔离**：每账号独立 DB 文件。
+- **查询隔离**：`KeywordFS.lookup` 强制 `account_id` 列过滤 + `viking_fs._ensure_access`（现有权限检查在调用前执行，不新增权限面）。
+- **peer/owner 过滤**：候选按 `owner_user_id` 后置过滤，行为与 `actor_peer_id` 一致。
+
+---
+
+## 11. 安全与隐私
+
+- 默认 `keyword.enabled=false`（显式开启）。
+- `respect_encryption=true` 时，`encryption.enabled` 的部署自动禁用 FTS 索引（`_grep_encrypted` 已覆盖加密 grep）；文档明确该权衡。
+- 超大原文用 `max_doc_bytes` 跳过（避免 verbatim 全文入库，呼应 #3006）。
+- 明文只落本地 `_system/keyword/`，与 queue.db 同级；`ovpack` 导出**不包含** keyword 库（`legacy_migration` 已把 `_system` 视为非用户内容）。
+
+---
+
+## 12. 可观测性与运维
+
+- **metrics**：`openviking_keyword_docs`（行数）、`openviking_keyword_queries_total`、`openviking_keyword_latency_seconds`、`openviking_keyword_rebuild_duration_seconds`（对齐 `metric-design.md` 边界）。
+- **observer**：`/api/v1/observer/keyword` 返回 `{enabled, db_path, docs, last_built_at, queue_pending, degraded}`。
+- **doctor**：`ov doctor` 检查 sidecar 可写、tokenizer 版本、行数与 `uri_map` 一致性。
+- **consistency**：`/api/v1/system/consistency` 增加 keyword 核对（每 URI 有向量是否也有关键词行，反向亦然——仅告警不阻塞）。
+
+---
+
+## 13. 测试计划
+
+| 层级 | 覆盖 |
+|---|---|
+| 单元 | `tokenizer`（拉丁/CJK/大小写/jieba 可选）；`KeywordFS`（upsert/delete/move/重建/原子替换）；`_resolve_grep_engine` 新分支；config 解析 |
+| 集成 | `add_resource(wait=True)` → 无 vikingdb 时 `grep` 命中原文；`rm/mv` 后 FTS 一致；snapshot restore 触发关键词重建；`wait_processed` 收敛；加密部署自动禁用 |
+| 检索质量 | 复用 `benchmark/RAG` 与 `benchmark/retrieval`：新增 keyword-only 与 hybrid 两组指标（recall@k、MRR）；构造代码名/缩写/版本号查询集 |
+| 回退 | sidecar 缺失/损坏/过期 → fs 扫描；`content_transform` 强制 fs；vikingdb 可用时仍走远程 |
+| 回归 | 现有 `tests/` 全部通过；`ov reindex --mode keyword` 幂等；多账号隔离 |
+
+---
+
+## 14. 里程碑与验收标准
+
+| 里程碑 | 内容 | 验收 |
+|---|---|---|
+| **M1 grep 落地** | `keywordfs` 基础库 + `tokenizer` + `_grep_local_then_fs` + 引擎解析 + 配置 | 本地部署 `grep "token"` 命中且不做全量扫描；`auto` 解析正确 |
+| **M2 构建管线** | `KeywordQueue/Processor` + 语义管线共发 + `rm/mv/restore/reindex` 一致性 + `wait_processed` | `add_resource` 后 `wait_processed` 即可 grep；rm/mv/restore 后无脏行 |
+| **M3 hybrid 检索** | `HybridKeywordRecaller` + RRF/weighted + API/CLI/SDK 透传 | `find("Version 2.4.1")` 召回改善（benchmark 对比）；默认关闭 |
+| **M4 可观测与文档** | metrics/observer/doctor/consistency + `docs/en` 配置与指南 + README | `ov doctor` 绿；`/observer/keyword` 正常；中文+英文文档 |
+
+每个里程碑独立可合入（PR 拆分建议：M1 → M2 → M3 → M4），便于社区 review 与灰度。
+
+---
+
+## 15. 风险与权衡
+
+| 风险 | 缓解 |
+|---|---|
+| 磁盘额外占用（索引副本） | `max_doc_bytes` + `content_source=content` 控制；与 VikingDB 远程索引等价（#1857 讨论已认可） |
+| 加密与明文索引冲突 | `respect_encryption` 默认跳过；加密场景用查询期解密扫描 |
+| 只读副本/共享后端 sidecar 过期 | sidecar 为加速器，回退 fs 扫描；副本默认 `keyword.enabled=false`（同 `enable_watch_scheduler` 先例） |
+| CJK 召回精度（按字切分） | `jieba` 可选增强；hybrid 由 dense 补语义；bigram 模式可选 |
+| 与远程 BM25 能力重叠 | 解析顺序保持远程优先；本地仅覆盖 vikingdb 不可用场景 |
+| 异步窗口导致新写入暂不可召回 | 与 embedding 同语义；`wait_processed` 收敛；grep 最终匹配基于磁盘原文 |
+| 超大语料 FTS 扫描 | `account_id`/`scope` 做 MATCH 列过滤收敛；重建用临时库原子替换 |
+
+---
+
+## 16. 参考
+
+- PR #1857 `feat: add local_bm25 sparse provider for hybrid retrieval`（未合并）及其评论：维护者指定 SQLite FTS5 sidecar + search-time BM25 方向、`jieba` 可选依赖。
+- Issue #2850 / PR #2900：远程 BM25 grep 空召回回退语义（本设计沿用“候选召回 + 磁盘精确匹配”）。
+- PR #2144：grep 接入 VikingDB BM25 的既有实现（`_grep_vikingdb_then_fs` 的模板）。
+- 现有代码：`viking_fs.grep/_resolve_grep_engine/_grep_vikingdb_then_fs/_grep_in_files`；`queuefs/embedding_*`、`semantic_processor._vectorize_*`；`ingest/cursor_store.py`、`observability/usage_audit/sqlite_store.py`（SQLite 范式）；`service/reindex_executor.py`、`_schedule_vector_rebuild`。

--- a/docs/design/local-keyword-fts5-sidecar-design.md
+++ b/docs/design/local-keyword-fts5-sidecar-design.md
@@ -163,7 +163,6 @@ CREATE TABLE uri_map (
   "keyword": {
     "enabled": false,                 // off-by-default
     "tokenizer": "auto",              // auto | char | jieba
-    "content_source": "content",      // content | summary | both（对齐 embedding.text_source）
     "max_doc_bytes": 65536,           // 跳过超大原文（对齐 #3006 的 verbatim 顾虑）
     "respect_encryption": true,       // encryption.enabled 时自动禁用索引
     "cjk_mode": "char"                // char | bigram（CJK 归一化粒度）
@@ -236,14 +235,13 @@ engine == "auto":
 
 ### 8.2 全量重建
 
-- 命令：`ov reindex <uri> --mode keyword --wait`，走 `reindex_executor`。
-- 流程：临时库 `*.sqlite3.tmp` 边扫边写 → 完成 `VACUUM INTO` 目标库 → 原子 rename → 更新 `meta.built_at`/`tokenizer_version`。
-- tokenizer 版本变更时自动触发全量重建（`meta.tokenizer_version` 比对）。
+**未实现（follow-up）**。`ov reindex <uri> --mode keyword --wait` 尚未接入 `reindex_executor`；当前只有 `KeywordFS.rebuild_account()` 这个库级入口（临时库 → 原子 rename → 写 `meta.built_at`/`tokenizer_version`），没有 CLI 命令、没有 tokenizer 版本变更时的自动重建。因此本轮 `auto` engine 不使用本地 sidecar：覆盖率不完整时无法保证不回退。
 
 ### 8.3 一致性语义
 
 - **不强一致**：新写入到可召回存在异步窗口（与 embedding 一致）；`wait_processed` 可等待收敛。
-- **回退保证正确性**：grep 的最终匹配始终基于磁盘原文（`_grep_in_files`）；FTS 召回为空 → 直接返回空（与远程 BM25 空召回语义一致，见 #2850 结论——索引确认无匹配）或按配置回退 fs 扫描。
+- **回退保证正确性**（已实现）：grep 的最终匹配始终基于磁盘原文（`_grep_in_files`）；本地引擎召回为空时回退 fs 扫描，因为 sidecar 覆盖率等于向量覆盖率（可能被截断，且不含 cp 产物与开启前的历史数据）。
+- **引擎选择**（已实现）：`auto` 不使用本地 sidecar，只解析为远程 BM25 或 fs 扫描；本地引擎必须显式 `grep.engine: local`。
 - `content_transform`（projection）存在时强制走 `fs`（与现有远程路径一致，FTS 无法安全做投影）。
 
 ---
@@ -255,17 +253,20 @@ engine == "auto":
 `_grep_local_then_fs`（镜像 `_grep_vikingdb_then_fs`）：
 
 ```python
-async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive, node_limit, level_limit, ctx):
-    query = " ".join(kw.strip() for kw in pattern.split("|") if kw.strip())   # 同现有
-    candidates = await self._keyword_fs.lookup(
-        query, scope=uri, exclude=exclude_uri, limit=min(node_limit*5, 100000), ctx=ctx)
+async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive,
+                             node_limit, level_limit, ctx, allowed_uris, ...):
+    candidates = self._keyword_fs.lookup(
+        query=..., scope_uri=uri, exclude_uri=..., limit=min(node_limit*5, 100000))
+    candidates = [u for u, _ in candidates if self._in_scope(u, allowed_uris, level_limit)]
     if not candidates:
-        return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+        # 空召回不是权威结论：回退 fs 扫描（sidecar 覆盖率 = 向量覆盖率）
+        return await self._local_fs_fallback(uri=uri, pattern=pattern, ..., allowed_uris=allowed_uris)
     return await self._grep_in_files(candidates, pattern, case_insensitive, node_limit, ctx)
 ```
 
 - 复用 `_grep_in_files`（精确匹配），API/CLI 无变化。
-- `engine=local` 显式开启；`auto` 在无 vikingdb 时落到 `local_then_fs`。
+- 候选先按 `allowed_uris`（tag/ACL 作用域）与 `level_limit` 深度过滤，再进入精确匹配，保证与 `fs`/`vikingdb_then_fs` 语义一致。
+- `engine=local` 显式开启；`auto` **不**使用本地 sidecar（只解析为远程 BM25 或 fs 扫描），见 §8.3。
 
 ### 9.2 Phase 2 —— find/search hybrid（独立合入）
 
@@ -283,7 +284,7 @@ async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive,
 
 - **存储隔离**：每账号独立 DB 文件。
 - **查询隔离**：`KeywordFS.lookup` 强制 `account_id` 列过滤 + `viking_fs._ensure_access`（现有权限检查在调用前执行，不新增权限面）。
-- **peer/owner 过滤**：候选按 `owner_user_id` 后置过滤，行为与 `actor_peer_id` 一致。
+- **peer/owner 过滤**：**未实现（follow-up）**。当前 `lookup`/`enhance` 不做 `owner_user_id` 后置过滤；peer 隔离尚未接入候选列表，读取仍需经过现有权限检查。
 
 ---
 
@@ -299,7 +300,7 @@ async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive,
 ## 12. 可观测性与运维
 
 - **metrics**：`openviking_keyword_docs`（行数）、`openviking_keyword_queries_total`、`openviking_keyword_latency_seconds`、`openviking_keyword_rebuild_duration_seconds`（对齐 `metric-design.md` 边界）。
-- **observer**：`/api/v1/observer/keyword` 返回 `{enabled, db_path, docs, last_built_at, queue_pending, degraded}`。
+- **observer**：`/api/v1/observer/keyword` 已实现 `{enabled, db_path, docs, last_built_at, state}`（`state` 为 `not_built`/`ready`/`error`，`not_built` 视为健康）。`queue_pending` 与 `degraded` **未实现（follow-up）**。
 - **doctor**：`ov doctor` 检查 sidecar 可写、tokenizer 版本、行数与 `uri_map` 一致性。
 - **consistency**：`/api/v1/system/consistency` 增加 keyword 核对（每 URI 有向量是否也有关键词行，反向亦然——仅告警不阻塞）。
 
@@ -334,7 +335,7 @@ async def _grep_local_then_fs(self, uri, pattern, exclude_uri, case_insensitive,
 
 | 风险 | 缓解 |
 |---|---|
-| 磁盘额外占用（索引副本） | `max_doc_bytes` + `content_source=content` 控制；与 VikingDB 远程索引等价（#1857 讨论已认可） |
+| 磁盘额外占用（索引副本） | `max_doc_bytes` 控制（索引文本来自被嵌入的文本，对齐 `embedding.text_source`；summary 索引为 follow-up）；与 VikingDB 远程索引等价（#1857 讨论已认可） |
 | 加密与明文索引冲突 | `respect_encryption` 默认跳过；加密场景用查询期解密扫描 |
 | 只读副本/共享后端 sidecar 过期 | sidecar 为加速器，回退 fs 扫描；副本默认 `keyword.enabled=false`（同 `enable_watch_scheduler` 先例） |
 | CJK 召回精度（按字切分） | `jieba` 可选增强；hybrid 由 dense 补语义；bigram 模式可选 |

--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -12,6 +12,14 @@ OpenViking provides multiple retrieval methods, including simple vector similari
 | Default Limit | 10 | 10 |
 | Use Case | Simple queries | Conversational search |
 
+> **Local keyword hybrid (experimental config).** When `keyword.enabled` is on
+> and the local FTS5 sidecar is built, set `retrieval.hybrid.enabled: true` (or
+> pass `hybrid: true` on a request) so `find`/`search` fuse search-time BM25
+> candidates with the dense results. This improves exact-token recall for code
+> names, acronyms, tickers and version strings. Without a remote VikingDB
+> full-text index, `grep` also uses the sidecar for BM25 recall (engine `auto`
+> / `local`), falling back to a filesystem scan when the sidecar is missing.
+
 ## Retrieval Pipeline
 
 The core retrieval pipeline is as follows:

--- a/docs/en/api/06-retrieval.md
+++ b/docs/en/api/06-retrieval.md
@@ -16,9 +16,15 @@ OpenViking provides multiple retrieval methods, including simple vector similari
 > and the local FTS5 sidecar is built, set `retrieval.hybrid.enabled: true` (or
 > pass `hybrid: true` on a request) so `find`/`search` fuse search-time BM25
 > candidates with the dense results. This improves exact-token recall for code
-> names, acronyms, tickers and version strings. Without a remote VikingDB
-> full-text index, `grep` also uses the sidecar for BM25 recall (engine `auto`
-> / `local`), falling back to a filesystem scan when the sidecar is missing.
+> names, acronyms, tickers and version strings. `hybrid` is tri-state: omitted
+> or `null` follows `retrieval.hybrid.enabled`, `true` forces fusion for that
+> request (a ready sidecar is still required), and `false` forces dense-only
+> results. `grep` uses the sidecar only when `grep.engine: local` is set — the
+> `auto` engine resolves to remote VikingDB BM25 or a filesystem scan, and a
+> local recall that returns nothing falls back to the filesystem scan.
+> When fusion runs, hits that were already in the dense result keep their dense
+> `score`; only keyword-only hits carry the fused score, so scores are not
+> directly comparable across the two groups.
 
 ## Retrieval Pipeline
 

--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -178,10 +178,11 @@ Setting `provider` explicitly requires the credentials that provider needs: `ak`
 | `score_propagation_alpha` | number, `0`–`1` | `1` | Child-result score weight in hierarchical retrieval |
 | `enable_intent` | boolean | `true` | Run intent analysis/query planning when `session_id` is present |
 | `hybrid` | object | disabled | Keyword/dense fusion for `find`/`search` (see below) |
+| `hybrid.min_token_query_len` | integer | `2` | Skip keyword recall when the query yields fewer tokens |
 
 Search and Find requests default to `limit: 10`; override the limit on each API or SDK request. `retrieval.enable_intent` controls LLM query planning for session-aware Search, while result reranking is enabled only when `rerank` has a usable provider configuration.
 
-When `keyword.enabled` is on and the sidecar is built, set `retrieval.hybrid.enabled: true` to fuse keyword candidates into `find`/`search` results (exact tokens like code names, acronyms, or version strings that dense retrieval handles poorly). `fusion: "rrf"` uses Reciprocal Rank Fusion; `"weighted"` blends normalized BM25 with the dense score using `keyword_weight`. A request may override this with the `hybrid` boolean field.
+When `keyword.enabled` is on and the sidecar is built, set `retrieval.hybrid.enabled: true` to fuse keyword candidates into `find`/`search` results (exact tokens like code names, acronyms, or version strings that dense retrieval handles poorly). `fusion: "rrf"` uses Reciprocal Rank Fusion; `"weighted"` blends normalized BM25 with the dense score using `keyword_weight`. `min_token_query_len` skips keyword recall for very short queries. A request may override the switch with the tri-state `hybrid` field: omitted or `null` follows `retrieval.hybrid.enabled`, `true` forces fusion for that request (a ready sidecar is still required), and `false` forces dense-only results.
 
 ### `keyword`
 
@@ -190,7 +191,6 @@ When `keyword.enabled` is on and the sidecar is built, set `retrieval.hybrid.ena
   "keyword": {
     "enabled": false,
     "tokenizer": "auto",
-    "content_source": "content",
     "max_doc_bytes": 65536,
     "cjk_mode": "char",
     "respect_encryption": true
@@ -202,17 +202,21 @@ When `keyword.enabled` is on and the sidecar is built, set `retrieval.hybrid.ena
 |---|---|---|---|
 | `enabled` | boolean | `false` | Master switch for the local FTS5 keyword sidecar |
 | `tokenizer` | `auto` / `char` / `jieba` | `auto` | CJK tokenization: `auto` uses optional `jieba`, falls back to char splitting |
-| `content_source` | `content` / `summary` / `both` | `content` | Text source indexed (currently indexes the same text that gets embedded) |
 | `max_doc_bytes` | integer | `65536` | Skip documents whose indexed text exceeds this size |
 | `cjk_mode` | `char` / `bigram` | `char` | CJK granularity when a word tokenizer is not used |
 | `respect_encryption` | boolean | `true` | Disable the sidecar when at-rest encryption is enabled (plaintext index) |
 
 The keyword sidecar is off by default. When enabled, leaf documents are indexed
-asynchronously alongside embedding, and `grep` (engine `auto` or `local`) uses
-search-time BM25 recall from the sidecar instead of a full filesystem scan on
-deployments without a remote VikingDB full-text index. The sidecar is a recall
-accelerator: final `grep` matching still runs against the on-disk content, and
-the index falls back to a filesystem scan when missing or incomplete. Sidecar
+asynchronously alongside embedding, and `grep` uses search-time BM25 recall from
+the sidecar when the engine is explicitly set to `local`. `auto` never selects
+the sidecar: it resolves to remote VikingDB BM25 when the collection exposes a
+`content` full-text index and the data volume passes
+`switch_to_remote_threshold`, and otherwise scans the filesystem. The sidecar is
+a recall accelerator: final `grep` matching still runs against the on-disk
+content, and an empty recall falls back to the filesystem scan so a partially
+built index cannot hide documents. Its coverage mirrors vector coverage — it
+indexes the same text that was embedded (which may be truncated) and does not
+include copies or documents written before the sidecar was enabled. Sidecar
 databases live under `<workspace>/_system/keyword/<account>.sqlite3`. Health is
 exposed through `GET /api/v1/observer/keyword`.
 

--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -48,8 +48,9 @@ Optional sections use their defaults when omitted. Unknown fields are rejected.
 | `vlm` | object | empty config | Content understanding, summaries, and memory extraction; configure a working model before using these capabilities |
 | `query_planner` | object / `null` | `null` | Retrieval intent model; falls back to `vlm` |
 | `rerank` | object | disabled | Retrieval result reranking |
-| `retrieval` | object | see below | Ranking and intent-analysis behavior |
-| `grep` | object | built-in defaults | Text search engine |
+| `retrieval` | object | see below | Ranking, intent-analysis, and keyword/dense hybrid fusion |
+| `grep` | object | built-in defaults | Text search engine (`auto` / `fs` / `local` / `vikingdb`) |
+| `keyword` | object | disabled | Local SQLite FTS5 keyword sidecar for search-time BM25 recall |
 | `storage` | object | local | Workspace, file system, and vector database |
 | `queue_workers` | object | see below | Runtime concurrency for QueueFS consumer workers |
 | `server` | object | local development | HTTP, authentication, uploads, and observability |
@@ -157,7 +158,14 @@ Setting `provider` explicitly requires the credentials that provider needs: `ak`
   "retrieval": {
     "hotness_alpha": 0,
     "score_propagation_alpha": 1,
-    "enable_intent": true
+    "enable_intent": true,
+    "hybrid": {
+      "enabled": false,
+      "fusion": "rrf",
+      "rrf_k": 60,
+      "keyword_weight": 0.3,
+      "min_token_query_len": 2
+    }
   }
 }
 ```
@@ -169,8 +177,44 @@ Setting `provider` explicitly requires the credentials that provider needs: `ak`
 | `hotness_alpha` | number, `0`–`1` | `0` | Hotness score weight; `0` disables it |
 | `score_propagation_alpha` | number, `0`–`1` | `1` | Child-result score weight in hierarchical retrieval |
 | `enable_intent` | boolean | `true` | Run intent analysis/query planning when `session_id` is present |
+| `hybrid` | object | disabled | Keyword/dense fusion for `find`/`search` (see below) |
 
 Search and Find requests default to `limit: 10`; override the limit on each API or SDK request. `retrieval.enable_intent` controls LLM query planning for session-aware Search, while result reranking is enabled only when `rerank` has a usable provider configuration.
+
+When `keyword.enabled` is on and the sidecar is built, set `retrieval.hybrid.enabled: true` to fuse keyword candidates into `find`/`search` results (exact tokens like code names, acronyms, or version strings that dense retrieval handles poorly). `fusion: "rrf"` uses Reciprocal Rank Fusion; `"weighted"` blends normalized BM25 with the dense score using `keyword_weight`. A request may override this with the `hybrid` boolean field.
+
+### `keyword`
+
+```json
+{
+  "keyword": {
+    "enabled": false,
+    "tokenizer": "auto",
+    "content_source": "content",
+    "max_doc_bytes": 65536,
+    "cjk_mode": "char",
+    "respect_encryption": true
+  }
+}
+```
+
+| Field | Type / values | Default | Purpose |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Master switch for the local FTS5 keyword sidecar |
+| `tokenizer` | `auto` / `char` / `jieba` | `auto` | CJK tokenization: `auto` uses optional `jieba`, falls back to char splitting |
+| `content_source` | `content` / `summary` / `both` | `content` | Text source indexed (currently indexes the same text that gets embedded) |
+| `max_doc_bytes` | integer | `65536` | Skip documents whose indexed text exceeds this size |
+| `cjk_mode` | `char` / `bigram` | `char` | CJK granularity when a word tokenizer is not used |
+| `respect_encryption` | boolean | `true` | Disable the sidecar when at-rest encryption is enabled (plaintext index) |
+
+The keyword sidecar is off by default. When enabled, leaf documents are indexed
+asynchronously alongside embedding, and `grep` (engine `auto` or `local`) uses
+search-time BM25 recall from the sidecar instead of a full filesystem scan on
+deployments without a remote VikingDB full-text index. The sidecar is a recall
+accelerator: final `grep` matching still runs against the on-disk content, and
+the index falls back to a filesystem scan when missing or incomplete. Sidecar
+databases live under `<workspace>/_system/keyword/<account>.sqlite3`. Health is
+exposed through `GET /api/v1/observer/keyword`.
 
 ## Storage Settings
 

--- a/openviking/retrieve/hybrid_keyword.py
+++ b/openviking/retrieve/hybrid_keyword.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Keyword/dense score fusion for find/search.
+
+The local FTS5 sidecar provides search-time BM25 recall for exact tokens (code
+names, acronyms, tickers, version strings) that dense retrieval handles poorly.
+This module merges dense ``MatchedContext`` results with keyword candidates
+using Reciprocal Rank Fusion (robust, no score calibration) or a weighted blend
+of normalized scores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
+
+from openviking_cli.retrieve.types import MatchedContext
+
+ReadAbstract = Callable[[str], Awaitable[str]]
+
+
+class HybridKeywordRecaller:
+    """Fuse keyword-sidecar recall into a dense retrieval result list."""
+
+    def __init__(
+        self,
+        keyword_fs: Any,
+        hybrid_config: Any,
+        keyword_config: Optional[Any] = None,
+    ):
+        self._keyword_fs = keyword_fs
+        self._config = hybrid_config
+        self._keyword_config = keyword_config
+
+    def enabled(self, ctx: Any = None) -> bool:
+        if self._keyword_fs is None or self._config is None:
+            return False
+        if not getattr(self._config, "enabled", False):
+            return False
+        account_id = getattr(ctx, "account_id", None) or "default"
+        try:
+            return self._keyword_fs.is_ready(account_id)
+        except Exception:
+            return False
+
+    async def enhance(
+        self,
+        query: str,
+        dense: Sequence[MatchedContext],
+        scope_uris: Sequence[str],
+        ctx: Any,
+        limit: int,
+        exclude_uri: str = "",
+        read_abstract: Optional[ReadAbstract] = None,
+    ) -> List[MatchedContext]:
+        """Merge keyword candidates into ``dense`` and return the fused top ``limit``."""
+        if not self.enabled(ctx) or not query:
+            return list(dense)
+        candidates = await self._recall(query, scope_uris, exclude_uri, ctx, limit)
+        if not candidates:
+            return list(dense)
+        fused = self._fuse(dense, candidates, limit)
+        # Enrich keyword-only hits with best-effort abstract text.
+        dense_uris = {m.uri for m in dense}
+        for mc in fused:
+            if mc.uri in dense_uris or not mc.abstract:
+                if read_abstract is not None and not mc.abstract:
+                    try:
+                        mc.abstract = await read_abstract(mc.uri)
+                    except Exception:
+                        pass
+        return fused
+
+    async def _recall(
+        self,
+        query: str,
+        scope_uris: Sequence[str],
+        exclude_uri: str,
+        ctx: Any,
+        limit: int,
+    ) -> List[Tuple[str, float]]:
+        account_id = getattr(ctx, "account_id", None) or "default"
+        collected: Dict[str, float] = {}
+        scopes = list(scope_uris) or [""]
+        for scope in scopes:
+            try:
+                hits = self._keyword_fs.lookup(
+                    account_id=account_id,
+                    query=query,
+                    scope_uri=scope,
+                    exclude_uri=exclude_uri,
+                    limit=max(limit * 3, 30),
+                )
+            except Exception:
+                continue
+            for uri, score in hits:
+                # Keep the best (lowest) bm25 score for a URI across scopes.
+                if uri not in collected or score < collected[uri]:
+                    collected[uri] = score
+        ranked = sorted(collected.items(), key=lambda x: x[1])
+        return ranked[: max(limit * 3, 30)]
+
+    def _fuse(
+        self,
+        dense: Sequence[MatchedContext],
+        candidates: Sequence[Tuple[str, float]],
+        limit: int,
+    ) -> List[MatchedContext]:
+        fusion = getattr(self._config, "fusion", "rrf")
+        if fusion == "weighted":
+            return self._fuse_weighted(dense, candidates, limit)
+        return self._fuse_rrf(dense, candidates, limit)
+
+    def _fuse_rrf(
+        self,
+        dense: Sequence[MatchedContext],
+        candidates: Sequence[Tuple[str, float]],
+        limit: int,
+    ) -> List[MatchedContext]:
+        k = float(getattr(self._config, "rrf_k", 60.0) or 60.0)
+        dense_rank = {m.uri: i for i, m in enumerate(dense)}
+        kw_rank = {uri: i for i, (uri, _s) in enumerate(candidates)}
+        scores: Dict[str, float] = {}
+        for uri in dense_rank:
+            scores[uri] = 1.0 / (k + dense_rank[uri] + 1)
+        for uri in kw_rank:
+            scores[uri] = scores.get(uri, 0.0) + 1.0 / (k + kw_rank[uri] + 1)
+
+        by_uri = {m.uri: m for m in dense}
+        ordered_uris = sorted(scores.keys(), key=lambda u: (-scores[u], dense_rank.get(u, 10**9)))
+        out: List[MatchedContext] = []
+        for uri in ordered_uris:
+            mc = by_uri.get(uri)
+            if mc is None:
+                mc = self._make_keyword_context(uri, candidates)
+            out.append(replace(mc, score=scores[uri]))
+            if len(out) >= limit:
+                break
+        # Always keep the dense ordering for ties handled above; append leftover
+        # dense results only if there is still headroom.
+        if len(out) < limit:
+            seen = {m.uri for m in out}
+            for m in dense:
+                if m.uri not in seen:
+                    out.append(m)
+                    seen.add(m.uri)
+                    if len(out) >= limit:
+                        break
+        return out
+
+    def _fuse_weighted(
+        self,
+        dense: Sequence[MatchedContext],
+        candidates: Sequence[Tuple[str, float]],
+        limit: int,
+    ) -> List[MatchedContext]:
+        w = float(getattr(self._config, "keyword_weight", 0.3) or 0.3)
+        raw_scores = {uri: score for uri, score in candidates}
+        if raw_scores:
+            lo = min(raw_scores.values())
+            hi = max(raw_scores.values())
+        else:
+            lo = hi = 0.0
+
+        def norm(uri: str) -> float:
+            if hi > lo:
+                return (raw_scores[uri] - lo) / (hi - lo)
+            return 0.5
+
+        by_uri = {m.uri: m for m in dense}
+        scores: Dict[str, float] = {}
+        for m in dense:
+            kw = norm(m.uri) if m.uri in raw_scores else 0.0
+            scores[m.uri] = (1 - w) * m.score + w * kw
+        for uri in raw_scores:
+            if uri not in scores:
+                scores[uri] = w * norm(uri)
+
+        ordered = sorted(scores.keys(), key=lambda u: -scores[u])
+        out: List[MatchedContext] = []
+        for uri in ordered:
+            mc = by_uri.get(uri)
+            if mc is None:
+                mc = self._make_keyword_context(uri, candidates)
+            out.append(replace(mc, score=scores[uri]))
+            if len(out) >= limit:
+                break
+        return out
+
+    def _make_keyword_context(self, uri: str, candidates: Sequence[Tuple[str, float]]) -> MatchedContext:
+        from openviking.core.context import ContextType
+        from openviking.core.namespace import context_type_for_uri
+
+        score = 0.0
+        for u, s in candidates:
+            if u == uri:
+                score = s
+                break
+        ctype = context_type_for_uri(uri)
+        try:
+            context_type = ContextType(ctype)
+        except ValueError:
+            context_type = ContextType.RESOURCE
+        return MatchedContext(
+            uri=uri,
+            context_type=context_type,
+            level=2,
+            abstract="",
+            category="",
+            score=score,
+            match_reason="keyword",
+        )

--- a/openviking/retrieve/hybrid_keyword.py
+++ b/openviking/retrieve/hybrid_keyword.py
@@ -32,16 +32,26 @@ class HybridKeywordRecaller:
         self._config = hybrid_config
         self._keyword_config = keyword_config
 
-    def enabled(self, ctx: Any = None) -> bool:
-        if self._keyword_fs is None or self._config is None:
-            return False
-        if not getattr(self._config, "enabled", False):
+    def sidecar_usable(self, ctx: Any = None) -> bool:
+        """True when a ready sidecar exists for this account (config-independent)."""
+        if self._keyword_fs is None:
             return False
         account_id = getattr(ctx, "account_id", None) or "default"
         try:
             return self._keyword_fs.is_ready(account_id)
         except Exception:
             return False
+
+    def enabled(self, ctx: Any = None) -> bool:
+        """Config-level switch (kept for callers that only know the config).
+
+        The request-level override is evaluated by the caller; ``enhance`` itself
+        only needs a usable sidecar so a forced request can fuse while the config
+        switch stays off.
+        """
+        if self._config is None or not getattr(self._config, "enabled", False):
+            return False
+        return self.sidecar_usable(ctx)
 
     async def enhance(
         self,
@@ -54,12 +64,16 @@ class HybridKeywordRecaller:
         read_abstract: Optional[ReadAbstract] = None,
     ) -> List[MatchedContext]:
         """Merge keyword candidates into ``dense`` and return the fused top ``limit``."""
-        if not self.enabled(ctx) or not query:
+        if not self.sidecar_usable(ctx) or not query:
             return list(dense)
         candidates = await self._recall(query, scope_uris, exclude_uri, ctx, limit)
         if not candidates:
             return list(dense)
-        fused = self._fuse(dense, candidates, limit)
+        meta_by_uri = self._keyword_fs.meta_for(
+            getattr(ctx, "account_id", None) or "default",
+            [uri for uri, _ in candidates],
+        )
+        fused = self._fuse(dense, candidates, limit, meta_by_uri=meta_by_uri)
         # Enrich keyword-only hits with best-effort abstract text.
         dense_uris = {m.uri for m in dense}
         for mc in fused:
@@ -80,6 +94,8 @@ class HybridKeywordRecaller:
         limit: int,
     ) -> List[Tuple[str, float]]:
         account_id = getattr(ctx, "account_id", None) or "default"
+        if not self._has_enough_tokens(query):
+            return []
         collected: Dict[str, float] = {}
         scopes = list(scope_uris) or [""]
         for scope in scopes:
@@ -100,22 +116,49 @@ class HybridKeywordRecaller:
         ranked = sorted(collected.items(), key=lambda x: x[1])
         return ranked[: max(limit * 3, 30)]
 
+    def _has_enough_tokens(self, query: str) -> bool:
+        """Apply ``min_token_query_len`` using the sidecar's own tokenizer.
+
+        A whitespace split would treat a CJK query such as ``单元圆`` as a single
+        token and silently skip recall, even though the index tokenizes it into
+        three searchable tokens.
+        """
+        min_tokens = int(getattr(self._config, "min_token_query_len", 2) or 1)
+        if min_tokens <= 1:
+            return True
+        from openviking.storage.keywordfs.tokenizer import tokenize
+
+        config = self._keyword_config
+        try:
+            tokenized = tokenize(
+                query,
+                getattr(config, "tokenizer", "auto"),
+                getattr(config, "cjk_mode", "char"),
+            )
+        except Exception:
+            tokenized = query
+        return len([tok for tok in tokenized.split() if tok]) >= min_tokens
+
     def _fuse(
         self,
         dense: Sequence[MatchedContext],
         candidates: Sequence[Tuple[str, float]],
         limit: int,
+        *,
+        meta_by_uri: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[MatchedContext]:
         fusion = getattr(self._config, "fusion", "rrf")
         if fusion == "weighted":
-            return self._fuse_weighted(dense, candidates, limit)
-        return self._fuse_rrf(dense, candidates, limit)
+            return self._fuse_weighted(dense, candidates, limit, meta_by_uri=meta_by_uri)
+        return self._fuse_rrf(dense, candidates, limit, meta_by_uri=meta_by_uri)
 
     def _fuse_rrf(
         self,
         dense: Sequence[MatchedContext],
         candidates: Sequence[Tuple[str, float]],
         limit: int,
+        *,
+        meta_by_uri: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[MatchedContext]:
         k = float(getattr(self._config, "rrf_k", 60.0) or 60.0)
         dense_rank = {m.uri: i for i, m in enumerate(dense)}
@@ -132,8 +175,13 @@ class HybridKeywordRecaller:
         for uri in ordered_uris:
             mc = by_uri.get(uri)
             if mc is None:
-                mc = self._make_keyword_context(uri, candidates)
-            out.append(replace(mc, score=scores[uri]))
+                mc = self._make_keyword_context(
+                    uri, candidates, meta=(meta_by_uri or {}).get(uri)
+                )
+                out.append(replace(mc, score=scores[uri]))
+            else:
+                # Dense hits keep the score clients already know.
+                out.append(mc)
             if len(out) >= limit:
                 break
         # Always keep the dense ordering for ties handled above; append leftover
@@ -153,9 +201,11 @@ class HybridKeywordRecaller:
         dense: Sequence[MatchedContext],
         candidates: Sequence[Tuple[str, float]],
         limit: int,
+        *,
+        meta_by_uri: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[MatchedContext]:
         w = float(getattr(self._config, "keyword_weight", 0.3) or 0.3)
-        raw_scores = {uri: score for uri, score in candidates}
+        raw_scores = dict(candidates)
         if raw_scores:
             lo = min(raw_scores.values())
             hi = max(raw_scores.values())
@@ -163,8 +213,9 @@ class HybridKeywordRecaller:
             lo = hi = 0.0
 
         def norm(uri: str) -> float:
+            """Map the strongest bm25 match (lowest score) to 1.0."""
             if hi > lo:
-                return (raw_scores[uri] - lo) / (hi - lo)
+                return 1.0 - (raw_scores[uri] - lo) / (hi - lo)
             return 0.5
 
         by_uri = {m.uri: m for m in dense}
@@ -181,13 +232,22 @@ class HybridKeywordRecaller:
         for uri in ordered:
             mc = by_uri.get(uri)
             if mc is None:
-                mc = self._make_keyword_context(uri, candidates)
-            out.append(replace(mc, score=scores[uri]))
+                mc = self._make_keyword_context(
+                    uri, candidates, meta=(meta_by_uri or {}).get(uri)
+                )
+                out.append(replace(mc, score=scores[uri]))
+            else:
+                out.append(mc)
             if len(out) >= limit:
                 break
         return out
 
-    def _make_keyword_context(self, uri: str, candidates: Sequence[Tuple[str, float]]) -> MatchedContext:
+    def _make_keyword_context(
+        self,
+        uri: str,
+        candidates: Sequence[Tuple[str, float]],
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> MatchedContext:
         from openviking.core.context import ContextType
         from openviking.core.namespace import context_type_for_uri
 
@@ -196,7 +256,8 @@ class HybridKeywordRecaller:
             if u == uri:
                 score = s
                 break
-        ctype = context_type_for_uri(uri)
+        meta = meta or {}
+        ctype = meta.get("context_type") or context_type_for_uri(uri)
         try:
             context_type = ContextType(ctype)
         except ValueError:
@@ -204,7 +265,7 @@ class HybridKeywordRecaller:
         return MatchedContext(
             uri=uri,
             context_type=context_type,
-            level=2,
+            level=int(meta.get("level", 2) or 2),
             abstract="",
             category="",
             score=score,

--- a/openviking/server/routers/observer.py
+++ b/openviking/server/routers/observer.py
@@ -92,6 +92,16 @@ async def observer_retrieval(
     return Response(status="ok", result=_component_to_dict(component))
 
 
+@router.get("/keyword")
+async def observer_keyword(
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Get local keyword (FTS5) sidecar status."""
+    service = get_service()
+    component = service.debug.observer.keyword
+    return Response(status="ok", result=_component_to_dict(component))
+
+
 @router.get("/filesystem")
 async def observer_filesystem(
     _ctx: RequestContext = Depends(get_request_context),

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -353,6 +353,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            hybrid=request.hybrid,
         ),
     )
     result = execution.result
@@ -467,6 +468,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            hybrid=request.hybrid,
         )
 
     execution = await run_operation(

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -138,6 +138,7 @@ class FindRequest(BaseModel):
     level: Optional[Union[int, str, List[int]]] = None
     read_content: bool = False
     telemetry: TelemetryRequest = False
+    hybrid: Optional[bool] = None
 
 
 def _reject_unknown_categories(value: Any, label: str, allowed: Sequence[str]) -> None:
@@ -200,6 +201,7 @@ class SearchRequest(BaseModel):
     level: Optional[Union[int, str, List[int]]] = None
     read_content: bool = False
     telemetry: TelemetryRequest = False
+    hybrid: Optional[bool] = None
 
     mode: Literal["list", "context"] = "list"
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -616,9 +616,10 @@ class OpenVikingService:
             self._queue_manager = None
             logger.info("Queue manager stopped")
 
-        if self._keyword_fs is not None:
+        keyword_fs = getattr(self, "_keyword_fs", None)
+        if keyword_fs is not None:
             try:
-                self._keyword_fs.close()
+                keyword_fs.close()
             except Exception:
                 logger.warning("Failed to close keyword sidecar", exc_info=True)
             self._keyword_fs = None

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -103,6 +103,7 @@ class OpenVikingService:
         self._watch_scheduler: Optional[WatchScheduler] = None
         self._session_auto_commit_scheduler: Optional[SessionAutoCommitScheduler] = None
         self._encryptor: Optional[Any] = None
+        self._keyword_fs: Optional[Any] = None
         self._privacy_config_service: Optional[UserPrivacyConfigService] = None
         self._data_dir_lock_acquired = False
         self._data_dir_lock_path: Optional[str] = None
@@ -205,9 +206,42 @@ class OpenVikingService:
         # in initialize(), so that recovered tasks don't race against VikingFS init.
         if self._queue_manager:
             self._queue_manager.setup_standard_queues(self._vikingdb_manager, start=False)
+            self._keyword_fs = self._build_keyword_fs()
+            if self._keyword_fs is not None:
+                self._queue_manager.setup_keyword_queue(
+                    self._keyword_fs,
+                    self._config.keyword,
+                    start=False,
+                )
 
         # PathLock has been moved to Rust ragfs; Python-layer LockManager is no longer needed.
         set_task_tracker(config.build_task_tracker(self._agfs_client))
+
+    def _build_keyword_fs(self) -> Optional[Any]:
+        """Build the keyword sidecar when enabled and safe; otherwise None.
+
+        Respects the at-rest encryption guard: the sidecar stores plaintext text,
+        so it is disabled on encrypted deployments unless ``respect_encryption``
+        is turned off.
+        """
+        from pathlib import Path
+
+        from openviking.storage.keywordfs.keyword_fs import KeywordFS
+
+        keyword_config = self._config.keyword
+        if not keyword_config.enabled:
+            return None
+        if keyword_config.respect_encryption and self._encryptor is not None:
+            logger.info("Keyword sidecar disabled: at-rest encryption is enabled")
+            return None
+        db_dir = keyword_config.db_dir or str(
+            Path(self._config.storage.workspace) / "_system" / "keyword"
+        )
+        try:
+            return KeywordFS(db_dir=db_dir, config=keyword_config)
+        except Exception as exc:
+            logger.warning(f"Failed to initialize keyword sidecar: {exc}")
+            return None
 
     def _build_ragfs_binding_config(self) -> Any:
         """Build the single runtime binding config from OpenViking storage + encryption settings."""
@@ -388,6 +422,8 @@ class OpenVikingService:
             acl_manager=self._vikingdb_manager.acl_manager,
             retrieval_config=config.retrieval,
             grep_config=config.grep,
+            keyword_config=config.keyword,
+            keyword_fs=self._keyword_fs,
             enable_recorder=enable_recorder,
             encryptor=self._encryptor,
         )
@@ -579,6 +615,13 @@ class OpenVikingService:
             await asyncio.to_thread(self._queue_manager.stop)
             self._queue_manager = None
             logger.info("Queue manager stopped")
+
+        if self._keyword_fs is not None:
+            try:
+                self._keyword_fs.close()
+            except Exception:
+                logger.warning("Failed to close keyword sidecar", exc_info=True)
+            self._keyword_fs = None
 
         if self._vikingdb_manager:
             self._vikingdb_manager.mark_closing()

--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -206,6 +206,53 @@ class ObserverService:
         )
 
     @property
+    def keyword(self) -> ComponentStatus:
+        """Get local keyword (FTS5) sidecar status."""
+        try:
+            from openviking.storage.viking_fs import get_viking_fs
+
+            viking_fs = get_viking_fs()
+            cfg = getattr(viking_fs, "keyword_config", None)
+            if cfg is None or not cfg.enabled:
+                return ComponentStatus(
+                    name="keyword",
+                    is_healthy=True,
+                    has_errors=False,
+                    status="Disabled (keyword.enabled=false)",
+                )
+            kfs = viking_fs._get_keyword_fs() if hasattr(viking_fs, "_get_keyword_fs") else None
+            if kfs is None:
+                return ComponentStatus(
+                    name="keyword",
+                    is_healthy=False,
+                    has_errors=True,
+                    status="Not initialized",
+                )
+            account = self._config.default_account if self._config else "default"
+            st = kfs.stats(account or "default")
+            lines = [
+                f"Enabled: true",
+                f"Ready: {st['ready']}",
+                f"Docs: {st['docs']}",
+                f"Tokenizer version: {st['tokenizer_version']}",
+                f"Last built: {st['last_built_at'] or 'never'}",
+                f"DB: {kfs.db_path(account or 'default')}",
+            ]
+            return ComponentStatus(
+                name="keyword",
+                is_healthy=bool(st["ready"]),
+                has_errors=not bool(st["ready"]),
+                status="\n".join(lines),
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            return ComponentStatus(
+                name="keyword",
+                is_healthy=False,
+                has_errors=True,
+                status=f"Error: {exc}",
+            )
+
+    @property
     def filesystem(self) -> ComponentStatus:
         """Get filesystem operation status."""
         observer = FilesystemObserver()
@@ -249,6 +296,7 @@ class ObserverService:
             "lock": self.lock,
             "retrieval": self.retrieval,
             "filesystem": self.filesystem,
+            "keyword": self.keyword,
         }
         errors = [f"{c.name} has errors" for c in components.values() if c.has_errors]
         return SystemStatus(

--- a/openviking/service/debug_service.py
+++ b/openviking/service/debug_service.py
@@ -231,13 +231,21 @@ class ObserverService:
             account = self._config.default_account if self._config else "default"
             st = kfs.stats(account or "default")
             lines = [
-                f"Enabled: true",
+                "Enabled: true",
                 f"Ready: {st['ready']}",
                 f"Docs: {st['docs']}",
                 f"Tokenizer version: {st['tokenizer_version']}",
                 f"Last built: {st['last_built_at'] or 'never'}",
                 f"DB: {kfs.db_path(account or 'default')}",
             ]
+            if st.get("state") == "not_built":
+                lines.append("State: enabled, not built yet")
+                return ComponentStatus(
+                    name="keyword",
+                    is_healthy=True,
+                    has_errors=False,
+                    status="\n".join(lines),
+                )
             return ComponentStatus(
                 name="keyword",
                 is_healthy=bool(st["ready"]),

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -99,6 +99,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        hybrid: Optional[bool] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -133,6 +134,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            hybrid=hybrid,
         )
         return result
 
@@ -146,6 +148,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        hybrid: Optional[bool] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -172,5 +175,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            hybrid=hybrid,
         )
         return result

--- a/openviking/storage/keywordfs/__init__.py
+++ b/openviking/storage/keywordfs/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Local keyword retrieval via a SQLite FTS5 sidecar.
+
+The keyword sidecar provides backend-owned, search-time BM25 recall for
+deployments without a remote VikingDB full-text index. It is an accelerator
+only: the final matching decision is always made against the on-disk content
+(grep) or by the vector retrieval pipeline (find/search hybrid).
+"""
+
+from openviking.storage.keywordfs.config import (
+    CjkMode,
+    ContentSource,
+    HybridRetrievalConfig,
+    KeywordConfig,
+    TokenizerMode,
+)
+from openviking.storage.keywordfs.keyword_fs import KeywordFS
+from openviking.storage.keywordfs.keyword_msg import KeywordMsg
+
+__all__ = [
+    "CjkMode",
+    "ContentSource",
+    "HybridRetrievalConfig",
+    "KeywordConfig",
+    "KeywordFS",
+    "KeywordMsg",
+    "TokenizerMode",
+]

--- a/openviking/storage/keywordfs/__init__.py
+++ b/openviking/storage/keywordfs/__init__.py
@@ -10,7 +10,6 @@ only: the final matching decision is always made against the on-disk content
 
 from openviking.storage.keywordfs.config import (
     CjkMode,
-    ContentSource,
     HybridRetrievalConfig,
     KeywordConfig,
     TokenizerMode,
@@ -20,7 +19,6 @@ from openviking.storage.keywordfs.keyword_msg import KeywordMsg
 
 __all__ = [
     "CjkMode",
-    "ContentSource",
     "HybridRetrievalConfig",
     "KeywordConfig",
     "KeywordFS",

--- a/openviking/storage/keywordfs/config.py
+++ b/openviking/storage/keywordfs/config.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Keyword sidecar configuration (re-exported from the shared cli config module)."""
+
+from openviking_cli.utils.config.keyword_config import (
+    CjkMode,
+    ContentSource,
+    HybridRetrievalConfig,
+    KeywordConfig,
+    TokenizerMode,
+)
+
+__all__ = [
+    "CjkMode",
+    "ContentSource",
+    "HybridRetrievalConfig",
+    "KeywordConfig",
+    "TokenizerMode",
+]

--- a/openviking/storage/keywordfs/config.py
+++ b/openviking/storage/keywordfs/config.py
@@ -4,7 +4,6 @@
 
 from openviking_cli.utils.config.keyword_config import (
     CjkMode,
-    ContentSource,
     HybridRetrievalConfig,
     KeywordConfig,
     TokenizerMode,
@@ -12,7 +11,6 @@ from openviking_cli.utils.config.keyword_config import (
 
 __all__ = [
     "CjkMode",
-    "ContentSource",
     "HybridRetrievalConfig",
     "KeywordConfig",
     "TokenizerMode",

--- a/openviking/storage/keywordfs/keyword_fs.py
+++ b/openviking/storage/keywordfs/keyword_fs.py
@@ -1,0 +1,478 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""SQLite FTS5 keyword sidecar.
+
+One database file per account under ``<db_dir>/<account_id>.sqlite3``. The FTS5
+table stores the pre-tokenized content plus an UNINDEXED canonical Viking URI.
+``uri_map`` keeps a stable ``uri -> rowid`` mapping so single-document upserts,
+deletes and moves stay cheap and idempotent.
+
+The sidecar is a *recall accelerator*: ``lookup`` returns candidate URIs ranked
+by SQLite's search-time ``bm25()``; callers are responsible for the final
+matching decision (grep matches against on-disk content, hybrid retrieval fuses
+with the dense scores).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from openviking_cli.utils.logger import get_logger
+
+from .config import KeywordConfig
+from .tokenizer import tokenize
+
+logger = get_logger(__name__)
+
+_SCHEMA_VERSION = "1"
+_TOKENIZER_VERSION = "1"
+
+_META_SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"""
+
+_URI_MAP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS uri_map (
+    uri            TEXT PRIMARY KEY,
+    kf_rowid       INTEGER NOT NULL,
+    level          INTEGER NOT NULL,
+    context_type   TEXT NOT NULL,
+    owner_user_id  TEXT NOT NULL,
+    byte_len       INTEGER NOT NULL,
+    updated_at     TEXT NOT NULL
+)
+"""
+
+_FTS_SCHEMA = (
+    "CREATE VIRTUAL TABLE IF NOT EXISTS kf USING fts5("
+    "uri UNINDEXED, "
+    "content, "
+    "tokenize='unicode61'"
+    ")"
+)
+
+_ACCOUNT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class KeywordFS:
+    """Per-account SQLite FTS5 keyword index."""
+
+    def __init__(self, db_dir: str | Path, config: Optional[KeywordConfig] = None):
+        self._db_dir = Path(db_dir)
+        self._db_dir.mkdir(parents=True, exist_ok=True)
+        self._config = config or KeywordConfig()
+        self._conns: Dict[str, sqlite3.Connection] = {}
+        self._locks: Dict[str, threading.RLock] = {}
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # connection / path management
+    # ------------------------------------------------------------------
+
+    def db_dir(self) -> Path:
+        return self._db_dir
+
+    def _safe_account_id(self, account_id: str) -> str:
+        if account_id and _ACCOUNT_ID_RE.match(account_id):
+            return account_id
+        digest = hashlib.sha256((account_id or "default").encode("utf-8")).hexdigest()[:16]
+        return f"acct_{digest}"
+
+    def db_path(self, account_id: str) -> Path:
+        return self._db_dir / f"{self._safe_account_id(account_id)}.sqlite3"
+
+    def _lock(self, account_id: str) -> threading.RLock:
+        lock = self._locks.get(account_id)
+        if lock is None:
+            lock = self._locks.setdefault(account_id, threading.RLock())
+        return lock
+
+    def _conn(self, account_id: str) -> sqlite3.Connection:
+        """Return the per-account connection, creating/initializing it on first use."""
+        conn = self._conns.get(account_id)
+        if conn is None:
+            path = self.db_path(account_id)
+            conn = sqlite3.connect(str(path), check_same_thread=False, timeout=15.0)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            self._init_schema(conn)
+            self._conns[account_id] = conn
+        return conn
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute(_META_SCHEMA)
+        conn.execute(_URI_MAP_SCHEMA)
+        conn.execute(_FTS_SCHEMA)
+        conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES('schema_version', ?)",
+            (_SCHEMA_VERSION,),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES('tokenizer_version', ?)",
+            (_TOKENIZER_VERSION,),
+        )
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    # mutations
+    # ------------------------------------------------------------------
+
+    def upsert(
+        self,
+        account_id: str,
+        uri: str,
+        text: str,
+        level: int = 2,
+        context_type: str = "resource",
+        owner_user_id: str = "",
+    ) -> bool:
+        """Index (or replace) one document. Returns True when a row was written.
+
+        Oversized documents and documents that tokenize to nothing are dropped
+        from the index (treated as delete).
+        """
+        if not uri or self._closed:
+            return False
+        raw_bytes = len((text or "").encode("utf-8"))
+        if raw_bytes > self._config.max_doc_bytes:
+            self.delete(account_id, uri)
+            return False
+        tokenized = tokenize(text or "", self._config.tokenizer, self._config.cjk_mode)
+        if not tokenized:
+            self.delete(account_id, uri)
+            return False
+
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            row = conn.execute("SELECT kf_rowid FROM uri_map WHERE uri=?", (uri,)).fetchone()
+            now = _utc_now()
+            if row is not None:
+                rowid = int(row["kf_rowid"])
+                self._delete_row(conn, rowid, uri)
+                conn.execute(
+                    "INSERT INTO kf(rowid, uri, content) VALUES(?, ?, ?)",
+                    (rowid, uri, tokenized),
+                )
+                conn.execute(
+                    "UPDATE uri_map SET level=?, context_type=?, owner_user_id=?, "
+                    "byte_len=?, updated_at=? WHERE uri=?",
+                    (int(level), context_type, owner_user_id, raw_bytes, now, uri),
+                )
+            else:
+                cur = conn.execute("INSERT INTO kf(uri, content) VALUES(?, ?)", (uri, tokenized))
+                rowid = int(cur.lastrowid)
+                conn.execute(
+                    "INSERT INTO uri_map(uri, kf_rowid, level, context_type, owner_user_id, "
+                    "byte_len, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?)",
+                    (uri, rowid, int(level), context_type, owner_user_id, raw_bytes, now),
+                )
+            conn.commit()
+            return True
+
+    def delete(self, account_id: str, uri: str) -> bool:
+        """Remove one document (idempotent). Returns True when a row was removed."""
+        if not uri or self._closed:
+            return False
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            row = conn.execute("SELECT kf_rowid FROM uri_map WHERE uri=?", (uri,)).fetchone()
+            if row is None:
+                return False
+            self._delete_row(conn, int(row["kf_rowid"]), uri)
+            conn.execute("DELETE FROM uri_map WHERE uri=?", (uri,))
+            conn.commit()
+            return True
+
+    def move(self, account_id: str, old_uri: str, new_uri: str) -> bool:
+        """Rewrite ``old_uri`` to ``new_uri`` (idempotent)."""
+        if not old_uri or not new_uri or old_uri == new_uri or self._closed:
+            return False
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            row = conn.execute(
+                "SELECT kf_rowid FROM uri_map WHERE uri=?", (old_uri,)
+            ).fetchone()
+            if row is None:
+                return False
+            rowid = int(row["kf_rowid"])
+            conn.execute("UPDATE kf SET uri=? WHERE rowid=?", (new_uri, rowid))
+            conn.execute("UPDATE uri_map SET uri=? WHERE uri=?", (new_uri, old_uri))
+            conn.commit()
+            return True
+
+    def delete_prefix(self, account_id: str, scope_uri: str) -> int:
+        """Delete all documents whose URI starts with ``scope_uri``. Returns row count."""
+        if not scope_uri or self._closed:
+            return 0
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            rows = conn.execute(
+                "SELECT kf_rowid, uri FROM uri_map WHERE uri LIKE ?", (scope_uri + "%",)
+            ).fetchall()
+            for r in rows:
+                self._delete_row(conn, int(r["kf_rowid"]), r["uri"])
+            if rows:
+                conn.execute("DELETE FROM uri_map WHERE uri LIKE ?", (scope_uri + "%",))
+                conn.commit()
+            return len(rows)
+
+    @staticmethod
+    def _delete_row(conn: sqlite3.Connection, rowid: int, uri: str) -> None:
+        """Delete a single FTS5 row by rowid."""
+        del uri  # rowid is sufficient for a regular (non-external) FTS5 table
+        conn.execute("DELETE FROM kf WHERE rowid=?", (rowid,))
+
+    # ------------------------------------------------------------------
+    # query
+    # ------------------------------------------------------------------
+
+    def lookup(
+        self,
+        account_id: str,
+        query: str,
+        scope_uri: str = "",
+        exclude_uri: str = "",
+        limit: int = 10,
+    ) -> List[Tuple[str, float]]:
+        """Search-time BM25 recall: return ``[(uri, score), ...]`` ranked best-first.
+
+        ``scope_uri`` and ``exclude_uri`` are canonical Viking URI prefixes that
+        are applied as post-filters over the FTS candidates.
+        """
+        if self._closed or not query:
+            return []
+        tokenized = tokenize(query, self._config.tokenizer, self._config.cjk_mode)
+        terms = [t for t in tokenized.split() if t]
+        if not terms:
+            return []
+        match_expr = "(" + " OR ".join(f'content:"{_escape_fts_term(t)}"' for t in terms) + ")"
+
+        limit = max(int(limit), 0)
+        max_candidates = self._config.max_candidates
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            results: List[Tuple[str, float]] = []
+            internal = max(limit * 5, min(max_candidates, 2000))
+            while True:
+                rows = conn.execute(
+                    "SELECT uri, bm25(kf) AS score FROM kf WHERE kf MATCH ? "
+                    "ORDER BY bm25(kf) ASC LIMIT ?",
+                    (match_expr, internal),
+                ).fetchall()
+                fetched = 0
+                for r in rows:
+                    fetched += 1
+                    uri = r["uri"]
+                    if not uri:
+                        continue
+                    if scope_uri and not uri.startswith(scope_uri):
+                        continue
+                    if exclude_uri and (
+                        uri == exclude_uri or uri.startswith(exclude_uri + "/")
+                    ):
+                        continue
+                    results.append((uri, float(r["score"])))
+                    if len(results) >= limit:
+                        break
+                if len(results) >= limit or fetched < internal or internal >= max_candidates:
+                    break
+                internal = min(internal * 4, max_candidates)
+            return results
+
+    # ------------------------------------------------------------------
+    # rebuild / maintenance
+    # ------------------------------------------------------------------
+
+    def rebuild_account(
+        self,
+        account_id: str,
+        items: Iterable[Dict],
+    ) -> int:
+        """Atomically rebuild an account's sidecar from ``items``.
+
+        Each item: ``{"uri", "text", "level", "context_type", "owner_user_id"}``.
+        Returns the number of documents indexed.
+        """
+        lock = self._lock(account_id)
+        with lock:
+            # Close the live connection first so its WAL checkpoint is flushed and
+            # no stale -wal/-shm sidecar files survive the atomic replacement.
+            conn_old = self._conns.pop(account_id, None)
+            if conn_old is not None:
+                try:
+                    conn_old.close()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            self._remove_wal_sidecars(account_id)
+
+            tmp_path = self.db_path(account_id).with_name(
+                f"{self._safe_account_id(account_id)}.tmp.{uuid.uuid4().hex[:8]}.sqlite3"
+            )
+            count = 0
+            try:
+                conn = sqlite3.connect(str(tmp_path), timeout=15.0)
+                conn.row_factory = sqlite3.Row
+                conn.execute("PRAGMA journal_mode=OFF")
+                conn.execute("PRAGMA synchronous=OFF")
+                conn.execute(_META_SCHEMA)
+                conn.execute(_URI_MAP_SCHEMA)
+                conn.execute(_FTS_SCHEMA)
+                conn.execute(
+                    "INSERT INTO meta(key, value) VALUES('schema_version', ?)",
+                    (_SCHEMA_VERSION,),
+                )
+                conn.execute(
+                    "INSERT INTO meta(key, value) VALUES('tokenizer_version', ?)",
+                    (_TOKENIZER_VERSION,),
+                )
+                now = _utc_now()
+                for item in items:
+                    uri = item.get("uri", "")
+                    text = item.get("text", "") or ""
+                    if not uri:
+                        continue
+                    raw_bytes = len(text.encode("utf-8"))
+                    if raw_bytes > self._config.max_doc_bytes:
+                        continue
+                    tokenized = tokenize(text, self._config.tokenizer, self._config.cjk_mode)
+                    if not tokenized:
+                        continue
+                    cur = conn.execute(
+                        "INSERT INTO kf(uri, content) VALUES(?, ?)", (uri, tokenized)
+                    )
+                    conn.execute(
+                        "INSERT INTO uri_map(uri, kf_rowid, level, context_type, owner_user_id, "
+                        "byte_len, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            uri,
+                            int(cur.lastrowid),
+                            int(item.get("level", 2)),
+                            item.get("context_type", "resource"),
+                            item.get("owner_user_id", ""),
+                            raw_bytes,
+                            now,
+                        ),
+                    )
+                    count += 1
+                conn.commit()
+                conn.close()
+                os.replace(tmp_path, self.db_path(account_id))
+                self._remove_wal_sidecars(account_id)
+                return count
+            finally:
+                if tmp_path.exists():
+                    try:
+                        tmp_path.unlink()
+                    except OSError:  # pragma: no cover - defensive
+                        pass
+
+    def clear(self, account_id: str) -> None:
+        """Drop the account's sidecar file entirely."""
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conns.pop(account_id, None)
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            try:
+                self.db_path(account_id).unlink(missing_ok=True)
+            except OSError:  # pragma: no cover - defensive
+                pass
+            self._remove_wal_sidecars(account_id)
+
+    def _remove_wal_sidecars(self, account_id: str) -> None:
+        """Remove orphaned -wal/-shm sidecar files for an account DB."""
+        base = str(self.db_path(account_id))
+        for suffix in ("-wal", "-shm"):
+            try:
+                Path(base + suffix).unlink(missing_ok=True)
+            except OSError:  # pragma: no cover - defensive
+                pass
+
+    # ------------------------------------------------------------------
+    # introspection
+    # ------------------------------------------------------------------
+
+    def is_ready(self, account_id: str) -> bool:
+        """True when the account sidecar file exists with a valid schema version."""
+        path = self.db_path(account_id)
+        if not path.exists():
+            return False
+        lock = self._lock(account_id)
+        with lock:
+            try:
+                conn = self._conn(account_id)
+                row = conn.execute(
+                    "SELECT value FROM meta WHERE key='schema_version'"
+                ).fetchone()
+                return row is not None and row["value"] == _SCHEMA_VERSION
+            except sqlite3.Error:
+                return False
+
+    def stats(self, account_id: str) -> Dict:
+        """Return sidecar statistics for one account."""
+        if not self.is_ready(account_id):
+            return {
+                "ready": False,
+                "docs": 0,
+                "tokenizer_version": _TOKENIZER_VERSION,
+                "last_built_at": None,
+            }
+        lock = self._lock(account_id)
+        with lock:
+            try:
+                conn = self._conn(account_id)
+                docs = conn.execute("SELECT COUNT(*) AS c FROM uri_map").fetchone()["c"]
+                built = conn.execute("SELECT value FROM meta WHERE key='built_at'").fetchone()
+                return {
+                    "ready": True,
+                    "docs": int(docs),
+                    "tokenizer_version": _TOKENIZER_VERSION,
+                    "last_built_at": built["value"] if built else None,
+                }
+            except sqlite3.Error:
+                return {
+                    "ready": False,
+                    "docs": 0,
+                    "tokenizer_version": _TOKENIZER_VERSION,
+                    "last_built_at": None,
+                }
+
+    def close(self) -> None:
+        self._closed = True
+        with threading.Lock():
+            conns = list(self._conns.values())
+            self._conns.clear()
+        for conn in conns:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+
+def _escape_fts_term(term: str) -> str:
+    """Escape a single token for use inside an FTS5 double-quoted phrase."""
+    return term.replace('"', "").replace("\\", "")

--- a/openviking/storage/keywordfs/keyword_fs.py
+++ b/openviking/storage/keywordfs/keyword_fs.py
@@ -127,6 +127,10 @@ class KeywordFS:
             "INSERT OR IGNORE INTO meta(key, value) VALUES('tokenizer_version', ?)",
             (_TOKENIZER_VERSION,),
         )
+        conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES('built_at', ?)",
+            (_utc_now(),),
+        )
         conn.commit()
 
     # ------------------------------------------------------------------
@@ -202,7 +206,7 @@ class KeywordFS:
             return True
 
     def move(self, account_id: str, old_uri: str, new_uri: str) -> bool:
-        """Rewrite ``old_uri`` to ``new_uri`` (idempotent)."""
+        """Rewrite ``old_uri`` to ``new_uri``, replacing any existing destination."""
         if not old_uri or not new_uri or old_uri == new_uri or self._closed:
             return False
         lock = self._lock(account_id)
@@ -214,9 +218,19 @@ class KeywordFS:
             if row is None:
                 return False
             rowid = int(row["kf_rowid"])
-            conn.execute("UPDATE kf SET uri=? WHERE rowid=?", (new_uri, rowid))
-            conn.execute("UPDATE uri_map SET uri=? WHERE uri=?", (new_uri, old_uri))
-            conn.commit()
+            try:
+                existing = conn.execute(
+                    "SELECT kf_rowid FROM uri_map WHERE uri=?", (new_uri,)
+                ).fetchone()
+                if existing is not None:
+                    self._delete_row(conn, int(existing["kf_rowid"]), new_uri)
+                    conn.execute("DELETE FROM uri_map WHERE uri=?", (new_uri,))
+                conn.execute("UPDATE kf SET uri=? WHERE rowid=?", (new_uri, rowid))
+                conn.execute("UPDATE uri_map SET uri=? WHERE uri=?", (new_uri, old_uri))
+                conn.commit()
+            except sqlite3.Error:
+                conn.rollback()
+                raise
             return True
 
     def delete_prefix(self, account_id: str, scope_uri: str) -> int:
@@ -226,15 +240,23 @@ class KeywordFS:
         lock = self._lock(account_id)
         with lock:
             conn = self._conn(account_id)
+            pattern = self._escape_like(scope_uri) + "%"
             rows = conn.execute(
-                "SELECT kf_rowid, uri FROM uri_map WHERE uri LIKE ?", (scope_uri + "%",)
+                "SELECT kf_rowid, uri FROM uri_map WHERE uri LIKE ? ESCAPE '\\'", (pattern,)
             ).fetchall()
             for r in rows:
                 self._delete_row(conn, int(r["kf_rowid"]), r["uri"])
             if rows:
-                conn.execute("DELETE FROM uri_map WHERE uri LIKE ?", (scope_uri + "%",))
+                conn.execute(
+                    "DELETE FROM uri_map WHERE uri LIKE ? ESCAPE '\\'", (pattern,)
+                )
                 conn.commit()
             return len(rows)
+
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        """Escape LIKE wildcards so a URI prefix matches literally."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     @staticmethod
     def _delete_row(conn: sqlite3.Connection, rowid: int, uri: str) -> None:
@@ -242,9 +264,87 @@ class KeywordFS:
         del uri  # rowid is sufficient for a regular (non-external) FTS5 table
         conn.execute("DELETE FROM kf WHERE rowid=?", (rowid,))
 
+    def copy(self, account_id: str, old_uri: str, new_uri: str) -> bool:
+        """Duplicate ``old_uri``'s index rows onto ``new_uri`` (idempotent).
+
+        Copies the tokenized FTS5 content and the URI metadata without re-reading
+        or re-tokenizing the document, matching how ``cp`` reuses vector records.
+        """
+        if not old_uri or not new_uri or old_uri == new_uri or self._closed:
+            return False
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            src = conn.execute(
+                "SELECT kf_rowid, level, context_type, owner_user_id, byte_len "
+                "FROM uri_map WHERE uri=?",
+                (old_uri,),
+            ).fetchone()
+            if src is None:
+                return False
+            content_row = conn.execute(
+                "SELECT content FROM kf WHERE rowid=?", (int(src["kf_rowid"]),)
+            ).fetchone()
+            if content_row is None:
+                return False
+            try:
+                existing = conn.execute(
+                    "SELECT kf_rowid FROM uri_map WHERE uri=?", (new_uri,)
+                ).fetchone()
+                if existing is not None:
+                    self._delete_row(conn, int(existing["kf_rowid"]), new_uri)
+                    conn.execute("DELETE FROM uri_map WHERE uri=?", (new_uri,))
+                cur = conn.execute(
+                    "INSERT INTO kf(uri, content) VALUES(?, ?)",
+                    (new_uri, content_row["content"]),
+                )
+                conn.execute(
+                    "INSERT INTO uri_map(uri, kf_rowid, level, context_type, owner_user_id, "
+                    "byte_len, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        new_uri,
+                        int(cur.lastrowid),
+                        int(src["level"]),
+                        src["context_type"],
+                        src["owner_user_id"],
+                        int(src["byte_len"]),
+                        _utc_now(),
+                    ),
+                )
+                conn.commit()
+            except sqlite3.Error:
+                conn.rollback()
+                raise
+            return True
+
     # ------------------------------------------------------------------
     # query
     # ------------------------------------------------------------------
+
+    def meta_for(self, account_id: str, uris: List[str]) -> Dict[str, Dict]:
+        """Return ``{uri: {level, context_type, owner_user_id}}`` for known URIs."""
+        if not uris or self._closed:
+            return {}
+        lock = self._lock(account_id)
+        with lock:
+            conn = self._conn(account_id)
+            out: Dict[str, Dict] = {}
+            # SQLite's parameter limit is 999; chunk to stay well below it.
+            for start in range(0, len(uris), 500):
+                chunk = uris[start : start + 500]
+                placeholders = ",".join("?" for _ in chunk)
+                rows = conn.execute(
+                    f"SELECT uri, level, context_type, owner_user_id FROM uri_map "
+                    f"WHERE uri IN ({placeholders})",
+                    tuple(chunk),
+                ).fetchall()
+                for row in rows:
+                    out[row["uri"]] = {
+                        "level": int(row["level"]),
+                        "context_type": row["context_type"],
+                        "owner_user_id": row["owner_user_id"],
+                    }
+            return out
 
     def lookup(
         self,
@@ -273,7 +373,7 @@ class KeywordFS:
         with lock:
             conn = self._conn(account_id)
             results: List[Tuple[str, float]] = []
-            internal = max(limit * 5, min(max_candidates, 2000))
+            internal = min(max(limit * 5, 30), max_candidates)
             while True:
                 rows = conn.execute(
                     "SELECT uri, bm25(kf) AS score FROM kf WHERE kf MATCH ? "
@@ -345,6 +445,10 @@ class KeywordFS:
                 conn.execute(
                     "INSERT INTO meta(key, value) VALUES('tokenizer_version', ?)",
                     (_TOKENIZER_VERSION,),
+                )
+                conn.execute(
+                    "INSERT INTO meta(key, value) VALUES('built_at', ?)",
+                    (_utc_now(),),
                 )
                 now = _utc_now()
                 for item in items:
@@ -437,6 +541,7 @@ class KeywordFS:
         if not self.is_ready(account_id):
             return {
                 "ready": False,
+                "state": "not_built",
                 "docs": 0,
                 "tokenizer_version": _TOKENIZER_VERSION,
                 "last_built_at": None,
@@ -449,6 +554,7 @@ class KeywordFS:
                 built = conn.execute("SELECT value FROM meta WHERE key='built_at'").fetchone()
                 return {
                     "ready": True,
+                    "state": "ready",
                     "docs": int(docs),
                     "tokenizer_version": _TOKENIZER_VERSION,
                     "last_built_at": built["value"] if built else None,
@@ -456,6 +562,7 @@ class KeywordFS:
             except sqlite3.Error:
                 return {
                     "ready": False,
+                    "state": "error",
                     "docs": 0,
                     "tokenizer_version": _TOKENIZER_VERSION,
                     "last_built_at": None,
@@ -463,14 +570,15 @@ class KeywordFS:
 
     def close(self) -> None:
         self._closed = True
-        with threading.Lock():
-            conns = list(self._conns.values())
-            self._conns.clear()
-        for conn in conns:
-            try:
-                conn.close()
-            except Exception:  # pragma: no cover - defensive
-                pass
+        for account_id in list(self._conns):
+            lock = self._lock(account_id)
+            with lock:
+                conn = self._conns.pop(account_id, None)
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # pragma: no cover - defensive
+                    pass
 
 
 def _escape_fts_term(term: str) -> str:

--- a/openviking/storage/keywordfs/keyword_msg.py
+++ b/openviking/storage/keywordfs/keyword_msg.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Keyword index mutation message, consumed by the KeywordQueue worker."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict
+from uuid import uuid4
+
+Upsert = "upsert"
+Delete = "delete"
+DeletePrefix = "delete_prefix"
+Move = "move"
+
+
+@dataclass
+class KeywordMsg:
+    """A single keyword-sidecar mutation.
+
+    ``kind`` is one of:
+      - ``upsert``: index ``uri`` with ``text`` (level/context_type/owner metadata).
+      - ``delete``: remove ``uri`` from the index.
+      - ``delete_prefix``: remove ``uri`` and every row whose URI starts with it.
+      - ``move``: rewrite ``old_uri`` to ``new_uri`` in the index.
+
+    The account is carried explicitly so the worker can route to the right DB
+    file; the URI is always the canonical Viking URI (same value that the
+    vector index stores for the record).
+    """
+
+    kind: str
+    uri: str = ""
+    account_id: str = "default"
+    text: str = ""
+    level: int = 2
+    context_type: str = "resource"
+    owner_user_id: str = ""
+    old_uri: str = ""
+    new_uri: str = ""
+    telemetry_id: str = ""
+    id: str = field(default_factory=lambda: str(uuid4()))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "KeywordMsg":
+        return cls(
+            kind=data["kind"],
+            uri=data["uri"],
+            account_id=data.get("account_id", "default"),
+            text=data.get("text", ""),
+            level=data.get("level", 2),
+            context_type=data.get("context_type", "resource"),
+            owner_user_id=data.get("owner_user_id", ""),
+            old_uri=data.get("old_uri", ""),
+            new_uri=data.get("new_uri", ""),
+            telemetry_id=data.get("telemetry_id", ""),
+            id=data.get("id", str(uuid4())),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "KeywordMsg":
+        return cls.from_dict(json.loads(json_str))
+
+    @classmethod
+    def from_embedding(cls, embedding_msg: Any) -> "KeywordMsg | None":
+        """Build an upsert message from an EmbeddingMsg for coverage parity.
+
+        The keyword sidecar indexes exactly the text that was embedded for the
+        leaf document, so keyword recall stays in sync with vector coverage.
+        """
+        context_data = getattr(embedding_msg, "context_data", {}) or {}
+        uri = context_data.get("uri", "")
+        if not uri:
+            return None
+        text = _message_text(getattr(embedding_msg, "message", ""))
+        if not text:
+            return None
+        return cls(
+            kind=Upsert,
+            uri=uri,
+            account_id=context_data.get("account_id", "default"),
+            text=text,
+            level=int(context_data.get("level", 2) or 2),
+            context_type=context_data.get("context_type", "resource"),
+            owner_user_id=context_data.get("owner_user_id", ""),
+            telemetry_id=getattr(embedding_msg, "telemetry_id", ""),
+        )
+
+
+def _message_text(message: Any) -> str:
+    """Extract plain text from an EmbeddingMsg message (str or multimodal parts)."""
+    if isinstance(message, str):
+        return message
+    if isinstance(message, list):
+        parts = []
+        for part in message:
+            if isinstance(part, dict) and part.get("type") == "text":
+                t = part.get("text", "")
+                if isinstance(t, str):
+                    parts.append(t)
+        return "\n".join(parts)
+    return ""

--- a/openviking/storage/keywordfs/keyword_msg.py
+++ b/openviking/storage/keywordfs/keyword_msg.py
@@ -13,6 +13,7 @@ Upsert = "upsert"
 Delete = "delete"
 DeletePrefix = "delete_prefix"
 Move = "move"
+Copy = "copy"
 
 
 @dataclass
@@ -24,6 +25,7 @@ class KeywordMsg:
       - ``delete``: remove ``uri`` from the index.
       - ``delete_prefix``: remove ``uri`` and every row whose URI starts with it.
       - ``move``: rewrite ``old_uri`` to ``new_uri`` in the index.
+      - ``copy``: duplicate ``old_uri`` onto ``new_uri`` in the index.
 
     The account is carried explicitly so the worker can route to the right DB
     file; the URI is always the canonical Viking URI (same value that the

--- a/openviking/storage/keywordfs/keyword_processor.py
+++ b/openviking/storage/keywordfs/keyword_processor.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Async worker that applies KeywordMsg mutations to the FTS5 sidecar."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional
+
+from openviking_cli.utils.logger import get_logger
+
+from ..queuefs.named_queue import DequeueHandlerBase
+from .keyword_fs import KeywordFS
+from .keyword_msg import Delete, DeletePrefix, Move, Upsert, KeywordMsg
+
+logger = get_logger(__name__)
+
+
+class KeywordProcessor(DequeueHandlerBase):
+    """Consumes KeywordMsg from the Keyword queue and applies them to KeywordFS.
+
+    Messages are dropped when the keyword sidecar is disabled (they should not
+    have been enqueued in that case), re-enqueued on transient SQLite errors,
+    and reported as errors on permanent failures.
+    """
+
+    def __init__(self, keyword_fs: Optional[KeywordFS], config: Optional[Any] = None):
+        self._keyword_fs = keyword_fs
+        self._config = config
+
+    async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not data:
+            return None
+        try:
+            raw = data.get("data")
+            if isinstance(raw, str):
+                msg = KeywordMsg.from_json(raw)
+            elif isinstance(raw, dict):
+                msg = KeywordMsg.from_dict(raw)
+            else:
+                msg = KeywordMsg.from_dict(data)
+        except Exception as e:
+            logger.warning(f"[KeywordProcessor] Failed to parse message: {e}")
+            self.report_error(f"Failed to parse KeywordMsg: {e}", data)
+            return None
+
+        if self._config is None or not getattr(self._config, "enabled", False):
+            self.report_success()
+            return None
+        kfs = self._keyword_fs
+        if kfs is None:
+            logger.warning("[KeywordProcessor] KeywordFS not wired; dropping message")
+            self.report_success()
+            return None
+
+        try:
+            if msg.kind == Upsert:
+                kfs.upsert(
+                    msg.account_id,
+                    msg.uri,
+                    msg.text,
+                    level=msg.level,
+                    context_type=msg.context_type,
+                    owner_user_id=msg.owner_user_id,
+                )
+            elif msg.kind == Delete:
+                kfs.delete(msg.account_id, msg.uri)
+            elif msg.kind == DeletePrefix:
+                kfs.delete_prefix(msg.account_id, msg.uri)
+            elif msg.kind == Move:
+                kfs.move(msg.account_id, msg.old_uri, msg.new_uri)
+            else:
+                logger.warning(f"[KeywordProcessor] Unknown kind: {msg.kind}")
+                self.report_error(f"Unknown KeywordMsg kind: {msg.kind}", data)
+                return None
+        except sqlite3.OperationalError as e:
+            logger.warning(f"[KeywordProcessor] Transient DB error, requeueing: {e}")
+            self.report_requeue()
+            return None
+        except Exception as e:
+            logger.error(f"[KeywordProcessor] Failed to apply message: {e}", exc_info=True)
+            self.report_error(f"Failed to apply KeywordMsg: {e}", data)
+            return None
+
+        self.report_success()
+        return None

--- a/openviking/storage/keywordfs/keyword_processor.py
+++ b/openviking/storage/keywordfs/keyword_processor.py
@@ -11,7 +11,7 @@ from openviking_cli.utils.logger import get_logger
 
 from ..queuefs.named_queue import DequeueHandlerBase
 from .keyword_fs import KeywordFS
-from .keyword_msg import Delete, DeletePrefix, Move, Upsert, KeywordMsg
+from .keyword_msg import Copy, Delete, DeletePrefix, KeywordMsg, Move, Upsert
 
 logger = get_logger(__name__)
 
@@ -69,11 +69,13 @@ class KeywordProcessor(DequeueHandlerBase):
                 kfs.delete_prefix(msg.account_id, msg.uri)
             elif msg.kind == Move:
                 kfs.move(msg.account_id, msg.old_uri, msg.new_uri)
+            elif msg.kind == Copy:
+                kfs.copy(msg.account_id, msg.old_uri, msg.new_uri)
             else:
                 logger.warning(f"[KeywordProcessor] Unknown kind: {msg.kind}")
                 self.report_error(f"Unknown KeywordMsg kind: {msg.kind}", data)
                 return None
-        except sqlite3.OperationalError as e:
+        except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
             logger.warning(f"[KeywordProcessor] Transient DB error, requeueing: {e}")
             self.report_requeue()
             return None

--- a/openviking/storage/keywordfs/keyword_queue.py
+++ b/openviking/storage/keywordfs/keyword_queue.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Named queue for keyword-sidecar mutations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from openviking_cli.utils.logger import get_logger
+
+from ..queuefs.named_queue import NamedQueue
+from .keyword_msg import KeywordMsg
+
+logger = get_logger(__name__)
+
+
+class KeywordQueue(NamedQueue):
+    """KeywordQueue: Named queue specifically for KeywordMsg objects."""
+
+    async def enqueue(self, msg: Optional[KeywordMsg]) -> str:
+        """Serialize a KeywordMsg object and store it in the queue."""
+        if msg is None:
+            logger.warning("Keyword message is None, skipping enqueuing")
+            return ""
+        return await super().enqueue(msg.to_dict())
+
+    async def dequeue(self) -> Optional[KeywordMsg]:
+        """Get a message from the queue and deserialize to KeywordMsg."""
+        data_dict = await super().dequeue()
+        if not data_dict:
+            return None
+        raw = data_dict.get("data")
+        try:
+            if isinstance(raw, str):
+                return KeywordMsg.from_json(raw)
+            if isinstance(raw, dict):
+                return KeywordMsg.from_dict(raw)
+        except Exception as e:
+            logger.debug(f"[KeywordQueue] Failed to parse message data: {e}")
+            return None
+        try:
+            return KeywordMsg.from_dict(data_dict)
+        except Exception:
+            return None

--- a/openviking/storage/keywordfs/tokenizer.py
+++ b/openviking/storage/keywordfs/tokenizer.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Text tokenization for the local keyword sidecar.
+
+FTS5's built-in ``unicode61`` tokenizer splits on whitespace and punctuation
+but treats a run of CJK characters as a single token, which makes Chinese /
+Japanese / Korean keyword recall unreliable. This module pre-tokenizes text
+before it is stored so that ``unicode61`` can index and match the intended
+terms:
+
+- Latin / digits are split into words (``[a-zA-Z0-9_]+``), lowercased.
+- CJK text is split per character (high recall) or into overlapping bigrams
+  (higher precision for short queries). When the optional ``jieba`` dependency
+  is installed and ``mode="auto"``, jieba word segmentation is used instead.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+# CJK Unified Ideographs + Extension A + Compatibility Ideographs
+_CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
+_WORD_RE = re.compile(r"[a-zA-Z0-9_]+")
+_NON_CJK_RUN_RE = re.compile(r"[^\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]+")
+
+
+def has_cjk(text: str) -> bool:
+    """Return True when the text contains CJK characters."""
+    return bool(_CJK_RE.search(text or ""))
+
+
+def _jieba_available() -> bool:
+    try:
+        import jieba  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _tokenize_cjk(seg: str, cjk_mode: str) -> List[str]:
+    """Tokenize a run of CJK characters."""
+    chars = list(seg)
+    if cjk_mode == "bigram":
+        tokens = list(chars)
+        for i in range(len(chars) - 1):
+            tokens.append(chars[i] + chars[i + 1])
+        return tokens
+    # char mode (default): one token per character
+    return chars
+
+
+def _tokenize_with_jieba(text: str) -> List[str]:
+    """Word-segment CJK text with jieba (optional dependency)."""
+    import jieba
+
+    segs = jieba.cut_for_search(text)
+    return [s for s in segs if s.strip()]
+
+
+def tokenize(
+    text: str,
+    tokenizer_mode: str = "auto",
+    cjk_mode: str = "char",
+) -> str:
+    """Normalize text into space-separated tokens for the FTS5 index/query.
+
+    Args:
+        text: Raw text to tokenize.
+        tokenizer_mode: 'auto' | 'char' | 'jieba'.
+        cjk_mode: 'char' | 'bigram' (used only when jieba is not applied).
+
+    Returns:
+        Space-separated token string (empty string for empty input).
+    """
+    if not text:
+        return ""
+    text = text.strip()
+    if not text:
+        return ""
+
+    use_jieba = tokenizer_mode == "jieba" or (
+        tokenizer_mode == "auto" and has_cjk(text) and _jieba_available()
+    )
+    if use_jieba:
+        tokens = _tokenize_with_jieba(text)
+        return " ".join(tokens)
+
+    tokens: List[str] = []
+    # Walk the text by CJK / non-CJK runs.
+    idx = 0
+    while idx < len(text):
+        match = _CJK_RE.search(text, idx)
+        if match is None:
+            for word in _WORD_RE.findall(text[idx:].lower()):
+                tokens.append(word)
+            break
+        start = match.start()
+        if start > idx:
+            for word in _WORD_RE.findall(text[idx:start].lower()):
+                tokens.append(word)
+        # Find the end of the contiguous CJK run.
+        end = start
+        while end < len(text) and _CJK_RE.match(text[end]):
+            end += 1
+        tokens.extend(_tokenize_cjk(text[start:end], cjk_mode))
+        idx = end
+    return " ".join(tokens)
+
+
+def terms(text: str, tokenizer_mode: str = "auto", cjk_mode: str = "char") -> List[str]:
+    """Return the token list for a query (used to decide whether to run keyword recall)."""
+    return [t for t in tokenize(text, tokenizer_mode, cjk_mode).split() if t]

--- a/openviking/storage/keywordfs/tokenizer.py
+++ b/openviking/storage/keywordfs/tokenizer.py
@@ -17,7 +17,7 @@ terms:
 from __future__ import annotations
 
 import re
-from typing import List, Optional
+from typing import List
 
 # CJK Unified Ideographs + Extension A + Compatibility Ideographs
 _CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -37,6 +37,7 @@ def init_queue_manager(
     max_concurrent_add_resource: int = 4,
     max_concurrent_session_commit: int = DEFAULT_MAX_CONCURRENT_SESSION_COMMIT,
     max_concurrent_external_task: int = 10,
+    max_concurrent_keyword: int = 4,
 ) -> "QueueManager":
     """Initialize QueueManager singleton.
 
@@ -61,6 +62,7 @@ def init_queue_manager(
         max_concurrent_add_resource=max_concurrent_add_resource,
         max_concurrent_session_commit=max_concurrent_session_commit,
         max_concurrent_external_task=max_concurrent_external_task,
+        max_concurrent_keyword=max_concurrent_keyword,
     )
     return _instance
 
@@ -89,6 +91,7 @@ class QueueManager:
     USER_DELETION = "UserDeletion"
     # Deferred work re-enqueues itself; throttle the next scheduling round.
     _REQUEUE_POLL_INTERVAL = 1.0
+    KEYWORD = "Keyword"
 
     def __init__(
         self,
@@ -101,6 +104,7 @@ class QueueManager:
         max_concurrent_add_resource: int = 4,
         max_concurrent_session_commit: int = DEFAULT_MAX_CONCURRENT_SESSION_COMMIT,
         max_concurrent_external_task: int = 10,
+        max_concurrent_keyword: int = 4,
     ):
         """Initialize QueueManager."""
         self._agfs = agfs
@@ -112,6 +116,7 @@ class QueueManager:
         self._max_concurrent_add_resource = max_concurrent_add_resource
         self._max_concurrent_session_commit = max_concurrent_session_commit
         self._max_concurrent_external_task = max_concurrent_external_task
+        self._max_concurrent_keyword = max_concurrent_keyword
         self._queues: Dict[str, NamedQueue] = {}
         self._started = False
         self._queue_threads: Dict[str, threading.Thread] = {}
@@ -143,6 +148,40 @@ class QueueManager:
         owners = self._task_work_index.rebuild(snapshots)
         tracker.attach_work_index(self._task_work_index)
         return await tracker.restore_work_tasks(owners)
+
+    def setup_keyword_queue(self, keyword_fs: Any, config: Any, start: bool = True) -> None:
+        """Setup the Keyword queue with its processor.
+
+        Args:
+            keyword_fs: KeywordFS sidecar instance.
+            config: KeywordConfig instance (or object with ``enabled``).
+            start: Whether to start the worker thread immediately.
+        """
+        from openviking.storage.keywordfs.keyword_processor import KeywordProcessor
+        from openviking.storage.keywordfs.keyword_queue import KeywordQueue
+
+        # Ensure the Keyword queue is created with the KeywordQueue class so
+        # serialized messages round-trip through KeywordMsg.
+        if self.KEYWORD not in self._queues:
+            self._queues[self.KEYWORD] = KeywordQueue(
+                self._agfs,
+                self.mount_point,
+                self.KEYWORD,
+                task_work_index=self._task_work_index,
+            )
+            if self._started:
+                self._start_queue_worker(self._queues[self.KEYWORD])
+
+        processor = KeywordProcessor(keyword_fs=keyword_fs, config=config)
+        self.get_queue(
+            self.KEYWORD,
+            dequeue_handler=processor,
+            allow_create=True,
+        )
+        logger.info("Keyword queue initialized with KeywordProcessor")
+
+        if start:
+            self.start()
 
     def setup_standard_queues(self, vector_store: Any, start: bool = True) -> None:
         """
@@ -212,6 +251,8 @@ class QueueManager:
             return self._max_concurrent_session_commit
         if queue_name == self.EXTERNAL_TASK:
             return self._max_concurrent_external_task
+        if queue_name == self.KEYWORD:
+            return self._max_concurrent_keyword
         return self._max_concurrent_semantic
 
     def _queue_worker_loop(
@@ -375,6 +416,15 @@ class QueueManager:
                 )
             elif name == self.SEMANTIC:
                 self._queues[name] = SemanticQueue(
+                    self._agfs,
+                    self.mount_point,
+                    name,
+                    enqueue_hook=enqueue_hook,
+                    dequeue_handler=dequeue_handler,
+                    task_work_index=self._task_work_index,
+                )
+            elif name == self.KEYWORD:
+                self._queues[name] = KeywordQueue(
                     self._agfs,
                     self.mount_point,
                     name,

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -424,6 +424,8 @@ class QueueManager:
                     task_work_index=self._task_work_index,
                 )
             elif name == self.KEYWORD:
+                from openviking.storage.keywordfs.keyword_queue import KeywordQueue
+
                 self._queues[name] = KeywordQueue(
                     self._agfs,
                     self.mount_point,

--- a/openviking/storage/viking_fs/__init__.py
+++ b/openviking/storage/viking_fs/__init__.py
@@ -78,6 +78,7 @@ from openviking.storage.viking_fs._base import (
     logger,
 )
 from openviking.storage.viking_fs._grep import _GrepMixin
+from openviking.storage.viking_fs._keyword import _KeywordMixin
 from openviking.storage.viking_fs._ops import _OpsMixin
 from openviking.storage.viking_fs._semantic import _SemanticMixin
 from openviking.storage.viking_fs._snapshot import _SnapshotMixin
@@ -100,8 +101,14 @@ from openviking_cli.utils.uri import VikingURI
 
 if TYPE_CHECKING:
     from openviking.storage.acl import AclManager
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
     from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
-    from openviking_cli.utils.config import GrepConfig, RerankConfig, RetrievalConfig
+    from openviking_cli.utils.config import (
+        GrepConfig,
+        KeywordConfig,
+        RerankConfig,
+        RetrievalConfig,
+    )
 
 
 # ========== VikingFS Main Class ==========
@@ -112,6 +119,7 @@ class VikingFS(
     _OpsMixin,
     _SyncMixin,
     _GrepMixin,
+    _KeywordMixin,
     _SemanticMixin,
     _SnapshotMixin,
     _VectorMixin,
@@ -134,6 +142,8 @@ class VikingFS(
         acl_manager: Optional["AclManager"] = None,
         retrieval_config: Optional["RetrievalConfig"] = None,
         grep_config: Optional["GrepConfig"] = None,
+        keyword_config: Optional["KeywordConfig"] = None,
+        keyword_fs: Optional["KeywordFS"] = None,
         timeout: int = 10,
         encryptor: Optional[Any] = None,
     ):
@@ -145,6 +155,8 @@ class VikingFS(
         self.acl_manager = acl_manager
         self.retrieval_config = retrieval_config
         self.grep_config = grep_config
+        self.keyword_config = keyword_config
+        self._keyword_fs = keyword_fs
         self._encryptor = encryptor
         self._count_cache: Dict[str, tuple] = {}  # cache_key → (count, timestamp)
         self._count_cache_max_size = 1024

--- a/openviking/storage/viking_fs/_base.py
+++ b/openviking/storage/viking_fs/_base.py
@@ -13,8 +13,8 @@ from openviking_cli.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from openviking.storage.acl import AclManager
-    from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
     from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
     from openviking_cli.utils.config import (
         GrepConfig,
         KeywordConfig,

--- a/openviking/storage/viking_fs/_base.py
+++ b/openviking/storage/viking_fs/_base.py
@@ -14,7 +14,13 @@ from openviking_cli.utils.logger import get_logger
 if TYPE_CHECKING:
     from openviking.storage.acl import AclManager
     from openviking.storage.viking_vector_index_backend import VikingVectorIndexBackend
-    from openviking_cli.utils.config import GrepConfig, RerankConfig, RetrievalConfig
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config import (
+        GrepConfig,
+        KeywordConfig,
+        RerankConfig,
+        RetrievalConfig,
+    )
 
 logger = get_logger(__name__)
 
@@ -200,6 +206,8 @@ def init_viking_fs(
     acl_manager: Optional["AclManager"] = None,
     retrieval_config: Optional["RetrievalConfig"] = None,
     grep_config: Optional["GrepConfig"] = None,
+    keyword_config: Optional["KeywordConfig"] = None,
+    keyword_fs: Optional["KeywordFS"] = None,
     timeout: int = 10,
     enable_recorder: bool = False,
     encryptor: Optional[Any] = None,
@@ -215,6 +223,8 @@ def init_viking_fs(
         vector_store: Vector store instance
         enable_recorder: Whether to enable IO recording
         encryptor: FileEncryptor instance for encryption/decryption
+        keyword_config: Local keyword sidecar configuration
+        keyword_fs: Local keyword sidecar instance
     """
     from openviking.storage.viking_fs import VikingFS
 
@@ -228,6 +238,8 @@ def init_viking_fs(
         acl_manager=acl_manager,
         retrieval_config=retrieval_config,
         grep_config=grep_config,
+        keyword_config=keyword_config,
+        keyword_fs=keyword_fs,
         encryptor=encryptor,
     )
 

--- a/openviking/storage/viking_fs/_grep.py
+++ b/openviking/storage/viking_fs/_grep.py
@@ -115,7 +115,7 @@ class _GrepMixin:
                 content_transform=content_transform,
                 allowed_uris=allowed_uris,
             )
-        else:  # "vikingdb_then_fs"
+        elif resolved_engine == "vikingdb_then_fs":
             result = await self._grep_vikingdb_then_fs(
                 uri=uri,
                 pattern=pattern,
@@ -128,46 +128,65 @@ class _GrepMixin:
                 tag_filter=tag_filter,
                 include_tags=include_tags,
             )
+        else:
+            # "local_then_fs"
+            result = await self._grep_local_then_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+            )
         return self._attach_grep_tags(result, tags_by_uri)
 
     async def _resolve_grep_engine(
         self, engine: GrepEngine, uri: str, ctx, switch_to_remote_threshold: int = 10000
     ) -> str:
-        """Resolve the actual grep engine to use."""
+        """Resolve the actual grep engine to use.
+
+        Resolution order for ``engine="auto"``:
+        1. remote VikingDB BM25 when the backend stores the ``content`` field and
+           the record count is at/above ``switch_to_remote_threshold``;
+        2. the local FTS5 keyword sidecar when enabled and ready;
+        3. filesystem scan.
+        """
         if engine == "fs":
             return "fs"
 
-        # auto mode: check vikingdb availability
         vector_store = self._get_vector_store()
-        if not vector_store:
-            return "fs"
+        remote_available = False
+        if vector_store is not None:
+            backend_type = getattr(vector_store, "_backend_type", "unknown")
+            # Keep this set consistent with ``CollectionAdapter.USE_CONTENT_FIELD``:
+            # only these backends store the ``content`` field required for full-text grep.
+            if backend_type in ("volcengine", "vikingdb"):
+                remote_available = await self._collection_has_fulltext(vector_store, ctx)
 
-        backend_type = getattr(vector_store, "_backend_type", "unknown")
-        # Keep this set consistent with ``CollectionAdapter.USE_CONTENT_FIELD``:
-        # only these backends store the ``content`` field required for full-text grep.
-        if backend_type not in ("volcengine", "vikingdb"):
-            return "fs"
+        if engine == "vikingdb":
+            if remote_available:
+                return "vikingdb_then_fs"
+            return "local_then_fs" if self._keyword_available(ctx) else "fs"
 
-        # Check collection has content field and FullText config
-        if not await self._collection_has_fulltext(vector_store, ctx):
-            return "fs"
+        if engine == "local":
+            return "local_then_fs" if self._keyword_available(ctx) else "fs"
 
-        # switch_to_remote_threshold=0 means always use vikingdb
-        if switch_to_remote_threshold == 0:
-            return "vikingdb_then_fs"
-
-        # Check data volume threshold
-        try:
-            count = await self._get_cached_count(uri, ctx)
-            if count < switch_to_remote_threshold:
-                return "fs"
-        except Exception:
-            logger.debug(
-                "grep engine=auto: count() check failed, falling back to fs", exc_info=True
-            )
-            return "fs"
-
-        return "vikingdb_then_fs"
+        # engine == "auto"
+        if remote_available:
+            # switch_to_remote_threshold=0 means always use vikingdb
+            if switch_to_remote_threshold == 0:
+                return "vikingdb_then_fs"
+            try:
+                count = await self._get_cached_count(uri, ctx)
+                if count >= switch_to_remote_threshold:
+                    return "vikingdb_then_fs"
+            except Exception:
+                logger.debug(
+                    "grep engine=auto: count() check failed, checking local keyword",
+                    exc_info=True,
+                )
+        return "local_then_fs" if self._keyword_available(ctx) else "fs"
 
     async def _collection_has_fulltext(self, vector_store, ctx) -> bool:
         """Check if collection has content field and FullText config.
@@ -412,6 +431,82 @@ class _GrepMixin:
             for match in result.get("matches", [])
         ]
         return result
+
+    async def _grep_local_then_fs(
+        self,
+        uri: str,
+        pattern: str,
+        exclude_uri: Optional[str],
+        case_insensitive: bool,
+        node_limit: Optional[int],
+        level_limit: int,
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict:
+        """Local FTS5 keyword recall + local fs precise matching.
+
+        Mirrors ``_grep_vikingdb_then_fs`` but recalls candidate URIs from the
+        local SQLite FTS5 sidecar instead of a remote VikingDB BM25 index. The
+        final regex match always runs against the on-disk content
+        (``_grep_in_files``), so the sidecar only accelerates recall.
+        """
+        kfs = self._get_keyword_fs()
+        if kfs is None or not self._keyword_available(ctx):
+            return await self._grep_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+            )
+
+        real_ctx = self._ctx_or_default(ctx)
+        query = " ".join(kw.strip() for kw in pattern.split("|") if kw.strip())
+        if not query.strip():
+            return await self._grep_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+            )
+
+        remote_return_limit = min(node_limit * 5, 100000) if node_limit else 100000
+        try:
+            candidates = kfs.lookup(
+                account_id=real_ctx.account_id,
+                query=query,
+                scope_uri=uri,
+                exclude_uri=exclude_uri.rstrip("/") if exclude_uri else "",
+                limit=remote_return_limit,
+            )
+        except Exception as e:
+            logger.warning(f"grep local keyword recall failed, falling back to fs: {e}")
+            return await self._grep_fs(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+            )
+
+        candidate_uris = [u for u, _score in candidates]
+        if not candidate_uris:
+            # The keyword index confirms no matching content.
+            return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+        return await self._grep_in_files(
+            candidate_uris,
+            pattern,
+            case_insensitive,
+            node_limit,
+            ctx,
+        )
 
     async def _grep_in_files(
         self,

--- a/openviking/storage/viking_fs/_grep.py
+++ b/openviking/storage/viking_fs/_grep.py
@@ -79,7 +79,7 @@ class _GrepMixin:
             else await self._resolve_grep_engine(engine, uri, ctx, switch_to_remote_threshold)
         )
         tags_by_uri: Dict[str, List[str]] = {}
-        if tag_filter is not None and resolved_engine == "fs":
+        if tag_filter is not None:
             vector_store = self._get_vector_store()
             if vector_store is None:
                 return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
@@ -138,6 +138,9 @@ class _GrepMixin:
                 node_limit=node_limit,
                 level_limit=level_limit,
                 ctx=ctx,
+                allowed_uris=allowed_uris,
+                tag_filter=tag_filter,
+                include_tags=include_tags,
             )
         return self._attach_grep_tags(result, tags_by_uri)
 
@@ -165,14 +168,15 @@ class _GrepMixin:
                 remote_available = await self._collection_has_fulltext(vector_store, ctx)
 
         if engine == "vikingdb":
-            if remote_available:
-                return "vikingdb_then_fs"
-            return "local_then_fs" if self._keyword_available(ctx) else "fs"
+            return "vikingdb_then_fs" if remote_available else "fs"
 
         if engine == "local":
             return "local_then_fs" if self._keyword_available(ctx) else "fs"
 
-        # engine == "auto"
+        # engine == "auto": remote BM25 when the collection has a usable full-text
+        # index and enough data; otherwise the filesystem scan. The local sidecar is
+        # deliberately excluded: its coverage mirrors vector coverage, so selecting
+        # it here could silently lose recall (design D1).
         if remote_available:
             # switch_to_remote_threshold=0 means always use vikingdb
             if switch_to_remote_threshold == 0:
@@ -183,10 +187,10 @@ class _GrepMixin:
                     return "vikingdb_then_fs"
             except Exception:
                 logger.debug(
-                    "grep engine=auto: count() check failed, checking local keyword",
+                    "grep engine=auto: count() check failed, falling back to fs",
                     exc_info=True,
                 )
-        return "local_then_fs" if self._keyword_available(ctx) else "fs"
+        return "fs"
 
     async def _collection_has_fulltext(self, vector_store, ctx) -> bool:
         """Check if collection has content field and FullText config.
@@ -441,17 +445,26 @@ class _GrepMixin:
         node_limit: Optional[int],
         level_limit: int,
         ctx: Optional[RequestContext] = None,
+        allowed_uris: Optional[Set[str]] = None,
+        tag_filter: Optional[Dict[str, Any]] = None,
+        include_tags: bool = False,
     ) -> Dict:
         """Local FTS5 keyword recall + local fs precise matching.
 
         Mirrors ``_grep_vikingdb_then_fs`` but recalls candidate URIs from the
         local SQLite FTS5 sidecar instead of a remote VikingDB BM25 index. The
         final regex match always runs against the on-disk content
-        (``_grep_in_files``), so the sidecar only accelerates recall.
+        (``_grep_in_files``), so the sidecar only accelerates recall. The same
+        tag/ACL scope and depth limits that constrain the other engines are
+        applied to the recalled candidates.
+
+        ``tag_filter``/``include_tags`` are accepted for call-site symmetry with
+        ``_grep_vikingdb_then_fs``; the tag scope itself reaches this method as
+        the caller-computed ``allowed_uris`` set.
         """
         kfs = self._get_keyword_fs()
         if kfs is None or not self._keyword_available(ctx):
-            return await self._grep_fs(
+            return await self._local_fs_fallback(
                 uri=uri,
                 pattern=pattern,
                 exclude_uri=exclude_uri,
@@ -459,12 +472,13 @@ class _GrepMixin:
                 node_limit=node_limit,
                 level_limit=level_limit,
                 ctx=ctx,
+                allowed_uris=allowed_uris,
             )
 
         real_ctx = self._ctx_or_default(ctx)
         query = " ".join(kw.strip() for kw in pattern.split("|") if kw.strip())
         if not query.strip():
-            return await self._grep_fs(
+            return await self._local_fs_fallback(
                 uri=uri,
                 pattern=pattern,
                 exclude_uri=exclude_uri,
@@ -472,6 +486,7 @@ class _GrepMixin:
                 node_limit=node_limit,
                 level_limit=level_limit,
                 ctx=ctx,
+                allowed_uris=allowed_uris,
             )
 
         remote_return_limit = min(node_limit * 5, 100000) if node_limit else 100000
@@ -485,7 +500,7 @@ class _GrepMixin:
             )
         except Exception as e:
             logger.warning(f"grep local keyword recall failed, falling back to fs: {e}")
-            return await self._grep_fs(
+            return await self._local_fs_fallback(
                 uri=uri,
                 pattern=pattern,
                 exclude_uri=exclude_uri,
@@ -493,12 +508,33 @@ class _GrepMixin:
                 node_limit=node_limit,
                 level_limit=level_limit,
                 ctx=ctx,
+                allowed_uris=allowed_uris,
             )
 
         candidate_uris = [u for u, _score in candidates]
+        if allowed_uris is not None:
+            candidate_uris = [u for u in candidate_uris if u in allowed_uris]
+        if level_limit is not None:
+            base_depth = self._uri_depth(uri)
+            candidate_uris = [
+                u for u in candidate_uris if self._uri_depth(u) - base_depth <= level_limit
+            ]
         if not candidate_uris:
-            # The keyword index confirms no matching content.
-            return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+            # A partial or not-yet-built sidecar must not turn a miss into a final
+            # "no results": fall back to the authoritative filesystem scan.
+            logger.debug(
+                "grep local keyword recall empty; falling back to filesystem scan for %s", uri
+            )
+            return await self._local_fs_fallback(
+                uri=uri,
+                pattern=pattern,
+                exclude_uri=exclude_uri,
+                case_insensitive=case_insensitive,
+                node_limit=node_limit,
+                level_limit=level_limit,
+                ctx=ctx,
+                allowed_uris=allowed_uris,
+            )
 
         return await self._grep_in_files(
             candidate_uris,
@@ -506,6 +542,35 @@ class _GrepMixin:
             case_insensitive,
             node_limit,
             ctx,
+        )
+
+    @staticmethod
+    def _uri_depth(uri: str) -> int:
+        """Number of non-empty path segments in a Viking URI."""
+        return len([seg for seg in uri.strip("/").split("/") if seg])
+
+    async def _local_fs_fallback(
+        self,
+        *,
+        uri: str,
+        pattern: str,
+        exclude_uri: Optional[str],
+        case_insensitive: bool,
+        node_limit: Optional[int],
+        level_limit: int,
+        ctx: Optional[RequestContext],
+        allowed_uris: Optional[Set[str]],
+    ) -> Dict:
+        """Delegate to the filesystem engine with the caller's ACL scope intact."""
+        return await self._grep_fs(
+            uri=uri,
+            pattern=pattern,
+            exclude_uri=exclude_uri,
+            case_insensitive=case_insensitive,
+            node_limit=node_limit,
+            level_limit=level_limit,
+            ctx=ctx,
+            allowed_uris=allowed_uris,
         )
 
     async def _grep_in_files(

--- a/openviking/storage/viking_fs/_keyword.py
+++ b/openviking/storage/viking_fs/_keyword.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Local keyword sidecar integration mixin for VikingFS."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from openviking.server.identity import RequestContext
+from openviking.storage.viking_fs._base import logger
+
+if TYPE_CHECKING:
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+
+class _KeywordMixin:
+    """Keyword sidecar wiring shared by grep, semantic search, and storage ops."""
+
+    def _get_keyword_fs(self) -> Optional["KeywordFS"]:
+        """Get the keyword sidecar instance (may be None when disabled)."""
+        return self._keyword_fs
+
+    def set_keyword_fs(self, keyword_fs: Optional["KeywordFS"]) -> None:
+        """Attach the keyword sidecar (for deferred initialization)."""
+        self._keyword_fs = keyword_fs
+
+    def _keyword_indexing_wired(self) -> bool:
+        """True when the keyword sidecar should receive mutations."""
+        if not self.keyword_config or not self.keyword_config.enabled:
+            return False
+        if self.keyword_config.respect_encryption and self._encryptor is not None:
+            return False
+        return self._get_keyword_fs() is not None
+
+    def _keyword_available(self, ctx: Optional[RequestContext] = None) -> bool:
+        """True when the local keyword sidecar is enabled, safe and ready."""
+        if not self.keyword_config or not self.keyword_config.enabled:
+            return False
+        if self.keyword_config.respect_encryption and self._encryptor is not None:
+            return False
+        kfs = self._get_keyword_fs()
+        if kfs is None:
+            return False
+        real_ctx = self._ctx_or_default(ctx)
+        try:
+            return kfs.is_ready(real_ctx.account_id)
+        except Exception:
+            return False
+
+    async def _enqueue_keyword_delete(self, uris: List[str], ctx) -> None:
+        """Best-effort enqueue of keyword delete messages (fire-and-forget)."""
+        if not self._keyword_indexing_wired() or not uris:
+            return
+        try:
+            from openviking.storage.keywordfs.keyword_msg import Delete, KeywordMsg
+            from openviking.storage.queuefs.queue_manager import get_queue_manager
+
+            qm = get_queue_manager()
+            queue = qm.get_queue(qm.KEYWORD)
+            real_ctx = self._ctx_or_default(ctx)
+            for u in uris:
+                await queue.enqueue(
+                    KeywordMsg(kind=Delete, uri=u, account_id=real_ctx.account_id)
+                )
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to enqueue keyword deletes: {e}")
+
+    async def _enqueue_keyword_move(
+        self, uris: List[str], old_base: str, new_base: str, ctx
+    ) -> None:
+        """Best-effort enqueue of keyword move messages (fire-and-forget)."""
+        if not self._keyword_indexing_wired() or not uris:
+            return
+        try:
+            from openviking.storage.keywordfs.keyword_msg import KeywordMsg, Move
+            from openviking.storage.queuefs.queue_manager import get_queue_manager
+
+            qm = get_queue_manager()
+            queue = qm.get_queue(qm.KEYWORD)
+            real_ctx = self._ctx_or_default(ctx)
+            for u in uris:
+                new_uri = new_base + u[len(old_base) :]
+                await queue.enqueue(
+                    KeywordMsg(
+                        kind=Move,
+                        old_uri=u,
+                        new_uri=new_uri,
+                        account_id=real_ctx.account_id,
+                    )
+                )
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to enqueue keyword moves: {e}")
+
+    async def _maybe_hybrid_keyword(
+        self,
+        query: str,
+        matched: List[Any],
+        target_directories: List[str],
+        ctx: RequestContext,
+        limit: int,
+        override: Optional[bool] = None,
+    ) -> List[Any]:
+        """Fuse keyword-sidecar recall into dense results when hybrid is enabled."""
+        hybrid_cfg = (
+            getattr(self.retrieval_config, "hybrid", None) if self.retrieval_config else None
+        )
+        enabled = (
+            override
+            if override is not None
+            else bool(hybrid_cfg and getattr(hybrid_cfg, "enabled", False))
+        )
+        if not enabled:
+            return matched
+        kfs = self._get_keyword_fs()
+        if kfs is None or not self._keyword_indexing_wired():
+            return matched
+        try:
+            from openviking.retrieve.hybrid_keyword import HybridKeywordRecaller
+
+            recaller = HybridKeywordRecaller(kfs, hybrid_cfg, self.keyword_config)
+            if not recaller.enabled(ctx):
+                return matched
+            return await recaller.enhance(
+                query=query,
+                dense=matched,
+                scope_uris=target_directories or [""],
+                ctx=ctx,
+                limit=limit,
+                read_abstract=lambda uri: self.abstract(uri, ctx=ctx),
+            )
+        except Exception:
+            logger.exception("[VikingFS] hybrid keyword fusion failed; using dense results")
+            return matched
+
+    def _schedule_keyword_rebuild(
+        self,
+        *,
+        written: List[str],
+        deleted: List[str],
+        ctx: RequestContext,
+    ) -> None:
+        """Fire-and-forget keyword-sidecar cleanup for a git restore."""
+        if not self._keyword_indexing_wired():
+            return
+        affected = list(dict.fromkeys([*written, *deleted]))
+        if not affected:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning(
+                "[VikingFS] git restore keyword rebuild skipped: no running event loop"
+            )
+            return
+
+        loop.create_task(
+            self._run_keyword_restore_cleanup(affected, ctx),
+            name=f"vikingfs-git-keyword:{ctx.account_id}",
+        )
+
+    async def _run_keyword_restore_cleanup(self, uris: List[str], ctx: RequestContext) -> None:
+        """Enqueue keyword delete_prefix messages for the restored paths."""
+        if not self._keyword_indexing_wired() or not uris:
+            return
+        try:
+            from openviking.storage.keywordfs.keyword_msg import DeletePrefix, KeywordMsg
+            from openviking.storage.queuefs.queue_manager import get_queue_manager
+
+            qm = get_queue_manager()
+            queue = qm.get_queue(qm.KEYWORD)
+            real_ctx = self._ctx_or_default(ctx)
+            for u in uris:
+                await queue.enqueue(
+                    KeywordMsg(kind=DeletePrefix, uri=u, account_id=real_ctx.account_id)
+                )
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to enqueue keyword restore cleanup: {e}")

--- a/openviking/storage/viking_fs/_keyword.py
+++ b/openviking/storage/viking_fs/_keyword.py
@@ -12,7 +12,6 @@ from openviking.storage.viking_fs._base import logger
 
 if TYPE_CHECKING:
     from openviking.storage.keywordfs.keyword_fs import KeywordFS
-    from openviking_cli.utils.config.keyword_config import KeywordConfig
 
 
 class _KeywordMixin:
@@ -20,7 +19,7 @@ class _KeywordMixin:
 
     def _get_keyword_fs(self) -> Optional["KeywordFS"]:
         """Get the keyword sidecar instance (may be None when disabled)."""
-        return self._keyword_fs
+        return getattr(self, "_keyword_fs", None)
 
     def set_keyword_fs(self, keyword_fs: Optional["KeywordFS"]) -> None:
         """Attach the keyword sidecar (for deferred initialization)."""
@@ -28,18 +27,24 @@ class _KeywordMixin:
 
     def _keyword_indexing_wired(self) -> bool:
         """True when the keyword sidecar should receive mutations."""
-        if not self.keyword_config or not self.keyword_config.enabled:
+        config = getattr(self, "keyword_config", None)
+        if not config or not config.enabled:
             return False
-        if self.keyword_config.respect_encryption and self._encryptor is not None:
+        if config.respect_encryption and getattr(self, "_encryptor", None) is not None:
             return False
         return self._get_keyword_fs() is not None
 
     def _keyword_available(self, ctx: Optional[RequestContext] = None) -> bool:
         """True when the local keyword sidecar is enabled, safe and ready."""
-        if not self.keyword_config or not self.keyword_config.enabled:
+        config = getattr(self, "keyword_config", None)
+        if not config or not config.enabled:
             return False
-        if self.keyword_config.respect_encryption and self._encryptor is not None:
+        if config.respect_encryption and getattr(self, "_encryptor", None) is not None:
             return False
+        return self._keyword_ready(ctx)
+
+    def _keyword_ready(self, ctx: Optional[RequestContext] = None) -> bool:
+        """Sidecar present and ready, ignoring the keyword.enabled switch."""
         kfs = self._get_keyword_fs()
         if kfs is None:
             return False
@@ -93,6 +98,31 @@ class _KeywordMixin:
         except Exception as e:
             logger.warning(f"[VikingFS] Failed to enqueue keyword moves: {e}")
 
+    async def _enqueue_keyword_copy(
+        self, uris: List[str], old_base: str, new_base: str, ctx
+    ) -> None:
+        """Best-effort enqueue of keyword copy messages (fire-and-forget)."""
+        if not self._keyword_indexing_wired() or not uris:
+            return
+        try:
+            from openviking.storage.keywordfs.keyword_msg import Copy, KeywordMsg
+            from openviking.storage.queuefs.queue_manager import get_queue_manager
+
+            qm = get_queue_manager()
+            queue = qm.get_queue(qm.KEYWORD)
+            real_ctx = self._ctx_or_default(ctx)
+            for u in uris:
+                await queue.enqueue(
+                    KeywordMsg(
+                        kind=Copy,
+                        old_uri=u,
+                        new_uri=new_base + u[len(old_base) :],
+                        account_id=real_ctx.account_id,
+                    )
+                )
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to enqueue keyword copies: {e}")
+
     async def _maybe_hybrid_keyword(
         self,
         query: str,
@@ -103,25 +133,23 @@ class _KeywordMixin:
         override: Optional[bool] = None,
     ) -> List[Any]:
         """Fuse keyword-sidecar recall into dense results when hybrid is enabled."""
-        hybrid_cfg = (
-            getattr(self.retrieval_config, "hybrid", None) if self.retrieval_config else None
-        )
-        enabled = (
-            override
-            if override is not None
-            else bool(hybrid_cfg and getattr(hybrid_cfg, "enabled", False))
-        )
-        if not enabled:
+        if override is False:
             return matched
-        kfs = self._get_keyword_fs()
-        if kfs is None or not self._keyword_indexing_wired():
+        hybrid_cfg = getattr(getattr(self, "retrieval_config", None), "hybrid", None)
+        if override is None and not getattr(hybrid_cfg, "enabled", False):
             return matched
+        if not self._keyword_ready(ctx):
+            return matched
+        if hybrid_cfg is None:
+            from openviking_cli.utils.config.keyword_config import HybridRetrievalConfig
+
+            hybrid_cfg = HybridRetrievalConfig()
         try:
             from openviking.retrieve.hybrid_keyword import HybridKeywordRecaller
 
-            recaller = HybridKeywordRecaller(kfs, hybrid_cfg, self.keyword_config)
-            if not recaller.enabled(ctx):
-                return matched
+            recaller = HybridKeywordRecaller(
+                self._get_keyword_fs(), hybrid_cfg, getattr(self, "keyword_config", None)
+            )
             return await recaller.enhance(
                 query=query,
                 dense=matched,

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -194,6 +194,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        hybrid: Optional[bool] = None,
     ):
         """Semantic search.
 
@@ -288,15 +289,24 @@ class _SemanticMixin:
             level=level,
         )
 
+        matched_contexts = await self._maybe_hybrid_keyword(
+            query,
+            result.matched_contexts,
+            retrieval_targets.target_directories,
+            real_ctx,
+            limit,
+            override=hybrid,
+        )
+
         # Convert QueryResult to FindResult
         memories, resources, skills = [], [], []
-        for ctx in result.matched_contexts:
-            if ctx.context_type == ContextType.MEMORY:
-                memories.append(ctx)
-            elif ctx.context_type == ContextType.RESOURCE:
-                resources.append(ctx)
-            elif ctx.context_type == ContextType.SKILL:
-                skills.append(ctx)
+        for mc in matched_contexts:
+            if mc.context_type == ContextType.MEMORY:
+                memories.append(mc)
+            elif mc.context_type == ContextType.RESOURCE:
+                resources.append(mc)
+            elif mc.context_type == ContextType.SKILL:
+                skills.append(mc)
 
         find_result = FindResult(
             memories=memories,
@@ -377,6 +387,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        hybrid: Optional[bool] = None,
     ):
         """Complex search with session context.
 
@@ -494,14 +505,25 @@ class _SemanticMixin:
 
         # Aggregate results to FindResult
         memories, resources, skills = [], [], []
+        flat = []
         for result in query_results:
-            for ctx in result.matched_contexts:
-                if ctx.context_type == ContextType.MEMORY:
-                    memories.append(ctx)
-                elif ctx.context_type == ContextType.RESOURCE:
-                    resources.append(ctx)
-                elif ctx.context_type == ContextType.SKILL:
-                    skills.append(ctx)
+            flat.extend(result.matched_contexts)
+        if flat:
+            flat = await self._maybe_hybrid_keyword(
+                query,
+                flat,
+                retrieval_targets.target_directories,
+                real_ctx,
+                limit,
+                override=hybrid,
+            )
+        for mc in flat:
+            if mc.context_type == ContextType.MEMORY:
+                memories.append(mc)
+            elif mc.context_type == ContextType.RESOURCE:
+                resources.append(mc)
+            elif mc.context_type == ContextType.SKILL:
+                skills.append(mc)
 
         find_result = FindResult(
             memories=memories,

--- a/openviking/storage/viking_fs/_snapshot.py
+++ b/openviking/storage/viking_fs/_snapshot.py
@@ -792,6 +792,7 @@ class _SnapshotMixin:
 
         tasks = self._collect_restore_vector_tasks(written, deleted)
         if not tasks:
+            self._schedule_keyword_rebuild(written=written, deleted=deleted, ctx=ctx)
             return
 
         executor = get_reindex_executor()
@@ -800,6 +801,11 @@ class _SnapshotMixin:
                 self._run_vector_rebuild(executor, op, uri, level, ctx),
                 name=f"vikingfs-git-{op}:{uri}:{int(level)}",
             )
+
+        # Keep the keyword sidecar consistent with the restored tree: drop any
+        # pre-restore rows under the affected paths; the reindex above re-emits
+        # embedding messages that co-enqueue fresh keyword upserts afterwards.
+        self._schedule_keyword_rebuild(written=written, deleted=deleted, ctx=ctx)
 
     async def _run_restore_rebuild_tracked(
         self,

--- a/openviking/storage/viking_fs/_vector.py
+++ b/openviking/storage/viking_fs/_vector.py
@@ -50,7 +50,7 @@ class _VectorMixin:
         vector_store = self._get_vector_store()
         if not vector_store:
             return None
-        return await vector_store.copy_uri_mapping(
+        result = await vector_store.copy_uri_mapping(
             ctx=self._ctx_or_default(ctx),
             source_uri=old_base,
             target_uri=new_base,
@@ -58,6 +58,14 @@ class _VectorMixin:
             target_entry_exists=partial(self.exists, ctx=ctx),  # type: ignore[attr-defined]
             **({"source_uris": source_uris} if source_uris is not None else {}),
         )
+        # Keep the keyword sidecar in sync with the copied scope.
+        await self._enqueue_keyword_copy(
+            list(source_uris) if source_uris is not None else [old_base],
+            old_base,
+            new_base,
+            ctx,
+        )
+        return result
 
     async def _update_vector_store_uris(
         self,

--- a/openviking/storage/viking_fs/_vector.py
+++ b/openviking/storage/viking_fs/_vector.py
@@ -35,6 +35,8 @@ class _VectorMixin:
             logger.warning(f"[VikingFS] Failed to delete from vector store: {e}")
             raise
 
+        await self._enqueue_keyword_delete(uris, ctx)
+
     async def _copy_vector_store_uris(
         self,
         old_base: str,
@@ -73,7 +75,7 @@ class _VectorMixin:
         vector_store = self._get_vector_store()
         if not vector_store:
             return None
-        return await vector_store.update_uri_mapping(
+        result = await vector_store.update_uri_mapping(
             ctx=self._ctx_or_default(ctx),
             source_uri=old_base,
             target_uri=new_base,
@@ -81,6 +83,15 @@ class _VectorMixin:
             target_entry_exists=partial(self.exists, ctx=ctx),  # type: ignore[attr-defined]
             **({"source_uris": source_uris} if source_uris is not None else {}),
         )
+
+        # Keep the keyword sidecar in sync with the moved scope.
+        await self._enqueue_keyword_move(
+            list(source_uris) if source_uris is not None else [old_base],
+            old_base,
+            new_base,
+            ctx,
+        )
+        return result
 
     def _get_vector_store(self) -> Optional["VikingVectorIndexBackend"]:
         """Get vector store instance."""

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -126,6 +126,42 @@ async def _enqueue_embedding_message(
     return True
 
 
+def _keyword_indexing_enabled(viking_fs: Any) -> bool:
+    """Whether keyword indexing should be enqueued for this deployment.
+
+    Matches the effective enablement used when wiring the keyword pipeline:
+    the config switch must be on, at-rest encryption must not disable it, and
+    the keyword sidecar must actually be wired into VikingFS.
+    """
+    config = get_openviking_config()
+    if not config.keyword.enabled:
+        return False
+    if config.keyword.respect_encryption and getattr(viking_fs, "_encryptor", None) is not None:
+        return False
+    getter = getattr(viking_fs, "_get_keyword_fs", None)
+    return bool(getter is not None and getter() is not None)
+
+
+async def _enqueue_keyword_message(
+    keyword_queue,
+    embedding_msg,
+    *,
+    failure_message: str,
+) -> bool:
+    """Persist one keyword message derived from an embedding message."""
+    from openviking.storage.keywordfs.keyword_msg import KeywordMsg
+
+    try:
+        keyword_msg = KeywordMsg.from_embedding(embedding_msg)
+        if keyword_msg is None:
+            return False
+        enqueue_id = await keyword_queue.enqueue(keyword_msg)
+        return bool(enqueue_id)
+    except Exception as exc:
+        logger.warning(f"{failure_message}: {exc}")
+        return False
+
+
 def _coerce_datetime(value: object) -> Optional[datetime]:
     if isinstance(value, datetime):
         return value
@@ -637,6 +673,20 @@ async def vectorize_file(
         if not enqueued:
             return False
         logger.debug(f"Enqueued file for vectorization: {file_path}")
+
+        # Co-enqueue a keyword-sidecar upsert for the same content so the local
+        # FTS5 index stays in sync with vector coverage (best-effort).
+        if _keyword_indexing_enabled(viking_fs):
+            try:
+                keyword_queue = queue_manager.get_queue(queue_manager.KEYWORD)
+            except Exception:
+                keyword_queue = None
+            if keyword_queue is not None:
+                await _enqueue_keyword_message(
+                    keyword_queue,
+                    embedding_msg,
+                    failure_message=f"Failed to enqueue keyword for {file_path}",
+                )
 
     except TaskWorkRejected:
         logger.debug("Skipped file vectorization for cancelling task: %s", file_path)

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -134,9 +134,10 @@ def _keyword_indexing_enabled(viking_fs: Any) -> bool:
     the keyword sidecar must actually be wired into VikingFS.
     """
     config = get_openviking_config()
-    if not config.keyword.enabled:
+    keyword_config = getattr(config, "keyword", None)
+    if keyword_config is None or not keyword_config.enabled:
         return False
-    if config.keyword.respect_encryption and getattr(viking_fs, "_encryptor", None) is not None:
+    if keyword_config.respect_encryption and getattr(viking_fs, "_encryptor", None) is not None:
         return False
     getter = getattr(viking_fs, "_get_keyword_fs", None)
     return bool(getter is not None and getter() is not None)

--- a/openviking_cli/utils/config/__init__.py
+++ b/openviking_cli/utils/config/__init__.py
@@ -54,6 +54,7 @@ from .consts import (
 from .embedding_config import EmbeddingConfig
 from .git_config import GitConfig, GitLocalConfig, GitS3Config
 from .grep_config import GrepConfig, GrepEngine
+from .keyword_config import HybridRetrievalConfig, KeywordConfig
 from .log_config import LogConfig
 from .open_viking_config import (
     CompileApiConfig,

--- a/openviking_cli/utils/config/grep_config.py
+++ b/openviking_cli/utils/config/grep_config.py
@@ -5,8 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-# Grep engine mode type alias — import this instead of repeating Literal["auto", "fs"]
-GrepEngine = Literal["auto", "fs"]
+# Grep engine mode type alias — import this instead of repeating Literal["auto", "fs", "local", "vikingdb"]
+GrepEngine = Literal["auto", "fs", "local", "vikingdb"]
 
 
 class GrepConfig(BaseModel):
@@ -15,8 +15,11 @@ class GrepConfig(BaseModel):
     engine: GrepEngine = Field(
         default="auto",
         description=(
-            "Search engine mode: 'auto' uses vikingdb bm25 recall when available, "
-            "'fs' forces local filesystem search."
+            "Search engine mode: 'auto' uses remote VikingDB BM25 recall when "
+            "available, falls back to the local FTS5 keyword sidecar when enabled, "
+            "otherwise forces filesystem scan. 'fs' forces filesystem search; "
+            "'local' forces the local FTS5 keyword sidecar; 'vikingdb' forces the "
+            "remote VikingDB BM25 path."
         ),
     )
 

--- a/openviking_cli/utils/config/keyword_config.py
+++ b/openviking_cli/utils/config/keyword_config.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Configuration for the local keyword (SQLite FTS5) sidecar."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+TokenizerMode = Literal["auto", "char", "jieba"]
+ContentSource = Literal["content", "summary", "both"]
+CjkMode = Literal["char", "bigram"]
+
+
+class KeywordConfig(BaseModel):
+    """Configuration for the local SQLite FTS5 keyword sidecar."""
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch for the local keyword index. Off by default. "
+            "When enabled and the sidecar is ready, grep/find can use "
+            "search-time BM25 recall without a remote VikingDB full-text index."
+        ),
+    )
+    tokenizer: TokenizerMode = Field(
+        default="auto",
+        description=(
+            "CJK tokenizer mode: 'auto' uses jieba when installed and falls back "
+            "to character-level splitting; 'char' always splits CJK per character; "
+            "'jieba' requires the optional 'jieba' dependency."
+        ),
+    )
+    content_source: ContentSource = Field(
+        default="content",
+        description=(
+            "Text source indexed by the keyword sidecar: 'content' uses the same "
+            "source as embedding.text_source for leaves, 'summary' uses the L0/L1 "
+            "summaries, 'both' indexes content and summaries."
+        ),
+    )
+    max_doc_bytes: int = Field(
+        default=65536,
+        ge=1,
+        description="Skip documents whose indexed text exceeds this byte size.",
+    )
+    cjk_mode: CjkMode = Field(
+        default="char",
+        description=(
+            "CJK splitting granularity when a word tokenizer is not used: 'char' "
+            "indexes each Han character as a token (high recall), 'bigram' also "
+            "emits overlapping bigrams (higher precision for short queries)."
+        ),
+    )
+    respect_encryption: bool = Field(
+        default=True,
+        description=(
+            "When true, the keyword sidecar is disabled on deployments with "
+            "at-rest encryption enabled, because the sidecar stores plaintext text."
+        ),
+    )
+    db_dir: str = Field(
+        default="",
+        description=(
+            "Optional override for the sidecar directory. When empty, the sidecar "
+            "is placed under <storage.workspace>/_system/keyword/."
+        ),
+    )
+    max_candidates: int = Field(
+        default=100000,
+        ge=1,
+        description="Upper bound on FTS5 candidate rows recalled per query.",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class HybridRetrievalConfig(BaseModel):
+    """Configuration for fusing keyword recall into find/search."""
+
+    enabled: bool = Field(
+        default=False,
+        description="When true, find/search also recall keyword candidates and fuse them.",
+    )
+    fusion: Literal["rrf", "weighted"] = Field(
+        default="rrf",
+        description=(
+            "Score fusion strategy: 'rrf' uses Reciprocal Rank Fusion (robust, "
+            "no score calibration); 'weighted' blends normalized BM25 with the "
+            "dense score."
+        ),
+    )
+    rrf_k: float = Field(default=60.0, gt=0.0, description="RRF constant k.")
+    keyword_weight: float = Field(
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description="Keyword weight used by the 'weighted' fusion.",
+    )
+    min_token_query_len: int = Field(
+        default=2,
+        ge=1,
+        description="Skip keyword recall when the query yields fewer tokens than this.",
+    )
+
+    model_config = {"extra": "forbid"}

--- a/openviking_cli/utils/config/keyword_config.py
+++ b/openviking_cli/utils/config/keyword_config.py
@@ -9,7 +9,6 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 TokenizerMode = Literal["auto", "char", "jieba"]
-ContentSource = Literal["content", "summary", "both"]
 CjkMode = Literal["char", "bigram"]
 
 
@@ -30,14 +29,6 @@ class KeywordConfig(BaseModel):
             "CJK tokenizer mode: 'auto' uses jieba when installed and falls back "
             "to character-level splitting; 'char' always splits CJK per character; "
             "'jieba' requires the optional 'jieba' dependency."
-        ),
-    )
-    content_source: ContentSource = Field(
-        default="content",
-        description=(
-            "Text source indexed by the keyword sidecar: 'content' uses the same "
-            "source as embedding.text_source for leaves, 'summary' uses the L0/L1 "
-            "summaries, 'both' indexes content and summaries."
         ),
     )
     max_doc_bytes: int = Field(

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -25,6 +25,7 @@ from .encryption_config import EncryptionConfig
 from .git_config import GitConfig
 from .grep_config import GrepConfig
 from .ingest_config import IngestConfig
+from .keyword_config import KeywordConfig
 from .log_config import LogConfig
 from .memory_config import MemoryConfig
 from .oauth_config import OAuthConfig
@@ -202,6 +203,11 @@ class OpenVikingConfig(BaseModel):
     grep: GrepConfig = Field(
         default_factory=GrepConfig,
         description="Grep engine configuration",
+    )
+
+    keyword: KeywordConfig = Field(
+        default_factory=KeywordConfig,
+        description="Local SQLite FTS5 keyword sidecar configuration",
     )
 
     # Encryption configuration

--- a/openviking_cli/utils/config/retrieval_config.py
+++ b/openviking_cli/utils/config/retrieval_config.py
@@ -3,6 +3,8 @@
 
 from pydantic import BaseModel, Field
 
+from .keyword_config import HybridRetrievalConfig
+
 
 class RetrievalConfig(BaseModel):
     """Configuration for retrieval ranking behavior."""
@@ -44,6 +46,10 @@ class RetrievalConfig(BaseModel):
             "get_context_for_search, and IntentAnalyzer — searches with the raw query only "
             "(same path as no-session search)."
         ),
+    )
+    hybrid: HybridRetrievalConfig = Field(
+        default_factory=HybridRetrievalConfig,
+        description="Keyword/dense score fusion for find/search.",
     )
 
     model_config = {"extra": "forbid"}

--- a/tests/retrieve/test_hybrid_keyword.py
+++ b/tests/retrieve/test_hybrid_keyword.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for keyword/dense fusion in find/search."""
+
+import pytest
+
+from openviking.core.context import ContextType
+from openviking.retrieve.hybrid_keyword import HybridKeywordRecaller
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.keywordfs.keyword_fs import KeywordFS
+from openviking_cli.retrieve.types import MatchedContext
+from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.config.keyword_config import HybridRetrievalConfig, KeywordConfig
+
+ACCOUNT = "default"
+
+
+def _ctx():
+    return RequestContext(user=UserIdentifier(account_id=ACCOUNT, user_id="alice"), role=Role.ROOT)
+
+
+def _seed(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/proj/B.md", "openviking rollback runbook", level=2, context_type="resource")
+    kfs.upsert(ACCOUNT, "viking://resources/proj/C.md", "token version 2.4.1 rollback", level=2, context_type="resource")
+    kfs.upsert(ACCOUNT, "viking://resources/proj/D.md", "unrelated", level=2, context_type="resource")
+
+
+@pytest.fixture
+def kfs(tmp_path):
+    fs = KeywordFS(tmp_path, KeywordConfig(enabled=True, cjk_mode="char"))
+    _seed(fs)
+    return fs
+
+
+def _dense():
+    return [
+        MatchedContext(uri="viking://resources/proj/A.md", context_type=ContextType.RESOURCE, level=2, score=0.9),
+        MatchedContext(uri="viking://resources/proj/B.md", context_type=ContextType.RESOURCE, level=2, score=0.7),
+    ]
+
+
+async def _read_abstract(uri):
+    return f"abstract of {uri.rsplit('/', 1)[-1]}"
+
+
+@pytest.mark.asyncio
+async def test_rrf_includes_keyword_only_hit(kfs):
+    rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=True, fusion="rrf"), KeywordConfig(enabled=True))
+    assert rec.enabled(_ctx())
+    out = await rec.enhance("rollback 2.4.1", _dense(), ["viking://resources/proj"], _ctx(), limit=10, read_abstract=_read_abstract)
+    uris = [m.uri for m in out]
+    assert "viking://resources/proj/C.md" in uris, uris  # keyword-only exact-token hit
+    assert "viking://resources/proj/D.md" not in uris, uris
+    # keyword-only hit is abstract-enriched
+    c = next(m for m in out if m.uri.endswith("C.md"))
+    assert c.abstract and "abstract" in c.abstract
+
+
+@pytest.mark.asyncio
+async def test_weighted_fusion_includes_keyword_hit(kfs):
+    rec = HybridKeywordRecaller(
+        kfs,
+        HybridRetrievalConfig(enabled=True, fusion="weighted", keyword_weight=0.5),
+        KeywordConfig(enabled=True),
+    )
+    out = await rec.enhance("rollback 2.4.1", _dense(), ["viking://resources/proj"], _ctx(), limit=10, read_abstract=_read_abstract)
+    uris = [m.uri for m in out]
+    assert "viking://resources/proj/C.md" in uris, uris
+
+
+@pytest.mark.asyncio
+async def test_disabled_returns_dense_unmodified(kfs):
+    rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=False), KeywordConfig(enabled=True))
+    out = await rec.enhance("rollback", _dense(), ["viking://resources/proj"], _ctx(), limit=10)
+    assert [m.uri for m in out] == ["viking://resources/proj/A.md", "viking://resources/proj/B.md"]
+
+
+@pytest.mark.asyncio
+async def test_no_keyword_hit_returns_dense(kfs):
+    rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=True), KeywordConfig(enabled=True))
+    out = await rec.enhance("qqqq zzzz", _dense(), ["viking://resources/proj"], _ctx(), limit=10)
+    assert [m.uri for m in out] == ["viking://resources/proj/A.md", "viking://resources/proj/B.md"]

--- a/tests/retrieve/test_hybrid_keyword.py
+++ b/tests/retrieve/test_hybrid_keyword.py
@@ -69,10 +69,12 @@ async def test_weighted_fusion_includes_keyword_hit(kfs):
 
 
 @pytest.mark.asyncio
-async def test_disabled_returns_dense_unmodified(kfs):
+async def test_config_switch_is_reported_but_enhance_only_needs_a_sidecar(kfs):
     rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=False), KeywordConfig(enabled=True))
+    assert rec.enabled(_ctx()) is False
+    assert rec.sidecar_usable(_ctx()) is True
     out = await rec.enhance("rollback", _dense(), ["viking://resources/proj"], _ctx(), limit=10)
-    assert [m.uri for m in out] == ["viking://resources/proj/A.md", "viking://resources/proj/B.md"]
+    assert out
 
 
 @pytest.mark.asyncio
@@ -80,3 +82,74 @@ async def test_no_keyword_hit_returns_dense(kfs):
     rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=True), KeywordConfig(enabled=True))
     out = await rec.enhance("qqqq zzzz", _dense(), ["viking://resources/proj"], _ctx(), limit=10)
     assert [m.uri for m in out] == ["viking://resources/proj/A.md", "viking://resources/proj/B.md"]
+
+
+def test_weighted_fusion_prefers_stronger_bm25(kfs):
+    rec = HybridKeywordRecaller(
+        kfs,
+        HybridRetrievalConfig(enabled=True, fusion="weighted", keyword_weight=0.5),
+        KeywordConfig(enabled=True),
+    )
+    # FTS5 bm25 scores are negative: -10 is a stronger match than -1.
+    fused = rec._fuse_weighted(
+        [],
+        [("viking://resources/strong.md", -10.0), ("viking://resources/weak.md", -1.0)],
+        limit=2,
+    )
+    assert [m.uri for m in fused] == [
+        "viking://resources/strong.md",
+        "viking://resources/weak.md",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_short_query_skips_keyword_recall(kfs):
+    rec = HybridKeywordRecaller(
+        kfs, HybridRetrievalConfig(enabled=True, min_token_query_len=2), KeywordConfig(enabled=True)
+    )
+    out = await rec.enhance("a", [], ["viking://resources/proj"], _ctx(), limit=5)
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_cjk_query_is_not_skipped_by_the_token_gate(kfs):
+    kfs.upsert(
+        ACCOUNT,
+        "viking://resources/proj/中文.md",
+        "单元圆 认证 接口",
+        level=2,
+        context_type="resource",
+    )
+    rec = HybridKeywordRecaller(
+        kfs,
+        HybridRetrievalConfig(enabled=True, min_token_query_len=2),
+        KeywordConfig(enabled=True, cjk_mode="char"),
+    )
+    # "单元圆" carries no spaces: a whitespace token count would treat it as one
+    # token and drop the query, even though the index tokenizes it into three.
+    out = await rec.enhance("单元圆", [], ["viking://resources/proj"], _ctx(), limit=10)
+    assert any(m.uri.endswith("中文.md") for m in out), out
+
+
+@pytest.mark.asyncio
+async def test_dense_hits_keep_their_dense_score(kfs):
+    rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=True), KeywordConfig(enabled=True))
+    out = await rec.enhance("rollback runbook", _dense(), ["viking://resources/proj"], _ctx(), limit=10)
+    b = next(m for m in out if m.uri.endswith("B.md"))
+    assert b.score == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_keyword_only_hit_uses_indexed_metadata(kfs):
+    kfs.upsert(
+        ACCOUNT,
+        "viking://resources/proj/E.md",
+        "rollback 2.4.1",
+        level=1,
+        context_type="memory",
+    )
+    rec = HybridKeywordRecaller(kfs, HybridRetrievalConfig(enabled=True), KeywordConfig(enabled=True))
+    out = await rec.enhance("rollback 2.4.1", [], ["viking://resources/proj"], _ctx(), limit=10)
+    e = next(m for m in out if m.uri.endswith("E.md"))
+    assert e.level == 1
+    assert e.context_type == ContextType.MEMORY

--- a/tests/server/test_search_hybrid.py
+++ b/tests/server/test_search_hybrid.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Request-level hybrid flag plumbing for /find and /search."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+FIND = "/api/v1/search/find"
+SEARCH = "/api/v1/search/search"
+
+
+def test_request_models_expose_hybrid():
+    """The router handlers read ``request.hybrid``; the models must define it."""
+    from openviking.server.routers.search import FindRequest, SearchRequest
+
+    assert FindRequest(query="q").hybrid is None
+    assert FindRequest(query="q", hybrid=True).hybrid is True
+    assert SearchRequest(query="q", hybrid=False).hybrid is False
+    with pytest.raises(ValidationError):
+        FindRequest(query="q", hybird=True)
+
+
+@pytest.mark.parametrize("endpoint", [FIND, SEARCH])
+@pytest.mark.parametrize("hybrid", [None, True, False])
+@pytest.mark.asyncio
+async def test_hybrid_flag_is_accepted(client, endpoint, hybrid):
+    body = {"query": "visible"}
+    if hybrid is not None:
+        body["hybrid"] = hybrid
+    response = await client.post(endpoint, json=body)
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_field_is_still_rejected(client):
+    response = await client.post(FIND, json={"query": "visible", "hybird": True})
+    assert response.status_code == 422

--- a/tests/service/test_observer_keyword.py
+++ b/tests/service/test_observer_keyword.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Observer component for the local keyword sidecar."""
+
+import pytest
+
+from openviking.service.debug_service import ObserverService
+from openviking.storage.keywordfs.keyword_fs import KeywordFS
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+
+class _DummyAgfs:
+    pass
+
+
+@pytest.fixture
+def obs():
+    return ObserverService(config=None)
+
+
+def _vfs_with_keyword(tmp_path, enabled=True):
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    if enabled:
+        kfs.upsert("default", "viking://resources/a.md", "foo token", level=2)
+    vfs = VikingFS(
+        agfs=_DummyAgfs(),
+        keyword_config=KeywordConfig(enabled=enabled),
+        keyword_fs=kfs if enabled else None,
+    )
+    return vfs
+
+
+def test_observer_keyword_ready(obs, tmp_path, monkeypatch):
+    import openviking.storage.viking_fs as vf_module
+
+    monkeypatch.setattr(vf_module, "get_viking_fs", lambda: _vfs_with_keyword(tmp_path))
+    c = obs.keyword
+    assert c.is_healthy and not c.has_errors
+    assert "Enabled: true" in c.status
+    assert "Docs: 1" in c.status
+
+
+def test_observer_keyword_disabled(obs, tmp_path, monkeypatch):
+    import openviking.storage.viking_fs as vf_module
+
+    monkeypatch.setattr(vf_module, "get_viking_fs", lambda: _vfs_with_keyword(tmp_path, enabled=False))
+    c = obs.keyword
+    assert c.is_healthy
+    assert "Disabled" in c.status
+
+
+def test_observer_keyword_not_wired(obs, tmp_path, monkeypatch):
+    import openviking.storage.viking_fs as vf_module
+
+    vfs = VikingFS(agfs=_DummyAgfs(), keyword_config=KeywordConfig(enabled=True), keyword_fs=None)
+    monkeypatch.setattr(vf_module, "get_viking_fs", lambda: vfs)
+    c = obs.keyword
+    assert not c.is_healthy and c.has_errors

--- a/tests/service/test_observer_keyword.py
+++ b/tests/service/test_observer_keyword.py
@@ -57,3 +57,20 @@ def test_observer_keyword_not_wired(obs, tmp_path, monkeypatch):
     monkeypatch.setattr(vf_module, "get_viking_fs", lambda: vfs)
     c = obs.keyword
     assert not c.is_healthy and c.has_errors
+
+
+def test_observer_keyword_enabled_but_not_built_is_healthy(obs, tmp_path, monkeypatch):
+    """Enabled with no documents written yet is a normal startup state."""
+    import openviking.storage.viking_fs as vf_module
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    vfs = VikingFS(
+        agfs=_DummyAgfs(),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    monkeypatch.setattr(vf_module, "get_viking_fs", lambda: vfs)
+    c = obs.keyword
+    assert c.is_healthy is True
+    assert c.has_errors is False
+    assert "not built" in c.status

--- a/tests/storage/keywordfs/test_keyword_fs.py
+++ b/tests/storage/keywordfs/test_keyword_fs.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for the local keyword (SQLite FTS5) sidecar."""
+
+import sqlite3
+
+import pytest
+
+from openviking.storage.keywordfs.keyword_fs import KeywordFS
+from openviking.storage.keywordfs.keyword_msg import Delete, DeletePrefix, KeywordMsg, Move, Upsert
+from openviking.storage.keywordfs.keyword_processor import KeywordProcessor
+from openviking.storage.keywordfs.tokenizer import has_cjk, terms, tokenize
+from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+ACCOUNT = "default"
+
+
+@pytest.fixture
+def kfs(tmp_path):
+    return KeywordFS(tmp_path, KeywordConfig(enabled=True, cjk_mode="char"))
+
+
+# ---------------------------------------------------------------------------
+# tokenizer
+# ---------------------------------------------------------------------------
+
+
+def test_tokenizer_latin_and_digits():
+    assert tokenize("OpenViking 2.4.1 rollback") == "openviking 2 4 1 rollback"
+    assert terms("Version 2.4.1") == ["version", "2", "4", "1"]
+    assert has_cjk("单元圆")
+    assert not has_cjk("openviking")
+
+
+def test_tokenizer_cjk_char_and_bigram():
+    assert tokenize("单元圆") == "单 元 圆"
+    assert tokenize("单元圆", cjk_mode="bigram") == "单 元 圆 单元 元圆"
+
+
+# ---------------------------------------------------------------------------
+# KeywordFS mutations
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_create_and_update(kfs):
+    uri = "viking://resources/proj/a.md"
+    assert kfs.upsert(ACCOUNT, uri, "OpenViking rollback runbook version 2.4.1", level=2)
+    assert kfs.upsert(ACCOUNT, uri, "OpenViking revised content only", level=2)
+    assert any(u == uri for u, _ in kfs.lookup(ACCOUNT, "revised", limit=10))
+    assert not kfs.lookup(ACCOUNT, "rollback", limit=10), "stale content after update"
+
+
+def test_upsert_oversized_dropped(kfs):
+    uri = "viking://resources/big.md"
+    big = "x" * (kfs._config.max_doc_bytes + 10)
+    assert kfs.upsert(ACCOUNT, uri, big) is False
+    assert kfs.lookup(ACCOUNT, "x", limit=10) == []
+
+
+def test_delete_and_move(kfs):
+    a = "viking://resources/proj/a.md"
+    b = "viking://resources/proj/b.md"
+    kfs.upsert(ACCOUNT, a, "foo bar token", level=2)
+    kfs.upsert(ACCOUNT, b, "foo bar token", level=2)
+    assert kfs.move(ACCOUNT, a, "viking://resources/proj/a2.md")
+    assert any(u.endswith("a2.md") for u, _ in kfs.lookup(ACCOUNT, "foo", limit=10))
+    assert kfs.delete(ACCOUNT, "viking://resources/proj/a2.md")
+    assert any(u == b for u, _ in kfs.lookup(ACCOUNT, "foo", limit=10))
+    assert not any(u.endswith("a2.md") for u, _ in kfs.lookup(ACCOUNT, "foo", limit=10))
+
+
+def test_delete_prefix(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/p/a.md", "foo token", level=2)
+    kfs.upsert(ACCOUNT, "viking://resources/p/sub/b.md", "foo token", level=2)
+    kfs.upsert(ACCOUNT, "viking://resources/other/c.md", "foo token", level=2)
+    assert kfs.delete_prefix(ACCOUNT, "viking://resources/p") == 2
+    uris = [u for u, _ in kfs.lookup(ACCOUNT, "foo", limit=100)]
+    assert uris == ["viking://resources/other/c.md"]
+
+
+def test_lookup_scope_and_exclude(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/proj/a.md", "openviking rollback", level=2)
+    kfs.upsert(ACCOUNT, "viking://resources/other/b.md", "openviking rollback", level=2)
+    hits = kfs.lookup(ACCOUNT, "rollback", scope_uri="viking://resources/proj", limit=10)
+    assert [u for u, _ in hits] == ["viking://resources/proj/a.md"]
+    hits = kfs.lookup(
+        ACCOUNT,
+        "rollback",
+        scope_uri="viking://resources",
+        exclude_uri="viking://resources/other",
+        limit=10,
+    )
+    assert [u for u, _ in hits] == ["viking://resources/proj/a.md"]
+
+
+def test_rebuild_after_live_wal_connection(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/old/a.md", "stale token", level=2)
+    items = [
+        {"uri": "viking://resources/rebuild/r1.md", "text": "rebuild item one token", "level": 2}
+    ]
+    assert kfs.rebuild_account(ACCOUNT, items) == 1
+    assert kfs.lookup(ACCOUNT, "rebuild", limit=10)
+    assert not kfs.lookup(ACCOUNT, "stale", limit=10), "stale rows after rebuild"
+    # On-disk db only contains the rebuilt row.
+    conn = sqlite3.connect(str(kfs.db_path(ACCOUNT)))
+    rows = [r[0] for r in conn.execute("SELECT uri FROM kf")]
+    conn.close()
+    assert rows == ["viking://resources/rebuild/r1.md"]
+
+
+def test_clear_and_is_ready(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/a.md", "foo", level=2)
+    assert kfs.is_ready(ACCOUNT)
+    kfs.clear(ACCOUNT)
+    assert not kfs.is_ready(ACCOUNT)
+
+
+# ---------------------------------------------------------------------------
+# KeywordProcessor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_processor_upsert_delete_move_delete_prefix(kfs):
+    proc = KeywordProcessor(keyword_fs=kfs, config=KeywordConfig(enabled=True))
+    await proc.on_dequeue(
+        {"data": KeywordMsg(kind=Upsert, uri="viking://resources/p/a.md", account_id=ACCOUNT, text="foo bar").to_dict()}
+    )
+    assert kfs.lookup(ACCOUNT, "foo", limit=10)
+    await proc.on_dequeue(
+        {"data": KeywordMsg(kind=Delete, uri="viking://resources/p/a.md", account_id=ACCOUNT).to_dict()}
+    )
+    assert not kfs.lookup(ACCOUNT, "foo", limit=10)
+
+    kfs.upsert(ACCOUNT, "viking://resources/p/b.md", "bar token", level=2)
+    await proc.on_dequeue(
+        {"data": KeywordMsg(kind=Move, old_uri="viking://resources/p/b.md", new_uri="viking://resources/p/b2.md", account_id=ACCOUNT).to_dict()}
+    )
+    assert any(u.endswith("b2.md") for u, _ in kfs.lookup(ACCOUNT, "bar", limit=10))
+
+    kfs.upsert(ACCOUNT, "viking://resources/p/c.md", "baz token", level=2)
+    await proc.on_dequeue(
+        {"data": KeywordMsg(kind=DeletePrefix, uri="viking://resources/p", account_id=ACCOUNT).to_dict()}
+    )
+    assert kfs.lookup(ACCOUNT, "baz", limit=10) == []
+    assert kfs.lookup(ACCOUNT, "bar", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_processor_disabled_drops(kfs):
+    proc = KeywordProcessor(keyword_fs=kfs, config=KeywordConfig(enabled=False))
+    await proc.on_dequeue(
+        {"data": KeywordMsg(kind=Upsert, uri="viking://resources/x.md", account_id=ACCOUNT, text="whatever").to_dict()}
+    )
+    assert kfs.lookup(ACCOUNT, "whatever", limit=10) == []
+
+
+# ---------------------------------------------------------------------------
+# KeywordMsg.from_embedding
+# ---------------------------------------------------------------------------
+
+
+def test_from_embedding_text_and_multimodal(kfs):
+    from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
+
+    emb = EmbeddingMsg(
+        message="OpenViking rollback runbook",
+        context_data={"uri": "viking://resources/a.md", "account_id": ACCOUNT, "level": 2},
+    )
+    msg = KeywordMsg.from_embedding(emb)
+    assert msg is not None and msg.kind == Upsert and msg.text == "OpenViking rollback runbook"
+
+    emb2 = EmbeddingMsg(
+        message=[{"type": "text", "text": "部分内容甲"}, {"type": "image_url", "url": "x"}],
+        context_data={"uri": "viking://resources/b.md", "account_id": ACCOUNT, "level": 2},
+    )
+    msg2 = KeywordMsg.from_embedding(emb2)
+    assert msg2 is not None and "部分内容甲" in msg2.text
+
+    emb3 = EmbeddingMsg(message="", context_data={"uri": "viking://resources/c.md", "account_id": ACCOUNT})
+    assert KeywordMsg.from_embedding(emb3) is None

--- a/tests/storage/keywordfs/test_keyword_fs.py
+++ b/tests/storage/keywordfs/test_keyword_fs.py
@@ -179,3 +179,31 @@ def test_from_embedding_text_and_multimodal(kfs):
 
     emb3 = EmbeddingMsg(message="", context_data={"uri": "viking://resources/c.md", "account_id": ACCOUNT})
     assert KeywordMsg.from_embedding(emb3) is None
+
+
+def test_move_onto_existing_uri_replaces_destination(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/a.md", "alpha", level=2)
+    kfs.upsert(ACCOUNT, "viking://resources/b.md", "beta", level=2)
+    assert kfs.move(ACCOUNT, "viking://resources/a.md", "viking://resources/b.md") is True
+    alpha = kfs.lookup(ACCOUNT, query="alpha", scope_uri="viking://resources")
+    assert [uri for uri, _ in alpha] == ["viking://resources/b.md"]
+    assert kfs.lookup(ACCOUNT, query="beta", scope_uri="viking://resources") == []
+
+
+def test_copy_duplicates_rows_without_rereading(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/a.md", "alpha", level=1)
+    assert kfs.copy(ACCOUNT, "viking://resources/a.md", "viking://resources/copy.md") is True
+    hits = kfs.lookup(ACCOUNT, query="alpha", scope_uri="viking://resources")
+    assert {uri for uri, _ in hits} == {
+        "viking://resources/a.md",
+        "viking://resources/copy.md",
+    }
+    assert kfs.copy(ACCOUNT, "viking://resources/missing.md", "viking://resources/x.md") is False
+
+
+def test_delete_prefix_does_not_treat_underscore_as_wildcard(kfs):
+    kfs.upsert(ACCOUNT, "viking://resources/a_b/x.md", "needle", level=2)
+    kfs.upsert(ACCOUNT, "viking://resources/axb/y.md", "needle", level=2)
+    assert kfs.delete_prefix(ACCOUNT, "viking://resources/a_b") == 1
+    hits = kfs.lookup(ACCOUNT, query="needle", scope_uri="viking://resources")
+    assert [uri for uri, _ in hits] == ["viking://resources/axb/y.md"]

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -737,7 +737,9 @@ async def test_resolve_grep_engine_local_and_auto(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(fs, "_get_vector_store", lambda: None)
     assert await fs._resolve_grep_engine("local", "viking://resources", None) == "local_then_fs"
-    assert await fs._resolve_grep_engine("auto", "viking://resources", None) == "local_then_fs"
+    # ``auto`` never selects the sidecar: its coverage mirrors vector coverage,
+    # so auto could silently lose recall (design D1).
+    assert await fs._resolve_grep_engine("auto", "viking://resources", None) == "fs"
     assert await fs._resolve_grep_engine("fs", "viking://resources", None) == "fs"
 
 
@@ -849,7 +851,7 @@ async def test_grep_local_then_fs_recalls_and_matches(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_grep_local_then_fs_no_match_empty(monkeypatch, tmp_path):
+async def test_grep_local_then_fs_empty_recall_delegates_to_fs(monkeypatch, tmp_path):
     from openviking.storage.keywordfs.keyword_fs import KeywordFS
     from openviking_cli.utils.config.keyword_config import KeywordConfig
 
@@ -861,11 +863,10 @@ async def test_grep_local_then_fs_no_match_empty(monkeypatch, tmp_path):
         keyword_config=KeywordConfig(enabled=True),
         keyword_fs=kfs,
     )
+    fallback = {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+    grep_fs = AsyncMock(return_value=fallback)
+    monkeypatch.setattr(fs, "_grep_fs", grep_fs)
 
-    async def fake_read(uri, offset=0, size=-1, ctx=None):
-        return b"OpenViking rollback\n"
-
-    monkeypatch.setattr(fs, "read", fake_read)
     result = await fs._grep_local_then_fs(
         uri="viking://resources/proj",
         pattern="nonexistenttoken12345",
@@ -875,7 +876,10 @@ async def test_grep_local_then_fs_no_match_empty(monkeypatch, tmp_path):
         level_limit=10,
         ctx=None,
     )
-    assert result == {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+    # An empty recall is not an authoritative "no results" — the filesystem scan
+    # decides, so a partially built sidecar cannot lose documents.
+    assert result == fallback
+    grep_fs.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -914,3 +918,145 @@ async def test_grep_local_then_fs_keyword_failure_falls_back_to_fs(monkeypatch, 
         ctx=None,
     )
     assert calls, "expected fallback to _grep_fs"
+
+
+@pytest.mark.asyncio
+async def test_grep_local_empty_recall_falls_back_to_fs_scan(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/other.md", "unrelated", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        return {"isDir": True}
+
+    async def fake_ls(uri, ctx=None, **kwargs):
+        return [{"name": "a.md", "isDir": False}]
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    monkeypatch.setattr(fs, "ls", fake_ls)
+    monkeypatch.setattr(fs, "_uri_to_path", lambda uri, ctx=None: uri.replace("viking://", "/"))
+    monkeypatch.setattr(fs.agfs, "read", lambda path, offset=0, size=-1: b"needle", raising=False)
+
+    result = await fs.grep("viking://resources", pattern="needle")
+    assert [m["uri"] for m in result["matches"]] == ["viking://resources/a.md"]
+
+
+@pytest.mark.asyncio
+async def test_grep_local_lookup_error_falls_back_to_fs(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/a.md", "needle", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    fallback = {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+    grep_fs = AsyncMock(return_value=fallback)
+
+    def boom(**kwargs):
+        raise RuntimeError("fts exploded")
+
+    monkeypatch.setattr(kfs, "lookup", boom)
+    monkeypatch.setattr(fs, "_grep_fs", grep_fs)
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        return {"isDir": True}
+
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    result = await fs.grep("viking://resources", pattern="needle")
+    assert result == fallback
+    grep_fs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_grep_vikingdb_without_remote_falls_back_to_fs(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/a.md", "needle", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="vikingdb"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: None)
+    assert await fs._resolve_grep_engine("vikingdb", "viking://resources", None) == "fs"
+
+
+@pytest.mark.asyncio
+async def test_grep_local_respects_tag_filter(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/tagged.md", "needle", level=2)
+    kfs.upsert("default", "viking://resources/untagged.md", "needle", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+
+    class _VectorStore:
+        async def filter(self, **kwargs):
+            return [{"uri": "viking://resources/tagged.md", "search_tags": ["keep"]}]
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        return {"isDir": True}
+
+    async def fake_read(uri, ctx=None, **kwargs):
+        return b"needle\n"
+
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: _VectorStore())
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    monkeypatch.setattr(fs, "read", fake_read)
+
+    result = await fs.grep(
+        "viking://resources", pattern="needle", tag_filter={"op": "must", "field": "tags"}
+    )
+    assert [m["uri"] for m in result["matches"]] == ["viking://resources/tagged.md"]
+    assert result["matches"][0]["tags"] == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_grep_local_respects_level_limit(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/shallow.md", "needle", level=2)
+    kfs.upsert("default", "viking://resources/deep/deeper/file.md", "needle", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+
+    async def fake_stat(uri, ctx=None, skip_count=False):
+        return {"isDir": True}
+
+    async def fake_read(uri, ctx=None, **kwargs):
+        return b"needle\n"
+
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: None)
+    monkeypatch.setattr(fs, "stat", fake_stat)
+    monkeypatch.setattr(fs, "read", fake_read)
+
+    result = await fs.grep("viking://resources", pattern="needle", level_limit=1)
+    assert [m["uri"] for m in result["matches"]] == ["viking://resources/shallow.md"]

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -710,3 +710,207 @@ async def test_grep_applies_node_limit_to_backend_results(monkeypatch, fs):
         "viking://resources/a.md",
         "viking://resources/b.md",
     ]
+
+
+# ---------------------------------------------------------------------------
+# Local keyword (FTS5) grep engine
+# ---------------------------------------------------------------------------
+
+
+def test_grep_config_engine_accepts_local():
+    assert GrepConfig(engine="local").engine == "local"
+    assert GrepConfig(engine="vikingdb").engine == "vikingdb"
+
+
+@pytest.mark.asyncio
+async def test_resolve_grep_engine_local_and_auto(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/a.md", "foo", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: None)
+    assert await fs._resolve_grep_engine("local", "viking://resources", None) == "local_then_fs"
+    assert await fs._resolve_grep_engine("auto", "viking://resources", None) == "local_then_fs"
+    assert await fs._resolve_grep_engine("fs", "viking://resources", None) == "fs"
+
+
+@pytest.mark.asyncio
+async def test_resolve_grep_engine_local_disabled_falls_back_to_fs(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,  # sidecar wired but not built -> not ready
+    )
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: None)
+    assert await fs._resolve_grep_engine("local", "viking://resources", None) == "fs"
+
+
+@pytest.mark.asyncio
+async def test_resolve_grep_engine_auto_remote_preferred_when_ready(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="auto", switch_to_remote_threshold=100),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    vector_store = _DummyVectorStore()
+    vector_store._backend_type = "vikingdb"
+    monkeypatch.setattr(fs, "_get_vector_store", lambda: vector_store)
+
+    async def fake_collection_has_fulltext(vector_store, ctx):
+        return True
+
+    async def fake_cached_count(uri, ctx):
+        return 500
+
+    monkeypatch.setattr(fs, "_collection_has_fulltext", fake_collection_has_fulltext)
+    monkeypatch.setattr(fs, "_get_cached_count", fake_cached_count)
+    assert (
+        await fs._resolve_grep_engine(
+            "auto", "viking://resources", None, switch_to_remote_threshold=100
+        )
+        == "vikingdb_then_fs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_grep_local_then_fs_recalls_and_matches(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert(
+        "default",
+        "viking://resources/proj/a.md",
+        "OpenViking rollback runbook for version 2.4.1",
+        level=2,
+    )
+    kfs.upsert(
+        "default",
+        "viking://resources/proj/b.md",
+        "如何 使用 认证 接口 处理 单元圆",
+        level=2,
+    )
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True, cjk_mode="char"),
+        keyword_fs=kfs,
+    )
+
+    file_contents = {
+        "viking://resources/proj/a.md": b"OpenViking rollback runbook\nfor version 2.4.1\n",
+        "viking://resources/proj/b.md": "认证 接口 处理 单元圆\n".encode("utf-8"),
+    }
+
+    async def fake_read(uri, offset=0, size=-1, ctx=None):
+        data = file_contents[uri]
+        return data[offset:size] if size != -1 else data[offset:]
+
+    monkeypatch.setattr(fs, "read", fake_read)
+
+    result = await fs._grep_local_then_fs(
+        uri="viking://resources/proj",
+        pattern="rollback",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=10,
+        ctx=None,
+    )
+    assert any("a.md" in m["uri"] for m in result["matches"]), result
+
+    result_cjk = await fs._grep_local_then_fs(
+        uri="viking://resources/proj",
+        pattern="单元圆",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=10,
+        ctx=None,
+    )
+    assert any("b.md" in m["uri"] for m in result_cjk["matches"]), result_cjk
+
+
+@pytest.mark.asyncio
+async def test_grep_local_then_fs_no_match_empty(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/proj/a.md", "OpenViking rollback", level=2)
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+
+    async def fake_read(uri, offset=0, size=-1, ctx=None):
+        return b"OpenViking rollback\n"
+
+    monkeypatch.setattr(fs, "read", fake_read)
+    result = await fs._grep_local_then_fs(
+        uri="viking://resources/proj",
+        pattern="nonexistenttoken12345",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=10,
+        ctx=None,
+    )
+    assert result == {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+
+@pytest.mark.asyncio
+async def test_grep_local_then_fs_keyword_failure_falls_back_to_fs(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+    from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        grep_config=GrepConfig(engine="local"),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+    # Break lookup to force fs fallback.
+    def broken_lookup(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(kfs, "lookup", broken_lookup)
+    monkeypatch.setattr(fs, "_keyword_available", lambda ctx=None: True)
+
+    calls = []
+
+    async def fake_grep_fs(**kwargs):
+        calls.append(kwargs)
+        return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+    monkeypatch.setattr(fs, "_grep_fs", fake_grep_fs)
+    await fs._grep_local_then_fs(
+        uri="viking://resources",
+        pattern="needle",
+        exclude_uri=None,
+        case_insensitive=False,
+        node_limit=10,
+        level_limit=10,
+        ctx=None,
+    )
+    assert calls, "expected fallback to _grep_fs"

--- a/tests/storage/test_viking_fs_keyword_hooks.py
+++ b/tests/storage/test_viking_fs_keyword_hooks.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""VikingFS enqueues keyword sidecar mutations for copy operations."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.utils.config.keyword_config import KeywordConfig
+
+
+class _DummyAgfs:
+    pass
+
+
+class _Queue:
+    def __init__(self):
+        self.messages = []
+
+    async def enqueue(self, msg):
+        self.messages.append(msg)
+        return "1"
+
+
+@pytest.mark.asyncio
+async def test_copy_enqueues_keyword_copy_messages(monkeypatch, tmp_path):
+    from openviking.storage.keywordfs.keyword_fs import KeywordFS
+
+    queue = _Queue()
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.queue_manager.get_queue_manager",
+        lambda: SimpleNamespace(KEYWORD="Keyword", get_queue=lambda name: queue),
+    )
+    fs = VikingFS(
+        agfs=_DummyAgfs(),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=KeywordFS(tmp_path, KeywordConfig(enabled=True)),
+    )
+    await fs._enqueue_keyword_copy(
+        ["viking://resources/a.md"],
+        "viking://resources",
+        "viking://archive",
+        SimpleNamespace(account_id="default"),
+    )
+    assert [(m.kind, m.old_uri, m.new_uri) for m in queue.messages] == [
+        ("copy", "viking://resources/a.md", "viking://archive/a.md")
+    ]

--- a/tests/unit/test_keyword_hybrid_gate.py
+++ b/tests/unit/test_keyword_hybrid_gate.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tri-state request override for hybrid keyword fusion."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.storage.keywordfs.keyword_fs import KeywordFS
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.utils.config.keyword_config import HybridRetrievalConfig, KeywordConfig
+
+
+class _DummyAgfs:
+    def read(self, path, offset=0, size=-1):  # pragma: no cover - unused here
+        return b""
+
+
+def _fs(tmp_path, *, config_enabled: bool) -> VikingFS:
+    kfs = KeywordFS(tmp_path, KeywordConfig(enabled=True))
+    kfs.upsert("default", "viking://resources/a.md", "needle")
+    return VikingFS(
+        agfs=_DummyAgfs(),
+        retrieval_config=SimpleNamespace(hybrid=HybridRetrievalConfig(enabled=config_enabled)),
+        keyword_config=KeywordConfig(enabled=True),
+        keyword_fs=kfs,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_enabled", "override", "expect_called"),
+    [
+        (True, None, True),
+        (False, None, False),
+        (False, True, True),
+        (True, False, False),
+    ],
+)
+async def test_tristate_override(
+    tmp_path, monkeypatch, config_enabled, override, expect_called
+):
+    fs = _fs(tmp_path, config_enabled=config_enabled)
+    calls = []
+
+    class _Recaller:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def enhance(self, **kwargs):
+            calls.append(kwargs)
+            return kwargs["dense"]
+
+    monkeypatch.setattr("openviking.retrieve.hybrid_keyword.HybridKeywordRecaller", _Recaller)
+    result = await fs._maybe_hybrid_keyword(
+        "needle",
+        ["dense"],
+        ["viking://resources"],
+        SimpleNamespace(account_id="default"),
+        limit=5,
+        override=override,
+    )
+    assert result == ["dense"]
+    assert bool(calls) is expect_called


### PR DESCRIPTION
## Description

Adds an opt-in per-account SQLite FTS5 keyword sidecar that provides backend-owned, search-time BM25 recall for deployments without a remote VikingDB full-text index.

The local keyword sidecar is a recall accelerator only: `grep` still performs its final regex match against on-disk content, and `find`/`search` fuse keyword candidates with dense results. When the sidecar is missing or incomplete, both paths degrade to their existing behavior.

This follows the direction maintainers indicated in #1857: search-time BM25 over a local SQLite FTS5 sidecar instead of precomputed sparse vectors.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

- Related to #1857 (previous `local_bm25` sparse-provider attempt, closed without merge)
- Related to #2850 and #2900 (remote BM25 grep fallback semantics)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test update

## Changes Made

- Add `openviking/storage/keywordfs/`: per-account `KeywordFS` SQLite FTS5 store with search-time `bm25()` recall, CJK-aware tokenizer (char/bigram/optional `jieba`), `KeywordMsg`, `KeywordQueue`, and `KeywordProcessor`
- Extend grep engine resolution: `auto` prefers remote VikingDB BM25 when available, falls back to the local sidecar, then to a filesystem scan; add explicit `local` and `vikingdb` engine modes
- Add `_grep_local_then_fs`: local keyword recall + `_grep_in_files` exact matching
- Add `KeywordQueue` setup to `QueueManager` and co-enqueue keyword upserts alongside embedding messages so the sidecar stays in sync with vector coverage
- Wire keyword delete/move messages into `rm`/`mv` and prefix cleanup into snapshot restore
- Add opt-in hybrid retrieval for `find`/`search` via `HybridKeywordRecaller` with RRF and weighted fusion, exposed through `retrieval.hybrid.enabled` and a request-level `hybrid` boolean
- Add `/api/v1/observer/keyword` for sidecar health and document `keyword`/`retrieval.hybrid` configuration
- Add design document `docs/design/local-keyword-fts5-sidecar-design.md`

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Added tests cover `KeywordFS` upsert/delete/move/prefix-delete/rebuild, `KeywordProcessor`, `KeywordMsg.from_embedding`, local grep engine resolution and recall, hybrid RRF/weighted fusion, and the keyword observer component. `71 passed` across the new and adjacent test suites.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The keyword sidecar is disabled by default (`keyword.enabled=false`), and it is automatically disabled on encrypted deployments when `respect_encryption=true` because it stores plaintext. Full `ov reindex --mode keyword` rebuild wiring is left as a follow-up.