### PR TITLE
fix(feishu): support legacy doc imports

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -47,7 +47,7 @@ OpenViking supports various resource types, categorized by functionality:
 
 | Type | Description |
 |------|-------------|
-| Feishu/Lark | URL-based, supports docx, wiki, sheets, bitable. By default uses app credentials from FEISHU_APP_ID and FEISHU_APP_SECRET; user-token imports can pass `args.feishu_access_token`, and user-token watches also pass `args.feishu_refresh_token` |
+| Feishu/Lark | URL-based, supports doc/docx, wiki, sheets, bitable. By default uses app credentials from FEISHU_APP_ID and FEISHU_APP_SECRET; user-token imports can pass `args.feishu_access_token`, and user-token watches also pass `args.feishu_refresh_token` |
 
 **Web Pages (recursive web crawler)**
 

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -42,7 +42,7 @@ OpenViking 支持多种资源类型，按照功能分类如下：
 云文档类
 | 类型 | 说明 |
 |------|------|
-| 飞书/Lark | URL 方式，支持 docx, wiki, sheets, bitable。默认使用 FEISHU_APP_ID 和 FEISHU_APP_SECRET 应用凭证；用户 token 导入可传 `args.feishu_access_token`，用户 token watch 还需传 `args.feishu_refresh_token` |
+| 飞书/Lark | URL 方式，支持 doc/docx, wiki, sheets, bitable。默认使用 FEISHU_APP_ID 和 FEISHU_APP_SECRET 应用凭证；用户 token 导入可传 `args.feishu_access_token`，用户 token watch 还需传 `args.feishu_refresh_token` |
 
 网页类（递归网页爬虫）
 | 类型 | 资源名 | 说明 |

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -35,10 +35,19 @@ _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
 _FEISHU_WIKI_NODE_PERMISSION_DENIED = 131006
 _FEISHU_BITABLE_PERMISSION_REQUIRED = 99991672
+_FEISHU_LEGACY_DOC_LOGIN_REQUIRED = 91404
+_FEISHU_PERMISSION_DENIED_CODES = {
+    _FEISHU_DOCUMENT_FORBIDDEN,
+    _FEISHU_WIKI_NODE_PERMISSION_DENIED,
+    91403,
+    95008,
+    95009,
+}
+_FEISHU_NOT_FOUND_CODES = {91402, 95006, 95007}
 _MAX_MEDIA_DOWNLOAD_CONTEXTS = 8
-_FEISHU_DOC_PATH_TYPES = {"docx", "wiki", "sheets", "base"}
+_FEISHU_DOC_PATH_TYPES = {"doc", "docs", "docx", "wiki", "sheets", "base"}
 _FEISHU_DRIVE_DOC_TYPES = {
-    "doc": "docx",
+    "doc": "docs",
     "docx": "docx",
     "sheet": "sheets",
     "sheets": "sheets",
@@ -189,11 +198,14 @@ def _raise_from_lark_response(
             f"Feishu application is missing required Bitable permissions: code={code}, msg={msg}"
         )
     else:
-        public_code = (
-            "PERMISSION_DENIED"
-            if code in {_FEISHU_DOCUMENT_FORBIDDEN, _FEISHU_WIKI_NODE_PERMISSION_DENIED}
-            else error_code_from_http_status(http_status)
-        )
+        if code in _FEISHU_PERMISSION_DENIED_CODES:
+            public_code = "PERMISSION_DENIED"
+        elif code in _FEISHU_NOT_FOUND_CODES:
+            public_code = "NOT_FOUND"
+        elif code == _FEISHU_LEGACY_DOC_LOGIN_REQUIRED:
+            public_code = "UNAUTHENTICATED"
+        else:
+            public_code = error_code_from_http_status(http_status)
         message = f"Feishu {operation} failed: code={code}, msg={msg}"
 
     raise OpenVikingError(message, code=public_code, details=details)
@@ -227,6 +239,7 @@ class FeishuAccessor(DataAccessor):
 
     Supports:
     - Documents: https://*.feishu.cn/docx/{document_id}
+    - Legacy documents: https://*.feishu.cn/docs/{doc_token}
     - Wiki pages: https://*.feishu.cn/wiki/{token}
     - Spreadsheets: https://*.feishu.cn/sheets/{token}
     - Bitable: https://*.feishu.cn/base/{app_token}
@@ -243,8 +256,9 @@ class FeishuAccessor(DataAccessor):
     PRIORITY = 100  # Higher than Git/HTTP, very specific
 
     # Wiki obj_type normalization (API returns short names)
-    _WIKI_TYPE_MAP = {"doc": "docx", "sheet": "sheets", "bitable": "base"}
+    _WIKI_TYPE_MAP = {"doc": "doc", "sheet": "sheets", "bitable": "base"}
     _DOC_TYPE_HANDLERS = {
+        "doc": "_parse_legacy_doc",
         "docx": "_parse_docx",
         "sheets": "_parse_sheets",
         "base": "_parse_bitable",
@@ -573,6 +587,13 @@ class FeishuAccessor(DataAccessor):
         table_id: Optional[str],
         view_id: Optional[str],
     ) -> Optional[str]:
+        if doc_type == "doc":
+            metadata = self._fetch_legacy_doc_metadata(
+                token,
+                feishu_access_token=feishu_access_token,
+            )
+            title = metadata.get("title") or None
+            return _title_as_filename(str(title)) if title else None
         if doc_type == "docx":
             self._probe_docx_document(token, feishu_access_token=feishu_access_token)
             return None
@@ -732,7 +753,7 @@ class FeishuAccessor(DataAccessor):
             return "folder", path_parts[2]
         if path_parts[0] == "file":
             return "file", path_parts[1]
-        doc_type = path_parts[0]  # docx, wiki, sheets, base
+        doc_type = "doc" if path_parts[0] in {"doc", "docs"} else path_parts[0]
         token = path_parts[1]
         return doc_type, token
 
@@ -940,7 +961,7 @@ class FeishuAccessor(DataAccessor):
                 resource=folder_token,
             )
 
