### PR TITLE
fix(mcp): return read errors from underlying fs

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -52,6 +52,7 @@ from openviking.utils.search_filters import SearchContextTypeInput, merge_search
 from openviking_cli.exceptions import (
     InvalidArgumentError,
     NotFoundError,
+    OpenVikingError,
     PermissionDeniedError,
     UnauthenticatedError,
 )
@@ -423,8 +424,12 @@ async def read(uris: str | list[str]) -> str:
 
     async def _read_one(uri: str) -> str:
         async with semaphore:
-            resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
-            return await service.fs.read_for_tool(resolved_uri, ctx=ctx, display_uri=uri)
+            try:
+                resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
+                content = await service.fs.read_visible(resolved_uri, ctx=ctx)
+                return content
+            except OpenVikingError as exc:
+                return str(exc)
 
     if len(uri_list) == 1:
         return await _read_one(uri_list[0])

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -29,7 +29,7 @@ from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import build_queue_status_payload
 from openviking.utils.embedding_utils import vectorize_directory_meta
-from openviking_cli.exceptions import DeadlineExceededError, NotFoundError, NotInitializedError
+from openviking_cli.exceptions import DeadlineExceededError, NotInitializedError
 from openviking_cli.utils import VikingURI, get_logger
 
 logger = get_logger(__name__)
@@ -586,29 +586,6 @@ class FSService:
             return await self.read(uri, ctx=ctx, offset=offset, limit=limit)
         content = await self.read(uri, ctx=ctx)
         return visible_content(content, uri=uri, offset=offset, limit=limit)
-
-    async def read_for_tool(
-        self,
-        uri: str,
-        ctx: RequestContext,
-        *,
-        display_uri: str | None = None,
-    ) -> str:
-        """Read content for agent tools, returning recoverable text for common read misses."""
-        display_uri = display_uri or uri
-        try:
-            stat = await self.stat(uri, ctx=ctx)
-        except NotFoundError:
-            return f"(not found at {display_uri})"
-        if stat.get("isDir", stat.get("is_dir", False)):
-            return (
-                f"Directory URI is not readable as a file: {display_uri}. "
-                "Use the list tool on this URI to inspect children, then use read on a file URI."
-            )
-        content = await self.read_visible(uri, ctx=ctx)
-        if isinstance(content, str) and content.strip():
-            return content
-        return f"(empty file at {display_uri})"
 
     async def abstract(self, uri: str, ctx: RequestContext) -> str:
         """Read L0 abstract (.abstract.md)."""

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -976,7 +976,8 @@ class _OpsMixin:
             raise NotFoundError(uri, "file") from last_not_found
         if isinstance(stat, dict) and stat.get("isDir", False):
             raise InvalidArgumentError(
-                f"Cannot read directory as file: {uri}",
+                f"Directory URI is not readable as a file: {uri}. "
+                "List it first, then read a file URI.",
                 details={"resource": uri, "expected": "file", "actual": "directory"},
             )
         try:

--- a/tests/server/test_api_content.py
+++ b/tests/server/test_api_content.py
@@ -113,7 +113,8 @@ async def test_read_directory_uri_returns_invalid_argument(client_with_resource)
     body = resp.json()
     assert body["status"] == "error"
     assert body["error"]["code"] == "INVALID_ARGUMENT"
