### PR TITLE
feat(bot): add Serply web search backend

### DIFF
--- a/bot/vikingbot/agent/tools/websearch/__init__.py
+++ b/bot/vikingbot/agent/tools/websearch/__init__.py
@@ -1,5 +1,5 @@
 """
-Web search tool with multiple backends (brave, ddgs, exa, tavily).
+Web search tool with multiple backends (brave, ddgs, exa, serply, tavily).
 
 To add a new backend:
     1. Create new file: websearch/mybackend.py
@@ -18,7 +18,7 @@ from .base import WebSearchBackend
 from .registry import registry
 
 # Import backends to register them
-from . import brave, ddgs, exa, tavily
+from . import brave, ddgs, exa, serply, tavily
 
 
 class WebSearchTool(Tool):
@@ -73,7 +73,7 @@ class WebSearchTool(Tool):
         Initialize WebSearchTool.
 
         Args:
-            backend: Backend name ("auto", "brave", "ddgs", "exa", "tavily") or WebSearchBackend instance
+            backend: Backend name ("auto", "brave", "ddgs", "exa", "serply", "tavily") or WebSearchBackend instance
             brave_api_key: Brave Search API key
             exa_api_key: Exa AI API key
             tavily_api_key: Tavily Search API key

--- a/bot/vikingbot/agent/tools/websearch/registry.py
+++ b/bot/vikingbot/agent/tools/websearch/registry.py
@@ -78,9 +78,9 @@ class WebSearchBackendRegistry:
         """
         Auto-select the best available backend.
 
-        Priority: tavily → exa → brave → ddgs
+        Priority: tavily → exa → brave → serply → ddgs
         """
-        priority = ["tavily", "exa", "brave", "ddgs"]
+        priority = ["tavily", "exa", "brave", "serply", "ddgs"]
 
         for name in priority:
             backend = self.create(name, brave_api_key, exa_api_key, tavily_api_key)

--- a/bot/vikingbot/agent/tools/websearch/serply.py
+++ b/bot/vikingbot/agent/tools/websearch/serply.py
@@ -1,0 +1,52 @@
+"""Serply Search backend."""
+
+import os
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from .base import WebSearchBackend
+from .registry import register_backend
+
+
+@register_backend
+class SerplyBackend(WebSearchBackend):
+    """Serply Search API backend."""
+
+    name = "serply"
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.environ.get("SERPLY_API_KEY", "")
+
+    @property
+    def is_available(self) -> bool:
+        return bool(self.api_key)
+
+    async def search(self, query: str, count: int, **kwargs: Any) -> str:
+        if not self.api_key:
+            return "Error: SERPLY_API_KEY not configured"
+
+        try:
+            n = min(max(count, 1), 20)
+            # Serply embeds the encoded query string in the URL path
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    f"https://api.serply.io/v1/search/{urlencode({'q': query, 'num': n})}",
+                    headers={"Accept": "application/json", "X-Api-Key": self.api_key},
+                    timeout=10.0,
+                )
+                r.raise_for_status()
+
+            results = r.json().get("results", [])
+            if not results:
+                return f"No results for: {query}"
+
+            lines = [f"Results for: {query}\n"]
+            for i, item in enumerate(results[:n], 1):
+                lines.append(f"{i}. {item.get('title', '')}\n   {item.get('link', '')}")
+                if desc := item.get("description"):
+                    lines.append(f"   {desc}")
+            return "\n".join(lines)
+        except Exception as e:
+            return f"Error: {e}"


### PR DESCRIPTION
## What

Adds a Serply (https://serply.io) backend to the web search tool, following the
existing backend pattern (new file + `@register_backend` + import), as described
in `websearch/__init__.py`.

- `websearch/serply.py`: backend modeled on `brave.py` (httpx GET, key header,
  same formatted output shape). Reads `SERPLY_API_KEY` from the environment,
  matching the `exa` precedent of env-only configuration, so no config schema or
  call-site changes are needed.
- `registry.py`: added `serply` to the auto-select priority after the existing
  keyed providers and before the keyless `ddgs` fallback, so current setups are
  unaffected unless only `SERPLY_API_KEY` is set.
- `websearch/__init__.py`: backend import plus docstring mentions.

The backend is strictly optional: without `SERPLY_API_KEY` it reports
unavailable and auto-select skips it, identical to the other keyed backends.

## Why

Serply is a Google SERP API with a simple key-based setup and EU/US/GB proxy
locations. Users who already have a Serply key get real Google results through
the same `web_search` tool without changing any code, and it gives `select_auto`
one more keyed option before falling back to DuckDuckGo scraping.

API reference: https://serply.io/docs (keys at https://serply.io).

## Testing

Live-tested against api.serply.io with a real key:

```
registered: ['brave', 'ddgs', 'exa', 'serply', 'tavily']
is_available with env key: True
is_available without key: False
no-key search: Error: SERPLY_API_KEY not configured
select_auto picked: serply   (only SERPLY_API_KEY set)
explicit WebSearchTool(backend='serply') resolves: serply

Results for: open source ai agent framework
1. The 4 Best Open Source Multi-Agent AI Frameworks 2026 - Towards AI
   https://pub.towardsai.net/the-4-best-open-source-multi-agent-ai-frameworks-2026-9da389f9407a
   ...
2. Welcome to Microsoft Agent Framework! - GitHub
   https://github.com/microsoft/agent-framework
   ...

bad key -> Error: Client error '401 Unauthorized' for url '...'
```

`ruff check` and `ruff format --check` pass on the new file with the repo
config; the two touched files only gained a name in an existing list.

## Disclosure

I work with Serply. This backend is optional, off by default, and follows the
repo's stated extension pattern; happy to adjust anything to fit your
conventions.
