### PR TITLE
fix(telemetry): use stable OpenTelemetry event names

### DIFF
--- a/docs/en/guides/05-observability.md
+++ b/docs/en/guides/05-observability.md
@@ -240,7 +240,9 @@ On the machine running OpenViking Server, edit `~/.openviking/ov.conf` (or the c
         "service_name": "openviking-server",
         "local_path": "~/.openviking/logs/traces.jsonl",
         "local_rotation_mb": 40,
-        "local_backup_count": 2
+        "local_backup_count": 2,
+        "capture_content": false,
+        "content_max_length": 4096
       }
     }
   }
@@ -252,6 +254,13 @@ Restart OpenViking Server after editing the config. The default local trace file
 ```text
 ~/.openviking/logs/traces.jsonl
 ```
+
+Diagnostic messages are recorded under the stable `openviking.log` event name, but
+their text is omitted by default. Set `capture_content` to `true` only when message
+content is required for troubleshooting. Exported text is subject to best-effort
+credential and inline-image redaction, then limited to `content_max_length` characters
+(1-65536). It can still contain user data or other sensitive values, so restrict access
+to trace exports and remove them when the investigation is complete.
 
 When the file reaches `local_rotation_mb`, it rotates like this:
 
@@ -331,7 +340,9 @@ The upload tool reads the current environment's `ov.conf` as the **upload target
         },
         "endpoint": "otel-collector:4317",
         "service_name": "openviking-server",
-        "headers": {}
+        "headers": {},
+        "capture_content": false,
+        "content_max_length": 4096
       }
     }
   }

--- a/docs/zh/guides/05-observability.md
+++ b/docs/zh/guides/05-observability.md
@@ -240,7 +240,9 @@ curl -X POST http://localhost:1933/api/v1/search/find \
         "service_name": "openviking-server",
         "local_path": "~/.openviking/logs/traces.jsonl",
         "local_rotation_mb": 40,
-        "local_backup_count": 2
+        "local_backup_count": 2,
+        "capture_content": false,
+        "content_max_length": 4096
       }
     }
   }
@@ -252,6 +254,11 @@ curl -X POST http://localhost:1933/api/v1/search/find \
 ```text
 ~/.openviking/logs/traces.jsonl
 ```
+
+诊断消息使用固定的 `openviking.log` 事件名，但消息正文默认不导出。只有排查确实需要
+正文时，才应将 `capture_content` 设为 `true`。导出的文本会先进行尽力而为的凭据和
+内联图片脱敏，再限制到 `content_max_length` 个字符（范围 1-65536）。正文仍可能包含
+用户数据或其他敏感值，因此应限制 trace 导出的访问范围，并在排查结束后及时删除。
 
 当文件达到 `local_rotation_mb` 后会轮转，例如：
 
@@ -331,7 +338,9 @@ python tests/upload_offline_trace.py \
         },
         "endpoint": "otel-collector:4317",
         "service_name": "openviking-server",
-        "headers": {}
+        "headers": {},
+        "capture_content": false,
+        "content_max_length": 4096
       }
     }
   }

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -36,6 +36,8 @@
                 "endpoint": "localhost:4317",
                 "service_name": "openviking-server",
                 "headers": {},
+                "capture_content": false,
+                "content_max_length": 4096,
             },
             "logs": {
                 "enabled": false,

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -4,6 +4,7 @@
 
 import base64
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -34,6 +35,16 @@ _DASHSCOPE_HOSTS = {
 
 
 _REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+_GEN_AI_PROVIDER_NAMES = {
+    "azure": "azure.ai.openai",
+    "openai": "openai",
+}
+
+
+def _get_field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
 
 
 def _is_reasoning_model(model: Optional[str]) -> bool:
@@ -156,7 +167,6 @@ class OpenAIVLM(VLMBase):
         duration_seconds: float = 0.0,
     ):
         if hasattr(response, "usage") and response.usage:
-            tracer.info(f"response.usage={response.usage}")
             prompt_tokens = response.usage.prompt_tokens
             completion_tokens = response.usage.completion_tokens
             prompt_tokens_details = getattr(response.usage, "prompt_tokens_details", None)
@@ -174,7 +184,79 @@ class OpenAIVLM(VLMBase):
                 prompt_cached_tokens=prompt_cached_tokens,
                 completion_reasoning_tokens=completion_reasoning_tokens,
             )
+        self._record_inference_event(response)
         return
