### PR TITLE
fix(queue): 合并重复的 Semantic 队列写入

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -156,8 +156,6 @@ class SemanticDagExecutor:
         changes: Optional[Dict[str, List[str]]] = None,
         skip_vectorization: bool = False,
         ingest_options: IngestOptions | None = None,
-        coalesce_key: str = "",
-        coalesce_version: int = 0,
     ):
         self._processor = processor
         self._context_type = context_type
@@ -170,11 +168,8 @@ class SemanticDagExecutor:
         self._changes = changes or {}
         self._skip_vectorization = skip_vectorization
         self._ingest_options = IngestOptions.from_value(ingest_options)
-        self._coalesce_key = coalesce_key
-        self._coalesce_version = coalesce_version
         self._task_context = get_task_context()
         self._telemetry = get_current_telemetry()
-        self._stale = False
         self._changed_paths = {
             path for key in ("added", "modified", "deleted") for path in self._changes.get(key, [])
         }
@@ -707,10 +702,6 @@ class SemanticDagExecutor:
             return None
         return summary
 
-    @property
-    def stale(self) -> bool:
-        return self._stale
-
     async def _finalize_children_abstracts(self, node: DirNode) -> List[Dict[str, str]]:
         results: List[Dict[str, str]] = []
         for idx, child_uri in enumerate(node.children_dirs):
@@ -725,11 +716,6 @@ class SemanticDagExecutor:
                 results.append(item)
         return results
 
-    def _is_stale(self) -> bool:
-        from openviking.storage.queuefs.semantic_queue import is_semantic_coalesce_stale
-
-        return is_semantic_coalesce_stale(self._coalesce_key, self._coalesce_version)
-
     async def _write_directory_semantics(
         self,
         dir_uri: str,
@@ -742,12 +728,8 @@ class SemanticDagExecutor:
             overview=overview,
             abstract=abstract,
             ctx=self._ctx,
-            is_stale=self._is_stale,
             lock=self._lock,
-            log_prefix="[SemanticDag]",
         )
-        if not wrote:
-            self._stale = True
         return wrote
 
     async def _overview_task(self, dir_uri: str) -> None:

--- a/openviking/storage/queuefs/semantic_msg.py
+++ b/openviking/storage/queuefs/semantic_msg.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from openviking.utils.ingest_options import IngestOptions
 
+
 def build_semantic_coalesce_key(
     *,
     context_type: str,
@@ -56,7 +57,6 @@ class SemanticMsg:
     target_preexisting: Optional[bool] = None
     ingest_options: IngestOptions = field(default_factory=IngestOptions)
     coalesce_key: str = ""
-    coalesce_version: int = 0
     changes: Optional[Dict[str, List[str]]] = (
         None  # {"added": [...], "modified": [...], "deleted": [...]}
     )
@@ -78,7 +78,6 @@ class SemanticMsg:
         target_preexisting: Optional[bool] = None,
         ingest_options: IngestOptions | Dict[str, Any] | None = None,
         coalesce_key: str = "",
-        coalesce_version: int = 0,
         changes: Optional[Dict[str, List[str]]] = None,
     ):
         self.id = str(uuid4())
@@ -97,7 +96,6 @@ class SemanticMsg:
         self.target_preexisting = target_preexisting
         self.ingest_options = IngestOptions.from_value(ingest_options)
         self.coalesce_key = coalesce_key
-        self.coalesce_version = coalesce_version
         self.changes = changes
 
     def to_dict(self) -> Dict[str, Any]:
@@ -149,7 +147,6 @@ class SemanticMsg:
                 }
             ),
             coalesce_key=data.get("coalesce_key", ""),
-            coalesce_version=data.get("coalesce_version", 0),
             changes=data.get("changes"),
         )
         if "id" in data and data["id"]:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -37,7 +37,12 @@ from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_lock import SemanticLockScope
 from openviking.storage.queuefs.semantic_msg import SemanticMsg, build_semantic_coalesce_key
-from openviking.storage.queuefs.semantic_queue import is_semantic_msg_stale
+from openviking.storage.queuefs.semantic_queue import (
+    abort_semantic_message,
+    claim_semantic_message,
+    finish_semantic_message,
+    prepare_semantic_retry,
+)
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.viking_fs import LS_ALL_NODES, SyncDiff, get_viking_fs
 from openviking.telemetry import bind_telemetry, bind_telemetry_stage, resolve_telemetry
@@ -82,6 +87,7 @@ class SemanticProcessor(DequeueHandlerBase):
     _request_stats_by_telemetry_id: Dict[str, RequestQueueStats] = {}
     _request_stats_order: List[str] = []
     _max_cached_stats = 256
