### PR TITLE
fix(observer): keep empty retrievals diagnostic-only

### DIFF
--- a/crates/ov_cli/src/status_ui.rs
+++ b/crates/ov_cli/src/status_ui.rs
@@ -646,9 +646,11 @@ fn retrieval_summary(status: Option<&str>) -> String {
         return "unknown".to_string();
     };
     let queries = metric_value(status, "Total Queries");
-    let errors = metric_value(status, "Total Errors");
-    match (queries, errors) {
-        (Some(queries), Some(errors)) => format!("{queries} queries, {errors} errors"),
+    let zero_rate = metric_value(status, "Zero-Result Rate");
+    match (queries, zero_rate) {
+        (Some(queries), Some(zero_rate)) => {
+            format!("{queries} queries, {zero_rate} zero-result rate")
+        }
         _ => "unknown".to_string(),
     }
 }
@@ -818,12 +820,12 @@ mod tests {
                     "is_healthy": true,
                     "has_errors": false,
                     "status": "\
-        +---------------+-------+\n\
-        |    Metric     | Value |\n\
-        +---------------+-------+\n\
-        | Total Queries |  121  |\n\
-        | Total Errors  |   0   |\n\
-        +---------------+-------+"
+        +---------------------+-----------------+\n\
+        |       Metric        |      Value      |\n\
+        +---------------------+-----------------+\n\
+        |    Total Queries    |       121       |\n\
+        | Zero-Result Rate   |      28.9%      |\n\
+        +---------------------+-----------------+"
                 },
                 "filesystem": {
                     "name": "filesystem",

--- a/openviking/retrieve/retrieval_stats.py
+++ b/openviking/retrieve/retrieval_stats.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Thread-safe retrieval statistics accumulator.
 
-Collects per-query metrics from the ``HierarchicalRetriever`` and retrieval
-errors from the service boundary for the observer API.
+Collects per-query metrics from the ``HierarchicalRetriever`` so that
+the ``RetrievalObserver`` can report aggregate health and quality data
+via the observer API.
 """
 
 import threading
@@ -21,8 +22,7 @@ class RetrievalStats:
 
     total_queries: int = 0
     total_results: int = 0
-    total_errors: int = 0
-    last_error: str | None = None
+    zero_result_queries: int = 0
     total_score_sum: float = 0.0
     max_score: float = 0.0
     min_score: float = float("inf")
@@ -37,6 +37,12 @@ class RetrievalStats:
         if self.total_queries == 0:
             return 0.0
         return self.total_results / self.total_queries
+
+    @property
+    def zero_result_rate(self) -> float:
+        if self.total_queries == 0:
+            return 0.0
+        return self.zero_result_queries / self.total_queries
 
     @property
     def avg_score(self) -> float:
@@ -55,8 +61,8 @@ class RetrievalStats:
         return {
             "total_queries": self.total_queries,
             "total_results": self.total_results,
-            "total_errors": self.total_errors,
-            "last_error": self.last_error,
+            "zero_result_queries": self.zero_result_queries,
+            "zero_result_rate": round(self.zero_result_rate, 4),
             "avg_results_per_query": round(self.avg_results_per_query, 2),
             "avg_score": round(self.avg_score, 4),
             "max_score": round(self.max_score, 4) if self.total_results > 0 else 0.0,
@@ -108,6 +114,9 @@ class RetrievalStatsCollector:
             self._stats.total_queries += 1
             self._stats.total_results += result_count
 
+            if result_count == 0:
+                self._stats.zero_result_queries += 1
+
             for s in scores:
                 self._stats.total_score_sum += s
                 if s > self._stats.max_score:
@@ -140,12 +149,6 @@ class RetrievalStatsCollector:
             )
         except Exception:
             pass
-
-    def record_error(self, error: Exception) -> None:
-        """Record a retrieval execution error observed by the service layer."""
-        with self._lock:
-            self._stats.total_errors += 1
-            self._stats.last_error = f"{type(error).__name__}: {error}"[:200]
 
     def snapshot(self) -> RetrievalStats:
         """Return a copy of the current stats."""

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.uri_validation import validate_optional_viking_uris
-from openviking.retrieve.retrieval_stats import get_stats_collector
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import VikingFS
 from openviking.utils.image_search import (
@@ -19,11 +18,7 @@ from openviking.utils.image_search import (
     is_http_url,
     is_viking_uri,
 )
-from openviking_cli.exceptions import (
-    InvalidArgumentError,
-    NotInitializedError,
-    PermissionDeniedError,
-)
+from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
 from openviking_cli.utils import get_logger
 
 if TYPE_CHECKING:
@@ -118,23 +113,17 @@ class SearchService:
         if session is not None and self.is_intent_enabled() and not resolved_image_url:
             session_info = await session.get_context_for_search(query)
 
-        try:
-            result = await viking_fs.search(
-                query=query,
-                ctx=ctx,
-                target_uri=target_uri,
-                session_info=session_info,
-                limit=limit,
-                score_threshold=score_threshold,
-                filter=filter,
-                level=level,
-                image_url=resolved_image_url,
-            )
-        except (InvalidArgumentError, PermissionDeniedError):
-            raise
-        except Exception as exc:
-            get_stats_collector().record_error(exc)
-            raise
+        result = await viking_fs.search(
+            query=query,
+            ctx=ctx,
+            target_uri=target_uri,
+            session_info=session_info,
+            limit=limit,
+            score_threshold=score_threshold,
+            filter=filter,
+            level=level,
+            image_url=resolved_image_url,
+        )
         return result
 
     async def find(
@@ -165,20 +154,14 @@ class SearchService:
         _ensure_non_empty_query(query, resolved_image_url)
         target_uri = validate_optional_viking_uris(target_uri, field_name="target_uri")
         viking_fs = self._ensure_initialized()
-        try:
-            result = await viking_fs.find(
-                query=query,
-                ctx=ctx,
-                target_uri=target_uri,
-                limit=limit,
-                score_threshold=score_threshold,
-                filter=filter,
-                level=level,
-                image_url=resolved_image_url,
-            )
-        except (InvalidArgumentError, PermissionDeniedError):
-            raise
-        except Exception as exc:
-            get_stats_collector().record_error(exc)
-            raise
+        result = await viking_fs.find(
+            query=query,
+            ctx=ctx,
+            target_uri=target_uri,
+            limit=limit,
+            score_threshold=score_threshold,
+            filter=filter,
+            level=level,
+            image_url=resolved_image_url,
+        )
         return result

--- a/openviking/storage/observers/retrieval_observer.py
+++ b/openviking/storage/observers/retrieval_observer.py
@@ -3,7 +3,7 @@
 """
 RetrievalObserver: Retrieval system observability tool.
 
-Provides retrieval diagnostics and reports actual execution errors.
+Provides retrieval diagnostics accumulated by the HierarchicalRetriever.
 """
 
 from openviking.storage.observers.base_observer import BaseObserver
@@ -16,8 +16,8 @@ class RetrievalObserver(BaseObserver):
     """
     RetrievalObserver: System observability tool for retrieval quality.
 
-    Empty retrievals are valid outcomes. Health reflects execution errors,
-    while result counts and scores remain diagnostics only.
+    Empty retrievals are valid outcomes. Result counts and scores are
+    diagnostics only and do not determine component health.
     """
 
     @staticmethod
@@ -37,14 +37,18 @@ class RetrievalObserver(BaseObserver):
 
         stats = self._get_collector().snapshot()
 
-        if stats.total_queries == 0 and stats.total_errors == 0:
+        if stats.total_queries == 0:
             return "No retrieval queries recorded."
 
         summary = [
             {"Metric": "Total Queries", "Value": stats.total_queries},
             {"Metric": "Total Results", "Value": stats.total_results},
             {"Metric": "Avg Results/Query", "Value": f"{stats.avg_results_per_query:.1f}"},
-            {"Metric": "Total Errors", "Value": stats.total_errors},
+            {"Metric": "Zero-Result Queries", "Value": stats.zero_result_queries},
+            {
+                "Metric": "Zero-Result Rate",
+                "Value": f"{stats.zero_result_rate:.1%}",
+            },
             {"Metric": "Avg Score", "Value": f"{stats.avg_score:.4f}"},
             {
                 "Metric": "Score Range",
@@ -57,8 +61,6 @@ class RetrievalObserver(BaseObserver):
             {"Metric": "Avg Latency (ms)", "Value": f"{stats.avg_latency_ms:.1f}"},
             {"Metric": "Max Latency (ms)", "Value": f"{stats.max_latency_ms:.1f}"},
         ]
-        if stats.last_error:
-            summary.append({"Metric": "Last Error", "Value": stats.last_error})
 
         lines = [tabulate(summary, headers="keys", tablefmt="pretty")]
 
@@ -79,9 +81,9 @@ class RetrievalObserver(BaseObserver):
         return self.get_status_table()
 
     def is_healthy(self) -> bool:
-        """Retrieval is healthy when no execution errors have been recorded."""
-        return not self.has_errors()
+        """Retrieval result diagnostics do not indicate component availability."""
+        return True
 
     def has_errors(self) -> bool:
-        """Return whether retrieval execution errors have been recorded."""
-        return self._get_collector().snapshot().total_errors > 0
+        """Empty retrieval results are valid outcomes, not errors."""
+        return False

--- a/tests/server/test_api_search_context.py
+++ b/tests/server/test_api_search_context.py
@@ -5,7 +5,6 @@ import json
 
 import httpx
 
-from openviking.retrieve.retrieval_stats import get_stats_collector
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.retrieve import ContextType, MatchedContext
 from openviking_cli.session.user_id import UserIdentifier
@@ -206,8 +205,7 @@ async def test_context_mode_degrades_a_retrieval_failure(
         del kwargs
         raise RuntimeError("embedder unreachable")
 
-    get_stats_collector().reset()
-    monkeypatch.setattr(service.viking_fs, "find", fake_find)
+    monkeypatch.setattr(service.search, "find", fake_find)
     response = await client.post(
         "/api/v1/search/search",
         json={"query": "still a valid request", "mode": "context"},
@@ -215,10 +213,6 @@ async def test_context_mode_degrades_a_retrieval_failure(
 
     assert response.status_code == 200
     assert response.json()["result"]["stats"]["retrieval_errors"]
-    retrieval_status = (await client.get("/api/v1/observer/retrieval")).json()["result"]
-    assert retrieval_status["is_healthy"] is False
-    assert retrieval_status["has_errors"] is True
-    assert "RuntimeError: embedder unreachable" in retrieval_status["status"]
 
 
 async def test_list_mode_response_is_unchanged(

--- a/tests/unit/retrieve/test_retrieval_stats.py
+++ b/tests/unit/retrieve/test_retrieval_stats.py
@@ -11,7 +11,7 @@ class TestRetrievalStats:
         stats = RetrievalStats()
         assert stats.total_queries == 0
         assert stats.avg_results_per_query == 0.0
-        assert stats.total_errors == 0
+        assert stats.zero_result_rate == 0.0
         assert stats.avg_score == 0.0
         assert stats.avg_latency_ms == 0.0
 
@@ -34,6 +34,7 @@ class TestRetrievalStatsCollector:
         stats = collector.snapshot()
         assert stats.total_queries == 1
         assert stats.total_results == 3
+        assert stats.zero_result_queries == 0
         assert stats.max_score == 0.9
         assert stats.min_score == 0.5
         assert stats.queries_by_type == {"memory": 1}
@@ -50,7 +51,8 @@ class TestRetrievalStatsCollector:
         stats = collector.snapshot()
         assert stats.total_queries == 1
         assert stats.total_results == 0
-        assert stats.total_errors == 0
+        assert stats.zero_result_queries == 1
+        assert stats.zero_result_rate == 1.0
 
     def test_record_multiple_queries(self):
         collector = RetrievalStatsCollector()
@@ -61,6 +63,7 @@ class TestRetrievalStatsCollector:
         stats = collector.snapshot()
         assert stats.total_queries == 3
         assert stats.total_results == 3
+        assert stats.zero_result_queries == 1
         assert stats.queries_by_type == {"memory": 2, "resource": 1}
         assert stats.avg_latency_ms == (30 + 20 + 5) / 3
 
@@ -139,15 +142,7 @@ class TestRetrievalObserver:
         observer = RetrievalObserver()
         assert observer.is_healthy() is True
         assert observer.has_errors() is False
-
-    def test_unhealthy_with_retrieval_error(self):
-        collector = self._setup_collector()
-        collector.record_error(RuntimeError("backend unavailable"))
-
-        observer = RetrievalObserver()
-        assert observer.is_healthy() is False
-        assert observer.has_errors() is True
-        assert "RuntimeError: backend unavailable" in observer.get_status_table()
+        assert "Zero-Result Rate" in observer.get_status_table()
 
     def test_status_table_no_data(self):
         self._setup_collector()
@@ -162,8 +157,7 @@ class TestRetrievalObserver:
         observer = RetrievalObserver()
         table = observer.get_status_table()
         assert "Total Queries" in table
-        assert "Total Errors" in table
-        assert "Zero-Result" not in table
+        assert "Zero-Result Rate" in table
         assert "memory" in table
         assert "resource" in table
 


### PR DESCRIPTION
## Description

相对 #3975 合并前的 `main`，本 PR 只改变 Retrieval Observer 的健康判断：空结果次数、空结果率、分数和延迟继续作为诊断数据，但空结果不再使 Retrieval 或系统进入异常状态。同时撤销 #3975 引入的进程级累计错误状态。

### Expected Behavior

场景一：一次 Context Search 拆成 10 次内部检索，10 次都正常返回空结果。

```text
# Before（#3975 合并前的 main）
result.is_healthy: false
result.has_errors: true
result.status:
  Total Queries: 10
  Total Results: 0
  Zero-Result Queries: 10
  Zero-Result Rate: 100.0%

# After（本 PR）
result.is_healthy: true
result.has_errors: false
result.status:
  Total Queries: 10
  Total Results: 0
  Zero-Result Queries: 10
  Zero-Result Rate: 100.0%
```

场景二：一次 Context Search 的底层检索抛出 `RuntimeError: embedder unreachable`。

- **Before（#3975 合并前的 `main`）:** Context Search 返回 HTTP 200，并在响应的 `retrieval_errors` 中报告本次降级；普通检索传播异常。Retrieval Observer 不保存原始请求错误。
- **After:** 请求级行为保持不变。Retrieval Observer 仍不保存原始请求错误，也不根据历史请求结果改变组件健康状态。

### Logic and Flow

- **Before（#3975 合并前的 `main`）:** 内部检索完成 → Retrieval Collector 记录结果数和空结果率 → Observer 在空结果率不低于 50% 且平均结果数低于 1 时判定异常。
- **After:** 内部检索继续记录相同的诊断指标 → Observer 不再用检索产出判断组件可用性 → 空结果保持健康。VikingDB 和模型可用性继续由各自 Observer 负责。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Follow-up to #3975. Related to #3958.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 删除 Retrieval Observer 的 `Total Errors`、`Last Error` 和 `SearchService` 累计错误逻辑。
- 恢复零结果次数、零结果率及 `ov status` 摘要，将它们保留为诊断信息而非健康条件。
- 精简现有契约测试，覆盖空结果保持健康及原有 Context Search 异常降级行为。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- `pytest`: 相关 Python 测试 29 项通过
- `cargo test -p ov_cli status_ui`: 5 项通过
- `ruff check`、`ruff format --check`、`rustfmt --check` 和 `git diff --check`: 通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本 PR 基于已经合并的 #3975，因此代码 Diff 包含对其中 `Total Errors`、`Last Error` 和 `SearchService` 累计逻辑的撤销。相对 #3975 合并前的 `main`，最终生产行为只有“零结果指标不再参与健康判断”这一项变化；请求级异常契约和零结果诊断字段保持不变。
