### PR TITLE
Perf/reindex vector enqueue concurrency

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -213,16 +213,23 @@ This setting controls queue-job concurrency. It is separate from `vlm.media.max_
 | Field | Type | Default | Description |
 |---|---|---:|---|
 | `max_concurrent` | integer | `4` | Number of complete AddResource jobs consumed concurrently; must be greater than `0`; requires a server restart after changes |
-| `vector_enqueue_concurrency` | integer | `8` | Number of files concurrently read and enqueued within one directory AddResource job when `processing_mode="vectors_only"`; must be greater than `0`; requires a server restart after changes |
-| `max_vector_enqueue_concurrency` | integer | `64` | Hard cap applied to `vector_enqueue_concurrency`; must be greater than `0`; requires a server restart after changes |
+| `file_vectorization_concurrency` | integer | `8` | Number of files concurrently read, prepared, and enqueued within one directory AddResource job when `processing_mode="vectors_only"`; must be greater than `0`; values above the internal safety limit of `64` are capped; requires a server restart after changes |
 
-`max_concurrent` controls independent AddResource jobs, while `vector_enqueue_concurrency` controls files within one vectors-only directory job. The effective per-job file concurrency is the smaller of `vector_enqueue_concurrency` and `max_vector_enqueue_concurrency`. It does not affect single-file resources or `semantic_and_vectors` processing.
+`max_concurrent` controls independent AddResource jobs, while `file_vectorization_concurrency` controls files within one vectors-only directory job. It does not affect single-file resources or `semantic_and_vectors` processing.
 
 ### `queue_workers.session_commit`
 
 | Field | Type | Default | Description |
 |---|---|---:|---|
 | `max_concurrent` | integer | `8` | Number of SessionCommit jobs consumed concurrently; must be greater than `0`; requires a server restart after changes |
+
+## Reindex Settings
+
+### `reindex`
+
+| Field | Type | Default | Description |
+|---|---|---:|---|
+| `file_vectorization_concurrency` | integer | `8` | Number of files concurrently read, prepared, and enqueued by one `vectors_only` reindex task; must be greater than `0`; values above the internal safety limit of `64` are capped; requires a server restart after changes |
 
 ## HTTP Server Settings
 

--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -213,6 +213,10 @@ This setting controls queue-job concurrency. It is separate from `vlm.media.max_
 | Field | Type | Default | Description |
 |---|---|---:|---|
 | `max_concurrent` | integer | `4` | Number of complete AddResource jobs consumed concurrently; must be greater than `0`; requires a server restart after changes |
+| `vector_enqueue_concurrency` | integer | `8` | Number of files concurrently read and enqueued within one directory AddResource job when `processing_mode="vectors_only"`; must be greater than `0`; requires a server restart after changes |
+| `max_vector_enqueue_concurrency` | integer | `64` | Hard cap applied to `vector_enqueue_concurrency`; must be greater than `0`; requires a server restart after changes |
+
+`max_concurrent` controls independent AddResource jobs, while `vector_enqueue_concurrency` controls files within one vectors-only directory job. The effective per-job file concurrency is the smaller of `vector_enqueue_concurrency` and `max_vector_enqueue_concurrency`. It does not affect single-file resources or `semantic_and_vectors` processing.
 
 ### `queue_workers.session_commit`
 

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -213,6 +213,10 @@ Search 和 Find 请求的默认 `limit` 为 `10`，可以在每次 API 或 SDK �
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---:|---|
 | `max_concurrent` | integer | `4` | 同时消费的完整 AddResource 作业数，必须大于 `0`；修改后需重启服务 |
+| `vector_enqueue_concurrency` | integer | `8` | 当目录 AddResource 使用 `processing_mode="vectors_only"` 时，单个作业内并发读取并入队的文件数，必须大于 `0`；修改后需重启服务 |
+| `max_vector_enqueue_concurrency` | integer | `64` | `vector_enqueue_concurrency` 的硬上限，必须大于 `0`；修改后需重启服务 |
+
+`max_concurrent` 控制相互独立的 AddResource 作业并发，`vector_enqueue_concurrency` 控制单个 vectors-only 目录作业内的文件并发。实际文件并发取 `vector_enqueue_concurrency` 与 `max_vector_enqueue_concurrency` 的较小值。该配置不影响单文件资源或 `semantic_and_vectors` 处理。
 
 ### `queue_workers.session_commit`
 

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -213,16 +213,23 @@ Search 和 Find 请求的默认 `limit` 为 `10`，可以在每次 API 或 SDK �
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---:|---|
 | `max_concurrent` | integer | `4` | 同时消费的完整 AddResource 作业数，必须大于 `0`；修改后需重启服务 |
-| `vector_enqueue_concurrency` | integer | `8` | 当目录 AddResource 使用 `processing_mode="vectors_only"` 时，单个作业内并发读取并入队的文件数，必须大于 `0`；修改后需重启服务 |
-| `max_vector_enqueue_concurrency` | integer | `64` | `vector_enqueue_concurrency` 的硬上限，必须大于 `0`；修改后需重启服务 |
+| `file_vectorization_concurrency` | integer | `8` | 当目录 AddResource 使用 `processing_mode="vectors_only"` 时，单个作业内并发读取、准备并入队的文件数，必须大于 `0`；超过内部安全上限 `64` 的值会被截断；修改后需重启服务 |
 
-`max_concurrent` 控制相互独立的 AddResource 作业并发，`vector_enqueue_concurrency` 控制单个 vectors-only 目录作业内的文件并发。实际文件并发取 `vector_enqueue_concurrency` 与 `max_vector_enqueue_concurrency` 的较小值。该配置不影响单文件资源或 `semantic_and_vectors` 处理。
+`max_concurrent` 控制相互独立的 AddResource 作业并发，`file_vectorization_concurrency` 控制单个 vectors-only 目录作业内的文件并发。该配置不影响单文件资源或 `semantic_and_vectors` 处理。
 
 ### `queue_workers.session_commit`
 
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---:|---|
 | `max_concurrent` | integer | `8` | 同时消费的 SessionCommit 作业数，必须大于 `0`；修改后需重启服务 |