+
+    def _record_inference_event(self, response: Any) -> None:
+        """Record safe metadata for a successful OpenAI-compatible response."""
+        try:
+            provider = str(self.provider or "unknown")
+            attributes: Dict[str, Any] = {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": _GEN_AI_PROVIDER_NAMES.get(provider.lower(), provider),
+                "gen_ai.request.model": str(self.model or "gpt-4o-mini"),
+            }
+
+            response_id = _get_field(response, "id")
+            if response_id:
+                attributes["gen_ai.response.id"] = str(response_id)
+            response_model = _get_field(response, "model")
+            if response_model:
+                attributes["gen_ai.response.model"] = str(response_model)
+
+            finish_reasons = []
+            for choice in _get_field(response, "choices") or []:
+                finish_reason = _get_field(choice, "finish_reason")
+                if finish_reason:
+                    finish_reasons.append(str(finish_reason))
+            if finish_reasons:
+                attributes["gen_ai.response.finish_reasons"] = finish_reasons
+
+            usage = _get_field(response, "usage")
+            prompt_details = _get_field(usage, "prompt_tokens_details")
+            completion_details = _get_field(usage, "completion_tokens_details")
+
+            def add_int(key: str, value: Any) -> None:
+                if value is None or isinstance(value, bool):
+                    return
+                try:
+                    attributes[key] = int(value)
+                except (TypeError, ValueError, OverflowError):
+                    return
+
+            add_int("gen_ai.usage.input_tokens", _get_field(usage, "prompt_tokens"))
+            add_int("gen_ai.usage.output_tokens", _get_field(usage, "completion_tokens"))
+            cache_creation_tokens = _get_field(usage, "cache_creation_input_tokens")
+            if cache_creation_tokens is None:
+                cache_creation_tokens = _get_field(prompt_details, "cache_write_tokens")
+            add_int(
+                "gen_ai.usage.cache_creation.input_tokens",
+                cache_creation_tokens,
+            )
+            cache_read_tokens = _get_field(usage, "cache_read_input_tokens")
+            if cache_read_tokens is None:
+                cache_read_tokens = _get_field(prompt_details, "cached_tokens")
+            add_int(
+                "gen_ai.usage.cache_read.input_tokens",
+                cache_read_tokens,
+            )
+            reasoning_tokens = _get_field(usage, "reasoning_tokens")
+            if reasoning_tokens is None:
+                reasoning_tokens = _get_field(completion_details, "reasoning_tokens")
+            add_int(
+                "gen_ai.usage.reasoning.output_tokens",
+                reasoning_tokens,
+            )
+            tracer.add_event("gen_ai.client.inference.operation.details", attributes)
+        except Exception as e:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "vlm inference event emit failed provider=%s model_name=%s err=%s: %s",
+                    self.provider,
+                    self.model,
+                    type(e).__name__,
+                    e,
+                )
 
     def _parse_tool_calls(self, message) -> List[ToolCall]:
         """Parse tool calls from OpenAI response message."""

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -154,6 +154,15 @@ class OTelExporterConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class TraceConfig(OTelExporterConfig):
+    """Trace exporter configuration, including optional diagnostic content."""
+
+    capture_content: bool = False
+    content_max_length: int = Field(default=4096, gt=0, le=65_536)
+
+    model_config = {"extra": "forbid"}
+
+
 class MetricsExportersConfig(BaseModel):
     """Metrics exporters configuration."""
 
@@ -234,7 +243,7 @@ class ObservabilityConfig(BaseModel):
 
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
     usage_audit: UsageAuditConfig = Field(default_factory=UsageAuditConfig)
-    traces: OTelExporterConfig = Field(default_factory=OTelExporterConfig)
+    traces: TraceConfig = Field(default_factory=TraceConfig)
     logs: OTelExporterConfig = Field(default_factory=OTelExporterConfig)
     dump_body: TraceDumpBodyConfig = Field(default_factory=TraceDumpBodyConfig)
 

--- a/openviking/telemetry/tracer.py
+++ b/openviking/telemetry/tracer.py
@@ -7,7 +7,9 @@ import inspect
 import json
 import logging
 import os
+import re
 import threading
+from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -67,10 +69,87 @@ except ImportError:
 _otel_tracer: Any = None
 _propagator: Any = None
 _trace_id_filter_added: bool = False