-        data = self._drive_response_data(response)
+        data = self._raw_response_data(response)
         items = _getattr_safe(data, "files", None) or _getattr_safe(data, "items", None) or []
         has_more = bool(_getattr_safe(data, "has_more", False))
         next_page_token = _getattr_safe(data, "next_page_token", None) or _getattr_safe(
@@ -1038,7 +1059,7 @@ class FeishuAccessor(DataAccessor):
                 resource=folder_token,
             )
 
-        data = self._drive_response_data(response)
+        data = self._raw_response_data(response)
         folder_meta = _getattr_safe(data, "folder", None) or _getattr_safe(data, "meta", None)
         name = _getattr_safe(data, "name", None) or _getattr_safe(folder_meta, "name", None)
         return str(name) if name else None
@@ -1109,7 +1130,7 @@ class FeishuAccessor(DataAccessor):
         return path
 
     @staticmethod
-    def _drive_response_data(response: Any) -> Any:
+    def _raw_response_data(response: Any) -> Any:
         data = getattr(response, "data", None)
         if data is not None:
             return data
@@ -1136,6 +1157,8 @@ class FeishuAccessor(DataAccessor):
 
     @staticmethod
     def _build_feishu_doc_url(doc_type: str, token: str) -> str:
+        if doc_type == "doc":
+            doc_type = "docs"
         return f"https://open.feishu.cn/{doc_type}/{token}"
 
     @staticmethod
@@ -1305,6 +1328,88 @@ class FeishuAccessor(DataAccessor):
         doc_type = self._WIKI_TYPE_MAP.get(obj_type, obj_type)
 
         return doc_type, obj_token, title
