### PR TITLE
feat(examples): add dsh-plugin — OpenViking memory & context plugin for deepseek-harness

### DIFF
--- a/examples/dsh-plugin/.gitignore
+++ b/examples/dsh-plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+lib/

--- a/examples/dsh-plugin/README.md
+++ b/examples/dsh-plugin/README.md
@@ -1,0 +1,87 @@
+# @openviking/dsh-plugin
+
+OpenViking memory & context plugin for [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`).
+
+A thin dsh adapter over the OpenViking memory-plugin family's shared runtime:
+everything in [`shared/`](./shared) is vendored from
+[`examples/memory-plugin-shared`](../memory-plugin-shared) by its `sync.mjs`
+(do not edit those files here). Credentials, capture filtering, durable
+delivery with replay, and recall — server-side query expansion, cross-turn
+dedup, peer scoping, graceful downgrade for older servers, token-budgeted
+rendering — are all family code shared with the Claude Code, Codex, OpenCode,
+pi, and zcode plugins. Only the dsh integration is new:
+
+- **Capture** — maps dsh `session/event` surface messages into family capture
+  payloads (ordered per session); `turn/end` flushes through `batch-send`
+  (failures spill into the durable pending queue and replay on next start)
+  and triggers a throttled `commit`, OpenViking's memory-extraction step.
+- **Recall** — an `agent/pre-step` waterfall appends the shared
+  `buildRecallBlock` output as a durable, source-attributed user message
+  (`source: { kind: 'plugin', plugin: 'openviking', form: 'recall' }`). It
+  never touches the system prompt, so it survives presets whose persona is
+  `complete: true` (e.g. `minimal`), where prompt-assembly contributions are
+  silently dropped.
+- **Session seed** — on `agent/session-start` (resume) the committed
+  OpenViking session overview is queued through `agent.inject()`.
+- **Tools** — optional `ov_search` / `ov_read` / `ov_add_memory`
+  (`ov_add_memory` mirrors the `ov add-memory` CLI flow: ephemeral session
+  plus commit).
+
+## Install
+
+```sh
+dsh plugin --profile <profile> add @openviking/dsh-plugin
+```
+
+The package declares `dsh.bundle.patch`, so dsh composes its
+[`cordis.patch.yml`](./cordis.patch.yml) into the profile automatically.
+
+## Configuration
+
+Credentials resolve through the family chain — `OPENVIKING_*` environment →
+`~/.openviking/ovcli.conf` → `~/.openviking/ov.conf` — so an `ov`-configured
+machine needs nothing. The actor peer defaults to the workspace-derived peer
+(same rule as the other plugins); set an explicit peer or `workspacePeer: false`
+to change that. Behaviour knobs live in cordis config:
+
+```yaml
+- id: openviking
+  name: '@openviking/dsh-plugin'
+  config:
+    syncTurns: true          # mirror conversation into OpenViking
+    autoRecall: true         # inject recalled context at eligible steps
+    recallLimit: 5
+    scoreThreshold: 0.35
+    minQueryLength: 3
+    recallTokenBudget: 2000
+    sessionSeed: true        # inject committed session overview on resume
+    seedTokenBudget: 2000
+    commitOnTurnEnd: true
+    commitMinIntervalMs: 300000
+    commitKeepRecentCount: 10
+    workspacePeer: true
+    tools: true              # ov_search / ov_read / ov_add_memory
+```
+
+All OpenViking traffic is failure-contained: an unreachable server degrades
+the plugin to a no-op (rate-limited warnings, durable queue for capture) and
+never breaks an agent step.
+
+## Development
+
+```sh
+npm install
+npm run typecheck
+npm test          # unit tests
+npm run test:e2e  # real Loader boot + mock LLM + OpenViking stub, keyless
+npm run build
+```
+
+The e2e boots a real dsh Loader composition (`tests/fixtures/dsh-plugin.cordis.yml`)
+with a deterministic mock LLM adapter and an in-process OpenViking stub whose
+context-face endpoints 404 (pinning the shared recall runtime to its raw
+`search/find` fallback), then asserts both directions on the persisted session
+log and the recorded stub traffic: the conversation is mirrored into one
+`dsh-<session>` OpenViking session and committed, and each turn's recall block
+is appended as a durable `user/message` that reaches the model surface but
+never the request headers and never echoes back into capture.

--- a/examples/dsh-plugin/cordis.patch.yml
+++ b/examples/dsh-plugin/cordis.patch.yml
@@ -1,0 +1,9 @@
+# Composed into the dsh profile when this bundle is added with
+# `dsh plugin --profile <name> add @openviking/dsh-plugin`.
+# Connection falls back to OPENVIKING_BASE_URL / OPENVIKING_API_KEY,
+# then ~/.openviking/ovcli.conf; override per-deployment via the profile's
+# own cordis.patch.yml (patches replace a row's whole config).
+- insert:
+    - id: openviking
+      name: '@openviking/dsh-plugin'
+      config: {}

--- a/examples/dsh-plugin/package-lock.json
+++ b/examples/dsh-plugin/package-lock.json
@@ -1,0 +1,3258 @@
+{
+  "name": "@openviking/dsh-plugin",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openviking/dsh-plugin",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent-spine-demo": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-app-boot": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-loader-smoke": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0",
+        "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=22.16.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+        "@deepseek-ai/schemastery": "^3.18.1"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
+      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "bin": {
+        "cordis": "bin.js"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-include": {
+          "optional": true
+        },
+        "@deepseek-ai/cordis-plugin-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-group": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.1.tgz",
+      "integrity": "sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-include": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
+      "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-loader": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
+      "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "peerDependenciesMeta": {
+        "node-addon-require-builtin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-timer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.3.tgz",
+      "integrity": "sha512-IOkey1VNmJwYa5U8bksyMOnM7mtirqjjbWLr3xA8QybLMK0sMooG3a6iJwtvd8P3MFwo3FQibEg+JPixp37MEw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1"
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
+      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.6.tgz",
+      "integrity": "sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-instructions": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.0-rc.6.tgz",
+      "integrity": "sha512-RCd3UWJI7b3X6EUnxnqwOFiMWh1PzRRg9GrVt4G0tVNDIxeYX+RF2FTbOrslIOkOCZxG3BlI2M/bZ6yQmB4Vwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-loop": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.0-rc.6.tgz",
+      "integrity": "sha512-yShuKIMW360H14L4y13j3gz3Ix1s/3lwEEpfJW4hnFAE09h9Z4yJA7UfTQmQdzMRMnuj4uWFPw0e0BbapnkFuw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-spine-demo": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-spine-demo/-/dsh-agent-spine-demo-0.1.0-rc.6.tgz",
+      "integrity": "sha512-urMS7CReaddhybJZCaPA8oI4VbD/A+62mLTOb2E4b8EKgZ55sMsOGfpkMZmFIs9nqJqxdFUmcxPXWKVMVtpb5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-app-boot": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.0-rc.6.tgz",
+      "integrity": "sha512-97Xb2wB0cuFMmbvW7/95pfMTyXwUNQxW/ROx19OdjS6PgHQNA28ZADZ19FgZmofguxzWuDD0lJPc1SWkSGLYcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/cordis-plugin-group": "^1.0.1",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-hmr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.6.tgz",
+      "integrity": "sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-brand": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.6.tgz",
+      "integrity": "sha512-E8j9Nby24qP4rfrdcfc7bpt1CHpGT3tYmycOJJkEOH4ptIdT1m2ro9nmnSd5CWYukTr64A77vjm2WGqHRI92UA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.6.tgz",
+      "integrity": "sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.6.tgz",
+      "integrity": "sha512-OTkwb4QsZgmjtA/8ZEPh1FapmrBr3N989/G4Wmo1JkAvKbMxkYty6LxjckOawTTz7GJTfUoZCrw9uopDfIMMNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.6.tgz",
+      "integrity": "sha512-cONQOvFqZmjtw5HSgbXJ5/8rZ2gHqdf69ONhH21cLFu5jJKVy9YbLt42SlD2sdGMv/co9nN8Kt9bWQiZ/96VbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal-round-driver": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.0-rc.6.tgz",
+      "integrity": "sha512-+tpbRXZ3nq/C2btBxyFC88RU0IC0H39JY1WyL07fq3j24AWS5jZb9/05gEJPyoyaIDkV/Li4dJVCdJH4VaF9Fw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-home-paths": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.6.tgz",
+      "integrity": "sha512-gIiUBmqB3L8inFr+hvjZv2/i6EVJOHIHCHg7bBFVhcl4HDK94+8wUCXTLGy80tcuISzIQiIaLuJq/NhSmV9Amw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.6.tgz",
+      "integrity": "sha512-WfEfOi99a4cpOugRAHTBSTnesLieu3ist1q9PXDXFBHX++K1rAl9+sB7YrdnbB8LH0UOY532gS9xJUYU6w0SLw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.6.tgz",
+      "integrity": "sha512-fmyvSOVsNObmRnciuH57ZntuCSb0gflRleCeQx1ToGHRoGrR4Ndnstx33SuIXUQt6OSUhD2w2WKQTReXogpnSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.0-rc.6.tgz",
+      "integrity": "sha512-vnCcHPjvXLQq2i80No61oKF/165+OvEC2iUBmVTxl6ka87yNECwYf4nrspHKqP9HbVWndtNP0lGgrnz7bo0XCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-launch-environment": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.6.tgz",
+      "integrity": "sha512-tTRJ1464PJUDe1Em1qq0mfdgGREzGGWo3JSqP6xeYDoX+MRXVP9/ChsZ5k6VBMjARAxw0HGBf7WR6VcupHbMZg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.6.tgz",
+      "integrity": "sha512-kuFGC8bHlzGTwlRxQhXjf3CYWl8M4NzH+EYIkrW8rri4iMc9W53xrdvkil5No/DUlMm8g1u7GdeiWYFy0TMvtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.6.tgz",
+      "integrity": "sha512-HdjBWcQ6spwA8B5dScRhndLQNiKoQTkq36O+kmJ80B9V4z08K5XrJwAInH9cCxJ91CqNzx/sxCdDds0oZDH1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-loader-smoke": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-loader-smoke/-/dsh-loader-smoke-0.1.0-rc.6.tgz",
+      "integrity": "sha512-6lnYvX/9UsAjmhKHlh19IFpXwAgq4BNdtUKd6pdljWiGBG8q3K5s8EsSYuzg+ws5oUuYKZj8qvAOlQ57hMKKfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^10.0.0",
+        "tsx": "^4.22.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-output-retention": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.6.tgz",
+      "integrity": "sha512-3TQJxGqjotWrvNKI+Da8nIDjzpKZEGpImeMBp7EklfO0CDbiXA5B0Ms39zBniWkWr1lvbm2iJiYERY5uDeP6og==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.6.tgz",
+      "integrity": "sha512-SLZjuivQQKHTx4H7xlsjraEGGMIEA8BYOwvlm/9uZBrBrlttMU+d8Ne6QYpDcOwIEubL8mvrWRg8j3rtY3lVyA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.6.tgz",
+      "integrity": "sha512-XEB7+pJZVPWmZXv27EX/4V/1noVLUF5ZHyy3EY5tC4XtEyayWKtvHL4y9OTLIYhlU4Ualv5ag8s5ueGGq3ID8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.6.tgz",
+      "integrity": "sha512-UlDLV4syLoJinNg9imhXrSAHrdaTa5Ff8gg46rzjFJGPUOhAk3DZff0hryT5OhrBi0A5Tj92qVpg2pRVvxnUzQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.6.tgz",
+      "integrity": "sha512-8tu8I6VWC7050GAUXWhcEWQw4pakALQc8TlhKr52m7Y4+kIKeNt3FBgP86PaGPBtpK0p5zUPRQNkFpzZbBdxyw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.0-rc.6.tgz",
+      "integrity": "sha512-wdWNyS/95wI3QB9SHeeeQ9HDIWeFQKInI54Wqlw35H+bGGjGZE92nx9QiqiiosoxHedQFBdA0TKgON4EIoxCgg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.6.tgz",
+      "integrity": "sha512-AbNBe+IYCbZqSHqOACVdj8QTynm2HZ0cThrEuI6nGMtlWLYLx6lzZ1rgO/56Av9mIScjyTBGJAIKhEYaMTBG9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.0-rc.6.tgz",
+      "integrity": "sha512-US9Q4b5CZJPRRqa/M+WESL5VAOLjfYWjdzb3TQ/7zmpR4/+EQWCOFA9CtDSMh4t1oFOQBjz2+YJJcGu59MKHDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.6.tgz",
+      "integrity": "sha512-DYLALBPdEI1LZjJ4B6rdGdGY4gy+iR2+5Xh2xJoAGa/pTyN5Z55TNfvuMJrmeRBjAuDXNUQpmURbvos5rJ4veg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.6.tgz",
+      "integrity": "sha512-RHV1ujuomvQB63HPI/n25c2/2It5XQ7zNQKozSqYOPQw7AIr16PT9iFqC7sCQ4l2gAY5GI3FbI1cQgHzjHNOag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-settings": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.6.tgz",
+      "integrity": "sha512-5ZlH2FNRU0kkdcCoEJohvdb2fiNnxM+iZqN3icbR3WQbMm8RPRrXlZlps5YUaQKPRbNRHA2LkOXW998QRlhHcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/schemastery": "^3.18.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.6.tgz",
+      "integrity": "sha512-l/pcwbdpM+Zgp2AzH0kH0z7bPU7L3k4uG1t5Du1V5ilk70tyMSxz2upNfAbjkDHZZZO18LTs33aq+zRWHX1CUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell-env": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.6.tgz",
+      "integrity": "sha512-znxHFSqduw8U/AxKSO8SgSt703Bl+irRzTU0ukJT+ySlnyAwSAg8sZHLo5ZlEt5K8BdWhxz8Vc5jibOtJPB3ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.6.tgz",
+      "integrity": "sha512-VyRlCOASIRuTflKwn4NvbdAXxSPnnLJ+RAQUI4GK5pOtPwI2DhJrbovqpyp5kNAkZMsqvIeHWu5PcCEJ+FpQ2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.6.tgz",
+      "integrity": "sha512-NCgz8lCAdvd0oSGIF0EKg1OXfIC7x9r0an7mgC19F0DGzYZJe5ve6AwEYpSvKITE3V8W4NbUzLKyyZG3VH5QtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "chokidar": "^5.0.0",
+        "yaml": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.6.tgz",
+      "integrity": "sha512-nZaZRjSnE1he+GAd14vURAH7n3Fw5eGx3nzMbkB96Y6Qx+oQB/7PTuXxKVxlCh8TSfMJTf851ahwWb1eALjKlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.6.tgz",
+      "integrity": "sha512-E7g+XChh4q4/wX++v56z1pV4SA1Rtz42xkznLPPi9FlXrrzJxwHMOUzBZ9Rz3Y1kLhQ++HJG3ZatmNx3rjFilg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.6.tgz",
+      "integrity": "sha512-CUean0fAnfsJVszFEip7PsU/S26W+JfDFfsza2dCtlw8n6xlkbHA9Gjxdk2aTwqDGCgXEPkRW7mYkdJ0n6FR7w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-bash": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.0-rc.6.tgz",
+      "integrity": "sha512-yzo/xPCObiFe+OU0e8E5nVOGpW6mp9vx/3q+MHQ0aqEbqrqHUfVMGPobfDAd/I1Ja/9Nag5NIvHpI2Hwx7lACg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-shell": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-goal": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.0-rc.6.tgz",
+      "integrity": "sha512-5rYb1wWJa2HfCxi1JNMkPJwN0upoblJEVlnV+omTx4ZDGekg2dyfftaQdFH9cwiW576is8bAUgPE9Rd0sZCAzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-goal": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-jobs": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.0-rc.6.tgz",
+      "integrity": "sha512-mcftmyHx2bq8u5Qwo7znysa3vOKO86ccJvgEZqfDV7S+UhOGbPDue7psyx1/jD/5fbK+653JbxQ8ds9wsLkiPw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-skill": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.0-rc.6.tgz",
+      "integrity": "sha512-AebSfHSt6j0PXuN3yK9+X4aC6tHSnFdm2hZglII7aEHr/lL9UbynPb3NTumh6thXZ9Earvwhf9JdOxHMsjHqfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.6.tgz",
+      "integrity": "sha512-Tu08EPK3JyK0iNjH4FGzu/1uADynNSS6SmwOLdfytUN0YNqwNuKFSt2OJUg19famNlTgy992DcHfDu0T+gLXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.6.tgz",
+      "integrity": "sha512-weWzN8r01YCkoDCAM7BsKw2YhRrD4zL8N2SAZu9hovYtXSq8xHXsP4Zh8RLYIlYcuotjyff/6hic+0TJPd14YA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-approval": {
+      "version": "0.1.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.6.tgz",
+      "integrity": "sha512-9rnkSDGOpu2XUeGwbPeTzVUTFWTND1PMPM5L/ZQPptV5yyZlQiNxM2rCC6OdL+ZVerwxEqrRhZIQn/KVtQfKag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6"
+      }
+    },
+    "node_modules/@deepseek-ai/schemastery": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
+      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.4.tgz",
+      "integrity": "sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.4.tgz",
+      "integrity": "sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.4.tgz",
+      "integrity": "sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.4.tgz",
+      "integrity": "sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.4.tgz",
+      "integrity": "sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.4.tgz",
+      "integrity": "sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.4.tgz",
+      "integrity": "sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.4.tgz",
+      "integrity": "sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.4.tgz",
+      "integrity": "sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.4.tgz",
+      "integrity": "sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.4.tgz",
+      "integrity": "sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.4.tgz",
+      "integrity": "sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.4.tgz",
+      "integrity": "sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.4.tgz",
+      "integrity": "sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.4.tgz",
+      "integrity": "sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+      "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.1",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.3.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.4.tgz",
+      "integrity": "sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.4",
+        "@koromix/koffi-darwin-x64": "3.1.4",
+        "@koromix/koffi-freebsd-arm64": "3.1.4",
+        "@koromix/koffi-freebsd-ia32": "3.1.4",
+        "@koromix/koffi-freebsd-x64": "3.1.4",
+        "@koromix/koffi-linux-arm64": "3.1.4",
+        "@koromix/koffi-linux-ia32": "3.1.4",
+        "@koromix/koffi-linux-loong64": "3.1.4",
+        "@koromix/koffi-linux-riscv64": "3.1.4",
+        "@koromix/koffi-linux-x64": "3.1.4",
+        "@koromix/koffi-openbsd-ia32": "3.1.4",
+        "@koromix/koffi-openbsd-x64": "3.1.4",
+        "@koromix/koffi-win32-arm64": "3.1.4",
+        "@koromix/koffi-win32-ia32": "3.1.4",
+        "@koromix/koffi-win32-x64": "3.1.4"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/dsh-plugin/package.json
+++ b/examples/dsh-plugin/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@openviking/dsh-plugin",
+  "version": "0.2.0",
+  "description": "OpenViking memory & context plugin for deepseek-harness (dsh): auto-captures conversation into OpenViking sessions, auto-recalls relevant memories into agent steps, and exposes OpenViking search/read tools.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "shared",
+    "cordis.patch.yml",
+    "README.md"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('lib', { recursive: true, force: true })\" && tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/volcengine/OpenViking.git",
+    "directory": "examples/dsh-plugin"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "^3.18.1"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-agent-spine-demo": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-app-boot": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-loader-smoke": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-checkpoint-policy": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-persistence-jsonl": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "^3.18.1",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.8"
+  },
+  "engines": {
+    "node": ">=22.16.0"
+  }
+}

--- a/examples/dsh-plugin/shared/batch-send.d.mts
+++ b/examples/dsh-plugin/shared/batch-send.d.mts
@@ -1,0 +1,16 @@
+export const BATCH_LIMIT: number;
+export function isRetryableSendFailure(res: unknown): boolean;
+export function sendSessionMessages(
+  fetchJSON: (path: string, init?: any, options?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
+  sessionId: string,
+  payloads: Array<Record<string, any>>,
+  opts?: { onSent?: (count: number) => void | Promise<void> },
+): Promise<{
+  sent: number;
+  queued: number;
+  enqueueFailed: number;
+  failed: number;
+  retryable: boolean;
+  usedBatch: boolean;
+  lastError: unknown;
+}>;

--- a/examples/dsh-plugin/shared/batch-send.mjs
+++ b/examples/dsh-plugin/shared/batch-send.mjs
@@ -1,0 +1,121 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { enqueue } from "./pending-queue.mjs";
+import { isRetryableFailure } from "./retryable.mjs";
+
+export const BATCH_LIMIT = 100;
+
+export function isRetryableSendFailure(res) {
+  return isRetryableFailure(res);
+}
+
+function makeResult() {
+  return {
+    sent: 0,
+    queued: 0,
+    enqueueFailed: 0,
+    failed: 0,
+    retryable: false,
+    usedBatch: true,
+    lastError: null,
+  };
+}
+
+async function enqueueRemainder(sessionId, payloads, startIndex, result, retryable, lastError) {
+  result.retryable = retryable;
+  result.lastError = lastError ?? null;
+
+  if (!retryable) {
+    result.failed += Math.max(0, payloads.length - startIndex);
+    return result;
+  }
+
+  const baseCreatedAt = Date.now();
+  for (let i = startIndex; i < payloads.length; i++) {
+    const queued = await enqueue("addMessage", sessionId, payloads[i], {
+      createdAt: baseCreatedAt + (i - startIndex),
+    });
+    if (!queued.ok) {
+      // Stop at the first enqueue failure so queued entries stay a contiguous
+      // prefix: consumers mark the first sent+queued payloads as captured, so
+      // skipping a payload here and queueing a later one would silently drop it.
+      result.enqueueFailed += payloads.length - i;
+      return result;
+    }
+    result.queued++;
+  }
+  return result;
+}
+
+async function sendSerial(fetchJSON, sessionId, payloads, startIndex, opts, result) {
+  result.usedBatch = false;
+  const encodedSid = encodeURIComponent(sessionId);
+  for (let i = startIndex; i < payloads.length; i++) {
+    const res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+      method: "POST",
+      body: JSON.stringify(payloads[i]),
+    });
+    if (res?.ok) {
+      result.sent++;
+      await opts.onSent?.(1);
+      continue;
+    }
+
+    const retryable = isRetryableSendFailure(res);
+    if (opts.enqueueOnRetryable) {
+      return enqueueRemainder(sessionId, payloads, i, result, retryable, res?.error ?? res);
+    }
+    result.retryable = retryable;
+    result.lastError = res?.error ?? res ?? null;
+    result.failed += payloads.length - i;
+    return result;
+  }
+  return result;
+}
+
+/**
+ * Send add-message payloads in server-sized batches with serial fallback.
+ *
+ * @param {Function} fetchJSON - (path, init) => { ok, status, result?, error? }
+ * @param {string} sessionId - OpenViking session id
+ * @param {Array<object>} payloads - sanitized add-message request bodies
+ * @param {object} opts
+ * @param {boolean} opts.enqueueOnRetryable - enqueue unsent payloads after a retryable failure
+ * @param {Function} opts.onSent - called with the number of messages durably sent after each success
+ * @returns {Promise<{sent:number,queued:number,enqueueFailed:number,failed:number,retryable:boolean,usedBatch:boolean,lastError:any}>}
+ */
+export async function sendSessionMessages(fetchJSON, sessionId, payloads, opts = {}) {
+  const result = makeResult();
+  const messages = Array.isArray(payloads) ? payloads : [];
+  if (messages.length === 0) return result;
+
+  const encodedSid = encodeURIComponent(sessionId);
+  for (let start = 0; start < messages.length; start += BATCH_LIMIT) {
+    const chunk = messages.slice(start, start + BATCH_LIMIT);
+    const res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages/batch`, {
+      method: "POST",
+      body: JSON.stringify({ messages: chunk }),
+    });
+
+    if (res?.ok) {
+      result.sent += chunk.length;
+      await opts.onSent?.(chunk.length);
+      continue;
+    }
+
+    const status = Number(res?.status || 0);
+    if (status === 404 || status === 405) {
+      return sendSerial(fetchJSON, sessionId, messages, start, opts, result);
+    }
+
+    const retryable = isRetryableSendFailure(res);
+    if (opts.enqueueOnRetryable) {
+      return enqueueRemainder(sessionId, messages, start, result, retryable, res?.error ?? res);
+    }
+    result.retryable = retryable;
+    result.lastError = res?.error ?? res ?? null;
+    result.failed += messages.length - start;
+    return result;
+  }
+
+  return result;
+}

