### PR TITLE
fix(retrieve): thread context_type into TypedQuery so the observer stops reporting 100% unknown

### DIFF
--- a/openviking/retrieve/context_assembler/gather.py
+++ b/openviking/retrieve/context_assembler/gather.py
@@ -273,6 +273,7 @@ async def gather_candidates(
         target_uri: str,
         find_limit: int,
         find_filter: Optional[Dict[str, Any]] = None,
+        find_context_type: Optional[ContextType] = None,
     ) -> Any:
         return _safe_find(
             service,
@@ -285,6 +286,7 @@ async def gather_candidates(
             filter=find_filter if find_filter is not None else filter,
             image_url=image_url,
             level=None,
+            context_type=find_context_type,
         )
 
     async def gather_bucket(bucket: str, quota: int) -> List[Candidate]:
@@ -301,6 +303,7 @@ async def gather_candidates(
                 target_uri=target,
                 find_limit=_overfetch(quota),
                 find_filter=bucket_filter,
+                find_context_type=context_type,
             )
             for query in planned
             for target in targets
@@ -314,6 +317,7 @@ async def gather_candidates(
                     target_uri=f"{user_root}/peers",
                     find_limit=_overfetch(max(quota * OTHER_PEER_OVERFETCH, quota)),
                     find_filter=bucket_filter,
+                    find_context_type=context_type,
                 )
                 for query in planned
             )

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -41,6 +41,7 @@ from openviking.utils.search_filters import (
     SearchContextTypeInput,
     _resolve_levels,
     merge_search_filter,
+    resolve_single_context_type,
 )
 from openviking.utils.tags import build_search_tags_filter
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
@@ -91,6 +92,19 @@ def _resolve_search_filter(
                 return {"op": "and", "conds": [merged, *tag_filter["conds"]]}
             return {"op": "and", "conds": [merged, tag_filter]}
         return tag_filter
+    except ValueError as exc:
+        raise InvalidArgumentError(str(exc)) from exc
+
+
+def _typed_context_type(context_type: Optional[SearchContextTypeInput]):
+    """Resolve a request's context_type into the single ContextType TypedQuery expects.
+
+    Returns None for multi-type requests; those keep result scoping via the
+    filter built by ``_resolve_search_filter`` and stay unclassified in
+    observer stats.
+    """
+    try:
+        return resolve_single_context_type(context_type)
     except ValueError as exc:
         raise InvalidArgumentError(str(exc)) from exc
 
@@ -353,6 +367,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_typed_context_type(request.context_type),
         ),
     )
     result = execution.result
