### PR TITLE
feat(plugins): install TraeCode CLI 2.0 via Codex alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Integrations inject OpenViking recall into your agent's context and auto-commit 
 - [OpenClaw](https://docs.openviking.ai/en/agent-integrations/03-openclaw)
 - [Hermes](https://docs.openviking.ai/en/agent-integrations/05-hermes)
 - [Cursor](https://docs.openviking.ai/en/agent-integrations/12-cursor)
-- [TRAE / TRAE CN / TRAE CLI](https://docs.openviking.ai/en/agent-integrations/13-trae)
+- [TRAE / TRAE CN / TraeCode CLI 2.0](https://docs.openviking.ai/en/agent-integrations/13-trae)
 - [OpenCode](https://docs.openviking.ai/en/agent-integrations/10-opencode)
 - [pi](https://docs.openviking.ai/en/agent-integrations/11-pi)
 - [Agent Plugins 1.0](https://docs.openviking.ai/en/agent-integrations/15-agent-plugins)

--- a/docs/en/agent-integrations/01-overview.md
+++ b/docs/en/agent-integrations/01-overview.md
@@ -8,9 +8,9 @@ OpenViking can act as the long-term memory and context backend for many agent ru
 |-------------|----------|
 | **Claude Code** | [Claude Code Memory Plugin](./02-claude-code.md) — auto-recall + auto-capture via hooks |
 | **OpenClaw** | [OpenClaw Plugin](./03-openclaw.md) — context-engine with full lifecycle integration |
-| **Codex** | [Codex Memory Plugin](./04-codex.md) — lifecycle hooks for auto-recall and incremental capture |
+| **Codex / TraeCode CLI 2.0** | [Codex Memory Plugin](./04-codex.md) — lifecycle hooks for auto-recall and incremental capture |
 | **Cursor** | [Cursor Memory Integration](./12-cursor.md) — one command installs lifecycle hooks, MCP tools, rules, and skills |
-| **TRAE / TRAE CN / TRAE CLI** | [TRAE Memory Integration](./13-trae.md) — one installer configures prompt-time recall, turn capture, and OpenViking tools |
+| **TRAE / TRAE CN** | [TRAE Memory Integration](./13-trae.md) — one installer configures prompt-time recall, turn capture, and OpenViking tools |
 | **Hermes Agent** | [Hermes Agent](./05-hermes.md) — built-in OpenViking memory provider, no plugin install needed |
 | **OpenCode** | [OpenCode Plugin](./10-opencode.md) — MCP tools plus lifecycle hooks for repo context, auto-recall, and capture |
 | **pi** | [pi Coding Agent Extension](./11-pi.md) — native extension with auto-recall, turn capture, and threshold commit |

--- a/docs/en/agent-integrations/04-codex.md
+++ b/docs/en/agent-integrations/04-codex.md
@@ -12,12 +12,12 @@ Claude Code and Codex share one installer. It asks for your language (English/ä¸
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh)
 ```
 
-TraeCode CLI 2.0 accepts this Codex-format plugin directly through its
-`trae-cli` command alias:
+TraeCode CLI 2.0 accepts this Codex-format plugin directly. Its default
+installer entry is `--harness trae-cli`:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli
+  --harness trae-cli
 ```
 
 In regions where GitHub is hard to reach, run the same installer from the Volcengine TOS mirror (or pick "TOS mirror" at the download-source prompt). Codex installs from a TOS-hosted git repo and keeps remote update support:

--- a/docs/en/agent-integrations/04-codex.md
+++ b/docs/en/agent-integrations/04-codex.md
@@ -12,6 +12,14 @@ Claude Code and Codex share one installer. It asks for your language (English/ä¸
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh)
 ```
 
+TraeCode CLI 2.0 accepts this Codex-format plugin directly through its
+`trae-cli` command alias:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
+  --harness codex --codex-bin trae-cli
+```
+
 In regions where GitHub is hard to reach, run the same installer from the Volcengine TOS mirror (or pick "TOS mirror" at the download-source prompt). Codex installs from a TOS-hosted git repo and keeps remote update support:
 
 ```bash
@@ -45,6 +53,7 @@ Prerequisites: Node.js >= 22, Codex >= 0.130.0, and the `plugin_hooks` feature e
 ## Verify
 
 Launch `codex`; on the first prompt of a session, the `SessionStart` hook should load your profile, and the plugin should then recall relevant memories for every prompt. Set `OPENVIKING_DEBUG=1` to write events to `~/.openviking/logs/codex-hooks.log`.
+For TraeCode CLI 2.0, launch `trae-cli` and use `trae-cli plugin list` to confirm the plugin is enabled.
 
 ## How it works
 

--- a/docs/en/agent-integrations/13-trae.md
+++ b/docs/en/agent-integrations/13-trae.md
@@ -1,10 +1,10 @@
-# TRAE, TRAE CN, and TRAE CLI Memory Integration
+# TRAE, TRAE CN, and TraeCode CLI 2.0 Memory Integration
 
-Give TRAE, TRAE CN, and TRAE CLI long-term memory across projects and sessions. OpenViking Hooks automatically load relevant context, capture each conversation turn, and commit it for memory extraction. MCP remains available for explicit memory search, reading, and management.
+Give TRAE, TRAE CN, and TraeCode CLI 2.0 long-term memory across projects and sessions. OpenViking Hooks automatically load relevant context, capture each conversation turn, and commit it for memory extraction. MCP remains available for explicit memory search, reading, and management.
 
 ## Install
 
-Prerequisites: macOS or Linux, Node.js 18+, and a TRAE/TRAE CN release that supports the `SessionStart`, `UserPromptSubmit`, `PreToolUse`, and `Stop` Hooks. TRAE CLI additionally needs a version that exposes those lifecycle hooks and can show its effective Hook and MCP sources through `/hooks` and `/mcp` (or `traecli mcp list`). The installer guides you through the OpenViking connection settings.
+Prerequisites: macOS or Linux, Node.js 18+, and a TRAE/TRAE CN release that supports the `SessionStart`, `UserPromptSubmit`, `PreToolUse`, and `Stop` Hooks. TraeCode CLI 2.0 uses the Codex-compatible plugin format directly. The installer guides you through the OpenViking connection settings.
 
 When prompted for the connection, Volcengine Cloud users should select **Volcengine OpenViking Cloud** and enter their API key. Select **Self-hosted / local** only when an OpenViking server is running locally.
 
@@ -21,9 +21,9 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
   --harness trae,trae-cn
 
-# TRAE CLI
+# TraeCode CLI 2.0
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness trae-cli
+  --harness codex --codex-bin trae-cli
 ```
 
 If GitHub is unavailable, use the TOS mirror:
@@ -32,9 +32,9 @@ If GitHub is unavailable, use the TOS mirror:
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
   --harness trae,trae-cn --dist tos
 
-# TRAE CLI
+# TraeCode CLI 2.0
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
-  --harness trae-cli --dist tos
+  --harness codex --codex-bin trae-cli --dist tos
 ```
 
 Quit and restart the corresponding client after installation.
@@ -49,17 +49,17 @@ Quit and restart the corresponding client after installation.
 
 ## Verify
 
-1. Restart TRAE, TRAE CN, or TRAE CLI and create a new Agent session.
+1. Restart TRAE, TRAE CN, or TraeCode CLI 2.0 and create a new Agent session.
 2. Confirm that `openviking` is connected in the client's MCP settings.
 3. Ask about an existing project or preference and confirm that the answer uses stored memory.
 4. Tell the Agent a temporary preference, wait for the response to finish, then create a new session and ask for it again to verify capture, commit, and cross-session recall.
-5. For TRAE CLI, use `/hooks` and `/mcp` (or `traecli mcp list`) to confirm that the client is consuming the installed user-level configuration. Treat the client's displayed source as authoritative if it differs from the default path.
+5. For TraeCode CLI 2.0, run `trae-cli plugin list` and confirm that `openviking-memory` is enabled.
 
 For Hook diagnostics, start the client with `OPENVIKING_DEBUG=1` and inspect:
 
 - TRAE: `~/.openviking/logs/trae-hooks.log`
 - TRAE CN: `~/.openviking/logs/trae-cn-hooks.log`
-- TRAE CLI: `~/.openviking/logs/trae-cli-hooks.log`
+- TraeCode CLI 2.0: `~/.openviking/logs/codex-hooks.log`
 
 ## Upgrade and uninstall
 
@@ -75,7 +75,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
   --harness trae-cn --uninstall --yes
 ```
 
-Replace `trae-cn` with `trae` or `trae-cli` for TRAE or TRAE CLI. Uninstall removes only OpenViking-managed configuration and runtime files.
+Replace `trae-cn` with `trae` for TRAE. For TraeCode CLI 2.0, use `trae-cli plugin uninstall openviking-memory@openviking`. The legacy `--harness trae-cli --uninstall` spelling remains available to remove the deprecated standalone Hooks integration.
 
 ## Troubleshooting
 
@@ -85,7 +85,7 @@ Replace `trae-cn` with `trae` or `trae-cli` for TRAE or TRAE CLI. Uninstall remo
 | MCP does not connect | Check the URL/API key in `~/.openviking/ovcli.conf`, then restart the client. |
 | A new session cannot recall the previous turn | Inspect the Hook log and confirm that `Stop` ran without `/commit` connection or authentication errors. |
 | The same content is captured more than once | Check user and project Hooks for older `trae-auto-recall.mjs` or `trae-auto-capture.mjs` entries. Re-running the installer removes OpenViking-managed legacy entries. |
-| TRAE CLI does not list the hook or MCP server | Use `/hooks` and `/mcp` (or `traecli mcp list`) to identify the effective source. The CLI's reported config source takes precedence over the installer's default path. |
+| TraeCode CLI 2.0 does not list the plugin | Run `trae-cli plugin list`; if `openviking-memory` is absent, rerun the installer with `--harness codex --codex-bin trae-cli`. |
 
 ## See also
 

--- a/docs/en/agent-integrations/13-trae.md
+++ b/docs/en/agent-integrations/13-trae.md
@@ -23,7 +23,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 
 # TraeCode CLI 2.0
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli
+  --harness trae-cli
 ```
 
 If GitHub is unavailable, use the TOS mirror:
@@ -34,7 +34,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 # TraeCode CLI 2.0
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli --dist tos
+  --harness trae-cli --dist tos
 ```
 
 Quit and restart the corresponding client after installation.
@@ -75,7 +75,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
   --harness trae-cn --uninstall --yes
 ```
 
-Replace `trae-cn` with `trae` for TRAE. For TraeCode CLI 2.0, use `trae-cli plugin uninstall openviking-memory@openviking`. The legacy `--harness trae-cli --uninstall` spelling remains available to remove the deprecated standalone Hooks integration.
+Replace `trae-cn` with `trae` for TRAE. For TraeCode CLI 2.0, use `trae-cli plugin uninstall openviking-memory@openviking`. Running the installer with `--harness trae-cli --uninstall` only removes the deprecated standalone Hooks integration from older installations.
 
 ## Troubleshooting
 
@@ -85,7 +85,7 @@ Replace `trae-cn` with `trae` for TRAE. For TraeCode CLI 2.0, use `trae-cli plug
 | MCP does not connect | Check the URL/API key in `~/.openviking/ovcli.conf`, then restart the client. |
 | A new session cannot recall the previous turn | Inspect the Hook log and confirm that `Stop` ran without `/commit` connection or authentication errors. |
 | The same content is captured more than once | Check user and project Hooks for older `trae-auto-recall.mjs` or `trae-auto-capture.mjs` entries. Re-running the installer removes OpenViking-managed legacy entries. |
-| TraeCode CLI 2.0 does not list the plugin | Run `trae-cli plugin list`; if `openviking-memory` is absent, rerun the installer with `--harness codex --codex-bin trae-cli`. |
+| TraeCode CLI 2.0 does not list the plugin | Run `trae-cli plugin list`; if `openviking-memory` is absent, rerun the installer with `--harness trae-cli`. |
 
 ## See also
 

--- a/docs/zh/agent-integrations/01-overview.md
+++ b/docs/zh/agent-integrations/01-overview.md
@@ -8,9 +8,9 @@ OpenViking 可以作为多种 Agent 运行时的长期记忆与上下文后端�
 |---------|---------|
 | **Claude Code** | [Claude Code 记忆插件](./02-claude-code.md) — 通过 hooks 实现自动召回与自动捕获 |
 | **OpenClaw** | [OpenClaw 插件](./03-openclaw.md) — 全生命周期一体化集成 |
-| **Codex** | [Codex 记忆插件](./04-codex.md) — 生命周期 hooks 自动召回与增量捕获 |
+| **Codex / TraeCode CLI 2.0** | [Codex 记忆插件](./04-codex.md) — 生命周期 hooks 自动召回与增量捕获 |
 | **Cursor** | [Cursor 记忆集成](./12-cursor.md) — 一条命令安装生命周期 Hook、MCP 工具、Rules 与 Skills |
-| **TRAE / TRAE CN / TRAE CLI** | [TRAE 记忆集成](./13-trae.md) — 一个安装器完成 prompt 召回、回合捕获与 OpenViking 工具接入 |
+| **TRAE / TRAE CN** | [TRAE 记忆集成](./13-trae.md) — 一个安装器完成 prompt 召回、回合捕获与 OpenViking 工具接入 |
 | **Hermes Agent** | [Hermes Agent](./05-hermes.md) — 内置 OpenViking 记忆提供方，无需安装插件 |
 | **OpenCode** | [OpenCode 插件](./10-opencode.md) — MCP 工具 + 生命周期 hooks，覆盖仓库上下文、自动召回与捕获 |
 | **pi** | [pi Coding Agent 扩展](./11-pi.md) — 原生扩展，自动召回、逐轮捕获与阈值 commit |

--- a/docs/zh/agent-integrations/04-codex.md
+++ b/docs/zh/agent-integrations/04-codex.md
@@ -12,11 +12,11 @@ Claude Code 和 Codex 共用同一个安装脚本。它会依次询问界面语�
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh)
 ```
 
-TraeCode CLI 2.0 可以通过 `trae-cli` 命令别名直接安装这一 Codex 格式插件：
+TraeCode CLI 2.0 可以直接安装这一 Codex 格式插件，默认安装入口是 `--harness trae-cli`：
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli
+  --harness trae-cli
 ```
 
 GitHub 访问受限的地区，从火山引擎 TOS 镜像运行同一个安装脚本（或在下载源提问时选择「TOS 镜像」）。Codex 走 TOS 时安装自 TOS 托管的 git 仓库，保留远程更新能力：

--- a/docs/zh/agent-integrations/04-codex.md
+++ b/docs/zh/agent-integrations/04-codex.md
@@ -12,6 +12,13 @@ Claude Code 和 Codex 共用同一个安装脚本。它会依次询问界面语�
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh)
 ```
 
+TraeCode CLI 2.0 可以通过 `trae-cli` 命令别名直接安装这一 Codex 格式插件：
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
+  --harness codex --codex-bin trae-cli
+```
+
 GitHub 访问受限的地区，从火山引擎 TOS 镜像运行同一个安装脚本（或在下载源提问时选择「TOS 镜像」）。Codex 走 TOS 时安装自 TOS 托管的 git 仓库，保留远程更新能力：
 
 ```bash
@@ -45,6 +52,7 @@ codex              # 首次启动需进入 /hooks 完成一次审批
 ## 验证
 
 启动 `codex` 后，当前会话首次提交 prompt 时触发的 `SessionStart` 会加载 profile，之后插件将在每次用户输入前自动召回相关记忆。若设置环境变量 `OPENVIKING_DEBUG=1`，则会将相关事件日志写入 `~/.openviking/logs/codex-hooks.log`。
+TraeCode CLI 2.0 用户启动 `trae-cli`，并可用 `trae-cli plugin list` 确认插件已启用。
 
 ## 工作原理
 

--- a/docs/zh/agent-integrations/13-trae.md
+++ b/docs/zh/agent-integrations/13-trae.md
@@ -1,10 +1,10 @@
-# TRAE、TRAE CN 与 TRAE CLI 记忆集成
+# TRAE、TRAE CN 与 TraeCode CLI 2.0 记忆集成
 
-为 TRAE、TRAE CN 和 TRAE CLI 添加跨项目、跨会话的长期记忆。安装后，OpenViking Hook 会自动加载相关上下文、捕获每轮对话并提交给记忆抽取器；MCP 用于主动搜索、读取和管理记忆。
+为 TRAE、TRAE CN 和 TraeCode CLI 2.0 添加跨项目、跨会话的长期记忆。安装后，OpenViking Hook 会自动加载相关上下文、捕获每轮对话并提交给记忆抽取器；MCP 用于主动搜索、读取和管理记忆。
 
 ## 安装
 
-前置条件：macOS 或 Linux、Node.js 18+，以及支持 `SessionStart`、`UserPromptSubmit`、`PreToolUse`、`Stop` Hook 的 TRAE/TRAE CN 版本。TRAE CLI 还需要能够通过 `/hooks` 和 `/mcp`（或 `traecli mcp list`）显示生效 Hook 与 MCP 来源的版本。安装过程中会引导配置 OpenViking 连接信息。
+前置条件：macOS 或 Linux、Node.js 18+，以及支持 `SessionStart`、`UserPromptSubmit`、`PreToolUse`、`Stop` Hook 的 TRAE/TRAE CN 版本。TraeCode CLI 2.0 直接使用兼容 Codex 的插件格式。安装过程中会引导配置 OpenViking 连接信息。
 
 安装器询问连接方式时，火山引擎云服务用户请选择 **火山引擎 OpenViking 云服务** 并填写 API Key。只有本机已运行 OpenViking 服务时才选择 **自建 / 本地**。
 
@@ -21,9 +21,9 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
   --harness trae,trae-cn
 
-# TRAE CLI
+# TraeCode CLI 2.0
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness trae-cli
+  --harness codex --codex-bin trae-cli
 ```
 
 GitHub 访问受限时使用 TOS 镜像：
@@ -32,9 +32,9 @@ GitHub 访问受限时使用 TOS 镜像：
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
   --harness trae,trae-cn --dist tos
 
-# TRAE CLI
+# TraeCode CLI 2.0
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
-  --harness trae-cli --dist tos
+  --harness codex --codex-bin trae-cli --dist tos
 ```
 
 安装后完全退出并重启对应客户端。
@@ -49,17 +49,17 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 ## 验证
 
-1. 重启 TRAE、TRAE CN 或 TRAE CLI，并新建 Agent 会话。
+1. 重启 TRAE、TRAE CN 或 TraeCode CLI 2.0，并新建 Agent 会话。
 2. 在客户端的 MCP 设置中确认 `openviking` 已连接。
 3. 提问一个与已有项目或个人偏好相关的问题，确认回答使用了已有记忆。
 4. 告诉 Agent 一个临时偏好，等待回复完成；新建会话后再次询问，确认捕获、提交和跨会话召回均生效。
-5. 对 TRAE CLI，使用 `/hooks` 和 `/mcp`（或 `traecli mcp list`）确认客户端确实读取了安装后的用户级配置；若与默认路径不同，以客户端显示的有效来源为准。
+5. 对 TraeCode CLI 2.0，运行 `trae-cli plugin list`，确认 `openviking-memory` 已启用。
 
 需要排查 Hook 时，设置 `OPENVIKING_DEBUG=1` 后启动客户端，并查看：
 
 - TRAE：`~/.openviking/logs/trae-hooks.log`
 - TRAE CN：`~/.openviking/logs/trae-cn-hooks.log`
-- TRAE CLI：`~/.openviking/logs/trae-cli-hooks.log`
+- TraeCode CLI 2.0：`~/.openviking/logs/codex-hooks.log`
 
 ## 升级与卸载
 
@@ -75,7 +75,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
   --harness trae-cn --uninstall --yes
 ```
 
-将 `trae-cn` 替换为 `trae` 或 `trae-cli` 可管理 TRAE 或 TRAE CLI 集成。卸载只移除 OpenViking 管理的配置与运行文件。
+将 `trae-cn` 替换为 `trae` 可管理 TRAE 集成。TraeCode CLI 2.0 请执行 `trae-cli plugin uninstall openviking-memory@openviking`。旧的 `--harness trae-cli --uninstall` 写法仍可用于移除已弃用的独立 Hooks 集成。
 
 ## 故障排查
 
@@ -85,7 +85,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 | MCP 未连接 | 检查 `~/.openviking/ovcli.conf` 中的 URL/API Key，然后重启客户端。 |
 | 新会话无法回忆上一轮内容 | 查看 Hook 日志，确认 `Stop` 已执行且 `/commit` 没有连接或鉴权错误。 |
 | 同一内容被捕获多次 | 检查用户级与项目级 Hook 中是否仍有旧版 `trae-auto-recall.mjs` 或 `trae-auto-capture.mjs`；重跑安装器会移除由 OpenViking 管理的旧条目。 |
-| TRAE CLI 未列出 Hook 或 MCP Server | 用 `/hooks` 和 `/mcp`（或 `traecli mcp list`）查看有效配置来源；客户端显示的来源优先于安装器默认路径。 |
+| TraeCode CLI 2.0 未列出插件 | 运行 `trae-cli plugin list`；若没有 `openviking-memory`，使用 `--harness codex --codex-bin trae-cli` 重跑安装器。 |
 
 ## 参见
 

--- a/docs/zh/agent-integrations/13-trae.md
+++ b/docs/zh/agent-integrations/13-trae.md
@@ -23,7 +23,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 
 # TraeCode CLI 2.0
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli
+  --harness trae-cli
 ```
 
 GitHub 访问受限时使用 TOS 镜像：
@@ -34,7 +34,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 # TraeCode CLI 2.0
 bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) \
-  --harness codex --codex-bin trae-cli --dist tos
+  --harness trae-cli --dist tos
 ```
 
 安装后完全退出并重启对应客户端。
@@ -75,7 +75,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
   --harness trae-cn --uninstall --yes
 ```
 
-将 `trae-cn` 替换为 `trae` 可管理 TRAE 集成。TraeCode CLI 2.0 请执行 `trae-cli plugin uninstall openviking-memory@openviking`。旧的 `--harness trae-cli --uninstall` 写法仍可用于移除已弃用的独立 Hooks 集成。
+将 `trae-cn` 替换为 `trae` 可管理 TRAE 集成。TraeCode CLI 2.0 请执行 `trae-cli plugin uninstall openviking-memory@openviking`。安装器的 `--harness trae-cli --uninstall` 只用于移除旧安装中已弃用的独立 Hooks 集成。
 
 ## 故障排查
 
@@ -85,7 +85,7 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 | MCP 未连接 | 检查 `~/.openviking/ovcli.conf` 中的 URL/API Key，然后重启客户端。 |
 | 新会话无法回忆上一轮内容 | 查看 Hook 日志，确认 `Stop` 已执行且 `/commit` 没有连接或鉴权错误。 |
 | 同一内容被捕获多次 | 检查用户级与项目级 Hook 中是否仍有旧版 `trae-auto-recall.mjs` 或 `trae-auto-capture.mjs`；重跑安装器会移除由 OpenViking 管理的旧条目。 |
-| TraeCode CLI 2.0 未列出插件 | 运行 `trae-cli plugin list`；若没有 `openviking-memory`，使用 `--harness codex --codex-bin trae-cli` 重跑安装器。 |
+| TraeCode CLI 2.0 未列出插件 | 运行 `trae-cli plugin list`；若没有 `openviking-memory`，使用 `--harness trae-cli` 重跑安装器。 |
 
 ## 参见
 

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -1,6 +1,7 @@
-# OpenViking Memory Plugin for Codex
+# OpenViking Memory Plugin for Codex and TraeCode CLI 2.0
 
 Long-term semantic memory for [Codex](https://developers.openai.com/codex), powered by [OpenViking](https://github.com/volcengine/OpenViking).
+TraeCode CLI 2.0 supports the same plugin format and installs this package through its `trae-cli` command alias.
 
 This is the Codex counterpart to [`claude-code-memory-plugin`](../claude-code-memory-plugin). It hooks Codex's lifecycle to:
 
@@ -20,6 +21,12 @@ There are two install paths. **Pick one — don't mix them** (both surface the s
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) --harness codex
+```
+
+For TraeCode CLI 2.0:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) --harness codex --codex-bin trae-cli
 ```
 
 Claude Code and Codex share this installer (drop `--harness codex` to pick interactively). It asks for your language (English/中文), the download source (GitHub, or a TOS mirror for GitHub-blocked regions — pass `--dist tos`; Codex on TOS installs from a TOS-hosted git repo and keeps remote updates), and your OpenViking credentials. It:

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -1,7 +1,7 @@
 # OpenViking Memory Plugin for Codex and TraeCode CLI 2.0
 
 Long-term semantic memory for [Codex](https://developers.openai.com/codex), powered by [OpenViking](https://github.com/volcengine/OpenViking).
-TraeCode CLI 2.0 supports the same plugin format and installs this package through its `trae-cli` command alias.
+TraeCode CLI 2.0 supports the same plugin format; use the shared installer's dedicated `--harness trae-cli` entry.
 
 This is the Codex counterpart to [`claude-code-memory-plugin`](../claude-code-memory-plugin). It hooks Codex's lifecycle to:
 
@@ -26,7 +26,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/e
 For TraeCode CLI 2.0:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) --harness codex --codex-bin trae-cli
+bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh) --harness trae-cli
 ```
 
 Claude Code and Codex share this installer (drop `--harness codex` to pick interactively). It asks for your language (English/中文), the download source (GitHub, or a TOS mirror for GitHub-blocked regions — pass `--dist tos`; Codex on TOS installs from a TOS-hosted git repo and keeps remote updates), and your OpenViking credentials. It:

--- a/examples/memory-plugin-shared/install-agent-hooks.test.mjs
+++ b/examples/memory-plugin-shared/install-agent-hooks.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,10 +14,15 @@ function writeJson(file, value) {
   writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function runInstaller(home, args) {
+function runInstaller(home, args, extraEnv = {}) {
   return spawnSync("bash", [installer, ...args], {
     cwd: resolve(dirname(installer), "..", ".."),
-    env: { ...process.env, HOME: home, OPENVIKING_HOME: join(home, ".openviking") },
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENVIKING_HOME: join(home, ".openviking"),
+      ...extraEnv,
+    },
     encoding: "utf8",
   });
 }
@@ -43,9 +48,25 @@ function runUninstall(home) {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 }
 
-test("TRAE CLI install preserves unrelated config and is idempotent", () => {
+test("TraeCode CLI 2.0 installs the Codex plugin alias and removes the deprecated integration", () => {
   const home = mkdtempSync(join(tmpdir(), "openviking-trae-cli-hooks-"));
   try {
+    const binDir = join(home, "bin");
+    const cliLog = join(home, "trae-cli.log");
+    mkdirSync(binDir, { recursive: true });
+    const cliPath = join(binDir, "trae-cli");
+    writeFileSync(cliPath, `#!/bin/sh
+printf '%s\n' "$*" >> "$TRAE_CLI_TEST_LOG"
+case "$*" in
+  "plugin marketplace list --json") printf '{"marketplaces":[]}\n' ;;
+  "plugin marketplace list") printf 'Marketplaces:\n' ;;
+  "plugin list") printf 'openviking-memory\n' ;;
+  "plugin add "*) exit 2 ;;
+esac
+exit 0
+`);
+    chmodSync(cliPath, 0o755);
+
     const hooksPath = join(home, ".trae", "cli", "hooks.json");
     const configPath = join(home, ".trae", "traecli.toml");
     writeJson(hooksPath, {
@@ -56,7 +77,7 @@ test("TRAE CLI install preserves unrelated config and is idempotent", () => {
           {
             hooks: [{
               type: "command",
-              command: "node /tmp/OpenViking/examples/trae-memory-hooks/scripts/auto-capture.mjs trae",
+              command: "OPENVIKING_INTEGRATION_ID=openviking-memory node /tmp/agent-integrations/trae-cli/scripts/auto-capture.mjs",
             }],
           },
         ],
@@ -69,91 +90,140 @@ test("TRAE CLI install preserves unrelated config and is idempotent", () => {
       "[mcp_servers.third_party]",
       'url = "https://example.com/mcp"',
       "",
-      "[mcp_servers.openviking]",
+      '[mcp_servers."openviking-memory"]',
       'command = "node"',
-      'args = ["/tmp/OpenViking/examples/trae-memory-hooks/servers/mcp-proxy.mjs"]',
-      "",
-      "[mcp_servers.openviking.tools.read]",
-      'approval_mode = "approve"',
+      'args = ["/tmp/agent-integrations/trae-cli/servers/mcp-proxy.mjs"]',
       "",
     ].join("\n"));
+    const integrationRoot = join(home, ".openviking", "agent-integrations", "trae-cli");
+    mkdirSync(integrationRoot, { recursive: true });
+    writeFileSync(join(integrationRoot, "integration.json"), "{}\n");
+    const sharedRoot = join(home, ".openviking", "agent-integrations", "memory-plugin-shared");
+    mkdirSync(sharedRoot, { recursive: true });
 
-    runInstall(home, "trae-cli");
-    runInstall(home, "trae-cli");
+    const installed = runInstaller(home, [
+      "--harness", "trae-cli",
+      "--source", "dev",
+      "--lang", "en",
+      "--url", "http://127.0.0.1:1933",
+      "--api-key", "",
+      "--yes",
+    ], {
+      PATH: `${binDir}:${dirname(installedNode)}:/usr/bin:/bin`,
+      TRAE_CLI_TEST_LOG: cliLog,
+    });
+    assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
+    assert.match(installed.stdout, /TraeCode CLI 2.0/);
+    assert.match(installed.stdout, /trae-cli harness is deprecated/);
 
     const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
     assert.ok(hooks.hooks.Stop.some((entry) => JSON.stringify(entry).includes("third-party stop")));
-    assert.equal(
-      hooks.hooks.Stop.filter((entry) => JSON.stringify(entry).includes("auto-capture.mjs")).length,
-      1,
-    );
-    assert.equal(
-      hooks.hooks.SessionStart.filter((entry) => JSON.stringify(entry).includes("session-start.mjs")).length,
-      1,
-    );
-    assert.equal(
-      hooks.hooks.UserPromptSubmit.filter((entry) => JSON.stringify(entry).includes("auto-recall.mjs")).length,
-      1,
-    );
-    assert.equal(
-      hooks.hooks.PreToolUse.filter((entry) => JSON.stringify(entry).includes("uri-guard.mjs")).length,
-      1,
-    );
-    assert.ok(JSON.stringify(hooks).includes("OPENVIKING_HOOK_SOURCE='trae-cli'"));
+    assert.doesNotMatch(JSON.stringify(hooks), /openviking/i);
 
     const config = readFileSync(configPath, "utf8");
     assert.match(config, /model = "test-model"/);
     assert.match(config, /\[mcp_servers\.third_party\]/);
-    assert.equal((config.match(/^\[mcp_servers\."openviking-memory"\]$/gmu) || []).length, 1);
-    assert.doesNotMatch(config, /^\[mcp_servers\.openviking\]$/mu);
-    assert.doesNotMatch(config, /^\[mcp_servers\.openviking\.tools\.read\]$/mu);
-    assert.match(config, /agent-integrations\/trae-cli\/servers\/mcp-proxy\.mjs/);
-
-    const integrationRoot = join(home, ".openviking", "agent-integrations", "trae-cli");
-    const manifest = JSON.parse(readFileSync(join(integrationRoot, "integration.json"), "utf8"));
-    assert.equal(manifest.id, "openviking-memory");
-    assert.equal(manifest.client, "trae-cli");
-    assert.equal(manifest.hooksConfig, hooksPath);
-    assert.equal(manifest.mcpConfig, configPath);
-
-    const smoke = spawnSync(process.execPath, [join(integrationRoot, "scripts", "session-start.mjs")], {
-      env: { ...process.env, HOME: home, OPENVIKING_MEMORY_ENABLED: "0" },
-      input: "{}",
-      encoding: "utf8",
-    });
-    assert.equal(smoke.status, 0, smoke.stderr);
-    assert.equal(smoke.stdout.trim(), "{}");
-
-    const guard = spawnSync(process.execPath, [join(integrationRoot, "scripts", "uri-guard.mjs")], {
-      env: { ...process.env, HOME: home },
-      input: JSON.stringify({
-        tool_name: "Read",
-        tool_input: { file_path: "viking://resources/project/file.md" },
-      }),
-      encoding: "utf8",
-    });
-    assert.equal(guard.status, 0, guard.stderr);
-    assert.match(guard.stdout, /"permissionDecision":"deny"/);
-
-    const uninstall = runInstaller(home, [
-      "--harness", "trae-cli",
-      "--uninstall",
-      "--yes",
-    ]);
-    assert.equal(uninstall.status, 0, `${uninstall.stdout}\n${uninstall.stderr}`);
-
-    const hooksAfter = JSON.parse(readFileSync(hooksPath, "utf8"));
-    assert.ok(hooksAfter.hooks.Stop.some((entry) => JSON.stringify(entry).includes("third-party stop")));
-    assert.equal(JSON.stringify(hooksAfter).includes("openviking-memory"), false);
-    const configAfter = readFileSync(configPath, "utf8");
-    assert.match(configAfter, /model = "test-model"/);
-    assert.match(configAfter, /\[mcp_servers\.third_party\]/);
-    assert.doesNotMatch(configAfter, /openviking-memory/);
+    assert.doesNotMatch(config, /openviking-memory/);
     assert.equal(existsSync(integrationRoot), false);
-    assert.equal(
-      existsSync(join(home, ".openviking", "agent-integrations", "memory-plugin-shared")),
-      false,
-    );
+    assert.equal(existsSync(sharedRoot), false);
+
+    const commands = readFileSync(cliLog, "utf8");
+    assert.match(commands, /plugin marketplace add .*\/examples/mu);
+    assert.match(commands, /plugin install openviking-memory@openviking/mu);
+    assert.match(commands, /plugin enable openviking-memory@openviking/mu);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("TraeCode CLI 2.0 keeps the deprecated integration when plugin installation fails", () => {
+  const home = mkdtempSync(join(tmpdir(), "openviking-trae-cli-failed-migration-"));
+  try {
+    const binDir = join(home, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const cliPath = join(binDir, "trae-cli");
+    writeFileSync(cliPath, `#!/bin/sh
+case "$*" in
+  "plugin marketplace list --json") printf '{"marketplaces":[]}\n' ;;
+  "plugin marketplace list") printf 'Marketplaces:\n' ;;
+  "plugin add "*|"plugin install "*) exit 1 ;;
+esac
+exit 0
+`);
+    chmodSync(cliPath, 0o755);
+
+    const hooksPath = join(home, ".trae", "cli", "hooks.json");
+    const configPath = join(home, ".trae", "traecli.toml");
+    writeJson(hooksPath, { hooks: { Stop: [{ hooks: [{
+      type: "command",
+      command: "OPENVIKING_INTEGRATION_ID=openviking-memory node /tmp/agent-integrations/trae-cli/scripts/auto-capture.mjs",
+    }] }] } });
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '[mcp_servers."openviking-memory"]\ncommand = "node"\n');
+    const integrationRoot = join(home, ".openviking", "agent-integrations", "trae-cli");
+    mkdirSync(integrationRoot, { recursive: true });
+
+    const installed = runInstaller(home, [
+      "--harness", "trae-cli",
+      "--source", "dev",
+      "--lang", "en",
+      "--url", "http://127.0.0.1:1933",
+      "--api-key", "",
+      "--yes",
+    ], { PATH: `${binDir}:${dirname(installedNode)}:/usr/bin:/bin` });
+
+    assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
+    assert.match(installed.stdout, /plugin add\/install returned non-zero/u);
+    assert.match(readFileSync(hooksPath, "utf8"), /openviking-memory/u);
+    assert.match(readFileSync(configPath, "utf8"), /openviking-memory/u);
+    assert.equal(existsSync(integrationRoot), true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("TraeCode CLI 2.0 keeps the deprecated integration when plugin enable fails", () => {
+  const home = mkdtempSync(join(tmpdir(), "openviking-trae-cli-failed-enable-"));
+  try {
+    const binDir = join(home, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const cliPath = join(binDir, "trae-cli");
+    writeFileSync(cliPath, `#!/bin/sh
+case "$*" in
+  "plugin marketplace list --json") printf '{"marketplaces":[]}\n' ;;
+  "plugin marketplace list") printf 'Marketplaces:\n' ;;
+  "plugin add "*) exit 2 ;;
+  "plugin enable "*) exit 1 ;;
+esac
+exit 0
+`);
+    chmodSync(cliPath, 0o755);
+
+    const hooksPath = join(home, ".trae", "cli", "hooks.json");
+    const configPath = join(home, ".trae", "traecli.toml");
+    writeJson(hooksPath, { hooks: { Stop: [{ hooks: [{
+      type: "command",
+      command: "OPENVIKING_INTEGRATION_ID=openviking-memory node /tmp/agent-integrations/trae-cli/scripts/auto-capture.mjs",
+    }] }] } });
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, '[mcp_servers."openviking-memory"]\ncommand = "node"\n');
+    const integrationRoot = join(home, ".openviking", "agent-integrations", "trae-cli");
+    mkdirSync(integrationRoot, { recursive: true });
+
+    const installed = runInstaller(home, [
+      "--harness", "trae-cli",
+      "--source", "dev",
+      "--lang", "en",
+      "--url", "http://127.0.0.1:1933",
+      "--api-key", "",
+      "--yes",
+    ], { PATH: `${binDir}:${dirname(installedNode)}:/usr/bin:/bin` });
+
+    assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
+    assert.match(installed.stdout, /could not be enabled/u);
+    assert.match(readFileSync(hooksPath, "utf8"), /openviking-memory/u);
+    assert.match(readFileSync(configPath, "utf8"), /openviking-memory/u);
+    assert.equal(existsSync(integrationRoot), true);
   } finally {
     rmSync(home, { recursive: true, force: true });
   }

--- a/examples/memory-plugin-shared/install-agent-hooks.test.mjs
+++ b/examples/memory-plugin-shared/install-agent-hooks.test.mjs
@@ -113,8 +113,10 @@ exit 0
       TRAE_CLI_TEST_LOG: cliLog,
     });
     assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
+    assert.match(installed.stdout, /Selected harnesses: trae-cli/u);
+    assert.doesNotMatch(installed.stdout, /Selected harnesses: codex/u);
     assert.match(installed.stdout, /TraeCode CLI 2.0/);
-    assert.match(installed.stdout, /trae-cli harness is deprecated/);
+    assert.doesNotMatch(installed.stdout, /trae-cli harness is deprecated/);
 
     const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
     assert.ok(hooks.hooks.Stop.some((entry) => JSON.stringify(entry).includes("third-party stop")));

--- a/examples/memory-plugin-shared/install-tui.test.mjs
+++ b/examples/memory-plugin-shared/install-tui.test.mjs
@@ -66,6 +66,7 @@ test("a pre-existing TRAE home directory keeps TRAE Desktop as the default", (t)
 PATH=/usr/bin:/bin
 HOME=${JSON.stringify(home)}
 refresh_available_harnesses
+HAVE_CURSOR=0
 INTERACTIVE=0
 REQUESTED_HARNESSES=""
 select_harnesses
@@ -86,6 +87,7 @@ test("TRAE CLI configuration does not auto-select the TRAE CLI harness", (t) => 
 PATH=/usr/bin:/bin
 HOME=${JSON.stringify(home)}
 refresh_available_harnesses
+HAVE_CURSOR=0
 INTERACTIVE=0
 REQUESTED_HARNESSES=""
 select_harnesses
@@ -96,7 +98,7 @@ printf '%s\\n' "$SELECTED_HARNESSES"
   assert.equal(result.stdout.trim(), "trae");
 });
 
-test("TRAE CLI command aliases are detected and auto-selected", (t) => {
+test("TraeCode CLI 2.0 command aliases use the Codex-format selection", (t) => {
   const home = makeTempHome(t);
   const cliHome = join(home, ".trae", "cli");
   mkdirSync(cliHome, { recursive: true });
@@ -111,16 +113,43 @@ test("TRAE CLI command aliases are detected and auto-selected", (t) => {
 PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}
 HOME=${JSON.stringify(home)}
 refresh_available_harnesses
+TUI_CODEX_BINS="$CODEX_BINS"
+add_detected_traecode_cli_alias
+refresh_available_harnesses
+HAVE_CURSOR=0
 tui_reset_bin_selection
-selected_in_tui="$SEL_TRAE_CLI"
 INTERACTIVE=0
 REQUESTED_HARNESSES=""
 select_harnesses
-if tui_bin_detected trae-cli traecli; then detected=yes; else detected=no; fi
-printf '%s:%s:%s\\n' "$selected_in_tui" "$SELECTED_HARNESSES" "$detected"
+if tui_bin_detected codex ${command}; then detected=yes; else detected=no; fi
+label="$(tui_bin_label codex ${command})"
+printf '%s:%s:%s\\n' "$SELECTED_HARNESSES" "$detected" "$label"
 `);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(result.stdout.trim(), "1:trae,trae-cli:yes", command);
+    assert.equal(result.stdout.trim(), "codex,trae:yes:TraeCode CLI 2.0", command);
   }
+});
+
+test("legacy trae-cli harness resolves to only the TraeCode CLI Codex alias", (t) => {
+  const home = makeTempHome(t);
+  const bin = join(home, "bin");
+  mkdirSync(bin);
+  writeFileSync(join(bin, "trae-cli"), "#!/bin/sh\nexit 0\n");
+  chmodSync(join(bin, "trae-cli"), 0o755);
+
+  const result = runInstallerPrelude(`
+PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}
+HOME=${JSON.stringify(home)}
+refresh_available_harnesses
+TUI_CODEX_BINS="$CODEX_BINS"
+INTERACTIVE=0
+REQUESTED_HARNESSES="trae-cli"
+select_harnesses
+printf '%s:%s\\n' "$SELECTED_HARNESSES" "$(list_words "$CODEX_BINS")"
+`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /codex:trae-cli$/mu);
+  assert.match(result.stdout, /TraeCode CLI 2.0/);
 });

--- a/examples/memory-plugin-shared/install-tui.test.mjs
+++ b/examples/memory-plugin-shared/install-tui.test.mjs
@@ -131,7 +131,7 @@ printf '%s:%s:%s\\n' "$SELECTED_HARNESSES" "$detected" "$label"
   }
 });
 
-test("legacy trae-cli harness resolves to only the TraeCode CLI Codex alias", (t) => {
+test("trae-cli is the public harness and resolves to the Codex plugin internally", (t) => {
   const home = makeTempHome(t);
   const bin = join(home, "bin");
   mkdirSync(bin);
@@ -146,10 +146,9 @@ TUI_CODEX_BINS="$CODEX_BINS"
 INTERACTIVE=0
 REQUESTED_HARNESSES="trae-cli"
 select_harnesses
-printf '%s:%s\\n' "$SELECTED_HARNESSES" "$(list_words "$CODEX_BINS")"
+printf '%s:%s:%s\\n' "$SELECTED_HARNESSES" "$(list_words "$CODEX_BINS")" "$(tui_bin_label codex trae-cli)"
 `);
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /codex:trae-cli$/mu);
-  assert.match(result.stdout, /TraeCode CLI 2.0/);
+  assert.equal(result.stdout.trim(), "codex:trae-cli:TraeCode CLI 2.0");
 });

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -8,9 +8,9 @@
 # One-liner (TOS mirror, for regions where GitHub is unreachable):
 #   bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --dist tos
 # Non-interactive:
-#   bash install.sh --harness claude,codex,cursor,trae,trae-cn,zcode,opencode,pi --dist github --lang en --url http://127.0.0.1:1933
+#   bash install.sh --harness claude,codex,cursor,trae,trae-cn,trae-cli,zcode,opencode,pi --dist github --lang en --url http://127.0.0.1:1933
 # Format-compatible CLI aliases:
-#   bash install.sh --harness codex --codex-bin codex,trae-cli
+#   bash install.sh --harness trae-cli
 #   bash install.sh --harness claude --claude-bin claude,seed
 # Fork / branch verification:
 #   OPENVIKING_REPO_URL=https://github.com/you/OpenViking.git \
@@ -79,6 +79,8 @@ CC_REMOTE_MKT_DIR="$OV_HOME/marketplaces/openviking-claude"
 CC_REMOTE_MANIFEST="$CC_REMOTE_MKT_DIR/.claude-plugin/marketplace.json"
 
 REQUESTED_HARNESSES=""
+PUBLIC_SELECTED_HARNESSES=""
+TRAECODE_CLI_BIN=""
 CLAUDE_BINS_ARG="${OPENVIKING_CLAUDE_BINS:-${OPENVIKING_CLAUDE_BIN:-}}"
 CODEX_BINS_ARG="${OPENVIKING_CODEX_BINS:-${OPENVIKING_CODEX_BIN:-}}"
 SOURCE_ARG=""
@@ -143,8 +145,8 @@ usage() {
 Usage: install.sh [options]
 
 Options:
-  --harness LIST     Comma-separated harnesses: claude, codex, cursor, trae, trae-cn, zcode, opencode, pi.
-                     Legacy trae-cli is accepted as codex --codex-bin trae-cli.
+  --harness LIST     Comma-separated harnesses: claude, codex, cursor, trae, trae-cn, trae-cli, zcode, opencode, pi.
+                     Use trae-cli for TraeCode CLI 2.0 (installed through its Codex-compatible plugin format).
   --claude-bin LIST  Comma-separated Claude-format CLI commands (default: claude).
   --codex-bin LIST   Comma-separated Codex-format CLI commands (default: codex).
   --dist CHANNEL     github (default) | tos (mirror for GitHub-blocked regions).
@@ -395,7 +397,7 @@ resolve_traecode_cli_bin() {
   printf '%s' 'trae-cli'
 }
 
-normalize_legacy_trae_cli_harness() {
+normalize_trae_cli_harness() {
   local h normalized="" found=0 trae_cli_bin
   while IFS= read -r h; do
     [ -n "$h" ] || continue
@@ -409,9 +411,11 @@ normalize_legacy_trae_cli_harness() {
 $(split_harnesses "$SELECTED_HARNESSES")
 EOF
   [ "$found" -eq 1 ] || return 0
+  PUBLIC_SELECTED_HARNESSES="$SELECTED_HARNESSES"
   [ "$UNINSTALL" -eq 0 ] || return 0
 
   trae_cli_bin="$(resolve_traecode_cli_bin)"
+  TRAECODE_CLI_BIN="$trae_cli_bin"
   if [ -z "$CODEX_BINS_ARG" ] \
     && ! list_contains_line "$(split_harnesses "$normalized")" codex; then
     CODEX_BINS="$trae_cli_bin"
@@ -425,7 +429,6 @@ EOF
   else
     SELECTED_HARNESSES="${normalized:+$normalized,}codex"
   fi
-  warn "$(t 'The trae-cli harness is deprecated; installing the Codex-format plugin for TraeCode CLI 2.0 instead.' 'trae-cli harness 已弃用；将改为给 TraeCode CLI 2.0 安装 Codex 格式插件。')"
 }
 
 add_detected_traecode_cli_alias() {
@@ -930,7 +933,7 @@ select_harnesses() {
 
   if [ -n "$REQUESTED_HARNESSES" ]; then
     SELECTED_HARNESSES="$REQUESTED_HARNESSES"
-    normalize_legacy_trae_cli_harness
+    normalize_trae_cli_harness
     return
   fi
   default="${detected:-claude,codex}"
@@ -3288,9 +3291,10 @@ select_harnesses
 validate_selected_harnesses
 select_compatible_bins
 refresh_available_harnesses
-info "$(t 'Selected harnesses:' '已选择：') $(printf '%s' "$SELECTED_HARNESSES" | tr ',' ' ')"
+info "$(t 'Selected harnesses:' '已选择：') $(printf '%s' "${PUBLIC_SELECTED_HARNESSES:-$SELECTED_HARNESSES}" | tr ',' ' ')"
 if contains_harness claude; then info "$(t 'Claude-format commands:' 'Claude 格式命令：') $(list_words "$CLAUDE_BINS")"; fi
-if contains_harness codex; then info "$(t 'Codex-format commands:' 'Codex 格式命令：') $(list_words "$CODEX_BINS")"; fi
+if [ -n "$TRAECODE_CLI_BIN" ]; then info "TraeCode CLI 2.0: $TRAECODE_CLI_BIN"; fi
+if contains_harness codex && [ -z "$TRAECODE_CLI_BIN" ]; then info "$(t 'Codex-format commands:' 'Codex 格式命令：') $(list_words "$CODEX_BINS")"; fi
 validate_selected_bins
 if [ "$UNINSTALL" -eq 1 ]; then
   uninstall_agent_integrations
@@ -3322,7 +3326,6 @@ fi
 if contains_harness cursor; then install_cursor; fi
 if contains_harness trae; then install_trae_variant trae; fi
 if contains_harness trae-cn; then install_trae_variant trae-cn; fi
-if contains_harness trae-cli; then install_trae_cli; fi
 if contains_harness zcode; then install_zcode; fi
 if contains_harness opencode; then install_opencode; fi
 if contains_harness pi; then install_pi; fi
@@ -3335,11 +3338,14 @@ case "$SOURCE_MODE" in
   *) if contains_harness claude || contains_harness codex; then info "Marketplace: ${MKT_DIR:-$CODEX_TOS_GIT_URL}"; fi ;;
 esac
 if contains_harness claude; then info "Claude-format: $(list_words "$CLAUDE_BINS") -> $PLUGIN_ID"; fi
-if contains_harness codex; then info "Codex-format:  $(list_words "$CODEX_BINS") -> $PLUGIN_ID"; fi
+if [ -n "$TRAECODE_CLI_BIN" ]; then
+  info "TraeCode CLI 2.0: $TRAECODE_CLI_BIN -> $PLUGIN_ID"
+elif contains_harness codex; then
+  info "Codex-format:  $(list_words "$CODEX_BINS") -> $PLUGIN_ID"
+fi
 if contains_harness cursor; then info "Cursor: Hooks + MCP + Rule + Skill"; fi
 if contains_harness trae; then info "TRAE: ~/.trae/hooks.json + MCP"; fi
 if contains_harness trae-cn; then info "TRAE CN: ~/.trae-cn/hooks.json + MCP"; fi
-if contains_harness trae-cli; then info "TRAE CLI: ${TRAECLI_HOME:-${TRAE_HOME:-~/.trae}/cli}/hooks.json + ${TRAE_HOME:-~/.trae}/traecli.toml"; fi
 if contains_harness zcode; then info "ZCode: ~/.zcode/cli/config.json (hooks + MCP)"; fi
 if contains_harness opencode; then info "OpenCode: @openviking/opencode-plugin"; fi
 if contains_harness pi; then info "pi: ~/.pi/agent/extensions/openviking"; fi

--- a/examples/memory-plugin-shared/install.sh
+++ b/examples/memory-plugin-shared/install.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
 # OpenViking Memory Plugin shared installer for Claude Code, Codex, Cursor,
-# TRAE / TRAE CN, TRAE CLI, ZCode, OpenCode, and pi.
+# TRAE / TRAE CN, TraeCode CLI 2.0, ZCode, OpenCode, and pi.
 #
 # One-liner (GitHub):
 #   bash <(curl -fsSL https://raw.githubusercontent.com/volcengine/OpenViking/main/examples/memory-plugin-shared/install.sh)
 # One-liner (TOS mirror, for regions where GitHub is unreachable):
 #   bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shared/install.sh) --dist tos
 # Non-interactive:
-#   bash install.sh --harness claude,codex,cursor,trae,trae-cn,trae-cli,zcode,opencode,pi --dist github --lang en --url http://127.0.0.1:1933
+#   bash install.sh --harness claude,codex,cursor,trae,trae-cn,zcode,opencode,pi --dist github --lang en --url http://127.0.0.1:1933
 # Format-compatible CLI aliases:
-#   bash install.sh --harness codex --codex-bin codex,traex
+#   bash install.sh --harness codex --codex-bin codex,trae-cli
 #   bash install.sh --harness claude --claude-bin claude,seed
 # Fork / branch verification:
 #   OPENVIKING_REPO_URL=https://github.com/you/OpenViking.git \
@@ -143,7 +143,8 @@ usage() {
 Usage: install.sh [options]
 
 Options:
-  --harness LIST     Comma-separated harnesses: claude, codex, cursor, trae, trae-cn, trae-cli, zcode, opencode, pi.
+  --harness LIST     Comma-separated harnesses: claude, codex, cursor, trae, trae-cn, zcode, opencode, pi.
+                     Legacy trae-cli is accepted as codex --codex-bin trae-cli.
   --claude-bin LIST  Comma-separated Claude-format CLI commands (default: claude).
   --codex-bin LIST   Comma-separated Codex-format CLI commands (default: codex).
   --dist CHANNEL     github (default) | tos (mirror for GitHub-blocked regions).
@@ -156,6 +157,7 @@ Options:
   --statusline       Register the Claude Code statusline without asking.
   --no-statusline    Skip the statusline prompt.
   --uninstall        Remove Cursor/TRAE OpenViking integration files and config.
+                     For Codex-format plugins, use the client's plugin uninstall command.
   --yes, -y          Use defaults for prompts when possible.
 EOF
 }
@@ -375,11 +377,65 @@ refresh_available_harnesses() {
   { command -v cursor >/dev/null 2>&1 || command -v cursor-agent >/dev/null 2>&1 || [ -d "/Applications/Cursor.app" ] || [ -d "$HOME/.cursor" ]; } && HAVE_CURSOR=1
   { [ -d "/Applications/Trae.app" ] || [ -d "/Applications/TRAE.app" ] || [ -d "$HOME/.trae" ]; } && HAVE_TRAE=1
   { [ -d "/Applications/Trae CN.app" ] || [ -d "/Applications/TRAE SOLO CN.app" ] || [ -d "$HOME/.trae-cn" ]; } && HAVE_TRAE_CN=1
-  { command -v traecli >/dev/null 2>&1 || command -v traex >/dev/null 2>&1; } && HAVE_TRAE_CLI=1
+  { command -v trae-cli >/dev/null 2>&1 || command -v traecli >/dev/null 2>&1 || command -v traex >/dev/null 2>&1; } && HAVE_TRAE_CLI=1
   command -v opencode >/dev/null 2>&1 && HAVE_OPENCODE=1
   command -v pi >/dev/null 2>&1 && HAVE_PI=1
   { command -v zcode >/dev/null 2>&1 || [ -d "$HOME/.zcode" ]; } && HAVE_ZCODE=1
   return 0
+}
+
+resolve_traecode_cli_bin() {
+  local bin
+  for bin in trae-cli traecli traex; do
+    if command -v "$bin" >/dev/null 2>&1; then
+      printf '%s' "$bin"
+      return 0
+    fi
+  done
+  printf '%s' 'trae-cli'
+}
+
+normalize_legacy_trae_cli_harness() {
+  local h normalized="" found=0 trae_cli_bin
+  while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    if [ "$h" = "trae-cli" ]; then
+      found=1
+      continue
+    fi
+    list_contains_line "$(split_harnesses "$normalized")" "$h" \
+      || normalized="${normalized:+$normalized,}$h"
+  done <<EOF
+$(split_harnesses "$SELECTED_HARNESSES")
+EOF
+  [ "$found" -eq 1 ] || return 0
+  [ "$UNINSTALL" -eq 0 ] || return 0
+
+  trae_cli_bin="$(resolve_traecode_cli_bin)"
+  if [ -z "$CODEX_BINS_ARG" ] \
+    && ! list_contains_line "$(split_harnesses "$normalized")" codex; then
+    CODEX_BINS="$trae_cli_bin"
+    TUI_CODEX_BINS="$trae_cli_bin"
+  else
+    CODEX_BINS="$(append_csv_list "$CODEX_BINS" "$trae_cli_bin")"
+    TUI_CODEX_BINS="$(append_csv_list "$TUI_CODEX_BINS" "$trae_cli_bin")"
+  fi
+  if list_contains_line "$(split_harnesses "$normalized")" codex; then
+    SELECTED_HARNESSES="$normalized"
+  else
+    SELECTED_HARNESSES="${normalized:+$normalized,}codex"
+  fi
+  warn "$(t 'The trae-cli harness is deprecated; installing the Codex-format plugin for TraeCode CLI 2.0 instead.' 'trae-cli harness 已弃用；将改为给 TraeCode CLI 2.0 安装 Codex 格式插件。')"
+}
+
+add_detected_traecode_cli_alias() {
+  local trae_cli_bin
+  [ -z "$CODEX_BINS_ARG" ] || return 0
+  [ "$HAVE_TRAE_CLI" -eq 1 ] || return 0
+  [ -z "$REQUESTED_HARNESSES" ] || return 0
+  trae_cli_bin="$(resolve_traecode_cli_bin)"
+  CODEX_BINS="$(append_csv_list "$CODEX_BINS" "$trae_cli_bin")"
+  TUI_CODEX_BINS="$(append_csv_list "$TUI_CODEX_BINS" "$trae_cli_bin")"
 }
 
 bin_basename() {
@@ -450,6 +506,8 @@ refresh_available_harnesses
 
 TUI_CLAUDE_BINS="$CLAUDE_BINS"
 TUI_CODEX_BINS="$CODEX_BINS"
+add_detected_traecode_cli_alias
+refresh_available_harnesses
 SEL_CLAUDE_BINS=""
 SEL_CODEX_BINS=""
 SEL_OPENCODE=0
@@ -457,7 +515,6 @@ SEL_PI=0
 SEL_CURSOR_APP=0
 SEL_TRAE=0
 SEL_TRAE_CN=0
-SEL_TRAE_CLI=0
 SEL_ZCODE=0
 TUI_CURSOR=0; TUI_LINES=0
 
@@ -472,7 +529,7 @@ EOF
 }
 
 tui_selectable_count() {
-  printf '%s' $(( $(list_count "$TUI_CLAUDE_BINS") + $(list_count "$TUI_CODEX_BINS") + 7 ))
+  printf '%s' $(( $(list_count "$TUI_CLAUDE_BINS") + $(list_count "$TUI_CODEX_BINS") + 6 ))
 }
 
 tui_total_count() {
@@ -505,8 +562,6 @@ EOF
   i=$((i + 1))
   if [ "$i" -eq "$idx" ]; then printf 'trae-cn|trae-cn'; return 0; fi
   i=$((i + 1))
-  if [ "$i" -eq "$idx" ]; then printf 'trae-cli|trae-cli'; return 0; fi
-  i=$((i + 1))
   if [ "$i" -eq "$idx" ]; then printf 'zcode|zcode'; return 0; fi
   printf 'add|'
 }
@@ -532,12 +587,12 @@ tui_bin_label() {
   case "$kind:$bin" in
     claude:claude) printf 'Claude Code' ;;
     codex:codex) printf 'Codex' ;;
+    codex:trae-cli|codex:traecli|codex:traex) printf 'TraeCode CLI 2.0' ;;
     opencode:*) printf 'OpenCode' ;;
     pi:*) printf 'pi' ;;
     cursor:*) printf 'Cursor' ;;
     trae:*) printf 'TRAE' ;;
     trae-cn:*) printf 'TRAE CN' ;;
-    trae-cli:*) printf 'TRAE CLI' ;;
     zcode:*) printf 'ZCode' ;;
     claude:*) printf '%s %s' "$bin" "$(t '(Claude-format)' '（Claude 格式）')" ;;
     codex:*) printf '%s %s' "$bin" "$(t '(Codex-format)' '（Codex 格式）')" ;;
@@ -560,8 +615,6 @@ tui_bin_selected() {
     [ "$SEL_TRAE" -eq 1 ]
   elif [ "$kind" = "trae-cn" ]; then
     [ "$SEL_TRAE_CN" -eq 1 ]
-  elif [ "$kind" = "trae-cli" ]; then
-    [ "$SEL_TRAE_CLI" -eq 1 ]
   else
     [ "$SEL_ZCODE" -eq 1 ]
   fi
@@ -572,7 +625,6 @@ tui_bin_detected() { # tui_bin_detected <kind> <bin>
     cursor) [ "$HAVE_CURSOR" -eq 1 ] ;;
     trae) [ "$HAVE_TRAE" -eq 1 ] ;;
     trae-cn) [ "$HAVE_TRAE_CN" -eq 1 ] ;;
-    trae-cli) [ "$HAVE_TRAE_CLI" -eq 1 ] ;;
     zcode) [ "$HAVE_ZCODE" -eq 1 ] ;;
     *) command -v "$2" >/dev/null 2>&1 ;;
   esac
@@ -586,7 +638,6 @@ tui_set_all_bins() {
   SEL_CURSOR_APP=1
   SEL_TRAE=1
   SEL_TRAE_CN=1
-  SEL_TRAE_CLI=1
   SEL_ZCODE=1
 }
 
@@ -608,8 +659,6 @@ tui_toggle_bin() {
     SEL_TRAE=$((1 - SEL_TRAE)); return 0
   elif [ "$kind" = "trae-cn" ]; then
     SEL_TRAE_CN=$((1 - SEL_TRAE_CN)); return 0
-  elif [ "$kind" = "trae-cli" ]; then
-    SEL_TRAE_CLI=$((1 - SEL_TRAE_CLI)); return 0
   else
     SEL_ZCODE=$((1 - SEL_ZCODE)); return 0
   fi
@@ -680,7 +729,6 @@ tui_reset_bin_selection() {
   SEL_CURSOR_APP=0
   SEL_TRAE=0
   SEL_TRAE_CN=0
-  SEL_TRAE_CLI=0
   SEL_ZCODE=0
   while IFS= read -r bin; do
     [ -n "$bin" ] || continue
@@ -705,7 +753,6 @@ EOF
   if [ "$HAVE_CURSOR" -eq 1 ]; then SEL_CURSOR_APP=1; any=1; fi
   if [ "$HAVE_TRAE" -eq 1 ]; then SEL_TRAE=1; any=1; fi
   if [ "$HAVE_TRAE_CN" -eq 1 ]; then SEL_TRAE_CN=1; any=1; fi
-  if [ "$HAVE_TRAE_CLI" -eq 1 ]; then SEL_TRAE_CLI=1; any=1; fi
   if [ "$HAVE_ZCODE" -eq 1 ]; then SEL_ZCODE=1; any=1; fi
   if [ "$any" -ne 1 ]; then
     SEL_CLAUDE_BINS="$TUI_CLAUDE_BINS"
@@ -794,7 +841,7 @@ tui_add_compatible_cli() {
 tui_has_selection() {
   [ -n "$(list_words "$SEL_CLAUDE_BINS")" ] || [ -n "$(list_words "$SEL_CODEX_BINS")" ] \
     || [ "$SEL_OPENCODE" -eq 1 ] || [ "$SEL_PI" -eq 1 ] || [ "$SEL_CURSOR_APP" -eq 1 ] \
-    || [ "$SEL_TRAE" -eq 1 ] || [ "$SEL_TRAE_CN" -eq 1 ] || [ "$SEL_TRAE_CLI" -eq 1 ] || [ "$SEL_ZCODE" -eq 1 ]
+    || [ "$SEL_TRAE" -eq 1 ] || [ "$SEL_TRAE_CN" -eq 1 ] || [ "$SEL_ZCODE" -eq 1 ]
 }
 
 tui_finish_selection() {
@@ -808,7 +855,6 @@ tui_finish_selection() {
   [ "$SEL_CURSOR_APP" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}cursor"
   [ "$SEL_TRAE" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}trae"
   [ "$SEL_TRAE_CN" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}trae-cn"
-  [ "$SEL_TRAE_CLI" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}trae-cli"
   [ "$SEL_ZCODE" -eq 1 ] && SELECTED_HARNESSES="${SELECTED_HARNESSES:+$SELECTED_HARNESSES,}zcode"
   return 0
 }
@@ -878,13 +924,13 @@ select_harnesses() {
   [ "$HAVE_CURSOR" -eq 1 ] && detected="${detected:+$detected,}cursor"
   [ "$HAVE_TRAE" -eq 1 ] && detected="${detected:+$detected,}trae"
   [ "$HAVE_TRAE_CN" -eq 1 ] && detected="${detected:+$detected,}trae-cn"
-  [ "$HAVE_TRAE_CLI" -eq 1 ] && detected="${detected:+$detected,}trae-cli"
   [ "$HAVE_OPENCODE" -eq 1 ] && detected="${detected:+$detected,}opencode"
   [ "$HAVE_PI" -eq 1 ] && detected="${detected:+$detected,}pi"
   [ "$HAVE_ZCODE" -eq 1 ] && detected="${detected:+$detected,}zcode"
 
   if [ -n "$REQUESTED_HARNESSES" ]; then
     SELECTED_HARNESSES="$REQUESTED_HARNESSES"
+    normalize_legacy_trae_cli_harness
     return
   fi
   default="${detected:-claude,codex}"
@@ -927,7 +973,8 @@ validate_selected_harnesses() {
   local h bad=0
   while IFS= read -r h; do
     case "$h" in
-      claude|codex|cursor|trae|trae-cn|trae-cli|opencode|pi|zcode) ;;
+      claude|codex|cursor|trae|trae-cn|opencode|pi|zcode) ;;
+      trae-cli) [ "$UNINSTALL" -eq 1 ] || bad=1 ;;
       *) err "Unsupported harness: $h"; bad=1 ;;
     esac
   done <<EOF
@@ -1549,6 +1596,37 @@ codex_cmd() {
   command "$CODEX_BIN" "$@"
 }
 
+codex_bin_label() {
+  case "$(bin_basename "$CODEX_BIN")" in
+    trae-cli|traecli|traex) printf 'TraeCode CLI 2.0' ;;
+    codex) printf 'Codex' ;;
+    *) printf '%s %s' "$CODEX_BIN" "$(t '(Codex-format)' '（Codex 格式）')" ;;
+  esac
+}
+
+remove_legacy_trae_cli_integration() {
+  case "$(bin_basename "$CODEX_BIN")" in
+    trae-cli|traecli|traex) ;;
+    *) return 0 ;;
+  esac
+  local trae_home="${TRAE_HOME:-$HOME/.trae}"
+  local trae_cli_home="${TRAECLI_HOME:-$trae_home/cli}"
+  if grep -qi 'openviking' "$trae_cli_home/hooks.json" 2>/dev/null \
+    || [ -d "$OV_HOME/agent-integrations/trae-cli" ] \
+    || grep -qF '[mcp_servers."openviking-memory"]' "$trae_home/traecli.toml" 2>/dev/null; then
+    agent_remove_trae_cli_configs "$trae_cli_home/hooks.json" "$trae_home/traecli.toml"
+    rm -rf "$OV_HOME/agent-integrations/trae-cli"
+    info "$(t 'Removed the deprecated TRAE CLI Hooks integration after installing the TraeCode CLI 2.0 plugin.' 'TraeCode CLI 2.0 插件安装成功后，已移除弃用的 TRAE CLI Hooks 集成。')"
+  fi
+  if [ ! -d "$OV_HOME/agent-integrations/cursor" ] \
+    && [ ! -d "$OV_HOME/agent-integrations/trae" ] \
+    && [ ! -d "$OV_HOME/agent-integrations/trae-cn" ] \
+    && [ ! -d "$OV_HOME/agent-integrations/trae-cli" ] \
+    && [ ! -d "$OV_HOME/agent-integrations/zcode" ]; then
+    rm -rf "$OV_HOME/agent-integrations/memory-plugin-shared"
+  fi
+}
+
 codex_marketplace_current_source() {
   local raw
   raw="$(codex_cmd plugin marketplace list --json 2>/dev/null || true)"
@@ -1658,7 +1736,12 @@ NODE
 }
 
 install_codex() {
-  heading "$(t '4. Codex plugin' '4. Codex 插件')"
+  local plugin_installed=0
+  if is_native_codex_bin; then
+    heading "$(t '4. Codex plugin' '4. Codex 插件')"
+  else
+    heading "4. $(codex_bin_label)"
+  fi
   command -v "$CODEX_BIN" >/dev/null 2>&1 || {
     warn "$(t 'Codex-format CLI not found; skipping:' '未找到 Codex 格式 CLI，跳过：') $CODEX_BIN"
     return 0
@@ -1693,11 +1776,20 @@ install_codex() {
       codex_marketplace_sync "$MKT_DIR" "$MKT_DIR" || return 1
       ;;
   esac
-  if ! codex_cmd plugin add "$PLUGIN_ID" >/dev/null 2>&1; then
-    codex_cmd plugin install "$PLUGIN_ID" >/dev/null 2>&1 || \
-      warn "$CODEX_BIN plugin add/install returned non-zero for $PLUGIN_ID"
+  if codex_cmd plugin add "$PLUGIN_ID" >/dev/null 2>&1; then
+    plugin_installed=1
+  elif codex_cmd plugin install "$PLUGIN_ID" >/dev/null 2>&1; then
+    plugin_installed=1
+  else
+    warn "$CODEX_BIN plugin add/install returned non-zero for $PLUGIN_ID"
   fi
-  codex_cmd plugin enable "$PLUGIN_ID" >/dev/null 2>&1 || true
+  if [ "$plugin_installed" -eq 1 ]; then
+    if codex_cmd plugin enable "$PLUGIN_ID" >/dev/null 2>&1; then
+      remove_legacy_trae_cli_integration
+    elif ! is_native_codex_bin; then
+      warn "$(t 'Plugin installed but could not be enabled; keeping the deprecated TRAE CLI Hooks integration.' '插件已安装但未能启用；保留弃用的 TRAE CLI Hooks 集成。')"
+    fi
+  fi
   if is_native_codex_bin; then
     ensure_codex_config
     info "$(t 'Codex plugin enabled in' 'Codex 插件已在配置中启用：') $CODEX_CONFIG"

--- a/examples/memory-plugin-shared/release-marketplace.test.mjs
+++ b/examples/memory-plugin-shared/release-marketplace.test.mjs
@@ -70,7 +70,7 @@ test("release marketplace archive supports a ZCode TOS install", () => {
   }
 });
 
-test("release marketplace archive supports a TRAE CLI TOS install", () => {
+test("release marketplace archive retains the deprecated TRAE CLI integration for cleanup compatibility", () => {
   const tmp = mkdtempSync(join(tmpdir(), "openviking-trae-cli-release-"));
   try {
     const stage = join(tmp, "memory-plugin-marketplace");
@@ -82,28 +82,10 @@ test("release marketplace archive supports a TRAE CLI TOS install", () => {
     });
     assert.equal(zipped.status, 0, `${zipped.stdout}\n${zipped.stderr}`);
 
-    const home = join(tmp, "home");
-    mkdirSync(home, { recursive: true });
-    const installed = run("bash", [
-      installer,
-      "--harness", "trae-cli",
-      "--dist", "tos",
-      "--source", "archive",
-      "--lang", "en",
-      "--url", "http://127.0.0.1:1933",
-      "--api-key", "",
-      "--yes",
-    ], {
-      env: {
-        ...process.env,
-        HOME: home,
-        OPENVIKING_HOME: join(home, ".openviking"),
-        OPENVIKING_MARKETPLACE_ARCHIVE_URL: `file://${join(tmp, "memory-plugin-marketplace.zip")}`,
-      },
-    });
-    assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
-
-    const integrationRoot = join(home, ".openviking", "agent-integrations", "trae-cli");
+    const integrationRoot = join(stage, "trae-cli-memory-hooks");
+    const manifest = JSON.parse(readFileSync(join(integrationRoot, "openviking.integration.json"), "utf8"));
+    assert.equal(manifest.deprecated, true);
+    assert.match(manifest.replacement, /codex-memory-plugin/u);
     assert.ok(existsSync(join(integrationRoot, "scripts", "trae-cli-hook.mjs")));
     assert.ok(existsSync(join(integrationRoot, "scripts", "uri-guard.mjs")));
     assert.ok(existsSync(join(integrationRoot, "servers", "mcp-proxy.mjs")));

--- a/examples/trae-cli-memory-hooks/README.md
+++ b/examples/trae-cli-memory-hooks/README.md
@@ -1,25 +1,37 @@
 # OpenViking Memory Hooks for TRAE CLI
 
+> **Deprecated.** TraeCode CLI 2.0 supports Codex-format plugins directly. New
+> installations use [`examples/codex-memory-plugin`](../codex-memory-plugin)
+> through the `trae-cli` command alias, so this adapter is retained only for
+> compatibility tests and removal of existing managed installations.
+
 This directory provides the TRAE CLI lifecycle adapter for OpenViking memory:
 three lifecycle hooks, a `PreToolUse` URI guard, and the `openviking-memory`
 MCP server.
 
 ## Installation
 
-Use the shared installer:
+Install the supported TraeCode CLI 2.0 plugin through the shared installer:
+
+```bash
+bash examples/memory-plugin-shared/install.sh --harness codex --codex-bin trae-cli
+```
+
+The legacy spelling below remains accepted and resolves to the same Codex-format
+plugin installation:
 
 ```bash
 bash examples/memory-plugin-shared/install.sh --harness trae-cli
 ```
 
-The installer:
+It no longer installs this adapter. The previous installer behavior was to:
 
-- assembles the shared runtime under
+- assemble the shared runtime under
   `$OPENVIKING_HOME/agent-integrations/memory-plugin-shared/lib`;
-- installs this adapter under
+- install this adapter under
   `$OPENVIKING_HOME/agent-integrations/trae-cli`;
-- merges hooks into `${TRAECLI_HOME:-${TRAE_HOME:-~/.trae}/cli}/hooks.json`;
-- registers `openviking-memory` in `${TRAE_HOME:-~/.trae}/traecli.toml`.
+- merge hooks into `${TRAECLI_HOME:-${TRAE_HOME:-~/.trae}/cli}/hooks.json`;
+- register `openviking-memory` in `${TRAE_HOME:-~/.trae}/traecli.toml`.
 
 Uninstall with:
 

--- a/examples/trae-cli-memory-hooks/README.md
+++ b/examples/trae-cli-memory-hooks/README.md
@@ -14,15 +14,12 @@ MCP server.
 Install the supported TraeCode CLI 2.0 plugin through the shared installer:
 
 ```bash
-bash examples/memory-plugin-shared/install.sh --harness codex --codex-bin trae-cli
-```
-
-The legacy spelling below remains accepted and resolves to the same Codex-format
-plugin installation:
-
-```bash
 bash examples/memory-plugin-shared/install.sh --harness trae-cli
 ```
+
+The installer keeps `trae-cli` as the user-facing harness name and resolves it
+internally to the Codex-format plugin installation. The deprecated component is
+this standalone Hooks adapter, not the `trae-cli` harness.
 
 It no longer installs this adapter. The previous installer behavior was to:
 

--- a/examples/trae-cli-memory-hooks/openviking.integration.json
+++ b/examples/trae-cli-memory-hooks/openviking.integration.json
@@ -2,6 +2,8 @@
   "schemaVersion": 1,
   "id": "openviking-memory",
   "version": "0.1.0",
+  "deprecated": true,
+  "replacement": "examples/codex-memory-plugin (install through the trae-cli Codex-format alias)",
   "clients": ["trae-cli"],
   "capabilities": ["hooks", "mcp"]
 }


### PR DESCRIPTION
## Description

Install the OpenViking Codex memory plugin directly in TraeCode CLI 2.0 instead of maintaining a separate TRAE CLI Hooks integration. The public installer entry remains `--harness trae-cli`; the Codex-compatible plugin mapping is an internal implementation detail.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Keep `--harness trae-cli` as the documented and displayed TraeCode CLI 2.0 installation path, while mapping it internally to the Codex-compatible plugin flow.
- Detect the `trae-cli`, `traecli`, and `traex` executable names and display them as **TraeCode CLI 2.0**.
- Mark only the old standalone `trae-cli-memory-hooks` adapter as deprecated and retain it for cleanup/backward compatibility.
- Migrate old managed Hooks/MCP configuration only after the replacement plugin is installed and enabled successfully, preserving the old integration when install or enable fails.
- Update English/Chinese integration docs and add installer regression coverage.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```text
node --test examples/memory-plugin-shared/*.test.mjs examples/codex-memory-plugin/scripts/marketplace.test.mjs examples/trae-cli-memory-hooks/scripts/trae-cli-hooks.test.mjs
# 76 passed

trae-cli plugin validate --path examples/codex-memory-plugin
# valid: provides 2 skills and MCP server config

bash -n examples/memory-plugin-shared/install.sh
git diff --check
```

Also verified with TraeCode CLI 2.0 (`traecli 0.201.1`) that the Codex-format marketplace plugin installs and appears as `openviking-memory@openviking`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The deprecated standalone TRAE CLI adapter remains in release archives so existing installations can still be identified and removed safely. The `trae-cli` harness itself is not deprecated.
