### PR TITLE
fix(task-store): handle concurrent LocalFS directory creation

### DIFF
--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -117,7 +117,8 @@ class PersistentTaskStore:
         except AGFSAlreadyExistsError:
             return
         except Exception as exc:
-            if "already exists" in str(exc).lower():
+            message = str(exc).lower()
+            if "already exists" in message or "file exists" in message:
                 return
             raise
 

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Unit tests for persistent task storage."""
+
+import pytest
+
+from openviking.pyagfs.exceptions import AGFSPluginError
+from openviking.service.task_store import PersistentTaskStore
+
+pytestmark = pytest.mark.asyncio
+
+
+class _MkdirPluginErrorAgfs:
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def mkdir(self, path: str, mode: str = "755"):
+        raise AGFSPluginError(self._message)
+
+
+async def test_mkdir_if_missing_ignores_localfs_file_exists_plugin_error():
+    store = PersistentTaskStore(
+        _MkdirPluginErrorAgfs("plugin error: failed to create directory: File exists (os error 17)")
+    )
+
+    await store._mkdir_if_missing("/local/acme")
+
+
+async def test_mkdir_if_missing_propagates_unrelated_plugin_error():
+    store = PersistentTaskStore(_MkdirPluginErrorAgfs("plugin error: permission denied"))
+
+    with pytest.raises(AGFSPluginError, match="permission denied"):
+        await store._mkdir_if_missing("/local/acme")


### PR DESCRIPTION
## Description

Concurrent task creation can race while initializing a TaskStore owner directory. LocalFS reports the losing `mkdir` as an `AGFSPluginError` containing `File exists`, which was not covered by the store's existing idempotent mkdir handling and could make Session commit return HTTP 503.

This change recognizes the LocalFS message alongside the existing `already exists` cases. Other plugin errors still propagate.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4018

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Treat LocalFS `File exists` plugin errors as idempotent during TaskStore directory initialization.
- Add regression coverage for the exact Linux error observed in CI.
- Verify unrelated plugin errors remain visible.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Validation:

- `python -m pytest --noconftest -o addopts='' -o asyncio_mode=auto tests/test_task_store.py -q` (`2 passed`)
- `ruff format --check openviking/service/task_store.py tests/test_task_store.py`
- `ruff check openviking/service/task_store.py tests/test_task_store.py`
- `mypy --follow-imports=skip tests/test_task_store.py`
- `python -m compileall -q openviking/service/task_store.py tests/test_task_store.py`
- `git diff --check upstream/main..HEAD`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The full API/CLI integration workflow and native AGFS build were not run locally. The observed failure and traceback come from repository CI run 31797907123.