--- a/examples/dsh-plugin/shared/capture-utils.d.mts
+++ b/examples/dsh-plugin/shared/capture-utils.d.mts
@@ -1,0 +1,9 @@
+export function extractPartsFromPayload(payload: any, options?: Record<string, any>): any[];
+export function extractTextFromPayload(payload: any, options?: Record<string, any>): string;
+export function shouldCaptureText(text: string, role: string, cfg?: Record<string, any>): {
+  shouldCapture: boolean;
+  reason: string;
+  text: string;
+};
+export function sanitizeCapturedText(text: string): string;
+export function truncateCaptureText(text: string, maxChars?: number): string;

--- a/examples/dsh-plugin/shared/capture-utils.mjs
+++ b/examples/dsh-plugin/shared/capture-utils.mjs
@@ -1,0 +1,515 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+const TEXT_BLOCK_TYPES = new Set(["text", "input_text", "output_text"]);
+const TOOL_CALL_TYPES = new Set([
+  "tool_call",
+  "toolcall",
+  "tool_use",
+  "tooluse",
+  "function_call",
+  "functioncall",
+]);
+const TOOL_RESULT_TYPES = new Set([
+  "tool_result",
+  "toolresult",
+  "tool_output",
+  "tooloutput",
+  "function_call_output",
+  "functioncalloutput",
+]);
+
+// Tool output is reported verbatim; the server owns truncation via
+// tool_output_externalization (threshold_chars, default 20000). This cap only
+// guards against pathological payloads.
+const DEFAULT_TOOL_MAX_CHARS = 1000000;
+
+const ACK_RE = /^(?:ok|okay|k|yes|yep|no|nope|thanks|thank you|thx|done|收到|好的|好|嗯|可以|继续|不用|不需要|没了|好了)[.!?。！？\s]*$/i;
+const SLASH_COMMAND_RE = /^\/[a-z0-9_-]{1,64}\b/i;
+const METADATA_KEYS = [
+  "session_id",
+  "sessionid",
+  "sessionkey",
+  "conversation_id",
+  "conversationid",
+  "channel",
+  "sender",
+  "user_id",
+  "userid",
+  "agent_id",
+  "agentid",
+  "timestamp",
+  "timezone",
+  "cwd",
+  "model",
+  "permission_mode",
+];
+
+function normalizeType(value) {
+  return String(value || "").toLowerCase().replace(/[-\s]/g, "_");
+}
+
+function isToolCallBlock(block) {
+  const type = normalizeType(block?.type || block?.kind || block?.role);
+  return TOOL_CALL_TYPES.has(type) || Boolean(block?.tool_calls) || Boolean(block?.function?.name);
+}
+
+function isToolResultBlock(block) {
+  const type = normalizeType(block?.type || block?.kind || block?.role);
+  return TOOL_RESULT_TYPES.has(type) || type === "tool" || type === "function";
+}
+
+function oneLine(text) {
+  return String(text || "").replace(/\s+/g, " ").trim();
+}
+
+export function truncateCaptureText(text, maxChars = 2000) {
+  const value = String(text || "").trim();
+  if (!Number.isFinite(maxChars) || maxChars <= 0 || value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 20)).trimEnd()}\n[truncated]`;
+}
+
+function stringifyCompact(value, maxChars) {
+  if (value == null) return "";
+  if (typeof value === "string") return truncateCaptureText(value, maxChars);
+  try {
+    return truncateCaptureText(JSON.stringify(value), maxChars);
+  } catch {
+    return truncateCaptureText(String(value), maxChars);
+  }
+}
+
+function parseMaybeJson(value) {
+  if (value == null || typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function blockText(block) {
+  if (!block || typeof block !== "object") return "";
+  if (typeof block.text === "string") return block.text;
+  if (typeof block.output_text === "string") return block.output_text;
+  if (typeof block.input_text === "string") return block.input_text;
+  if (typeof block.content === "string") return block.content;
+  return "";
+}
+
+function toolName(block) {
+  return oneLine(
+    block?.name ||
+    block?.tool_name ||
+    block?.toolName ||
+    block?.tool ||
+    block?.function?.name ||
+    block?.call?.name ||
+    "",
+  );
+}
+
+function toolPayload(block, kind) {
+  if (!block || typeof block !== "object") return "";
+  if (kind === "call") {
+    return block.input ??
+      block.state?.input ??
+      block.arguments ??
+      block.args ??
+      block.params ??
+      block.function?.arguments ??
+      block.command ??
+      block.call?.input ??
+      block.call?.arguments ??
+      "";
+  }
+  return block.output ??
+    block.state?.output ??
+    block.result ??
+    block.error ??
+    block.state?.error ??
+    block.data ??
+    block.content ??
+    block.text ??
+    "";
+}
+
+function toolId(block) {
+  return oneLine(
+    block?.call_id ||
+    block?.callId ||
+    block?.callID ||
+    block?.tool_call_id ||
+    block?.toolCallId ||
+    block?.tool_use_id ||
+    block?.toolUseId ||
+    block?.function_call_id ||
+    block?.functionCallId ||
+    block?.id ||
+    "",
+  );
+}
+
+function toolStatus(block, kind) {
+  if (kind === "call") return "running";
+  if (block?.is_error || block?.error || block?.state?.error) return "error";
+  const status = oneLine(block?.status || block?.state?.status || "");
+  return status || "completed";
+}
+
+function setToolInput(part, payload) {
+  const input = parseMaybeJson(payload);
+  if (input === "" || input == null) return;
+  part.tool_input = typeof input === "object" && !Array.isArray(input)
+    ? input
+    : { value: input };
+}
+
+function buildToolPart(block, kind, { toolMaxChars = DEFAULT_TOOL_MAX_CHARS, toolNameById = {} } = {}) {
+  const id = toolId(block);
+  const name = toolName(block) || (id ? toolNameById[id] : "");
+  const payload = toolPayload(block, kind);
+  const part = {
+    type: "tool",
+    tool_id: id || undefined,
+    tool_name: name || undefined,
+    tool_status: toolStatus(block, kind),
+  };
+  if (kind === "call") {
+    setToolInput(part, payload);
+  } else {
+    if (block?.state?.input !== undefined) {
+      setToolInput(part, block.state.input);
+    }
+    part.tool_output = stringifyCompact(payload, toolMaxChars);
+  }
+  return part;
+}
+
+function formatToolBlock(block, kind, maxChars) {
+  const name = toolName(block);
+  const payload = toolPayload(block, kind);
+  const body = oneLine(stringifyCompact(payload, maxChars));
+  const label = kind === "call" ? "tool-call" : "tool-result";
+  return body
+    ? `[${label}${name ? ` ${name}` : ""}] ${body}`
+    : `[${label}${name ? ` ${name}` : ""}]`;
+}
+
+function blockToText(block, options) {
+  if (!block) return "";
+  if (typeof block === "string") return block;
+  if (Array.isArray(block)) return extractTextFromContent(block, options);
+  if (typeof block !== "object") return "";
+
+  if (block.item && typeof block.item === "object") {
+    const itemText = blockToText(block.item, options);
+    if (itemText) return itemText;
+  }
+
+  const type = normalizeType(block.type || block.kind || block.role);
+  if (TEXT_BLOCK_TYPES.has(type)) return blockText(block);
+  if (isToolCallBlock(block)) return formatToolBlock(block, "call", options.toolMaxChars);
+  if (isToolResultBlock(block)) return formatToolBlock(block, "result", options.toolMaxChars);
+  if (Array.isArray(block.content)) return extractTextFromContent(block.content, options);
+  if (!type) return blockText(block);
+  return "";
+}
+
+export function extractTextFromContent(content, options = {}) {
+  const opts = { toolMaxChars: DEFAULT_TOOL_MAX_CHARS, ...options };
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => blockToText(block, opts))
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  if (typeof content === "object") {
+    return blockToText(content, opts) || stringifyCompact(content, opts.toolMaxChars);
+  }
+  return "";
+}
+
+export function extractTextFromPayload(payload, options = {}) {
+  if (!payload || typeof payload !== "object") return "";
+  const chunks = [];
+  const directType = normalizeType(payload.type || payload.kind || payload.role);
+  if (TOOL_RESULT_TYPES.has(directType) || directType === "tool" || TOOL_CALL_TYPES.has(directType)) {
+    const direct = blockToText(payload, { toolMaxChars: DEFAULT_TOOL_MAX_CHARS, ...options });
+    if (direct) return direct;
+  }
+
+  if (payload.message && typeof payload.message === "object") {
+    const messageText = extractTextFromPayload(payload.message, options);
+    if (messageText) chunks.push(messageText);
+  } else if (payload.content !== undefined) {
+    const contentText = extractTextFromContent(payload.content, options);
+    if (contentText) chunks.push(contentText);
+  }
+
+  for (const key of ["tool_calls", "toolCalls", "function_call", "functionCall", "tool_call", "toolCall"]) {
+    const value = payload[key];
+    if (!value) continue;
+    const toolText = extractTextFromContent(value, options);
+    if (toolText) chunks.push(toolText);
+  }
+
+  if (chunks.length === 0) {
+    const direct = blockToText(payload, { toolMaxChars: DEFAULT_TOOL_MAX_CHARS, ...options });
+    if (direct) chunks.push(direct);
+  }
+
+  return chunks.join("\n\n");
+}
+
+function collectToolNamesByIdFromEntries(entries) {
+  const map = {};
+  for (const entry of entries || []) {
+    const payload = entry?.payload && typeof entry.payload === "object" ? entry.payload : entry;
+    collectToolNamesByIdFromPayload(payload, map);
+  }
+  return map;
+}
+
+function collectToolNamesByIdFromPayload(payload, out) {
+  if (!payload || typeof payload !== "object") return;
+  if (payload.message && typeof payload.message === "object") {
+    collectToolNamesByIdFromPayload(payload.message, out);
+  }
+  const candidates = [];
+  if (Array.isArray(payload.content)) candidates.push(...payload.content);
+  for (const key of ["tool_calls", "toolCalls", "function_call", "functionCall", "tool_call", "toolCall"]) {
+    const value = payload[key];
+    if (!value) continue;
+    if (Array.isArray(value)) candidates.push(...value);
+    else candidates.push(value);
+  }
+  if (isToolCallBlock(payload)) candidates.push(payload);
+  for (const block of candidates) {
+    if (!block || typeof block !== "object") continue;
+    if (!isToolCallBlock(block)) continue;
+    const id = toolId(block);
+    const name = toolName(block);
+    if (id && name) out[id] = name;
+  }
+}
+
+function extractPartsFromContent(content, options = {}) {
+  const opts = { toolMaxChars: DEFAULT_TOOL_MAX_CHARS, toolNameById: {}, ...options };
+  const parts = [];
+  if (!content) return parts;
+  if (typeof content === "string") {
+    if (content.trim()) parts.push({ type: "text", text: content });
+    return parts;
+  }
+  if (!Array.isArray(content)) {
+    const text = blockToText(content, opts);
+    if (text.trim()) parts.push({ type: "text", text });
+    return parts;
+  }
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (isToolCallBlock(block)) {
+      parts.push(buildToolPart(block, "call", opts));
+    } else if (isToolResultBlock(block)) {
+      parts.push(buildToolPart(block, "result", opts));
+    } else {
+      const text = blockToText(block, opts);
+      if (text.trim()) parts.push({ type: "text", text });
+    }
+  }
+  return parts;
+}
+
+export function extractPartsFromPayload(payload, options = {}) {
+  if (!payload || typeof payload !== "object") return [];
+  const opts = { toolMaxChars: DEFAULT_TOOL_MAX_CHARS, toolNameById: {}, ...options };
+  if (payload.message && typeof payload.message === "object") {
+    return extractPartsFromPayload(payload.message, opts);
+  }
+
+  const directType = normalizeType(payload.type || payload.kind || payload.role);
+  if (TOOL_CALL_TYPES.has(directType) || isToolCallBlock(payload)) {
+    return [buildToolPart(payload, "call", opts)];
+  }
+  if (TOOL_RESULT_TYPES.has(directType) || directType === "tool" || directType === "function") {
+    return [buildToolPart(payload, "result", opts)];
+  }
+
+  const parts = [];
+  if (payload.content !== undefined) {
+    parts.push(...extractPartsFromContent(payload.content, opts));
+  }
+  for (const key of ["tool_calls", "toolCalls", "function_call", "functionCall", "tool_call", "toolCall"]) {
+    const value = payload[key];
+    if (!value) continue;
+    if (Array.isArray(value)) {
+      for (const block of value) parts.push(...extractPartsFromPayload(block, opts));
+    } else {
+      parts.push(...extractPartsFromPayload(value, opts));
+    }
+  }
+  return parts;
+}
+
+export function extractCaptureTurns(rolloutEntries, cfg = {}) {
+  const toolNameById = collectToolNamesByIdFromEntries(rolloutEntries);
+  const turns = [];
+  for (const entry of rolloutEntries || []) {
+    if (!entry || typeof entry !== "object") continue;
+    const payload = entry.payload && typeof entry.payload === "object" ? entry.payload : entry;
+    const message = payload.message && typeof payload.message === "object" ? payload.message : null;
+    const rawRole = message?.role || payload.role || payload.type || payload.kind;
+    const role = normalizeCaptureRole(rawRole);
+    if (!role) continue;
+    if (isAssistantSideCaptureRole(rawRole) && !cfg.captureAssistantTurns) continue;
+
+    const rawText = extractTextFromPayload(payload, { toolMaxChars: cfg.captureToolMaxChars });
+    const parts = extractPartsFromPayload(payload, {
+      toolMaxChars: cfg.captureToolMaxChars,
+      toolNameById,
+    });
+    const decision = shouldCaptureText(rawText, role, cfg);
+    if (!decision.shouldCapture && parts.length === 0) continue;
+    const text = decision.shouldCapture ? decision.text : "";
+    turns.push({ role, text, parts });
+  }
+  return turns;
+}
+
+export function normalizeCaptureRole(role) {
+  const value = normalizeType(role);
+  if (value === "user") return "user";
+  if (value === "assistant") return "assistant";
+  if (value === "tool" || value === "tool_result" || value === "function" || value === "function_call_output") {
+    return "user";
+  }
+  if (value === "tool_call" || value === "function_call") return "assistant";
+  return null;
+}
+
+export function isAssistantSideCaptureRole(role) {
+  const value = normalizeType(role);
+  return value === "assistant" ||
+    value === "tool" ||
+    value === "tool_result" ||
+    value === "tool_call" ||
+    value === "function" ||
+    value === "function_call" ||
+    value === "function_call_output";
+}
+
+function stripMetadataFences(text) {
+  return String(text || "").replace(/```(?:json)?\s*([\s\S]*?)```/gi, (match, body) => {
+    const lower = body.toLowerCase();
+    let hits = 0;
+    for (const key of METADATA_KEYS) {
+      const re = new RegExp(`["']?${key}["']?\\s*:`, "i");
+      if (re.test(lower)) hits += 1;
+    }
+    return hits >= 3 ? "" : match;
+  });
+}
+
+function stripInjectedDigestBlocks(text) {
+  const lines = String(text || "").split(/\r?\n/);
+  const out = [];
+  let skipping = false;
+  let skipUntilMcpHint = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^OpenViking session archive digest:/i.test(trimmed)) {
+      skipping = true;
+      skipUntilMcpHint = true;
+      continue;
+    }
+    if (/^OpenViking memory digest:/i.test(trimmed)) {
+      skipping = true;
+      skipUntilMcpHint = false;
+      continue;
+    }
+    if (skipping) {
+      if (skipUntilMcpHint) {
+        if (/^More detail: use the OpenViking MCP /i.test(trimmed)) {
+          skipping = false;
+          skipUntilMcpHint = false;
+        }
+        continue;
+      }
+      if (!trimmed) {
+        skipping = false;
+        continue;
+      }
+      if (
+        /^(?:[-*]\s+|#{1,6}\s+|More detail:|Use OpenViking MCP|Latest committed archive|Resume continuity|viking:\/\/)/i.test(trimmed) ||
+        /^\s{2,}\S/.test(line)
+      ) {
+        continue;
+      }
+      skipping = false;
+    }
+    out.push(line);
+  }
+
+  return out.join("\n");
+}
+
+export function sanitizeCapturedText(text) {
+  let value = String(text || "");
+  value = value
+    .replace(/\u0000/g, "")
+    .replace(/<openviking-context\b[^>]*>[\s\S]*?<\/openviking-context>/gi, " ")
+    .replace(/<relevant-memor(?:y|ies)\b[^>]*>[\s\S]*?<\/relevant-memor(?:y|ies)>/gi, " ")
+    .replace(/^\s*Sender\s*\([^)]+\)\s*```[\s\S]*?```\s*/gim, " ")
+    .replace(/^\s*Conversation (?:metadata|info):\s*```[\s\S]*?```\s*/gim, " ")
+    .replace(/^\s*\[?\d{4}-\d{2}-\d{2}[T ][^\]\n]{3,80}\]?\s*/gm, "")
+    .replace(/^\s*\d{10,13}\s+/gm, "");
+  value = stripMetadataFences(value);
+  value = stripInjectedDigestBlocks(value);
+  value = value.replace(/^\s*More detail: use the OpenViking MCP .*$/gim, " ");
+  return value
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function hasEnoughSignal(text) {
+  const cjk = text.match(/[\u3400-\u9fff]/g)?.length || 0;
+  const alnum = text.match(/[a-z0-9]/gi)?.length || 0;
+  return cjk >= 4 || alnum >= 6 || text.length >= 12;
+}
+
+function isPunctuationOnly(text) {
+  return !/[a-z0-9\u3400-\u9fff]/i.test(text);
+}
+
+export function shouldCaptureText(text, role, cfg = {}) {
+  const maxLength = cfg.captureMaxLength || 24000;
+  const sanitized = sanitizeCapturedText(text);
+  if (!sanitized) return { shouldCapture: false, reason: "empty", text: "" };
+
+  const capped = truncateCaptureText(sanitized, maxLength);
+  const compact = oneLine(capped);
+  const isToolSummary = /^\[tool-(?:call|result)\b/i.test(compact);
+
+  if (!isToolSummary && role === "user" && SLASH_COMMAND_RE.test(compact)) {
+    return { shouldCapture: false, reason: "slash_command", text: "" };
+  }
+  if (!isToolSummary && ACK_RE.test(compact)) {
+    return { shouldCapture: false, reason: "ack", text: "" };
+  }
+  if (!isToolSummary && isPunctuationOnly(compact)) {
+    return { shouldCapture: false, reason: "punctuation", text: "" };
+  }
+  if (!isToolSummary && !hasEnoughSignal(compact)) {
+    return { shouldCapture: false, reason: "too_short", text: "" };
+  }
+  if (/^\[openviking-memory\]/i.test(compact)) {
+    return { shouldCapture: false, reason: "plugin_status", text: "" };
+  }
+
+  return { shouldCapture: true, reason: "ok", text: capped };
+}

--- a/examples/dsh-plugin/shared/credentials.d.mts
+++ b/examples/dsh-plugin/shared/credentials.d.mts
@@ -1,0 +1,14 @@
+export function buildUserAgent(harness: string, version?: string): string;
+
+export function readManifestVersion(manifest: string | URL): string;
+
+export function resolveOpenVikingCredentials(env?: Record<string, string | undefined>): {
+  credentialSource: string;
+  baseUrl: string;
+  mcpUrl: string;
+  apiKey: string;
+  account: string;
+  user: string;
+  peerId: string;
+  hasApiKey: boolean;
+};

--- a/examples/dsh-plugin/shared/credentials.mjs
+++ b/examples/dsh-plugin/shared/credentials.mjs
@@ -1,0 +1,228 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_OVCLI_CONF_PATH = join(homedir(), ".openviking", "ovcli.conf");
+const DEFAULT_OV_CONF_PATH = join(homedir(), ".openviking", "ov.conf");
+const DEFAULT_BASE_URL = "http://127.0.0.1:1933";
+
+function str(val, fallback = "") {
+  if (typeof val === "string" && val.trim()) return val.trim();
+  return fallback;
+}
+
+function normalizePath(value) {
+  const raw = str(value, "");
+  if (!raw) return "";
+  if (raw === "~") return homedir();
+  if (raw.startsWith("~/")) return resolvePath(join(homedir(), raw.slice(2)));
+  return resolvePath(raw);
+}
+
+function tryLoadJson(path) {
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the User-Agent every harness plugin sends on OpenViking-bound requests.
+ * Shape is `name/semver` so downstream stats layers can parse it as one token.
+ */
+export function buildUserAgent(harness, version) {
+  return `openviking-memory-${harness}/${str(version, "") || "0.0.0"}`;
+}
+
+/**
+ * Read a plugin manifest's `version` field. Accepts a path or a URL (so callers
+ * can resolve relative to import.meta.url). Returns "" when unreadable so the
+ * User-Agent falls back to 0.0.0 instead of throwing inside a short-lived hook.
+ */
+export function readManifestVersion(manifest) {
+  try {
+    return str(JSON.parse(readFileSync(manifest, "utf-8")).version, "");
+  } catch {
+    return "";
+  }
+}
+
+function looksLikeOvcli(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  if (obj.server && typeof obj.server === "object") return false;
+  return Boolean(
+    typeof obj.url === "string" ||
+    typeof obj.api_key === "string" ||
+    typeof obj.account === "string" ||
+    typeof obj.account_id === "string" ||
+    typeof obj.user === "string" ||
+    typeof obj.user_id === "string" ||
+    typeof obj.actor_peer_id === "string",
+  );
+}
+
+function hasCredentialFields(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  return [
+    "url",
+    "api_key",
+    "account",
+    "account_id",
+    "user",
+    "user_id",
+    "actor_peer_id",
+    "peer_id",
+  ].some((key) => typeof obj[key] === "string");
+}
+
+export function loadCredentialFiles(env = process.env) {
+  const cliPathCandidate = normalizePath(env.OPENVIKING_CLI_CONFIG_FILE) || DEFAULT_OVCLI_CONF_PATH;
+  const ovPathCandidate = normalizePath(env.OPENVIKING_CONFIG_FILE) || DEFAULT_OV_CONF_PATH;
+  const cliPathEnv = Boolean(str(env.OPENVIKING_CLI_CONFIG_FILE, ""));
+  const ovPathEnv = Boolean(str(env.OPENVIKING_CONFIG_FILE, ""));
+
+  let cliFile = tryLoadJson(cliPathCandidate);
+  let cliPath = cliFile ? cliPathCandidate : "";
+  let ovFile = tryLoadJson(ovPathCandidate);
+  let ovPath = ovFile ? ovPathCandidate : "";
+
+  // Backward compat: older plugin installs used OPENVIKING_CONFIG_FILE for
+  // both ov.conf and ovcli.conf. Preserve that when the file is ovcli-shaped.
+  if (ovPathEnv && !cliPathEnv && looksLikeOvcli(ovFile)) {
+    cliFile = ovFile;
+    cliPath = ovPath;
+    ovFile = null;
+    ovPath = "";
+  }
+
+  return {
+    cliFile: cliFile || {},
+    cliPath,
+    cliPathCandidate,
+    ovFile: ovFile || {},
+    ovPath,
+  };
+}
+
+function sourceMode(env) {
+  const raw = str(env.OPENVIKING_CREDENTIAL_SOURCE, str(env.OPENVIKING_CREDENTIALS_SOURCE, "auto"))
+    .toLowerCase();
+  if (raw === "env" || raw === "environment") return "env";
+  if (raw === "cli" || raw === "ovcli" || raw === "file" || raw === "config") return "cli";
+  return "auto";
+}
+
+function hasEnvCredentialFields(env) {
+  return Boolean(
+    str(env.OPENVIKING_URL, str(env.OPENVIKING_BASE_URL, "")) ||
+    str(env.OPENVIKING_MCP_URL, "") ||
+    str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, "")) ||
+    str(env.OPENVIKING_ACCOUNT, "") ||
+    str(env.OPENVIKING_USER, "") ||
+    str(env.OPENVIKING_PEER_ID, ""),
+  );
+}
+
+function deriveBaseUrl({ env, cliFile, ovFile, mode, useCli }) {
+  const envUrl = str(env.OPENVIKING_URL, str(env.OPENVIKING_BASE_URL, ""));
+  const cliUrl = str(cliFile.url, "");
+
+  if (mode !== "cli" && envUrl) return envUrl.replace(/\/+$/, "");
+  if (useCli && cliUrl) return cliUrl.replace(/\/+$/, "");
+  if (mode !== "env" && cliUrl) return cliUrl.replace(/\/+$/, "");
+
+  const server = ovFile.server || {};
+  const ovUrl = str(server.url, "");
+  if (ovUrl) return ovUrl.replace(/\/+$/, "");
+
+  const host = str(server.host, "127.0.0.1").replace("0.0.0.0", "127.0.0.1");
+  const port = Number.isFinite(Number(server.port)) ? Math.floor(Number(server.port)) : 1933;
+  return `http://${host}:${port}`;
+}
+
+export function resolveOpenVikingCredentials(env = process.env) {
+  const files = loadCredentialFiles(env);
+  const mode = sourceMode(env);
+  const envHasCredentials = hasEnvCredentialFields(env);
+  const useCli = mode === "cli" ||
+    (mode === "auto" && !envHasCredentials && files.cliPath && hasCredentialFields(files.cliFile));
+  const cx = files.ovFile.codex || {};
+  const server = files.ovFile.server || {};
+
+  const baseUrl = deriveBaseUrl({ env, ...files, mode, useCli });
+
+  const apiKey = useCli
+    ? str(files.cliFile.api_key, "")
+    : (
+        str(env.OPENVIKING_BEARER_TOKEN, "") ||
+        str(env.OPENVIKING_API_KEY, "") ||
+        str(files.cliFile.api_key, "") ||
+        str(cx.apiKey, "") ||
+        str(server.root_api_key, "")
+      );
+
+  const account = useCli
+    ? str(files.cliFile.account, str(files.cliFile.account_id, ""))
+    : (
+        str(env.OPENVIKING_ACCOUNT, "") ||
+        str(files.cliFile.account, str(files.cliFile.account_id, "")) ||
+        str(cx.accountId, "")
+      );
+
+  const user = useCli
+    ? str(files.cliFile.user, str(files.cliFile.user_id, ""))
+    : (
+        str(env.OPENVIKING_USER, "") ||
+        str(files.cliFile.user, str(files.cliFile.user_id, "")) ||
+        str(cx.userId, "")
+      );
+
+  const peerId = useCli
+    ? str(files.cliFile.actor_peer_id, str(files.cliFile.peer_id, ""))
+    : (
+        str(env.OPENVIKING_PEER_ID, "") ||
+        str(files.cliFile.actor_peer_id, str(files.cliFile.peer_id, "")) ||
+        str(cx.peerId, str(cx.peer_id, ""))
+      );
+
+  const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
+  const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
+
+  return {
+    ...files,
+    credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    baseUrl,
+    mcpUrl,
+    apiKey,
+    account,
+    user,
+    peerId,
+    hasApiKey: Boolean(apiKey),
+  };
+}
+
+function main() {
+  const cmd = process.argv[2] || "";
+  if (cmd === "mcp-url") {
+    process.stdout.write(resolveOpenVikingCredentials().mcpUrl);
+    return;
+  }
+  if (cmd === "has-api-key") {
+    process.stdout.write(resolveOpenVikingCredentials().hasApiKey ? "1" : "0");
+    return;
+  }
+  if (cmd === "has-peer-id") {
+    process.stdout.write(resolveOpenVikingCredentials().peerId ? "1" : "0");
+    return;
+  }
+  process.stderr.write("usage: ov-credentials.mjs <mcp-url|has-api-key|has-peer-id>\n");
+  process.exitCode = 2;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolvePath(process.argv[1])) {
+  main();
+}

