### PR TITLE
docs: document ov get raw download

### DIFF
--- a/docs/en/api/12-content.md
+++ b/docs/en/api/12-content.md
@@ -453,6 +453,12 @@ curl --get http://localhost:1933/api/v1/content/download \
   --output logo.png
 ```
 
+**CLI**
+
+```bash
+ov get viking://resources/images/logo.png ./logo.png
+```
+
 **Response**
 
 On success, the endpoint returns HTTP `200` with the raw file bytes instead of the standard JSON envelope:
@@ -465,7 +471,7 @@ Content-Disposition: attachment; filename*=UTF-8''logo.png
 <binary body>
 ```
 
-The public SDKs and CLI do not currently expose a dedicated raw-byte download method, so this section shows only the HTTP tab.
+`ov get <uri> <local-path>` downloads through the HTTP API above and writes the file to a local path. The Python, TypeScript, and Go SDKs do not currently expose a dedicated raw-byte download method.
 
 ---
 

--- a/docs/zh/api/12-content.md
+++ b/docs/zh/api/12-content.md
@@ -453,6 +453,12 @@ curl --get http://localhost:1933/api/v1/content/download \
   --output logo.png
 ```
 
+**CLI**
+
+```bash
+ov get viking://resources/images/logo.png ./logo.png
+```
+
 **响应**
 
 成功时返回 HTTP `200` 和文件原始字节，不使用标准 JSON 响应包：
@@ -465,7 +471,7 @@ Content-Disposition: attachment; filename*=UTF-8''logo.png
 <binary body>
 ```
 
-公共 SDK 和 CLI 当前没有独立的原始字节下载方法，因此本节只展示 HTTP Tab。
+`ov get <uri> <local-path>` 通过上述 HTTP API 下载文件并写入本地路径。Python、TypeScript 和 Go SDK 当前没有独立的原始字节下载方法。
 
 ---
 


### PR DESCRIPTION
Clarify that `ov get <uri> <local-path>` wraps `GET /api/v1/content/download`, add CLI examples in Chinese and English, and retain the SDK limitation.