### PR TITLE
fix(queuefs): 合并重复的目录语义刷新

### DIFF
--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -23,7 +23,6 @@ from openviking.session.memory.memory_updater import MemoryUpdater
 from openviking.session.memory.utils.content_visibility import visible_content
 from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
-from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
@@ -245,7 +244,6 @@ class FSService:
                     request_registered = True
                 await self._enqueue_delete_refresh(
                     root_uri=refresh_parent_uri,
-                    deleted_uri=uri,
                     context_type=context_type,
                     ctx=ctx,
                 )
@@ -358,7 +356,6 @@ class FSService:
         self,
         *,
         root_uri: str,
-        deleted_uri: str,
         context_type: str,
         ctx: RequestContext,
     ) -> None:
@@ -379,14 +376,7 @@ class FSService:
             role=str(ctx.role),
             skip_vectorization=False,
             telemetry_id=telemetry_id,
-            coalesce_key=build_semantic_coalesce_key(
-                context_type=context_type,
-                uri=root_uri,
-                account_id=ctx.account_id,
-                user_id=ctx.user.user_id,
-                peer_id=ctx.user.user_id,
-            ),
-            changes={"deleted": [deleted_uri]},
+            directory_refresh_only=True,
         )
         if telemetry_id:
             get_request_wait_tracker().register_semantic_root(telemetry_id, msg.id)

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -35,7 +35,6 @@ from openviking.session.memory.utils.resource_refs import (
 )
 from openviking.storage.errors import LockAcquisitionError, ResourceBusyError
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
-from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.viking_fs import VikingFS
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
@@ -539,16 +538,6 @@ class ContentWriteCoordinator:
             role=str(ctx.role),
             skip_vectorization=False,
             telemetry_id=telemetry.telemetry_id,
