### PR TITLE
fix(web-studio): render raw HTML in Markdown preview with sanitization

### DIFF
--- a/web-studio/package-lock.json
+++ b/web-studio/package-lock.json
@@ -57,6 +57,8 @@
         "react-i18next": "^17.0.2",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.2",
         "sonner": "^2.0.7",

--- a/web-studio/package.json
+++ b/web-studio/package.json
@@ -67,6 +67,8 @@
     "react-i18next": "^17.0.2",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
     "sonner": "^2.0.7",

--- a/web-studio/src/routes/resources/-components/file-preview-html.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview-html.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { VikingFsEntry } from '../-types/viking-fm'
+import { FilePreview } from './file-preview'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('#/gen/ov-client/client.gen', () => ({
+  client: {
+    buildUrl: ({ query }: { query: { uri: string } }) =>
+      `/api/v1/content/download?uri=${encodeURIComponent(query.uri)}`,
+  },
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  getContentDownload: vi.fn(),
+  ovClient: { getOptions: () => ({ baseUrl: '' }) },
+}))
+
+const markdown = [
+  '# Heading',
+  '',
+  '<div>rendered</div>',
+  '',
+  '<table><tbody><tr><th colspan="2">head</th></tr><tr><td rowspan="2">cell</td><td>a</td></tr><tr><td>b</td></tr></tbody></table>',
+  '',
+  '<script>window.__pwned = true</script>',
+].join('\n')
+
+vi.mock('../-hooks/viking-fm', () => ({
+  useInvalidateVikingFs: () => ({
+    invalidateList: vi.fn(),
+    invalidatePreview: vi.fn(),
+    invalidateTree: vi.fn(),
+  }),
+  useVikingFilePreview: () => ({
+    canLoadContent: false,
+    isContentLoaded: true,
+    isFetching: false,
+    isLoading: false,
+    preview: {
+      content: markdown,
+      fileType: 'markdown',
+      shouldAutoRead: true,
+    },
+    refetch: vi.fn(),
+  }),
+  useVikingFsStat: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}))
+
+const file: VikingFsEntry = {
+  abstract: '',
+  isDir: false,
+  modTime: '2026-08-04 12:00',
+  modTimestamp: null,
+  name: 'index.md',
+  overview: '',
+  size: '24 B',
+  sizeBytes: 24,
+  uri: 'viking://resources/wiki/index.md',
+}
+
+function renderPreview() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return render(
+    <FilePreview
+      file={file}
+      onClose={vi.fn()}
+      onNavigate={vi.fn()}
+      showCloseButton={false}
+    />,
+    { wrapper },
+  )
+}
+
+describe('FilePreview Markdown raw HTML', () => {
+  it('renders raw HTML elements instead of escaping them', () => {
+    const { container } = renderPreview()
+
+    const rendered = Array.from(container.querySelectorAll('div')).find(
+      (el) => el.textContent === 'rendered',
+    )
+    expect(rendered).toBeTruthy()
+    expect(container.textContent).not.toContain('<div>')
+  })
+
+  it('renders raw HTML tables through the shared table components', () => {
+    const { container } = renderPreview()
+
+    const head = container.querySelector('table th')
+    const spanned = container.querySelector('table td')
+    expect(head?.textContent).toBe('head')
+    expect(head?.getAttribute('colspan')).toBe('2')
+    expect(spanned?.textContent).toBe('cell')
+    expect(spanned?.getAttribute('rowspan')).toBe('2')
+  })
+
+  it('strips script tags', () => {
+    const { container } = renderPreview()
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+})

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -3,6 +3,8 @@ import type { ComponentProps, ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import hljs from 'highlight.js/lib/core'
 import ReactMarkdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 import { X, Pencil, Save, XCircle, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -629,15 +631,27 @@ const markdownComponents = {
   code: MarkdownCode,
   pre: MarkdownPre,
   table: ({ children }: ComponentProps<'table'>) => (
-    <div className="my-4 overflow-x-auto rounded-md border">
+    <div className="overflow-x-auto">
       <table className="w-full border-collapse text-sm">{children}</table>
     </div>
   ),
-  td: ({ children }: ComponentProps<'td'>) => (
-    <td className="border-t px-3 py-2 align-top">{children}</td>
+  td: ({ children, colSpan, rowSpan }: ComponentProps<'td'>) => (
+    <td
+      className="border px-3 py-2 text-center align-middle"
+      colSpan={colSpan}
+      rowSpan={rowSpan}
+    >
+      {children}
+    </td>
   ),
-  th: ({ children }: ComponentProps<'th'>) => (
-    <th className="bg-muted/50 px-3 py-2 text-left font-medium">{children}</th>
+  th: ({ children, colSpan, rowSpan }: ComponentProps<'th'>) => (
+    <th
+      className="border bg-muted/50 px-3 py-2 text-center align-middle font-medium"
+      colSpan={colSpan}
+      rowSpan={rowSpan}
+    >
+      {children}
+    </th>
   ),
 }
 
@@ -1589,6 +1603,7 @@ export function FilePreview({
               <article className="prose prose-sm max-w-none break-words dark:prose-invert dark:prose-pre:bg-muted-foreground/20">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
                   urlTransform={(url) => url}
                   components={{
                     ...markdownComponents,


### PR DESCRIPTION
- Add rehype-raw and rehype-sanitize so raw HTML in Markdown renders while stripping scripts and other dangerous tags
- Give table cells full borders, center content both axes, and pass through colSpan / rowSpan
- Add file-preview-html tests covering raw HTML rendering, table attribute passthrough, and script stripping

## Description

react-markdown 现在版本不会默认渲染html，加上我需要展示表格比较复杂，然后处理合并单元格情况，同时修改样式，居中加全边框

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 引入 rehype-raw / rehype-sanitize，使 Markdown 中的原始 HTML 正常渲染，并剥离 script 等危险标签
- 表格组件补齐完整边框，单元格上下左右居中，并透传 colSpan / rowSpan
- 新增 file-preview-html 测试，覆盖原始 HTML 渲染、表格属性透传与 script 剥离

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="921" height="165" alt="image" src="https://github.com/user-attachments/assets/f3232d73-a237-41a8-8039-66e2bc98a874" />

<img width="909" height="419" alt="image" src="https://github.com/user-attachments/assets/32ff5568-9f90-4d5a-8236-635d9169b788" />

## Additional Notes
