### PR TITLE
test: fix root collection boundary and CLI fixture pollution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,8 +253,10 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
+norecursedirs = ["api_test", "oc2ov_test"]
 markers = [
     "integration: tests that require external services or real model configuration",
+    "cli_remote: tests that require a remote OpenViking CLI binary and server connection",
 ]
 addopts = "-v --cov=openviking --cov-report=term-missing"
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -607,7 +607,16 @@ def _find_file_in_pack(pack_uri, retries=10, interval=5):
     return None
 
 
-@pytest.fixture(scope="session", autouse=True)
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if (
+            item.get_closest_marker("cli_remote")
+            and "ensure_resources_dir" not in item.fixturenames
+        ):
+            item.fixturenames.append("ensure_resources_dir")
+
+
+@pytest.fixture(scope="session")
 def ensure_resources_dir():
     r = ov_mkdir("viking://resources")
     if r["exit_code"] != 0:

--- a/tests/integration/test_gemini_e2e.py
+++ b/tests/integration/test_gemini_e2e.py
@@ -8,6 +8,8 @@ Run: pytest tests/integration/test_gemini_e2e.py -v -m integration
 
 import pytest
 
+pytest.importorskip("google.genai")
+
 from openviking.models.embedder.gemini_embedders import GeminiDenseEmbedder
 from tests.integration.conftest import GOOGLE_API_KEY, l2_norm, requires_api_key
 

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -4,6 +4,7 @@
 """Session lifecycle tests"""
 
 import re
+from functools import partial
 
 from openviking.server.identity import RequestContext
 from openviking.service.core import OpenVikingService
@@ -90,8 +91,8 @@ class TestSessionLoad:
         # Nonexistent session should be empty after loading
         assert len(session.messages) == 0
 
-    async def test_load_ignores_non_archive_history_entries(self, client: AsyncOpenViking):
-        session = client.session(session_id="archive_name_validation_test")
+    async def test_load_ignores_non_archive_history_entries(self, client: partial):
+        session = client(session_id="archive_name_validation_test")
         for name in ("archive_001", "archive_002", "archive_001.bak.20260628"):
             await session._viking_fs.mkdir(
                 f"{session.uri}/history/{name}",
@@ -99,7 +100,7 @@ class TestSessionLoad:
                 ctx=session.ctx,
             )
 
-        loaded = client.session(session_id=session.session_id)
+        loaded = client(session_id=session.session_id)
         await loaded.load()
 
         assert loaded.compression.compression_index == 2


### PR DESCRIPTION
Closes #4086

## What

Test-infrastructure fixes so the root `pytest` run works:

- `norecursedirs = ["api_test", "oc2ov_test"]` keeps root collection out of the two self-contained E2E subprojects.
- `pytest.importorskip("google.genai")` lets the Gemini E2E module skip cleanly when the optional dependency is missing.
- Session lifecycle tests use the current `partial`-based client fixture instead of the removed `AsyncOpenViking` API.
- The remote-server `ensure_resources_dir` fixture is no longer session-wide `autouse`; it is injected only into `cli_remote`-marked tests, and the `cli_remote` marker is registered in the root config.

## Tests

- Root collection: `6535 tests collected` (no longer enters the E2E subprojects).
- `tests/session/test_session_lifecycle.py`: 14 passed.
- `tests/integration/test_gemini_e2e.py`: 1 skipped (module skip without `google.genai`).
- CLI unit tests no longer require a remote server unless marked `cli_remote`; the remote doctor suite still requires `OPENVIKING_API_KEY` (environment-gated).
