### PR TITLE
docs: document tkstack HTTP integration

### DIFF
--- a/docs/en/agent-integrations/01-overview.md
+++ b/docs/en/agent-integrations/01-overview.md
@@ -16,6 +16,7 @@ OpenViking can act as the long-term memory and context backend for many agent ru
 | **pi** | [pi Coding Agent Extension](./11-pi.md) — native extension with auto-recall, turn capture, and threshold commit |
 | **LangChain / LangGraph** | [LangChain and LangGraph](./07-langchain-langgraph.md) — retriever, tools, context backend, store, and middleware |
 | **Multiple local coding agents / a desktop UI** | [OpenViking Helper](./14-openviking-helper.md) — visual agent setup, session inspection, and memory management |
+| **tkstack / multiple local agents** | [tkstack HTTP Integration](./16-tkstack.md) — direct HTTP SDK access, shared identity boundaries, LiteLLM routing, and validation notes |
 | **Any Agent Plugins 1.0 client** | [Agent Plugins 1.0 Package](./15-agent-plugins.md) — one portable package: `openviking-memory` skill plus the OpenViking MCP tools |
 | **Manus / Claude Desktop / ChatGPT / other MCP clients** | [MCP Clients](./06-mcp-clients.md) — point any MCP-compatible client at the built-in `/mcp` endpoint |
 | **ZCode / AstrBot / …** | [Community Plugins](./08-community-plugins.md) — community-maintained integrations for various runtimes |

--- a/docs/en/agent-integrations/01-overview.md
+++ b/docs/en/agent-integrations/01-overview.md
@@ -16,7 +16,7 @@ OpenViking can act as the long-term memory and context backend for many agent ru
 | **pi** | [pi Coding Agent Extension](./11-pi.md) — native extension with auto-recall, turn capture, and threshold commit |
 | **LangChain / LangGraph** | [LangChain and LangGraph](./07-langchain-langgraph.md) — retriever, tools, context backend, store, and middleware |
 | **Multiple local coding agents / a desktop UI** | [OpenViking Helper](./14-openviking-helper.md) — visual agent setup, session inspection, and memory management |
-| **tkstack / multiple local agents** | [tkstack HTTP Integration](./16-tkstack.md) — direct HTTP SDK access, shared identity boundaries, LiteLLM routing, and validation notes |
+| **HTTP clients / multiple local agents** | [HTTP Integration for Multiple Local Agents](./16-tkstack.md) — direct HTTP SDK access, shared identity boundaries, LiteLLM routing, and validation guidance |
 | **Any Agent Plugins 1.0 client** | [Agent Plugins 1.0 Package](./15-agent-plugins.md) — one portable package: `openviking-memory` skill plus the OpenViking MCP tools |
 | **Manus / Claude Desktop / ChatGPT / other MCP clients** | [MCP Clients](./06-mcp-clients.md) — point any MCP-compatible client at the built-in `/mcp` endpoint |
 | **ZCode / AstrBot / …** | [Community Plugins](./08-community-plugins.md) — community-maintained integrations for various runtimes |

