### PR TITLE
fix(sdk): serialize message parts in add and batch

### DIFF
--- a/openviking_cli/client/_http_compat.py
+++ b/openviking_cli/client/_http_compat.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any, Dict
 
@@ -37,6 +38,40 @@ from openviking_cli.exceptions import (
 from openviking_cli.utils.async_utils import run_async
 
 _SESSION_CONFIG_UNSET = object()
+# Keep the conversion local so the main package remains compatible with the
+# minimum supported openviking-sdk version, which may not expose this helper.
+_MESSAGE_PART_TYPES = frozenset({"text", "context", "image_url", "tool"})
+
+
+def _message_part_to_payload(part: Any) -> Any:
+    """Convert a structured message Part into its JSON wire representation."""
+    if isinstance(part, type) or not is_dataclass(part):
+        return part
+
+    serialized_part = asdict(part)
+    part_type = serialized_part.get("type")
+    if part_type not in _MESSAGE_PART_TYPES:
+        return part
+    if part_type != "image_url":
+        return serialized_part
+
+    image_url = {"url": serialized_part.get("url", "")}
+    if serialized_part.get("detail") is not None:
+        image_url["detail"] = serialized_part["detail"]
+    return {"type": "image_url", "image_url": image_url}
+
+
+def _message_parts_to_payload(parts: list[Any]) -> list[Any]:
+    return [_message_part_to_payload(part) for part in parts]
+
+
+def _message_to_payload(message: dict[str, Any]) -> dict[str, Any]:
+    """Copy one batch message and serialize its structured parts, if present."""
+    payload = dict(message)
+    if payload.get("parts") is not None:
+        payload["parts"] = _message_parts_to_payload(payload["parts"])
+    return payload
+
 
 ERROR_CODE_TO_EXCEPTION = {
     "INVALID_ARGUMENT": InvalidArgumentError,
@@ -173,7 +208,7 @@ class AsyncHTTPClient(import_openviking_sdk().AsyncHTTPClient):
         session_id: str,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         telemetry: Any = False,
@@ -183,7 +218,7 @@ class AsyncHTTPClient(import_openviking_sdk().AsyncHTTPClient):
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"role": role}
         if parts is not None:
-            payload["parts"] = parts
+            payload["parts"] = _message_parts_to_payload(parts)
         elif content is not None:
             payload["content"] = content
         else:
@@ -203,6 +238,17 @@ class AsyncHTTPClient(import_openviking_sdk().AsyncHTTPClient):
             "POST", f"/api/v1/sessions/{session_path}/messages", json=payload
         )
         return self._handle_response_data(response).get("result", {})
