### PR TITLE
fix(memory): isolate Self case extraction from Peer memories

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -3,11 +3,11 @@
 """Session Compressor V3.
 
 V3 keeps the V2 extraction interface while changing user-memory commits to a
-patch-merge flow without directory-level memory locks.  Training cases are not
-extracted by a separate LLM call; they are a normal user-memory ``memory_type``
-(``cases``) emitted by the same ExtractLoop that extracts profile/preferences/
-events/etc.  When such case memories are produced, the same commit rollout is
-submitted to the process-global StreamingPolicyTrainer.
+patch-merge flow without directory-level memory locks. Training cases are a
+normal user-memory ``memory_type`` (``cases``). When Self and Peer scopes are
+both active, cases use a dedicated Self-only extraction pass so Peer memories
+cannot crowd them out of the structured output. Produced cases submit the same
+commit rollout to the process-global StreamingPolicyTrainer.
 """
 
 from __future__ import annotations
@@ -377,6 +377,7 @@ class SessionCompressorV3:
             message_list,
             allowed_memory_types,
         )
+        cases_allowed = allowed_memory_types is None or _CASES_MEMORY_TYPE in allowed_memory_types
         try:
             if fast_path_case is not None:
                 return await self._commit_training_case_fast_path(
@@ -390,23 +391,71 @@ class SessionCompressorV3:
                     allowed_memory_types=allowed_memory_types,
                 )
 
-            result = await self._extract_user_memories(
-                messages=message_list,
-                user=user,
-                session_id=session_id,
-                ctx=ctx,
-                strict_extract_errors=strict_extract_errors,
-                latest_archive_overview=latest_archive_overview,
-                archive_uri=archive_uri,
-                allowed_memory_types=allowed_memory_types,
-                allow_self_memory=allow_self_memory,
-                allowed_peer_ids=allowed_peer_ids,
-                event_search_tags=event_search_tags,
-            )
+            # Cases are Self-only training inputs. Keep them out of the mixed
+            # Self/Peer schema so Peer outputs cannot consume the structured
+            # response without producing the case required by Agent training.
+            if allow_self_memory and allowed_peer_ids and cases_allowed:
+                registry = create_default_registry()
+                user_memory_types = {
+                    schema.memory_type
+                    for schema in registry.list_all(include_disabled=False)
+                    if getattr(schema, "stage", "user") == "user"
+                }
+                if allowed_memory_types is not None:
+                    user_memory_types &= allowed_memory_types
+
+                scoped_results = []
+                non_case_memory_types = user_memory_types - {_CASES_MEMORY_TYPE}
+                if non_case_memory_types:
+                    scoped_results.append(
+                        await self._extract_user_memories(
+                            messages=message_list,
+                            user=user,
+                            session_id=session_id,
+                            ctx=ctx,
+                            strict_extract_errors=strict_extract_errors,
+                            latest_archive_overview=latest_archive_overview,
+                            archive_uri=archive_uri,
+                            allowed_memory_types=non_case_memory_types,
+                            allow_self_memory=allow_self_memory,
+                            allowed_peer_ids=allowed_peer_ids,
+                            event_search_tags=event_search_tags,
+                        )
+                    )
+                scoped_results.append(
+                    await self._extract_user_memories(
+                        messages=message_list,
+                        user=user,
+                        session_id=session_id,
+                        ctx=ctx,
+                        strict_extract_errors=strict_extract_errors,
+                        latest_archive_overview=latest_archive_overview,
+                        archive_uri=archive_uri,
+                        allowed_memory_types={_CASES_MEMORY_TYPE},
+                        allow_self_memory=True,
+                        allowed_peer_ids=set(),
+                        event_search_tags=event_search_tags,
+                    )
+                )
+                result = _merge_v3_extraction_results(
+                    scoped_results,
+                    archive_uri=archive_uri or "",
+                )
+            else:
+                result = await self._extract_user_memories(
+                    messages=message_list,
+                    user=user,
+                    session_id=session_id,
+                    ctx=ctx,
+                    strict_extract_errors=strict_extract_errors,
+                    latest_archive_overview=latest_archive_overview,
+                    archive_uri=archive_uri,
+                    allowed_memory_types=allowed_memory_types,
+                    allow_self_memory=allow_self_memory,
+                    allowed_peer_ids=allowed_peer_ids,
+                    event_search_tags=event_search_tags,
+                )
             agent_memory_types = _allowed_agent_memory_types(allowed_memory_types)
