### PR TITLE
fix(retrieval): classify retrieval observer metrics by context_type (server + DSH plugin)

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/dsh-memory-plugin/client.mjs
+++ b/examples/dsh-memory-plugin/client.mjs
@@ -129,6 +129,7 @@ export class OpenVikingClient {
     if (options.targetUri) body.target_uri = options.targetUri;
     if (options.limit) body.limit = options.limit;
     if (options.scoreThreshold !== undefined) body.score_threshold = options.scoreThreshold;
+    if (options.contextType) body.context_type = options.contextType;
     const response = await this.fetchJSON("/api/v1/search/find", {
       method: "POST",
       body: JSON.stringify(body),

--- a/examples/dsh-memory-plugin/config.mjs
+++ b/examples/dsh-memory-plugin/config.mjs
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG = Object.freeze({
   recallPeerScope: "all",
   recallQueryExpansion: "auto",
   recallQueryExpansionConfigured: false,
+  recallContextType: "",
   syncTurns: true,
   recallTokenBudget: 2000,
   recallMaxContentChars: 500,
@@ -75,12 +76,18 @@ export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()
     config.recallLimit = env.OPENVIKING_RECALL_LIMIT;
     config.recallLimitConfigured = true;
   }
+  if (env.OPENVIKING_RECALL_CONTEXT_TYPE) {
+    config.recallContextType = env.OPENVIKING_RECALL_CONTEXT_TYPE;
+  }
 
   config.endpoint = String(config.endpoint || DEFAULT_CONFIG.endpoint).replace(/\/+$/, "");
   config.workspacePeer = config.workspacePeer !== false;
   config.peerId = resolveEffectivePeerId({ cfg: config, cwd }).peerId;
   config.recallPeerScope = config.recallPeerScope === "actor" ? "actor" : "all";
   config.recallQueryExpansion = config.recallQueryExpansion === "off" ? "off" : "auto";
+  config.recallContextType = ["memory", "resource", "skill"].includes(config.recallContextType)
+    ? config.recallContextType
+    : "";
   config.recallLimit = clampInteger(config.recallLimit, 1, 50, DEFAULT_CONFIG.recallLimit);
   config.recallMaxContentChars = clampInteger(
     config.recallMaxContentChars,

--- a/examples/dsh-memory-plugin/config.test.mjs
+++ b/examples/dsh-memory-plugin/config.test.mjs
@@ -9,6 +9,7 @@ test("behavior environment overrides are applied and normalized", () => {
     OPENVIKING_RECALL_PEER_SCOPE: "actor",
     OPENVIKING_RECALL_QUERY_EXPANSION: "off",
     OPENVIKING_RECALL_LIMIT: "7",
+    OPENVIKING_RECALL_CONTEXT_TYPE: "resource",
   }, "/workspace/project");
 
   assert.equal(config.endpoint, "http://127.0.0.1:19464");
@@ -19,6 +20,7 @@ test("behavior environment overrides are applied and normalized", () => {
   assert.equal(config.recallQueryExpansionConfigured, true);
   assert.equal(config.recallLimit, 7);
   assert.equal(config.recallLimitConfigured, true);
+  assert.equal(config.recallContextType, "resource");
 });
 
 test("explicit plugin config overrides credential files", () => {

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -107,6 +107,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -284,7 +287,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -294,9 +297,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -574,6 +577,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -582,13 +586,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -108,6 +108,9 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
+  if (contextType) body.context_type = contextType;
+
   const sessionId = String(options.sessionId || "").trim();
   if (sessionId) {
     body.session_id = sessionId;
@@ -285,7 +288,7 @@ async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
 
 async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = "") {
   const resolvedUri = await resolveTargetUri(fetchJSON, source.uri, actorPeerId);
-  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0 };
+  const body = { query, target_uri: resolvedUri, limit, score_threshold: 0, context_type: source.type };
   const res = await fetchJSON("/api/v1/search/find", {
     method: "POST",
     body: JSON.stringify(body),
@@ -295,9 +298,9 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}, sources = SOURCES) {
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
@@ -575,6 +578,7 @@ export async function postRecall(fetchJSON, body, opts = {}) {
 export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const actorPeerId = options.actorPeerId ?? cfg.peerId ?? "";
   const log = options.log || (() => {});
+  const contextType = String(options.contextType || cfg.recallContextType || "").trim();
   const trimmed = String(query || "").trim();
   if (!trimmed) return null;
 
@@ -583,13 +587,17 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
   const serverBlock = await buildServerAssembledBlock(fetchJSON, cfg, trimmed, {
     ...options,
     actorPeerId,
+    contextType,
     log,
   });
   if (serverBlock !== null) return serverBlock || null;
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const sources = contextType
+    ? SOURCES.filter((src) => src.type === contextType)
+    : SOURCES;
+  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log, sources);
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/openviking/retrieve/context_assembler/gather.py
+++ b/openviking/retrieve/context_assembler/gather.py
@@ -273,6 +273,7 @@ async def gather_candidates(
         target_uri: str,
         find_limit: int,
         find_filter: Optional[Dict[str, Any]] = None,
+        context_type: Optional[ContextType] = None,
     ) -> Any:
         return _safe_find(
             service,
@@ -285,6 +286,7 @@ async def gather_candidates(
             filter=find_filter if find_filter is not None else filter,
             image_url=image_url,
             level=None,
+            context_type=context_type,
         )
 
     async def gather_bucket(bucket: str, quota: int) -> List[Candidate]:
@@ -301,6 +303,7 @@ async def gather_candidates(
                 target_uri=target,
                 find_limit=_overfetch(quota),
                 find_filter=bucket_filter,
+                context_type=context_type,
             )
             for query in planned
             for target in targets
@@ -314,6 +317,7 @@ async def gather_candidates(
                     target_uri=f"{user_root}/peers",
                     find_limit=_overfetch(max(quota * OTHER_PEER_OVERFETCH, quota)),
                     find_filter=bucket_filter,
+                    context_type=context_type,
                 )
                 for query in planned
             )

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -118,6 +118,28 @@ def _resolve_image_url(image_url: Optional[str], ctx: RequestContext) -> Optiona
     return resolved
 
 
+def _typed_context_type(value: Any) -> Optional["ContextType"]:
+    """Map an API context_type (str | list) onto a single retriever type.
+
+    The API accepts one or more types; TypedQuery carries a single type, so
+    a multi-type request keeps its filter-based scoping and is left
+    unclassified (the filter still narrows results correctly).
+    """
+    from openviking_cli.retrieve import ContextType
+
+    if isinstance(value, str):
+        try:
+            return ContextType(value)
+        except ValueError:
+            return None
+    if isinstance(value, list) and len(value) == 1:
+        try:
+            return ContextType(value[0])
+        except ValueError:
+            return None
+    return None
+
+
 class FindRequest(BaseModel):
     """Request model for find."""
 
@@ -316,6 +338,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_typed_context_type(request.context_type),
         ),
     )
     result = execution.result
@@ -428,6 +451,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_typed_context_type(request.context_type),
         )
 
     execution = await run_operation(

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -123,20 +123,23 @@ def _typed_context_type(value: Any) -> Optional["ContextType"]:
 
     The API accepts one or more types; TypedQuery carries a single type, so
     a multi-type request keeps its filter-based scoping and is left
-    unclassified (the filter still narrows results correctly).
+    unclassified (the filter still narrows results correctly). Values are
+    normalized (strip + lower) the same way as resolve_context_types.
     """
     from openviking_cli.retrieve import ContextType
 
+    def _coerce(value: Any) -> Optional["ContextType"]:
+        if not isinstance(value, str):
+            return None
+        try:
+            return ContextType(value.strip().lower())
+        except ValueError:
+            return None
+
     if isinstance(value, str):
-        try:
-            return ContextType(value)
-        except ValueError:
-            return None
+        return _coerce(value)
     if isinstance(value, list) and len(value) == 1:
-        try:
-            return ContextType(value[0])
-        except ValueError:
-            return None
+        return _coerce(value[0])
     return None
 
 

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -85,6 +85,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Any] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -119,6 +120,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result
 
@@ -132,6 +134,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Any] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -158,5 +161,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -23,7 +23,9 @@ def _normalize_context_type(value: Any) -> Optional[Any]:
     """Coerce an API context_type (str | list | enum) onto TypedQuery.context_type.
 
     TypedQuery carries a single ContextType; multi-type requests stay on
-    the filter path (scope_dsl) and are left unclassified here.
+    the filter path (scope_dsl) and are left unclassified here. Values are
+    normalized the same way as resolve_context_types (strip + lower) so the
+    observer classification matches the filter behaviour.
     """
     from openviking_cli.retrieve import ContextType
 
@@ -31,7 +33,7 @@ def _normalize_context_type(value: Any) -> Optional[Any]:
         return value
     if isinstance(value, str):
         try:
-            return ContextType(value)
+            return ContextType(value.strip().lower())
         except ValueError:
             return None
     return None
@@ -362,7 +364,7 @@ class _SemanticMixin:
             typed_queries = [
                 TypedQuery(
                     query=query,
-                    context_type=None,
+                    context_type=_normalize_context_type(context_type),
                     intent="",
                     priority=1,
                     target_directories=retrieval_targets.target_directories,

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -19,6 +19,24 @@ from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking_cli.exceptions import NotFoundError
 
 
+def _normalize_context_type(value: Any) -> Optional[Any]:
+    """Coerce an API context_type (str | list | enum) onto TypedQuery.context_type.
+
+    TypedQuery carries a single ContextType; multi-type requests stay on
+    the filter path (scope_dsl) and are left unclassified here.
+    """
+    from openviking_cli.retrieve import ContextType
+
+    if isinstance(value, ContextType):
+        return value
+    if isinstance(value, str):
+        try:
+            return ContextType(value)
+        except ValueError:
+            return None
+    return None
+
+
 class _SemanticMixin:
     """Abstract/overview/find/search semantic retrieval layer."""
 
@@ -190,6 +208,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Any] = None,
     ):
         """Semantic search.
 
@@ -235,7 +254,7 @@ class _SemanticMixin:
 
         typed_query = TypedQuery(
             query=query,
-            context_type=None,
+            context_type=_normalize_context_type(context_type),
             intent="",
             target_directories=retrieval_targets.target_directories,
             embedding_input=(
@@ -287,6 +306,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[Any] = None,
     ):
         """Complex search with session context.
 
@@ -367,7 +387,7 @@ class _SemanticMixin:
             typed_queries = [
                 TypedQuery(
                     query=query,
-                    context_type=None,
+                    context_type=_normalize_context_type(context_type),
                     intent="",
                     priority=1,
                     target_directories=retrieval_targets.target_directories,

--- a/tests/misc/test_vikingfs_context_type_propagation.py
+++ b/tests/misc/test_vikingfs_context_type_propagation.py
@@ -16,7 +16,7 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
-from openviking_cli.retrieve.types import ContextType, QueryResult
+from openviking_cli.retrieve.types import ContextType, QueryResult, TypedQuery
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -129,3 +129,119 @@ async def test_search_fallback_propagates_context_type(monkeypatch):
 
     assert captured["typed_query"].context_type == ContextType.MEMORY
     assert captured["typed_query"].intent == ""
+
+
+@pytest.mark.asyncio
+async def test_find_image_query_propagates_context_type(monkeypatch):
+    """find() threads a typed image request (no image->RESOURCE fallback)."""
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find(
+        "photo",
+        target_uri=V + "resources/docs",
+        ctx=_ctx(),
+        context_type="memory",
+        image_url="data:image/png;base64,abc",
+    )
+
+    assert captured["typed_query"].context_type == ContextType.MEMORY
+    assert captured["typed_query"].image_query is True
+
+
+@pytest.mark.asyncio
+async def test_search_image_query_propagates_context_type(monkeypatch):
+    """search()'s image branch is consistent with find() (review #4091)."""
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.search(
+        "photo",
+        target_uri=V + "resources/docs",
+        ctx=_ctx(),
+        context_type="skill",
+        image_url="data:image/png;base64,abc",
+    )
+
+    assert captured["typed_query"].context_type == ContextType.SKILL
+    assert captured["typed_query"].image_query is True
+
+
+@pytest.mark.asyncio
+async def test_find_normalizes_context_type_case_and_whitespace(monkeypatch):
+    """Observer classification matches the filter: "Memory" -> memory."""
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find("x", target_uri=V + "resources/docs", ctx=_ctx(), context_type=" Memory ")
+
+    assert captured["typed_query"].context_type == ContextType.MEMORY
+
+
+@pytest.mark.asyncio
+async def test_observer_records_threaded_context_type(monkeypatch):
+    """End-to-end pin for #4090: the threaded type reaches record_query().
+
+    The propagation tests above stub HierarchicalRetriever; this one drives
+    the real retriever against a fake vector proxy so the observer bucket
+    counter (the line #4090 is about) is exercised.
+    """
+    from openviking.models.embedder.base import EmbedResult
+    from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
+    from openviking.retrieve.retrieval_stats import get_stats_collector
+
+    class FakeProxy:
+        captured = {}
+
+        def __init__(self, _storage, _ctx):
+            pass
+
+        @property
+        def collection_name(self):
+            return "test"
+
+        async def collection_exists_bound(self):
+            return True
+
+        async def search_in_tenant(self, **kwargs):
+            self.captured.update(kwargs)
+            return []
+
+    class Embedder:
+        supports_multimodal = False
+
+        def prepare_embedding_input(self, content):
+            return content
+
+        async def embed_async(self, content, is_query=False):
+            return EmbedResult(dense_vector=[1.0])
+
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.VikingDBManagerProxy",
+        FakeProxy,
+    )
+
+    collector = get_stats_collector()
+    collector.reset()
+    try:
+        retriever = HierarchicalRetriever(storage=object(), embedder=Embedder())
+        await retriever.retrieve(
+            TypedQuery(
+                query="guide",
+                context_type=ContextType.MEMORY,
+                intent="",
+                target_directories=[V + "user/acc1/user1"],
+            ),
+            ctx=_ctx(),
+            limit=5,
+        )
+
+        snapshot = collector.snapshot()
+        assert snapshot.queries_by_type.get("memory") == 1
+        assert snapshot.queries_by_type.get("unknown", 0) == 0
+        assert FakeProxy.captured["context_type"] == "memory"
+    finally:
+        collector.reset()

--- a/tests/misc/test_vikingfs_context_type_propagation.py
+++ b/tests/misc/test_vikingfs_context_type_propagation.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests: API context_type reaches TypedQuery.context_type.
+
+The retrieval observer buckets every query under "unknown" when
+TypedQuery.context_type is None. The API's context_type used to be applied
+only as a result filter (scope_dsl); these tests pin the new behavior that a
+single-type request is threaded through to the retriever query while
+multi-type / invalid values stay on the filter path (unclassified).
+"""
+
+import contextvars
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.retrieve.types import ContextType, QueryResult
+from openviking_cli.session.user_id import UserIdentifier
+
+
+V = "viking:" + "//"
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+
+
+def _make_viking_fs() -> VikingFS:
+    fs = VikingFS.__new__(VikingFS)
+    fs.agfs = MagicMock()
+    fs.query_embedder = MagicMock(name="embedder")
+    fs.rerank_config = None
+    fs.retrieval_config = None
+    fs.vector_store = MagicMock(name="vector_store")
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx_ctx_type", default=None)
+    fs._ensure_access = MagicMock()
+    fs._get_vector_store = MagicMock(return_value=fs.vector_store)
+    fs._get_embedder = MagicMock(return_value=fs.query_embedder)
+    fs._ctx_or_default = MagicMock(return_value=_ctx())
+    fs.abstract = AsyncMock(return_value="")
+    return fs
+
+
+def _install_fake_retriever(monkeypatch, captured):
+    class FakeRetriever:
+        def __init__(self, storage, embedder, rerank_config, retrieval_config):
+            pass
+
+        async def retrieve(self, typed_query, **kwargs):
+            captured["typed_query"] = typed_query
+            return QueryResult(
+                query=typed_query,
+                matched_contexts=[],
+                searched_directories=typed_query.target_directories,
+            )
+
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.HierarchicalRetriever",
+        FakeRetriever,
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_propagates_single_context_type_string(monkeypatch):
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find("guide", target_uri=V + "resources/docs", ctx=_ctx(), context_type="resource")
+
+    assert captured["typed_query"].context_type == ContextType.RESOURCE
+
+
+@pytest.mark.asyncio
+async def test_find_propagates_context_type_enum(monkeypatch):
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find(
+        "skill query",
+        target_uri=V + "resources/docs",
+        ctx=_ctx(),
+        context_type=ContextType.SKILL,
+    )
+
+    assert captured["typed_query"].context_type == ContextType.SKILL
+
+
+@pytest.mark.asyncio
+async def test_find_multi_type_list_stays_on_filter_path(monkeypatch):
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find(
+        "both",
+        target_uri=V + "resources/docs",
+        ctx=_ctx(),
+        context_type=["memory", "skill"],
+    )
+
+    # TypedQuery carries a single type; a multi-type request is scoped by the
+    # filter and intentionally left unclassified for the observer.
+    assert captured["typed_query"].context_type is None
+
+
+@pytest.mark.asyncio
+async def test_find_invalid_context_type_stays_unclassified(monkeypatch):
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    await fs.find("weird", target_uri=V + "resources/docs", ctx=_ctx(), context_type="not-a-type")
+
+    assert captured["typed_query"].context_type is None
+
+
+@pytest.mark.asyncio
+async def test_search_fallback_propagates_context_type(monkeypatch):
+    fs = _make_viking_fs()
+    captured = {}
+    _install_fake_retriever(monkeypatch, captured)
+
+    # No session context and no image query: the raw-query fallback runs.
+    await fs.search("raw", ctx=_ctx(), context_type="memory")
+
+    assert captured["typed_query"].context_type == ContextType.MEMORY
+    assert captured["typed_query"].intent == ""

--- a/tests/retrieve/test_hierarchical_retriever_image.py
+++ b/tests/retrieve/test_hierarchical_retriever_image.py
@@ -4,7 +4,7 @@ from openviking.models.embedder.base import EmbedResult
 from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.exceptions import InvalidArgumentError
-from openviking_cli.retrieve.types import TypedQuery
+from openviking_cli.retrieve.types import ContextType, TypedQuery
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -93,6 +93,33 @@ async def test_image_query_uses_multimodal_input_without_filtering_non_images(mo
     assert FakeProxy.captured["context_type"] == "resource"
     assert FakeProxy.captured["level"] == [2]
     assert FakeProxy.captured["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_image_query_with_typed_context_skips_resource_fallback(monkeypatch):
+    """An explicit context_type must not be overridden by the image->RESOURCE default."""
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.VikingDBManagerProxy",
+        FakeProxy,
+    )
+    embedder = MultimodalEmbedder()
+    retriever = HierarchicalRetriever(storage=object(), embedder=embedder)
+    query_input = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}]
+
+    result = await retriever.retrieve(
+        TypedQuery(
+            query="",
+            context_type=ContextType.MEMORY,
+            intent="",
+            embedding_input=query_input,
+            image_query=True,
+        ),
+        ctx=_ctx(),
+        limit=2,
+    )
+
+    assert len(result.matched_contexts) == 2
+    assert FakeProxy.captured["context_type"] == "memory"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes the retrieval observer's `unknown` context-type bucket (see [#4090](https://github.com/volcengine/OpenViking/issues/4090)): the API's `context_type` is currently applied only as a result filter and never reaches `TypedQuery.context_type`, so `HierarchicalRetriever.record_query()` classifies **every** query as `unknown`.

This PR threads the type through the server pipeline and lets the DSH memory plugin carry it on the request side.

## Changes

### Server

- `openviking/server/routers/search.py`
  - New `_typed_context_type()`: maps the API `context_type` (single string, or 1-element list) onto `ContextType`, normalizing case/whitespace (strip + lower) the same way `resolve_context_types` does.
  - `/api/v1/search/find` and `/api/v1/search/search` (mode=list) now pass `context_type` into `service.search.find/search`.
- `openviking/service/search_service.py`
  - `search()` / `find()` accept `context_type` and forward it to `VikingFS`.
- `openviking/storage/viking_fs/_semantic.py`
  - New `_normalize_context_type()` (accepts str / enum; invalid or multi-type stays `None`; normalized with strip + lower).
  - `find()` now sets `TypedQuery.context_type` from the request instead of hardcoded `None`.
  - `search()`'s raw-query fallback **and image branch** set `TypedQuery.context_type` (the image branch was previously hardcoded to `None`; see Design notes).
  - Intent-analysis-assigned types are unchanged.
- `openviking/retrieve/context_assembler/gather.py`
  - Context-assembly bucket searches (`mode="context"` with quotas) pass their bucket type (`memory` / `resource` / `skill`) into the underlying find, so context-mode stats classify per bucket.

### DSH memory plugin (`examples/dsh-memory-plugin`)

- `client.mjs`: `find()` forwards `context_type` into the request body when a caller supplies it.
- `shared/recall-core.mjs` (regenerated from `examples/memory-plugin-shared/lib` via `sync.mjs` — the lib source of truth is edited, never the vendored copy):
  - Fallback per-source finds are tagged with the source type.
  - Context-face requests carry `context_type` when configured.
  - `buildRecallBlock()` threads `recallContextType` (env `OPENVIKING_RECALL_CONTEXT_TYPE`) through both server-assembled and fallback paths.
- `config.mjs` / `config.test.mjs`: new `recallContextType` option + tests.

> Rebased onto current `main` (which moved the plugin's tool surface to an MCP-proxy bridge). The plugin no longer registers a local `viking_search` tool, so the previously proposed tool parameter is gone; the request-side threading lives in `buildRecallBlock`/`client.find`, and the recall flow still reaches the classified HTTP API path.

### Tests

- New `tests/misc/test_vikingfs_context_type_propagation.py`: pins that a single-type request reaches `TypedQuery.context_type` (string and enum), multi-type lists and invalid values stay unclassified, case/whitespace is normalized, and — end-to-end via the real `HierarchicalRetriever` with a fake vector proxy — that `record_query()` records the typed bucket.
- `tests/retrieve/test_hierarchical_retriever_image.py`: an explicit `context_type` on an image query is honored (the image->RESOURCE default is skipped).

## Design notes / limitations

- `TypedQuery.context_type` is a single value; multi-type list requests (e.g. `["memory","skill"]`) keep their existing filter-based scoping and remain unclassified in the observer.
- For **text queries** there is no retrieval behavior change: the type was already used as a filter; threading it into `TypedQuery.context_type` adds a semantically identical predicate and, importantly, fixes observer classification. Directory selection is unaffected (`default_target_directories` honors the type only for non-ROOT users, and `resolve_retrieval_targets` does not thread it).
- For **image queries** there is a deliberate behavior change: with an explicit single type, the image->RESOURCE default is skipped and the image search runs within the requested type. Before this PR, `find(image_url=…, context_type="memory")` produced an unsatisfiable filter (RESOURCE AND memory on one scalar field) and returned nothing. `/find` and `/search` now behave consistently. With no type, the RESOURCE default is unchanged.
- The server's MCP `find`/`search` tools accept `context_type` as a pre-existing **retrieval filter** (not threaded into `TypedQuery.context_type`); those requests therefore remain unclassified in the observer. The HTTP API path — which the plugin's recall uses — is classified by this PR.
- Observer counters are in-memory and reset on restart.

## Verification

Live against a patched v0.4.13 deployment (fresh counters after restart):

| Request | Observer bucket |
| --- | --- |
| `find` without context_type | `unknown` (expected) |
| `find` + `context_type: "resource"` | `resource` |
| `find` + `context_type: ["memory","skill"]` | `unknown` (documented) |
| `search` mode=context + quotas | `memory` / `resource` / `skill` per bucket |

Real traffic after restart: 44 queries -> memory 26, resource 9, skill 6, unknown 3 (previously 100% unknown).

Plugin test suite (current `main`): 39 passed, 1 skipped (live-server integration), 0 failed.

Fixes [#4090](https://github.com/volcengine/OpenViking/issues/4090)