@@ -467,6 +482,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_typed_context_type(request.context_type),
         )
 
     execution = await run_operation(

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -17,6 +17,7 @@ from openviking.utils.image_search import (
     is_viking_uri,
 )
 from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
+from openviking_cli.retrieve.types import ContextType
 from openviking_cli.utils import get_logger
 
 if TYPE_CHECKING:
@@ -99,6 +100,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -110,6 +112,7 @@ class SearchService:
             score_threshold: Score threshold
             filter: Metadata filters
             level: Filter by level (0=abstract, 1=overview, 2=file)
+            context_type: Single context type for observer classification
 
         Returns:
             FindResult
@@ -133,6 +136,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result
 
@@ -146,6 +150,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -156,6 +161,7 @@ class SearchService:
             score_threshold: Score threshold
             filter: Metadata filters
             level: Filter by level (0=abstract, 1=overview, 2=file)
+            context_type: Single context type for observer classification
 
         Returns:
             FindResult
@@ -172,5 +178,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -21,6 +21,7 @@ from openviking.storage.viking_fs._base import (
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking_cli.exceptions import NotFoundError
+from openviking_cli.retrieve.types import ContextType
 
 
 class _SemanticMixin:
@@ -194,6 +195,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ):
         """Semantic search.
 
@@ -203,6 +205,7 @@ class _SemanticMixin:
             limit: Return count
             score_threshold: Score threshold
             filter: Metadata filter
+            context_type: Single context type for observer classification
 
         Returns:
             FindResult
@@ -264,7 +267,7 @@ class _SemanticMixin:
 
         typed_query = TypedQuery(
             query=query,
-            context_type=None,
+            context_type=context_type,
             intent="",
             target_directories=retrieval_targets.target_directories,
             embedding_input=(
@@ -377,6 +380,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ):
         """Complex search with session context.
 
@@ -386,6 +390,9 @@ class _SemanticMixin:
             session_info: Session information
             limit: Return count
             filter: Metadata filter
+            context_type: Single context type for observer classification.
+                Only applies to the no-session/no-intent fallback query below;
+                intent-assigned and image-query TypedQueries set their own type.
 
         Returns:
             FindResult
@@ -457,7 +464,7 @@ class _SemanticMixin:
             typed_queries = [
                 TypedQuery(
                     query=query,
-                    context_type=None,
+                    context_type=context_type,
                     intent="",
                     priority=1,
                     target_directories=retrieval_targets.target_directories,

--- a/openviking/utils/search_filters.py
+++ b/openviking/utils/search_filters.py
@@ -95,6 +95,22 @@ def resolve_context_types(context_type: Optional[SearchContextTypeInput]) -> Lis
     return normalized_values
 
 
+def resolve_single_context_type(
+    context_type: Optional[SearchContextTypeInput],
+) -> Optional[ContextType]:
+    """Resolve context_type into a single ContextType for TypedQuery classification.
+
+    TypedQuery.context_type carries one value, not a list. When zero or more
+    than one type was requested, this returns None: multi-type requests keep
+    scope_dsl filtering as the source of truth for results and stay
+    unclassified in observer stats.
+    """
+    resolved = resolve_context_types(context_type)
+    if len(resolved) != 1:
+        return None
+    return ContextType(resolved[0])
+
+
 def merge_time_filter(
     existing_filter: Optional[Dict[str, Any]],
     since: Optional[str] = None,

--- a/tests/misc/test_retrieval_enable_intent.py
+++ b/tests/misc/test_retrieval_enable_intent.py
@@ -89,6 +89,40 @@ async def test_search_skips_intent_and_uses_raw_query_when_disabled(monkeypatch)
     assert captured["typed_query"].target_directories == ["viking://resources/docs"]
 
 
+@pytest.mark.asyncio
+async def test_search_forwards_context_type_to_raw_query_fallback(monkeypatch):
+    from openviking_cli.retrieve.types import ContextType
+
+    fs = _make_viking_fs(enable_intent=False)
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, storage, embedder, rerank_config, retrieval_config):
+            pass
+
+        async def retrieve(self, typed_query, **kwargs):
+            captured["typed_query"] = typed_query
+            return QueryResult(
+                query=typed_query,
+                matched_contexts=[],
+                searched_directories=typed_query.target_directories,
+            )
+
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.HierarchicalRetriever",
+        FakeRetriever,
+    )
+
+    await fs.search(
+        "raw query",
+        target_uri="viking://resources/docs",
+        ctx=_ctx(),
+        context_type=ContextType.SKILL,
+    )
+
+    assert captured["typed_query"].context_type is ContextType.SKILL
+
+
 def test_search_service_is_intent_enabled_follows_config():
     from openviking.service.search_service import SearchService
 

--- a/tests/misc/test_vikingfs_find_without_rerank.py
+++ b/tests/misc/test_vikingfs_find_without_rerank.py
@@ -109,6 +109,45 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_find_forwards_context_type_to_typed_query(monkeypatch) -> None:
+    fs = _make_viking_fs()
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, storage, embedder, rerank_config, retrieval_config):
+            pass
+
+        async def retrieve(
+            self,
+            typed_query,
+            ctx,
+            limit,
+            score_threshold,
+            scope_dsl,
+            level,
+        ):
+            captured["typed_query"] = typed_query
+            return QueryResult(
+                query=typed_query,
+                matched_contexts=[],
+                searched_directories=[],
+            )
+
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.HierarchicalRetriever",
+        FakeRetriever,
+    )
+
+    await fs.find(
+        "guide",
+        target_uri="viking://resources/docs",
+        context_type=ContextType.RESOURCE,
+    )
+
+    assert captured["typed_query"].context_type is ContextType.RESOURCE
+
+
+@pytest.mark.asyncio
 async def test_find_accepts_image_url_without_text_query(monkeypatch) -> None:
     fs = _make_viking_fs()
     captured = {}

--- a/tests/retrieve/test_context_assembler_pipeline.py
+++ b/tests/retrieve/test_context_assembler_pipeline.py
@@ -246,6 +246,47 @@ async def test_resource_bucket_uses_actor_scope_without_other_peer_scan():
     assert [(entry.uri, entry.origin) for entry in result.entries] == [(actor_uri, "actor_peer")]
 
 
