### PR TITLE
fix(retrieval): normalize malformed intent query plans

### DIFF
--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -88,6 +88,17 @@ class IntentAnalyzer:
 
         # Parse result
         parsed = parse_json_from_response(response)
+        if parsed is None:
+            raise ValueError("Failed to parse intent analysis response")
+
+        if isinstance(parsed, list):
+            parsed = {"reasoning": "", "queries": parsed}
+        elif not isinstance(parsed, dict):
+            raise ValueError(
+                "Intent analysis response must be a JSON object or array, got "
+                f"{type(parsed).__name__}"
+            )
+
         if not parsed:
             raise ValueError("Failed to parse intent analysis response")
 
@@ -96,8 +107,21 @@ class IntentAnalyzer:
             reasoning = str(reasoning)
 
         # Build QueryPlan
+        raw_queries = parsed.get("queries", [])
+        if not isinstance(raw_queries, list):
+            raise ValueError(
+                "Intent analysis response field 'queries' must be a JSON array, got "
+                f"{type(raw_queries).__name__}"
+            )
+
         queries = []
-        for q in parsed.get("queries", []):
+        for q in raw_queries:
+            if not isinstance(q, dict):
+                logger.warning(
+                    f"[IntentAnalyzer] Skipping non-object query item of type {type(q).__name__}"
+                )
+                continue
+
             try:
                 context_type = ContextType(q.get("context_type", "resource"))
             except ValueError:

--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -19,6 +19,7 @@ logger = get_logger(__name__)
 
 DEFAULT_INTENT_ANALYSIS_PROMPT = "retrieval.intent_analysis"
 MAX_INTENT_ANALYSIS_QUERIES = 5
+MAX_SFT_V4_INTENT_ANALYSIS_QUERIES = 15
 DEFAULT_QUERY_PRIORITY = 3
 
 # Model-specific query-planner prompts. Models not listed here keep using the
@@ -35,6 +36,14 @@ def resolve_intent_analysis_prompt_id(query_planner: Any) -> str:
     if not isinstance(model, str):
         return DEFAULT_INTENT_ANALYSIS_PROMPT
     return QUERY_PLANNER_PROMPT_BY_MODEL.get(model.strip(), DEFAULT_INTENT_ANALYSIS_PROMPT)
+
+
+def _max_queries_for_prompt(prompt_id: str) -> int:
+    """Return the largest query plan allowed by the selected prompt contract."""
+    if prompt_id == "retrieval.ov_intent_analysis_sft_v4":
+        # v4 permits up to five queries for each of the three context types.
+        return MAX_SFT_V4_INTENT_ANALYSIS_QUERIES
+    return MAX_INTENT_ANALYSIS_QUERIES
 
 
 def _normalize_query_plan_response(parsed: Any) -> tuple[str, list[Any]]:
@@ -98,17 +107,20 @@ def _normalize_query_priority(value: Any) -> int:
     return DEFAULT_QUERY_PRIORITY
 
 
-def _build_typed_queries(raw_queries: list[Any]) -> list[TypedQuery]:
+def _build_typed_queries(
+    raw_queries: list[Any],
+    max_queries: int = MAX_INTENT_ANALYSIS_QUERIES,
+) -> list[TypedQuery]:
     """Build a bounded query list while preserving valid items from mixed output."""
     queries: list[TypedQuery] = []
     skipped_items = 0
 
     for index, raw_query in enumerate(raw_queries):
-        if len(queries) >= MAX_INTENT_ANALYSIS_QUERIES:
+        if len(queries) >= max_queries:
             logger.warning(
                 "[IntentAnalyzer] Ignoring "
                 f"{len(raw_queries) - index} query item(s) beyond the "
-                f"{MAX_INTENT_ANALYSIS_QUERIES}-query limit"
+                f"{max_queries}-query limit"
             )
             break
 
@@ -193,13 +205,14 @@ class IntentAnalyzer:
 
         # Build context prompt. Some fine-tuned planner models expect a compact
         # prompt/output contract, selected by exact model mapping above.