-            coalesce_key=(
-                build_semantic_coalesce_key(
-                    context_type=context_type,
-                    uri=root_uri,
-                    account_id=ctx.account_id,
-                    user_id=ctx.user.user_id,
-                )
-                if context_type in {"resource", "skill"}
-                else ""
-            ),
             changes={
                 change_type: sorted(changes.get(change_type, []))
                 for change_type in ("added", "modified")

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -102,6 +102,9 @@ class DequeueHandlerBase(abc.ABC):
         self.report_success()
         return None
 
+    def prepare_dequeued_batch(self, messages: List[Dict[str, Any]]) -> None:
+        """Observe one bounded worker batch before processing starts."""
+
     @abc.abstractmethod
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Called after message dequeue. Returns None to discard message."""
@@ -214,6 +217,10 @@ class NamedQueue:
     def has_dequeue_handler(self) -> bool:
         """Check if dequeue handler exists."""
         return self._dequeue_handler is not None
+
+    def prepare_dequeued_batch(self, messages: List[Dict[str, Any]]) -> None:
+        if self._dequeue_handler is not None:
+            self._dequeue_handler.prepare_dequeued_batch(messages)
 
     async def _ensure_initialized(self):
         """Ensure queue directory is created in AGFS."""

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -135,6 +135,9 @@ class QueueManager:
     async def prepare_task_tracking(self, tracker: Any) -> None:
         """Rebuild task work from QueueFS before any consumer starts."""
         snapshots = {name: await queue.snapshot() for name, queue in self._queues.items()}
+        semantic_queue = self._queues.get(self.SEMANTIC)
+        if isinstance(semantic_queue, SemanticQueue):
+            semantic_queue.restore_directory_refreshes(snapshots.get(self.SEMANTIC, []))
         owners = self._task_work_index.rebuild(snapshots)
         tracker.attach_work_index(self._task_work_index)
         await tracker.restore_work_tasks(owners)
@@ -278,8 +281,9 @@ class QueueManager:
             # Prune completed tasks
             active_tasks = {t for t in active_tasks if not t.done()}
 
-            # While capacity remains, keep draining the queue
-            while len(active_tasks) < max_concurrent:
+            batch: list[Dict[str, Any]] = []
+            available = max_concurrent - len(active_tasks)
+            while len(batch) < available:
                 try:
                     queue_size = await queue.size()
                 except Exception:
@@ -292,6 +296,12 @@ class QueueManager:
                 # Increment before task creation to close the race window where
                 # size=0 and in_progress=0 between dequeue_raw() and task execution.
                 queue._on_dequeue_start()
+                batch.append(data)
+
+            if batch:
+                queue.prepare_dequeued_batch(batch)
+
+            for data in batch:
                 task = asyncio.create_task(process_one(data))
                 active_tasks.add(task)
                 logger.debug(

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -12,7 +12,11 @@ from weakref import WeakKeyDictionary
 
 from openviking.parse.parsers.media import get_media_type
 from openviking.server.identity import RequestContext
-from openviking.service.task_work_index import bind_task_context, get_task_context
+from openviking.service.task_work_index import (
+    TaskExecutionContext,
+    bind_task_context,
+    get_task_context,
+)
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry import bind_telemetry, get_current_telemetry
@@ -156,8 +160,11 @@ class SemanticDagExecutor:
         changes: Optional[Dict[str, List[str]]] = None,
         skip_vectorization: bool = False,
         ingest_options: IngestOptions | None = None,
-        coalesce_key: str = "",
-        coalesce_version: int = 0,
+        file_ingest_options: Optional[Dict[str, IngestOptions]] = None,
+        file_task_contexts: Optional[Dict[str, TaskExecutionContext]] = None,
+        file_telemetry: Optional[Dict[str, Any]] = None,
+        directory_ingest_options: IngestOptions | None = None,
+        directory_refresh_only: bool = False,
     ):
         self._processor = processor
         self._context_type = context_type
@@ -170,11 +177,20 @@ class SemanticDagExecutor:
         self._changes = changes or {}
         self._skip_vectorization = skip_vectorization
         self._ingest_options = IngestOptions.from_value(ingest_options)
-        self._coalesce_key = coalesce_key
-        self._coalesce_version = coalesce_version
+        self._file_ingest_options = {
+            path: IngestOptions.from_value(options)
+            for path, options in (file_ingest_options or {}).items()
+        }
+        self._file_task_contexts = file_task_contexts or {}
+        self._file_telemetry = file_telemetry or {}
+        self._directory_ingest_options = (
+            self._ingest_options
+            if directory_ingest_options is None
+            else IngestOptions.from_value(directory_ingest_options)
+        )
+        self._directory_refresh_only = directory_refresh_only
         self._task_context = get_task_context()
         self._telemetry = get_current_telemetry()
-        self._stale = False
         self._changed_paths = {
             path for key in ("added", "modified", "deleted") for path in self._changes.get(key, [])
         }
@@ -297,16 +313,26 @@ class SemanticDagExecutor:
         return stats
 
     async def _run_work(self, work: DagWork) -> None:
+        active_task_context = (
+            self._file_task_contexts.get(work.file_path)
+            if work.kind == "file" and work.file_path is not None
+            else None
+        ) or self._task_context
         task_context = (
             bind_task_context(
-                self._task_context.task_id,
-                self._task_context.account_id,
-                self._task_context.user_id,
+                active_task_context.task_id,
+                active_task_context.account_id,
+                active_task_context.user_id,
             )
-            if self._task_context is not None
+            if active_task_context is not None
             else nullcontext()
         )
-        with bind_telemetry(self._telemetry), task_context:
+        telemetry = (
+            self._file_telemetry.get(work.file_path)
+            if work.kind == "file" and work.file_path is not None
+            else None
+        ) or self._telemetry
+        with bind_telemetry(telemetry), task_context:
             await self._run_work_bound(work)
 
     async def _run_work_bound(self, work: DagWork) -> None:
@@ -430,7 +456,7 @@ class SemanticDagExecutor:
     def _is_direct_incremental_update(self) -> bool:
         return (
             self._incremental_update
-            and bool(self._changed_paths)
+            and (bool(self._changed_paths) or self._directory_refresh_only)
             and self._target_uri == self._root_uri
         )
 
@@ -441,6 +467,8 @@ class SemanticDagExecutor:
         return any(path.startswith(prefix) for path in self._changed_paths)
 
     async def _check_file_content_changed(self, file_path: str) -> bool:
+        if self._directory_refresh_only:
+            return False
         if self._is_direct_incremental_update():
             return file_path in self._changed_paths
         target_path = self._get_target_file_path(file_path)
@@ -518,6 +546,8 @@ class SemanticDagExecutor:
     async def _check_dir_children_changed(
         self, dir_uri: str, current_files: List[str], current_dirs: List[str]
     ) -> bool:
+        if self._directory_refresh_only:
+            return True
         if self._is_direct_incremental_update():
             if self._path_has_direct_change(dir_uri):
                 return True
@@ -582,6 +612,9 @@ class SemanticDagExecutor:
                     summary_dict = await self._read_existing_summary(file_path)
                     if summary_dict is not None:
                         need_vectorize = False
+                    elif self._directory_refresh_only:
+                        summary_dict = {"name": file_name, "summary": ""}
+                        need_vectorize = False
                     else:
                         self._file_change_status[file_path] = True
             else:
@@ -609,7 +642,9 @@ class SemanticDagExecutor:
                     summary_dict=summary_dict,
                     ctx=self._ctx,
                     use_summary=use_summary,
-                    ingest_options=self._ingest_options,
+                    ingest_options=self._file_ingest_options.get(
+                        file_path, self._ingest_options
+                    ),
                 )
             except Exception as e:
                 logger.error(
@@ -707,10 +742,6 @@ class SemanticDagExecutor:
             return None
         return summary
 
-    @property
-    def stale(self) -> bool:
-        return self._stale
-
     async def _finalize_children_abstracts(self, node: DirNode) -> List[Dict[str, str]]:
         results: List[Dict[str, str]] = []
         for idx, child_uri in enumerate(node.children_dirs):
@@ -725,30 +756,20 @@ class SemanticDagExecutor:
                 results.append(item)
         return results
 
-    def _is_stale(self) -> bool:
-        from openviking.storage.queuefs.semantic_queue import is_semantic_coalesce_stale
-
-        return is_semantic_coalesce_stale(self._coalesce_key, self._coalesce_version)
-
     async def _write_directory_semantics(
         self,
         dir_uri: str,
         overview: str,
         abstract: str,
-    ) -> bool:
-        wrote = await write_semantic_sidecars(
+    ) -> None:
+        await write_semantic_sidecars(
             viking_fs=self._viking_fs,
             dir_uri=dir_uri,
             overview=overview,
             abstract=abstract,
             ctx=self._ctx,
-            is_stale=self._is_stale,
             lock=self._lock,
-            log_prefix="[SemanticDag]",
         )
-        if not wrote:
-            self._stale = True
-        return wrote
 
     async def _overview_task(self, dir_uri: str) -> None:
         node = self._nodes.get(dir_uri)
@@ -785,9 +806,7 @@ class SemanticDagExecutor:
 
             # Write directly, protected by the outer semantic lock.
             try:
-                wrote = await self._write_directory_semantics(dir_uri, overview, abstract)
-                if not wrote:
-                    need_vectorize = False
+                await self._write_directory_semantics(dir_uri, overview, abstract)
             except Exception:
                 logger.info(f"[SemanticDag] {dir_uri} write failed, skipping")
 
@@ -802,7 +821,7 @@ class SemanticDagExecutor:
                         abstract=abstract,
                         overview=overview,
                         ctx=self._ctx,
-                        ingest_options=self._ingest_options,
+                        ingest_options=self._directory_ingest_options,
                     )
                 except Exception as e:
                     logger.error(

--- a/openviking/storage/queuefs/semantic_msg.py
+++ b/openviking/storage/queuefs/semantic_msg.py
@@ -9,16 +9,16 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from openviking.utils.ingest_options import IngestOptions
+from openviking_cli.utils.uri import VikingURI
 
-def build_semantic_coalesce_key(
+
+def semantic_directory_key(
     *,
     context_type: str,
     uri: str,
     account_id: str = "default",
-    user_id: str = "default",
-    peer_id: str = "default",
-) -> str:
-    return "|".join([context_type, account_id, user_id, peer_id, uri.rstrip("/")])
+) -> tuple[str, str, str]:
+    return account_id, context_type, VikingURI.normalize(uri).rstrip("/")
 
 
 @dataclass
@@ -55,8 +55,8 @@ class SemanticMsg:
     is_code_repo: bool = False
     target_preexisting: Optional[bool] = None
     ingest_options: IngestOptions = field(default_factory=IngestOptions)
-    coalesce_key: str = ""
-    coalesce_version: int = 0
+    tag_parent_directory: bool = True
+    directory_refresh_only: bool = False
     changes: Optional[Dict[str, List[str]]] = (
         None  # {"added": [...], "modified": [...], "deleted": [...]}
     )
@@ -77,8 +77,8 @@ class SemanticMsg:
         is_code_repo: bool = False,
         target_preexisting: Optional[bool] = None,
         ingest_options: IngestOptions | Dict[str, Any] | None = None,
-        coalesce_key: str = "",
-        coalesce_version: int = 0,
+        tag_parent_directory: bool = True,
+        directory_refresh_only: bool = False,
         changes: Optional[Dict[str, List[str]]] = None,
     ):
         self.id = str(uuid4())
@@ -96,8 +96,8 @@ class SemanticMsg:
         self.is_code_repo = is_code_repo
         self.target_preexisting = target_preexisting
         self.ingest_options = IngestOptions.from_value(ingest_options)
-        self.coalesce_key = coalesce_key
-        self.coalesce_version = coalesce_version
+        self.tag_parent_directory = tag_parent_directory
+        self.directory_refresh_only = directory_refresh_only
         self.changes = changes
 
     def to_dict(self) -> Dict[str, Any]:
@@ -148,8 +148,8 @@ class SemanticMsg:
                     "search_tag_mode": data.get("search_tag_mode", "replace"),
                 }
             ),
-            coalesce_key=data.get("coalesce_key", ""),
-            coalesce_version=data.get("coalesce_version", 0),
+            tag_parent_directory=data.get("tag_parent_directory", True),
+            directory_refresh_only=data.get("directory_refresh_only", False),
             changes=data.get("changes"),
         )
         if "id" in data and data["id"]:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -6,6 +6,7 @@ import asyncio
 import re
 import threading
 from contextlib import nullcontext
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from openviking.observability.context import (
@@ -32,13 +33,17 @@ from openviking.parse.parsers.media.utils import (
 )
 from openviking.prompts import render_prompt
 from openviking.server.identity import RequestContext, Role
-from openviking.service.task_work_index import detach_task_context
+from openviking.service.task_work_index import (
+    TaskExecutionContext,
+    detach_task_context,
+    extract_task_metadata,
+)
 from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.semantic_dag import DagStats, SemanticDagExecutor
 from openviking.storage.queuefs.semantic_lock import SemanticLockScope
-from openviking.storage.queuefs.semantic_msg import SemanticMsg, build_semantic_coalesce_key
-from openviking.storage.queuefs.semantic_queue import is_semantic_msg_stale
+from openviking.storage.queuefs.semantic_msg import SemanticMsg, semantic_directory_key
+from openviking.storage.queuefs.semantic_queue import SemanticQueue
 from openviking.storage.queuefs.semantic_sidecar import write_semantic_sidecars
 from openviking.storage.viking_fs import LS_ALL_NODES, SyncDiff, get_viking_fs
 from openviking.telemetry import bind_telemetry, bind_telemetry_stage, resolve_telemetry
@@ -64,6 +69,77 @@ class RequestQueueStats:
     requeue_count: int = 0
     error_count: int = 0
 
+
+@dataclass
+class _SemanticBatch:
+    members: List[SemanticMsg]
+    task_contexts: Dict[str, TaskExecutionContext]
+    arrived: Set[str] = field(default_factory=set)
+    cancelled: Set[str] = field(default_factory=set)
+    runner_id: Optional[str] = None
+    ready: asyncio.Event = field(default_factory=asyncio.Event)
+    done: asyncio.Future[None] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.done = asyncio.get_running_loop().create_future()
+        self.done.add_done_callback(
+            lambda future: None if future.cancelled() else future.exception()
+        )
+
+    def arrive(self, msg_id: str, *, cancelled: bool = False) -> None:
+        self.arrived.add(msg_id)
+        if cancelled:
+            self.cancelled.add(msg_id)
+        self._select_runner()
+
+    def _select_runner(self) -> None:
+        if len(self.arrived) == len(self.members):
+            self.runner_id = next(
+                (msg.id for msg in self.members if msg.id not in self.cancelled),
+                None,
+            )
+            if self.runner_id is None and not self.done.done():
+                self.done.set_result(None)
+            self.ready.set()
+
+    def merged_input(
+        self,
+    ) -> tuple[
+        Dict[str, List[str]],
+        Dict[str, IngestOptions],
+        IngestOptions,
+        Dict[str, TaskExecutionContext],
+        Dict[str, Any],
+    ]:
+        changes: Dict[str, List[str]] = {}
+        file_options: Dict[str, IngestOptions] = {}
+        file_task_contexts: Dict[str, TaskExecutionContext] = {}
+        file_telemetry: Dict[str, Any] = {}
+        directory_options = IngestOptions()
+        active = [
+            msg for msg in self.members if msg.id not in self.cancelled
+        ]
+        for msg in active:
+            collector = resolve_telemetry(msg.telemetry_id)
+            msg_changes = msg.changes or {}
+            for change_type, paths in msg_changes.items():
+                merged = changes.setdefault(change_type, [])
+                merged.extend(path for path in paths if path not in merged)
+            for path in msg_changes.get("added", []) + msg_changes.get("modified", []):
+                file_options[path] = msg.ingest_options
+                if msg.id in self.task_contexts:
+                    file_task_contexts[path] = self.task_contexts[msg.id]
+                if collector is not None:
+                    file_telemetry[path] = collector
+            if msg.tag_parent_directory:
+                directory_options = msg.ingest_options
+        return (
+            changes,
+            file_options,
+            directory_options,
+            file_task_contexts,
+            file_telemetry,
+        )
 
 class SemanticProcessor(DequeueHandlerBase):
     """
@@ -94,6 +170,66 @@ class SemanticProcessor(DequeueHandlerBase):
         self.max_concurrent_llm = max_concurrent_llm
         self._default_ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
         self._circuit_breaker = CircuitBreaker()
+        self._semantic_batches: Dict[str, _SemanticBatch] = {}
+
+    @staticmethod
+    def _batch_key(msg: SemanticMsg) -> tuple[str, str, str, bool, bool]:
+        return (
+            *semantic_directory_key(
+                context_type=msg.context_type,
+                uri=msg.target_uri or msg.uri,
+                account_id=msg.account_id,
+            ),
+            msg.skip_vectorization,
+            msg.is_code_repo,
+        )
+
+    @staticmethod
+    def _can_batch(msg: SemanticMsg) -> bool:
+        return bool(
+            msg.context_type in {"resource", "skill"}
+            and not msg.recursive
+            and not msg.lock_handoff
+            and msg.changes
+            and (not msg.target_uri or msg.target_uri == msg.uri)
+            and not SemanticQueue.is_directory_refresh(msg)
+        )
+
+    def prepare_dequeued_batch(self, messages: List[Dict[str, Any]]) -> None:
+        import json
+
+        groups: Dict[tuple[str, str, str, bool, bool], List[SemanticMsg]] = {}
+        task_contexts: Dict[str, TaskExecutionContext] = {}
+        for data in messages:
+            try:
+                metadata = extract_task_metadata(data)
+                payload = data.get("data", data)
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+                msg = SemanticMsg.from_dict(payload)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if self._can_batch(msg):
+                groups.setdefault(self._batch_key(msg), []).append(msg)
+                if metadata is not None:
+                    task_contexts[msg.id] = TaskExecutionContext(
+                        task_id=metadata.task_id,
+                        account_id=metadata.account_id,
+                        user_id=metadata.user_id,
+                    )
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            batch = _SemanticBatch(
+                members=members,
+                task_contexts={
+                    msg.id: task_contexts[msg.id]
+                    for msg in members
+                    if msg.id in task_contexts
+                },
+            )
+            for msg in members:
+                self._semantic_batches[msg.id] = batch
 
     @classmethod
     def _cache_dag_stats(cls, telemetry_id: str, uri: str, stats: DagStats) -> None:
@@ -160,6 +296,53 @@ class SemanticProcessor(DequeueHandlerBase):
             role=role,
         )
 
