### PR TITLE
Fix: fall back to self space when memory ranges resolve to no writable target

### DIFF
--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -261,6 +261,17 @@ class MemoryIsolationHandler:
                 fallback_target = self._unique_target_id_in_messages()
                 if fallback_target:
                     target_ids = [fallback_target]
+            if not target_ids and self.allow_self:
+                # Last-resort fallback: unresolved ranges (invalid, out of bounds, or
+                # pointing only at non-writable peers) must not silently drop the
+                # memory. Persist it to the session owner's own space instead.
+                logger.warning(
+                    "Memory ranges %r resolved to no writable target for memory_type=%s; "
+                    "falling back to self space",
+                    operation.memory_fields.get("ranges"),
+                    getattr(memory_type_schema, "memory_type", ""),
+                )
+                target_ids = [_SELF_PEER_ID]
             operation.memory_fields.pop("peer_id", None)
         else:
             target_id = self._resolve_operation_target_id(

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -842,6 +842,76 @@ class TestCalculateMemoryUris:
         mock_generate_uri.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_ranges_with_foreign_peer_fall_back_to_self_when_allowed(self, mock_generate_uri):
+        """Ranges resolving to no writable target fall back to self space (issue #4131)."""
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="user_a")
+        messages = [
+            create_message("user", "foreign peer event", peer_id="some-foreign-peer"),
+        ]
+        extract_ctx = create_mock_extract_context(messages)
+        mock_range = MagicMock()
+        mock_range.elements = [[messages[0]]]
+        extract_ctx.read_message_ranges.return_value = mock_range
+        handler = MemoryIsolationHandler(ctx, extract_ctx)
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": "0"},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/user_a/memories/events/demo"]
+        assert "peer_id" not in operation.memory_fields
+
+    @pytest.mark.parametrize("ranges", ["99", "0,99", "invalid"])
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
+    def test_unresolvable_ranges_fall_back_to_self_when_allowed(
+        self, mock_generate_uri, ranges
+    ):
+        """Invalid or out-of-bounds ranges fall back to self space instead of dropping."""
+        mock_generate_uri.side_effect = lambda **kwargs: (
+            f"viking://user/{kwargs.get('user_space')}/memories/events/demo"
+        )
+
+        ctx = create_ctx(user_id="user_a")
+        messages = [create_message("user", "self event")]
+        extract_ctx = ExtractContext(messages, split_long_text_messages=False)
+        handler = MemoryIsolationHandler(ctx, extract_ctx)
+
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        schema = MemoryTypeSchema(
+            memory_type="events",
+            filename_template="demo.md",
+            directory="viking://user/{user_space}/memories/events",
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"event_name": "demo", "ranges": ranges},
+            memory_type="events",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
+
+        assert uris == ["viking://user/user_a/memories/events/demo"]
+        assert "peer_id" not in operation.memory_fields
+
+    @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_calculate_memory_uris_unallowed_peer_id_does_not_fallback(self, mock_generate_uri):
         mock_generate_uri.side_effect = lambda **kwargs: (
             f"viking://user/{kwargs.get('user_space')}/memories/preferences"

--- a/tests/session/memory/test_memory_timestamp_parsing.py
+++ b/tests/session/memory/test_memory_timestamp_parsing.py
@@ -159,7 +159,10 @@ def test_peer_id_routes_peer_memory_for_all_role_selected_types(stub_provider_co
     ]
 
 
-def test_peer_id_range_does_not_route_without_allowed_peer_ids(stub_provider_config):
+def test_peer_id_range_falls_back_to_self_without_allowed_peer_ids(stub_provider_config):
+    # Issue #4131: ranges that resolve to no writable peer must not silently drop
+    # the memory; they fall back to the session owner's self space (never routed
+    # to another peer's space).
     messages = [
         Message(
             id="msg-peer",
@@ -190,7 +193,7 @@ def test_peer_id_range_does_not_route_without_allowed_peer_ids(stub_provider_con
         extract_context,
     )
 
-    assert profile_uris == []
+    assert profile_uris == ["viking://user/support_bot/memories/profile.md"]
 
 
 def test_deserialize_full_parses_memory_metadata_timestamps_with_z_suffix():


### PR DESCRIPTION
## Description

Fixes the silent memory drop reported in #4131. When an extracted memory operation carries `ranges` that resolve to no writable target (e.g. messages from a foreign peer that is not in `allowed_peer_ids`, or invalid/out-of-bounds ranges), `MemoryIsolationHandler.calculate_memory_uris()` returned an empty list. `MemoryUpdater.apply_operations()` then skipped the operation with only a `Missing resolved URI` log entry, while upper-layer `remember` / `add-memory` APIs still reported success — the memory was silently dropped and no file was generated under `memories/`.

This PR implements the fallback option from the issue's expected behavior: as a last resort in the ranges branch, when no writable target resolves and self writes are allowed, the memory is persisted to the session owner's own space (`__self` target) instead of being dropped.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4131

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/session/memory/memory_isolation_handler.py`: in the ranges branch of `calculate_memory_uris()`, after the existing fallback logic, fall back to the `_SELF_PEER_ID` target when `target_ids` is still empty and `allow_self` is true (with a warning log). Deliberately unchanged: operations with an explicit unallowed/invalid `peer_id` still return `[]` (per existing tests), and `allow_self=False` deployments keep the previous behavior.
- `tests/session/memory/test_memory_isolation_handler.py`: added tests covering the issue scenario (ranges pointing at a foreign peer fall back to self space) and unresolvable ranges (invalid / out-of-bounds fall back to self space, parametrized).
- `tests/session/memory/test_memory_timestamp_parsing.py`: updated `test_peer_id_range_does_not_route_without_allowed_peer_ids` (renamed to `test_peer_id_range_falls_back_to_self_without_allowed_peer_ids`), which asserted the exact drop behavior reported as a bug in #4131; it now asserts the fallback routes to the owner's self space and never to another peer's space.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Reproduced the issue scenario from #4131 (a `user` message with a foreign `peer_id` + an `events` memory with `ranges: "0"`): before the fix `calculate_memory_uris()` returned `[]` (memory dropped), after the fix it resolves to `viking://user/<user>/memories/events/<date>_<event>.md` in the owner's space.

`pytest tests/session/memory`: identical failure set before and after the change (56 pre-existing failures, all caused by the missing local `ov.conf` config in this environment, unrelated to this change); 4 new tests pass.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

## Additional Notes

`MemoryUpdater.apply_operations()` still records `Missing resolved URI` errors for operations constructed with empty `uris` by other callers; that defensive layer is intentionally kept unchanged.
