### PR TITLE
fix(memory): 修复仅引用assistant消息时的事件记忆归属

### DIFF
--- a/openviking/prompts/templates/memory/events.yaml
+++ b/openviking/prompts/templates/memory/events.yaml
@@ -146,4 +146,7 @@ fields:
       - Range: "start-end" (e.g., "0-3" means messages 0 to 3)
       - Single index: "N" (e.g., "7" means only message 7)
       - Mixed: "0-3,7,15-20" (ranges and single indices combined)
+      For events, ranges MUST include at least one user-role message that states or supports the event.
+      If an assistant message confirms, normalizes, or completes the event, include both the originating user message and the assistant message.
+      Never output assistant-only ranges for events.
     merge_op: immutable

--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -69,9 +69,11 @@ class MemoryIsolationHandler:
         return messages if isinstance(messages, list) else []
 
     def _message_target_id(self, msg: Any) -> Optional[str]:
+        if not self._is_peer_owner_message(msg):
+            return None
         raw_peer_id = getattr(msg, "peer_id", None)
         peer_id = safe_peer_id(raw_peer_id)
-        if peer_id and self._is_peer_owner_message(msg) and self._can_write_peer(peer_id):
+        if peer_id and self._can_write_peer(peer_id):
             return peer_id
         if raw_peer_id in (None, "") and self.allow_self:
             return _SELF_PEER_ID
@@ -143,6 +145,37 @@ class MemoryIsolationHandler:
         peer_ids = list(dict.fromkeys(targets))
         return peer_ids[0] if len(peer_ids) == 1 else None
 
+    def _unique_target_id_in_messages(self) -> Optional[str]:
+        targets = [
+            target_id for msg in self._messages() if (target_id := self._message_target_id(msg))
+        ]
+        target_ids = list(dict.fromkeys(targets))
+        return target_ids[0] if len(target_ids) == 1 else None
+
+    def _range_is_fully_in_bounds(self, ranges: Any) -> bool:
+        parts = str(ranges).split(",")
+        if not parts or any(not part.strip() for part in parts):
+            return False
+
+        message_count = len(self._messages())
+        if message_count == 0:
+            return False
+
+        try:
+            for part in parts:
+                bounds = part.strip().split("-")
+                if len(bounds) == 1:
+                    start = end = int(bounds[0])
+                elif len(bounds) == 2 and all(bound.strip() for bound in bounds):
+                    start, end = (int(bound) for bound in bounds)
+                else:
+                    return False
+                if start < 0 or start > end or end >= message_count:
+                    return False
+        except ValueError:
+            return False
+        return True
+
     def render_schema_directories(self, memory_type_schema: MemoryTypeSchema) -> List[str]:
         user_id = self.ctx.user.user_id if self.ctx and self.ctx.user else "default"
         user_space = user_id
@@ -164,22 +197,29 @@ class MemoryIsolationHandler:
             )
         return directories
 
-    def _range_targets(self, ranges: Any) -> List[str]:
+    def _range_targets(self, ranges: Any) -> tuple[List[str], bool]:
         if not ranges or not self._extract_context:
-            return []
+            return [], False
+        range_is_fully_in_bounds = self._range_is_fully_in_bounds(ranges)
         try:
             msg_range = self._extract_context.read_message_ranges(str(ranges))
         except Exception:
             logger.warning("Failed to parse memory ranges for peer memory: %s", ranges)
-            return []
+            return [], False
 
         target_ids = []
+        has_message = False
+        has_user_message = False
         for msg_group in getattr(msg_range, "elements", []) or []:
             for msg in msg_group:
+                has_message = True
+                if self._is_peer_owner_message(msg):
+                    has_user_message = True
                 target_id = self._message_target_id(msg)
                 if target_id:
                     target_ids.append(target_id)
-        return list(dict.fromkeys(target_ids))
+        can_fallback = range_is_fully_in_bounds and has_message and not has_user_message
+        return list(dict.fromkeys(target_ids)), can_fallback
 
     def _resolve_operation_target_id(self, raw_peer_id: Any) -> Optional[str]:
         peer_id = safe_peer_id(raw_peer_id)
@@ -214,9 +254,13 @@ class MemoryIsolationHandler:
             operation.memory_fields.pop("peer_id", None)
             target_ids = [_SELF_PEER_ID] if self.allow_self else []
         elif operation.memory_fields.get("ranges") is not None:
-            target_ids = self._range_targets(
+            target_ids, can_fallback = self._range_targets(
                 operation.memory_fields.get("ranges"),
             )
+            if not target_ids and can_fallback:
+                fallback_target = self._unique_target_id_in_messages()
+                if fallback_target:
+                    target_ids = [fallback_target]
             operation.memory_fields.pop("peer_id", None)
         else:
             target_id = self._resolve_operation_target_id(

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -6,12 +6,15 @@ Tests for MemoryIsolationHandler.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from openviking.message.message import Message
 from openviking.message.part import TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.memory_isolation_handler import (
     MemoryIsolationHandler,
 )
+from openviking.session.memory.memory_updater import ExtractContext
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -542,6 +545,301 @@ class TestCalculateMemoryUris:
         assert uris == ["viking://user/support_bot/peers/web-visitor-alice/memories/events/demo"]
         assert operation.memory_fields["user_id"] == "support_bot"
         assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_without_user_fall_back_to_unique_user_peer(self, mock_generate_uri):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "peer event", peer_id="peer-a"),
+            create_message("assistant", "processed", peer_id="peer-a"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[1]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "1-1"},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/support_bot/peers/peer-a/memories/events/demo"]
+        assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_without_user_fall_back_to_unique_self(self, mock_generate_uri):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "self event"),
+            create_message("assistant", "processed", peer_id="assistant-peer"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[1]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=True,
+            allowed_peer_ids={"assistant-peer"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "1-1"},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/support_bot/memories/events/demo"]
+        assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_with_unowned_assistant_fall_back_to_unique_user_peer(self, mock_generate_uri):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "peer event", peer_id="peer-a"),
+            create_message("assistant", "processed"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[1]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=True,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "1-1"},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/support_bot/peers/peer-a/memories/events/demo"]
+        assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_without_user_do_not_fallback_to_ambiguous_users(self, mock_generate_uri):
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "event a", peer_id="peer-a"),
+            create_message("user", "event b", peer_id="peer-b"),
+            create_message("assistant", "processed", peer_id="peer-a"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[2]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a", "peer-b"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "2-2"},
+            memory_type="events",
+            uris=[],
+        )
+
+        assert handler.calculate_memory_uris(schema, operation, extract_ctx) == []
+        mock_generate_uri.assert_not_called()
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_without_user_ignore_assistant_only_peer(self, mock_generate_uri):
+        ctx = create_ctx(user_id="support_bot")
+        messages = [create_message("assistant", "processed", peer_id="peer-a")]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [messages]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "0-0"},
+            memory_type="events",
+            uris=[],
+        )
+
+        assert handler.calculate_memory_uris(schema, operation, extract_ctx) == []
+        mock_generate_uri.assert_not_called()
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_unallowed_range_user_does_not_fallback_to_another_user(self, mock_generate_uri):
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("user", "allowed event", peer_id="peer-a"),
+            create_message("user", "denied event", peer_id="peer-b"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[1]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "1-1"},
+            memory_type="events",
+            uris=[],
+        )
+
+        assert handler.calculate_memory_uris(schema, operation, extract_ctx) == []
+        mock_generate_uri.assert_not_called()
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_invalid_ranges_do_not_fallback_to_all_messages(self, mock_generate_uri):
+        ctx = create_ctx(user_id="support_bot")
+        messages = [create_message("user", "peer event", peer_id="peer-a")]
+        extract_ctx = create_mock_extract_context(messages)
+        extract_ctx.read_message_ranges.side_effect = ValueError("invalid ranges")
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "invalid"},
+            memory_type="events",
+            uris=[],
+        )
+
+        assert handler.calculate_memory_uris(schema, operation, extract_ctx) == []
+        mock_generate_uri.assert_not_called()
+
+    @pytest.mark.parametrize("ranges", ["99", "0,99", " , "])
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_invalid_real_ranges_do_not_fallback_to_conversation_owner(
+        self, mock_generate_uri, ranges
+    ):
+        ctx = create_ctx(user_id="support_bot")
+        messages = [
+            create_message("assistant", "processed", peer_id="peer-a"),
+            create_message("user", "peer event", peer_id="peer-a"),
+        ]
+        extract_ctx = ExtractContext(messages, split_long_text_messages=False)
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids={"peer-a"},
+        )
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": ranges},
+            memory_type="events",
+            uris=[],
+        )
+
+        assert handler.calculate_memory_uris(schema, operation, extract_ctx) == []
+        mock_generate_uri.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_calculate_memory_uris_unallowed_peer_id_does_not_fallback(self, mock_generate_uri):

--- a/tests/session/memory/test_schema_models.py
+++ b/tests/session/memory/test_schema_models.py
@@ -143,6 +143,16 @@ class TestSchemaModelGenerator:
 
         assert "First test field" in model.model_fields["field1"].description
 