+async def test_gather_passes_bucket_context_type_to_find():
+    from openviking_cli.retrieve.types import ContextType
+
+    async def make_calls(quotas):
+        calls = []
+
+        async def fake_find(**kwargs):
+            calls.append(kwargs)
+            return _FakeFindResult()
+
+        service = SimpleNamespace(
+            search=SimpleNamespace(find=fake_find),
+            fs=SimpleNamespace(read=None),
+            sessions=SimpleNamespace(),
+            viking_fs=None,
+        )
+        await assemble_context(
+            service=service,
+            ctx=_ctx(),
+            params=AssembleParams(
+                query="faq",
+                quotas=quotas,
+                peer_scope="actor",
+                max_tokens=1600,
+            ),
+        )
+        return calls
+
+    resource_calls = await make_calls({"resources": 1})
+    assert resource_calls
+    assert all(call["context_type"] is ContextType.RESOURCE for call in resource_calls)
+
+    skill_calls = await make_calls({"skills": 1})
+    assert skill_calls
+    assert all(call["context_type"] is ContextType.SKILL for call in skill_calls)
+
+    memory_calls = await make_calls({"events": 1})
+    assert memory_calls
+    assert all(call["context_type"] is ContextType.MEMORY for call in memory_calls)
+
+
 async def test_purpose_quotas_are_not_truncated_by_global_limit():
     async def fake_find(**kwargs):
         target_uri = kwargs["target_uri"]

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -758,6 +758,94 @@ async def test_search_combines_context_type_list_with_existing_filter(
     }
 
 