+    @staticmethod
+    def _semantic_queue() -> SemanticQueue:
+        from openviking.storage.queuefs import get_queue_manager
+
+        queue_manager = get_queue_manager()
+        queue = queue_manager.get_queue(queue_manager.SEMANTIC, allow_create=True)
+        if not isinstance(queue, SemanticQueue):
+            raise RuntimeError("SemanticQueue is unavailable")
+        return queue
+
+    @classmethod
+    def _mark_semantic_done(
+        cls,
+        msg: SemanticMsg,
+        events: Optional[Dict[str, str]] = None,
+    ) -> None:
+        tracker = get_request_wait_tracker()
+        for event_id, telemetry_id in (events or {msg.id: msg.telemetry_id}).items():
+            if telemetry_id and event_id:
+                tracker.mark_semantic_done(telemetry_id, event_id)
+            cls._merge_request_stats(telemetry_id, processed=1)
+
+    @classmethod
+    def _mark_semantic_failed(
+        cls,
+        msg: SemanticMsg,
+        error: str,
+        events: Optional[Dict[str, str]] = None,
+    ) -> None:
+        tracker = get_request_wait_tracker()
+        for event_id, telemetry_id in (events or {msg.id: msg.telemetry_id}).items():
+            if telemetry_id and event_id:
+                tracker.mark_semantic_failed(telemetry_id, event_id, error)
+            cls._merge_request_stats(telemetry_id, error_count=1)
+
+    @classmethod
+    def _record_semantic_requeue(
+        cls,
+        msg: SemanticMsg,
+        events: Optional[Dict[str, str]] = None,
+    ) -> None:
+        tracker = get_request_wait_tracker()
+        for telemetry_id in (events or {msg.id: msg.telemetry_id}).values():
+            if telemetry_id:
+                tracker.record_semantic_requeue(telemetry_id)
+            cls._merge_request_stats(telemetry_id, requeue_count=1)
+
     def _detect_file_type(self, file_name: str) -> str:
         """
         Detect file type for summary prompt selection.
@@ -199,36 +382,30 @@ class SemanticProcessor(DequeueHandlerBase):
         """
         import asyncio
 
-        from openviking.storage.queuefs import get_queue_manager
-
         # Throttle to prevent re-enqueue storm during OPEN window
         wait = self._circuit_breaker.retry_after
         if wait > 0:
             await asyncio.sleep(wait)
 
-        queue_manager = get_queue_manager()
-        if queue_manager is not None:
-            semantic_queue = queue_manager.get_queue(queue_manager.SEMANTIC)
-            await semantic_queue.enqueue(msg)
-            logger.info(f"Re-enqueued semantic message: {msg.uri}")
-        else:
-            logger.warning(f"No queue manager available, cannot re-enqueue: {msg.uri}")
+        await self._semantic_queue().enqueue(msg)
+        logger.info(f"Re-enqueued semantic message: {msg.uri}")
 
     async def _requeue_semantic_msg_after_error(
         self,
         msg: SemanticMsg,
         data: Optional[Dict[str, Any]],
         error: Exception,
+        events: Optional[Dict[str, str]] = None,
     ) -> None:
         try:
             await self._reenqueue_semantic_msg(msg)
-            self._merge_request_stats(msg.telemetry_id, requeue_count=1)
-            get_request_wait_tracker().record_semantic_requeue(msg.telemetry_id)
+            self._record_semantic_requeue(msg, events)
             self.report_requeue()
         except Exception as requeue_err:
             logger.error(f"Failed to re-enqueue semantic message: {requeue_err}")
-            self._merge_request_stats(msg.telemetry_id, error_count=1)
-            get_request_wait_tracker().mark_semantic_failed(msg.telemetry_id, msg.id, str(error))
+            if SemanticQueue.is_directory_refresh(msg):
+                events = self._semantic_queue().abort_directory_refresh(msg)
+            self._mark_semantic_failed(msg, str(error), events)
             self.report_error(str(error), data)
             return
         self.report_success()
@@ -262,14 +439,8 @@ class SemanticProcessor(DequeueHandlerBase):
             peer_id=msg.peer_id,
             role=msg.role,
             skip_vectorization=msg.skip_vectorization,
-            changes={"modified": [uri]},
-            coalesce_key=build_semantic_coalesce_key(
-                context_type=msg.context_type,
-                uri=parent_uri,
-                account_id=msg.account_id,
-                user_id=msg.user_id,
-                peer_id=msg.peer_id,
-            ),
+            tag_parent_directory=False,
+            directory_refresh_only=True,
         )
         with detach_task_context():
             await semantic_queue.enqueue(parent_msg)