+        prompt_id = resolve_intent_analysis_prompt_id(query_planner)
         prompt = self._build_context_prompt(
             compression_summary,
             messages,
             current_message,
             context_type,
             target_abstract,
-            prompt_id=resolve_intent_analysis_prompt_id(query_planner),
+            prompt_id=prompt_id,
         )
 
         response = await query_planner.get_completion_async(prompt)
@@ -207,7 +220,10 @@ class IntentAnalyzer:
         # Parse result
         parsed = parse_json_from_response(response)
         reasoning, raw_queries = _normalize_query_plan_response(parsed)
-        queries = _build_typed_queries(raw_queries)
+        queries = _build_typed_queries(
+            raw_queries,
+            max_queries=_max_queries_for_prompt(prompt_id),
+        )
 
         # Log analysis result
         for i, q in enumerate(queries):

--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -18,6 +18,8 @@ from openviking_cli.utils.logger import get_logger
 logger = get_logger(__name__)
 
 DEFAULT_INTENT_ANALYSIS_PROMPT = "retrieval.intent_analysis"
+MAX_INTENT_ANALYSIS_QUERIES = 5
+DEFAULT_QUERY_PRIORITY = 3
 
 # Model-specific query-planner prompts. Models not listed here keep using the
 # default intent-analysis prompt for backward compatibility.
@@ -33,6 +35,122 @@ def resolve_intent_analysis_prompt_id(query_planner: Any) -> str:
     if not isinstance(model, str):
         return DEFAULT_INTENT_ANALYSIS_PROMPT
     return QUERY_PLANNER_PROMPT_BY_MODEL.get(model.strip(), DEFAULT_INTENT_ANALYSIS_PROMPT)
+
+
+def _normalize_query_plan_response(parsed: Any) -> tuple[str, list[Any]]:
+    """Normalize recoverable planner response shapes and reject ambiguous ones."""
+    if parsed is None:
+        raise ValueError("Failed to parse intent analysis response")
+
+    if isinstance(parsed, list):
+        parsed = {"reasoning": "", "queries": parsed}
+    elif not isinstance(parsed, dict):
+        raise ValueError(
+            f"Intent analysis response must be a JSON object or array, got {type(parsed).__name__}"
+        )
+
+    if not parsed:
+        raise ValueError("Failed to parse intent analysis response")
+
+    # Some planners omit the wrapper even when they emit only one query.
+    if "queries" not in parsed and "query" in parsed:
+        parsed = {"reasoning": "", "queries": [parsed]}
+    elif "queries" not in parsed and "reasoning" not in parsed:
+        raise ValueError("Intent analysis response must contain 'queries' or 'query'")
+
+    reasoning = parsed.get("reasoning", "")
+    if reasoning is None:
+        reasoning = ""
+    elif not isinstance(reasoning, str):
+        reasoning = str(reasoning)
+
+    raw_queries = parsed.get("queries", [])
+    if raw_queries is None:
+        raw_queries = []
+    elif isinstance(raw_queries, dict):
+        raw_queries = [raw_queries]
+    elif not isinstance(raw_queries, list):
+        raise ValueError(
+            "Intent analysis response field 'queries' must be a JSON array or object, got "
+            f"{type(raw_queries).__name__}"
+        )
+
+    return reasoning, raw_queries
+
+
+def _normalize_query_priority(value: Any) -> int:
+    """Return a planner priority in the documented 1-5 range."""
+    if isinstance(value, bool):
+        return DEFAULT_QUERY_PRIORITY
+
+    if isinstance(value, float):
+        if not value.is_integer():
+            return DEFAULT_QUERY_PRIORITY
+        value = int(value)
+    elif isinstance(value, str):
+        try:
+            value = int(value.strip())
+        except ValueError:
+            return DEFAULT_QUERY_PRIORITY
+
+    if isinstance(value, int) and 1 <= value <= 5:
+        return value
+    return DEFAULT_QUERY_PRIORITY
+
+
+def _build_typed_queries(raw_queries: list[Any]) -> list[TypedQuery]:
+    """Build a bounded query list while preserving valid items from mixed output."""
+    queries: list[TypedQuery] = []
+    skipped_items = 0
+
+    for index, raw_query in enumerate(raw_queries):
+        if len(queries) >= MAX_INTENT_ANALYSIS_QUERIES:
+            logger.warning(
+                "[IntentAnalyzer] Ignoring "
+                f"{len(raw_queries) - index} query item(s) beyond the "
+                f"{MAX_INTENT_ANALYSIS_QUERIES}-query limit"
+            )
+            break
+
+        if not isinstance(raw_query, dict):
+            skipped_items += 1
+            continue
+
+        query_text = raw_query.get("query")
+        if not isinstance(query_text, str) or not query_text.strip():
+            skipped_items += 1
+            continue
+        query_text = query_text.strip()
+
+        raw_context_type = raw_query.get("context_type", "resource")
+        if isinstance(raw_context_type, str):
+            raw_context_type = raw_context_type.strip().lower()
+        try:
+            query_context_type = ContextType(raw_context_type)
+        except (TypeError, ValueError):
+            query_context_type = ContextType.RESOURCE
+
+        intent = raw_query.get("intent", "")
+        if intent is None:
+            intent = ""
+        elif not isinstance(intent, str):
+            intent = str(intent)
+
+        queries.append(
+            TypedQuery(
+                query=query_text,
+                context_type=query_context_type,
+                intent=intent,
+                priority=_normalize_query_priority(raw_query.get("priority", 3)),
+            )
+        )
+
+    if skipped_items:
+        logger.warning(f"[IntentAnalyzer] Skipped {skipped_items} malformed query item(s)")
+    if raw_queries and not queries:
+        raise ValueError("Intent analysis response does not contain any valid query objects")
+
+    return queries
 
 
 class IntentAnalyzer:
@@ -88,53 +206,8 @@ class IntentAnalyzer:
 
         # Parse result
         parsed = parse_json_from_response(response)
-        if parsed is None:
-            raise ValueError("Failed to parse intent analysis response")
-
-        if isinstance(parsed, list):
-            parsed = {"reasoning": "", "queries": parsed}
-        elif not isinstance(parsed, dict):
-            raise ValueError(
-                "Intent analysis response must be a JSON object or array, got "
-                f"{type(parsed).__name__}"
-            )
-
-        if not parsed:
-            raise ValueError("Failed to parse intent analysis response")
-
-        reasoning = parsed.get("reasoning", "")
-        if not isinstance(reasoning, str):
-            reasoning = str(reasoning)
-
-        # Build QueryPlan
-        raw_queries = parsed.get("queries", [])
-        if not isinstance(raw_queries, list):
-            raise ValueError(
-                "Intent analysis response field 'queries' must be a JSON array, got "
-                f"{type(raw_queries).__name__}"
-            )
-
-        queries = []
-        for q in raw_queries:
-            if not isinstance(q, dict):
-                logger.warning(
-                    f"[IntentAnalyzer] Skipping non-object query item of type {type(q).__name__}"
-                )
-                continue
-
-            try:
-                context_type = ContextType(q.get("context_type", "resource"))
-            except ValueError:
-                context_type = ContextType.RESOURCE
-
-            queries.append(
-                TypedQuery(
-                    query=q.get("query", ""),
-                    context_type=context_type,
-                    intent=q.get("intent", ""),
-                    priority=q.get("priority", 3),
-                )
-            )
+        reasoning, raw_queries = _normalize_query_plan_response(parsed)
+        queries = _build_typed_queries(raw_queries)
 
         # Log analysis result
         for i, q in enumerate(queries):

