### PR TITLE
fix(tasks): keep parent semantic refresh asynchronous

### DIFF
--- a/openviking/service/task_work_index.py
+++ b/openviking/service/task_work_index.py
@@ -66,6 +66,16 @@ def bind_task_context(
         _current_task_context.reset(token)
 
 
+@contextmanager
+def detach_task_context() -> Iterator[None]:
+    """Keep independently scheduled work outside the current task lifecycle."""
+    token = _current_task_context.set(None)
+    try:
+        yield
+    finally:
+        _current_task_context.reset(token)
+
+
 def get_task_context() -> Optional[TaskExecutionContext]:
     return _current_task_context.get()
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -32,6 +32,7 @@ from openviking.parse.parsers.media.utils import (
 )
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
+from openviking.service.task_work_index import detach_task_context
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
@@ -270,7 +271,8 @@ class SemanticProcessor(DequeueHandlerBase):
                 peer_id=msg.peer_id,
             ),
         )
-        await semantic_queue.enqueue(parent_msg)
+        with detach_task_context():
+            await semantic_queue.enqueue(parent_msg)
         logger.info("Enqueued parent semantic refresh: %s", parent_uri)
 
     async def on_dequeue(


### PR DESCRIPTION
## Description

Parent semantic refreshes unintentionally inherited the originating task ID after task-aware queue ownership was introduced.

**Before:** Adding `viking://resources/team/document` waited for semantic refreshes of `viking://resources/team` and its ancestors before the add-resource task could complete.

**After:** The added resource's own semantic and embedding work remains task-owned, while parent semantic refreshes are queued independently and continue in the background.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Regression introduced by #3577.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- Add a scoped way to detach independently scheduled queue work from the current task.
- Detach parent semantic refresh enqueueing from the add-resource task lifecycle.
- Preserve task ownership for the added resource's own semantic and embedding work.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validated with the existing semantic DAG and semantic processor tests (9 passed), a focused task-context check, Ruff, and `git diff --check`.