--- a/docs/en/agent-integrations/16-tkstack.md
+++ b/docs/en/agent-integrations/16-tkstack.md
@@ -1,0 +1,133 @@
+# tkstack HTTP Integration
+
+Use this integration when several local coding agents need to share one OpenViking server through HTTP. It is intended for a fork-maintained tkstack deployment and does not require an MCP client.
+
+## Deployment boundary
+
+The recommended boundary is:
+
+```text
+local agents -> OpenViking HTTP server -> storage and vector index
+                             |
+                             +-> LiteLLM for embedding and VLM requests
+```
+
+Keep the OpenViking server behind a private network or a loopback gateway. Use `api_key` authentication for a shared service. Use `trusted` only when a trusted gateway terminates authentication and injects the account/user identity; do not expose a trusted server directly to an untrusted network. See [Authentication](../guides/04-authentication.md) and [Multi-Tenant](../concepts/11-multi-tenant.md).
+
+Treat the Markdown or Git repository that feeds the deployment as the human-readable source of truth unless the deployment explicitly defines OpenViking as authoritative. The OpenViking workspace and vector index should be recoverable derived state.
+
+## Model configuration
+
+OpenViking supports LiteLLM as an embedding and VLM provider. The following is a template; replace the model routes, vector dimension, paths, and credentials at deployment time. Do not commit API keys.
+
+```json
+{
+  "storage": {
+    "workspace": "/var/lib/openviking",
+    "vectordb": {
+      "name": "context",
+      "backend": "local"
+    }
+  },
+  "embedding": {
+    "dense": {
+      "provider": "litellm",
+      "api_base": "http://127.0.0.1:4000/v1",
+      "api_key": "${LITELLM_API_KEY}",
+      "model": "<embedding-route>",
+      "dimension": 768,
+      "input": "text",
+      "max_concurrent": 1,
+      "max_retries": 0
+    }
+  },
+  "vlm": {
+    "provider": "litellm",
+    "api_base": "http://127.0.0.1:4000/v1",
+    "api_key": "${LITELLM_API_KEY}",
+    "model": "<chat-route>",
+    "max_concurrent": 1,
+    "max_retries": 0,
+    "stream": false
+  },
+  "server": {
+    "host": "127.0.0.1",
+    "port": 1933,
+    "auth_mode": "api_key",
+    "root_api_key": "${OPENVIKING_ROOT_API_KEY}"
+  }
+}
+```
+
+Before indexing data, verify the exact LiteLLM routes with a minimal `/v1/models`, chat, and embeddings request. `openviking-server doctor` validates configuration readiness, but it does not prove that every proxy route can complete an end-to-end request. Model names that contain provider keywords can be auto-detected by LiteLLM; use the route format required by the proxy and test it directly before importing a large corpus.
+
+Self-hosted OpenAI-compatible and LiteLLM embedding endpoints are dense-only. OpenViking does not automatically add a BM25 or other sparse fallback when the configured endpoint returns dense vectors. If Japanese exact matching is required, keep `grep` or a separate lexical index in the retrieval path. See [Embedding Configuration](../guides/01-configuration.md#embedding) for the provider and hybrid-search constraints.
+
+## Client pattern
+
+Use a user-scoped API key for each agent in production. The server resolves the account and user from the key, so agents can share an account while retaining an auditable identity.
+
+```python
+import os
+
+import openviking as ov
+
+
+client = ov.SyncHTTPClient(
+    url=os.environ["OPENVIKING_URL"],
+    api_key=os.environ["OPENVIKING_API_KEY"],
+    agent_id=os.environ.get("OPENVIKING_AGENT_ID", "local-agent"),
+    timeout=60,
+)
+
+try:
+    client.initialize()
+    result = client.find("shared deployment decision", limit=5)
+    print(result)
+finally:
+    client.close()
+```
+
+For a trusted loopback gateway, pass the account/user identity supplied by that gateway instead of using this pattern. Do not mix identity headers with `api_key` mode; in authenticated mode the key is the source of tenant identity.
+
+## Validation and fallback order
+
+After adding a resource, wait for processing before searching:
+
+```python
+client.add_resource("/path/to/context.md", parent="viking://resources", wait=True)
+client.wait_processed(timeout=300)
+```
+
+Use the following validation order:
+
+1. `GET /health` to confirm the server process.
+2. `ls` and `read` to confirm the resource tree and content.
+3. `grep` to confirm exact lexical retrieval.
+4. `find` and `search` to confirm semantic retrieval.
+5. A second client identity and a small concurrent request set to confirm sharing and latency.
+
+Do not treat a successful upload or completed embedding queue as proof that semantic retrieval works. If `grep` succeeds while `find` returns no results, inspect the server queue and VLM/embedding logs before importing more data. OpenViking issue [#677](https://github.com/volcengine/OpenViking/issues/677) documents the same symptom pattern for uploaded resources; a local reproduction should be treated as a release blocker until the root cause is isolated or a lexical fallback is in place.
+
+## Fork validation record
+
+The following smoke test was run against OpenViking `0.4.13` on 2026-08-16 with Python 3.13 and a local HTTP server:
+
+| Check | Result |
+| --- | --- |
+| Install with Python/uv, without Bun | Pass |
+| HTTP health on port 1933 | Pass |
+| Read/list/grep from four agent identities with 12 concurrent requests | Pass; all requests succeeded, maximum observed latency about 147 ms |
+| Japanese Markdown storage and exact retrieval | Pass |
+| Semantic `find` for the uploaded resource | Blocked; zero results in this run |
+| Existing LiteLLM VLM route | Blocked; the configured model alias was routed as DashScope and returned 429 |
+| Existing LiteLLM embedding route | Blocked upstream by an LM Studio `node ENOENT` failure; a temporary local GGUF embedder was used for the storage smoke test |
+
+The result supports OpenViking as an HTTP-accessible shared resource store for the pilot. It does not yet approve it as the production semantic context layer. Re-run the semantic checks after the LiteLLM routes are healthy, and record the exact OpenViking version, model IDs, vector dimension, and backend in the deployment change.
+
+## Related documentation
+
+- [Quick Start: Server Mode](../getting-started/03-quickstart-server.md)
+- [Authentication](../guides/04-authentication.md)
+- [Multi-Tenant](../concepts/11-multi-tenant.md)
+- [Embedding and VLM Configuration](../guides/01-configuration.md)

--- a/docs/en/agent-integrations/16-tkstack.md
+++ b/docs/en/agent-integrations/16-tkstack.md
@@ -1,6 +1,6 @@
-# tkstack HTTP Integration
+# HTTP Integration for Multiple Local Agents
 
-Use this integration when several local coding agents need to share one OpenViking server through HTTP. It is intended for a fork-maintained tkstack deployment and does not require an MCP client.
+Use this integration when several local coding agents need to share one OpenViking server through HTTP. The setup pattern is generic, while the fork-local validation record at the end documents one tkstack deployment. It does not require an MCP client.
 
 ## Deployment boundary
 
@@ -59,13 +59,15 @@ OpenViking supports LiteLLM as an embedding and VLM provider. The following is a
 }
 ```
 
+The example binds to `127.0.0.1` because it assumes that the agents, OpenViking, and LiteLLM run on the same host. If agents run on separate hosts, bind OpenViking to a private interface/address, restrict TCP port `1933` with the network firewall, and keep `api_key` authentication enabled. Never expose an unauthenticated or trusted-mode listener on a public interface.
+
 Before indexing data, verify the exact LiteLLM routes with a minimal `/v1/models`, chat, and embeddings request. `openviking-server doctor` validates configuration readiness, but it does not prove that every proxy route can complete an end-to-end request. Model names that contain provider keywords can be auto-detected by LiteLLM; use the route format required by the proxy and test it directly before importing a large corpus.
 
 Self-hosted OpenAI-compatible and LiteLLM embedding endpoints are dense-only. OpenViking does not automatically add a BM25 or other sparse fallback when the configured endpoint returns dense vectors. If Japanese exact matching is required, keep `grep` or a separate lexical index in the retrieval path. See [Embedding Configuration](../guides/01-configuration.md#embedding) for the provider and hybrid-search constraints.
 
 ## Client pattern
 
-Use a user-scoped API key for each agent in production. The server resolves the account and user from the key, so agents can share an account while retaining an auditable identity.
+Use a user-scoped API key for each agent in production. The server resolves the account and user from the key, so agents can share an account while retaining an auditable identity. `actor_peer_id` is optional request-scoped actor metadata; it is not a substitute for the user API key.
 
 ```python
 import os
@@ -76,7 +78,7 @@ import openviking as ov
 client = ov.SyncHTTPClient(
     url=os.environ["OPENVIKING_URL"],
     api_key=os.environ["OPENVIKING_API_KEY"],
-    agent_id=os.environ.get("OPENVIKING_AGENT_ID", "local-agent"),
+    actor_peer_id=os.environ.get("OPENVIKING_ACTOR_PEER_ID", "local-agent"),
     timeout=60,
 )
 
@@ -107,11 +109,11 @@ Use the following validation order:
 4. `find` and `search` to confirm semantic retrieval.
 5. A second client identity and a small concurrent request set to confirm sharing and latency.
 
-Do not treat a successful upload or completed embedding queue as proof that semantic retrieval works. If `grep` succeeds while `find` returns no results, inspect the server queue and VLM/embedding logs before importing more data. OpenViking issue [#677](https://github.com/volcengine/OpenViking/issues/677) documents the same symptom pattern for uploaded resources; a local reproduction should be treated as a release blocker until the root cause is isolated or a lexical fallback is in place.
+Do not treat a successful upload or completed embedding queue as proof that semantic retrieval works. If `grep` succeeds while `find` returns no results, inspect the server queue and VLM/embedding logs before importing more data. OpenViking issue [#677](https://github.com/volcengine/OpenViking/issues/677) documents the same symptom pattern for uploaded resources; a local reproduction means the deployment is not ready for semantic production until the root cause is isolated or a lexical fallback is in place.
 
-## Fork validation record
+## Fork-local validation record
 
-The following smoke test was run against OpenViking `0.4.13` on 2026-08-16 with Python 3.13 and a local HTTP server:
+The following fork-local smoke test was run against OpenViking `0.4.13` on 2026-08-16 with Python 3.13 and a local HTTP server. It is an environment-specific record, not a compatibility guarantee for every provider or deployment.
 
 | Check | Result |
 | --- | --- |
@@ -123,7 +125,7 @@ The following smoke test was run against OpenViking `0.4.13` on 2026-08-16 with 
 | Existing LiteLLM VLM route | Blocked; the configured model alias was routed as DashScope and returned 429 |
 | Existing LiteLLM embedding route | Blocked upstream by an LM Studio `node ENOENT` failure; a temporary local GGUF embedder was used for the storage smoke test |
 
-The result supports OpenViking as an HTTP-accessible shared resource store for the pilot. It does not yet approve it as the production semantic context layer. Re-run the semantic checks after the LiteLLM routes are healthy, and record the exact OpenViking version, model IDs, vector dimension, and backend in the deployment change.
+The result validates the HTTP/read/grep path for the pilot but does not validate production semantic retrieval. Re-run the semantic checks after the LiteLLM routes are healthy, and record the exact OpenViking version, model IDs, vector dimension, and backend in the deployment change.
 
 ## Related documentation
 


### PR DESCRIPTION
## Summary

- Add a tkstack HTTP integration guide for multiple local agents sharing one OpenViking server.
- Document API-key and trusted-gateway boundaries, LiteLLM model-route validation, and dense-only retrieval constraints.
- Record the fork-local OpenViking 0.4.13 smoke-test results and the semantic-search follow-up condition.
- Add the integration to the agent integrations overview.

## Validation

- `npm run docs:build`
- `npm run test:theme` (13 passing)
- `npm run test:search` (4 passing)
- Relative-link check (no missing targets)
- `git diff --check`

## Scope

This is documentation-only. It does not change runtime behavior, authentication code, storage, or retrieval code. The validation record distinguishes the HTTP/read/grep passes from the semantic-search and existing LiteLLM upstream blockers.