+    _max_coalesced_rounds = 2
 
     def __init__(self, max_concurrent_llm: int = 32):
         """
@@ -159,6 +165,40 @@ class SemanticProcessor(DequeueHandlerBase):
             role=role,
         )
 
+    @staticmethod
+    def _completion_events(msg: SemanticMsg) -> List[Dict[str, str]]:
+        events = getattr(msg, "_coalesced_events", None)
+        return events or [{"id": msg.id, "telemetry_id": msg.telemetry_id}]
+
+    @classmethod
+    def _mark_semantic_done(cls, msg: SemanticMsg) -> None:
+        tracker = get_request_wait_tracker()
+        for event in cls._completion_events(msg):
+            telemetry_id = event.get("telemetry_id", "")
+            event_id = event.get("id", "")
+            if telemetry_id and event_id:
+                tracker.mark_semantic_done(telemetry_id, event_id)
+            cls._merge_request_stats(telemetry_id, processed=1)
+
+    @classmethod
+    def _mark_semantic_failed(cls, msg: SemanticMsg, error: str) -> None:
+        tracker = get_request_wait_tracker()
+        for event in cls._completion_events(msg):
+            telemetry_id = event.get("telemetry_id", "")
+            event_id = event.get("id", "")
+            if telemetry_id and event_id:
+                tracker.mark_semantic_failed(telemetry_id, event_id, error)
+            cls._merge_request_stats(telemetry_id, error_count=1)
+
+    @classmethod
+    def _record_semantic_requeue(cls, msg: SemanticMsg) -> None:
+        tracker = get_request_wait_tracker()
+        for event in cls._completion_events(msg):
+            telemetry_id = event.get("telemetry_id", "")
+            if telemetry_id:
+                tracker.record_semantic_requeue(telemetry_id)
+            cls._merge_request_stats(telemetry_id, requeue_count=1)
+
     def _detect_file_type(self, file_name: str) -> str:
         """
         Detect file type for summary prompt selection.
@@ -190,7 +230,7 @@ class SemanticProcessor(DequeueHandlerBase):
         # Default to other
         return FILE_TYPE_OTHER
 
