### PR TITLE
test(mock-agfs): align test double with production AGFS

### DIFF
--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -40,8 +40,8 @@ class MockLocalAGFS:
     @staticmethod
     def _queue_operation(path):
         parts = str(path).strip("/").split("/")
-        if len(parts) >= 3 and parts[-3] == "queue":
-            return parts[-2], parts[-1]
+        if len(parts) >= 3 and parts[0] == "queue":
+            return "/".join(parts[1:-1]), parts[-1]
         return None
 
     def _resolve(self, path):
@@ -167,19 +167,20 @@ class MockLocalAGFS:
         if queue_operation:
             queue_name, operation = queue_operation
             raw = content.decode("utf-8") if isinstance(content, bytes) else str(content)
+            written = f"Written {len(raw.encode('utf-8'))} bytes"
             with self._queue_guard:
                 if operation == "enqueue":
                     message_id = str(uuid.uuid4())
                     message = {"id": message_id, "data": raw}
                     self._queues.setdefault(queue_name, []).append(message)
-                    return message_id
+                    return written
                 if operation == "ack":
                     self._queue_processing.setdefault(queue_name, {}).pop(raw, None)
-                    return ""
+                    return written
                 if operation == "clear":
                     self._queues[queue_name] = []
                     self._queue_processing[queue_name] = {}
-                    return ""
+                    return written
 
         p = self._resolve(path)
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -30,6 +30,7 @@ class MockLocalAGFS:
         self._pathlocks_guard = threading.Lock()
         self._pathlocks = {}
         self._pathlock_leases = {}
+        self._pathlock_handoffs = {}
         self._queue_guard = threading.Lock()
         self._queues = {}
         self._queue_processing = {}
@@ -375,7 +376,7 @@ class MockLocalAGFS:
             "ownership_ref": str(uuid.uuid4()),
             "owner_id": "mock-local-agfs",
             "owned": True,
-            "lock_paths": [{"path": p, "kind": "exact"} for p in paths],
+            "lock_paths": list(paths),
         }
         with self._pathlocks_guard:
             self._pathlock_leases[lease_ref] = dict(locks)
@@ -447,7 +448,9 @@ class MockLocalAGFS:
         if not owned_lease_ref.get("owned", True):
             raise ValueError("cannot release a borrowed lease")
         with self._pathlocks_guard:
-            locks = self._pathlock_leases.pop(lease_ref)
+            locks = self._pathlock_leases.pop(lease_ref, None)
+        if locks is None:
+            raise ValueError("cannot release an unknown lease")
         if not isinstance(locks, dict):
             locks = {owned_lease_ref.get("lease_ref", ""): locks}
         for lock in reversed(list(locks.values())):
@@ -486,8 +489,12 @@ class MockLocalAGFS:
             if lease_ref not in self._pathlock_leases:
                 raise ValueError("cannot hand off an unknown lease")
         return {
+            "lease_ref": lease_ref,
             "owner_id": owned_lease_ref.get("owner_id") or "mock-local-agfs",
             "lock_paths": owned_lease_ref.get("lock_paths", []),
+            "covered_paths": [
+                {"path": path, "kind": "exact"} for path in owned_lease_ref.get("lock_paths", [])
+            ],
         }
 
     def pathlock_handoff(self, ctx, owned_lease_ref):
@@ -495,19 +502,41 @@ class MockLocalAGFS:
         lease_ref = owned_lease_ref["lease_ref"]
         with self._pathlocks_guard:
             locks = self._pathlock_leases.pop(lease_ref, None)
-        if locks is None:
-            raise ValueError("cannot hand off an unknown lease")
-        if isinstance(locks, dict):
-            for lock in reversed(list(locks.values())):
-                if lock.locked():
-                    lock.release()
+            if locks is None:
+                raise ValueError("cannot hand off an unknown lease")
+            self._pathlock_handoffs[lease_ref] = {
+                "locks": locks,
+                "owner_id": owned_lease_ref.get("owner_id"),
+                "lock_paths": list(owned_lease_ref.get("lock_paths", [])),
+                "covered_paths": [
+                    {"path": path, "kind": "exact"}
+                    for path in owned_lease_ref.get("lock_paths", [])
+                ],
+            }
 
     def pathlock_adopt(self, ctx, handoff_ref):
+        del ctx
+        lease_ref = handoff_ref.get("lease_ref")
         lock_paths = handoff_ref.get("lock_paths", [])
-        if not lock_paths:
-            raise ValueError("handoff has no lock paths to adopt")
-        paths = [lp["path"] for lp in lock_paths]
-        return self.pathlock_acquire_exact_batch(ctx, paths)
+        owner_id = handoff_ref.get("owner_id") or handoff_ref.get("handle_id")
+        if not lease_ref or not owner_id or not lock_paths:
+            raise ValueError("handoff requires lease_ref, owner_id, and lock_paths")
+        paths = [lp["path"] if isinstance(lp, dict) else lp for lp in lock_paths]
+        covered_paths = handoff_ref.get("covered_paths", [])
+        with self._pathlocks_guard:
+            pending = self._pathlock_handoffs.pop(lease_ref, None)
+        if pending is None:
+            raise ValueError("cannot adopt a lease that is not pending handoff")
+        if (
+            owner_id != pending["owner_id"]
+            or paths != pending["lock_paths"]
+            or covered_paths != pending["covered_paths"]
+        ):
+            with self._pathlocks_guard:
+                self._pathlock_handoffs[lease_ref] = pending
+            raise ValueError("handoff metadata does not match the pending lease")
+        locks = pending["locks"]
+        return self._make_owned_lease(list(locks.items()), paths)
 
     def pathlock_is_locked(self, ctx, path, ignore_stale=True):
         del ctx, ignore_stale

--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -1,8 +1,13 @@
+import json
+import re
 import shutil
 import threading
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
+
+_ISO_TIMESTAMP = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class MockLocalAGFS:
@@ -10,6 +15,12 @@ class MockLocalAGFS:
     A mock implementation of the AGFS binding client that operates on a local
     directory. Useful for tests where running the real RAGFS binding is not
     feasible or desired.
