### PR TITLE
fix(bot): correct session and WhatsApp typos

### DIFF
--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -1560,7 +1560,7 @@ class AgentLoop:
                 await self.sessions.save(session)
                 return OutboundMessage(
                     session_key=msg.session_key,
-                    content="🐈 New session started. Session history droped.",
+                    content="🐈 New session started. Session history dropped.",
                     metadata=msg.metadata,
                 )
             elif cmd == "/compact":

--- a/bot/vikingbot/channels/whatsapp.py
+++ b/bot/vikingbot/channels/whatsapp.py
@@ -105,9 +105,9 @@ class WhatsAppChannel(BaseChannel):
 
         if msg_type == "message":
             # Incoming message from WhatsApp
-            # Deprecated by whatsapp: old phone number style typically: <phone>@s.whatspp.net
+            # Deprecated by WhatsApp: old phone number style typically: <phone>@s.whatsapp.net
             pn = data.get("pn", "")
-            # New LID sytle typically:
+            # New LID style typically:
             sender = data.get("sender", "")
             content = data.get("content", "")
 


### PR DESCRIPTION
## Description

Correct typos in the session reset message and WhatsApp channel comments.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Correct `droped` in the user-visible session reset message.
- Correct the WhatsApp JID domain example.
- Correct capitalization and spelling in WhatsApp comments.

## Testing

- `git diff --check`
- Python AST parsing for both modified files
- Targeted `codespell`

Tested on Windows.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

No runtime behavior changes other than correcting the user-visible spelling.