-    async def _reenqueue_semantic_msg(self, msg: SemanticMsg) -> None:
+    async def _reenqueue_semantic_msg(self, msg: SemanticMsg) -> Optional[SemanticMsg]:
         """Re-enqueue a semantic message for later processing.
 
         Throttles with a sleep when the circuit breaker is open to prevent
@@ -206,12 +246,17 @@ class SemanticProcessor(DequeueHandlerBase):
             await asyncio.sleep(wait)
 
         queue_manager = get_queue_manager()
-        if queue_manager is not None:
-            semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC)
-            await semantic_queue.enqueue(msg)
-            logger.info(f"Re-enqueued semantic message: {msg.uri}")
-        else:
-            logger.warning(f"No queue manager available, cannot re-enqueue: {msg.uri}")
+        if queue_manager is None:
+            raise RuntimeError("QueueManager is unavailable for semantic retry")
+        semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC)
+        retry_msg = prepare_semantic_retry(msg)
+        try:
+            await semantic_queue.enqueue(retry_msg)
+        except Exception:
+            msg._coalesced_events = self._completion_events(retry_msg)
+            raise
+        logger.info(f"Re-enqueued semantic message: {retry_msg.uri}")
+        return retry_msg
 
     async def _requeue_semantic_msg_after_error(
         self,
@@ -220,14 +265,12 @@ class SemanticProcessor(DequeueHandlerBase):
         error: Exception,
     ) -> None:
         try:
-            await self._reenqueue_semantic_msg(msg)
-            self._merge_request_stats(msg.telemetry_id, requeue_count=1)
-            get_request_wait_tracker().record_semantic_requeue(msg.telemetry_id)
+            requeued_msg = await self._reenqueue_semantic_msg(msg) or msg
+            self._record_semantic_requeue(requeued_msg)
             self.report_requeue()
         except Exception as requeue_err:
             logger.error(f"Failed to re-enqueue semantic message: {requeue_err}")
-            self._merge_request_stats(msg.telemetry_id, error_count=1)
-            get_request_wait_tracker().mark_semantic_failed(msg.telemetry_id, msg.id, str(error))
+            self._mark_semantic_failed(abort_semantic_message(msg), str(error))
             self.report_error(str(error), data)
             return
         self.report_success()
@@ -273,167 +316,161 @@ class SemanticProcessor(DequeueHandlerBase):
         await semantic_queue.enqueue(parent_msg)
         logger.info("Enqueued parent semantic refresh: %s", parent_uri)
 
+    async def _process_semantic_message(
+        self,
+        msg: SemanticMsg,
+        lock: Optional[Dict[str, Any]],
+    ) -> None:
+        collector = resolve_telemetry(msg.telemetry_id)
+        telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
+        with telemetry_ctx:
+            root_attrs = create_root_span_attributes(
+                http_method="QUEUE",
+                http_route=msg.context_type or "/queuefs/semantic",
+                request_id=msg.telemetry_id or msg.id,
+                url_path=msg.uri,
+            )
+            root_attrs.account_id = msg.account_id
+            root_attrs.user_id = msg.user_id
+            root_context_token = bind_root_observability_context(root_attrs)
+            try:
+                current_ctx = self._ctx_from_semantic_msg(msg)
+                logger.info(
+                    "Processing semantic generation for: %s (recursive=%s)",
+                    msg.uri,
+                    msg.recursive,
+                )
+                semantic_lock = await SemanticLockScope.resolve(
+                    msg.lock_handoff,
+                    caller_lock=lock,
+                    fallback_path_factory=lambda: get_viking_fs()._uri_to_path(
+                        msg.uri, ctx=current_ctx
+                    ),
+                )
+                try:
+                    if msg.context_type == "memory":
+                        await self._process_memory_directory(
+                            msg,
+                            ctx=current_ctx,
+                            lock=semantic_lock.lock,
+                        )
+                        return
+
+                    is_incremental = False
+                    target_uri = msg.target_uri
+                    run_uri = msg.uri
+                    changes = msg.changes
+                    viking_fs = get_viking_fs()
+                    if msg.target_uri:
+                        target_exists = await viking_fs.exists(msg.target_uri, ctx=current_ctx)
+                        if msg.uri != msg.target_uri:
+                            logger.info(
+                                "Syncing semantic source into target before processing: %s -> %s",
+                                msg.uri,
+                                msg.target_uri,
+                            )
+                            diff = await self._sync_topdown_recursive(
+                                msg.uri,
+                                msg.target_uri,
+                                ctx=current_ctx,
+                                lock=semantic_lock.lock,
+                            )
+                            logger.info(
+                                "[SyncDiff] Diff computed: added_files=%s, deleted_files=%s, "
+                                "updated_files=%s, added_dirs=%s, deleted_dirs=%s",
+                                len(diff.added_files),
+                                len(diff.deleted_files),
+                                len(diff.updated_files),
+                                len(diff.added_dirs),
+                                len(diff.deleted_dirs),
+                            )
+                            changes = diff.to_changes()
+                            is_incremental = True
+                            target_uri = msg.target_uri
+                            run_uri = msg.target_uri
+                        elif target_exists and msg.changes:
+                            is_incremental = True
+                            logger.info(
+                                "Using direct incremental semantic update for: %s", msg.uri
+                            )
+                    elif msg.changes:
+                        is_incremental = True
+                        target_uri = msg.uri
+                        logger.info("Using direct incremental semantic update for: %s", msg.uri)
+
+                    executor = SemanticDagExecutor(
+                        processor=self,
+                        context_type=msg.context_type,
+                        max_concurrent_llm=self.max_concurrent_llm,
+                        ctx=current_ctx,
+                        incremental_update=is_incremental,
+                        target_uri=target_uri,
+                        recursive=msg.recursive,
+                        lock=semantic_lock.lock,
+                        is_code_repo=msg.is_code_repo,
+                        changes=changes,
+                        skip_vectorization=msg.skip_vectorization,
+                        ingest_options=msg.ingest_options,
+                    )
+                    await executor.run(run_uri)
+                    self._cache_dag_stats(msg.telemetry_id, run_uri, executor.get_stats())
+                    await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
+                finally:
+                    await semantic_lock.close()
+            finally:
+                reset_root_observability_context(root_context_token)
+
     async def on_dequeue(
         self,
         data: Optional[Dict[str, Any]],
         lock: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Process dequeued SemanticMsg, recursively process all subdirectories."""
+        """Process one physical queue trigger until its coalesced work is stable."""
         msg: Optional[SemanticMsg] = None
-        collector = None
         try:
             import json
 
             if not data:
                 return None
-
             if "data" in data and isinstance(data["data"], str):
                 data = json.loads(data["data"])
 
             assert data is not None
-            msg = SemanticMsg.from_dict(data)
-            if VikingURI(msg.uri).parent is None:
-                logger.warning("Skipping semantic generation for root URI: %s", msg.uri)
-                if msg.telemetry_id and msg.id:
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                self.report_success()
-                return None
-            if is_semantic_msg_stale(msg):
-                logger.info(
-                    "Skipping stale semantic message: uri=%s version=%s",
-                    msg.uri,
-                    msg.coalesce_version,
-                )
-                if msg.telemetry_id and msg.id:
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                self.report_success()
-                return None
-            # Circuit breaker: if API is known-broken, re-enqueue and wait
-            try:
-                self._circuit_breaker.check()
-            except CircuitBreakerOpen:
-                logger.warning(
-                    f"Circuit breaker is open, re-enqueueing semantic message: {msg.uri}"
-                )
-                await self._reenqueue_semantic_msg(msg)
-                self._merge_request_stats(msg.telemetry_id, requeue_count=1)
-                get_request_wait_tracker().record_semantic_requeue(msg.telemetry_id)
-                self.report_requeue()
-                self.report_success()
-                return None
-            collector = resolve_telemetry(msg.telemetry_id)
-            telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
-            with telemetry_ctx:
-                root_attrs = create_root_span_attributes(
-                    http_method="QUEUE",
-                    http_route=msg.context_type or "/queuefs/semantic",
-                    request_id=msg.telemetry_id or msg.id,
-                    url_path=msg.uri,
-                )
-                root_attrs.account_id = msg.account_id
-                root_attrs.user_id = msg.user_id
-                root_context_token = bind_root_observability_context(root_attrs)
-                try:
-                    current_ctx = self._ctx_from_semantic_msg(msg)
-                    logger.info(
-                        f"Processing semantic generation for: {msg.uri} (recursive={msg.recursive})"
-                    )
-
-                    logger.info(f"Processing semantic generation for: {msg})")
-
-                    semantic_lock = await SemanticLockScope.resolve(
-                        msg.lock_handoff,
-                        caller_lock=lock,
-                        fallback_path_factory=lambda: get_viking_fs()._uri_to_path(
-                            msg.uri, ctx=current_ctx
-                        ),
-                    )
+            msg = claim_semantic_message(SemanticMsg.from_dict(data))
+            rounds = 0
+            while True:
+                if VikingURI(msg.uri).parent is None:
+                    logger.warning("Skipping semantic generation for root URI: %s", msg.uri)
+                else:
                     try:
-                        if msg.context_type == "memory":
-                            await self._process_memory_directory(
-                                msg,
-                                ctx=current_ctx,
-                                lock=semantic_lock.lock,
-                            )
-                        else:
-                            is_incremental = False
-                            target_uri = msg.target_uri
-                            run_uri = msg.uri
-                            changes = msg.changes
-                            viking_fs = get_viking_fs()
-                            if msg.target_uri:
-                                target_exists = await viking_fs.exists(
-                                    msg.target_uri, ctx=current_ctx
-                                )
-                                if msg.uri != msg.target_uri:
-                                    logger.info(
-                                        "Syncing semantic source into target before processing: "
-                                        f"{msg.uri} -> {msg.target_uri}"
-                                    )
-                                    diff = await self._sync_topdown_recursive(
-                                        msg.uri,
-                                        msg.target_uri,
-                                        ctx=current_ctx,
-                                        lock=semantic_lock.lock,
-                                    )
-                                    logger.info(
-                                        "[SyncDiff] Diff computed: "
-                                        f"added_files={len(diff.added_files)}, "
-                                        f"deleted_files={len(diff.deleted_files)}, "
-                                        f"updated_files={len(diff.updated_files)}, "
-                                        f"added_dirs={len(diff.added_dirs)}, "
-                                        f"deleted_dirs={len(diff.deleted_dirs)}"
-                                    )
-                                    changes = diff.to_changes()
-                                    is_incremental = True
-                                    target_uri = msg.target_uri
-                                    run_uri = msg.target_uri
-                                elif target_exists and msg.changes and msg.uri == msg.target_uri:
-                                    is_incremental = True
-                                    logger.info(
-                                        f"Using direct incremental semantic update for: {msg.uri}"
-                                    )
-                            elif msg.changes:
-                                is_incremental = True
-                                target_uri = msg.uri
-                                logger.info(
-                                    f"Using direct incremental semantic update for: {msg.uri}"
-                                )
+                        self._circuit_breaker.check()
+                    except CircuitBreakerOpen:
+                        logger.warning(
+                            "Circuit breaker is open, re-enqueueing semantic message: %s",
+                            msg.uri,
+                        )
+                        requeued_msg = await self._reenqueue_semantic_msg(msg) or msg
+                        self._record_semantic_requeue(requeued_msg)
+                        self.report_requeue()
+                        self.report_success()
+                        return None
+                    await self._process_semantic_message(msg, lock)
 
-                            executor = SemanticDagExecutor(
-                                processor=self,
-                                context_type=msg.context_type,
-                                max_concurrent_llm=self.max_concurrent_llm,
-                                ctx=current_ctx,
-                                incremental_update=is_incremental,
-                                target_uri=target_uri,
-                                recursive=msg.recursive,
-                                lock=semantic_lock.lock,
-                                is_code_repo=msg.is_code_repo,
-                                changes=changes,
-                                skip_vectorization=msg.skip_vectorization,
-                                ingest_options=msg.ingest_options,
-                                coalesce_key=msg.coalesce_key,
-                                coalesce_version=msg.coalesce_version,
-                            )
-                            await executor.run(run_uri)
-                            self._cache_dag_stats(
-                                msg.telemetry_id,
-                                run_uri,
-                                executor.get_stats(),
-                            )
-                            if not executor.stale:
-                                await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
-                    finally:
-                        await semantic_lock.close()
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                    self._merge_request_stats(msg.telemetry_id, processed=1)
-                    logger.info(f"Completed semantic generation for: {msg.uri}")
+                self._mark_semantic_done(msg)
+                rounds += 1
+                logger.info("Completed semantic generation for: %s", msg.uri)
+                next_msg = finish_semantic_message(msg)
+                if next_msg is None:
                     self.report_success()
                     self._circuit_breaker.record_success()
                     return None
