### PR TITLE
fix(embedder): refresh async client after gateway 5xx

### DIFF
--- a/openviking/models/embedder/base.py
+++ b/openviking/models/embedder/base.py
@@ -21,6 +21,7 @@ from openviking.utils.model_retry import (
     classify_api_error,
     retry_async,
     retry_sync,
+    is_stale_gateway_error,
 )
 from openviking_cli.utils import get_logger
 
@@ -255,7 +256,28 @@ class EmbedderBase(ABC):
             operation_name=operation_name,
         )
 
-    async def _run_with_async_retry(
+
+    async def _refresh_async_clients_after_gateway_error(self, error: Exception) -> None:
+        """Drop cached async HTTP clients after gateway 5xx so retries use fresh connections."""
+        if not is_stale_gateway_error(error):
+            return
+
+        from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
+
+        caches: list[LoopScopedAsyncClientCache] = []
+        for attr in (
+            "_async_client_cache",
+            "_async_openai_client_cache",
+            "_async_httpx_client_cache",
+        ):
+            cache = getattr(self, attr, None)
+            if isinstance(cache, LoopScopedAsyncClientCache):
+                caches.append(cache)
+
+        for cache in caches:
+            await cache.invalidate_current()
+
+        async def _run_with_async_retry(
         self,
         func: Callable[[], Awaitable[T]],
         *,
@@ -296,6 +318,7 @@ class EmbedderBase(ABC):
             max_retries=self.max_retries,
             logger=logger,
             operation_name=operation_name,
+            on_retry=self._refresh_async_clients_after_gateway_error,
         )
 
     @property

--- a/openviking/models/embedder/jina_embedders.py
+++ b/openviking/models/embedder/jina_embedders.py
@@ -218,9 +218,8 @@ class JinaDenseEmbedder(DenseEmbedderBase):
             raise RuntimeError(f"Embedding failed: {str(e)}") from e
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _call() -> EmbedResult:
+            client = self._get_async_client()
             response = await client.embeddings.create(**self._build_kwargs(text, is_query=is_query))
             return EmbedResult(dense_vector=response.data[0].embedding)
 

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -339,9 +339,8 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             raise RuntimeError(f"Embedding failed: {str(e)}") from e
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _call() -> EmbedResult:
+            client = self._get_async_client()
             response = await client.embeddings.create(**self._build_kwargs(text, is_query=is_query))
             self._update_telemetry_token_usage(response)
             return EmbedResult(dense_vector=self._truncate_vector(response.data[0].embedding))

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -227,9 +227,8 @@ class VolcengineDenseEmbedder(DenseEmbedderBase):
         )
 
     async def embed_async(self, content: "EmbeddingInput", is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _embed_call() -> EmbedResult:
+            client = self._get_async_client()
             if self.input_type == "multimodal":
                 response = await client.multimodal_embeddings.create(
                     input=to_multimodal_input(content),
@@ -380,9 +379,8 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         )
 
     async def embed_async(self, content: "EmbeddingInput", is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _embed_call() -> EmbedResult:
+            client = self._get_async_client()
             response = await client.multimodal_embeddings.create(
                 input=to_multimodal_input(content),
                 model=self.model_name,
@@ -540,9 +538,8 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
         )
 
     async def embed_async(self, content: "EmbeddingInput", is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _embed_call() -> EmbedResult:
+            client = self._get_async_client()
             response = await client.multimodal_embeddings.create(
                 input=to_multimodal_input(content),
                 model=self.model_name,

--- a/openviking/models/embedder/voyage_embedders.py
+++ b/openviking/models/embedder/voyage_embedders.py
@@ -130,9 +130,8 @@ class VoyageDenseEmbedder(DenseEmbedderBase):
             raise RuntimeError(f"Embedding failed: {str(e)}") from e
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
-        client = self._get_async_client()
-
         async def _call() -> EmbedResult:
+            client = self._get_async_client()
             response = await client.embeddings.create(**self._build_kwargs(text))
             return EmbedResult(dense_vector=response.data[0].embedding)
 

--- a/openviking/utils/async_client_cache.py
+++ b/openviking/utils/async_client_cache.py
@@ -72,6 +72,34 @@ class LoopScopedAsyncClientCache:
                 self._clients_by_loop[loop] = client
             return client
 
+    def pop_current(self) -> Any | None:
+        """Remove and return the client for the current loop (or fallback)."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            with self._lock:
+                client = self._fallback_client
+                self._fallback_client = None
+                return client
+
+        with self._lock:
+            return self._clients_by_loop.pop(loop, None)
+
+    async def invalidate_current(
+        self, close_client: Callable[[Any], Any] = _aclose_client
+    ) -> None:
+        """Drop the current-loop client and close it so the next get() rebuilds.
+
+        Used after gateway 5xx responses that leave keep-alive connections pinned
+        to a failed upstream backend while the TCP connection remains reusable.
+        """
+        client = self.pop_current()
+        if client is None:
+            return
+        result = close_client(client)
+        if inspect.isawaitable(result):
+            await result
+
     def has_clients(self) -> bool:
         """Return whether the cache currently retains any clients."""
 

--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import random
 import re
@@ -365,6 +366,41 @@ def retry_sync(
             attempt += 1
 
 
+
+def _extract_http_status_code(error: BaseException) -> int | None:
+    """Best-effort HTTP status extraction from SDK / httpx-shaped errors."""
+    for item in _iter_exception_chain(error):
+        status_code = getattr(item, "status_code", None)
+        if status_code is None and hasattr(item, "response"):
+            status_code = getattr(item.response, "status_code", None)
+        try:
+            if status_code is not None:
+                return int(status_code)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def is_stale_gateway_error(error: Exception) -> bool:
+    """Return True for gateway errors that may poison keep-alive connection pools.
+
+    502/503/504 are valid HTTP responses on an otherwise healthy TCP connection,
+    so httpx/OpenAI clients can keep reusing the same pooled connection after the
+    upstream recovers. Callers should drop and recreate the async client before retry.
+    """
+    status = _extract_http_status_code(error)
+    if status in (502, 503, 504):
+        return True
+    text = str(error or "")
+    if not text:
+        return False
+    text_lower = text.lower()
+    text_compact = re.sub(r"\s+", "", text_lower)
+    return any(
+        _pattern_matches(text_lower, text_compact, code) for code in ("502", "503", "504")
+    )
+
+
 async def retry_async(
     func: Callable[[], Awaitable[T]],
     *,
@@ -373,6 +409,7 @@ async def retry_async(
     max_delay: float = 8.0,
     jitter: bool = True,
     is_retryable: Callable[[Exception], bool] = is_retryable_api_error,
+    on_retry: Callable[[Exception], Awaitable[None] | None] | None = None,
     logger=None,
     operation_name: str = "operation",
 ) -> T:
@@ -401,6 +438,10 @@ async def retry_async(
                     e,
                     delay,
                 )
+            if on_retry is not None:
+                maybe = on_retry(e)
+                if inspect.isawaitable(maybe):
+                    await maybe
             await asyncio.sleep(delay)
             attempt += 1
 

--- a/tests/unit/test_async_client_cache.py
+++ b/tests/unit/test_async_client_cache.py
@@ -59,3 +59,32 @@ def test_loop_scoped_async_client_cache_copies_without_live_clients():
     assert cache.has_clients()
     assert not shallow.has_clients()
     assert not deep.has_clients()
+
+def test_invalidate_current_drops_client_for_rebuild():
+    cache = LoopScopedAsyncClientCache()
+    created = []
+    closed = []
+
+    class Client:
+        def aclose(self):
+            closed.append(self)
+            return None
+
+    def build_client():
+        client = Client()
+        created.append(client)
+        return client
+
+    async def run():
+        first = cache.get(build_client)
+        second = cache.get(build_client)
+        assert first is second
+        await cache.invalidate_current()
+        third = cache.get(build_client)
+        return first, third
+
+    first, third = asyncio.run(run())
+    assert first is not third
+    assert first in closed
+    assert len(created) == 2
+

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -250,3 +250,44 @@ def test_numeric_status_code_with_compact_error_code_context_still_matches():
     assert classify_api_error(RuntimeError("Error code:413-Payload Too Large")) == (
         ERROR_CLASS_INPUT_TOO_LARGE
     )
+
+def test_is_stale_gateway_error_detects_status_codes():
+    from openviking.utils.model_retry import is_stale_gateway_error
+
+    class FakeHTTPError(Exception):
+        def __init__(self, status_code: int):
+            self.status_code = status_code
+            super().__init__(f"HTTP {status_code}")
+
+    assert is_stale_gateway_error(FakeHTTPError(502))
+    assert is_stale_gateway_error(FakeHTTPError(503))
+    assert is_stale_gateway_error(FakeHTTPError(504))
+    assert not is_stale_gateway_error(FakeHTTPError(429))
+    assert not is_stale_gateway_error(Exception("unrelated failure"))
+
+
+def test_retry_async_invokes_on_retry_before_next_attempt():
+    import asyncio
+    from openviking.utils.model_retry import retry_async
+
+    calls = {"n": 0, "retries": 0}
+
+    async def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            err = Exception("gateway 502 bad gateway")
+            err.status_code = 502  # type: ignore[attr-defined]
+            raise err
+        return "ok"
+
+    async def on_retry(error):
+        calls["retries"] += 1
+        assert getattr(error, "status_code") == 502
+
+    async def run():
+        return await retry_async(flaky, max_retries=2, on_retry=on_retry, base_delay=0.01, jitter=False)
+
+    assert asyncio.run(run()) == "ok"
+    assert calls["n"] == 2
+    assert calls["retries"] == 1
+


### PR DESCRIPTION
## Summary

Async embedding clients cache keep-alive connections. After a gateway returns 502/503/504, those pooled connections can stay pinned to a failed upstream backend even after the gateway recovers, so find/search keeps failing until process restart.

This change:

1. Adds `LoopScopedAsyncClientCache.invalidate_current()` to drop/close the current-loop client
2. Detects stale gateway errors (`is_stale_gateway_error`)
3. On async embedder retry, refreshes cached clients before the next attempt
4. Moves async client acquisition inside the retried call for OpenAI/Jina/Voyage/Volcengine embedders so retries actually pick up the new client

Fixes #4116

## Testing plan

- [x] Unit: `test_invalidate_current_drops_client_for_rebuild`
- [x] Unit: `test_is_stale_gateway_error_detects_status_codes`
- [x] Unit: `test_retry_async_invokes_on_retry_before_next_attempt`
- [ ] Reproduce gateway 502 then recovery; confirm find/search self-heals without process restart
