### PR TITLE
fix(vlm): bound concurrent extraction calls with shared semaphore + 429 backoff (#3008)

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -19,7 +19,12 @@ try:
 except ImportError:
     openai = None
 
-from openviking.utils.model_retry import retry_async, retry_sync
+from openviking.utils.model_retry import (
+    completion_retry_delay,
+    is_completion_retryable,
+    retry_async,
+    retry_sync,
+)
 
 from ..base import ToolCall, VLMBase, VLMResponse
 from ..registry import DEFAULT_AZURE_API_VERSION
@@ -349,12 +354,25 @@ class OpenAIVLM(VLMBase):
             f"messages={json.dumps(redact_image_data_urls(kwargs), ensure_ascii=False, indent=2)}"
         )
 
-        return await retry_async(
-            _call,
-            max_retries=self.max_retries,
-            logger=logger,
-            operation_name="OpenAI VLM async completion",
-        )
+        # Bound in-flight completions process-wide via vlm.max_concurrent (shared
+        # across sessions/backends) and retry rate-limit (429) responses with
+        # backoff instead of failing the extraction (issue #3008).
+        semaphore = self._get_completion_semaphore()
+
+        async def _retry() -> Union[str, VLMResponse]:
+            return await retry_async(
+                _call,
+                max_retries=self.max_retries,
+                is_retryable=is_completion_retryable,
+                delay_fn=completion_retry_delay,
+                logger=logger,
+                operation_name="OpenAI VLM async completion",
+            )
+
+        if semaphore is None:
+            return await _retry()
+        async with semaphore:
+            return await _retry()
 
     def _detect_image_format(self, data: bytes) -> str:
         """Detect image format from magic bytes.
@@ -464,9 +482,19 @@ class OpenAIVLM(VLMBase):
                 return self._build_vlm_response(response, has_tools=True)
             return await self._extract_completion_content_async(response, elapsed)
 
-        return await retry_async(
-            _call,
-            max_retries=self.max_retries,
-            logger=logger,
-            operation_name="OpenAI VLM async vision completion",
-        )
+        semaphore = self._get_completion_semaphore()
+
+        async def _retry() -> Union[str, VLMResponse]:
+            return await retry_async(
+                _call,
+                max_retries=self.max_retries,
+                is_retryable=is_completion_retryable,
+                delay_fn=completion_retry_delay,
+                logger=logger,
+                operation_name="OpenAI VLM async vision completion",
+            )
+
+        if semaphore is None:
+            return await _retry()
+        async with semaphore:
+            return await _retry()

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VLM base interface and abstract classes"""
 
+import asyncio
 import logging
 import re
+import threading
+import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,6 +24,38 @@ from .token_usage import TokenUsageTracker
 
 _THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>")
 logger = get_logger(__name__)
+
+# Process-wide registry of shared concurrency semaphores for VLM completion
+# calls, keyed by (event_loop, max_concurrent). An asyncio.Semaphore is bound to
+# the event loop that created it, so — like the embedder semaphore
+# (openviking/models/embedder/base.py) — we key by loop and lazily create the
+# semaphore inside the running loop. Because get_vlm_instance() returns a single
+# cached VLM instance per process, all memory-extraction paths (summary /
+# long-term / execution) and all concurrently-committing sessions funnel through
+# the same semaphore, bounding the in-flight get_completion_async call count to
+# ``vlm.max_concurrent`` and preventing 429 rate-limit bursts (issue #3008).
+_ASYNC_VLM_SEMAPHORES: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, Dict[int, asyncio.Semaphore]]" = (
+    weakref.WeakKeyDictionary()
+)
+_ASYNC_VLM_SEMAPHORE_LOCK = threading.Lock()
+
+
+def _get_async_vlm_semaphore(limit: int) -> asyncio.Semaphore:
+    """Return the shared, per-event-loop VLM completion semaphore for ``limit``.
+
+    Mirrors ``_get_async_embed_semaphore``: one ``asyncio.Semaphore(limit)`` per
+    (event loop, limit) pair, shared across every VLM instance and backend on
+    that loop. Created lazily inside the running loop.
+    """
+    loop = asyncio.get_running_loop()
+    normalized_limit = max(1, limit)
+    with _ASYNC_VLM_SEMAPHORE_LOCK:
+        semaphores_by_limit = _ASYNC_VLM_SEMAPHORES.setdefault(loop, {})
+        semaphore = semaphores_by_limit.get(normalized_limit)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(normalized_limit)
+            semaphores_by_limit[normalized_limit] = semaphore
+        return semaphore
 
 
 class UnsupportedMediaInputError(RuntimeError):
