### PR TITLE
test(session): cover offline memory pipeline

### DIFF
--- a/tests/session/test_local_memory_pipeline.py
+++ b/tests/session/test_local_memory_pipeline.py
@@ -8,9 +8,6 @@ import asyncio
 from openviking.message import TextPart
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOperations
-from openviking.session.memory.memory_type_registry import create_default_registry
-from openviking.session.memory.memory_updater import ExtractContext, MemoryUpdater
-from openviking.utils.time_utils import get_current_timestamp
 
 
 async def _wait_for_task(task_id: str, timeout: float = 30.0) -> dict:
@@ -30,68 +27,40 @@ async def test_local_commit_writes_and_recalls_preference_memory(
     monkeypatch,
 ):
     memory_uri = "viking://user/default/memories/preferences/default/python_code_style.md"
+    operations = ResolvedOperations(
+        upsert_operations=[
+            ResolvedOperation(
+                memory_fields={
+                    "user": "default",
+                    "topic": "python_code_style",
+                    "content": "- Prefers double quotes in Python code.",
+                },
+                memory_type="preferences",
+                uris=[memory_uri],
+            )
+        ],
+        delete_file_contents=[],
+        errors=[],
+    )
 
-    async def extract_fixed_preference(*, messages, ctx, **_kwargs):
-        operations = ResolvedOperations(
-            upsert_operations=[
-                ResolvedOperation(
-                    memory_fields={
-                        "user": "default",
-                        "topic": "python_code_style",
-                        "content": "- Prefers double quotes in Python code.",
-                    },
-                    memory_type="preferences",
-                    uris=[memory_uri],
-                )
-            ],
-            delete_file_contents=[],
-            errors=[],
-        )
-        updater = MemoryUpdater(
-            registry=create_default_registry(),
-            vikingdb=None,
-        )
-        await updater.apply_operations(
-            operations,
-            ctx,
-            extract_context=ExtractContext(messages),
-        )
-        memory = await service.viking_fs.read_file(memory_uri, ctx=ctx)
-        vector = service.vikingdb_manager.get_embedder().embed(memory).dense_vector
-        timestamp = get_current_timestamp()
-        await service.vikingdb_manager.upsert(
-            {
-                "uri": memory_uri,
-                "parent_uri": "viking://user/default/memories/preferences/default",
-                "is_leaf": True,
-                "abstract": "Prefers double quotes in Python code.",
-                "context_type": "memory",
-                "category": "preferences",
-                "created_at": timestamp,
-                "updated_at": timestamp,
-                "active_count": 0,
-                "vector": vector,
-                "meta": {},
-                "related_uri": [],
-                "account_id": ctx.account_id,
-                "owner_space": ctx.user.user_id,
-                "level": 2,
-            },
-            ctx=ctx,
-        )
-        return {"contexts": [], "session_skills": []}
+    class FixedOrchestrator:
+        def __init__(self, isolation_handler):
+            assert isolation_handler.allowed_memory_types == {"preferences"}
+
+        async def run(self):
+            return operations, []
 
     session = client(session_id="local-memory-pipeline")
     await session.ensure_exists()
