### PR TITLE
fix(queuefs): resume add-resource tasks without reacquiring locks

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -547,14 +547,8 @@ class ResourceService:
                 create_parent=msg.create_parent,
                 **internal_kwargs,
             )
-            stage_result = stage_callback("processing_queue")
-            if inspect.isawaitable(stage_result):
-                await stage_result
             return result
 
-        stage_result = stage_callback("processing_queue")
-        if inspect.isawaitable(stage_result):
-            await stage_result
         return await self._resource_processor.finish_prepared_resource(
             msg.prepared,
             ctx=ctx,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -512,6 +512,49 @@ class TaskTracker:
                 updated.updated_at = self._next_updated_at(task)
                 await self._persist_and_publish("update", updated)
 
+    async def checkpoint(
+        self,
+        task_id: str,
+        *,
+        stage: str,
+        result: Dict[str, Any],
+        account_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        resource_id: Optional[str] = None,
+    ) -> None:
+        """Persist resumable task progress without finalizing the task."""
+        await self._dispatcher.run(
+            lambda: self._checkpoint_on_owner(
+                task_id,
+                stage=stage,
+                result=result,
+                account_id=account_id,
+                user_id=user_id,
+                resource_id=resource_id,
+            )
+        )
+
+    async def _checkpoint_on_owner(
+        self,
+        task_id: str,
+        *,
+        stage: str,
+        result: Dict[str, Any],
+        account_id: Optional[str],
+        user_id: Optional[str],
+        resource_id: Optional[str],
+    ) -> None:
+        async with self._task_locks.acquire(task_id):
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task and task.status in (TaskStatus.PENDING, TaskStatus.RUNNING):
+                updated = deepcopy(task)
+                updated.stage = stage
+                updated.result = deepcopy(result)
+                if resource_id is not None:
+                    updated.resource_id = resource_id
+                updated.updated_at = self._next_updated_at(task)
+                await self._persist_and_publish("update", updated)
+
     async def complete(
         self,
         task_id: str,
@@ -792,9 +835,9 @@ class TaskTracker:
         while self._work_index.has_work(task_id, exclude_work_id=current_work_id):
             await asyncio.sleep(0.05)
 
-    def has_work(self, task_id: str) -> bool:
+    def has_work(self, task_id: str, exclude_work_id: Optional[str] = None) -> bool:
         """Return whether a task still owns durable or active queue work."""
-        return self._work_index.has_work(task_id)
+        return self._work_index.has_work(task_id, exclude_work_id=exclude_work_id)
 
     def register_running_task(self, task_id: str) -> None:
         """Register the current asyncio task so cancellation can interrupt it."""

--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -22,6 +22,8 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+_PROCESSING_QUEUE_STAGE = "processing_queue"
+
 
 class AddResourceProcessor(DequeueHandlerBase):
     """Own an add-resource task until it reaches a terminal state and can be ACKed."""
@@ -82,6 +84,7 @@ class AddResourceProcessor(DequeueHandlerBase):
 
     async def _process(self, msg: AddResourceMsg, data: Dict[str, Any]) -> None:
         telemetry_id = msg.telemetry_id or ""
+        metadata = extract_task_metadata(data)
         ctx = RequestContext(
             user=UserIdentifier(msg.account_id, msg.user_id),
             role=Role(msg.role),
@@ -108,21 +111,41 @@ class AddResourceProcessor(DequeueHandlerBase):
             self.report_success()
             return None
 
-        resource_lock = None
-        try:
-            resource_lock = await self._load_lock(msg, ctx)
-        except Exception as exc:
-            if await self._requeue_lock_handoff(msg, exc):
-                return None
-            await tracker.fail(
+        resumed_result = dict(task.result) if isinstance(task.result, dict) else None
+        resume_processing_queue = (
+            task.stage == _PROCESSING_QUEUE_STAGE and resumed_result is not None
+        )
+        if (
+            not resume_processing_queue
+            and metadata is not None
+            and tracker.has_work(msg.task_id, exclude_work_id=metadata.work_id)
+        ):
+            resume_processing_queue = True
+            resumed_result = {
+                "status": "success",
+                "root_uri": task.resource_id or msg.root_uri,
+            }
+            logger.info(
+                "[AddResource] Resuming task %s from durable downstream work",
                 msg.task_id,
-                f"Invalid lock_handoff: {exc}",
-                account_id=ctx.account_id,
-                user_id=ctx.user.user_id,
             )
-            self.report_error(f"Invalid lock_handoff: {exc}", data)
-            unregister_telemetry(telemetry_id)
-            return None
+
+        resource_lock = None
+        if not resume_processing_queue:
+            try:
+                resource_lock = await self._load_lock(msg, ctx)
+            except Exception as exc:
+                if await self._requeue_lock_handoff(msg, exc):
+                    return None
+                await tracker.fail(
+                    msg.task_id,
+                    f"Invalid lock_handoff: {exc}",
+                    account_id=ctx.account_id,
+                    user_id=ctx.user.user_id,
+                )
+                self.report_error(f"Invalid lock_handoff: {exc}", data)
+                unregister_telemetry(telemetry_id)
+                return None
 
         telemetry = resolve_telemetry(telemetry_id) if telemetry_id else None
         if telemetry is None:
@@ -148,29 +171,45 @@ class AddResourceProcessor(DequeueHandlerBase):
             bind_task_context(msg.task_id, ctx.account_id, ctx.user.user_id),
         ):
             try:
-                metadata = extract_task_metadata(data)
-                await tracker.start(
-                    msg.task_id,
-                    account_id=ctx.account_id,
-                    user_id=ctx.user.user_id,
-                    stage="queued",
-                )
-                result = await self._resource_service.execute_add_resource_job(
-                    msg,
-                    ctx=ctx,
-                    resource_lock=resource_lock,
-                    stage_callback=_set_stage,
-                )
-                if result.get("status") == "error":
-                    errors = result.get("errors") or ["resource processing failed"]
-                    await tracker.fail(
+                result = resumed_result
+                if not resume_processing_queue:
+                    await tracker.start(
                         msg.task_id,
-                        "; ".join(str(error) for error in errors),
                         account_id=ctx.account_id,
                         user_id=ctx.user.user_id,
+                        stage="queued",
                     )
-                    self.report_error("resource processing failed", data)
-                    return None
+                    result = await self._resource_service.execute_add_resource_job(
+                        msg,
+                        ctx=ctx,
+                        resource_lock=resource_lock,
+                        stage_callback=_set_stage,
+                    )
+                    if result.get("status") == "error":
+                        errors = result.get("errors") or ["resource processing failed"]
+                        await tracker.fail(
+                            msg.task_id,
+                            "; ".join(str(error) for error in errors),
+                            account_id=ctx.account_id,
+                            user_id=ctx.user.user_id,
+                        )
+                        self.report_error("resource processing failed", data)
+                        return None
+
+                if result is None:
+                    raise RuntimeError("AddResource recovery result is missing")
+                if task.stage != _PROCESSING_QUEUE_STAGE or task.result is None:
+                    await tracker.checkpoint(
+                        msg.task_id,
+                        stage=_PROCESSING_QUEUE_STAGE,
+                        result=result,
+                        account_id=ctx.account_id,
+                        user_id=ctx.user.user_id,
+                        resource_id=result.get("root_uri"),
+                    )
+
+                if metadata is None:
+                    raise RuntimeError("AddResource queue message is missing task work metadata")
                 await tracker.wait_for_descendants(msg.task_id, metadata.work_id)
                 result["queue_status"] = request_wait_tracker.build_queue_status(telemetry_id)
                 record_resource_queue_metrics(

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -787,15 +787,21 @@ async def test_prepared_add_resource_job_forwards_processing_mode():
 async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
     final_uri = "viking://resources/真实文档标题"
     service = SimpleNamespace(
-        execute_add_resource_job=AsyncMock(
-            return_value={"status": "success", "root_uri": final_uri}
-        ),
+        execute_add_resource_job=AsyncMock(),
         _link_resource_reason_memory=AsyncMock(),
     )
     task_tracker = SimpleNamespace(
-        create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
+        create=AsyncMock(
+            return_value=SimpleNamespace(
+                status=TaskStatus.RUNNING,
+                stage="processing_queue",
+                result={"status": "success", "root_uri": final_uri},
+                resource_id=final_uri,
+            )
+        ),
         start=AsyncMock(),
         update_stage=AsyncMock(),
+        checkpoint=AsyncMock(),
         complete=AsyncMock(),
         fail=AsyncMock(),
         wait_for_descendants=AsyncMock(),
@@ -803,11 +809,6 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
     monkeypatch.setattr(
         "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
         Mock(return_value=task_tracker),
-    )
-    queue_manager = SimpleNamespace(enqueue=AsyncMock())
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.get_queue_manager",
-        Mock(return_value=queue_manager),
     )
     processor = AddResourceProcessor(
         service,
@@ -828,16 +829,12 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
 
     data = msg.to_dict()
     data[TASK_WORK_ID_FIELD] = "work-1"
+    load_lock = AsyncMock(return_value=None)
+    monkeypatch.setattr(processor, "_load_lock", load_lock)
     await processor._process(msg, data)
 
-    task_tracker.create.assert_awaited_once_with(
-        "add_resource",
-        resource_id=None,
-        account_id="account-1",
-        user_id="user-1",
-        task_id="task-1",
-        meta={"source_path": ""},
-    )
+    service.execute_add_resource_job.assert_not_awaited()
+    load_lock.assert_not_awaited()
     task_tracker.complete.assert_awaited_once_with(
         "task-1",
         {
@@ -862,8 +859,6 @@ async def test_add_resource_processor_persists_final_resource_uri(monkeypatch):
         user_id="user-1",
         resource_id=final_uri,
     )
-    assert await processor._requeue_lock_handoff(msg, RuntimeError("stale lock"))
-    assert queue_manager.enqueue.await_args.args[0] == QueueManager.ADD_RESOURCE
 
 
 def test_feishu_direct_submission_requires_configured_auth(monkeypatch):


### PR DESCRIPTION
## Description

AddResource now persists a resumable `processing_queue` checkpoint after ingestion succeeds. A replayed AddResource message resumes descendant waiting and final post-processing without adopting the lock already transferred to Semantic work.

### Expected Behavior

**Before:** after AddResource enqueues Semantic work, a service restart replays both messages. AddResource tries to adopt the transferred `lock_handoff` again and may fail with `already adopted`.

**After:** AddResource restores the persisted result, skips lock adoption and ingestion, waits for its Semantic descendants, and completes the remaining post-processing.

**Example:** for task `T1`, AddResource imports `viking://resources/repo` and enqueues its Semantic message. After restart, the AddResource replay keeps `task_id=T1` and `root_uri=viking://resources/repo`, but resumes at `processing_queue` instead of importing the resource again.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3891

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Persist AddResource stage, result and resolved resource URI as one non-terminal checkpoint.
- Resume replayed AddResource work without acquiring the ingestion lock; use durable descendant work to cover the enqueue/checkpoint crash window.
- Remove the old request-layer `processing_queue` callbacks and update the existing recovery contract test.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

- `pytest -q tests/parse/test_feishu_parser_api.py -k 'add_resource_processor_persists_final_resource_uri or prepared_add_resource_job' --no-cov`
- `pytest -q tests/test_task_tracker.py tests/test_task_tracker_concurrency.py --no-cov`
- `ruff check` and `ruff format --check` on changed files

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No QueueFS message schema or lock handoff protocol changes are required. Existing tasks without the checkpoint keep the previous recovery behavior; newly checkpointed tasks use the optimized resume path.