@@ -77,9 +112,25 @@ class VLMBase(ABC):
         self.extra_request_body = dict(config.get("extra_request_body") or {})
         self.stream = config.get("stream", False)
         self.thinking = config.get("thinking", False)
+        # Cap on in-flight async completion calls. ``vlm.max_concurrent`` is the
+        # value configured on VLMConfig (default 32) and threaded into the VLM
+        # instance config; 0 / unset means unbounded (backward compatible).
+        self.max_concurrent = int(config.get("max_concurrent", 0) or 0)
 
         # Token usage tracking
         self._token_tracker = TokenUsageTracker()
+
+    def _get_completion_semaphore(self) -> Optional[asyncio.Semaphore]:
+        """Shared semaphore bounding concurrent async VLM completion calls.
+
+        Returns ``None`` when ``max_concurrent <= 0`` (unbounded, the historical
+        behavior). Otherwise returns the process-wide semaphore shared across all
+        VLM instances on the current event loop, so memory-extraction bursts and
+        cross-session concurrent extractions share a single concurrency budget.
+        """
+        if self.max_concurrent <= 0:
+            return None
+        return _get_async_vlm_semaphore(self.max_concurrent)
 
     @abstractmethod
     def get_completion(

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: AGPL-3.0
 """VLM base interface and abstract classes"""
 
+import asyncio
 import logging
 import re
+import threading
+import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -22,6 +25,38 @@ from .token_usage import TokenUsageTracker
 
 _THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>")
 logger = get_logger(__name__)
+
+# Process-wide registry of shared concurrency semaphores for VLM completion
+# calls, keyed by (event_loop, max_concurrent). An asyncio.Semaphore is bound to
+# the event loop that created it, so — like the embedder semaphore
+# (openviking/models/embedder/base.py) — we key by loop and lazily create the
+# semaphore inside the running loop. Because get_vlm_instance() returns a single
+# cached VLM instance per process, all memory-extraction paths (summary /
+# long-term / execution) and all concurrently-committing sessions funnel through
+# the same semaphore, bounding the in-flight get_completion_async call count to
+# ``vlm.max_concurrent`` and preventing 429 rate-limit bursts (issue #3008).
+_ASYNC_VLM_SEMAPHORES: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, Dict[int, asyncio.Semaphore]]" = (
+    weakref.WeakKeyDictionary()
+)
+_ASYNC_VLM_SEMAPHORE_LOCK = threading.Lock()
+
+
+def _get_async_vlm_semaphore(limit: int) -> asyncio.Semaphore:
+    """Return the shared, per-event-loop VLM completion semaphore for ``limit``.
+
+    Mirrors ``_get_async_embed_semaphore``: one ``asyncio.Semaphore(limit)`` per
+    (event loop, limit) pair, shared across every VLM instance and backend on
+    that loop. Created lazily inside the running loop.
+    """
+    loop = asyncio.get_running_loop()
+    normalized_limit = max(1, limit)
+    with _ASYNC_VLM_SEMAPHORE_LOCK:
+        semaphores_by_limit = _ASYNC_VLM_SEMAPHORES.setdefault(loop, {})
+        semaphore = semaphores_by_limit.get(normalized_limit)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(normalized_limit)
+            semaphores_by_limit[normalized_limit] = semaphore
+        return semaphore
 
 
 class UnsupportedMediaInputError(RuntimeError):
@@ -77,9 +112,25 @@ class VLMBase(ABC):
         self.extra_headers = config.get("extra_headers")
         self.extra_request_body = dict(config.get("extra_request_body") or {})
         self.thinking = config.get("thinking", False)