+
+    # ========== Legacy Doc Parsing ==========
+
+    def _parse_legacy_doc(
+        self,
+        doc_token: str,
+        feishu_access_token: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        metadata = self._fetch_legacy_doc_metadata(
+            doc_token,
+            feishu_access_token=feishu_access_token,
+        )
+        title = str(metadata.get("title") or "Untitled")
+        content = self._fetch_legacy_doc_raw_content(
+            doc_token,
+            feishu_access_token=feishu_access_token,
+        ).strip()
+
+        if title and title != "Untitled":
+            markdown = f"# {title}\n\n{content}" if content else f"# {title}"
+        else:
+            markdown = content
+        return markdown, title
+
+    def _fetch_legacy_doc_metadata(
+        self,
+        doc_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        import lark_oapi as lark
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        token_type = (
+            lark.AccessTokenType.USER if feishu_access_token else lark.AccessTokenType.TENANT
+        )
+        request = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri(f"/open-apis/doc/v2/meta/{doc_token}")
+            .token_types({token_type})
+            .build()
+        )
+        response = self._call_api(client.request, request, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"fetch legacy document metadata for {doc_token}",
+                resource=doc_token,
+            )
+        data = self._raw_response_data(response)
+        return data if isinstance(data, dict) else {}
+
+    def _fetch_legacy_doc_raw_content(
+        self,
+        doc_token: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> str:
+        import lark_oapi as lark
+
+        client = self._get_client(use_user_token=bool(feishu_access_token))
+        token_type = (
+            lark.AccessTokenType.USER if feishu_access_token else lark.AccessTokenType.TENANT
+        )
+        request = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri(f"/open-apis/doc/v2/{doc_token}/raw_content")
+            .token_types({token_type})
+            .build()
+        )
+        response = self._call_api(client.request, request, feishu_access_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation=f"fetch legacy document content for {doc_token}",
+                resource=doc_token,
+            )
+        data = self._raw_response_data(response)
+        content = _getattr_safe(data, "content", "")
+        return str(content or "")
 
     # ========== Docx Parsing ==========
 

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -154,6 +154,8 @@ def _install_fake_lark_modules(monkeypatch):
     lark.AccessTokenType = SimpleNamespace(TENANT="tenant", USER="user")
     docx_v1 = ModuleType("lark_oapi.api.docx.v1")
     docx_v1.ListDocumentBlockRequest = _FakeListDocumentBlockRequest
+    wiki_v2 = ModuleType("lark_oapi.api.wiki.v2")
+    wiki_v2.GetNodeSpaceRequest = _FakeTypedRequest
     bitable_v1 = ModuleType("lark_oapi.api.bitable.v1")
     bitable_v1.ListAppTableRequest = _FakeTypedRequest
     bitable_v1.ListAppTableFieldRequest = _FakeTypedRequest
@@ -162,6 +164,7 @@ def _install_fake_lark_modules(monkeypatch):
     core_model.RequestOption = _FakeRequestOption
     monkeypatch.setitem(sys.modules, "lark_oapi", lark)
     monkeypatch.setitem(sys.modules, "lark_oapi.api.docx.v1", docx_v1)
+    monkeypatch.setitem(sys.modules, "lark_oapi.api.wiki.v2", wiki_v2)
     monkeypatch.setitem(sys.modules, "lark_oapi.api.bitable.v1", bitable_v1)
     monkeypatch.setitem(sys.modules, "lark_oapi.core.model", core_model)
 
@@ -173,28 +176,41 @@ def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
             SimpleNamespace(items=[], has_more=False, page_token=None),
         )
     )
-    list_drive = MagicMock(
-        side_effect=[
-            _SuccessResponse(
-                SimpleNamespace(
-                    files=[SimpleNamespace(token="doc_token")],
-                    has_more=True,
-                    next_page_token="page-2",
-                )
-            ),
-            _SuccessResponse(
-                SimpleNamespace(
-                    files=[SimpleNamespace(token="file_token")],
-                    has_more=False,
-                    next_page_token=None,
-                )
-            ),
-        ]
-    )
+    drive_pages = [
+        _SuccessResponse(
+            SimpleNamespace(
+                files=[SimpleNamespace(token="doc_token")],
+                has_more=True,
+                next_page_token="page-2",
+            )
+        ),
+        _SuccessResponse(
+            SimpleNamespace(
+                files=[SimpleNamespace(token="file_token")],
+                has_more=False,
+                next_page_token=None,
+            )
+        ),
+    ]
+
+    def fake_raw_request(request, _option):
+        if request.uri == "/open-apis/drive/v1/files":
+            return drive_pages.pop(0)
+        if request.uri == "/open-apis/doc/v2/meta/doccn_token":
+            return _FakeMediaResponse(
+                content=json.dumps({"data": {"title": "Legacy Doc"}}),
+            )
+        if request.uri == "/open-apis/doc/v2/doccn_token/raw_content":
+            return _FakeMediaResponse(
+                content=json.dumps({"data": {"content": "legacy body"}}),
+            )
+        raise AssertionError(f"Unexpected Feishu raw request: {request.uri}")
+
+    raw_request = MagicMock(side_effect=fake_raw_request)
     accessor = FeishuAccessor()
     accessor._user_token_client = SimpleNamespace(
         docx=SimpleNamespace(v1=SimpleNamespace(document_block=SimpleNamespace(list=list_blocks))),
-        request=list_drive,
+        request=raw_request,
     )
 
     blocks = accessor._fetch_all_blocks("doc_token", feishu_access_token="u-test")
@@ -202,14 +218,23 @@ def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
         "folder_token",
         feishu_access_token="u-test",
     )
+    legacy_markdown, legacy_title = accessor._parse_legacy_doc(
+        "doccn_token",
+        feishu_access_token="u-test",
+    )
 
     assert blocks == []
     assert [child.token for child in children] == ["doc_token", "file_token"]
+    assert legacy_markdown == "# Legacy Doc\n\nlegacy body"
+    assert legacy_title == "Legacy Doc"
     request, option = list_blocks.call_args.args
     assert request.document_id == "doc_token"
     assert option.user_access_token == "u-test"
