### PR TITLE
feat(plugins): session idle auto-commit across harnesses, plus close-path fixes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
             examples/codex-memory-plugin/scripts/auto-recall.test.mjs \
             examples/codex-memory-plugin/scripts/session-start-commit.test.mjs \
             examples/claude-code-memory-plugin/scripts/auto-capture.test.mjs \
+            examples/claude-code-memory-plugin/scripts/session-start.test.mjs \
             examples/claude-code-memory-plugin/scripts/marketplace.test.mjs \
             examples/claude-code-memory-plugin/scripts/skill-experience.test.mjs \
             examples/claude-code-memory-plugin/scripts/uri-guard.test.mjs \
@@ -54,6 +55,7 @@ jobs:
             examples/zcode-memory-plugin/scripts/zcode-turns.test.mjs \
             examples/memory-plugin-shared/agent-hook-runtime.test.mjs \
             examples/memory-plugin-shared/batch-send.test.mjs \
+            examples/memory-plugin-shared/session-policy.test.mjs \
             examples/memory-plugin-shared/install-agent-hooks.test.mjs \
             examples/memory-plugin-shared/install-opencode-jsonc.test.mjs \
             examples/memory-plugin-shared/install-tui.test.mjs \

--- a/docs/en/agent-integrations/02-claude-code.md
+++ b/docs/en/agent-integrations/02-claude-code.md
@@ -85,6 +85,7 @@ Configuration priority: Environment variables > `ovcli.conf` > `ov.conf` > Built
 | `OPENVIKING_RECALL_LIMIT` | `10` | Legacy width override converted to per-category coding quotas |
 | `OPENVIKING_RECALL_TOKEN_BUDGET` | `2000` | Inline token budget for the final raw-find fallback |
 | `OPENVIKING_AUTO_CAPTURE` | `true` | Auto-capture after each turn |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Idle timeout sent as a per-session server policy; `0`/`off` disables it |
 | `OPENVIKING_BYPASS_SESSION` | `false` | Skip all hooks for this session |
 | `OPENVIKING_BYPASS_SESSION_PATTERNS` | `""` | CSV glob patterns to auto-bypass |
 | `OPENVIKING_MEMORY_ENABLED` | (auto) | Force on/off |
