### PR TITLE
fix(privacy): serialize config mutations under pathlock and propagate storage errors

### DIFF
--- a/openviking/privacy/service.py
+++ b/openviking/privacy/service.py
@@ -3,7 +3,8 @@
 """User privacy config storage service."""
 
 import json
-from typing import Any, Optional
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Optional
 
 from openviking.core.namespace import canonical_user_root
 from openviking.privacy.helpers import (
@@ -41,22 +42,49 @@ class UserPrivacyConfigService:
         try:
             await self._viking_fs.stat(self.get_config_root(ctx, category, target_key), ctx=ctx)
             return True
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return False
 
     async def delete(self, ctx: RequestContext, category: str, target_key: str) -> bool:
         root_uri = self.get_config_root(ctx, category, target_key)
-        if not await self.exists(ctx, category, target_key):
-            return False
-        await self._viking_fs.rm(root_uri, recursive=True, ctx=ctx)
-        return True
+        async with self._config_lock(ctx, category, target_key) as lease:
+            if not await self.exists(ctx, category, target_key):
+                return False
+            await self._viking_fs.rm(root_uri, recursive=True, ctx=ctx, lease_ref=lease)
+            return True
 
-    async def _ensure_root(self, ctx: RequestContext, category: str, target_key: str) -> None:
+    async def _ensure_root(
+        self,
+        ctx: RequestContext,
+        category: str,
+        target_key: str,
+        lease_ref: Optional[dict[str, Any]] = None,
+    ) -> None:
         root_uri = self.get_config_root(ctx, category, target_key)
-        await self._viking_fs.mkdir(root_uri, exist_ok=True, ctx=ctx)
+        await self._viking_fs.mkdir(root_uri, exist_ok=True, ctx=ctx, lease_ref=lease_ref)
         await self._viking_fs.mkdir(
-            history_dir_uri(self._user_space(ctx), category, target_key), exist_ok=True, ctx=ctx
+            history_dir_uri(self._user_space(ctx), category, target_key),
+            exist_ok=True,
+            ctx=ctx,
+            lease_ref=lease_ref,
         )
+
+    @asynccontextmanager
+    async def _config_lock(
+        self, ctx: RequestContext, category: str, target_key: str
+    ) -> AsyncIterator[Optional[dict[str, Any]]]:
+        uri_to_path = getattr(self._viking_fs, "_uri_to_path", None)
+        agfs = getattr(self._viking_fs, "_async_agfs", None)
+        acquire = getattr(agfs, "pathlock_acquire_tree", None)
+        release = getattr(agfs, "pathlock_release", None)
+        if not callable(uri_to_path) or not callable(acquire) or not callable(release):
+            yield None
+            return
+        lease = await acquire(uri_to_path(self.get_config_root(ctx, category, target_key), ctx=ctx))
+        try:
+            yield lease
+        finally:
+            await release(lease)
 
     async def get_meta(
         self, ctx: RequestContext, category: str, target_key: str
@@ -65,18 +93,24 @@ class UserPrivacyConfigService:
             content = await self._viking_fs.read_file(
                 meta_uri(self._user_space(ctx), category, target_key), ctx=ctx
             )
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return None
         return UserPrivacyConfigMeta.from_dict(json.loads(content))
 
     async def _save_meta(
-        self, ctx: RequestContext, category: str, target_key: str, meta: UserPrivacyConfigMeta
+        self,
+        ctx: RequestContext,
+        category: str,
+        target_key: str,
+        meta: UserPrivacyConfigMeta,
+        lease_ref: Optional[dict[str, Any]] = None,
     ) -> None:
         meta.updated_at = get_current_timestamp()
         await self._viking_fs.write_file(
             meta_uri(self._user_space(ctx), category, target_key),
             json.dumps(meta.to_dict(), ensure_ascii=False),
             ctx=ctx,
+            lease_ref=lease_ref,
         )
 
     async def get_current(
@@ -86,7 +120,7 @@ class UserPrivacyConfigService:
             content = await self._viking_fs.read_file(
                 current_uri(self._user_space(ctx), category, target_key), ctx=ctx
             )
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return None
         return UserPrivacyConfigVersion.from_dict(json.loads(content))
 
@@ -97,7 +131,7 @@ class UserPrivacyConfigService:
             content = await self._viking_fs.read_file(
                 version_uri(self._user_space(ctx), category, target_key, version), ctx=ctx
             )
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return None
         return UserPrivacyConfigVersion.from_dict(json.loads(content))
 
@@ -105,7 +139,7 @@ class UserPrivacyConfigService:
         uri = f"{self._user_root(ctx)}/privacy"
         try:
             entries = await self._viking_fs.ls(uri, ctx=ctx)
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return []
         return sorted(entry["name"] for entry in entries if entry.get("name"))
 
@@ -113,7 +147,7 @@ class UserPrivacyConfigService:
         uri = f"{self._user_root(ctx)}/privacy/{category}"
         try:
             entries = await self._viking_fs.ls(uri, ctx=ctx)
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return []
         return sorted(entry["name"] for entry in entries if entry.get("name"))
 
@@ -122,7 +156,7 @@ class UserPrivacyConfigService:
             entries = await self._viking_fs.ls(
                 history_dir_uri(self._user_space(ctx), category, target_key), ctx=ctx
             )
-        except Exception:
+        except (NotFoundError, FileNotFoundError):
             return []
         versions = []
         for entry in entries:
@@ -141,63 +175,66 @@ class UserPrivacyConfigService:
         change_reason: str = "",
         labels: Optional[dict[str, Any]] = None,
     ) -> UserPrivacyConfigVersion:
-        await self._ensure_root(ctx, category, target_key)
-        now = get_current_timestamp()
-        meta = await self.get_meta(ctx, category, target_key)
-        current = await self.get_current(ctx, category, target_key)
+        async with self._config_lock(ctx, category, target_key) as lease:
+            await self._ensure_root(ctx, category, target_key, lease)
+            now = get_current_timestamp()
+            meta = await self.get_meta(ctx, category, target_key)
+            current = await self.get_current(ctx, category, target_key)
 
-        if current and canonicalize_values(current.values) == canonicalize_values(values):
+            if current and canonicalize_values(current.values) == canonicalize_values(values):
+                if meta is None:
+                    meta = UserPrivacyConfigMeta(
+                        category=category,
+                        target_key=target_key,
+                        active_version=current.version,
+                        latest_version=current.version,
+                        created_at=now,
+                    )
+                meta.updated_by = updated_by
+                meta.last_accessed_at = now
+                if labels is not None:
+                    meta.labels = dict(labels)
+                await self._save_meta(ctx, category, target_key, meta, lease)
+                return current
+
+            version_number = 1 if meta is None else meta.latest_version + 1
+            version = UserPrivacyConfigVersion(
+                version=version_number,
+                category=category,
+                target_key=target_key,
+                values=dict(values),
+                created_at=now,
+                created_by=updated_by,
+                change_reason=change_reason,
+            )
+
+            await self._viking_fs.write_file(
+                version_uri(self._user_space(ctx), category, target_key, version_number),
+                json.dumps(version.to_dict(), ensure_ascii=False),
+                ctx=ctx,
+                lease_ref=lease,
+            )
+            await self._viking_fs.write_file(
+                current_uri(self._user_space(ctx), category, target_key),
+                json.dumps(version.to_dict(), ensure_ascii=False),
+                ctx=ctx,
+                lease_ref=lease,
+            )
+
             if meta is None:
                 meta = UserPrivacyConfigMeta(
                     category=category,
                     target_key=target_key,
-                    active_version=current.version,
-                    latest_version=current.version,
                     created_at=now,
                 )
+            meta.active_version = version_number
+            meta.latest_version = version_number
             meta.updated_by = updated_by
             meta.last_accessed_at = now
             if labels is not None:
                 meta.labels = dict(labels)
-            await self._save_meta(ctx, category, target_key, meta)
-            return current
-
-        version_number = 1 if meta is None else meta.latest_version + 1
-        version = UserPrivacyConfigVersion(
-            version=version_number,
-            category=category,
-            target_key=target_key,
-            values=dict(values),
-            created_at=now,
-            created_by=updated_by,
-            change_reason=change_reason,
-        )
-
-        await self._viking_fs.write_file(
-            version_uri(self._user_space(ctx), category, target_key, version_number),
-            json.dumps(version.to_dict(), ensure_ascii=False),
-            ctx=ctx,
-        )
-        await self._viking_fs.write_file(
-            current_uri(self._user_space(ctx), category, target_key),
-            json.dumps(version.to_dict(), ensure_ascii=False),
-            ctx=ctx,
-        )
-
-        if meta is None:
-            meta = UserPrivacyConfigMeta(
-                category=category,
-                target_key=target_key,
-                created_at=now,
-            )
-        meta.active_version = version_number
-        meta.latest_version = version_number
-        meta.updated_by = updated_by
-        meta.last_accessed_at = now
-        if labels is not None:
-            meta.labels = dict(labels)
-        await self._save_meta(ctx, category, target_key, meta)
-        return version
+            await self._save_meta(ctx, category, target_key, meta, lease)
+            return version
 
     async def activate_version(
         self,
@@ -207,18 +244,20 @@ class UserPrivacyConfigService:
         version: int,
         updated_by: str = "",
     ) -> UserPrivacyConfigVersion:
-        meta = await self.get_meta(ctx, category, target_key)
-        snapshot = await self.get_version(ctx, category, target_key, version)
-        if meta is None or snapshot is None:
-            raise NotFoundError(f"{category}/{target_key}/versions/{version}", "privacy config")
+        async with self._config_lock(ctx, category, target_key) as lease:
+            meta = await self.get_meta(ctx, category, target_key)
+            snapshot = await self.get_version(ctx, category, target_key, version)
+            if meta is None or snapshot is None:
+                raise NotFoundError(f"{category}/{target_key}/versions/{version}", "privacy config")
 
-        await self._viking_fs.write_file(
-            current_uri(self._user_space(ctx), category, target_key),
-            json.dumps(snapshot.to_dict(), ensure_ascii=False),
-            ctx=ctx,
-        )
-        meta.active_version = version
-        meta.updated_by = updated_by
-        meta.last_accessed_at = get_current_timestamp()
-        await self._save_meta(ctx, category, target_key, meta)
-        return snapshot
+            await self._viking_fs.write_file(
+                current_uri(self._user_space(ctx), category, target_key),
+                json.dumps(snapshot.to_dict(), ensure_ascii=False),
+                ctx=ctx,
+                lease_ref=lease,
+            )
+            meta.active_version = version
+            meta.updated_by = updated_by
+            meta.last_accessed_at = get_current_timestamp()
+            await self._save_meta(ctx, category, target_key, meta, lease)
+            return snapshot

--- a/openviking/privacy/service.py
+++ b/openviking/privacy/service.py
@@ -80,7 +80,10 @@ class UserPrivacyConfigService:
         if not callable(uri_to_path) or not callable(acquire) or not callable(release):
             yield None
             return
-        lease = await acquire(uri_to_path(self.get_config_root(ctx, category, target_key), ctx=ctx))
+        lease = await acquire(
+            uri_to_path(self.get_config_root(ctx, category, target_key), ctx=ctx),
+            timeout_secs=30.0,
+        )
         try:
             yield lease
         finally:

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -989,8 +989,10 @@ class _OpsMixin:
                 raw = b""
 
             text = self._decode_bytes(raw)
-        except Exception:
-            raise NotFoundError(uri, "file")
+        except Exception as exc:
+            if is_not_found_error(exc):
+                raise NotFoundError(uri, "file") from exc
+            raise
 
         if offset == 0 and limit == -1:
             return text
@@ -1029,8 +1031,10 @@ class _OpsMixin:
         try:
             raw = self._handle_agfs_read(await self._async_agfs.read(path))
             return raw
-        except Exception:
-            raise NotFoundError(uri, "file")
+        except Exception as exc:
+            if is_not_found_error(exc):
+                raise NotFoundError(uri, "file") from exc
+            raise
 
     async def write_file_bytes(
         self,

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -1,13 +1,56 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
+
 import pytest
 
 from openviking.core.namespace import canonical_user_root
 from openviking.privacy.skill_extractor import extract_skill_privacy_values
 from openviking.privacy.skill_placeholder import placeholderize_skill_content_with_blocks
+from openviking.privacy.service import UserPrivacyConfigService
 from openviking.server.identity import RequestContext, Role
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
+
+
+class _MemoryPrivacyStorage:
+    def __init__(self):
+        self.files: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._async_agfs = self
+
+    def _uri_to_path(self, uri, ctx=None):
+        return uri
+
+    async def pathlock_acquire_tree(self, _path):
+        await self._lock.acquire()
+        return {"lease_ref": "test"}
+
+    async def pathlock_release(self, _lease):
+        self._lock.release()
+
+    async def mkdir(self, *_args, **_kwargs):
+        await asyncio.sleep(0)
+
+    async def read_file(self, uri, **_kwargs):
+        await asyncio.sleep(0)
+        if uri not in self.files:
+            raise NotFoundError(uri, "file")
+        return self.files[uri]
+
+    async def write_file(self, uri, content, **_kwargs):
+        await asyncio.sleep(0)
+        self.files[uri] = content
+
+    async def ls(self, uri, **_kwargs):
+        await asyncio.sleep(0)
+        prefix = f"{uri}/"
+        return [
+            {"name": path.removeprefix(prefix)}
+            for path in self.files
+            if path.startswith(prefix) and "/" not in path.removeprefix(prefix)
+        ]
 
 
 @pytest.mark.asyncio
@@ -50,6 +93,40 @@ async def test_privacy_config_service_versions(service):
     assert restored.version == 1
     assert current.version == 1
     assert current.values["api_key"] == "secret-1"
+
+
+@pytest.mark.asyncio
+async def test_privacy_config_concurrent_updates_keep_every_version():
+    ctx = RequestContext(user=UserIdentifier.the_default_user("privacy_race"), role=Role.ROOT)
+    privacy = UserPrivacyConfigService(_MemoryPrivacyStorage())
+    results = await asyncio.gather(
+        *(
+            privacy.upsert(
+                ctx=ctx,
+                category="skill",
+                target_key="concurrent-skill",
+                values={"api_key": f"secret-{index}"},
+                updated_by=ctx.user.user_id,
+            )
+            for index in range(8)
+        )
+    )
+
+    assert sorted(result.version for result in results) == list(range(1, 9))
+    assert await privacy.list_versions(ctx, "skill", "concurrent-skill") == list(range(1, 9))
+
+
+@pytest.mark.asyncio
+async def test_privacy_config_exists_propagates_storage_errors():
+    class FailingStorage:
+        async def stat(self, *_args, **_kwargs):
+            raise RuntimeError("storage unavailable")
+
+    privacy = UserPrivacyConfigService(FailingStorage())
+    ctx = RequestContext(user=UserIdentifier.the_default_user("privacy_error"), role=Role.ROOT)
+
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await privacy.exists(ctx, "skill", "demo-skill")
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -10,6 +10,7 @@ from openviking.privacy.skill_extractor import extract_skill_privacy_values
 from openviking.privacy.skill_placeholder import placeholderize_skill_content_with_blocks
 from openviking.privacy.service import UserPrivacyConfigService
 from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
 from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 
@@ -19,12 +20,23 @@ class _MemoryPrivacyStorage:
         self.files: dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._async_agfs = self
+        self.lock_timeouts = []
 
     def _uri_to_path(self, uri, ctx=None):
         return uri
 
-    async def pathlock_acquire_tree(self, _path):
-        await self._lock.acquire()
+    async def pathlock_acquire_tree(self, _path, timeout_secs=0.0):
+        self.lock_timeouts.append(timeout_secs)
+        if timeout_secs == 0.0:
+            acquired = self._lock.locked() is False and await self._lock.acquire()
+        else:
+            try:
+                await asyncio.wait_for(self._lock.acquire(), timeout_secs)
+                acquired = True
+            except asyncio.TimeoutError:
+                acquired = False
+        if not acquired:
+            raise RuntimeError("lock acquire timed out")
         return {"lease_ref": "test"}
 
     async def pathlock_release(self, _lease):
@@ -127,6 +139,23 @@ async def test_privacy_config_exists_propagates_storage_errors():
 
     with pytest.raises(RuntimeError, match="storage unavailable"):
         await privacy.exists(ctx, "skill", "demo-skill")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("read_method", ["read_file", "read_file_bytes"])
+async def test_viking_fs_read_propagates_storage_errors(read_method):
+    class FailingReadStorage:
+        def stat(self, _path, **_kwargs):
+            return {"isDir": False}
+
+        def read(self, _path, **_kwargs):
+            raise RuntimeError("storage unavailable")
+
+    fs = VikingFS(FailingReadStorage())
+    ctx = RequestContext(user=UserIdentifier.the_default_user("privacy_read_error"), role=Role.ROOT)
+
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await getattr(fs, read_method)("viking://user/privacy/meta.json", ctx=ctx)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #4080

## What

- `upsert()` / `activate_version()` / `delete()` now hold the existing AGFS tree pathlock for the config root across their read-modify-write, and pass the lease to directory creation, writes, and removal. Concurrent mutations for one config root are serialized and each keeps its own version.
- Error handling is narrowed: only `NotFoundError` / `FileNotFoundError` map to empty results; storage, permission, and deserialization errors now propagate to the caller.

## Tests

- `test_privacy_config_concurrent_updates_keep_every_version`: 8 concurrent upserts all succeed and versions are `1..8` (previously all version 1). 
- `test_privacy_config_exists_propagates_storage_errors`: `exists()` re-raises `RuntimeError("storage unavailable")` instead of returning `False`.
- Verified: 2 new regression tests pass. (Other tests in this file error at setup with the local pytest-asyncio 1.3.0 due to a pre-existing async-gen fixture incompatibility unrelated to this change.)