### PR TITLE
fix: encode str to bytes before xxhash to fix vectordb upsert/get

### DIFF
--- a/openviking/storage/vectordb/utils/str_to_uint64.py
+++ b/openviking/storage/vectordb/utils/str_to_uint64.py
@@ -7,4 +7,7 @@ def str_to_uint64(input_string: str) -> int:
     """
     Generate a 64-bit unsigned integer hash from a string using xxHash.
     """
-    return xxhash.xxh64(input_string).intdigest()
+    # xxhash >= 3.x requires bytes input; passing a str raises
+    # "TypeError: Strings must be encoded before hashing" on every
+    # vectordb upsert/get partial-update path.
+    return xxhash.xxh64(input_string.encode("utf-8")).intdigest()


### PR DESCRIPTION
## Problem

`str_to_uint64` passes a `str` directly to `xxhash.xxh64()`. With xxhash >= 3.x (current PyPI release), this raises:

```
TypeError: Strings must be encoded before hashing
```

on every vectordb partial-update path (`fetch_data` → `str_to_uint64(str(key))`). The error is swallowed by the upsert wrapper, so the vector write silently fails — semantic search returns empty results while the queue reports `processed`. Observed on Windows with openviking 0.4.13 (Python 3.12 and 3.14), but any environment with xxhash 3.x is affected.

Full traceback:

```
File ".../viking_vector_index_backend.py", line 348, in upsert
    existing_records = await self._async_adapter.call("get", [payload["id"]])
File ".../local_collection.py", line 874, in fetch_data
    [str_to_uint64(str(key)) for key in primary_keys]
File ".../str_to_uint64.py", line 10, in str_to_uint64
    return xxhash.xxh64(input_string).intdigest()
TypeError: Strings must be encoded before hashing
```

## Fix

Encode the input as UTF-8 before hashing — one line:

```python
return xxhash.xxh64(input_string.encode("utf-8")).intdigest()
```

Verified locally: after the patch, add_resource → semantic search works end-to-end (Chinese queries return correct hits).