-            cases_allowed = (
-                allowed_memory_types is None or _CASES_MEMORY_TYPE in allowed_memory_types
-            )
             session_skills_enabled = self._session_skill_extraction_enabled()
             if (
                 agent_evolution_enabled
@@ -1230,6 +1279,33 @@ class _V3AppliedMemory:
     result: Any
     operations: ResolvedOperations
     memory_diff: dict[str, Any] | None = None
+
+
+def _merge_v3_extraction_results(
+    results: list[_V3ExtractionResult],
+    *,
+    archive_uri: str,
+) -> _V3ExtractionResult:
+    contexts: list[Context] = []
+    cases: list[Case] = []
+    case_uri_by_name: dict[str, str] = {}
+    memory_diffs: list[dict[str, Any]] = []
+
+    for result in results:
+        contexts.extend(result.contexts)
+        cases.extend(result.cases)
+        case_uri_by_name.update(result.case_uri_by_name)
+        if isinstance(result.memory_diff, dict):
+            memory_diffs.append(result.memory_diff)
+
+    return _V3ExtractionResult(
+        contexts=contexts,
+        cases=cases,
+        memory_diff=(
+            _merge_memory_diffs(memory_diffs, archive_uri=archive_uri) if memory_diffs else None
+        ),
+        case_uri_by_name=case_uri_by_name,
+    )
 
 
 def _contexts_from_update_result(result: Any) -> list[Context]:

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -295,6 +295,76 @@ async def test_v3_passes_allowed_execution_types_to_agent_training(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_v3_extracts_self_cases_separately_when_peer_scope_is_active(monkeypatch):
+    peer_context = SimpleNamespace(uri="viking://user/u/peers/alice/memories/preferences/p.md")
+    case_context = SimpleNamespace(uri="viking://user/u/memories/cases/c.md")
+    extraction_calls = []
+
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+    compressor = SessionCompressorV3(vikingdb=None)
+
+    async def fake_extract_user_memories(**kwargs):
+        extraction_calls.append(kwargs)
+        if kwargs["allowed_memory_types"] == {"cases"}:
+            return SimpleNamespace(
+                contexts=[case_context],
+                cases=[_training_case()],
+                memory_diff={
+                    "operations": {
+                        "adds": [{"uri": case_context.uri}],
+                        "updates": [],
+                        "deletes": [],
+                    }
+                },
+                case_uri_by_name={"duplicate_booking": case_context.uri},
+            )
+        return SimpleNamespace(
+            contexts=[peer_context],
+            cases=[],
+            memory_diff={
+                "operations": {
+                    "adds": [{"uri": peer_context.uri}],
+                    "updates": [],
+                    "deletes": [],
+                }
+            },
+            case_uri_by_name={},
+        )
+
+    compressor._extract_user_memories = fake_extract_user_memories
+    compressor.train_from_extracted_cases = AsyncMock(
+        return_value={"case_count": 1, "submitted": 1}
+    )
+    compressor._write_final_memory_diff = AsyncMock()
+
+    contexts = await compressor.extract_long_term_memories(
+        messages=_messages(),
+        ctx=_ctx(),
+        archive_uri="viking://user/u/sessions/s/history/archive_001",
+        allowed_memory_types={"cases", "experiences", "preferences", "trajectories"},
+        allowed_peer_ids={"alice"},
+    )
+
+    assert len(extraction_calls) == 2
+    assert extraction_calls[0]["allowed_memory_types"] == {"preferences"}
+    assert extraction_calls[0]["allowed_peer_ids"] == {"alice"}
+    assert extraction_calls[1]["allowed_memory_types"] == {"cases"}
+    assert extraction_calls[1]["allow_self_memory"] is True
+    assert extraction_calls[1]["allowed_peer_ids"] == set()
+    assert compressor.train_from_extracted_cases.await_args.kwargs["cases"] == [_training_case()]
+    assert contexts == [peer_context, case_context]
+
+    merged_diff = compressor._write_final_memory_diff.await_args.kwargs["memory_diffs"][0]
+    assert [item["uri"] for item in merged_diff["operations"]["adds"]] == [
+        peer_context.uri,
+        case_context.uri,
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v3_initializes_only_allowed_memory_files(monkeypatch):
     initialized_with = []
 


### PR DESCRIPTION
## Description

Prevent Peer user-memory outputs from crowding Self training cases out of the V3 structured extraction result. When Self and Peer scopes are both active and cases are enabled, cases are now extracted in a dedicated Self-only pass before the existing case-to-trajectory-to-experience training flow.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Keep regular Self and Peer user memories on the existing extraction path while excluding cases from its mixed output schema.
- Extract cases in a dedicated Self-only pass and merge contexts, case mappings, and memory diffs before Agent training.
- Add regression coverage for extraction scopes, merged diffs, and downstream case training input.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Focused new and existing unit tests pass locally with my changes: 71 passed
- [x] Ruff format/check and git diff validation pass
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have commented the non-obvious scope split
- [x] This change requires no public documentation update
- [x] My changes generate no new warnings
- [x] No dependent changes are required

## Screenshots (if applicable)

N/A

## Additional Notes

The defect is not introduced by the User MemoryPolicy feature. The one-pass V3 extraction architecture already exists on current main and dates back to fd73dcf2; the User MemoryPolicy branch only provides a product configuration that makes the mixed Self and Peer scope easier to trigger.

A broader compressor test selection exposed six failures. Re-running those exact six tests on clean ov/main at da138de7 reproduces all six: five require a globally initialized VikingFS fixture, and one has a pre-existing submitted-count expectation mismatch. The focused affected suite passes 71/71 on this branch.