### PR TITLE
docs: add API key blocks to agent guides

### DIFF
--- a/docs/images/agents/en/cli.md
+++ b/docs/images/agents/en/cli.md
@@ -15,6 +15,8 @@ https://api.vikingdb.cn-beijing.volces.com/openviking
 
 - API Key: Copy the API Key shown on the page into your terminal
 
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ### Step 3: After configuration, run the following command to view CLI usage:
 
 ```bash

--- a/docs/images/agents/en/cursor.md
+++ b/docs/images/agents/en/cursor.md
@@ -6,6 +6,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 Select **Volcengine OpenViking Cloud**. Paste the API key from this page.
 
+API Key: Copy the API Key shown on the page and paste it when the installer prompts for it.
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## Verify
 
 1. Restart Cursor and start a new Agent session.

--- a/docs/images/agents/en/hermes.md
+++ b/docs/images/agents/en/hermes.md
@@ -4,7 +4,9 @@
 hermes memory setup openviking
 ```
 
-Keep **OpenViking Service (VolcEngine Cloud)**. Paste the API key from this page.
+Keep **OpenViking Service (VolcEngine Cloud)**. Paste the API key from this page:
+
+{{OPENVIKING_API_KEY_BLOCK}}
 
 ## Verify
 

--- a/docs/images/agents/en/openclaw.md
+++ b/docs/images/agents/en/openclaw.md
@@ -1,5 +1,9 @@
 ## Install
 
+Copy the API key from this page:
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
 openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <API-key-from-this-page>

--- a/docs/images/agents/en/trae.md
+++ b/docs/images/agents/en/trae.md
@@ -10,6 +10,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 Select **Volcengine OpenViking Cloud**. Paste the API key from this page.
 
+API Key: Copy the API Key shown on the page and paste it when the installer prompts for it.
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## Verify
 
 Restart TRAE. Confirm `openviking` is connected in settings.

--- a/docs/images/agents/zh/cli.md
+++ b/docs/images/agents/zh/cli.md
@@ -16,6 +16,8 @@ https://api.vikingdb.cn-beijing.volces.com/openviking
 ```
 - API Key: 把本页展示的 API Key 粘贴到终端
 
+{{OPENVIKING_API_KEY_BLOCK}}
+
 
 ### 步骤3：配置完成后，可运行以下命令查看 CLI 用法：
 

--- a/docs/images/agents/zh/cursor.md
+++ b/docs/images/agents/zh/cursor.md
@@ -6,6 +6,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 选 **火山引擎 OpenViking 云服务**，把本页 API Key 贴进去。
 
+API Key：复制页面中展示的 API Key，并在安装器提示时粘贴。
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## 验证
 
 1. 重启 Cursor，新建 Agent 会话。

--- a/docs/images/agents/zh/hermes.md
+++ b/docs/images/agents/zh/hermes.md
@@ -4,7 +4,9 @@
 hermes memory setup openviking
 ```
 
-保持 **OpenViking Service (VolcEngine Cloud)**，把本页 API Key 贴进去。
+保持 **OpenViking Service (VolcEngine Cloud)**，把本页 API Key 贴进去：
+
+{{OPENVIKING_API_KEY_BLOCK}}
 
 ## 验证
 

--- a/docs/images/agents/zh/openclaw.md
+++ b/docs/images/agents/zh/openclaw.md
@@ -1,5 +1,9 @@
 ## 安装
 
+复制本页 API Key：
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
 openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <本页的-API-Key>

--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -10,6 +10,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 选 **火山引擎 OpenViking 云服务**，把本页 API Key 贴进去。
 
+API Key：复制页面中展示的 API Key，并在安装器提示时粘贴。
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## 验证
 
 重启 TRAE。在设置里确认 `openviking` 已连接。


### PR DESCRIPTION
## 背景

OpenViking 控制台的「接入 Agent」页面会从 docs.openviking.net 拉取 Agent 接入文档，并在文档中的 API Key 占位位置注入当前页面可复制的 API Key。部分 Agent 文档只写了让用户复制/粘贴本页 API Key，但没有显式占位块，导致页面上缺少 API Key 展示和复制入口。

## 变更内容

- 为中英文 CLI 接入文档补充 `{{OPENVIKING_API_KEY_BLOCK}}`，使「API Key」步骤下方能渲染 API Key 展示与复制块。
- 为中英文 OpenClaw 接入文档补充 API Key 提示和 `{{OPENVIKING_API_KEY_BLOCK}}`，保留 upstream/main 上已有的一段式安装命令。
- 为中英文 Hermes Agent 接入文档补充 `{{OPENVIKING_API_KEY_BLOCK}}`。
- 将中文 Hermes 文案 `把本页 API Key 贴进去。` 调整为 `把本页 API Key 贴进去：`，让后续展示的 API Key 块语义更连贯。
- 为中英文 Cursor、TRAE 接入文档补充安装器输入 API Key 的提示和 `{{OPENVIKING_API_KEY_BLOCK}}`。

## 影响范围

- 仅影响 `docs/images/agents/{zh,en}` 下的 Agent 接入文档静态资源。
- 不改运行时代码、不改 API、不影响 OpenViking 服务端逻辑。
- 前端渲染时仍由 OpenViking 控制台负责把占位符替换为脱敏展示的 API Key；复制按钮继续复制完整真实值。

## 验证

- `pnpm --dir docs docs:build`
- `git diff --cached --check`
