### PR TITLE
fix(vectordb): encode string IDs before hashing

### DIFF
--- a/.github/workflows/_test_lite.yml
+++ b/.github/workflows/_test_lite.yml
@@ -86,4 +86,5 @@ jobs:
         uv run pytest -q -o addopts='' \
           tests/vectordb/test_cuvs_config.py \
           tests/vectordb/test_cuvs_index.py \
-          tests/vectordb/test_cuvs_collection.py
+          tests/vectordb/test_cuvs_collection.py \
+          tests/vectordb/test_str_to_uint64.py

--- a/openviking/storage/vectordb/utils/str_to_uint64.py
+++ b/openviking/storage/vectordb/utils/str_to_uint64.py
@@ -7,4 +7,4 @@ def str_to_uint64(input_string: str) -> int:
     """
     Generate a 64-bit unsigned integer hash from a string using xxHash.
     """
-    return xxhash.xxh64(input_string).intdigest()
+    return xxhash.xxh64(input_string.encode("utf-8")).intdigest()

--- a/tests/vectordb/test_str_to_uint64.py
+++ b/tests/vectordb/test_str_to_uint64.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+import openviking.storage.vectordb.utils.str_to_uint64 as subject
+from openviking.storage.vectordb.collection.local_collection import (
+    get_or_create_local_collection,
+)
+
+
+def test_str_to_uint64_preserves_stable_utf8_hashes():
+    assert subject.str_to_uint64("abc") == 4952883123889572249
+    assert subject.str_to_uint64("部署") == 4215394785105220848
+
+
+def test_str_to_uint64_passes_utf8_bytes_to_xxhash(monkeypatch):
+    seen = []
+
+    class _Digest:
+        @staticmethod
+        def intdigest():
+            return 42
+
+    def _xxh64(value):
+        seen.append(value)
+        return _Digest()
+
+    monkeypatch.setattr(subject.xxhash, "xxh64", _xxh64)
+
+    assert subject.str_to_uint64("部署") == 42
+    assert seen == ["部署".encode("utf-8")]
+
+
+def test_local_collection_round_trips_string_primary_keys():
+    collection = get_or_create_local_collection(
+        meta_data={
+            "CollectionName": "string_pk_compat",
+            "Fields": [
+                {"FieldName": "id", "FieldType": "string", "IsPrimaryKey": True},
+                {"FieldName": "uri", "FieldType": "path"},
+                {"FieldName": "vector", "FieldType": "vector", "Dim": 4},
+            ],
+        }
+    )
+
+    inserted = collection.upsert_data(
+        [
+            {
+                "id": "部署-1",
+                "uri": "viking://resources/string-pk",
+                "vector": [1.0, 0.0, 0.0, 0.0],
+            }
+        ]
+    )
+    fetched = collection.fetch_data(["部署-1"])
+    collection.delete_data(["部署-1"])
+    missing = collection.fetch_data(["部署-1"])
+
+    assert inserted.ids == ["部署-1"]
+    assert [(item.id, item.fields["uri"]) for item in fetched.items] == [
+        ("部署-1", "viking://resources/string-pk")
+    ]
+    assert missing.ids_not_exist == ["部署-1"]


### PR DESCRIPTION
## Description

Encode local VectorDB string primary keys as UTF-8 bytes before passing them to xxHash.

OpenViking allows `xxhash>=3.0.0`. xxHash 3.x accepts Python strings directly, while xxHash 4.x requires a bytes-like value and otherwise raises `TypeError: Strings must be encoded before hashing`. The local and cuVS backends use this helper for string primary keys, so the exception could prevent partial-update reads and drop embedding upserts.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- No linked issue -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Encode string IDs with UTF-8 before calling `xxhash.xxh64`
- Pin the existing ASCII and Unicode hash values to prevent local-index label drift
- Add a real local-collection round trip for string primary-key upsert, fetch, and delete

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Validation detail:

- xxHash 3.6.0: focused helper and local projection tests, 10/10 passed
- xxHash 4.0.0: the same focused tests, 10/10 passed
- Local VectorDB targeted CRUD tests: 4/4 passed
- Ruff and `git diff --check` passed
- A current-main local OpenViking server with xxHash 4.0.0 wrote and retrieved a new memory without hash or partial-update errors
- A short session committed with `keep_recent_count=0` completed extraction (`memory_edit=1`), and the extracted memory was retrieved through a real DSH `agent/pre-step` auto-recall
- Added `tests/vectordb/test_str_to_uint64.py` to the cuVS CPU-only regression job (`.github/workflows/_test_lite.yml`) so it actually runs in CI instead of only locally

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The UTF-8 byte representation produces the same xxHash values that xxHash 3.6.0 produced when it accepted strings directly, so existing local index labels do not require migration.
