### PR TITLE
feat(plugins): add OpenViking memory integration for Antigravity CLI (agy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Integrations inject OpenViking recall into your agent's context and auto-commit 
 - [TRAE / TRAE CN / TRAE CLI](https://docs.openviking.ai/en/agent-integrations/13-trae)
 - [OpenCode](https://docs.openviking.ai/en/agent-integrations/10-opencode)
 - [pi](https://docs.openviking.ai/en/agent-integrations/11-pi)
+- [Antigravity CLI (agy)](https://docs.openviking.ai/en/agent-integrations/16-agy)
 - [Agent Plugins 1.0](https://docs.openviking.ai/en/agent-integrations/15-agent-plugins)
 - [MCP clients](https://docs.openviking.ai/en/agent-integrations/06-mcp-clients)
 - [LangChain / LangGraph](https://docs.openviking.ai/en/agent-integrations/07-langchain-langgraph)

--- a/docs/en/agent-integrations/01-overview.md
+++ b/docs/en/agent-integrations/01-overview.md
@@ -11,6 +11,7 @@ OpenViking can act as the long-term memory and context backend for many agent ru
 | **Codex** | [Codex Memory Plugin](./04-codex.md) — lifecycle hooks for auto-recall and incremental capture |
 | **Cursor** | [Cursor Memory Integration](./12-cursor.md) — one command installs lifecycle hooks, MCP tools, rules, and skills |
 | **TRAE / TRAE CN / TRAE CLI** | [TRAE Memory Integration](./13-trae.md) — one installer configures prompt-time recall, turn capture, and OpenViking tools |
+| **Antigravity CLI (agy)** | [Antigravity CLI Memory Integration](./16-agy.md) — lifecycle hooks for prompt-time recall and transcript capture |
 | **Hermes Agent** | [Hermes Agent](./05-hermes.md) — built-in OpenViking memory provider, no plugin install needed |
 | **OpenCode** | [OpenCode Plugin](./10-opencode.md) — MCP tools plus lifecycle hooks for repo context, auto-recall, and capture |
 | **pi** | [pi Coding Agent Extension](./11-pi.md) — native extension with auto-recall, turn capture, and threshold commit |

--- a/docs/en/agent-integrations/16-agy.md
+++ b/docs/en/agent-integrations/16-agy.md
@@ -1,0 +1,91 @@
+# Antigravity CLI (agy) Memory Integration
+
+Give the Antigravity CLI (`agy`) long-term memory across projects and sessions. OpenViking lifecycle hooks load relevant context before each model call and capture the session transcript on `Stop`, committing it for memory extraction. The built-in `/mcp` endpoint remains available for explicit memory search, reading, and management.
+
+## Prerequisites
+
+- Linux or macOS with the Antigravity CLI (`agy`).
+- Node.js 18+ (the hooks are plain Node scripts run via `sh -c`).
+- A running OpenViking server; remote use requires an API key (see [Authentication](../guides/04-authentication.md)).
+
+## Install
+
+Installer support is not wired yet, so register the hooks manually:
+
+```bash
+# 1. copy the adapter into a stable location
+mkdir -p "$HOME/.openviking/agent-integrations/agy"
+rsync -a --delete ./examples/agy-memory-hooks/ "$HOME/.openviking/agent-integrations/agy/"
+```
+
+Then edit `~/.gemini/config/hooks.json`: it must be valid JSON with a single
+`openviking` key, and the two commands must point at absolute paths:
+
+```json
+{
+  "openviking": {
+    "PreInvocation": [
+      { "type": "command", "command": "node $HOME/.openviking/agent-integrations/agy/scripts/auto-recall.mjs", "timeout": 20 }
+    ],
+    "Stop": [
+      { "type": "command", "command": "node $HOME/.openviking/agent-integrations/agy/scripts/auto-capture.mjs", "timeout": 30 }
+    ]
+  }
+}
+```
+
+`~` is expanded and commands run with the hooks.json directory as the working
+directory; `node` must be on `PATH`. Quit and restart the CLI afterwards.
+
+### Bypassing sensitive projects
+
+Add an `agy` section to `~/.openviking/ov.conf`; sessions whose conversation id
+or workspace path matches a pattern are fully inert (no recall, no capture):
+
+```json
+{
+  "agy": {
+    "bypassSessionPatterns": ["**sensitive-project**"]
+  }
+}
+```
+
+`OPENVIKING_BYPASS_SESSION_PATTERNS` (comma-separated) overrides the array. The
+same section also accepts `enabled`, `autoRecall`, `autoCapture`,
+`workspacePeer`, `scoreThreshold` and `recallLimit`.
+
+## What gets installed
+
+- `PreInvocation` replays pending writes, loads the actor profile once per
+  session, then recalls relevant memory for the current user turn and injects it
+  via `injectSteps[].ephemeralMessage`.
+- `Stop` parses the session transcript
+  (`~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl`),
+  captures new user/assistant turns and immediately commits the session,
+  including short sessions.
+- Only conversational records become turns. agy emits tool results under the
+  model's own source (`MODEL/VIEW_FILE`, `MODEL/RUN_COMMAND`, …) and IDE edit
+  notices under the user's (`USER_EXPLICIT/CODE_ACTION`), so the adapter selects
+  on the record type as well: `USER_INPUT` for user turns and `PLANNER_RESPONSE`
+  for assistant turns. Raw command output and file dumps never reach memory.
+- Prompts are stored as written: agy wraps them in `<USER_REQUEST>` and appends
+  an `<ADDITIONAL_METADATA>` block with the local time, and both are stripped.
+- Turns are ordered by `step_index`, not by their position in the file: agy
+  flushes the transcript asynchronously, so records can land out of order around
+  `Stop`.
+- Deduplication is by content hash (not a step cursor), so a re-scan is
+  idempotent and no turn is silently dropped.
+
+## Verify
+
+1. Restart `agy` and start a new session in a project directory.
+2. Ask about an existing project or preference and confirm the response uses stored memory.
+3. Tell the Agent a temporary preference, wait for the response to finish, then start a new session and ask for it again — the value should come back from memory.
+
+For Hook diagnostics, run with `OPENVIKING_DEBUG=1` and inspect `~/.openviking/logs/agy-hooks.log`.
+
+## See also
+
+- [TRAE, TRAE CN and TRAE CLI Memory Integration](./13-trae.md)
+- [Authentication](../guides/04-authentication.md)
+- [Agent Integrations Overview](./01-overview.md)

--- a/docs/zh/agent-integrations/01-overview.md
+++ b/docs/zh/agent-integrations/01-overview.md
@@ -11,6 +11,7 @@ OpenViking 可以作为多种 Agent 运行时的长期记忆与上下文后端�
 | **Codex** | [Codex 记忆插件](./04-codex.md) — 生命周期 hooks 自动召回与增量捕获 |
 | **Cursor** | [Cursor 记忆集成](./12-cursor.md) — 一条命令安装生命周期 Hook、MCP 工具、Rules 与 Skills |
 | **TRAE / TRAE CN / TRAE CLI** | [TRAE 记忆集成](./13-trae.md) — 一个安装器完成 prompt 召回、回合捕获与 OpenViking 工具接入 |
+| **Antigravity CLI（agy）** | [Antigravity CLI 记忆集成](./16-agy.md) — 生命周期 hooks 实现 prompt 召回与 transcript 捕获 |
 | **Hermes Agent** | [Hermes Agent](./05-hermes.md) — 内置 OpenViking 记忆提供方，无需安装插件 |
 | **OpenCode** | [OpenCode 插件](./10-opencode.md) — MCP 工具 + 生命周期 hooks，覆盖仓库上下文、自动召回与捕获 |
 | **pi** | [pi Coding Agent 扩展](./11-pi.md) — 原生扩展，自动召回、逐轮捕获与阈值 commit |

--- a/docs/zh/agent-integrations/16-agy.md
+++ b/docs/zh/agent-integrations/16-agy.md
@@ -1,0 +1,86 @@
+# Antigravity CLI（agy）记忆集成
+
+为 Antigravity CLI（`agy`）添加跨项目、跨会话的长期记忆。OpenViking 生命周期 Hook 会在每次模型调用前加载相关上下文，并在 `Stop` 时捕获会话 transcript 并提交给记忆抽取器。内置的 `/mcp` 端点仍可用于主动搜索、读取和管理记忆。
+
+## 前置条件
+
+- Linux 或 macOS，并已安装 Antigravity CLI（`agy`）。
+- Node.js 18+（Hook 是通过 `sh -c` 执行的普通 Node 脚本）。
+- 一个正在运行的 OpenViking 服务；远程使用需要 API Key（参见[鉴权](../guides/04-authentication.md)）。
+
+## 安装
+
+安装器尚未接入该 harness，请手动注册 Hook：
+
+```bash
+# 1. 把适配器复制到一个固定位置
+mkdir -p "$HOME/.openviking/agent-integrations/agy"
+rsync -a --delete ./examples/agy-memory-hooks/ "$HOME/.openviking/agent-integrations/agy/"
+```
+
+然后编辑 `~/.gemini/config/hooks.json`：它必须是合法 JSON，只有一个 `openviking`
+键，并且两条命令都指向绝对路径：
+
+```json
+{
+  "openviking": {
+    "PreInvocation": [
+      { "type": "command", "command": "node $HOME/.openviking/agent-integrations/agy/scripts/auto-recall.mjs", "timeout": 20 }
+    ],
+    "Stop": [
+      { "type": "command", "command": "node $HOME/.openviking/agent-integrations/agy/scripts/auto-capture.mjs", "timeout": 30 }
+    ]
+  }
+}
+```
+
+`~` 会被展开，命令以 hooks.json 所在目录作为工作目录执行；`node` 必须在 `PATH`
+中。修改后请完全退出并重启 CLI。
+
+### 排除敏感项目
+
+在 `~/.openviking/ov.conf` 中添加 `agy` 段；会话 id 或工作区路径匹配到模式的会话
+将完全不生效（不召回、不捕获）：
+
+```json
+{
+  "agy": {
+    "bypassSessionPatterns": ["**sensitive-project**"]
+  }
+}
+```
+
+`OPENVIKING_BYPASS_SESSION_PATTERNS`（逗号分隔）会覆盖该数组。该段同样接受
+`enabled`、`autoRecall`、`autoCapture`、`workspacePeer`、`scoreThreshold` 和
+`recallLimit`。
+
+## 安装内容
+
+- `PreInvocation`：重放待写入队列，每个会话加载一次用户画像，然后针对当前用户输入
+  召回相关记忆，并通过 `injectSteps[].ephemeralMessage` 注入。
+- `Stop`：解析会话 transcript
+  （`~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl`），
+  捕获新增的用户/助手轮次并立即提交，使短会话也能进入记忆抽取流程。
+- 只有对话类记录会成为轮次。agy 把工具结果也标记为模型来源
+  （`MODEL/VIEW_FILE`、`MODEL/RUN_COMMAND` 等），把 IDE 改动通知标记为用户来源
+  （`USER_EXPLICIT/CODE_ACTION`），因此适配器同时按记录类型筛选：用户轮次取
+  `USER_INPUT`，助手轮次取 `PLANNER_RESPONSE`。原始命令输出和文件内容不会进入记忆。
+- 用户输入按原文保存：agy 会用 `<USER_REQUEST>` 包裹提问，并追加带本地时间的
+  `<ADDITIONAL_METADATA>` 块，两者都会被剥离。
+- 轮次按 `step_index` 排序，而不是按文件中的先后顺序：agy 异步刷写 transcript，
+  记录在 `Stop` 前后可能乱序落盘。
+- 去重基于内容哈希（而非步骤游标），因此重复扫描是幂等的，也不会静默丢弃轮次。
+
+## 验证
+
+1. 重启 `agy`，在一个项目目录下新建会话。
+2. 提问一个与已有项目或个人偏好相关的问题，确认回答使用了已有记忆。
+3. 告诉 Agent 一个临时偏好，等待回复完成；新建会话后再次询问，确认该值能从记忆中召回。
+
+需要排查 Hook 时，设置 `OPENVIKING_DEBUG=1` 后运行，并查看 `~/.openviking/logs/agy-hooks.log`。
+
+## 相关文档
+
+- [TRAE、TRAE CN 与 TRAE CLI 记忆集成](./13-trae.md)
+- [鉴权](../guides/04-authentication.md)
+- [Agent 集成总览](./01-overview.md)

--- a/examples/agy-memory-hooks/README.md
+++ b/examples/agy-memory-hooks/README.md
@@ -1,0 +1,93 @@
+# OpenViking Memory Hooks for Antigravity CLI (agy)
+
+Lifecycle hooks that give the Antigravity CLI (`agy`) automatic memory recall and
+session capture against OpenViking, mirroring the TRAE CLI adapter
+([`examples/trae-cli-memory-hooks`](../trae-cli-memory-hooks)).
+
+Contrast with the Claude Code plugin: agy capture does **not** read prompt fields
+from the hook payload. It parses the session transcript that agy writes to
+`transcriptPath` (CLI: `~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl`)
+and stores sessions with the `ag-` prefix.
+
+This adapter depends on the shared hook runtime in
+[`examples/memory-plugin-shared/lib`](../memory-plugin-shared/lib) (same commit as
+this adapter), which reads credentials from `~/.openviking/ovcli.conf` /
+`ov.conf` exactly like the other harness adapters.
+
+## Events
+
+| agy event       | Adapter event    | Script                       |
+| --------------- | ---------------- | ---------------------------- |
+| `PreInvocation` | `pre-invocation` | `auto-recall.mjs`            |
+| `Stop`          | `stop`           | `auto-capture.mjs`           |
+| `SessionStart`  | `session-start`  | `session-start.mjs` (opt-in) |
+
+- `PreInvocation` replays pending writes, loads the actor profile once per
+  session, then recalls for the latest user turn from the transcript and injects
+  it via `injectSteps[].ephemeralMessage`.
+- `Stop` parses the transcript, captures turns that were not captured yet and
+  commits them to the session.
+
+`SessionStart` is implemented but not registered in `hooks/hooks.json`: the event
+is not part of the documented agy hook API, and `PreInvocation` already covers
+the profile bootstrap. Register it only if your agy build emits it.
+
+## Tuning
+
+`~/.openviking/ov.conf` section `agy`:
+
+```json
+{
+  "agy": {
+    "bypassSessionPatterns": ["**sensitive-project**"]
+  }
+}
+```
+
+`bypassSessionPatterns` follows env-first precedence
+(`OPENVIKING_BYPASS_SESSION_PATTERNS` CSV overrides the `ov.conf` array);
+`enabled`, `autoRecall`, `autoCapture`, `workspacePeer`, `scoreThreshold` and
+`recallLimit` can also be set in this section.
+
+## Transcript parsing
+
+`source` tells you who produced a record, `type` tells you what the record is.
+Tool results carry the model's own source (`MODEL/VIEW_FILE`,
+`MODEL/RUN_COMMAND`, …) and IDE edit notices carry the user's
+(`USER_EXPLICIT/CODE_ACTION`), so selecting on `source` alone would push raw
+command output and file dumps into memory. Turns are therefore taken from
+`USER_INPUT` and `PLANNER_RESPONSE` records only; a record with no `type` is
+allowed through so other agy builds keep working.
+
+agy also appends an `<ADDITIONAL_METADATA>` block carrying the local time to
+user prompts, and wraps them in `<USER_REQUEST>`; both are stripped so stored
+turns hold the prompt itself.
+
+Ordering follows `step_index`, not file order — agy flushes the transcript
+asynchronously and records can land out of order around `Stop`.
+
+Deduplication is by hash of `stepKey + role + content` in the hook state rather
+than a monotonic step cursor, so re-scans are idempotent and no turn is silently
+dropped.
+
+## Install (manual, until install.sh supports `agy`)
+
+```bash
+# 1. copy the adapter into a stable location (use the AGY_ROOT value below)
+mkdir -p "$HOME/.openviking/agent-integrations/agy"
+rsync -a --delete examples/agy-memory-hooks/ "$HOME/.openviking/agent-integrations/agy/"
+
+# 2. register the global hook: merge hooks/hooks.json into ~/.gemini/config/hooks.json
+#    replacing __OPENVIKING_AGY_ROOT__ with the absolute path above
+#    (commands run via sh -c; ~ is expanded; node must be on PATH)
+
+# 3. OPTIONAL bypass patterns for sensitive projects: add the "agy" section to ov.conf
+```
+
+## Tests
+
+```bash
+node examples/agy-memory-hooks/scripts/agy-hooks.test.mjs
+```
+
+See the [Antigravity CLI integration guide](../../docs/en/agent-integrations/16-agy.md).

--- a/examples/agy-memory-hooks/hooks/hooks.json
+++ b/examples/agy-memory-hooks/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "openviking": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "node __OPENVIKING_AGY_ROOT__/scripts/auto-recall.mjs",
+        "timeout": 20
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "node __OPENVIKING_AGY_ROOT__/scripts/auto-capture.mjs",
+        "timeout": 30
+      }
+    ]
+  }
+}

--- a/examples/agy-memory-hooks/openviking.integration.json
+++ b/examples/agy-memory-hooks/openviking.integration.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "openviking-memory",
+  "version": "0.1.0",
+  "clients": ["agy"],
+  "capabilities": ["hooks"]
+}

--- a/examples/agy-memory-hooks/scripts/agy-hook.mjs
+++ b/examples/agy-memory-hooks/scripts/agy-hook.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import {
+  addAgentMessages,
+  buildAgentProfile,
+  commitAgentSession,
+  createAgentLogger,
+  deriveAgentSessionId,
+  loadAgentHookConfig,
+  makeAgentFetchJSON,
+  readHookInput,
+  readHookState,
+  recallForPrompt,
+  replayAgentPending,
+  resolveAgentCwd,
+  resolveNativeSessionId,
+  shouldBypassAgent,
+  stableHash,
+  withAgentHookLock,
+  writeHookState,
+} from "../../memory-plugin-shared/lib/agent-hook-runtime.mjs";
+import { buildAgyTurns, latestAgyPrompt } from "./agy-turns.mjs";
+
+const eventName = process.env.OPENVIKING_HOOK_EVENT || process.argv[2] || "";
+const clientId = "agy";
+const prefix = "ag-";
+
+function applyAgyTuning(cfg) {
+  const tuning = cfg.ovFile && typeof cfg.ovFile.agy === "object" ? cfg.ovFile.agy : {};
+  const envPatterns = String(process.env.OPENVIKING_BYPASS_SESSION_PATTERNS || "").trim();
+  cfg.bypassSessionPatterns = envPatterns
+    ? envPatterns.split(",").map((item) => item.trim()).filter(Boolean)
+    : (Array.isArray(tuning.bypassSessionPatterns)
+        ? tuning.bypassSessionPatterns.filter((pattern) => typeof pattern === "string" && pattern.trim())
+        : (cfg.bypassSessionPatterns || []));
+  if (tuning.enabled === false) cfg.enabled = false;
+  if (tuning.autoRecall === false) cfg.autoRecall = false;
+  if (tuning.autoCapture === false) cfg.autoCapture = false;
+  if (tuning.workspacePeer === false) cfg.workspacePeer = false;
+  if (Number.isFinite(Number(tuning.scoreThreshold))) cfg.scoreThreshold = Number(tuning.scoreThreshold);
+  if (Number.isFinite(Number(tuning.recallLimit))) cfg.recallLimit = Number(tuning.recallLimit);
+  return cfg;
+}
+
+const cfg = applyAgyTuning(loadAgentHookConfig(clientId));
+const { log, logError } = createAgentLogger(clientId, eventName, cfg);
+
+function output(value = {}) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+const input = await readHookInput();
+const nativeSessionId = resolveNativeSessionId(input);
+const sessionId = deriveAgentSessionId(prefix, input);
+const cwd = resolveAgentCwd(input);
+const { fetchJSON } = makeAgentFetchJSON(cfg, cwd);
+
+function injectBlocks(blocks) {
+  const messages = (blocks || []).map((block) => block?.trim()).filter(Boolean);
+  if (messages.length) return { injectSteps: messages.map((message) => ({ ephemeralMessage: message })) };
+  return {};
+}
+
+async function main() {
+  if (!cfg.enabled || shouldBypassAgent(cfg, input)) { output({}); return; }
+  let state = await readHookState(clientId, nativeSessionId);
+
+  if (eventName === "session-start") {
+    const profile = await withAgentHookLock(clientId, nativeSessionId, async () => {
+      state = await readHookState(clientId, nativeSessionId);
+      const now = Date.now();
+      if (now - Number(state.lastSessionStartAt || 0) < 2000) return null;
+      state = { ...state, lastSessionStartAt: now };
+      await writeHookState(clientId, nativeSessionId, state);
+      await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+      return buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
+        logError("profile", error);
+        return null;
+      });
+    });
+    output(injectBlocks(profile ? [`<openviking-context source="session-start">\n${profile}\n</openviking-context>`] : []));
+    return;
+  }
+
+  if (eventName === "pre-invocation") {
+    await withAgentHookLock(clientId, nativeSessionId, async () => {
+      state = await readHookState(clientId, nativeSessionId);
+      const blocks = [];
+      if (!state.bootstrapDone) {
+        await replayAgentPending(fetchJSON, log).catch((error) => logError("pending", error));
+        const profile = await buildAgentProfile(fetchJSON, cfg, cwd).catch((error) => {
+          logError("profile", error);
+          return null;
+        });
+        if (profile) blocks.push(`<openviking-context source="session-start">\n${profile}\n</openviking-context>`);
+      }
+      const prompt = latestAgyPrompt(input, state);
+      if (prompt) {
+        const promptHash = stableHash(prompt);
+        const now = Date.now();
+        const duplicate = state.promptHash === promptHash && now - Number(state.promptAt || 0) < 500;
+        const recallBlock = duplicate
+          ? state.recallBlock
+          : await recallForPrompt(fetchJSON, cfg, prompt, cwd, log, { sessionId }).catch((error) => {
+            logError("recall", error);
+            return null;
+          });
+        if (!duplicate && recallBlock) blocks.push(recallBlock);
+        await writeHookState(clientId, nativeSessionId, {
+          ...state,
+          bootstrapDone: true,
+          promptHash,
+          promptAt: now,
+          recallBlock,
+          pendingPrompt: { prompt, hash: promptHash, at: now },
+        });
+      } else {
+        await writeHookState(clientId, nativeSessionId, { ...state, bootstrapDone: true });
+      }
+      output(injectBlocks(blocks));
+    });
+    return;
+  }
+
+  if (eventName === "stop") {
+    if (!cfg.autoCapture) { output({}); return; }
+    await withAgentHookLock(clientId, nativeSessionId, async () => {
+      state = await readHookState(clientId, nativeSessionId);
+      const hashes = new Set(Array.isArray(state.capturedHashes) ? state.capturedHashes : []);
+      const toSend = [];
+      for (const { stepKey, role, content } of buildAgyTurns(input, state)) {
+        const hash = stableHash(stepKey, role, content);
+        if (hashes.has(hash)) continue;
+        toSend.push({ hash, turn: { role, content } });
+      }
+      const result = await addAgentMessages(fetchJSON, sessionId, toSend.map((item) => item.turn));
+      const captured = result.sent + result.queued;
+      for (const item of toSend.slice(0, captured)) hashes.add(item.hash);
+      let nextCount = Number(state.capturedSinceCommit || 0) + captured;
+      if (captured > 0) {
+        const committed = await commitAgentSession(fetchJSON, sessionId, log);
+        if (committed.ok) nextCount = 0;
+      }
+      await writeHookState(clientId, nativeSessionId, {
+        ...state,
+        capturedHashes: [...hashes].slice(-1000),
+        capturedSinceCommit: nextCount,
+        pendingPrompt: null,
+        recallBlock: null,
+        promptHash: null,
+        promptAt: null,
+      });
+    });
+    output({});
+    return;
+  }
+
+  output({});
+}
+
+main().catch((error) => {
+  logError("uncaught", error);
+  output({});
+});