-    session.meta.memory_policy = {
+    memory_policy = {
         "peer": {"enabled": False},
         "working_memory": {"enabled": False},
         "memory_types": ["preferences"],
     }
     monkeypatch.setattr(
         session._session_compressor,
-        "extract_long_term_memories",
-        extract_fixed_preference,
+        "_get_or_create_react",
+        lambda **kwargs: FixedOrchestrator(kwargs["isolation_handler"]),
     )
 
     session.add_message(
@@ -99,10 +68,12 @@ async def test_local_commit_writes_and_recalls_preference_memory(
         [TextPart("When you generate Python code, use double quotes.")],
     )
 
-    commit = await session.commit_async()
+    commit = await session.commit_async(memory_policy=memory_policy)
     task = await _wait_for_task(commit["task_id"])
 
     assert task["status"] == "completed", task.get("error")
+    queue_status = await service.resources.wait_processed(timeout=30.0)
+    assert all(status["error_count"] == 0 for status in queue_status.values()), queue_status
     memory = await service.viking_fs.read_file(memory_uri, ctx=request_context)
     assert "Prefers double quotes in Python code." in memory
 

--- a/tests/session/test_local_memory_pipeline.py
+++ b/tests/session/test_local_memory_pipeline.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Offline integration coverage for the Session-to-Memory pipeline."""
+
+import asyncio
+
+from openviking.message import TextPart
+from openviking.service.task_tracker import get_task_tracker
+from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOperations
+from openviking.session.memory.memory_type_registry import create_default_registry
+from openviking.session.memory.memory_updater import ExtractContext, MemoryUpdater
+from openviking.utils.time_utils import get_current_timestamp
+
+
+async def _wait_for_task(task_id: str, timeout: float = 30.0) -> dict:
+    tracker = get_task_tracker()
+    for _ in range(int(timeout / 0.1)):
+        task = await tracker.get(task_id)
+        if task and task.status.value in {"completed", "failed"}:
+            return task.to_dict()
+        await asyncio.sleep(0.1)
+    raise TimeoutError(f"Task {task_id} did not complete within {timeout}s")
+
+
+async def test_local_commit_writes_and_recalls_preference_memory(
+    client,
+    service,
+    request_context,
+    monkeypatch,
+):
+    memory_uri = "viking://user/default/memories/preferences/default/python_code_style.md"
+
+    async def extract_fixed_preference(*, messages, ctx, **_kwargs):
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={
+                        "user": "default",
+                        "topic": "python_code_style",
+                        "content": "- Prefers double quotes in Python code.",
+                    },
+                    memory_type="preferences",
+                    uris=[memory_uri],
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+        updater = MemoryUpdater(
+            registry=create_default_registry(),
+            vikingdb=None,
+        )
+        await updater.apply_operations(
+            operations,
+            ctx,
+            extract_context=ExtractContext(messages),
+        )
+        memory = await service.viking_fs.read_file(memory_uri, ctx=ctx)
+        vector = service.vikingdb_manager.get_embedder().embed(memory).dense_vector
+        timestamp = get_current_timestamp()
+        await service.vikingdb_manager.upsert(
+            {
+                "uri": memory_uri,
+                "parent_uri": "viking://user/default/memories/preferences/default",
+                "is_leaf": True,
+                "abstract": "Prefers double quotes in Python code.",
+                "context_type": "memory",
+                "category": "preferences",
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "active_count": 0,
+                "vector": vector,
+                "meta": {},
+                "related_uri": [],
+                "account_id": ctx.account_id,
+                "owner_space": ctx.user.user_id,
+                "level": 2,
+            },
+            ctx=ctx,
+        )
+        return {"contexts": [], "session_skills": []}
+
+    session = client(session_id="local-memory-pipeline")
+    await session.ensure_exists()
+    session.meta.memory_policy = {
+        "peer": {"enabled": False},
+        "working_memory": {"enabled": False},
+        "memory_types": ["preferences"],
+    }
+    monkeypatch.setattr(
+        session._session_compressor,
+        "extract_long_term_memories",
+        extract_fixed_preference,
+    )
+
+    session.add_message(
+        "user",
+        [TextPart("When you generate Python code, use double quotes.")],
+    )
+
+    commit = await session.commit_async()
+    task = await _wait_for_task(commit["task_id"])
+
+    assert task["status"] == "completed", task.get("error")
+    memory = await service.viking_fs.read_file(memory_uri, ctx=request_context)
+    assert "Prefers double quotes in Python code." in memory
+
+    result = await service.search.find(
+        query="What Python code style does the user prefer?",
+        ctx=request_context,
+        target_uri="viking://user/default/memories",
+        score_threshold=-1.0,
+        level=[2],
+    )
+
+    assert memory_uri in {item.uri for item in result.memories}

--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import threading
 import uuid
@@ -19,6 +20,16 @@ class MockLocalAGFS:
         self._pathlocks_guard = threading.Lock()
         self._pathlocks = {}
         self._pathlock_leases = {}
+        self._queue_guard = threading.Lock()
+        self._queues = {}
+        self._queue_processing = {}
+
+    @staticmethod
+    def _queue_operation(path):
+        parts = str(path).strip("/").split("/")
+        if len(parts) >= 3 and parts[-3] == "queue":
+            return parts[-2], parts[-1]
+        return None
 
     def _resolve(self, path):
         if str(path).startswith("viking://"):
@@ -87,6 +98,23 @@ class MockLocalAGFS:
         }
 
     def writeto(self, path, content, ctx=None, **kwargs):
+        queue_operation = self._queue_operation(path)
+        if queue_operation:
+            queue_name, operation = queue_operation
+            raw = content.decode("utf-8") if isinstance(content, bytes) else str(content)
+            with self._queue_guard:
+                if operation == "enqueue":
+                    message_id = str(uuid.uuid4())
+                    self._queues.setdefault(queue_name, []).append({"id": message_id, "data": raw})
+                    return message_id
+                if operation == "ack":
+                    self._queue_processing.setdefault(queue_name, {}).pop(raw, None)
+                    return ""
+                if operation == "clear":
+                    self._queues[queue_name] = []
+                    self._queue_processing[queue_name] = {}
+                    return ""
+
         p = self._resolve(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(content, str):
@@ -102,6 +130,25 @@ class MockLocalAGFS:
         return self.writeto(path, content, ctx, **kwargs)
 
     def read_file(self, path, ctx=None, **kwargs):
+        queue_operation = self._queue_operation(path)
+        if queue_operation:
+            queue_name, operation = queue_operation
+            with self._queue_guard:
+                queue = self._queues.setdefault(queue_name, [])
+                processing = self._queue_processing.setdefault(queue_name, {})
+                if operation == "dequeue":
+                    if not queue:
+                        return b"{}"
+                    message = queue.pop(0)
+                    processing[message["id"]] = message
+                    return json.dumps(message).encode("utf-8")
+                if operation == "peek":
+                    return json.dumps(queue[0] if queue else {}).encode("utf-8")
+                if operation == "size":
+                    return str(len(queue)).encode("utf-8")
+                if operation == "messages":
+                    return json.dumps(queue + list(processing.values())).encode("utf-8")
+
         p = self._resolve(path)
         if not p.exists():
             raise FileNotFoundError(path)
@@ -176,9 +223,47 @@ class MockLocalAGFS:
 
     pathlock_acquire_exact = pathlock_acquire_tree
 
+    def pathlock_acquire_exact_batch(
+        self,
+        ctx,
+        paths,
+        timeout_secs=0.0,
+        owner_lease_ref=None,
+    ):
+        del ctx, owner_lease_ref
+        with self._pathlocks_guard:
+            locks = [
+                self._pathlocks.setdefault(path, threading.Lock()) for path in sorted(set(paths))
+            ]
+
+        acquired = []
+        try:
+            for lock in locks:
+                if not lock.acquire(timeout=timeout_secs):
+                    raise TimeoutError("timed out acquiring test path lock batch")
+                acquired.append(lock)
+        except BaseException:
+            for lock in reversed(acquired):
+                lock.release()
+            raise
+
+        lease_ref = str(uuid.uuid4())
+        lease = {
+            "lease_ref": lease_ref,
+            "ownership_ref": str(uuid.uuid4()),
+            "owner_id": "mock-local-agfs",
+            "owned": True,
+        }
+        with self._pathlocks_guard:
+            self._pathlock_leases[lease_ref] = locks
+        return lease
+
     def pathlock_release(self, ctx, owned_lease_ref):
         del ctx
         lease_ref = owned_lease_ref["lease_ref"]
         with self._pathlocks_guard:
-            lock = self._pathlock_leases.pop(lease_ref)
-        lock.release()
+            locks = self._pathlock_leases.pop(lease_ref)
+        if not isinstance(locks, list):
+            locks = [locks]
+        for lock in reversed(locks):
+            lock.release()


### PR DESCRIPTION
## Summary

- Add one deterministic offline test for Session Commit memory processing.
- Write a preference memory through the real `MemoryUpdater`.
- Index the memory with the local embedder and Local VectorDB.
- Verify Search recalls the generated memory URI.

The fixed extraction adapter replaces only remote LLM output.

Closes #4009.

## Verification

- `.venv/bin/python -m pytest -q -o addopts='' tests/session/test_local_memory_pipeline.py`
- `.venv/bin/python -m pytest -q -o addopts='' tests/session/test_session_commit.py tests/session/test_local_memory_pipeline.py`
- `uvx ruff format --check tests/session/test_local_memory_pipeline.py`
- `uvx ruff check tests/session/test_local_memory_pipeline.py`