--- a/examples/dsh-plugin/shared/debug-log.mjs
+++ b/examples/dsh-plugin/shared/debug-log.mjs
@@ -1,0 +1,58 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Shared structured debug logger for OpenViking memory plugin hook scripts.
+ *
+ * Harness-specific wrappers load config and pass {debug, debugLogPath}. This
+ * module stays path-agnostic so it can be vendored into each plugin snapshot.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+function ensureDir(filePath) {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+  } catch { /* best effort */ }
+}
+
+function writeLine(filePath, obj) {
+  try {
+    appendFileSync(filePath, JSON.stringify(obj) + "\n");
+  } catch { /* best effort */ }
+}
+
+function localISO() {
+  const d = new Date();
+  const off = d.getTimezoneOffset();
+  const sign = off <= 0 ? "+" : "-";
+  const abs = Math.abs(off);
+  const local = new Date(d.getTime() - off * 60000);
+  return local.toISOString().replace(
+    "Z",
+    `${sign}${String(Math.floor(abs / 60)).padStart(2, "0")}:${String(abs % 60).padStart(2, "0")}`,
+  );
+}
+
+const noop = () => {};
+
+export function createLogger(hookName, overrideCfg) {
+  const c = overrideCfg || {};
+  if (!c.debug) return { log: noop, logError: noop };
+
+  const logPath = c.debugLogPath;
+  if (!logPath) return { log: noop, logError: noop };
+  ensureDir(logPath);
+
+  function log(stage, data) {
+    writeLine(logPath, { ts: localISO(), hook: hookName, stage, data });
+  }
+
+  function logError(stage, err) {
+    const error = err instanceof Error
+      ? { message: err.message, stack: err.stack }
+      : String(err);
+    writeLine(logPath, { ts: localISO(), hook: hookName, stage, error });
+  }
+
+  return { log, logError };
+}

--- a/examples/dsh-plugin/shared/pending-queue.d.mts
+++ b/examples/dsh-plugin/shared/pending-queue.d.mts
@@ -1,0 +1,7 @@
+export function enqueue(type: string, sessionId: string, payload: Record<string, any>): Promise<{ ok: boolean; path?: string; error?: string }>;
+export function listPending(): Promise<Array<{ filename: string; entry: Record<string, any> }>>;
+export function replayPending(
+  fetchJSON: (path: string, init?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
+  log: (stage: string, data?: any) => void,
+): Promise<{ replayed: number; failed: number; skipped: number; deferred: number }>;
+export function cleanStale(): Promise<number>;

--- a/examples/dsh-plugin/shared/pending-queue.mjs
+++ b/examples/dsh-plugin/shared/pending-queue.mjs
@@ -1,0 +1,451 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Local pending queue for offline resilience.
+ *
+ * When the OpenViking server is temporarily unreachable, write operations
+ * (addMessage, commitSession) serialize their payloads to
+ * `~/.openviking/pending/` as JSON files. On the next session-start, the
+ * queue is replayed in small batches. This is a session-start-triggered retry
+ * path with maxRetries/TTL, not a long-running background worker.
+ *
+ * Each file contains: { type, sessionId, payload, createdAt, retries, dedupKey }
+ *
+ * Config (env vars):
+ *   OPENVIKING_PENDING_DIR         pending queue directory
+ *                                  (default: ~/.openviking/pending)
+ *   OPENVIKING_PENDING_MAX_RETRIES max retry attempts per item (default: 3)
+ *   OPENVIKING_PENDING_TTL_DAYS    max age in days before stale cleanup
+ *                                  (default: 7)
+ *   OPENVIKING_PENDING_REPLAY_LIMIT max items replayed per session-start
+ *                                  (default: 50)
+ */
+
+import { mkdir, readdir, readFile, rename, writeFile, unlink, stat, chmod } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isRetryableFailure } from "./retryable.mjs";
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TTL_DAYS = 7;
+const DEFAULT_REPLAY_LIMIT = 50;
+const PROCESSING_STALE_MS = 10 * 60 * 1000;
+const DEFAULT_PENDING_DIR = () => join(homedir(), ".openviking", "pending");
+
+// Pending queue files may contain raw memory payload / transcript content.
+// Use restrictive permissions explicitly so we don't depend on umask.
+//   - dir: 0o700  (owner: rwx; group/other: none)
+//   - file: 0o600 (owner: rw;  group/other: none)
+const PENDING_DIR_MODE = 0o700;
+const PENDING_FILE_MODE = 0o600;
+
+/**
+ * Ensure the pending directory exists with 0o700 permissions. If the
+ * directory was created by a previous version of this code (or by hand)
+ * with looser permissions, best-effort chmod it on first use.
+ */
+async function ensurePendingDir(dir) {
+  await mkdir(dir, { recursive: true, mode: PENDING_DIR_MODE });
+  try {
+    await chmod(dir, PENDING_DIR_MODE);
+  } catch {
+    // Best effort: chmod may fail on some platforms (e.g. Windows); not fatal.
+  }
+}
+
+function getPendingDir() {
+  return process.env.OPENVIKING_PENDING_DIR || DEFAULT_PENDING_DIR();
+}
+
+function getMaxRetries() {
+  const v = parseInt(process.env.OPENVIKING_PENDING_MAX_RETRIES || "", 10);
+  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_MAX_RETRIES;
+}
+
+function getTTLDays() {
+  const v = parseInt(process.env.OPENVIKING_PENDING_TTL_DAYS || "", 10);
+  return Number.isFinite(v) && v >= 0 ? v : DEFAULT_TTL_DAYS;
+}
+
+function getReplayLimit() {
+  const v = parseInt(process.env.OPENVIKING_PENDING_REPLAY_LIMIT || "", 10);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_REPLAY_LIMIT;
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+}
+
+function makeDedupKey(type, sessionId, payload) {
+  return createHash("sha256")
+    .update(type)
+    .update("\n")
+    .update(sessionId)
+    .update("\n")
+    .update(stableStringify(payload))
+    .digest("hex");
+}
+
+function pendingFilename(dedupKey, retries = 0) {
+  return `${dedupKey}_${Math.max(0, Number(retries) || 0)}.json`;
+}
+
+function retryFilename(filename, retries) {
+  const bare = filename.replace(/\.(json|processing)$/, "");
+  const nextBare = /_\d+$/.test(bare)
+    ? bare.replace(/_\d+$/, `_${retries}`)
+    : `${bare}_${retries}`;
+  return `${nextBare}.json`;
+}
+
+function processingFilename(filename) {
+  return filename.replace(/\.json$/, ".processing");
+}
+
+function pendingFromProcessingFilename(filename) {
+  return filename.replace(/\.processing$/, ".json");
+}
+
+function isRetryableReplayFailure(res) {
+  return isRetryableFailure(res);
+}
+
+async function readEntry(dir, filename) {
+  const raw = await readFile(join(dir, filename), "utf-8");
+  return JSON.parse(raw);
+}
+
+async function findExistingByDedupKey(dir, dedupKey) {
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch {
+    return null;
+  }
+
+  // Fast path: filenames are `${dedupKey}_${retries}.json` (or
+  // .processing). `dedupKey` is a sha256 hex produced by makeDedupKey
+  // (no underscores), so `${dedupKey}_` is a unique prefix per key.
+  // Filter on prefix BEFORE opening the file to avoid readFile +
+  // JSON.parse on every entry in the directory on every enqueue call —
+  // the previous implementation was O(n²) in queue size. Worst case here
+  // is O(n) readdir entries, but only the (typically single) prefix
+  // match actually gets opened and parsed.
+  const prefix = `${dedupKey}_`;
+
+  for (const f of files) {
+    if (!f.startsWith(prefix)) continue;
+    if (!f.endsWith(".json") && !f.endsWith(".processing")) continue;
+    try {
+      const entry = await readEntry(dir, f);
+      if (entry?.dedupKey === dedupKey) return { filename: f, entry };
+    } catch {
+      // Corrupted file - ignore for dedup lookup.
+    }
+  }
+  return null;
+}
+
+async function recoverStaleProcessing(dir) {
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch {
+    return 0;
+  }
+
+  const now = Date.now();
+  let recovered = 0;
+  for (const f of files) {
+    if (!f.endsWith(".processing")) continue;
+    const from = join(dir, f);
+    try {
+      const s = await stat(from);
+      if (now - s.mtimeMs < PROCESSING_STALE_MS) continue;
+      const to = join(dir, pendingFromProcessingFilename(f));
+      await rename(from, to);
+      recovered++;
+    } catch {
+      // Best effort. A concurrent process may have already handled it.
+    }
+  }
+  return recovered;
+}
+
+/**
+ * Enqueue a failed operation to local disk.
+ *
+ * @param {string} type - "addMessage" or "commitSession"
+ * @param {string} sessionId - OV session ID
+ * @param {object} payload - the data that failed to send
+ * @param {object} options
+ * @param {number} options.createdAt - optional queue timestamp override
+ */
+export async function enqueue(type, sessionId, payload, options = {}) {
+  const dir = getPendingDir();
+  const now = Number.isFinite(options.createdAt) ? options.createdAt : Date.now();
+  const dedupKey = makeDedupKey(type, sessionId, payload);
+  const filename = pendingFilename(dedupKey, 0);
+  const entry = {
+    type,
+    sessionId,
+    payload,
+    createdAt: now,
+    retries: 0,
+    dedupKey,
+  };
+
+  try {
+    await ensurePendingDir(dir);
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err), dedupKey };
+  }
+
+  const existing = await findExistingByDedupKey(dir, dedupKey);
+  if (existing) {
+    return { ok: true, path: existing.filename, deduped: true, dedupKey };
+  }
+
+  try {
+    await writeFile(join(dir, filename), JSON.stringify(entry), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: PENDING_FILE_MODE,
+    });
+    return { ok: true, path: filename, dedupKey };
+  } catch (err) {
+    if (err?.code !== "EEXIST") {
+      return { ok: false, error: err?.message || String(err), dedupKey };
+    }
+  }
+
+  const duplicate = await findExistingByDedupKey(dir, dedupKey);
+  if (duplicate) {
+    return { ok: true, path: duplicate.filename, deduped: true, dedupKey };
+  }
+  return { ok: false, error: `pending file exists but dedup entry was not readable: ${filename}`, dedupKey };
+}
+
+/**
+ * List all pending queue entries.
+ * Returns array of { filename, entry } sorted by createdAt ascending.
+ */
+export async function listPending() {
+  const dir = getPendingDir();
+  let files;
+  try {
+    await recoverStaleProcessing(dir);
+    files = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const entries = [];
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const entry = await readEntry(dir, f);
+      entries.push({ filename: f, entry });
+    } catch {
+      // Corrupted file - skip.
+    }
+  }
+
+  entries.sort((a, b) => (a.entry.createdAt || 0) - (b.entry.createdAt || 0));
+  return entries;
+}
+
+/**
+ * Atomically claim a pending file for replay. Only the process that successfully
+ * renames the file may send the HTTP replay.
+ */
+export async function claimForReplay(filename) {
+  if (!filename.endsWith(".json")) return null;
+  const dir = getPendingDir();
+  const claimed = processingFilename(filename);
+  try {
+    await rename(join(dir, filename), join(dir, claimed));
+    return claimed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove a pending entry after successful replay.
+ */
+export async function dequeue(filename) {
+  const dir = getPendingDir();
+  try {
+    await unlink(join(dir, filename));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Increment retry count on a pending entry. Returns false if max retries exceeded.
+ */
+export async function incrementRetry(filename, entry) {
+  const dir = getPendingDir();
+  const maxRetries = getMaxRetries();
+  entry.retries = (entry.retries || 0) + 1;
+
+  if (entry.retries > maxRetries) {
+    try {
+      await unlink(join(dir, filename));
+    } catch {
+      // Best effort.
+    }
+    return false;
+  }
+
+  const newFilename = retryFilename(filename, entry.retries);
+  // Atomic write: write to a unique temp file in the same directory, then
+  // rename into place. Avoids leaving a half-written JSON if the process
+  // crashes mid-write.
+  const tmpFilename = `${newFilename}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    await writeFile(join(dir, tmpFilename), JSON.stringify(entry), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: PENDING_FILE_MODE,
+    });
+    await rename(join(dir, tmpFilename), join(dir, newFilename));
+    await unlink(join(dir, filename)).catch(() => {});
+    return true;
+  } catch {
+    await unlink(join(dir, tmpFilename)).catch(() => {});
+    return false;
+  }
+}
+
+/**
+ * Clean up stale entries older than TTL.
+ */
+export async function cleanStale() {
+  const ttlMs = getTTLDays() * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  const pending = await listPending();
+  let cleaned = 0;
+
+  for (const { filename, entry } of pending) {
+    const age = now - (entry.createdAt || 0);
+    if (age > ttlMs) {
+      await dequeue(filename);
+      cleaned++;
+    }
+  }
+  return cleaned;
+}
+
+/**
+ * Replay pending entries. Call this during session-start when the server is
+ * healthy. Each run processes at most OPENVIKING_PENDING_REPLAY_LIMIT items so
+ * a just-recovered server is not hit with an unbounded replay burst.
+ *
+ * @param {Function} fetchJSON - the configured fetchJSON from makeFetchJSON
+ * @param {Function} log - logger function
+ * @returns {{ replayed: number, failed: number, skipped: number, deferred: number }}
+ */
+export async function replayPending(fetchJSON, log) {
+  const pending = await listPending();
+
+  if (pending.length === 0) {
+    return { replayed: 0, failed: 0, skipped: 0, deferred: 0 };
+  }
+
+  const replayLimit = getReplayLimit();
+  log("pending-queue", { count: pending.length, replayLimit, action: "replay-start" });
+
+  let replayed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let deferred = 0;
+  let processed = 0;
+
+  for (const { filename, entry } of pending) {
+    if (processed >= replayLimit) {
+      deferred++;
+      continue;
+    }
+
+    if ((entry.retries || 0) >= getMaxRetries()) {
+      await dequeue(filename);
+      skipped++;
+      continue;
+    }
+
+    const claimedFilename = await claimForReplay(filename);
+    if (!claimedFilename) {
+      skipped++;
+      continue;
+    }
+    processed++;
+
+    let res;
+    try {
+      const encodedSid = encodeURIComponent(entry.sessionId);
+      if (entry.type === "addMessage") {
+        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/messages`, {
+          method: "POST",
+          body: JSON.stringify(entry.payload),
+        });
+      } else if (entry.type === "commitSession") {
+        res = await fetchJSON(`/api/v1/sessions/${encodedSid}/commit`, {
+          method: "POST",
+          body: JSON.stringify(entry.payload || {}),
+        });
+      } else {
+        await dequeue(claimedFilename);
+        skipped++;
+        continue;
+      }
+    } catch {
+      res = { ok: false };
+    }
+
+    if (entry.type === "commitSession") {
+      log("pending-queue", {
+        action: "commit-replay",
+        sessionId: entry.sessionId,
+        ok: Boolean(res?.ok),
+        status: res?.result?.status || res?.status,
+        trace_id: res?.traceId || res?.result?.trace_id,
+        error: res?.ok ? undefined : res?.error?.message || res?.error?.code,
+      });
+    }
+
+    if (res?.ok) {
+      await dequeue(claimedFilename);
+      replayed++;
+    } else if (!isRetryableReplayFailure(res)) {
+      await dequeue(claimedFilename);
+      skipped++;
+    } else {
+      await incrementRetry(claimedFilename, entry);
+      failed++;
+      if (entry.type === "addMessage") {
+        deferred += Math.max(0, pending.length - processed);
+        break;
+      }
+    }
+  }
+
+  const cleaned = await cleanStale();
+
+  log("pending-queue", {
+    action: "replay-done",
+    replayed,
+    failed,
+    skipped,
+    deferred,
+    cleaned,
+  });
+
+  return { replayed, failed, skipped, deferred };
+}

