### PR TITLE
fix(openclaw-plugin): restore runtimeQueryConfigPath in configSchema (#3901)

### DIFF
--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -261,6 +261,12 @@
       "placeholder": "memory",
       "help": "Agent-visible tool blocklist applied after enabledTools. Accepts the same tool names or groups.",
       "advanced": true
+    },
+    "runtimeQueryConfigPath": {
+      "label": "Runtime Query Config Path",
+      "placeholder": "~/.openclaw/openviking/runtime-query-config.json",
+      "help": "Optional JSON file for /ov-query-config runtime overrides. Empty keeps overrides in memory only.",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -514,6 +520,10 @@
             "type": "string"
           }
         ]
+      },
+      "runtimeQueryConfigPath": {
+        "type": "string",
+        "description": "Optional JSON file path for runtime query config overrides. Empty means in-memory only."
       },
       "agentExperience": {
         "type": "object",


### PR DESCRIPTION
## Summary

Fixes #3901.

In `openclaw.plugin.json` v2026.8.7, `configSchema.properties` is missing `runtimeQueryConfigPath` while `additionalProperties: false`. The runtime code fully supports the field (declared, allow-listed, parsed, and even carries a schema entry in `config.ts`), but any deployment that sets `runtimeQueryConfigPath` in `openclaw.json` fails config validation:

    plugins.entries.openviking.config: invalid config: must not have additional properties: "runtimeQueryConfigPath"

The plugin then fails to load. The field was present in the v2026.7.15 schema and was lost during the v2026.8.7 refactor.

## Changes

`examples/openclaw-plugin/openclaw.plugin.json` (+10 lines), restoring `runtimeQueryConfigPath` in two places that drifted in v2026.8.7:

1. **`configSchema.properties`** — the core fix. Added between `disabledTools` and `agentExperience`, matching the `assertAllowedKeys` order in `config.ts`. Type (`string`) and description sourced from the `config.ts` type definition and JSDoc.
2. **`uiHints`** — the same drift event also dropped the field from UI hints, so it is restored here too (label / placeholder / help / advanced copied verbatim from the `config.ts` UI metadata).

The manifest schema is hand-maintained (not generated): `build.sh` only runs `tsc` and copies the manifest; there is no schema generator. Editing the JSON manifest is therefore the correct fix — `config.ts` already contains the field everywhere it should.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 746 / 750 pass. The 4 failures are all in `architecture-boundaries.test.ts` (pre-existing, unrelated static-pattern checks; this PR touches only the manifest JSON — zero `.ts` files, confirmed via `git diff 33043cb1b HEAD --stat`).
- Schema-level repro of the bug: a config containing `runtimeQueryConfigPath` is now accepted (previously rejected), while a genuinely unknown key is still rejected — i.e. validation is fixed without being loosened.
- Plugin config parse layer: `runtimeQueryConfigPath` with a `~`-prefixed path parses and expands correctly; unknown keys still throw.

## Notes

- The `uiHints` addition is slightly beyond the issue's literal scope (which names only `configSchema`), but it is the same field in the same file lost in the same v2026.8.7 drift. Happy to revert those lines if a minimal diff is preferred.
- Opened as draft while an additional adversarial pass runs; will mark ready for review once confirmed.

Closes #3901.
