### PR TITLE
fix(usage): emit RFC3339 UTC event timestamps

### DIFF
--- a/docs/design/openviking-usage-count-record-implementation-plan.md
+++ b/docs/design/openviking-usage-count-record-implementation-plan.md
@@ -31,7 +31,7 @@
 
 ```json
 {
-  "event_time": "2026-08-05 11:30:00",
+  "event_time": "2026-08-05T11:30:00Z",
   "tenant_id": "resource_id:ov-resource-id;account_id:2101858484;user_id:user-1;resource_uri:viking://user/user-1/memories/experiences/exchange.md",
   "event_name": "experience.recall.count",
   "object_id": "ue_recall",

--- a/docs/design/openviking-usage-reporter-sink-design.md
+++ b/docs/design/openviking-usage-reporter-sink-design.md
@@ -154,7 +154,7 @@ HTTP 请求。日志文件使用 UTC 小时滚动，默认保留 168 个小时�
 一行：
 
 ```json
-{"event_time":"2026-08-05 11:30:00","tenant_id":"resource_id:ov-xxx;account_id:new;user_id:test;resource_uri:viking://user/test/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
+{"event_time":"2026-08-05T11:30:00Z","tenant_id":"resource_id:ov-xxx;account_id:new;user_id:test;resource_uri:viking://user/test/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
 ```
 
 字段映射：

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1603,10 +1603,10 @@ Set the environment variable named by `resource_id_env` before starting the serv
 Each line has the following form:
 
 ```json
-{"event_time":"2026-08-05 11:30:00","tenant_id":"resource_id:ov-example;account_id:default;user_id:default;resource_uri:viking://user/default/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
+{"event_time":"2026-08-05T11:30:00Z","tenant_id":"resource_id:ov-example;account_id:default;user_id:default;resource_uri:viking://user/default/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
 ```
 
-`event_time` is UTC. `tenant_id` combines the deployment resource ID, event account, user, and Experience URI. `memory.recalled` maps to `experience.recall.count`, while `memory.injected` maps to `experience.inject.count`. `object_id` is the stable Usage Event ID. Downstream consumers must deduplicate by the composite `(tenant_id, object_id)` key rather than by `object_id` globally. Aggregate usage with `sum(count)` after filtering by `tenant_id`, `event_name`, and the desired `event_time` range. File collection and downstream delivery remain best-effort.
+`event_time` is an RFC 3339 UTC timestamp with an explicit `Z` suffix. `tenant_id` combines the deployment resource ID, event account, user, and Experience URI. `memory.recalled` maps to `experience.recall.count`, while `memory.injected` maps to `experience.inject.count`. `object_id` is the stable Usage Event ID. Downstream consumers must deduplicate by the composite `(tenant_id, object_id)` key rather than by `object_id` globally. Aggregate usage with `sum(count)` after filtering by `tenant_id`, `event_name`, and the desired `event_time` range. File collection and downstream delivery remain best-effort.
 
 Supported add target URIs:
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1684,10 +1684,10 @@ openviking add-resource ./docs --exclude "*.tmp"
 每行格式如下：
 
 ```json
-{"event_time":"2026-08-05 11:30:00","tenant_id":"resource_id:ov-example;account_id:default;user_id:default;resource_uri:viking://user/default/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
+{"event_time":"2026-08-05T11:30:00Z","tenant_id":"resource_id:ov-example;account_id:default;user_id:default;resource_uri:viking://user/default/memories/experiences/example.md","event_name":"experience.recall.count","object_id":"ue_<sha256>","count":1,"tags":{"resource_type":"experience"}}
 ```
 
-`event_time` 使用 UTC 时间。`tenant_id` 由部署 resource ID、事件所属的 account、user 和 Experience URI 拼接。`memory.recalled` 映射为 `experience.recall.count`，`memory.injected` 映射为 `experience.inject.count`。`object_id` 是稳定的 Usage Event ID。下游必须使用 `(tenant_id, object_id)` 复合键去重，不能跨 tenant 仅按 `object_id` 全局去重。查询时按 `tenant_id`、`event_name` 和 `event_time` 范围过滤，再通过 `sum(count)` 汇总。文件采集和下游投递仍为 best-effort。
+`event_time` 使用 RFC 3339 UTC 时间格式，并显式携带 `Z` 后缀。`tenant_id` 由部署 resource ID、事件所属的 account、user 和 Experience URI 拼接。`memory.recalled` 映射为 `experience.recall.count`，`memory.injected` 映射为 `experience.inject.count`。`object_id` 是稳定的 Usage Event ID。下游必须使用 `(tenant_id, object_id)` 复合键去重，不能跨 tenant 仅按 `object_id` 全局去重。查询时按 `tenant_id`、`event_name` 和 `event_time` 范围过滤，再通过 `sum(count)` 汇总。文件采集和下游投递仍为 best-effort。
 
 支持的 add target URI：
 

--- a/openviking/usage_reporter/file_log_sink.py
+++ b/openviking/usage_reporter/file_log_sink.py
@@ -123,7 +123,7 @@ def _format_event_time(value: str) -> str:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return parsed.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def _build_tenant_id(

--- a/tests/unit/usage_reporter/test_file_log_sink.py
+++ b/tests/unit/usage_reporter/test_file_log_sink.py
@@ -18,6 +18,7 @@ class FakeUsageEvent:
         event_id: str = "ue_recall",
         event_type: str = "memory.recalled",
         session_id: str = "session-1",
+        occurred_at: str = "2026-08-05T19:30:00+08:00",
         resource_uri: str = ("viking://user/default/memories/experiences/生成请假邮件通用模版.md"),
     ) -> None:
         self._record = {
@@ -28,7 +29,7 @@ class FakeUsageEvent:
             "user_id": "default",
             "session_id": session_id,
             "task_id": "task-1",
-            "occurred_at": "2026-08-05T19:30:00+08:00",
+            "occurred_at": occurred_at,
             "resource_uri": resource_uri,
             "resource_type": "experience",
             "evidence": {
@@ -66,7 +67,7 @@ async def test_file_log_sink_writes_usage_event_record(tmp_path):
     lines = log_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert _parse_line(lines[0]) == {
-        "event_time": "2026-08-05 11:30:00",
+        "event_time": "2026-08-05T11:30:00Z",
         "tenant_id": (
             "resource_id:ov-test;account_id:default;user_id:default;resource_uri:"
             "viking://user/default/memories/experiences/生成请假邮件通用模版.md"
@@ -76,6 +77,28 @@ async def test_file_log_sink_writes_usage_event_record(tmp_path):
         "count": 1,
         "tags": {"resource_type": "experience"},
     }
+
+
+@pytest.mark.parametrize(
+    ("occurred_at", "expected"),
+    [
+        ("2026-08-05T11:30:00Z", "2026-08-05T11:30:00Z"),
+        ("2026-08-05T11:30:00", "2026-08-05T11:30:00Z"),
+        ("2026-08-05T07:30:00-04:00", "2026-08-05T11:30:00Z"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_file_log_sink_emits_rfc3339_utc_event_time(tmp_path, occurred_at, expected):
+    log_path = tmp_path / "usage.log"
+    sink = FileLogUsageSink(path=log_path)
+
+    try:
+        await sink.write(events=[FakeUsageEvent(occurred_at=occurred_at)])
+    finally:
+        sink.close()
+
+    record = _parse_line(log_path.read_text(encoding="utf-8").strip())
+    assert record["event_time"] == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Emit usage event timestamps as explicit RFC 3339 UTC values so downstream collectors do not interpret UTC wall-clock strings using a local or regional timezone.

Before this change, the file sink serialized a UTC instant as `2026-08-05 11:30:00`, which did not retain its timezone. It now emits `2026-08-05T11:30:00Z`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Serialize usage `event_time` values as RFC 3339 UTC timestamps with an explicit `Z` suffix.
- Preserve the existing behavior that treats timezone-naive input as UTC and converts offset-aware input to UTC.
- Cover UTC, timezone-naive, positive-offset, and negative-offset input timestamps in file sink tests.
- Update the English, Chinese, and design documentation examples to match the new schema.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
uv run --frozen ruff format --check openviking/usage_reporter/file_log_sink.py tests/unit/usage_reporter/test_file_log_sink.py
uv run --frozen ruff check openviking/usage_reporter/file_log_sink.py tests/unit/usage_reporter/test_file_log_sink.py
uv run --frozen pytest tests/unit/usage_reporter/test_file_log_sink.py -q
```

Result: 17 tests passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Downstream consumers should parse `event_time` as RFC 3339. Existing records written in the previous timezone-less format are not rewritten by this change.
