### PR TITLE
fix(tasks): paginate Studio task queries

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -90,16 +90,18 @@ async def list_tasks(
     ),
     resource_id: Optional[str] = Query(None, description="Filter by resource ID (e.g. session_id)"),
     limit: int = Query(50, le=200, description="Max results"),
+    offset: int = Query(0, ge=0, description="Number of results to skip"),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """List background tasks with optional filters."""
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
+        fetch_limit = offset + limit
         system_tasks = await tracker.list_tasks(
             task_type=task_type,
             status=status,
             resource_id=resource_id,
-            limit=limit,
+            limit=fetch_limit,
             account_id=SYSTEM_TASK_ACCOUNT_ID,
             user_id=SYSTEM_TASK_USER_ID,
         )
@@ -107,17 +109,20 @@ async def list_tasks(
             task_type=task_type,
             status=status,
             resource_id=resource_id,
-            limit=limit,
+            limit=fetch_limit,
         )
         tasks_by_id = {task.task_id: task for task in cached_tasks}
         tasks_by_id.update({task.task_id: task for task in system_tasks})
-        tasks = sorted(tasks_by_id.values(), key=lambda task: task.created_at, reverse=True)[:limit]
+        tasks = sorted(tasks_by_id.values(), key=lambda task: task.created_at, reverse=True)[
+            offset : offset + limit
+        ]
     else:
         tasks = await tracker.list_tasks(
             task_type=task_type,
             status=status,
             resource_id=resource_id,
             limit=limit,
+            offset=offset,
             account_id=_ctx.account_id,
             user_id=_ctx.user.user_id,
         )

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -875,6 +875,7 @@ class TaskTracker:
         status: Optional[str] = None,
         resource_id: Optional[str] = None,
         limit: int = 50,
+        offset: int = 0,
         account_id: Optional[str] = None,
         user_id: Optional[str] = None,
     ) -> List[TaskRecord]:
@@ -885,6 +886,7 @@ class TaskTracker:
                 status,
                 resource_id,
                 limit,
+                offset,
                 account_id,
                 user_id,
             )
@@ -896,6 +898,7 @@ class TaskTracker:
         status: Optional[str],
         resource_id: Optional[str],
         limit: int,
+        offset: int,
         account_id: Optional[str],
         user_id: Optional[str],
     ) -> List[TaskRecord]:
@@ -910,7 +913,7 @@ class TaskTracker:
         if resource_id:
             tasks = [t for t in tasks if t.resource_id == resource_id]
         tasks.sort(key=lambda t: t.created_at, reverse=True)