--- a/examples/dsh-plugin/shared/plugin-config.mjs
+++ b/examples/dsh-plugin/shared/plugin-config.mjs
@@ -1,0 +1,90 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Per-harness plugin settings from ovcli.conf.
+ *
+ * ovcli.conf carried connection fields only, so every harness had to keep its
+ * tuning knobs in ov.conf's harness section — a server-side file that a
+ * client-side plugin has no business editing. The `plugin` section fixes that:
+ * shared keys apply to every harness that reads them, and a per-harness object
+ * overrides them.
+ *
+ *   {
+ *     "url": "...", "api_key": "...",
+ *     "plugin": {
+ *       "recallQueryExpansion": "off",
+ *       "recallCompress": "auto"
+ *     }
+ *   }
+ *
+ * Resolution stays env → ovcli.conf plugin.<harness> → ovcli.conf plugin →
+ * ov.conf harness section (legacy) → defaults.
+ *
+ * Consumers: Claude Code and Codex only. The other harnesses ship this module
+ * through `sync.mjs` but still read their knobs from the environment, so a
+ * `plugin` entry named after them is inert. `HARNESS_KEYS` lists what a harness
+ * loader actually consumes today — add a key here as its loader starts calling
+ * `loadPluginSettings`, not before, so the section never promises a knob that
+ * silently does nothing.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+const DEFAULT_OVCLI_CONF_PATH = join(homedir(), ".openviking", "ovcli.conf");
+
+export const HARNESS_KEYS = {
+  claudeCode: "claude_code",
+  codex: "codex",
+};
+
+function tryLoadJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge the shared plugin section with the harness-specific override.
+ * Returns a flat settings object; unknown keys pass through untouched so a
+ * harness can add its own knobs without touching this module.
+ */
+export function loadPluginSettings(harness, env = process.env) {
+  const path = resolvePath(
+    (env.OPENVIKING_CLI_CONFIG_FILE || DEFAULT_OVCLI_CONF_PATH).replace(/^~/, homedir()),
+  );
+  const file = tryLoadJson(path);
+  const plugin = file && typeof file.plugin === "object" && file.plugin ? file.plugin : {};
+
+  const shared = {};
+  for (const [key, value] of Object.entries(plugin)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) continue;
+    shared[key] = value;
+  }
+  const scoped = harness && plugin[harness] && typeof plugin[harness] === "object"
+    ? plugin[harness]
+    : {};
+
+  return { ...shared, ...scoped };
+}
+
+const REWRITE_MODES = new Set(["off", "client", "server", "auto"]);
+
+/**
+ * Normalize the tri-state rewrite knob.
+ *
+ * off    — never compress
+ * client — always compress locally through the host CLI
+ * server — always ask the server for a digest
+ * auto   — prefer local (cost lands on the user's own subscription), fall back
+ *          to the server when no healthy host CLI is available
+ */
+export function normalizeRewriteMode(value, fallback = "off") {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (REWRITE_MODES.has(raw)) return raw;
+  if (raw === "1" || raw === "true" || raw === "yes") return "auto";
+  if (raw === "0" || raw === "false" || raw === "no") return "off";
+  return fallback;
+}

--- a/examples/dsh-plugin/shared/profile-inject.d.mts
+++ b/examples/dsh-plugin/shared/profile-inject.d.mts
@@ -1,0 +1,17 @@
+export function buildProfileBlock(
+  fetchJSON: (path: string, init?: any, options?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
+  totalBudgetTokens: number,
+  actorPeerId?: string,
+): Promise<null | {
+  block: string;
+  chars: number;
+  tokens: number;
+  profileUri: string;
+  profileChars: number;
+  prefCount: number;
+  entCount: number;
+  droppedPref: number;
+  droppedEnt: number;
+}>;
+
+export function estimateTokens(text: string): number;

--- a/examples/dsh-plugin/shared/profile-inject.mjs
+++ b/examples/dsh-plugin/shared/profile-inject.mjs
@@ -1,0 +1,294 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Session-start profile injection helper.
+ *
+ * Builds a <user-profile> + <available-memories> block from
+ *   viking://user/<space>/memories/profile.md
+ *   viking://user/<space>/memories/preferences/   (ls with abstracts)
+ *   viking://user/<space>/memories/entities/      (ls with abstracts)
+ *
+ * Budget enforced via the CJK-aware estimateTokens() below — codepoint >=
+ * 0x3000 counts at 1.5 tokens, else chars/4. The estimator is exported so
+ * callers (e.g. session-start.mjs) can log token counts that match what
+ * the budget logic actually sees.
+ *
+ * Returned block is the *inner* content only (no outer <openviking-context>);
+ * session-start.mjs composes the outer wrapper so the archive block can sit
+ * alongside in a single context envelope.
+ */
+
+const USER_RESERVED_DIRS = new Set(["memories"]);
+let _userSpaceCache = null;
+
+/**
+ * Mirrors auto-recall.mjs resolveScopeSpace for scope="user" (lines 123-147).
+ * Duplicated rather than imported to avoid coupling session-start to
+ * auto-recall's module-level fetchJSON closure.
+ */
+async function resolveUserSpace(fetchJSON, actorPeerId = "") {
+  if (_userSpaceCache) return _userSpaceCache;
+
+  let fallbackSpace = "default";
+  const status = await fetchJSON("/api/v1/system/status");
+  if (status.ok && typeof status.result?.user === "string" && status.result.user.trim()) {
+    fallbackSpace = status.result.user.trim();
+  }
+
+  const lsRes = await fetchJSON(
+    `/api/v1/fs/ls?uri=${encodeURIComponent("viking://user")}&output=original`,
+    {},
+    { actorPeerId },
+  );
+  if (lsRes.ok && Array.isArray(lsRes.result)) {
+    const spaces = lsRes.result
+      .filter((e) => e?.isDir)
+      .map((e) => (typeof e.name === "string" ? e.name.trim() : ""))
+      .filter((n) => n && !n.startsWith(".") && !USER_RESERVED_DIRS.has(n));
+    if (spaces.length > 0) {
+      if (spaces.includes(fallbackSpace)) { _userSpaceCache = fallbackSpace; return fallbackSpace; }
+      if (spaces.includes("default")) { _userSpaceCache = "default"; return "default"; }
+      if (spaces.length === 1) { _userSpaceCache = spaces[0]; return spaces[0]; }
+    }
+  }
+  _userSpaceCache = fallbackSpace;
+  return fallbackSpace;
+}
+
+/**
+ * Token estimate that splits CJK from the rest. The rest of the plugin uses a
+ * flat chars/4 heuristic, which silently undercounts CJK content by 4-6× and
+ * makes a "5000 token budget" really worth ~1k real tokens for Chinese text.
+ *
+ * Rule:
+ *   - codepoint >= 0x3000 → CJK / Hiragana / Katakana / Hangul / CJK
+ *     punctuation / fullwidth ASCII; counted at 1.5 tokens/char (empirical
+ *     average for cl100k_base on Chinese; Claude's tokenizer is in the same
+ *     ballpark).
+ *   - everything else → chars/4 (the standard English-ish heuristic).
+ *
+ * Single linear pass, no dependencies. Errs on the side of overcounting CJK
+ * by ~10-20% in the worst case (some common Chinese phrases compress better
+ * than 1.5 tokens/char), which is the safe direction for budget enforcement.
+ */
+export function estimateTokens(text) {
+  if (!text) return 0;
+  let cjk = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) >= 0x3000) cjk++;
+  }
+  const other = text.length - cjk;
+  return Math.ceil(cjk * 1.5 + other / 4);
+}
+
+/**
+ * Convert a token budget to a max-chars budget that respects this content's
+ * actual CJK density. Avoids the chars/4 trap where a "5000 token" sub-cap
+ * yields 20000 chars of pure-CJK text → 30000 actual tokens (6× over).
+ *
+ * For an empty/missing string, returns 0.
+ */
+function tokensToCharsBudget(content, maxTokens) {
+  if (!content) return 0;
+  let cjk = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) >= 0x3000) cjk++;
+  }
+  const ratio = cjk / content.length;
+  const tokensPerChar = ratio * 1.5 + (1 - ratio) * 0.25;
+  return Math.floor(maxTokens / Math.max(tokensPerChar, 0.25));
+}
+
+async function readProfile(fetchJSON, profileUri, actorPeerId = "") {
+  const res = await fetchJSON(
+    `/api/v1/content/read?uri=${encodeURIComponent(profileUri)}`,
+    {},
+    { actorPeerId },
+  );
+  if (!res.ok || typeof res.result !== "string") return null;
+  const trimmed = res.result.trim();
+  return trimmed || null;
+}
+
+/**
+ * Recursive ls of a memory directory, flattening to .md leaves.
+ *
+ * Memory layout under preferences/ and entities/ is two-level:
+ *   <dir>/<owner_name>/<topic>.md
+ * so we use the server's recursive=true flag and filter to leaf .md files.
+ * `rel_path` (e.g. "zhengxiao.wu/pr_workflow.md") is preserved as display name
+ * to keep owner-namespacing visible and unambiguous when multiple owners exist.
+ */
+async function lsDir(fetchJSON, dirUri, actorPeerId = "") {
+  const url = `/api/v1/fs/ls?uri=${encodeURIComponent(dirUri)}&output=agent&recursive=true&abs_limit=512&node_limit=512`;
+  const res = await fetchJSON(url, {}, { actorPeerId });
+  if (!res.ok || !Array.isArray(res.result)) return [];
+  return res.result
+    .filter((e) => !e.isDir)
+    .map((e) => {
+      const rel = typeof e.rel_path === "string" && e.rel_path
+        ? e.rel_path
+        : (typeof e.name === "string" ? e.name : "");
+      return {
+        name: rel,
+        abstract: typeof e.abstract === "string" ? e.abstract.trim() : "",
+      };
+    })
+    .filter((e) => e.name && e.name.endsWith(".md"))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * When profile exceeds its sub-cap, keep the head (identity block + first
+ * timeline events) and the tail (most-recent events), drop the middle. This
+ * preserves both stable identity facts (top of file) and most-recent activity
+ * (bottom of file) — only the noisy middle timeline is sacrificed.
+ *
+ * Layout:
+ *   <first HEAD_LINES lines>
+ *   ... [profile middle elided] ...
+ *   <as many trailing lines as fit in remaining budget>
+ *
+ * Falls back to head-only truncate when the file is too short to elide
+ * meaningfully (<HEAD_LINES + 4 lines) or the budget is too tight to fit
+ * both head and a useful tail.
+ */
+function elideProfile(content, maxTokens) {
+  // Compute char budget from token budget using *this* content's CJK density,
+  // not chars/4 — otherwise the truncated string can still blow the token cap
+  // for CJK-heavy profiles (Copilot review point).
+  const maxChars = Math.max(400, tokensToCharsBudget(content, maxTokens));
+  if (estimateTokens(content) <= maxTokens) return content;
+
+  const HEAD_LINES = 8;
+  const ELLIPSIS = "\n... [profile middle elided] ...\n";
+  const lines = content.split("\n");
+
+  const fallbackHeadTruncate = () =>
+    content.slice(0, maxChars).trimEnd() + "\n... [profile truncated]";
+
+  if (lines.length <= HEAD_LINES + 4) return fallbackHeadTruncate();
+
+  const head = lines.slice(0, HEAD_LINES).join("\n");
+  const reserveForTail = maxChars - head.length - ELLIPSIS.length;
+  if (reserveForTail < 200) return fallbackHeadTruncate();
+
+  let tailChars = 0;
+  let tailStart = lines.length;
+  for (let i = lines.length - 1; i > HEAD_LINES; i--) {
+    const lineLen = lines[i].length + 1;
+    if (tailChars + lineLen > reserveForTail) break;
+    tailChars += lineLen;
+    tailStart = i;
+  }
+  if (tailStart >= lines.length - 1) return fallbackHeadTruncate();
+
+  return `${head}${ELLIPSIS}${lines.slice(tailStart).join("\n")}`;
+}
+
+function formatListing(headerUri, entries, budgetTokens) {
+  if (entries.length === 0) return { lines: [], used: 0, dropped: 0 };
+  // Header is the full directory URI; child lines are relative paths so the
+  // agent can reconstruct each leaf's full URI by concatenation while the
+  // listing itself stays compact.
+  const header = `  ${headerUri}/`;
+  const headerTokens = estimateTokens(header);
+  // If the header alone busts the budget, emit just a one-line stub instead
+  // of silently violating the cap (Copilot review point).
+  if (headerTokens > budgetTokens) {
+    const stub = `  ${headerUri}/  (${entries.length} entries, budget too tight; use \`memory_recall\`)`;
+    return { lines: [stub], used: estimateTokens(stub), dropped: entries.length };
+  }
+  const lines = [header];
+  let used = headerTokens;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    const desc = e.abstract
+      ? ` — ${e.abstract.replace(/\s+/g, " ").slice(0, 200)}`
+      : "";
+    const line = `    - ${e.name}${desc}`;
+    const tokens = estimateTokens(line);
+    if (used + tokens > budgetTokens) {
+      const remaining = entries.length - i;
+      const tail = `    ... +${remaining} more, use \`memory_recall\``;
+      const tailTokens = estimateTokens(tail);
+      // Only emit the tail if it fits; otherwise the listing closes silently
+      // rather than violating the cap to advertise its own truncation.
+      if (used + tailTokens <= budgetTokens) {
+        lines.push(tail);
+        return { lines, used: used + tailTokens, dropped: remaining };
+      }
+      return { lines, used, dropped: remaining };
+    }
+    lines.push(line);
+    used += tokens;
+  }
+  return { lines, used, dropped: 0 };
+}
+
+/**
+ * Build the profile injection block.
+ *
+ * Returns null when neither profile.md nor either listing has any content.
+ * The returned `block` is just the inner <user-profile>/<available-memories>
+ * payload — the caller wraps it in <openviking-context source="...">.
+ *
+ * @param {Function} fetchJSON  ov-session.mjs:makeFetchJSON closure
+ * @param {number} totalBudgetTokens  chars/4 budget, total for the whole block
+ * @returns {Promise<null | {
+ *   block: string, chars: number, tokens: number, profileUri: string,
+ *   profileChars: number, prefCount: number, entCount: number,
+ *   droppedPref: number, droppedEnt: number,
+ * }>}
+ */
+export async function buildProfileBlock(fetchJSON, totalBudgetTokens, actorPeerId = "") {
+  const space = await resolveUserSpace(fetchJSON, actorPeerId);
+  const profileUri = `viking://user/${space}/memories/profile.md`;
+  const prefUri = `viking://user/${space}/memories/preferences`;
+  const entUri = `viking://user/${space}/memories/entities`;
+
+  const [profile, prefs, ents] = await Promise.all([
+    readProfile(fetchJSON, profileUri, actorPeerId),
+    lsDir(fetchJSON, prefUri, actorPeerId),
+    lsDir(fetchJSON, entUri, actorPeerId),
+  ]);
+
+  if (!profile && prefs.length === 0 && ents.length === 0) return null;
+
+  // Profile gets up to half the total budget; listings split the rest.
+  // Sub-cap protects against a runaway profile blowing the listing budget.
+  const profileBudget = Math.floor(totalBudgetTokens / 2);
+  const profileTrunc = profile ? elideProfile(profile, profileBudget) : null;
+  const profileTokens = estimateTokens(profileTrunc || "");
+
+  const listingBudget = Math.max(0, totalBudgetTokens - profileTokens);
+  const halfListing = Math.floor(listingBudget / 2);
+  const prefBlock = formatListing(prefUri, prefs, halfListing);
+  const entBudget = Math.max(0, listingBudget - prefBlock.used);
+  const entBlock = formatListing(entUri, ents, entBudget);
+
+  const lines = [];
+  if (profileTrunc) {
+    lines.push(`<user-profile uri="${profileUri}">`);
+    lines.push(profileTrunc);
+    lines.push(`</user-profile>`);
+  }
+  if (prefBlock.lines.length > 0 || entBlock.lines.length > 0) {
+    lines.push(`<available-memories>`);
+    lines.push(...prefBlock.lines);
+    lines.push(...entBlock.lines);
+    lines.push(`</available-memories>`);
+  }
+
+  const block = lines.join("\n");
+  return {
+    block,
+    chars: block.length,
+    tokens: estimateTokens(block),
+    profileUri,
+    profileChars: profile?.length ?? 0,
+    prefCount: prefs.length,
+    entCount: ents.length,
+    droppedPref: prefBlock.dropped,
+    droppedEnt: entBlock.dropped,
+  };
+}