@@ -280,212 +451,291 @@ class SemanticProcessor(DequeueHandlerBase):
         data: Optional[Dict[str, Any]],
         lock: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Process dequeued SemanticMsg, recursively process all subdirectories."""
+        """Process one semantic message, merging only the current worker batch."""
         msg: Optional[SemanticMsg] = None
-        collector = None
+        batch: Optional[_SemanticBatch] = None
+        batch_runner = False
+        directory_queue: Optional[SemanticQueue] = None
+        directory_revision: Optional[int] = 0
+        completion_events: Optional[Dict[str, str]] = None
         try:
             import json
 
             if not data:
                 return None
-
+            queue_id = str(data.get("id", ""))
             if "data" in data and isinstance(data["data"], str):
                 data = json.loads(data["data"])
-
             assert data is not None
             msg = SemanticMsg.from_dict(data)
+
+            batch = self._semantic_batches.pop(msg.id, None)
+            if batch is not None:
+                batch.arrive(msg.id)
+                await batch.ready.wait()
+                batch_runner = batch.runner_id == msg.id
+                if not batch_runner:
+                    await asyncio.shield(batch.done)
+                    self._mark_semantic_done(msg)
+                    self.report_success()
+                    return None
+
+            directory_refresh = SemanticQueue.is_directory_refresh(msg)
+            if directory_refresh:
+                directory_queue = self._semantic_queue()
+                directory_revision = directory_queue.claim_directory_refresh(
+                    msg, queue_id
+                )
+                if directory_revision is None:
+                    self.report_success()
+                    return None
+
             if VikingURI(msg.uri).parent is None:
                 logger.warning("Skipping semantic generation for root URI: %s", msg.uri)
-                if msg.telemetry_id and msg.id:
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                self.report_success()
-                return None
-            if is_semantic_msg_stale(msg):
-                logger.info(
-                    "Skipping stale semantic message: uri=%s version=%s",
-                    msg.uri,
-                    msg.coalesce_version,
-                )
-                if msg.telemetry_id and msg.id:
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                self.report_success()
-                return None
-            # Circuit breaker: if API is known-broken, re-enqueue and wait
-            try:
+                if directory_queue is not None:
+                    while completion_events is None:
+                        completion_events = directory_queue.finish_directory_refresh(
+                            msg, directory_revision
+                        )
+                        directory_revision = directory_queue.claim_directory_refresh(
+                            msg, queue_id
+                        )
+            else:
                 self._circuit_breaker.check()
-            except CircuitBreakerOpen:
-                logger.warning(
-                    f"Circuit breaker is open, re-enqueueing semantic message: {msg.uri}"
+                collector = resolve_telemetry(msg.telemetry_id)
+                telemetry_ctx = (
+                    bind_telemetry(collector) if collector is not None else nullcontext()
                 )
-                await self._reenqueue_semantic_msg(msg)
-                self._merge_request_stats(msg.telemetry_id, requeue_count=1)
-                get_request_wait_tracker().record_semantic_requeue(msg.telemetry_id)
-                self.report_requeue()
-                self.report_success()
-                return None
-            collector = resolve_telemetry(msg.telemetry_id)
-            telemetry_ctx = bind_telemetry(collector) if collector is not None else nullcontext()
-            with telemetry_ctx:
-                root_attrs = create_root_span_attributes(
-                    http_method="QUEUE",
-                    http_route=msg.context_type or "/queuefs/semantic",
-                    request_id=msg.telemetry_id or msg.id,
-                    url_path=msg.uri,
-                )
-                root_attrs.account_id = msg.account_id
-                root_attrs.user_id = msg.user_id
-                root_context_token = bind_root_observability_context(root_attrs)
-                try:
-                    current_ctx = self._ctx_from_semantic_msg(msg)
-                    logger.info(
-                        f"Processing semantic generation for: {msg.uri} (recursive={msg.recursive})"
+                with telemetry_ctx:
+                    root_attrs = create_root_span_attributes(
+                        http_method="QUEUE",
+                        http_route=msg.context_type or "/queuefs/semantic",
+                        request_id=msg.telemetry_id or msg.id,
+                        url_path=msg.uri,
                     )
-
-                    logger.info(f"Processing semantic generation for: {msg})")
-
-                    semantic_lock = await SemanticLockScope.resolve(
-                        msg.lock_handoff,
-                        caller_lock=lock,
-                        fallback_path_factory=lambda: get_viking_fs()._uri_to_path(
-                            msg.uri, ctx=current_ctx
-                        ),
-                    )
+                    root_attrs.account_id = msg.account_id
+                    root_attrs.user_id = msg.user_id
+                    root_context_token = bind_root_observability_context(root_attrs)
                     try:
-                        if msg.context_type == "memory":
-                            await self._process_memory_directory(
-                                msg,
-                                ctx=current_ctx,
-                                lock=semantic_lock.lock,
-                            )
-                        else:
-                            is_incremental = False
-                            target_uri = msg.target_uri
-                            run_uri = msg.uri
-                            changes = msg.changes
-                            viking_fs = get_viking_fs()
-                            if msg.target_uri:
-                                target_exists = await viking_fs.exists(
-                                    msg.target_uri, ctx=current_ctx
+                        current_ctx = self._ctx_from_semantic_msg(msg)
+                        logger.info(
+                            "Processing semantic generation for: %s (recursive=%s)",
+                            msg.uri,
+                            msg.recursive,
+                        )
+                        semantic_lock = await SemanticLockScope.resolve(
+                            msg.lock_handoff,
+                            caller_lock=lock,
+                            fallback_path_factory=lambda: get_viking_fs()._uri_to_path(
+                                msg.uri, ctx=current_ctx
+                            ),
+                        )
+                        try:
+                            if msg.context_type == "memory":
+                                await self._process_memory_directory(
+                                    msg,
+                                    ctx=current_ctx,
+                                    lock=semantic_lock.lock,
                                 )
-                                if msg.uri != msg.target_uri:
-                                    logger.info(
-                                        "Syncing semantic source into target before processing: "
-                                        f"{msg.uri} -> {msg.target_uri}"
-                                    )
-                                    diff = await self._sync_topdown_recursive(
-                                        msg.uri,
-                                        msg.target_uri,
-                                        ctx=current_ctx,
-                                        lock=semantic_lock.lock,
-                                    )
-                                    logger.info(
-                                        "[SyncDiff] Diff computed: "
-                                        f"added_files={len(diff.added_files)}, "
-                                        f"deleted_files={len(diff.deleted_files)}, "
-                                        f"updated_files={len(diff.updated_files)}, "
-                                        f"added_dirs={len(diff.added_dirs)}, "
-                                        f"deleted_dirs={len(diff.deleted_dirs)}"
-                                    )
-                                    changes = diff.to_changes()
-                                    is_incremental = True
+                            else:
+                                changes = msg.changes
+                                file_ingest_options: Dict[str, IngestOptions] = {}
+                                file_task_contexts: Dict[str, TaskExecutionContext] = {}
+                                file_telemetry: Dict[str, Any] = {}
+                                directory_ingest_options = (
+                                    msg.ingest_options
+                                    if msg.tag_parent_directory
+                                    else IngestOptions()
+                                )
+                                if batch is not None:
+                                    (
+                                        changes,
+                                        file_ingest_options,
+                                        directory_ingest_options,
+                                        file_task_contexts,
+                                        file_telemetry,
+                                    ) = batch.merged_input()
+
+                                while True:
+                                    is_incremental = False
                                     target_uri = msg.target_uri
-                                    run_uri = msg.target_uri
-                                elif target_exists and msg.changes and msg.uri == msg.target_uri:
-                                    is_incremental = True
-                                    logger.info(
-                                        f"Using direct incremental semantic update for: {msg.uri}"
+                                    run_uri = msg.uri
+                                    viking_fs = get_viking_fs()
+                                    if msg.target_uri:
+                                        target_exists = await viking_fs.exists(
+                                            msg.target_uri, ctx=current_ctx
+                                        )
+                                        if msg.uri != msg.target_uri:
+                                            logger.info(
+                                                "Syncing semantic source into target before "
+                                                "processing: %s -> %s",
+                                                msg.uri,
+                                                msg.target_uri,
+                                            )
+                                            diff = await self._sync_topdown_recursive(
+                                                msg.uri,
+                                                msg.target_uri,
+                                                ctx=current_ctx,
+                                                lock=semantic_lock.lock,
+                                            )
+                                            logger.info(
+                                                "[SyncDiff] Diff computed: added_files=%s, "
+                                                "deleted_files=%s, updated_files=%s, "
+                                                "added_dirs=%s, deleted_dirs=%s",
+                                                len(diff.added_files),
+                                                len(diff.deleted_files),
+                                                len(diff.updated_files),
+                                                len(diff.added_dirs),
+                                                len(diff.deleted_dirs),
+                                            )
+                                            changes = diff.to_changes()
+                                            is_incremental = True
+                                            target_uri = msg.target_uri
+                                            run_uri = msg.target_uri
+                                        elif target_exists and changes:
+                                            is_incremental = True
+                                    elif changes or directory_refresh:
+                                        is_incremental = True
+                                        target_uri = msg.uri
+
+                                    executor = SemanticDagExecutor(
+                                        processor=self,
+                                        context_type=msg.context_type,
+                                        max_concurrent_llm=self.max_concurrent_llm,
+                                        ctx=current_ctx,
+                                        incremental_update=is_incremental,
+                                        target_uri=target_uri,
+                                        recursive=msg.recursive,
+                                        lock=semantic_lock.lock,
+                                        is_code_repo=msg.is_code_repo,
+                                        changes=changes,
+                                        skip_vectorization=msg.skip_vectorization,
+                                        ingest_options=msg.ingest_options,
+                                        file_ingest_options=file_ingest_options,
+                                        file_task_contexts=file_task_contexts,
+                                        file_telemetry=file_telemetry,
+                                        directory_ingest_options=(
+                                            IngestOptions()
+                                            if directory_refresh
+                                            else directory_ingest_options
+                                        ),
+                                        directory_refresh_only=directory_refresh,
                                     )
-                            elif msg.changes:
-                                is_incremental = True
-                                target_uri = msg.uri
-                                logger.info(
-                                    f"Using direct incremental semantic update for: {msg.uri}"
+                                    await executor.run(run_uri)
+                                    self._cache_dag_stats(
+                                        msg.telemetry_id,
+                                        run_uri,
+                                        executor.get_stats(),
+                                    )
+                                    if directory_queue is None:
+                                        break
+                                    completion_events = (
+                                        directory_queue.finish_directory_refresh(
+                                            msg, directory_revision
+                                        )
+                                    )
+                                    if completion_events is not None:
+                                        break
+                                    directory_revision = (
+                                        directory_queue.claim_directory_refresh(
+                                            msg, queue_id
+                                        )
+                                    )
+
+                                await self._enqueue_parent_refresh(
+                                    msg, target_uri or msg.uri
                                 )
-
-                            executor = SemanticDagExecutor(
-                                processor=self,
-                                context_type=msg.context_type,
-                                max_concurrent_llm=self.max_concurrent_llm,
-                                ctx=current_ctx,
-                                incremental_update=is_incremental,
-                                target_uri=target_uri,
-                                recursive=msg.recursive,
-                                lock=semantic_lock.lock,
-                                is_code_repo=msg.is_code_repo,
-                                changes=changes,
-                                skip_vectorization=msg.skip_vectorization,
-                                ingest_options=msg.ingest_options,
-                                coalesce_key=msg.coalesce_key,
-                                coalesce_version=msg.coalesce_version,
-                            )
-                            await executor.run(run_uri)
-                            self._cache_dag_stats(
-                                msg.telemetry_id,
-                                run_uri,
-                                executor.get_stats(),
-                            )
-                            if not executor.stale:
-                                await self._enqueue_parent_refresh(msg, target_uri or msg.uri)
+                        finally:
+                            await semantic_lock.close()
                     finally:
-                        await semantic_lock.close()
-                    get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
-                    self._merge_request_stats(msg.telemetry_id, processed=1)
-                    logger.info(f"Completed semantic generation for: {msg.uri}")
-                    self.report_success()
-                    self._circuit_breaker.record_success()
-                    return None
-                finally:
-                    reset_root_observability_context(root_context_token)
+                        reset_root_observability_context(root_context_token)
 
-        except Exception as e:
-            if isinstance(e, LockAcquisitionError):
+            if batch is not None:
+                if not batch.done.done():
+                    batch.done.set_result(None)
+            self._mark_semantic_done(msg, completion_events)
+            logger.info("Completed semantic generation for: %s", msg.uri)
+            self.report_success()
+            self._circuit_breaker.record_success()
+            return None
+
+        except asyncio.CancelledError:
+            if batch is not None:
+                if batch_runner:
+                    if not batch.done.done():
+                        batch.done.set_exception(
+                            RuntimeError("semantic batch runner was cancelled")
+                        )
+                else:
+                    batch.cancelled.add(msg.id if msg is not None else "")
+                    batch._select_runner()
+            raise
+        except Exception as error:
+            if batch is not None and batch_runner and not batch.done.done():
+                batch.done.set_exception(error)
+            events = (
+                directory_queue.directory_refresh_events(msg)
+                if directory_queue is not None and msg is not None
+                else None
+            )
+            if isinstance(error, (LockAcquisitionError, CircuitBreakerOpen)):
                 logger.warning(
-                    "Lock error processing semantic message, re-enqueueing without "
-                    "tripping API circuit breaker: %s",
-                    e,
+                    "Semantic processing is temporarily blocked; re-enqueueing %s: %s",
+                    msg.uri if msg is not None else "",
+                    error,
                     exc_info=True,
                 )
                 if msg is not None:
-                    await self._requeue_semantic_msg_after_error(msg, data, e)
+                    await self._requeue_semantic_msg_after_error(
+                        msg, data, error, events
+                    )
                 else:
-                    self.report_error(str(e), data)
+                    self.report_error(str(error), data)
                 return None
 
-            error_class = classify_api_error(e)
+            error_class = classify_api_error(error)
             if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
                 logger.error(
-                    f"Input too large processing semantic message, dropping: {e}",
+                    "Input too large processing semantic message, dropping: %s",
+                    error,
                     exc_info=True,
                 )
                 if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
+                    failed_events = (
+                        directory_queue.abort_directory_refresh(msg)
+                        if directory_queue is not None
+                        else events
                     )
-                self.report_error(str(e), data)
+                    self._mark_semantic_failed(msg, str(error), failed_events)
+                self.report_error(str(error), data)
             elif error_class == ERROR_CLASS_PERMANENT:
                 logger.critical(
-                    f"Permanent API error processing semantic message, dropping: {e}",
+                    "Permanent API error processing semantic message, dropping: %s",
+                    error,
                     exc_info=True,
                 )
-                self._circuit_breaker.record_failure(e)
+                self._circuit_breaker.record_failure(error)
                 if msg is not None:
-                    self._merge_request_stats(msg.telemetry_id, error_count=1)
-                    get_request_wait_tracker().mark_semantic_failed(
-                        msg.telemetry_id, msg.id, str(e)
+                    failed_events = (
+                        directory_queue.abort_directory_refresh(msg)
+                        if directory_queue is not None
+                        else events
                     )
-                self.report_error(str(e), data)
+                    self._mark_semantic_failed(msg, str(error), failed_events)
+                self.report_error(str(error), data)
             else:
-                # Transient or unknown — re-enqueue for retry
                 logger.warning(
-                    f"Transient API error processing semantic message, re-enqueueing: {e}",
+                    "Transient API error processing semantic message, re-enqueueing: %s",
+                    error,
                     exc_info=True,
                 )
-                self._circuit_breaker.record_failure(e)
+                self._circuit_breaker.record_failure(error)
                 if msg is not None:
-                    await self._requeue_semantic_msg_after_error(msg, data, e)
+                    await self._requeue_semantic_msg_after_error(
+                        msg, data, error, events
+                    )
                 else:
-                    self.report_error(str(e), data)
+                    self.report_error(str(error), data)
             return None
 
     async def on_cancelled(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -501,6 +751,10 @@ class SemanticProcessor(DequeueHandlerBase):
             self.report_error(str(exc), data)
             return None
 
+        batch = self._semantic_batches.pop(msg.id, None)
+        if batch is not None:
+            batch.arrive(msg.id, cancelled=True)
+            await batch.ready.wait()
         if msg.telemetry_id and msg.id:
             get_request_wait_tracker().mark_semantic_done(msg.telemetry_id, msg.id)
         if msg.lock_handoff is not None:
@@ -659,7 +913,7 @@ class SemanticProcessor(DequeueHandlerBase):
         overview, abstract = self._normalize_overview_generation(generated_content)
 
         try:
-            wrote_semantics = await self._write_memory_directory_semantics(
+            await self._write_memory_directory_semantics(
                 msg=msg,
                 viking_fs=viking_fs,
                 dir_uri=dir_uri,
@@ -670,8 +924,6 @@ class SemanticProcessor(DequeueHandlerBase):
             )
         except Exception as e:
             raise RuntimeError(f"Failed to write abstract/overview for {dir_uri}: {e}") from e
-        if not wrote_semantics:
-            return
         logger.info(f"Generated abstract.md and overview.md for {dir_uri}")
 
         if msg.skip_vectorization:
@@ -696,16 +948,14 @@ class SemanticProcessor(DequeueHandlerBase):
         abstract: str,
         ctx: Optional[RequestContext],
         lock: Optional[Dict[str, Any]] = None,
-    ) -> bool:
-        return await write_semantic_sidecars(
+    ) -> None:
+        await write_semantic_sidecars(
             viking_fs=viking_fs,
             dir_uri=dir_uri,
             overview=overview,
             abstract=abstract,
             ctx=ctx,
-            is_stale=lambda: is_semantic_msg_stale(msg),
             lock=lock,
-            log_prefix="[MemorySemantic]",
         )
 
     async def _sync_topdown_recursive(

--- a/openviking/storage/queuefs/semantic_queue.py
+++ b/openviking/storage/queuefs/semantic_queue.py
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: AGPL-3.0
 """SemanticQueue: Semantic extraction queue."""
 
+import asyncio
+import json
 import threading
 import time
+from concurrent.futures import Future
+from dataclasses import dataclass
 from typing import Optional
 
+from openviking.service.task_work_index import extract_task_metadata, get_task_context
+from openviking.utils.ingest_options import IngestOptions
 from openviking_cli.utils.logger import get_logger
 
 from .named_queue import NamedQueue
-from .semantic_msg import SemanticMsg
+from .semantic_msg import SemanticMsg, semantic_directory_key
 
 logger = get_logger(__name__)
 
 # Coalesce rapid re-enqueues for the same memory parent directory (github #769).
 _MEMORY_PARENT_SEMANTIC_DEDUPE_SEC = 45.0
-_SEMANTIC_COALESCE_LOCK = threading.Lock()
-_SEMANTIC_COALESCE_VERSION: dict[str, int] = {}
 
 
-def is_semantic_coalesce_stale(coalesce_key: str, coalesce_version: int) -> bool:
-    if not coalesce_key or coalesce_version <= 0:
-        return False
-    with _SEMANTIC_COALESCE_LOCK:
-        return coalesce_version < _SEMANTIC_COALESCE_VERSION.get(coalesce_key, 0)
-
-
-def is_semantic_msg_stale(msg: SemanticMsg) -> bool:
-    return is_semantic_coalesce_stale(msg.coalesce_key, msg.coalesce_version)
+@dataclass
+class _PendingDirectoryRefresh:
+    trigger_id: str
+    queue_id: str
+    revision: int
+    events: dict[str, str]
+    enqueue_result: Future[str]
 
 
 class SemanticQueue(NamedQueue):
@@ -37,14 +39,67 @@ class SemanticQueue(NamedQueue):
         super().__init__(*args, **kwargs)
         self._memory_parent_semantic_last: dict[str, float] = {}
         self._memory_parent_semantic_lock = threading.Lock()
+        self._directory_refreshes: dict[
+            tuple[str, str, str], _PendingDirectoryRefresh
+        ] = {}
+        self._directory_refresh_lock = threading.Lock()
 
     @staticmethod
     def _memory_parent_semantic_key(msg: SemanticMsg) -> str:
         return f"{msg.account_id}|{msg.user_id}|{msg.peer_id}|{msg.uri}"
 
+    @staticmethod
+    def is_directory_refresh(msg: SemanticMsg) -> bool:
+        return bool(
+            msg.directory_refresh_only
+            or (
+                msg.context_type in {"resource", "skill"}
+                and not msg.recursive
+                and msg.changes
+                and set(msg.changes) == {"deleted"}
+            )
+        )
+
+    @staticmethod
+    def _directory_key(msg: SemanticMsg) -> tuple[str, str, str]:
+        return semantic_directory_key(
+            context_type=msg.context_type,
+            uri=msg.target_uri or msg.uri,
+            account_id=msg.account_id,
+        )
+
+    @staticmethod
+    def _observe_future(future: Future[str]) -> None:
+        if not future.cancelled():
+            future.exception()
+
+    def _join_directory_refresh(
+        self, msg: SemanticMsg
+    ) -> tuple[bool, Future[str]]:
+        key = self._directory_key(msg)
+        with self._directory_refresh_lock:
+            state = self._directory_refreshes.get(key)
+            if state is None:
+                enqueue_result: Future[str] = Future()
+                enqueue_result.add_done_callback(self._observe_future)
+                self._directory_refreshes[key] = _PendingDirectoryRefresh(
+                    trigger_id=msg.id,
+                    queue_id="",
+                    revision=1,
+                    events={msg.id: msg.telemetry_id},
+                    enqueue_result=enqueue_result,
+                )
+                return True, enqueue_result
+            if msg.id == state.trigger_id:
+                state.queue_id = ""
+                return True, state.enqueue_result
+            state.revision += 1
+            state.events.setdefault(msg.id, msg.telemetry_id)
+            return False, state.enqueue_result
+
     async def enqueue(self, msg: SemanticMsg) -> str:
         """Serialize SemanticMsg object and store in queue."""
-        if msg.context_type == "memory" and not msg.coalesce_key:
+        if msg.context_type == "memory":
             key = self._memory_parent_semantic_key(msg)
             now = time.monotonic()
             with self._memory_parent_semantic_lock:
@@ -61,16 +116,122 @@ class SemanticQueue(NamedQueue):
                 if len(self._memory_parent_semantic_last) > 2000:
                     cutoff = now - (_MEMORY_PARENT_SEMANTIC_DEDUPE_SEC * 4)
                     stale = [k for k, t in self._memory_parent_semantic_last.items() if t < cutoff]
-                    for k in stale[:800]:
-                        self._memory_parent_semantic_last.pop(k, None)
+                    for stale_key in stale[:800]:
+                        self._memory_parent_semantic_last.pop(stale_key, None)
 
-        if msg.coalesce_key:
-            with _SEMANTIC_COALESCE_LOCK:
-                version = _SEMANTIC_COALESCE_VERSION.get(msg.coalesce_key, 0) + 1
-                _SEMANTIC_COALESCE_VERSION[msg.coalesce_key] = version
-                msg.coalesce_version = version
+        if not msg.directory_refresh_only:
+            return await super().enqueue(msg.to_dict())
 
-        return await super().enqueue(msg.to_dict())
+        # A directory trigger reads the current AGFS state. Child paths and tags
+        # belong to file work and must not be carried into this message.
+        msg.changes = None
+        msg.ingest_options = IngestOptions()
+        msg.tag_parent_directory = False
+
+        # Task-owned messages keep their own durable lifecycle.
+        if get_task_context() is not None or msg.lock_handoff is not None:
+            return await super().enqueue(msg.to_dict())
+
+        leader, enqueue_result = self._join_directory_refresh(msg)
+        if not leader:
+            return await asyncio.shield(asyncio.wrap_future(enqueue_result))
+
+        try:
+            result = await super().enqueue(msg.to_dict())
+        except BaseException as error:
+            with self._directory_refresh_lock:
+                state = self._directory_refreshes.get(self._directory_key(msg))
+                if state is not None and state.trigger_id == msg.id:
+                    self._directory_refreshes.pop(self._directory_key(msg), None)
+            if not enqueue_result.done():
+                enqueue_result.set_exception(error)
+            raise
+        with self._directory_refresh_lock:
+            state = self._directory_refreshes.get(self._directory_key(msg))
+            if state is not None and state.trigger_id == msg.id:
+                state.queue_id = result
+        if not enqueue_result.done():
+            enqueue_result.set_result(result)
+        return result
+
+    def restore_directory_refreshes(self, messages: list[dict]) -> None:
+        """Rebuild pending directory triggers before workers start."""
+        with self._directory_refresh_lock:
+            self._directory_refreshes.clear()
+            for envelope in messages:
+                if extract_task_metadata(envelope) is not None:
+                    continue
+                try:
+                    payload = envelope.get("data", envelope)
+                    if isinstance(payload, str):
+                        payload = json.loads(payload)
+                    msg = SemanticMsg.from_dict(payload)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+                if not self.is_directory_refresh(msg):
+                    continue
+                key = self._directory_key(msg)
+                state = self._directory_refreshes.get(key)
+                if state is not None:
+                    state.events.setdefault(msg.id, msg.telemetry_id)
+                    continue
+                enqueue_result: Future[str] = Future()
+                queue_id = str(envelope.get("id", msg.id))
+                enqueue_result.set_result(queue_id)
+                self._directory_refreshes[key] = _PendingDirectoryRefresh(
+                    trigger_id=msg.id,
+                    queue_id=queue_id,
+                    revision=1,
+                    events={msg.id: msg.telemetry_id},
+                    enqueue_result=enqueue_result,
+                )
+
+    def claim_directory_refresh(
+        self, msg: SemanticMsg, queue_id: str
+    ) -> Optional[int]:
+        with self._directory_refresh_lock:
+            state = self._directory_refreshes.get(self._directory_key(msg))
+            if state is None:
+                return 0
+            if state.queue_id and state.queue_id != queue_id:
+                return None
+            return state.revision
+
+    def directory_refresh_events(self, msg: SemanticMsg) -> dict[str, str]:
+        with self._directory_refresh_lock:
+            state = self._directory_refreshes.get(self._directory_key(msg))
+            if state is None or state.trigger_id != msg.id:
+                return {msg.id: msg.telemetry_id}
+            return dict(state.events)
+
+    def finish_directory_refresh(
+        self, msg: SemanticMsg, revision: int
+    ) -> Optional[dict[str, str]]:
+        with self._directory_refresh_lock:
+            key = self._directory_key(msg)
+            state = self._directory_refreshes.get(key)
+            if state is None or state.trigger_id != msg.id:
+                return {msg.id: msg.telemetry_id}
+            if state.revision != revision:
+                return None
+            self._directory_refreshes.pop(key, None)
+            return dict(state.events)
+
+    def abort_directory_refresh(self, msg: SemanticMsg) -> dict[str, str]:
+        with self._directory_refresh_lock:
+            key = self._directory_key(msg)
+            state = self._directory_refreshes.get(key)
+            if state is None or state.trigger_id != msg.id:
+                return {msg.id: msg.telemetry_id}
+            self._directory_refreshes.pop(key, None)
+            return dict(state.events)
+
+    async def clear(self) -> bool:
+        cleared = await super().clear()
+        if cleared:
+            with self._directory_refresh_lock:
+                self._directory_refreshes.clear()
+        return cleared
 
     async def dequeue(self) -> Optional[SemanticMsg]:
         """Get message from queue and deserialize to SemanticMsg object."""

--- a/openviking/storage/queuefs/semantic_sidecar.py
+++ b/openviking/storage/queuefs/semantic_sidecar.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Shared writeback for semantic sidecar files."""
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 
 from openviking.server.identity import RequestContext
