### PR TITLE
fix(vlm): add cooperative deadline to async retries

### DIFF
--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-import httpx
-
 from openviking.telemetry import tracer
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking.utils.multimodal import redact_image_data_urls
@@ -36,13 +34,6 @@ _DASHSCOPE_HOSTS = {
 
 
 _REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
-DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS = 30.0
-
-
-def _build_openai_http_timeout(timeout: float) -> httpx.Timeout:
-    """Keep the configured read/write budget and cap TCP connect separately."""
-    connect = min(float(timeout), DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS)
-    return httpx.Timeout(timeout, connect=connect)
 
 
 def _is_reasoning_model(model: Optional[str]) -> bool:
@@ -72,11 +63,11 @@ def _build_openai_client_kwargs(
             "api_key": api_key,
             "azure_endpoint": api_base,
             "api_version": api_version or DEFAULT_AZURE_API_VERSION,
-            "timeout": _build_openai_http_timeout(timeout),
+            "timeout": timeout,
         }
     else:
         kwargs = {"api_key": api_key, "base_url": api_base}
-    kwargs["timeout"] = _build_openai_http_timeout(timeout)
+    kwargs["timeout"] = timeout
     # OpenViking owns provider retry/backoff via retry_sync/retry_async.
     kwargs["max_retries"] = 0
     if extra_headers:
@@ -94,8 +85,12 @@ class OpenAIVLM(VLMBase):
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
 
-    def _retry_timeout_seconds(self) -> float:
-        """Overall async retry budget: first attempt plus each configured retry."""
+    def _retry_timeout_seconds(self) -> float | None:
+        """Return the retry budget for cancellation-cooperative async clients."""
+        if self.provider == "openai-codex":
+            # Codex delegates to a sync request in asyncio.to_thread, which
+            # cannot be stopped through asyncio cancellation.
+            return None
         return retry_deadline_seconds(self.timeout, self.max_retries)
 
     def get_client(self):

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+import httpx
+
 from openviking.telemetry import tracer
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking.utils.multimodal import redact_image_data_urls
@@ -19,7 +21,7 @@ try:
 except ImportError:
     openai = None
 
-from openviking.utils.model_retry import retry_async, retry_sync
+from openviking.utils.model_retry import retry_async, retry_deadline_seconds, retry_sync
 
 from ..base import ToolCall, VLMBase, VLMResponse
 from ..registry import DEFAULT_AZURE_API_VERSION
@@ -34,6 +36,13 @@ _DASHSCOPE_HOSTS = {
 
 
 _REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS = 30.0
+
+
+def _build_openai_http_timeout(timeout: float) -> httpx.Timeout:
+    """Keep the configured read/write budget and cap TCP connect separately."""
+    connect = min(float(timeout), DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS)
+    return httpx.Timeout(timeout, connect=connect)
 
 
 def _is_reasoning_model(model: Optional[str]) -> bool:
@@ -63,11 +72,11 @@ def _build_openai_client_kwargs(
             "api_key": api_key,
             "azure_endpoint": api_base,
             "api_version": api_version or DEFAULT_AZURE_API_VERSION,
-            "timeout": timeout,
+            "timeout": _build_openai_http_timeout(timeout),
         }
     else:
         kwargs = {"api_key": api_key, "base_url": api_base}
-    kwargs["timeout"] = timeout
+    kwargs["timeout"] = _build_openai_http_timeout(timeout)
     # OpenViking owns provider retry/backoff via retry_sync/retry_async.
     kwargs["max_retries"] = 0
     if extra_headers:
@@ -84,6 +93,10 @@ class OpenAIVLM(VLMBase):
         self._async_client_cache = LoopScopedAsyncClientCache()
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
+
+    def _retry_timeout_seconds(self) -> float:
+        """Overall async retry budget: first attempt plus each configured retry."""
+        return retry_deadline_seconds(self.timeout, self.max_retries)
 
     def get_client(self):
         """Get sync client"""
@@ -354,6 +367,7 @@ class OpenAIVLM(VLMBase):
             max_retries=self.max_retries,
             logger=logger,
             operation_name="OpenAI VLM async completion",
+            timeout=self._retry_timeout_seconds(),
         )
 
     def _detect_image_format(self, data: bytes) -> str:
@@ -469,4 +483,5 @@ class OpenAIVLM(VLMBase):
             max_retries=self.max_retries,
             logger=logger,
             operation_name="OpenAI VLM async vision completion",
+            timeout=self._retry_timeout_seconds(),
         )

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -6,7 +6,7 @@ import random
 import re
 import threading
 import time
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar, cast
 
 from openviking.utils.exceptions import AllCredentialsFailedError
 