-    assert list_drive.call_args_list[1].args[0].queries["page_token"] == "page-2"
-    assert all(call.args[1].user_access_token == "u-test" for call in list_drive.call_args_list)
+    drive_calls = [
+        call for call in raw_request.call_args_list if call.args[0].uri == "/open-apis/drive/v1/files"
+    ]
+    assert drive_calls[1].args[0].queries["page_token"] == "page-2"
+    assert all(call.args[1].user_access_token == "u-test" for call in raw_request.call_args_list)
 
 
 def test_resolve_image_refs_respects_download_images_disabled():
@@ -435,6 +460,7 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
     children = {
         "root_folder": [
             SimpleNamespace(token="doc_one", name=long_name, type="docx", url=""),
+            SimpleNamespace(token="doc_legacy", name="Legacy", type="doc", url=""),
             SimpleNamespace(token="doc_two", name=long_name, type="docx", url=""),
             SimpleNamespace(token="nested", name="Nested", type="folder", url=""),
             SimpleNamespace(token="design", name="Design.pdf", type="file", url=""),
@@ -442,8 +468,10 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
         ],
         "nested": [SimpleNamespace(token="sheet", name="Metrics", type="sheet", url="")],
     }
+    fetched_urls = []
 
     async def fake_fetch_document(url, **_kwargs):
