### PR TITLE
build: stop vendored leveldb from linking system tcmalloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,16 @@ set(LEVELDB_INSTALL OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
 
+# The vendored leveldb (third_party/leveldb-1.23/CMakeLists.txt) auto-detects a
+# system tcmalloc via check_library_exists() and links it with PUBLIC
+# propagation. Because the Python abi3 extension module ends up transitively
+# linking that tcmalloc, the extension mixes the tcmalloc heap with the Python
+# allocator, which corrupts memory and intermittently SIGSEGVs inside
+# vectordb::Schema/bytes_row construction. Official wheels never link tcmalloc.
+# Default to OFF (opt-in via -DHAVE_TCMALLOC=ON) so builds behave like the
+# released wheels.
+set(HAVE_TCMALLOC OFF CACHE BOOL "Link system tcmalloc into the Python extension" FORCE)
+
 add_subdirectory(../third_party/leveldb-1.23 ${CMAKE_BINARY_DIR}/leveldb_build)
 if(TARGET leveldb)
     target_compile_options(leveldb PRIVATE -fPIC)


### PR DESCRIPTION
## Problem

The vendored `third_party/leveldb-1.23/CMakeLists.txt` auto-detects a **system tcmalloc** with `check_library_exists(tcmalloc malloc ...)` and links it with PUBLIC propagation. Because `engine_common → leveldb` is linked PUBLIC, the tcmalloc dependency transitively reaches the Python **abi3 extension module** (`_x86_*.abi3.so`).

The result is a process that mixes the tcmalloc heap with the Python allocator inside one extension module. On machines that have `libtcmalloc` installed (e.g. `/usr/lib/libtcmalloc.so.4`, common on Arch-based distros), this corrupts memory and produces **intermittent SIGSEGVs** during `vectordb::Schema` / `bytes_row` construction — even for a trivial `engine.Schema([{...}])` call with ordinary field names.

Official wheels never link tcmalloc, so this only reproduced with source builds on machines that happen to have tcmalloc present.

## Fix

Force `HAVE_TCMALLOC` off before `add_subdirectory(third_party/leveldb-1.23 ...)` in `src/CMakeLists.txt`, keeping the allocator opt-in via `-DHAVE_TCMALLOC=ON`:

```cmake
set(HAVE_TCMALLOC OFF CACHE BOOL "Link system tcmalloc into the Python extension" FORCE)
```

## Evidence

Same machine, identical sources, only the linker input differs:

| Build | links tcmalloc | `engine.Schema` with 5+ fields |
|-------|----------------|--------------------------------|
| source build (gcc 16 / clang 22) | yes (`-ltcmalloc`) | SIGSEGV (`Fatal Python error: Segmentation fault` in `_new_schema`) |
| published `openviking==0.4.13` wheel | no | works |
| source build with `-DHAVE_TCMALLOC=OFF` | no | works |

Environment (found while setting up the OpenViking OpenCode memory plugin):

- OS: Linux x86_64 (Arch-based "omarchy"), CPU with AVX2 (no AVX512)
- Python 3.13.15 (uv-managed), compilers GCC 16.2.1 / Clang 22, cmake 4.4.2, Rust 1.97.1
- opencode 1.18.18 with the bundled OpenCode plugin; local `openviking-server --with-bot`
- `libtcmalloc.so.4` present on the system

## Verification

After the change, a clean `setup.py build_ext` produces engine modules with no `-ltcmalloc` on the link line and the schema-construction crash disappears (`openviking-server doctor` passes, resource ingestion + `find` work).