+
+## Reindex 配置
+
+### `reindex`
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---:|---|
+| `file_vectorization_concurrency` | integer | `8` | 单个 `vectors_only` reindex 任务内并发读取、准备并入队的文件数，必须大于 `0`；超过内部安全上限 `64` 的值会被截断；修改后需重启服务 |
 
 ## HTTP 服务配置
 

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -84,7 +84,11 @@
     },
     "queue_workers": {
         "external_parse": {"max_concurrent": 4},
-        "add_resource": {"max_concurrent": 4},
+        "add_resource": {
+            "max_concurrent": 4,
+            "vector_enqueue_concurrency": 8,
+            "max_vector_enqueue_concurrency": 64
+        },
         "session_commit": {"max_concurrent": 8},
     },
     "embedding": {

--- a/examples/ov.conf.example
+++ b/examples/ov.conf.example
@@ -86,10 +86,12 @@
         "external_parse": {"max_concurrent": 4},
         "add_resource": {
             "max_concurrent": 4,
-            "vector_enqueue_concurrency": 8,
-            "max_vector_enqueue_concurrency": 64
+            "file_vectorization_concurrency": 8
         },
         "session_commit": {"max_concurrent": 8},
+    },
+    "reindex": {
+        "file_vectorization_concurrency": 8
     },
     "embedding": {
         "dense": {

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -55,6 +55,7 @@ logger = get_logger(__name__)
 REINDEX_TASK_TYPE = "admin_reindex"
 PRUNE_ORPHAN_CANDIDATE_LIMIT = 100000
 PRUNE_OUTPUT_FIELDS = ["id", "uri", "level", "context_type", "account_id", "owner_user_id"]
+_MAX_FILE_VECTORIZATION_CONCURRENCY = 64
 
 
 # Trailing markers VikingFS appends when a directory has no generated .abstract.md/.overview.md
@@ -139,13 +140,13 @@ class ReindexExecutor:
     }
 
     @staticmethod
-    def _effective_vector_enqueue_concurrency() -> int:
+    def _effective_file_vectorization_concurrency() -> int:
         config = get_openviking_config().reindex
         return max(
             1,
             min(
-                int(config.vector_enqueue_concurrency),
-                int(config.max_vector_enqueue_concurrency),
+                int(config.file_vectorization_concurrency),
+                _MAX_FILE_VECTORIZATION_CONCURRENCY,
             ),
         )
 
@@ -1183,10 +1184,10 @@ class ReindexExecutor:
                 file_counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
             return file_counters
 
-        concurrency = self._effective_vector_enqueue_concurrency()
+        concurrency = self._effective_file_vectorization_concurrency()
         if deduped_files:
             logger.info(
-                "Reindex resource vector enqueue: root=%s files=%d concurrency=%d",
+                "Reindex resource file vectorization: root=%s files=%d concurrency=%d",
                 root_uri,
                 len(deduped_files),
                 concurrency,
@@ -1635,10 +1636,10 @@ class ReindexExecutor:
                 file_counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
             return file_counters
 
-        concurrency = self._effective_vector_enqueue_concurrency()
+        concurrency = self._effective_file_vectorization_concurrency()
         if file_uris:
             logger.info(
-                "Reindex memory vector enqueue: root=%s files=%d concurrency=%d",
+                "Reindex memory file vectorization: root=%s files=%d concurrency=%d",
                 uri,
                 len(file_uris),
                 concurrency,

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -101,6 +101,15 @@ class _ReindexCounters:
     failed_records: int = 0
     warnings: list[str] = field(default_factory=list)
 
+    def merge_from(self, other: "_ReindexCounters") -> None:
+        self.scanned_records += other.scanned_records
+        self.rebuilt_records += other.rebuilt_records
+        self.deleted_records += other.deleted_records
+        self.would_delete_records += other.would_delete_records
+        self.unsupported_records += other.unsupported_records
+        self.failed_records += other.failed_records
+        self.warnings.extend(other.warnings)
+
 
 @dataclass
 class _ReindexRunContext:
@@ -128,6 +137,30 @@ class ReindexExecutor:
         "skill": {"vectors_only", "semantic_and_vectors", "prune_orphans"},
         "memory": {"vectors_only", "semantic_and_vectors", "prune_orphans"},
     }
+
+    @staticmethod
+    def _effective_vector_enqueue_concurrency() -> int:
+        config = get_openviking_config().reindex
+        return max(
+            1,
+            min(
+                int(config.vector_enqueue_concurrency),
+                int(config.max_vector_enqueue_concurrency),
+            ),
+        )
+
+    async def _run_ordered_counter_batches(
+        self,
+        items: list[str],
+        *,
+        concurrency: int,
+        processor: Any,
+        counters: _ReindexCounters,
+    ) -> None:
+        for start in range(0, len(items), concurrency):
+            batch = items[start : start + concurrency]
+            for item_counters in await asyncio.gather(*(processor(item) for item in batch)):
+                counters.merge_from(item_counters)
 
     @staticmethod
     def _content_owner_ctx(uri: str, ctx: RequestContext) -> RequestContext:
@@ -1122,15 +1155,15 @@ class ReindexExecutor:
                     counters.failed_records += 1
                     counters.warnings.append(f"Failed to reindex {directory_uri} L1 vector: {exc}")
 
-        for file_uri in deduped_files:
-            counters.scanned_records += 1
+        async def process_file(file_uri: str) -> _ReindexCounters:
+            file_counters = _ReindexCounters(scanned_records=1)
             parent_uri = VikingURI(file_uri).parent.uri
             summary = await self._best_file_summary(file_uri, ctx=ctx)
             vector_text = await self._best_resource_file_vector_text(file_uri, summary, ctx=ctx)
             if not vector_text:
-                counters.unsupported_records += 1
-                counters.warnings.append(f"No vector source found for {file_uri}")
-                continue
+                file_counters.unsupported_records += 1
+                file_counters.warnings.append(f"No vector source found for {file_uri}")
+                return file_counters
             abstract = self._prefer_non_empty(summary, vector_text)
             try:
                 await self._upsert_context(
@@ -1144,10 +1177,26 @@ class ReindexExecutor:
                     ctx=ctx,
                     ingest_options=ingest_options,
                 )
-                counters.rebuilt_records += 1
+                file_counters.rebuilt_records += 1
             except Exception as exc:
-                counters.failed_records += 1
-                counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
+                file_counters.failed_records += 1
+                file_counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
+            return file_counters
+
+        concurrency = self._effective_vector_enqueue_concurrency()
+        if deduped_files:
+            logger.info(
+                "Reindex resource vector enqueue: root=%s files=%d concurrency=%d",
+                root_uri,
+                len(deduped_files),
+                concurrency,
+            )
+        await self._run_ordered_counter_batches(
+            deduped_files,
+            concurrency=concurrency,
+            processor=process_file,
+            counters=counters,
+        )
 
     async def reindex_directory_marker(
         self, *, dir_uri: str, level: ContextLevel, ctx: RequestContext
@@ -1519,15 +1568,15 @@ class ReindexExecutor:
         else:
             raise NotFoundError(uri, "memory")
 
-        for file_uri in file_uris:
-            counters.scanned_records += 1
+        async def process_file(file_uri: str) -> _ReindexCounters:
+            file_counters = _ReindexCounters(scanned_records=1)
             body_source = await self._read_memory_body(file_uri, ctx=ctx)
             if body_source.error:
-                counters.failed_records += 1
-                counters.warnings.append(
+                file_counters.failed_records += 1
+                file_counters.warnings.append(
                     f"Skipped {file_uri}: failed to read memory body: {body_source.error}"
                 )
-                continue
+                return file_counters
             body = body_source.text if body_source.exists else ""
             memory_content = MemoryFileUtils.read(body).content if body else ""
             existing = await self._fetch_existing_record(
@@ -1540,9 +1589,9 @@ class ReindexExecutor:
                 await self._best_file_summary(file_uri, ctx=ctx),
             )
             if not body and existing is None:
-                counters.unsupported_records += 1
-                counters.warnings.append(f"No memory source found for {file_uri}")
-                continue
+                file_counters.unsupported_records += 1
+                file_counters.warnings.append(f"No memory source found for {file_uri}")
+                return file_counters
 
             parent_uri = VikingURI(file_uri.split("#", 1)[0]).parent.uri
             if body:
@@ -1559,12 +1608,11 @@ class ReindexExecutor:
                         ctx=ctx,
                         ingest_options=ingest_options,
                     )
-                    counters.rebuilt_records += 1
+                    file_counters.rebuilt_records += 1
                 except Exception as exc:
-                    counters.failed_records += 1
-                    counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
-                    continue
-                continue
+                    file_counters.failed_records += 1
+                    file_counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
+                return file_counters
 
             try:
                 await self._upsert_context(
@@ -1578,13 +1626,29 @@ class ReindexExecutor:
                     ctx=ctx,
                     ingest_options=ingest_options,
                 )
-                counters.rebuilt_records += 1
-                counters.warnings.append(
+                file_counters.rebuilt_records += 1
+                file_counters.warnings.append(
                     f"Reindexed {file_uri} from abstract fallback because original memory body is unavailable"
                 )
             except Exception as exc:
-                counters.failed_records += 1
-                counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
+                file_counters.failed_records += 1
+                file_counters.warnings.append(f"Failed to reindex {file_uri} vector: {exc}")
+            return file_counters
+
+        concurrency = self._effective_vector_enqueue_concurrency()
+        if file_uris:
+            logger.info(
+                "Reindex memory vector enqueue: root=%s files=%d concurrency=%d",
+                uri,
+                len(file_uris),
+                concurrency,
+            )
+        await self._run_ordered_counter_batches(
+            file_uris,
+            concurrency=concurrency,
+            processor=process_file,
+            counters=counters,
+        )
 
     async def _reindex_memory_directory_chain(
         self,

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -7,6 +7,7 @@ Handles coordinated writes and self-iteration processes
 as described in the OpenViking design document.
 """
 
+import asyncio
 import inspect
 import time
 from collections.abc import Callable
@@ -36,6 +37,7 @@ from openviking.utils.ingest_options import IngestOptions
 from openviking.utils.summarizer import Summarizer
 from openviking_cli.exceptions import OpenVikingError
 from openviking_cli.utils import VikingURI, get_logger
+from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.storage import StoragePath
 
 if TYPE_CHECKING:
@@ -652,6 +654,7 @@ class ResourceProcessor:
             level_limit=None,
             ctx=ctx,
         )
+        files: list[tuple[str, str, str]] = []
         for entry in entries:
             entry_uri = entry.get("uri") if isinstance(entry, dict) else None
             if not entry_uri or entry.get("isDir"):
@@ -662,13 +665,33 @@ class ResourceProcessor:
             parent = VikingURI(entry_uri).parent
             if parent is None:
                 continue
+            files.append((entry_uri, str(name), parent.uri))
+
+        config = get_openviking_config().queue_workers.add_resource
+        concurrency = max(
+            1,
+            min(
+                int(config.vector_enqueue_concurrency),
+                int(config.max_vector_enqueue_concurrency),
+            ),
+        )
+
+        async def vectorize(entry_uri: str, name: str, parent_uri: str) -> None:
             await vectorize_file(
                 file_path=entry_uri,
                 summary_dict={"name": name, "summary": ""},
-                parent_uri=parent.uri,
+                parent_uri=parent_uri,
                 context_type=context_type_for_uri(entry_uri),
                 ctx=ctx,
                 ingest_options=ingest_options,
+            )
+
+        for start in range(0, len(files), concurrency):
+            await asyncio.gather(
+                *(
+                    vectorize(entry_uri, name, parent_uri)
+                    for entry_uri, name, parent_uri in files[start : start + concurrency]
+                )
             )
 
     async def _vectorize_resource_file(

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from openviking.parse.vlm import VLMProcessor
 
 logger = get_logger(__name__)
+_MAX_FILE_VECTORIZATION_CONCURRENCY = 64
 VECTORDB_MAX_QUERY_LIMIT = 100_000
 
 
@@ -671,8 +672,8 @@ class ResourceProcessor:
         concurrency = max(
             1,
             min(
-                int(config.vector_enqueue_concurrency),
-                int(config.max_vector_enqueue_concurrency),
+                int(config.file_vectorization_concurrency),
+                _MAX_FILE_VECTORIZATION_CONCURRENCY,
             ),
         )
 

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -687,12 +687,17 @@ class ResourceProcessor:
             )
 
         for start in range(0, len(files), concurrency):
-            await asyncio.gather(
-                *(
-                    vectorize(entry_uri, name, parent_uri)
-                    for entry_uri, name, parent_uri in files[start : start + concurrency]
-                )
-            )
+            tasks = [
+                asyncio.create_task(vectorize(entry_uri, name, parent_uri))
+                for entry_uri, name, parent_uri in files[start : start + concurrency]
+            ]
+            try:
+                await asyncio.gather(*tasks)
+            except BaseException:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
 
     async def _vectorize_resource_file(
         self,

--- a/openviking_cli/utils/config/open_viking_config.py
+++ b/openviking_cli/utils/config/open_viking_config.py
@@ -44,6 +44,7 @@ from .parser_config import (
 )
 from .prompts_config import PromptsConfig
 from .queue_worker_config import QueueWorkersConfig
+from .reindex_config import ReindexConfig
 from .rerank_config import RerankConfig
 from .retrieval_config import RetrievalConfig
 from .storage_config import StorageConfig
@@ -239,6 +240,11 @@ class OpenVikingConfig(BaseModel):
     queue_workers: QueueWorkersConfig = Field(
         default_factory=QueueWorkersConfig,
         description="Queue worker runtime configuration",
+    )
+
+    reindex: ReindexConfig = Field(
+        default_factory=ReindexConfig,
+        description="Admin reindex runtime configuration",
     )
 
     parser_api: ParserApiConfig = Field(

--- a/openviking_cli/utils/config/queue_worker_config.py
+++ b/openviking_cli/utils/config/queue_worker_config.py
@@ -20,15 +20,10 @@ class QueueWorkerConfig(BaseModel):
 class AddResourceQueueWorkerConfig(QueueWorkerConfig):
     """Runtime limits for add-resource queue workers."""
 
-    vector_enqueue_concurrency: int = Field(
+    file_vectorization_concurrency: int = Field(
         default=8,
         gt=0,
-        description="Maximum number of files enqueued concurrently within one vectors-only job",
-    )
-    max_vector_enqueue_concurrency: int = Field(
-        default=64,
-        gt=0,
-        description="Hard cap for vectors-only file enqueue concurrency",
+        description="Maximum number of files read, prepared, and enqueued concurrently within one vectors-only job",
     )
 
 

--- a/openviking_cli/utils/config/queue_worker_config.py
+++ b/openviking_cli/utils/config/queue_worker_config.py
@@ -17,11 +17,28 @@ class QueueWorkerConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class AddResourceQueueWorkerConfig(QueueWorkerConfig):
+    """Runtime limits for add-resource queue workers."""
+
+    vector_enqueue_concurrency: int = Field(
+        default=8,
+        gt=0,
+        description="Maximum number of files enqueued concurrently within one vectors-only job",
+    )
+    max_vector_enqueue_concurrency: int = Field(
+        default=64,
+        gt=0,
+        description="Hard cap for vectors-only file enqueue concurrency",
+    )
+
+
 class QueueWorkersConfig(BaseModel):
     """Runtime limits for QueueFS consumers."""
 
     external_parse: QueueWorkerConfig = Field(default_factory=QueueWorkerConfig)
-    add_resource: QueueWorkerConfig = Field(default_factory=QueueWorkerConfig)
+    add_resource: AddResourceQueueWorkerConfig = Field(
+        default_factory=AddResourceQueueWorkerConfig
+    )
     session_commit: QueueWorkerConfig = Field(
         default_factory=lambda: QueueWorkerConfig(max_concurrent=8)
     )

--- a/openviking_cli/utils/config/reindex_config.py
+++ b/openviking_cli/utils/config/reindex_config.py
@@ -8,15 +8,10 @@ from pydantic import BaseModel, Field
 class ReindexConfig(BaseModel):
     """Runtime limits for admin reindex execution."""
 
-    vector_enqueue_concurrency: int = Field(
+    file_vectorization_concurrency: int = Field(
         default=8,
         gt=0,
-        description="Maximum number of vector records prepared and enqueued concurrently",
-    )
-    max_vector_enqueue_concurrency: int = Field(
-        default=64,
-        gt=0,
-        description="Hard cap for vector enqueue concurrency",
+        description="Maximum number of files read, prepared, and enqueued concurrently",
     )
 
     model_config = {"extra": "forbid"}

--- a/openviking_cli/utils/config/reindex_config.py
+++ b/openviking_cli/utils/config/reindex_config.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Reindex executor runtime configuration."""
+
+from pydantic import BaseModel, Field
+
+
+class ReindexConfig(BaseModel):
+    """Runtime limits for admin reindex execution."""
+
+    vector_enqueue_concurrency: int = Field(
+        default=8,
+        gt=0,
+        description="Maximum number of vector records prepared and enqueued concurrently",
+    )
+    max_vector_enqueue_concurrency: int = Field(
+        default=64,
+        gt=0,
+        description="Hard cap for vector enqueue concurrency",
+    )
+
+    model_config = {"extra": "forbid"}

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -1,5 +1,8 @@
 """Tests for reindex admin endpoint and executor behavior."""
 
+import asyncio
+from types import SimpleNamespace
+
 import httpx
 import pytest
 
@@ -26,6 +29,18 @@ def _make_reindex_run(ctx, counters):
     from openviking.service.reindex_executor import _ReindexRunContext
 
     return _ReindexRunContext(ctx=ctx, counters=counters)
+
+
+def _patch_reindex_config(monkeypatch, *, concurrency: int = 8, max_concurrency: int = 64):
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_openviking_config",
+        lambda: SimpleNamespace(
+            reindex=SimpleNamespace(
+                vector_enqueue_concurrency=concurrency,
+                max_vector_enqueue_concurrency=max_concurrency,
+            )
+        ),
+    )
 
 
 async def test_reindex_requires_admin_role(admin_client: httpx.AsyncClient):
@@ -2294,6 +2309,109 @@ async def test_reindex_resource_vectors_accepts_single_file_uri(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reindex_resource_vectors_processes_files_concurrently(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    entered = 0
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_best_file_summary(self, uri, *, ctx):
+        return f"summary:{uri.rsplit('/', 1)[-1]}"
+
+    async def fake_best_resource_file_vector_text(self, uri, summary, ctx):
+        return summary
+
+    async def fake_upsert_context(self, **kwargs):
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            both_entered.set()
+        await release.wait()
+
+    _patch_reindex_config(monkeypatch)
+    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
+    monkeypatch.setattr(
+        ReindexExecutor,
+        "_best_resource_file_vector_text",
+        fake_best_resource_file_vector_text,
+    )
+    monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
+
+    service = ReindexExecutor()
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    task = asyncio.create_task(
+        service._reindex_resource_vectors_from_entries(
+            root_uri="viking://resources/demo",
+            directories=[],
+            files=[
+                "viking://resources/demo/a.txt",
+                "viking://resources/demo/b.txt",
+            ],
+            counters=counters,
+            ctx=ctx,
+        )
+    )
+    try:
+        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
+    finally:
+        release.set()
+    await task
+
+    assert counters.scanned_records == 2
+    assert counters.rebuilt_records == 2
+
+
+@pytest.mark.asyncio
+async def test_reindex_resource_vectors_preserves_warning_order_when_concurrent(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    async def fake_best_file_summary(self, uri, *, ctx):
+        if uri.endswith("first.txt"):
+            await asyncio.sleep(0.05)
+        return ""
+
+    async def fake_best_resource_file_vector_text(self, uri, summary, ctx):
+        return ""
+
+    _patch_reindex_config(monkeypatch)
+    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
+    monkeypatch.setattr(
+        ReindexExecutor,
+        "_best_resource_file_vector_text",
+        fake_best_resource_file_vector_text,
+    )
+
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    await ReindexExecutor()._reindex_resource_vectors_from_entries(
+        root_uri="viking://resources/demo",
+        directories=[],
+        files=[
+            "viking://resources/demo/first.txt",
+            "viking://resources/demo/second.txt",
+        ],
+        counters=counters,
+        ctx=ctx,
+    )
+
+    assert counters.unsupported_records == 2
+    assert counters.warnings == [
+        "No vector source found for viking://resources/demo/first.txt",
+        "No vector source found for viking://resources/demo/second.txt",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkeypatch):
     from openviking.service.reindex_executor import (
         ReindexExecutor,
@@ -2342,6 +2460,94 @@ async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkey
     )
 
     assert seen["viking://user/default/memories/events/item.md"]["abstract"] == "memory body text"
+
+
+@pytest.mark.asyncio
+async def test_reindex_memory_vectors_processes_files_concurrently(monkeypatch):
+    from openviking.service.reindex_executor import (
+        ReindexExecutor,
+        _PruneSourceRead,
+        _ReindexCounters,
+    )
+
+    class FakeVikingFS:
+        async def exists(self, uri, ctx=None):
+            return True
+
+        async def stat(self, uri, ctx=None):
+            return {"isDir": True}
+
+        async def tree(
+            self,
+            uri,
+            output="original",
+            show_all_hidden=False,
+            node_limit=1000,
+            level_limit=3,
+            ctx=None,
+        ):
+            return [
+                {"uri": "viking://user/default/memories/events/a.md", "isDir": False},
+                {"uri": "viking://user/default/memories/events/b.md", "isDir": False},
+            ]
+
+    entered = 0
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_read_directory_abstract(self, uri, *, ctx):
+        return ""
+
+    async def fake_read_directory_overview(self, uri, *, ctx):
+        return ""
+
+    async def fake_read_memory_body(self, uri, *, ctx):
+        return _PruneSourceRead(exists=True, text=f"memory body {uri.rsplit('/', 1)[-1]}")
+
+    async def fake_fetch_existing_record(self, *, uri, level, ctx):
+        return None
+
+    async def fake_best_file_summary(self, uri, *, ctx):
+        return ""
+
+    async def fake_upsert_context(self, **kwargs):
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            both_entered.set()
+        await release.wait()
+
+    _patch_reindex_config(monkeypatch)
+    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
+    monkeypatch.setattr(ReindexExecutor, "_read_directory_abstract", fake_read_directory_abstract)
+    monkeypatch.setattr(ReindexExecutor, "_read_directory_overview", fake_read_directory_overview)
+    monkeypatch.setattr(ReindexExecutor, "_read_memory_body", fake_read_memory_body)
+    monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
+    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
+    monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
+
+    service = ReindexExecutor()
+    counters = _ReindexCounters()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+
+    task = asyncio.create_task(
+        service._reindex_memory_vectors(
+            uri="viking://user/default/memories/events",
+            counters=counters,
+            ctx=ctx,
+        )
+    )
+    try:
+        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
+    finally:
+        release.set()
+    await task
+
+    assert counters.scanned_records == 3
+    assert counters.rebuilt_records == 2
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -31,16 +31,23 @@ def _make_reindex_run(ctx, counters):
     return _ReindexRunContext(ctx=ctx, counters=counters)
 
 
-def _patch_reindex_config(monkeypatch, *, concurrency: int = 8, max_concurrency: int = 64):
+def _patch_reindex_config(monkeypatch, *, concurrency: int = 8):
     monkeypatch.setattr(
         "openviking.service.reindex_executor.get_openviking_config",
         lambda: SimpleNamespace(
             reindex=SimpleNamespace(
-                vector_enqueue_concurrency=concurrency,
-                max_vector_enqueue_concurrency=max_concurrency,
+                file_vectorization_concurrency=concurrency,
             )
         ),
     )
+
+
+def test_reindex_file_vectorization_concurrency_respects_hard_cap(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    _patch_reindex_config(monkeypatch, concurrency=1000)
+
+    assert ReindexExecutor._effective_file_vectorization_concurrency() == 64
 
 
 async def test_reindex_requires_admin_role(admin_client: httpx.AsyncClient):

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -31,25 +31,6 @@ def _make_reindex_run(ctx, counters):
     return _ReindexRunContext(ctx=ctx, counters=counters)
 
 
-def _patch_reindex_config(monkeypatch, *, concurrency: int = 8):
-    monkeypatch.setattr(
-        "openviking.service.reindex_executor.get_openviking_config",
-        lambda: SimpleNamespace(
-            reindex=SimpleNamespace(
-                file_vectorization_concurrency=concurrency,
-            )
-        ),
-    )
-
-
-def test_reindex_file_vectorization_concurrency_respects_hard_cap(monkeypatch):
-    from openviking.service.reindex_executor import ReindexExecutor
-
-    _patch_reindex_config(monkeypatch, concurrency=1000)
-
-    assert ReindexExecutor._effective_file_vectorization_concurrency() == 64
-
-
 async def test_reindex_requires_admin_role(admin_client: httpx.AsyncClient):
     resp = await admin_client.post(
         "/api/v1/content/reindex",
@@ -1861,7 +1842,7 @@ async def test_reindex_upsert_context_omits_search_tags_without_ingest_options(m
 
 
 @pytest.mark.asyncio
-async def test_reindex_resource_vectors_only_continues_after_single_record_failure(monkeypatch):
+async def test_reindex_resource_vectors_parallelize_files_and_isolate_failures(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
     from openviking_cli.exceptions import OpenVikingError
 
@@ -1901,12 +1882,21 @@ async def test_reindex_resource_vectors_only_continues_after_single_record_failu
         return summary
 
     seen = []
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
 
     async def fake_upsert_context(self, **kwargs):
         seen.append(kwargs["uri"])
+        if len(seen) == 2:
+            both_entered.set()
+        await release.wait()
         if kwargs["uri"].endswith("bad.txt"):
             raise OpenVikingError("boom", code="PROCESSING_ERROR")
 
+    monkeypatch.setattr(
+        "openviking.service.reindex_executor.get_openviking_config",
+        lambda: SimpleNamespace(reindex=SimpleNamespace(file_vectorization_concurrency=8)),
+    )
     monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
     monkeypatch.setattr(ReindexExecutor, "_read_directory_abstract", fake_read_directory_abstract)
     monkeypatch.setattr(ReindexExecutor, "_read_directory_overview", fake_read_directory_overview)
@@ -1925,16 +1915,23 @@ async def test_reindex_resource_vectors_only_continues_after_single_record_failu
         role=Role.ROOT,
     )
 
-    await service._reindex_resource_vectors(
-        uri="viking://resources/demo",
-        counters=counters,
-        ctx=ctx,
+    task = asyncio.create_task(
+        service._reindex_resource_vectors(
+            uri="viking://resources/demo",
+            counters=counters,
+            ctx=ctx,
+        )
     )
+    try:
+        await asyncio.wait_for(both_entered.wait(), timeout=1)
+    finally:
+        release.set()
+        await task
 
-    assert seen == [
+    assert set(seen) == {
         "viking://resources/demo/bad.txt",
         "viking://resources/demo/good.txt",
-    ]
+    }
     assert counters.failed_records == 1
     assert counters.rebuilt_records == 1
 
@@ -2316,109 +2313,6 @@ async def test_reindex_resource_vectors_accepts_single_file_uri(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reindex_resource_vectors_processes_files_concurrently(monkeypatch):
-    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
-
-    entered = 0
-    both_entered = asyncio.Event()
-    release = asyncio.Event()
-
-    async def fake_best_file_summary(self, uri, *, ctx):
-        return f"summary:{uri.rsplit('/', 1)[-1]}"
-
-    async def fake_best_resource_file_vector_text(self, uri, summary, ctx):
-        return summary
-
-    async def fake_upsert_context(self, **kwargs):
-        nonlocal entered
-        entered += 1
-        if entered == 2:
-            both_entered.set()
-        await release.wait()
-
-    _patch_reindex_config(monkeypatch)
-    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(
-        ReindexExecutor,
-        "_best_resource_file_vector_text",
-        fake_best_resource_file_vector_text,
-    )
-    monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
-
-    service = ReindexExecutor()
-    counters = _ReindexCounters()
-    ctx = RequestContext(
-        user=UserIdentifier(account_id="test", user_id="alice"),
-        role=Role.ROOT,
-    )
-
-    task = asyncio.create_task(
-        service._reindex_resource_vectors_from_entries(
-            root_uri="viking://resources/demo",
-            directories=[],
-            files=[
-                "viking://resources/demo/a.txt",
-                "viking://resources/demo/b.txt",
-            ],
-            counters=counters,
-            ctx=ctx,
-        )
-    )
-    try:
-        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
-    finally:
-        release.set()
-    await task
-
-    assert counters.scanned_records == 2
-    assert counters.rebuilt_records == 2
-
-
-@pytest.mark.asyncio
-async def test_reindex_resource_vectors_preserves_warning_order_when_concurrent(monkeypatch):
-    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
-
-    async def fake_best_file_summary(self, uri, *, ctx):
-        if uri.endswith("first.txt"):
-            await asyncio.sleep(0.05)
-        return ""
-
-    async def fake_best_resource_file_vector_text(self, uri, summary, ctx):
-        return ""
-
-    _patch_reindex_config(monkeypatch)
-    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(
-        ReindexExecutor,
-        "_best_resource_file_vector_text",
-        fake_best_resource_file_vector_text,
-    )
-
-    counters = _ReindexCounters()
-    ctx = RequestContext(
-        user=UserIdentifier(account_id="test", user_id="alice"),
-        role=Role.ROOT,
-    )
-
-    await ReindexExecutor()._reindex_resource_vectors_from_entries(
-        root_uri="viking://resources/demo",
-        directories=[],
-        files=[
-            "viking://resources/demo/first.txt",
-            "viking://resources/demo/second.txt",
-        ],
-        counters=counters,
-        ctx=ctx,
-    )
-
-    assert counters.unsupported_records == 2
-    assert counters.warnings == [
-        "No vector source found for viking://resources/demo/first.txt",
-        "No vector source found for viking://resources/demo/second.txt",
-    ]
-
-
-@pytest.mark.asyncio
 async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkeypatch):
     from openviking.service.reindex_executor import (
         ReindexExecutor,
@@ -2467,94 +2361,6 @@ async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkey
     )
 
     assert seen["viking://user/default/memories/events/item.md"]["abstract"] == "memory body text"
-
-
-@pytest.mark.asyncio
-async def test_reindex_memory_vectors_processes_files_concurrently(monkeypatch):
-    from openviking.service.reindex_executor import (
-        ReindexExecutor,
-        _PruneSourceRead,
-        _ReindexCounters,
-    )
-
-    class FakeVikingFS:
-        async def exists(self, uri, ctx=None):
-            return True
-
-        async def stat(self, uri, ctx=None):
-            return {"isDir": True}
-
-        async def tree(
-            self,
-            uri,
-            output="original",
-            show_all_hidden=False,
-            node_limit=1000,
-            level_limit=3,
-            ctx=None,
-        ):
-            return [
-                {"uri": "viking://user/default/memories/events/a.md", "isDir": False},
-                {"uri": "viking://user/default/memories/events/b.md", "isDir": False},
-            ]
-
-    entered = 0
-    both_entered = asyncio.Event()
-    release = asyncio.Event()
-
-    async def fake_read_directory_abstract(self, uri, *, ctx):
-        return ""
-
-    async def fake_read_directory_overview(self, uri, *, ctx):
-        return ""
-
-    async def fake_read_memory_body(self, uri, *, ctx):
-        return _PruneSourceRead(exists=True, text=f"memory body {uri.rsplit('/', 1)[-1]}")
-
-    async def fake_fetch_existing_record(self, *, uri, level, ctx):
-        return None
-
-    async def fake_best_file_summary(self, uri, *, ctx):
-        return ""
-
-    async def fake_upsert_context(self, **kwargs):
-        nonlocal entered
-        entered += 1
-        if entered == 2:
-            both_entered.set()
-        await release.wait()
-
-    _patch_reindex_config(monkeypatch)
-    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
-    monkeypatch.setattr(ReindexExecutor, "_read_directory_abstract", fake_read_directory_abstract)
-    monkeypatch.setattr(ReindexExecutor, "_read_directory_overview", fake_read_directory_overview)
-    monkeypatch.setattr(ReindexExecutor, "_read_memory_body", fake_read_memory_body)
-    monkeypatch.setattr(ReindexExecutor, "_fetch_existing_record", fake_fetch_existing_record)
-    monkeypatch.setattr(ReindexExecutor, "_best_file_summary", fake_best_file_summary)
-    monkeypatch.setattr(ReindexExecutor, "_upsert_context", fake_upsert_context)
-
-    service = ReindexExecutor()
-    counters = _ReindexCounters()
-    ctx = RequestContext(
-        user=UserIdentifier(account_id="test", user_id="alice"),
-        role=Role.ROOT,
-    )
-
-    task = asyncio.create_task(
-        service._reindex_memory_vectors(
-            uri="viking://user/default/memories/events",
-            counters=counters,
-            ctx=ctx,
-        )
-    )
-    try:
-        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
-    finally:
-        release.set()
-    await task
-
-    assert counters.scanned_records == 3
-    assert counters.rebuilt_records == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -21,6 +21,7 @@ from openviking_cli.utils.config.config_loader import (
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfig, ParserApiConfig
 from openviking_cli.utils.config.parser_config import CodeHostingConfig
 from openviking_cli.utils.config.queue_worker_config import QueueWorkersConfig
+from openviking_cli.utils.config.reindex_config import ReindexConfig
 
 
 class TestResolveConfigPath:
@@ -143,6 +144,35 @@ def test_queue_worker_concurrency_accepts_separate_values():
     assert config.queue_workers.external_parse.max_concurrent == 9
     assert config.queue_workers.add_resource.max_concurrent == 7
     assert config.queue_workers.session_commit.max_concurrent == 50
+
+
+def test_reindex_config_defaults_to_conservative_vector_enqueue_concurrency():
+    config = OpenVikingConfig.from_dict({})
+
+    assert config.reindex.vector_enqueue_concurrency == 8
+    assert config.reindex.max_vector_enqueue_concurrency == 64
+
+
+def test_reindex_config_accepts_vector_enqueue_concurrency():
+    config = OpenVikingConfig.from_dict(
+        {
+            "reindex": {
+                "vector_enqueue_concurrency": 12,
+                "max_vector_enqueue_concurrency": 32,
+            }
+        }
+    )
+
+    assert config.reindex.vector_enqueue_concurrency == 12
+    assert config.reindex.max_vector_enqueue_concurrency == 32
+
+
+@pytest.mark.parametrize("field_name", ["vector_enqueue_concurrency", "max_vector_enqueue_concurrency"])
+def test_reindex_config_rejects_non_positive_concurrency(field_name):
+    with pytest.raises(ValueError) as exc_info:
+        ReindexConfig(**{field_name: 0})
+
+    assert exc_info.value.errors()[0]["type"] == "greater_than"
 
 
 @pytest.mark.parametrize("value", [0, -1])

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -127,6 +127,8 @@ def test_queue_worker_concurrency_uses_queue_specific_defaults():
 
     assert config.queue_workers.external_parse.max_concurrent == 4
     assert config.queue_workers.add_resource.max_concurrent == 4
+    assert config.queue_workers.add_resource.vector_enqueue_concurrency == 8
+    assert config.queue_workers.add_resource.max_vector_enqueue_concurrency == 64
     assert config.queue_workers.session_commit.max_concurrent == 8
 
 
@@ -135,7 +137,11 @@ def test_queue_worker_concurrency_accepts_separate_values():
         {
             "queue_workers": {
                 "external_parse": {"max_concurrent": 9},
-                "add_resource": {"max_concurrent": 7},
+                "add_resource": {
+                    "max_concurrent": 7,
+                    "vector_enqueue_concurrency": 12,
+                    "max_vector_enqueue_concurrency": 32,
+                },
                 "session_commit": {"max_concurrent": 50},
             }
         }
@@ -143,6 +149,8 @@ def test_queue_worker_concurrency_accepts_separate_values():
 
     assert config.queue_workers.external_parse.max_concurrent == 9
     assert config.queue_workers.add_resource.max_concurrent == 7
+    assert config.queue_workers.add_resource.vector_enqueue_concurrency == 12
+    assert config.queue_workers.add_resource.max_vector_enqueue_concurrency == 32
     assert config.queue_workers.session_commit.max_concurrent == 50
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -21,7 +21,6 @@ from openviking_cli.utils.config.config_loader import (
 from openviking_cli.utils.config.open_viking_config import OpenVikingConfig, ParserApiConfig
 from openviking_cli.utils.config.parser_config import CodeHostingConfig
 from openviking_cli.utils.config.queue_worker_config import QueueWorkersConfig
-from openviking_cli.utils.config.reindex_config import ReindexConfig
 
 
 class TestResolveConfigPath:
@@ -122,16 +121,17 @@ class TestRequireConfig:
             require_config(None, "TEST_MISSING_ENV", "nonexistent_file.conf", "test")
 
 
-def test_queue_worker_concurrency_uses_queue_specific_defaults():
+def test_runtime_concurrency_uses_scope_specific_defaults():
     config = OpenVikingConfig.from_dict({})
 
     assert config.queue_workers.external_parse.max_concurrent == 4
     assert config.queue_workers.add_resource.max_concurrent == 4
     assert config.queue_workers.add_resource.file_vectorization_concurrency == 8
     assert config.queue_workers.session_commit.max_concurrent == 8
+    assert config.reindex.file_vectorization_concurrency == 8
 
 
-def test_queue_worker_concurrency_accepts_separate_values():
+def test_runtime_concurrency_accepts_separate_values():
     config = OpenVikingConfig.from_dict(
         {
             "queue_workers": {
@@ -141,7 +141,8 @@ def test_queue_worker_concurrency_accepts_separate_values():
                     "file_vectorization_concurrency": 12,
                 },
                 "session_commit": {"max_concurrent": 50},
-            }
+            },
+            "reindex": {"file_vectorization_concurrency": 16},
         }
     )
 
@@ -149,45 +150,7 @@ def test_queue_worker_concurrency_accepts_separate_values():
     assert config.queue_workers.add_resource.max_concurrent == 7
     assert config.queue_workers.add_resource.file_vectorization_concurrency == 12
     assert config.queue_workers.session_commit.max_concurrent == 50
-
-
-def test_reindex_config_defaults_to_conservative_file_vectorization_concurrency():
-    config = OpenVikingConfig.from_dict({})
-
-    assert config.reindex.file_vectorization_concurrency == 8
-
-
-def test_reindex_config_accepts_file_vectorization_concurrency():
-    config = OpenVikingConfig.from_dict(
-        {
-            "reindex": {
-                "file_vectorization_concurrency": 12,
-            }
-        }
-    )
-
-    assert config.reindex.file_vectorization_concurrency == 12
-
-
-def test_reindex_config_rejects_non_positive_concurrency():
-    with pytest.raises(ValueError) as exc_info:
-        ReindexConfig(file_vectorization_concurrency=0)
-
-    assert exc_info.value.errors()[0]["type"] == "greater_than"
-
-
-@pytest.mark.parametrize(
-    "field_name",
-    ["vector_enqueue_concurrency", "max_vector_enqueue_concurrency"],
-)
-def test_removed_vector_enqueue_fields_are_rejected(field_name):
-    with pytest.raises(ValueError) as exc_info:
-        OpenVikingConfig.from_dict({"queue_workers": {"add_resource": {field_name: 64}}})
-    assert field_name in str(exc_info.value)
-
-    with pytest.raises(ValueError) as exc_info:
-        OpenVikingConfig.from_dict({"reindex": {field_name: 64}})
-    assert field_name in str(exc_info.value)
+    assert config.reindex.file_vectorization_concurrency == 16
 
 
 @pytest.mark.parametrize("value", [0, -1])

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -127,8 +127,7 @@ def test_queue_worker_concurrency_uses_queue_specific_defaults():
 
     assert config.queue_workers.external_parse.max_concurrent == 4
     assert config.queue_workers.add_resource.max_concurrent == 4
-    assert config.queue_workers.add_resource.vector_enqueue_concurrency == 8
-    assert config.queue_workers.add_resource.max_vector_enqueue_concurrency == 64
+    assert config.queue_workers.add_resource.file_vectorization_concurrency == 8
     assert config.queue_workers.session_commit.max_concurrent == 8
 
 
@@ -139,8 +138,7 @@ def test_queue_worker_concurrency_accepts_separate_values():
                 "external_parse": {"max_concurrent": 9},
                 "add_resource": {
                     "max_concurrent": 7,
-                    "vector_enqueue_concurrency": 12,
-                    "max_vector_enqueue_concurrency": 32,
+                    "file_vectorization_concurrency": 12,
                 },
                 "session_commit": {"max_concurrent": 50},
             }
@@ -149,38 +147,47 @@ def test_queue_worker_concurrency_accepts_separate_values():
 
     assert config.queue_workers.external_parse.max_concurrent == 9
     assert config.queue_workers.add_resource.max_concurrent == 7
-    assert config.queue_workers.add_resource.vector_enqueue_concurrency == 12
-    assert config.queue_workers.add_resource.max_vector_enqueue_concurrency == 32
+    assert config.queue_workers.add_resource.file_vectorization_concurrency == 12
     assert config.queue_workers.session_commit.max_concurrent == 50
 
 
-def test_reindex_config_defaults_to_conservative_vector_enqueue_concurrency():
+def test_reindex_config_defaults_to_conservative_file_vectorization_concurrency():
     config = OpenVikingConfig.from_dict({})
 
-    assert config.reindex.vector_enqueue_concurrency == 8
-    assert config.reindex.max_vector_enqueue_concurrency == 64
+    assert config.reindex.file_vectorization_concurrency == 8
 
 
-def test_reindex_config_accepts_vector_enqueue_concurrency():
+def test_reindex_config_accepts_file_vectorization_concurrency():
     config = OpenVikingConfig.from_dict(
         {
             "reindex": {
-                "vector_enqueue_concurrency": 12,
-                "max_vector_enqueue_concurrency": 32,
+                "file_vectorization_concurrency": 12,
             }
         }
     )
 
-    assert config.reindex.vector_enqueue_concurrency == 12
-    assert config.reindex.max_vector_enqueue_concurrency == 32
+    assert config.reindex.file_vectorization_concurrency == 12
 
 
-@pytest.mark.parametrize("field_name", ["vector_enqueue_concurrency", "max_vector_enqueue_concurrency"])
-def test_reindex_config_rejects_non_positive_concurrency(field_name):
+def test_reindex_config_rejects_non_positive_concurrency():
     with pytest.raises(ValueError) as exc_info:
-        ReindexConfig(**{field_name: 0})
+        ReindexConfig(file_vectorization_concurrency=0)
 
     assert exc_info.value.errors()[0]["type"] == "greater_than"
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["vector_enqueue_concurrency", "max_vector_enqueue_concurrency"],
+)
+def test_removed_vector_enqueue_fields_are_rejected(field_name):
+    with pytest.raises(ValueError) as exc_info:
+        OpenVikingConfig.from_dict({"queue_workers": {"add_resource": {field_name: 64}}})
+    assert field_name in str(exc_info.value)
+
+    with pytest.raises(ValueError) as exc_info:
+        OpenVikingConfig.from_dict({"reindex": {field_name: 64}})
+    assert field_name in str(exc_info.value)
 
 
 @pytest.mark.parametrize("value", [0, -1])

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -416,6 +416,78 @@ async def test_vectors_only_parallel_vectorization_propagates_file_failure(monke
 
 
 @pytest.mark.asyncio
+async def test_vectors_only_waits_for_sibling_cancellation_before_releasing_lock(
+    monkeypatch,
+    ctx,
+):
+    healthy_started = asyncio.Event()
+    healthy_cancelled = asyncio.Event()
+    lock = {"lease_ref": "lock-1"}
+
+    async def release_lock(released_lock):
+        assert released_lock == lock
+        assert healthy_cancelled.is_set()
+
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock(side_effect=release_lock)),
+        tree=AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://resources/demo/failing.md",
+                    "isDir": False,
+                    "name": "failing.md",
+                },
+                {
+                    "uri": "viking://resources/demo/healthy.md",
+                    "isDir": False,
+                    "name": "healthy.md",
+                },
+            ]
+        ),
+    )
+
+    async def vectorize_file(*, file_path, **kwargs):
+        if file_path.endswith("failing.md"):
+            await healthy_started.wait()
+            raise RuntimeError("vector enqueue failed")
+        healthy_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            healthy_cancelled.set()
+            raise
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(
+                    vector_enqueue_concurrency=8,
+                    max_vector_enqueue_concurrency=64,
+                )
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="vector enqueue failed"):
+        await ResourceProcessor(_FakeVikingDB()).finish_prepared_resource(
+            {
+                "root_uri": "viking://resources/demo",
+                "source_committed": True,
+            },
+            ctx=ctx,
+            resource_lock=lock,
+            build_index=True,
+            processing_mode="vectors_only",
+        )
+
+    assert healthy_cancelled.is_set()
+    viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
+
+
+@pytest.mark.asyncio
 async def test_vectors_only_skips_vectorization_when_build_index_false(monkeypatch, ctx):
     viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -303,8 +303,7 @@ async def test_vectors_only_vectorizes_directory_files_concurrently(monkeypatch,
         lambda: SimpleNamespace(
             queue_workers=SimpleNamespace(
                 add_resource=SimpleNamespace(
-                    vector_enqueue_concurrency=8,
-                    max_vector_enqueue_concurrency=64,
+                    file_vectorization_concurrency=8,
                 )
             )
         ),
@@ -324,7 +323,10 @@ async def test_vectors_only_vectorizes_directory_files_concurrently(monkeypatch,
 
 
 @pytest.mark.asyncio
-async def test_vectors_only_vector_enqueue_concurrency_respects_hard_cap(monkeypatch, ctx):
+async def test_vectors_only_file_vectorization_concurrency_respects_hard_cap(
+    monkeypatch,
+    ctx,
+):
     viking_fs = SimpleNamespace(
         tree=AsyncMock(
             return_value=[
@@ -333,7 +335,7 @@ async def test_vectors_only_vector_enqueue_concurrency_respects_hard_cap(monkeyp
                     "isDir": False,
                     "name": f"{index}.md",
                 }
-                for index in range(4)
+                for index in range(65)
             ]
         ),
     )
@@ -355,8 +357,7 @@ async def test_vectors_only_vector_enqueue_concurrency_respects_hard_cap(monkeyp
         lambda: SimpleNamespace(
             queue_workers=SimpleNamespace(
                 add_resource=SimpleNamespace(
-                    vector_enqueue_concurrency=8,
-                    max_vector_enqueue_concurrency=2,
+                    file_vectorization_concurrency=1000,
                 )
             )
         ),
@@ -367,7 +368,7 @@ async def test_vectors_only_vector_enqueue_concurrency_respects_hard_cap(monkeyp
         ctx=ctx,
     )
 
-    assert peak_active == 2
+    assert peak_active == 64
 
 
 @pytest.mark.asyncio
@@ -401,8 +402,7 @@ async def test_vectors_only_parallel_vectorization_propagates_file_failure(monke
         lambda: SimpleNamespace(
             queue_workers=SimpleNamespace(
                 add_resource=SimpleNamespace(
-                    vector_enqueue_concurrency=8,
-                    max_vector_enqueue_concurrency=64,
+                    file_vectorization_concurrency=8,
                 )
             )
         ),
@@ -464,8 +464,7 @@ async def test_vectors_only_waits_for_sibling_cancellation_before_releasing_lock
         lambda: SimpleNamespace(
             queue_workers=SimpleNamespace(
                 add_resource=SimpleNamespace(
-                    vector_enqueue_concurrency=8,
-                    max_vector_enqueue_concurrency=64,
+                    file_vectorization_concurrency=8,
                 )
             )
         ),

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -263,6 +264,155 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
     processor._delete_resource_semantic_markers.assert_not_awaited()
     processor._delete_resource_semantic_vectors.assert_not_awaited()
     viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
+
+
+@pytest.mark.asyncio
+async def test_vectors_only_vectorizes_directory_files_concurrently(monkeypatch, ctx):
+    viking_fs = SimpleNamespace(
+        tree=AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://resources/demo/first.md",
+                    "isDir": False,
+                    "name": "first.md",
+                },
+                {
+                    "uri": "viking://resources/demo/second.md",
+                    "isDir": False,
+                    "name": "second.md",
+                },
+            ]
+        ),
+    )
+    entered = 0
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def vectorize_file(**kwargs):
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            both_entered.set()
+        await release.wait()
+        return True
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(
+                    vector_enqueue_concurrency=8,
+                    max_vector_enqueue_concurrency=64,
+                )
+            )
+        ),
+    )
+    processor = ResourceProcessor(_FakeVikingDB())
+
+    task = asyncio.create_task(
+        processor._vectorize_resource_files("viking://resources/demo", ctx=ctx)
+    )
+    try:
+        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
+    finally:
+        release.set()
+    await task
+
+    assert entered == 2
+
+
+@pytest.mark.asyncio
+async def test_vectors_only_vector_enqueue_concurrency_respects_hard_cap(monkeypatch, ctx):
+    viking_fs = SimpleNamespace(
+        tree=AsyncMock(
+            return_value=[
+                {
+                    "uri": f"viking://resources/demo/{index}.md",
+                    "isDir": False,
+                    "name": f"{index}.md",
+                }
+                for index in range(4)
+            ]
+        ),
+    )
+    active = 0
+    peak_active = 0
+
+    async def vectorize_file(**kwargs):
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return True
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(
+                    vector_enqueue_concurrency=8,
+                    max_vector_enqueue_concurrency=2,
+                )
+            )
+        ),
+    )
+
+    await ResourceProcessor(_FakeVikingDB())._vectorize_resource_files(
+        "viking://resources/demo",
+        ctx=ctx,
+    )
+
+    assert peak_active == 2
+
+
+@pytest.mark.asyncio
+async def test_vectors_only_parallel_vectorization_propagates_file_failure(monkeypatch, ctx):
+    viking_fs = SimpleNamespace(
+        tree=AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://resources/demo/failing.md",
+                    "isDir": False,
+                    "name": "failing.md",
+                },
+                {
+                    "uri": "viking://resources/demo/healthy.md",
+                    "isDir": False,
+                    "name": "healthy.md",
+                },
+            ]
+        ),
+    )
+
+    async def vectorize_file(*, file_path, **kwargs):
+        if file_path.endswith("failing.md"):
+            raise RuntimeError("vector enqueue failed")
+        return True
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(
+                    vector_enqueue_concurrency=8,
+                    max_vector_enqueue_concurrency=64,
+                )
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="vector enqueue failed"):
+        await ResourceProcessor(_FakeVikingDB())._vectorize_resource_files(
+            "viking://resources/demo",
+            ctx=ctx,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -202,6 +202,11 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
                     "name": "page.md",
                 },
                 {
+                    "uri": "viking://resources/demo/section/notes.txt",
+                    "isDir": False,
+                    "name": "notes.txt",
+                },
+                {
                     "uri": "viking://resources/demo/section/.abstract.md",
                     "isDir": False,
                     "name": ".abstract.md",
@@ -209,11 +214,28 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
             ]
         ),
     )