-        return tasks[:limit]
+        return tasks[offset : offset + limit]
 
     async def has_running(
         self,

--- a/tests/api_test/api/client.py
+++ b/tests/api_test/api/client.py
@@ -662,9 +662,10 @@ class OpenVikingAPIClient:
         status: Optional[str] = None,
         resource_id: Optional[str] = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> requests.Response:
         endpoint = "/api/v1/tasks"
-        params = {"limit": limit}
+        params = {"limit": limit, "offset": offset}
         if task_type:
             params["task_type"] = task_type
         if status:

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -22,7 +22,11 @@ from openviking.server.dependencies import set_service
 from openviking.server.identity import ResolvedIdentity, Role
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
 from openviking.service.core import OpenVikingService
-from openviking.service.task_store import PersistentTaskStore
+from openviking.service.task_store import (
+    SYSTEM_TASK_ACCOUNT_ID,
+    SYSTEM_TASK_USER_ID,
+    PersistentTaskStore,
+)
 from openviking.service.task_tracker import (
     TaskTracker,
     get_task_tracker,
@@ -470,6 +474,67 @@ async def test_task_endpoints_are_user_scoped():
         assert bob_list.status_code == 200
         assert {task["task_id"] for task in bob_list.json()["result"]} == {bob_task.task_id}
 
+    set_task_tracker(None)
+
+
+async def test_root_task_list_applies_offset_after_merging_task_scopes():
+    set_task_tracker(None)
+    _set_fake_task_tracker()
+    tracker = get_task_tracker()
+    await tracker.create(
+        "session_commit",
+        resource_id="oldest",
+        account_id="acme",
+        user_id="alice",
+    )
+    middle = await tracker.create(
+        "session_commit",
+        resource_id="middle",
+        account_id=SYSTEM_TASK_ACCOUNT_ID,
+        user_id=SYSTEM_TASK_USER_ID,
+    )
+    await tracker.create(
+        "session_commit",
+        resource_id="latest",
+        account_id="acme",
+        user_id="alice",
+    )
+    app = _build_task_http_test_app(
+        ResolvedIdentity(role=Role.ROOT, account_id="root", user_id="root")
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/api/v1/tasks", params={"limit": 1, "offset": 1})
+
+    assert response.status_code == 200
+    assert [task["task_id"] for task in response.json()["result"]] == [middle.task_id]
+    set_task_tracker(None)
+
+
+async def test_user_task_list_applies_offset_after_sorting():
+    set_task_tracker(None)
+    _set_fake_task_tracker()
+    tracker = get_task_tracker()
+    task_ids = []
+    for resource_id in ("oldest", "middle", "latest"):
+        task = await tracker.create(
+            "session_commit",
+            resource_id=resource_id,
+            account_id="acme",
+            user_id="alice",
+        )
+        task_ids.append(task.task_id)
+    app = _build_task_http_test_app(
+        ResolvedIdentity(role=Role.USER, account_id="acme", user_id="alice")
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/api/v1/tasks", params={"limit": 1, "offset": 1})
+
+    assert response.status_code == 200
+    assert [task["task_id"] for task in response.json()["result"]] == [task_ids[1]]
     set_task_tracker(None)
 
 

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -291,6 +291,15 @@ async def test_list_limit(tracker: TaskTracker):
     assert len(tasks) == 3
 
 
+async def test_list_offset_applies_after_sorting(tracker: TaskTracker):
+    for i in range(5):
+        await tracker.create("session_commit", resource_id=f"s{i}", **_owner_kwargs())
+
+    tasks = await tracker.list_tasks(limit=2, offset=1)
+
+    assert [task.resource_id for task in tasks] == ["s3", "s2"]
+
+
 async def test_list_order_most_recent_first(tracker: TaskTracker):
     await tracker.create("session_commit", resource_id="first", **_owner_kwargs())
     await tracker.create("session_commit", resource_id="second", **_owner_kwargs())

--- a/web-studio/src/gen/ov-client/types.gen.ts
+++ b/web-studio/src/gen/ov-client/types.gen.ts
@@ -4347,6 +4347,12 @@ export type GetTasksData = {
          * Max results
          */
         limit?: number;
+        /**
+         * Offset
+         *
+         * Number of results to skip
+         */
+        offset?: number;
     };
     url: '/api/v1/tasks';
 };

--- a/web-studio/src/routes/tasks/route.test.ts
+++ b/web-studio/src/routes/tasks/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTasks } from './route'
+
+const ovClientMocks = vi.hoisted(() => ({
+  getOvResult: vi.fn(),
+  getTasks: vi.fn(),
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  getOvResult: ovClientMocks.getOvResult,
+  getTasks: ovClientMocks.getTasks,
+  ovClient: {},
+}))
+
+beforeEach(() => {
+  ovClientMocks.getOvResult.mockReset()
+  ovClientMocks.getTasks.mockReset()
+  ovClientMocks.getOvResult.mockImplementation(async (request) => request)
+})
+
+describe('fetchTasks', () => {
+  it('fetches the latest 300 tasks in API-sized pages', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    ovClientMocks.getTasks
+      .mockResolvedValueOnce(
+        Array.from({ length: 200 }, (_, index) => ({
+          created_at: now,
+          task_id: `task-${index}`,
+        })),
+      )
+      .mockResolvedValueOnce(
+        Array.from({ length: 100 }, (_, index) => ({
+          created_at: now,
+          task_id: `task-${index + 200}`,
+        })),
+      )
+
+    const tasks = await fetchTasks('all', 'all', '24h')
+
+    expect(tasks).toHaveLength(300)
+    expect(ovClientMocks.getTasks).toHaveBeenNthCalledWith(1, {
+      query: {
+        limit: 200,
+        offset: 0,
+        status: undefined,
+        task_type: undefined,
+      },
+    })
+    expect(ovClientMocks.getTasks).toHaveBeenNthCalledWith(2, {
+      query: {
+        limit: 100,
+        offset: 200,
+        status: undefined,
+        task_type: undefined,
+      },
+    })
+  })
+
+  it('continues loading all task pages until the API returns a short page', async () => {
+    ovClientMocks.getTasks
+      .mockResolvedValueOnce(
+        Array.from({ length: 200 }, (_, index) => ({
+          task_id: `task-${index}`,
+        })),
+      )
+      .mockResolvedValueOnce([{ task_id: 'task-200' }])
+
+    const tasks = await fetchTasks('all', 'all', 'all')
+
+    expect(tasks).toHaveLength(201)
+    expect(ovClientMocks.getTasks).toHaveBeenNthCalledWith(2, {
+      query: {
+        limit: 200,
+        offset: 200,
+        status: undefined,
+        task_type: undefined,
+      },
+    })
+    expect(ovClientMocks.getTasks).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes task type filters through every page', async () => {
+    ovClientMocks.getTasks.mockResolvedValue([])
+
+    await fetchTasks('session_commit', 'all', 'all')
+
+    expect(ovClientMocks.getTasks).toHaveBeenCalledWith({
+      query: {
+        limit: 200,
+        offset: 0,
+        status: undefined,
+        task_type: 'session_commit',
+      },
+    })
+  })
+
+  it('stops when an older API repeats the first page', async () => {
+    const page = Array.from({ length: 200 }, (_, index) => ({
+      task_id: `task-${index}`,
+    }))
+    ovClientMocks.getTasks.mockResolvedValue(page)
+
+    const tasks = await fetchTasks('all', 'all', 'all')
+
+    expect(tasks).toHaveLength(200)
+    expect(ovClientMocks.getTasks).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -75,7 +75,9 @@ type TaskTypeFilter =
   | 'all'
 
 const DEFAULT_PAGE_SIZE = 20
+const TASK_API_PAGE_SIZE = 200
 const MAX_TASKS = 300
+const MAX_ALL_TASKS = 10000
 const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
 const TASK_TYPE_OPTIONS: Exclude<TaskTypeFilter, 'all'>[] = [
   'session_commit',
@@ -111,24 +113,42 @@ export function getEffectiveTaskStatus(taskItem: any, list: any[]): string {
 
 export type TaskDataScope = '24h' | 'all'
 
-async function fetchTasks(
+export async function fetchTasks(
   taskType: TaskTypeFilter,
   status: TaskStatusFilter,
   dataScope: TaskDataScope = '24h',
 ): Promise<TaskRecord[]> {
+  const maxTasks = dataScope === 'all' ? MAX_ALL_TASKS : MAX_TASKS
   const query = {
-    limit: dataScope === 'all' ? 10000 : MAX_TASKS,
     status: undefined,
     task_type: taskType === 'all' ? undefined : taskType,
-    include_archived: dataScope === 'all' ? true : undefined,
   }
   try {
-    const result = await getOvResult<unknown>(
-      getTasks({
-        query: query as any,
-      }),
-    )
-    let fetched = normalizeTasks(result).sort(
+    const tasksById = new Map<string, TaskRecord>()
+    let offset = 0
+    while (offset < maxTasks) {
+      const limit = Math.min(TASK_API_PAGE_SIZE, maxTasks - offset)
+      const result = await getOvResult<unknown>(
+        getTasks({
+          query: {
+            ...query,
+            limit,
+            offset,
+          },
+        }),
+      )
+      const page = normalizeTasks(result)
+      const previousSize = tasksById.size
+      for (const task of page) {
+        tasksById.set(task.task_id, task)
+      }
+      offset += page.length
+      if (page.length < limit) break
+      // Avoid repeating the same page forever when cached Studio assets talk
+      // to an older API that does not support the offset parameter yet.
+      if (tasksById.size === previousSize) break
+    }
+    let fetched = Array.from(tasksById.values()).sort(
       (a, b) => Number(b.created_at || 0) - Number(a.created_at || 0),
     )
     if (dataScope === '24h') {


### PR DESCRIPTION
## Description

The Studio task center requested 300 tasks for the 24-hour view and 10,000 tasks for the all-time view, while `GET /api/v1/tasks` rejects limits above 200. The rejected request was caught by the UI and presented as an empty task center.

This change adds offset pagination to the task API and makes Studio load task data in API-sized pages. It preserves the existing 300/10,000 view caps instead of silently reducing them, and stops safely if cached Studio assets are temporarily paired with an older API that repeats the first page.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add an optional non-negative `offset` query parameter to `GET /api/v1/tasks` and apply it after filtering and newest-first sorting.
- Apply root-role pagination after merging and deduplicating cached and system task scopes.
- Fetch Studio tasks in pages of at most 200, deduplicate task IDs, and stop on a short or non-advancing page.
- Update the generated request type and API test client for the new query parameter.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Completed locally:

- `pytest tests/test_task_tracker.py tests/server/test_auth.py::test_root_task_list_applies_offset_after_merging_task_scopes tests/server/test_auth.py::test_user_task_list_applies_offset_after_sorting -q --no-cov` (47 passed)
- `npm test -- src/routes/tasks/route.test.ts` (4 passed)
- `npm run build`
- Ruff checks for all changed Python files
- ESLint for the new Studio test

The full Python suite was not marked complete because this Windows checkout's installed native vector engine package reports that it has no compatible x86 backend. The pagination-specific lightweight tests do not require that native component.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; the visible result is that the existing task center renders its task data instead of falling back to an empty state.

## Additional Notes

The existing public response shape remains unchanged; `offset` is optional and defaults to zero.