@@ -93,6 +94,11 @@ Configuration priority: Environment variables > `ovcli.conf` > `ov.conf` > Built
 If recall latency matters most, see [Low-latency recall](./01-overview.md#low-latency-recall) for the environment-variable and `ovcli.conf` settings that disable query expansion and result compression.
 
 For multi-tenant deployments, configure `OPENVIKING_ACCOUNT` and `OPENVIKING_USER`. The complete list of environment variables is available in the [plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md#configuration).
+
+Claude Code normally commits on `SessionEnd`. For a server-side backstop against
+an interrupted async writer or machine shutdown, enable
+`memory.session_auto_commit.idle_enabled=true`; see
+[Session Auto Commit Configuration](../guides/01-configuration.md#session-auto-commit-configuration).
 
 </details>
 

--- a/docs/en/agent-integrations/03-openclaw.md
+++ b/docs/en/agent-integrations/03-openclaw.md
@@ -108,7 +108,8 @@ openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 The plugin now commits active sessions from the awaited `session_end` and
 `gateway_stop` hooks on gateway shutdown, restart, and session supersession.
 A conversation that simply goes quiet is still not ended until the next
-inbound message or reset. Enable the server-side backstop for that gap:
+inbound message or reset. To cover that gap, enable the backstop in the
+OpenViking **server's** `ov.conf` (not in the plugin config above):
 
 ```json
 {

--- a/docs/en/agent-integrations/03-openclaw.md
+++ b/docs/en/agent-integrations/03-openclaw.md
@@ -98,11 +98,34 @@ Plugin config lives under `plugins.entries.openviking.config`. Setup usually wri
 | `apiKey` | empty | OpenViking API key |
 | `peer_prefix` | empty | Optional prefix for assistant peer identity when `peer_role=assistant` |
 | `autoRecallTimeoutMs` | `5000` | Outer timeout (ms) for the whole auto-recall flow; increase for slow local embedding hardware (clamped 1000–300000) |
+| `commitIdleTimeoutSeconds` | `3600` | Per-session server idle policy; `0` or `off` disables it |
 
 ```bash
 openclaw config set plugins.entries.openviking.config.baseUrl http://your-server:1933
 openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 ```
+
+The plugin now commits active sessions from the awaited `session_end` and
+`gateway_stop` hooks on gateway shutdown, restart, and session supersession.
+A conversation that simply goes quiet is still not ended until the next
+inbound message or reset. Enable the server-side backstop for that gap:
+
+```json
+{
+  "memory": {
+    "session_auto_commit": {
+      "default_enabled": false,
+      "idle_enabled": true,
+      "check_interval_seconds": 60.0,
+      "scan_batch_size": 16,
+      "scan_batch_pause_seconds": 0.0
+    }
+  }
+}
+```
+
+You can also set `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS`; `0`/`off` disables
+the per-session policy.
 
 </details>
 

--- a/docs/en/agent-integrations/04-codex.md
+++ b/docs/en/agent-integrations/04-codex.md
@@ -50,7 +50,7 @@ Launch `codex`; on the first prompt of a session, the `SessionStart` hook should
 
 The plugin integrates with Codex's lifecycle by hooking into key events. On `SessionStart` (`startup`, `clear`, or `resume`), it injects `profile.md` plus URI and abstract indexes for `preferences/` and `entities/` through the same shared, CJK-aware profile builder used by the other coding-agent integrations. It then searches OpenViking and injects relevant memories before every prompt (`UserPromptSubmit`), appends new turns to the session after each response (`Stop`), and commits the full transcript before compaction (`PreCompact`) to ensure memory extraction processes the entire conversation. Upon starting a fresh session, it also cleans up any orphaned sessions from previous runs. A resumed session may combine the fixed profile block with its latest archive digest.
 
-> **Known limitation**: Codex does not fire a hook upon `SIGTERM`, `Ctrl+C`, or `/exit`. Orphaned sessions are recovered during the next `SessionStart` via the idle-TTL sweep (30 minutes) or the active-window heuristic.
+> **Known limitation**: Codex does not fire a hook upon `SIGTERM`, `Ctrl+C`, or `/exit`. Every session receives a one-hour idle policy, but the server executes it only when `memory.session_auto_commit.idle_enabled=true`. When the server confirms that scheduler, the local state-file sweep steps aside and only garbage-collects its marker later. On old or idle-disabled servers, the existing next-`SessionStart` active-window and 30-minute idle-TTL recovery remains active.
 
 Tool calls and results are captured as dedicated `tool` parts, and `tool_output` is reported verbatim. Truncation is the server's job: output larger than `tool_output_externalization.threshold_chars` (default `20000`) is written to the session's tool-result store, and the part keeps a synopsis stub plus `tool_output_ref`, so the original stays readable through [`/api/v1/sessions/{id}/tool-results`](../api/05-sessions.md#read_tool_result).
 
@@ -67,6 +67,7 @@ Credential source: active `ovcli.conf` wins by default (`OPENVIKING_CLI_CONFIG_F
 | `OPENVIKING_CREDENTIAL_SOURCE` | `auto` | Set `env` to force env-var credentials instead of active ovcli config |
 | `OPENVIKING_NO_AUTO_INJECT` | `false` | Disable fixed session-start profile/background injection without disabling per-prompt recall |
 | `OPENVIKING_PROFILE_TOKEN_BUDGET` | `10000` | CJK-aware token budget for `profile.md` plus `preferences/` and `entities/` indexes |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Server-side idle backstop; `0`/`off` disables sending the policy |
 | `OPENVIKING_CODEX_ACTIVE_WINDOW_MS` | `120000` | SessionStart active-window threshold |
 | `OPENVIKING_CODEX_IDLE_TTL_MS` | `1800000` | SessionStart idle-TTL sweep threshold |
 | `OPENVIKING_DEBUG` | `false` | Write logs to `~/.openviking/logs/codex-hooks.log` |
@@ -74,6 +75,22 @@ Credential source: active `ovcli.conf` wins by default (`OPENVIKING_CLI_CONFIG_F
 If recall latency matters most, see [Low-latency recall](./01-overview.md#low-latency-recall) for the environment-variable and `ovcli.conf` settings that disable query expansion and Codex's local result compression.
 
 Additional tuning options (e.g., `OPENVIKING_RECALL_LIMIT`, `OPENVIKING_CAPTURE_ASSISTANT_TURNS`) are documented in the [plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md#tuning-the-plugin).
+
+Enable the server-side backstop:
+
+```json
+{
+  "memory": {
+    "session_auto_commit": {
+      "default_enabled": false,
+      "idle_enabled": true,
+      "check_interval_seconds": 60.0,
+      "scan_batch_size": 16,
+      "scan_batch_pause_seconds": 0.0
+    }
+  }
+}
+```
 
 </details>
 

--- a/docs/en/agent-integrations/04-codex.md
+++ b/docs/en/agent-integrations/04-codex.md
@@ -76,7 +76,8 @@ If recall latency matters most, see [Low-latency recall](./01-overview.md#low-la
 
 Additional tuning options (e.g., `OPENVIKING_RECALL_LIMIT`, `OPENVIKING_CAPTURE_ASSISTANT_TURNS`) are documented in the [plugin README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md#tuning-the-plugin).
 
-Enable the server-side backstop:
+Enable the backstop in the OpenViking **server's** `ov.conf` (this is a server
+setting, not a plugin one):
 
 ```json
 {

--- a/docs/en/agent-integrations/10-opencode.md
+++ b/docs/en/agent-integrations/10-opencode.md
@@ -115,6 +115,7 @@ node examples/opencode-plugin/scripts/setup.mjs
   },
   "commitTokenThreshold": 20000,
   "commitKeepRecentCount": 10,
+  "commitIdleTimeoutSeconds": 3600,
   "profileTokenBudget": 10000,
   "resumeContextBudget": 32000
 }
@@ -127,9 +128,17 @@ export OPENVIKING_API_KEY="your-api-key-here"
 export OPENVIKING_ACCOUNT="default"   # optional, trusted-mode deployments only
 export OPENVIKING_USER="opencode"     # optional, trusted-mode deployments only
 export OPENVIKING_PEER_ID="opencode"  # optional, peer-scoped memory routing
+export OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS="3600"
 ```
 
 API keys are sent as `Authorization: Bearer ...` by both hooks and the MCP proxy. `account` and `user` are trusted-mode headers; `peerId` is sent as `X-OpenViking-Actor-Peer` and as `peer_id` on captured session messages. Existing `openviking-config.json` credential fields are still read as a migration fallback, but new installs should use `ovcli.conf` or env vars.
+
+OpenCode's awaited `dispose` hook requires OpenCode `>=1.15.11`. The plugin
+uses a three-second commit deadline inside OpenCode's five-second shutdown
+budget so retryable failures can reach the pending queue. On the next startup,
+rehydrated uncommitted session entries are flushed and committed. Enable
+`memory.session_auto_commit.idle_enabled=true` for an additional server-side
+backstop; use `0`/`off` for the environment variable to disable its policy.
 
 ## Verify
 

--- a/docs/en/agent-integrations/11-pi.md
+++ b/docs/en/agent-integrations/11-pi.md
@@ -64,6 +64,7 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
   "resumeContextBudget": 32000,
   "commitTokenThreshold": 20000,
   "commitKeepRecentCount": 10,
+  "commitIdleTimeoutSeconds": 3600,
   "takeover": {
     "enabled": true,
     "tokenThreshold": 30000,
@@ -78,6 +79,13 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
 ```
 
 Takeover is fail-open: if pending writes cannot flush, commit fails, the archive overview is not ready, or the branch fingerprint no longer matches, pi keeps full local history or falls back to its default compaction. Set `OV_DEBUG_LOG=/tmp/ov-pi.log` when validating boundary advances.
+
+Pi awaits `session_shutdown`. The extension now performs a bounded final
+commit in takeover mode too, and advances the persisted watermark only after
+that commit succeeds; a failed commit is neither queued nor treated as a
+completed boundary. `SIGKILL` remains uncovered. Enable
+`memory.session_auto_commit.idle_enabled=true` for a server-side idle backstop,
+and use `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=off` to disable the policy.
 
 ## Verify
 

--- a/docs/en/agent-integrations/12-cursor.md
+++ b/docs/en/agent-integrations/12-cursor.md
@@ -42,7 +42,7 @@ Quit Cursor completely and restart it after installation.
 - `beforeSubmitPrompt` recalls context for the current request and injects it through `additional_context`.
 - `beforeReadFile` and `beforeShellExecution` redirect accidental local access to `viking://` paths back to OpenViking MCP tools.
 - `stop` incrementally captures new user and assistant messages and commits after every captured turn by default.
-- `preCompact` and `sessionEnd` commit pending messages for memory extraction.
+- `preCompact` commits pending messages for memory extraction. `sessionEnd` is registered too, but Cursor cannot currently execute it (see below), so commit-on-every-turn is what actually protects the session tail.
 
 Project identity uses Cursor's `workspace_roots`, keeping workspace peers separate. Hooks and MCP share credentials from `~/.openviking/ovcli.conf`.
 

--- a/docs/en/agent-integrations/12-cursor.md
+++ b/docs/en/agent-integrations/12-cursor.md
@@ -41,10 +41,24 @@ Quit Cursor completely and restart it after installation.
 - `sessionStart` loads your profile and the current project's memory index.
 - `beforeSubmitPrompt` recalls context for the current request and injects it through `additional_context`.
 - `beforeReadFile` and `beforeShellExecution` redirect accidental local access to `viking://` paths back to OpenViking MCP tools.
-- `stop` incrementally captures new user and assistant messages.
+- `stop` incrementally captures new user and assistant messages and commits after every captured turn by default.
 - `preCompact` and `sessionEnd` commit pending messages for memory extraction.
 
 Project identity uses Cursor's `workspace_roots`, keeping workspace peers separate. Hooks and MCP share credentials from `~/.openviking/ovcli.conf`.
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_TURN_THRESHOLD` | `1` | Captured-turn threshold for the client-driven commit |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Server idle policy; `0`/`off` disables it |
+
+Cursor currently fires `sessionEnd` only during `window_close`, after its
+shell-exec host has already been torn down, so the hook command cannot spawn
+([Cursor bug 165492](https://forum.cursor.com/t/sessionend-hook-fires-only-on-window-close-after-shell-exec-teardown-plugin-hook-commands-can-never-execute/165492)).
+Commit-on-every-`stop` removes the normal tail-loss dependency on that hook;
+only the last in-flight turn can still be lost. The default can be overridden
+with `OPENVIKING_COMMIT_TURN_THRESHOLD`. For an additional server backstop,
+enable `memory.session_auto_commit.idle_enabled=true`; tune or disable the
+one-hour policy with `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS`.
 
 ## Upgrade and uninstall
 

--- a/docs/en/agent-integrations/13-trae.md
+++ b/docs/en/agent-integrations/13-trae.md
@@ -47,6 +47,16 @@ Quit and restart the corresponding client after installation.
 - `Stop` captures and immediately commits the completed turn, including short sessions.
 - The OpenViking MCP server provides explicit tools such as `search`, `recall`, `read`, and `remember`.
 
+TRAE and TRAE CLI do not expose a separate session-end event, so only the last
+in-flight turn can be lost. Each `SessionStart` also sends a one-hour idle
+policy. Enable `memory.session_auto_commit.idle_enabled=true` to activate that
+server-side backstop; tune or disable it with
+`OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS`.
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Server idle policy; `0`/`off` disables it |
+
 ## Verify
 
 1. Restart TRAE, TRAE CN, or TRAE CLI and create a new Agent session.

--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -159,11 +159,16 @@ ov session new
       "account_id": "default",
       "user_id": "alice"
     },
-    "auto_commit_policy": null
+    "auto_commit_policy": null,
+    "auto_commit_idle_enabled": false
   },
   "time": 0.1
 }
 ```
+
+`auto_commit_idle_enabled` is a server feature-detection field. It is `true`
+only when this server is running the idle auto-commit scheduler. A stored
+`auto_commit_policy` does not by itself mean idle sweeping is active.
 
 ---
 
@@ -269,6 +274,7 @@ Get session details including metadata, message statistics, commit history, etc.
 - `memories_extracted`: Count statistics of extracted memories by category
 - `last_commit_at`: Time of last commit
 - `auto_commit_policy`: Effective auto-commit policy with defaults filled in; `null` when not enabled
+- `auto_commit_idle_enabled`: Whether this server is actively running the idle auto-commit scheduler
 
 **Code Entries:**
 - `openviking/session/session.py:Session.load()` - Session loading
@@ -392,7 +398,8 @@ ov session get a1b2c3d4
       "idle_timeout_seconds": 86400,
       "keep_recent_count": 2,
       "min_commit_interval_seconds": 0
-    }
+    },
+    "auto_commit_idle_enabled": false
   }
 }
 ```
@@ -428,6 +435,8 @@ effect on subsequent message writes, idle scans, and commits. Only the
 An empty request object is a valid no-op and returns the effective configuration.
 Unknown request fields are rejected. The response always returns the effective
 policy with defaults filled in, or `null` when automatic commits are disabled.
+It also returns `auto_commit_idle_enabled`, allowing clients to distinguish a
+stored policy from an actively running idle scheduler.
 
 #### 3. Usage Examples
 
@@ -518,6 +527,7 @@ ov session config set a1b2c3d4 --no-auto-commit
       "keep_recent_count": 2,
       "min_commit_interval_seconds": 0
     },
+    "auto_commit_idle_enabled": false,
     "memory_extraction_config": {
       "events": {
         "tags": ["team=search", "channel=app"]

--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -1238,6 +1238,8 @@ Notes:
 
 - `memory.session_auto_commit` is a server-wide control surface, not a per-session business policy.
 - Per-session auto-commit behavior is configured through the session-level `auto_commit_policy` (see the table below). Set it when creating a session with `POST /api/v1/sessions`, or partially update it through `PATCH /api/v1/sessions/{session_id}/config`. Omitting `auto_commit_policy` from a PATCH preserves it; sending `null` disables automatic commits. Use `GET /api/v1/sessions/{session_id}` to inspect the effective policy.
+- Memory plugins send an idle-only per-session policy by default (`idle_timeout_seconds=3600`; token and message thresholds disabled). That policy is inert while `idle_enabled=false`. Set `idle_enabled=true` to activate the server-side backstop for sessions whose harness close hook is missing or interrupted. Plugin clients detect activation through `auto_commit_idle_enabled`; the policy echo alone is not proof that the scheduler is running.
+- Tune the plugin policy with `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS`; use `0`, `off`, `false`, or `no` to stop sending it. The server-side scan still requires `idle_enabled=true`.
 - When `default_enabled=false`, sessions created without `auto_commit_policy` keep auto commit disabled and return `auto_commit_policy: null`. Providing `{}` or any policy field explicitly enables auto commit for that session and fills missing fields from the defaults below.
 - When `default_enabled=true`, sessions created without `auto_commit_policy` get the default policy below.
 - When `idle_enabled=false`:

--- a/docs/zh/agent-integrations/02-claude-code.md
+++ b/docs/zh/agent-integrations/02-claude-code.md
@@ -85,6 +85,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 | `OPENVIKING_RECALL_LIMIT` | `10` | 遗留宽度覆盖，会转换为各分类 coding 配额 |
 | `OPENVIKING_RECALL_TOKEN_BUDGET` | `2000` | 最终 raw-find fallback 的内联 Token 预算 |
 | `OPENVIKING_AUTO_CAPTURE` | `true` | 每轮对话结束后自动捕获新记忆 |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | 作为 session policy 发送给服务端的 idle timeout；`0`/`off` 可禁用 |
 | `OPENVIKING_BYPASS_SESSION` | `false` | 禁用当前会话的所有 Hook |
 | `OPENVIKING_BYPASS_SESSION_PATTERNS` | `""` | 通过 CSV 格式的 glob 模式匹配并自动跳过特定会话 |
 | `OPENVIKING_MEMORY_ENABLED` | (auto) | 强制开启或关闭插件 |
@@ -93,6 +94,8 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 如果更看重召回响应速度，请参阅[低延迟召回](./01-overview.md#低延迟召回)，其中说明了如何通过环境变量或 `ovcli.conf` 关闭查询扩展与结果压缩。
 
 在多租户场景下，请额外配置 `OPENVIKING_ACCOUNT` 和 `OPENVIKING_USER`。完整的环境变量列表请参阅 [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/claude-code-memory-plugin/README.md#configuration)。
+
+Claude Code 正常情况下会在 `SessionEnd` commit。若希望在异步写入被中断或机器直接关机时仍有服务端兜底，可启用 `memory.session_auto_commit.idle_enabled=true`；详见 [Session Auto Commit 配置](../guides/01-configuration.md#session-auto-commit-配置)。
 
 </details>
 

--- a/docs/zh/agent-integrations/03-openclaw.md
+++ b/docs/zh/agent-integrations/03-openclaw.md
@@ -98,11 +98,33 @@ python examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
 | `apiKey` | 空 | OpenViking API Key |
 | `peer_prefix` | 空 | `peer_role=assistant` 时 assistant peer 身份的可选前缀 |
 | `autoRecallTimeoutMs` | `5000` | 整个 auto-recall 流程的外层超时（毫秒）；本地嵌入硬件较慢时可调大（取值范围 1000–300000） |
+| `commitIdleTimeoutSeconds` | `3600` | session 级服务端 idle policy；`0` 或 `off` 可禁用 |
 
 ```bash
 openclaw config set plugins.entries.openviking.config.baseUrl http://your-server:1933
 openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 ```
+
+插件现在会在 gateway 关闭、重启和 session supersession 时，通过 awaited
+`session_end` 与 `gateway_stop` hook commit 活跃 session。若对话只是长时间无
+新消息，则要等下一条入站消息或 reset 才会结束；可为这个缺口启用服务端 backstop：
+
+```json
+{
+  "memory": {
+    "session_auto_commit": {
+      "default_enabled": false,
+      "idle_enabled": true,
+      "check_interval_seconds": 60.0,
+      "scan_batch_size": 16,
+      "scan_batch_pause_seconds": 0.0
+    }
+  }
+}
+```
+
+也可通过 `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` 调整；`0`/`off` 会禁用
+session policy。
 
 </details>
 

--- a/docs/zh/agent-integrations/03-openclaw.md
+++ b/docs/zh/agent-integrations/03-openclaw.md
@@ -107,7 +107,8 @@ openclaw config set plugins.entries.openviking.config.apiKey your-api-key
 
 插件现在会在 gateway 关闭、重启和 session supersession 时，通过 awaited
 `session_end` 与 `gateway_stop` hook commit 活跃 session。若对话只是长时间无
-新消息，则要等下一条入站消息或 reset 才会结束；可为这个缺口启用服务端 backstop：
+新消息，则要等下一条入站消息或 reset 才会结束。要覆盖这个缺口，请在 OpenViking
+**服务端**的 `ov.conf` 中启用 backstop（不是上面的插件配置）：
 
 ```json
 {

--- a/docs/zh/agent-integrations/04-codex.md
+++ b/docs/zh/agent-integrations/04-codex.md
@@ -76,7 +76,7 @@ codex              # 首次启动需进入 /hooks 完成一次审批
 
 更多调参说明（如 `OPENVIKING_RECALL_LIMIT`、`OPENVIKING_CAPTURE_ASSISTANT_TURNS` 等），请参考 [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md#tuning-the-plugin)。
 
-启用服务端 backstop：
+在 OpenViking **服务端**的 `ov.conf` 中启用 backstop（这是服务端配置，不是插件配置）：
 
 ```json
 {

--- a/docs/zh/agent-integrations/04-codex.md
+++ b/docs/zh/agent-integrations/04-codex.md
@@ -50,7 +50,7 @@ codex              # 首次启动需进入 /hooks 完成一次审批
 
 本插件深度挂载于 Codex 的生命周期之中：在 `SessionStart`（`startup`、`clear` 或 `resume`）阶段，它会复用其他 coding-agent 集成共用的 CJK-aware profile 构建逻辑，注入 `profile.md`，以及 `preferences/`、`entities/` 的 URI 和摘要索引；在每次用户输入前，它会搜索 OpenViking 并注入相关的记忆（触发 `UserPromptSubmit`）；在每轮对话结束后，会将新的对话追加至当前会话（触发 `Stop`）；在上下文压缩前，补齐并提交（commit）完整的对话记录（触发 `PreCompact`），以确保记忆抽取器能够在完整的上下文环境中运行。此外，在启动新会话时，插件还会自动清理前次运行遗留的孤儿会话（orphan session）。恢复已有会话时，固定 profile 背景还会与最新的 archive digest 合并注入。
 
-> **已知局限**：当通过 `SIGTERM`、`Ctrl+C` 或输入 `/exit` 退出 Codex 时，不会触发任何 hook（钩子）。遗留的孤儿会话将在下一次触发 `SessionStart` 时，通过闲置 TTL（生存时间，默认为 30 分钟）机制或活动窗口启发式策略进行回收清理。
+> **已知局限**：当通过 `SIGTERM`、`Ctrl+C` 或输入 `/exit` 退出 Codex 时，不会触发任何 hook。插件会为每个 session 发送默认一小时的 idle policy，但只有服务端启用 `memory.session_auto_commit.idle_enabled=true` 后才会实际执行。服务端明确确认 scheduler 已启用时，本地 state-file sweep 会让出 commit，仅在更晚时清理 marker；旧服务或 idle-disabled 服务仍沿用下一次 `SessionStart` 的活动窗口和 30 分钟 idle-TTL 回收。
 
 工具调用和结果会作为独立的 `tool` part 捕获，`tool_output` 原样上报。截断由服务端负责：超过 `tool_output_externalization.threshold_chars`（默认 `20000`）的输出会写入 session 的 tool-result 存储，part 中只保留 synopsis stub 和 `tool_output_ref`，原文仍可通过 [`/api/v1/sessions/{id}/tool-results`](../api/05-sessions.md#read_tool_result) 读回。
 
@@ -67,6 +67,7 @@ codex              # 首次启动需进入 /hooks 完成一次审批
 | `OPENVIKING_CREDENTIAL_SOURCE` | `auto` | 设置为 `env` 时强制使用环境变量凭据 |
 | `OPENVIKING_NO_AUTO_INJECT` | `false` | 关闭会话启动阶段的固定 profile/背景注入，但不关闭逐 prompt 语义召回 |
 | `OPENVIKING_PROFILE_TOKEN_BUDGET` | `10000` | `profile.md` 及 `preferences/`、`entities/` 索引共用的 CJK-aware token 预算 |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | 服务端 idle backstop；`0`/`off` 可停止发送 policy |
 | `OPENVIKING_CODEX_ACTIVE_WINDOW_MS` | `120000` | `SessionStart` 活动窗口阈值（毫秒） |
 | `OPENVIKING_CODEX_IDLE_TTL_MS` | `1800000` | `SessionStart` 闲置 TTL 清理阈值（毫秒） |
 | `OPENVIKING_DEBUG` | `false` | 是否将日志写入 `~/.openviking/logs/codex-hooks.log` |
@@ -74,6 +75,22 @@ codex              # 首次启动需进入 /hooks 完成一次审批
 如果更看重召回响应速度，请参阅[低延迟召回](./01-overview.md#低延迟召回)，其中说明了如何通过环境变量或 `ovcli.conf` 关闭查询扩展与 Codex 本地结果压缩。
 
 更多调参说明（如 `OPENVIKING_RECALL_LIMIT`、`OPENVIKING_CAPTURE_ASSISTANT_TURNS` 等），请参考 [插件 README](https://github.com/volcengine/OpenViking/blob/main/examples/codex-memory-plugin/README.md#tuning-the-plugin)。
+
+启用服务端 backstop：
+
+```json
+{
+  "memory": {
+    "session_auto_commit": {
+      "default_enabled": false,
+      "idle_enabled": true,
+      "check_interval_seconds": 60.0,
+      "scan_batch_size": 16,
+      "scan_batch_pause_seconds": 0.0
+    }
+  }
+}
+```
 
 </details>
 

--- a/docs/zh/agent-integrations/10-opencode.md
+++ b/docs/zh/agent-integrations/10-opencode.md
@@ -115,6 +115,7 @@ node examples/opencode-plugin/scripts/setup.mjs
   },
   "commitTokenThreshold": 20000,
   "commitKeepRecentCount": 10,
+  "commitIdleTimeoutSeconds": 3600,
   "profileTokenBudget": 10000,
   "resumeContextBudget": 32000
 }
@@ -127,9 +128,16 @@ export OPENVIKING_API_KEY="your-api-key-here"
 export OPENVIKING_ACCOUNT="default"   # 可选，仅 trusted-mode 部署需要
 export OPENVIKING_USER="opencode"     # 可选，仅 trusted-mode 部署需要
 export OPENVIKING_PEER_ID="opencode"  # 可选，peer 维度记忆路由需要
+export OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS="3600"
 ```
 
 API key 会由 hooks 和 MCP proxy 作为 `Authorization: Bearer ...` 发送；`account` 和 `user` 是 trusted-mode headers；`peerId` 会作为 `X-OpenViking-Actor-Peer` 和捕获 session message 的 `peer_id` 使用。旧版 `openviking-config.json` 里的凭据字段仍会作为迁移 fallback 读取，但新安装建议使用 `ovcli.conf` 或环境变量。
+
+OpenCode 的 awaited `dispose` hook 要求 OpenCode `>=1.15.11`。插件在
+OpenCode 五秒 shutdown 总预算内使用三秒 commit deadline，使 retryable 失败仍有
+时间进入 pending queue；下次启动时会 flush 并 commit 重载出的未提交 session。
+还可启用 `memory.session_auto_commit.idle_enabled=true` 作为服务端 backstop；
+将环境变量设为 `0`/`off` 可禁用其 policy。
 
 ## 验证
 

--- a/docs/zh/agent-integrations/11-pi.md
+++ b/docs/zh/agent-integrations/11-pi.md
@@ -64,6 +64,7 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
   "resumeContextBudget": 32000,
   "commitTokenThreshold": 20000,
   "commitKeepRecentCount": 10,
+  "commitIdleTimeoutSeconds": 3600,
   "takeover": {
     "enabled": true,
     "tokenThreshold": 30000,
@@ -78,6 +79,12 @@ node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
 ```
 
 Takeover 是 fail-open：如果 pending 写入无法 flush、commit 失败、archive overview 尚未生成，或 branch 指纹不匹配，pi 会继续保留完整本地历史，或回退到默认 compaction。验证边界推进时可设置 `OV_DEBUG_LOG=/tmp/ov-pi.log`。
+
+Pi 会 await `session_shutdown`。扩展现在在 takeover 模式下也执行 bounded 最终
+commit，并且只有 commit 成功后才推进持久化 watermark；失败既不会排队，也不会被
+视为边界已完成。`SIGKILL` 仍无法覆盖。可启用
+`memory.session_auto_commit.idle_enabled=true` 作为服务端 idle backstop；设置
+`OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=off` 可禁用 policy。
 
 ## 验证
 

--- a/docs/zh/agent-integrations/12-cursor.md
+++ b/docs/zh/agent-integrations/12-cursor.md
@@ -42,7 +42,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 - `beforeSubmitPrompt`：根据当前问题召回记忆并通过 `additional_context` 注入。
 - `beforeReadFile` 和 `beforeShellExecution`：阻止把 `viking://` 虚拟路径当作本地文件访问，并提示改用 OpenViking MCP 工具。
 - `stop`：增量捕获本轮新增的用户与助手消息，默认每个已捕获 turn 都会 commit。
-- `preCompact` / `sessionEnd`：提交尚未处理的消息，触发记忆抽取。
+- `preCompact`：提交尚未处理的消息，触发记忆抽取。`sessionEnd` 同样已注册，但目前 Cursor 无法真正执行它（见下文），因此真正保住会话尾巴的是每轮 commit。
 
 项目身份优先使用 Cursor 提供的 `workspace_roots`，因此不同项目会使用不同的 workspace peer。连接信息统一读取 `~/.openviking/ovcli.conf`。
 

--- a/docs/zh/agent-integrations/12-cursor.md
+++ b/docs/zh/agent-integrations/12-cursor.md
@@ -41,10 +41,22 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 - `sessionStart`：加载用户画像和当前项目的记忆索引。
 - `beforeSubmitPrompt`：根据当前问题召回记忆并通过 `additional_context` 注入。
 - `beforeReadFile` 和 `beforeShellExecution`：阻止把 `viking://` 虚拟路径当作本地文件访问，并提示改用 OpenViking MCP 工具。
-- `stop`：增量捕获本轮新增的用户与助手消息。
+- `stop`：增量捕获本轮新增的用户与助手消息，默认每个已捕获 turn 都会 commit。
 - `preCompact` / `sessionEnd`：提交尚未处理的消息，触发记忆抽取。
 
 项目身份优先使用 Cursor 提供的 `workspace_roots`，因此不同项目会使用不同的 workspace peer。连接信息统一读取 `~/.openviking/ovcli.conf`。
+
+| 环境变量 | 默认值 | 含义 |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_TURN_THRESHOLD` | `1` | 客户端 commit 的已捕获 turn 阈值 |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | 服务端 idle policy；`0`/`off` 可禁用 |
+
+Cursor 当前只会在 `window_close` 时触发 `sessionEnd`，但此时 shell-exec host 已经
+teardown，hook 命令无法启动（[Cursor bug 165492](https://forum.cursor.com/t/sessionend-hook-fires-only-on-window-close-after-shell-exec-teardown-plugin-hook-commands-can-never-execute/165492)）。
+每个 `stop` 都 commit 后，正常尾部不再依赖这个 hook；仍可能丢失最后一个尚未完成的
+in-flight turn。可用 `OPENVIKING_COMMIT_TURN_THRESHOLD` 覆盖默认值。若需额外服务端
+兜底，启用 `memory.session_auto_commit.idle_enabled=true`，并用
+`OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` 调整或禁用默认一小时 policy。
 
 ## 升级与卸载
 

--- a/docs/zh/agent-integrations/13-trae.md
+++ b/docs/zh/agent-integrations/13-trae.md
@@ -47,6 +47,15 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 - `Stop`：捕获本轮消息并立即提交，使短会话也能进入记忆抽取流程。
 - OpenViking MCP Server：提供 `search`、`recall`、`read`、`remember` 等主动记忆工具。
 
+TRAE 与 TRAE CLI 没有单独的 session-end event，因此只可能丢失最后一个尚未完成的
+in-flight turn。每次 `SessionStart` 也会发送默认一小时的 idle policy；启用
+`memory.session_auto_commit.idle_enabled=true` 后服务端 backstop 才会实际运行，
+可用 `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` 调整或禁用。
+
+| 环境变量 | 默认值 | 含义 |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | 服务端 idle policy；`0`/`off` 可禁用 |
+
 ## 验证
 
 1. 重启 TRAE、TRAE CN 或 TRAE CLI，并新建 Agent 会话。

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -159,11 +159,16 @@ ov session new
       "account_id": "default",
       "user_id": "alice"
     },
-    "auto_commit_policy": null
+    "auto_commit_policy": null,
+    "auto_commit_idle_enabled": false
   },
   "time": 0.1
 }
 ```
+
+`auto_commit_idle_enabled` 是服务端 feature-detection 字段。只有当前服务端
+实际运行 idle auto-commit scheduler 时才为 `true`；仅保存了
+`auto_commit_policy` 并不代表 idle sweep 已启用。
 
 ---
 
@@ -269,6 +274,7 @@ ov session list
 - `memories_extracted`: 各类记忆的提取数量统计
 - `last_commit_at`: 最后一次提交的时间
 - `auto_commit_policy`: 填充默认值后的生效自动 commit 策略；未启用时为 `null`
+- `auto_commit_idle_enabled`: 当前服务端是否实际运行 idle auto-commit scheduler
 
 **代码入口**：
 - `openviking/session/session.py:Session.load()` - 会话加载
@@ -392,7 +398,8 @@ ov session get a1b2c3d4
       "idle_timeout_seconds": 86400,
       "keep_recent_count": 2,
       "min_commit_interval_seconds": 0
-    }
+    },
+    "auto_commit_idle_enabled": false
   }
 }
 ```
@@ -426,6 +433,8 @@ ov session get a1b2c3d4
 
 空请求对象是合法的 no-op，并会返回当前生效配置。未知请求字段会被拒绝。
 响应始终返回补齐默认值后的生效策略；自动 commit 已禁用时返回 `null`。
+响应还会返回 `auto_commit_idle_enabled`，用于区分“policy 已保存”和“服务端
+idle scheduler 已实际运行”。
 
 #### 3. 使用示例
 
@@ -516,6 +525,7 @@ ov session config set a1b2c3d4 --no-auto-commit
       "keep_recent_count": 2,
       "min_commit_interval_seconds": 0
     },
+    "auto_commit_idle_enabled": false,
     "memory_extraction_config": {
       "events": {
         "tags": ["team=search", "channel=app"]

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -1324,6 +1324,8 @@ Redis Sentinel 分别配置数据节点和 Sentinel 的 ACL：
 
 - `memory.session_auto_commit` 是服务端全局配置，不是单个 session 的业务 policy。
 - session 级别的自动触发参数通过 session 级 `auto_commit_policy` 设置（见下表）。可以在创建 session 时通过 `POST /api/v1/sessions` 设置，也可以通过 `PATCH /api/v1/sessions/{session_id}/config` 部分更新。PATCH 时省略 `auto_commit_policy` 会保留现有策略，传 `null` 会禁用自动 commit；通过 `GET /api/v1/sessions/{session_id}` 查看生效策略。
+- 记忆插件默认发送 idle-only 的 session policy（`idle_timeout_seconds=3600`，token 和 message 阈值关闭）。`idle_enabled=false` 时该 policy 只会保存，不会执行；设置 `idle_enabled=true` 后，服务端才会为缺少 close hook 或 close hook 被中断的会话提供 backstop。插件通过 `auto_commit_idle_enabled` 判断调度器是否实际运行，不能只根据 policy echo 判断。
+- 可用 `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` 调整插件发送的 idle timeout；设置为 `0`、`off`、`false` 或 `no` 可停止发送。服务端扫描仍然要求 `idle_enabled=true`。
 - `default_enabled=false` 时，未传 `auto_commit_policy` 创建的 session 保持 auto commit 关闭，返回 `auto_commit_policy: null`。显式传 `{}` 或任意 policy 字段会为该 session 开启 auto commit，并用下方默认值补齐缺失字段。
 - `default_enabled=true` 时，未传 `auto_commit_policy` 创建的 session 会带上下方默认 policy。
 - `idle_enabled=false` 时：

--- a/examples/claude-code-memory-plugin/scripts/config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.mjs
@@ -45,6 +45,7 @@ import { join, resolve as resolvePath } from "node:path";
 
 import { buildUserAgent, readManifestVersion } from "./shared/credentials.mjs";
 import { HARNESS_KEYS, loadPluginSettings, normalizeRewriteMode } from "./shared/plugin-config.mjs";
+import { normalizeIdleTimeoutSeconds } from "./shared/session-policy.mjs";
 
 const DEFAULT_OV_CONF_PATH = join(homedir(), ".openviking", "ov.conf");
 const DEFAULT_OVCLI_CONF_PATH = join(homedir(), ".openviking", "ovcli.conf");
@@ -346,6 +347,11 @@ export function loadConfig() {
       process.env.OPENVIKING_COMMIT_KEEP_RECENT_COUNT,
       num(cc.commitKeepRecentCount, 10),
     ))),
+    commitIdleTimeoutSeconds: normalizeIdleTimeoutSeconds(
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS
+        ?? cc.commitIdleTimeoutSeconds,
+      3600,
+    ),
 
     // P0-3b: token budget for session-start archive-overview fetch
     resumeContextBudget: Math.max(1024, Math.floor(num(

--- a/examples/claude-code-memory-plugin/scripts/session-start.mjs
+++ b/examples/claude-code-memory-plugin/scripts/session-start.mjs
@@ -36,6 +36,10 @@ import { replayPending } from "./lib/pending-queue.mjs";
 import { buildProfileBlock, estimateTokens } from "./lib/profile-inject.mjs";
 import { writeJsonState } from "./lib/state.mjs";
 import { getEffectivePeerId } from "./lib/workspace-peer.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+} from "./shared/session-policy.mjs";
 
 if (!isPluginEnabled()) {
   process.stdout.write(JSON.stringify({ decision: "approve" }) + "\n");
@@ -135,6 +139,23 @@ async function main() {
     }
   } catch (err) {
     logError("pending-replay", err);
+  }
+
+  if (sessionId) {
+    try {
+      await applySessionAutoCommitPolicy(
+        fetchJSON,
+        deriveOvSessionId(sessionId),
+        buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds),
+        {
+          cacheKey: `${cfg.baseUrl}|${cfg.accountId || ""}|${cfg.userId || ""}`,
+          actorPeerId: effectivePeer.peerId,
+          log,
+        },
+      );
+    } catch (err) {
+      logError("session-policy", err);
+    }
   }
 
   if (!willInjectProfile && !willInjectArchive) {

--- a/examples/claude-code-memory-plugin/scripts/session-start.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/session-start.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+function runSessionStart(baseUrl, stateDir, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const cleanEnv = { ...process.env };
+    for (const key of Object.keys(cleanEnv)) {
+      if (key.startsWith("OPENVIKING_")) delete cleanEnv[key];
+    }
+    const child = spawn(process.execPath, [join(SCRIPT_DIR, "session-start.mjs")], {
+      env: {
+        ...cleanEnv,
+        HOME: stateDir,
+        OPENVIKING_MEMORY_ENABLED: "1",
+        OPENVIKING_URL: baseUrl,
+        OPENVIKING_CREDENTIAL_SOURCE: "env",
+        OPENVIKING_CONFIG_FILE: join(stateDir, "missing-ov.conf"),
+        OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
+        OPENVIKING_STATE_DIR: join(stateDir, "shared-state"),
+        OPENVIKING_PENDING_DIR: join(stateDir, "pending"),
+        OPENVIKING_NO_AUTO_INJECT: "1",
+        ...extraEnv,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`session-start exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve(JSON.parse(stdout.trim()));
+    });
+    child.stdin.end(JSON.stringify({
+      session_id: "claude-policy",
+      source: "startup",
+      cwd: "/tmp/claude-policy",
+      hook_event_name: "SessionStart",
+    }));
+  });
+}
+
+test("Claude SessionStart creates the session with an idle policy", async () => {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    requests.push({ method: req.method, url: req.url, body });
+    res.setHeader("Content-Type", "application/json");
+    if (req.url === "/health") {
+      res.end(JSON.stringify({ status: "ok", result: {} }));
+      return;
+    }
+    if (req.url === "/api/v1/sessions") {
+      const payload = JSON.parse(body);
+      res.end(JSON.stringify({
+        status: "ok",
+        result: {
+          session_id: payload.session_id,
+          auto_commit_policy: payload.auto_commit_policy,
+          auto_commit_idle_enabled: true,
+        },
+      }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ status: "error", error: { code: "NOT_FOUND" } }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-claude-session-start-"));
+  try {
+    const { port } = server.address();
+    await runSessionStart(`http://127.0.0.1:${port}`, stateDir);
+    const policyRequest = requests.find((request) =>
+      request.method === "POST" && request.url === "/api/v1/sessions"
+    );
+    assert.deepEqual(JSON.parse(policyRequest.body), {
+      session_id: "cc-claude-policy",
+      auto_commit_policy: {
+        idle_timeout_seconds: 3600,
+        pending_token_threshold: 0,
+        message_count_threshold: 0,
+      },
+    });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Claude SessionStart sends no session policy when the knob is off", async () => {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    requests.push({ method: req.method, url: req.url });
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ status: "ok", result: {} }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-claude-session-off-"));
+  try {
+    const { port } = server.address();
+    await runSessionStart(`http://127.0.0.1:${port}`, stateDir, {
+      OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS: "off",
+    });
+    assert.equal(
+      requests.some((request) =>
+        request.method === "POST" && request.url === "/api/v1/sessions"
+      ),
+      false,
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/examples/claude-code-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/claude-code-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/codex-memory-plugin/DESIGN.md
+++ b/examples/codex-memory-plugin/DESIGN.md
@@ -118,10 +118,23 @@ If local state still has a live `ovSessionId`, resume injection is skipped:
 the session is appendable and Codex should already be resuming its own
 transcript.
 
-### 5. Idle TTL sweep — fallback
+### 5. Server-side idle auto-commit and local sweep fallback
+
+Every `SessionStart` source best-effort applies an idle-only per-session
+policy: one-hour `idle_timeout_seconds`, with token and message-count triggers
+disabled. The policy is inert unless the server explicitly returns
+`auto_commit_idle_enabled=true`; a policy echo alone is not proof that the
+scheduler is running.
+
+When the server confirms idle sweeping, the state file records
+`serverIdleCommit=true`. The active-window heuristic and local idle sweep both
+skip that session. After the server timeout plus a 10-minute margin, the local
+marker file is garbage-collected without sending a duplicate commit. Old
+servers, transient failures, a disabled knob, and
+`auto_commit_idle_enabled=false` keep the local recovery below unchanged.
 
 State files whose `lastUpdatedAt` is older than `IDLE_TTL_MS` (default 30
-min) get committed and cleared. Mental model: a session not touched for
+min), and are not server-covered, get committed and cleared. Mental model: a session not touched for
 30 min is "temporarily concluded"; if the user resumes later, subsequent
 turns append under the same deterministic OV session id, and the next
 commit creates another archive there.
@@ -140,9 +153,10 @@ is the right cadence. The Stop hook contains a comment marking the option
 to add sweep there if codex's session creation rate is low enough that
 arbitrarily-orphaned state files accumulate.
 
-**Known limitation**: if the user never starts another codex on this
-machine, no sweep ever runs and the OV session stays open server-side
-forever. Accepted. Future work could add an MCP tool
+**Known limitation without the server backstop**: if the user never starts
+another codex on this machine, no local sweep ever runs and the OV session
+stays open server-side. Enable
+`memory.session_auto_commit.idle_enabled=true` to cover that case. Future work could add an MCP tool
 `openviking_commit_pending` so the model can commit explicitly.
 
 ## Stop hook — append + threshold commit
@@ -227,7 +241,10 @@ OV session id, while commits create additional archives under that session.
 {
   "codexSessionId": "0193af...",   // codex thread id
   "ovSessionId": "cx-0193af...-or-null", // null means "committed, awaiting next Stop"
+  "workspacePeerId": "-path-to-workspace", // identity used by a later swept commit
   "capturedTurnCount": 7,            // turns from transcript already appended
+  "serverIdleCommit": true,          // present only when the server confirms idle sweeping
+  "serverIdleTimeoutSeconds": 3600,  // timeout paired with that marker
   "createdAt": 1715000000000,
   "lastUpdatedAt": 1715000300000
 }
@@ -239,6 +256,8 @@ next resolve. The migration window for preserving old UUID sessions has
 closed.
 
 State files are atomic-write (tmpfile + rename) to survive crash mid-write.
+Swept commits send the stored `workspacePeerId`; only pre-upgrade files without
+that field fall back to the new session's active peer.
 
 ## Configuration
 
@@ -249,6 +268,7 @@ Env var overrides for tuning without rebuilding:
 | `OPENVIKING_CODEX_STATE_DIR` | `~/.openviking/codex-plugin-state` | state file dir |
 | `OPENVIKING_CODEX_ACTIVE_WINDOW_MS` | `120000` (2 min) | rule-3 active window |
 | `OPENVIKING_CODEX_IDLE_TTL_MS` | `1800000` (30 min) | idle sweep TTL |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` (1 hour) | per-session server idle policy; `0`/`off` disables it |
 | `OPENVIKING_RECALL_TIMEOUT_MS` | `120000` (2 min) | whole UserPromptSubmit auto-recall deadline |
 | `OPENVIKING_RECALL_COMPRESS` | `1` | set `0` / `off` to skip `codex exec` compression |
 | `OPENVIKING_RECALL_COMPRESS_MODEL` | unset | custom first-choice compressor model; `off` disables compression |

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -182,13 +182,20 @@ Codex fires `SessionStart` with one of three `source` values: `startup` (fresh p
 
 On all three sources, the hook uses the same shared `buildProfileBlock()` implementation as the Claude Code, OpenCode, and pi integrations. It reads the user's `profile.md` and adds URI plus abstract indexes for `preferences/` and `entities/`, with a CJK-aware token budget. The default budget is `10000`; set `OPENVIKING_PROFILE_TOKEN_BUDGET` or `plugin.codex.profileTokenBudget` to change it. Set `OPENVIKING_NO_AUTO_INJECT=1` or `plugin.codex.noAutoInject=true` to disable only this fixed profile/background injection; per-prompt semantic recall remains controlled separately by `OPENVIKING_AUTO_RECALL`.
 
+The same hook also applies a one-hour server idle policy. If the response
+explicitly reports `auto_commit_idle_enabled=true`, the state file is marked
+server-covered and the local heuristic/sweep skips it. A covered state file is
+removed only after the server timeout plus a 10-minute margin. Old servers,
+idle-disabled servers, failures, and `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=0`
+keep the local fallback unchanged.
+
 On `startup` or `clear`, the script:
 
-1. Counts state files (excluding the new session_id) whose `lastUpdatedAt` is within `OPENVIKING_CODEX_ACTIVE_WINDOW_MS` (default 2 min) of "now":
+1. Counts uncovered state files (excluding the new session_id) whose `lastUpdatedAt` is within `OPENVIKING_CODEX_ACTIVE_WINDOW_MS` (default 2 min) of "now":
    - **0 active** → no-op (no orphan to commit)
    - **1 active** → commit it (the just-ended session)
    - **≥2 active** → skip; rely on idle TTL (we can't tell which one ended)
-2. **Idle-TTL sweep at the tail**: any state file (regardless of session_id) older than `OPENVIKING_CODEX_IDLE_TTL_MS` (default 30 min) gets committed and cleared.
+2. **Idle-TTL sweep at the tail**: any uncovered state file (regardless of session_id) older than `OPENVIKING_CODEX_IDLE_TTL_MS` (default 30 min) gets committed and cleared.
 
 On any /commit failure (OV unreachable, non-2xx, timeout) we **preserve state** (don't `clearState`) so the next sweep can retry.
 
@@ -225,6 +232,7 @@ Config knobs:
 | `OPENVIKING_RECALL_MAX_TOKENS` | `1600` | Token budget the server assembles the context block within, independent of the local compressor input limit. |
 | `OPENVIKING_RECALL_DEDUP_TURNS` | `5` | Cross-turn cooldown: URIs served in the last N turns are skipped. |
 | `OPENVIKING_RECALL_QUERY_EXPANSION` | `auto` | `auto` lets the server widen short prompts using session context; `off` disables it. |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Server idle backstop; `0`/`off` disables sending the policy. |
 
 Recall now asks the server to assemble the context block in one request
 (`POST /api/v1/search/search` with `mode="context"`), so budgeting, detail tiers
@@ -259,7 +267,7 @@ After a successful append, Stop reads the session meta and commits when `pending
 
 ### Known gap: SIGTERM / Ctrl+C / `/exit` are silent
 
-Codex fires no hook on process exit. `/compact` is the only fully-deterministic "context disappearing" signal. If you `/exit` without `/compact`, the OV session for that codex session_id stays open. Two fallbacks recover the orphan:
+Codex fires no hook on process exit. `/compact` is the only fully-deterministic "context disappearing" signal. If you `/exit` without `/compact`, the server-side idle scheduler is the only fallback that does not require launching Codex again. Enable `memory.session_auto_commit.idle_enabled=true` to activate the default one-hour policy. Otherwise two local fallbacks recover the orphan only on the next `SessionStart`:
 
 1. The idle-TTL sweep at the next `SessionStart` commits any state file older than 30 min
 2. The active-window heuristic catches it if you `/new` or `/clear` shortly after

--- a/examples/codex-memory-plugin/VERIFICATION.md
+++ b/examples/codex-memory-plugin/VERIFICATION.md
@@ -239,6 +239,29 @@ echo '{"session_id":"any","source":"startup","cwd":"/tmp","model":"x","permissio
 # Expect: normal SessionStart behavior without spawning `codex exec` for model probing.
 ```
 
+### 6g. Server-covered marker, skip, and cleanup
+
+Run a local server with `memory.session_auto_commit.idle_enabled=true`, then
+start Codex with:
+
+```bash
+export OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=60
+```
+
+After `SessionStart`, inspect the current state file. Expect
+`"serverIdleCommit":true` and `"serverIdleTimeoutSeconds":60`. Kill Codex
+without `/compact`, then start another session:
+
+- before 11 minutes, expect `server_covered_skip` and no client `/commit`;
+- after the 60-second timeout plus the 10-minute margin, expect
+  `server_covered_gc` and the local state file removed;
+- `GET /api/v1/sessions/{id}` should report `commit_count >= 1` and
+  `pending_tokens: 0`.
+
+Repeat against a default-config server. Expect
+`auto_commit_idle_enabled:false`, no marker in the state file, and the active
+window / 30-minute idle sweep to behave exactly as in sections 6a–6d.
+
 ## 7. Memory extraction landed in user namespace
 
 Wait ~60 s for OV's extractor, then:

--- a/examples/codex-memory-plugin/scripts/config.mjs
+++ b/examples/codex-memory-plugin/scripts/config.mjs
@@ -43,6 +43,7 @@ import { join } from "node:path";
 import { resolveOpenVikingCredentials } from "./ov-credentials.mjs";
 import { buildUserAgent, readManifestVersion } from "./shared/credentials.mjs";
 import { HARNESS_KEYS, loadPluginSettings } from "./shared/plugin-config.mjs";
+import { normalizeIdleTimeoutSeconds } from "./shared/session-policy.mjs";
 
 const USER_AGENT = buildUserAgent(
   "codex",
@@ -254,6 +255,11 @@ export function loadConfig() {
       process.env.OPENVIKING_COMMIT_KEEP_RECENT_COUNT,
       num(cx.commitKeepRecentCount, 10),
     ))),
+    commitIdleTimeoutSeconds: normalizeIdleTimeoutSeconds(
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS
+        ?? cx.commitIdleTimeoutSeconds,
+      3600,
+    ),
 
     autoCommitOnCompact: envBool("OPENVIKING_AUTO_COMMIT_ON_COMPACT") ?? (cx.autoCommitOnCompact !== false),
     noAutoInject: envBool("OPENVIKING_NO_AUTO_INJECT") ?? (cx.noAutoInject === true),

--- a/examples/codex-memory-plugin/scripts/session-start-commit.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.mjs
@@ -280,6 +280,12 @@ async function commitAndClear(state, reason) {
 }
 
 async function applyCurrentSessionPolicy(codexSessionId) {
+  // Same guard main() uses before persisting workspacePeerId: without a real
+  // session id we would create an "unknown" state file (polluting the active
+  // window) plus a bogus cx-unknown session server-side.
+  if (!codexSessionId || codexSessionId === "unknown") {
+    return { applied: false, idleActive: null, method: "disabled" };
+  }
   const state = await loadState(codexSessionId);
   const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
   const result = await applySessionAutoCommitPolicy(
@@ -462,11 +468,13 @@ async function main() {
   for (const s of postHeuristic) {
     if (!s?.codexSessionId) continue;
     if (typeof s.lastUpdatedAt !== "number") continue;
-    if (s.serverIdleCommit === true) {
-      const timeoutMs = Math.max(0, Number(s.serverIdleTimeoutSeconds || 0) * 1000);
-      const gcAfterMs = timeoutMs + 600_000;
+    const coveredTimeoutMs = s.serverIdleCommit === true
+      ? Math.max(0, Number(s.serverIdleTimeoutSeconds || 0) * 1000)
+      : 0;
+    if (s.serverIdleCommit === true && coveredTimeoutMs > 0) {
+      const gcAfterMs = coveredTimeoutMs + 600_000;
       const ageMs = now - s.lastUpdatedAt;
-      if (timeoutMs > 0 && ageMs > gcAfterMs) {
+      if (ageMs > gcAfterMs) {
         log("server_covered_gc", {
           codexSessionId: s.codexSessionId,
           ovSessionId: s.ovSessionId,
@@ -484,6 +492,17 @@ async function main() {
         });
       }
       continue;
+    }
+    if (s.serverIdleCommit === true) {
+      // Marked covered but the paired timeout is missing or unusable, so we
+      // cannot tell when the server would have committed. Fall through to the
+      // local sweep rather than leaving the file neither committed nor GC'd.
+      log("server_covered_invalid", {
+        stage: "idle_sweep",
+        codexSessionId: s.codexSessionId,
+        ovSessionId: s.ovSessionId,
+        serverIdleTimeoutSeconds: s.serverIdleTimeoutSeconds ?? null,
+      });
     }
     if ((now - s.lastUpdatedAt) <= IDLE_TTL_MS) continue;
     log("idle_sweep", {

--- a/examples/codex-memory-plugin/scripts/session-start-commit.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.mjs
@@ -42,6 +42,10 @@ import { createLogger } from "./debug-log.mjs";
 import { detectRecallCompressorProfile } from "./recall-compressor-profile.mjs";
 import { clearState, deriveOvSessionId, listStates, loadState, saveState } from "./session-state.mjs";
 import { buildProfileBlock } from "./shared/profile-inject.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+} from "./shared/session-policy.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
 
 const cfg = loadConfig();
@@ -117,11 +121,12 @@ async function fetchJSON(path, init = {}, options = {}) {
   return response.ok ? response.result : null;
 }
 
-async function commitOvSession(ovSessionId) {
+async function commitOvSession(ovSessionId, actorPeerId) {
   if (!ovSessionId) return null;
   return requestJSON(
     `/api/v1/sessions/${encodeURIComponent(ovSessionId)}/commit`,
     { method: "POST", body: JSON.stringify({}) },
+    { actorPeerId },
   );
 }
 
@@ -240,7 +245,8 @@ async function buildResumeArchiveContext(newSessionId) {
 async function commitAndClear(state, reason) {
   if (state.ovSessionId) {
     const ovSessionId = state.ovSessionId;
-    const commit = await commitOvSession(state.ovSessionId);
+    const actorPeerId = state.workspacePeerId || activePeerId;
+    const commit = await commitOvSession(state.ovSessionId, actorPeerId);
     if (!commit?.ok) {
       log("commit", {
         reason,
@@ -271,6 +277,34 @@ async function commitAndClear(state, reason) {
   log("clear_no_ov", { reason, codexSessionId: state.codexSessionId });
   await clearState(state.codexSessionId);
   return { committed: true, ovSessionId: null, traceId: "" };
+}
+
+async function applyCurrentSessionPolicy(codexSessionId) {
+  const state = await loadState(codexSessionId);
+  const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
+  const result = await applySessionAutoCommitPolicy(
+    requestJSON,
+    deriveOvSessionId(codexSessionId),
+    policy,
+    {
+      cacheKey: `${cfg.baseUrl}|${cfg.account || ""}|${cfg.user || ""}`,
+      actorPeerId: activePeerId,
+      log,
+    },
+  );
+  const {
+    serverIdleCommit: _serverIdleCommit,
+    serverIdleTimeoutSeconds: _serverIdleTimeoutSeconds,
+    ...uncoveredState
+  } = state;
+  await saveState(result.idleActive === true
+    ? {
+        ...uncoveredState,
+        serverIdleCommit: true,
+        serverIdleTimeoutSeconds: result.idleTimeoutSeconds,
+      }
+    : uncoveredState);
+  return result;
 }
 
 function describeCommittedSessions(commits) {
@@ -332,6 +366,9 @@ async function main() {
       noop();
       return;
     }
+    await applyCurrentSessionPolicy(newSessionId).catch((err) => {
+      logError("session_policy", err);
+    });
     const [profileContext, archiveContext] = await Promise.all([
       buildSessionProfileContext(),
       buildResumeArchiveContext(newSessionId),
@@ -356,6 +393,9 @@ async function main() {
     return;
   }
 
+  await applyCurrentSessionPolicy(newSessionId).catch((err) => {
+    logError("session_policy", err);
+  });
   const profileContext = await buildSessionProfileContext();
   const now = Date.now();
   const states = await listStates();
@@ -366,9 +406,18 @@ async function main() {
   const otherStates = states.filter(
     (s) => s?.codexSessionId && s.codexSessionId !== newSessionId,
   );
+  const serverCovered = otherStates.filter((s) => s.serverIdleCommit === true);
+  for (const state of serverCovered) {
+    log("server_covered_skip", {
+      stage: "active_window",
+      codexSessionId: state.codexSessionId,
+      ovSessionId: state.ovSessionId,
+    });
+  }
 
   const recentlyActive = otherStates.filter(
-    (s) => typeof s.lastUpdatedAt === "number"
+    (s) => s.serverIdleCommit !== true
+      && typeof s.lastUpdatedAt === "number"
       && (now - s.lastUpdatedAt) <= ACTIVE_WINDOW_MS,
   );
 
@@ -413,6 +462,29 @@ async function main() {
   for (const s of postHeuristic) {
     if (!s?.codexSessionId) continue;
     if (typeof s.lastUpdatedAt !== "number") continue;
+    if (s.serverIdleCommit === true) {
+      const timeoutMs = Math.max(0, Number(s.serverIdleTimeoutSeconds || 0) * 1000);
+      const gcAfterMs = timeoutMs + 600_000;
+      const ageMs = now - s.lastUpdatedAt;
+      if (timeoutMs > 0 && ageMs > gcAfterMs) {
+        log("server_covered_gc", {
+          codexSessionId: s.codexSessionId,
+          ovSessionId: s.ovSessionId,
+          ageMs,
+          gcAfterMs,
+        });
+        await clearState(s.codexSessionId);
+      } else {
+        log("server_covered_skip", {
+          stage: "idle_sweep",
+          codexSessionId: s.codexSessionId,
+          ovSessionId: s.ovSessionId,
+          ageMs,
+          gcAfterMs,
+        });
+      }
+      continue;
+    }
     if ((now - s.lastUpdatedAt) <= IDLE_TTL_MS) continue;
     log("idle_sweep", {
       codexSessionId: s.codexSessionId,

--- a/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -371,6 +371,109 @@ test("server-covered stale state skips local commit and is eventually garbage-co
     } finally {
       await rm(stateDir, { recursive: true, force: true });
     }
+  }
+});
+
+// Regression guard for the gate itself: broadening the covered-skip predicate
+// (e.g. `!== false` instead of `=== true`) would silently stop committing
+// killed sessions on every stock server, where auto_commit_idle_enabled is
+// false. These two cases must keep sweeping locally.
+test("local idle sweep still commits stale state the server does not cover", async () => {
+  for (const [label, extraState] of [
+    ["unmarked", {}],
+    ["marked without a usable timeout", { serverIdleCommit: true }],
+  ]) {
+    const stateDir = await mkdtemp(join(tmpdir(), "ov-codex-uncovered-"));
+    const requests = [];
+    try {
+      const now = Date.now();
+      await writeFile(join(stateDir, "stale.json"), JSON.stringify({
+        codexSessionId: "stale",
+        ovSessionId: "cx-stale",
+        capturedTurnCount: 2,
+        createdAt: now - 2_000_000,
+        lastUpdatedAt: now - 2_000_000,
+        ...extraState,
+      }));
+      await withMockOpenViking(
+        profileHandler(requests, { sessionPolicyIdleActive: false }),
+        async (baseUrl) => {
+          await runSessionStart({
+            session_id: "new-uncovered",
+            source: "startup",
+            cwd: "/tmp/codex-uncovered",
+            hook_event_name: "SessionStart",
+          }, baseEnv(baseUrl, stateDir));
+        },
+      );
+
+      assert.equal(
+        requests.some((request) =>
+          request.method === "POST"
+          && request.path === "/api/v1/sessions/cx-stale/commit"
+        ),
+        true,
+        `expected a local sweep commit for ${label} stale state`,
+      );
+      const files = await readdir(stateDir);
+      assert.equal(files.includes("stale.json"), false, `expected ${label} state cleared`);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("idle-inactive server leaves no covered marker on the current session", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-codex-inactive-marker-"));
+  const requests = [];
+  try {
+    await withMockOpenViking(
+      profileHandler(requests, { sessionPolicyIdleActive: false }),
+      async (baseUrl) => {
+        await runSessionStart({
+          session_id: "inactive-marker",
+          source: "startup",
+          cwd: "/tmp/codex-inactive",
+          hook_event_name: "SessionStart",
+        }, baseEnv(baseUrl, stateDir));
+      },
+    );
+
+    const state = JSON.parse(await readFile(join(stateDir, "inactive-marker.json"), "utf-8"));
+    assert.equal(state.serverIdleCommit, undefined);
+    assert.equal(state.serverIdleTimeoutSeconds, undefined);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("startup without a session id writes no unknown state file", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-codex-unknown-"));
+  const requests = [];
+  try {
+    await withMockOpenViking(
+      profileHandler(requests, { sessionPolicyIdleActive: true }),
+      async (baseUrl) => {
+        await runSessionStart({
+          source: "startup",
+          cwd: "/tmp/codex-unknown",
+          hook_event_name: "SessionStart",
+        }, baseEnv(baseUrl, stateDir));
+      },
+    );
+
+    const files = (await readdir(stateDir)).filter((name) => name.endsWith(".json"));
+    assert.equal(files.includes("unknown.json"), false);
+    assert.equal(
+      requests.some((request) =>
+        request.method === "POST"
+        && request.path === "/api/v1/sessions"
+        && request.body.includes("cx-unknown")
+      ),
+      false,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
+++ b/examples/codex-memory-plugin/scripts/session-start-commit.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -63,20 +63,30 @@ function baseEnv(baseUrl, stateDir) {
     OPENVIKING_CONFIG_FILE: join(stateDir, "missing-ov.conf"),
     OPENVIKING_CLI_CONFIG_FILE: join(stateDir, "missing-ovcli.conf"),
     OPENVIKING_CODEX_STATE_DIR: stateDir,
+    OPENVIKING_STATE_DIR: join(stateDir, "shared-state"),
     OPENVIKING_RECALL_COMPRESS_DETECT_ON_STARTUP: "0",
     OPENVIKING_TIMEOUT_MS: "5000",
     OPENVIKING_CAPTURE_TIMEOUT_MS: "5000",
   };
 }
 
-function profileHandler(requests, { archiveOverview = "" } = {}) {
+function profileHandler(
+  requests,
+  {
+    archiveOverview = "",
+    sessionPolicyIdleActive,
+  } = {},
+) {
   return async (req, res) => {
     const url = new URL(req.url, "http://127.0.0.1");
+    let body = "";
+    for await (const chunk of req) body += chunk;
     requests.push({
       method: req.method,
       path: url.pathname,
       uri: url.searchParams.get("uri"),
       actorPeerId: req.headers["x-openviking-actor-peer"] || "",
+      body,
     });
 
     if (req.method === "GET" && url.pathname === "/health") {
@@ -134,6 +144,22 @@ function profileHandler(requests, { archiveOverview = "" } = {}) {
         result: {
           latest_archive_overview: archiveOverview,
           pre_archive_abstracts: [],
+        },
+      });
+      return;
+    }
+    if (
+      req.method === "POST"
+      && url.pathname === "/api/v1/sessions"
+      && typeof sessionPolicyIdleActive === "boolean"
+    ) {
+      const payload = JSON.parse(body || "{}");
+      writeJson(res, {
+        status: "ok",
+        result: {
+          session_id: payload.session_id,
+          auto_commit_policy: payload.auto_commit_policy,
+          auto_commit_idle_enabled: sessionPolicyIdleActive,
         },
       });
       return;
@@ -224,6 +250,156 @@ test("startup preserves the existing commit systemMessage alongside profile cont
       request.method === "POST"
       && request.path === "/api/v1/sessions/cx-old-session/commit"
     ));
+    const commitRequest = requests.find((request) =>
+      request.method === "POST"
+      && request.path === "/api/v1/sessions/cx-old-session/commit"
+    );
+    assert.equal(commitRequest.actorPeerId, "-tmp-codex-commit");
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("policy marker is written only when the server confirms idle sweeping", async () => {
+  for (const [idleActive, expectedMarker] of [[true, true], [false, undefined]]) {
+    const stateDir = await mkdtemp(join(tmpdir(), `ov-codex-policy-${idleActive}-`));
+    const requests = [];
+    try {
+      await withMockOpenViking(
+        profileHandler(requests, { sessionPolicyIdleActive: idleActive }),
+        async (baseUrl) => {
+          await runSessionStart({
+            session_id: `policy-${idleActive}`,
+            source: "startup",
+            cwd: "/tmp/codex-policy",
+            hook_event_name: "SessionStart",
+          }, baseEnv(baseUrl, stateDir));
+        },
+      );
+
+      const state = JSON.parse(await readFile(
+        join(stateDir, `policy-${idleActive}.json`),
+        "utf8",
+      ));
+      assert.equal(state.serverIdleCommit, expectedMarker);
+      assert.equal(
+        state.serverIdleTimeoutSeconds,
+        expectedMarker ? 3600 : undefined,
+      );
+      const policyRequest = requests.find((request) =>
+        request.method === "POST" && request.path === "/api/v1/sessions"
+      );
+      assert.deepEqual(JSON.parse(policyRequest.body), {
+        session_id: `cx-policy-${idleActive}`,
+        auto_commit_policy: {
+          idle_timeout_seconds: 3600,
+          pending_token_threshold: 0,
+          message_count_threshold: 0,
+        },
+      });
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("idle policy knob off sends no session create request", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-codex-policy-off-"));
+  const requests = [];
+  try {
+    await withMockOpenViking(profileHandler(requests), async (baseUrl) => {
+      await runSessionStart({
+        session_id: "policy-off",
+        source: "startup",
+        cwd: "/tmp/codex-policy-off",
+        hook_event_name: "SessionStart",
+      }, {
+        ...baseEnv(baseUrl, stateDir),
+        OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS: "off",
+      });
+    });
+
+    assert.equal(
+      requests.some((request) =>
+        request.method === "POST" && request.path === "/api/v1/sessions"
+      ),
+      false,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("server-covered stale state skips local commit and is eventually garbage-collected", async () => {
+  for (const [ageMs, shouldExist] of [
+    [2_000_000, true],
+    [4_300_000, false],
+  ]) {
+    const stateDir = await mkdtemp(join(tmpdir(), `ov-codex-covered-${ageMs}-`));
+    const requests = [];
+    const now = Date.now();
+    try {
+      await writeFile(join(stateDir, "covered.json"), JSON.stringify({
+        codexSessionId: "covered",
+        ovSessionId: "cx-covered",
+        capturedTurnCount: 2,
+        serverIdleCommit: true,
+        serverIdleTimeoutSeconds: 3600,
+        createdAt: now - ageMs,
+        lastUpdatedAt: now - ageMs,
+      }));
+      await withMockOpenViking(
+        profileHandler(requests, { sessionPolicyIdleActive: true }),
+        async (baseUrl) => {
+          await runSessionStart({
+            session_id: `new-covered-${ageMs}`,
+            source: "startup",
+            cwd: "/tmp/codex-covered",
+            hook_event_name: "SessionStart",
+          }, baseEnv(baseUrl, stateDir));
+        },
+      );
+
+      assert.equal(
+        requests.some((request) =>
+          request.path === "/api/v1/sessions/cx-covered/commit"
+        ),
+        false,
+      );
+      const files = await import("node:fs/promises").then((fs) => fs.readdir(stateDir));
+      assert.equal(files.includes("covered.json"), shouldExist);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("swept commit uses the stored workspace peer identity", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "ov-codex-stored-peer-"));
+  const requests = [];
+  try {
+    const now = Date.now();
+    await writeFile(join(stateDir, "stored-peer.json"), JSON.stringify({
+      codexSessionId: "stored-peer",
+      ovSessionId: "cx-stored-peer",
+      workspacePeerId: "-old-workspace",
+      capturedTurnCount: 2,
+      createdAt: now - 1000,
+      lastUpdatedAt: now,
+    }));
+    await withMockOpenViking(profileHandler(requests), async (baseUrl) => {
+      await runSessionStart({
+        session_id: "new-peer",
+        source: "startup",
+        cwd: "/tmp/new-workspace",
+        hook_event_name: "SessionStart",
+      }, baseEnv(baseUrl, stateDir));
+    });
+
+    const commitRequest = requests.find((request) =>
+      request.path === "/api/v1/sessions/cx-stored-peer/commit"
+    );
+    assert.equal(commitRequest.actorPeerId, "-old-workspace");
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }

--- a/examples/codex-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/codex-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/cursor-memory-plugin/scripts/cursor-hook.mjs
+++ b/examples/cursor-memory-plugin/scripts/cursor-hook.mjs
@@ -5,6 +5,7 @@ import { parseCursorTranscript } from "./cursor-transcript.mjs";
 
 import {
   addAgentMessages,
+  applyAgentSessionPolicy,
   buildAgentProfile,
   commitAgentSession,
   createAgentLogger,
@@ -83,6 +84,9 @@ async function main() {
       state = { ...state, lastSessionStartAt: now };
       await writeHookState(CLIENT_ID, nativeSessionId, state);
       await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      await applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log).catch((error) => {
+        logError("session-policy", error);
+      });
       const profile = await buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
         logError("profile", error);
         return null;

--- a/examples/cursor-memory-plugin/scripts/cursor-plugin.test.mjs
+++ b/examples/cursor-memory-plugin/scripts/cursor-plugin.test.mjs
@@ -105,6 +105,7 @@ test("Cursor transcript parser keeps only user and assistant text", () => {
 test("Cursor injects recall before the request and Stop captures transcript deltas", async () => {
   const messages = [];
   const actorPeers = [];
+  let commits = 0;
   const server = createServer((request, response) => {
     let body = "";
     request.on("data", (chunk) => { body += chunk; });
@@ -119,6 +120,7 @@ test("Cursor injects recall before the request and Stop captures transcript delt
         messages.push(...(parsed.messages ?? [parsed]));
         response.end(JSON.stringify({ result: { ok: true } }));
       } else if (request.url?.endsWith("/commit")) {
+        commits += 1;
         response.end(JSON.stringify({ result: { ok: true } }));
       } else {
         response.statusCode = 404;
@@ -156,6 +158,56 @@ test("Cursor injects recall before the request and Stop captures transcript delt
       { role: "user", content: "question" },
       { role: "assistant", content: "answer" },
     ]);
+    assert.equal(commits, 1, "Cursor commits after the first captured turn by default");
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Cursor SessionStart applies the idle auto-commit policy", async () => {
+  const requests = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      requests.push({ method: request.method, url: request.url, body });
+      response.setHeader("Content-Type", "application/json");
+      if (request.url === "/api/v1/sessions") {
+        response.end(JSON.stringify({
+          status: "ok",
+          result: {
+            auto_commit_policy: JSON.parse(body).auto_commit_policy,
+            auto_commit_idle_enabled: true,
+          },
+        }));
+        return;
+      }
+      response.end(JSON.stringify({ status: "ok", result: {} }));
+    });
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const root = mkdtempSync(join(tmpdir(), "openviking-cursor-policy-"));
+  try {
+    await runHook("sessionStart", {
+      conversation_id: "cursor-policy",
+      cwd: "/workspace",
+    }, {
+      HOME: root,
+      OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
+      OPENVIKING_HOOK_STATE_DIR: join(root, "state"),
+      OPENVIKING_STATE_DIR: join(root, "policy-state"),
+      OPENVIKING_MEMORY_ENABLED: "1",
+    });
+    const created = requests.find((request) => request.url === "/api/v1/sessions");
+    assert.deepEqual(JSON.parse(created.body), {
+      session_id: "cu-cursor-policy",
+      auto_commit_policy: {
+        idle_timeout_seconds: 3600,
+        pending_token_threshold: 0,
+        message_count_threshold: 0,
+      },
+    });
   } finally {
     server.close();
     rmSync(root, { recursive: true, force: true });

--- a/examples/dsh-memory-plugin/README.md
+++ b/examples/dsh-memory-plugin/README.md
@@ -69,6 +69,8 @@ Common environment variables:
 | `OPENVIKING_PEER_ID` | Explicit actor peer |
 | `OPENVIKING_WORKSPACE_PEER` | Derive a peer from each DSH session workspace by default |
 | `OPENVIKING_RECALL_PEER_SCOPE` | `all` for cross-workspace recall or `actor` for isolation |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | Server-side idle policy in seconds (default `3600`; `0`/`off` disables it) |
+| `OPENVIKING_DSH_SIGHUP` | Set `0` to disable the plugin's graceful SIGHUP teardown |
 
 The patch can also carry plugin config:
 
@@ -88,6 +90,7 @@ The patch can also carry plugin config:
             scoreThreshold: 0.35
             captureToolResults: false
             commitTokenThreshold: 20000
+            commitIdleTimeoutSeconds: 3600
 ```
 
 ## Behavior
@@ -96,10 +99,16 @@ The patch can also carry plugin config:
 - `agent/pre-step` retrieves with the current step input and appends a durable plugin message to that same step.
 - `session/event` captures user, assistant, and optionally tool-result messages without scraping a transcript.
 - `turn/end` checks the OpenViking pending-token threshold and commits when required.
+- Cordis teardown performs a bounded final commit on normal exit, `Ctrl+C`, `SIGTERM`, and terminal-close `SIGHUP`. The shutdown commit bypasses a long in-flight write chain so it fits DSH's process grace period.
 - Failed writes enter the shared OpenViking pending queue for replay at the next session start.
 - `tools/pre-execute` blocks DSH filesystem and shell tools from treating `viking://` URIs as local paths.
 
 Each DSH session maps to `dsh-<session-id>` in OpenViking. Workspace-derived actor peers are resolved per session and sent on every session-specific request.
+
+The remaining hard gaps are a second `Ctrl+C` (upstream force-exits), `SIGKILL`,
+and closing only the browser tab in DSH's web profile. Enable
+`memory.session_auto_commit.idle_enabled=true` on the OpenViking server to
+activate the idle policy as a backstop.
 
 ## Tools
 

--- a/examples/dsh-memory-plugin/config.mjs
+++ b/examples/dsh-memory-plugin/config.mjs
@@ -1,4 +1,5 @@
 import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
+import { normalizeIdleTimeoutSeconds } from "./shared/session-policy.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
 
 export const PLUGIN_VERSION = "0.1.0";
@@ -25,6 +26,7 @@ const DEFAULT_CONFIG = Object.freeze({
   profileTokenBudget: 10000,
   commitTokenThreshold: 20000,
   commitKeepRecentCount: 10,
+  commitIdleTimeoutSeconds: 3600,
   captureToolResults: false,
   captureMode: "semantic",
   captureMaxLength: 24000,
@@ -66,6 +68,9 @@ export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()
   if (env.OPENVIKING_RECALL_LIMIT) {
     config.recallLimit = env.OPENVIKING_RECALL_LIMIT;
     config.recallLimitConfigured = true;
+  }
+  if (env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS !== undefined) {
+    config.commitIdleTimeoutSeconds = env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS;
   }
 
   config.endpoint = String(config.endpoint || DEFAULT_CONFIG.endpoint).replace(/\/+$/, "");
@@ -115,6 +120,10 @@ export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()
     0,
     1000,
     DEFAULT_CONFIG.commitKeepRecentCount,
+  );
+  config.commitIdleTimeoutSeconds = normalizeIdleTimeoutSeconds(
+    config.commitIdleTimeoutSeconds,
+    DEFAULT_CONFIG.commitIdleTimeoutSeconds,
   );
   config.captureMaxLength = clampInteger(
     config.captureMaxLength,

--- a/examples/dsh-memory-plugin/config.test.mjs
+++ b/examples/dsh-memory-plugin/config.test.mjs
@@ -19,6 +19,7 @@ test("behavior environment overrides are applied and normalized", () => {
   assert.equal(config.recallQueryExpansionConfigured, true);
   assert.equal(config.recallLimit, 7);
   assert.equal(config.recallLimitConfigured, true);
+  assert.equal(config.commitIdleTimeoutSeconds, 3600);
 });
 
 test("explicit plugin config overrides credential files", () => {
@@ -41,4 +42,12 @@ test("explicit plugin config overrides credential files", () => {
   assert.equal(config.account, "plugin-account");
   assert.equal(config.user, "plugin-user");
   assert.equal(config.peerId, "plugin-peer");
+});
+
+test("idle policy can be disabled through the environment", () => {
+  const config = resolveConfig({}, {
+    OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS: "off",
+  }, "/workspace/project");
+
+  assert.equal(config.commitIdleTimeoutSeconds, 0);
 });

--- a/examples/dsh-memory-plugin/index.mjs
+++ b/examples/dsh-memory-plugin/index.mjs
@@ -1,6 +1,6 @@
 import { OpenVikingClient } from "./client.mjs";
 import { resolveConfig } from "./config.mjs";
-import { injectStartupProfile } from "./lifecycle.mjs";
+import { injectStartupProfile, registerSighupTeardown } from "./lifecycle.mjs";
 import { OpenVikingRuntime } from "./runtime.mjs";
 import { registerOpenVikingTools } from "./tools.mjs";
 import { guardVikingUri } from "./uri-guard.mjs";
@@ -13,8 +13,12 @@ export function apply(ctx, input = {}) {
   const client = new OpenVikingClient(config);
   const runtime = new OpenVikingRuntime(client, config, ctx.logger);
   ctx.provide("openvikingMemory", runtime);
+  const unregisterSighup = registerSighupTeardown(() => runtime.disposeAll());
   ctx.effect(
-    () => () => runtime.disposeAll(),
+    () => async () => {
+      unregisterSighup();
+      await runtime.disposeAll();
+    },
     "openvikingMemory.disposeAll()",
   );
 

--- a/examples/dsh-memory-plugin/lifecycle.mjs
+++ b/examples/dsh-memory-plugin/lifecycle.mjs
@@ -6,3 +6,28 @@ export async function injectStartupProfile(agent, runtime) {
   agent.inject(profile);
   return true;
 }
+
+export function registerSighupTeardown(
+  dispose,
+  {
+    processRef = process,
+    enabled = process.env.OPENVIKING_DSH_SIGHUP !== "0",
+  } = {},
+) {
+  if (!enabled || typeof processRef?.once !== "function") return () => {};
+  let handling = false;
+  const handler = async () => {
+    if (handling) return;
+    handling = true;
+    try {
+      await dispose();
+    } finally {
+      processRef.removeListener?.("SIGHUP", handler);
+      if (typeof processRef.kill === "function" && Number.isInteger(processRef.pid)) {
+        processRef.kill(processRef.pid, "SIGHUP");
+      }
+    }
+  };
+  processRef.once("SIGHUP", handler);
+  return () => processRef.removeListener?.("SIGHUP", handler);
+}

--- a/examples/dsh-memory-plugin/lifecycle.test.mjs
+++ b/examples/dsh-memory-plugin/lifecycle.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { injectStartupProfile } from "./lifecycle.mjs";
+import { injectStartupProfile, registerSighupTeardown } from "./lifecycle.mjs";
 
 test("startup injection leaves profile ownership to pre-step after a turn starts", async () => {
   let release;
@@ -51,4 +51,32 @@ test("startup injection claims and injects a profile while the agent remains idl
 
   assert.equal(await injectStartupProfile(agent, runtime), true);
   assert.deepEqual(injected, [{ profile: true }]);
+});
+
+test("SIGHUP waits for teardown and then re-raises the signal", async () => {
+  const handlers = new Map();
+  const calls = [];
+  const processRef = {
+    pid: 42,
+    once(signal, handler) {
+      handlers.set(signal, handler);
+    },
+    removeListener(signal, handler) {
+      if (handlers.get(signal) === handler) handlers.delete(signal);
+    },
+    kill(pid, signal) {
+      calls.push({ pid, signal });
+    },
+  };
+  registerSighupTeardown(async () => {
+    calls.push("disposed");
+  }, { processRef });
+
+  await handlers.get("SIGHUP")();
+
+  assert.deepEqual(calls, [
+    "disposed",
+    { pid: 42, signal: "SIGHUP" },
+  ]);
+  assert.equal(handlers.has("SIGHUP"), false);
 });

--- a/examples/dsh-memory-plugin/runtime.mjs
+++ b/examples/dsh-memory-plugin/runtime.mjs
@@ -228,7 +228,14 @@ export class OpenVikingRuntime {
           await this.enqueueFinalCommit(state, commitPayload);
           return;
         }
-        if (!state.ready && !(await this.ensureState(state)).ready) return;
+        if (!state.ready) {
+          // Never re-run initializeState here: health check, policy apply,
+          // pending replay and profile build are each unbounded relative to
+          // DSH's 5s process grace, so a force-kill mid-init would lose the
+          // tail entirely. Queue the commit for the next startup instead.
+          await this.enqueueFinalCommit(state, commitPayload);
+          return;
+        }
         if (!writesDrained) {
           // The direct commit may overtake an in-flight addMessage. Keep one
           // ordered retry on disk so a late-successful write is committed on

--- a/examples/dsh-memory-plugin/runtime.mjs
+++ b/examples/dsh-memory-plugin/runtime.mjs
@@ -1,6 +1,10 @@
 import { createUserMessage } from "@deepseek-ai/dsh-llm";
 import { buildProfileBlock } from "./shared/profile-inject.mjs";
 import { buildRecallBlock } from "./shared/recall-core.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+} from "./shared/session-policy.mjs";
 import { deriveHarnessSessionId } from "./shared/session-model.mjs";
 import {
   dequeue,
@@ -47,6 +51,7 @@ export class OpenVikingRuntime {
       initializationRetryable: false,
       hasPendingWrites: false,
       pendingCreatedAt: 0,
+      shutdownCommitPayload: null,
       disposing: null,
     };
     this.states.set(session.id, state);
@@ -74,15 +79,29 @@ export class OpenVikingRuntime {
       state.initializationRetryable = isRetryableFailure(health);
       return state;
     }
-    const ensured = await this.client.ensureSessionResult(
+    const ensured = await applySessionAutoCommitPolicy(
+      (path, init, options) => this.client.fetchJSON(path, init, options),
       state.ovSessionId,
-      state.config.peerId,
+      buildIdleAutoCommitPolicy(state.config.commitIdleTimeoutSeconds),
+      {
+        cacheKey: `${state.config.endpoint}|${state.config.account || ""}|${state.config.user || ""}`,
+        actorPeerId: state.config.peerId,
+        log: (stage, data) => this.log(stage, data),
+      },
     );
-    if (
-      !ensured.ok
-      && !(ensured.status === 409 && ensured.error?.code === "ALREADY_EXISTS")
-    ) {
-      state.initializationRetryable = isRetryableFailure(ensured);
+    let sessionEnsured = ensured.ensured;
+    let initializationRetryable = ensured.retryable;
+    if (ensured.method === "disabled") {
+      const legacyEnsure = await this.client.ensureSessionResult(
+        state.ovSessionId,
+        state.config.peerId,
+      );
+      sessionEnsured = legacyEnsure.ok
+        || (legacyEnsure.status === 409 && legacyEnsure.error?.code === "ALREADY_EXISTS");
+      initializationRetryable = isRetryableFailure(legacyEnsure);
+    }
+    if (!sessionEnsured) {
+      state.initializationRetryable = initializationRetryable;
       return state;
     }
     await replayPending(
@@ -196,15 +215,27 @@ export class OpenVikingRuntime {
     if (!state) return;
     if (state.disposing) return state.disposing;
     state.disposing = (async () => {
-      this.enqueueWrite(state, async () => {
-        const commitPayload = {
-          keep_recent_count: state.config.commitKeepRecentCount,
-        };
+      const commitPayload = {
+        keep_recent_count: state.config.commitKeepRecentCount,
+      };
+      state.shutdownCommitPayload = commitPayload;
+      const writesDrained = await Promise.race([
+        state.writes.then(() => true),
+        new Promise(resolve => setTimeout(() => resolve(false), 500)),
+      ]);
+      try {
         if (state.hasPendingWrites) {
           await this.enqueueFinalCommit(state, commitPayload);
           return;
         }
         if (!state.ready && !(await this.ensureState(state)).ready) return;
+        if (!writesDrained) {
+          // The direct commit may overtake an in-flight addMessage. Keep one
+          // ordered retry on disk so a late-successful write is committed on
+          // the next startup; enqueuePendingMessage will move it behind any
+          // late-failed write that enters the same queue.
+          await this.enqueueFinalCommit(state, commitPayload);
+        }
         const response = await this.client.commitSession(
           state.ovSessionId,
           state.config.peerId,
@@ -214,13 +245,11 @@ export class OpenVikingRuntime {
           sessionId: state.ovSessionId,
           ok: response.ok,
           trace_id: response.result?.trace_id || response.traceId,
+          bypassedWriteQueue: !writesDrained,
         });
         if (isRetryableFailure(response)) {
           await this.enqueueFinalCommit(state, commitPayload);
         }
-      });
-      try {
-        await state.writes;
       } finally {
         if (this.states.get(session.id) === state) this.states.delete(session.id);
       }
@@ -265,7 +294,12 @@ export class OpenVikingRuntime {
 
   async enqueuePendingMessage(state, payload) {
     const result = await this.enqueuePending(state, "addMessage", payload);
-    if (result.ok) await this.removePendingCommits(state);
+    if (result.ok) {
+      await this.removePendingCommits(state);
+      if (state.shutdownCommitPayload) {
+        await this.enqueueFinalCommit(state, state.shutdownCommitPayload);
+      }
+    }
     return result;
   }
 

--- a/examples/dsh-memory-plugin/runtime.test.mjs
+++ b/examples/dsh-memory-plugin/runtime.test.mjs
@@ -56,6 +56,59 @@ test("initialization queues capture only when the failure is retryable", async (
   }
 });
 
+test("initialization applies policy to an existing session through PATCH", async () => {
+  const pendingDir = await mkdtemp(join(tmpdir(), "dsh-memory-policy-"));
+  tempDirs.push(pendingDir);
+  process.env.OPENVIKING_PENDING_DIR = pendingDir;
+  const calls = [];
+  const runtime = new OpenVikingRuntime({
+    async healthResult() {
+      return { ok: true };
+    },
+    async fetchJSON(path, init = {}) {
+      calls.push({ path, method: init.method, body: init.body });
+      if (path === "/api/v1/sessions") {
+        return {
+          ok: false,
+          status: 409,
+          error: { code: "ALREADY_EXISTS" },
+        };
+      }
+      if (path.endsWith("/config")) {
+        const policy = JSON.parse(init.body).auto_commit_policy;
+        return {
+          ok: true,
+          status: 200,
+          result: {
+            auto_commit_policy: policy,
+            auto_commit_idle_enabled: true,
+          },
+        };
+      }
+      return { ok: true, status: 200, result: {} };
+    },
+  }, config({ commitIdleTimeoutSeconds: 3600 }), { debug() {} });
+  const state = runtime.stateFor({
+    id: "policy-existing",
+    header: { cwd: "/workspace" },
+  });
+
+  await runtime.ensureState(state);
+
+  assert.equal(state.ready, true);
+  assert.deepEqual(calls.slice(0, 2).map((call) => call.path), [
+    "/api/v1/sessions",
+    "/api/v1/sessions/dsh-policy-existing/config",
+  ]);
+  assert.deepEqual(JSON.parse(calls[1].body), {
+    auto_commit_policy: {
+      idle_timeout_seconds: 3600,
+      pending_token_threshold: 0,
+      message_count_threshold: 0,
+    },
+  });
+});
+
 test("a retryable threshold commit failure is queued", async () => {
   const pendingDir = await mkdtemp(join(tmpdir(), "dsh-memory-commit-"));
   tempDirs.push(pendingDir);
@@ -196,7 +249,7 @@ test("dispose waits for the final commit before deleting session state", async (
   const disposing = runtime.dispose(session).then(() => {
     settled = true;
   });
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
 
   assert.equal(settled, false);
   assert.equal(runtime.states.has(session.id), true);
@@ -224,7 +277,33 @@ test("disposeAll drains every live session", async () => {
   assert.equal(runtime.states.size, 0);
 });
 
-function config() {
+test("dispose is not starved by an in-flight long write", async () => {
+  const pendingDir = await mkdtemp(join(tmpdir(), "dsh-memory-starved-"));
+  tempDirs.push(pendingDir);
+  process.env.OPENVIKING_PENDING_DIR = pendingDir;
+  let commitCalls = 0;
+  const runtime = new OpenVikingRuntime({
+    async commitSession() {
+      commitCalls += 1;
+      return { ok: true };
+    },
+  }, config(), { debug() {} });
+  const session = { id: "starved", header: { cwd: "/workspace" } };
+  const state = runtime.stateFor(session);
+  state.ready = true;
+  state.writes = new Promise(() => {});
+
+  const started = Date.now();
+  await runtime.dispose(session);
+
+  assert.ok(Date.now() - started < 2000);
+  assert.equal(commitCalls, 1);
+  assert.deepEqual((await listPending()).map((item) => item.entry.type), [
+    "commitSession",
+  ]);
+});
+
+function config(overrides = {}) {
   return {
     explicitPeerId: "",
     workspacePeer: false,
@@ -236,6 +315,9 @@ function config() {
     captureMaxLength: 24000,
     captureMode: "semantic",
     commitKeepRecentCount: 10,
+    commitIdleTimeoutSeconds: 0,
+    profileTokenBudget: 10000,
+    ...overrides,
   };
 }
 

--- a/examples/dsh-memory-plugin/shared/session-policy.mjs
+++ b/examples/dsh-memory-plugin/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/dsh-memory-plugin/shared/session-policy.mjs
+++ b/examples/dsh-memory-plugin/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
+++ b/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  applyAgentSessionPolicy,
   commitAgentSession,
+  loadAgentHookConfig,
   makeAgentFetchJSON,
 } from "./lib/agent-hook-runtime.mjs";
 
@@ -77,4 +79,33 @@ test("agent fetch and commit logging preserve response trace_id", async (t) => {
       error: "commit failed",
     },
   });
+});
+
+test("agent hook config defaults idle policy to one hour and supports off", () => {
+  const previous = process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS;
+  try {
+    delete process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS;
+    assert.equal(loadAgentHookConfig("cursor").commitIdleTimeoutSeconds, 3600);
+    assert.equal(loadAgentHookConfig("cursor").commitTurnThreshold, 1);
+
+    process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS = "off";
+    assert.equal(loadAgentHookConfig("cursor").commitIdleTimeoutSeconds, 0);
+  } finally {
+    if (previous === undefined) delete process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS;
+    else process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS = previous;
+  }
+});
+
+test("applyAgentSessionPolicy makes no request when disabled", async () => {
+  let called = false;
+  const result = await applyAgentSessionPolicy(
+    async () => {
+      called = true;
+      return { ok: true, result: {} };
+    },
+    { commitIdleTimeoutSeconds: 0 },
+    "cu-disabled",
+  );
+  assert.equal(called, false);
+  assert.equal(result.method, "disabled");
 });

--- a/examples/memory-plugin-shared/install-agent-hooks.test.mjs
+++ b/examples/memory-plugin-shared/install-agent-hooks.test.mjs
@@ -231,6 +231,7 @@ test("combined Cursor and TRAE install preserves unrelated hooks and is idempote
     assert.ok(existsSync(join(shared, "agent-uri-guard.mjs")));
     assert.ok(existsSync(join(shared, "batch-send.mjs")));
     assert.ok(existsSync(join(shared, "mcp-proxy-core.mjs")));
+    assert.ok(existsSync(join(shared, "session-policy.mjs")));
     assert.ok(existsSync(join(shared, "uri-guard.mjs")));
     for (const client of ["cursor", "trae", "trae-cn"]) {
       const manifest = JSON.parse(readFileSync(join(home, ".openviking", "agent-integrations", client, "integration.json"), "utf8"));

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -1773,7 +1773,7 @@ assemble_agent_integration() { # assemble_agent_integration <source-subdir> <des
   for file in \
     agent-hook-runtime.mjs agent-uri-guard.mjs credentials.mjs debug-log.mjs \
     batch-send.mjs mcp-proxy-core.mjs pending-queue.mjs plugin-config.mjs profile-inject.mjs \
-    retryable.mjs \
+    retryable.mjs session-policy.mjs \
     recall-compress-core.mjs recall-core.mjs \
     session-model.mjs uri-guard.mjs workspace-peer.mjs; do
     cp "$shared/lib/$file" "$shared_dest.tmp/$file"

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -10,6 +10,11 @@ import { enqueue, replayPending } from "./pending-queue.mjs";
 import { buildProfileBlock } from "./profile-inject.mjs";
 import { buildRecallBlock } from "./recall-core.mjs";
 import { isRetryableFailure } from "./retryable.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+  normalizeIdleTimeoutSeconds,
+} from "./session-policy.mjs";
 import { deriveHarnessSessionId, isBypassed } from "./session-model.mjs";
 import { resolveEffectivePeerId } from "./workspace-peer.mjs";
 
@@ -66,7 +71,11 @@ export function loadAgentHookConfig(clientId) {
     recallPeerScope: process.env.OPENVIKING_RECALL_PEER_SCOPE === "actor" ? "actor" : "all",
     timeoutMs: envNumber("OPENVIKING_TIMEOUT_MS", 15000, 1000),
     profileTokenBudget: envNumber("OPENVIKING_PROFILE_TOKEN_BUDGET", 6000, 500),
-    commitTurnThreshold: envNumber("OPENVIKING_COMMIT_TURN_THRESHOLD", 8, 1),
+    commitTurnThreshold: envNumber("OPENVIKING_COMMIT_TURN_THRESHOLD", 1, 1),
+    commitIdleTimeoutSeconds: normalizeIdleTimeoutSeconds(
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS,
+      3600,
+    ),
     writePathAsync: envBool("OPENVIKING_WRITE_PATH_ASYNC", true),
     debug: envBool("OPENVIKING_DEBUG", false),
     debugLogPath,
@@ -237,6 +246,14 @@ export async function commitAgentSession(fetchJSON, sessionId, log = () => {}) {
 
 export async function replayAgentPending(fetchJSON, log = () => {}) {
   return replayPending(fetchJSON, log);
+}
+
+export async function applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log = () => {}) {
+  const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
+  return applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
+    cacheKey: `${cfg.baseUrl || ""}|${cfg.account || ""}|${cfg.user || ""}`,
+    log,
+  });
 }
 
 export async function recallForPrompt(fetchJSON, cfg, prompt, cwd, log = () => {}, options = {}) {

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -250,10 +250,23 @@ export async function replayAgentPending(fetchJSON, log = () => {}) {
 
 export async function applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log = () => {}) {
   const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
-  return applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
+  const result = await applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
     cacheKey: `${cfg.baseUrl || ""}|${cfg.account || ""}|${cfg.user || ""}`,
     log,
+    // These hooks have no /health pre-gate, so cap each request well below
+    // cfg.timeoutMs: a hung server must not stall session start twice over.
+    timeoutMs: 3000,
   });
+  // The helper only logs the two applied paths; these harnesses discard the
+  // outcome, so without this a legacy/error apply is undiagnosable.
+  if (result.method !== "create" && result.method !== "patch") {
+    log("session_policy_skipped", {
+      sessionId,
+      method: result.method,
+      status: result.status,
+    });
+  }
+  return result;
 }
 
 export async function recallForPrompt(fetchJSON, cfg, prompt, cwd, log = () => {}, options = {}) {

--- a/examples/memory-plugin-shared/lib/session-policy.mjs
+++ b/examples/memory-plugin-shared/lib/session-policy.mjs
@@ -54,6 +54,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -126,6 +138,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -137,7 +150,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -171,7 +187,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/memory-plugin-shared/lib/session-policy.mjs
+++ b/examples/memory-plugin-shared/lib/session-policy.mjs
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/memory-plugin-shared/session-policy.test.mjs
+++ b/examples/memory-plugin-shared/session-policy.test.mjs
@@ -93,6 +93,38 @@ test("create without policy echo marks legacy and later sends only policy-less e
   assert.ok(JSON.parse(await readFile(cache, "utf8")).legacyUntil > 2000);
 });
 
+test("a 200 whose body is not a session result never poisons the legacy cache", async () => {
+  // Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+  // interstitial) into ok:true with an empty object or a raw string. Treating
+  // that as "old server" would disable the backstop for the whole 6h TTL.
+  for (const [label, garbled] of [
+    ["empty object", {}],
+    ["raw string", "<html>gateway timeout</html>"],
+  ]) {
+    const cache = await cachePath(`garbled-${label.replace(/\s/g, "-")}`);
+    const calls = [];
+    const fetchJSON = async (path, init) => {
+      calls.push({ path, body: JSON.parse(init.body) });
+      return response({ result: garbled });
+    };
+
+    const first = await applySessionAutoCommitPolicy(fetchJSON, "session-g", POLICY, {
+      legacyCachePath: cache,
+      now: 1000,
+    });
+    const second = await applySessionAutoCommitPolicy(fetchJSON, "session-g", POLICY, {
+      legacyCachePath: cache,
+      now: 2000,
+    });
+
+    assert.equal(first.method, "create-legacy", label);
+    await assert.rejects(() => readFile(cache, "utf8"), `${label} must not write a cache file`);
+    // The next attempt still sends the policy instead of short-circuiting.
+    assert.equal(second.method, "create-legacy", label);
+    assert.deepEqual(calls[1].body, { session_id: "session-g", auto_commit_policy: POLICY }, label);
+  }
+});
+
 test("policy echo distinguishes inactive and unknown idle scheduler states", async () => {
   const inactive = await applySessionAutoCommitPolicy(
     async () => response({

--- a/examples/memory-plugin-shared/session-policy.test.mjs
+++ b/examples/memory-plugin-shared/session-policy.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+  normalizeIdleTimeoutSeconds,
+  readIdleActive,
+} from "./lib/session-policy.mjs";
+
+const POLICY = {
+  idle_timeout_seconds: 3600,
+  pending_token_threshold: 0,
+  message_count_threshold: 0,
+};
+
+async function cachePath(name) {
+  return join(await mkdtemp(join(tmpdir(), `ov-session-policy-${name}-`)), "cache.json");
+}
+
+function response({ ok = true, status = 200, result = {}, error } = {}) {
+  return { ok, status, result, error };
+}
+
+test("normalizes idle timeout values and builds disabled policies", () => {
+  assert.equal(normalizeIdleTimeoutSeconds(undefined), 3600);
+  assert.equal(normalizeIdleTimeoutSeconds("off"), 0);
+  assert.equal(normalizeIdleTimeoutSeconds("FALSE"), 0);
+  assert.equal(normalizeIdleTimeoutSeconds(-10), 0);
+  assert.equal(normalizeIdleTimeoutSeconds(9999999), 604800);
+  assert.deepEqual(buildIdleAutoCommitPolicy(3600), POLICY);
+  assert.equal(buildIdleAutoCommitPolicy(0), null);
+});
+
+test("reads the idle scheduler feature flag as a tri-state", () => {
+  assert.equal(readIdleActive({ auto_commit_idle_enabled: true }), true);
+  assert.equal(readIdleActive({ auto_commit_idle_enabled: false }), false);
+  assert.equal(readIdleActive({}), null);
+});
+
+test("fresh create applies policy and reports active idle scheduler", async () => {
+  const calls = [];
+  const result = await applySessionAutoCommitPolicy(
+    async (path, init) => {
+      calls.push({ path, body: JSON.parse(init.body) });
+      return response({
+        result: {
+          auto_commit_policy: POLICY,
+          auto_commit_idle_enabled: true,
+        },
+      });
+    },
+    "session-a",
+    POLICY,
+    { legacyCachePath: await cachePath("create") },
+  );
+
+  assert.deepEqual(calls, [{
+    path: "/api/v1/sessions",
+    body: { session_id: "session-a", auto_commit_policy: POLICY },
+  }]);
+  assert.equal(result.ensured, true);
+  assert.equal(result.applied, true);
+  assert.equal(result.idleActive, true);
+  assert.equal(result.method, "create");
+});
+
+test("create without policy echo marks legacy and later sends only policy-less ensure", async () => {
+  const cache = await cachePath("legacy-create");
+  const calls = [];
+  const fetchJSON = async (path, init) => {
+    calls.push({ path, body: JSON.parse(init.body) });
+    return response({ result: { session_id: "session-b" } });
+  };
+
+  const first = await applySessionAutoCommitPolicy(fetchJSON, "session-b", POLICY, {
+    legacyCachePath: cache,
+    now: 1000,
+  });
+  const second = await applySessionAutoCommitPolicy(fetchJSON, "session-b", POLICY, {
+    legacyCachePath: cache,
+    now: 2000,
+  });
+
+  assert.equal(first.method, "create-legacy");
+  assert.equal(first.ensured, true);
+  assert.equal(first.applied, false);
+  assert.equal(second.method, "cached-legacy");
+  assert.deepEqual(calls[1].body, { session_id: "session-b" });
+  assert.ok(JSON.parse(await readFile(cache, "utf8")).legacyUntil > 2000);
+});
+
+test("policy echo distinguishes inactive and unknown idle scheduler states", async () => {
+  const inactive = await applySessionAutoCommitPolicy(
+    async () => response({
+      result: {
+        auto_commit_policy: POLICY,
+        auto_commit_idle_enabled: false,
+      },
+    }),
+    "session-c",
+    POLICY,
+    { legacyCachePath: await cachePath("inactive") },
+  );
+  const unknown = await applySessionAutoCommitPolicy(
+    async () => response({ result: { auto_commit_policy: POLICY } }),
+    "session-d",
+    POLICY,
+    { legacyCachePath: await cachePath("unknown") },
+  );
+
+  assert.equal(inactive.applied, true);
+  assert.equal(inactive.idleActive, false);
+  assert.equal(unknown.applied, true);
+  assert.equal(unknown.idleActive, null);
+});
+
+test("already-existing session is updated through PATCH", async () => {
+  const calls = [];
+  const result = await applySessionAutoCommitPolicy(
+    async (path) => {
+      calls.push(path);
+      if (calls.length === 1) {
+        return response({
+          ok: false,
+          status: 409,
+          error: { code: "ALREADY_EXISTS" },
+        });
+      }
+      return response({
+        result: {
+          auto_commit_policy: POLICY,
+          auto_commit_idle_enabled: true,
+        },
+      });
+    },
+    "session-e",
+    POLICY,
+    { legacyCachePath: await cachePath("patch") },
+  );
+
+  assert.deepEqual(calls, [
+    "/api/v1/sessions",
+    "/api/v1/sessions/session-e/config",
+  ]);
+  assert.equal(result.method, "patch");
+  assert.equal(result.applied, true);
+  assert.equal(result.idleActive, true);
+});
+
+for (const status of [404, 405, 422]) {
+  test(`PATCH ${status} is cached as a legacy server`, async () => {
+    const cache = await cachePath(`patch-${status}`);
+    let calls = 0;
+    const result = await applySessionAutoCommitPolicy(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          return response({
+            ok: false,
+            status: 409,
+            error: { code: "ALREADY_EXISTS" },
+          });
+        }
+        return response({ ok: false, status, error: { code: "UNSUPPORTED" } });
+      },
+      `session-${status}`,
+      POLICY,
+      { legacyCachePath: cache, now: 1000 },
+    );
+
+    assert.equal(result.method, "patch-legacy");
+    assert.equal(result.ensured, true);
+    assert.ok(JSON.parse(await readFile(cache, "utf8")).legacyUntil > 1000);
+  });
+}
+
+test("create 422 retries without the policy and keeps the session ensured", async () => {
+  const calls = [];
+  const result = await applySessionAutoCommitPolicy(
+    async (_path, init) => {
+      calls.push(JSON.parse(init.body));
+      if (calls.length === 1) {
+        return response({ ok: false, status: 422, error: { code: "VALIDATION_ERROR" } });
+      }
+      return response({ result: { session_id: "session-f" } });
+    },
+    "session-f",
+    POLICY,
+    { legacyCachePath: await cachePath("create-422") },
+  );
+
+  assert.deepEqual(calls, [
+    { session_id: "session-f", auto_commit_policy: POLICY },
+    { session_id: "session-f" },
+  ]);
+  assert.equal(result.method, "create-legacy");
+  assert.equal(result.ensured, true);
+});
+
+test("network failures are retryable and never poison the legacy cache", async () => {
+  const cache = await cachePath("network");
+  let calls = 0;
+  const fetchJSON = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return response({ ok: false, status: 0, error: { message: "offline" } });
+    }
+    return response({
+      result: {
+        auto_commit_policy: POLICY,
+        auto_commit_idle_enabled: true,
+      },
+    });
+  };
+
+  const first = await applySessionAutoCommitPolicy(fetchJSON, "session-g", POLICY, {
+    legacyCachePath: cache,
+  });
+  const second = await applySessionAutoCommitPolicy(fetchJSON, "session-g", POLICY, {
+    legacyCachePath: cache,
+  });
+
+  assert.equal(first.method, "error");
+  assert.equal(first.retryable, true);
+  assert.equal(second.method, "create");
+  assert.equal(calls, 2);
+});
+
+test("disabled policy makes no request", async () => {
+  let called = false;
+  const result = await applySessionAutoCommitPolicy(
+    async () => {
+      called = true;
+      return response();
+    },
+    "session-h",
+    null,
+  );
+
+  assert.equal(called, false);
+  assert.equal(result.method, "disabled");
+  assert.equal(result.ensured, false);
+});

--- a/examples/memory-plugin-shared/sync.mjs
+++ b/examples/memory-plugin-shared/sync.mjs
@@ -17,6 +17,7 @@ const HARNESS_SHARED_FILES = [
   "recall-compress-core.mjs",
   "recall-core.mjs",
   "retryable.mjs",
+  "session-policy.mjs",
   "workspace-peer.mjs",
   "profile-inject.mjs",
   "uri-guard.mjs",

--- a/examples/memory-plugin-shared/sync.test.mjs
+++ b/examples/memory-plugin-shared/sync.test.mjs
@@ -14,6 +14,8 @@ const HARNESS_SHARED_FILES = [
   "debug-log.mjs",
   "setup-wizard.mjs",
   "recall-core.mjs",
+  "retryable.mjs",
+  "session-policy.mjs",
   "workspace-peer.mjs",
   "profile-inject.mjs",
   "uri-guard.mjs",

--- a/examples/openclaw-plugin/README.md
+++ b/examples/openclaw-plugin/README.md
@@ -98,7 +98,7 @@ This plugin is registered as the `openviking` context engine in OpenClaw.
 In the current implementation, the plugin plays four roles at once:
 
 - `context-engine`: implements `assemble`, `afterTurn`, and `compact`
-- hook layer: handles `session_start`, `session_end`, and `before_reset`
+- hook layer: handles `session_start`, `session_end`, `gateway_stop`, and `before_reset`
 - tool provider: registers memory/archive tools plus OpenViking resource and skill import tools
 - runtime manager: connects to and monitors a remote OpenViking service
 
@@ -211,6 +211,14 @@ After that, the plugin checks `pending_tokens`. Once it reaches `commitTokenThre
 - if `logFindRequests` is enabled, the logs include the task id and follow-up extraction detail
 
 This automatic path is best-effort and commit-dependent. Short but important facts can stay only in the live session until a threshold commit, `/compact`, or an explicit store happens.
+
+The awaited lifecycle hooks close that gap on gateway shutdown and restart:
+`session_end` performs a short bounded commit for each ending session, while
+`gateway_stop` flushes any remaining live sessions within the gateway shutdown
+budget. Session supersession also emits `session_end`. A conversation that
+only goes quiet still waits for its next inbound message unless the OpenViking
+server enables `memory.session_auto_commit.idle_enabled`; the plugin sends a
+one-hour per-session idle policy by default.
 
 ### Explicit long-term memory writes
 

--- a/examples/openclaw-plugin/client.ts
+++ b/examples/openclaw-plugin/client.ts
@@ -70,6 +70,19 @@ export type OVMemoryPolicy = {
   memory_types?: string[];
 };
 
+export type OVAutoCommitPolicy = {
+  idle_timeout_seconds: number;
+  pending_token_threshold: number;
+  message_count_threshold: number;
+};
+
+export type SessionConfigResult = {
+  session_id: string;
+  user?: unknown;
+  auto_commit_policy?: OVAutoCommitPolicy | null;
+  auto_commit_idle_enabled?: boolean;
+};
+
 export type TaskResult = {
   task_id: string;
   task_type: string;
@@ -408,15 +421,34 @@ export class OpenVikingClient {
 
   async createSession(
     sessionId: string,
-    options?: { memoryPolicy?: OVMemoryPolicy },
-  ): Promise<{ session_id: string; user?: unknown }> {
+    options?: {
+      memoryPolicy?: OVMemoryPolicy;
+      autoCommitPolicy?: OVAutoCommitPolicy;
+    },
+  ): Promise<SessionConfigResult> {
     const body: Record<string, unknown> = { session_id: sessionId };
     if (options?.memoryPolicy) {
       body.memory_policy = options.memoryPolicy;
     }
-    return this.request<{ session_id: string; user?: unknown }>(
+    if (options?.autoCommitPolicy) {
+      body.auto_commit_policy = options.autoCommitPolicy;
+    }
+    return this.request<SessionConfigResult>(
       "/api/v1/sessions",
       { method: "POST", body: JSON.stringify(body) },
+    );
+  }
+
+  async updateSessionConfig(
+    sessionId: string,
+    autoCommitPolicy: OVAutoCommitPolicy,
+  ): Promise<SessionConfigResult> {
+    return this.request<SessionConfigResult>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/config`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ auto_commit_policy: autoCommitPolicy }),
+      },
     );
   }
 
@@ -864,7 +896,7 @@ export class OpenVikingClient {
     const result = await this.request<CommitSessionResult>(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
       { method: "POST", body: JSON.stringify(body) },
-      undefined,
+      options?.timeoutMs,
       options?.agentId,
     );
 

--- a/examples/openclaw-plugin/commands/setup.ts
+++ b/examples/openclaw-plugin/commands/setup.ts
@@ -79,6 +79,7 @@ const CONFIG_KEYS_TO_PRESERVE = [
   "recallTokenBudget",
   "commitTokenThresholdRatio",
   "commitKeepRecentCount",
+  "commitIdleTimeoutSeconds",
   "bypassSessionPatterns",
   "emitStandardDiagnostics",
   "logFindRequests",

--- a/examples/openclaw-plugin/config.ts
+++ b/examples/openclaw-plugin/config.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import { readFileSync } from "node:fs";
 
 import { getEnv } from "./runtime-utils.js";
+import { normalizeIdleTimeoutSeconds } from "./plugin/openviking-session-policy.js";
 
 /**
  * Subset of OpenClaw's standard `SecretRef` shape supported by the OpenViking
@@ -74,6 +75,8 @@ export type MemoryOpenVikingConfig = {
    * value and always passes 0.
    */
   commitKeepRecentCount?: number;
+  /** Server-side idle auto-commit timeout in seconds. Set 0/off to disable policy plumbing. */
+  commitIdleTimeoutSeconds?: number | string;
   bypassSessionPatterns?: string[];
   /**
    * When true (default), emit structured `openviking: diag {...}` lines (and any future
@@ -127,10 +130,14 @@ export type MemoryOpenVikingConfig = {
 
 /** Runtime config after memoryOpenVikingConfigSchema.parse() has applied defaults. */
 export type ParsedMemoryOpenVikingConfig = Required<
-  Omit<MemoryOpenVikingConfig, "agentExperience" | "recallTargetTypes" | "apiKey">
+  Omit<
+    MemoryOpenVikingConfig,
+    "agentExperience" | "recallTargetTypes" | "apiKey" | "commitIdleTimeoutSeconds"
+  >
 > & {
   /** parse() resolves SecretRef values, so the runtime shape is always a plain string. */
   apiKey: string;
+  commitIdleTimeoutSeconds: number;
   agentExperience: Required<NonNullable<MemoryOpenVikingConfig["agentExperience"]>>;
   recallTargetTypes: Array<"resource" | "user" | "agent">;
 };
@@ -148,6 +155,7 @@ const DEFAULT_RECALL_PREFER_ABSTRACT = false;
 const DEFAULT_RECALL_MAX_INJECTED_CHARS = 4000;
 const DEFAULT_COMMIT_TOKEN_THRESHOLD_RATIO = 0.5;
 const DEFAULT_COMMIT_KEEP_RECENT_COUNT = 10;
+const DEFAULT_COMMIT_IDLE_TIMEOUT_SECONDS = 3600;
 const DEFAULT_BYPASS_SESSION_PATTERNS: string[] = [];
 const DEFAULT_EMIT_STANDARD_DIAGNOSTICS = false;
 const DEFAULT_PEER_ROLE = "assistant" as const;
@@ -527,6 +535,7 @@ export const memoryOpenVikingConfigSchema = {
         "commitTokenThreshold",
         "commitTokenThresholdRatio",
         "commitKeepRecentCount",
+        "commitIdleTimeoutSeconds",
         "bypassSessionPatterns",
         "ingestReplyAssist",
         "ingestReplyAssistMinSpeakerTurns",
@@ -660,6 +669,11 @@ export const memoryOpenVikingConfigSchema = {
           1_000,
           Math.floor(toNumber(cfg.commitKeepRecentCount, DEFAULT_COMMIT_KEEP_RECENT_COUNT)),
         ),
+      ),
+      commitIdleTimeoutSeconds: normalizeIdleTimeoutSeconds(
+        getEnv("OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS")
+          ?? cfg.commitIdleTimeoutSeconds,
+        DEFAULT_COMMIT_IDLE_TIMEOUT_SECONDS,
       ),
       bypassSessionPatterns: toStringArray(
         cfg.bypassSessionPatterns,
@@ -908,6 +922,12 @@ export const memoryOpenVikingConfigSchema = {
       help:
         "Number of most-recent messages to keep live after an afterTurn commit. " +
         "Forwarded as keep_recent_count to the server. Compact path always uses 0.",
+    },
+    commitIdleTimeoutSeconds: {
+      label: "Commit Idle Timeout Seconds",
+      placeholder: String(DEFAULT_COMMIT_IDLE_TIMEOUT_SECONDS),
+      advanced: true,
+      help: "Per-session idle timeout sent to OpenViking. The server must enable memory.session_auto_commit.idle_enabled for it to run.",
     },
     emitStandardDiagnostics: {
       label: "Standard diagnostics (diag JSON lines)",

--- a/examples/openclaw-plugin/index.ts
+++ b/examples/openclaw-plugin/index.ts
@@ -374,6 +374,9 @@ const contextEnginePlugin = {
       isBypassedSession,
       verboseRoutingInfo,
       getContextEngine,
+      getClient,
+      toOvSessionId: openClawSessionToOvStorageId,
+      commitIdleTimeoutSeconds: cfg.commitIdleTimeoutSeconds,
       logger: api.logger,
     });
 

--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -216,6 +216,12 @@
       "advanced": true,
       "help": "WM v2: number of most-recent messages kept live after an afterTurn commit. Compact path always uses 0."
     },
+    "commitIdleTimeoutSeconds": {
+      "label": "Commit Idle Timeout Seconds",
+      "placeholder": "3600",
+      "advanced": true,
+      "help": "Per-session idle timeout sent to OpenViking. The server must enable memory.session_auto_commit.idle_enabled for it to run."
+    },
     "emitStandardDiagnostics": {
       "label": "Standard diagnostics (diag JSON lines)",
       "advanced": true,
@@ -408,6 +414,9 @@
         "type": "number",
         "minimum": 0,
         "maximum": 1000
+      },
+      "commitIdleTimeoutSeconds": {
+        "type": ["number", "string"]
       },
       "bypassSessionPatterns": {
         "type": "array",

--- a/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
+++ b/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
@@ -71,20 +71,25 @@ export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksD
   ): Promise<boolean> => {
     if (deps.isBypassedSession(ctx)) return true;
     const sessionRef = ctx.sessionId || ctx.sessionKey;
+    if (!sessionRef) return false;
     const ovSessionId = deps.toOvSessionId(ctx.sessionId, ctx.sessionKey);
-    if (!sessionRef || !ovSessionId) return false;
+    if (!ovSessionId) return false;
     const key = sessionRef;
     let pending = commitsInFlight.get(key);
     if (!pending) {
       pending = deps.getClient()
         .then(async (client) => {
+          // No agentId: the raw hook ctx.agentId is neither prefixed nor
+          // sanitized, so sending it as X-OpenViking-Actor-Peer would scope
+          // the commit to a peer the session's messages were never written
+          // under (and openclaw ids may contain ':', which the server
+          // rejects). Every other commit path here omits it too.
           const result = await client.commitSession(
             ovSessionId,
             {
               wait: false,
               timeoutMs,
               keepRecentCount: 0,
-              agentId: ctx.agentId,
             },
           );
           return result.status !== "failed" && result.status !== "timeout";
@@ -114,8 +119,11 @@ export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksD
     deps.rememberSessionAgentId(ctx ?? {});
     if (deps.isBypassedSession(ctx)) return;
     rememberLiveSession(ctx);
-    const ovSessionId = deps.toOvSessionId(ctx?.sessionId, ctx?.sessionKey);
-    if (!ovSessionId || deps.commitIdleTimeoutSeconds <= 0) return;
+    // toOvSessionId throws when both ids are absent; keep this hook fail-open.
+    if (!ctx?.sessionId && !ctx?.sessionKey) return;
+    if (deps.commitIdleTimeoutSeconds <= 0) return;
+    const ovSessionId = deps.toOvSessionId(ctx.sessionId, ctx.sessionKey);
+    if (!ovSessionId) return;
     void deps.getClient()
       .then((client) => applyOpenVikingSessionPolicy(
         client,

--- a/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
+++ b/examples/openclaw-plugin/plugin/openviking-lifecycle-hooks.ts
@@ -1,3 +1,6 @@
+import type { OpenVikingClient } from "../client.js";
+import { applyOpenVikingSessionPolicy } from "./openviking-session-policy.js";
+
 export type OpenVikingHookContext = {
   agentId?: string;
   sessionId?: string;
@@ -23,18 +26,114 @@ export type OpenVikingLifecycleHooksDeps = {
   isBypassedSession: (ctx?: OpenVikingHookContext) => boolean;
   verboseRoutingInfo: (message: string) => void;
   getContextEngine: () => ContextEngineCommitPort | null;
+  getClient: () => Promise<OpenVikingClient>;
+  toOvSessionId: (sessionId?: string, sessionKey?: string) => string;
+  commitIdleTimeoutSeconds: number;
   logger: {
     info: (message: string) => void;
     warn: (message: string) => void;
   };
 };
 
+const SESSION_END_TIMEOUT_MS = 1500;
+const GATEWAY_STOP_TIMEOUT_MS = 4500;
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksDeps): void {
+  const liveSessions = new Map<string, OpenVikingHookContext>();
+  const commitsInFlight = new Map<string, Promise<boolean>>();
+
+  const rememberLiveSession = (ctx?: OpenVikingHookContext) => {
+    const key = ctx?.sessionId || ctx?.sessionKey;
+    if (key) liveSessions.set(key, { ...ctx });
+  };
+
+  const commitSession = async (
+    ctx: OpenVikingHookContext,
+    reason: "session_end" | "gateway_stop",
+    timeoutMs: number,
+  ): Promise<boolean> => {
+    if (deps.isBypassedSession(ctx)) return true;
+    const sessionRef = ctx.sessionId || ctx.sessionKey;
+    const ovSessionId = deps.toOvSessionId(ctx.sessionId, ctx.sessionKey);
+    if (!sessionRef || !ovSessionId) return false;
+    const key = sessionRef;
+    let pending = commitsInFlight.get(key);
+    if (!pending) {
+      pending = deps.getClient()
+        .then(async (client) => {
+          const result = await client.commitSession(
+            ovSessionId,
+            {
+              wait: false,
+              timeoutMs,
+              keepRecentCount: 0,
+              agentId: ctx.agentId,
+            },
+          );
+          return result.status !== "failed" && result.status !== "timeout";
+        })
+        .finally(() => {
+          commitsInFlight.delete(key);
+        });
+      commitsInFlight.set(key, pending);
+    }
+    try {
+      const ok = await pending;
+      if (ok) {
+        deps.logger.info(
+          `openviking: committed OV session on ${reason} for session=${sessionRef}`,
+        );
+      }
+      return ok;
+    } catch (err) {
+      deps.logger.warn(
+        `openviking: failed to commit OV session on ${reason}: ${String(err)}`,
+      );
+      return false;
+    }
+  };
+
   deps.api.on("session_start", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
+    if (deps.isBypassedSession(ctx)) return;
+    rememberLiveSession(ctx);
+    const ovSessionId = deps.toOvSessionId(ctx?.sessionId, ctx?.sessionKey);
+    if (!ovSessionId || deps.commitIdleTimeoutSeconds <= 0) return;
+    void deps.getClient()
+      .then((client) => applyOpenVikingSessionPolicy(
+        client,
+        ovSessionId,
+        deps.commitIdleTimeoutSeconds,
+      ))
+      .catch((err) => {
+        deps.logger.warn(`openviking: failed to apply session auto-commit policy: ${String(err)}`);
+      });
   });
   deps.api.on("session_end", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     deps.rememberSessionAgentId(ctx ?? {});
+    const key = ctx?.sessionId || ctx?.sessionKey;
+    if (!ctx || !key) return;
+    rememberLiveSession(ctx);
+    if (await commitSession(ctx, "session_end", SESSION_END_TIMEOUT_MS)) {
+      liveSessions.delete(key);
+    }
   });
   deps.api.on("before_reset", async (_event: unknown, ctx?: OpenVikingHookContext) => {
     if (deps.isBypassedSession(ctx)) {
@@ -57,6 +156,21 @@ export function registerOpenVikingLifecycleHooks(deps: OpenVikingLifecycleHooksD
       } catch (err) {
         deps.logger.warn(`openviking: failed to commit OV session on reset: ${String(err)}`);
       }
+    }
+  });
+  deps.api.on("gateway_stop", async () => {
+    const sessions = [...liveSessions.entries()];
+    if (sessions.length === 0) return;
+    const results = await withTimeout(
+      Promise.all(sessions.map(async ([key, ctx]) => {
+        const ok = await commitSession(ctx, "gateway_stop", GATEWAY_STOP_TIMEOUT_MS);
+        if (ok) liveSessions.delete(key);
+        return ok;
+      })),
+      GATEWAY_STOP_TIMEOUT_MS,
+    );
+    if (results === null) {
+      deps.logger.warn("openviking: gateway_stop session flush timed out");
     }
   });
   deps.api.on("after_compaction", async (_event: unknown, _ctx?: OpenVikingHookContext) => {

--- a/examples/openclaw-plugin/plugin/openviking-session-policy.ts
+++ b/examples/openclaw-plugin/plugin/openviking-session-policy.ts
@@ -1,0 +1,140 @@
+import type {
+  OpenVikingClient,
+  OVAutoCommitPolicy,
+  SessionConfigResult,
+} from "../client.js";
+
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const legacyUntilByClient = new WeakMap<OpenVikingClient, number>();
+
+export type SessionPolicyApplyResult = {
+  ensured: boolean;
+  applied: boolean;
+  idleActive: boolean | null;
+  method: "disabled" | "cached-legacy" | "create" | "create-legacy" | "patch" | "patch-legacy" | "error";
+};
+
+export function normalizeIdleTimeoutSeconds(value: unknown, fallback = 3600): number {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (
+    typeof value === "string"
+    && ["off", "false", "no"].includes(value.trim().toLowerCase())
+  ) {
+    return 0;
+  }
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds: number): OVAutoCommitPolicy | null {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+function readIdleActive(result: SessionConfigResult): boolean | null {
+  return typeof result.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+function supportsPolicy(result: SessionConfigResult): boolean {
+  return Object.prototype.hasOwnProperty.call(result, "auto_commit_policy");
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return String(error).includes("[ALREADY_EXISTS]");
+}
+
+function isLegacyCreateError(error: unknown): boolean {
+  return /HTTP 422|\[(VALIDATION_ERROR|INVALID_ARGUMENT)\]/.test(String(error));
+}
+
+function isLegacyPatchError(error: unknown): boolean {
+  return /HTTP (404|405|422)|\[(NOT_FOUND|VALIDATION_ERROR|INVALID_ARGUMENT)\]/.test(
+    String(error),
+  );
+}
+
+async function ensureLegacySession(client: OpenVikingClient, sessionId: string): Promise<boolean> {
+  try {
+    await client.createSession(sessionId);
+    return true;
+  } catch (error) {
+    return isAlreadyExists(error);
+  }
+}
+
+export async function applyOpenVikingSessionPolicy(
+  client: OpenVikingClient,
+  sessionId: string,
+  idleTimeoutSeconds: number,
+  now = Date.now(),
+): Promise<SessionPolicyApplyResult> {
+  const policy = buildIdleAutoCommitPolicy(idleTimeoutSeconds);
+  if (!policy) {
+    return { ensured: false, applied: false, idleActive: null, method: "disabled" };
+  }
+
+  if ((legacyUntilByClient.get(client) ?? 0) > now) {
+    const ensured = await ensureLegacySession(client, sessionId);
+    return { ensured, applied: false, idleActive: null, method: "cached-legacy" };
+  }
+
+  try {
+    const created = await client.createSession(sessionId, { autoCommitPolicy: policy });
+    if (supportsPolicy(created)) {
+      return {
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(created),
+        method: "create",
+      };
+    }
+    legacyUntilByClient.set(client, now + LEGACY_CACHE_TTL_MS);
+    return { ensured: true, applied: false, idleActive: null, method: "create-legacy" };
+  } catch (error) {
+    if (isLegacyCreateError(error)) {
+      const ensured = await ensureLegacySession(client, sessionId);
+      if (ensured) legacyUntilByClient.set(client, now + LEGACY_CACHE_TTL_MS);
+      return {
+        ensured,
+        applied: false,
+        idleActive: null,
+        method: ensured ? "create-legacy" : "error",
+      };
+    }
+    if (!isAlreadyExists(error)) {
+      return { ensured: false, applied: false, idleActive: null, method: "error" };
+    }
+  }
+
+  try {
+    const updated = await client.updateSessionConfig(sessionId, policy);
+    if (supportsPolicy(updated)) {
+      return {
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(updated),
+        method: "patch",
+      };
+    }
+    legacyUntilByClient.set(client, now + LEGACY_CACHE_TTL_MS);
+    return { ensured: true, applied: false, idleActive: null, method: "patch-legacy" };
+  } catch (error) {
+    if (isLegacyPatchError(error)) {
+      legacyUntilByClient.set(client, now + LEGACY_CACHE_TTL_MS);
+      return { ensured: true, applied: false, idleActive: null, method: "patch-legacy" };
+    }
+    return { ensured: true, applied: false, idleActive: null, method: "error" };
+  }
+}

--- a/examples/openclaw-plugin/tests/ut/config.test.ts
+++ b/examples/openclaw-plugin/tests/ut/config.test.ts
@@ -20,6 +20,7 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
     expect(cfg.recallMaxInjectedChars).toBe(4000);
     expect(cfg.recallTokenBudget).toBe(4000);
     expect(cfg.commitTokenThresholdRatio).toBe(0.5);
+    expect(cfg.commitIdleTimeoutSeconds).toBe(3600);
     expect(cfg.captureMode).toBe("semantic");
     expect(cfg.captureMaxLength).toBe(24000);
     expect(cfg.autoRecallTimeoutMs).toBe(5000);
@@ -52,6 +53,18 @@ describe("memoryOpenVikingConfigSchema.parse()", () => {
   it("tolerates the deprecated commitTokenThreshold key and ignores it", () => {
     const cfg = memoryOpenVikingConfigSchema.parse({ commitTokenThreshold: 20000 });
     expect(cfg.commitTokenThresholdRatio).toBe(0.5);
+  });
+
+  it("supports disabling the idle policy with config or env", () => {
+    expect(
+      memoryOpenVikingConfigSchema.parse({ commitIdleTimeoutSeconds: "off" })
+        .commitIdleTimeoutSeconds,
+    ).toBe(0);
+    process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS = "7200";
+    expect(
+      memoryOpenVikingConfigSchema.parse({ commitIdleTimeoutSeconds: 60 })
+        .commitIdleTimeoutSeconds,
+    ).toBe(7200);
   });
 
   it("enables add_resource only when explicitly allowed", () => {

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -477,11 +477,13 @@ describe("plugin module seams", () => {
         message_count_threshold: 0,
       },
     });
+    // No agentId: the raw hook ctx.agentId is neither peer-prefixed nor
+    // sanitized, so sending it would scope the commit to a peer the session's
+    // messages were never written under. Every other commit path omits it.
     expect(commitSession).toHaveBeenCalledWith("oc-session-2", {
       wait: false,
       timeoutMs: 1500,
       keepRecentCount: 0,
-      agentId: "agent-main",
     });
 
     await handlers.get("before_reset")?.({}, { sessionId: "session-3", sessionKey: "key-3" });
@@ -497,7 +499,6 @@ describe("plugin module seams", () => {
       wait: false,
       timeoutMs: 4500,
       keepRecentCount: 0,
-      agentId: "agent-main",
     });
   });
 

--- a/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/plugin-modules.test.ts
@@ -434,6 +434,15 @@ describe("plugin module seams", () => {
     const rememberSessionAgentId = vi.fn();
     const verboseRoutingInfo = vi.fn();
     const commitOVSession = vi.fn().mockResolvedValue(true);
+    const createSession = vi.fn().mockResolvedValue({
+      session_id: "oc-session-1",
+      auto_commit_policy: {},
+      auto_commit_idle_enabled: true,
+    });
+    const commitSession = vi.fn().mockResolvedValue({
+      session_id: "oc-session-1",
+      status: "accepted",
+    });
     const logger = { info: vi.fn(), warn: vi.fn() };
 
     registerOpenVikingLifecycleHooks({
@@ -442,6 +451,9 @@ describe("plugin module seams", () => {
       isBypassedSession: (ctx) => ctx?.sessionKey === "bypass",
       verboseRoutingInfo,
       getContextEngine: () => ({ commitOVSession }),
+      getClient: async () => ({ createSession, commitSession } as any),
+      toOvSessionId: (sessionId) => `oc-${sessionId}`,
+      commitIdleTimeoutSeconds: 3600,
       logger,
     });
 
@@ -449,13 +461,28 @@ describe("plugin module seams", () => {
       "session_start",
       "session_end",
       "before_reset",
+      "gateway_stop",
       "after_compaction",
     ]);
 
     await handlers.get("session_start")?.({}, { sessionId: "session-1", agentId: "agent-main" });
     await handlers.get("session_end")?.({}, { sessionId: "session-2", agentId: "agent-main" });
+    await Promise.resolve();
     expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-1", agentId: "agent-main" });
     expect(rememberSessionAgentId).toHaveBeenCalledWith({ sessionId: "session-2", agentId: "agent-main" });
+    expect(createSession).toHaveBeenCalledWith("oc-session-1", {
+      autoCommitPolicy: {
+        idle_timeout_seconds: 3600,
+        pending_token_threshold: 0,
+        message_count_threshold: 0,
+      },
+    });
+    expect(commitSession).toHaveBeenCalledWith("oc-session-2", {
+      wait: false,
+      timeoutMs: 1500,
+      keepRecentCount: 0,
+      agentId: "agent-main",
+    });
 
     await handlers.get("before_reset")?.({}, { sessionId: "session-3", sessionKey: "key-3" });
     expect(commitOVSession).toHaveBeenCalledWith({ sessionId: "session-3", sessionKey: "key-3" });
@@ -464,6 +491,14 @@ describe("plugin module seams", () => {
     await handlers.get("before_reset")?.({}, { sessionId: "session-4", sessionKey: "bypass" });
     expect(verboseRoutingInfo).toHaveBeenCalledWith(expect.stringContaining("bypassing before_reset"));
     expect(commitOVSession).toHaveBeenCalledTimes(1);
+
+    await handlers.get("gateway_stop")?.({});
+    expect(commitSession).toHaveBeenCalledWith("oc-session-1", {
+      wait: false,
+      timeoutMs: 4500,
+      keepRecentCount: 0,
+      agentId: "agent-main",
+    });
   });
 
   it("registers the context engine through a dedicated plugin module", () => {

--- a/examples/openclaw-plugin/tests/ut/session-policy.test.ts
+++ b/examples/openclaw-plugin/tests/ut/session-policy.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { OpenVikingClient } from "../../client.js";
+import {
+  applyOpenVikingSessionPolicy,
+  buildIdleAutoCommitPolicy,
+  normalizeIdleTimeoutSeconds,
+} from "../../plugin/openviking-session-policy.js";
+
+function response(status: number, value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OpenClaw session auto-commit policy", () => {
+  it("normalizes config values and builds the idle-only policy", () => {
+    expect(normalizeIdleTimeoutSeconds("off")).toBe(0);
+    expect(normalizeIdleTimeoutSeconds(9999999)).toBe(604800);
+    expect(buildIdleAutoCommitPolicy(3600)).toEqual({
+      idle_timeout_seconds: 3600,
+      pending_token_threshold: 0,
+      message_count_threshold: 0,
+    });
+  });
+
+  it("serializes create and PATCH config bodies", async () => {
+    const transport = vi.fn()
+      .mockResolvedValueOnce(response(200, {
+        status: "ok",
+        result: {
+          session_id: "oc-policy",
+          auto_commit_policy: buildIdleAutoCommitPolicy(3600),
+          auto_commit_idle_enabled: true,
+        },
+      }))
+      .mockResolvedValueOnce(response(200, {
+        status: "ok",
+        result: {
+          session_id: "oc-policy",
+          auto_commit_policy: buildIdleAutoCommitPolicy(7200),
+          auto_commit_idle_enabled: true,
+        },
+      }));
+    const client = new OpenVikingClient(
+      "http://127.0.0.1:1933",
+      "",
+      "agent",
+      5000,
+      "",
+      "",
+      undefined,
+      { transport },
+    );
+
+    await client.createSession("oc-policy", {
+      autoCommitPolicy: buildIdleAutoCommitPolicy(3600)!,
+    });
+    await client.updateSessionConfig(
+      "oc-policy",
+      buildIdleAutoCommitPolicy(7200)!,
+    );
+
+    expect(transport.mock.calls[0]![0]).toBe(
+      "http://127.0.0.1:1933/api/v1/sessions",
+    );
+    expect(JSON.parse(String(transport.mock.calls[0]![1].body))).toEqual({
+      session_id: "oc-policy",
+      auto_commit_policy: buildIdleAutoCommitPolicy(3600),
+    });
+    expect(transport.mock.calls[1]![0]).toBe(
+      "http://127.0.0.1:1933/api/v1/sessions/oc-policy/config",
+    );
+    expect(transport.mock.calls[1]![1].method).toBe("PATCH");
+  });
+
+  it("falls back from ALREADY_EXISTS to PATCH", async () => {
+    const transport = vi.fn()
+      .mockResolvedValueOnce(response(409, {
+        status: "error",
+        error: { code: "ALREADY_EXISTS", message: "exists" },
+      }))
+      .mockResolvedValueOnce(response(200, {
+        status: "ok",
+        result: {
+          session_id: "oc-existing",
+          auto_commit_policy: buildIdleAutoCommitPolicy(3600),
+          auto_commit_idle_enabled: false,
+        },
+      }));
+    const client = new OpenVikingClient(
+      "http://127.0.0.1:1933",
+      "",
+      "agent",
+      5000,
+      "",
+      "",
+      undefined,
+      { transport },
+    );
+
+    const result = await applyOpenVikingSessionPolicy(
+      client,
+      "oc-existing",
+      3600,
+    );
+
+    expect(result).toMatchObject({
+      ensured: true,
+      applied: true,
+      idleActive: false,
+      method: "patch",
+    });
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries create without the policy on legacy validation errors", async () => {
+    const transport = vi.fn()
+      .mockResolvedValueOnce(response(422, {
+        status: "error",
+        error: { code: "VALIDATION_ERROR", message: "unknown field" },
+      }))
+      .mockResolvedValueOnce(response(200, {
+        status: "ok",
+        result: { session_id: "oc-legacy" },
+      }));
+    const client = new OpenVikingClient(
+      "http://127.0.0.1:1933",
+      "",
+      "agent",
+      5000,
+      "",
+      "",
+      undefined,
+      { transport },
+    );
+
+    const result = await applyOpenVikingSessionPolicy(
+      client,
+      "oc-legacy",
+      3600,
+    );
+
+    expect(result).toMatchObject({
+      ensured: true,
+      applied: false,
+      method: "create-legacy",
+    });
+    expect(JSON.parse(String(transport.mock.calls[1]![1].body))).toEqual({
+      session_id: "oc-legacy",
+    });
+  });
+});

--- a/examples/opencode-plugin/index.mjs
+++ b/examples/opencode-plugin/index.mjs
@@ -90,7 +90,7 @@ export async function OpenVikingPlugin({ client, directory }) {
     },
 
     dispose: async () => {
-      await sessionManager.flushAll({ commit: true })
+      await sessionManager.flushAll({ commit: true, commitTimeoutMs: 3000 })
       log("INFO", "plugin", "OpenViking plugin disposed")
     },
   }

--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -2,6 +2,7 @@ import fs from "fs"
 import path from "path"
 import { homedir } from "os"
 import { buildUserAgent, readManifestVersion, resolveOpenVikingCredentials } from "./shared/credentials.mjs"
+import { normalizeIdleTimeoutSeconds } from "./shared/session-policy.mjs"
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs"
 
 const USER_AGENT = buildUserAgent(
@@ -48,6 +49,7 @@ const DEFAULT_CONFIG = {
   captureToolMaxChars: 1000000,
   commitTokenThreshold: 20000,
   commitKeepRecentCount: 10,
+  commitIdleTimeoutSeconds: 3600,
   profileTokenBudget: 10000,
   resumeContextBudget: 32000,
   noAutoInject: false,
@@ -162,6 +164,7 @@ function applyBehaviorConfig(config, fileConfig = {}) {
     "captureToolMaxChars",
     "commitTokenThreshold",
     "commitKeepRecentCount",
+    "commitIdleTimeoutSeconds",
     "profileTokenBudget",
     "resumeContextBudget",
     "noAutoInject",
@@ -221,6 +224,9 @@ function applyEnv(config) {
   if (process.env.OPENVIKING_COMMIT_KEEP_RECENT_COUNT) {
     config.commitKeepRecentCount = process.env.OPENVIKING_COMMIT_KEEP_RECENT_COUNT
   }
+  if (process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS !== undefined) {
+    config.commitIdleTimeoutSeconds = process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS
+  }
   if (process.env.OPENVIKING_PROFILE_TOKEN_BUDGET) config.profileTokenBudget = process.env.OPENVIKING_PROFILE_TOKEN_BUDGET
   if (process.env.OPENVIKING_RESUME_CONTEXT_BUDGET) config.resumeContextBudget = process.env.OPENVIKING_RESUME_CONTEXT_BUDGET
   if (process.env.OPENVIKING_NO_AUTO_INJECT !== undefined) {
@@ -271,6 +277,10 @@ function normalizeConfig(config) {
   config.commitKeepRecentCount = Number.isFinite(commitKeepRecentCount)
     ? Math.max(0, Math.round(commitKeepRecentCount))
     : DEFAULT_CONFIG.commitKeepRecentCount
+  config.commitIdleTimeoutSeconds = normalizeIdleTimeoutSeconds(
+    config.commitIdleTimeoutSeconds,
+    DEFAULT_CONFIG.commitIdleTimeoutSeconds,
+  )
   config.profileTokenBudget = Math.max(500, Math.round(Number(config.profileTokenBudget) || 10000))
   config.resumeContextBudget = Math.max(1024, Math.round(Number(config.resumeContextBudget) || 32000))
   if (!Array.isArray(config.bypassSessionPatterns)) config.bypassSessionPatterns = []

--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -62,10 +62,19 @@ export function createMemorySessionManager({ config, pluginRoot }) {
         (stage, data) => log("DEBUG", "pending", stage, data),
       )
       for (const sessionId of rehydratedSessionIds) {
-        await flushSession(sessionId, {
-          commit: true,
-          reason: "startup-recovery",
-        })
+        // A single unrecoverable entry (e.g. an OV session that no longer
+        // exists server-side) must not reject init() and take the plugin down.
+        try {
+          await flushSession(sessionId, {
+            commit: true,
+            reason: "startup-recovery",
+          })
+        } catch (error) {
+          log("WARN", "session", "Startup recovery commit failed", {
+            opencode_session: sessionId,
+            error: error?.message,
+          })
+        }
       }
     }
   }
@@ -332,11 +341,15 @@ export function createMemorySessionManager({ config, pluginRoot }) {
         ? Math.max(0, commitDeadline - Date.now())
         : commitTimeoutMs
       if (hasUncapturedMessages) {
-        log("WARN", "session", "Deferred commit because unsent messages remain", {
+        // Still commit: what already reached the server must be archived. On
+        // the session.deleted/error path the state entry is dropped right
+        // after this call, so skipping the commit would strand it forever.
+        log("WARN", "session", "Committing while unsent messages remain", {
           openviking_session: state.ovSessionId,
           reason,
         })
-      } else if (hasPendingMessages || effectiveCommitTimeoutMs === 0) {
+      }
+      if (hasPendingMessages || effectiveCommitTimeoutMs === 0) {
         const createdAt = sessionPendingMessages.reduce(
           (latest, item) => Math.max(latest, Number(item.entry?.createdAt || 0)),
           Date.now(),

--- a/examples/opencode-plugin/lib/memory-session.mjs
+++ b/examples/opencode-plugin/lib/memory-session.mjs
@@ -10,6 +10,7 @@ import {
 } from "./shared/session-model.mjs"
 import {
   enqueue,
+  listPending,
   replayPending,
 } from "./shared/pending-queue.mjs"
 import {
@@ -19,6 +20,10 @@ import {
   isRetryableFailure,
 } from "./shared/retryable.mjs"
 import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+} from "./shared/session-policy.mjs"
+import {
   log,
   effectivePeerId,
   fetchJSON,
@@ -27,6 +32,7 @@ import {
 
 export function createMemorySessionManager({ config, pluginRoot }) {
   const sessions = new Map()
+  const policyAppliedFor = new Set()
   const statePath = path.join(pluginRoot, "openviking-session-state.json")
   const oldSessionMapPath = path.join(pluginRoot, "openviking-session-map.json")
   let saveTimer = null
@@ -48,12 +54,19 @@ export function createMemorySessionManager({ config, pluginRoot }) {
   async function init() {
     if (config.autoCapture) await migrateLegacySessionMap()
     await loadState()
+    const rehydratedSessionIds = [...sessions.keys()]
     const health = await fetchJSON(config, "/health", {}, { timeoutMs: 5000 })
     if (health.ok) {
       await replayPending(
         (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
         (stage, data) => log("DEBUG", "pending", stage, data),
       )
+      for (const sessionId of rehydratedSessionIds) {
+        await flushSession(sessionId, {
+          commit: true,
+          reason: "startup-recovery",
+        })
+      }
     }
   }
 
@@ -178,6 +191,20 @@ export function createMemorySessionManager({ config, pluginRoot }) {
         (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
         (stage, data) => log("DEBUG", "pending", stage, data),
       )
+      if (!policyAppliedFor.has(state.ovSessionId)) {
+        policyAppliedFor.add(state.ovSessionId)
+        const policyResult = await applySessionAutoCommitPolicy(
+          (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, options),
+          state.ovSessionId,
+          buildIdleAutoCommitPolicy(config.commitIdleTimeoutSeconds),
+          {
+            cacheKey: `${config.endpoint}|${config.account || ""}|${config.user || ""}`,
+            actorPeerId: effectivePeerId(config) || "",
+            log: (stage, data) => log("DEBUG", "session-policy", stage, data),
+          },
+        )
+        if (policyResult.method === "error") policyAppliedFor.delete(state.ovSessionId)
+      }
     }
     log("INFO", "event", "OpenViking session derived", {
       opencode_session: sessionId,
@@ -259,25 +286,71 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     debouncedSaveState()
   }
 
-  async function flushAll({ commit = false } = {}) {
+  async function flushAll({ commit = false, commitTimeoutMs } = {}) {
     if (saveTimer) {
       clearTimeout(saveTimer)
       saveTimer = null
     }
+    const commitDeadline = Number.isFinite(Number(commitTimeoutMs))
+      ? Date.now() + Math.max(0, Number(commitTimeoutMs))
+      : 0
     for (const sessionId of sessions.keys()) {
-      await flushSession(sessionId, { commit, reason: "flushAll" })
+      const remainingCommitMs = commitDeadline
+        ? Math.max(0, commitDeadline - Date.now())
+        : commitTimeoutMs
+      await flushSession(sessionId, {
+        commit,
+        reason: "flushAll",
+        commitTimeoutMs: remainingCommitMs,
+        commitDeadline,
+      })
     }
     await enqueueSave()
   }
 
-  async function flushSession(opencodeSessionId, { commit = false, reason = "manual" } = {}) {
+  async function flushSession(
+    opencodeSessionId,
+    { commit = false, reason = "manual", commitTimeoutMs, commitDeadline = 0 } = {},
+  ) {
     if (!opencodeSessionId) return false
     const state = sessions.get(opencodeSessionId)
     if (!state) return false
 
-    const added = await flushPendingMessages(opencodeSessionId, state)
+    const added = await flushPendingMessages(opencodeSessionId, state, {
+      deadlineMs: commitDeadline,
+    })
     if (commit && config.autoCapture) {
-      await commitOvSession(state.ovSessionId, { force: true, reason })
+      const sessionPendingMessages = (await listPending()).filter((item) =>
+        item.entry?.type === "addMessage"
+        && item.entry?.sessionId === state.ovSessionId
+      )
+      const hasPendingMessages = sessionPendingMessages.length > 0
+      const hasUncapturedMessages = [...state.messages.values()].some(
+        (message) => !message.captured,
+      )
+      const effectiveCommitTimeoutMs = commitDeadline
+        ? Math.max(0, commitDeadline - Date.now())
+        : commitTimeoutMs
+      if (hasUncapturedMessages) {
+        log("WARN", "session", "Deferred commit because unsent messages remain", {
+          openviking_session: state.ovSessionId,
+          reason,
+        })
+      } else if (hasPendingMessages || effectiveCommitTimeoutMs === 0) {
+        const createdAt = sessionPendingMessages.reduce(
+          (latest, item) => Math.max(latest, Number(item.entry?.createdAt || 0)),
+          Date.now(),
+        ) + 1
+        await enqueue("commitSession", state.ovSessionId, {
+          keep_recent_count: config.commitKeepRecentCount,
+        }, { createdAt })
+      } else {
+        await commitOvSession(state.ovSessionId, {
+          force: true,
+          reason,
+          timeoutMs: effectiveCommitTimeoutMs,
+        })
+      }
     } else if (added > 0) {
       await maybeCommitByThreshold(state)
     }
@@ -377,7 +450,7 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     return body
   }
 
-  async function flushPendingMessages(opencodeSessionId, state) {
+  async function flushPendingMessages(opencodeSessionId, state, { deadlineMs = 0 } = {}) {
     if (!config.autoCapture) return 0
     const toSend = []
     for (const [messageId, message] of state.messages.entries()) {
@@ -392,9 +465,14 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     if (toSend.length === 0) return 0
 
     let added = 0
-    const health = await fetchJSON(config, "/health", {}, { timeoutMs: 5000 })
+    const remainingMs = deadlineMs ? Math.max(0, deadlineMs - Date.now()) : 0
+    if (deadlineMs && remainingMs === 0) return 0
+    const health = await fetchJSON(config, "/health", {}, {
+      timeoutMs: deadlineMs ? Math.min(5000, remainingMs) : 5000,
+    })
     if (!health.ok) {
       for (const item of toSend) {
+        if (deadlineMs && Date.now() >= deadlineMs) break
         const queued = await enqueue("addMessage", state.ovSessionId, item.body)
         if (!queued.ok) break
         item.message.captured = true
@@ -402,7 +480,15 @@ export function createMemorySessionManager({ config, pluginRoot }) {
       }
     } else {
       const res = await sendSessionMessages(
-        (endpoint, init = {}, options = {}) => fetchJSON(config, endpoint, init, { timeoutMs: 10000, ...options }),
+        (endpoint, init = {}, options = {}) => {
+          const requestRemainingMs = deadlineMs
+            ? Math.max(1, deadlineMs - Date.now())
+            : 10000
+          return fetchJSON(config, endpoint, init, {
+            timeoutMs: requestRemainingMs,
+            ...options,
+          })
+        },
         state.ovSessionId,
         toSend.map((item) => item.body),
         { enqueueOnRetryable: true },
@@ -443,14 +529,17 @@ export function createMemorySessionManager({ config, pluginRoot }) {
     return commitOvSession(state.ovSessionId, { force: true, reason: "threshold" })
   }
 
-  async function commitOvSession(ovSessionId, { force = false, reason = "manual", abortSignal } = {}) {
+  async function commitOvSession(
+    ovSessionId,
+    { force = false, reason = "manual", abortSignal, timeoutMs = 30000 } = {},
+  ) {
     if (!force && config.commitTokenThreshold <= 0) return { status: "skipped" }
     const body = { keep_recent_count: config.commitKeepRecentCount }
     const res = await fetchJSON(config, `/api/v1/sessions/${encodeURIComponent(ovSessionId)}/commit`, {
       method: "POST",
       body: JSON.stringify(body),
       signal: abortSignal,
-    }, { timeoutMs: 30000 })
+    }, { timeoutMs })
     if (res.ok) {
       for (const state of sessions.values()) {
         if (state.ovSessionId === ovSessionId) state.lastCommitTime = Date.now()

--- a/examples/opencode-plugin/lib/shared/session-policy.mjs
+++ b/examples/opencode-plugin/lib/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/opencode-plugin/lib/shared/session-policy.mjs
+++ b/examples/opencode-plugin/lib/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -267,3 +267,28 @@ test("loadConfig defaults an invalid commit keep recent count", async () => {
     }
   })
 })
+
+test("loadConfig defaults and disables the idle session policy", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-idle-policy-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const project = join(dir, "project")
+      process.env.OPENVIKING_CREDENTIAL_SOURCE = "env"
+      process.env.OPENVIKING_URL = "https://env.example.com"
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(
+        join(project, ".opencode", "openviking-config.json"),
+        JSON.stringify({}),
+      )
+
+      assert.equal(loadConfig(dir, project).commitIdleTimeoutSeconds, 3600)
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS = "off"
+      assert.equal(loadConfig(dir, project).commitIdleTimeoutSeconds, 0)
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})

--- a/examples/opencode-plugin/tests/memory-session.test.mjs
+++ b/examples/opencode-plugin/tests/memory-session.test.mjs
@@ -18,7 +18,7 @@ async function withTempDir(prefix, fn) {
   }
 }
 
-async function withCaptureServer(fn) {
+async function withCaptureServer(fn, { commitStatus = 0, batchStatus = 0 } = {}) {
   const requests = []
   const server = createServer(async (req, res) => {
     let body = ""
@@ -27,6 +27,16 @@ async function withCaptureServer(fn) {
     requests.push({ method: req.method, url: req.url, body })
 
     res.setHeader("Content-Type", "application/json")
+    if (commitStatus && req.url?.endsWith("/commit")) {
+      res.statusCode = commitStatus
+      res.end(JSON.stringify({ status: "error", error: { message: "session not found" } }))
+      return
+    }
+    if (batchStatus && req.url?.endsWith("/messages/batch")) {
+      res.statusCode = batchStatus
+      res.end(JSON.stringify({ status: "error", error: { message: "rejected" } }))
+      return
+    }
     if (req.url === "/health") {
       res.end(JSON.stringify({ status: "ok" }))
     } else if (req.url === "/api/v1/sessions" && req.method === "POST") {
@@ -262,6 +272,83 @@ test("init flushes and commits stale rehydrated session state", async () => {
       await manager.flushAll({ commit: false })
     })
   })
+})
+
+test("an unrecoverable startup-recovery commit never rejects init", async () => {
+  await withCaptureServer(async ({ endpoint, requests }) => {
+    await withTempDir("ov-oc-init-throw-", async (dir) => {
+      await fs.promises.writeFile(
+        join(dir, "openviking-session-state.json"),
+        JSON.stringify({
+          version: 2,
+          sessions: {
+            "oc-poison": {
+              ovSessionId: "oc-oc-poison",
+              createdAt: Date.now() - 1000,
+              lastActivityAt: Date.now() - 1000,
+              messages: [],
+            },
+          },
+        }),
+      )
+      const manager = createMemorySessionManager({
+        config: baseConfig(endpoint),
+        pluginRoot: dir,
+      })
+
+      // A 404 on /commit is non-retryable and makes commitOvSession throw. It
+      // must not take the whole plugin down on every subsequent launch.
+      await manager.init()
+
+      assert.ok(requests.some((request) =>
+        request.url === "/api/v1/sessions/oc-oc-poison/commit"
+      ))
+    })
+  }, { commitStatus: 404 })
+})
+
+test("a non-retryable message send still commits what reached the server", async () => {
+  await withCaptureServer(async ({ endpoint, requests }) => {
+    await withTempDir("ov-oc-uncaptured-commit-", async (dir) => {
+      await fs.promises.writeFile(
+        join(dir, "openviking-session-state.json"),
+        JSON.stringify({
+          version: 2,
+          sessions: {
+            "oc-partial": {
+              ovSessionId: "oc-oc-partial",
+              createdAt: Date.now() - 1000,
+              lastActivityAt: Date.now() - 1000,
+              messages: [[
+                "message-partial",
+                {
+                  role: "user",
+                  captured: false,
+                  parts: [["part-partial", { type: "text", text: "Never sendable." }]],
+                },
+              ]],
+            },
+          },
+        }),
+      )
+      const manager = createMemorySessionManager({
+        config: baseConfig(endpoint),
+        pluginRoot: dir,
+      })
+
+      await manager.init()
+
+      // The batch POST is rejected 400 (non-retryable, nothing queued), so the
+      // message stays uncaptured — but the commit must still archive whatever
+      // earlier flushes already stored server-side.
+      assert.ok(requests.some((request) =>
+        request.url === "/api/v1/sessions/oc-oc-partial/messages/batch"
+      ))
+      assert.ok(requests.some((request) =>
+        request.url === "/api/v1/sessions/oc-oc-partial/commit"
+      ))
+    })
+  }, { batchStatus: 400 })
 })
 
 test("an exhausted dispose deadline queues the remaining commit", async () => {

--- a/examples/opencode-plugin/tests/memory-session.test.mjs
+++ b/examples/opencode-plugin/tests/memory-session.test.mjs
@@ -6,6 +6,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createMemorySessionManager } from "../lib/memory-session.mjs"
+import { listPending } from "../lib/shared/pending-queue.mjs"
 import { initLogger } from "../lib/utils.mjs"
 
 async function withTempDir(prefix, fn) {
@@ -28,6 +29,16 @@ async function withCaptureServer(fn) {
     res.setHeader("Content-Type", "application/json")
     if (req.url === "/health") {
       res.end(JSON.stringify({ status: "ok" }))
+    } else if (req.url === "/api/v1/sessions" && req.method === "POST") {
+      const payload = JSON.parse(body || "{}")
+      res.end(JSON.stringify({
+        status: "ok",
+        result: {
+          session_id: payload.session_id,
+          auto_commit_policy: payload.auto_commit_policy,
+          auto_commit_idle_enabled: true,
+        },
+      }))
     } else if (req.url?.startsWith("/api/v1/sessions/") && req.url.endsWith("/messages/batch")) {
       res.end(JSON.stringify({ status: "ok", result: { accepted: true } }))
     } else if (req.url?.startsWith("/api/v1/sessions/")) {
@@ -62,6 +73,7 @@ function baseConfig(endpoint) {
     captureMaxLength: 24000,
     commitTokenThreshold: 20000,
     commitKeepRecentCount: 10,
+    commitIdleTimeoutSeconds: 3600,
   }
 }
 
@@ -171,6 +183,162 @@ test("session.idle event flushes pending OpenCode capture", async () => {
       assert.match(body.messages[0].content, /idle events must flush captures/)
       await manager.flushAll({ commit: false })
     })
+  })
+})
+
+test("session.created applies the idle policy once per OpenViking session", async () => {
+  await withCaptureServer(async ({ endpoint, requests }) => {
+    await withTempDir("ov-oc-policy-", async (dir) => {
+      const manager = createMemorySessionManager({ config: baseConfig(endpoint), pluginRoot: dir })
+      const event = {
+        type: "session.created",
+        properties: { info: { id: "oc-policy" } },
+      }
+
+      await manager.init()
+      await manager.handleEvent(event)
+      await manager.handleEvent(event)
+
+      const creates = requests.filter((request) =>
+        request.method === "POST" && request.url === "/api/v1/sessions"
+      )
+      assert.equal(creates.length, 1)
+      assert.deepEqual(JSON.parse(creates[0].body), {
+        session_id: "oc-oc-policy",
+        auto_commit_policy: {
+          idle_timeout_seconds: 3600,
+          pending_token_threshold: 0,
+          message_count_threshold: 0,
+        },
+      })
+      await manager.flushAll({ commit: false })
+    })
+  })
+})
+
+test("init flushes and commits stale rehydrated session state", async () => {
+  await withCaptureServer(async ({ endpoint, requests }) => {
+    await withTempDir("ov-oc-rehydrate-", async (dir) => {
+      await fs.promises.writeFile(
+        join(dir, "openviking-session-state.json"),
+        JSON.stringify({
+          version: 2,
+          sessions: {
+            "oc-stale": {
+              ovSessionId: "oc-oc-stale",
+              createdAt: Date.now() - 1000,
+              lastActivityAt: Date.now() - 1000,
+              messages: [[
+                "message-stale",
+                {
+                  role: "user",
+                  captured: false,
+                  parts: [[
+                    "part-stale",
+                    {
+                      type: "text",
+                      text: "Recover this stale OpenCode turn.",
+                    },
+                  ]],
+                },
+              ]],
+            },
+          },
+        }),
+      )
+      const manager = createMemorySessionManager({
+        config: baseConfig(endpoint),
+        pluginRoot: dir,
+      })
+
+      await manager.init()
+
+      assert.ok(requests.some((request) =>
+        request.url === "/api/v1/sessions/oc-oc-stale/messages/batch"
+      ))
+      assert.ok(requests.some((request) =>
+        request.url === "/api/v1/sessions/oc-oc-stale/commit"
+      ))
+      await manager.flushAll({ commit: false })
+    })
+  })
+})
+
+test("an exhausted dispose deadline queues the remaining commit", async () => {
+  await withCaptureServer(async ({ endpoint }) => {
+    await withTempDir("ov-oc-dispose-deadline-", async (dir) => {
+      const previous = process.env.OPENVIKING_PENDING_DIR
+      process.env.OPENVIKING_PENDING_DIR = join(dir, "pending")
+      try {
+        const manager = createMemorySessionManager({
+          config: baseConfig(endpoint),
+          pluginRoot: dir,
+        })
+        await manager.init()
+        await manager.handleEvent({
+          type: "session.created",
+          properties: { info: { id: "oc-deadline" } },
+        })
+
+        await manager.flushAll({ commit: true, commitTimeoutMs: 0 })
+
+        assert.deepEqual((await listPending()).map((item) => item.entry.type), [
+          "commitSession",
+        ])
+      } finally {
+        if (previous === undefined) delete process.env.OPENVIKING_PENDING_DIR
+        else process.env.OPENVIKING_PENDING_DIR = previous
+      }
+    })
+  })
+})
+
+test("dispose queues commit after a retryable pending message", async () => {
+  await withTempDir("ov-oc-dispose-order-", async (dir) => {
+    const previous = process.env.OPENVIKING_PENDING_DIR
+    process.env.OPENVIKING_PENDING_DIR = join(dir, "pending")
+    try {
+      const manager = createMemorySessionManager({
+        config: { ...baseConfig("http://127.0.0.1:1"), timeoutMs: 100 },
+        pluginRoot: dir,
+      })
+      const sessionID = "oc-dispose-order"
+      await manager.handleEvent({
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "message-dispose-order",
+            sessionID,
+            role: "user",
+          },
+        },
+      })
+      await manager.handleEvent({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "part-dispose-order",
+            messageID: "message-dispose-order",
+            sessionID,
+            type: "text",
+            text: "Queue this turn before the final commit.",
+          },
+        },
+      })
+
+      await manager.flushAll({ commit: true, commitTimeoutMs: 3000 })
+
+      const pending = await listPending()
+      assert.deepEqual(pending.map((item) => item.entry.type), [
+        "addMessage",
+        "commitSession",
+      ])
+      assert.ok(pending[1].entry.createdAt > pending[0].entry.createdAt)
+      await manager.flushAll({ commit: false })
+    } finally {
+      if (previous === undefined) delete process.env.OPENVIKING_PENDING_DIR
+      else process.env.OPENVIKING_PENDING_DIR = previous
+    }
   })
 })
 

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -186,6 +186,13 @@
         "version": "v2",
         "extraction_enabled": true,
         "session_skill_extraction_enabled": false,
+        "session_auto_commit": {
+            "default_enabled": false,
+            "idle_enabled": false,
+            "check_interval_seconds": 60.0,
+            "scan_batch_size": 16,
+            "scan_batch_pause_seconds": 0.0
+        }
     },
     "ingest": {
         "enabled": false,

--- a/examples/pi-coding-agent-extension/DESIGN.md
+++ b/examples/pi-coding-agent-extension/DESIGN.md
@@ -65,7 +65,6 @@ interface OVConfig {
   captureMaxLength: number;     // Max sanitized text length for capture decision (default: 24000)
   captureAssistantTurns: boolean; // Include assistant turns in capture (default: true — memory extraction needs both sides)
   commitTokenThreshold: number;  // Commit after N pending tokens synced (default: 20000)
-  mirrorMemoryWrites: boolean;   // Mirror MEMORY.md to OV at commit time (default: true)
   writeQueueFlushInterval: number; // Write queue flush interval in ms (default: 5000)
   writeQueueFlushThreshold: number; // Write queue flush after N queued turns (default: 5)
   bypassPatterns: string[];      // Glob patterns for cwd to skip (default: [])
@@ -898,7 +897,6 @@ Default: `~/.pi/agent/extensions/openviking/config.json`
   "captureMode": "semantic",
   "captureMaxLength": 24000,
   "captureAssistantTurns": true,
-  "mirrorMemoryWrites": true,
   "writeQueueFlushInterval": 5000,
   "writeQueueFlushThreshold": 5,
   "bypassPatterns": [],

--- a/examples/pi-coding-agent-extension/DESIGN.md
+++ b/examples/pi-coding-agent-extension/DESIGN.md
@@ -64,8 +64,7 @@ interface OVConfig {
   captureMode: "semantic" | "keyword"; // "semantic" = always capture, "keyword" = only when trigger phrases match (default: "semantic")
   captureMaxLength: number;     // Max sanitized text length for capture decision (default: 24000)
   captureAssistantTurns: boolean; // Include assistant turns in capture (default: true — memory extraction needs both sides)
-  commitTokenThreshold: number;  // Commit after N pending tokens synced (default: 20000, 0 = session-end only)
-  commitOnShutdown: boolean;     // Commit session on session_shutdown (default: true)
+  commitTokenThreshold: number;  // Commit after N pending tokens synced (default: 20000)
   mirrorMemoryWrites: boolean;   // Mirror MEMORY.md to OV at commit time (default: true)
   writeQueueFlushInterval: number; // Write queue flush interval in ms (default: 5000)
   writeQueueFlushThreshold: number; // Write queue flush after N queued turns (default: 5)
@@ -443,7 +442,7 @@ Three commit triggers (matching Claude Code plugin's three-way approach):
 
 2. **Pre-compact commit**: When pi fires `compaction` event (before it rewrites the transcript), trigger `commit(wait=true)`. This is critical — without it, content that gets compacted away is lost to OV forever. The Claude Code plugin's `PreCompact` hook does the same thing.
 
-3. **Shutdown commit**: On `session_shutdown`, trigger `commit(wait=true)`. Blocks until extraction completes (with timeout). The safety net for the final turns.
+3. **Shutdown commit**: On awaited `session_shutdown`, flush pending writes and run a bounded synchronous commit in both takeover and non-takeover modes. In takeover mode the local watermark is persisted only after commit succeeds; failure does not advance the boundary and does not queue a delayed commit.
 
 ```typescript
 class SyncManager {
@@ -633,7 +632,7 @@ Main entry point. Wires everything together.
 | `context` | Recall search + injection | Search after user-message rendering, then prepend `<relevant-memories>` (reuse cached block on later LLM iterations) |
 | `turn_end` | Sync | Strip all injected blocks, **capture filter (shouldCapture)**, **preserve tool USE inputs + tool summary line**, drop tool RESULTS, **enqueue to write queue** (auto-flushes at threshold/interval), track pending tokens, check commit threshold |
 | `session_before_compact` | Pre-compact commit + rehydration | Synchronous `commit(wait=true)` before pi rewrites the transcript, then fetch new archive overview and cache for next `before_agent_start` injection — content about to be compacted is preserved in OV and rehydrated after compaction |
-| `session_shutdown` | Final commit | Commit OV session (blocking), rebuild index, optionally mirror MEMORY.md |
+| `session_shutdown` | Final commit | Bounded OV commit in both modes; persist takeover watermark only after success |
 | `agent_end` | Cleanup | Invalidate recall cache |
 
 #### Guard pattern
@@ -786,13 +785,11 @@ A `/viking commit` command (or a `viking_commit` tool) triggers a synchronous `c
 
 ### Session Shutdown
 ```
-1. session_shutdown fires
-2. writeQueue.cancelPending()  ← cancel any pending flush timer
-3. writeQueue.flush()  ← flush remaining queued turns
-4. If mirrorMemoryWrites: read .memory/MEMORY.md → send to OV as session message
-5. sync.commit(wait=true)  ← blocking, with timeout
-6. index_builder.buildIndex()  ← refresh index after commit (new memories extracted)
-7. Cleanup
+1. `session_shutdown` fires and is awaited by pi.
+2. Flush pending writes.
+3. Commit synchronously with a 5-second local bound and `queueOnFailure=false`.
+4. In takeover mode, only a successful commit may persist the current sync watermark.
+5. On failure or timeout, leave the previous watermark unchanged; the next run may replay the unadvanced tail.
 ```
 
 ## Comparison: Hermes vs OpenClaw vs Claude Code vs This Extension
@@ -897,7 +894,6 @@ Default: `~/.pi/agent/extensions/openviking/config.json`
   "resumeContextBudget": 2000,
   "indexBudget": 2000,
   "commitTokenThreshold": 20000,
-  "commitOnShutdown": true,
   "captureToolResults": false,
   "captureMode": "semantic",
   "captureMaxLength": 24000,

--- a/examples/pi-coding-agent-extension/README.md
+++ b/examples/pi-coding-agent-extension/README.md
@@ -130,6 +130,7 @@ integrations should configure category `quotas` when they need exact ceilings.
 | `captureToolMaxChars`    | `1000000`  | Guard cap on one tool part's `tool_output`; the server externalizes oversized output |
 | `commitTokenThreshold`   | `20000`    | Pending-token threshold for client-driven commit                         |
 | `commitKeepRecentCount`  | `10`       | Live tail kept after commit                                              |
+| `commitIdleTimeoutSeconds` | `3600`   | Server-side idle policy; `0`/`off` disables sending it                   |
 
 ### Context takeover
 
@@ -193,7 +194,7 @@ The extension is a single directory of TypeScript files loaded by pi's `jiti` tr
 | `context`              | Run current-prompt recall after UI rendering, then inject takeover and recall context |
 | `turn_end`             | Extract branch entries → write or pending-queue OV messages → maybe advance boundary |
 | `session_before_compact`| Takeover mode returns OV overview as pi compaction summary; otherwise commits pending messages |
-| `session_shutdown`     | Persist takeover state or final non-takeover commit                              |
+| `session_shutdown`     | Bounded final commit in both modes; takeover watermark advances only on success  |
 
 ### Recall: Synchronous, Not Stale
 

--- a/examples/pi-coding-agent-extension/client.ts
+++ b/examples/pi-coding-agent-extension/client.ts
@@ -216,11 +216,12 @@ export class OVClient {
   async commitSessionResponse(
     sessionId: string,
     keepRecentCount = this.cfg.commitKeepRecentCount,
+    timeoutMs = 30000,
   ): Promise<OVCommitResponse> {
     const res = await this.fetchJSON<OVCommitResult>(
       `/api/v1/sessions/${encodeURIComponent(sessionId)}/commit`,
       { method: "POST", body: JSON.stringify({ keep_recent_count: keepRecentCount }) },
-      30000,
+      timeoutMs,
     );
     if (res.ok && res.result && !res.result.trace_id && res.traceId) {
       res.result.trace_id = res.traceId;

--- a/examples/pi-coding-agent-extension/config.json
+++ b/examples/pi-coding-agent-extension/config.json
@@ -10,6 +10,7 @@
   "resumeContextBudget": 32000,
   "commitTokenThreshold": 20000,
   "commitKeepRecentCount": 10,
+  "commitIdleTimeoutSeconds": 3600,
   "takeover": {
     "enabled": true,
     "tokenThreshold": 30000,

--- a/examples/pi-coding-agent-extension/config.ts
+++ b/examples/pi-coding-agent-extension/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
+import { normalizeIdleTimeoutSeconds } from "./shared/session-policy.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
 
 /** Hand-maintained: this extension ships no manifest to read a version from. */
@@ -31,6 +32,7 @@ export interface OVConfig {
   resumeContextBudget: number;
   commitTokenThreshold: number;
   commitKeepRecentCount: number;
+  commitIdleTimeoutSeconds: number;
   takeoverEnabled: boolean;
   takeoverTokenThreshold: number;
   takeoverKeepRecentTurns: number;
@@ -72,6 +74,7 @@ const DEFAULT_CONFIG: OVConfig = {
   resumeContextBudget: 32000,
   commitTokenThreshold: 20000,
   commitKeepRecentCount: 10,
+  commitIdleTimeoutSeconds: 3600,
   takeoverEnabled: true,
   takeoverTokenThreshold: 30000,
   takeoverKeepRecentTurns: 3,
@@ -144,6 +147,9 @@ export function loadConfig(extensionDir: string): OVConfig {
     config.recallQueryExpansion = process.env.OPENVIKING_RECALL_QUERY_EXPANSION === "off" ? "off" : "auto";
     config.recallQueryExpansionConfigured = true;
   }
+  if (process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS !== undefined) {
+    config.commitIdleTimeoutSeconds = process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS as any;
+  }
 
   config.recallLimit = clampInt(config.recallLimit, 1, 50, DEFAULT_CONFIG.recallLimit);
   config.recallMaxContentChars = clampInt(config.recallMaxContentChars, 100, 5000, DEFAULT_CONFIG.recallMaxContentChars);
@@ -154,6 +160,10 @@ export function loadConfig(extensionDir: string): OVConfig {
   config.resumeContextBudget = clampInt(config.resumeContextBudget, 1024, 128000, DEFAULT_CONFIG.resumeContextBudget);
   config.commitTokenThreshold = clampInt(config.commitTokenThreshold, 1000, 1000000, DEFAULT_CONFIG.commitTokenThreshold);
   config.commitKeepRecentCount = clampInt(config.commitKeepRecentCount, 0, 1000, DEFAULT_CONFIG.commitKeepRecentCount);
+  config.commitIdleTimeoutSeconds = normalizeIdleTimeoutSeconds(
+    config.commitIdleTimeoutSeconds,
+    DEFAULT_CONFIG.commitIdleTimeoutSeconds,
+  );
   config.takeoverEnabled = config.takeoverEnabled !== false;
   config.takeoverTokenThreshold = clampInt(config.takeoverTokenThreshold, 1, 1000000, DEFAULT_CONFIG.takeoverTokenThreshold);
   config.takeoverKeepRecentTurns = clampInt(config.takeoverKeepRecentTurns, 0, 100, DEFAULT_CONFIG.takeoverKeepRecentTurns);

--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -92,6 +92,7 @@ export default async function (pi: ExtensionAPI) {
         return;
       }
       await sync.replayPending();
+      await sync.applyAutoCommitPolicy();
 
       // Profile injection
       profileBlock = await buildSessionProfileBlock(client, config);
@@ -222,7 +223,7 @@ export default async function (pi: ExtensionAPI) {
     if (config.takeoverEnabled) {
       await takeover.shutdown();
     } else {
-      await sync.commit();
+      await sync.commit({ queueOnFailure: false, timeoutMs: 5000 });
     }
   });
 

--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -223,7 +223,9 @@ export default async function (pi: ExtensionAPI) {
     if (config.takeoverEnabled) {
       await takeover.shutdown();
     } else {
-      await sync.commit({ queueOnFailure: false, timeoutMs: 5000 });
+      // Non-takeover mode keeps no local context boundary, so queueing a
+      // failed final commit is safe and is the only recovery path.
+      await sync.commit({ timeoutMs: 5000 });
     }
   });
 

--- a/examples/pi-coding-agent-extension/lib/takeover-core.mjs
+++ b/examples/pi-coding-agent-extension/lib/takeover-core.mjs
@@ -337,8 +337,24 @@ export class TakeoverCore {
 
   async shutdown() {
     if (!this.enabled) return;
+    if (this.shutdownComplete) return;
+    const deadline = Date.now() + 5000;
+    let remainingMs = Math.max(1, deadline - Date.now());
+    const flushed = await withTimeout(this.io.flush(remainingMs), remainingMs);
+    if (!flushed) return;
+    remainingMs = Math.max(1, deadline - Date.now());
+    const committed = await withTimeout(
+      this.io.commit({
+        queueOnFailure: false,
+        keepRecentCount: this.config.takeoverKeepRecentTurns,
+        timeoutMs: remainingMs,
+      }),
+      remainingMs,
+    );
+    if (!committed) return;
     this.syncedEntryCount = Math.max(0, Math.floor(Number(this.io.getWatermark()) || 0));
     this.persist();
+    this.shutdownComplete = true;
   }
 
   resetBoundary(reason = "reset") {
@@ -402,5 +418,19 @@ export class TakeoverCore {
     } catch {
       // Logging must not affect pi's context path.
     }
+  }
+}
+
+async function withTimeout(promise, timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise(resolve => {
+        timer = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/examples/pi-coding-agent-extension/shared/session-policy.mjs
+++ b/examples/pi-coding-agent-extension/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/pi-coding-agent-extension/shared/session-policy.mjs
+++ b/examples/pi-coding-agent-extension/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/pi-coding-agent-extension/sync.ts
+++ b/examples/pi-coding-agent-extension/sync.ts
@@ -4,6 +4,10 @@ import { dirname } from "node:path";
 import type { OVConfig } from "./config.js";
 import { deriveHarnessSessionId } from "./shared/session-model.mjs";
 import { enqueue, listPending, replayPending } from "./shared/pending-queue.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+} from "./shared/session-policy.mjs";
 import { extractBranchCapturePayloads } from "./lib/capture-adapter.mjs";
 import { countUndeliveredForSession, estimatePayloadTokens } from "./lib/takeover-core.mjs";
 
@@ -58,18 +62,31 @@ export class SyncManager {
     return true;
   }
 
-  async replayPending(): Promise<void> {
+  async replayPending(timeoutMs = 10000): Promise<void> {
     if (!this.client.connected) return;
     await replayPending(
-      (path: string, init?: any) => this.client.fetchJSON(path, init, 10000),
+      (path: string, init?: any) => this.client.fetchJSON(path, init, timeoutMs),
       (stage: string, data: unknown) =>
         debugLog(`${stage}: ${JSON.stringify(data)}`),
     );
   }
 
-  async flushForTakeover(): Promise<boolean> {
+  async applyAutoCommitPolicy(): Promise<void> {
+    if (!this.ovSessionId || !this.client.connected) return;
+    await applySessionAutoCommitPolicy(
+      (path: string, init?: RequestInit, options: { timeoutMs?: number } = {}) =>
+        this.client.fetchJSON(path, init, options.timeoutMs ?? 10000),
+      this.ovSessionId,
+      buildIdleAutoCommitPolicy(this.config.commitIdleTimeoutSeconds),
+      {
+        cacheKey: `${this.config.endpoint}|${this.config.account || ""}|${this.config.user || ""}`,
+      },
+    );
+  }
+
+  async flushForTakeover(timeoutMs = 10000): Promise<boolean> {
     if (!this.ovSessionId) return false;
-    await this.replayPending();
+    await this.replayPending(timeoutMs);
     const pending = await listPending();
     return countUndeliveredForSession(pending, this.ovSessionId) === 0;
   }
@@ -115,11 +132,18 @@ export class SyncManager {
     }
   }
 
-  async commit(opts: { queueOnFailure?: boolean; keepRecentCount?: number } = {}): Promise<any | null> {
+  async commit(
+    opts: {
+      queueOnFailure?: boolean;
+      keepRecentCount?: number;
+      timeoutMs?: number;
+    } = {},
+  ): Promise<any | null> {
     if (!this.ovSessionId) return null;
     const response = await this.client.commitSessionResponse(
       this.ovSessionId,
       opts.keepRecentCount,
+      opts.timeoutMs,
     );
     const result = response.result;
     if (!result) {

--- a/examples/pi-coding-agent-extension/takeover.ts
+++ b/examples/pi-coding-agent-extension/takeover.ts
@@ -14,8 +14,12 @@ export function createTakeoverManager(opts: {
   return new TakeoverCore({
     config,
     io: {
-      flush: () => sync.flushForTakeover(),
-      commit: (commitOpts?: { queueOnFailure?: boolean; keepRecentCount?: number }) => sync.commit(commitOpts),
+      flush: (timeoutMs?: number) => sync.flushForTakeover(timeoutMs),
+      commit: (commitOpts?: {
+        queueOnFailure?: boolean;
+        keepRecentCount?: number;
+        timeoutMs?: number;
+      }) => sync.commit(commitOpts),
       fetchOverview: async (tokenBudget?: number) => {
         if (!sync.sessionId) return "";
         const ctx = await client.getSessionContext(

--- a/examples/pi-coding-agent-extension/tests/config.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/config.test.mjs
@@ -16,6 +16,8 @@ async function withConfigFile(body, fn, env = {}) {
     OPENVIKING_PEER_ID: process.env.OPENVIKING_PEER_ID,
     OPENVIKING_WORKSPACE_PEER: process.env.OPENVIKING_WORKSPACE_PEER,
     OPENVIKING_RECALL_PEER_SCOPE: process.env.OPENVIKING_RECALL_PEER_SCOPE,
+    OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS:
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS,
     OPENVIKING_CREDENTIAL_SOURCE: process.env.OPENVIKING_CREDENTIAL_SOURCE,
     OPENVIKING_CLI_CONFIG_FILE: process.env.OPENVIKING_CLI_CONFIG_FILE,
     OPENVIKING_CONFIG_FILE: process.env.OPENVIKING_CONFIG_FILE,
@@ -28,6 +30,7 @@ async function withConfigFile(body, fn, env = {}) {
   delete process.env.OPENVIKING_PEER_ID;
   delete process.env.OPENVIKING_WORKSPACE_PEER;
   delete process.env.OPENVIKING_RECALL_PEER_SCOPE;
+  delete process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS;
   delete process.env.OPENVIKING_CLI_CONFIG_FILE;
   delete process.env.OPENVIKING_CONFIG_FILE;
   for (const [key, value] of Object.entries(env)) {
@@ -55,7 +58,14 @@ test("loadConfig defaults takeover on", async () => {
     assert.equal(cfg.takeoverOverviewBudget, 3000);
     assert.equal(cfg.takeoverOverviewPollMs, 2000);
     assert.equal(cfg.takeoverOverviewPollMax, 15);
+    assert.equal(cfg.commitIdleTimeoutSeconds, 3600);
   });
+});
+
+test("loadConfig supports disabling the idle policy", async () => {
+  await withConfigFile({}, (cfg) => {
+    assert.equal(cfg.commitIdleTimeoutSeconds, 0);
+  }, { OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS: "off" });
 });
 
 test("loadConfig maps nested takeover block", async () => {

--- a/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
@@ -10,6 +10,10 @@ function config(overrides = {}) {
   return {
     commitTokenThreshold: 20000,
     commitKeepRecentCount: 10,
+    commitIdleTimeoutSeconds: 3600,
+    endpoint: "http://127.0.0.1:1933",
+    account: "",
+    user: "",
     captureAssistantTurns: true,
     captureToolMaxChars: 2000,
     captureMaxLength: 24000,
@@ -34,13 +38,17 @@ function client(overrides = {}) {
 
 async function withPendingDir(fn) {
   const previous = process.env.OPENVIKING_PENDING_DIR;
+  const previousState = process.env.OPENVIKING_STATE_DIR;
   const dir = await mkdtemp(join(tmpdir(), "ov-pi-pending-"));
   process.env.OPENVIKING_PENDING_DIR = dir;
+  process.env.OPENVIKING_STATE_DIR = join(dir, "state");
   try {
     return await fn(dir);
   } finally {
     if (previous === undefined) delete process.env.OPENVIKING_PENDING_DIR;
     else process.env.OPENVIKING_PENDING_DIR = previous;
+    if (previousState === undefined) delete process.env.OPENVIKING_STATE_DIR;
+    else process.env.OPENVIKING_STATE_DIR = previousState;
     await rm(dir, { recursive: true, force: true });
   }
 }
@@ -59,6 +67,41 @@ test("syncBranch returns added token accounting and delivered status", async () 
     assert.ok(result.tokens > 0);
     assert.equal(result.allDelivered, true);
     assert.equal(sync.syncedCount, 1);
+  });
+});
+
+test("applyAutoCommitPolicy sends the idle-only session policy", async () => {
+  await withPendingDir(async () => {
+    const calls = [];
+    const c = client({
+      fetchJSON: async (path, init) => {
+        calls.push({ path, body: JSON.parse(init.body) });
+        return {
+          ok: true,
+          status: 200,
+          result: {
+            auto_commit_policy: JSON.parse(init.body).auto_commit_policy,
+            auto_commit_idle_enabled: true,
+          },
+        };
+      },
+    });
+    const sync = new SyncManager(c, config());
+    await sync.ensureSession("pi-policy");
+
+    await sync.applyAutoCommitPolicy();
+
+    assert.deepEqual(calls, [{
+      path: "/api/v1/sessions",
+      body: {
+        session_id: "pi-pi-policy",
+        auto_commit_policy: {
+          idle_timeout_seconds: 3600,
+          pending_token_threshold: 0,
+          message_count_threshold: 0,
+        },
+      },
+    }]);
   });
 });
 

--- a/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/sync-barrier.test.mjs
@@ -162,6 +162,31 @@ test("commit writes failure trace_id to the pi debug log", async () => {
   });
 });
 
+test("a failed shutdown commit is queued for replay in non-takeover mode", async () => {
+  await withPendingDir(async () => {
+    const c = client({
+      commitSessionResponse: async () => ({
+        result: null,
+        status: 503,
+        error: { message: "server down" },
+      }),
+    });
+    const sync = new SyncManager(c, config({ takeoverEnabled: false }));
+    await sync.ensureSession("pi-shutdown-queue");
+
+    // Mirrors the session_shutdown call in index.ts: bounded, but queueing
+    // stays on because non-takeover mode keeps no local context boundary, so
+    // replay at next start is the only recovery path.
+    assert.equal(await sync.commit({ timeoutMs: 5000 }), null);
+
+    const pending = await listPending();
+    assert.equal(
+      pending.filter((item) => item.entry?.type === "commitSession").length,
+      1,
+    );
+  });
+});
+
 test("queued addMessage makes takeover flush barrier false until replay succeeds", async () => {
   await withPendingDir(async () => {
     let replayOk = false;

--- a/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/takeover-core.test.mjs
@@ -31,6 +31,7 @@ function assistant(text, timestamp = 0) {
 function makeCore(overrides = {}) {
   const calls = {
     flushed: 0,
+    flushTimeouts: [],
     committed: 0,
     persisted: [],
     slept: [],
@@ -38,8 +39,9 @@ function makeCore(overrides = {}) {
   };
   let watermark = overrides.watermark ?? 0;
   const io = {
-    flush: async () => {
+    flush: async (timeoutMs) => {
       calls.flushed++;
+      calls.flushTimeouts.push(timeoutMs);
       return overrides.flushResult ?? true;
     },
     commit: async (opts) => {
@@ -329,6 +331,30 @@ test("shutdown persists deduped state once", async () => {
   core.transformContext([user("one")]);
   await core.shutdown();
   await core.shutdown();
+  assert.equal(calls.committed, 1);
+  assert.equal(calls.lastCommitOpts.queueOnFailure, false);
+  assert.ok(calls.lastCommitOpts.timeoutMs > 0);
+  assert.ok(calls.lastCommitOpts.timeoutMs <= 5000);
+  assert.ok(calls.flushTimeouts[0] > 0);
+  assert.ok(calls.flushTimeouts[0] <= 5000);
   assert.equal(calls.persisted.length, 1);
   assert.equal(calls.persisted[0].data.syncedEntryCount, 9);
+});
+
+test("shutdown does not advance the watermark after a failed commit", async () => {
+  const { core, calls } = makeCore({ watermark: 9, commitResult: null });
+  core.restore([
+    {
+      type: "custom",
+      customType: TAKEOVER_ENTRY_TYPE,
+      data: { syncedEntryCount: 4, pendingTokens: 10 },
+    },
+  ]);
+
+  await core.shutdown();
+
+  assert.equal(calls.committed, 1);
+  assert.equal(calls.lastCommitOpts.queueOnFailure, false);
+  assert.equal(core.state.syncedEntryCount, 4);
+  assert.equal(calls.persisted.length, 0);
 });

--- a/examples/trae-cli-memory-hooks/scripts/trae-cli-hook.mjs
+++ b/examples/trae-cli-memory-hooks/scripts/trae-cli-hook.mjs
@@ -2,6 +2,7 @@
 
 import {
   addAgentMessages,
+  applyAgentSessionPolicy,
   buildAgentProfile,
   commitAgentSession,
   createAgentLogger,
@@ -60,6 +61,9 @@ async function main() {
       state = { ...state, lastSessionStartAt: now };
       await writeHookState(clientId, nativeSessionId, state);
       await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      await applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log).catch((error) => {
+        logError("session-policy", error);
+      });
       return buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
         logError("profile", error);
         return null;

--- a/examples/trae-memory-hooks/scripts/trae-hook.mjs
+++ b/examples/trae-memory-hooks/scripts/trae-hook.mjs
@@ -2,6 +2,7 @@
 
 import {
   addAgentMessages,
+  applyAgentSessionPolicy,
   buildAgentProfile,
   commitAgentSession,
   createAgentLogger,
@@ -61,6 +62,9 @@ async function main() {
       state = { ...state, lastSessionStartAt: now };
       await writeHookState(requestedClient, nativeSessionId, state);
       await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      await applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log).catch((error) => {
+        logError("session-policy", error);
+      });
       return buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
         logError("profile", error);
         return null;

--- a/examples/zcode-memory-plugin/README.md
+++ b/examples/zcode-memory-plugin/README.md
@@ -11,6 +11,15 @@ This package provides a ZCode lifecycle adapter for OpenViking long-term memory.
 
 ZCode does not support `PreCompact`/`SessionEnd`/`SubagentStart`/`SubagentStop`, so the commit-on-`Stop` strategy compensates for the absence of compact/end-of-session signals. The rollout file is the authoritative incremental transcript: stable host `turnId` values drive deduplication and allow a later Stop to recover missed turns. Hook stdin is only a fallback when the rollout file is unavailable.
 
+Only the last in-flight turn can still be lost. `SessionStart` sends a
+one-hour idle auto-commit policy by default; enable
+`memory.session_auto_commit.idle_enabled=true` on the server to activate it.
+Set `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=off` to disable the policy.
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | Server idle policy; `0`/`off` disables it |
+
 ## Install
 
 Use the shared installer:

--- a/examples/zcode-memory-plugin/README_CN.md
+++ b/examples/zcode-memory-plugin/README_CN.md
@@ -11,6 +11,14 @@
 
 ZCode 不支持 `PreCompact`/`SessionEnd`/`SubagentStart`/`SubagentStop`，因此通过 Stop 时 commit 补足 compact/会话结束信号。Rollout 文件是权威增量对话源：稳定的 host `turnId` 用于去重，也让后续 Stop 能恢复漏掉的回合；只有 rollout 文件不可用时才回退到 Hook stdin。
 
+仍可能丢失最后一个尚未完成的 in-flight turn。`SessionStart` 默认发送一小时 idle
+auto-commit policy；服务端启用 `memory.session_auto_commit.idle_enabled=true`
+后才会执行。设置 `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS=off` 可禁用该 policy。
+
+| 环境变量 | 默认值 | 含义 |
+| --- | --- | --- |
+| `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` | `3600` | 服务端 idle policy；`0`/`off` 可禁用 |
+
 ## 安装
 
 使用共享安装脚本：

--- a/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
@@ -11,6 +11,11 @@ import { enqueue, replayPending } from "./pending-queue.mjs";
 import { buildProfileBlock } from "./profile-inject.mjs";
 import { buildRecallBlock } from "./recall-core.mjs";
 import { isRetryableFailure } from "./retryable.mjs";
+import {
+  applySessionAutoCommitPolicy,
+  buildIdleAutoCommitPolicy,
+  normalizeIdleTimeoutSeconds,
+} from "./session-policy.mjs";
 import { deriveHarnessSessionId, isBypassed } from "./session-model.mjs";
 import { resolveEffectivePeerId } from "./workspace-peer.mjs";
 
@@ -67,7 +72,11 @@ export function loadAgentHookConfig(clientId) {
     recallPeerScope: process.env.OPENVIKING_RECALL_PEER_SCOPE === "actor" ? "actor" : "all",
     timeoutMs: envNumber("OPENVIKING_TIMEOUT_MS", 15000, 1000),
     profileTokenBudget: envNumber("OPENVIKING_PROFILE_TOKEN_BUDGET", 6000, 500),
-    commitTurnThreshold: envNumber("OPENVIKING_COMMIT_TURN_THRESHOLD", 8, 1),
+    commitTurnThreshold: envNumber("OPENVIKING_COMMIT_TURN_THRESHOLD", 1, 1),
+    commitIdleTimeoutSeconds: normalizeIdleTimeoutSeconds(
+      process.env.OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS,
+      3600,
+    ),
     writePathAsync: envBool("OPENVIKING_WRITE_PATH_ASYNC", true),
     debug: envBool("OPENVIKING_DEBUG", false),
     debugLogPath,
@@ -238,6 +247,14 @@ export async function commitAgentSession(fetchJSON, sessionId, log = () => {}) {
 
 export async function replayAgentPending(fetchJSON, log = () => {}) {
   return replayPending(fetchJSON, log);
+}
+
+export async function applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log = () => {}) {
+  const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
+  return applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
+    cacheKey: `${cfg.baseUrl || ""}|${cfg.account || ""}|${cfg.user || ""}`,
+    log,
+  });
 }
 
 export async function recallForPrompt(fetchJSON, cfg, prompt, cwd, log = () => {}, options = {}) {

--- a/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/agent-hook-runtime.mjs
@@ -251,10 +251,23 @@ export async function replayAgentPending(fetchJSON, log = () => {}) {
 
 export async function applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log = () => {}) {
   const policy = buildIdleAutoCommitPolicy(cfg.commitIdleTimeoutSeconds);
-  return applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
+  const result = await applySessionAutoCommitPolicy(fetchJSON, sessionId, policy, {
     cacheKey: `${cfg.baseUrl || ""}|${cfg.account || ""}|${cfg.user || ""}`,
     log,
+    // These hooks have no /health pre-gate, so cap each request well below
+    // cfg.timeoutMs: a hung server must not stall session start twice over.
+    timeoutMs: 3000,
   });
+  // The helper only logs the two applied paths; these harnesses discard the
+  // outcome, so without this a legacy/error apply is undiagnosable.
+  if (result.method !== "create" && result.method !== "patch") {
+    log("session_policy_skipped", {
+      sessionId,
+      method: result.method,
+      status: result.status,
+    });
+  }
+  return result;
 }
 
 export async function recallForPrompt(fetchJSON, cfg, prompt, cwd, log = () => {}, options = {}) {

--- a/examples/zcode-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/session-policy.mjs
@@ -55,6 +55,18 @@ function hasPolicyEcho(result) {
   );
 }
 
+// Only a body that actually looks like a session result proves the server is
+// old. Plugin fetch helpers turn an unparseable 200 (truncated stream, proxy
+// interstitial) into {ok:true, result:{}} or a raw string, and caching that as
+// "legacy" would silently disable the idle backstop for the whole TTL.
+function looksLikeSessionResult(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "session_id"),
+  );
+}
+
 async function callFetch(fetchJSON, path, init, options) {
   try {
     const result = await fetchJSON(path, init, options);
@@ -127,6 +139,7 @@ export async function applySessionAutoCommitPolicy(
     log = () => {},
     ensureOnLegacy = true,
     legacyCachePath,
+    timeoutMs = 0,
     now = Date.now(),
   } = {},
 ) {
@@ -138,7 +151,10 @@ export async function applySessionAutoCommitPolicy(
   const encodedSessionId = encodeURIComponent(sessionId);
   const createPath = "/api/v1/sessions";
   const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
-  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const fetchOptions = {
+    ...(actorPeerId ? { actorPeerId } : {}),
+    ...(Number(timeoutMs) > 0 ? { timeoutMs: Number(timeoutMs) } : {}),
+  };
   const cachePath = legacyCachePath || stateFile(cacheKey);
   const legacyUntil = await readLegacyUntil(cachePath);
 
@@ -172,7 +188,7 @@ export async function applySessionAutoCommitPolicy(
       log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
       return result;
     }
-    await markLegacy(cachePath, now);
+    if (looksLikeSessionResult(create.result)) await markLegacy(cachePath, now);
     return outcome({
       ensured: true,
       method: "create-legacy",

--- a/examples/zcode-memory-plugin/scripts/shared/session-policy.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/session-policy.mjs
@@ -1,0 +1,239 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const LEGACY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_IDLE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+const DISABLED_VALUES = new Set(["off", "false", "no"]);
+
+function stateFile(cacheKey) {
+  const root = String(process.env.OPENVIKING_STATE_DIR || "").trim()
+    || join(homedir(), ".openviking", "state");
+  const digest = createHash("sha256").update(String(cacheKey || "default")).digest("hex").slice(0, 20);
+  return join(root, `session-policy-${digest}.json`);
+}
+
+async function readLegacyUntil(path) {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return Number(parsed?.legacyUntil || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function markLegacy(path, now) {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, JSON.stringify({ legacyUntil: now + LEGACY_CACHE_TTL_MS }), "utf8");
+    await rename(tmp, path);
+  } catch {
+    // Best effort: compatibility detection must never block a harness hook.
+  }
+}
+
+function isAlreadyExists(result) {
+  return Number(result?.status || 0) === 409
+    && result?.error?.code === "ALREADY_EXISTS";
+}
+
+function isRetryable(result) {
+  if (!result || result.ok) return false;
+  const status = Number(result.status || 0);
+  if (!status || status === 408 || status === 429 || status >= 500) return true;
+  return status === 409 && result.error?.details?.retryable === true;
+}
+
+function hasPolicyEcho(result) {
+  return Boolean(
+    result
+    && typeof result === "object"
+    && Object.prototype.hasOwnProperty.call(result, "auto_commit_policy"),
+  );
+}
+
+async function callFetch(fetchJSON, path, init, options) {
+  try {
+    const result = await fetchJSON(path, init, options);
+    return result && typeof result === "object"
+      ? result
+      : { ok: false, status: 0, error: { message: "empty response" } };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+function outcome({
+  ensured = false,
+  applied = false,
+  idleActive = null,
+  idleTimeoutSeconds = 0,
+  method,
+  raw = null,
+}) {
+  return {
+    ensured,
+    applied,
+    idleActive,
+    idleTimeoutSeconds,
+    method,
+    retryable: isRetryable(raw),
+    status: Number(raw?.status || (raw?.ok ? 200 : 0)),
+    raw,
+  };
+}
+
+export function normalizeIdleTimeoutSeconds(value, fallback = 3600) {
+  const normalizedFallback = Number.isFinite(Number(fallback))
+    ? Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(Number(fallback))))
+    : 3600;
+  if (typeof value === "string" && DISABLED_VALUES.has(value.trim().toLowerCase())) return 0;
+  if (value == null || value === "") return normalizedFallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return normalizedFallback;
+  return Math.min(MAX_IDLE_TIMEOUT_SECONDS, Math.max(0, Math.floor(numeric)));
+}
+
+export function buildIdleAutoCommitPolicy(seconds) {
+  const idleTimeoutSeconds = normalizeIdleTimeoutSeconds(seconds, 0);
+  if (idleTimeoutSeconds <= 0) return null;
+  return {
+    idle_timeout_seconds: idleTimeoutSeconds,
+    pending_token_threshold: 0,
+    message_count_threshold: 0,
+  };
+}
+
+export function readIdleActive(result) {
+  return typeof result?.auto_commit_idle_enabled === "boolean"
+    ? result.auto_commit_idle_enabled
+    : null;
+}
+
+export async function applySessionAutoCommitPolicy(
+  fetchJSON,
+  sessionId,
+  policy,
+  {
+    cacheKey = "default",
+    actorPeerId = "",
+    log = () => {},
+    ensureOnLegacy = true,
+    legacyCachePath,
+    now = Date.now(),
+  } = {},
+) {
+  const idleTimeoutSeconds = Number(policy?.idle_timeout_seconds || 0);
+  if (!policy || idleTimeoutSeconds <= 0) {
+    return outcome({ method: "disabled", idleTimeoutSeconds: 0 });
+  }
+
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const createPath = "/api/v1/sessions";
+  const patchPath = `/api/v1/sessions/${encodedSessionId}/config`;
+  const fetchOptions = actorPeerId ? { actorPeerId } : {};
+  const cachePath = legacyCachePath || stateFile(cacheKey);
+  const legacyUntil = await readLegacyUntil(cachePath);
+
+  if (legacyUntil > now) {
+    if (!ensureOnLegacy) {
+      return outcome({ method: "cached-legacy", idleTimeoutSeconds });
+    }
+    const raw = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = raw.ok || isAlreadyExists(raw);
+    return outcome({ ensured, method: "cached-legacy", idleTimeoutSeconds, raw });
+  }
+
+  const create = await callFetch(fetchJSON, createPath, {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, auto_commit_policy: policy }),
+  }, fetchOptions);
+
+  if (create.ok) {
+    if (hasPolicyEcho(create.result)) {
+      const result = outcome({
+        ensured: true,
+        applied: true,
+        idleActive: readIdleActive(create.result),
+        idleTimeoutSeconds,
+        method: "create",
+        raw: create,
+      });
+      log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+      return result;
+    }
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "create-legacy",
+      idleTimeoutSeconds,
+      raw: create,
+    });
+  }
+
+  if (Number(create.status || 0) === 422) {
+    const stripped = await callFetch(fetchJSON, createPath, {
+      method: "POST",
+      body: JSON.stringify({ session_id: sessionId }),
+    }, fetchOptions);
+    const ensured = stripped.ok || isAlreadyExists(stripped);
+    if (ensured) await markLegacy(cachePath, now);
+    return outcome({
+      ensured,
+      method: ensured ? "create-legacy" : "error",
+      idleTimeoutSeconds,
+      raw: stripped,
+    });
+  }
+
+  if (!isAlreadyExists(create)) {
+    return outcome({ method: "error", idleTimeoutSeconds, raw: create });
+  }
+
+  const patch = await callFetch(fetchJSON, patchPath, {
+    method: "PATCH",
+    body: JSON.stringify({ auto_commit_policy: policy }),
+  }, fetchOptions);
+  if (patch.ok && hasPolicyEcho(patch.result)) {
+    const result = outcome({
+      ensured: true,
+      applied: true,
+      idleActive: readIdleActive(patch.result),
+      idleTimeoutSeconds,
+      method: "patch",
+      raw: patch,
+    });
+    log("session_policy", { sessionId, method: result.method, idleActive: result.idleActive });
+    return result;
+  }
+
+  if (
+    (patch.ok && !hasPolicyEcho(patch.result))
+    || [404, 405, 422].includes(Number(patch.status || 0))
+  ) {
+    await markLegacy(cachePath, now);
+    return outcome({
+      ensured: true,
+      method: "patch-legacy",
+      idleTimeoutSeconds,
+      raw: patch,
+    });
+  }
+
+  return outcome({
+    ensured: true,
+    method: "error",
+    idleTimeoutSeconds,
+    raw: patch,
+  });
+}

--- a/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
@@ -19,6 +19,7 @@
 
 import {
   addAgentMessages,
+  applyAgentSessionPolicy,
   buildAgentProfile,
   commitAgentSession,
   createAgentLogger,
@@ -84,6 +85,9 @@ async function main() {
       state = { ...state, lastSessionStartAt: now };
       await writeHookState("zcode", nativeSessionId, state);
       await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      await applyAgentSessionPolicy(fetchJSON, cfg, sessionId, log).catch((error) => {
+        logError("session-policy", error);
+      });
       return buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
         logError("profile", error);
         return null;

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -13,7 +13,7 @@ from openviking.message.part import Part, TextPart, part_from_dict
 from openviking.server.auth import get_session_request_context
 from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext
-from openviking.server.models import ErrorInfo, Response
+from openviking.server.models import Response
 from openviking.server.responses import error_response
 from openviking.server.telemetry import run_operation
 from openviking.telemetry import TelemetryRequest
@@ -306,6 +306,7 @@ async def create_session(
             "uri": session.uri,
             "user": session.user.to_dict(),
             "auto_commit_policy": service.sessions.effective_auto_commit_policy(session),
+            "auto_commit_idle_enabled": service.sessions.idle_auto_commit_enabled,
             "memory_extraction_config": service.sessions.effective_memory_extraction_config(
                 session
             ),
@@ -348,6 +349,7 @@ async def get_session(
     result["user"] = session.user.to_dict()
     result["pending_tokens"] = int(session.meta.pending_tokens or 0)
     result["auto_commit_policy"] = service.sessions.effective_auto_commit_policy(session)
+    result["auto_commit_idle_enabled"] = service.sessions.idle_auto_commit_enabled
     result.pop("event_search_tags", None)
     result["memory_extraction_config"] = (
         service.sessions.effective_memory_extraction_config(session)
@@ -404,6 +406,7 @@ async def update_session_config(
         return {
             "session_id": session.session_id,
             "auto_commit_policy": service.sessions.effective_auto_commit_policy(session),
+            "auto_commit_idle_enabled": service.sessions.idle_auto_commit_enabled,
             "memory_extraction_config": service.sessions.effective_memory_extraction_config(
                 session
             ),

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -484,6 +484,11 @@ class SessionService:
             return None
         return AutoCommitPolicy.from_dict(session.meta.auto_commit_policy).to_dict()
 
+    @property
+    def idle_auto_commit_enabled(self) -> bool:
+        """Return whether this server runs the idle auto-commit scheduler."""
+        return bool(self._session_auto_commit_config.idle_enabled)
+
     @staticmethod
     def effective_memory_extraction_config(session: Session) -> Dict[str, Any]:
         """Return the caller-facing memory extraction config."""

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -632,7 +632,40 @@ async def test_create_session_defaults_auto_commit_policy_to_disabled(
 ):
     resp = await client.post("/api/v1/sessions", json={})
     assert resp.status_code == 200
-    assert resp.json()["result"]["auto_commit_policy"] is None
+    result = resp.json()["result"]
+    assert result["auto_commit_policy"] is None
+    assert result["auto_commit_idle_enabled"] is False
+
+    session_resp = await client.get(f"/api/v1/sessions/{result['session_id']}")
+    assert session_resp.status_code == 200
+    assert session_resp.json()["result"]["auto_commit_policy"] is None
+    assert session_resp.json()["result"]["auto_commit_idle_enabled"] is False
+
+
+async def test_session_responses_report_idle_auto_commit_enabled_when_config_on(
+    client: httpx.AsyncClient,
+    service,
+):
+    service.sessions.set_session_auto_commit_config(SessionAutoCommitConfig(idle_enabled=True))
+
+    created = await client.post(
+        "/api/v1/sessions",
+        json={"auto_commit_policy": {"idle_timeout_seconds": 3600}},
+    )
+    assert created.status_code == 200
+    session_id = created.json()["result"]["session_id"]
+    assert created.json()["result"]["auto_commit_idle_enabled"] is True
+
+    fetched = await client.get(f"/api/v1/sessions/{session_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["result"]["auto_commit_idle_enabled"] is True
+
+    updated = await client.patch(
+        f"/api/v1/sessions/{session_id}/config",
+        json={"auto_commit_policy": {"idle_timeout_seconds": 7200}},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["result"]["auto_commit_idle_enabled"] is True
 
 
 async def test_create_session_uses_default_policy_when_server_default_enabled(
@@ -744,6 +777,7 @@ async def test_get_session_returns_effective_config(client: httpx.AsyncClient):
     resp = await client.get(f"/api/v1/sessions/{session_id}")
     assert resp.status_code == 200
     assert resp.json()["result"]["auto_commit_policy"] is None
+    assert resp.json()["result"]["auto_commit_idle_enabled"] is False
 
 
 async def test_patch_session_config_is_not_supported(client: httpx.AsyncClient):

--- a/tests/server/test_api_sessions_event_tags.py
+++ b/tests/server/test_api_sessions_event_tags.py
@@ -1,7 +1,43 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import json
+
 import httpx
+import pytest
+
+from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
+from openviking_cli.utils.config.open_viking_config import OpenVikingConfigSingleton
+
+
+@pytest.fixture(autouse=True)
+def _configure_test_env(monkeypatch, tmp_path):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text(
+        json.dumps(
+            {
+                "storage": {
+                    "workspace": str(tmp_path / "workspace"),
+                    "agfs": {"backend": "local"},
+                    "vectordb": {"backend": "local"},
+                },
+                "embedding": {
+                    "dense": {
+                        "provider": "openai",
+                        "model": "test-embedder",
+                        "api_base": "http://127.0.0.1:11434/v1",
+                        "dimension": 1024,
+                    }
+                },
+                "encryption": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(OPENVIKING_CONFIG_ENV, str(config_path))
+    OpenVikingConfigSingleton.reset_instance()
+    yield
+    OpenVikingConfigSingleton.reset_instance()
 
 
 def _event_tags(response: httpx.Response) -> list[str]:
@@ -41,6 +77,7 @@ async def test_session_config_updates_event_tags_and_auto_commit_policy(
     result = updated.json()["result"]
     assert updated.status_code == 200
     assert _event_tags(updated) == ["channel=app"]
+    assert result["auto_commit_idle_enabled"] is False
     assert result["auto_commit_policy"]["pending_token_threshold"] == 8000
     assert result["auto_commit_policy"]["message_count_threshold"] == 25
 

--- a/tests/unit/service/test_session_auto_commit.py
+++ b/tests/unit/service/test_session_auto_commit.py
@@ -23,7 +23,6 @@ from openviking.service.session_service import SessionService
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config.memory_config import SessionAutoCommitConfig
 
-
 _REAL_DATETIME = datetime
 
 
@@ -228,6 +227,18 @@ def _session_service_for_auto_commit_test(
     monkeypatch.setattr(service, "get", fake_get)
     monkeypatch.setattr(session_service_module, "get_task_tracker", lambda: _FakeTaskTracker())
     return service
+
+
+def test_idle_auto_commit_enabled_reflects_server_config():
+    service = SessionService()
+    defaults = SessionAutoCommitConfig()
+
+    assert defaults.default_enabled is False
+    assert defaults.idle_enabled is False
+    assert service.idle_auto_commit_enabled is False
+
+    service.set_session_auto_commit_config(SessionAutoCommitConfig(idle_enabled=True))
+    assert service.idle_auto_commit_enabled is True
 
 
 def _meta(


### PR DESCRIPTION
## Description

Harness memory plugins commit an OV session at end-of-conversation, but several
harnesses never fire a usable hook when the user simply closes them. Codex fires
nothing at all on `SIGTERM`/`Ctrl+C`/`/exit` (upstream declined a `SessionEnd`
hook), so its plugin emulates one with local state files, a 2-minute
active-window heuristic and a 30-minute idle-TTL sweep — and its own design doc
accepts that if the user never relaunches Codex, the session stays open forever.

The server already has the right mechanism (`auto_commit_policy.idle_timeout_seconds`
plus `SessionAutoCommitScheduler`, #3736/#3850), but nothing used it: the `.mjs`
plugins never create sessions at all (they rely on `auto_create` inside
`POST /messages`, which takes no options), and the sweeper is gated by
`memory.session_auto_commit.idle_enabled`, which is not reachable over HTTP.

This PR makes every harness plugin request a per-session idle policy, lets
plugins detect whether the server will actually act on it, retires Codex's local
sweep on servers that do, and fixes each harness's real close path.

Upstream close behavior was verified against source/docs per harness before
writing any of it; the findings changed the plan (Cursor and pi turned out to be
in the "does not commit on close" group, DSH turned out to be better than
assumed), and the docs now describe what remains uncovered rather than a guess.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

**Server — capability detection only, defaults unchanged**

- `POST /api/v1/sessions`, `GET /api/v1/sessions/{id}` and
  `PATCH /api/v1/sessions/{id}/config` now return `auto_commit_idle_enabled`.
  It gives clients a tri-state: field absent means an old server, `false` means
  a server that stored the policy but will not sweep, `true` means it will.
  The policy echo alone cannot express that difference, which is why the field
  exists.
- `memory.session_auto_commit` defaults are deliberately untouched
  (`default_enabled=false`, `idle_enabled=false`); a unit test pins both so a
  future accidental flip fails CI. `examples/ov.conf.example` documents the
  block at its shipped values.

**Plugins — one shared, idempotent policy path**

- New `examples/memory-plugin-shared/lib/session-policy.mjs`: normalize/build
  the policy, then `POST /sessions` with it and fall back to
  `PATCH /{id}/config` on `ALREADY_EXISTS`. Old servers ignore the unknown
  create field, so they are detected by the missing echo and negative-cached for
  6h; transient failures never write that cache.
- Payload is `{idle_timeout_seconds, pending_token_threshold: 0,
  message_count_threshold: 0}`. The two zeros matter: they disable the
  server-side threshold triggers so they cannot race the plugins' own
  client-side threshold commits, which use different keep-recent semantics.
- Wired into claude-code, codex, cursor, zcode, trae, opencode, pi, dsh and
  openclaw, once per session start, best-effort, never blocking the hook.
  Knob: `OPENVIKING_COMMIT_IDLE_TIMEOUT_SECONDS` / `commitIdleTimeoutSeconds`,
  default 3600, `0`/`off` to disable.

**Codex — the local sweep now retires itself**

- The state file records `serverIdleCommit` only when the server reported
  `auto_commit_idle_enabled: true`. Both the active-window heuristic and the
  idle-TTL sweep skip marked sessions, and a marked file is garbage-collected
  (never committed) once it is past the server's own timeout plus a margin.
- Everything else keeps today's behavior: an old server, `idle_enabled=false`,
  a failed apply or the knob turned off all leave the marker absent, so on stock
  servers the sweep stays fully active. Zero regression by construction.
- Fixes a real bug on that path: the swept commit sent the *new* session's peer
  as `X-OpenViking-Actor-Peer` instead of the swept session's stored
  `workspacePeerId`, misattributing extracted memories.

**Close-path fixes, per harness**

- **openclaw** — upstream emits an *awaited* `session_end(reason=shutdown|restart)`
  per active session during shutdown drain, plus an awaited `gateway_stop`; the
  plugin received the first and discarded it and never registered the second.
  Both now commit, bounded to fit the 2s drain and 5s per-hook budgets.
- **pi** — `session_shutdown` fires on every close mode and is fully awaited,
  but in the default takeover config the handler only persisted local state.
  It now commits, ordered commit-before-watermark and refusing to advance on
  failure so a delayed commit can never move the local context boundary.
- **cursor** — upstream `sessionEnd` fires only on `window_close`, where the
  shell-exec host is already torn down, so the hook command never spawns
  (Cursor-staff-confirmed, no ETA). Commit-turn threshold now defaults to 1,
  adopting the zcode/trae per-turn model that already ships.
- **dsh** — the shutdown commit no longer queues behind an in-flight
  `addMessage` (10s) or threshold commit (30s), a SIGHUP listener covers
  terminal close, and dispose no longer re-runs full initialization on the
  teardown path.
- **opencode** — the dispose commit now fits the 5s shutdown budget so the
  pending-queue fallback can still enqueue, and startup flushes and commits
  rehydrated entries that a dead process left behind.

**Docs (EN + ZH)**

- Per-integration pages state the real remaining gap after these fixes and how
  to enable the server backstop, explicitly in the server's `ov.conf` — the
  earlier draft showed the snippet with no file named, right after plugin-config
  commands, where setting it does nothing.
- Codex `DESIGN.md`/`VERIFICATION.md` cover the new marker, the gating decision
  tree and the manual runbook.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

- `pytest tests/server/test_api_sessions.py tests/server/test_api_sessions_event_tags.py
  tests/unit/service/test_session_auto_commit.py tests/unit/session/test_auto_commit_policy.py`
  → 90 passed.
- `node --test` across memory-plugin-shared, codex, claude-code, cursor, zcode,
  trae, opencode, pi and dsh → 183 passed.
- `examples/openclaw-plugin`: `npm run typecheck` clean, `npm run test` → 751
  passed. The 4 failures in `tests/ut/architecture-boundaries.test.ts` are
  pre-existing and fail identically on `main` (verified in a clean worktree);
  they are unrelated to this branch.
- The gating logic carries an explicit mutation guard: a test asserts that stale
  state the server does *not* cover is still swept locally, for both an unmarked
  file and a marked file missing its timeout. Without it, relaxing the predicate
  from `=== true` to `!== false` left the whole suite green while silently
  disabling commits on every stock server.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Rollout is order-independent. Plugins against an old server negative-cache and
keep today's behavior; the server field against old plugins is inert because no
policy is sent. Codex's sweep only retires where an operator has enabled
`idle_enabled` — intentionally, since that is the only state in which the server
actually sweeps.

Draft while a review pass finishes. Known follow-ups, deliberately not in scope:

- `openviking-session-state.json` in the OpenCode plugin is one global file
  rewritten wholesale from a single process's in-memory map, so concurrent
  OpenCode servers clobber each other's entries. Needs a layout change.
- The claude-code capture watermark lives in `os.tmpdir()` and its
  `writePathAsync` default detaches the SessionEnd write.
- Codex skips the whole sweep when `/health` fails at that instant — the same
  outage that stranded the session disables its recovery.
- `examples/ov.conf.example` cannot be loaded by the server's strict
  `json.loads` because of pre-existing trailing commas; now that docs point
  users at it to find this knob, that is worth fixing separately.
- A dedicated DSH integration doc page still does not exist.