+
+    async def batch_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        telemetry: Any = False,
+    ) -> Dict[str, Any]:
+        serialized_messages = [_message_to_payload(message) for message in messages]
+        if telemetry is False:
+            return await super().batch_add_messages(session_id, serialized_messages)
+        return await super().batch_add_messages(session_id, serialized_messages, telemetry)
 
     async def update_session_config(
         self,
@@ -272,7 +318,7 @@ class SyncHTTPClient(import_openviking_sdk().SyncHTTPClient):
         session_id: str,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         telemetry: Any = False,

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import uuid
 import zipfile
+from dataclasses import asdict, is_dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -66,6 +67,37 @@ ERROR_CODE_TO_EXCEPTION = {
 GATEWAY_MARKER_HEADER = "X-VikingBot-Gateway"
 GATEWAY_TOKEN_HEADER = "X-Gateway-Token"
 _SESSION_CONFIG_UNSET = object()
+_MESSAGE_PART_TYPES = frozenset({"text", "context", "image_url", "tool"})
+
+
+def _message_part_to_payload(part: Any) -> Any:
+    """Convert a structured message Part into its JSON wire representation."""
+    if isinstance(part, type) or not is_dataclass(part):
+        return part
+
+    serialized_part = asdict(part)
+    part_type = serialized_part.get("type")
+    if part_type not in _MESSAGE_PART_TYPES:
+        return part
+    if part_type != "image_url":
+        return serialized_part
+
+    image_url = {"url": serialized_part.get("url", "")}
+    if serialized_part.get("detail") is not None:
+        image_url["detail"] = serialized_part["detail"]
+    return {"type": "image_url", "image_url": image_url}
+
+
+def _message_parts_to_payload(parts: list[Any]) -> list[Any]:
+    return [_message_part_to_payload(part) for part in parts]
+
+
+def _message_to_payload(message: dict[str, Any]) -> dict[str, Any]:
+    """Copy one batch message and serialize its structured parts, if present."""
+    payload = dict(message)
+    if payload.get("parts") is not None:
+        payload["parts"] = _message_parts_to_payload(payload["parts"])
+    return payload
 
 
 def _image_mime_type(file_name: str = "") -> str:
@@ -137,7 +169,7 @@ class Session:
         self,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         turn_id: str | None = None,
@@ -216,7 +248,7 @@ class SyncSession:
         self,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         turn_id: str | None = None,
@@ -758,7 +790,9 @@ class AsyncHTTPClient:
         telemetry: Any = False,
     ) -> Dict[str, Any]:
         session_path = self._path_segment(session_id)
-        payload: Dict[str, Any] = {"messages": messages}
+        payload: Dict[str, Any] = {
+            "messages": [_message_to_payload(message) for message in messages]
+        }
         if telemetry is not False:
             payload["telemetry"] = telemetry
         response = await self._request(
@@ -1513,7 +1547,7 @@ class AsyncHTTPClient:
         session_id: str,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         telemetry: Any = False,
@@ -1523,7 +1557,7 @@ class AsyncHTTPClient:
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"role": role}
         if parts is not None:
-            payload["parts"] = parts
+            payload["parts"] = _message_parts_to_payload(parts)
         elif content is not None:
             payload["content"] = content
         else:
@@ -2518,7 +2552,7 @@ class SyncHTTPClient:
         session_id: str,
         role: str,
         content: str | None = None,
-        parts: list[dict] | None = None,
+        parts: list[Any] | None = None,
         created_at: str | None = None,
         peer_id: str | None = None,
         telemetry: Any = False,

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -1,12 +1,44 @@
 import inspect
+import json
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 from openviking_sdk import AsyncHTTPClient, SyncHTTPClient
 from openviking_sdk.client import Session, SyncSession
 from openviking_sdk.errors import NotFoundError
+
+
+@dataclass
+class _TextPart:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _ContextPart:
+    uri: str
+    context_type: str
+    abstract: str
+    type: str = "context"
+
+
+@dataclass
+class _ImagePart:
+    url: str
+    detail: str | None = None
+    type: str = "image_url"
+
+
+@dataclass
+class _ToolPart:
+    tool_id: str
+    tool_name: str
+    tool_input: dict | None = None
+    type: str = "tool"
 
 
 def test_add_resource_signatures_keep_telemetry_position():
@@ -133,6 +165,150 @@ async def test_async_http_client_sends_message_semantics_and_turn_retention():
         "retained_message_token_budget": 12_000,
         "min_raw_tail_steps": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_async_http_client_serializes_structured_message_parts():
+    captured_payload = None
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_payload
+        captured_payload = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok", "result": {"status": "ok"}})
+
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    async with httpx.AsyncClient(
+        base_url="http://localhost:1933",
+        transport=httpx.MockTransport(handle_request),
+    ) as http:
+        client._http = http
+        result = await client.add_message(
+            "structured-session",
+            "assistant",
+            parts=[
+                _TextPart(text="hello"),
+                _ContextPart(
+                    uri="viking://resources/docs/",
+                    context_type="resource",
+                    abstract="Docs",
+                ),
+                _ImagePart(url="https://example.com/image.png", detail="auto"),
+                _ToolPart(
+                    tool_id="call-1",
+                    tool_name="search",
+                    tool_input={"query": "OpenViking"},
+                ),
+                {
+                    "type": "text",
+                    "text": "already serialized",
+                    "metadata": {"source": "raw"},
+                },
+            ],
+        )
+
+    assert result == {"status": "ok"}
+    assert captured_payload == {
+        "role": "assistant",
+        "parts": [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "context",
+                "uri": "viking://resources/docs/",
+                "context_type": "resource",
+                "abstract": "Docs",
+            },
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://example.com/image.png",
+                    "detail": "auto",
+                },
+            },
+            {
+                "type": "tool",
+                "tool_id": "call-1",
+                "tool_name": "search",
+                "tool_input": {"query": "OpenViking"},
+            },
+            {
+                "type": "text",
+                "text": "already serialized",
+                "metadata": {"source": "raw"},
+            },
+        ],
+    }
+
+
+def test_sync_http_client_serializes_structured_message_parts():
+    captured_payload = None
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_payload
+        captured_payload = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok", "result": {"status": "ok"}})
+
+    client = SyncHTTPClient(url="http://localhost:1933")
+    client._async_client._http = httpx.AsyncClient(
+        base_url="http://localhost:1933",
+        transport=httpx.MockTransport(handle_request),
+    )
+    try:
+        result = client.add_message(
+            "structured-session",
+            "user",
+            parts=[_TextPart(text="hello")],
+        )
+    finally:
+        client.close()
+
+    assert result == {"status": "ok"}
+    assert captured_payload == {
+        "role": "user",
+        "parts": [{"type": "text", "text": "hello"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_http_client_serializes_batch_parts_without_mutating_input():
+    captured_payload = None
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_payload
+        captured_payload = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok", "result": {"added": 2}})
+
+    text_part = _TextPart(text="hello")
+    image_part = _ImagePart(url="https://example.com/image.png")
+    messages = [
+        {"role": "user", "content": "plain text"},
+        {"role": "assistant", "parts": [text_part, image_part]},
+    ]
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    async with httpx.AsyncClient(
+        base_url="http://localhost:1933",
+        transport=httpx.MockTransport(handle_request),
+    ) as http:
+        client._http = http
+        result = await client.batch_add_messages("structured-session", messages)
+
+    assert result == {"added": 2}
+    assert captured_payload == {
+        "messages": [
+            {"role": "user", "content": "plain text"},
+            {
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "text": "hello"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                ],
+            },
+        ]
+    }
+    assert messages[1]["parts"][0] is text_part
+    assert messages[1]["parts"][1] is image_part
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_rebuild_clients.py
+++ b/tests/client/test_rebuild_clients.py
@@ -1,14 +1,17 @@
 import asyncio
+import json
 import threading
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 
 import openviking_cli.client.http as http_module
 import openviking_cli.utils.async_utils as async_utils
+from openviking.message import ContextPart, ImagePart, TextPart, ToolPart
 from openviking_cli.client.http import AsyncHTTPClient
 from openviking_cli.client.sync_http import SyncHTTPClient
 from openviking_cli.utils.config import OPENVIKING_CLI_CONFIG_ENV
@@ -119,6 +122,131 @@ async def test_async_http_client_batch_add_messages_url_encodes_session_id():
         "/messages/batch",
         json={"messages": [{"role": "user", "content": "hello"}]},
     )
+
+
+async def test_async_http_client_batch_serializes_before_sdk_delegation():
+    base_calls = []
+
+    async def record_base_call(_client, *args):
+        base_calls.append(args)
+        return {"added": 1}
+
+    base_client = AsyncHTTPClient.__mro__[1]
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    messages = [{"role": "user", "parts": [TextPart(text="hello")]}]
+
+    with patch.object(base_client, "batch_add_messages", record_base_call):
+        assert await client.batch_add_messages("batch-session", messages) == {"added": 1}
+        assert await client.batch_add_messages(
+            "batch-session",
+            messages,
+            telemetry={"trace_id": "trace-1"},
+        ) == {"added": 1}
+
+    expected_messages = [{"role": "user", "parts": [{"type": "text", "text": "hello"}]}]
+    assert base_calls == [
+        ("batch-session", expected_messages),
+        ("batch-session", expected_messages, {"trace_id": "trace-1"}),
+    ]
+
+
+def test_sync_http_client_serializes_openviking_message_parts():
+    captured_payload = None
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_payload
+        captured_payload = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok", "result": {"status": "ok"}})
+
+    client = SyncHTTPClient(url="http://localhost:1933")
+    client._async_client._http = httpx.AsyncClient(
+        base_url="http://localhost:1933",
+        transport=httpx.MockTransport(handle_request),
+    )
+    try:
+        result = client.add_message(
+            "structured-session",
+            "assistant",
+            parts=[
+                TextPart(text="hello"),
+                ContextPart(
+                    uri="viking://resources/docs/",
+                    context_type="resource",
+                    abstract="Docs",
+                ),
+                ImagePart(url="https://example.com/image.png", detail="auto"),
+                ToolPart(
+                    tool_id="call-1",
+                    tool_name="search",
+                    tool_input={"query": "OpenViking"},
+                    tool_status="completed",
+                ),
+            ],
+        )
+    finally:
+        client.close()
+
+    assert result == {"status": "ok"}
+    assert captured_payload["role"] == "assistant"
+    assert captured_payload["parts"][0] == {"type": "text", "text": "hello"}
+    assert captured_payload["parts"][1] == {
+        "type": "context",
+        "uri": "viking://resources/docs/",
+        "context_type": "resource",
+        "abstract": "Docs",
+    }
+    assert captured_payload["parts"][2] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/image.png", "detail": "auto"},
+    }
+    assert captured_payload["parts"][3]["type"] == "tool"
+    assert captured_payload["parts"][3]["tool_id"] == "call-1"
+    assert captured_payload["parts"][3]["tool_input"] == {"query": "OpenViking"}
+
+
+def test_sync_http_client_serializes_openviking_batch_message_parts():
+    captured_payload = None
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_payload
+        captured_payload = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok", "result": {"added": 1}})
+
+    text_part = TextPart(text="hello")
+    image_part = ImagePart(url="https://example.com/image.png")
+    messages = [{"role": "user", "parts": [text_part, image_part]}]
+    client = SyncHTTPClient(url="http://localhost:1933")
+    client._async_client._http = httpx.AsyncClient(
+        base_url="http://localhost:1933",
+        transport=httpx.MockTransport(handle_request),
+    )
+    try:
+        result = client.batch_add_messages(
+            "structured-session",
+            messages,
+            telemetry={"trace_id": "trace-1"},
+        )
+    finally:
+        client.close()
+
+    assert result == {"added": 1}
+    assert captured_payload == {
+        "messages": [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "text": "hello"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                ],
+            }
+        ],
+        "telemetry": {"trace_id": "trace-1"},
+    }
+    assert messages[0]["parts"][0] is text_part
+    assert messages[0]["parts"][1] is image_part
 
 
 async def test_async_http_client_reindex_posts_content_reindex():