--- a/examples/dsh-plugin/shared/recall-compress-core.mjs
+++ b/examples/dsh-plugin/shared/recall-compress-core.mjs
@@ -1,0 +1,195 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const NO_RELEVANT_MEMORY = "NO_RELEVANT_MEMORY";
+export const DIGEST_HEADER = "OpenViking memory digest:";
+const COMPRESS_OK = "ok";
+const COMPRESS_EMPTY = "empty";
+const COMPRESS_FAILED = "failed";
+
+// Medium-constraint prompt: state the goal and two structural floors, but no hard
+// bullet-length contract. Hard per-bullet limits pin the digest to headline
+// density; leaving it unconstrained lets small models rewrite long URIs into dead
+// links, which the URI repair below cleans up.
+export function buildRecallCompressionPrompt({ query, rendered, maxBullets = 6 }) {
+  return `You are a memory relevance compressor utility.
+Do not use any tools. Do not investigate. Only transform the given text.
+
+User query:
+${query}
+
+Retrieved OpenViking context fragments:
+${rendered}
+
+Write a memory digest for a coding agent about to answer that query. Keep the
+concrete facts (paths, identifiers, decisions, constraints); drop pleasantries
+and conversational filler.
+
+Format rules:
+- Group related facts by topic, one bullet per topic, at most ${maxBullets} bullets.
+- Start every bullet with "- ".
+- End every bullet with its source, copied verbatim from the fragments above:
+  "来源：viking://..." or "source: viking://...". Never edit, shorten, or invent a URI.
+- Output the digest body only. No preamble, no closing remark.
+
+If nothing above is relevant to the query, output exactly: ${NO_RELEVANT_MEMORY}`;
+}
+
+function editDistance(a, b) {
+  if (a === b) return 0;
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  let prev = Array.from({ length: cols }, (_, i) => i);
+  for (let i = 1; i < rows; i += 1) {
+    const cur = [i];
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(cur[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    prev = cur;
+  }
+  return prev[cols - 1];
+}
+
+function nearestUri(candidate, validUris) {
+  let best = "";
+  let bestDistance = Infinity;
+  for (const uri of validUris) {
+    const distance = editDistance(candidate, uri);
+    if (distance < bestDistance) {
+      best = uri;
+      bestDistance = distance;
+    }
+  }
+  // Only repair near-misses; an unrelated hallucination is dropped instead.
+  const tolerance = Math.max(4, Math.floor(candidate.length * 0.25));
+  return bestDistance <= tolerance ? best : "";
+}
+
+/**
+ * Small models occasionally mangle long URIs. Snap every cited URI back onto the
+ * set the server actually returned, and drop bullets whose citation cannot be
+ * recovered so the digest never carries a dead link.
+ */
+export function repairDigestUris(digest, validUris = []) {
+  const text = String(digest || "");
+  if (!text) return "";
+  const valid = validUris.map((uri) => String(uri || "").trim()).filter(Boolean);
+  if (!valid.length) return text;
+  const validSet = new Set(valid);
+
+  const lines = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim().startsWith("- ")) {
+      lines.push(line);
+      continue;
+    }
+    let dropped = false;
+    const repaired = line.replace(/viking:\/\/[^\s<>"')\]]+/g, (uri) => {
+      if (validSet.has(uri)) return uri;
+      const nearest = nearestUri(uri, valid);
+      if (nearest) return nearest;
+      dropped = true;
+      return uri;
+    });
+    if (!dropped) lines.push(repaired);
+  }
+  return lines.join("\n").trim();
+}
+
+export function normalizeCompressedContext(raw, maxChars = 4000, maxBullets = 6) {
+  const text = String(raw || "").trim();
+  if (!text) return null;
+  if (text.toUpperCase() === NO_RELEVANT_MEMORY) return "";
+  const bullets = text.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line) && line.includes("viking://"))
+    .slice(0, Math.max(1, maxBullets))
+    .map((line) => `- ${line.replace(/^[-*]\s+/, "").slice(0, 500).trim()}`);
+  if (!bullets.length) return null;
+  return (`${DIGEST_HEADER}\n${bullets.join("\n")}`).slice(0, Math.max(100, maxChars));
+}
+
+export function recallDigestCacheKey({
+  query = "",
+  rendered = "",
+  entries = [],
+  maxInputChars = 18000,
+  maxBullets = 6,
+} = {}) {
+  const uris = entries.map((entry) => String(entry?.uri || "").trim()).filter(Boolean).sort();
+  const source = JSON.stringify({
+    version: 2,
+    query: String(query),
+    rendered: String(rendered).slice(0, maxInputChars),
+    uris,
+    maxInputChars,
+    maxBullets,
+  });
+  return createHash("sha256").update(source).digest("hex");
+}
+
+async function readCache(path) {
+  if (!path) return null;
+  try { return JSON.parse(await readFile(path, "utf8")); } catch { return null; }
+}
+
+async function writeCache(path, value) {
+  if (!path) return;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, JSON.stringify(value));
+    await rename(tmp, path);
+  } catch { /* best effort */ }
+}
+
+export async function compressRecallContext({
+  query,
+  rendered,
+  entries = [],
+  cfg = {},
+  runCompressor,
+  cachePath = "",
+  now = 0,
+}) {
+  const input = String(rendered || "").trim();
+  if (!input) return { status: COMPRESS_EMPTY, context: "" };
+  const minChars = Math.max(0, Number(cfg.recallCompressMinInputChars ?? 1500));
+  if (input.length < minChars) return { status: COMPRESS_OK, context: input };
+
+  const maxInputChars = Math.max(1000, Number(cfg.recallCompressMaxInputChars || 18000));
+  const maxBullets = Math.max(1, Number(cfg.recallCompressMaxBullets || 6));
+  const key = recallDigestCacheKey({
+    query,
+    rendered: input,
+    entries,
+    maxInputChars,
+    maxBullets,
+  });
+  const cached = await readCache(cachePath);
+  if (cached?.key === key && typeof cached.digest === "string") {
+    return { status: COMPRESS_OK, context: cached.digest };
+  }
+
+  const prompt = buildRecallCompressionPrompt({
+    query,
+    rendered: input.slice(0, maxInputChars),
+    maxBullets,
+  });
+  const raw = await runCompressor(prompt);
+  const normalized = normalizeCompressedContext(raw, 4000, maxBullets);
+  if (normalized === null) return { status: COMPRESS_FAILED, context: "" };
+  if (!normalized) return { status: COMPRESS_EMPTY, context: "" };
+
+  const validUris = entries.map((entry) => entry?.uri).filter(Boolean);
+  const digest = repairDigestUris(normalized, validUris.length
+    ? validUris
+    : (input.match(/viking:\/\/[^\s<>"']+/g) || []));
+  if (!digest) return { status: COMPRESS_FAILED, context: "" };
+
+  await writeCache(cachePath, { key, digest, updatedAt: now || 0 });
+  return { status: COMPRESS_OK, context: digest };
+}

--- a/examples/dsh-plugin/shared/recall-core.d.mts
+++ b/examples/dsh-plugin/shared/recall-core.d.mts
@@ -1,0 +1,13 @@
+export function buildRecallBlock(
+  fetchJSON: (path: string, init?: any, options?: any) => Promise<{ ok: boolean; status?: number; result?: any; error?: any }>,
+  cfg: Record<string, any>,
+  query: string,
+  options?: {
+    actorPeerId?: string;
+    sessionId?: string;
+    log?: (stage: string, data?: any) => void;
+  },
+): Promise<string | null>;
+
+export function buildRecallEndpointBody(cfg?: Record<string, any>): Record<string, any>;
+export function estimateTokens(text: string): number;

--- a/examples/dsh-plugin/shared/recall-core.mjs
+++ b/examples/dsh-plugin/shared/recall-core.mjs
@@ -1,0 +1,609 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { compressRecallContext } from "./recall-compress-core.mjs";
+
+const PREFERENCE_QUERY_RE = /prefer|preference|favorite|favourite|like|偏好|喜欢|爱好|更倾向/i;
+const TEMPORAL_QUERY_RE = /when|what time|date|day|month|year|yesterday|today|tomorrow|last|next|什么时候|何时|哪天|几月|几年|昨天|今天|明天/i;
+const QUERY_TOKEN_RE = /[a-z0-9一-龥]{2,}/gi;
+const STOPWORDS = new Set([
+  "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
+  "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
+]);
+const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
+const SOURCES = [
+  { type: "memory", uri: "viking://user/memories", bucket: "memories" },
+  { type: "skill", uri: "viking://user/skills", bucket: "skills" },
+];
+const DEFAULT_CONTEXT_LIMIT = 10;
+const DEFAULT_CONTEXT_MAX_TOKENS = 1600;
+const DEFAULT_REWRITE_MAX_BULLETS = 6;
+const CODING_QUOTA_WEIGHTS = {
+  events: 1,
+  entities: 2,
+  preferences: 1,
+  experiences: 1,
+  resources: 3,
+  skills: 2,
+};
+
+let userSpaceCache = "";
+
+export function estimateTokens(text) {
+  return text ? Math.ceil(String(text).length / 4) : 0;
+}
+
+function scaleQuotas(limit, weights) {
+  const slots = Math.max(1, Math.floor(Number(limit) || DEFAULT_CONTEXT_LIMIT));
+  const order = Object.keys(weights);
+  const quotas = Object.fromEntries(order.map((key) => [key, 0]));
+  if (slots < order.length) {
+    for (const key of order) quotas[key] = 1;
+    return quotas;
+  }
+
+  for (const key of order) quotas[key] = 1;
+  const totalWeight = Object.values(weights).reduce((sum, weight) => sum + weight, 0);
+  const ideals = Object.fromEntries(
+    order.map((key) => [key, slots * weights[key] / totalWeight]),
+  );
+  while (order.reduce((sum, key) => sum + quotas[key], 0) < slots) {
+    const key = order.reduce((best, candidate) => (
+      ideals[candidate] - quotas[candidate] > ideals[best] - quotas[best]
+        ? candidate
+        : best
+    ));
+    quotas[key] += 1;
+  }
+  return quotas;
+}
+
+function legacyMemoryQuotas(limit) {
+  return {
+    ...scaleQuotas(limit, { events: 10, entities: 10, preferences: 3 }),
+    experiences: 0,
+  };
+}
+
+function codingQuotas(limit) {
+  return scaleQuotas(limit, CODING_QUOTA_WEIGHTS);
+}
+
+export function buildRecallEndpointBody(cfg = {}) {
+  const limit = Math.max(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT), 1);
+  const body = {
+    query: "",
+    quotas: legacyMemoryQuotas(limit),
+    max_chars: Math.max(Number(cfg.recallMaxContentChars || 0) * limit, 1000),
+    min_score: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
+    render: true,
+  };
+  if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
+  return body;
+}
+
+/**
+ * Body for the server-side context face. The plugin declares intent (coding
+ * purpose, budget, session) and leaves the mechanics — quota ratios, tier
+ * degradation, cross-turn dedup — to the server's defaults.
+ */
+export function buildContextSearchBody(cfg = {}, options = {}) {
+  const rewriteMode = String(cfg.recallRewrite || "off").toLowerCase();
+  const limit = Math.max(1, Math.floor(Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT)));
+  const maxTokens = Math.max(
+    64,
+    Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
+  );
+  const body = {
+    query: "",
+    mode: "context",
+    purpose: "coding",
+    score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
+  };
+  const limitConfigured = cfg.recallLimitConfigured === true;
+  const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
+  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (maxTokensConfigured) body.max_tokens = maxTokens;
+  if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
+
+  const sessionId = String(options.sessionId || "").trim();
+  if (sessionId) {
+    body.session_id = sessionId;
+    const queryExpansionConfigured = cfg.recallQueryExpansionConfigured === true;
+    if (queryExpansionConfigured) {
+      body.query_expansion = cfg.recallQueryExpansion === "off" ? "off" : "auto";
+    }
+    const dedupTurns = Number(cfg.recallDedupTurns);
+    const resolvedDedupTurns = Number.isFinite(dedupTurns)
+      ? Math.max(0, Math.floor(dedupTurns))
+      : 5;
+    if (resolvedDedupTurns > 0) body.dedup_turns = resolvedDedupTurns;
+  }
+
+  const excludeUris = Array.isArray(options.excludeUris) ? options.excludeUris.slice(0, 200) : [];
+  if (excludeUris.length) body.exclude_uris = excludeUris;
+
+  if (rewriteMode === "server") body.rewrite = true;
+  else if (rewriteMode === "auto" && !options.localCompressorAvailable) body.rewrite = "auto";
+  const rewriteMaxBullets = Math.max(
+    1,
+    Math.floor(Number(cfg.recallCompressMaxBullets || DEFAULT_REWRITE_MAX_BULLETS)),
+  );
+  const rewriteMaxBulletsConfigured = cfg.recallCompressMaxBulletsConfigured === true;
+  if (body.rewrite !== undefined && rewriteMaxBulletsConfigured) {
+    body.rewrite_max_bullets = rewriteMaxBullets;
+  }
+  return body;
+}
+
+// The server pipeline is serial and each optional stage has its own fuse. A
+// request is aborted client-side unless its deadline covers every stage it
+// asked for, and aborting discards the whole response rather than just the
+// stage that ran long.
+//
+//   session_id  -> query expansion   (retrieval.recall_intent_timeout_s,  5s)
+//   always      -> retrieval, body reads, budget planning
+//   rewrite     -> digest            (retrieval.recall_rewrite_timeout_s, 30s)
+//
+// Both budgets stay inside the 60s prompt-hook allowance, the rewrite one with
+// a quarter to spare.
+const EXPANSION_REQUEST_TIMEOUT_MS = 15000;
+const SERVER_REWRITE_REQUEST_TIMEOUT_MS = 45000;
+
+/**
+ * HTTP deadline for one context request, or undefined to keep the caller's own.
+ *
+ * Derived from the request body, because the body is what states which server
+ * stages will run: reading `cfg` alone cannot tell a bare retrieval from one
+ * that also spends the expansion or rewrite fuse.
+ */
+export function contextRequestTimeoutMs(cfg = {}, body = {}) {
+  const wantsRewrite = body.rewrite !== undefined;
+  // `query_expansion` defaults to "auto" server-side, so only an explicit "off"
+  // takes the expansion fuse back out of the budget.
+  const wantsExpansion = Boolean(body.session_id) && body.query_expansion !== "off";
+  if (!wantsRewrite && !wantsExpansion) return undefined;
+
+  const configured = Number(cfg.recallContextTimeoutMs);
+  if (Number.isFinite(configured) && configured > 0) return Math.max(1000, Math.floor(configured));
+  const floor = wantsRewrite ? SERVER_REWRITE_REQUEST_TIMEOUT_MS : EXPANSION_REQUEST_TIMEOUT_MS;
+  return Math.max(Number(cfg.timeoutMs) || 0, floor);
+}
+
+/**
+ * Strip the context-face fields a pre-context server rejects, converting the
+ * token budget back to v1's character budget.
+ */
+export function downgradeToRecallBody(contextBody = {}, cfg = {}) {
+  const body = buildRecallEndpointBody(cfg);
+  body.query = contextBody.query || "";
+  body.max_chars = Math.max(1000, Math.floor(Number(contextBody.max_tokens || 1600) * 4));
+  if (contextBody.peer_scope) body.peer_scope = contextBody.peer_scope;
+  return body;
+}
+
+function clampScore(v) {
+  if (typeof v !== "number" || Number.isNaN(v)) return 0;
+  return Math.max(0, Math.min(1, v));
+}
+
+function buildQueryProfile(query) {
+  const text = query.trim();
+  const allTokens = text.toLowerCase().match(QUERY_TOKEN_RE) || [];
+  return {
+    tokens: allTokens.filter((t) => !STOPWORDS.has(t)),
+    wantsPreference: PREFERENCE_QUERY_RE.test(text),
+    wantsTemporal: TEMPORAL_QUERY_RE.test(text),
+  };
+}
+
+function lexicalOverlapBoost(tokens, text) {
+  if (tokens.length === 0 || !text) return 0;
+  const haystack = ` ${text.toLowerCase()} `;
+  let matched = 0;
+  for (const token of tokens.slice(0, 8)) {
+    if (haystack.includes(token)) matched += 1;
+  }
+  return Math.min(0.2, (matched / Math.min(tokens.length, 4)) * 0.2);
+}
+
+function rankItem(item, profile) {
+  const base = clampScore(item.score);
+  const abstract = (item.abstract || item.overview || "").trim();
+  const cat = (item.category || "").toLowerCase();
+  const uri = (item.uri || "").toLowerCase();
+  const leafBoost = (item.level === 2 || uri.endsWith(".md")) ? 0.12 : 0;
+  const eventBoost = profile.wantsTemporal && (cat === "events" || uri.includes("/events/")) ? 0.1 : 0;
+  const prefBoost = profile.wantsPreference && (cat === "preferences" || uri.includes("/preferences/")) ? 0.08 : 0;
+  const overlapBoost = lexicalOverlapBoost(profile.tokens, `${item.uri} ${abstract}`);
+  return base + leafBoost + eventBoost + prefBoost + overlapBoost;
+}
+
+function isEventOrCaseItem(item) {
+  const cat = (item.category || "").toLowerCase();
+  const uri = (item.uri || "").toLowerCase();
+  return cat === "events" || cat === "cases" || uri.includes("/events/") || uri.includes("/cases/");
+}
+
+function dedupeItems(items) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    const key = isEventOrCaseItem(item)
+      ? `uri:${item.uri}`
+      : ((item.abstract || item.overview || "").trim().toLowerCase() || `uri:${item.uri}`);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+async function resolveUserSpace(fetchJSON, actorPeerId = "") {
+  if (userSpaceCache) return userSpaceCache;
+
+  let fallbackSpace = "default";
+  const status = await fetchJSON("/api/v1/system/status");
+  if (status.ok && typeof status.result?.user === "string" && status.result.user.trim()) {
+    fallbackSpace = status.result.user.trim();
+  }
+
+  const lsRes = await fetchJSON(
+    `/api/v1/fs/ls?uri=${encodeURIComponent("viking://user")}&output=original`,
+    {},
+    { actorPeerId },
+  );
+  if (lsRes.ok && Array.isArray(lsRes.result)) {
+    const spaces = lsRes.result
+      .filter((e) => e?.isDir)
+      .map((e) => (typeof e.name === "string" ? e.name.trim() : ""))
+      .filter((n) => n && !n.startsWith(".") && !USER_RESERVED_DIRS.has(n));
+    if (spaces.length > 0) {
+      if (spaces.includes(fallbackSpace)) { userSpaceCache = fallbackSpace; return fallbackSpace; }
+      if (spaces.includes("default")) { userSpaceCache = "default"; return "default"; }
+      if (spaces.length === 1) { userSpaceCache = spaces[0]; return spaces[0]; }
+    }
+  }
+  userSpaceCache = fallbackSpace;
+  return fallbackSpace;
+}
+
+async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
+  const trimmed = targetUri.trim().replace(/\/+$/, "");
+  const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);
+  if (!m) return trimmed;
+  const rawRest = (m[1] ?? "").trim();
+  if (!rawRest) return trimmed;
+  const parts = rawRest.split("/").filter(Boolean);
+  if (parts.length === 0) return trimmed;
+  if (!USER_RESERVED_DIRS.has(parts[0])) return trimmed;
+  const space = await resolveUserSpace(fetchJSON, actorPeerId);
+  return `viking://user/${space}/${parts.join("/")}`;
+}
+
+async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
+  const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const res = await fetchJSON("/api/v1/search/find", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }, { actorPeerId });
+  if (!res.ok) return [];
+  const items = res.result?.[source.bucket] || [];
+  return items.map((item) => ({ ...item, _sourceType: source.type }));
+}
+
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+  const results = await Promise.all(
+    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+  );
+  const all = results.flat();
+  log("recall_search_summary", {
+    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    total: all.length,
+  });
+  return all;
+}
+
+async function resolveItemContent(fetchJSON, item, cfg, actorPeerId = "") {
+  let content;
+
+  if (cfg.recallPreferAbstract && (item.abstract || item.overview || "").trim()) {
+    content = (item.abstract || item.overview).trim();
+  } else if (item.level === 2) {
+    try {
+      const res = await fetchJSON(
+        `/api/v1/content/read?uri=${encodeURIComponent(item.uri)}`,
+        {},
+        { actorPeerId },
+      );
+      const body = res.ok && typeof res.result === "string" ? res.result.trim() : "";
+      content = body || (item.abstract || item.overview || "").trim() || item.uri;
+    } catch {
+      content = (item.abstract || item.overview || "").trim() || item.uri;
+    }
+  } else {
+    content = (item.abstract || item.overview || "").trim() || item.uri;
+  }
+
+  const maxChars = Math.max(50, Number(cfg.recallMaxContentChars || 500));
+  if (content.length > maxChars) content = `${content.slice(0, maxChars)}...`;
+  return content;
+}
+
+async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = "", log = () => {}) {
+  if (items.length === 0) return null;
+
+  let budgetRemaining = Math.max(200, Number(cfg.recallTokenBudget || 2000));
+  const lines = [
+    "<openviking-context>",
+    "Relevant context from OpenViking. Use the read MCP tool to expand URIs.",
+  ];
+  let contentCount = 0;
+  let hintCount = 0;
+
+  for (const item of items) {
+    const score = (clampScore(item.score) * 100).toFixed(0);
+    const uriLine = `- [${item._sourceType} ${score}%] ${item.uri}`;
+
+    if (budgetRemaining > 0) {
+      const content = await resolveItemContent(fetchJSON, item, cfg, actorPeerId);
+      const contentLine = `- [${item._sourceType} ${score}%] ${content}`;
+      const lineTokens = estimateTokens(contentLine);
+
+      if (lineTokens > budgetRemaining && contentCount > 0) {
+        lines.push(uriLine);
+        hintCount++;
+      } else {
+        lines.push(contentLine);
+        budgetRemaining -= lineTokens;
+        contentCount++;
+      }
+    } else {
+      lines.push(uriLine);
+      hintCount++;
+    }
+  }
+
+  lines.push("</openviking-context>");
+
+  const budgetUsed = Math.max(200, Number(cfg.recallTokenBudget || 2000)) - budgetRemaining;
+  log("recall_injection_built", {
+    contentItems: contentCount,
+    hintItems: hintCount,
+    budgetUsed,
+    budgetTotal: Math.max(200, Number(cfg.recallTokenBudget || 2000)),
+  });
+
+  return lines.join("\n");
+}
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+function stateFile(name) {
+  const override = String(process.env.OPENVIKING_STATE_DIR || "").trim();
+  return override ? join(override, name) : join(homedir(), ".openviking", "state", name);
+}
+
+async function readJsonFile(path) {
+  try { return JSON.parse(await readFile(path, "utf8")); } catch { return null; }
+}
+
+async function writeJsonFile(path, value) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, JSON.stringify(value));
+    await rename(tmp, path);
+  } catch { /* best effort */ }
+}
+
+/**
+ * Hooks are one-shot processes, so "this server has no context face" has to be
+ * remembered on disk or every turn pays for a rejected request.
+ */
+export async function isContextFaceLegacy(path = stateFile("context-face.json"), now = Date.now()) {
+  const cached = await readJsonFile(path);
+  return Boolean(cached?.legacyUntil && Number(cached.legacyUntil) > now);
+}
+
+export async function markContextFaceLegacy(path = stateFile("context-face.json"), now = Date.now()) {
+  await writeJsonFile(path, { legacyUntil: now + LEGACY_CACHE_TTL_MS });
+}
+
+function looksLikeUnknownField(res) {
+  const text = JSON.stringify(res?.error ?? res?.result ?? res?.detail ?? "").toLowerCase();
+  return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
+}
+
+function wrapContext(body) {
+  return [
+    "<openviking-context>",
+    "Relevant memory from OpenViking. Use the recall/read MCP tools to expand URIs.",
+    body,
+    "</openviking-context>",
+  ].join("\n");
+}
+
+/**
+ * Server-assembled context: the context face when the deployment has it, else
+ * the deprecated /recall preset. Returns the injection block, "" when there was
+ * nothing relevant, or null when no server-side path was usable at all.
+ */
+export async function buildServerAssembledBlock(fetchJSON, cfg, query, options = {}) {
+  const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
+  const log = options.log || (() => {});
+
+  const block = await recallViaContextFace(fetchJSON, cfg, query, { ...options, actorPeerId }, log);
+  if (block !== null) return block;
+  return recallViaEndpoint(fetchJSON, cfg, query, actorPeerId, log);
+}
+
+/**
+ * Raw server-assembled context, or null when the deployment has no context face.
+ * Returns `{ rendered, entries, digest, stats }` — callers that need the entries
+ * (their own compression, their own envelope) use this instead of the block
+ * builders below.
+ */
+export async function fetchAssembledContext(fetchJSON, cfg, query, options = {}) {
+  const actorPeerId = options.actorPeerId || "";
+  const log = options.log || (() => {});
+  if (await isContextFaceLegacy(options.legacyCachePath)) return null;
+
+  const body = buildContextSearchBody(cfg, options);
+  body.query = query;
+  const res = await fetchJSON("/api/v1/search/search", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }, { actorPeerId, timeoutMs: contextRequestTimeoutMs(cfg, body) });
+
+  if (!res.ok) {
+    const status = res.status || 0;
+    if ((status === 400 || status === 422) && looksLikeUnknownField(res)) {
+      await markContextFaceLegacy(options.legacyCachePath);
+      log("recall_context_face_unsupported", { status });
+    } else {
+      log("recall_context_face_error", { status });
+    }
+    return null;
+  }
+
+  const result = res.result || {};
+  const stats = result.stats || {};
+  log("recall_context_assembled", {
+    entries: Array.isArray(result.entries) ? result.entries.length : 0,
+    usedTokens: stats.used_tokens || 0,
+    tiers: stats.tier_counts || {},
+    rewrite: stats.rewrite || "off",
+  });
+  return {
+    rendered: String(result.rendered || "").trim(),
+    entries: Array.isArray(result.entries) ? result.entries : [],
+    digest: String(result.digest || "").trim(),
+    stats,
+  };
+}
+
+/**
+ * Entry field compatibility: the context face returns `category`/`text`, while
+ * the deprecated /recall v1 shape used `type` plus `content`/`summary`.
+ */
+export function normalizeContextEntry(entry = {}) {
+  return {
+    uri: String(entry.uri || "").trim(),
+    category: String(entry.category || entry.type || "memory").trim() || "memory",
+    detail: String(entry.detail || entry.mode || "").trim(),
+    score: Number(entry.score) || 0,
+    text: String(
+      entry.text || entry.content || entry.summary || entry.abstract || entry.uri || "",
+    ).trim(),
+  };
+}
+
+async function recallViaContextFace(fetchJSON, cfg, query, options, log) {
+  const assembled = await fetchAssembledContext(fetchJSON, cfg, query, { ...options, log });
+  if (assembled === null) return null;
+
+  const { rendered, entries } = assembled;
+  let digest = assembled.digest;
+  const mode = String(cfg.recallRewrite || "off").toLowerCase();
+  if (String(assembled.stats?.rewrite || "").toLowerCase() === "no_relevant") {
+    log("recall_server_compression", { status: "empty" });
+    return "";
+  }
+  const wantsLocal = mode === "client" || (mode === "auto" && !digest);
+  if (wantsLocal && rendered && typeof options.runCompressor === "function") {
+    try {
+      const compression = await compressRecallContext({
+        query,
+        rendered,
+        entries,
+        cfg,
+        runCompressor: options.runCompressor,
+        cachePath: options.digestCachePath || stateFile("recall-digest.json"),
+        now: Date.now(),
+      });
+      log("recall_local_compression", { status: compression.status });
+      if (compression.status === "ok") digest = compression.context;
+      if (compression.status === "empty") return "";
+    } catch (err) {
+      log("recall_local_compression_failed", { error: String(err?.message || err) });
+    }
+  }
+
+  const injected = digest || rendered;
+  if (!injected) return "";
+  return wrapContext(injected);
+}
+
+async function recallViaEndpoint(fetchJSON, cfg, query, actorPeerId = "", log = () => {}) {
+  const body = buildRecallEndpointBody(cfg);
+  body.query = query;
+  const res = await postRecall(fetchJSON, body, { actorPeerId, log });
+  if (!res.ok) {
+    log("recall_endpoint_fallback", { status: res.status || 0 });
+    return null;
+  }
+  const rendered = String(res.result?.rendered || "").trim();
+  if (!rendered) return "";
+  return wrapContext(rendered);
+}
+
+export async function postRecall(fetchJSON, body, opts = {}) {
+  const actorPeerId = opts.actorPeerId || "";
+  const log = opts.log || (() => {});
+  const request = { ...body };
+  const res = await fetchJSON("/api/v1/search/recall", {
+    method: "POST",
+    body: JSON.stringify(request),
+  }, { actorPeerId });
+  if (!request.peer_scope || (res.status !== 400 && res.status !== 422)) {
+    return res;
+  }
+
+  const downgraded = { ...request };
+  delete downgraded.peer_scope;
+  log("recall_peer_scope_downgrade", { status: res.status || 0 });
+  return fetchJSON("/api/v1/search/recall", {
+    method: "POST",
+    body: JSON.stringify(downgraded),
+  }, { actorPeerId });
+}
+
+export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
+  const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
+  const log = options.log || (() => {});
+  const trimmed = String(query || "").trim();
+  if (!trimmed) return null;
+
+  // Assembly happens server-side when the deployment offers the context face;
+  // older servers fall through to /recall, then to raw find.
+  const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
+    ...options,
+    actorPeerId,
+    log,
+  });
+  if (serverBlock !== null) return serverBlock || null;
+
+  const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
+  const perSourceLimit = Math.max(recallLimit * 2, 8);
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  if (raw.length === 0) return null;
+
+  const profile = buildQueryProfile(trimmed);
+  const scoreThreshold = Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35;
+  const filtered = raw.filter((it) => clampScore(it.score) >= scoreThreshold);
+  filtered.sort((a, b) => rankItem(b, profile) - rankItem(a, profile));
+  const picked = dedupeItems(filtered).slice(0, recallLimit);
+  log("recall_picked", {
+    rawCount: raw.length,
+    filteredCount: filtered.length,
+    pickedCount: picked.length,
+    items: picked.map((it) => ({ type: it._sourceType, uri: it.uri, score: clampScore(it.score) })),
+  });
+
+  if (picked.length === 0) return null;
+  return buildFallbackInjectionBlock(fetchJSON, picked, cfg, actorPeerId, log);
+}