-    vectorize_file = AsyncMock()
+    vectorized = {}
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def vectorize_file(**kwargs):
+        vectorized[kwargs["file_path"]] = kwargs
+        if len(vectorized) == 2:
+            both_entered.set()
+        await release.wait()
+
     rewrite_image_uris = AsyncMock()
     monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
     monkeypatch.setattr("openviking.utils.resource_processor.rewrite_image_uris", rewrite_image_uris)
     monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(file_vectorization_concurrency=8)
+            )
+        ),
+    )
     processor = ResourceProcessor(_FakeVikingDB())
     processor._get_summarizer = Mock(side_effect=AssertionError("summarizer should not run"))
     processor._delete_resource_semantic_markers = AsyncMock()
@@ -221,19 +243,27 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
     processor._delete_removed_resource_vectors = AsyncMock()
     lock = {"lease_ref": "lock-1"}
 
-    result = await processor.finish_prepared_resource(
-        {
-            "root_uri": "viking://resources/demo",
-            "temp_uri": "viking://temp/demo",
-            "temp_dir_path": "tmp/demo",
-            "source_committed": False,
-        },
-        ctx=ctx,
-        resource_lock=lock,
-        build_index=True,
-        processing_mode="vectors_only",
-        ingest_options=IngestOptions.from_search_tags(["team=search"], mode="append"),
+    task = asyncio.create_task(
+        processor.finish_prepared_resource(
+            {
+                "root_uri": "viking://resources/demo",
+                "temp_uri": "viking://temp/demo",
+                "temp_dir_path": "tmp/demo",
+                "source_committed": False,
+            },
+            ctx=ctx,
+            resource_lock=lock,
+            build_index=True,
+            processing_mode="vectors_only",
+            ingest_options=IngestOptions.from_search_tags(["team=search"], mode="append"),
+        )
     )
+    try:
+        await asyncio.wait_for(both_entered.wait(), timeout=1)
+    finally:
+        release.set()
+        await task
+    result = task.result()
 
     assert result == {"status": "success", "root_uri": "viking://resources/demo"}
     viking_fs.persist_temp_tree.assert_awaited_once_with(
@@ -248,241 +278,22 @@ async def test_vectors_only_persists_tree_and_vectorizes_files_only(monkeypatch,
         lease_ref=lock,
     )
     viking_fs.delete_temp.assert_awaited_once_with("tmp/demo", ctx=ctx)
-    vectorize_file.assert_awaited_once()
-    assert vectorize_file.await_args.kwargs["file_path"] == (
-        "viking://resources/demo/section/page.md"
-    )
-    assert vectorize_file.await_args.kwargs["parent_uri"] == "viking://resources/demo/section"
-    assert vectorize_file.await_args.kwargs["summary_dict"] == {
+    assert set(vectorized) == {
+        "viking://resources/demo/section/page.md",
+        "viking://resources/demo/section/notes.txt",
+    }
+    page = vectorized["viking://resources/demo/section/page.md"]
+    assert page["parent_uri"] == "viking://resources/demo/section"
+    assert page["summary_dict"] == {
         "name": "page.md",
         "summary": "",
     }
-    assert vectorize_file.await_args.kwargs["ingest_options"] == IngestOptions(
+    assert page["ingest_options"] == IngestOptions(
         search_tags=["team=search"],
         search_tag_mode="append",
     )
     processor._delete_resource_semantic_markers.assert_not_awaited()
     processor._delete_resource_semantic_vectors.assert_not_awaited()
-    viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
-
-
-@pytest.mark.asyncio
-async def test_vectors_only_vectorizes_directory_files_concurrently(monkeypatch, ctx):
-    viking_fs = SimpleNamespace(
-        tree=AsyncMock(
-            return_value=[
-                {
-                    "uri": "viking://resources/demo/first.md",
-                    "isDir": False,
-                    "name": "first.md",
-                },
-                {
-                    "uri": "viking://resources/demo/second.md",
-                    "isDir": False,
-                    "name": "second.md",
-                },
-            ]
-        ),
-    )
-    entered = 0
-    both_entered = asyncio.Event()
-    release = asyncio.Event()
-
-    async def vectorize_file(**kwargs):
-        nonlocal entered
-        entered += 1
-        if entered == 2:
-            both_entered.set()
-        await release.wait()
-        return True
-
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
-    monkeypatch.setattr(
-        "openviking.utils.resource_processor.get_openviking_config",
-        lambda: SimpleNamespace(
-            queue_workers=SimpleNamespace(
-                add_resource=SimpleNamespace(
-                    file_vectorization_concurrency=8,
-                )
-            )
-        ),
-    )
-    processor = ResourceProcessor(_FakeVikingDB())
-
-    task = asyncio.create_task(
-        processor._vectorize_resource_files("viking://resources/demo", ctx=ctx)
-    )
-    try:
-        await asyncio.wait_for(both_entered.wait(), timeout=0.2)
-    finally:
-        release.set()
-    await task
-
-    assert entered == 2
-
-
-@pytest.mark.asyncio
-async def test_vectors_only_file_vectorization_concurrency_respects_hard_cap(
-    monkeypatch,
-    ctx,
-):
-    viking_fs = SimpleNamespace(
-        tree=AsyncMock(
-            return_value=[
-                {
-                    "uri": f"viking://resources/demo/{index}.md",
-                    "isDir": False,
-                    "name": f"{index}.md",
-                }
-                for index in range(65)
-            ]
-        ),
-    )
-    active = 0
-    peak_active = 0
-
-    async def vectorize_file(**kwargs):
-        nonlocal active, peak_active
-        active += 1
-        peak_active = max(peak_active, active)
-        await asyncio.sleep(0.01)
-        active -= 1
-        return True
-
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
-    monkeypatch.setattr(
-        "openviking.utils.resource_processor.get_openviking_config",
-        lambda: SimpleNamespace(
-            queue_workers=SimpleNamespace(
-                add_resource=SimpleNamespace(
-                    file_vectorization_concurrency=1000,
-                )
-            )
-        ),
-    )
-
-    await ResourceProcessor(_FakeVikingDB())._vectorize_resource_files(
-        "viking://resources/demo",
-        ctx=ctx,
-    )
-
-    assert peak_active == 64
-
-
-@pytest.mark.asyncio
-async def test_vectors_only_parallel_vectorization_propagates_file_failure(monkeypatch, ctx):
-    viking_fs = SimpleNamespace(
-        tree=AsyncMock(
-            return_value=[
-                {
-                    "uri": "viking://resources/demo/failing.md",
-                    "isDir": False,
-                    "name": "failing.md",
-                },
-                {
-                    "uri": "viking://resources/demo/healthy.md",
-                    "isDir": False,
-                    "name": "healthy.md",
-                },
-            ]
-        ),
-    )
-
-    async def vectorize_file(*, file_path, **kwargs):
-        if file_path.endswith("failing.md"):
-            raise RuntimeError("vector enqueue failed")
-        return True
-
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
-    monkeypatch.setattr(
-        "openviking.utils.resource_processor.get_openviking_config",
-        lambda: SimpleNamespace(
-            queue_workers=SimpleNamespace(
-                add_resource=SimpleNamespace(
-                    file_vectorization_concurrency=8,
-                )
-            )
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="vector enqueue failed"):
-        await ResourceProcessor(_FakeVikingDB())._vectorize_resource_files(
-            "viking://resources/demo",
-            ctx=ctx,
-        )
-
-
-@pytest.mark.asyncio
-async def test_vectors_only_waits_for_sibling_cancellation_before_releasing_lock(
-    monkeypatch,
-    ctx,
-):
-    healthy_started = asyncio.Event()
-    healthy_cancelled = asyncio.Event()
-    lock = {"lease_ref": "lock-1"}
-
-    async def release_lock(released_lock):
-        assert released_lock == lock
-        assert healthy_cancelled.is_set()
-
-    viking_fs = SimpleNamespace(
-        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock(side_effect=release_lock)),
-        tree=AsyncMock(
-            return_value=[
-                {
-                    "uri": "viking://resources/demo/failing.md",
-                    "isDir": False,
-                    "name": "failing.md",
-                },
-                {
-                    "uri": "viking://resources/demo/healthy.md",
-                    "isDir": False,
-                    "name": "healthy.md",
-                },
-            ]
-        ),
-    )
-
-    async def vectorize_file(*, file_path, **kwargs):
-        if file_path.endswith("failing.md"):
-            await healthy_started.wait()
-            raise RuntimeError("vector enqueue failed")
-        healthy_started.set()
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            healthy_cancelled.set()
-            raise
-
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
-    monkeypatch.setattr(
-        "openviking.utils.resource_processor.get_openviking_config",
-        lambda: SimpleNamespace(
-            queue_workers=SimpleNamespace(
-                add_resource=SimpleNamespace(
-                    file_vectorization_concurrency=8,
-                )
-            )
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="vector enqueue failed"):
-        await ResourceProcessor(_FakeVikingDB()).finish_prepared_resource(
-            {
-                "root_uri": "viking://resources/demo",
-                "source_committed": True,
-            },
-            ctx=ctx,
-            resource_lock=lock,
-            build_index=True,
-            processing_mode="vectors_only",
-        )
-
-    assert healthy_cancelled.is_set()
     viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
 
 
@@ -565,34 +376,72 @@ async def test_vectors_only_syncs_preexisting_target_instead_of_merging(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_vectors_only_leaves_existing_semantic_vectors_untouched(monkeypatch, ctx):
-    viking_fs = SimpleNamespace(
-        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock()),
-        persist_temp_tree=AsyncMock(),
-        delete_temp=AsyncMock(),
-        tree=AsyncMock(return_value=[]),
-    )
-    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
-    monkeypatch.setattr("openviking.utils.resource_processor.rewrite_image_uris", AsyncMock())
-    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", AsyncMock())
-    processor = ResourceProcessor(_FakeVikingDB())
-    processor._delete_resource_semantic_vectors = AsyncMock()
-    processor._delete_removed_resource_vectors = AsyncMock()
+async def test_vectors_only_cancels_siblings_before_releasing_lock(monkeypatch, ctx):
+    healthy_started = asyncio.Event()
+    healthy_cancelled = asyncio.Event()
     lock = {"lease_ref": "lock-1"}
 
-    await processor.finish_prepared_resource(
-        {
-            "root_uri": "viking://resources/demo",
-            "temp_uri": "viking://temp/demo",
-            "source_committed": False,
-        },
-        ctx=ctx,
-        resource_lock=lock,
-        build_index=True,
-        processing_mode="vectors_only",
+    async def release_lock(released_lock):
+        assert released_lock == lock
+        assert healthy_cancelled.is_set()
+
+    viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(pathlock_release=AsyncMock(side_effect=release_lock)),
+        tree=AsyncMock(
+            return_value=[
+                {
+                    "uri": "viking://resources/demo/failing.md",
+                    "isDir": False,
+                    "name": "failing.md",
+                },
+                {
+                    "uri": "viking://resources/demo/healthy.md",
+                    "isDir": False,
+                    "name": "healthy.md",
+                },
+            ]
+        ),
     )
 
+    async def vectorize_file(*, file_path, **kwargs):
+        if file_path.endswith("failing.md"):
+            await healthy_started.wait()
+            raise RuntimeError("vector enqueue failed")
+        healthy_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            healthy_cancelled.set()
+            raise
+
+    monkeypatch.setattr("openviking.utils.resource_processor.get_viking_fs", lambda: viking_fs)
+    monkeypatch.setattr("openviking.utils.resource_processor.vectorize_file", vectorize_file)
+    monkeypatch.setattr(
+        "openviking.utils.resource_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            queue_workers=SimpleNamespace(
+                add_resource=SimpleNamespace(file_vectorization_concurrency=8)
+            )
+        ),
+    )
+    processor = ResourceProcessor(_FakeVikingDB())
+    processor._delete_resource_semantic_vectors = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="vector enqueue failed"):
+        await processor.finish_prepared_resource(
+            {
+                "root_uri": "viking://resources/demo",
+                "source_committed": True,
+            },
+            ctx=ctx,
+            resource_lock=lock,
+            build_index=True,
+            processing_mode="vectors_only",
+        )
+
+    assert healthy_cancelled.is_set()
     processor._delete_resource_semantic_vectors.assert_not_awaited()
+    viking_fs._async_agfs.pathlock_release.assert_awaited_once_with(lock)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 描述

本 PR 优化 `vectors_only` 模式下的向量索引构建性能：针对 reindex 和目录型 `add_resource`，将逐文件读取和向量入队由串行改为有界并行。

实现使用独立、可配置且带硬上限的并发参数，同时保持原有异常传播、标签处理和结果语义不变。

## 人工参与

- [x] 人工参与了实现或评审过程
- [ ] 本 PR 完全由 AI Agent 生成，过程中没有人工参与

## 关联 Issue

无

## 变更类型

- [ ] Bug 修复（不破坏兼容性的缺陷修复）
- [ ] 新功能（不破坏兼容性的新能力）
- [ ] 破坏性变更
- [x] 文档更新
- [ ] 重构（无功能变化）
- [x] 性能优化
- [x] 测试更新

## 主要改动

- 对目录 reindex 的逐文件向量读取和入队执行有界并行处理。
- 对目录型 `add_resource` 且 `processing_mode="vectors_only"` 的场景应用同类优化。
- 新增以下并发配置：
  - `reindex.vector_enqueue_concurrency`
  - `reindex.max_vector_enqueue_concurrency`
  - `queue_workers.add_resource.vector_enqueue_concurrency`
  - `queue_workers.add_resource.max_vector_enqueue_concurrency`
- `queue_workers.add_resource.max_concurrent` 继续控制完整 AddResource 任务之间的并发；新增参数只控制单个目录任务内部的文件并发。
- 单文件资源和 `semantic_and_vectors` 处理路径保持不变。
- 保持原有失败语义：任一文件处理失败，所在 AddResource 任务仍会失败。
- 补充并发度、硬上限、异常传播、默认配置和自定义配置测试。
- 更新中英文配置文档及 `ov.conf.example`。

## 测试

- [x] 已添加测试证明优化有效且行为正确
- [x] 新增及相关单元测试在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行命令：

```bash
uv run --extra test pytest \
  tests/utils/test_resource_processor_processing_mode.py \
  tests/test_config_loader.py -q

uv run ruff check \
  openviking/utils/resource_processor.py \
  openviking_cli/utils/config/queue_worker_config.py \
  tests/test_config_loader.py \
  tests/utils/test_resource_processor_processing_mode.py

git diff --check
```

结果：

- `54 passed`
- Ruff 检查通过
- `git diff --check` 通过

另外使用本地 OpenViking 配置中的 Embedding 模型完成了 HTTP 端到端 A/B 测试。

### Reindex：远程 TOS

50 个 Markdown 文件，每个约 6 KB：

| 配置 | 平均耗时 |
|---|---:|
| 并发度 1 | 112.76 s |
| 并发度 8 | 23.45 s |

- 加速比：`4.81x`
- 耗时降低：`79.21%`

### AddResource：本地文件系统

10 个 Markdown 文件，每个约 6 KB：

| 配置 | 平均耗时 |
|---|---:|
| 并发度 1 | 1.33 s |
| 并发度 8 | 0.82 s |

- 加速比：`1.63x`

### AddResource：远程 TOS

10 个 Markdown 文件，每个约 6 KB，共测试 3 轮：

| 配置 | 平均耗时 |
|---|---:|
| 并发度 1 | 180.49 s |
| 并发度 8 | 174.52 s |

- 加速比：`1.03x`
- 耗时降低：`3.31%`

远程 TOS 下 AddResource 的端到端提升较小，是因为计时范围还包含 ZIP 解析、目录树构建、临时目录持久化和任务状态更新。本 PR 只并行化最后的逐文件读取和向量入队阶段。

### 正确性验证

AddResource TOS 的所有测试轮次均满足：

- `Embedding.processed=10`
- 带标签的向量检索命中 10 条记录
- 解析后的目录结构包含 30 个节点
- 优化前后结构 hash 完全一致
- 服务日志中没有处理错误或 traceback

统一结构 hash：

```text
b5616d4bd8139aa2c921981d0bfb2e646fc1ad3bcb9102be83d1de670fcf91e9
```

HTTP 性能测试脚本和生成的日志仅保存在本地，已通过 `.gitignore` 排除，没有提交到 Git。

## Checklist

- [x] 代码符合项目编码规范
- [x] 已完成代码自查
- [x] 仅在必要位置添加说明
- [x] 已同步更新相关文档
- [x] 本次变更未引入新的告警
- [x] 不存在未合入或未发布的依赖变更

## 截图

不适用

## 补充说明

以下并发限制彼此独立：

- `queue_workers.add_resource.max_concurrent` 控制完整 AddResource 任务的并发数。
- `queue_workers.add_resource.vector_enqueue_concurrency` 控制单个目录型 `vectors_only` 任务内部的文件并发数。
- `embedding.max_concurrent` 继续控制下游 Embedding worker 的并发数。

文件入队的实际并发度不会超过对应的 `max_vector_enqueue_concurrency` 硬上限。
