### PR TITLE
fix(cli): exec npm shebang wrappers instead of skipping all shebang files

### DIFF
--- a/openviking_cli/rust_cli.py
+++ b/openviking_cli/rust_cli.py
@@ -75,19 +75,20 @@ def main():
     except Exception:
         pass
 
-    # 3. 检查 PATH，但跳过当前 Python 脚本
+    # 3. 检查 PATH，但跳过当前 Python 入口点
     path_binary = which("ov")
     if path_binary:
-        # 检查文件是否是 Python 脚本（避免无限循环）
         try:
             candidate_path = Path(path_binary).resolve()
-            with open(candidate_path, "rb") as f:
-                first_bytes = f.read(2)
-            # Skip if it starts with #! (shebang, likely Python script)
-            if first_bytes != b"#!":
-                _exec_binary(path_binary, sys.argv[1:])
-        except Exception:
+            current_path = Path(sys.argv[0])
+            if not current_path.is_absolute():
+                current_path = Path(which(sys.argv[0]) or current_path)
+            current_path = current_path.resolve()
+        except OSError:
             pass
+        else:
+            if candidate_path != current_path:
+                _exec_binary(path_binary, sys.argv[1:])
 
     # 都找不到，提示用户
     print(

--- a/tests/misc/test_rust_cli.py
+++ b/tests/misc/test_rust_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from openviking_cli import rust_cli
+
+
+def test_main_executes_npm_shebang_wrapper(monkeypatch, tmp_path):
+    wrapper = tmp_path / "ov"
+    wrapper.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+
+    class Executed(Exception):
+        pass
+
+    monkeypatch.setattr(rust_cli.Path, "exists", lambda _path: False)
+    monkeypatch.setattr(rust_cli, "which", lambda _name: str(wrapper))
+    monkeypatch.setattr(rust_cli, "_exec_binary", lambda *_args: (_ for _ in ()).throw(Executed))
+    monkeypatch.setattr(rust_cli.sys, "argv", [str(tmp_path / "openviking"), "--version"])
+
+    with pytest.raises(Executed):
+        rust_cli.main()


### PR DESCRIPTION
Closes #4084

## What

The Python entry-point fallback in `rust_cli.py` previously skipped **every** shebang file on `PATH` (assuming shebang = Python script). The official npm CLI ships `ov.mjs` with `#!/usr/bin/env node`, so the Node wrapper was never exec'd.

Now the fallback only compares against — and skips — the current Python entry point itself. Any other PATH executable (including the Node shebang wrapper) is exec'd normally, and exec failures are no longer swallowed.

## Tests

- `tests/misc/test_rust_cli.py::test_main_executes_npm_shebang_wrapper`: builds a fake `ov` with a `#!/usr/bin/env node` shebang on PATH and asserts `main()` execs it (passes with the fix; fails before it).
- The broader CLI doctor suite requires a live server + API key (`OPENVIKING_API_KEY`), so it is environment-gated and was verified in the previous session (`58 passed`); it is unaffected by this change.
