### PR TITLE
fix(bot): normalize cron one-shot datetimes

### DIFF
--- a/bot/tests/test_cron_datetime_parsing.py
+++ b/bot/tests/test_cron_datetime_parsing.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for cron ISO datetime parsing."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vikingbot.agent.tools.cron import CronTool  # noqa: E402
+from vikingbot.cli.commands import cron_add  # noqa: E402
+from vikingbot.config.schema import SessionKey  # noqa: E402
+from vikingbot.cron.service import CronService  # noqa: E402
+
+
+def test_cron_cli_accepts_z_datetime(tmp_path, monkeypatch):
+    monkeypatch.setattr("vikingbot.config.loader.get_data_dir", lambda: tmp_path)
+
+    cron_add(
+        name="release",
+        message="ship it",
+        every=None,
+        cron_expr=None,
+        at="2099-08-17T10:00:00Z",
+        deliver=False,
+    )
+
+    jobs = CronService(tmp_path / "cron" / "jobs.json").list_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].schedule.at_ms == 4090644000000
+
+
+def test_cron_cli_reports_invalid_datetime(tmp_path, monkeypatch):
+    monkeypatch.setattr("vikingbot.config.loader.get_data_dir", lambda: tmp_path)
+
+    with pytest.raises(typer.Exit):
+        cron_add(
+            name="release",
+            message="ship it",
+            every=None,
+            cron_expr=None,
+            at="not-a-date",
+            deliver=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_accepts_z_datetime(tmp_path):
+    service = CronService(tmp_path / "jobs.json")
+    tool = CronTool(service)
+    context = SimpleNamespace(
+        session_key=SessionKey(type="cli", channel_id="default", chat_id="default"),
+        channel_metadata=None,
+    )
+
+    result = await tool.execute(
+        context,
+        action="add",
+        name="release",
+        message="ship it",
+        at="2099-08-17T10:00:00Z",
+    )
+
+    assert result.startswith("Created job")
+    assert service.list_jobs()[0].schedule.at_ms == 4090644000000
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_reports_invalid_datetime(tmp_path):
+    tool = CronTool(CronService(tmp_path / "jobs.json"))
+    context = SimpleNamespace(
+        session_key=SessionKey(type="cli", channel_id="default", chat_id="default"),
+        channel_metadata=None,
+    )
+
+    result = await tool.execute(
+        context,
+        action="add",
+        name="release",
+        message="ship it",
+        at="not-a-date",
+    )
+
+    assert result.startswith("Error: invalid at datetime:")

--- a/bot/vikingbot/agent/tools/cron.py
+++ b/bot/vikingbot/agent/tools/cron.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
+from openviking.utils.time_utils import parse_iso_datetime
 from vikingbot.agent.tools.base import Tool
 from vikingbot.cron.service import CronService
 from vikingbot.cron.types import CronSchedule
@@ -104,9 +105,10 @@ class CronTool(Tool):
         elif cron_expr:
             schedule = CronSchedule(kind="cron", expr=cron_expr)
         elif at:
-            from datetime import datetime
-
-            dt = datetime.fromisoformat(at)
+            try:
+                dt = parse_iso_datetime(at)
+            except ValueError as e:
+                return f"Error: invalid at datetime: {e}"
             at_ms = int(dt.timestamp() * 1000)
             schedule = CronSchedule(kind="at", at_ms=at_ms)
             delete_after = True

--- a/bot/vikingbot/cli/commands.py
+++ b/bot/vikingbot/cli/commands.py
@@ -21,6 +21,7 @@ from prompt_toolkit.styles import Style as PromptStyle
 from rich.console import Console
 from rich.table import Table
 
+from openviking.utils.time_utils import parse_iso_datetime
 from vikingbot import __logo__, __version__
 from vikingbot.agent.loop import AgentLoop
 from vikingbot.bus.queue import MessageBus
@@ -1134,9 +1135,11 @@ def cron_add(
     elif cron_expr:
         schedule = CronSchedule(kind="cron", expr=cron_expr)
     elif at:
-        import datetime
-
-        dt = datetime.datetime.fromisoformat(at)
+        try:
+            dt = parse_iso_datetime(at)
+        except ValueError as e:
+            console.print(f"[red]Error: invalid --at datetime: {e}[/red]")
+            raise typer.Exit(1) from e
         schedule = CronSchedule(kind="at", at_ms=int(dt.timestamp() * 1000))
     else:
         console.print("[red]Error: Must specify --every, --cron, or --at[/red]")


### PR DESCRIPTION
## Description

Use OpenViking's existing tolerant ISO datetime parser for vikingbot one-shot cron jobs. Invalid values are now translated into the existing CLI/tool error formats instead of escaping as raw `ValueError`s.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4063

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Reuse `parse_iso_datetime()` in the CLI and agent cron tool.
- Return user-facing errors for invalid one-shot datetime values.
- Cover `Z`-suffixed and invalid datetimes in both caller paths.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands and results:

- New regression tests: `4 passed`.
- Adjacent cron/channel delivery tests: `16 passed`.
- Ruff on all changed files: `All checks passed`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No documentation change is needed because this restores the documented ISO datetime input behavior without changing the public interface. Existing dependency deprecation warnings remain unchanged.