@@ -377,6 +377,31 @@ def _timeout_error(operation_name: str, timeout: float) -> TimeoutError:
     return TimeoutError(f"{operation_name} timed out after {timeout:.1f}s")
 
 
+class _RetryDeadlineExpired(Exception):
+    """Internal signal that the overall retry deadline expired."""
+
+
+async def _capture_attempt(awaitable: Awaitable[T]) -> tuple[T | None, Exception | None]:
+    """Capture child exceptions so only ``wait_for`` can signal deadline expiry."""
+    try:
+        return await awaitable, None
+    except Exception as error:
+        return None, error
+
+
+async def _await_attempt_with_timeout(awaitable: Awaitable[T], timeout: float) -> T:
+    """Apply a cooperative timeout while preserving child exception identity."""
+    try:
+        result, error = await asyncio.wait_for(_capture_attempt(awaitable), timeout=timeout)
+    except asyncio.TimeoutError:
+        raise _RetryDeadlineExpired from None
+
+    if error is not None:
+        raise error
+
+    return cast(T, result)
+
+
 async def retry_async(
     func: Callable[[], Awaitable[T]],
     *,
@@ -392,29 +417,31 @@ async def retry_async(
     """Retry an async function on known transient errors.
 
     ``timeout`` is an optional overall deadline in seconds for the whole retry
-    loop, including backoff sleeps. When it expires, the in-flight attempt is
-    cancelled and ``TimeoutError`` is raised without further retries. Existing
-    callers that omit it keep the previous unbounded behavior.
+    loop, including backoff sleeps. At expiry, asyncio cancellation is requested;
+    cancellation-cooperative awaitables raise ``TimeoutError`` after cancellation
+    completes. An awaitable that suppresses cancellation, or work delegated to a
+    thread, may outlive the deadline. Existing callers that omit ``timeout`` keep
+    the previous unbounded behavior and exception retry semantics.
     """
     if timeout is not None and timeout <= 0:
         raise ValueError("timeout must be positive")
 
-    deadline = None if timeout is None else time.monotonic() + timeout
+    loop = asyncio.get_running_loop()
+    timeout_seconds = 0.0 if timeout is None else float(timeout)
+    deadline = None if timeout is None else loop.time() + timeout_seconds
     attempt = 0
 
     while True:
-        remaining = None if deadline is None else deadline - time.monotonic()
+        remaining = None if deadline is None else deadline - loop.time()
         if remaining is not None and remaining <= 0:
-            raise _timeout_error(operation_name, timeout)
+            raise _timeout_error(operation_name, timeout_seconds)
 
         try:
             if remaining is None:
                 return await func()
-            return await asyncio.wait_for(func(), timeout=remaining)
-        except asyncio.TimeoutError as exc:
-            if timeout is None:
-                raise
-            raise _timeout_error(operation_name, timeout) from exc
+            return await _await_attempt_with_timeout(func(), remaining)
+        except _RetryDeadlineExpired:
+            raise _timeout_error(operation_name, timeout_seconds) from None
         except Exception as e:
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
@@ -426,9 +453,9 @@ async def retry_async(
                 jitter=jitter,
             )
             if deadline is not None:
-                remaining_after = deadline - time.monotonic()
+                remaining_after = deadline - loop.time()
                 if remaining_after <= 0:
-                    raise _timeout_error(operation_name, timeout)
+                    raise _timeout_error(operation_name, timeout_seconds)
                 delay = min(delay, remaining_after)
             if logger:
                 logger.warning(

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -365,6 +365,18 @@ def retry_sync(
             attempt += 1
 
 
+def retry_deadline_seconds(attempt_timeout: float, max_retries: int) -> float:
+    """Return an overall retry budget covering the first call and each retry."""
+    if attempt_timeout <= 0:
+        raise ValueError("attempt_timeout must be positive")
+    attempts = max(int(max_retries), 0) + 1
+    return float(attempt_timeout) * attempts
+
+
+def _timeout_error(operation_name: str, timeout: float) -> TimeoutError:
+    return TimeoutError(f"{operation_name} timed out after {timeout:.1f}s")
+
+
 async def retry_async(
     func: Callable[[], Awaitable[T]],
     *,
@@ -375,13 +387,34 @@ async def retry_async(
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
     logger=None,
     operation_name: str = "operation",
+    timeout: float | None = None,
 ) -> T:
-    """Retry an async function on known transient errors."""
+    """Retry an async function on known transient errors.
+
+    ``timeout`` is an optional overall deadline in seconds for the whole retry
+    loop, including backoff sleeps. When it expires, the in-flight attempt is
+    cancelled and ``TimeoutError`` is raised without further retries. Existing
+    callers that omit it keep the previous unbounded behavior.
+    """
+    if timeout is not None and timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    deadline = None if timeout is None else time.monotonic() + timeout
     attempt = 0
 
     while True:
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            raise _timeout_error(operation_name, timeout)
+
         try:
-            return await func()
+            if remaining is None:
+                return await func()
+            return await asyncio.wait_for(func(), timeout=remaining)
+        except asyncio.TimeoutError as exc:
+            if timeout is None:
+                raise
+            raise _timeout_error(operation_name, timeout) from exc
         except Exception as e:
             if max_retries <= 0 or attempt >= max_retries or not is_retryable(e):
                 raise
@@ -392,6 +425,11 @@ async def retry_async(
                 max_delay=max_delay,
                 jitter=jitter,
             )
+            if deadline is not None:
+                remaining_after = deadline - time.monotonic()
+                if remaining_after <= 0:
+                    raise _timeout_error(operation_name, timeout)
+                delay = min(delay, remaining_after)
             if logger:
                 logger.warning(
                     "%s failed with retryable error (retry %d/%d): %s; retrying in %.2fs",

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -6,7 +6,7 @@ import random
 import re
 import threading
 import time
-from typing import Awaitable, Callable, TypeVar, cast
+from typing import Any, Awaitable, Callable, TypeVar
 
 from openviking.utils.exceptions import AllCredentialsFailedError
 
@@ -381,25 +381,43 @@ class _RetryDeadlineExpired(Exception):
     """Internal signal that the overall retry deadline expired."""
 
 
-async def _capture_attempt(awaitable: Awaitable[T]) -> tuple[T | None, Exception | None]:
-    """Capture child exceptions so only ``wait_for`` can signal deadline expiry."""
+def _consume_attempt_exception(attempt: asyncio.Future[Any]) -> None:
+    """Retrieve an exception from an attempt that finished during cleanup."""
+    if not attempt.cancelled():
+        attempt.exception()
+
+
+async def _cancel_and_wait(attempt: asyncio.Future[T]) -> None:
+    """Cancel an attempt without conflating its cancellation with the caller's."""
+    attempt.cancel()
     try:
-        return await awaitable, None
-    except Exception as error:
-        return None, error
+        # asyncio.wait observes completion without propagating the attempt's own
+        # CancelledError into this cleanup task. A CancelledError raised here is
+        # therefore always cancellation of the retry_async caller and must win.
+        await asyncio.wait((attempt,))
+    finally:
+        if attempt.done():
+            _consume_attempt_exception(attempt)
+        else:
+            attempt.add_done_callback(_consume_attempt_exception)
 
 
 async def _await_attempt_with_timeout(awaitable: Awaitable[T], timeout: float) -> T:
     """Apply a cooperative timeout while preserving child exception identity."""
+    attempt = asyncio.ensure_future(awaitable)
     try:
-        result, error = await asyncio.wait_for(_capture_attempt(awaitable), timeout=timeout)
-    except asyncio.TimeoutError:
+        # wait_for() can swallow caller cancellation when the attempt completes
+        # in the same event-loop turn on Python 3.10/3.11 (CPython #86296).
+        done, _ = await asyncio.wait((attempt,), timeout=timeout)
+    except asyncio.CancelledError:
+        await _cancel_and_wait(attempt)
+        raise
+
+    if not done:
+        await _cancel_and_wait(attempt)
         raise _RetryDeadlineExpired from None
 
-    if error is not None:
-        raise error
-
-    return cast(T, result)
+    return attempt.result()
 
 
 async def retry_async(
@@ -419,9 +437,11 @@ async def retry_async(
     ``timeout`` is an optional overall deadline in seconds for the whole retry
     loop, including backoff sleeps. At expiry, asyncio cancellation is requested;
     cancellation-cooperative awaitables raise ``TimeoutError`` after cancellation
-    completes. An awaitable that suppresses cancellation, or work delegated to a
-    thread, may outlive the deadline. Existing callers that omit ``timeout`` keep
-    the previous unbounded behavior and exception retry semantics.
+    completes. Cancellation of the ``retry_async`` caller is propagated after the
+    active attempt is cancelled. An awaitable that suppresses cancellation, or
+    work delegated to a thread, may outlive the deadline. Existing callers that
+    omit ``timeout`` keep the previous unbounded behavior and exception retry
+    semantics.
     """
     if timeout is not None and timeout <= 0:
         raise ValueError("timeout must be positive")

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -110,7 +110,10 @@ class VLMConfig(BaseModel):
         description=(
             "Per-request HTTP timeout in seconds for VLM API calls. Applied to "
             "the underlying OpenAI/Azure/LiteLLM clients. Increase for slow or "
-            "high-latency endpoints (e.g., DashScope, local inference servers)."
+            "high-latency endpoints (e.g., DashScope, local inference servers). "
+            "Cancellation-cooperative OpenAI-compatible async calls also derive "
+            "an overall retry deadline as (max_retries + 1) * timeout; threaded "
+            "providers such as Codex keep the per-request timeout only."
         ),
     )
 

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -9,26 +9,19 @@ These tests lock in that the config value flows through to the underlying
 OpenAI and LiteLLM clients.
 """
 
+import asyncio
 from unittest import mock
 
 import httpx
+import openai
 import pytest
 from pydantic import ValidationError
 
 from openviking.models.vlm.backends.openai_vlm import (
-    DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS,
     OpenAIVLM,
     _build_openai_client_kwargs,
-    _build_openai_http_timeout,
 )
 from openviking_cli.utils.config.vlm_config import VLMConfig
-
-
-def _assert_openai_timeout(value, *, read: float) -> None:
-    assert isinstance(value, httpx.Timeout)
-    assert value.read == read
-    assert value.write == read
-    assert value.connect == min(read, DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS)
 
 
 def test_vlm_config_accepts_timeout():
@@ -48,7 +41,7 @@ def test_vlm_config_rejects_non_positive_timeout():
 
 def test_build_openai_client_kwargs_default_timeout():
     kwargs = _build_openai_client_kwargs("openai", "sk-x", "https://example.invalid", None, None)
-    _assert_openai_timeout(kwargs["timeout"], read=600.0)
+    assert kwargs["timeout"] == 600.0
 
 
 def test_build_openai_client_kwargs_custom_timeout():
@@ -60,19 +53,7 @@ def test_build_openai_client_kwargs_custom_timeout():
         None,
         timeout=120.0,
     )
-    _assert_openai_timeout(kwargs["timeout"], read=120.0)
-
-
-def test_build_openai_http_timeout_caps_connect_below_long_read():
-    timeout = _build_openai_http_timeout(600.0)
-    _assert_openai_timeout(timeout, read=600.0)
-    assert timeout.connect == DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS
-
-
-def test_build_openai_http_timeout_does_not_exceed_short_read():
-    timeout = _build_openai_http_timeout(10.0)
-    _assert_openai_timeout(timeout, read=10.0)
-    assert timeout.connect == 10.0
+    assert kwargs["timeout"] == 120.0
 
 
 def test_openai_vlm_propagates_config_timeout():
@@ -89,7 +70,7 @@ def test_openai_vlm_propagates_config_timeout():
 
     with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
-    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=120.0)
+    assert fake.call_args.kwargs.get("timeout") == 120.0
 
 
 def test_openai_vlm_defaults_to_600_timeout_when_config_omits_it():
@@ -105,7 +86,7 @@ def test_openai_vlm_defaults_to_600_timeout_when_config_omits_it():
 
     with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
-    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=600.0)
+    assert fake.call_args.kwargs.get("timeout") == 600.0
 
 
 def test_litellm_build_kwargs_includes_timeout():
@@ -158,7 +139,23 @@ def test_codex_vlm_propagates_config_timeout():
         )
         assert vlm.get_completion("hello") == "timeout ok"
 
-    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=45.0)
+    assert fake.call_args.kwargs.get("timeout") == 45.0
+
+
+def test_codex_vlm_skips_asyncio_deadline_for_threaded_requests():
+    from openviking.models.vlm.backends.codex_vlm import CodexVLM
+
+    vlm = CodexVLM(
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.3-codex",
+            "api_key": "oauth-token",
+            "api_base": "https://example.invalid/codex",
+            "timeout": 45.0,
+        }
+    )
+
+    assert vlm._retry_timeout_seconds() is None
 
 
 def test_openai_vlm_retry_deadline_scales_with_attempts():
@@ -173,3 +170,46 @@ def test_openai_vlm_retry_deadline_scales_with_attempts():
         }
     )
     assert vlm._retry_timeout_seconds() == 40.0