--- a/examples/dsh-plugin/shared/retryable.mjs
+++ b/examples/dsh-plugin/shared/retryable.mjs
@@ -1,0 +1,9 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+export function isRetryableFailure(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) {
+    return true;
+  }
+  return status === 409 && result.error?.details?.retryable === true;
+}

--- a/examples/dsh-plugin/shared/session-model.d.mts
+++ b/examples/dsh-plugin/shared/session-model.d.mts
@@ -1,0 +1,3 @@
+export function deriveHarnessSessionId(prefix: string, sessionId: string, suffix?: string): string;
+export function deriveCodexSessionId(codexSessionId: string): string;
+export function isBypassed(cfg: Record<string, any>, options?: { sessionId?: string; cwd?: string }): boolean;

--- a/examples/dsh-plugin/shared/session-model.mjs
+++ b/examples/dsh-plugin/shared/session-model.mjs
@@ -1,0 +1,57 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Shared OpenViking session-id helpers for memory plugin harnesses.
+ */
+
+/**
+ * Glob -> RegExp. Minimal implementation: supports `*`, `**`, and literals.
+ */
+function globToRe(glob) {
+  let re = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") { re += ".*"; i++; }
+      else re += "[^/]*";
+    } else if (/[.+?^${}()|[\]\\]/.test(c)) {
+      re += "\\" + c;
+    } else {
+      re += c;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}
+
+export function isBypassed(cfg, { sessionId, cwd } = {}) {
+  if (cfg.bypassSession) return true;
+  const patterns = cfg.bypassSessionPatterns || [];
+  if (patterns.length === 0) return false;
+  const haystacks = [sessionId, cwd].filter(Boolean);
+  for (const pat of patterns) {
+    const re = globToRe(pat);
+    if (haystacks.some((h) => re.test(h))) return true;
+  }
+  return false;
+}
+
+function safeId(value, replacement = "_") {
+  return String(value || "unknown").replace(/[^A-Za-z0-9._-]/g, replacement);
+}
+
+export function deriveHarnessSessionId(prefix, sessionId, suffix = "") {
+  if (!prefix || typeof prefix !== "string") {
+    throw new Error("deriveHarnessSessionId requires a non-empty prefix");
+  }
+  if (!sessionId || typeof sessionId !== "string") {
+    throw new Error("deriveHarnessSessionId requires a non-empty sessionId");
+  }
+  const base = `${prefix}${sessionId}`;
+  if (!suffix) return base;
+  const normalized = String(suffix).replace(/:/g, "-").replace(/[^A-Za-z0-9._-]/g, "-");
+  return `${base}__${normalized}`;
+}
+
+export function deriveCodexSessionId(codexSessionId) {
+  return `cx-${safeId(codexSessionId, "_")}`;
+}

--- a/examples/dsh-plugin/shared/setup-wizard.mjs
+++ b/examples/dsh-plugin/shared/setup-wizard.mjs
@@ -1,0 +1,111 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+/**
+ * Interactive ovcli.conf setup wizard shared by the OpenViking memory plugins.
+ *
+ * Lets a pure-marketplace install (no installer script) configure the server
+ * URL and API key that both the lifecycle hooks and the stdio MCP proxy read:
+ *
+ *   node <plugin>/scripts/setup.mjs
+ *
+ * Conventions: show current values, keep existing secrets on empty input,
+ * merge-write (never drop unknown fields), back up the previous file, 0600.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { dirname } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { loadCredentialFiles } from "./credentials.mjs";
+
+const CLOUD_URL = "https://api.vikingdb.cn-beijing.volces.com/openviking";
+const LOCAL_URL = "http://127.0.0.1:1933";
+
+function maskSecret(value) {
+  const s = String(value || "");
+  if (!s) return "(not set)";
+  if (s.length <= 8) return "****";
+  return `${s.slice(0, 4)}…${s.slice(-4)} (${s.length} chars)`;
+}
+
+function readJsonSafe(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+export async function runSetupWizard({
+  input = process.stdin,
+  output = process.stdout,
+  env = process.env,
+} = {}) {
+  const { cliPath } = loadCredentialFiles(env);
+  const current = readJsonSafe(cliPath);
+  const rl = createInterface({ input, output });
+  const say = (line = "") => output.write(`${line}\n`);
+
+  try {
+    say("OpenViking memory plugin setup");
+    say(`Config file: ${cliPath}`);
+    say("");
+    say("Current values:");
+    say(`  url:     ${current.url || "(not set)"}`);
+    say(`  api_key: ${maskSecret(current.api_key)}`);
+    if (current.account) say(`  account: ${current.account}`);
+    if (current.user) say(`  user:    ${current.user}`);
+    say("");
+
+    const defaultUrl = current.url || LOCAL_URL;
+    say("Where do you connect to OpenViking?");
+    say(`  1) Self-hosted / local        [${LOCAL_URL}]`);
+    say(`  2) Volcengine OpenViking Cloud [${CLOUD_URL}]`);
+    say(`  3) Custom URL / keep current   [${defaultUrl}]`);
+    const mode = (await rl.question("Choice [1/2/3, default 3]: ")).trim();
+    let url = defaultUrl;
+    if (mode === "1") {
+      url = LOCAL_URL;
+    } else if (mode === "2") {
+      url = CLOUD_URL;
+    } else {
+      const answer = (await rl.question(`Server URL [${defaultUrl}]: `)).trim();
+      if (answer) url = answer;
+    }
+
+    const keyPrompt = current.api_key
+      ? `API key [enter = keep ${maskSecret(current.api_key)}, '-' = clear]: `
+      : "API key (leave empty for unauthenticated local mode): ";
+    const keyAnswer = await rl.question(keyPrompt);
+    let apiKey = current.api_key || "";
+    if (keyAnswer === "-") apiKey = "";
+    else if (keyAnswer.trim()) apiKey = keyAnswer.trim();
+    else if (!current.api_key) apiKey = "";
+
+    const next = { ...current, url, api_key: apiKey };
+
+    say("");
+    say("Changes:");
+    say(`  url:     ${current.url || "(not set)"} -> ${next.url}`);
+    say(`  api_key: ${maskSecret(current.api_key)} -> ${maskSecret(next.api_key)}`);
+    const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
+    if (confirm === "n" || confirm === "no") {
+      say("Aborted; nothing written.");
+      return { written: false, path: cliPath };
+    }
+
+    mkdirSync(dirname(cliPath), { recursive: true });
+    if (existsSync(cliPath)) {
+      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    }
+    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    try {
+      chmodSync(cliPath, 0o600);
+    } catch {
+      /* best effort on platforms without chmod semantics */
+    }
+    say(`Written: ${cliPath}`);
+    say("The stdio MCP proxy and hooks pick this up on the next harness start.");
+    return { written: true, path: cliPath };
+  } finally {
+    rl.close();
+  }
+}

--- a/examples/dsh-plugin/shared/uri-guard.mjs
+++ b/examples/dsh-plugin/shared/uri-guard.mjs
@@ -1,0 +1,56 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+const DEFAULT_URI_KEYS = [
+  "filePath",
+  "file_path",
+  "filepath",
+  "path",
+  "uri",
+  "target_uri",
+  "targetUri",
+  "pattern",
+];
+
+export function normalizeToolName(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  if (!args || typeof args !== "object") return null;
+  for (const key of keys) {
+    const uri = findVikingUriInValue(args[key]);
+    if (uri) return uri;
+  }
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInValue(value) {
+  if (typeof value === "string") {
+    const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
+    return match?.[0] || null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const uri = findVikingUriInValue(item);
+      if (uri) return uri;
+    }
+    return null;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      const uri = findVikingUriInValue(item);
+      if (uri) return uri;
+    }
+  }
+  return null;
+}
+
+export function buildGuardMessage(uri, hint = {}) {
+  const tool = hint.tool || "the OpenViking MCP tools";
+  const example = typeof hint.example === "function" ? hint.example(uri) : hint.example;
+  const lines = [
+    "viking:// URIs are OpenViking virtual paths, not local filesystem paths.",
+    `Use ${tool} instead.`,
+  ];
+  if (example) lines.push(`Example: ${example}`);
+  return lines.join("\n");
+}

--- a/examples/dsh-plugin/shared/workspace-peer.d.mts
+++ b/examples/dsh-plugin/shared/workspace-peer.d.mts
@@ -1,0 +1,5 @@
+export function deriveWorkspacePeerId(cwd: unknown): string;
+export function resolveEffectivePeerId(input?: {
+  cfg?: { peerId?: string; workspacePeer?: boolean };
+  cwd?: string;
+}): { peerId: string; source: "explicit" | "workspace" | "none" };

--- a/examples/dsh-plugin/shared/workspace-peer.mjs
+++ b/examples/dsh-plugin/shared/workspace-peer.mjs
@@ -1,0 +1,16 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+export function deriveWorkspacePeerId(cwd) {
+  return String(cwd || "").replace(/[^A-Za-z0-9]/g, "-");
+}
+
+export function resolveEffectivePeerId({ cfg = {}, cwd = "" } = {}) {
+  const explicit = String(cfg.peerId || "").trim();
+  if (explicit) return { peerId: explicit, source: "explicit" };
+
+  if (cfg.workspacePeer !== false) {
+    const peerId = deriveWorkspacePeerId(cwd);
+    if (peerId) return { peerId, source: "workspace" };
+  }
+
+  return { peerId: "", source: "none" };
+}

--- a/examples/dsh-plugin/src/client.ts
+++ b/examples/dsh-plugin/src/client.ts
@@ -1,0 +1,171 @@
+/**
+ * Thin OpenViking HTTP client in the memory-plugin family shape: one
+ * `fetchJSON` that normalizes the `{ status, result }` envelope to
+ * `{ ok, result }`, which is exactly the contract the vendored shared
+ * helpers (`recall-core`, `batch-send`, `pending-queue`) consume.
+ *
+ * @module @openviking/dsh-plugin
+ */
+
+import type { RuntimeCfg } from './config.ts'
+
+/** Normalized OpenViking response. */
+export interface OVResponse<T = unknown> {
+  ok: boolean
+  result: T | null
+  status?: number
+  error?: { message?: string } & Record<string, unknown>
+}
+
+/** The fetchJSON contract shared helpers consume. */
+export type FetchJSON = (
+  path: string,
+  init?: RequestInit,
+  options?: { timeoutMs?: number, actorPeerId?: string },
+) => Promise<OVResponse>
+
+/** One normalized search hit. */
+export interface OVSearchItem {
+  uri: string
+  score: number
+  abstract: string
+}
+
+export class OVClient {
+  readonly cfg: RuntimeCfg
+  readonly fetchJSON: FetchJSON
+
+  constructor(cfg: RuntimeCfg) {
+    this.cfg = cfg
+    this.fetchJSON = async (path, init, options) => {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), options?.timeoutMs ?? 10_000)
+      timer.unref?.()
+      try {
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        if (this.cfg.apiKey !== '') headers.Authorization = `Bearer ${this.cfg.apiKey}`
+        if (this.cfg.account !== '') headers['X-OpenViking-Account'] = this.cfg.account
+        if (this.cfg.user !== '') headers['X-OpenViking-User'] = this.cfg.user
+        const peer = options?.actorPeerId ?? this.cfg.peerId
+        if (peer !== '') headers['X-OpenViking-Actor-Peer'] = peer
+        headers['User-Agent'] = this.cfg.userAgent
+        const response = await fetch(`${this.cfg.baseUrl}${path}`, {
+          ...init,
+          headers: { ...headers, ...init?.headers as Record<string, string> | undefined },
+          signal: controller.signal,
+        })
+        const body = await response.json().catch(() => ({})) as {
+          status?: string
+          result?: unknown
+          error?: { message?: string }
+        }
+        if (!response.ok || body.status === 'error') {
+          return {
+            ok: false,
+            result: null,
+            status: response.status,
+            error: body.error ?? { message: `HTTP ${response.status}` },
+          }
+        }
+        return { ok: true, result: body.result ?? body }
+      } catch (error) {
+        return { ok: false, result: null, status: 0, error: { message: error instanceof Error ? error.message : String(error) } }
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+  }
+
+  async health(): Promise<boolean> {
+    const response = await this.fetchJSON('/health', undefined, { timeoutMs: 5000 })
+    return response.ok
+  }
+
+  /** Ensure a session exists (idempotent server-side). */
+  async ensureSession(sessionId: string): Promise<boolean> {
+    const response = await this.fetchJSON(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}?auto_create=true`,
+      undefined,
+      { timeoutMs: 5000 },
+    )
+    return response.ok
+  }
+
+  async commitSession(sessionId: string, keepRecentCount: number): Promise<boolean> {
+    const response = await this.fetchJSON(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
+      { method: 'POST', body: JSON.stringify({ keep_recent_count: keepRecentCount }) },
+      { timeoutMs: 30_000 },
+    )
+    return response.ok
+  }
+
+  /** Assembled session context (used for resume seeding). */
+  async getSessionContext(sessionId: string, tokenBudget: number): Promise<string> {
+    const response = await this.fetchJSON(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/context?token_budget=${tokenBudget}`,
+      undefined,
+      { timeoutMs: 10_000 },
+    )
+    if (!response.ok || response.result === null || typeof response.result !== 'object') return ''
+    const record = response.result as Record<string, unknown>
+    const overview = record.latest_archive_overview
+    return typeof overview === 'string' ? overview.trim() : ''
+  }
+
+  /** Raw semantic search across memories / resources / skills. */
+  async find(query: string, limit: number): Promise<OVSearchItem[]> {
+    const response = await this.fetchJSON('/api/v1/search/find', {
+      method: 'POST',
+      body: JSON.stringify({ query, limit }),
+    })
+    if (!response.ok || response.result === null || typeof response.result !== 'object') return []
+    const record = response.result as Record<string, unknown>
+    const items: OVSearchItem[] = []
+    for (const bucket of ['memories', 'resources', 'skills']) {
+      const list = record[bucket]
+      if (!Array.isArray(list)) continue
+      for (const raw of list) {
+        if (raw === null || typeof raw !== 'object') continue
+        const item = raw as Record<string, unknown>
+        if (typeof item.uri !== 'string' || item.uri === '') continue
+        items.push({
+          uri: item.uri,
+          score: typeof item.score === 'number' ? item.score : 0,
+          abstract: typeof item.abstract === 'string' ? item.abstract : '',
+        })
+      }
+    }
+    items.sort((a, b) => b.score - a.score)
+    return items
+  }
+
+  /** Full content read for one URI. */
+  async readContent(uri: string): Promise<string> {
+    const response = await this.fetchJSON(`/api/v1/content/read?uri=${encodeURIComponent(uri)}`)
+    return response.ok && typeof response.result === 'string' ? response.result : ''
+  }
+
+  /** Ephemeral session + commit: the `ov add-memory` flow. */
+  async addMemory(content: string): Promise<string> {
+    const created = await this.fetchJSON('/api/v1/sessions', { method: 'POST', body: JSON.stringify({}) })
+    const sessionId = created.ok && created.result !== null && typeof created.result === 'object'
+      ? (created.result as { session_id?: unknown }).session_id
+      : undefined
+    if (typeof sessionId !== 'string' || sessionId === '') {
+      throw new Error('OpenViking did not return a session_id')
+    }
+    const added = await this.fetchJSON(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      { method: 'POST', body: JSON.stringify({ role: 'user', content }) },
+    )
+    if (!added.ok) throw new Error(added.error?.message ?? 'failed to add memory message')
+    const committed = await this.fetchJSON(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
+      { method: 'POST', body: JSON.stringify({}) },
+      { timeoutMs: 30_000 },
+    )
+    if (!committed.ok) throw new Error(committed.error?.message ?? 'failed to commit memory session')
+    return sessionId
+  }
+}

