### PR TITLE
fix(sdk): expose tree level limit

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -205,6 +205,42 @@ func TestListSendsOrderingOptions(t *testing.T) {
 	}
 }
 
+func TestTreeSendsLevelLimitAndPreservesDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		options *TreeOptions
+		want    string
+	}{
+		{name: "nil options", options: nil, want: "3"},
+		{name: "zero-value options", options: &TreeOptions{}, want: "3"},
+		{name: "custom depth", options: &TreeOptions{LevelLimit: Int(2)}, want: "2"},
+		{name: "explicit zero", options: &TreeOptions{LevelLimit: Int(0)}, want: "0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/api/v1/fs/tree" {
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				if got := r.URL.Query().Get("level_limit"); got != test.want {
+					t.Fatalf("level_limit = %q, want %q", got, test.want)
+				}
+				writeOK(t, w, []any{})
+			}))
+			defer closeServer()
+
+			if _, err := client.Tree(
+				context.Background(),
+				"viking://resources/docs",
+				test.options,
+			); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestFindSendsImageQuery(t *testing.T) {
 	imagePath := filepath.Join(t.TempDir(), "query.png")
 	if err := os.WriteFile(imagePath, []byte("\x89PNG\r\n\x1a\n"), 0o600); err != nil {

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -177,67 +177,44 @@ func TestFindOmitsSearchFiltersWhenUnset(t *testing.T) {
 	}
 }
 
-func TestListSendsOrderingOptions(t *testing.T) {
+func TestListAndTreeSendQueryOptions(t *testing.T) {
+	wantTreeLimits := []string{"0", "3"}
 	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/fs/ls" {
-			t.Fatalf("path = %s", r.URL.Path)
-		}
-		if got := r.URL.Query().Get("node_limit"); got != "200" {
-			t.Fatalf("node_limit = %q", got)
-		}
-		if got := r.URL.Query().Get("sort_by"); got != "mtime" {
-			t.Fatalf("sort_by = %q", got)
-		}
-		if got := r.URL.Query().Get("sort_order"); got != "desc" {
-			t.Fatalf("sort_order = %q", got)
+		switch r.URL.Path {
+		case "/api/v1/fs/ls":
+			if got := r.URL.Query().Get("node_limit"); got != "200" {
+				t.Fatalf("node_limit = %q", got)
+			}
+			if got := r.URL.Query().Get("sort_by"); got != "mtime" {
+				t.Fatalf("sort_by = %q", got)
+			}
+			if got := r.URL.Query().Get("sort_order"); got != "desc" {
+				t.Fatalf("sort_order = %q", got)
+			}
+		case "/api/v1/fs/tree":
+			if got := r.URL.Query().Get("level_limit"); got != wantTreeLimits[0] {
+				t.Fatalf("level_limit = %q, want %q", got, wantTreeLimits[0])
+			}
+			wantTreeLimits = wantTreeLimits[1:]
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		writeOK(t, w, []any{})
 	}))
 	defer closeServer()
 
-	_, err := client.List(context.Background(), "viking://session", &ListOptions{
+	if _, err := client.List(context.Background(), "viking://session", &ListOptions{
 		NodeLimit: 200,
 		SortBy:    "mtime",
 		SortOrder: "desc",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestTreeSendsLevelLimitAndPreservesDefault(t *testing.T) {
-	tests := []struct {
-		name    string
-		options *TreeOptions
-		want    string
-	}{
-		{name: "nil options", options: nil, want: "3"},
-		{name: "zero-value options", options: &TreeOptions{}, want: "3"},
-		{name: "custom depth", options: &TreeOptions{LevelLimit: Int(2)}, want: "2"},
-		{name: "explicit zero", options: &TreeOptions{LevelLimit: Int(0)}, want: "0"},
+	if _, err := client.Tree(context.Background(), "viking://resources/docs", &TreeOptions{LevelLimit: Int(0)}); err != nil {
+		t.Fatal(err)
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodGet || r.URL.Path != "/api/v1/fs/tree" {
-					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-				}
-				if got := r.URL.Query().Get("level_limit"); got != test.want {
-					t.Fatalf("level_limit = %q, want %q", got, test.want)
-				}
-				writeOK(t, w, []any{})
-			}))
-			defer closeServer()
-
-			if _, err := client.Tree(
-				context.Background(),
-				"viking://resources/docs",
-				test.options,
-			); err != nil {
-				t.Fatal(err)
-			}
-		})
+	if _, err := client.Tree(context.Background(), "viking://resources/docs", nil); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/sdk/go/filesystem.go
+++ b/sdk/go/filesystem.go
@@ -59,12 +59,17 @@ func (c *Client) Tree(ctx context.Context, uri string, opts *TreeOptions) ([]map
 	if nodeLimit == 0 {
 		nodeLimit = 1000
 	}
+	levelLimit := 3
+	if opts.LevelLimit != nil {
+		levelLimit = *opts.LevelLimit
+	}
 	query := url.Values{}
 	query.Set("uri", NormalizeURI(uri))
 	query.Set("output", output)
 	queryInt(query, "abs_limit", absLimit)
 	queryBool(query, "show_all_hidden", opts.ShowAllHidden)
 	queryInt(query, "node_limit", nodeLimit)
+	queryInt(query, "level_limit", levelLimit)
 	var result []map[string]any
 	err := c.doJSON(ctx, http.MethodGet, "/api/v1/fs/tree", query, nil, &result)
 	return result, err

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -160,6 +160,7 @@ type TreeOptions struct {
 	AbsLimit      int
 	ShowAllHidden bool
 	NodeLimit     int
+	LevelLimit    *int
 }
 
 // RemoveOptions controls Remove.

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -1063,6 +1063,7 @@ class AsyncHTTPClient:
         abs_limit: int = 128,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        level_limit: int = 3,
     ) -> List[Dict[str, Any]]:
         response = await self._request(
             "GET",
@@ -1073,6 +1074,7 @@ class AsyncHTTPClient:
                 "abs_limit": abs_limit,
                 "show_all_hidden": show_all_hidden,
                 "node_limit": node_limit,
+                "level_limit": level_limit,
             },
         )
         return self._handle_response(response)
@@ -2198,6 +2200,7 @@ class SyncHTTPClient:
         abs_limit: int = 128,
         show_all_hidden: bool = False,
         node_limit: int = 1000,
+        level_limit: int = 3,
     ) -> List[Dict[str, Any]]:
         return run_async(
             self._async_client.tree(
@@ -2206,6 +2209,7 @@ class SyncHTTPClient:
                 abs_limit=abs_limit,
                 show_all_hidden=show_all_hidden,
                 node_limit=node_limit,
+                level_limit=level_limit,
             )
         )
 

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -297,27 +297,6 @@ def test_sync_http_client_reindex_forwards_to_async_client():
     )
 
 
