### PR TITLE
fix: delete account remain data in filesystem

### DIFF
--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -335,24 +335,14 @@ async def delete_account(
     """Delete an account and cascade-clean its storage (AGFS + VectorDB)."""
     manager = _get_api_key_manager(request)
 
-    # Build a ROOT-level context scoped to the target account for cleanup
-    cleanup_ctx = RequestContext(
-        user=UserIdentifier(account_id, "system"),
-        role=Role.ROOT,
-    )
-
-    # Cascade: remove AGFS data for the account
+    # Cascade: remove AGFS data for the account.
+    # Use the raw AGFS path to bypass the VikingFS namespace guard
+    # (viking://user is a protected namespace root, not a real directory).
     viking_fs = get_viking_fs()
-    account_prefixes = [
-        "viking://user/",
-        "viking://resources/",
-        "viking://upload/",
-    ]
-    for prefix in account_prefixes:
-        try:
-            await viking_fs.rm(prefix, recursive=True, ctx=cleanup_ctx)
-        except Exception as e:
-            logger.warning(f"AGFS cleanup for {prefix} in account {account_id}: {e}")
+    try:
+        await viking_fs._async_agfs.rm(f"/local/{account_id}", recursive=True)
+    except Exception as e:
+        logger.warning(f"AGFS cleanup for account {account_id}: {e}")
 
     # Cascade: remove VectorDB records for the account
     try:


### PR DESCRIPTION
## Description

`ov admin delete-account` threw `PermissionDeniedError` when calling `viking_fs.rm("viking://user/", recursive=True)` because `_ensure_supported_delete_namespace` unconditionally blocks deletion of the `viking://user` namespace root. The exception was swallowed by `try/except`, leaving account metadata deleted from `accounts.json` but all filesystem data intact.

Fix: use `_async_agfs.rm("/local/{account_id}", recursive=True)` directly to bypass the namespace guard.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/server/routers/admin.py` — `delete_account` endpoint: replace 3 `viking_fs.rm()` calls (`viking://user/`, `viking://resources/`, `viking://upload/`) with a single `_async_agfs.rm("/local/{account_id}", recursive=True)`
- Remove now-unnecessary `cleanup_ctx` variable
- Net: -10 lines

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- 权限不变：`@require_auth_root` 仍在校验。
- `accounts.json` 不受影响：`/local/_system/accounts.json` 在 account 目录外。
- 现在也正确删除了 `_system/users.json`，此前该文件不在 `viking://user/` 或 `viking://resources/` 下，属于漏删。