-from openviking_cli.utils.logger import get_logger
-
-logger = get_logger(__name__)
 
 
 async def write_semantic_sidecars(
@@ -17,15 +14,9 @@ async def write_semantic_sidecars(
     overview: str,
     abstract: str,
     ctx: Optional[RequestContext],
-    is_stale: Callable[[], bool],
     lock: Optional[Dict[str, Any]] = None,
-    log_prefix: str = "[Semantic]",
-) -> bool:
+) -> None:
     """Write .overview.md and .abstract.md sidecar files under dir_uri with exact-path locking."""
-    if is_stale():
-        logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
-        return False
-
     lock_paths = [
         viking_fs._uri_to_path(f"{dir_uri}/.overview.md", ctx=ctx),
         viking_fs._uri_to_path(f"{dir_uri}/.abstract.md", ctx=ctx),
@@ -35,11 +26,7 @@ async def write_semantic_sidecars(
     if sidecar_lease is None:
         sidecar_lease = await viking_fs._async_agfs.pathlock_acquire_exact_batch(lock_paths)
     try:
-        if is_stale():
-            logger.info("%s Skipping stale semantic write for %s", log_prefix, dir_uri)
-            return False
         await _write_sidecars(viking_fs, dir_uri, overview, abstract, ctx, sidecar_lease)
-        return True
     finally:
         if owns_lease:
             await viking_fs._async_agfs.pathlock_release(sidecar_lease)

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -441,6 +441,7 @@ class ResourceProcessor:
                 "target_preexisting": target_preexisting,
                 "is_code_repo": parse_result.source_format == "repository",
                 "root_is_file": root_is_file,
+                "tag_parent_directory": not bool(parent),
             }
             if defer_post_processing:
                 result["_post_process"] = prepared
@@ -485,6 +486,8 @@ class ResourceProcessor:
         processing_mode = normalize_processing_mode(processing_mode)
         vectors_only = processing_mode == VECTORS_ONLY
         root_is_file = bool(prepared.get("root_is_file"))
+        # Prepared payloads already persisted before this field existed keep the old behavior.
+        tag_parent_directory = bool(prepared.get("tag_parent_directory", True))
         ingest_options = IngestOptions.from_value(kwargs.pop("ingest_options", None))
         should_summarize = not root_is_file and not vectors_only and (summarize or build_index)
         should_refresh_file_parent = (
@@ -573,6 +576,7 @@ class ResourceProcessor:
                         ctx=ctx,
                         skip_vectorization=not build_index,
                         ingest_options=ingest_options,
+                        tag_parent_directory=tag_parent_directory,
                     )
                 elif build_index:
                     if root_is_file:
@@ -591,6 +595,7 @@ class ResourceProcessor:
                 ctx=ctx,
                 skip_vectorization=not build_index,
                 ingest_options=ingest_options,
+                tag_parent_directory=tag_parent_directory,
             )
         elif vectors_only or root_is_file:
             if not build_index:

--- a/openviking/utils/summarizer.py
+++ b/openviking/utils/summarizer.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from openviking.core.namespace import context_type_for_uri
 from openviking.storage.queuefs import SemanticMsg, get_queue_manager
-from openviking.storage.queuefs.semantic_msg import build_semantic_coalesce_key
 from openviking.storage.viking_fs import LS_ALL_NODES, get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
@@ -39,6 +38,7 @@ class Summarizer:
         ctx: "RequestContext",
         skip_vectorization: bool = False,
         ingest_options: IngestOptions | None = None,
+        tag_parent_directory: bool = True,
     ) -> Dict[str, Any]:
         """Summarize one flat file and refresh its parent directory semantics."""
         parent = VikingURI(file_uri).parent
@@ -60,13 +60,7 @@ class Summarizer:
             skip_vectorization=skip_vectorization,
             telemetry_id=telemetry_id,
             changes={"modified": [file_uri]},
-            coalesce_key=build_semantic_coalesce_key(
-                context_type=context_type_for_uri(file_uri),
-                uri=parent_uri,
-                account_id=ctx.account_id,
-                user_id=ctx.user.user_id,
-                peer_id=ctx.user.user_id,
-            ),
+            tag_parent_directory=tag_parent_directory,
             ingest_options=ingest_options,
         )
         if telemetry_id:

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -410,7 +410,7 @@ class _FakeQueueManager:
 
 
 @pytest.mark.asyncio
