### PR TITLE
fix: encode str to bytes before xxhash to fix Chinese ID crash

### DIFF
--- a/openviking/storage/vectordb/utils/str_to_uint64.py
+++ b/openviking/storage/vectordb/utils/str_to_uint64.py
@@ -7,4 +7,8 @@ def str_to_uint64(input_string: str) -> int:
     """
     Generate a 64-bit unsigned integer hash from a string using xxHash.
     """
-    return xxhash.xxh64(input_string).intdigest()
+    if isinstance(input_string, bytes):
+        data = input_string
+    else:
+        data = input_string.encode("utf-8", "surrogatepass")
+    return xxhash.xxh64(data).intdigest()


### PR DESCRIPTION
## Problem

`xxhash.xxh64()` requires bytes-like input; passing a `str` raises `TypeError: Strings must be encoded before hashing`. In local (PersistentIndex) mode, this crashes every vector write for non-ASCII record IDs — e.g. any Chinese memory URI/term. Symptom in logs:

```
Error reading existing record before partial update: Strings must be encoded before hashing
```

## Fix

Accept both `str` and `bytes`; encode `str` with UTF-8 + `surrogatepass` so lone surrogates stay deterministic instead of crashing.

```python
def str_to_uint64(input_string: str) -> int:
    if isinstance(input_string, bytes):
        data = input_string
    else:
        data = input_string.encode("utf-8", "surrogatepass")
    return xxhash.xxh64(data).intdigest()
```

## Verification (local, macOS, v0.4.13)

- Chinese, emoji, bytes, lone-surrogate, empty-string inputs all hash correctly
- Chinese memory write + `ov find` retrieval now works end-to-end (was 100% broken before)