+
+    The mock mirrors the synchronous AGFS interface the production code
+    dispatches through AsyncAGFSClient (see openviking/pyagfs/async_client.py).
+    Keep the method surface in sync with AGFSSyncClientProtocol and the
+    pathlock_* family; the contract tests in tests/utils/test_mock_agfs_contract.py
+    enforce that.
     """
 
     def __init__(self, config=None, root_path=None):
@@ -19,6 +30,16 @@ class MockLocalAGFS:
         self._pathlocks_guard = threading.Lock()
         self._pathlocks = {}
         self._pathlock_leases = {}
+        self._queue_guard = threading.Lock()
+        self._queues = {}
+        self._queue_processing = {}
+
+    @staticmethod
+    def _queue_operation(path):
+        parts = str(path).strip("/").split("/")
+        if len(parts) >= 3 and parts[-3] == "queue":
+            return parts[-2], parts[-1]
+        return None
 
     def _resolve(self, path):
         if str(path).startswith("viking://"):
@@ -30,8 +51,14 @@ class MockLocalAGFS:
     def exists(self, path, ctx=None):
         return self._resolve(path).exists()
 
-    def mkdir(self, path, ctx=None, parents=True, exist_ok=True):
+    def mkdir(self, path, mode="755", ctx=None, parents=True, exist_ok=True):
         self._resolve(path).mkdir(parents=parents, exist_ok=exist_ok)
+        return {"path": path}
+
+    def ensure_parent_dirs(self, path, mode="755", ctx=None):
+        parent = self._resolve(path).parent
+        parent.mkdir(parents=True, exist_ok=True)
+        return {"path": str(parent)}
 
     def ls(self, path, ctx=None, **kwargs):
         p = self._resolve(path)
@@ -86,7 +113,80 @@ class MockLocalAGFS:
             "next_token": str(end) if end < len(matches) else None,
         }
 
+    def tree_directory(
+        self,
+        path,
+        show_hidden=False,
+        node_limit=None,
+        level_limit=None,
+        ctx=None,
+    ):
+        del ctx
+        root = self._resolve(path)
+        if not root.exists():
+            return []
+        entries = []
+
+        def _walk(current: Path, depth: int) -> None:
+            if node_limit is not None and len(entries) >= node_limit:
+                return
+            if level_limit is not None and depth > level_limit:
+                return
+            for item in sorted(current.iterdir()):
+                if node_limit is not None and len(entries) >= node_limit:
+                    return
+                if not show_hidden and item.name.startswith("."):
+                    continue
+                rel = item.relative_to(root)
+                entries.append(
+                    {
+                        "path": f"{str(path).rstrip('/')}/{rel.as_posix()}",
+                        "rel_path": rel.as_posix(),
+                        "info": {
+                            "name": item.name,
+                            "size": item.stat().st_size if item.is_file() else 0,
+                            "mode": item.stat().st_mode & 0o777,
+                            "modTime": datetime.fromtimestamp(
+                                item.stat().st_mtime, tz=timezone.utc
+                            ).strftime(_ISO_TIMESTAMP),
+                            "isDir": item.is_dir(),
+                        },
+                    }
+                )
+                if item.is_dir():
+                    _walk(item, depth + 1)
+
+        _walk(root, 0)
+        return entries
+
     def writeto(self, path, content, ctx=None, **kwargs):
+        queue_operation = self._queue_operation(path)
+        if queue_operation:
+            queue_name, operation = queue_operation
+            raw = content.decode("utf-8") if isinstance(content, bytes) else str(content)
+            with self._queue_guard:
+                if operation == "enqueue":
+                    try:
+                        parsed = json.loads(raw)
+                    except (ValueError, TypeError):
+                        parsed = None
+                    if isinstance(parsed, dict):
+                        message = dict(parsed)
+                        message.setdefault("id", str(uuid.uuid4()))
+                        message_id = message["id"]
+                    else:
+                        message_id = str(uuid.uuid4())
+                        message = {"id": message_id, "data": raw}
+                    self._queues.setdefault(queue_name, []).append(message)
+                    return message_id
+                if operation == "ack":
+                    self._queue_processing.setdefault(queue_name, {}).pop(raw, None)
+                    return ""
+                if operation == "clear":
+                    self._queues[queue_name] = []
+                    self._queue_processing[queue_name] = {}
+                    return ""
+
         p = self._resolve(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(content, str):
@@ -102,6 +202,25 @@ class MockLocalAGFS:
         return self.writeto(path, content, ctx, **kwargs)
 
     def read_file(self, path, ctx=None, **kwargs):
+        queue_operation = self._queue_operation(path)
+        if queue_operation:
+            queue_name, operation = queue_operation
+            with self._queue_guard:
+                queue = self._queues.setdefault(queue_name, [])
+                processing = self._queue_processing.setdefault(queue_name, {})
+                if operation == "dequeue":
+                    if not queue:
+                        return b"{}"
+                    message = queue.pop(0)
+                    processing[message["id"]] = message
+                    return json.dumps(message).encode("utf-8")
+                if operation == "peek":
+                    return json.dumps(queue[0] if queue else {}).encode("utf-8")
+                if operation == "size":
+                    return str(len(queue)).encode("utf-8")
+                if operation == "messages":
+                    return json.dumps(queue + list(processing.values())).encode("utf-8")
+
         p = self._resolve(path)
         if not p.exists():
             raise FileNotFoundError(path)
@@ -113,16 +232,20 @@ class MockLocalAGFS:
     def cat(self, path, ctx=None, **kwargs):
         return self.read_file(path, ctx, **kwargs)
 
-    def rm(self, path, recursive=False, ctx=None):
+    def rm(self, path, recursive=False, force=True, ctx=None):
         p = self._resolve(path)
-        if p.exists():
-            if p.is_dir():
-                if recursive:
-                    shutil.rmtree(p)
-                else:
-                    p.rmdir()
+        if not p.exists():
+            if force:
+                return {"removed": path}
+            raise FileNotFoundError(path)
+        if p.is_dir():
+            if recursive:
+                shutil.rmtree(p)
             else:
-                p.unlink()
+                p.rmdir()
+        else:
+            p.unlink()
+        return {"removed": path}
 
     def delete_temp(self, path, ctx=None):
         self.rm(path, recursive=True, ctx=ctx)
@@ -132,6 +255,78 @@ class MockLocalAGFS:
         d = self._resolve(dst)
         d.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(s), str(d))
+        return {"moved": dst}
+
+    def copy_within_mount(self, src_path, dst_path, ctx=None):
+        del ctx
+        src = self._resolve(src_path)
+        dst = self._resolve(dst_path)
+        if not src.exists():
+            raise FileNotFoundError(src_path)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_dir():
+            shutil.copytree(str(src), str(dst), dirs_exist_ok=True)
+        else:
+            shutil.copy2(str(src), str(dst))
+        return {"performed": True}
+
+    def grep(self, **kwargs):
+        path = kwargs.get("path", "")
+        pattern = kwargs.get("pattern", "")
+        exclude_path = kwargs.get("exclude_path")
+        node_limit = kwargs.get("node_limit")
+        case_insensitive = kwargs.get("case_insensitive", False)
+        root = self._resolve(path)
+        if not root.exists():
+            return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+        flags = re.IGNORECASE if case_insensitive else 0
+        try:
+            regex = re.compile(pattern, flags)
+        except re.error:
+            return {"matches": [], "count": 0, "match_count": 0, "files_scanned": 0}
+
+        matches = []
+        files_scanned = 0
+        exclude_prefix = str(exclude_path) if exclude_path else None
+        for item in sorted(root.rglob("*")):
+            if not item.is_file():
+                continue
+            rel = item.relative_to(root)
+            if exclude_prefix is not None and str(rel).startswith(exclude_prefix):
+                continue
+            files_scanned += 1
+            try:
+                text = item.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                if regex.search(line):
+                    matches.append(
+                        {
+                            "file": str(rel),
+                            "line": line_number,
+                            "line_number": line_number,
+                            "content": line,
+                        }
+                    )
+                    if node_limit is not None and len(matches) >= node_limit:
+                        break
+            if node_limit is not None and len(matches) >= node_limit:
+                break
+
+        return {
+            "matches": matches,
+            "count": len(matches),
+            "match_count": len(matches),
+            "files_scanned": files_scanned,
+        }
+
+    def system_sync_status(self, path, ctx=None):
+        return {"status": "synced", "path": path}
+
+    def system_sync_retry(self, path, ctx=None):
+        return {"status": "ok", "path": path}
 
     def stat(self, path, ctx=None):
         p = self._resolve(path)
@@ -148,37 +343,187 @@ class MockLocalAGFS:
     def bind_request_context(self, ctx):
         return MagicMock(__enter__=lambda x: None, __exit__=lambda x, y, z: None)
 
-    def pathlock_acquire_tree(
-        self,
-        ctx,
-        path,
-        timeout_secs=0.0,
-        owner_lease_ref=None,
-    ):
-        del ctx, owner_lease_ref
-        with self._pathlocks_guard:
-            lock = self._pathlocks.setdefault(path, threading.Lock())
+    # ========== Pathlock family ==========
 
+    def _lease_locks(self, path):
+        with self._pathlocks_guard:
+            return self._pathlocks.setdefault(path, threading.Lock())
+
+    def _acquire_lock(self, path, timeout_secs):
+        lock = self._lease_locks(path)
         acquired = lock.acquire(timeout=timeout_secs)
         if not acquired:
             raise TimeoutError(f"timed out acquiring test path lock: {path}")
+        return lock
 
+    def _acquire_paths(self, paths, timeout_secs):
+        ordered = sorted(set(paths))
+        locks = []
+        try:
+            for path in ordered:
+                locks.append((path, self._acquire_lock(path, timeout_secs)))
+        except BaseException:
+            for _, lock in reversed(locks):
+                lock.release()
+            raise
+        return locks
+
+    def _make_owned_lease(self, locks, paths):
         lease_ref = str(uuid.uuid4())
         lease = {
             "lease_ref": lease_ref,
             "ownership_ref": str(uuid.uuid4()),
             "owner_id": "mock-local-agfs",
             "owned": True,
+            "lock_paths": [{"path": p, "kind": "exact"} for p in paths],
         }
         with self._pathlocks_guard:
-            self._pathlock_leases[lease_ref] = lock
+            self._pathlock_leases[lease_ref] = dict(locks)
         return lease
 
-    pathlock_acquire_exact = pathlock_acquire_tree
+    def pathlock_acquire_exact(self, ctx, path, timeout_secs=0.0, owner_lease_ref=None):
+        del ctx, owner_lease_ref
+        locks = self._acquire_paths([path], timeout_secs)
+        return self._make_owned_lease(locks, [path])
 
-    def pathlock_release(self, ctx, owned_lease_ref):
+    pathlock_acquire_tree = pathlock_acquire_exact
+
+    def pathlock_acquire_exact_batch(self, ctx, paths, timeout_secs=0.0, owner_lease_ref=None):
+        del ctx, owner_lease_ref
+        ordered = sorted(set(paths))
+        locks = self._acquire_paths(ordered, timeout_secs)
+        return self._make_owned_lease(locks, ordered)
+
+    pathlock_acquire_tree_batch = pathlock_acquire_exact_batch
+
+    def pathlock_acquire_exact_tree_batch(
+        self, ctx, exact_paths, tree_paths, timeout_secs=0.0, owner_lease_ref=None
+    ):
+        del ctx, owner_lease_ref
+        ordered = sorted(set(exact_paths) | set(tree_paths))
+        locks = self._acquire_paths(ordered, timeout_secs)
+        return self._make_owned_lease(locks, ordered)
+
+    def pathlock_acquire_batch(self, ctx, requests, timeout_secs=0.0, owner_lease_ref=None):
+        del owner_lease_ref
+        if not requests:
+            raise ValueError("pathlock request batch must not be empty")
+        paths = []
+        for request in requests:
+            path = request.get("path")
+            if not path or not path.startswith("/"):
+                raise ValueError("pathlock request.path must be an absolute path")
+            if request.get("kind") not in {"exact", "tree"}:
+                raise ValueError("pathlock request.kind must be 'exact' or 'tree'")
+            paths.append(path)
+        return self.pathlock_acquire_exact_batch(ctx, paths, timeout_secs)
+
+    def pathlock_as_borrowed(self, ctx, owned_lease_ref):
         del ctx
         lease_ref = owned_lease_ref["lease_ref"]
         with self._pathlocks_guard:
-            lock = self._pathlock_leases.pop(lease_ref)
-        lock.release()
+            if lease_ref not in self._pathlock_leases:
+                raise ValueError("cannot borrow an unknown lease")
+        return {
+            "lease_ref": lease_ref,
+            "ownership_ref": owned_lease_ref.get("ownership_ref"),
+            "owner_id": owned_lease_ref.get("owner_id"),
+            "owned": False,
+        }
+
+    def pathlock_refresh(self, ctx, owned_lease_ref):
+        del ctx
+        lease_ref = owned_lease_ref["lease_ref"]
+        with self._pathlocks_guard:
+            if lease_ref not in self._pathlock_leases:
+                return "lost"
+        return "refreshed"
+
+    def pathlock_release(self, ctx, owned_lease_ref):
+        del ctx
+        if isinstance(owned_lease_ref, str):
+            raise TypeError("pathlock_release requires a lease ref dict, not a raw string")
+        lease_ref = owned_lease_ref["lease_ref"]
+        if not owned_lease_ref.get("owned", True):
+            raise ValueError("cannot release a borrowed lease")
+        with self._pathlocks_guard:
+            locks = self._pathlock_leases.pop(lease_ref)
+        if not isinstance(locks, dict):
+            locks = {owned_lease_ref.get("lease_ref", ""): locks}
+        for lock in reversed(list(locks.values())):
+            if lock.locked():
+                lock.release()
+
+    def pathlock_release_selected(self, ctx, owned_lease_ref, lock_paths):
+        del ctx
+        lease_ref = owned_lease_ref["lease_ref"]
+        if not owned_lease_ref.get("owned", True):
+            raise ValueError("cannot release a borrowed lease")
+        with self._pathlocks_guard:
+            locks = self._pathlock_leases.get(lease_ref)
+        if locks is None:
+            raise ValueError("cannot release an unknown lease")
+        if not isinstance(locks, dict):
+            locks = {lease_ref: locks}
+        selected = set(lock_paths)
+        released = []
+        for path in selected:
+            lock = locks.pop(path, None)
+            if lock is not None and lock.locked():
+                lock.release()
+                released.append(path)
+        if locks:
+            self._pathlock_leases[lease_ref] = locks
+        else:
+            with self._pathlocks_guard:
+                self._pathlock_leases.pop(lease_ref, None)
+        return released
+
+    def pathlock_to_handoff(self, ctx, owned_lease_ref):
+        del ctx
+        lease_ref = owned_lease_ref["lease_ref"]
+        with self._pathlocks_guard:
+            if lease_ref not in self._pathlock_leases:
+                raise ValueError("cannot hand off an unknown lease")
+        return {
+            "owner_id": owned_lease_ref.get("owner_id") or "mock-local-agfs",
+            "lock_paths": owned_lease_ref.get("lock_paths", []),
+        }
+
+    def pathlock_handoff(self, ctx, owned_lease_ref):
+        del ctx
+        lease_ref = owned_lease_ref["lease_ref"]
+        with self._pathlocks_guard:
+            locks = self._pathlock_leases.pop(lease_ref, None)
+        if locks is None:
+            raise ValueError("cannot hand off an unknown lease")
+        if isinstance(locks, dict):
+            for lock in reversed(list(locks.values())):
+                if lock.locked():
+                    lock.release()
+
+    def pathlock_adopt(self, ctx, handoff_ref):
+        lock_paths = handoff_ref.get("lock_paths", [])
+        if not lock_paths:
+            raise ValueError("handoff has no lock paths to adopt")
+        paths = [lp["path"] for lp in lock_paths]
+        return self.pathlock_acquire_exact_batch(ctx, paths)
+
+    def pathlock_is_locked(self, ctx, path, ignore_stale=True):
+        del ctx, ignore_stale
+        with self._pathlocks_guard:
+            lock = self._pathlocks.get(path)
+            if lock is None:
+                return False
+            return lock.locked()
+
+    def pathlock_observe(self, ctx):
+        del ctx
+        with self._pathlocks_guard:
+            active = sum(1 for lock in self._pathlocks.values() if lock.locked())
+        return {
+            "active_locks": active,
+            "waiting_locks": 0,
+            "stale_locks_removed": 0,
+            "conflicts": [],
+        }

--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -29,6 +29,8 @@ class MockLocalAGFS:
         self.root.mkdir(parents=True, exist_ok=True)
         self._pathlocks_guard = threading.Lock()
         self._pathlocks = {}
+        self._pathlock_owner_ids = {}
+        self._pathlock_refcounts = {}
         self._pathlock_leases = {}
         self._pathlock_handoffs = {}
         self._queue_guard = threading.Lock()
@@ -346,25 +348,47 @@ class MockLocalAGFS:
             raise TimeoutError(f"timed out acquiring test path lock: {path}")
         return lock
 
-    def _acquire_paths(self, paths, timeout_secs):
-        ordered = sorted(set(paths))
-        locks = []
+    def _acquire_requests(self, requests, timeout_secs, owner_lease_ref=None):
+        normalized = {}
+        for request in requests:
+            path = request["path"]
+            current = normalized.get(path)
+            if current is None or request["kind"] == "tree":
+                normalized[path] = dict(request)
+        ordered = sorted(normalized.values(), key=lambda request: request["path"])
+        if owner_lease_ref is None:
+            owner_id = str(uuid.uuid4())
+        else:
+            _, owner_entry = self._require_owned_lease(owner_lease_ref)
+            owner_id = owner_entry["owner_id"]
+        acquired = []
         try:
-            for path in ordered:
-                locks.append((path, self._acquire_lock(path, timeout_secs)))
+            for request in ordered:
+                path = request["path"]
+                with self._pathlocks_guard:
+                    lock = self._pathlocks.setdefault(path, threading.Lock())
+                    current_owner = self._pathlock_owner_ids.get(path)
+                    if lock.locked() and current_owner == owner_id:
+                        self._pathlock_refcounts[path] += 1
+                        acquired.append((path, lock))
+                        continue
+                acquired.append((path, self._acquire_lock(path, timeout_secs)))
+                with self._pathlocks_guard:
+                    self._pathlock_owner_ids[path] = owner_id
+                    self._pathlock_refcounts[path] = 1
         except BaseException:
-            for _, lock in reversed(locks):
-                lock.release()
+            self._release_lock_refs(dict(acquired), owner_id)
             raise
-        return locks
+        return acquired, ordered, owner_id
 
-    def _make_owned_lease(self, locks, paths):
+    def _make_owned_lease(self, locks, requests, owner_id):
         lease_ref = str(uuid.uuid4())
         ownership_ref = str(uuid.uuid4())
+        paths = [request["path"] for request in requests]
         lease = {
             "lease_ref": lease_ref,
             "ownership_ref": ownership_ref,
-            "owner_id": "mock-local-agfs",
+            "owner_id": owner_id,
             "owned": True,
             "lock_paths": list(paths),
         }
@@ -374,9 +398,23 @@ class MockLocalAGFS:
                 "locks": dict(locks),
                 "owner_id": lease["owner_id"],
                 "lock_paths": list(paths),
-                "covered_paths": [{"path": path, "kind": "exact"} for path in paths],
+                "covered_paths": [dict(request) for request in requests],
             }
         return lease
+
+    def _release_lock_refs(self, locks, owner_id):
+        for path, lock in reversed(list(locks.items())):
+            with self._pathlocks_guard:
+                if self._pathlock_owner_ids.get(path) != owner_id:
+                    continue
+                remaining = self._pathlock_refcounts[path] - 1
+                if remaining:
+                    self._pathlock_refcounts[path] = remaining
+                    continue
+                self._pathlock_refcounts.pop(path, None)
+                self._pathlock_owner_ids.pop(path, None)
+            if lock.locked():
+                lock.release()
 
     def _require_owned_lease(self, owned_lease_ref):
         if isinstance(owned_lease_ref, str):
@@ -394,52 +432,64 @@ class MockLocalAGFS:
         return lease_ref, entry
 
     def pathlock_acquire_exact(self, ctx, path, timeout_secs=0.0, owner_lease_ref=None):
-        del ctx, owner_lease_ref
-        locks = self._acquire_paths([path], timeout_secs)
-        return self._make_owned_lease(locks, [path])
+        del ctx
+        requests = [{"path": path, "kind": "exact"}]
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
-    pathlock_acquire_tree = pathlock_acquire_exact
+    def pathlock_acquire_tree(self, ctx, path, timeout_secs=0.0, owner_lease_ref=None):
+        del ctx
+        requests = [{"path": path, "kind": "tree"}]
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
     def pathlock_acquire_exact_batch(self, ctx, paths, timeout_secs=0.0, owner_lease_ref=None):
-        del ctx, owner_lease_ref
-        ordered = sorted(set(paths))
-        locks = self._acquire_paths(ordered, timeout_secs)
-        return self._make_owned_lease(locks, ordered)
+        del ctx
+        requests = [{"path": path, "kind": "exact"} for path in paths]
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
-    pathlock_acquire_tree_batch = pathlock_acquire_exact_batch
+    def pathlock_acquire_tree_batch(self, ctx, paths, timeout_secs=0.0, owner_lease_ref=None):
+        del ctx
+        requests = [{"path": path, "kind": "tree"} for path in paths]
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
     def pathlock_acquire_exact_tree_batch(
         self, ctx, exact_paths, tree_paths, timeout_secs=0.0, owner_lease_ref=None
     ):
-        del ctx, owner_lease_ref
-        ordered = sorted(set(exact_paths) | set(tree_paths))
-        locks = self._acquire_paths(ordered, timeout_secs)
-        return self._make_owned_lease(locks, ordered)
+        del ctx
+        requests = [
+            *({"path": path, "kind": "exact"} for path in exact_paths),
+            *({"path": path, "kind": "tree"} for path in tree_paths),
+        ]
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
     def pathlock_acquire_batch(self, ctx, requests, timeout_secs=0.0, owner_lease_ref=None):
-        del owner_lease_ref
+        del ctx
         if not requests:
             raise ValueError("pathlock request batch must not be empty")
-        paths = []
         for request in requests:
             path = request.get("path")
             if not path or not path.startswith("/"):
                 raise ValueError("pathlock request.path must be an absolute path")
             if request.get("kind") not in {"exact", "tree"}:
                 raise ValueError("pathlock request.kind must be 'exact' or 'tree'")
-            paths.append(path)
-        return self.pathlock_acquire_exact_batch(ctx, paths, timeout_secs)
+        locks, requests, owner_id = self._acquire_requests(requests, timeout_secs, owner_lease_ref)
+        return self._make_owned_lease(locks, requests, owner_id)
 
     def pathlock_as_borrowed(self, ctx, owned_lease_ref):
         del ctx
         lease_ref = owned_lease_ref["lease_ref"]
         with self._pathlocks_guard:
-            if lease_ref not in self._pathlock_leases:
+            entry = self._pathlock_leases.get(lease_ref)
+            if entry is None:
                 raise ValueError("cannot borrow an unknown lease")
         return {
             "lease_ref": lease_ref,
-            "ownership_ref": owned_lease_ref.get("ownership_ref"),
-            "owner_id": owned_lease_ref.get("owner_id"),
+            "owner_id": entry["owner_id"],
+            "lock_paths": list(entry["lock_paths"]),
             "owned": False,
         }
 
@@ -454,9 +504,7 @@ class MockLocalAGFS:
         with self._pathlocks_guard:
             self._pathlock_leases.pop(lease_ref)
         locks = entry["locks"]
-        for lock in reversed(list(locks.values())):
-            if lock.locked():
-                lock.release()
+        self._release_lock_refs(locks, entry["owner_id"])
 
     def pathlock_release_selected(self, ctx, owned_lease_ref, lock_paths):
         del ctx
@@ -466,8 +514,8 @@ class MockLocalAGFS:
         released = []
         for path in selected:
             lock = locks.pop(path, None)
-            if lock is not None and lock.locked():
-                lock.release()
+            if lock is not None:
+                self._release_lock_refs({path: lock}, entry["owner_id"])
                 released.append(path)
         if locks:
             entry["locks"] = locks
@@ -524,7 +572,9 @@ class MockLocalAGFS:
                 self._pathlock_handoffs[lease_ref] = pending
             raise ValueError("handoff metadata does not match the pending lease")
         locks = pending["locks"]
-        return self._make_owned_lease(list(locks.items()), paths)
+        return self._make_owned_lease(
+            list(locks.items()), pending["covered_paths"], pending["owner_id"]
+        )
 
     def pathlock_is_locked(self, ctx, path, ignore_stale=True):
         del ctx, ignore_stale

--- a/tests/utils/mock_agfs.py
+++ b/tests/utils/mock_agfs.py
@@ -167,17 +167,8 @@ class MockLocalAGFS:
             raw = content.decode("utf-8") if isinstance(content, bytes) else str(content)
             with self._queue_guard:
                 if operation == "enqueue":
-                    try:
-                        parsed = json.loads(raw)
-                    except (ValueError, TypeError):
-                        parsed = None
-                    if isinstance(parsed, dict):
-                        message = dict(parsed)
-                        message.setdefault("id", str(uuid.uuid4()))
-                        message_id = message["id"]
-                    else:
-                        message_id = str(uuid.uuid4())
-                        message = {"id": message_id, "data": raw}
+                    message_id = str(uuid.uuid4())
+                    message = {"id": message_id, "data": raw}
                     self._queues.setdefault(queue_name, []).append(message)
                     return message_id
                 if operation == "ack":
@@ -233,11 +224,9 @@ class MockLocalAGFS:
     def cat(self, path, ctx=None, **kwargs):
         return self.read_file(path, ctx, **kwargs)
 
-    def rm(self, path, recursive=False, force=True, ctx=None):
+    def rm(self, path, recursive=False, ctx=None):
         p = self._resolve(path)
         if not p.exists():
-            if force:
-                return {"removed": path}
             raise FileNotFoundError(path)
         if p.is_dir():
             if recursive:
@@ -246,7 +235,7 @@ class MockLocalAGFS:
                 p.rmdir()
         else:
             p.unlink()
-        return {"removed": path}
+        return {"message": "deleted"}
 
     def delete_temp(self, path, ctx=None):
         self.rm(path, recursive=True, ctx=ctx)
@@ -371,16 +360,38 @@ class MockLocalAGFS:
 
     def _make_owned_lease(self, locks, paths):
         lease_ref = str(uuid.uuid4())
+        ownership_ref = str(uuid.uuid4())
         lease = {
             "lease_ref": lease_ref,
-            "ownership_ref": str(uuid.uuid4()),
+            "ownership_ref": ownership_ref,
             "owner_id": "mock-local-agfs",
             "owned": True,
             "lock_paths": list(paths),
         }
         with self._pathlocks_guard:
-            self._pathlock_leases[lease_ref] = dict(locks)
+            self._pathlock_leases[lease_ref] = {
+                "ownership_ref": ownership_ref,
+                "locks": dict(locks),
+                "owner_id": lease["owner_id"],
+                "lock_paths": list(paths),
+                "covered_paths": [{"path": path, "kind": "exact"} for path in paths],
+            }
         return lease
+
+    def _require_owned_lease(self, owned_lease_ref):
+        if isinstance(owned_lease_ref, str):
+            raise TypeError("owned lease operations require a lease ref dict")
+        if not owned_lease_ref.get("owned", False):
+            raise ValueError("owned lease operation requires an owned lease")
+        lease_ref = owned_lease_ref.get("lease_ref")
+        ownership_ref = owned_lease_ref.get("ownership_ref")
+        if not lease_ref or not ownership_ref:
+            raise ValueError("owned lease requires lease_ref and ownership_ref")
+        with self._pathlocks_guard:
+            entry = self._pathlock_leases.get(lease_ref)
+        if entry is None or entry["ownership_ref"] != ownership_ref:
+            raise ValueError(f"owned lease capability does not match ref '{lease_ref}'")
+        return lease_ref, entry
 
     def pathlock_acquire_exact(self, ctx, path, timeout_secs=0.0, owner_lease_ref=None):
         del ctx, owner_lease_ref
@@ -434,40 +445,23 @@ class MockLocalAGFS:
 
     def pathlock_refresh(self, ctx, owned_lease_ref):
         del ctx
-        lease_ref = owned_lease_ref["lease_ref"]
-        with self._pathlocks_guard:
-            if lease_ref not in self._pathlock_leases:
-                return "lost"
+        self._require_owned_lease(owned_lease_ref)
         return "refreshed"
 
     def pathlock_release(self, ctx, owned_lease_ref):
         del ctx
-        if isinstance(owned_lease_ref, str):
-            raise TypeError("pathlock_release requires a lease ref dict, not a raw string")
-        lease_ref = owned_lease_ref["lease_ref"]
-        if not owned_lease_ref.get("owned", True):
-            raise ValueError("cannot release a borrowed lease")
+        lease_ref, entry = self._require_owned_lease(owned_lease_ref)
         with self._pathlocks_guard:
-            locks = self._pathlock_leases.pop(lease_ref, None)
-        if locks is None:
-            raise ValueError("cannot release an unknown lease")
-        if not isinstance(locks, dict):
-            locks = {owned_lease_ref.get("lease_ref", ""): locks}
+            self._pathlock_leases.pop(lease_ref)
+        locks = entry["locks"]
         for lock in reversed(list(locks.values())):
             if lock.locked():
                 lock.release()
 
     def pathlock_release_selected(self, ctx, owned_lease_ref, lock_paths):
         del ctx
-        lease_ref = owned_lease_ref["lease_ref"]
-        if not owned_lease_ref.get("owned", True):
-            raise ValueError("cannot release a borrowed lease")
-        with self._pathlocks_guard:
-            locks = self._pathlock_leases.get(lease_ref)
-        if locks is None:
-            raise ValueError("cannot release an unknown lease")
-        if not isinstance(locks, dict):
-            locks = {lease_ref: locks}
+        lease_ref, entry = self._require_owned_lease(owned_lease_ref)
+        locks = entry["locks"]
         selected = set(lock_paths)
         released = []
         for path in selected:
@@ -476,7 +470,11 @@ class MockLocalAGFS:
                 lock.release()
                 released.append(path)
         if locks:
-            self._pathlock_leases[lease_ref] = locks
+            entry["locks"] = locks
+            entry["lock_paths"] = [path for path in entry["lock_paths"] if path not in selected]
+            entry["covered_paths"] = [
+                request for request in entry["covered_paths"] if request["path"] not in selected
+            ]
         else:
             with self._pathlocks_guard:
                 self._pathlock_leases.pop(lease_ref, None)
@@ -484,34 +482,24 @@ class MockLocalAGFS:
 
     def pathlock_to_handoff(self, ctx, owned_lease_ref):
         del ctx
-        lease_ref = owned_lease_ref["lease_ref"]
-        with self._pathlocks_guard:
-            if lease_ref not in self._pathlock_leases:
-                raise ValueError("cannot hand off an unknown lease")
+        lease_ref, entry = self._require_owned_lease(owned_lease_ref)
         return {
             "lease_ref": lease_ref,
-            "owner_id": owned_lease_ref.get("owner_id") or "mock-local-agfs",
-            "lock_paths": owned_lease_ref.get("lock_paths", []),
-            "covered_paths": [
-                {"path": path, "kind": "exact"} for path in owned_lease_ref.get("lock_paths", [])
-            ],
+            "owner_id": entry["owner_id"],
+            "lock_paths": list(entry["lock_paths"]),
+            "covered_paths": list(entry["covered_paths"]),
         }
 
     def pathlock_handoff(self, ctx, owned_lease_ref):
         del ctx
-        lease_ref = owned_lease_ref["lease_ref"]
+        lease_ref, entry = self._require_owned_lease(owned_lease_ref)
         with self._pathlocks_guard:
-            locks = self._pathlock_leases.pop(lease_ref, None)
-            if locks is None:
-                raise ValueError("cannot hand off an unknown lease")
+            self._pathlock_leases.pop(lease_ref)
             self._pathlock_handoffs[lease_ref] = {
-                "locks": locks,
-                "owner_id": owned_lease_ref.get("owner_id"),
-                "lock_paths": list(owned_lease_ref.get("lock_paths", [])),
-                "covered_paths": [
-                    {"path": path, "kind": "exact"}
-                    for path in owned_lease_ref.get("lock_paths", [])
-                ],
+                "locks": entry["locks"],
+                "owner_id": entry["owner_id"],
+                "lock_paths": list(entry["lock_paths"]),
+                "covered_paths": list(entry["covered_paths"]),
             }
 
     def pathlock_adopt(self, ctx, handoff_ref):

--- a/tests/utils/test_mock_agfs_contract.py
+++ b/tests/utils/test_mock_agfs_contract.py
@@ -339,27 +339,42 @@ class TestMockAgfsQueueContract:
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
         payload = '{"task_id":"abc"}'
-        msg_id = mock.writeto(f"{queue_path}/enqueue", payload.encode())
-        assert msg_id
+        write_result = mock.writeto(f"{queue_path}/enqueue", payload.encode())
+        assert write_result == f"Written {len(payload.encode())} bytes"
         raw = mock.read_file(f"{queue_path}/dequeue")
         import json as json_mod
 
         message = json_mod.loads(raw)
-        assert message["id"] == msg_id
+        assert message["id"] != write_result
         assert message["data"] == payload
         assert message["id"] != "abc"
+
+    def test_worker_queue_path_uses_nested_queue_name(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        queue_path = "/queue/worker-2/TestQueue"
+        payload = '{"task_id":"nested"}'
+        mock.writeto(f"{queue_path}/enqueue", payload.encode())
+
+        import json as json_mod
+
+        peeked = json_mod.loads(mock.read_file(f"{queue_path}/peek"))
+        assert peeked["data"] == payload
+        assert int(mock.read_file(f"{queue_path}/size")) == 1
+        dequeued = json_mod.loads(mock.read_file(f"{queue_path}/dequeue"))
+        assert dequeued == peeked
 
     def test_queue_size_and_messages(self, tmp_path):
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
-        first_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-1"}')
-        second_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-2"}')
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-1"}')
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-2"}')
         assert int(mock.read_file(f"{queue_path}/size")) == 2
         snapshot = mock.read_file(f"{queue_path}/messages")
         import json as json_mod
 
         messages = json_mod.loads(snapshot)
-        assert {m["id"] for m in messages} == {first_id, second_id}
+        assert len({m["id"] for m in messages}) == 2
+        assert not {"business-1", "business-2"} & {m["id"] for m in messages}
         assert {m["data"] for m in messages} == {
             '{"id": "business-1"}',
             '{"id": "business-2"}',
@@ -368,11 +383,12 @@ class TestMockAgfsQueueContract:
     def test_ack_removes_processing_message(self, tmp_path):
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
-        msg_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-id"}')
-        mock.read_file(f"{queue_path}/dequeue")
-        mock.writeto(f"{queue_path}/ack", msg_id.encode())
-        snapshot = mock.read_file(f"{queue_path}/messages")
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-id"}')
         import json as json_mod
+
+        message = json_mod.loads(mock.read_file(f"{queue_path}/dequeue"))
+        mock.writeto(f"{queue_path}/ack", message["id"].encode())
+        snapshot = mock.read_file(f"{queue_path}/messages")
 
         messages = json_mod.loads(snapshot)
         assert messages == []

--- a/tests/utils/test_mock_agfs_contract.py
+++ b/tests/utils/test_mock_agfs_contract.py
@@ -97,11 +97,61 @@ class TestMockAgfsPathlockContract:
         assert mock.pathlock_is_locked(None, "/local/test/a.txt") is False
         assert mock.pathlock_is_locked(None, "/local/test/b.txt") is False
 
+    def test_reentrant_acquire_reuses_owner_and_reference_counts(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        path = "/local/test/a.txt"
+        outer = mock.pathlock_acquire_exact(None, path)
+        nested = mock.pathlock_acquire_exact(None, path, owner_lease_ref=outer)
+        assert nested["owner_id"] == outer["owner_id"]
+        assert nested["lease_ref"] != outer["lease_ref"]
+
+        mock.pathlock_release(None, outer)
+        assert mock.pathlock_is_locked(None, path) is True
+        mock.pathlock_release(None, nested)
+        assert mock.pathlock_is_locked(None, path) is False
+
+    def test_reentrant_acquire_rejects_forged_owner_capability(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        outer = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        forged = dict(outer, ownership_ref="attacker-value")
+        with pytest.raises(ValueError, match="capability does not match"):
+            mock.pathlock_acquire_exact(
+                None,
+                "/local/test/a.txt",
+                owner_lease_ref=forged,
+            )
+        mock.pathlock_release(None, outer)
+
+    def test_tree_handoff_preserves_covered_path_kind(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_tree(None, "/local/test/tree")
+        handoff = mock.pathlock_to_handoff(None, lease)
+        assert handoff["covered_paths"] == [{"path": "/local/test/tree", "kind": "tree"}]
+        mock.pathlock_release(None, lease)
+
+    def test_mixed_batch_preserves_kinds_and_prefers_tree_for_same_path(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_exact_tree_batch(
+            None,
+            ["/local/test/exact", "/local/test/shared"],
+            ["/local/test/tree", "/local/test/shared"],
+        )
+        handoff = mock.pathlock_to_handoff(None, lease)
+        assert handoff["covered_paths"] == [
+            {"path": "/local/test/exact", "kind": "exact"},
+            {"path": "/local/test/shared", "kind": "tree"},
+            {"path": "/local/test/tree", "kind": "tree"},
+        ]
+        mock.pathlock_release(None, lease)
+
     def test_borrowed_lease_cannot_release(self, tmp_path):
         mock = _make_mock(tmp_path)
         owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
         borrowed = mock.pathlock_as_borrowed(None, owned)
         assert borrowed["owned"] is False
+        assert borrowed["owner_id"] == owned["owner_id"]
+        assert borrowed["lock_paths"] == owned["lock_paths"]
+        assert "ownership_ref" not in borrowed
         with pytest.raises(ValueError):
             mock.pathlock_release(None, borrowed)
         with pytest.raises((TypeError, ValueError)):

--- a/tests/utils/test_mock_agfs_contract.py
+++ b/tests/utils/test_mock_agfs_contract.py
@@ -107,6 +107,34 @@ class TestMockAgfsPathlockContract:
         with pytest.raises((TypeError, ValueError)):
             mock.pathlock_release(None, borrowed["lease_ref"])
 
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda mock, lease: mock.pathlock_refresh(None, lease),
+            lambda mock, lease: mock.pathlock_release(None, lease),
+            lambda mock, lease: mock.pathlock_release_selected(None, lease, ["/local/test/a.txt"]),
+            lambda mock, lease: mock.pathlock_to_handoff(None, lease),
+            lambda mock, lease: mock.pathlock_handoff(None, lease),
+        ],
+    )
+    def test_owned_lifecycle_rejects_forged_ownership_ref(self, tmp_path, operation):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        forged = dict(owned, ownership_ref="attacker-value")
+        with pytest.raises(ValueError, match="capability does not match"):
+            operation(mock, forged)
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
+        mock.pathlock_release(None, owned)
+
+    def test_handoff_uses_canonical_lease_metadata(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        forged = dict(owned, owner_id="forged-owner", lock_paths=["/local/test/b.txt"])
+        handoff = mock.pathlock_to_handoff(None, forged)
+        assert handoff["owner_id"] == owned["owner_id"]
+        assert handoff["lock_paths"] == owned["lock_paths"]
+        mock.pathlock_release(None, owned)
+
     def test_handoff_and_adopt_roundtrip(self, tmp_path):
         mock = _make_mock(tmp_path)
         owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
@@ -189,7 +217,8 @@ class TestMockAgfsPathlockContract:
         owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
         assert mock.pathlock_refresh(None, owned) == "refreshed"
         mock.pathlock_release(None, owned)
-        assert mock.pathlock_refresh(None, owned) == "lost"
+        with pytest.raises(ValueError, match="capability does not match"):
+            mock.pathlock_refresh(None, owned)
 
 
 class TestMockAgfsFileContract:
@@ -210,15 +239,12 @@ class TestMockAgfsFileContract:
         assert mock.read("/local/test/a.txt") == b"hello"
         assert mock.cat("/local/test/a.txt") == b"hello"
 
-    def test_rm_force_and_recursive(self, tmp_path):
+    def test_rm_and_recursive(self, tmp_path):
         mock = _make_mock(tmp_path)
         mock.write("/local/test/file.txt", b"x")
         assert isinstance(mock.rm("/local/test/file.txt"), dict)
-        assert (
-            mock.rm("/local/test/missing.txt", force=True)["removed"] == "/local/test/missing.txt"
-        )
         with pytest.raises(FileNotFoundError):
-            mock.rm("/local/test/missing.txt", force=False)
+            mock.rm("/local/test/missing.txt")
 
         mock.mkdir("/local/test/dir")
         mock.write("/local/test/dir/f.txt", b"x")
@@ -262,33 +288,39 @@ class TestMockAgfsQueueContract:
     def test_enqueue_dequeue_roundtrip(self, tmp_path):
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
-        msg_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1", "data": "hello"}')
+        payload = '{"task_id":"abc"}'
+        msg_id = mock.writeto(f"{queue_path}/enqueue", payload.encode())
         assert msg_id
         raw = mock.read_file(f"{queue_path}/dequeue")
         import json as json_mod
 
         message = json_mod.loads(raw)
-        assert message["id"] == "m1"
-        assert message["data"] == "hello"
+        assert message["id"] == msg_id
+        assert message["data"] == payload
+        assert message["id"] != "abc"
 
     def test_queue_size_and_messages(self, tmp_path):
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
-        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1"}')
-        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m2"}')
+        first_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-1"}')
+        second_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-2"}')
         assert int(mock.read_file(f"{queue_path}/size")) == 2
         snapshot = mock.read_file(f"{queue_path}/messages")
         import json as json_mod
 
         messages = json_mod.loads(snapshot)
-        assert {m["id"] for m in messages} == {"m1", "m2"}
+        assert {m["id"] for m in messages} == {first_id, second_id}
+        assert {m["data"] for m in messages} == {
+            '{"id": "business-1"}',
+            '{"id": "business-2"}',
+        }
 
     def test_ack_removes_processing_message(self, tmp_path):
         mock = _make_mock(tmp_path)
         queue_path = "/queue/TestQueue"
-        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1"}')
+        msg_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "business-id"}')
         mock.read_file(f"{queue_path}/dequeue")
-        mock.writeto(f"{queue_path}/ack", b"m1")
+        mock.writeto(f"{queue_path}/ack", msg_id.encode())
         snapshot = mock.read_file(f"{queue_path}/messages")
         import json as json_mod
 

--- a/tests/utils/test_mock_agfs_contract.py
+++ b/tests/utils/test_mock_agfs_contract.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Contract tests for the AGFS test double.
+
+These tests keep tests.utils.mock_agfs.MockLocalAGFS in sync with the
+production AGFS interface the rest of the codebase dispatches through
+AsyncAGFSClient. If the production interface grows or changes, these tests
+fail until the test double catches up.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from openviking.pyagfs import AsyncAGFSClient
+from openviking.pyagfs.protocols import AGFSSyncClientProtocol
+from tests.utils.mock_agfs import MockLocalAGFS
+
+
+def _async_client_run_method_names() -> set[str]:
+    """Collect every sync client method name AsyncAGFSClient dispatches via run()."""
+    source = inspect.getsource(AsyncAGFSClient)
+    return set(re.findall(r'self\.run\(\s*"([a-z_]+)"', source))
+
+
+def _protocol_method_names() -> set[str]:
+    """Collect every method name required by AGFSSyncClientProtocol."""
+    names = set()
+    for name, member in inspect.getmembers(AGFSSyncClientProtocol):
+        if name.startswith("_"):
+            continue
+        if inspect.isfunction(member):
+            names.add(name)
+    return names
+
+
+def _make_mock(tmp_path: Path) -> MockLocalAGFS:
+    return MockLocalAGFS(root_path=tmp_path / "mock_agfs_root")
+
+
+class TestMockAgfsSatisfiesProductionProtocol:
+    """The test double must implement the documented sync client protocol."""
+
+    def test_mock_is_agfs_sync_client_protocol(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        assert isinstance(mock, AGFSSyncClientProtocol)
+
+    def test_mock_implements_every_protocol_method(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        missing = sorted(_protocol_method_names() - set(dir(mock)))
+        assert not missing, f"MockLocalAGFS missing protocol methods: {missing}"
+
+    def test_mock_implements_every_async_dispatch_method(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        missing = sorted(_async_client_run_method_names() - set(dir(mock)))
+        assert not missing, f"MockLocalAGFS missing dispatch methods: {missing}"
+
+
+class TestMockAgfsPathlockContract:
+    """Pathlock behavior must match the semantics production code relies on."""
+
+    def test_acquire_returns_owned_lease(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        assert lease["owned"] is True
+        assert lease["lease_ref"]
+        assert lease["ownership_ref"]
+        assert lease["owner_id"]
+
+    def test_release_frees_lock(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        mock.pathlock_release(None, lease)
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is False
+
+    def test_acquired_lock_is_observed(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
+        snapshot = mock.pathlock_observe(None)
+        assert snapshot["active_locks"] >= 1
+
+    def test_acquire_batch_acquires_all(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_exact_batch(
+            None,
+            ["/local/test/a.txt", "/local/test/b.txt"],
+        )
+        assert lease["owned"] is True
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
+        assert mock.pathlock_is_locked(None, "/local/test/b.txt") is True
+        mock.pathlock_release(None, lease)
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is False
+        assert mock.pathlock_is_locked(None, "/local/test/b.txt") is False
+
+    def test_borrowed_lease_cannot_release(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        borrowed = mock.pathlock_as_borrowed(None, owned)
+        assert borrowed["owned"] is False
+        with pytest.raises(ValueError):
+            mock.pathlock_release(None, borrowed)
+        with pytest.raises((TypeError, ValueError)):
+            mock.pathlock_release(None, borrowed["lease_ref"])
+
+    def test_handoff_and_adopt_roundtrip(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        handoff = mock.pathlock_to_handoff(None, owned)
+        assert handoff["lock_paths"]
+        mock.pathlock_handoff(None, owned)
+        adopted = mock.pathlock_adopt(None, handoff)
+        assert adopted["owned"] is True
+        mock.pathlock_release(None, adopted)
+
+    def test_release_selected_keeps_others(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        lease = mock.pathlock_acquire_exact_batch(
+            None,
+            ["/local/test/a.txt", "/local/test/b.txt"],
+        )
+        mock.pathlock_release_selected(None, lease, ["/local/test/a.txt"])
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is False
+        assert mock.pathlock_is_locked(None, "/local/test/b.txt") is True
+        mock.pathlock_release(None, lease)
+
+    def test_acquire_batch_rejects_invalid_requests(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        with pytest.raises(ValueError):
+            mock.pathlock_acquire_batch(None, [])
+        with pytest.raises(ValueError):
+            mock.pathlock_acquire_batch(None, [{"kind": "exact"}])
+        with pytest.raises(ValueError):
+            mock.pathlock_acquire_batch(None, [{"path": "relative", "kind": "tree"}])
+        with pytest.raises(ValueError):
+            mock.pathlock_acquire_batch(None, [{"path": "/local/test/a", "kind": "other"}])
+
+    def test_refresh_reports_state(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        assert mock.pathlock_refresh(None, owned) == "refreshed"
+        mock.pathlock_release(None, owned)
+        assert mock.pathlock_refresh(None, owned) == "lost"
+
+
+class TestMockAgfsFileContract:
+    """Filesystem methods must follow the production return shapes."""
+
+    def test_mkdir_returns_dict(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        assert isinstance(mock.mkdir("/local/test/dir"), dict)
+
+    def test_ensure_parent_dirs_creates_parents(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.ensure_parent_dirs("/local/test/a/b/c.txt")
+        assert mock.exists("/local/test/a/b")
+
+    def test_write_read_roundtrip(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.write("/local/test/a.txt", b"hello")
+        assert mock.read("/local/test/a.txt") == b"hello"
+        assert mock.cat("/local/test/a.txt") == b"hello"
+
+    def test_rm_force_and_recursive(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.write("/local/test/file.txt", b"x")
+        assert isinstance(mock.rm("/local/test/file.txt"), dict)
+        assert (
+            mock.rm("/local/test/missing.txt", force=True)["removed"] == "/local/test/missing.txt"
+        )
+        with pytest.raises(FileNotFoundError):
+            mock.rm("/local/test/missing.txt", force=False)
+
+        mock.mkdir("/local/test/dir")
+        mock.write("/local/test/dir/f.txt", b"x")
+        mock.rm("/local/test/dir", recursive=True)
+        assert not mock.exists("/local/test/dir")
+
+    def test_copy_within_mount(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.write("/local/test/a.txt", b"copy me")
+        result = mock.copy_within_mount("/local/test/a.txt", "/local/test/b.txt")
+        assert result["performed"] is True
+        assert mock.read("/local/test/b.txt") == b"copy me"
+
+    def test_tree_directory_shape(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.write("/local/test/dir/nested/file.md", b"# t")
+        entries = mock.tree_directory("/local/test/dir", level_limit=3)
+        assert any(e["rel_path"] == "nested/file.md" for e in entries)
+        for entry in entries:
+            assert "path" in entry
+            assert "info" in entry
+            assert entry["info"]["name"]
+
+    def test_grep_shape(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        mock.write("/local/test/dir/a.md", b"needle here\nplain line\n")
+        result = mock.grep(path="/local/test/dir", pattern="needle")
+        assert result["count"] == 1
+        assert result["matches"][0]["content"] == "needle here"
+        assert "files_scanned" in result
+
+    def test_system_sync_returns_dicts(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        assert isinstance(mock.system_sync_status("/local/test/a.txt"), dict)
+        assert isinstance(mock.system_sync_retry("/local/test/a.txt"), dict)
+
+
+class TestMockAgfsQueueContract:
+    """QueueFS virtual-path semantics must keep NamedQueue working."""
+
+    def test_enqueue_dequeue_roundtrip(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        queue_path = "/queue/TestQueue"
+        msg_id = mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1", "data": "hello"}')
+        assert msg_id
+        raw = mock.read_file(f"{queue_path}/dequeue")
+        import json as json_mod
+
+        message = json_mod.loads(raw)
+        assert message["id"] == "m1"
+        assert message["data"] == "hello"
+
+    def test_queue_size_and_messages(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        queue_path = "/queue/TestQueue"
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1"}')
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m2"}')
+        assert int(mock.read_file(f"{queue_path}/size")) == 2
+        snapshot = mock.read_file(f"{queue_path}/messages")
+        import json as json_mod
+
+        messages = json_mod.loads(snapshot)
+        assert {m["id"] for m in messages} == {"m1", "m2"}
+
+    def test_ack_removes_processing_message(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        queue_path = "/queue/TestQueue"
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1"}')
+        mock.read_file(f"{queue_path}/dequeue")
+        mock.writeto(f"{queue_path}/ack", b"m1")
+        snapshot = mock.read_file(f"{queue_path}/messages")
+        import json as json_mod
+
+        messages = json_mod.loads(snapshot)
+        assert messages == []
+
+    def test_clear_empties_queue(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        queue_path = "/queue/TestQueue"
+        mock.writeto(f"{queue_path}/enqueue", b'{"id": "m1"}')
+        mock.writeto(f"{queue_path}/clear", b"")
+        assert int(mock.read_file(f"{queue_path}/size")) == 0

--- a/tests/utils/test_mock_agfs_contract.py
+++ b/tests/utils/test_mock_agfs_contract.py
@@ -69,6 +69,7 @@ class TestMockAgfsPathlockContract:
         assert lease["lease_ref"]
         assert lease["ownership_ref"]
         assert lease["owner_id"]
+        assert lease["lock_paths"] == ["/local/test/a.txt"]
 
     def test_release_frees_lock(self, tmp_path):
         mock = _make_mock(tmp_path)
@@ -110,11 +111,56 @@ class TestMockAgfsPathlockContract:
         mock = _make_mock(tmp_path)
         owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
         handoff = mock.pathlock_to_handoff(None, owned)
+        assert handoff["lease_ref"] == owned["lease_ref"]
         assert handoff["lock_paths"]
         mock.pathlock_handoff(None, owned)
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
+        with pytest.raises(ValueError):
+            mock.pathlock_release(None, owned)
         adopted = mock.pathlock_adopt(None, handoff)
         assert adopted["owned"] is True
+        assert adopted["lease_ref"] != owned["lease_ref"]
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
         mock.pathlock_release(None, adopted)
+
+    def test_adopt_requires_pending_handoff(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        handoff = mock.pathlock_to_handoff(None, owned)
+        with pytest.raises(ValueError):
+            mock.pathlock_adopt(None, handoff)
+        mock.pathlock_release(None, owned)
+
+    def test_adopt_rejects_forged_lock_paths(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        handoff = mock.pathlock_to_handoff(None, owned)
+        mock.pathlock_handoff(None, owned)
+        handoff["lock_paths"] = ["/local/test/b.txt"]
+        with pytest.raises(ValueError):
+            mock.pathlock_adopt(None, handoff)
+        assert mock.pathlock_is_locked(None, "/local/test/a.txt") is True
+        handoff["lock_paths"] = ["/local/test/a.txt"]
+        adopted = mock.pathlock_adopt(None, handoff)
+        mock.pathlock_release(None, adopted)
+
+    def test_adopt_rejects_forged_owner(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        handoff = mock.pathlock_to_handoff(None, owned)
+        mock.pathlock_handoff(None, owned)
+        handoff["owner_id"] = "forged-owner"
+        with pytest.raises(ValueError):
+            mock.pathlock_adopt(None, handoff)
+
+    def test_adopt_rejects_forged_coverage(self, tmp_path):
+        mock = _make_mock(tmp_path)
+        owned = mock.pathlock_acquire_exact(None, "/local/test/a.txt")
+        handoff = mock.pathlock_to_handoff(None, owned)
+        mock.pathlock_handoff(None, owned)
+        handoff["covered_paths"] = [{"path": "/local/test/b.txt", "kind": "exact"}]
+        with pytest.raises(ValueError):
+            mock.pathlock_adopt(None, handoff)
 
     def test_release_selected_keeps_others(self, tmp_path):
         mock = _make_mock(tmp_path)


### PR DESCRIPTION
## Summary

- align `MockLocalAGFS` with `AGFSSyncClientProtocol` and `AsyncAGFSClient` dispatch targets
- support nested worker-mode QueueFS names
- model QueueFS payloads as opaque data with queue-generated message IDs
- match the binding write result instead of returning the queue message ID
- enforce `ownership_ref` for owned pathlock lifecycle operations
- support owner-capability reentrant pathlock acquisition
- preserve exact and tree lock kinds in mixed batches and handoffs
- preserve locks across handoff and validate handoff metadata
- add contract tests that detect future interface drift

## Contract Notes

Queue paths retain every nested name segment after `/queue/`. This supports paths such as `/queue/worker-2/SessionCommit/enqueue`.

Queue enqueue stores the input bytes as opaque payload data. Dequeue and peek return an outer queue ID with the original payload string. The write call returns `Written N bytes`, not the queue message ID.

Owned pathlock operations validate both `lease_ref` and `ownership_ref`. Reentrant acquisitions reuse the original owner and maintain independent lease references. Lock reference counts prevent outer release from dropping nested locks.

Tree acquisitions retain `kind: tree` in `covered_paths`. Mixed batches preserve each request kind and prefer tree coverage for duplicate paths.

Handoff keeps locks active until adoption rotates the owned capability.

The mock does not expose `rm(force=...)`. The current Python and Rust binding mismatch is tracked in #4016.

## Verification

- `94 passed` from the contract, queue manager, API listing, and session tests
- `ruff format --check` passed
- `ruff check` passed
- `git diff --check` passed

Closes #4013