-def test_sync_http_client_tree_forwards_level_limit():
-    client = SyncHTTPClient(url="http://localhost:1933")
-    with patch.object(
-        client._async_client,
-        "tree",
-        new_callable=Mock,
-        return_value=[],
-    ) as mock_tree:
-        with patch(
-            "openviking_sdk.client.run_async",
-            return_value=[],
-        ) as mock_run:
-            explicit_result = client.tree("viking://resources/demo", level_limit=2)
-            zero_result = client.tree("viking://resources/demo", level_limit=0)
-            default_result = client.tree("viking://resources/demo")
-
-    assert explicit_result == zero_result == default_result == []
-    assert mock_run.call_count == 3
-    assert [call.kwargs["level_limit"] for call in mock_tree.call_args_list] == [2, 0, 3]
-
-
 def test_sync_http_client_batch_add_messages_forwards_to_async_client():
     client = SyncHTTPClient(url="http://localhost:1933")
     messages = [
@@ -944,7 +923,7 @@ async def test_glob_normalizes_scope_uri():
 
 
 @pytest.mark.asyncio
-async def test_ls_passes_full_query_params():
+async def test_ls_and_tree_pass_query_params():
     client = AsyncHTTPClient(url="http://localhost:1933")
     fake_http = SimpleNamespace(get=AsyncMock(return_value=object()))
     client._http = fake_http
@@ -961,10 +940,14 @@ async def test_ls_passes_full_query_params():
         sort_by="mtime",
         sort_order="desc",
     )
+    await client.tree("viking://resources/", level_limit=2)
+    await client.tree("viking://resources/", level_limit=0)
+    await client.tree("viking://resources/")
 