--- a/examples/dsh-plugin/src/config.ts
+++ b/examples/dsh-plugin/src/config.ts
@@ -1,0 +1,106 @@
+/**
+ * Plugin configuration.
+ *
+ * Behaviour knobs live in cordis config (validated by schemastery) and use
+ * the memory-plugin family's canonical names. Credentials are NOT plugin
+ * config: they resolve through the shared `credentials.mjs` chain
+ * (`OPENVIKING_*` env → `~/.openviking/ovcli.conf` → `~/.openviking/ov.conf`),
+ * identical to every other OpenViking memory plugin.
+ *
+ * @module @openviking/dsh-plugin
+ */
+
+import z from '@deepseek-ai/schemastery'
+import { resolveOpenVikingCredentials } from '../shared/credentials.mjs'
+import { resolveEffectivePeerId } from '../shared/workspace-peer.mjs'
+
+/** Behaviour switches; every knob has a working default. */
+export interface Config {
+  /** Override the resolved server base URL (testing / special deployments). */
+  baseUrl?: string
+  /** Mirror user/assistant messages into an OpenViking session. */
+  syncTurns?: boolean
+  /** Inject recalled OpenViking context at steps that claim user input. */
+  autoRecall?: boolean
+  /** Maximum recalled items per injection. */
+  recallLimit?: number
+  /** Minimum relevance score for recalled items. */
+  scoreThreshold?: number
+  /** Shortest query worth a recall round-trip. */
+  minQueryLength?: number
+  /** Token budget for one recall block. */
+  recallTokenBudget?: number
+  /** Prefer stored abstracts over full content reads during recall. */
+  recallPreferAbstract?: boolean
+  /** Seed a resumed session with committed OpenViking session context. */
+  sessionSeed?: boolean
+  /** Token budget for the session seed context. */
+  seedTokenBudget?: number
+  /** Commit the OpenViking session (memory extraction) after turns end. */
+  commitOnTurnEnd?: boolean
+  /** Minimum milliseconds between commits. 0 commits at every turn end. */
+  commitMinIntervalMs?: number
+  /** Messages preserved verbatim across a commit. */
+  commitKeepRecentCount?: number
+  /** Derive an actor peer from the workspace path when none is configured. */
+  workspacePeer?: boolean
+  /** Register the ov_search / ov_read / ov_add_memory model-facing tools. */
+  tools?: boolean
+}
+
+/** Schemastery validation for {@link Config}. */
+export const Config: z<Config> = z.object({
+  baseUrl: z.string(),
+  syncTurns: z.boolean().default(true),
+  autoRecall: z.boolean().default(true),
+  recallLimit: z.number().default(5),
+  scoreThreshold: z.number().default(0.35),
+  minQueryLength: z.number().default(3),
+  recallTokenBudget: z.number().default(2000),
+  recallPreferAbstract: z.boolean().default(true),
+  sessionSeed: z.boolean().default(true),
+  seedTokenBudget: z.number().default(2000),
+  commitOnTurnEnd: z.boolean().default(true),
+  commitMinIntervalMs: z.number().default(300_000),
+  commitKeepRecentCount: z.number().default(10),
+  workspacePeer: z.boolean().default(true),
+  tools: z.boolean().default(true),
+})
+
+/** Resolved connection identity plus the flat cfg the shared helpers read. */
+export interface RuntimeCfg {
+  baseUrl: string
+  apiKey: string
+  account: string
+  user: string
+  peerId: string
+  userAgent: string
+  /** Flat knob view consumed by shared recall-core / capture-utils. */
+  [key: string]: unknown
+}
+
+/**
+ * Merge shared-chain credentials, the workspace peer, and plugin knobs into
+ * the flat cfg object every shared helper consumes.
+ * @returns the runtime cfg, or `undefined` when no server is configured.
+ */
+export function buildRuntimeCfg(config: Config, version: string): RuntimeCfg | undefined {
+  const credentials = resolveOpenVikingCredentials(process.env)
+  const baseUrl = config.baseUrl !== undefined && config.baseUrl !== ''
+    ? config.baseUrl.replace(/\/+$/, '')
+    : credentials.baseUrl
+  if (baseUrl === undefined || baseUrl === '') return undefined
+  const { peerId } = resolveEffectivePeerId({
+    cfg: { peerId: credentials.peerId, workspacePeer: config.workspacePeer !== false },
+    cwd: process.cwd(),
+  })
+  return {
+    ...config,
+    baseUrl,
+    apiKey: credentials.apiKey,
+    account: credentials.account,
+    user: credentials.user,
+    peerId,
+    userAgent: `openviking-dsh-plugin/${version}`,
+  }
+}

--- a/examples/dsh-plugin/src/index.ts
+++ b/examples/dsh-plugin/src/index.ts
@@ -1,0 +1,281 @@
+/**
+ * OpenViking memory & context plugin for deepseek-harness (dsh).
+ *
+ * A thin dsh adapter over the OpenViking memory-plugin family's shared
+ * runtime (`shared/`, vendored from `examples/memory-plugin-shared` by its
+ * `sync.mjs`): credentials, capture filtering, durable delivery with replay,
+ * and recall (server-side query expansion, cross-turn dedup, peer scoping,
+ * compression) are all family code. What is dsh-specific here:
+ *
+ * - **Capture** maps dsh `session/event` surface messages into family
+ *   capture payloads; `turn/end` flushes and commits (throttled).
+ * - **Recall** runs in an `agent/pre-step` waterfall and appends the shared
+ *   `buildRecallBlock` output as a durable, source-attributed user message.
+ *   It never touches the system prompt, so it works under every preset —
+ *   including personas declared `complete: true`, where prompt-assembly
+ *   contributions are silently discarded.
+ * - **Seed**: on `agent/session-start` (resume) the committed OpenViking
+ *   session overview is queued via `agent.inject()`.
+ * - **Tools**: optional `ov_search` / `ov_read` / `ov_add_memory`.
+ *
+ * @module @openviking/dsh-plugin
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { PreStepDecision } from '@deepseek-ai/dsh-agent'
+import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import type { UserMessage } from '@deepseek-ai/dsh-llm'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type {} from '@deepseek-ai/dsh-session'
+import { buildRecallBlock } from '../shared/recall-core.mjs'
+import { OVClient } from './client.ts'
+import { Config, buildRuntimeCfg } from './config.ts'
+import { CaptureSync } from './sync.ts'
+
+export type { Config } from './config.ts'
+export { OVClient } from './client.ts'
+export { CaptureSync } from './sync.ts'
+
+/** Cordis plugin name used by loader diagnostics and message sources. */
+export const name = 'openviking'
+
+/** The agent registry that owns pre-step processing and session events. */
+export const inject = ['agents']
+
+const VERSION = '0.2.0'
+
+/** Extract the plain text of one message's content blocks. */
+function contentText(content: readonly unknown[] | undefined): string {
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((block): block is { type: 'text', text: string } =>
+      block !== null && typeof block === 'object'
+      && (block as { type?: unknown }).type === 'text'
+      && typeof (block as { text?: unknown }).text === 'string')
+    .map(block => block.text)
+    .join('\n')
+}
+
+/** Find the newest genuine (human-sourced) user text in a claimed batch. */
+function latestUserText(messages: readonly UserMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!
+    if (message.source.kind !== 'user') continue
+    const text = contentText(message.content)
+    if (text.trim() !== '') return text.slice(0, 2000)
+  }
+  return ''
+}
+
+/**
+ * Register capture, recall, seeding, and tools for the lifetime of `ctx`.
+ * Without a resolvable connection the plugin logs once and stays inert.
+ */
+export function apply(ctx: Context, config: Config): void {
+  const cfg = buildRuntimeCfg(config, VERSION)
+  if (cfg === undefined) {
+    console.warn(
+      'openviking-dsh-plugin: no server configured '
+      + '(set OPENVIKING_BASE_URL / OPENVIKING_API_KEY or ~/.openviking/ovcli.conf) — plugin is inactive',
+    )
+    return
+  }
+  const client = new OVClient(cfg)
+  const sync = new CaptureSync(client, config)
+  sync.replayOnce()
+
+  // ---- capture: mirror surface messages, flush + commit on turn end ----
+  if (config.syncTurns !== false) {
+    ctx.on('session/event', (session, event) => {
+      const dshSessionId = String(session.id)
+      switch (event.type) {
+        case 'user/message': {
+          // Only human input: plugin/tool-sourced injections (including our
+          // own recall messages) must never echo back into memory.
+          if (event.data.source.kind !== 'user') break
+          sync.capture(dshSessionId, 'user', contentText(event.data.content))
+          break
+        }
+        case 'assistant/message': {
+          sync.capture(dshSessionId, 'assistant', contentText(event.data.message.content))
+          break
+        }
+        case 'turn/end': {
+          sync.turnEnd(dshSessionId)
+          break
+        }
+        default:
+          break
+      }
+    })
+  }
+
+  // ---- recall: append shared recall block at steps that claim user input ----
+  if (config.autoRecall !== false) {
+    ctx.on('agent/pre-step', async ({ agent, signal }, next): Promise<PreStepDecision> => {
+      const decision = await next()
+      if (decision.kind === 'reject' || signal.aborted) return decision
+      const query = latestUserText(decision.messages)
+      if (query.trim().length < (config.minQueryLength ?? 3)) return decision
+      let block: string | null = null
+      try {
+        // Passing the OV session id turns on server-side query expansion and
+        // the cross-turn dedup ledger; peer scoping rides the cfg.
+        block = await buildRecallBlock(client.fetchJSON, cfg, query, {
+          sessionId: CaptureSync.ovSessionId(String(agent.session.id)),
+        })
+      } catch {
+        return decision
+      }
+      if (block === null || block === '') return decision
+      return {
+        kind: 'enter',
+        messages: [
+          ...decision.messages,
+          createUserMessage({
+            content: [{ type: 'text', text: block }],
+            source: { kind: 'plugin', plugin: name, form: 'recall' },
+          }),
+        ],
+      }
+    }, { prepend: true })
+  }
+
+  // ---- seed: queue committed session overview for the first pre-step ----
+  if (config.sessionSeed !== false) {
+    ctx.on('agent/session-start', ({ agent, source }) => {
+      if (source !== 'resume') return
+      const ovId = CaptureSync.ovSessionId(String(agent.session.id))
+      void client.getSessionContext(ovId, config.seedTokenBudget ?? 2000)
+        .then((text) => {
+          if (text === '') return
+          agent.inject(createUserMessage({
+            content: [{ type: 'text', text }],
+            source: {
+              kind: 'plugin',
+              plugin: name,
+              form: 'snapshot',
+              sections: [{ name: 'openviking-session-context', text }],
+            },
+          }))
+        })
+        .catch(() => {})
+    })
+  }
+
+  // ---- tools: explicit model-facing access (optional seam) ----
+  if (config.tools !== false) {
+    ctx.inject(['tools'], (child) => {
+      registerTools(child, client)
+    })
+  }
+}
+
+/** Register the three OpenViking tools on one tools-capable context. */
+function registerTools(ctx: Context, client: OVClient): void {
+  ctx.tools.register(defineTool({
+    name: 'ov_search',
+    description:
+      'Semantic search over the OpenViking context database (agent memories, indexed '
+      + 'resources, and skills). Returns URIs with relevance scores and abstracts. '
+      + 'Use ov_read to fetch the full content of a result.',
+    parameters: {
+      query: { type: 'string', required: true, description: 'What to look for, in natural language.' },
+      limit: { type: 'integer', description: 'Maximum results (default 10).' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          results: {
+            type: 'array',
+            required: true,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                uri: { type: 'string', required: true },
+                score: { type: 'number', required: true },
+                abstract: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      render: (_args, value) => [{
+        type: 'text',
+        text: value.results.length === 0
+          ? 'No OpenViking results.'
+          : value.results.map(item =>
+            `${item.uri} (${item.score.toFixed(2)})${item.abstract ? ` — ${item.abstract}` : ''}`,
+          ).join('\n'),
+      }],
+    },
+    async execute(args) {
+      const items = await client.find(args.query, args.limit ?? 10)
+      return {
+        results: items.map(item => ({
+          uri: item.uri,
+          score: item.score,
+          ...item.abstract === '' ? {} : { abstract: item.abstract.slice(0, 500) },
+        })),
+      }
+    },
+    presentCall: args => ({ card: 'generic', title: 'OpenViking search', kind: 'read', rawInput: args.query }),
+  }))
+
+  ctx.tools.register(defineTool({
+    name: 'ov_read',
+    description: 'Read the full text content of one OpenViking URI (viking://...) returned by ov_search.',
+    parameters: {
+      uri: { type: 'string', required: true, description: 'The viking:// URI to read.' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          uri: { type: 'string', required: true },
+          content: { type: 'string', required: true },
+        },
+      },
+      render: (_args, value) => [{ type: 'text', text: value.content }],
+    },
+    async execute(args) {
+      if (!args.uri.startsWith('viking://')) throw new Error('ov_read requires a viking:// URI')
+      const content = await client.readContent(args.uri)
+      return { uri: args.uri, content: content.length > 16_000 ? `${content.slice(0, 16_000)}…` : content }
+    },
+    presentCall: args => ({ card: 'generic', title: 'OpenViking read', kind: 'read', rawInput: args.uri }),
+  }))
+
+  ctx.tools.register(defineTool({
+    name: 'ov_add_memory',
+    description:
+      'Store one durable memory in OpenViking (facts, decisions, preferences worth '
+      + 'remembering across sessions). Write the memory as one self-contained statement.',
+    parameters: {
+      content: { type: 'string', required: true, description: 'The memory text to store.' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          stored: { type: 'boolean', required: true },
+          sessionId: { type: 'string', required: true },
+        },
+      },
+      render: (_args, value) => [{
+        type: 'text',
+        text: value.stored ? 'Memory stored in OpenViking.' : 'Memory storage failed.',
+      }],
+    },
+    async execute(args) {
+      const sessionId = await client.addMemory(args.content)
+      return { stored: true, sessionId }
+    },
+    presentCall: args => ({ card: 'generic', title: 'OpenViking add memory', kind: 'other', rawInput: args.content }),
+  }))
+}

--- a/examples/dsh-plugin/src/sync.ts
+++ b/examples/dsh-plugin/src/sync.ts
@@ -1,0 +1,155 @@
+/**
+ * Capture side: mirrors dsh conversation turns into OpenViking sessions
+ * through the shared family runtime — `capture-utils` filters and bounds
+ * text, `batch-send` delivers with automatic spill into the durable
+ * `pending-queue` (replayed on the next start), and commits are throttled
+ * per session.
+ *
+ * Ordering: appends join a per-session promise chain, so a slow batch never
+ * reorders mirrored history. Every entry point is failure-contained.
+ *
+ * @module @openviking/dsh-plugin
+ */
+
+import { sendSessionMessages } from '../shared/batch-send.mjs'
+import { sanitizeCapturedText, shouldCaptureText, truncateCaptureText } from '../shared/capture-utils.mjs'
+import { replayPending } from '../shared/pending-queue.mjs'
+import { deriveHarnessSessionId } from '../shared/session-model.mjs'
+import type { OVClient } from './client.ts'
+import type { Config } from './config.ts'
+
+/** One mirrored message payload in the family wire shape. */
+interface CapturePayload {
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+/** Report one degraded operation per kind per minute, not a log storm. */
+class RateLimitedReporter {
+  private readonly last = new Map<string, number>()
+
+  report(kind: string, error: unknown): void {
+    const now = Date.now()
+    const previous = this.last.get(kind)
+    if (previous !== undefined && now - previous < 60_000) return
+    this.last.set(kind, now)
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`openviking-dsh-plugin: ${kind} degraded — ${message}`)
+  }
+}
+
+export class CaptureSync {
+  private readonly client: OVClient
+  private readonly config: Config
+  private readonly ensured = new Set<string>()
+  private readonly pending = new Map<string, CapturePayload[]>()
+  private readonly chains = new Map<string, Promise<void>>()
+  private readonly flushTimers = new Map<string, NodeJS.Timeout>()
+  private readonly lastCommit = new Map<string, number>()
+  private readonly reporter = new RateLimitedReporter()
+  private replayed = false
+
+  constructor(client: OVClient, config: Config) {
+    this.client = client
+    this.config = config
+  }
+
+  /** Map a dsh session id onto its mirrored OpenViking session id. */
+  static ovSessionId(dshSessionId: string): string {
+    return deriveHarnessSessionId('dsh-', dshSessionId)
+  }
+
+  /** Queue one mirrored message; flushes are batched and ordered. */
+  capture(dshSessionId: string, role: 'user' | 'assistant', rawText: string): void {
+    const sanitized = sanitizeCapturedText(rawText)
+    const decision = shouldCaptureText(sanitized, role, this.config as Record<string, unknown>)
+    if (!decision.shouldCapture) return
+    const text = truncateCaptureText(decision.text)
+    const queue = this.pending.get(dshSessionId) ?? []
+    queue.push({ role, content: text, created_at: new Date().toISOString() })
+    this.pending.set(dshSessionId, queue)
+    this.scheduleFlush(dshSessionId, queue.length >= 20 ? 0 : 250)
+  }
+
+  /** Flush queued messages now and commit when the throttle allows. */
+  turnEnd(dshSessionId: string): void {
+    this.chain(dshSessionId, async () => {
+      await this.flushNow(dshSessionId)
+      if (this.config.commitOnTurnEnd === false) return
+      const now = Date.now()
+      const previous = this.lastCommit.get(dshSessionId)
+      if (previous !== undefined && now - previous < (this.config.commitMinIntervalMs ?? 300_000)) return
+      this.lastCommit.set(dshSessionId, now)
+      const committed = await this.client.commitSession(
+        CaptureSync.ovSessionId(dshSessionId),
+        this.config.commitKeepRecentCount ?? 10,
+      )
+      if (!committed) this.reporter.report('commit', 'commit request failed')
+    })
+  }
+
+  /** Replay messages a previous process failed to deliver. Runs once. */
+  replayOnce(): void {
+    if (this.replayed) return
+    this.replayed = true
+    void replayPending(this.client.fetchJSON, () => {}).catch((error: unknown) => {
+      this.reporter.report('replay', error)
+    })
+  }
+
+  /** Resolve when every queued message and commit has settled. */
+  async quiesce(): Promise<void> {
+    for (const timer of this.flushTimers.values()) clearTimeout(timer)
+    this.flushTimers.clear()
+    const sessions = [...new Set([...this.pending.keys(), ...this.chains.keys()])]
+    for (const id of sessions) this.chain(id, () => this.flushNow(id))
+    await Promise.all([...this.chains.values()])
+  }
+
+  private scheduleFlush(dshSessionId: string, delayMs: number): void {
+    if (delayMs === 0) {
+      const timer = this.flushTimers.get(dshSessionId)
+      if (timer !== undefined) {
+        clearTimeout(timer)
+        this.flushTimers.delete(dshSessionId)
+      }
+      this.chain(dshSessionId, () => this.flushNow(dshSessionId))
+      return
+    }
+    if (this.flushTimers.has(dshSessionId)) return
+    const timer = setTimeout(() => {
+      this.flushTimers.delete(dshSessionId)
+      this.chain(dshSessionId, () => this.flushNow(dshSessionId))
+    }, delayMs)
+    timer.unref?.()
+    this.flushTimers.set(dshSessionId, timer)
+  }
+
+  private async flushNow(dshSessionId: string): Promise<void> {
+    const queue = this.pending.get(dshSessionId)
+    if (queue === undefined || queue.length === 0) return
+    this.pending.set(dshSessionId, [])
+    const ovId = CaptureSync.ovSessionId(dshSessionId)
+    try {
+      if (!this.ensured.has(dshSessionId)) {
+        if (await this.client.ensureSession(ovId)) this.ensured.add(dshSessionId)
+      }
+      // Delivery failures spill into the durable pending queue and replay
+      // on the next start — shared behaviour, not plugin logic.
+      const result = await sendSessionMessages(this.client.fetchJSON, ovId, queue)
+      if (result.failed > 0 || result.enqueueFailed > 0) {
+        this.reporter.report('capture', result.lastError ?? 'send failed')
+      }
+    } catch (error) {
+      this.reporter.report('capture', error)
+    }
+  }
+
+  /** Serialize work per session so mirrored history keeps its order. */
+  private chain(dshSessionId: string, task: () => Promise<void>): void {
+    const previous = this.chains.get(dshSessionId) ?? Promise.resolve()
+    const next = previous.then(task, task)
+    this.chains.set(dshSessionId, next)
+  }
+}

