### PR TITLE
fix(studio): prevent token chart Y-axis label clipping

### DIFF
--- a/web-studio/src/routes/home/-components/token-trend-chart.test.tsx
+++ b/web-studio/src/routes/home/-components/token-trend-chart.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import type { PropsWithChildren } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HomeT } from '../-types/dashboard'
+import { TokenTrendChart } from './token-trend-chart'
+
+vi.mock('recharts', () => ({
+  Area: () => null,
+  AreaChart: ({ children }: PropsWithChildren) => <svg>{children}</svg>,
+  CartesianGrid: () => null,
+  ResponsiveContainer: ({ children }: PropsWithChildren) => <>{children}</>,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: ({ width }: { width?: number | 'auto' }) => (
+    <g data-testid="token-trend-y-axis" data-width={width} />
+  ),
+}))
+
+afterEach(cleanup)
+
+describe('TokenTrendChart', () => {
+  it('lets the Y-axis fit million-scale labels without clipping', () => {
+    render(
+      <TokenTrendChart
+        items={[
+          {
+            date: '2026-08-18',
+            embedding_input: 1_411_688,
+            total: 26_946_050,
+            vlm_input: 21_445_905,
+            vlm_output: 4_088_457,
+          },
+        ]}
+        t={((key: string) => key) as HomeT}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('token-trend-y-axis').getAttribute('data-width'),
+    ).toBe('auto')
+  })
+})

--- a/web-studio/src/routes/home/-components/token-trend-chart.tsx
+++ b/web-studio/src/routes/home/-components/token-trend-chart.tsx
@@ -112,7 +112,7 @@ export function TokenTrendChart({
               tick={{ fill: 'currentColor', fontSize: 12 }}
               tickFormatter={(value) => Number(value).toLocaleString()}
               tickLine={false}
-              width={64}
+              width="auto"
             />
             <Tooltip
               cursor={{ stroke: 'currentColor', strokeOpacity: 0.12 }}


### PR DESCRIPTION
## Description

Fix the Studio token trend chart clipping the leading characters of Y-axis labels once token counts reach the millions.

The chart reserved a fixed 64 px for the Y-axis, which is narrower than locale-formatted labels such as `10,000,000`. Letting Recharts measure the axis width keeps the complete value visible and continues to scale when token totals grow.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4174

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Replace the token trend Y-axis fixed width with Recharts' measured `auto` width.
- Add a component regression test that locks in automatic Y-axis sizing for million-scale data.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands run:

```text
npm test
npx prettier --check src/routes/home/-components/token-trend-chart.tsx src/routes/home/-components/token-trend-chart.test.tsx
npx eslint src/routes/home/-components/token-trend-chart.tsx src/routes/home/-components/token-trend-chart.test.tsx
npm run build
```

All 47 frontend test files passed (179 tests total), and the production build completed successfully.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

The original report showed the leading digit clipped from million-scale Y-axis labels. A Playwright check in Microsoft Edge at 1440 x 900 rendered the complete `10,000,000` label, with its left edge at 56.65 px inside the viewport.

### Before repair
<img width="3288" height="900" alt="image" src="https://github.com/user-attachments/assets/510f03c7-1432-41fa-b109-96b4bc13d8e6" />

### After repair
<img width="1440" height="1000" alt="download" src="https://github.com/user-attachments/assets/f32fc483-d68d-45f1-8dbb-9b4f2938fb3c" />


## Additional Notes

This intentionally uses the chart library's measured width instead of replacing 64 px with another fixed value, so larger future totals remain visible.