-async def test_resource_write_semantic_refresh_uses_coalesce_key(monkeypatch):
+async def test_resource_write_semantic_refresh_keeps_file_change(monkeypatch):
     file_uri = "viking://resources/demo/doc.md"
     root_uri = "viking://resources/demo"
     ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.USER)
@@ -432,9 +432,8 @@ async def test_resource_write_semantic_refresh_uses_coalesce_key(monkeypatch):
     )
 
     assert len(queue.messages) == 1
-    assert queue.messages[0].coalesce_key == (
-        "resource|default|default|default|viking://resources/demo"
-    )
+    assert queue.messages[0].changes == {"modified": [file_uri]}
+    assert queue.messages[0].directory_refresh_only is False
     assert queue.messages[0].lock_handoff is None
 
 

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -439,6 +439,8 @@ async def test_resource_rm_wait_registers_request_before_semantic_root(
     assert tracker.registered_roots
     assert tracker.registered_roots[0]["request_was_registered"] is True
     assert queue_manager.messages[0].recursive is False
+    assert queue_manager.messages[0].directory_refresh_only is True
+    assert queue_manager.messages[0].changes is None
     assert tracker.wait_calls == [("tm-fs-rm", 3)]
     assert tracker.cleaned == ["tm-fs-rm"]
     assert result["semantic_status"] == "complete"

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from openviking.server.identity import RequestContext, Role
+from openviking.service.task_work_index import TaskExecutionContext, get_task_context
 from openviking.storage.queuefs.semantic_dag import SemanticDagExecutor
+from openviking.utils.ingest_options import IngestOptions
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -56,6 +58,9 @@ class _FakeProcessor:
         self.summarized_files = []
         self.sync_calls = []
         self.vectorized_files = []
+        self.file_task_ids = {}
+        self.directory_options = []
+        self.overview_calls = 0
 
     def _parse_overview_md(self, overview_content):
         results = {}
@@ -71,6 +76,7 @@ class _FakeProcessor:
         return {"name": file_path.split("/")[-1], "summary": "summary"}
 
     async def _generate_overview(self, dir_uri, file_summaries, children_abstracts):
+        self.overview_calls += 1
         lines = ["FILES:"]
         for item in file_summaries:
             name = item.get("name", "")
@@ -91,7 +97,8 @@ class _FakeProcessor:
         use_summary=False,
         ingest_options=None,
     ):
-        self.vectorized_files.append(file_path)
+        self.vectorized_files.append((file_path, ingest_options))
+        self.file_task_ids[file_path] = get_task_context().task_id
 
     async def _vectorize_directory(
         self,
@@ -102,7 +109,7 @@ class _FakeProcessor:
         ctx=None,
         ingest_options=None,
     ):
-        return None
+        self.directory_options.append(ingest_options)
 
     async def _sync_topdown_recursive(
         self, root_uri, target_uri, ctx=None, file_change_status=None, lock=None
@@ -154,17 +161,38 @@ async def test_direct_incremental_update_uses_changes_without_temp_sync(monkeypa
         ctx=ctx,
         incremental_update=True,
         target_uri=root_uri,
-        changes={"modified": [f"{root_uri}/a.txt"]},
+        changes={"modified": [f"{root_uri}/a.txt", f"{root_uri}/b.txt"]},
+        file_ingest_options={
+            f"{root_uri}/a.txt": IngestOptions(search_tags=["file=a"]),
+            f"{root_uri}/b.txt": IngestOptions(search_tags=["file=b"]),
+        },
+        file_task_contexts={
+            f"{root_uri}/a.txt": TaskExecutionContext("task-a", "acc1", "user1"),
+            f"{root_uri}/b.txt": TaskExecutionContext("task-b", "acc1", "user1"),
+        },
+        directory_ingest_options=IngestOptions(search_tags=["file=b"]),
     )
 
     await executor.run(root_uri)
 
-    assert processor.summarized_files == [f"{root_uri}/a.txt"]
-    assert processor.vectorized_files == [f"{root_uri}/a.txt"]
+    assert set(processor.summarized_files) == {
+        f"{root_uri}/a.txt",
+        f"{root_uri}/b.txt",
+    }
+    assert dict(processor.vectorized_files) == {
+        f"{root_uri}/a.txt": IngestOptions(search_tags=["file=a"]),
+        f"{root_uri}/b.txt": IngestOptions(search_tags=["file=b"]),
+    }
+    assert processor.file_task_ids == {
+        f"{root_uri}/a.txt": "task-a",
+        f"{root_uri}/b.txt": "task-b",
+    }
+    assert processor.overview_calls == 1
+    assert processor.directory_options == [IngestOptions(search_tags=["file=b"])]
     assert processor.sync_calls == []
     overview = fake_fs._file_contents[f"{root_uri}/.overview.md"]
     assert "- a.txt: summary" in overview
-    assert "- b.txt: old-b" in overview
+    assert "- b.txt: summary" in overview
 
 
 if __name__ == "__main__":

--- a/tests/storage/test_semantic_msg_ingest_options.py
+++ b/tests/storage/test_semantic_msg_ingest_options.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
-from openviking.utils.ingest_options import IngestOptions
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
+from openviking.utils.ingest_options import IngestOptions
 
 
 def test_semantic_msg_serializes_ingest_options():
@@ -10,6 +10,7 @@ def test_semantic_msg_serializes_ingest_options():
         uri="viking://resources/demo",
         context_type="resource",
         ingest_options=IngestOptions(search_tags=["team=search"], search_tag_mode="append"),
+        tag_parent_directory=False,
     )
 
     data = msg.to_dict()
@@ -23,6 +24,7 @@ def test_semantic_msg_serializes_ingest_options():
         search_tags=["team=search"],
         search_tag_mode="append",
     )
+    assert restored.tag_parent_directory is False
 
 
 def test_semantic_msg_reads_legacy_search_tag_fields():