+    def test_events_ranges_description_requires_user_source(self, real_registry):
+        events = real_registry.get("events")
+        model = SchemaModelGenerator([events]).create_flat_data_model(events)
+
+        description = model.model_fields["ranges"].description
+
+        assert "MUST include at least one user-role message" in description
+        assert "include both the originating user message and the assistant message" in description
+        assert "Never output assistant-only ranges for events" in description
+
     def test_render_description_template_conditional_branch(self):
         memory_type = MemoryTypeSchema(
             memory_type="conditional",


### PR DESCRIPTION
## 变更说明

当event记忆引用的有效消息范围中只有assistant的消息时，保留正确的记忆归属。此前assistant消息不能作为记忆所有者，即使整段会话只有一个符合条件的用户，该事件操作也可能被丢弃。

本次引入了 fallback 兜底机制：仅当消息范围语法有效、完全处于边界内、非空且不包含用户消息时才允许fallback兜底；兜底机制就是从当前 session 中捞取包含有效的 peer_id 进行返回。

此外，`events.yaml` 现在明确要求事件的 `ranges` 至少包含一条陈述或支撑该事件的 user 消息。如果 assistant 消息对事件进行了确认、规范化或补全，则应同时引用原始 user 消息和 assistant 消息，禁止生成 assistant-only ranges。该 Prompt 约束用于减少异常抽取，代码侧的安全回退仍作为兜底。

## 日志表现

这个问题发生在记忆 URI 解析阶段，因此 session commit 的第一阶段通常仍会成功。但在 event 抽取时如果只抽取了 assistant 消息，由于 assistant 消息无法被写到某一个 peer_id 目录下，因此 event 写入会被跳过：

当仅包含assistant消息的范围无法确定任何归属目标时，`ResolvedOperation.uris` 为空，后续会出现类似日志：

```text
Skipping unresolved memory operation: events(page_id=None): Missing resolved URI
Memory operations applied: Written: 0, Edited: 0, Deleted: 0, Errors: 1
StreamingMemoryUpdater submit finished ... written_uris=[] ... errors=[(..., Missing resolved URI)]
```

## 问题示例

假设客服机器人与 `customer-a` 的会话如下：

```text
[0] user(peer_id=customer-a): 把周五的项目会议改到下午三点。
[1] assistant: 已将项目会议调整为周五 15:00。
```

记忆抽取模型生成事件：

```json
{
  "event_name": "meeting_rescheduled",
  "summary": "项目会议调整到周五 15:00",
  "ranges": "1-1"
}
```

由于 `ranges` 只引用第 1 条助手消息，旧逻辑不能从该范围得到 `customer-a`：

- 如果没有得到任何目标 URI，这条事件会以 `Missing resolved URI` 被跳过。之后机器人召回历史时看不到改期事件，可能仍回答旧会议时间。

修复后，代码确认引用范围有效且只包含助手消息，再从完整会话中识别唯一符合条件的归属 `customer-a`，将事件写入其 peer 记忆目录。若会话中存在多个候选 peer、引用了未授权用户或范围无效，则继续拒绝回退，避免错误归属。

## 人工参与

- [x] 有人工参与实现或评审过程
- [ ] 此 PR 完全由 AI 智能体生成，没有人工参与

## 关联问题

无。

## 变更类型

- [x] 缺陷修复（不破坏现有功能）
- [ ] 新功能（不破坏现有功能）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（无功能变化）
- [ ] 性能优化
- [x] 测试更新

## 主要改动

- 排除助手消息参与 `peer/self` 归属判定，避免将助手消息错误识别为自身归属。
- 对有效的仅包含助手消息的事件范围，回退到完整会话中唯一符合条件的归属目标。
- 对归属目标有歧义、引用未授权用户、范围为空、格式错误或范围越界的情况禁止回退。
- 在事件 `ranges` 的输出 Schema 中明确要求至少包含一条 user 消息；assistant 对事件进行确认或规范化时，同时引用 user 和 assistant，禁止 assistant-only ranges。

## 测试

- [x] 已增加能够证明修复有效的测试
- [x] 新增及现有相关单元测试均在本地通过
- [x] 已在以下平台验证：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行结果：

- `pytest -q --no-cov tests/session/memory/test_schema_models.py tests/session/memory/test_memory_isolation_handler.py`：61 个测试通过
- 使用真实 `MemoryTypeRegistry` 加载 `events.yaml` 并校验三条 ranges 约束：通过
- 对新增 Python 测试执行 `ruff check`：通过
- 执行 `git diff --check upstream/main..HEAD`：通过

扩大执行 `tests/session/memory` 后共有 321 个测试通过、5 个测试失败。这 5 个失败已在当前 `upstream/main@84c0895c` 上逐项复现，分别属于图谱渲染和语言检测问题，与本次修复无关。

## 检查清单

- [x] 代码符合项目现有风格
- [x] 已完成代码自查
- [x] 对不易理解的逻辑进行了必要说明
- [ ] 已同步更新相关文档
- [x] 本次改动未引入新的警告
- [x] 依赖的改动已合入并发布

## 截图

不适用。

## 补充说明

独立代码评审发现无效消息范围可能错误触发归属回退。修正该边界并补充真实 `ExtractContext` 解析测试后，复审未发现严重、重要或次要级别的遗留问题。
