### PR TITLE
fix(resource): collect stats for queued uploads

### DIFF
--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -15,7 +15,13 @@ from openviking.service.task_tracker import TaskStatus, get_task_tracker
 from openviking.service.task_work_index import bind_task_context, extract_task_metadata
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg
 from openviking.storage.queuefs.named_queue import DequeueHandlerBase
-from openviking.telemetry import bind_telemetry, resolve_telemetry, unregister_telemetry
+from openviking.telemetry import (
+    OperationTelemetry,
+    bind_telemetry,
+    register_telemetry,
+    resolve_telemetry,
+    unregister_telemetry,
+)
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.telemetry.resource_summary import record_resource_queue_metrics
 from openviking_cli.session.user_id import UserIdentifier
@@ -148,11 +154,12 @@ class AddResourceProcessor(DequeueHandlerBase):
 
         telemetry = resolve_telemetry(telemetry_id) if telemetry_id else None
         if telemetry is None:
-            from openviking.telemetry.operation import OperationTelemetry
-
-            telemetry = OperationTelemetry(operation="add_resource_job", enabled=False)
+            telemetry = OperationTelemetry(operation="add_resource_job", enabled=True)
             if telemetry_id:
                 telemetry.telemetry_id = telemetry_id
+            else:
+                telemetry_id = telemetry.telemetry_id
+            register_telemetry(telemetry)
         request_wait_tracker = get_request_wait_tracker()
         request_wait_tracker.register_request(telemetry_id)
 

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -1142,6 +1142,7 @@ async def test_add_resource_processor_reports_zero_vectors(monkeypatch):
         update_stage=AsyncMock(),
         complete=AsyncMock(),
         fail=AsyncMock(),
+        get_task_auth=AsyncMock(return_value={}),
         wait_for_descendants=AsyncMock(),
     )
     monkeypatch.setattr(

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -16,6 +16,7 @@ from openviking.service.task_work_index import TASK_WORK_ID_FIELD
 from openviking.storage.queuefs.add_resource_msg import AddResourceMsg, AddResourcePhase
 from openviking.storage.queuefs.add_resource_processor import AddResourceProcessor
 from openviking.storage.queuefs.queue_manager import QueueManager
+from openviking.telemetry import get_current_telemetry, resolve_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.media_processor import UnifiedResourceProcessor
 from openviking_cli.exceptions import InvalidArgumentError
@@ -984,6 +985,84 @@ async def test_add_resource_processor_persists_final_uri_and_cleans_staged_sourc
     assert cleanup_call.kwargs["ctx"].user.user_id == "user-1"
     assert await processor._requeue_lock_handoff(msg, RuntimeError("stale lock"))
     assert queue_manager.enqueue.await_args.args[0] == QueueManager.ADD_RESOURCE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("telemetry_id", [None, "telemetry-unregistered-resource"])
+async def test_add_resource_processor_collects_stats_without_registered_telemetry(
+    monkeypatch,
+    telemetry_id: str | None,
+):
+    final_uri = "viking://resources/unregistered"
+    observed_telemetry_ids = []
+    task_tracker = SimpleNamespace(
+        create=AsyncMock(return_value=SimpleNamespace(status=TaskStatus.PENDING)),
+        start=AsyncMock(),
+        update_stage=AsyncMock(),
+        complete=AsyncMock(),
+        fail=AsyncMock(),
+        get_task_auth=AsyncMock(return_value={}),
+        wait_for_descendants=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.add_resource_processor.get_task_tracker",
+        Mock(return_value=task_tracker),
+    )
+
+    async def execute_add_resource_job(*_args, **_kwargs):
+        telemetry = get_current_telemetry()
+        effective_telemetry_id = telemetry.telemetry_id
+        observed_telemetry_ids.append(effective_telemetry_id)
+        if telemetry_id is not None:
+            assert effective_telemetry_id == telemetry_id
+        assert resolve_telemetry(effective_telemetry_id) is telemetry
+        assert telemetry.enabled
+        telemetry.record_token_usage("embedding", 21)
+        telemetry.add_token_usage(13, 5)
+
+        wait_tracker = get_request_wait_tracker()
+        wait_tracker.register_embedding_root(effective_telemetry_id, "embedding-1")
+        wait_tracker.mark_embedding_done(
+            effective_telemetry_id,
+            "embedding-1",
+            vector_written=True,
+        )
+        return {"status": "success", "root_uri": final_uri}
+
+    processor = AddResourceProcessor(
+        SimpleNamespace(
+            execute_add_resource_job=AsyncMock(side_effect=execute_add_resource_job),
+            _link_resource_reason_memory=AsyncMock(),
+        ),
+        asyncio.get_running_loop(),
+        QueueManager.ADD_RESOURCE,
+        SimpleNamespace(_async_agfs=SimpleNamespace(pathlock_release=AsyncMock())),
+    )
+    msg = AddResourceMsg(
+        task_id="task-unregistered",
+        path="https://example.com/document.pdf",
+        root_uri=final_uri,
+        account_id="account-1",
+        user_id="user-1",
+        role="user",
+        telemetry_id=telemetry_id,
+    )
+    data = msg.to_dict()
+    data[TASK_WORK_ID_FIELD] = "work-1"
+
+    await processor._process(msg, data)
+
+    task_tracker.fail.assert_not_awaited()
+    final_result = task_tracker.complete.await_args_list[-1].args[1]
+    assert final_result["context_count"] == 1
+    assert final_result["usage"]["tokens"]["embedding"]["total"] == 21
+    assert final_result["usage"]["tokens"]["llm"] == {
+        "input": 13,
+        "output": 5,
+        "total": 18,
+    }
+    assert len(observed_telemetry_ids) == 1
+    assert resolve_telemetry(observed_telemetry_ids[0]) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Queued resource imports can lose upload statistics when the durable add-resource processor cannot resolve an enabled telemetry collector.

The exact symptom depends on the queue message. If the message has no telemetry ID, the request wait tracker cannot associate successful vector writes with the upload, so the completed task reports `context_count: 0` and omits token usage. If the message has an ID but its collector is unregistered, as in the source-queue path introduced by #4100, the wait tracker can still report `context_count`, but the disabled fallback collector drops token usage. For example, a one-context upload reports `context_count: 1` with no `usage.tokens`.

This change creates and registers an enabled operation collector when the queued task has no usable collector. It preserves a supplied telemetry ID, generates one when the message has none, and uses the existing cleanup path to unregister the collector after the task finishes.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Register an enabled telemetry collector when a queued add-resource task cannot resolve its original collector.
- Preserve supplied telemetry IDs and generate an ID for messages that do not contain one.
- Add regression coverage for both missing and unregistered telemetry IDs, including context count, embedding tokens, LLM tokens, and registry cleanup.
- Refresh the existing zero-context processor test fixture for the task-auth contract introduced by #4100.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with:

- Four focused add-resource processor tests.
- All 35 tests in `tests/parse/test_feishu_parser_api.py`.
- 44 related telemetry, semantic statistics, and embedding-message tests.
- Ruff lint and format checks for both changed files.
- `git diff --check`.
- An end-to-end local upload through the temporary-file API and durable queue. A PDF completed with `context_count: 11`, 14,331 embedding tokens, and 49,783 VLM/LLM tokens.

A broader local service run reported 239 passes, 11 failures, and one error in untouched memory, content-write, and reindex tests. The resource API module reported 47 passes and two failures in untouched response and fixture contracts. This PR does not claim those broader suites as passing.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The fallback uses the existing in-memory telemetry registry and request wait tracker. It adds no database scan or external request. Existing task messages with a valid registered collector keep the current path unchanged.
