### PR TITLE
fix(server): recover from port-in-use at startup with bind retry and pre-bound sockets

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -246,6 +246,9 @@ This setting controls queue-job concurrency. It is separate from `vlm.media.max_
 | `port` | integer | `1933` | Listen port |
 | `workers` | integer | `1` | Worker process count |
 | `timeout_keep_alive` | integer (seconds) | `5` | Idle HTTP keep-alive timeout; raise it above the upstream's idle-connection lifetime |
+| `bind_retry_max_attempts` | integer, `>= 0` | `5` | Retries when the listen port is occupied at startup (stale process, restart race); `0` fails fast |
+| `bind_retry_initial_delay_seconds` | number, `> 0` | `1.0` | Delay before the first bind retry |
+| `bind_retry_backoff_factor` | number, `>= 1` | `2.0` | Multiplier applied to the retry delay after each failed bind attempt |
 | `auth_mode` | `dev`, `api_key`, `trusted` / `null` | `null` | Auth mode; null is inferred from `root_api_key` |
 | `root_api_key` | string / `null` | `null` | Root key; setting it defaults auth to `api_key` |
 | `cors_origins` | string[] | `["*"]` | Allowed origins |

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -246,6 +246,9 @@ Search 和 Find 请求的默认 `limit` 为 `10`，可以在每次 API 或 SDK �
 | `port` | integer | `1933` | HTTP 监听端口 |
 | `workers` | integer | `1` | 服务进程数量 |
 | `timeout_keep_alive` | integer（秒） | `5` | 空闲 HTTP keep-alive 超时；应调大到超过上游空闲连接寿命 |
+| `bind_retry_max_attempts` | integer，`>= 0` | `5` | 启动时监听端口被占用（残留进程、重启竞争）的重试次数；`0` 表示立即失败 |
+| `bind_retry_initial_delay_seconds` | number，`> 0` | `1.0` | 首次绑定重试前的等待秒数 |
+| `bind_retry_backoff_factor` | number，`>= 1` | `2.0` | 每次绑定失败后重试间隔的倍增系数 |
 | `auth_mode` | `dev`、`api_key`、`trusted` / `null` | `null` | 鉴权模式；空值根据 `root_api_key` 自动判断 |
 | `root_api_key` | string / `null` | `null` | Root API Key；配置后默认启用 `api_key` 模式 |
 | `cors_origins` | string[] | `["*"]` | 允许的跨域来源 |

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -3,6 +3,9 @@
         "host": "0.0.0.0",
         "port": 1933,
         "timeout_keep_alive": 5,
+        "bind_retry_max_attempts": 5,
+        "bind_retry_initial_delay_seconds": 1.0,
+        "bind_retry_backoff_factor": 2.0,
         "root_api_key": null,
         "cors_origins": ["*"],
         "agent_evolution": {

--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Bootstrap script for OpenViking HTTP Server."""
 
-import asyncio
 import argparse
+import asyncio
+import errno
 import json
 import os
 import shutil
@@ -13,7 +14,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 
 import uvicorn
 
@@ -85,6 +86,158 @@ def _normalize_host_arg(host: Optional[str]) -> Optional[str]:
     if host.strip().lower() == "all":
         return None
     return host
+
+
+# Bind errors a retry can plausibly clear: the port is held by a process
+# that may exit, or — on Windows — by a socket in another login session
+# (WSAEACCES maps to EACCES). Anything else, e.g. EADDRNOTAVAIL for a host
+# not configured on this machine, is a configuration error that no retry
+# budget can fix, so it propagates immediately.
+_RETRYABLE_BIND_ERRNOS = frozenset({errno.EADDRINUSE, errno.EACCES})
+
+# Errors meaning "this machine has no usable IPv6 stack": the wildcard
+# bind then degrades to IPv4-only instead of failing startup.
+_IPV6_UNAVAILABLE_ERRNOS = frozenset({errno.EAFNOSUPPORT, errno.EADDRNOTAVAIL})
+
+
+def _new_listen_socket(family: int) -> socket.socket:
+    """Create a listen socket with the platform-appropriate options."""
+    sock = socket.socket(family=family, type=socket.SOCK_STREAM)
+    if sys.platform != "win32":
+        # POSIX: survive TIME_WAIT leftovers from prior runs; a live
+        # listener still fails the bind, which drives the retry loop.
+        # Windows: deliberately off — SO_REUSEADDR there allows binding
+        # over a live listener (silent port hijack) instead of detecting it.
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    return sock
+
+
+def _bind_explicit_listen_socket(host: str, port: int) -> socket.socket:
+    """Bind one explicitly configured address (uvicorn ``bind_socket`` parity)."""
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    sock = _new_listen_socket(family)
+    try:
+        sock.bind((host, port))
+    except OSError:
+        sock.close()
+        raise
+    return sock
+
+
+def _bind_wildcard_listen_sockets(port: int) -> list[socket.socket]:
+    """Bind both ``::`` and ``0.0.0.0`` — asyncio ``AI_PASSIVE`` parity.
+
+    The pre-retry code path (``loop.create_server(host=None)``) resolved the
+    wildcard with ``AI_PASSIVE`` and bound every returned family, so
+    ``--host all`` accepted IPv6 connections; uvicorn's ``bind_socket``
+    binds IPv4 only. Machines without an IPv6 stack degrade to IPv4-only
+    rather than failing startup. A partial failure closes the sockets
+    bound so far so the retry loop always starts from a clean slate.
+    """
+    socks: list[socket.socket] = []
+    try:
+        sock6 = _new_listen_socket(socket.AF_INET6)
+    except OSError as exc:
+        if exc.errno not in _IPV6_UNAVAILABLE_ERRNOS:
+            raise
+        sock6 = None
+    if sock6 is not None:
+        try:
+            sock6.bind(("::", port))
+        except OSError as exc:
+            sock6.close()
+            if exc.errno not in _IPV6_UNAVAILABLE_ERRNOS:
+                raise
+        else:
+            socks.append(sock6)
+    sock4 = _new_listen_socket(socket.AF_INET)
+    try:
+        sock4.bind(("0.0.0.0", port))
+    except OSError:
+        sock4.close()
+        for sock in socks:
+            sock.close()
+        raise
+    socks.append(sock4)
+    return socks
+
+
+def _acquire_listen_sockets(
+    host: Optional[str],
+    port: int,
+    max_attempts: int,
+    initial_delay: float,
+    backoff_factor: float,
+    label: str,
+) -> Optional[list[socket.socket]]:
+    """Bind ``(host, port)`` for listening, retrying while it is occupied.
+
+    Returns the bound socket(s) on success, or ``None`` after
+    ``max_attempts + 1`` failed tries. They are meant to be handed straight
+    to ``uvicorn.Server.run(sockets=[...])`` so the bind is never released
+    between acquisition and serving (no check-then-bind race window).
+    An explicit host binds a single socket with uvicorn ``bind_socket``
+    semantics (IPv6 family when the host contains ``:``); a wildcard host
+    (``None``) binds both families as ``loop.create_server(host=None)``
+    did. Only occupancy-class errors are retried; other bind errors (e.g.
+    ``EADDRNOTAVAIL`` when the configured host does not exist on this
+    machine) propagate to the caller immediately.
+    """
+    for attempt in range(max(0, max_attempts) + 1):
+        try:
+            if host:
+                socks = [_bind_explicit_listen_socket(host, port)]
+            else:
+                socks = _bind_wildcard_listen_sockets(port)
+        except OSError as exc:
+            if exc.errno not in _RETRYABLE_BIND_ERRNOS:
+                raise
+            if attempt >= max_attempts:
+                return None
+            delay = initial_delay * (backoff_factor**attempt)
+            print(
+                f"{label}: port {port} still in use "
+                f"(attempt {attempt + 1}/{max_attempts + 1}), "
+                f"retrying in {delay:.1f}s...",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+        else:
+            if attempt > 0:
+                print(f"{label}: port {port} acquired after {attempt + 1} attempt(s)")
+            return socks
+    return None  # pragma: no cover - loop always returns or exhausts
+
+
+def _abort_port_acquisition_failed(port: int, max_attempts: int) -> NoReturn:
+    """Exit with a clear message when the listen port cannot be acquired."""
+    print(
+        f"Error: OpenViking server port {port} is still in use after "
+        f"{max_attempts + 1} bind attempt(s).\n"
+        f"  A stale or duplicate process is likely holding it.\n"
+        f"  Identify it:  lsof -nP -iTCP:{port} -sTCP:LISTEN   (Linux/macOS)\n"
+        f"                netstat -ano | findstr :{port}        (Windows)\n"
+        f"  On Windows, an empty result can mean the port sits in an OS\n"
+        f"  excluded range (bind denied, nothing listening):\n"
+        f"                netsh interface ipv4 show excludedportrange protocol=tcp\n"
+        f"  Kill the holder or move the port, or raise\n"
+        f"  server.bind_retry_max_attempts in ov.conf.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _serve_single_process(app, config, listen_socks: list[socket.socket]) -> None:
+    """Serve ``app`` on the pre-bound ``listen_socks`` (no re-bind race)."""
+    server_config = uvicorn.Config(
+        app,
+        host=config.host,
+        port=config.port,
+        timeout_keep_alive=config.timeout_keep_alive,
+        log_config=None,
+    )
+    # uvicorn's Server.run() -> Config.load() loads the app itself.
+    uvicorn.Server(server_config).run(sockets=listen_socks)
 
 
 def _resolve_default_bot_log_dir(config_path: Optional[str]) -> str:
@@ -301,15 +454,42 @@ def main():
         ),
     )
     workers_info = f" (workers: {config.workers})" if config.workers > 1 else ""
-    print(f"OpenViking HTTP Server is running on {config.host}:{config.port}{workers_info}")
 
+    listen_socks: Optional[list[socket.socket]] = None
     try:
+        # Port-binding recovery: acquire the listen socket(s) up-front with
+        # retry + exponential backoff, then serve on them. Without this, a
+        # stale or concurrently-restarting process holding the port makes
+        # uvicorn exit(1) with EADDRINUSE on the first try (e.g. watchdog
+        # restart races). Both failure modes here — the abort exit below and
+        # a raised non-retryable bind error — pass through the finally
+        # below, which owns stopping the gateway child.
+        listen_socks = _acquire_listen_sockets(
+            config.host,
+            config.port,
+            max_attempts=config.bind_retry_max_attempts,
+            initial_delay=config.bind_retry_initial_delay_seconds,
+            backoff_factor=config.bind_retry_backoff_factor,
+            label="OpenViking HTTP server",
+        )
+        if listen_socks is None:
+            _abort_port_acquisition_failed(config.port, config.bind_retry_max_attempts)
+
+        print(
+            f"OpenViking HTTP Server is running on {config.host}:{config.port}{workers_info}"
+        )
+
         workers = config.workers
         if workers > 1:
             # Multi-worker mode requires an import string so each worker
             # can independently import the application.  We stash the
             # resolved config path in an env-var so that the factory can
             # pick it up (ServerConfig already reads OPENVIKING_CONFIG_FILE).
+            # The multiprocess supervisor binds its own sockets; the acquire
+            # loop above has already waited out any stale holder, so close
+            # the probe sockets and hand the bind to uvicorn.
+            for sock in listen_socks:
+                sock.close()
             os.environ[WORKER_WITH_BOT_ENV] = "1" if config.with_bot else "0"
             os.environ[WORKER_BOT_API_URL_ENV] = config.bot_api_url
             uvicorn.run(
@@ -322,14 +502,14 @@ def main():
                 log_config=None,
             )
         else:
-            uvicorn.run(
-                app,
-                host=config.host,
-                port=config.port,
-                timeout_keep_alive=config.timeout_keep_alive,
-                log_config=None,
-            )
+            _serve_single_process(app, config, listen_socks)
     finally:
+        # uvicorn closes sockets it was given, but be defensive against
+        # early exits. Double-close is a no-op for closed Python sockets.
+        if listen_socks is not None:
+            for sock in listen_socks:
+                if sock.fileno() != -1:
+                    sock.close()
         # Cleanup vikingbot process on shutdown
         if bot_process is not None:
             _stop_vikingbot_gateway(bot_process)

--- a/openviking/server/config.py
+++ b/openviking/server/config.py
@@ -279,6 +279,14 @@ class ServerConfig(BaseModel):
     # connections the client still believes are reusable, causing sporadic
     # connection-reset / EOF errors.
     timeout_keep_alive: int = 5
+    # Port-binding recovery. When the listen port is still occupied at startup
+    # (stale process from a previous run, watchdog restart race, duplicate
+    # launch), retry the bind with exponential backoff instead of exiting on
+    # the first EADDRINUSE. 0 preserves the old fail-fast behavior; the delay
+    # grows as initial * backoff_factor ** attempt.
+    bind_retry_max_attempts: int = Field(default=5, ge=0)
+    bind_retry_initial_delay_seconds: float = Field(default=1.0, gt=0)
+    bind_retry_backoff_factor: float = Field(default=2.0, ge=1.0)
     auth_mode: Optional[str] = None  # If None, auto-detect based on root_api_key
     root_api_key: Optional[str] = None
     # OIDC/LDAP authentication configuration

--- a/tests/server/test_bind_retry.py
+++ b/tests/server/test_bind_retry.py
@@ -1,0 +1,405 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Port-binding recovery for the OpenViking HTTP server.
+
+``bootstrap._acquire_listen_sockets`` binds the listen port up-front with
+retry + exponential backoff and the bound sockets are handed to uvicorn, so
+a stale or concurrently-restarting process holding the port no longer
+crashes the server on the first EADDRINUSE.
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import openviking.server.bootstrap as bootstrap
+from openviking.server.config import ServerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port(host: str = "127.0.0.1") -> int:
+    """Reserve then release a port so tests never collide on a fixed one."""
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    with socket.socket(family=family) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+def _occupy(port: int, host: str = "127.0.0.1") -> socket.socket:
+    sock = socket.socket(family=socket.AF_INET)
+    sock.bind((host, port))
+    sock.listen(1)
+    return sock
+
+
+def _patch_sleep(monkeypatch, delays: list[float]) -> None:
+    """Record sleep calls without actually sleeping (scoped to bootstrap)."""
+    monkeypatch.setattr(bootstrap, "time", SimpleNamespace(sleep=delays.append))
+
+
+def _main_battery(monkeypatch, config: ServerConfig) -> dict:
+    """Monkeypatch everything bootstrap.main() needs except bind acquisition."""
+    captured: dict = {}
+
+    monkeypatch.setattr(bootstrap, "load_server_config", lambda config_path: config)
+    monkeypatch.setattr(bootstrap, "create_app", lambda config, **kwargs: "app")
+    monkeypatch.setattr(bootstrap, "configure_uvicorn_logging", lambda: None)
+    monkeypatch.setattr(
+        bootstrap.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: SimpleNamespace(
+            host=None,
+            port=None,
+            config=None,
+            workers=None,
+            bot=False,
+            with_bot=False,
+            bot_port=bootstrap.VIKINGBOT_DEFAULT_PORT,
+            bot_url="http://localhost:18790",
+            enable_bot_logging=None,
+            bot_log_dir="/tmp/bot-logs",
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.ollama.detect_ollama_in_config",
+        lambda config: (False, "127.0.0.1", 11434),
+    )
+
+    def fake_config(app, **kwargs):
+        captured.update({"config_kwargs": {"app": app, **kwargs}})
+        return SimpleNamespace(load_app=lambda: None)
+
+    monkeypatch.setattr(bootstrap.uvicorn, "Config", fake_config)
+
+    def fake_server_run(self, sockets=None):
+        # Capture the bound address NOW: main() closes the socket in its
+        # finally block after serve() returns, and getsockname() on a closed
+        # socket raises.
+        captured.update(
+            {
+                "sockets": sockets,
+                "bound_port": sockets[0].getsockname()[1] if sockets else None,
+            }
+        )
+
+    monkeypatch.setattr(bootstrap.uvicorn.Server, "run", fake_server_run)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# _acquire_listen_socket
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_returns_bound_socket_when_port_free():
+    port = _free_port()
+
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 0, 0.01, 2.0, "test")
+
+    assert socks is not None
+    assert len(socks) == 1  # explicit host binds exactly one family
+    assert socks[0].getsockname()[1] == port
+    socks[0].close()
+
+
+def test_acquire_retries_until_port_released():
+    port = _free_port()
+    blocker = _occupy(port)
+
+    def release_soon():
+        time.sleep(0.05)
+        blocker.close()
+
+    threading.Thread(target=release_soon, daemon=True).start()
+
+    # Real (tiny) delays: cumulative 0.01+0.02+0.04+... comfortably covers
+    # the 0.05s hold while staying fast when the port frees early.
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 8, 0.01, 2.0, "test")
+
+    assert socks is not None
+    assert socks[0].getsockname()[1] == port
+    socks[0].close()
+
+
+def test_acquire_returns_none_after_exhausting_attempts(monkeypatch, capsys):
+    port = _free_port()
+    blocker = _occupy(port)
+    delays: list[float] = []
+    _patch_sleep(monkeypatch, delays)
+
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 2, 0.01, 2.0, "test")
+
+    assert socks is None
+    # 3 total tries -> 2 sleeps between them, exponential backoff.
+    assert delays == [0.01, 0.02]
+    err = capsys.readouterr().err
+    assert "still in use" in err
+    assert "attempt 1/3" in err
+    blocker.close()
+
+
+def test_acquire_zero_attempts_is_fail_fast(monkeypatch):
+    port = _free_port()
+    blocker = _occupy(port)
+    delays: list[float] = []
+    _patch_sleep(monkeypatch, delays)
+
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 0, 0.01, 2.0, "test")
+
+    assert socks is None
+    assert delays == []
+    blocker.close()
+
+
+def test_acquire_backoff_sequence(monkeypatch):
+    port = _free_port()
+    blocker = _occupy(port)
+    delays: list[float] = []
+    _patch_sleep(monkeypatch, delays)
+
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 3, 0.5, 2.0, "test")
+
+    assert socks is None
+    assert delays == [0.5, 1.0, 2.0]
+    blocker.close()
+
+
+def test_acquire_wildcard_host_binds_both_families():
+    port = _free_port()
+
+    socks = bootstrap._acquire_listen_sockets(None, port, 0, 0.01, 2.0, "test")
+
+    assert socks is not None
+    addrs = {sock.getsockname()[0] for sock in socks}
+    # Wildcard keeps asyncio AI_PASSIVE parity: v4 always, v6 when the
+    # machine has an IPv6 stack.
+    assert "0.0.0.0" in addrs
+    assert addrs <= {"0.0.0.0", "::"}
+    for sock in socks:
+        sock.close()
+
+
+def test_acquire_wildcard_degrades_to_ipv4_when_ipv6_unavailable(monkeypatch):
+    port = _free_port()
+    real_socket = bootstrap.socket.socket
+
+    def fake_socket(family=socket.AF_INET, type=socket.SOCK_STREAM, *args, **kwargs):
+        if family == socket.AF_INET6:
+            raise OSError(errno.EAFNOSUPPORT, "address family not supported")
+        return real_socket(family=family, type=type)
+
+    monkeypatch.setattr(bootstrap.socket, "socket", fake_socket)
+
+    socks = bootstrap._acquire_listen_sockets(None, port, 0, 0.01, 2.0, "test")
+
+    assert socks is not None
+    assert [sock.getsockname()[0] for sock in socks] == ["0.0.0.0"]
+    socks[0].close()
+
+
+def test_acquire_propagates_config_errors_without_retry(monkeypatch):
+    delays: list[float] = []
+    _patch_sleep(monkeypatch, delays)
+
+    class _UnbindableSocket(socket.socket):
+        def bind(self, addr):
+            raise OSError(errno.EADDRNOTAVAIL, "address not available")
+
+    monkeypatch.setattr(bootstrap.socket, "socket", _UnbindableSocket)
+
+    # EADDRNOTAVAIL means the host is not on this machine — no retry
+    # budget can clear it, so it must propagate immediately.
+    with pytest.raises(OSError) as excinfo:
+        bootstrap._acquire_listen_sockets("198.51.100.1", 1933, 5, 0.01, 2.0, "test")
+
+    assert excinfo.value.errno == errno.EADDRNOTAVAIL
+    assert delays == []
+
+
+def test_acquire_so_reuseaddr_matches_platform_semantics():
+    port = _free_port()
+
+    socks = bootstrap._acquire_listen_sockets("127.0.0.1", port, 0, 0.01, 2.0, "test")
+
+    assert socks is not None
+    enabled = bool(socks[0].getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR))
+    # POSIX keeps TIME_WAIT-safe restarts; Windows must detect live listeners.
+    assert enabled == (sys.platform != "win32")
+    socks[0].close()
+
+
+# ---------------------------------------------------------------------------
+# ServerConfig wiring
+# ---------------------------------------------------------------------------
+
+
+def test_server_config_bind_retry_defaults():
+    config = ServerConfig()
+
+    assert config.bind_retry_max_attempts == 5
+    assert config.bind_retry_initial_delay_seconds == 1.0
+    assert config.bind_retry_backoff_factor == 2.0
+
+
+def test_server_config_bind_retry_validation():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ServerConfig(bind_retry_max_attempts=-1)
+    with pytest.raises(ValidationError):
+        ServerConfig(bind_retry_initial_delay_seconds=0)
+    with pytest.raises(ValidationError):
+        ServerConfig(bind_retry_backoff_factor=0.5)
+
+
+# ---------------------------------------------------------------------------
+# bootstrap.main() integration
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_with_clear_message_when_port_stays_occupied(monkeypatch, capsys):
+    port = _free_port()
+    blocker = _occupy(port)
+    config = ServerConfig(host="127.0.0.1", port=port, bind_retry_max_attempts=0)
+    _main_battery(monkeypatch, config)
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main()
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert f"port {port} is still in use after 1 bind attempt(s)" in err
+    assert "bind_retry_max_attempts" in err
+    blocker.close()
+
+
+def test_main_stops_vikingbot_when_port_stays_occupied(monkeypatch):
+    port = _free_port()
+    blocker = _occupy(port)
+    config = ServerConfig(
+        host="127.0.0.1", port=port, bind_retry_max_attempts=0, with_bot=True
+    )
+    _main_battery(monkeypatch, config)
+    # Neutralize environment-dependent pre-flight checks so the test is
+    # about the abort path alone.
+    monkeypatch.setattr(bootstrap, "_abort_if_port_in_use", lambda port, label: None)
+    monkeypatch.setattr(
+        bootstrap, "get_server_url_from_server_data", lambda config: None
+    )
+    fake_bot = SimpleNamespace()
+    monkeypatch.setattr(
+        bootstrap, "_start_vikingbot_gateway", lambda *args, **kwargs: fake_bot
+    )
+    stopped: list[object] = []
+    monkeypatch.setattr(
+        bootstrap, "_stop_vikingbot_gateway", lambda proc: stopped.append(proc)
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main()
+
+    assert excinfo.value.code == 1
+    # The gateway child must not outlive the failed server: an orphaned
+    # bot keeps its port and blocks every later --with-bot restart.
+    assert stopped == [fake_bot]
+    blocker.close()
+
+
+def test_main_stops_vikingbot_when_acquire_raises(monkeypatch):
+    # Non-retryable bind errors (e.g. EADDRNOTAVAIL for a host that no
+    # longer exists on this machine) propagate out of main() — the finally
+    # must still stop the gateway child, or it holds port 18790 and blocks
+    # every later --with-bot restart.
+    config = ServerConfig(host="198.51.100.1", port=1933, with_bot=True)
+    _main_battery(monkeypatch, config)
+    monkeypatch.setattr(bootstrap, "_abort_if_port_in_use", lambda port, label: None)
+    monkeypatch.setattr(
+        bootstrap, "get_server_url_from_server_data", lambda config: None
+    )
+    fake_bot = SimpleNamespace()
+    monkeypatch.setattr(
+        bootstrap, "_start_vikingbot_gateway", lambda *args, **kwargs: fake_bot
+    )
+    stopped: list[object] = []
+    monkeypatch.setattr(
+        bootstrap, "_stop_vikingbot_gateway", lambda proc: stopped.append(proc)
+    )
+
+    def raising_acquire(*args, **kwargs):
+        raise OSError(errno.EADDRNOTAVAIL, "address not available")
+
+    monkeypatch.setattr(bootstrap, "_acquire_listen_sockets", raising_acquire)
+
+    with pytest.raises(OSError) as excinfo:
+        bootstrap.main()
+
+    assert excinfo.value.errno == errno.EADDRNOTAVAIL
+    assert stopped == [fake_bot]
+
+
+def test_main_serves_on_prebound_socket_and_closes_it(monkeypatch):
+    port = _free_port()
+    config = ServerConfig(host="127.0.0.1", port=port, bind_retry_max_attempts=0)
+    captured = _main_battery(monkeypatch, config)
+
+    # _acquire_listen_sockets is NOT stubbed here: main() must really bind
+    # the free port and hand the very same bound socket to uvicorn.
+    bootstrap.main()
+
+    served = captured["sockets"]
+    assert served is not None and len(served) == 1
+    # The socket uvicorn served on is the very one main() bound to our port.
+    assert captured["bound_port"] == port
+    assert captured["config_kwargs"]["host"] == "127.0.0.1"
+    assert captured["config_kwargs"]["port"] == port
+    # main()'s finally block defensively closes the socket.
+    assert served[0].fileno() == -1
+
+
+def test_main_multiworker_closes_probe_socket_and_delegates_to_uvicorn_run(
+    monkeypatch,
+):
+    port = _free_port()
+    config = ServerConfig(host="127.0.0.1", port=port, workers=2)
+    closed: list[bool] = []
+
+    class _ProbeSocket:
+        def fileno(self) -> int:
+            return -1  # already-closed marker so main()'s finally skips it
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(
+        bootstrap,
+        "_acquire_listen_sockets",
+        lambda host, port, **kwargs: [_ProbeSocket()],
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        bootstrap.uvicorn,
+        "run",
+        lambda app, **kwargs: captured.update({"app": app, **kwargs}),
+    )
+    battery = _main_battery(monkeypatch, config)
+
+    bootstrap.main()
+
+    # Multi-worker path: uvicorn.run receives the import-string factory and
+    # the pre-flight socket was closed before handing the bind to uvicorn.
+    assert captured["app"] == "openviking.server.app:create_worker_app"
+    assert captured["workers"] == 2
+    assert captured["port"] == port
+    assert closed == [True]
+    # Single-process serving path must not have run.
+    assert battery.get("sockets") is None

--- a/tests/server/test_bootstrap.py
+++ b/tests/server/test_bootstrap.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import socket
 from types import SimpleNamespace
 
 import openviking.server.app as app_module
@@ -12,6 +13,44 @@ from openviking.server.config import ServerConfig
 from openviking.utils.agfs_utils import resolve_queuefs_mount_point
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
 from openviking_cli.utils.config.storage_config import StorageConfig
+
+
+class _RecordingUvicornConfig:
+    """Test double for uvicorn.Config that records constructor kwargs."""
+
+    def __init__(self, app, **kwargs):
+        self.captured = {"app": app, **kwargs}
+
+    def load_app(self):
+        return None
+
+
+def _stub_bind_retry(monkeypatch, captured):
+    """Stub port acquisition (returns unbound dummies) and record host/port."""
+
+    def fake_acquire(host, port, **kwargs):
+        captured.update({"acquire_host": host, "acquire_port": port})
+        return [socket.socket()]
+
+    monkeypatch.setattr(bootstrap, "_acquire_listen_sockets", fake_acquire)
+
+
+def _stub_single_process_serving(monkeypatch, captured):
+    """Stub uvicorn Config/Server.run for the single-worker serving path."""
+    config_holder = {}
+
+    def fake_config(app, **kwargs):
+        config_holder["config"] = _RecordingUvicornConfig(app, **kwargs)
+        return config_holder["config"]
+
+    monkeypatch.setattr(bootstrap.uvicorn, "Config", fake_config)
+    monkeypatch.setattr(
+        bootstrap.uvicorn.Server,
+        "run",
+        lambda self, sockets=None: captured.update(
+            {"config_kwargs": config_holder["config"].captured, "sockets": sockets}
+        ),
+    )
 
 
 def test_main_keeps_config_host_when_cli_host_is_omitted(monkeypatch):
@@ -61,11 +100,15 @@ def test_main_keeps_config_host_when_cli_host_is_omitted(monkeypatch):
             {"app": app, "host": host, "port": port, "log_config": log_config, **kwargs}
         ),
     )
+    _stub_bind_retry(monkeypatch, captured)
+    _stub_single_process_serving(monkeypatch, captured)
 
     bootstrap.main()
 
-    assert captured["host"] == "127.0.0.1"
-    assert captured["port"] == 1933
+    assert captured["acquire_host"] == "127.0.0.1"
+    assert captured["acquire_port"] == 1933
+    assert captured["config_kwargs"]["host"] == "127.0.0.1"
+    assert captured["config_kwargs"]["port"] == 1933
 
 
 def test_main_coerces_cli_host_all_to_none(monkeypatch):
@@ -115,11 +158,16 @@ def test_main_coerces_cli_host_all_to_none(monkeypatch):
             {"app": app, "host": host, "port": port, "log_config": log_config, **kwargs}
         ),
     )
+    _stub_bind_retry(monkeypatch, captured)
+    _stub_single_process_serving(monkeypatch, captured)
 
     bootstrap.main()
 
-    assert captured["host"] is None
-    assert captured["port"] == 1933
+    # CLI --host all coerces to None (bind all interfaces).
+    assert captured["acquire_host"] is None
+    assert captured["config_kwargs"]["host"] is None
+    assert captured["acquire_port"] == 1933
+    assert captured["config_kwargs"]["port"] == 1933
 
 
 def test_main_enables_bot_logging_when_with_bot_comes_from_config(monkeypatch):
@@ -165,6 +213,10 @@ def test_main_enables_bot_logging_when_with_bot_comes_from_config(monkeypatch):
     monkeypatch.setattr(bootstrap, "_start_vikingbot_gateway", _fake_start)
     monkeypatch.setattr(bootstrap, "_stop_vikingbot_gateway", lambda process: None)
     monkeypatch.setattr(bootstrap.uvicorn, "run", lambda *args, **kwargs: None)
+    # Port acquisition and serving are stubbed into a throwaway dict so the
+    # exact-match assertion below only sees the bot-related captures.
+    _stub_bind_retry(monkeypatch, {})
+    _stub_single_process_serving(monkeypatch, {})
 
     bootstrap.main()
 
@@ -206,6 +258,9 @@ def test_bot_alias_propagates_resolved_config_to_workers(monkeypatch):
         "run",
         lambda app, **kwargs: captured.update({"app": app, **kwargs}),
     )
+    # Multi-worker path closes the acquired socket and hands the bind to
+    # uvicorn; stub acquisition so no real port is touched.
+    _stub_bind_retry(monkeypatch, {})
 
     with monkeypatch.context() as worker_env:
         worker_env.delenv(app_module.WORKER_WITH_BOT_ENV, raising=False)


### PR DESCRIPTION
## Summary

The server currently dies on the first `EADDRINUSE` when the listen port is
momentarily held — e.g. a previous process still winding down after Windows
logoff/logon, or a watchdog restarting the server while the old process is
still bound. This PR makes startup resilient:

- **Bind up-front with retry + backoff**: acquire the listen socket(s)
  before serving and hand the pre-bound sockets to
  `uvicorn.Server.run(sockets=...)`, so the bind is never released between
  acquisition and serving (no check-then-bind race window). New
  `server.bind_retry_max_attempts` / `bind_retry_initial_delay_seconds` /
  `bind_retry_backoff_factor` options (default budget ≈ 31 s) tune the loop.
- **Retry only what retries can fix**: only `EADDRINUSE`/`EACCES`
  (occupancy-class, incl. Windows sockets held in another login session)
  are retried. Configuration errors such as `EADDRNOTAVAIL` (host not on
  this machine, e.g. VPN down) fail immediately with the original error
  instead of burning the budget and printing a misleading "stale process"
  message.
- **Dual-stack parity preserved**: `--host all` still binds both `::` and
  `0.0.0.0` (matching the previous `loop.create_server(host=None)`
  behavior), degrading to IPv4-only on machines without IPv6.
- **No orphaned gateway on failure**: with `--with-bot`, the vikingbot
  child is stopped on every failed-acquisition path (retry exhaustion
  *and* raised bind errors). Previously it could survive the server,
  keep port 18790, and block every later `--with-bot` start.
- **Better diagnostics**: the abort message now also points at Windows
  excluded port ranges (`netsh interface ipv4 show excludedportrange
  protocol=tcp`) for the "nothing in netstat but bind denied" case.

## Type of Change

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

- [x] Unit tests pass: `pytest tests/server/test_bind_retry.py tests/server/test_bootstrap.py` → **24 passed** (12 new covering retry/backoff, errno filtering, dual-stack + IPv6-less fallback, bot cleanup on both failure paths)
- [x] `ruff check`: no new violations (fixed a pre-existing I001 in `bootstrap.py`)
- [x] `mypy`: no new errors vs HEAD baseline (unchanged 4 pre-existing in `bootstrap.py`)
- [x] Manual: wildcard acquisition verified binding both `::` and `0.0.0.0` on Windows

## Related Issues

- None yet — no existing issue covers this. Can file a bug report and link it if maintainers prefer.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (`docs/en`, `docs/zh`, `examples/ov.conf.example`)
- [x] All tests pass