-    fake_http.get.assert_awaited_once_with(
-        "/api/v1/fs/ls",
-        params={
+    ls_call = fake_http.get.await_args_list[0]
+    assert ls_call.args == ("/api/v1/fs/ls",)
+    assert ls_call.kwargs == {
+        "params": {
             "uri": "viking://resources/",
             "simple": True,
             "recursive": True,
@@ -975,25 +958,11 @@ async def test_ls_passes_full_query_params():
             "sort_by": "mtime",
             "sort_order": "desc",
         },
-    )
-
-
-@pytest.mark.asyncio
-async def test_tree_passes_level_limit_and_preserves_default():
-    client = AsyncHTTPClient(url="http://localhost:1933")
-    fake_http = SimpleNamespace(get=AsyncMock(return_value=object()))
-    client._http = fake_http
-    client._handle_response = lambda _response: []
-
-    await client.tree("viking://resources/", level_limit=2)
-    await client.tree("viking://resources/", level_limit=0)
-    await client.tree("viking://resources/")
-
-    assert [call.kwargs["params"]["level_limit"] for call in fake_http.get.await_args_list] == [
-        2,
-        0,
-        3,
-    ]
+    }
+    assert [
+        tree_call.kwargs["params"]["level_limit"]
+        for tree_call in fake_http.get.await_args_list[1:]
+    ] == [2, 0, 3]
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -297,6 +297,27 @@ def test_sync_http_client_reindex_forwards_to_async_client():
     )
 
 
+def test_sync_http_client_tree_forwards_level_limit():
+    client = SyncHTTPClient(url="http://localhost:1933")
+    with patch.object(
+        client._async_client,
+        "tree",
+        new_callable=Mock,
+        return_value=[],
+    ) as mock_tree:
+        with patch(
+            "openviking_sdk.client.run_async",
+            return_value=[],
+        ) as mock_run:
+            explicit_result = client.tree("viking://resources/demo", level_limit=2)
+            zero_result = client.tree("viking://resources/demo", level_limit=0)
+            default_result = client.tree("viking://resources/demo")
+
+    assert explicit_result == zero_result == default_result == []
+    assert mock_run.call_count == 3
+    assert [call.kwargs["level_limit"] for call in mock_tree.call_args_list] == [2, 0, 3]
+
+
 def test_sync_http_client_batch_add_messages_forwards_to_async_client():
     client = SyncHTTPClient(url="http://localhost:1933")
     messages = [
@@ -955,6 +976,24 @@ async def test_ls_passes_full_query_params():
             "sort_order": "desc",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_tree_passes_level_limit_and_preserves_default():
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    fake_http = SimpleNamespace(get=AsyncMock(return_value=object()))
+    client._http = fake_http
+    client._handle_response = lambda _response: []
+
+    await client.tree("viking://resources/", level_limit=2)
+    await client.tree("viking://resources/", level_limit=0)
+    await client.tree("viking://resources/")
+
+    assert [call.kwargs["params"]["level_limit"] for call in fake_http.get.await_args_list] == [
+        2,
+        0,
+        3,
+    ]
 
 
 @pytest.mark.asyncio

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -441,6 +441,7 @@ export class OpenVikingClient {
         abs_limit: options.absLimit ?? 128,
         show_all_hidden: options.showAllHidden ?? false,
         node_limit: options.nodeLimit ?? 1000,
+        level_limit: options.levelLimit ?? 3,
       },
     });
   }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -136,6 +136,7 @@ export interface TreeOptions {
   absLimit?: number;
   showAllHidden?: boolean;
   nodeLimit?: number;
+  levelLimit?: number;
 }
 /** Session message payload. */
 export interface Message {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -201,8 +201,10 @@ describe("OpenVikingClient", () => {
     );
   });
 