+async def test_find_with_single_context_type_passes_typed_context_type(
+    client: httpx.AsyncClient, service, monkeypatch
+):
+    from openviking_cli.retrieve.types import ContextType
+
+    captured = {}
+
+    async def fake_find(*, context_type=None, **kwargs):
+        captured["context_type"] = context_type
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample", "context_type": "resource"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["context_type"] == ContextType.RESOURCE
+
+
+async def test_search_with_single_context_type_passes_typed_context_type(
+    client: httpx.AsyncClient, service, monkeypatch
+):
+    from openviking_cli.retrieve.types import ContextType
+
+    captured = {}
+
+    async def fake_search(*, context_type=None, **kwargs):
+        captured["context_type"] = context_type
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "search", fake_search)
+
+    resp = await client.post(
+        "/api/v1/search/search",
+        json={"query": "sample", "context_type": "memory"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["context_type"] == ContextType.MEMORY
+
+
+async def test_find_with_multi_context_type_leaves_typed_context_type_unset(
+    client: httpx.AsyncClient, service, monkeypatch
+):
+    captured = {}
+
+    async def fake_find(*, context_type=None, **kwargs):
+        captured["context_type"] = context_type
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample", "context_type": ["memory", "resource"]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["context_type"] is None
+
+
+async def test_find_without_context_type_passes_none(
+    client: httpx.AsyncClient, service, monkeypatch
+):
+    captured = {}
+
+    async def fake_find(*, context_type=None, **kwargs):
+        captured["context_type"] = context_type
+        return {"items": []}
+
+    monkeypatch.setattr(service.search, "find", fake_find)
+
+    resp = await client.post(
+        "/api/v1/search/find",
+        json={"query": "sample"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert captured["context_type"] is None
+
+
 async def test_search_compiles_tags_only_filter(client: httpx.AsyncClient, service, monkeypatch):
     captured = {}
 

--- a/tests/unit/test_search_filters.py
+++ b/tests/unit/test_search_filters.py
@@ -5,8 +5,9 @@ from datetime import datetime, timezone
 
 import pytest
 
-from openviking.utils.search_filters import merge_time_filter
+from openviking.utils.search_filters import merge_time_filter, resolve_single_context_type
 from openviking.utils.time_utils import parse_iso_datetime
+from openviking_cli.retrieve.types import ContextType
 
 
 def test_merge_time_filter_builds_relative_range():
@@ -119,3 +120,28 @@ def test_merge_time_filter_date_only_uses_now_timezone():
 
     assert result["gte"].endswith("Z")
     assert result["lte"].endswith("Z")
+
+
+def test_resolve_single_context_type_returns_none_when_absent():
+    assert resolve_single_context_type(None) is None
+
+
+def test_resolve_single_context_type_resolves_single_string():
+    assert resolve_single_context_type("resource") is ContextType.RESOURCE
+
+
+def test_resolve_single_context_type_resolves_single_enum():
+    assert resolve_single_context_type(ContextType.SKILL) is ContextType.SKILL
+
+
+def test_resolve_single_context_type_returns_none_for_list_of_two():
+    assert resolve_single_context_type(["memory", "resource"]) is None
+
+
+def test_resolve_single_context_type_resolves_single_item_list():
+    assert resolve_single_context_type(["memory"]) is ContextType.MEMORY
+
+
+def test_resolve_single_context_type_rejects_invalid_value():
+    with pytest.raises(ValueError, match="context_type must be one or more of"):
+        resolve_single_context_type("archive")


### PR DESCRIPTION
## Summary

`/api/v1/search/find` and `/api/v1/search/search` accept a `context_type` field, but it only ever became a `scope_dsl` result filter — `TypedQuery.context_type` stayed hardcoded to `None`, so `HierarchicalRetriever.record_query()` always classified queries as `unknown` in the retrieval observer stats (`GET /api/v1/observer/retrieval`), even when the request or a context-assembly bucket search already knew the single type it wanted.

## Fix

Thread a resolved single `ContextType` from the request down to `TypedQuery.context_type`:

- `openviking/utils/search_filters.py`: add `resolve_single_context_type()`, returning a `ContextType` only when exactly one type was requested. Multi-type requests (e.g. `["memory", "resource"]`) return `None` here and keep `scope_dsl` filtering as the source of truth for results — `TypedQuery.context_type` is a single value, not a list, so it can't represent them and stays unclassified in observer stats (matches the "acceptable, documented limitation" called out in the issue).
- `openviking/server/routers/search.py`: add `_typed_context_type()` and pass it to `service.search.find`/`service.search.search` for `/find` and `/search` (`mode="list"`).
- `openviking/service/search_service.py`: accept and forward `context_type` through to `viking_fs.find`/`viking_fs.search`.
- `openviking/storage/viking_fs/_semantic.py`: populate `TypedQuery.context_type` in `find()` and in the no-session/no-intent fallback branch of `search()`. The image-query fallback and the intent-assigned branches (via `IntentAnalyzer`/`QueryPlan`) are left untouched — they already classify themselves (image queries default to `RESOURCE` downstream in `HierarchicalRetriever.retrieve()`; intent-assigned queries set their own type per query).
- `openviking/retrieve/context_assembler/gather.py`: `gather_bucket()` already resolves a `ContextType` per bucket (`resources` → `RESOURCE`, `skills` → `SKILL`, else `MEMORY`) to build the `scope_dsl` filter — now it also passes that type through to `TypedQuery`, so `mode="context"` bucket searches classify correctly in observer stats too. `gather_flat()` (used when no quotas are given) has no single bucket to attribute a query to, so it's left as `None` by design.

I checked `examples/dsh-memory-plugin` mentioned in the original issue write-up (`viking_search`, `recallContextType`/`OPENVIKING_RECALL_CONTEXT_TYPE`) — none of that exists in the current plugin code, so that part of the original report is stale and out of scope here.

## Tests

Added regression tests at each layer, confirming `context_type` reaches `TypedQuery` for single-type requests and stays `None` for multi-type ones:

- `tests/unit/test_search_filters.py`: unit tests for `resolve_single_context_type()`.
- `tests/server/test_api_search.py`: HTTP-level tests asserting `service.search.find`/`.search` receive the typed `ContextType` for `/find` and `/search`, and `None` for multi-type or absent `context_type`.
- `tests/misc/test_vikingfs_find_without_rerank.py`: `VikingFS.find()` forwards `context_type` into `TypedQuery`.
- `tests/misc/test_retrieval_enable_intent.py`: `VikingFS.search()` forwards `context_type` into the no-session/no-intent fallback `TypedQuery`.
- `tests/retrieve/test_context_assembler_pipeline.py`: `gather_candidates()`/`assemble_context()` pass the correct per-bucket `ContextType` (`resources`/`skills`/memory categories) down to `service.search.find`.

Ran the full affected test set: `pytest tests/unit/test_search_filters.py tests/server/test_api_search.py tests/misc/test_retrieval_enable_intent.py tests/misc/test_vikingfs_find_without_rerank.py tests/retrieve/test_context_assembler_pipeline.py` — 104 passed.

Also ran the broader `tests/server/ tests/retrieve/ tests/service/ tests/unit/ tests/misc/ tests/cli/test_cli_search.py` sweep on both this branch and a clean `main` checkout to confirm no regressions — the same 135 tests fail in both (pre-existing environment gaps in this sandbox unrelated to this change, e.g. missing native/service dependencies), and the failure sets are identical.

Fixes #4090