--- a/examples/agy-memory-hooks/scripts/agy-hooks.test.mjs
+++ b/examples/agy-memory-hooks/scripts/agy-hooks.test.mjs
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { buildAgyTurns, cleanAgyText, latestAgyPrompt } from "./agy-turns.mjs";
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(pluginRoot, "..", "..");
+
+test("AGY integration contains hook, scripts and shared runtime", () => {
+  for (const file of [
+    "hooks/hooks.json",
+    "openviking.integration.json",
+    "scripts/agy-hook.mjs",
+    "scripts/agy-turns.mjs",
+    "scripts/session-start.mjs",
+    "scripts/auto-recall.mjs",
+    "scripts/auto-capture.mjs",
+  ]) {
+    assert.ok(existsSync(join(pluginRoot, file)), `${file} must exist`);
+  }
+  for (const shared of [
+    "examples/memory-plugin-shared/lib/agent-hook-runtime.mjs",
+    "examples/memory-plugin-shared/lib/credentials.mjs",
+    "examples/memory-plugin-shared/lib/session-model.mjs",
+  ]) {
+    assert.ok(existsSync(join(repoRoot, shared)), `${shared} must exist in the shared library`);
+  }
+  const hooks = JSON.parse(readFileSync(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
+  assert.deepEqual(Array.isArray(hooks.openviking) ? hooks.openviking : Object.keys(hooks.openviking), [
+    "PreInvocation",
+    "Stop",
+  ]);
+  const integration = JSON.parse(readFileSync(join(pluginRoot, "openviking.integration.json"), "utf8"));
+  assert.deepEqual(integration.clients, ["agy"]);
+  assert.ok(integration.capabilities.includes("hooks"));
+});
+
+// Shape taken from a real agy 1.1.13 transcript: the model's tool results share
+// the `MODEL` source with its prose, IDE edit notices share `USER_EXPLICIT`
+// with the user's prompt, and the injected context comes back as `SYSTEM_SDK`.
+const transcriptLines = [
+  { step_index: 0, source: "USER_EXPLICIT", type: "USER_INPUT", status: "DONE", content: "<USER_REQUEST>\nremember this\n</USER_REQUEST>" },
+  { step_index: 1, source: "SYSTEM_SDK", type: "EPHEMERAL_MESSAGE", status: "DONE", content: "<openviking-context>injected</openviking-context>" },
+  { step_index: 3, source: "MODEL", type: "VIEW_FILE", status: "DONE", content: "File Path: `file:///repo/notes.md`\nTotal Lines: 2" },
+  { step_index: 2, source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", tool_calls: [{ name: "view_file" }] },
+  { step_index: 4, source: "USER_EXPLICIT", type: "CODE_ACTION", status: "DONE", content: "The following changes were made by the USER to: /repo/notes.md" },
+  { step_index: 5, source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", content: "done" },
+];
+
+function writeTranscript(root, lines = transcriptLines) {
+  const logs = join(root, ".system_generated", "logs");
+  mkdirSync(logs, { recursive: true });
+  const path = join(logs, "transcript.jsonl");
+  writeFileSync(path, lines.map((line) => JSON.stringify(line)).join("\n"), "utf8");
+  return path;
+}
+
+test("AGY transcript parsing keeps conversation turns and drops tool output", () => {
+  assert.equal(cleanAgyText("x<openviking-context>secret</openviking-context>y"), "xy");
+  assert.equal(cleanAgyText("<USER_REQUEST>\nhello\n</USER_REQUEST>"), "hello");
+  assert.equal(
+    cleanAgyText("ship it\n\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-01-01T00:00:00Z.\n</ADDITIONAL_METADATA>"),
+    "ship it",
+  );
+  const root = mkdtempSync(join(tmpdir(), "openviking-agy-turns-"));
+  try {
+    const path = writeTranscript(root);
+    const all = buildAgyTurns({ transcriptPath: path }, {});
+    assert.deepEqual(
+      all.map((turn) => [turn.role, turn.content]),
+      [
+        ["user", "remember this"],
+        ["assistant", "done"],
+      ],
+      "tool results, IDE edit notices and injected context must never become turns",
+    );
+    const again = buildAgyTurns({ transcriptPath: path }, { lastStepKey: 5 });
+    assert.deepEqual(
+      again.map((turn) => [turn.role, turn.content]),
+      [
+        ["user", "remember this"],
+        ["assistant", "done"],
+      ],
+      "a scan past the cursor must still surface un-hashed turns (transcripts can be written out of order)",
+    );
+    assert.equal(latestAgyPrompt({ transcriptPath: path }, {}), "remember this");
+    assert.equal(latestAgyPrompt({}, { pendingPrompt: { prompt: "fallback" } }), "fallback");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("AGY turns are ordered by step_index numerically", () => {
+  const root = mkdtempSync(join(tmpdir(), "openviking-agy-order-"));
+  try {
+    // Written out of order and crossing the 10 boundary, where a lexicographic
+    // sort of the `s:<n>` keys would place `s:10` before `s:2`.
+    const lines = [];
+    for (const step of [2, 1, 0, 11, 10, 9, 3, 4, 5, 6, 7, 8]) {
+      lines.push({
+        step_index: step,
+        source: step % 2 === 0 ? "USER_EXPLICIT" : "MODEL",
+        type: step % 2 === 0 ? "USER_INPUT" : "PLANNER_RESPONSE",
+        content: `msg-${step}`,
+      });
+    }
+    const path = writeTranscript(root, lines);
+    assert.deepEqual(
+      buildAgyTurns({ transcriptPath: path }, {}).map((turn) => turn.content),
+      Array.from({ length: 12 }, (_, step) => `msg-${step}`),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runHook(entrypoint, input, env) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [join(pluginRoot, "scripts", entrypoint)], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) reject(new Error(stderr || `hook exited ${code}`));
+      else resolveRun(JSON.parse(stdout.trim() || "{}"));
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+test("AGY PreInvocation injects recall and Stop captures transcript turns", async () => {
+  const messages = [];
+  const commits = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      if (request.url?.includes("/search")) {
+        response.end(JSON.stringify({ result: { rendered: "agy memory", entries: [], stats: {} } }));
+      } else if (request.url?.includes("/messages")) {
+        const parsed = JSON.parse(body);
+        messages.push(...(parsed.messages ?? [parsed]).map((message) => ({ url: request.url, message })));
+        response.end(JSON.stringify({ result: { ok: true } }));
+      } else if (request.url?.endsWith("/commit")) {
+        commits.push(request.url);
+        response.end(JSON.stringify({ result: { ok: true } }));
+      } else {
+        response.end(JSON.stringify({ result: { ok: true } }));
+      }
+    });
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const root = mkdtempSync(join(tmpdir(), "openviking-agy-hook-"));
+  const env = {
+    HOME: root,
+    OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
+    OPENVIKING_HOOK_STATE_DIR: join(root, "state"),
+    OPENVIKING_MEMORY_ENABLED: "1",
+  };
+  try {
+    const transcriptPath = writeTranscript(root);
+    const base = { conversationId: "conv-test-1", workspacePaths: ["/workspace"], transcriptPath };
+
+    const recalled = await Promise.all([
+      runHook("auto-recall.mjs", { ...base, invocationNum: 1 }, env),
+      runHook("auto-recall.mjs", { ...base, invocationNum: 2 }, env),
+    ]);
+    assert.equal(
+      recalled.filter((item) => item.injectSteps?.some((step) => /agy memory/.test(step.ephemeralMessage || ""))).length,
+      1,
+    );
+
+    await Promise.all([
+      runHook("auto-capture.mjs", { ...base, executionNum: 1 }, env),
+      runHook("auto-capture.mjs", { ...base, executionNum: 2 }, env),
+    ]);
+    const sent = messages.filter((item) => item.url.includes("ag-conv-test-1"));
+    assert.equal(sent.length, 2, "user + assistant turns captured once");
+    assert.equal(commits.length, 1, "completed AGY session committed immediately");
+    assert.deepEqual(
+      sent.map((item) => item.message),
+      [
+        { role: "user", content: "remember this" },
+        { role: "assistant", content: "done" },
+      ],
+      "turns are sent in step order and carry no adapter-internal fields",
+    );
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("AGY hooks are inert for bypassed workspaces", async () => {
+  const root = mkdtempSync(join(tmpdir(), "openviking-agy-bypass-"));
+  const transcriptPath = writeTranscript(root);
+  const input = {
+    conversationId: "conv-private",
+    workspacePaths: ["/workspace/private-project/secrets"],
+    transcriptPath,
+    invocationNum: 1,
+  };
+  const baseEnv = {
+    HOME: root,
+    OPENVIKING_HOOK_STATE_DIR: join(root, "state"),
+    OPENVIKING_MEMORY_ENABLED: "1",
+  };
+  try {
+    assert.deepEqual(
+      await runHook("auto-recall.mjs", input, {
+        ...baseEnv,
+        OPENVIKING_BYPASS_SESSION_PATTERNS: "**private-project**",
+      }),
+      {},
+      "the environment variable bypasses the workspace",
+    );
+
+    // Same bypass, this time declared in the `agy` section of ov.conf.
+    const ovConfPath = join(root, "ov.conf");
+    writeFileSync(
+      ovConfPath,
+      JSON.stringify({ agy: { bypassSessionPatterns: ["**private-project**"] } }),
+      "utf8",
+    );
+    assert.deepEqual(
+      await runHook("auto-recall.mjs", input, { ...baseEnv, OPENVIKING_CONFIG_FILE: ovConfPath }),
+      {},
+      "the ov.conf agy section bypasses the workspace",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/examples/agy-memory-hooks/scripts/agy-turns.mjs
+++ b/examples/agy-memory-hooks/scripts/agy-turns.mjs
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const USER_SOURCES = new Set(["USER_INPUT", "USER_EXPLICIT", "USER", "HUMAN"]);
+const ASSISTANT_SOURCES = new Set(["MODEL", "AGENT", "ASSISTANT"]);
+
+// agy marks every transcript record with the actor that produced it (`source`)
+// and with what the record *is* (`type`). Tool results are emitted under the
+// model's own source (`MODEL/VIEW_FILE`, `MODEL/RUN_COMMAND`, …) and IDE edit
+// notices under the user's (`USER_EXPLICIT/CODE_ACTION`), so filtering by
+// source alone would capture raw command output and file dumps as turns. Only
+// the conversational record types are kept; a record with no `type` at all is
+// allowed through so other agy builds keep working.
+const USER_TYPES = new Set(["USER_INPUT"]);
+const ASSISTANT_TYPES = new Set(["PLANNER_RESPONSE"]);
+
+export function stableAgyHash(...values) {
+  return createHash("sha256")
+    .update(values.map((value) => String(value ?? "")).join("\n"))
+    .digest("hex");
+}
+
+export function cleanAgyText(value) {
+  return String(value || "")
+    .replace(/<openviking-context\b[^>]*>[\s\S]*?<\/openviking-context>/gi, "")
+    .replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/gi, "")
+    .replace(/<ADDITIONAL_METADATA>[\s\S]*?<\/ADDITIONAL_METADATA>/gi, "")
+    .replace(/<\/?USER_REQUEST>/g, "")
+    .trim();
+}
+
+function extractText(content) {
+  if (typeof content === "string") return cleanAgyText(content);
+  if (content == null) return "";
+  if (typeof content === "object") {
+    if (typeof content.text === "string") return cleanAgyText(content.text);
+    if (Array.isArray(content)) {
+      const parts = [];
+      for (const part of content) {
+        if (!part || typeof part !== "object") continue;
+        if (typeof part.text === "string" && part.text.trim()) parts.push(cleanAgyText(part.text));
+        if (typeof part.content === "string" && part.content.trim()) parts.push(cleanAgyText(part.content));
+      }
+      if (parts.length) return parts.join("\n");
+    }
+  }
+  return "";
+}
+
+export function readAgyTranscript(transcriptPath) {
+  if (!transcriptPath) return [];
+  let text = "";
+  try {
+    text = readFileSync(transcriptPath, "utf8");
+  } catch {
+    return [];
+  }
+  const records = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed);
+      if (record && typeof record === "object") records.push(record);
+    } catch {}
+  }
+  return records;
+}
+
+export function recordRole(record) {
+  const source = String(record.source || record.sender || "").toUpperCase();
+  const type = String(record.type || "").toUpperCase();
+  if (USER_SOURCES.has(source)) return !type || USER_TYPES.has(type) ? "user" : null;
+  if (ASSISTANT_SOURCES.has(source)) return !type || ASSISTANT_TYPES.has(type) ? "assistant" : null;
+  return null;
+}
+
+function recordStep(record) {
+  const step = Number(record.step_index ?? record.stepIndex ?? record.step_idx ?? record.seq ?? -1);
+  return Number.isFinite(step) && step >= 0 ? step : null;
+}
+
+export function latestAgyPrompt(input = {}, state = {}) {
+  const records = readAgyTranscript(input.transcriptPath || input.transcript_path);
+  for (let index = records.length - 1; index >= 0; index--) {
+    const record = records[index];
+    if (recordRole(record) !== "user") continue;
+    const content = extractText(record.content);
+    if (content) return content;
+  }
+  return cleanAgyText(state.pendingPrompt?.prompt);
+}
+
+export function buildAgyTurns(input = {}, state = {}) {
+  const records = readAgyTranscript(input.transcriptPath || input.transcript_path);
+  const turns = [];
+  for (const record of records) {
+    const step = recordStep(record);
+    if (step === null) continue;
+    const role = recordRole(record);
+    if (!role) continue;
+    const content = extractText(record.content);
+    if (!content) continue;
+    turns.push({ step, stepKey: `s:${step}`, role, content });
+  }
+  if (turns.length === 0) {
+    const pending = state.pendingPrompt;
+    if (pending?.prompt && cleanAgyText(pending.prompt)) {
+      return [{
+        stepKey: `p:${pending.hash || stableAgyHash(pending.prompt)}`,
+        role: "user",
+        content: cleanAgyText(pending.prompt),
+      }];
+    }
+    return [];
+  }
+  // agy flushes the transcript asynchronously, so records can land out of
+  // order around `Stop` (the user request step is sometimes persisted after the
+  // model step). `step_index` is the authoritative order and must be compared
+  // numerically: sorting the `s:<n>` keys as strings puts `s:10` before `s:2`.
+  turns.sort((a, b) => a.step - b.step);
+  return turns.map(({ stepKey, role, content }) => ({ stepKey, role, content }));
+}

--- a/examples/agy-memory-hooks/scripts/auto-capture.mjs
+++ b/examples/agy-memory-hooks/scripts/auto-capture.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "stop";
+await import("./agy-hook.mjs");

--- a/examples/agy-memory-hooks/scripts/auto-recall.mjs
+++ b/examples/agy-memory-hooks/scripts/auto-recall.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "pre-invocation";
+await import("./agy-hook.mjs");

--- a/examples/agy-memory-hooks/scripts/session-start.mjs
+++ b/examples/agy-memory-hooks/scripts/session-start.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+process.env.OPENVIKING_HOOK_EVENT = "session-start";
+await import("./agy-hook.mjs");

--- a/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
+++ b/examples/memory-plugin-shared/agent-hook-runtime.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
   commitAgentSession,
   makeAgentFetchJSON,
+  resolveAgentCwd,
+  resolveNativeSessionId,
 } from "./lib/agent-hook-runtime.mjs";
 
 function jsonResponse(status, value) {
@@ -77,4 +79,19 @@ test("agent fetch and commit logging preserve response trace_id", async (t) => {
       error: "commit failed",
     },
   });
+});
+
+test("hook payload aliases cover camelCase session id and workspace paths", () => {
+  assert.equal(resolveNativeSessionId({ conversationId: "conv-1" }), "conv-1");
+  assert.equal(
+    resolveNativeSessionId({ conversation_id: "snake", conversationId: "camel" }),
+    "snake",
+    "the snake_case field keeps precedence",
+  );
+  assert.equal(resolveAgentCwd({ workspacePaths: ["/repo"] }), "/repo");
+  assert.equal(
+    resolveAgentCwd({ workspaceRoots: ["/roots"], workspacePaths: ["/paths"] }),
+    "/roots",
+    "workspaceRoots keeps precedence over workspacePaths",
+  );
 });

--- a/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
+++ b/examples/memory-plugin-shared/lib/agent-hook-runtime.mjs
@@ -88,7 +88,9 @@ export async function readHookInput() {
 export function resolveAgentCwd(input = {}) {
   const workspaceRoots = Array.isArray(input.workspace_roots)
     ? input.workspace_roots
-    : Array.isArray(input.workspaceRoots) ? input.workspaceRoots : [];
+    : Array.isArray(input.workspaceRoots)
+      ? input.workspaceRoots
+      : Array.isArray(input.workspacePaths) ? input.workspacePaths : [];
   return String(
     input.cwd
       || workspaceRoots.find((value) => typeof value === "string" && value.trim())
@@ -98,7 +100,8 @@ export function resolveAgentCwd(input = {}) {
 }
 
 export function resolveNativeSessionId(input = {}) {
-  const direct = input.conversation_id || input.session_id || input.sessionId || input.generation_id;
+  const direct = input.conversation_id || input.conversationId
+    || input.session_id || input.sessionId || input.generation_id;
   if (direct) return safePart(direct);
   const transcript = input.transcript_path || input.transcriptPath;
   if (transcript) {


### PR DESCRIPTION
# Antigravity CLI (agy) memory integration for OpenViking

Adds automatic memory recall and session capture for the Antigravity CLI (`agy`)
via lifecycle hooks, mirroring the existing TRAE CLI adapter.

## What this PR adds

- **`examples/agy-memory-hooks/`** — a dedicated agy adapter:
  - `scripts/agy-hook.mjs` — single event dispatcher (session-start /
    pre-invocation / stop) built on the shared hook runtime.
  - `scripts/agy-turns.mjs` — parser for the agy session transcript
    (`~/.gemini/antigravity-cli/brain/<uuid>/.system_generated/logs/transcript.jsonl`).
  - `hooks/hooks.json` — agy hook registration: `PreInvocation` (profile +
    recall injected via `injectSteps[].ephemeralMessage`) and `Stop` (capture
    + commit). `SessionStart` is implemented but opt-in.
  - `openviking.integration.json` manifest for future installer support.
  - `scripts/agy-hooks.test.mjs` — 5 tests against a mock server (transcript
    filtering, step ordering, recall injection, incremental capture with dedup,
    commit-on-stop, bypass inertness via both env and `ov.conf`).
- **`examples/memory-plugin-shared/lib/agent-hook-runtime.mjs`** — two additive
  field reads so the shared runtime understands agy's camelCase hook payload:
  `resolveNativeSessionId` also accepts `conversationId` and `resolveAgentCwd`
  also accepts `workspacePaths`. Both are appended after the existing fields, so
  precedence for current harnesses is unchanged; covered by a new case in
  `examples/memory-plugin-shared/agent-hook-runtime.test.mjs`.
- **Docs** — `docs/en/agent-integrations/16-agy.md` and
  `docs/zh/agent-integrations/16-agy.md`, plus a row in both overview tables and
  in the root `README.md` integrations list.

## Design notes

- **Transcript-based capture, not payload fields**: the agy `Stop` payload does
  not carry the prompt/assistant text (unlike TRAE), so capture parses the
  transcript file the hook payload points to via `transcriptPath`.
- **Records are selected by `source` *and* `type`.** In agy, `source` says who
  produced a record and `type` says what it is. Tool results carry the model's
  own source (`MODEL/VIEW_FILE`, `MODEL/RUN_COMMAND`, `MODEL/LIST_DIRECTORY`, …)
  and IDE edit notices carry the user's (`USER_EXPLICIT/CODE_ACTION`), so
  selecting on `source` alone would push raw command output and whole-file dumps
  into long-term memory. Turns are taken from `USER_INPUT` and
  `PLANNER_RESPONSE` records only; a record with no `type` at all is allowed
  through so other agy builds keep working. Measured over 39 real transcripts,
  this drops ~1.8k tool-output records and keeps 1791 conversational turns.
- **Prompt text is unwrapped.** agy wraps user prompts in `<USER_REQUEST>` and
  appends an `<ADDITIONAL_METADATA>` block carrying the local time; both are
  stripped, so a repeated prompt stays byte-identical instead of drifting with
  the clock.
- **Ordering follows `step_index`, not file order.** agy flushes the transcript
  asynchronously, so records land out of order around `Stop` (the user request
  step is sometimes persisted after the model step). The comparison is numeric —
  ordering the `s:<n>` keys as strings would put step 10 before step 2.
- **Hash dedup instead of a monotonic step cursor**: deduplicating by
  `stepKey+role+content` hash means no turn is silently dropped when the
  transcript is re-scanned, and re-scans are idempotent.
- **Per-harness tuning**: an optional `agy` section in `ov.conf` provides
  `bypassSessionPatterns` (env `OPENVIKING_BYPASS_SESSION_PATTERNS` wins) plus
  `enabled`/`autoRecall`/`autoCapture`/`workspacePeer`/`scoreThreshold`/`recallLimit`,
  following the same pattern as the `claude_code`/`codex` sections and read from
  the same `ovFile` the shared credential loader already resolves.

## Not included: `install.sh` support

`examples/memory-plugin-shared/install.sh` is untouched, so installation is
manual (documented in both doc pages). This is deliberate rather than an
oversight: agy's hook file has its own schema — a single top-level `openviking`
key with `PreInvocation`/`Stop` arrays, no `matcher` wrapper — which does not fit
the installer's current hook-template rendering, and the status/teardown paths
are shaped around the existing harnesses. Wiring agy in the way `trae-cli` was
wired in #4026 is follow-up work; `openviking.integration.json` is already in
place for it. Happy to do that in this PR instead if you'd prefer it landed
together.

## Verification

- `node examples/agy-memory-hooks/scripts/agy-hooks.test.mjs` — 5/5 pass, and
  `node examples/memory-plugin-shared/agent-hook-runtime.test.mjs` — 2/2 pass,
  on a pristine checkout with this patch applied. (The `install-*`,
  `release-marketplace` and `sync` suites in `memory-plugin-shared` fail
  identically before and after this change on the machine used here — they are
  POSIX-shell driven and unrelated to this patch.)
- End-to-end against a real OpenViking server (agy CLI 1.1.13 on Linux):
  `PreInvocation` injected profile + recall into a live conversation, `Stop`
  created the `ag-<conversationId>` session with the user/assistant turns and the
  commit extracted the expected event memory; bypassed workspaces produced no
  hooks output, no state, and no session.
- The transcript parser was replayed offline over 39 real agy transcripts to
  confirm the type filter and the ordering fix on production-shaped data.