--- a/tests/storage/test_semantic_queue_memory_dedupe.py
+++ b/tests/storage/test_semantic_queue_memory_dedupe.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for memory-context semantic enqueue deduplication (#769)."""
+"""Semantic queue deduplication contracts."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
 
 import pytest
 
 from openviking.storage.queuefs.named_queue import NamedQueue
 from openviking.storage.queuefs.semantic_msg import SemanticMsg
 from openviking.storage.queuefs.semantic_processor import SemanticProcessor
-from openviking.storage.queuefs.semantic_queue import SemanticQueue, is_semantic_msg_stale
+from openviking.storage.queuefs.semantic_queue import SemanticQueue
 
 
 @pytest.mark.asyncio
@@ -75,59 +75,31 @@ async def test_non_memory_context_not_deduped():
 
 
 @pytest.mark.asyncio
-async def test_coalesced_semantic_messages_mark_old_version_stale():
+async def test_directory_refresh_keeps_one_durable_trigger():
     mock_agfs = MagicMock()
     with patch.object(NamedQueue, "enqueue", new_callable=AsyncMock) as named_enqueue:
         named_enqueue.return_value = "queued-id"
         q = SemanticQueue(mock_agfs, "/queue", "semantic")
-        coalesce_key = f"resource|acc|u|p|viking://resources/docs/{uuid4().hex}"
         first = SemanticMsg(
             uri="viking://resources/docs",
             context_type="resource",
-            coalesce_key=coalesce_key,
+            account_id="acc",
+            directory_refresh_only=True,
         )
         second = SemanticMsg(
             uri="viking://resources/docs",
             context_type="resource",
-            coalesce_key=first.coalesce_key,
+            account_id="acc",
+            directory_refresh_only=True,
         )
 
         await q.enqueue(first)
         await q.enqueue(second)
 
-        assert first.coalesce_version == 1
-        assert second.coalesce_version == 2
-        assert is_semantic_msg_stale(first)
-        assert not is_semantic_msg_stale(second)
-
-
-class _FakePathLock:
-    """Mock for _async_agfs pathlock operations."""
-
-    def __init__(self):
-        self.acquired_batches = []
-        self.release_calls = []
-
-    async def pathlock_acquire_exact_batch(self, paths):
-        self.acquired_batches.append(paths)
-        return {"id": "lock-1"}
-
-    async def pathlock_release(self, lease):
-        self.release_calls.append(lease["id"])
-
-
-class _FakeVikingFS:
-    def __init__(self, pathlock=None):
-        self._async_agfs = pathlock or _FakePathLock()
-        self.writes = []
-
-    def _uri_to_path(self, uri, ctx=None):
-        del ctx
-        return f"/fake/{uri.replace('://', '/').strip('/')}"
-
-    async def write_file(self, uri, content, ctx=None, lease_ref=None):
-        del ctx, lease_ref
-        self.writes.append((uri, content))
+        assert named_enqueue.call_count == 1
+        revision = q.claim_directory_refresh(first, "queued-id")
+        events = q.finish_directory_refresh(first, revision)
+        assert list(events) == [first.id, second.id]
 
 
 class _FakeMemoryDirFS:
@@ -140,56 +112,30 @@ class _FakeMemoryDirFS:
 
 
 @pytest.mark.asyncio
-async def test_stale_memory_semantic_write_is_skipped(monkeypatch):
-    pathlock = _FakePathLock()
-    viking_fs = _FakeVikingFS(pathlock)
-    processor = SemanticProcessor()
-    coalesce_key = f"memory|acc|u|p|viking://user/default/memories/preferences/{uuid4().hex}"
-
-    with patch.object(NamedQueue, "enqueue", new_callable=AsyncMock):
-        q = SemanticQueue(MagicMock(), "/queue", "semantic")
-        first = SemanticMsg(
-            uri="viking://user/default/memories/preferences",
-            context_type="memory",
-            coalesce_key=coalesce_key,
+async def test_restart_keeps_one_directory_refresh_from_legacy_delete_messages():
+    q = SemanticQueue(MagicMock(), "/queue", "semantic")
+    messages = [
+        SemanticMsg(
+            uri="viking://resources/docs",
+            context_type="resource",
+            recursive=False,
+            account_id="acc",
+            changes={"deleted": [f"viking://resources/docs/{name}.md"]},
         )
-        latest = SemanticMsg(
-            uri="viking://user/default/memories/preferences",
-            context_type="memory",
-            coalesce_key=coalesce_key,
-        )
-        await q.enqueue(first)
-        await q.enqueue(latest)
-
-    wrote_first = await processor._write_memory_directory_semantics(
-        msg=first,
-        viking_fs=viking_fs,
-        dir_uri=first.uri,
-        overview="old overview",
-        abstract="old abstract",
-        ctx=None,
-    )
-    wrote_latest = await processor._write_memory_directory_semantics(
-        msg=latest,
-        viking_fs=viking_fs,
-        dir_uri=latest.uri,
-        overview="latest overview",
-        abstract="latest abstract",
-        ctx=None,
-    )
-
-    assert not wrote_first
-    assert wrote_latest
-    assert pathlock.acquired_batches == [
+        for name in ("a", "b", "c")
+    ]
+    q.restore_directory_refreshes(
         [
-            "/fake/viking/user/default/memories/preferences/.overview.md",
-            "/fake/viking/user/default/memories/preferences/.abstract.md",
+            {"id": f"queue-{index}", "data": json.dumps(msg.to_dict())}
+            for index, msg in enumerate(messages)
         ]
-    ]
-    assert viking_fs.writes == [
-        ("viking://user/default/memories/preferences/.overview.md", "latest overview"),
-        ("viking://user/default/memories/preferences/.abstract.md", "latest abstract"),
-    ]
+    )
+
+    revision = q.claim_directory_refresh(messages[0], "queue-0")
+    assert q.claim_directory_refresh(messages[1], "queue-1") is None
+    assert q.claim_directory_refresh(messages[2], "queue-2") is None
+    events = q.finish_directory_refresh(messages[0], revision)
+    assert list(events) == [msg.id for msg in messages]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_summarizer_resources_root_split.py
+++ b/tests/unit/test_summarizer_resources_root_split.py
@@ -220,6 +220,7 @@ async def test_flat_file_refresh_enqueues_incremental_parent_summary():
     assert msg.recursive is False
     assert msg.changes == {"modified": ["viking://resources/神雕.md"]}
     assert msg.skip_vectorization is False
+    assert msg.tag_parent_directory is True
     assert msg.telemetry_id == "tid"
     assert wait_tracker.registered == [("tid", msg.id)]
 

--- a/tests/utils/test_resource_processor_processing_mode.py
+++ b/tests/utils/test_resource_processor_processing_mode.py
@@ -72,6 +72,7 @@ async def test_flat_file_refreshes_parent_semantics_and_vectorizes_via_summary(
             "temp_uri": "viking://resources/神雕_副本.md",
             "source_committed": True,
             "root_is_file": True,
+            "tag_parent_directory": False,
         },
         ctx=ctx,
         resource_lock={"lease_ref": "flat-file"},
@@ -88,6 +89,7 @@ async def test_flat_file_refreshes_parent_semantics_and_vectorizes_via_summary(
         ctx=ctx,
         skip_vectorization=False,
         ingest_options=IngestOptions(),
+        tag_parent_directory=False,
     )
 
 


### PR DESCRIPTION
## Description

修复同目录语义消息使用“持久化队列 + 内存版本号”去重导致的正确性和重复计算问题。

### Before

- 删除同目录下的 A、B、C 会持久化 3 条目录刷新消息。进程内依赖版本号跳过旧消息；重启后版本号丢失，3 条消息都会重新生成同一个目录摘要。
- 独立添加同目录文件时，旧消息会被整体判定为过期，文件自身的摘要、向量和 tag 也可能一起被跳过。
- 文件语义和目录刷新共用同一个过期判断，目录级去重会误伤文件级工作。

### After

- 删除和祖先目录传播只提交目录刷新触发消息。同一 `account + context type + directory URI` 只保留一条持久化触发消息；处理时始终读取当前 AGFS 内容。
- 启动时从 QueueFS 快照恢复每个目录唯一的触发消息，旧版本遗留的重复删除消息只执行一次目录摘要生成。
- 独立文件消息仍分别持久化；同一轮从 QueueFS 取出的同目录消息合并文件变更后，复用现有 Semantic DAG 执行一次：每个文件分别生成摘要和向量，目录摘要只生成一次。
- 普通 `add-resource --tag x` 会把 `x` 用于对应目录向量；使用 `--parent P` 时，文件保留 `x`，P 和祖先目录不修改 tag。
- 文件失败或目录失败时，本轮相关消息不会提前完成，并沿用 QueueFS 重试语义。

### Example

输入：依次删除 `docs/A.md`、`docs/B.md`、`docs/C.md`，随后进程重启。

- Before：QueueFS 中有 3 条 `docs` 刷新消息；重启后生成 3 次 `docs` 目录摘要。
- After：QueueFS 中只保留 1 条 `docs` 触发消息；重启后根据当前 AGFS 内容生成 1 次 `docs` 目录摘要，三个请求的完成状态在该结果提交后统一结算。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3891
Fixes #3892

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 删除 `coalesce_key`、`coalesce_version` 和整条消息 stale 判断，避免目录去重跳过文件语义工作。
- 为纯目录刷新维护单个持久化触发消息、进程内 revision/完成订阅，以及基于 QueueFS 快照的重启恢复。
- 在现有 QueueFS 消费批次内合并同目录文件变更，并分别保留文件 tag、任务归属和 telemetry。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- 修改后的 39 个相关现有测试通过。
- Ruff 检查通过。
- `git diff --check` 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

- 按维护要求未新增单元测试或测试文件，只修改和删除了现有测试内容。
- 扩展语义相关测试共 107 项，其中 105 项通过；另外 2 项失败位于本 PR 未修改的 prompt 文案和 VikingFS `mv` 测试。
