### PR TITLE
fix: align v7 query planner prompt contract

### DIFF
--- a/openviking/prompts/templates/retrieval/ov_intent_analysis_sft_v7.yaml
+++ b/openviking/prompts/templates/retrieval/ov_intent_analysis_sft_v7.yaml
@@ -149,7 +149,7 @@ template: |
   6. **Query Style** (optimize for vector / semantic retrieval):
      - Queries are embedded and matched against indexed content by **semantic similarity**. Write each query so its embedding lands close to the target content — not necessarily a verbatim fragment, any phrasing that captures the same meaning works.
      - **Declarative, not interrogative**: state the information need as a noun/verb phrase rather than a question. Drop question framings ("what / who / when / how is ...").
-     - **One information need per query**: each query targets one retrievable fact, relation, comparison, event, or procedure. Do not pile unrelated intents into one query.
+     - **One information need per query**: each query targets one retrievable fact, relation, comparison, event, or procedure. Do not pile unrelated information needs into one query.
      - **Self-contained**: resolve pronouns and references using the session context; the retriever only sees the query string.
      - **Concept-dense and natural**: use a grammatical, well-formed phrase carrying the key entities, attributes, and qualifiers. Avoid both bare single keywords and telegraphic word-salad.
      - **No retrieval-meta words**: exclude words describing the act of retrieval or generic containers ("find", "search", "records", "information about", "content", "details", etc.) — they do not appear in the target content and only dilute the embedding.
@@ -159,12 +159,10 @@ template: |
 
   ```json
   {
-      "reasoning": "1. Task type (operational/informational/conversational); 2. What context is needed (skill/resource/memory); 3. What is already in context; 4. What is missing and needs to be queried",
       "queries": [
           {
               "query": "Specific query text (following the style of the corresponding type)",
               "context_type": "skill|resource|memory",
-              "intent": "Purpose of the query",
               "priority": 1-5
           }
       ]
@@ -174,4 +172,4 @@ template: |
   Please output JSON:
 
 llm_config:
-  temperature: 0.0
+  temperature: 0.1

--- a/tests/prompts/test_retrieval_intent_prompt_contract.py
+++ b/tests/prompts/test_retrieval_intent_prompt_contract.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import pytest
+
+from openviking.prompts.manager import PromptManager
+
+
+@pytest.mark.parametrize(
+    "prompt_id",
+    [
+        "retrieval.ov_intent_analysis_sft_v4",
+        "retrieval.ov_intent_analysis_sft_v7",
+    ],
+)
+def test_sft_intent_prompts_use_compact_queries_contract(prompt_id: str):
+    manager = PromptManager(templates_dir=PromptManager._get_bundled_templates_dir())
+    rendered = manager.render(
+        prompt_id,
+        {
+            "compression_summary": "The user is working on OpenViking retrieval.",
+            "recent_messages": "[user]: Improve semantic search.",
+            "current_message": "Use the style we discussed earlier.",
+            "context_type": "",
+            "target_abstract": "",
+        },
+    )
+
+    output_contract = rendered.split("## Output Format", maxsplit=1)[1]
+
+    assert "queries" in output_contract
+    assert "query" in output_contract
+    assert "context_type" in output_contract
+    assert "priority" in output_contract
+    assert '"reasoning"' not in output_contract
+    assert '"intent"' not in output_contract


### PR DESCRIPTION
## Description

The `ov_intent_analysis_sft` v7 query-planner model expects a compact JSON response with query objects under the top-level `queries` array. The bundled v7 prompt still requested a `reasoning` field and per-query `intent`, creating a conflicting output contract.

In the reported session-aware search path, `v7_q8` placed query objects under `reasoning`. OpenViking reads planned queries from `parsed.get("queries", [])`, so the mismatch produced an empty query plan (`query_count=0`) and retrieval returned no results.

This PR aligns the bundled v7 prompt with the compact model contract while preserving the existing HTTP `QueryPlan` response shape.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3970

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Request only `queries`, `query`, `context_type`, and `priority` in the v7 output schema.
- Clarify that each query should contain one information need and must not combine unrelated information needs.
- Set the v7 prompt template's low-temperature configuration to `0.1`.
- Add rendered-prompt contract coverage for both v4 and v7 SFT templates.

## Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing query-planner tests pass locally
- [x] Tested on macOS

```text
.venv/bin/python -m pytest tests/prompts/test_retrieval_intent_prompt_contract.py tests/retrieve/test_intent_analyzer_query_planner.py -q --no-cov
11 passed
```

Also tested through a source-started OpenViking service configured with `ollama/guoxuter/ov_intent_analysis_sft:v7_q8`:

- Eleven distinct session-aware search inputs produced top-level `queries` arrays, including valid empty arrays for conversational inputs.
- The issue reproduction input was repeated three additional times and consistently produced three top-level queries.
- No run placed query objects under `reasoning`.

## Compatibility

This changes only the model-facing v7 prompt contract. OpenViking's internal `QueryPlan` serializer may continue to expose empty `reasoning` and `intent` fields in the HTTP response, so the API response remains backward-compatible.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [ ] I have made corresponding documentation changes (not required for this prompt-only fix)
- [ ] Any dependent changes have been merged and published (not applicable)