-                finally:
-                    reset_root_observability_context(root_context_token)
+                msg = next_msg
+                if rounds >= self._max_coalesced_rounds:
+                    await self._reenqueue_semantic_msg(msg)
+                    self.report_success()
+                    self._circuit_breaker.record_success()
+                    return None
+                logger.info("Continuing coalesced semantic generation for: %s", msg.uri)
 
         except Exception as e:
             if isinstance(e, LockAcquisitionError):
@@ -456,10 +493,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     exc_info=True,
                 )
                 if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
-                    )
+                    self._mark_semantic_failed(abort_semantic_message(msg), str(e))
                 self.report_error(str(e), data)
             elif error_class == ERROR_CLASS_PERMANENT:
                 logger.critical(
@@ -468,13 +502,9 @@ class SemanticProcessor(DequeueHandlerBase):
                 )
                 self._circuit_breaker.record_failure(e)
                 if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
-                    )
+                    self._mark_semantic_failed(abort_semantic_message(msg), str(e))
                 self.report_error(str(e), data)
             else:
-                # Transient or unknown — re-enqueue for retry
                 logger.warning(
                     f"Transient API error processing semantic message, re-enqueueing: {e}",
                     exc_info=True,
@@ -701,9 +731,7 @@ class SemanticProcessor(DequeueHandlerBase):
             overview=overview,
             abstract=abstract,
             ctx=ctx,
-            is_stale=lambda: is_semantic_msg_stale(msg),
             lock=lock,
-            log_prefix="[MemorySemantic]",
         )
 
     async def _sync_topdown_recursive(

--- a/openviking/storage/queuefs/semantic_queue.py
+++ b/openviking/storage/queuefs/semantic_queue.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: AGPL-3.0
 """SemanticQueue: Semantic extraction queue."""
 
+import asyncio
 import threading
 import time
+from concurrent.futures import Future
+from dataclasses import dataclass
 from typing import Optional
 
+from openviking.service.task_work_index import get_task_context
 from openviking_cli.utils.logger import get_logger
 
 from .named_queue import NamedQueue
@@ -15,19 +19,198 @@ logger = get_logger(__name__)
 
 # Coalesce rapid re-enqueues for the same memory parent directory (github #769).
 _MEMORY_PARENT_SEMANTIC_DEDUPE_SEC = 45.0
-_SEMANTIC_COALESCE_LOCK = threading.Lock()
-_SEMANTIC_COALESCE_VERSION: dict[str, int] = {}
 
 
-def is_semantic_coalesce_stale(coalesce_key: str, coalesce_version: int) -> bool:
-    if not coalesce_key or coalesce_version <= 0:
-        return False
-    with _SEMANTIC_COALESCE_LOCK:
-        return coalesce_version < _SEMANTIC_COALESCE_VERSION.get(coalesce_key, 0)
+@dataclass
+class _SemanticBatch:
+    msg: SemanticMsg
+    events: list[dict[str, str]]
 
 
-def is_semantic_msg_stale(msg: SemanticMsg) -> bool:
-    return is_semantic_coalesce_stale(msg.coalesce_key, msg.coalesce_version)
+@dataclass
+class _SemanticCoalesceState:
+    trigger_id: str
+    status: str
+    pending: Optional[_SemanticBatch]
+    enqueue_result: Future[str]
+    active: Optional[_SemanticBatch] = None
+    dirty: Optional[_SemanticBatch] = None
+
+
+class _InMemorySemanticCoalescer:
+    """Keep one process-local queue trigger per semantic key and merge work around it."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._states: dict[str, _SemanticCoalesceState] = {}
+
+    @staticmethod
+    def _clone_msg(msg: SemanticMsg) -> SemanticMsg:
+        return SemanticMsg.from_dict(msg.to_dict())
+
+    @classmethod
+    def _batch_from_msg(cls, msg: SemanticMsg) -> _SemanticBatch:
+        events = getattr(msg, "_coalesced_events", None)
+        if events:
+            completions = [dict(event) for event in events]
+        else:
+            completions = [{"id": msg.id, "telemetry_id": msg.telemetry_id}]
+        return _SemanticBatch(cls._clone_msg(msg), completions)
+
+    @classmethod
+    def _merge_batches(
+        cls,
+        current: Optional[_SemanticBatch],
+        incoming: _SemanticBatch,
+    ) -> _SemanticBatch:
+        if current is None:
+            return incoming
+
+        merged = cls._clone_msg(incoming.msg)
+        merged.recursive = current.msg.recursive or incoming.msg.recursive
+        merged.skip_vectorization = (
+            current.msg.skip_vectorization and incoming.msg.skip_vectorization
+        )
+        merged.is_code_repo = current.msg.is_code_repo or incoming.msg.is_code_repo
+
+        if current.msg.changes is None or incoming.msg.changes is None:
+            merged.changes = None
+        else:
+            path_states: dict[str, str] = {}
+            for changes in (current.msg.changes, incoming.msg.changes):
+                for change_type in ("added", "modified", "deleted"):
+                    for path in changes.get(change_type, []):
+                        path_states[path] = change_type
+            merged.changes = {
+                change_type: sorted(
+                    path for path, state in path_states.items() if state == change_type
+                )
+                for change_type in ("added", "modified", "deleted")
+                if change_type in path_states.values()
+            }
+
+        events = list(current.events)
+        known_ids = {event["id"] for event in events}
+        events.extend(event for event in incoming.events if event["id"] not in known_ids)
+        return _SemanticBatch(merged, events)
+
+    @classmethod
+    def _claimed_msg(cls, state: _SemanticCoalesceState) -> SemanticMsg:
+        assert state.active is not None
+        msg = cls._clone_msg(state.active.msg)
+        msg._coalesced_events = [dict(event) for event in state.active.events]
+        msg._coalesce_trigger_id = state.trigger_id
+        return msg
+
+    def submit(self, msg: SemanticMsg) -> tuple[bool, Future[str]]:
+        incoming = self._batch_from_msg(msg)
+        with self._lock:
+            state = self._states.get(msg.coalesce_key)
+            if state is None:
+                enqueue_result: Future[str] = Future()
+                self._states[msg.coalesce_key] = _SemanticCoalesceState(
+                    trigger_id=msg.id,
+                    status="enqueuing",
+                    pending=incoming,
+                    enqueue_result=enqueue_result,
+                )
+                return True, enqueue_result
+
+            if state.status in {"enqueuing", "pending"}:
+                state.pending = self._merge_batches(state.pending, incoming)
+            else:
+                state.dirty = self._merge_batches(state.dirty, incoming)
+            return False, state.enqueue_result
+
+    def enqueue_succeeded(self, key: str, future: Future[str], result: str) -> None:
+        with self._lock:
+            state = self._states.get(key)
+            if state is not None and state.enqueue_result is future:
+                if state.status == "enqueuing":
+                    state.status = "pending"
+        if not future.done():
+            future.set_result(result)
+
+    def enqueue_failed(self, key: str, future: Future[str], error: BaseException) -> None:
+        with self._lock:
+            state = self._states.get(key)
+            if state is not None and state.enqueue_result is future:
+                self._states.pop(key, None)
+        if not future.done():
+            future.set_exception(error)
+
+    def claim(self, msg: SemanticMsg) -> SemanticMsg:
+        if not msg.coalesce_key:
+            return msg
+        with self._lock:
+            state = self._states.get(msg.coalesce_key)
+            if state is None or state.trigger_id != msg.id:
+                return msg
+            if state.status in {"enqueuing", "pending"} and state.pending is not None:
+                state.status = "processing"
+                state.active = state.pending
+                state.pending = None
+            elif state.status == "processing" and state.active is not None:
+                state.active = self._merge_batches(state.active, state.dirty)
+                state.dirty = None
+            else:
+                return msg
+            return self._claimed_msg(state)
+
+    def finish(self, msg: SemanticMsg) -> Optional[SemanticMsg]:
+        trigger_id = getattr(msg, "_coalesce_trigger_id", "")
+        if not trigger_id:
+            return None
+        with self._lock:
+            state = self._states.get(msg.coalesce_key)
+            if state is None or state.trigger_id != trigger_id:
+                return None
+            if state.dirty is None:
+                self._states.pop(msg.coalesce_key, None)
+                return None
+            state.active = state.dirty
+            state.dirty = None
+            return self._claimed_msg(state)
+
+    def abort(self, msg: SemanticMsg) -> SemanticMsg:
+        trigger_id = getattr(msg, "_coalesce_trigger_id", "")
+        if not trigger_id:
+            return msg
+        with self._lock:
+            state = self._states.get(msg.coalesce_key)
+            if state is None or state.trigger_id != trigger_id or state.active is None:
+                return msg
+            batch = self._merge_batches(state.active, state.dirty) if state.dirty else state.active
+            self._states.pop(msg.coalesce_key, None)
+        aborted = self._clone_msg(batch.msg)
+        aborted._coalesced_events = [dict(event) for event in batch.events]
+        return aborted
+
+    def prepare_retry(self, msg: SemanticMsg) -> SemanticMsg:
+        return self.abort(msg)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._states.clear()
+
+
+_SEMANTIC_COALESCER = _InMemorySemanticCoalescer()
+
+
+def claim_semantic_message(msg: SemanticMsg) -> SemanticMsg:
+    return _SEMANTIC_COALESCER.claim(msg)
+
+
+def finish_semantic_message(msg: SemanticMsg) -> Optional[SemanticMsg]:
+    return _SEMANTIC_COALESCER.finish(msg)
+
+
+def abort_semantic_message(msg: SemanticMsg) -> SemanticMsg:
+    return _SEMANTIC_COALESCER.abort(msg)
+
+
+def prepare_semantic_retry(msg: SemanticMsg) -> SemanticMsg:
+    return _SEMANTIC_COALESCER.prepare_retry(msg)
 
 
 class SemanticQueue(NamedQueue):
@@ -64,13 +247,31 @@ class SemanticQueue(NamedQueue):
                     for k in stale[:800]:
                         self._memory_parent_semantic_last.pop(k, None)
 
-        if msg.coalesce_key:
-            with _SEMANTIC_COALESCE_LOCK:
-                version = _SEMANTIC_COALESCE_VERSION.get(msg.coalesce_key, 0) + 1
-                _SEMANTIC_COALESCE_VERSION[msg.coalesce_key] = version
-                msg.coalesce_version = version
+        if not msg.coalesce_key or get_task_context() is not None or msg.lock_handoff is not None:
+            return await super().enqueue(msg.to_dict())
 
-        return await super().enqueue(msg.to_dict())
+        should_enqueue, enqueue_result = _SEMANTIC_COALESCER.submit(msg)
+        if not should_enqueue:
+            return await asyncio.shield(asyncio.wrap_future(enqueue_result))
+
+        try:
+            # The durable trigger falls back to a full refresh if this process
+            # restarts and loses the in-memory incremental batch.
+            trigger = msg.to_dict()
+            trigger["changes"] = None
+            trigger["skip_vectorization"] = False
+            result = await super().enqueue(trigger)
+        except BaseException as error:
+            _SEMANTIC_COALESCER.enqueue_failed(msg.coalesce_key, enqueue_result, error)
+            raise
+        _SEMANTIC_COALESCER.enqueue_succeeded(msg.coalesce_key, enqueue_result, result)
+        return result
+
+    async def clear(self) -> bool:
+        cleared = await super().clear()
+        if cleared:
+            _SEMANTIC_COALESCER.clear()
+        return cleared
 
     async def dequeue(self) -> Optional[SemanticMsg]:
         """Get message from queue and deserialize to SemanticMsg object."""

--- a/openviking/storage/queuefs/semantic_sidecar.py
+++ b/openviking/storage/queuefs/semantic_sidecar.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Shared writeback for semantic sidecar files."""
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 
 from openviking.server.identity import RequestContext
-from openviking_cli.utils.logger import get_logger
-
-logger = get_logger(__name__)
 
 
 async def write_semantic_sidecars(
@@ -17,15 +14,9 @@ async def write_semantic_sidecars(
     overview: str,
     abstract: str,
     ctx: Optional[RequestContext],
-    is_stale: Callable[[], bool],
     lock: Optional[Dict[str, Any]] = None,
-    log_prefix: str = "[Semantic]",
 ) -> bool:
     """Write .overview.md and .abstract.md sidecar files under dir_uri with exact-path locking."""
-    if is_stale():
-        logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
-        return False
-
     lock_paths = [
         viking_fs._uri_to_path(f"{dir_uri}/.overview.md", ctx=ctx),
         viking_fs._uri_to_path(f"{dir_uri}/.abstract.md", ctx=ctx),
@@ -35,9 +26,6 @@ async def write_semantic_sidecars(
     if sidecar_lease is None:
         sidecar_lease = await viking_fs._async_agfs.pathlock_acquire_exact_batch(lock_paths)
     try:
-        if is_stale():
-            logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
-            return False
         await _write_sidecars(viking_fs, dir_uri, overview, abstract, ctx, sidecar_lease)
         return True
     finally:

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -10,7 +10,7 @@ import pytest
 from openviking.storage.queuefs.named_queue import NamedQueue
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
 from openviking.storage.queuefs.semantic_processor import SemanticProcessor
-from openviking.storage.queuefs.semantic_queue import SemanticQueue, is_semantic_msg_stale
+from openviking.storage.queuefs.semantic_queue import SemanticQueue
 
 
 @pytest.mark.asyncio
@@ -75,7 +75,7 @@ async def test_non_memory_context_not_deduped():
 
 
 @pytest.mark.asyncio
-async def test_coalesced_semantic_messages_mark_old_version_stale():
+async def test_coalesced_semantic_messages_share_one_queue_trigger():
     mock_agfs = MagicMock()
     with patch.object(NamedQueue, "enqueue", new_callable=AsyncMock) as named_enqueue:
         named_enqueue.return_value = "queued-id"
@@ -85,20 +85,47 @@ async def test_coalesced_semantic_messages_mark_old_version_stale():
             uri="viking://resources/docs",
             context_type="resource",
             coalesce_key=coalesce_key,
+            changes={"modified": ["a.md"]},
         )
         second = SemanticMsg(
             uri="viking://resources/docs",
             context_type="resource",
             coalesce_key=first.coalesce_key,
+            changes={"modified": ["b.md"], "deleted": ["a.md"]},
         )
 
-        await q.enqueue(first)
-        await q.enqueue(second)
+        assert await q.enqueue(first) == "queued-id"
+        assert await q.enqueue(second) == "queued-id"
+        assert named_enqueue.call_count == 1
 
-        assert first.coalesce_version == 1
-        assert second.coalesce_version == 2
-        assert is_semantic_msg_stale(first)
-        assert not is_semantic_msg_stale(second)
+        third = SemanticMsg(
+            uri="viking://resources/docs",
+            context_type="resource",
+            coalesce_key=first.coalesce_key,
+            changes={"modified": ["c.md"]},
+        )
+        processed = []
+
+        async def process(msg, lock):
+            del lock
+            processed.append(msg)
+            if len(processed) == 1:
+                assert await q.enqueue(third) == "queued-id"
+
+        processor = SemanticProcessor()
+        with patch.object(processor, "_process_semantic_message", new=process):
+            await processor.on_dequeue({"data": first.to_json()})
+
+        assert named_enqueue.call_count == 1
+        assert processed[0].changes == {
+            "modified": ["b.md"],
+            "deleted": ["a.md"],
+        }
+        assert {event["id"] for event in processed[0]._coalesced_events} == {
+            first.id,
+            second.id,
+        }
+        assert processed[1].changes == {"modified": ["c.md"]}
 
 
 class _FakePathLock:
@@ -140,46 +167,25 @@ class _FakeMemoryDirFS:
 
 
 @pytest.mark.asyncio
-async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
+async def test_memory_semantic_write_uses_sidecar_lock(monkeypatch):
     pathlock = _FakePathLock()
     viking_fs = _FakeVikingFS(pathlock)
     processor = SemanticProcessor()
-    coalesce_key = f"memory|acc|u|p|viking://user/default/memories/preferences/{uuid4().hex}"
-
-    with patch.object(NamedQueue, "enqueue", new_callable=AsyncMock):
-        q = SemanticQueue(MagicMock(), "/queue", "semantic")
-        first = SemanticMsg(
-            uri="viking://user/default/memories/preferences",
-            context_type="memory",
-            coalesce_key=coalesce_key,
-        )
-        latest = SemanticMsg(
-            uri="viking://user/default/memories/preferences",
-            context_type="memory",
-            coalesce_key=coalesce_key,
-        )
-        await q.enqueue(first)
-        await q.enqueue(latest)
-
-    wrote_first = await processor._write_memory_directory_semantics(
-        msg=first,
-        viking_fs=viking_fs,
-        dir_uri=first.uri,
-        overview="old overview",
-        abstract="old abstract",
-        ctx=None,
+    msg = SemanticMsg(
+        uri="viking://user/default/memories/preferences",
+        context_type="memory",
     )
-    wrote_latest = await processor._write_memory_directory_semantics(
-        msg=latest,
+
+    wrote = await processor._write_memory_directory_semantics(
+        msg=msg,
         viking_fs=viking_fs,
-        dir_uri=latest.uri,
-        overview="latest overview",
-        abstract="latest abstract",
+        dir_uri=msg.uri,
+        overview="overview",
+        abstract="abstract",
         ctx=None,
     )
 
-    assert not wrote_first
-    assert wrote_latest
+    assert wrote
     assert pathlock.acquired_batches == [
         [
             "/fake/viking/user/default/memories/preferences/.overview.md",
@@ -187,8 +193,8 @@ async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
         ]
     ]
     assert viking_fs.writes == [
-        ("viking://user/default/memories/preferences/.overview.md", "latest overview"),
-        ("viking://user/default/memories/preferences/.abstract.md", "latest abstract"),
+        ("viking://user/default/memories/preferences/.overview.md", "overview"),
+        ("viking://user/default/memories/preferences/.abstract.md", "abstract"),
     ]
 
 


### PR DESCRIPTION
## Description

Semantic 队列原先会把同一 `coalesce_key` 的每次变更都写入 QueueFS，再依赖进程内版本号跳过旧消息。实例重启后版本号丢失，已写入的旧消息会全部执行。

本 PR 将合并前移到写入阶段，不改变现有 `coalesce_key` 的生成规则和身份字段语义。

### Before / After

同一目录在 Worker 开始处理前连续产生 100 次删除刷新：

- **Before：** QueueFS 写入 100 条消息；进程内可跳过前 99 条，但重启后可能全部执行。
- **After：** QueueFS 只写入 1 条持久化触发消息，100 次变更在进程内合并；处理中到达的新变更由当前 Worker 继续处理，必要时写入一条后续触发消息。

持久化触发消息使用完整刷新语义。进程重启导致内存合并状态丢失时，仍能根据 AGFS 当前内容安全重建语义结果。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3891

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 使用进程内状态按现有 `coalesce_key` 合并待处理和处理中变更，减少 QueueFS 写入。
- 保留单个可恢复的完整刷新触发消息，并将被合并请求的完成、失败和重试状态一起结算。
- 删除 `coalesce_version`、stale 检查及对应的 sidecar 写入分支。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证内容：

- Ruff 检查通过。
- Python 编译检查通过。
- 31 个 Semantic 队列、处理器、DAG 和内容写入相关测试通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

- 升级前已经存在于 QueueFS 的旧消息不会被重新合并，仍按原行为逐条执行。
- 旧消息中的 `coalesce_version` 会被新代码忽略，不会造成反序列化失败。
- 当前合并状态是单进程内状态；多实例场景保证持久化触发消息的结果正确，但不提供跨实例的全局合并。