+_trace_capture_content: bool = False
+_trace_content_max_length: int = 4096
+
+_TRACE_CONTENT_MAX_LENGTH_LIMIT = 65_536
+_TRACE_CONTENT_TRUNCATED_SUFFIX = "...[truncated]"
+_TRACE_SENSITIVE_KEY = (
+    r"[a-z0-9_.-]*(?:api[_-]?key|app[_-]?key|authorization|access[_-]?token|"
+    r"refresh[_-]?token|token|secret|password)"
+)
+_TRACE_SENSITIVE_QUOTED_VALUE_RE = re.compile(
+    rf"""(?ix)
+    (?P<prefix>
+        ["']?{_TRACE_SENSITIVE_KEY}["']?\s*[:=]\s*["']
+    )
+    (?P<value>[^"']*)
+    (?P<suffix>["'])
+    """
+)
+_TRACE_SENSITIVE_UNQUOTED_VALUE_RE = re.compile(
+    rf"(?i)(\b{_TRACE_SENSITIVE_KEY}\b\s*[:=]\s*)((?:Bearer\s+)?[^\s,}}\]]+)"
+)
+_TRACE_BEARER_TOKEN_RE = re.compile(r"""(?i)(\bBearer\s+)([^\s,}\]'\"]+)""")
+_TRACE_IMAGE_DATA_URL_RE = re.compile(r"(?i)(data:image/[^,\s'\"]+;base64,)([a-z0-9+/=_-]+)")
 
 
 def _log_trace_internal_failure(message: str) -> None:
     logger.debug(message, exc_info=True)
+
+
+def _validate_trace_content_max_length(content_max_length: int) -> int:
+    if not 1 <= content_max_length <= _TRACE_CONTENT_MAX_LENGTH_LIMIT:
+        raise ValueError(
+            f"content_max_length must be between 1 and {_TRACE_CONTENT_MAX_LENGTH_LIMIT}"
+        )
+    return content_max_length
+
+
+def _configure_trace_content(capture_content: bool, content_max_length: int) -> None:
+    global _trace_capture_content, _trace_content_max_length
+
+    _trace_capture_content = bool(capture_content)
+    _trace_content_max_length = _validate_trace_content_max_length(content_max_length)
+
+
+def _redact_trace_content(value: str) -> str:
+    value = _TRACE_IMAGE_DATA_URL_RE.sub(r"\1[redacted]", value)
+    value = _TRACE_SENSITIVE_QUOTED_VALUE_RE.sub(
+        lambda match: f"{match.group('prefix')}[redacted]{match.group('suffix')}",
+        value,
+    )
+    value = _TRACE_SENSITIVE_UNQUOTED_VALUE_RE.sub(r"\1[redacted]", value)
+    return _TRACE_BEARER_TOKEN_RE.sub(r"\1[redacted]", value)
+
+
+def _truncate_trace_content(value: str, max_length: int) -> str:
+    if len(value) <= max_length:
+        return value
+    if max_length <= len(_TRACE_CONTENT_TRUNCATED_SUFFIX):
+        return _TRACE_CONTENT_TRUNCATED_SUFFIX[:max_length]
+    return value[: max_length - len(_TRACE_CONTENT_TRUNCATED_SUFFIX)] + (
+        _TRACE_CONTENT_TRUNCATED_SUFFIX
+    )
+
+
+def _prepare_trace_content(value: Any) -> str:
+    return _truncate_trace_content(
+        _redact_trace_content(str(value)),
+        _trace_content_max_length,
+    )
+
+
+def _source_attributes(frame: Any) -> dict[str, Any]:
+    if frame is None:
+        return {}
+    namespace = str(frame.f_globals.get("__name__", "unknown"))
+    function_name = getattr(frame.f_code, "co_qualname", frame.f_code.co_name)
+    return {
+        "code.namespace": namespace,
+        "code.function.name": f"{namespace}.{function_name}",
+        "code.line.number": frame.f_lineno,
+    }
 
 
 _SpanExporterBase = SpanExporter if SpanExporter is not None else object
@@ -230,10 +309,12 @@ def init_tracer_from_server_config(server_config: Any) -> Any:
     try:
         trace_cfg = server_config.observability.traces
         if not trace_cfg.enabled:
+            _configure_trace_content(False, 4096)
             logger.info("[TRACER] disabled in server.observability.traces")
             return None
 
         if trace_cfg.protocol.lower() != "local" and not trace_cfg.endpoint:
+            _configure_trace_content(False, 4096)
             logger.warning("[TRACER] server.observability.traces.endpoint not configured")
             return None
 
@@ -247,8 +328,11 @@ def init_tracer_from_server_config(server_config: Any) -> Any:
             local_path=trace_cfg.local_path,
             local_rotation_mb=trace_cfg.local_rotation_mb,
             local_backup_count=trace_cfg.local_backup_count,
