### PR TITLE
feat(bot): support exact add-resource targets

### DIFF
--- a/bot/tests/test_openviking_add_resource.py
+++ b/bot/tests/test_openviking_add_resource.py
@@ -1,0 +1,72 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from vikingbot.agent.tools.base import ToolContext
+from vikingbot.agent.tools.ov_file import VikingAddResourceTool
+from vikingbot.openviking_mount.ov_server import VikingClient
+
+
+class _FakeClient:
+    def __init__(self, root_uri):
+        self.root_uri = root_uri
+        self.calls = []
+
+    async def add_resource(self, path, description, to=None):
+        self.calls.append((path, description, to))
+        return {"root_uri": self.root_uri}
+
+
+def test_add_resource_schema_exposes_optional_target_uri():
+    tool = VikingAddResourceTool()
+
+    assert tool.parameters["properties"]["to"] == {
+        "type": "string",
+        "description": "Optional exact target URI under viking://resources/. When omitted, OpenViking chooses the resource URI.",
+    }
+    assert "to" not in tool.parameters["required"]
+    assert tool.validate_params({"path": "https://example.com/doc", "description": "doc"}) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_uri", "root_uri"),
+    [
+        (None, "viking://resources/doc"),
+        ("viking://resources/feishu/doc/config", "viking://resources/feishu/doc/config"),
+    ],
+)
+async def test_add_resource_tool_forwards_optional_target(monkeypatch, target_uri, root_uri):
+    tool = VikingAddResourceTool()
+    client = _FakeClient(root_uri)
+
+    async def _fake_get_client(_tool_context):
+        return client
+
+    monkeypatch.setattr(tool, "_get_client", _fake_get_client)
+
+    kwargs = {"path": "https://example.com/doc", "description": "conversation export"}
+    if target_uri is not None:
+        kwargs["to"] = target_uri
+    result = await tool.execute(ToolContext(), **kwargs)
+
+    assert client.calls == [("https://example.com/doc", "conversation export", target_uri)]
+    assert result == f"Successfully added resource: {root_uri}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_uri", [None, "viking://resources/feishu/doc/config"])
+async def test_viking_client_add_resource_forwards_optional_target(target_uri):
+    expected_uri = target_uri or "viking://resources/doc"
+    sdk_client = AsyncMock()
+    sdk_client.add_resource.return_value = {"root_uri": expected_uri}
+    client = object.__new__(VikingClient)
+    client.client = sdk_client
+
+    result = await client.add_resource("/tmp/doc.md", "conversation export", to=target_uri)
+
+    sdk_client.add_resource.assert_awaited_once_with(
+        path="/tmp/doc.md",
+        to=target_uri,
+        reason="conversation export",
+    )
+    assert result["root_uri"] == expected_uri

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -514,6 +514,10 @@ class VikingAddResourceTool(OVFileTool):
             "properties": {
                 "path": {"type": "string", "description": "Url or local file path"},
                 "description": {"type": "string", "description": "Description of the resource"},
+                "to": {
+                    "type": "string",
+                    "description": "Optional exact target URI under viking://resources/. When omitted, OpenViking chooses the resource URI.",
+                },
             },
             "required": ["path", "description"],
         }
@@ -523,6 +527,7 @@ class VikingAddResourceTool(OVFileTool):
         tool_context: "ToolContext",
         path: str,
         description: str,
+        to: Optional[str] = None,
         **kwargs: Any,
     ) -> str:
         client = None
@@ -535,7 +540,7 @@ class VikingAddResourceTool(OVFileTool):
                     return f"Error: Not a file: {path}"
 
             client = await self._get_client(tool_context)
-            result = await client.add_resource(path, description)
+            result = await client.add_resource(path, description, to=to)
 
             if result:
                 root_uri = result.get("root_uri", "")

--- a/bot/vikingbot/openviking_mount/ov_server.py
+++ b/bot/vikingbot/openviking_mount/ov_server.py
@@ -581,9 +581,14 @@ class VikingClient:
             return await self.client.find(query, target_uri=target_uri, **kwargs)
         return await self.client.find(query, **kwargs)
 
-    async def add_resource(self, local_path: str, desc: str) -> Optional[Dict[str, Any]]:
+    async def add_resource(
+        self,
+        local_path: str,
+        desc: str,
+        to: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """添加资源到 Viking"""
-        result = await self.client.add_resource(path=local_path, reason=desc)
+        result = await self.client.add_resource(path=local_path, to=to, reason=desc)
         return result
 
     async def list_resources(


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

VikingBot currently drops a user-specified resource destination even though the
OpenViking client already supports exact placement through `to`. This change exposes
that optional target in `openviking_add_resource` and forwards it through the Bot
adapter. Calls that omit `to` keep the existing automatic naming behavior.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

Fixes #4008

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- add an optional exact `to` URI to the VikingBot resource tool schema;
- forward `to` through `VikingClient.add_resource()` to the existing SDK API; and
- cover explicit targets, omitted-target compatibility, returned `root_uri`, and SDK call arguments.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Focused checks:

- `pytest -q -o addopts='' bot/tests/test_openviking_add_resource.py` (5 passed)
- the same test file against `upstream/main` (4 failed, 1 passed)
- `ruff check` on all three changed Python files
- `ruff format --check` on the changed tool and new test file
- Python compile checks and `git diff --check`

The broader `bot/tests/test_openviking_api_key_type.py` module could not be collected
in the available reused environment because its Bot-only `prompt_toolkit` dependency
was not installed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

Not applicable.

## Additional Notes

<!-- Add any additional notes or context about the PR -->

The JSON tool schema is the model-facing parameter contract; the existing Bot docs
list this tool but do not document individual parameters. A general-purpose `mv` tool
and changes to SDK, server, storage, or authorization behavior are intentionally out of
scope. No Feishu end-to-end environment was available for this local validation.
