### PR TITLE
fix(vikingbot): make session identifiers filesystem-safe

### DIFF
--- a/bot/tests/test_session_key.py
+++ b/bot/tests/test_session_key.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Tests for filesystem-safe VikingBot session identifiers."""
+
+import pytest
+from vikingbot.config.schema import SessionKey
+
+
+def test_safe_name_preserves_existing_safe_identifier():
+    key = SessionKey(type="cli", channel_id="default", chat_id="session-1")
+
+    assert key.safe_name() == "cli__default__session-1"
+    assert SessionKey.from_safe_name(key.safe_name()) == key
+
+
+@pytest.mark.parametrize("invalid_character", list('<>:"/\\|?*') + ["\x00", "\x1f"])
+def test_safe_name_round_trips_windows_invalid_characters(invalid_character):
+    key = SessionKey(
+        type="cli",
+        channel_id="default",
+        chat_id=f"scope{invalid_character}session",
+    )
+
+    safe_name = key.safe_name()
+
+    assert invalid_character not in safe_name
+    assert SessionKey.from_safe_name(safe_name) == key
+
+
+@pytest.mark.parametrize("suffix", [" ", "."])
+def test_safe_name_encodes_windows_invalid_trailing_characters(suffix):
+    key = SessionKey(type="cli", channel_id="default", chat_id=f"session{suffix}")
+
+    safe_name = key.safe_name()
+
+    assert not safe_name.endswith(suffix)
+    assert SessionKey.from_safe_name(safe_name) == key
+
+
+def test_safe_name_encoding_does_not_collide_with_underscore_replacement():
+    colon_key = SessionKey(type="cli", channel_id="default", chat_id="scope:session")
+    underscore_key = SessionKey(type="cli", channel_id="default", chat_id="scope_session")
+
+    assert colon_key.safe_name() != underscore_key.safe_name()
+
+
+def test_safe_name_round_trips_encoding_prefix():
+    key = SessionKey(type="cli", channel_id="default", chat_id="~b32~legacy-looking")
+
+    assert SessionKey.from_safe_name(key.safe_name()) == key

--- a/bot/vikingbot/config/schema.py
+++ b/bot/vikingbot/config/schema.py
@@ -1,14 +1,14 @@
 """Configuration schema using Pydantic."""
 
+import base64
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, ClassVar, Dict, Literal, Optional
 
+from openviking_cli.utils.config.vlm_config import VLMCredential
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 from pydantic.json_schema import SkipJsonSchema
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from openviking_cli.utils.config.vlm_config import VLMCredential
 
 
 class ChannelType(str, Enum):
@@ -1047,15 +1047,45 @@ class SessionKey(BaseModel):
     def __hash__(self):
         return hash((self.type, self.channel_id, self.chat_id))
 
+    _ENCODED_COMPONENT_PREFIX: ClassVar[str] = "~b32~"
+    _WINDOWS_INVALID_FILENAME_CHARS: ClassVar[frozenset[str]] = frozenset('<>:"/\\|?*')
+
+    @classmethod
+    def _encode_component(cls, value: str) -> str:
+        needs_encoding = (
+            value.startswith(cls._ENCODED_COMPONENT_PREFIX)
+            or any(ord(char) < 32 or char in cls._WINDOWS_INVALID_FILENAME_CHARS for char in value)
+            or value.endswith((" ", "."))
+        )
+        if not needs_encoding:
+            return value
+
+        encoded = base64.b32encode(value.encode("utf-8")).decode("ascii").rstrip("=")
+        return f"{cls._ENCODED_COMPONENT_PREFIX}{encoded}"
+
+    @classmethod
+    def _decode_component(cls, value: str) -> str:
+        if not value.startswith(cls._ENCODED_COMPONENT_PREFIX):
+            return value
+
+        encoded = value.removeprefix(cls._ENCODED_COMPONENT_PREFIX)
+        padding = "=" * (-len(encoded) % 8)
+        return base64.b32decode(encoded + padding).decode("utf-8")
+
     def safe_name(self):
-        return f"{self.type}__{self.channel_id}__{self.chat_id}"
+        return "__".join(
+            self._encode_component(component)
+            for component in (self.type, self.channel_id, self.chat_id)
+        )
 
     def channel_key(self):
         return f"{self.type}__{self.channel_id}"
 
     @staticmethod
     def from_safe_name(safe_name: str):
-        file_name_split = safe_name.split("__")
+        file_name_split = safe_name.split("__", 2)
         return SessionKey(
-            type=file_name_split[0], channel_id=file_name_split[1], chat_id=file_name_split[2]
+            type=SessionKey._decode_component(file_name_split[0]),
+            channel_id=SessionKey._decode_component(file_name_split[1]),
+            chat_id=SessionKey._decode_component(file_name_split[2]),
         )


### PR DESCRIPTION
## Description

Make VikingBot session identifiers portable across Windows filesystems. Session key components that contain Windows-invalid characters are encoded reversibly, while existing filesystem-safe identifiers remain unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4023

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve existing session names when all components are already filesystem-safe.
- Encode unsafe SessionKey components with reversible Base32 instead of lossy character replacement.
- Decode encoded components in from_safe_name() and add collision and Windows filename regression tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local verification:
- 16 targeted SessionKey tests passed.
- Ruff lint and format checks passed.
- git diff --check passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The Windows behavior is covered with platform-independent unit cases for all invalid filename characters, control characters, trailing spaces and periods. The change was not exercised on a Windows host.