### PR DESCRIPTION
## Description

Serialize structured message Part dataclasses before they reach httpx's JSON encoder in the standalone Python SDK and the main-package compatibility clients. The same normalization is applied to `batch_add_messages()`, which shared the reported root cause.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #3890

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Convert Text, Context, and Tool dataclasses to JSON-compatible dictionaries and emit Image parts in the required nested `image_url` shape.
- Normalize both single-message and batch requests while preserving existing dictionaries and avoiding mutation of caller-owned batch payloads.
- Keep the compatibility client working with the declared `openviking-sdk>=0.1.1` minimum by serializing before delegating batch transport to the installed SDK.
- Add real httpx encoding regressions for standalone async/sync clients and main-package compatibility clients.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and relevant existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands and results on a Debian/Linux Docker test environment:

- `ruff check` and `ruff format --check` on all four changed files — passed.
- `pytest sdk/python/tests` — 112 passed, 1 verified pre-existing failure deselected.
- `pytest tests/client` — 78 passed, 1 skipped, 1 verified pre-existing failure deselected.
- `pytest tests/unit/test_message.py` — 59 passed.
- Built the standalone SDK wheel, installed it into an isolated target, and passed public sync add + batch MockTransport smoke tests.
- Installed the published `openviking-sdk==0.1.1` wheel in an offline container and passed the compatibility async batch + telemetry MockTransport smoke test; this version does not expose `_request`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] No documentation update is required; this restores the behavior already described by the existing API documentation
- [x] My changes generate no new warnings
- [x] No dependent changes are required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This follow-up credits the serialization approach explored in #3900, which was closed without merge. It extends that work to Context parts, batch requests, raw-dict preservation, input non-mutation, async coverage, and the minimum supported SDK compatibility path.

The two deselected tests fail identically on clean `main` and are unrelated to this change:

- `test_glob_normalizes_scope_uri` expects no default `node_limit`, while current main sends `node_limit=256`.
- `test_async_http_client_loads_missing_fields_from_ovcli_config` expects a gateway token that current main does not load in the test environment.

#3737 also edits the standalone SDK client but does not implement Part serialization. If it lands first, this branch will need a normal rebase and adaptation to its proposed Options API.