--- a/examples/dsh-plugin/tests/dsh-plugin.e2e.ts
+++ b/examples/dsh-plugin/tests/dsh-plugin.e2e.ts
@@ -1,0 +1,101 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { LOADER_SMOKE_TEST_TIMEOUT_MS, runLoaderSmoke } from '@deepseek-ai/dsh-loader-smoke'
+
+const driver = fileURLToPath(new URL('./fixtures/driver.ts', import.meta.url))
+const configPath = fileURLToPath(new URL('./fixtures/dsh-plugin.cordis.yml', import.meta.url))
+const tsconfigPath = fileURLToPath(new URL('../tsconfig.json', import.meta.url))
+
+interface StubRequest {
+  method: string
+  path: string
+  body: unknown
+}
+
+async function jsonlFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const paths = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return jsonlFiles(path)
+    return entry.isFile() && entry.name.endsWith('.jsonl') ? [path] : []
+  }))
+  return paths.flat()
+}
+
+describe('openviking dsh plugin through a real headless cordis.yml', () => {
+  it('captures the conversation into OpenViking and injects shared-runtime recall blocks', async () => {
+    let events: SessionEvent[] = []
+    let stubLog: StubRequest[] = []
+    const { stderr } = await runLoaderSmoke({
+      label: 'openviking-dsh-plugin headless smoke',
+      tempDirPrefix: 'openviking-dsh-plugin-e2e-',
+      binScript: driver,
+      libBinScript: driver,
+      configPath,
+      tsconfigPath,
+      mode: 'src',
+      inspect: async (cwd) => {
+        const logs = await jsonlFiles(join(cwd, '.sessions'))
+        expect(logs).toHaveLength(1)
+        const lines = (await readFile(logs[0] as string, 'utf8')).trimEnd().split('\n')
+        events = lines.slice(1).map(line => JSON.parse(line) as SessionEvent)
+        stubLog = JSON.parse(await readFile(join(cwd, 'ov-stub-log.json'), 'utf8')) as StubRequest[]
+      },
+    })
+    expect(stderr).not.toContain('UNHANDLED')
+    expect(events.filter(event => event.type === 'turn/end')).toHaveLength(2)
+
+    // ---- recall: the shared block injected as a durable, attributed user message ----
+    const recalls = events.filter(
+      (event): event is SessionEvent<'user/message'> =>
+        event.type === 'user/message' && event.data.source.kind === 'plugin',
+    )
+    // The raw-find fallback has no cross-turn ledger: one injection per turn.
+    expect(recalls).toHaveLength(2)
+    const firstStepStart = events.find(event => event.type === 'step/start')
+    expect(firstStepStart).toBeDefined()
+    for (const recall of recalls) {
+      expect(recall.surfaceOp).toBe('append')
+      expect(recall.data.source).toMatchObject({
+        kind: 'plugin',
+        plugin: 'openviking',
+        form: 'recall',
+      })
+      const text = recall.data.content
+        .filter(block => block.type === 'text')
+        .map(block => block.text)
+        .join('\n')
+      expect(text).toContain('<openviking-context>')
+      expect(text).toContain('concise answers')
+      expect(recall.seq).toBeGreaterThan(firstStepStart!.seq)
+    }
+
+    // The injected context reaches the request surface but never the headers.
+    const headers = events.filter(event => event.type === 'request/header')
+    expect(JSON.stringify(headers)).not.toContain('openviking-context')
+
+    // ---- recall traffic: context face 404s, then the find fallback ----
+    expect(stubLog.filter(request => request.path === '/api/v1/search/search').length).toBeGreaterThanOrEqual(1)
+    expect(stubLog.filter(request => request.path === '/api/v1/search/find').length).toBeGreaterThanOrEqual(2)
+
+    // ---- capture: the conversation was mirrored and committed ----
+    const messagePosts = stubLog.filter(request =>
+      request.method === 'POST' && /\/api\/v1\/sessions\/[^/]+\/messages/.test(request.path))
+    expect(messagePosts.length).toBeGreaterThanOrEqual(1)
+    const mirroredText = JSON.stringify(messagePosts.map(request => request.body))
+    expect(mirroredText).toContain('first task about the dsh e2e note')
+    expect(mirroredText).toContain('second task about the dsh e2e note')
+    expect(mirroredText).toContain('ov plugin mock reply')
+    // The plugin's own injected recall must not echo back into memory.
+    expect(mirroredText).not.toContain('openviking-context')
+    const commits = stubLog.filter(request => request.path.endsWith('/commit'))
+    expect(commits.length).toBeGreaterThanOrEqual(2)
+    // One mirrored session, derived via the family session-id scheme.
+    const sessionIds = new Set(messagePosts.map(request => request.path.split('/')[4]))
+    expect(sessionIds.size).toBe(1)
+    expect([...sessionIds][0]).toMatch(/^dsh-/)
+  }, LOADER_SMOKE_TEST_TIMEOUT_MS)
+})

--- a/examples/dsh-plugin/tests/fixtures/driver.ts
+++ b/examples/dsh-plugin/tests/fixtures/driver.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Test driver: starts the OpenViking stub, isolates all shared state
+ * (credentials, pending queue, recall state) into the temp cwd, boots one
+ * real Loader composition, runs two turns, waits for the plugin's async
+ * mirroring to reach the stub, and writes the recorded stub traffic for the
+ * e2e test to assert on.
+ */
+
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { boot, resolveConfigPath } from '@deepseek-ai/dsh-app-boot'
+import { runFixtureTurn } from '@deepseek-ai/dsh-loader-smoke'
+import { startOvStub } from './ov-stub.ts'
+
+const configPath = process.argv[2]
+if (configPath === undefined) throw new Error('dsh-plugin driver requires a config path')
+
+const stub = await startOvStub()
+process.env.OV_STUB_URL = stub.baseUrl
+// Isolate every shared-runtime side channel into the temp cwd: no machine
+// credentials, no shared pending queue, no cross-run recall state.
+process.env.OPENVIKING_CLI_CONFIG_FILE = join(process.cwd(), 'no-ovcli.conf')
+process.env.OPENVIKING_CONFIG_FILE = join(process.cwd(), 'no-ov.conf')
+process.env.OPENVIKING_PENDING_DIR = join(process.cwd(), '.ov-pending')
+process.env.OPENVIKING_STATE_DIR = join(process.cwd(), '.ov-state')
+delete process.env.OPENVIKING_CREDENTIAL_SOURCE
+delete process.env.OPENVIKING_CREDENTIALS_SOURCE
+delete process.env.OPENVIKING_BASE_URL
+delete process.env.OPENVIKING_URL
+delete process.env.OPENVIKING_API_KEY
+
+const ctx = await boot('openviking-dsh-plugin-e2e', resolveConfigPath(configPath, undefined))
+try {
+  await runFixtureTurn(ctx, { task: 'first task about the dsh e2e note' })
+  await runFixtureTurn(ctx, { task: 'second task about the dsh e2e note' })
+  // Mirroring and commits are fire-and-forget; wait for both commits.
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    const commits = stub.requests.filter(item => item.path.endsWith('/commit')).length
+    if (commits >= 2) break
+    await sleep(100)
+  }
+} finally {
+  await ctx.fiber.dispose()
+  await writeFile('./ov-stub-log.json', JSON.stringify(stub.requests, null, 2))
+  await stub.close()
+}

--- a/examples/dsh-plugin/tests/fixtures/dsh-plugin.cordis.yml
+++ b/examples/dsh-plugin/tests/fixtures/dsh-plugin.cordis.yml
@@ -1,0 +1,33 @@
+# Test composition: a real Loader tree with a mock LLM and the OpenViking
+# plugin pointed at the in-driver stub server (OV_STUB_URL).
+- id: mock-llm
+  name: './mock-llm.ts'
+
+- id: openviking
+  name: '../../src/index.ts'
+  config:
+    baseUrl: !!js process.env.OV_STUB_URL
+    commitMinIntervalMs: 0
+    scoreThreshold: 0
+    sessionSeed: false
+    workspacePeer: false
+
+- id: agent-spine
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    agents:
+      - id: main
+        provider: ov-plugin-mock
+        model: ov-plugin-mock
+        cwd: !!js process.cwd()
+    persona: 'Test the OpenViking plugin.'
+    workspaceContext: false
+
+- id: persistence
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: './.sessions'
+    compression: 'none'
+
+- id: checkpoint-policy
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'

--- a/examples/dsh-plugin/tests/fixtures/mock-llm.ts
+++ b/examples/dsh-plugin/tests/fixtures/mock-llm.ts
@@ -1,0 +1,22 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { LlmAdapter, type StreamChunk } from '@deepseek-ai/dsh-llm'
+
+/** Deterministic one-step adapter for the plugin Loader fixture. */
+class OvPluginMockAdapter extends LlmAdapter {
+  async * stream(): AsyncIterable<StreamChunk> {
+    const text = 'ov plugin mock reply'
+    yield { type: 'block-start', index: 0, blockType: 'text' }
+    yield { type: 'text-delta', index: 0, text }
+    yield { type: 'block-end', index: 0, block: { type: 'text', text } }
+    yield { type: 'usage', usage: { inputTokens: 1, outputTokens: 1 } }
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+}
+
+export const name = 'ov-plugin-mock-llm'
+export const inject = ['llm']
+
+/** Register the test-only `ov-plugin-mock` adapter. */
+export function apply(ctx: Context): void {
+  ctx.llm.registerAdapter(['ov-plugin-mock'], new OvPluginMockAdapter())
+}

--- a/examples/dsh-plugin/tests/fixtures/ov-stub.ts
+++ b/examples/dsh-plugin/tests/fixtures/ov-stub.ts
@@ -1,0 +1,113 @@
+/**
+ * In-process OpenViking server stub for keyless e2e runs. Implements the
+ * endpoints the plugin and the shared recall runtime call, in the real
+ * response envelope (`{ status, result }`), and records every request.
+ *
+ * The context-face endpoints (`search/search`, `search/recall`) return 404 so
+ * the shared `buildRecallBlock` deterministically exercises its raw
+ * `search/find` fallback.
+ */
+
+import { createServer } from 'node:http'
+import type { Server } from 'node:http'
+
+/** One recorded request. */
+export interface StubRequest {
+  method: string
+  path: string
+  body: unknown
+}
+
+/** A running stub with its base URL and recorded traffic. */
+export interface OvStub {
+  baseUrl: string
+  requests: StubRequest[]
+  close: () => Promise<void>
+}
+
+const FIND_RESULT = {
+  memories: [{
+    uri: 'viking://memory/dsh-e2e-note',
+    score: 0.92,
+    abstract: 'The dsh e2e user prefers concise answers.',
+    level: 0,
+  }],
+  resources: [],
+  skills: [],
+}
+
+function envelope(result: unknown): string {
+  return JSON.stringify({ status: 'ok', result })
+}
+
+/** Start the stub on an ephemeral loopback port. */
+export async function startOvStub(): Promise<OvStub> {
+  const requests: StubRequest[] = []
+  const server: Server = createServer((request, response) => {
+    const chunks: Buffer[] = []
+    request.on('data', chunk => chunks.push(chunk as Buffer))
+    request.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8')
+      let body: unknown
+      try {
+        body = raw === '' ? undefined : JSON.parse(raw)
+      } catch {
+        body = raw
+      }
+      const path = (request.url ?? '').split('?')[0] ?? ''
+      requests.push({ method: request.method ?? '', path, body })
+      response.setHeader('content-type', 'application/json')
+
+      if (path === '/health') {
+        response.end(JSON.stringify({ status: 'ok' }))
+        return
+      }
+      // Force the shared recall runtime onto its raw find() fallback.
+      if (path === '/api/v1/search/search' || path === '/api/v1/search/recall') {
+        response.statusCode = 404
+        response.end(JSON.stringify({ status: 'error', error: { message: 'not found' } }))
+        return
+      }
+      if (path === '/api/v1/search/find') {
+        response.end(envelope(FIND_RESULT))
+        return
+      }
+      if (path === '/api/v1/system/status') {
+        response.end(envelope({ user: 'e2e' }))
+        return
+      }
+      if (path === '/api/v1/fs/ls') {
+        response.end(envelope([]))
+        return
+      }
+      if (path === '/api/v1/content/read') {
+        response.end(envelope('stub content'))
+        return
+      }
+      if (path === '/api/v1/sessions' && request.method === 'POST') {
+        response.end(envelope({ session_id: `stub-${requests.length}` }))
+        return
+      }
+      if (path.startsWith('/api/v1/sessions/')) {
+        if (path.endsWith('/context')) {
+          response.end(envelope({ latest_archive_overview: null }))
+          return
+        }
+        response.end(envelope({ session_id: path.split('/')[4], ok: true }))
+        return
+      }
+      response.statusCode = 404
+      response.end(JSON.stringify({ status: 'error', error: { message: `no stub for ${path}` } }))
+    })
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (address === null || typeof address === 'string') throw new Error('stub failed to bind')
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    }),
+  }
+}

--- a/examples/dsh-plugin/tests/plugin.spec.ts
+++ b/examples/dsh-plugin/tests/plugin.spec.ts
@@ -1,0 +1,88 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OVClient } from '../src/client.ts'
+import { buildRuntimeCfg } from '../src/config.ts'
+import { CaptureSync } from '../src/sync.ts'
+
+const savedEnv = { ...process.env }
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key]
+  }
+  Object.assign(process.env, savedEnv)
+})
+
+function isolateCredentials(): void {
+  process.env.OPENVIKING_CLI_CONFIG_FILE = '/nonexistent/ovcli.conf'
+  process.env.OPENVIKING_CONFIG_FILE = '/nonexistent/ov.conf'
+  delete process.env.OPENVIKING_CREDENTIAL_SOURCE
+  delete process.env.OPENVIKING_CREDENTIALS_SOURCE
+  delete process.env.OPENVIKING_BASE_URL
+  delete process.env.OPENVIKING_URL
+  delete process.env.OPENVIKING_MCP_URL
+  delete process.env.OPENVIKING_API_KEY
+  delete process.env.OPENVIKING_BEARER_TOKEN
+}
+
+describe('buildRuntimeCfg', () => {
+  it('prefers plugin baseUrl, then env, and derives a workspace peer', () => {
+    isolateCredentials()
+    process.env.OPENVIKING_BASE_URL = 'http://env-server:1933'
+    const fromEnv = buildRuntimeCfg({}, '0.0.0')
+    expect(fromEnv?.baseUrl).toBe('http://env-server:1933')
+    expect(fromEnv?.peerId).toBe(process.cwd().replace(/[^A-Za-z0-9]/g, '-'))
+
+    const explicit = buildRuntimeCfg({ baseUrl: 'http://explicit/' }, '0.0.0')
+    expect(explicit?.baseUrl).toBe('http://explicit')
+
+    const noPeer = buildRuntimeCfg({ workspacePeer: false }, '0.0.0')
+    expect(noPeer?.peerId).toBe('')
+  })
+
+  it('falls back to the family default local server when unconfigured', () => {
+    isolateCredentials()
+    const cfg = buildRuntimeCfg({}, '0.0.0')
+    // credentials.mjs resolves ov.conf defaults to a local server rather
+    // than "nothing" — the plugin then health-checks lazily.
+    expect(cfg?.baseUrl).toBe('http://127.0.0.1:1933')
+  })
+})
+
+describe('CaptureSync.ovSessionId', () => {
+  it('derives the family harness session id', () => {
+    expect(CaptureSync.ovSessionId('abc-123')).toBe('dsh-abc-123')
+  })
+})
+
+describe('OVClient.find', () => {
+  it('flattens buckets, tolerates junk, and sorts by score', async () => {
+    const server = createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({ status: 'ok', result: {
+        memories: [
+          { uri: 'viking://a', score: 0.4, abstract: 'A' },
+          { score: 1 },
+          null,
+        ],
+        resources: [{ uri: 'viking://b', score: 0.9 }],
+      } }))
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as AddressInfo).port
+    try {
+      isolateCredentials()
+      process.env.OPENVIKING_BASE_URL = `http://127.0.0.1:${port}`
+      const cfg = buildRuntimeCfg({}, '0.0.0')
+      expect(cfg).toBeDefined()
+      const client = new OVClient(cfg!)
+      const items = await client.find('anything', 5)
+      expect(items.map(item => item.uri)).toEqual(['viking://b', 'viking://a'])
+      expect(items[0]!.abstract).toBe('')
+      expect(items[1]!.abstract).toBe('A')
+    } finally {
+      await new Promise(resolve => server.close(resolve))
+    }
+  })
+})

--- a/examples/dsh-plugin/tsconfig.build.json
+++ b/examples/dsh-plugin/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "sourceMap": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/dsh-plugin/tsconfig.json
+++ b/examples/dsh-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["node"],
+    "outDir": "lib",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/examples/dsh-plugin/vitest.config.ts
+++ b/examples/dsh-plugin/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.spec.ts'],
+  },
+})

--- a/examples/dsh-plugin/vitest.e2e.config.ts
+++ b/examples/dsh-plugin/vitest.e2e.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.e2e.ts'],
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+})

--- a/examples/memory-plugin-shared/sync.mjs
+++ b/examples/memory-plugin-shared/sync.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SHARED_DIR = join(ROOT, "examples", "memory-plugin-shared", "lib");
+const HARNESS_SHARED_FILES = [
+  "credentials.mjs",
+  "capture-utils.mjs",
+  "session-model.mjs",
+  "pending-queue.mjs",
+  "debug-log.mjs",
+  "setup-wizard.mjs",
+  "plugin-config.mjs",
+  "recall-compress-core.mjs",
+  "recall-core.mjs",
+  "retryable.mjs",
+  "workspace-peer.mjs",
+  "profile-inject.mjs",
+  "uri-guard.mjs",
+];
+const OPENCODE_SHARED_FILES = [...HARNESS_SHARED_FILES, "mcp-proxy-core.mjs", "async-writer.mjs", "batch-send.mjs"];
+const TARGETS = [
+  { dir: join(ROOT, "examples", "claude-code-memory-plugin", "scripts", "shared"), files: OPENCODE_SHARED_FILES },
+  { dir: join(ROOT, "examples", "codex-memory-plugin", "scripts", "shared"), files: OPENCODE_SHARED_FILES },
+  { dir: join(ROOT, "examples", "opencode-plugin", "lib", "shared"), files: OPENCODE_SHARED_FILES },
+  { dir: join(ROOT, "examples", "pi-coding-agent-extension", "shared"), files: HARNESS_SHARED_FILES },
+  { dir: join(ROOT, "examples", "dsh-plugin", "shared"), files: [...HARNESS_SHARED_FILES, "batch-send.mjs"] },
+  { dir: join(ROOT, "examples", "zcode-memory-plugin", "scripts", "shared") },
+];
+
+const GENERATED_HEADER = "// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.\n";
+
+async function listSharedFiles() {
+  const files = await readdir(SHARED_DIR);
+  return files.filter((file) => file.endsWith(".mjs")).sort();
+}
+
+async function copySharedFile(file, targetDir) {
+  await mkdir(targetDir, { recursive: true });
+  const source = join(SHARED_DIR, file);
+  const target = join(targetDir, file);
+  const body = await readFile(source, "utf-8");
+  await writeFile(target, `${GENERATED_HEADER}${body}`, "utf-8");
+}
+
+async function main() {
+  const allFiles = await listSharedFiles();
+  for (const target of TARGETS) {
+    const files = target.files ?? allFiles;
+    for (const file of files) {
+      if (!allFiles.includes(file)) {
+        throw new Error(`shared file not found: ${file}`);
+      }
+      await copySharedFile(file, target.dir);
+      process.stdout.write(`synced ${file} -> ${relative(ROOT, target.dir)}\n`);
+    }
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err?.stack || err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds `examples/dsh-plugin` (`@openviking/dsh-plugin`): an OpenViking memory & context plugin for [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`), built as a **thin adapter over the family shared runtime** (`examples/memory-plugin-shared`) — same architecture as the pi / zcode / opencode plugins. This PR also registers the dsh vendor target in `memory-plugin-shared/sync.mjs`.

## What's shared vs new

**Shared (vendored `shared/`, zero new memory logic):** credential chain (`OPENVIKING_*` env → `ovcli.conf` → `ov.conf`), workspace-derived actor peer, capture filtering/sanitizing/bounding, `batch-send` delivery with durable `pending-queue` spill + replay, and `buildRecallBlock` recall (server-side query expansion + cross-turn dedup via session id, peer scoping, graceful downgrade on older servers, token-budgeted rendering).

**New (dsh adapter only):**
- **Capture** — dsh `session/event` surface messages → family capture payloads, ordered per session; `turn/end` flushes and triggers a throttled `commit`.
- **Recall** — an `agent/pre-step` waterfall appends the shared recall block as a durable, source-attributed user message (`source: {kind: 'plugin', plugin: 'openviking', form: 'recall'}`). Deliberately not the system prompt: presets whose persona declares `complete: true` (e.g. dsh `minimal`) silently drop prompt-assembly contributions.
- **Session seed** — on `agent/session-start` (resume), the committed session overview is queued via `agent.inject()`.
- **Tools** — `ov_search` / `ov_read` / `ov_add_memory` (the `ov add-memory` flow: ephemeral session + commit).
- **Distribution** — `dsh.bundle.patch` + `cordis.patch.yml`, so `dsh plugin --profile <p> add @openviking/dsh-plugin` composes a profile layer. `@deepseek-ai/*` peers pinned to exact rc versions (several subpackages have stale `latest` dist-tags during dsh rc).

## Testing

- `npm test` — unit tests (credential/peer resolution incl. env isolation, session-id derivation, find normalization).
- `npm run test:e2e` — keyless: boots a real dsh Loader composition (mock LLM adapter + in-process OpenViking stub whose context-face endpoints 404, pinning recall to the raw `search/find` fallback), runs two turns, then asserts both directions: conversation mirrored into one `dsh-<session>` OpenViking session with 2 commits; each turn's `<openviking-context>` block appended as a durable `user/message` after `step/start` that reaches the model surface but never `request/header`; the plugin's own injection never echoes back into capture.
- Capture, commit, and recall additionally validated against a live OpenViking server, where recall exercised the server-assembled context-face path end to end.
