### PR TITLE
fix(vectordb): encode str before xxhash in str_to_uint64

### DIFF
--- a/openviking/storage/vectordb/utils/str_to_uint64.py
+++ b/openviking/storage/vectordb/utils/str_to_uint64.py
@@ -7,4 +7,4 @@ def str_to_uint64(input_string: str) -> int:
     """
     Generate a 64-bit unsigned integer hash from a string using xxHash.
     """
-    return xxhash.xxh64(input_string).intdigest()
+    return xxhash.xxh64(input_string.encode("utf-8")).intdigest()

--- a/tests/vectordb/test_str_to_uint64.py
+++ b/tests/vectordb/test_str_to_uint64.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+import unittest
+
+from openviking.storage.vectordb.utils.str_to_uint64 import str_to_uint64
+
+
+class TestStrToUint64(unittest.TestCase):
+    def test_returns_uint64_within_range(self):
+        for sample in ("", "a", "00000000-0000-0000-0000-000000000000", "viking://resources/README"):
+            value = str_to_uint64(sample)
+            self.assertIsInstance(value, int)
+            self.assertTrue(0 <= value < (1 << 64), f"value out of uint64 range: {value}")
+
+    def test_deterministic(self):
+        sample = "viking://resources/README/.abstract.md"
+        self.assertEqual(str_to_uint64(sample), str_to_uint64(sample))
+
+    def test_accepts_non_ascii_strings(self):
+        # Regression test: str was previously passed straight to xxhash, which
+        # raised ``TypeError: Strings must be encoded before hashing`` and
+        # caused every partial-update upsert to be skipped silently.
+        for sample in ("中文记忆", "混合 viking://资源/路径", "\U0001f600emoji"):
+            value = str_to_uint64(sample)
+            self.assertIsInstance(value, int)
+            self.assertTrue(0 <= value < (1 << 64))
+
+    def test_distinct_inputs_have_distinct_values(self):
+        a = str_to_uint64("sparse_raw_terms")
+        b = str_to_uint64("sparse_values")
+        self.assertNotEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`str_to_uint64()` (used to derive the numeric label for string primary keys in the local vectordb backend) passed the raw `input_string` directly to `xxhash.xxh64()`, which requires **bytes** and raises:

```
TypeError: Strings must be encoded before hashing
```

Because the read-before-partial-update path in `viking_vector_index_backend.upsert(partial_update=True)` wraps this lookup in `try/except` and **silently skips the upsert on failure**, every partial update was dropped:

- semantic vectors were never persisted into the local store, and
- `find` / `search` kept returning "No results found" even after resource ingestion reported success.

## Fix

Encode the string as UTF-8 before hashing:

```python
return xxhash.xxh64(input_string.encode("utf-8")).intdigest()
```

## Reproduction

Environment (found while setting up the OpenViking OpenCode memory plugin):

- OS: Linux x86_64 (Arch-based "omarchy"), CPU with AVX2 (no AVX512)
- Python 3.13.15 (uv-managed), compilers GCC 16.2.1 / Clang 22, cmake 4.4.2, Rust 1.97.1
- opencode 1.18.18 with the bundled OpenCode plugin; local `openviking-server --with-bot`
- `storage.vectordb.backend: local`, local embedding

Steps:

1. Configure local vectordb and start `openviking-server`.
2. `ov add-resource <some local file>` and wait for ingestion to finish.
3. `ov find "any query"` → no results, while the server log is flooded with:

```
ERROR Error reading existing record before partial update: Strings must be encoded before hashing
```

Minimal repro:

```python
from openviking.storage.vectordb.utils.str_to_uint64 import str_to_uint64
str_to_uint64("any-string")   # TypeError before the fix
```

## Tests

Added `tests/vectordb/test_str_to_uint64.py` covering ASCII, non-ASCII, emoji, empty strings, determinism, and uint64 range. All pass:

```
4 passed
```