+            capture_content=getattr(trace_cfg, "capture_content", False),
+            content_max_length=getattr(trace_cfg, "content_max_length", 4096),
         )
     except Exception as e:
+        _configure_trace_content(False, 4096)
         logger.warning(f"[TRACER] init from server config failed: {e}")
         return None
 
@@ -276,6 +360,8 @@ def init_tracer(
     local_path: str = "~/.openviking/logs/traces.jsonl",
     local_rotation_mb: int = 40,
     local_backup_count: int = 2,
+    capture_content: bool = False,
+    content_max_length: int = 4096,
 ) -> Any:
     """Initialize the OpenTelemetry tracer.
 
@@ -289,6 +375,8 @@ def init_tracer(
         local_path: JSONL file path when protocol is "local".
         local_rotation_mb: Maximum size in MB before rotating local JSONL file.
         local_backup_count: Number of rotated local JSONL files to keep.
+        capture_content: Whether diagnostic message content may be exported.
+        content_max_length: Maximum characters exported for one diagnostic message.
 
     Returns:
         The initialized tracer, or None if initialization failed
@@ -296,10 +384,12 @@ def init_tracer(
     global _otel_tracer, _propagator
 
     if not enabled:
+        _configure_trace_content(False, 4096)
         logger.info("[TRACER] disabled by config")
         return None
 
     if otel_trace is None or TracerProvider is None or Resource is None:
+        _configure_trace_content(False, 4096)
         logger.warning(
             "OpenTelemetry not installed. Install with: uv pip install opentelemetry-api "
             "opentelemetry-sdk opentelemetry-exporter-otlpprotogrpc"
@@ -307,6 +397,7 @@ def init_tracer(
         return None
 
     try:
+        validated_content_max_length = _validate_trace_content_max_length(content_max_length)
         normalized_headers = {str(key): str(value) for key, value in (headers or {}).items()}
         resource_attributes = {
             "service.name": service_name,
@@ -361,6 +452,7 @@ def init_tracer(
 
         _otel_tracer = otel_trace.get_tracer(service_name)
         _propagator = TraceContextTextMapPropagator()
+        _configure_trace_content(capture_content, validated_content_max_length)
 
         # Setup logging with trace_id
         _setup_logging()
@@ -377,6 +469,7 @@ def init_tracer(
         return _otel_tracer
 
     except Exception as e:
+        _configure_trace_content(False, 4096)
         logger.warning(f"[TRACER] initialized failed: {type(e).__name__}: {e}")
         return None
 
@@ -474,9 +567,9 @@ def set_attribute(key: str, value: Any) -> None:
     tracer.set(key, value)
 
 
-def add_event(name: str) -> None:
-    """Add an event to the current span."""
-    tracer.info(name)
+def add_event(name: str, attributes: Optional[Mapping[str, Any]] = None) -> None:
+    """Add a named event with optional typed attributes to the current span."""
+    tracer.add_event(name, attributes)
 
 
 def record_exception(exception: Exception) -> None:
@@ -546,11 +639,11 @@ class tracer:
                 with self.start_as_current_span(name=span_name, context=context) as span:
                     try:
                         # 记录输入参数
-                        if not self.ignore_args and args:
-                            self.set("func_args", str(args))
+                        if _trace_capture_content and not self.ignore_args and args:
+                            self.set("func_args", _prepare_trace_content(args))
                         func_kwargs = {k: v for k, v in kwargs.items() if self.arg_trace_checker(k)}
-                        if len(func_kwargs) > 0:
-                            self.set("func_kwargs", str(func_kwargs))
+                        if _trace_capture_content and func_kwargs:
+                            self.set("func_kwargs", _prepare_trace_content(func_kwargs))
 
                         result = await func(*args, **kwargs)
 
@@ -576,11 +669,11 @@ class tracer:
                 with self.start_as_current_span(name=span_name, context=context) as span:
                     try:
                         # 记录输入参数
-                        if not self.ignore_args and args:
-                            self.set("func_args", str(args))
+                        if _trace_capture_content and not self.ignore_args and args:
+                            self.set("func_args", _prepare_trace_content(args))
                         func_kwargs = {k: v for k, v in kwargs.items() if self.arg_trace_checker(k)}
-                        if len(func_kwargs) > 0:
-                            self.set("func_kwargs", str(func_kwargs))
+                        if _trace_capture_content and func_kwargs:
+                            self.set("func_kwargs", _prepare_trace_content(func_kwargs))
 
                         result = func(*args, **kwargs)
 
@@ -643,24 +736,46 @@ class tracer:
             _log_trace_internal_failure(f"[TRACER] failed to set span attribute key={key}")
 
     @staticmethod
-    def info(line: str, console: bool = False) -> None:
-        """Add an event to the current span."""
-        if console:
-            logger.opt(depth=1).info(line)
+    def add_event(name: str, attributes: Optional[Mapping[str, Any]] = None) -> None:
+        """Add a named event while preserving supported attribute value types."""
         if _otel_tracer is None:
             return
 
         try:
             current_span = otel_trace.get_current_span()
             if current_span:
-                # 检查 span 是否已结束
                 if hasattr(current_span, "end_time") and current_span.end_time:
-                    return  # span 已结束，不添加 event
-                current_span.add_event(line)
+                    return
+                if attributes is None:
+                    current_span.add_event(name)
+                else:
+                    current_span.add_event(name, attributes=dict(attributes))
         except Exception:
-            import traceback
+            _log_trace_internal_failure(f"[TRACER] failed to add span event name={name}")
 
-            traceback.print_stack()
+    @staticmethod
+    def info(line: str, console: bool = False) -> None:
+        """Record a diagnostic under a stable event name.
+
+        Diagnostic text is treated as potentially sensitive and is exported only
+        when trace content capture is explicitly enabled.
+        """
+        if console:
+            logger.opt(depth=1).info(line)
+        if _otel_tracer is None:
+            return
+
+        frame = inspect.currentframe()
+        caller = frame.f_back if frame is not None else None
+        try:
+            attributes = _source_attributes(caller)
+            if _trace_capture_content:
+                attributes["openviking.log.message"] = _prepare_trace_content(line)
+            tracer.add_event("openviking.log", attributes)
+        except Exception:
+            _log_trace_internal_failure("[TRACER] failed to record diagnostic event")
+        finally:
+            del frame
 
     @staticmethod
     def info_span(line: str, console: bool = False) -> None:
@@ -717,7 +832,7 @@ class _DummySpanContext:
     def set_attribute(self, key: str, value: Any):
         pass
 
-    def add_event(self, name: str):
+    def add_event(self, name: str, attributes: Optional[Mapping[str, Any]] = None):
         pass
 
     def record_exception(self, exception: Exception):

--- a/tests/models/vlm/test_openai_telemetry_events.py
+++ b/tests/models/vlm/test_openai_telemetry_events.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+try:
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+except ImportError:
+    from opentelemetry.sdk.trace.export import InMemorySpanExporter
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking.telemetry import tracer_module
+
+
+@pytest.mark.asyncio
+async def test_async_completion_exports_typed_metadata_without_content(monkeypatch):
+    sentinels = {
+        "message": "MESSAGE_SECRET_47",
+        "tool": "TOOL_SECRET_53",
+        "body": "BODY_SECRET_59",
+        "output": "OUTPUT_SECRET_61",
+    }
+    usage = SimpleNamespace(
+        prompt_tokens=17,
+        completion_tokens=5,
+        total_tokens=22,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=3, cache_write_tokens=6),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=4),
+    )
+    response = SimpleNamespace(
+        id="chatcmpl-safe-id",
+        model="gpt-safe-response-model",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=sentinels["output"], tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+    received = {}
+
+    async def create(**kwargs):
+        received.update(kwargs)
+        return response
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-safe-request-model",
+            "extra_request_body": {"metadata": sentinels["body"]},
+        }
+    )
+    monkeypatch.setattr(vlm, "get_async_client", lambda: client)
+    monkeypatch.setattr(vlm, "update_token_usage", lambda **_kwargs: None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracer_module, "_otel_tracer", provider.get_tracer("test"))
+    monkeypatch.setattr(tracer_module, "_trace_capture_content", False)
+
+    result = await vlm.get_completion_async(
+        messages=[{"role": "user", "content": sentinels["message"]}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": sentinels["tool"],
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    assert result.content == sentinels["output"]
+    assert received["messages"][0]["content"] == sentinels["message"]
+    assert received["tools"][0]["function"]["description"] == sentinels["tool"]
+    assert received["extra_body"]["metadata"] == sentinels["body"]
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "openai.vlm.call"
+    assert all(
+        event.name in {"openviking.log", "gen_ai.client.inference.operation.details"}
+        for event in span.events
+    )
+
+    gen_ai_events = [
+        event for event in span.events if event.name == "gen_ai.client.inference.operation.details"
+    ]
+    assert len(gen_ai_events) == 1
+    attributes = gen_ai_events[0].attributes
+    assert dict(attributes) == {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": "gpt-safe-request-model",
+        "gen_ai.response.id": "chatcmpl-safe-id",
+        "gen_ai.response.model": "gpt-safe-response-model",
+        "gen_ai.response.finish_reasons": ("stop",),
+        "gen_ai.usage.input_tokens": 17,
+        "gen_ai.usage.output_tokens": 5,
+        "gen_ai.usage.cache_creation.input_tokens": 6,
+        "gen_ai.usage.cache_read.input_tokens": 3,
+        "gen_ai.usage.reasoning.output_tokens": 4,
+    }
+    assert type(attributes["gen_ai.usage.input_tokens"]) is int
+    assert type(attributes["gen_ai.usage.output_tokens"]) is int
+
+    exported = repr((span.attributes, tuple(span.events)))
+    for sentinel in sentinels.values():
+        assert sentinel not in exported
+    assert "response.usage=" not in exported
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [("openai", "openai"), ("azure", "azure.ai.openai")],
+)
+def test_provider_name_uses_semantic_convention_value(monkeypatch, provider, expected):
+    events = []
+    monkeypatch.setattr(
+        tracer_module.tracer,
+        "add_event",
+        lambda name, attributes=None: events.append((name, attributes)),
+    )
+    vlm = OpenAIVLM({"provider": provider, "model": "test-model"})
+
+    vlm._record_inference_event(SimpleNamespace())
+
+    assert events == [
+        (
+            "gen_ai.client.inference.operation.details",
+            {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": expected,
+                "gen_ai.request.model": "test-model",
+            },
+        )
+    ]
+
+
+def test_zero_token_counts_are_preserved(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        tracer_module.tracer,
+        "add_event",
+        lambda name, attributes=None: events.append((name, attributes)),
+    )
+    vlm = OpenAIVLM({"provider": "openai", "model": "test-model"})
+    monkeypatch.setattr(vlm, "update_token_usage", lambda **_kwargs: None)
+
+    vlm._update_token_usage_from_response(
+        SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=0,
+                completion_tokens=0,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0, cache_write_tokens=0),
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+            )
+        )
+    )
+
+    attributes = events[0][1]
+    assert attributes["gen_ai.usage.input_tokens"] == 0
+    assert attributes["gen_ai.usage.output_tokens"] == 0
+    assert attributes["gen_ai.usage.cache_creation.input_tokens"] == 0
+    assert attributes["gen_ai.usage.cache_read.input_tokens"] == 0
+    assert attributes["gen_ai.usage.reasoning.output_tokens"] == 0

--- a/tests/telemetry/test_tracer_events.py
+++ b/tests/telemetry/test_tracer_events.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.telemetry import tracer_module
+
+
+class _RecordingSpan:
+    def __init__(self, *, end_time=None):
+        self.end_time = end_time
+        self.events = []
+        self.attributes = {}
+
+    def add_event(self, name, attributes=None):
+        self.events.append((name, attributes))
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class _SpanContext:
+    def __init__(self, span):
+        self.span = span
+
+    def __enter__(self):
+        return self.span
+
+    def __exit__(self, *_args):
+        return None
+
+
+def _enable_tracing(monkeypatch, span):
+    sdk_tracer = SimpleNamespace(
+        start_as_current_span=lambda **_kwargs: _SpanContext(span),
+    )
+    monkeypatch.setattr(tracer_module, "_otel_tracer", sdk_tracer)
+    monkeypatch.setattr(
+        tracer_module,
+        "otel_trace",
+        SimpleNamespace(get_current_span=lambda: span),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_content_capture(monkeypatch):
+    monkeypatch.setattr(tracer_module, "_trace_capture_content", False)
+    monkeypatch.setattr(tracer_module, "_trace_content_max_length", 4096)
+
+
+def test_info_uses_stable_name_and_omits_message_by_default(monkeypatch):
+    span = _RecordingSpan()
+    _enable_tracing(monkeypatch, span)
+
+    tracer_module.tracer.info(
+        "Skipping unresolved memory operation: events(page_id=102): PROMPT_SECRET_17"
+    )
+
+    assert len(span.events) == 1
+    name, attributes = span.events[0]
+    assert name == "openviking.log"
+    assert "openviking.log.message" not in attributes
+    assert "page_id=102" not in repr(attributes)
+    assert "PROMPT_SECRET_17" not in repr(attributes)
+    assert attributes["code.namespace"].endswith("test_tracer_events")
+    assert attributes["code.function.name"].endswith(
+        "test_info_uses_stable_name_and_omits_message_by_default"
+    )
+    assert type(attributes["code.line.number"]) is int
+
+
+def test_content_capture_redacts_and_bounds_message(monkeypatch):
+    span = _RecordingSpan()
+    _enable_tracing(monkeypatch, span)
+    tracer_module._configure_trace_content(True, 80)
+
+    tracer_module.tracer.info(
+        'api_key="KEY_SECRET_19" Authorization: Bearer BEARER_SECRET_23 '
+        "image=data:image/png;base64,IMAGE_SECRET_29 " + "x" * 100
+    )
+
+    name, attributes = span.events[0]
+    message = attributes["openviking.log.message"]
+    assert name == "openviking.log"
+    assert len(message) == 80
+    assert message.endswith("...[truncated]")
+    assert "KEY_SECRET_19" not in message
+    assert "BEARER_SECRET_23" not in message
+    assert "IMAGE_SECRET_29" not in message
+
+
+def test_add_event_preserves_attribute_types(monkeypatch):
+    span = _RecordingSpan()
+    _enable_tracing(monkeypatch, span)
+
+    tracer_module.add_event(
+        "gen_ai.client.inference.operation.details",
+        {
+            "gen_ai.usage.input_tokens": 17,
+            "gen_ai.usage.output_tokens": 5,
+            "openviking.cached": 3,
+            "openviking.success": True,
+        },
+    )
+
+    assert span.events == [
+        (
+            "gen_ai.client.inference.operation.details",
+            {
+                "gen_ai.usage.input_tokens": 17,
+                "gen_ai.usage.output_tokens": 5,
+                "openviking.cached": 3,
+                "openviking.success": True,
+            },
+        )
+    ]
+    assert type(span.events[0][1]["gen_ai.usage.input_tokens"]) is int
+    assert span.events[0][1]["openviking.success"] is True
+
+
+def test_decorator_arguments_and_result_are_content_opt_in(monkeypatch):
+    span = _RecordingSpan()
+    _enable_tracing(monkeypatch, span)
+
+    @tracer_module.tracer("test.decorated", ignore_args=False, ignore_result=False)
+    def decorated(value, *, metadata):
+        return f"RESULT_SECRET_31:{value}:{metadata}"
+
+    result = decorated("ARG_SECRET_37", metadata="KWARG_SECRET_41")
+
+    assert result == "RESULT_SECRET_31:ARG_SECRET_37:KWARG_SECRET_41"
+    assert span.attributes == {}
+    assert span.events[0][0] == "openviking.log"
+    assert "openviking.log.message" not in span.events[0][1]
+    assert "SECRET" not in repr((span.attributes, span.events))
+
+
+def test_decorator_content_capture_is_redacted_and_bounded(monkeypatch):
+    span = _RecordingSpan()
+    _enable_tracing(monkeypatch, span)
+    tracer_module._configure_trace_content(True, 48)
+
+    @tracer_module.tracer("test.decorated", ignore_args=False, ignore_result=False)
+    def decorated(value):
+        return value
+
+    decorated("api_key=DECORATOR_SECRET_43 " + "x" * 80)
+
+    assert "DECORATOR_SECRET_43" not in span.attributes["func_args"]
+    assert len(span.attributes["func_args"]) == 48
+    message = span.events[0][1]["openviking.log.message"]
+    assert "DECORATOR_SECRET_43" not in message
+    assert len(message) == 48
+
+
+def test_info_console_logging_is_unchanged_when_tracing_is_disabled(monkeypatch):
+    messages = []
+    fake_logger = SimpleNamespace(
+        opt=lambda **_kwargs: SimpleNamespace(info=messages.append),
+    )
+    monkeypatch.setattr(tracer_module, "logger", fake_logger)
+    monkeypatch.setattr(tracer_module, "_otel_tracer", None)
+
+    tracer_module.tracer.info("still visible", console=True)
+
+    assert messages == ["still visible"]
+
+
+def test_init_from_server_config_forwards_content_settings(monkeypatch):
+    captured = {}
+    trace_config = SimpleNamespace(
+        enabled=True,
+        endpoint="",
+        service_name="test",
+        protocol="local",
+        tls=SimpleNamespace(insecure=False),
+        headers={},
+        local_path="trace.jsonl",
+        local_rotation_mb=40,
+        local_backup_count=2,
+        capture_content=True,
+        content_max_length=1234,
+    )
+    server_config = SimpleNamespace(
+        observability=SimpleNamespace(traces=trace_config),
+    )
+    monkeypatch.setattr(
+        tracer_module,
+        "init_tracer",
+        lambda **kwargs: captured.update(kwargs) or "tracer",
+    )
+
+    result = tracer_module.init_tracer_from_server_config(server_config)
+
+    assert result == "tracer"
+    assert captured["capture_content"] is True
+    assert captured["content_max_length"] == 1234
+
+
+def test_disabled_trace_config_disables_content_capture(monkeypatch):
+    monkeypatch.setattr(tracer_module, "_trace_capture_content", True)
+    server_config = SimpleNamespace(
+        observability=SimpleNamespace(traces=SimpleNamespace(enabled=False))
+    )
+
+    assert tracer_module.init_tracer_from_server_config(server_config) is None
+    assert tracer_module._trace_capture_content is False
+
+
+def test_invalid_content_limit_fails_before_exporter_creation(monkeypatch):
+    exporter_calls = []
+    monkeypatch.setattr(
+        tracer_module,
+        "OTLPGrpcSpanExporter",
+        lambda **kwargs: exporter_calls.append(kwargs) or object(),
+    )
+
+    result = tracer_module.init_tracer(
+        endpoint="localhost:4317",
+        service_name="test",
+        content_max_length=0,
+    )
+
+    assert result is None
+    assert exporter_calls == []
+    assert tracer_module._trace_capture_content is False

--- a/tests/test_server_config_loader.py
+++ b/tests/test_server_config_loader.py
@@ -228,6 +228,8 @@ def test_load_server_config_preserves_otlp_headers_fields(tmp_path):
                     "observability": {
                         "traces": {
                             "enabled": True,
+                            "capture_content": True,
+                            "content_max_length": 1234,
                             "headers": {
                                 "X-ByteAPM-AppKey": "trace-appkey",
                             },
@@ -260,6 +262,8 @@ def test_load_server_config_preserves_otlp_headers_fields(tmp_path):
     assert config.observability.traces.headers == {
         "X-ByteAPM-AppKey": "trace-appkey",
     }
+    assert config.observability.traces.capture_content is True
+    assert config.observability.traces.content_max_length == 1234
     assert config.observability.logs.headers == {
         "X-ByteAPM-AppKey": "log-appkey",
     }
@@ -293,3 +297,5 @@ def test_load_server_config_trace_local_defaults(tmp_path):
     assert traces.local_path == "~/.openviking/logs/traces.jsonl"
     assert traces.local_rotation_mb == 40
     assert traces.local_backup_count == 2
+    assert traces.capture_content is False
+    assert traces.content_max_length == 4096


### PR DESCRIPTION
## Description

`tracer.info()` currently passes diagnostic text directly to `Span.add_event()` as the
event name. OpenAI-compatible requests and usage data therefore produce dynamic event
names that can contain prompt, tool, response, and token-usage content.

This change records `tracer.info()` diagnostics under the stable `openviking.log` name
and retains their source location as attributes. Diagnostic text and decorator
arguments/results are omitted by default; `capture_content` enables bounded content
with best-effort redaction when it is needed for troubleshooting.

Successful OpenAI-compatible responses also emit a typed
`gen_ai.client.inference.operation.details` event for provider, model, response
metadata, finish reasons, and token usage. The redundant stringified
`response.usage` event is removed.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3952

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `tracer.add_event(name, attributes)` without stringifying supported attribute values.
- Give every `tracer.info()` event a stable name and retain source location metadata.
- Make diagnostic content capture an explicit, redacted, size-limited trace setting.
- Emit typed OpenTelemetry GenAI metadata for OpenAI-compatible response usage.
- Document the trace content controls in English, Chinese, and the example configuration.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Focused telemetry, configuration, and OpenAI-compatible VLM tests: `107 passed`.

Ruff format/check on the changed Python files, `compileall`, and `git diff --check`
pass. The broader selected VLM suite has the same 12 failing tests on this branch and a
clean archive of `upstream/main`; the branch adds four passing tests to that comparison.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This PR does not change global tracer-provider ownership, replacement, shutdown, or
reset behavior. It also leaves `tracer.error()` unchanged.

The focused tests emit four Pydantic deprecation warnings that are also present on the
base. A project-importing Mypy invocation did not provide a clean focused result and
reported 1379 errors across 207 files. `make check-deps` stopped because CMake is not
installed, so native build validation is left to CI.