+        fetched_urls.append(url)
         doc_type, token = accessor._parse_feishu_url(url)
         return FeishuDocument(
             doc_type=doc_type,
@@ -476,8 +504,10 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
         markdown_files = sorted(resource.path.glob("*.md"))
         assert {path.read_text(encoding="utf-8") for path in markdown_files} == {
             "# doc_one",
+            "# doc_legacy",
             "# doc_two",
         }
+        assert "https://open.feishu.cn/docs/doc_legacy" in fetched_urls
         assert all(len(path.name.encode("utf-8")) <= 240 for path in markdown_files)
         assert any(" (2).md" in path.name for path in markdown_files)
         assert (resource.path / "Nested" / "Metrics.md").read_text(encoding="utf-8") == "# sheet"
@@ -582,8 +612,10 @@ def test_access_writes_downloaded_images_next_to_markdown(monkeypatch):
 
 
 def test_fetch_document_dispatches_all_supported_types(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
     accessor = FeishuAccessor()
     handlers = {
+        "_parse_legacy_doc": MagicMock(return_value=("doc body", "Legacy Doc")),
         "_parse_docx": MagicMock(return_value=("docx body", "Doc")),
         "_parse_sheets": MagicMock(return_value=("sheet body", "Sheet")),
         "_parse_bitable": MagicMock(return_value=("base body", "Base")),
@@ -591,6 +623,42 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     for name, handler in handlers.items():
         monkeypatch.setattr(accessor, name, handler)
 
+    get_wiki_node = MagicMock(
+        return_value=_SuccessResponse(
+            SimpleNamespace(
+                node=SimpleNamespace(
+                    obj_type="doc",
+                    obj_token="doccn_from_wiki",
+                    title="Wiki Legacy",
+                )
+            )
+        )
+    )
+    accessor._user_token_client = SimpleNamespace(
+        wiki=SimpleNamespace(v2=SimpleNamespace(space=SimpleNamespace(get_node=get_wiki_node)))
+    )
+
+    assert accessor._resolve_wiki_node("wiki_token", "u-test") == (
+        "doc",
+        "doccn_from_wiki",
+        "Wiki Legacy",
+    )
+    assert get_wiki_node.call_args.args[1].user_access_token == "u-test"
+    accessor._user_token_client = None
+
+    assert accessor.can_handle("https://example.feishu.cn/doc/doccn_token")
+    assert accessor.can_handle("https://example.feishu.cn/docs/doccn_token")
+    assert accessor._parse_feishu_url("https://example.feishu.cn/docs/doccn_token") == (
+        "doc",
+        "doccn_token",
+    )
+
+    legacy_doc = asyncio.run(
+        accessor._fetch_document(
+            "https://example.feishu.cn/docs/doccn_token",
+            feishu_access_token="u-test",
+        )
+    )
     docx = asyncio.run(
         accessor._fetch_document(
             "https://example.feishu.cn/docx/doc_token",
@@ -602,26 +670,60 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     monkeypatch.setattr(
         accessor,
         "_resolve_wiki_node",
-        MagicMock(return_value=("base", "wiki_app_token", "Wiki Base")),
+        MagicMock(
+            side_effect=[
+                ("doc", "wiki_doccn_token", "Wiki Legacy"),
+                ("base", "wiki_app_token", "Wiki Base"),
+            ]
+        ),
     )
-    wiki = asyncio.run(accessor._fetch_document("https://example.feishu.cn/wiki/wiki_token"))
+    wiki_doc = asyncio.run(
+        accessor._fetch_document(
+            "https://example.feishu.cn/wiki/wiki_doc_token",
+            feishu_access_token="u-test",
+        )
+    )
+    wiki = asyncio.run(
+        accessor._fetch_document(
+            "https://example.feishu.cn/wiki/wiki_token",
+            feishu_access_token="u-test",
+        )
+    )
 
-    assert (docx.doc_type, sheets.doc_type, base.doc_type, wiki.doc_type) == (
+    assert (
+        legacy_doc.doc_type,
+        docx.doc_type,
+        sheets.doc_type,
+        base.doc_type,
+        wiki_doc.doc_type,
+        wiki.doc_type,
+    ) == (
+        "doc",
         "docx",
         "sheets",
         "base",
+        "doc",
         "base",
     )
+    assert legacy_doc.title == "Legacy Doc"
+    assert wiki_doc.title == "Wiki Legacy"
     assert wiki.title == "Wiki Base"
+    handlers["_parse_legacy_doc"].assert_any_call("doccn_token", "u-test")
+    handlers["_parse_legacy_doc"].assert_any_call("wiki_doccn_token", "u-test")
     handlers["_parse_docx"].assert_called_once_with("doc_token", "u-test")
     handlers["_parse_sheets"].assert_called_once_with(
         "sht_token",
         None,
         media_download_extras=sheets.media_download_extras,
     )
-    assert handlers["_parse_bitable"].call_args_list[-1].args == ("wiki_app_token", None)
+    assert handlers["_parse_bitable"].call_args_list[-1].args == ("wiki_app_token", "u-test")
 
     monkeypatch.setattr(accessor, "_probe_docx_document", MagicMock())
+    monkeypatch.setattr(
+        accessor,
+        "_fetch_legacy_doc_metadata",
+        MagicMock(return_value={"title": "Legacy/Title"}),
+    )
     monkeypatch.setattr(
         accessor,
         "_fetch_spreadsheet_metadata",
@@ -640,7 +742,13 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     monkeypatch.setattr(accessor, "_probe_bitable_table", MagicMock())
     monkeypatch.setattr(accessor, "_get_drive_folder_name", MagicMock(return_value="Docs/Root"))
     monkeypatch.setattr(accessor, "_probe_drive_folder_children", MagicMock())
+    monkeypatch.setattr(
+        accessor,
+        "_resolve_wiki_node",
+        MagicMock(return_value=("base", "wiki_app_token", "Wiki Base")),
+    )
 
+    legacy_identity = asyncio.run(accessor.preflight_source("https://example.feishu.cn/doc/doccn"))
     docx_identity = asyncio.run(accessor.preflight_source("https://example.feishu.cn/docx/doc"))
     sheets_identity = asyncio.run(
         accessor.preflight_source("https://example.feishu.cn/sheets/sht")
@@ -654,6 +762,8 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     )
     wiki_identity = asyncio.run(accessor.preflight_source("https://example.feishu.cn/wiki/wiki"))
 
+    assert legacy_identity.doc_type == "doc"
+    assert legacy_identity.source_name == "Legacy_Title"
     assert docx_identity.source_name is None
     assert sheets_identity.source_name == "Sheet_Title"
     assert base_identity.source_name == "Bitable (2 tables)"

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -176,41 +176,28 @@ def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
             SimpleNamespace(items=[], has_more=False, page_token=None),
         )
     )
-    drive_pages = [
-        _SuccessResponse(
-            SimpleNamespace(
-                files=[SimpleNamespace(token="doc_token")],
-                has_more=True,
-                next_page_token="page-2",
-            )
-        ),
-        _SuccessResponse(
-            SimpleNamespace(
-                files=[SimpleNamespace(token="file_token")],
-                has_more=False,
-                next_page_token=None,
-            )
-        ),
-    ]
-
-    def fake_raw_request(request, _option):
-        if request.uri == "/open-apis/drive/v1/files":
-            return drive_pages.pop(0)
-        if request.uri == "/open-apis/doc/v2/meta/doccn_token":
-            return _FakeMediaResponse(
-                content=json.dumps({"data": {"title": "Legacy Doc"}}),
-            )
-        if request.uri == "/open-apis/doc/v2/doccn_token/raw_content":
-            return _FakeMediaResponse(
-                content=json.dumps({"data": {"content": "legacy body"}}),
-            )
-        raise AssertionError(f"Unexpected Feishu raw request: {request.uri}")
-
-    raw_request = MagicMock(side_effect=fake_raw_request)
+    list_drive = MagicMock(
+        side_effect=[
+            _SuccessResponse(
+                SimpleNamespace(
+                    files=[SimpleNamespace(token="doc_token")],
+                    has_more=True,
+                    next_page_token="page-2",
+                )
+            ),
+            _SuccessResponse(
+                SimpleNamespace(
+                    files=[SimpleNamespace(token="file_token")],
+                    has_more=False,
+                    next_page_token=None,
+                )
+            ),
+        ]
+    )
     accessor = FeishuAccessor()
     accessor._user_token_client = SimpleNamespace(
         docx=SimpleNamespace(v1=SimpleNamespace(document_block=SimpleNamespace(list=list_blocks))),
-        request=raw_request,
+        request=list_drive,
     )
 
     blocks = accessor._fetch_all_blocks("doc_token", feishu_access_token="u-test")
@@ -218,23 +205,14 @@ def test_feishu_api_lists_paginated_content_with_user_token(monkeypatch):
         "folder_token",
         feishu_access_token="u-test",
     )
-    legacy_markdown, legacy_title = accessor._parse_legacy_doc(
-        "doccn_token",
-        feishu_access_token="u-test",
-    )
 
     assert blocks == []
     assert [child.token for child in children] == ["doc_token", "file_token"]
-    assert legacy_markdown == "# Legacy Doc\n\nlegacy body"
-    assert legacy_title == "Legacy Doc"
     request, option = list_blocks.call_args.args
     assert request.document_id == "doc_token"
     assert option.user_access_token == "u-test"
-    drive_calls = [
-        call for call in raw_request.call_args_list if call.args[0].uri == "/open-apis/drive/v1/files"
-    ]
-    assert drive_calls[1].args[0].queries["page_token"] == "page-2"
-    assert all(call.args[1].user_access_token == "u-test" for call in raw_request.call_args_list)
+    assert list_drive.call_args_list[1].args[0].queries["page_token"] == "page-2"
+    assert all(call.args[1].user_access_token == "u-test" for call in list_drive.call_args_list)
 
 
 def test_resolve_image_refs_respects_download_images_disabled():
@@ -468,11 +446,11 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
         ],
         "nested": [SimpleNamespace(token="sheet", name="Metrics", type="sheet", url="")],
     }
-    fetched_urls = []
 
     async def fake_fetch_document(url, **_kwargs):
-        fetched_urls.append(url)
         doc_type, token = accessor._parse_feishu_url(url)
+        if token == "doc_legacy":
+            assert doc_type == "doc"
         return FeishuDocument(
             doc_type=doc_type,
             token=token,
@@ -507,7 +485,6 @@ def test_access_materializes_drive_folder_contract(monkeypatch):
             "# doc_legacy",
             "# doc_two",
         }
-        assert "https://open.feishu.cn/docs/doc_legacy" in fetched_urls
         assert all(len(path.name.encode("utf-8")) <= 240 for path in markdown_files)
         assert any(" (2).md" in path.name for path in markdown_files)
         assert (resource.path / "Nested" / "Metrics.md").read_text(encoding="utf-8") == "# sheet"
@@ -615,7 +592,6 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     _install_fake_lark_modules(monkeypatch)
     accessor = FeishuAccessor()
     handlers = {
-        "_parse_legacy_doc": MagicMock(return_value=("doc body", "Legacy Doc")),
         "_parse_docx": MagicMock(return_value=("docx body", "Doc")),
         "_parse_sheets": MagicMock(return_value=("sheet body", "Sheet")),
         "_parse_bitable": MagicMock(return_value=("base body", "Base")),
@@ -623,6 +599,14 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     for name, handler in handlers.items():
         monkeypatch.setattr(accessor, name, handler)
 
+    def raw_doc_response(data):
+        return _FakeMediaResponse(content=json.dumps({"data": data}))
+
+    legacy_responses = {
+        "/open-apis/doc/v2/meta/doccn_token": raw_doc_response({"title": "Legacy Doc"}),
+        "/open-apis/doc/v2/doccn_token/raw_content": raw_doc_response({"content": "doc body"}),
+    }
+    raw_request = MagicMock(side_effect=lambda request, _option: legacy_responses[request.uri])
     get_wiki_node = MagicMock(
         return_value=_SuccessResponse(
             SimpleNamespace(
@@ -635,7 +619,8 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
         )
     )
     accessor._user_token_client = SimpleNamespace(
-        wiki=SimpleNamespace(v2=SimpleNamespace(space=SimpleNamespace(get_node=get_wiki_node)))
+        request=raw_request,
+        wiki=SimpleNamespace(v2=SimpleNamespace(space=SimpleNamespace(get_node=get_wiki_node))),
     )
 
     assert accessor._resolve_wiki_node("wiki_token", "u-test") == (
@@ -643,8 +628,6 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
         "doccn_from_wiki",
         "Wiki Legacy",
     )
-    assert get_wiki_node.call_args.args[1].user_access_token == "u-test"
-    accessor._user_token_client = None
 
     assert accessor.can_handle("https://example.feishu.cn/doc/doccn_token")
     assert accessor.can_handle("https://example.feishu.cn/docs/doccn_token")
@@ -670,53 +653,33 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     monkeypatch.setattr(
         accessor,
         "_resolve_wiki_node",
-        MagicMock(
-            side_effect=[
-                ("doc", "wiki_doccn_token", "Wiki Legacy"),
-                ("base", "wiki_app_token", "Wiki Base"),
-            ]
-        ),
+        MagicMock(return_value=("base", "wiki_app_token", "Wiki Base")),
     )
-    wiki_doc = asyncio.run(
-        accessor._fetch_document(
-            "https://example.feishu.cn/wiki/wiki_doc_token",
-            feishu_access_token="u-test",
-        )
-    )
-    wiki = asyncio.run(
-        accessor._fetch_document(
-            "https://example.feishu.cn/wiki/wiki_token",
-            feishu_access_token="u-test",
-        )
-    )
+    wiki = asyncio.run(accessor._fetch_document("https://example.feishu.cn/wiki/wiki_token"))
 
     assert (
         legacy_doc.doc_type,
         docx.doc_type,
         sheets.doc_type,
         base.doc_type,
-        wiki_doc.doc_type,
         wiki.doc_type,
     ) == (
         "doc",
         "docx",
         "sheets",
         "base",
-        "doc",
         "base",
     )
     assert legacy_doc.title == "Legacy Doc"
-    assert wiki_doc.title == "Wiki Legacy"
+    assert legacy_doc.markdown_content == "# Legacy Doc\n\ndoc body"
     assert wiki.title == "Wiki Base"
-    handlers["_parse_legacy_doc"].assert_any_call("doccn_token", "u-test")
-    handlers["_parse_legacy_doc"].assert_any_call("wiki_doccn_token", "u-test")
     handlers["_parse_docx"].assert_called_once_with("doc_token", "u-test")
     handlers["_parse_sheets"].assert_called_once_with(
         "sht_token",
         None,
         media_download_extras=sheets.media_download_extras,
     )
-    assert handlers["_parse_bitable"].call_args_list[-1].args == ("wiki_app_token", "u-test")
+    assert handlers["_parse_bitable"].call_args_list[-1].args == ("wiki_app_token", None)
 
     monkeypatch.setattr(accessor, "_probe_docx_document", MagicMock())
     monkeypatch.setattr(

--- a/tests/parse/test_feishu_errors.py
+++ b/tests/parse/test_feishu_errors.py
@@ -29,7 +29,7 @@ def _raised_error(response, *, operation="resolve wiki node", resource=None):
     return exc_info.value
 
 
-@pytest.mark.parametrize("feishu_code", [1770032, 131006, 91403, 95008, 95009])
+@pytest.mark.parametrize("feishu_code", [1770032, 131006])
 def test_maps_feishu_forbidden_to_permission_denied_and_keeps_details(feishu_code):
     response = _fake_response(
         code=feishu_code,
@@ -67,28 +67,20 @@ def test_maps_missing_bitable_scope_without_parsing_message():
 
 
 @pytest.mark.parametrize(
-    ("feishu_code", "http_status", "error_code"),
+    ("http_status", "error_code"),
     [
-        (123, 401, "UNAUTHENTICATED"),
-        (123, 404, "NOT_FOUND"),
-        (123, 429, "RESOURCE_EXHAUSTED"),
-        (123, 500, "UNAVAILABLE"),
-        (123, 400, "INVALID_ARGUMENT"),
-        (91402, 200, "NOT_FOUND"),
-        (95006, 200, "NOT_FOUND"),
-        (95007, 200, "NOT_FOUND"),
-        (91404, 200, "UNAUTHENTICATED"),
+        (401, "UNAUTHENTICATED"),
+        (404, "NOT_FOUND"),
+        (429, "RESOURCE_EXHAUSTED"),
+        (500, "UNAVAILABLE"),
+        (400, "INVALID_ARGUMENT"),
     ],
 )
-def test_maps_provider_or_http_status_to_openviking_error(
-    feishu_code,
-    http_status,
-    error_code,
-):
-    response = _fake_response(code=feishu_code, msg="failed", http_status=http_status)
+def test_maps_http_status_to_openviking_error(http_status, error_code):
+    response = _fake_response(code=123, msg="failed", http_status=http_status)
 
     exc = _raised_error(response)
 
     assert exc.code == error_code
-    assert exc.details["feishu_code"] == feishu_code
+    assert exc.details["feishu_code"] == 123
     assert exc.details["http_status"] == http_status

--- a/tests/parse/test_feishu_errors.py
+++ b/tests/parse/test_feishu_errors.py
@@ -29,7 +29,7 @@ def _raised_error(response, *, operation="resolve wiki node", resource=None):
     return exc_info.value
 
 
-@pytest.mark.parametrize("feishu_code", [1770032, 131006])
+@pytest.mark.parametrize("feishu_code", [1770032, 131006, 91403, 95008, 95009])
 def test_maps_feishu_forbidden_to_permission_denied_and_keeps_details(feishu_code):
     response = _fake_response(
         code=feishu_code,
@@ -67,20 +67,28 @@ def test_maps_missing_bitable_scope_without_parsing_message():
 
 
 @pytest.mark.parametrize(
-    ("http_status", "error_code"),
+    ("feishu_code", "http_status", "error_code"),
     [
-        (401, "UNAUTHENTICATED"),
-        (404, "NOT_FOUND"),
-        (429, "RESOURCE_EXHAUSTED"),
-        (500, "UNAVAILABLE"),
-        (400, "INVALID_ARGUMENT"),
+        (123, 401, "UNAUTHENTICATED"),
+        (123, 404, "NOT_FOUND"),
+        (123, 429, "RESOURCE_EXHAUSTED"),
+        (123, 500, "UNAVAILABLE"),
+        (123, 400, "INVALID_ARGUMENT"),
+        (91402, 200, "NOT_FOUND"),
+        (95006, 200, "NOT_FOUND"),
+        (95007, 200, "NOT_FOUND"),
+        (91404, 200, "UNAUTHENTICATED"),
     ],
 )
-def test_maps_http_status_to_openviking_error(http_status, error_code):
-    response = _fake_response(code=123, msg="failed", http_status=http_status)
+def test_maps_provider_or_http_status_to_openviking_error(
+    feishu_code,
+    http_status,
+    error_code,
+):
+    response = _fake_response(code=feishu_code, msg="failed", http_status=http_status)
 
     exc = _raised_error(response)
 
     assert exc.code == error_code
-    assert exc.details["feishu_code"] == 123
+    assert exc.details["feishu_code"] == feishu_code
     assert exc.details["http_status"] == http_status


### PR DESCRIPTION
## Description

修复旧版飞书 Docs 文档被当成新版 Docx 处理的问题。

### Before

当 Feishu Wiki 节点解析结果是 `obj_type=doc`、`obj_token=doccn...` 时，OpenViking 会把 `doc` 归一化成 `docx`，随后用 `doccn...` 调用新版 Docx blocks API。飞书会返回 `1770002 not found`，资源处理失败。

同一个问题也影响 Drive 文件夹中的旧版 `doc` 项，以及用户直接导入 `/doc/...` 或 `/docs/...` URL 的场景。

### After

旧版 `doc` 保持为独立内部类型，不再进入 `docx` 路径。旧版文档通过 `/open-apis/doc/v2/{docToken}/raw_content` 读取纯文本内容；新版 `docx` 仍使用原来的 blocks API。

### Example

输入：Wiki 节点解析得到 `obj_type=doc`、`obj_token=doccnABC`

- 修改前：`doccnABC` 被当成 `docx` document_id，调用 Docx blocks API，导入失败。
- 修改后：`doccnABC` 作为旧版 doc token，调用 Doc v2 raw_content API，导入成功。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4115

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 保留飞书旧版 `doc` 类型，并新增旧版 doc raw_content 读取路径。
- 支持 `/doc/...`、`/docs/...` URL，以及 Drive 文件夹中的 `type=doc` 项。
- 补充旧版 doc 相关错误码映射和 Feishu 资源文档说明。

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

- `uv run ruff check openviking/parse/accessors/feishu_accessor.py tests/parse/test_feishu_accessor.py tests/parse/test_feishu_errors.py`
- `uv run pytest tests/parse/test_feishu_accessor.py tests/parse/test_feishu_errors.py`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

旧版 `doc` 使用飞书 raw_content 接口，只提供纯文本内容；新版 `docx` 的 blocks 解析能力不变。