+        # Cap on in-flight async completion calls. ``vlm.max_concurrent`` is the
+        # value configured on VLMConfig (default 32) and threaded into the VLM
+        # instance config; 0 / unset means unbounded (backward compatible).
+        self.max_concurrent = int(config.get("max_concurrent", 0) or 0)
 
         # Token usage tracking
         self._token_tracker = TokenUsageTracker()
+
+    def _get_completion_semaphore(self) -> Optional[asyncio.Semaphore]:
+        """Shared semaphore bounding concurrent async VLM completion calls.
+
+        Returns ``None`` when ``max_concurrent <= 0`` (unbounded, the historical
+        behavior). Otherwise returns the process-wide semaphore shared across all
+        VLM instances on the current event loop, so memory-extraction bursts and
+        cross-session concurrent extractions share a single concurrency budget.
+        """
+        if self.max_concurrent <= 0:
+            return None
+        return _get_async_vlm_semaphore(self.max_concurrent)
 
     @abstractmethod
     def get_completion(

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -325,6 +325,34 @@ def _compute_delay(
     return delay
 
 
+def is_completion_retryable(error: Exception) -> bool:
+    """Retry predicate for LLM/VLM completion calls.
+
+    Extends :func:`is_retryable_api_error` (transient errors) to also retry
+    rate-limit (429) responses. Rate-limit errors are sometimes classified as
+    ``quota_exceeded`` (e.g. ``"429 ... AccountQuotaExceeded"``) which the base
+    predicate treats as non-retryable; during memory-extraction bursts they are
+    transient load conditions that should back off and retry rather than fail
+    the extraction and drop memories (issue #3008).
+    """
+    if is_retryable_api_error(error):
+        return True
+    return is_retryable_rate_limit_error(error)
+
+
+def completion_retry_delay(attempt: int, error: Exception) -> float:
+    """Backoff delay for LLM/VLM completion retries.
+
+    Rate-limit (429) errors use the longer :func:`rate_limit_retry_delay`
+    schedule (5s base, 120s cap) so concurrent extraction bursts back off
+    instead of hammering the provider. Other transient errors keep the default
+    short backoff.
+    """
+    if is_retryable_rate_limit_error(error):
+        return rate_limit_retry_delay(attempt + 1)
+    return _compute_delay(attempt, base_delay=0.5, max_delay=8.0, jitter=True)
+
+
 def retry_sync(
     func: Callable[[], T],
     *,
@@ -333,10 +361,16 @@ def retry_sync(
     max_delay: float = 8.0,
     jitter: bool = True,
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    delay_fn: Callable[[int, Exception], float] | None = None,
     logger=None,
     operation_name: str = "operation",
 ) -> T:
-    """Retry a sync function on known transient errors."""
+    """Retry a sync function on known transient errors.
+
+    If ``delay_fn`` is provided it overrides the default backoff: it receives the
+    current ``attempt`` index and the caught exception, letting callers tailor the
+    delay to the error type (e.g. longer sleeps for rate-limit responses).
+    """
     attempt = 0
 
     while True:
@@ -346,12 +380,15 @@ def retry_sync(
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
 
-            delay = _compute_delay(
-                attempt,
-                base_delay=base_delay,
-                max_delay=max_delay,
-                jitter=jitter,
-            )
+            if delay_fn is not None:
+                delay = delay_fn(attempt, e)
+            else:
+                delay = _compute_delay(
+                    attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    jitter=jitter,
+                )
             if logger:
                 logger.warning(
                     "%s failed with retryable error (retry %d/%d): %s; retrying in %.2fs",
@@ -373,10 +410,16 @@ async def retry_async(
     max_delay: float = 8.0,
     jitter: bool = True,
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    delay_fn: Callable[[int, Exception], float] | None = None,
     logger=None,
     operation_name: str = "operation",
 ) -> T:
-    """Retry an async function on known transient errors."""
+    """Retry an async function on known transient errors.
+
+    If ``delay_fn`` is provided it overrides the default backoff: it receives the
+    current ``attempt`` index and the caught exception, letting callers tailor the
+    delay to the error type (e.g. longer sleeps for rate-limit responses).
+    """
     attempt = 0
 
     while True:
@@ -386,12 +429,15 @@ async def retry_async(
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
 
-            delay = _compute_delay(
-                attempt,
-                base_delay=base_delay,
-                max_delay=max_delay,
-                jitter=jitter,
-            )
+            if delay_fn is not None:
+                delay = delay_fn(attempt, e)
+            else:
+                delay = _compute_delay(
+                    attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    jitter=jitter,
+                )
             if logger:
                 logger.warning(
                     "%s failed with retryable error (retry %d/%d): %s; retrying in %.2fs",

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -376,6 +376,34 @@ def _compute_delay(
     return delay
 
 
+def is_completion_retryable(error: Exception) -> bool:
+    """Retry predicate for LLM/VLM completion calls.
+
+    Extends :func:`is_retryable_api_error` (transient errors) to also retry
+    rate-limit (429) responses. Rate-limit errors are sometimes classified as
+    ``quota_exceeded`` (e.g. ``"429 ... AccountQuotaExceeded"``) which the base
+    predicate treats as non-retryable; during memory-extraction bursts they are
+    transient load conditions that should back off and retry rather than fail
+    the extraction and drop memories (issue #3008).
+    """
+    if is_retryable_api_error(error):
+        return True
+    return is_retryable_rate_limit_error(error)
+
+
+def completion_retry_delay(attempt: int, error: Exception) -> float:
+    """Backoff delay for LLM/VLM completion retries.
+
+    Rate-limit (429) errors use the longer :func:`rate_limit_retry_delay`
+    schedule (5s base, 120s cap) so concurrent extraction bursts back off
+    instead of hammering the provider. Other transient errors keep the default
+    short backoff.
+    """
+    if is_retryable_rate_limit_error(error):
+        return rate_limit_retry_delay(attempt + 1)
+    return _compute_delay(attempt, base_delay=0.5, max_delay=8.0, jitter=True)
+
+
 def retry_sync(
     func: Callable[[], T],
     *,
@@ -384,10 +412,16 @@ def retry_sync(
     max_delay: float = 8.0,
     jitter: bool = True,
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    delay_fn: Callable[[int, Exception], float] | None = None,
     logger=None,
     operation_name: str = "operation",
 ) -> T:
-    """Retry a sync function on known transient errors."""
+    """Retry a sync function on known transient errors.
+
+    If ``delay_fn`` is provided it overrides the default backoff: it receives the
+    current ``attempt`` index and the caught exception, letting callers tailor the
+    delay to the error type (e.g. longer sleeps for rate-limit responses).
+    """
     attempt = 0
 
     while True:
@@ -397,12 +431,15 @@ def retry_sync(
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
 
-            delay = _compute_delay(
-                attempt,
-                base_delay=base_delay,
-                max_delay=max_delay,
-                jitter=jitter,
-            )
+            if delay_fn is not None:
+                delay = delay_fn(attempt, e)
+            else:
+                delay = _compute_delay(
+                    attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    jitter=jitter,
+                )
             if logger:
                 logger.warning(
                     "%s failed with retryable error (retry %d/%d): %s; retrying in %.2fs",
@@ -424,10 +461,16 @@ async def retry_async(
     max_delay: float = 8.0,
     jitter: bool = True,
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    delay_fn: Callable[[int, Exception], float] | None = None,
     logger=None,
     operation_name: str = "operation",
 ) -> T:
-    """Retry an async function on known transient errors."""
+    """Retry an async function on known transient errors.
+
+    If ``delay_fn`` is provided it overrides the default backoff: it receives the
+    current ``attempt`` index and the caught exception, letting callers tailor the
+    delay to the error type (e.g. longer sleeps for rate-limit responses).
+    """
     attempt = 0
 
     while True:
@@ -437,12 +480,15 @@ async def retry_async(
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
 
-            delay = _compute_delay(
-                attempt,
-                base_delay=base_delay,
-                max_delay=max_delay,
-                jitter=jitter,
-            )
+            if delay_fn is not None:
+                delay = delay_fn(attempt, e)
+            else:
+                delay = _compute_delay(
+                    attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    jitter=jitter,
+                )
             if logger:
                 logger.warning(
                     "%s failed with retryable error (retry %d/%d): %s; retrying in %.2fs",

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -644,6 +644,7 @@ class VLMConfig(BaseModel):
                 credential.max_tokens if credential.max_tokens is not None else self.max_tokens
             ),
             "api_version": credential.api_version,
+            "max_concurrent": self.max_concurrent,
             "media": self.media.model_dump(),
         }
 
@@ -675,6 +676,7 @@ class VLMConfig(BaseModel):
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,
             "api_version": self.api_version,
+            "max_concurrent": self.max_concurrent,
             "media": self.media.model_dump(),
         }
 

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -607,6 +607,7 @@ class VLMConfig(BaseModel):
             ),
             "stream": credential.stream if credential.stream is not None else self.stream,
             "api_version": credential.api_version,
+            "max_concurrent": self.max_concurrent,
             "media": self.media.model_dump(),
         }
 
@@ -642,6 +643,7 @@ class VLMConfig(BaseModel):
             "max_tokens": self.max_tokens,
             "stream": stream,
             "api_version": self.api_version,
+            "max_concurrent": self.max_concurrent,
             "media": self.media.model_dump(),
         }
 

--- a/tests/models/vlm/test_vlm_extraction_concurrency.py
+++ b/tests/models/vlm/test_vlm_extraction_concurrency.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for bounding concurrent VLM calls during memory extraction (#3008).
+
+Multiple sessions committing at once each spawn summary / long-term / execution
+VLM calls. ``vlm.max_concurrent`` must bound the in-flight
+``get_completion_async`` count process-wide (shared across sessions and VLM
+instances), and 429 rate-limit responses must back off and retry rather than
+failing the extraction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+
+
+def _fake_response(text: str = "ok"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+
+def _make_vlm(max_concurrent: int, max_retries: int = 2) -> OpenAIVLM:
+    return OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-test",
+            "api_base": "http://localhost",
+            "max_concurrent": max_concurrent,
+            "max_retries": max_retries,
+        }
+    )
+
+
+def _fake_client(create_fn):
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_fn))
+    )
+
+
+class _FakeQuotaRateLimit(Exception):
+    """A 429 the provider worded as quota-exceeded.
+
+    ``classify_api_error`` matches the ``quotaexceeded`` pattern first, so this
+    is classified as ``quota_exceeded`` and is NOT retryable via
+    ``is_retryable_api_error`` (the historical behavior). It is however a
+    rate-limit burst that ``is_retryable_rate_limit_error`` recognises, which is
+    what the #3008 fix wires into VLM completion retries.
+    """
+
+
+_QUOTA_429_MESSAGE = "Error code: 429 - AccountQuotaExceeded, rate limit exceeded"
+
+
+def test_max_concurrent_zero_is_unbounded():
+    """max_concurrent <= 0 keeps the historical unbounded behavior (no semaphore)."""
+    vlm = _make_vlm(max_concurrent=0)
+    assert vlm.max_concurrent == 0
+    assert vlm._get_completion_semaphore() is None
+
+
+async def test_concurrent_completions_bounded_by_max_concurrent(monkeypatch):
+    """A single VLM instance never exceeds max_concurrent in-flight calls."""
+    max_concurrent = 4
+    n_calls = 40
+    vlm = _make_vlm(max_concurrent)
+
+    state = {"in_flight": 0, "peak": 0, "count": 0}
+
+    async def fake_create(**kwargs):
+        state["in_flight"] += 1
+        state["count"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        try:
+            await asyncio.sleep(0.01)  # hold the slot so concurrency builds up
+            return _fake_response("ok")
+        finally:
+            state["in_flight"] -= 1
+
+    monkeypatch.setattr(vlm, "get_async_client", lambda: _fake_client(fake_create))
+
+    results = await asyncio.gather(
+        *[
+            vlm.get_completion_async(messages=[{"role": "user", "content": "hi"}])
+            for _ in range(n_calls)
+        ]
+    )
+
+    assert len(results) == n_calls
+    assert state["count"] == n_calls
+    assert state["peak"] <= max_concurrent, (
+        f"peak in-flight {state['peak']} exceeded max_concurrent={max_concurrent}"
+    )
+    assert state["peak"] > 1, "concurrency was not exercised"
+
+
+async def test_semaphore_shared_across_vlm_instances(monkeypatch):
+    """Two VLM instances with the same max_concurrent share one semaphore.
+
+    This mirrors multiple sessions (each gets the shared singleton VLM, or
+    independent instances built from the same config) committing concurrently:
+    their combined in-flight VLM calls must stay within max_concurrent.
+    """
+    max_concurrent = 3
+    vlm_a = _make_vlm(max_concurrent)
+    vlm_b = _make_vlm(max_concurrent)  # same limit on the same loop => shared semaphore
+
+    state = {"in_flight": 0, "peak": 0}
+
+    async def fake_create(**kwargs):
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        try:
+            await asyncio.sleep(0.01)
+            return _fake_response("ok")
+        finally:
+            state["in_flight"] -= 1
+
+    client = _fake_client(fake_create)
+    monkeypatch.setattr(vlm_a, "get_async_client", lambda: client)
+    monkeypatch.setattr(vlm_b, "get_async_client", lambda: client)
+
+    tasks = [
+        vlm_a.get_completion_async(messages=[{"role": "user", "content": "hi"}])
+        for _ in range(15)
+    ]
+    tasks += [
+        vlm_b.get_completion_async(messages=[{"role": "user", "content": "hi"}])
+        for _ in range(15)
+    ]
+    await asyncio.gather(*tasks)
+
+    assert state["peak"] <= max_concurrent, (
+        f"combined peak in-flight {state['peak']} exceeded max_concurrent={max_concurrent}"
+    )
+    assert state["peak"] > 1, "concurrency was not exercised"
+
+
+async def test_429_quota_rate_limit_is_retried_with_backoff(monkeypatch):
+    """A 429 rate-limit response is retried (with backoff) instead of failing fast.
+
+    The fake 429 is classified as quota_exceeded (non-retryable historically), so
+    this exercises the new rate-limit retry path. Backoff delay is stubbed to 0
+    to keep the test fast.
+    """
+    monkeypatch.setattr(
+        "openviking.models.vlm.backends.openai_vlm.completion_retry_delay",
+        lambda attempt, error: 0,
+    )
+
+    vlm = _make_vlm(max_concurrent=0, max_retries=3)  # unbounded; focus on retry
+
+    calls = {"n": 0}
+
+    async def fake_create(**kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _FakeQuotaRateLimit(_QUOTA_429_MESSAGE)
+        return _fake_response("recovered")
+
+    monkeypatch.setattr(vlm, "get_async_client", lambda: _fake_client(fake_create))
+
+    result = await vlm.get_completion_async(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "recovered"
+    assert calls["n"] == 3, f"expected 2 retries + 1 success, got {calls['n']} calls"
+
+
+async def test_429_raises_after_exhausting_retries(monkeypatch):
+    """Persistent 429 still surfaces after retries are exhausted (no infinite loop)."""
+    monkeypatch.setattr(
+        "openviking.models.vlm.backends.openai_vlm.completion_retry_delay",
+        lambda attempt, error: 0,
+    )
+
+    vlm = _make_vlm(max_concurrent=0, max_retries=2)
+    calls = {"n": 0}
+
+    async def fake_create(**kwargs):
+        calls["n"] += 1
+        raise _FakeQuotaRateLimit(_QUOTA_429_MESSAGE)
+
+    monkeypatch.setattr(vlm, "get_async_client", lambda: _fake_client(fake_create))
+
+    with pytest.raises(_FakeQuotaRateLimit):
+        await vlm.get_completion_async(messages=[{"role": "user", "content": "hi"}])
+
+    # initial attempt (0) + 2 retries => 3 total calls
+    assert calls["n"] == 3


### PR DESCRIPTION
## Summary

Fixes #3008.

Concurrent VLM calls during multi-session memory extraction overran provider rate limits (`429`). `vlm.max_concurrent` only bounded the semantic queue, not the `summary` / `long-term` / `execution` extraction paths, which fired unbounded through `ExtractLoop._call_llm`. This PR adds a process-wide shared semaphore bound by `vlm.max_concurrent`, plus 429 backoff/retry.

## Changes (5 files, +355/-27)

- **`vlm/base.py`** — module-level shared `_get_async_vlm_semaphore(limit)` + `VLMBase.max_concurrent` + `_get_completion_semaphore()` helper. Mirrors the embedder's existing `_get_async_embed_semaphore` pattern (`WeakKeyDictionary` keyed by event loop, since `asyncio.Semaphore` is loop-bound).
- **`vlm/backends/openai_vlm.py`** — semaphore acquired around `get_completion_async` / `get_vision_completion_async` (all four backends — GLM/Kimi/Codex/VolcEngine — inherit `OpenAIVLM`), plus 429 backoff retry.
- **`utils/model_retry.py`** — new `is_completion_retryable` / `completion_retry_delay`; `retry_sync`/`retry_async` gain an optional `delay_fn` (backward compatible). `is_completion_retryable` now treats `quota_exceeded` rate-limit errors as retryable — **the old `is_retryable_api_error` returned `False` for these, so they were never retried**.
- **`vlm_config.py`** — `max_concurrent` plumbed into both config-dict builders (per-credential + legacy).
- **`tests/models/vlm/test_vlm_extraction_concurrency.py`** — 5 new tests.

## How the semaphore covers all three paths and is shared across sessions

All four backends inherit `OpenAIVLM`; `get_vlm_instance()` is a process-level cached singleton; `summary` / `long-term` / `execution` all flow through `ExtractLoop._call_llm` → singleton VLM → `OpenAIVLM.get_completion_async`. The semaphore is module-level, cached per event-loop + limit. `test_semaphore_shared_across_vlm_instances` uses two VLM instances (≈ two sessions) and verifies the combined peak ≤ `max_concurrent`.

## Honest scope / behavior changes

1. **Shared within one OV process, not across processes.** OV runs sessions on one event loop, so intra-process sharing is real; each process gets its own registry (total budget = processes × `max_concurrent`). This matches the embedder and is an inherent asyncio-semaphore constraint.
2. **Default behavior change**: `VLMConfig.max_concurrent` defaults to 32. Memory-extraction VLM calls were previously unbounded and are now process-capped at 32 — this is the fix. If the semantic queue also routes through `get_completion_async`, it now shares the same 32 budget (more correct for provider rate limits, possibly slightly slower semantic processing); tunable via `vlm.max_concurrent`.
3. **MultiCredentialVLM (N credentials)**: N backends share one module-level semaphore → total concurrency = `max_concurrent` (not N×). Correct for the single-credential case in this issue; conservative for multi-credential (raise `max_concurrent` for higher throughput).
4. The semaphore wraps the retry, so rate-limit backoff sleeps hold a slot — natural back-pressure during recovery, which serves the anti-429 goal.
5. Did **not** adopt the issue author's global `Semaphore(1)` (too aggressive); used configurable `max_concurrent`.

## Verification

5 new tests pass (standard pytest, `asyncio_mode = "auto"`, no `ragfs_python` import dependency): single-instance peak ≤ `max_concurrent`, two instances share the semaphore, 429-quota backoff retries successfully, 429 raises after exhausting retries, `max_concurrent = 0` disables limiting.

The failing tests in the VLM config suite (`test_stream_config_vlm.py`, `test_vlm_config_uses_canonical_provider_names`, `test_vlm_config_default_provider_resolves_codex`) were confirmed **pre-existing** by reverting the four source files to `33043cb1b` and re-running (same failures; they concern `stream` kwarg / `get_provider_config()` logic untouched here).

Opened as draft while an adversarial pass runs.

Closes #3008.