--- a/tests/retrieve/test_intent_analyzer_query_planner.py
+++ b/tests/retrieve/test_intent_analyzer_query_planner.py
@@ -88,6 +88,21 @@ def test_query_planner_prompt_mapping_targets_are_bundled():
 
 
 @pytest.mark.parametrize(
+    ("prompt_id", "expected"),
+    [
+        (
+            "retrieval.ov_intent_analysis_sft_v4",
+            intent_module.MAX_SFT_V4_INTENT_ANALYSIS_QUERIES,
+        ),
+        ("retrieval.ov_intent_analysis_sft_v7", intent_module.MAX_INTENT_ANALYSIS_QUERIES),
+        (intent_module.DEFAULT_INTENT_ANALYSIS_PROMPT, intent_module.MAX_INTENT_ANALYSIS_QUERIES),
+    ],
+)
+def test_query_limit_matches_prompt_contract(prompt_id, expected):
+    assert intent_module._max_queries_for_prompt(prompt_id) == expected
+
+
+@pytest.mark.parametrize(
     ("value", "expected"),
     [
         (1, 1),
@@ -335,6 +350,36 @@ async def test_intent_analyzer_caps_valid_queries(monkeypatch):
     assert [query.query for query in result.queries] == [
         f"query {index}" for index in range(intent_module.MAX_INTENT_ANALYSIS_QUERIES)
     ]
+
+
+@pytest.mark.asyncio
+async def test_intent_analyzer_preserves_v4_per_context_query_limit(monkeypatch):
+    response = json.dumps(
+        [
+            {
+                "query": f"query {index}",
+                "context_type": "resource",
+                "priority": 1,
+            }
+            for index in range(intent_module.MAX_INTENT_ANALYSIS_QUERIES + 1)
+        ]
+    )
+    planner = RecordingModel(
+        response,
+        model="ollama/guoxuter/ov_intent_analysis_sft:v4_q8",
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert len(result.queries) == intent_module.MAX_INTENT_ANALYSIS_QUERIES + 1
 
 
 @pytest.mark.asyncio

--- a/tests/retrieve/test_intent_analyzer_query_planner.py
+++ b/tests/retrieve/test_intent_analyzer_query_planner.py
@@ -136,6 +136,89 @@ async def test_intent_analyzer_normalizes_non_string_reasoning(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_intent_analyzer_accepts_bare_query_array(monkeypatch):
+    planner = RecordingModel(
+        """[
+          {
+            "query": "planned query",
+            "context_type": "memory",
+            "intent": "test intent",
+            "priority": 1
+          }
+        ]"""
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert result.reasoning == ""
+    assert [query.query for query in result.queries] == ["planned query"]
+
+
+@pytest.mark.asyncio
+async def test_intent_analyzer_skips_non_object_items_in_bare_array(monkeypatch):
+    planner = RecordingModel(
+        """[
+          "invalid item",
+          {
+            "query": "planned query",
+            "context_type": "memory",
+            "intent": "test intent",
+            "priority": 1
+          }
+        ]"""
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert [query.query for query in result.queries] == ["planned query"]
+
+
+@pytest.mark.parametrize(
+    ("response", "error_match"),
+    [
+        (
+            '"invalid response"',
+            "Intent analysis response must be a JSON object or array, got str",
+        ),
+        (
+            '{"queries": {"query": "nested query"}}',
+            "Intent analysis response field 'queries' must be a JSON array, got dict",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_intent_analyzer_rejects_invalid_response_shape(monkeypatch, response, error_match):
+    planner = RecordingModel(response)
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    with pytest.raises(ValueError, match=error_match):
+        await IntentAnalyzer().analyze(
+            compression_summary="",
+            messages=[],
+            current_message="where is my preference?",
+        )
+
+
+@pytest.mark.asyncio
 async def test_intent_analyzer_uses_model_specific_prompt(monkeypatch):
     planner = RecordingModel(
         _query_plan_response("planned query"),

--- a/tests/retrieve/test_intent_analyzer_query_planner.py
+++ b/tests/retrieve/test_intent_analyzer_query_planner.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -86,6 +87,26 @@ def test_query_planner_prompt_mapping_targets_are_bundled():
         assert manager.load_template(prompt_id).metadata.id == prompt_id
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, 1),
+        (5, 5),
+        (" 2 ", 2),
+        (4.0, 4),
+        (None, intent_module.DEFAULT_QUERY_PRIORITY),
+        (True, intent_module.DEFAULT_QUERY_PRIORITY),
+        (0, intent_module.DEFAULT_QUERY_PRIORITY),
+        (6, intent_module.DEFAULT_QUERY_PRIORITY),
+        (2.5, intent_module.DEFAULT_QUERY_PRIORITY),
+        ("2.5", intent_module.DEFAULT_QUERY_PRIORITY),
+        ("invalid", intent_module.DEFAULT_QUERY_PRIORITY),
+    ],
+)
+def test_query_priority_normalization(value, expected):
+    assert intent_module._normalize_query_priority(value) == expected
+
+
 @pytest.mark.asyncio
 async def test_intent_analyzer_uses_query_planner_when_configured(monkeypatch):
     planner = RecordingModel(_query_plan_response("planned query"))
@@ -162,6 +183,58 @@ async def test_intent_analyzer_accepts_bare_query_array(monkeypatch):
     assert [query.query for query in result.queries] == ["planned query"]
 
 
+@pytest.mark.parametrize(
+    "response",
+    [
+        "[]",
+        '{"reasoning": null, "queries": null}',
+        '{"reasoning": "nothing missing"}',
+    ],
+)
+@pytest.mark.asyncio
+async def test_intent_analyzer_accepts_recoverable_empty_query_plans(monkeypatch, response):
+    planner = RecordingModel(response)
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="hello",
+    )
+
+    assert result.queries == []
+    assert isinstance(result.reasoning, str)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        '{"query": "top-level query", "context_type": "memory"}',
+        '{"queries": {"query": "top-level query", "context_type": "memory"}}',
+    ],
+)
+@pytest.mark.asyncio
+async def test_intent_analyzer_accepts_single_query_objects(monkeypatch, response):
+    planner = RecordingModel(response)
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert [(query.query, query.context_type) for query in result.queries] == [
+        ("top-level query", intent_module.ContextType.MEMORY)
+    ]
+
+
 @pytest.mark.asyncio
 async def test_intent_analyzer_skips_non_object_items_in_bare_array(monkeypatch):
     planner = RecordingModel(
@@ -189,6 +262,100 @@ async def test_intent_analyzer_skips_non_object_items_in_bare_array(monkeypatch)
     assert [query.query for query in result.queries] == ["planned query"]
 
 
+@pytest.mark.asyncio
+async def test_intent_analyzer_normalizes_recoverable_query_fields(monkeypatch):
+    planner = RecordingModel(
+        """{
+          "queries": [
+            null,
+            {"query": "   "},
+            {"query": 42},
+            {
+              "query": "  planned query  ",
+              "context_type": ["invalid"],
+              "intent": {"goal": "test"},
+              "priority": "2"
+            },
+            {
+              "query": "default priority",
+              "context_type": " Skill ",
+              "intent": null,
+              "priority": 9
+            }
+          ]
+        }"""
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert [query.query for query in result.queries] == ["planned query", "default priority"]
+    assert result.queries[0].context_type == intent_module.ContextType.RESOURCE
+    assert result.queries[0].intent == "{'goal': 'test'}"
+    assert result.queries[0].priority == 2
+    assert result.queries[1].context_type == intent_module.ContextType.SKILL
+    assert result.queries[1].intent == ""
+    assert result.queries[1].priority == intent_module.DEFAULT_QUERY_PRIORITY
+
+
+@pytest.mark.asyncio
+async def test_intent_analyzer_caps_valid_queries(monkeypatch):
+    response = json.dumps(
+        [
+            None,
+            *[
+                {
+                    "query": f"query {index}",
+                    "context_type": "resource",
+                    "priority": 1,
+                }
+                for index in range(intent_module.MAX_INTENT_ANALYSIS_QUERIES + 1)
+            ],
+        ]
+    )
+    planner = RecordingModel(response)
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert [query.query for query in result.queries] == [
+        f"query {index}" for index in range(intent_module.MAX_INTENT_ANALYSIS_QUERIES)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_intent_analyzer_rejects_nonempty_plan_without_valid_queries(monkeypatch):
+    planner = RecordingModel('[null, "invalid", {"query": ""}, {"query": 42}]')
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    with pytest.raises(
+        ValueError,
+        match="Intent analysis response does not contain any valid query objects",
+    ):
+        await IntentAnalyzer().analyze(
+            compression_summary="",
+            messages=[],
+            current_message="where is my preference?",
+        )
+
+
 @pytest.mark.parametrize(
     ("response", "error_match"),
     [
@@ -197,8 +364,24 @@ async def test_intent_analyzer_skips_non_object_items_in_bare_array(monkeypatch)
             "Intent analysis response must be a JSON object or array, got str",
         ),
         (
-            '{"queries": {"query": "nested query"}}',
-            "Intent analysis response field 'queries' must be a JSON array, got dict",
+            "42",
+            "Intent analysis response must be a JSON object or array, got int",
+        ),
+        (
+            "true",
+            "Intent analysis response must be a JSON object or array, got bool",
+        ),
+        (
+            "{}",
+            "Failed to parse intent analysis response",
+        ),
+        (
+            '{"unexpected": []}',
+            "Intent analysis response must contain 'queries' or 'query'",
+        ),
+        (
+            '{"queries": "nested query"}',
+            "Intent analysis response field 'queries' must be a JSON array or object, got str",
         ),
     ],
 )


### PR DESCRIPTION
## Description

`IntentAnalyzer` assumed every successfully parsed query-planner response was a JSON object containing a `queries` array. OpenAI-compatible planner models can return semantically recoverable variants such as a bare array, a single query object, or `null` for an empty plan. Malformed entries and field types could also leak into `TypedQuery`, trigger downstream failures, or cause unbounded retrieval work.

This PR establishes a defensive normalization boundary between model output and the retrieval pipeline. It preserves valid queries from mixed output, rejects ambiguous shapes with intentional `ValueError` messages, and bounds execution to each selected prompt's documented query limit.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4022

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Accept top-level query arrays and normalize them into the existing query-plan shape.
- Accept unambiguous single-query objects, both at the top level and under `queries`.
- Treat empty arrays, missing `queries`, and `queries: null` as valid empty plans.
- Reject scalar, unknown, and invalid container shapes with clear `ValueError` messages.
- Skip malformed entries while preserving valid queries; reject a non-empty plan when no valid query remains.
- Require non-empty string query text and trim surrounding whitespace.
- Normalize case and whitespace in `context_type`, retaining the existing `resource` fallback for unknown values.
- Normalize nullable/non-string `reasoning` and `intent` fields.
- Normalize priority to the documented integer range 1-5, defaulting invalid values to 3.
- Enforce prompt-specific limits: five queries for the default and v7 contracts, and fifteen for v4's per-context contract.
- Add regression coverage across valid, recoverable, mixed, empty, bounded, and unrecoverable response shapes.

## Compatibility

The documented wrapped-object response remains unchanged. Existing unknown `context_type` values continue to fall back to `resource`. Invalid planner output now fails as `INVALID_ARGUMENT` through the existing server `ValueError` mapping instead of surfacing an accidental exception or malformed downstream request.

## Testing

```text
.venv/Scripts/python.exe -m pytest -q -o "addopts=" \
  tests/prompts/test_retrieval_intent_prompt_contract.py \
  tests/retrieve/test_intent_analyzer_query_planner.py \
  tests/retrieve/test_context_assembler_pipeline.py \
  tests/server/test_error_mapping.py

76 passed, 4 pre-existing Pydantic deprecation warnings
```

```text
.venv/Scripts/ruff.exe check openviking/retrieve/intent_analyzer.py tests/retrieve/test_intent_analyzer_query_planner.py
All checks passed!

.venv/Scripts/ruff.exe format --check openviking/retrieve/intent_analyzer.py tests/retrieve/test_intent_analyzer_query_planner.py
2 files already formatted

.venv/Scripts/mypy.exe --follow-imports=skip openviking/retrieve/intent_analyzer.py
Success: no issues found in 1 source file
```

`git diff --check` also passes. Validation was performed on Windows with Python 3.12.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review
- [x] Recoverable and unrecoverable response shapes are covered by tests
- [x] Existing server error mapping was verified
- [x] My changes generate no new warnings
- [ ] Documentation changes are required (not applicable; this is an internal compatibility boundary)
- [ ] Any dependent changes have been merged and published (not applicable)