+
+
+@pytest.mark.asyncio
+async def test_openai_vlm_retry_deadline_cancels_async_transport(monkeypatch):
+    request_started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+
+    async def handle_request(_request: httpx.Request) -> httpx.Response:
+        request_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            raise
+        raise AssertionError("unreachable")
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+    client = openai.AsyncOpenAI(
+        api_key="sk-x",
+        base_url="https://example.invalid/v1",
+        http_client=http_client,
+        max_retries=0,
+    )
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid/v1",
+            "timeout": 1.0,
+            "max_retries": 0,
+        }
+    )
+    monkeypatch.setattr(vlm, "get_async_client", lambda: client)
+
+    try:
+        with pytest.raises(TimeoutError, match="timed out after 1.0s"):
+            await vlm.get_completion_async("hello")
+    finally:
+        await client.close()
+
+    assert request_started.is_set()
+    assert cancellation_seen.is_set()

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -11,14 +11,24 @@ OpenAI and LiteLLM clients.
 
 from unittest import mock
 
+import httpx
 import pytest
 from pydantic import ValidationError
 
 from openviking.models.vlm.backends.openai_vlm import (
+    DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS,
     OpenAIVLM,
     _build_openai_client_kwargs,
+    _build_openai_http_timeout,
 )
 from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+def _assert_openai_timeout(value, *, read: float) -> None:
+    assert isinstance(value, httpx.Timeout)
+    assert value.read == read
+    assert value.write == read
+    assert value.connect == min(read, DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS)
 
 
 def test_vlm_config_accepts_timeout():
@@ -38,7 +48,7 @@ def test_vlm_config_rejects_non_positive_timeout():
 
 def test_build_openai_client_kwargs_default_timeout():
     kwargs = _build_openai_client_kwargs("openai", "sk-x", "https://example.invalid", None, None)
-    assert kwargs["timeout"] == 600.0
+    _assert_openai_timeout(kwargs["timeout"], read=600.0)
 
 
 def test_build_openai_client_kwargs_custom_timeout():
@@ -50,7 +60,19 @@ def test_build_openai_client_kwargs_custom_timeout():
         None,
         timeout=120.0,
     )
-    assert kwargs["timeout"] == 120.0
+    _assert_openai_timeout(kwargs["timeout"], read=120.0)
+
+
+def test_build_openai_http_timeout_caps_connect_below_long_read():
+    timeout = _build_openai_http_timeout(600.0)
+    _assert_openai_timeout(timeout, read=600.0)
+    assert timeout.connect == DEFAULT_OPENAI_CONNECT_TIMEOUT_SECONDS
+
+
+def test_build_openai_http_timeout_does_not_exceed_short_read():
+    timeout = _build_openai_http_timeout(10.0)
+    _assert_openai_timeout(timeout, read=10.0)
+    assert timeout.connect == 10.0
 
 
 def test_openai_vlm_propagates_config_timeout():