-  it("passes directory list ordering to the server", async () => {
-    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(ok([]));
+  it("passes directory list ordering and tree depth to the server", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => ok([]));
     const client = new OpenVikingClient({
       baseUrl: "https://example.com",
       fetch: fetcher,
@@ -213,32 +215,18 @@ describe("OpenVikingClient", () => {
       sortBy: "mtime",
       sortOrder: "desc",
     });
-
-    const url = new URL(String(fetcher.mock.calls[0]![0]));
-    expect(url.searchParams.get("node_limit")).toBe("200");
-    expect(url.searchParams.get("sort_by")).toBe("mtime");
-    expect(url.searchParams.get("sort_order")).toBe("desc");
-  });
-
-  it("passes directory tree depth and preserves the server default", async () => {
-    const fetcher = vi
-      .fn<typeof fetch>()
-      .mockImplementation(async () => ok([]));
-    const client = new OpenVikingClient({
-      baseUrl: "https://example.com",
-      fetch: fetcher,
-    });
-
     await client.tree("viking://resources/docs", { levelLimit: 2 });
     await client.tree("viking://resources/docs", { levelLimit: 0 });
     await client.tree("viking://resources/docs");
 
-    const explicitUrl = new URL(String(fetcher.mock.calls[0]![0]));
-    const zeroUrl = new URL(String(fetcher.mock.calls[1]![0]));
-    const defaultUrl = new URL(String(fetcher.mock.calls[2]![0]));
-    expect(explicitUrl.searchParams.get("level_limit")).toBe("2");
-    expect(zeroUrl.searchParams.get("level_limit")).toBe("0");
-    expect(defaultUrl.searchParams.get("level_limit")).toBe("3");
+    const listUrl = new URL(String(fetcher.mock.calls[0]![0]));
+    expect(listUrl.searchParams.get("node_limit")).toBe("200");
+    expect(listUrl.searchParams.get("sort_by")).toBe("mtime");
+    expect(listUrl.searchParams.get("sort_order")).toBe("desc");
+    const treeLimits = fetcher.mock.calls
+      .slice(1)
+      .map((call) => new URL(String(call[0])).searchParams.get("level_limit"));
+    expect(treeLimits).toEqual(["2", "0", "3"]);
   });
 
   it("sends addResource tags and tagMode to the server", async () => {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -220,6 +220,27 @@ describe("OpenVikingClient", () => {
     expect(url.searchParams.get("sort_order")).toBe("desc");
   });
 
+  it("passes directory tree depth and preserves the server default", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => ok([]));
+    const client = new OpenVikingClient({
+      baseUrl: "https://example.com",
+      fetch: fetcher,
+    });
+
+    await client.tree("viking://resources/docs", { levelLimit: 2 });
+    await client.tree("viking://resources/docs", { levelLimit: 0 });
+    await client.tree("viking://resources/docs");
+
+    const explicitUrl = new URL(String(fetcher.mock.calls[0]![0]));
+    const zeroUrl = new URL(String(fetcher.mock.calls[1]![0]));
+    const defaultUrl = new URL(String(fetcher.mock.calls[2]![0]));
+    expect(explicitUrl.searchParams.get("level_limit")).toBe("2");
+    expect(zeroUrl.searchParams.get("level_limit")).toBe("0");
+    expect(defaultUrl.searchParams.get("level_limit")).toBe("3");
+  });
+
   it("sends addResource tags and tagMode to the server", async () => {
     const fetcher = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Description

Expose the filesystem tree depth limit through the Python, TypeScript, and Go HTTP SDKs. The server and bilingual API references already define `level_limit` with a default of `3`, and the bundled Python example already uses it, but the SDK request boundaries did not expose or forward the parameter.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4109

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `level_limit` to Python async and sync `tree()` clients and forward it in the request.
- Add `TreeOptions.levelLimit` in TypeScript and `TreeOptions.LevelLimit` in Go, using each SDK's existing option conventions.
- Preserve the documented default depth of `3` and the server's valid explicit depth of `0`.
- Add request-contract coverage for Python async/sync, TypeScript, and Go callers.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Server-side validation:

- Python focused tree tests: `2 passed`
- Python SDK suite excluding one independently reproduced baseline failure: `111 passed, 1 deselected`
- Python Ruff check and format check on both changed files
- TypeScript: `npm run typecheck`, `npm run build`, `npm run test:node-types`, `npm test` (`39 passed`), and `npm pack --dry-run`
- Go: `go vet ./...`, `go test ./... -count=1`, and `go test -race ./... -count=1`

TDD RED checks on the base revision confirmed:

- Python rejected `level_limit` in both public `tree()` methods.
- TypeScript rejected `levelLimit` during type checking and omitted the query at runtime.
- Go rejected `LevelLimit` at compile time and omitted the query.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

The existing English and Chinese filesystem API references already document `level_limit`, so no documentation text needed to change.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- The Python SDK suite currently has an unrelated stale assertion in `test_glob_normalizes_scope_uri`: current `main` sends its established default `node_limit=256`, while the test expects that parameter to be omitted. The same failure was reproduced on the clean base revision, so it is excluded rather than changed in this PR.
- The repository-wide TypeScript Prettier check also reports pre-existing formatting in `src/client.ts` and `tests/client.test.ts` on clean `main`; the added hunk is formatted and all TypeScript compile/runtime/package checks pass.
- Open PRs #3737 and #4048 touch some of the same SDK files but do not implement tree depth forwarding. This PR keeps the change isolated so any future rebase remains small.