-    assert "Cannot read directory as file" in body["error"]["message"]
+    assert "Directory URI is not readable as a file" in body["error"]["message"]
+    assert "List it first, then read a file URI." in body["error"]["message"]
     assert body["error"]["details"] == {
         "resource": uri,
         "expected": "file",

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -540,8 +540,8 @@ async def test_read_directory_uri_returns_recoverable_hint(service):
     result = await read(uri)
 
     assert "Directory URI is not readable as a file" in result
-    assert "Use the list tool" in result
-    assert "then use read on a file URI" in result
+    assert "List it first, then read a file URI." in result
+    assert uri in result
     assert "nothing found" not in result.lower()
 
 
@@ -556,20 +556,19 @@ async def test_read_batch(service):
     assert "not found" in result.lower()
 
 
-async def test_read_delegates_to_tool_read(monkeypatch):
-    read_for_tool = AsyncMock(return_value="visible memory")
+async def test_read_delegates_to_visible_read(monkeypatch):
+    read_visible = AsyncMock(return_value="visible memory")
     monkeypatch.setattr(
         mcp_endpoint,
         "get_service",
-        lambda: SimpleNamespace(fs=SimpleNamespace(read_for_tool=read_for_tool)),
+        lambda: SimpleNamespace(fs=SimpleNamespace(read_visible=read_visible)),
     )
     uri = "viking://user/project/private.md"
 
     assert await read(uri) == "visible memory"
-    read_for_tool.assert_awaited_once_with(
+    read_visible.assert_awaited_once_with(
         "viking://user/test_user/project/private.md",
         ctx=DEFAULT_CTX,
-        display_uri=uri,
     )
 
 

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -9,7 +9,6 @@ import pytest
 
 from openviking.server.identity import RequestContext, Role
 from openviking.service.fs_service import FSService
-from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -182,46 +181,6 @@ async def test_read_visible_preserves_non_memory_content(request_context):
         )
         == '<!-- MEMORY_FIELDS {"example":true} -->'
     )
-
-
-@pytest.mark.asyncio
-async def test_read_for_tool_returns_not_found_message(request_context):
-    uri = "viking://resources/missing.md"
-    viking_fs = SimpleNamespace(stat=AsyncMock(side_effect=NotFoundError(uri)))
-    service = FSService(viking_fs=viking_fs)
-
-    result = await service.read_for_tool(uri, ctx=request_context, display_uri="viking://alias.md")
-
-    assert result == "(not found at viking://alias.md)"
-
-
-@pytest.mark.asyncio
-async def test_read_for_tool_returns_directory_hint(request_context):
-    viking_fs = SimpleNamespace(
-        stat=AsyncMock(return_value={"isDir": True}),
-        read_file=AsyncMock(),
-    )
-    service = FSService(viking_fs=viking_fs)
-
-    result = await service.read_for_tool("viking://resources/docs", ctx=request_context)
-
-    assert "Directory URI is not readable as a file" in result
-    assert "Use the list tool" in result
-    viking_fs.read_file.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_read_for_tool_returns_empty_file_message(request_context):
-    uri = "viking://resources/empty.md"
-    viking_fs = SimpleNamespace(
-        stat=AsyncMock(return_value={"isDir": False}),
-        read_file=AsyncMock(return_value=""),
-    )
-    service = FSService(viking_fs=viking_fs)
-
-    result = await service.read_for_tool(uri, ctx=request_context)
-
-    assert result == f"(empty file at {uri})"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

修复 MCP `read` 读取目录 URI 时缺少可操作错误提示的问题。现在 MCP `read` 直接复用底层文本读取错误信息：当目标 URI 是目录时，返回提示让用户先使用 `list` 查看目录内容，再对文件 URI 使用 `read`。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- MCP `read` 直接调用底层 `read_visible()`，不再使用独立的目录读取 helper。
- 目录读取错误由底层文本读取逻辑返回，避免 MCP 层重复判断。
- 改进文本读取目录时的错误提示，引导先 `list` 目录再 `read` 文件。
- MCP `read` 成功时原样返回文件内容，包括空文件和只包含空白字符的文件。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已通过：

```
tests/server/test_mcp_endpoint.py::test_read_directory_uri_returns_recoverable_hint PASSED
tests/server/test_mcp_endpoint.py::test_read_delegates_to_visible_read PASSED
tests/server/test_api_content.py::test_read_directory_uri_returns_invalid_argument PASSED
tests/service/test_fs_service.py 18 passed
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="1197" height="277" alt="image" src="https://github.com/user-attachments/assets/07c56ed8-93b7-4283-8fa0-386d2202605b" />


## Additional Notes