@@ -67,7 +89,7 @@ def test_openai_vlm_propagates_config_timeout():
 
     with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
-    assert fake.call_args.kwargs.get("timeout") == 120.0
+    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=120.0)
 
 
 def test_openai_vlm_defaults_to_600_timeout_when_config_omits_it():
@@ -83,7 +105,7 @@ def test_openai_vlm_defaults_to_600_timeout_when_config_omits_it():
 
     with mock.patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI") as fake:
         vlm.get_client()
-    assert fake.call_args.kwargs.get("timeout") == 600.0
+    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=600.0)
 
 
 def test_litellm_build_kwargs_includes_timeout():
@@ -136,4 +158,18 @@ def test_codex_vlm_propagates_config_timeout():
         )
         assert vlm.get_completion("hello") == "timeout ok"
 
-    assert fake.call_args.kwargs.get("timeout") == 45.0
+    _assert_openai_timeout(fake.call_args.kwargs.get("timeout"), read=45.0)
+
+
+def test_openai_vlm_retry_deadline_scales_with_attempts():
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-x",
+            "api_base": "https://example.invalid",
+            "timeout": 10.0,
+            "max_retries": 3,
+        }
+    )
+    assert vlm._retry_timeout_seconds() == 40.0

--- a/tests/models/vlm/test_timeout_config.py
+++ b/tests/models/vlm/test_timeout_config.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for ``vlm.timeout`` configuration propagation.
+"""Tests for ``vlm.timeout`` propagation and derived async retry deadlines.
 
 Before this was wired through, ``_build_openai_client_kwargs`` exposed a
 ``timeout`` parameter (#1208) but callers never passed it, so the default
 timeout was always used and end users could not override it via ``ov.conf``.
 These tests lock in that the config value flows through to the underlying
-OpenAI and LiteLLM clients.
+OpenAI and LiteLLM clients. They also cover the cancellation-cooperative retry
+deadline derived by OpenAI-compatible async backends and the threaded Codex
+exception to that policy.
 """
 
 import asyncio

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -186,9 +186,20 @@ def test_retry_deadline_seconds_covers_first_call_and_retries():
     assert retry_deadline_seconds(600.0, 0) == 600.0
 
 
