### PR TITLE
fix(opencode): let recall use server relevance

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -39,7 +39,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -95,15 +98,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -25,11 +25,25 @@ test("context requests preserve the configured recall width and server budget", 
     recallCompressMaxInputChars: 18000,
   });
 
-  assert.equal(Object.values(body.quotas).reduce((sum, quota) => sum + quota, 0), 6);
+  assert.equal(Object.values(body.quotas).reduce((sum, quota) => sum + quota, 0), 1);
   assert.equal(body.quotas.resources, 1);
-  assert.equal(body.quotas.skills, 1);
+  assert.equal(body.quotas.skills, 0);
   assert.equal(body.max_tokens, 800);
   assert.equal(body.purpose, "coding");
+});
+
+test("context requests can delegate relevance entirely to the server", () => {
+  const body = buildContextSearchBody({
+    recallPurpose: null,
+    recallLimit: 1,
+    recallLimitConfigured: true,
+    recallMaxTokens: 800,
+    recallMaxTokensConfigured: true,
+  });
+
+  assert.equal(body.purpose, undefined);
+  assert.equal(body.quotas, undefined);
+  assert.equal(body.max_tokens, 800);
 });
 
 test("context requests omit defaults owned by the server", () => {

--- a/examples/opencode-plugin/README.md
+++ b/examples/opencode-plugin/README.md
@@ -116,6 +116,7 @@ Create `~/.config/opencode/openviking-config.json`:
   "enabled": true,
   "mcp": { "enabled": true },
   "timeoutMs": 30000,
+  "recallPurpose": "coding",
   "repoContext": { "enabled": true, "cacheTtlMs": 60000 },
   "autoRecall": {
     "enabled": true,
@@ -133,10 +134,15 @@ Create `~/.config/opencode/openviking-config.json`:
 }
 ```
 
-`autoRecall.limit` is a legacy quota-scaling input, not a final result cap.
-Explicit values from 1 through 5 produce an effective total quota of 6 because
-each coding category keeps one retrieval slot. Use Context `quotas` directly
-when exact category ceilings are required.
+`autoRecall.limit` scales the category quotas used by the `coding` recall
+purpose. When the limit is smaller than the number of categories, only the
+highest-weighted categories receive a slot, so the total quota still equals the
+configured limit.
+
+The default `recallPurpose` is `"coding"`. Set it to `"chat"` to use the
+server's chat preset, or set it explicitly to `null` to omit both `purpose` and
+preset quotas. The latter lets server relevance and `autoRecall.tokenBudget`
+select context without forcing one result from every coding category.
 
 API keys are resolved from environment variables or `~/.openviking/ovcli.conf` and sent as `Authorization: Bearer ...` by both hooks and the MCP proxy. Recall goes through the server-side context face (`POST /api/v1/search/search` with `mode="context"`), falling back to the deprecated `/api/v1/search/recall` on older deployments. `account` and `user` are trusted-mode identity
 headers sent as `X-OpenViking-Account` and `X-OpenViking-User`; leave them empty

--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG = {
   // Server-side query expansion costs a model call before retrieval starts, so
   // it has to be switchable from the client that pays the latency.
   recallQueryExpansion: "auto",
+  recallPurpose: "coding",
   enabled: true,
   mcp: {
     enabled: true,
@@ -142,6 +143,8 @@ function applyBehaviorConfig(config, fileConfig = {}) {
   const autoRecall = fileConfig.autoRecall ?? {}
   config.recallLimitConfigured = autoRecall.limit !== undefined ||
     fileConfig.recallLimit !== undefined
+  config.recallMaxTokensConfigured = autoRecall.tokenBudget !== undefined ||
+    fileConfig.recallTokenBudget !== undefined
   config.autoRecall = {
     ...DEFAULT_CONFIG.autoRecall,
     ...autoRecall,
@@ -172,6 +175,7 @@ function applyBehaviorConfig(config, fileConfig = {}) {
     "workspacePeer",
     "recallPeerScope",
     "recallQueryExpansion",
+    "recallPurpose",
   ]) {
     if (fileConfig[key] !== undefined) config[key] = fileConfig[key]
   }
@@ -191,7 +195,10 @@ function applyEnv(config) {
   if (process.env.OPENVIKING_RECALL_MAX_CONTENT_CHARS) {
     config.autoRecall.maxContentChars = process.env.OPENVIKING_RECALL_MAX_CONTENT_CHARS
   }
-  if (process.env.OPENVIKING_RECALL_TOKEN_BUDGET) config.autoRecall.tokenBudget = process.env.OPENVIKING_RECALL_TOKEN_BUDGET
+  if (process.env.OPENVIKING_RECALL_TOKEN_BUDGET) {
+    config.autoRecall.tokenBudget = process.env.OPENVIKING_RECALL_TOKEN_BUDGET
+    config.recallMaxTokensConfigured = true
+  }
   if (process.env.OPENVIKING_RECALL_PREFER_ABSTRACT !== undefined) {
     config.autoRecall.preferAbstract = envBool("OPENVIKING_RECALL_PREFER_ABSTRACT") ?? config.autoRecall.preferAbstract
   }
@@ -260,6 +267,9 @@ function normalizeConfig(config) {
   config.captureMode = config.captureMode === "keyword" ? "keyword" : "semantic"
   config.recallPeerScope = config.recallPeerScope === "actor" ? "actor" : "all"
   config.recallQueryExpansion = config.recallQueryExpansion === "off" ? "off" : "auto"
+  config.recallPurpose = config.recallPurpose === null
+    ? null
+    : (config.recallPurpose === "chat" ? "chat" : "coding")
   config.captureMaxLength = Math.max(200, Math.min(100000, Math.round(Number(config.captureMaxLength) || 24000)))
   config.captureToolMaxChars = Math.max(200, Math.min(1000000, Math.round(Number(config.captureToolMaxChars) || 1000000)))
   config.commitTokenThreshold = Math.max(1000, Math.round(Number(config.commitTokenThreshold) || 20000))
@@ -280,6 +290,7 @@ function normalizeConfig(config) {
   config.recallMaxContentChars = config.autoRecall.maxContentChars
   config.recallPreferAbstract = config.autoRecall.preferAbstract !== false
   config.recallTokenBudget = config.autoRecall.tokenBudget
+  config.recallMaxTokens = config.autoRecall.tokenBudget
   config.minQueryLength = config.autoRecall.minQueryLength
   return config
 }

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -185,6 +185,33 @@ test("loadConfig supports hook-only mode without registering the bundled MCP ser
   })
 })
 
+test("loadConfig preserves an explicit null recall purpose", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-recall-purpose-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const project = join(dir, "project")
+      process.env.OPENVIKING_CREDENTIAL_SOURCE = "env"
+      process.env.OPENVIKING_URL = "https://env.example.com"
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        recallPurpose: null,
+        autoRecall: { tokenBudget: 2000 },
+      }))
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.recallPurpose, null)
+      assert.equal(cfg.recallLimitConfigured, false)
+      assert.equal(cfg.recallMaxTokensConfigured, true)
+      assert.equal(cfg.recallMaxTokens, 2000)
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})
+
 test("OpenVikingPlugin keeps lifecycle hooks without mutating MCP config in hook-only mode", async () => {
   const snapshot = { ...process.env }
   await withTempDir("ov-oc-hook-only-runtime-", async (dir) => {

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -40,7 +40,10 @@ function scaleQuotas(limit, weights) {
   const order = Object.keys(weights);
   const quotas = Object.fromEntries(order.map((key) => [key, 0]));
   if (slots < order.length) {
-    for (const key of order) quotas[key] = 1;
+    const selected = [...order]
+      .sort((a, b) => weights[b] - weights[a])
+      .slice(0, slots);
+    for (const key of selected) quotas[key] = 1;
     return quotas;
   }
 
@@ -96,15 +99,18 @@ export function buildContextSearchBody(cfg = {}, options = {}) {
     64,
     Math.floor(Number(cfg.recallMaxTokens || DEFAULT_CONTEXT_MAX_TOKENS)),
   );
+  const recallPurpose = cfg.recallPurpose === null
+    ? null
+    : (cfg.recallPurpose === "chat" ? "chat" : "coding");
   const body = {
     query: "",
     mode: "context",
-    purpose: "coding",
     score_threshold: Number.isFinite(Number(cfg.scoreThreshold)) ? Number(cfg.scoreThreshold) : 0.35,
   };
+  if (recallPurpose) body.purpose = recallPurpose;
   const limitConfigured = cfg.recallLimitConfigured === true;
   const maxTokensConfigured = cfg.recallMaxTokensConfigured === true;
-  if (limitConfigured) body.quotas = codingQuotas(limit);
+  if (limitConfigured && recallPurpose === "coding") body.quotas = codingQuotas(limit);
   if (maxTokensConfigured) body.max_tokens = maxTokens;
   if (cfg.recallPeerScope === "actor") body.peer_scope = "actor";
 


### PR DESCRIPTION
## Summary

- make small coding quota limits exact instead of forcing one slot into every category
- add an optional `recallPurpose` setting; explicit `null` omits both the purpose and preset quotas so server relevance can select context
- forward an explicitly configured OpenCode recall token budget to the Context API as `max_tokens`
- preserve the existing `coding` default and synchronize the shared recall implementation across agent integrations

This fixes a concrete case where `autoRecall.limit: 1` produced six quota slots and injected unrelated categories. OpenCode users can now choose server relevance without disabling automatic recall or query expansion.

## Type of Change

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [x] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

- [x] `node --test examples/memory-plugin-shared/*.test.mjs` (62 passed)
- [x] `npm test --prefix examples/opencode-plugin` (28 passed)
- [x] `npm run check --prefix examples/opencode-plugin`
- [x] `node examples/memory-plugin-shared/sync.mjs`
- [x] `git diff --check`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated
- [x] All focused tests pass