-def test_retry_deadline_seconds_rejects_non_positive_timeout():
+@pytest.mark.parametrize("attempt_timeout", [0, -1])
+def test_retry_deadline_seconds_rejects_non_positive_timeout(attempt_timeout):
     with pytest.raises(ValueError, match="attempt_timeout must be positive"):
-        retry_deadline_seconds(0, 3)
+        retry_deadline_seconds(attempt_timeout, 3)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout", [0, -1])
+async def test_retry_async_rejects_non_positive_timeout(timeout):
+    async def _call():
+        return "unreachable"
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        await retry_async(_call, max_retries=0, timeout=timeout)
 
 
 @pytest.mark.asyncio
@@ -234,6 +245,27 @@ async def test_retry_async_expires_when_a_later_attempt_hangs():
 
     assert attempts["count"] == 2
     assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
+async def test_retry_async_deadline_includes_backoff_sleep():
+    attempts = {"count": 0}
+
+    async def _call():
+        attempts["count"] += 1
+        raise RuntimeError("Connection error")
+
+    with pytest.raises(TimeoutError, match="timed out after 0.1s"):
+        await retry_async(
+            _call,
+            max_retries=3,
+            timeout=0.1,
+            base_delay=10,
+            max_delay=10,
+            jitter=False,
+        )
+
+    assert attempts["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -300,6 +332,57 @@ async def test_retry_async_with_deadline_preserves_inner_timeout_error():
         await retry_async(_call, max_retries=0, timeout=1)
 
     assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+async def test_retry_async_preserves_caller_cancellation_racing_attempt_completion():
+    async def _run_once():
+        attempt_started = asyncio.Event()
+        release_attempt = asyncio.Event()
+
+        async def _call():
+            attempt_started.set()
+            await release_attempt.wait()
+            return "ok"
+
+        task = asyncio.create_task(retry_async(_call, max_retries=0, timeout=10))
+        await attempt_started.wait()
+
+        release_attempt.set()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    for _ in range(20):
+        await _run_once()
+
+
+@pytest.mark.asyncio
+async def test_retry_async_preserves_caller_cancellation_during_deadline_cleanup():
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    attempt_finished = asyncio.Event()
+
+    async def _call():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            return "late"
+        finally:
+            attempt_finished.set()
+
+    task = asyncio.create_task(retry_async(_call, max_retries=0, timeout=0.01))
+    await cleanup_started.wait()
+
+    task.cancel()
+    release_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await attempt_finished.wait()
 
 
 def test_quota_exceeded_case_insensitive():

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for shared model retry helpers."""
 
+import asyncio
+import time
+
 import pytest
 
 from openviking.utils.exceptions import AllCredentialsFailedError
@@ -14,6 +17,7 @@ from openviking.utils.model_retry import (
     ERROR_CLASS_TRANSIENT,
     classify_api_error,
     retry_async,
+    retry_deadline_seconds,
     retry_sync,
 )
 
@@ -175,6 +179,69 @@ async def test_retry_async_does_not_retry_quota_exceeded():
         await retry_async(_call, max_retries=5)
 
     assert attempts["count"] == 1
+
+
+def test_retry_deadline_seconds_covers_first_call_and_retries():
+    assert retry_deadline_seconds(10.0, 3) == 40.0
+    assert retry_deadline_seconds(600.0, 0) == 600.0
+
+
+def test_retry_deadline_seconds_rejects_non_positive_timeout():
+    with pytest.raises(ValueError, match="attempt_timeout must be positive"):
+        retry_deadline_seconds(0, 3)
+
+
+@pytest.mark.asyncio
+async def test_retry_async_cancels_hanging_attempt_when_timeout_expires():
+    attempts = {"count": 0}
+
+    async def _call():
+        attempts["count"] += 1
+        await asyncio.sleep(10)
+        return "ok"
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="timed out after 0.2s"):
+        await retry_async(_call, max_retries=3, timeout=0.2, jitter=False)
+    elapsed = time.monotonic() - started
+
+    assert attempts["count"] == 1
+    assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
+async def test_retry_async_expires_when_a_later_attempt_hangs():
+    attempts = {"count": 0}
+
+    async def _call():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("Connection error")
+        await asyncio.sleep(10)
+        return "ok"
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="timed out after 0.3s"):
+        await retry_async(
+            _call,
+            max_retries=3,
+            timeout=0.3,
+            base_delay=0.01,
+            max_delay=0.01,
+            jitter=False,
+        )
+    elapsed = time.monotonic() - started
+
+    assert attempts["count"] == 2
+    assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
+async def test_retry_async_omitting_timeout_keeps_success_path():
+    async def _call():
+        return "ok"
+
+    assert await retry_async(_call, max_retries=3) == "ok"
 
 
 def test_quota_exceeded_case_insensitive():

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -244,6 +244,64 @@ async def test_retry_async_omitting_timeout_keeps_success_path():
     assert await retry_async(_call, max_retries=3) == "ok"
 
 
+@pytest.mark.asyncio
+async def test_retry_async_without_deadline_retries_inner_timeout_error():
+    attempts = {"count": 0}
+
+    async def _call():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise asyncio.TimeoutError("timeout while reading provider response")
+        return "ok"
+
+    result = await retry_async(
+        _call,
+        max_retries=1,
+        base_delay=0,
+        max_delay=0,
+        jitter=False,
+    )
+
+    assert result == "ok"
+    assert attempts["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_async_with_deadline_retries_inner_timeout_error():
+    attempts = {"count": 0}
+
+    async def _call():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise asyncio.TimeoutError("timeout while reading provider response")
+        return "ok"
+
+    result = await retry_async(
+        _call,
+        max_retries=1,
+        timeout=1,
+        base_delay=0,
+        max_delay=0,
+        jitter=False,
+    )
+
+    assert result == "ok"
+    assert attempts["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_async_with_deadline_preserves_inner_timeout_error():
+    error = asyncio.TimeoutError("timeout while reading provider response")
+
+    async def _call():
+        raise error
+
+    with pytest.raises(asyncio.TimeoutError) as exc_info:
+        await retry_async(_call, max_retries=0, timeout=1)
+
+    assert exc_info.value is error
+
+
 def test_quota_exceeded_case_insensitive():
     """Quota detection is case-insensitive."""
     assert classify_api_error(RuntimeError("QUOTA LIMIT")) == ERROR_CLASS_QUOTA_EXCEEDED


### PR DESCRIPTION
## Description

Session commit Phase 2 can remain `running` indefinitely after a transient VLM `Connection error` when a later asynchronous retry attempt stalls.

Although `vlm.timeout` bounds individual client requests, `retry_async()` previously had no overall deadline covering the complete retry loop, including subsequent attempts and backoff sleeps.

This PR adds an optional, cancellation-cooperative deadline to asynchronous retries and applies it to OpenAI-compatible async VLM paths. The deadline is derived as:

```text
(max_retries + 1) * vlm.timeout
```

The existing scalar client timeout remains unchanged. This PR does not introduce a separate connect-timeout cap.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4017

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add an optional overall `timeout` to `retry_async()`.
- Cover active attempts and retry backoff sleeps with the same monotonic deadline.
- Cancel and await an in-flight cancellation-cooperative attempt when the deadline expires.
- Preserve the existing behavior of callers that omit `timeout`.
- Keep child `TimeoutError` exceptions on the existing retry path and preserve their original exception identity.
- Preserve caller `CancelledError` when cancellation races with attempt completion on Python 3.10/3.11.
- Derive the OpenAI-compatible async retry deadline from `(max_retries + 1) * vlm.timeout`.
- Apply the deadline to both async text completion and async vision completion.
- Exclude the `openai-codex` path because it delegates synchronous work through `asyncio.to_thread()` and cannot stop the underlying request through asyncio cancellation.
- Document the derived retry-deadline behavior in the VLM timeout configuration.

## Review Follow-ups

The implementation incorporates the reviewer feedback:

- Removed the global 30-second connect-timeout cap. Sync OpenAI/Azure clients and inherited Kimi, GLM, and Codex paths retain the configured scalar `vlm.timeout`.
- Scoped the deadline contract to cancellation-cooperative asynchronous operations.
- Added a transport-level cancellation regression using `AsyncOpenAI` and `httpx.MockTransport`.
- Distinguished retry-deadline expiry from a `TimeoutError` raised by the provider call itself.
- Replaced the `asyncio.wait_for()` wrapper to avoid the Python 3.10/3.11 cancellation race described in CPython #86296.
- Added deterministic regression coverage for caller cancellation racing with attempt completion and cancellation during deadline cleanup.

## Testing

- [x] I have added tests that prove the fix is effective.
- [x] New and existing focused unit tests pass locally.
- [x] Tested on Windows.

Focused checks:

```text
python -m pytest -q -o "addopts=" --noconftest tests/unit/test_model_retry.py tests/models/vlm/test_timeout_config.py
56 passed, 1 third-party deprecation warning
```

```text
ruff check openviking/utils/model_retry.py openviking_cli/utils/config/vlm_config.py tests/models/vlm/test_timeout_config.py tests/unit/test_model_retry.py
All checks passed
```

```text
ruff format --check openviking/utils/model_retry.py openviking_cli/utils/config/vlm_config.py tests/models/vlm/test_timeout_config.py tests/unit/test_model_retry.py
4 files already formatted
```

`git diff --check` also passes.

The focused pytest run uses `--noconftest` because the root shared test configuration imports `apscheduler`, which is not installed in the local environment. These tests do not depend on the shared service fixtures.

## Checklist

- [x] My code follows the project's coding style.
- [x] I have performed a self-review.
- [x] Complex cancellation behavior is documented with focused comments.
- [x] The VLM timeout configuration description has been updated.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published.

## Additional Notes

The deadline is cancellation-cooperative: an awaitable that suppresses `CancelledError` may outlive the configured budget. Threaded requests cannot be stopped through asyncio cancellation and are therefore excluded.

Task cancellation policy, RUNNING TTL/watchdog behavior, QueueFS concurrency, SessionCommit orchestration, `retry_sync()`, and unrelated VLM backends remain outside the scope of this PR.