### PR TITLE
fix(pi-extension): persist recall injections so provider prompt-prefix caches keep hitting

### DIFF
--- a/examples/pi-coding-agent-extension/README.md
+++ b/examples/pi-coding-agent-extension/README.md
@@ -1,0 +1,312 @@
+# OpenViking Memory Extension for Pi Coding Agent
+
+Long-term semantic memory and context takeover for [pi](https://github.com/earendil-works/pi) sessions, powered by [OpenViking](https://github.com/volcengine/OpenViking). Recall happens automatically before every prompt, capture happens after every turn, and OpenViking can own long-term context by replacing committed history with an archive overview in pi's `context` hook.
+
+> Design informed by lessons from all three OpenViking agent plugins: synchronous recall from OpenClaw, production-hardened capture/ranking from Claude Code, and anti-patterns dodged from Hermes's stale prefetch approach. See [DESIGN.md](./DESIGN.md) for the base design and [TAKEOVER.md](./TAKEOVER.md) for the context-takeover layer.
+
+## Quick Start
+
+### Prerequisites
+
+- **pi coding agent** installed (`npm i -g @earendil-works/pi-coding-agent`)
+- **Node.js 18+** (for the extension's TypeScript runtime)
+- **An OpenViking server** reachable — local or remote
+
+### 1. Have an OpenViking server reachable
+
+Either run one locally or point at a remote one. The [quickstart guide](../../docs/en/getting-started/02-quickstart.md) walks through both options. Default port is `1933`; local mode runs without authentication.
+
+Verify it's up:
+
+```bash
+curl http://localhost:1933/health   # or your remote URL
+```
+
+### 2. Install the extension
+
+Use the shared installer:
+
+```bash
+bash examples/memory-plugin-shared/install.sh --harness pi
+```
+
+The installer copies the extension to `~/.pi/agent/extensions/openviking` and registers it with `pi install`. The extension loads on next `pi` invocation.
+
+### 3. Configure (optional)
+
+Credentials are resolved from `OPENVIKING_*` environment variables, `~/.openviking/ovcli.conf`, then `~/.openviking/ov.conf`. Run the setup wizard when you need to configure a remote server:
+
+```bash
+node ~/.pi/agent/extensions/openviking/scripts/setup.mjs
+```
+
+`~/.pi/agent/extensions/openviking/config.json` is for behavior knobs only:
+
+```json
+{
+  "enabled": true,
+  "syncTurns": true,
+  "recallTokenBudget": 2000,
+  "scoreThreshold": 0.35,
+  "minQueryLength": 3,
+  "profileTokenBudget": 10000,
+  "resumeContextBudget": 32000,
+  "commitTokenThreshold": 20000,
+  "takeover": {
+    "enabled": true,
+    "tokenThreshold": 30000,
+    "keepRecentTurns": 3,
+    "overviewBudget": 3000,
+    "overviewPollMs": 2000,
+    "overviewPollMax": 15
+  }
+}
+```
+
+Credential environment variables:
+
+| Env Var | Meaning |
+|---------|---------|
+| `OPENVIKING_URL` | OpenViking server URL |
+| `OPENVIKING_API_KEY` / `OPENVIKING_BEARER_TOKEN` | Bearer token |
+| `OPENVIKING_ACCOUNT` | Trusted-mode account |
+| `OPENVIKING_USER` | Trusted-mode user |
+| `OPENVIKING_PEER_ID` | Actor peer id |
+| `OPENVIKING_WORKSPACE_PEER` | Derive an actor peer from the current workspace by default; set `0` to disable |
+| `OPENVIKING_RECALL_PEER_SCOPE` | `all` recalls other project memories with a score penalty; `actor` only sees global plus the current project |
+
+Recall asks the server to assemble the context block in one request
+(`POST /api/v1/search/search` with `mode="context"`), so token budgeting, detail
+tiers and cross-turn dedup are shared with every other harness. Deployments
+without that endpoint fall back to `/api/v1/search/recall`, and that outcome is
+cached so only the first turn pays for the probe.
+
+API keys are sent as `Authorization: Bearer ...`. By default the extension derives a peer from the process workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. The effective peer is sent as `X-OpenViking-Actor-Peer` and stored as `peer_id` on captured session messages. `OPENVIKING_PEER_ID` overrides the workspace-derived value.
+
+Recall defaults to the broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces penalized and rendered later. Set `OPENVIKING_RECALL_PEER_SCOPE=actor` for the isolation mode, which only sees global memory plus the current workspace. In deployments where one bot serves multiple real people, such as zouk, vikingbot, or AstrBot, use the isolation mode with an explicit actor peer so one person's memories are not recalled into another person's session.
+
+### 4. Start Pi
+
+```bash
+pi
+```
+
+The extension shows an `[OpenViking]` status line on startup. Tools (`viking_search`, `viking_remember`, etc.) are registered automatically. Memories persist across sessions — no additional setup.
+
+## Configuration Reference
+
+### Tuning fields
+
+All fields below live in `config.json`. Defaults are shown.
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `enabled`                | `true`     | Set `false` to disable the extension entirely                            |
+| `syncTurns`              | `true`     | Enable auto-capture of conversation turns                                |
+
+### Recall tuning
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `recallTokenBudget`      | `2000`     | Token budget for inline recall content                                   |
+| `recallMaxContentChars`  | `500`      | Per-item content cap for search results                                  |
+| `recallPreferAbstract`   | `true`     | Prefer L0 abstract over L2 full body when available                      |
+| `recallLimit`            | `10`       | Legacy quota-scaling input converted to six coding quotas, not a final cap |
+| `scoreThreshold`         | `0.35`     | Min relevance score (0–1)                                                |
+| `minQueryLength`         | `3`        | Skip recall for queries shorter than N characters                        |
+| `recallLedger`           | `true`     | Persist injected blocks and re-apply them to historical user messages so provider prompt-prefix caches keep hitting |
+
+### Recall injection ledger
+
+Pi's `context` hook hands extensions a deep copy of the session messages, so
+an injected `<openviking-context>` block is never written back to session
+storage. Without compensation, every request's history diverges from what the
+provider saw last turn, and strict-prefix prompt caches (DeepSeek and other
+OpenAI-compatible providers) miss from the first injected message onward
+(#4137). The ledger records exactly which block was injected into which user
+message (keyed by position + content hash) in
+`~/.openviking/pi-recall-ledger/<session>.json` and re-applies them on every
+request, keeping the prefix byte-identical across turns while the newest
+message still gets fresh, current-query recall. Disable with
+`"recallLedger": false` or `OPENVIKING_RECALL_LEDGER=0`. Losing the ledger
+file only costs one cache miss; alignment resumes on the next turn.
+
+Explicit `recallLimit` values from 1 through 5 produce an effective total
+quota of 6 because each coding category keeps one retrieval slot. Direct API
+integrations should configure category `quotas` when they need exact ceilings.
+
+### Capture tuning
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `captureMode`            | `"semantic"` | `"semantic"` (always capture) or `"keyword"` (trigger-based)           |
+| `captureMaxLength`       | `24000`    | Max sanitized text length for the capture decision                       |
+| `captureAssistantTurns`  | `true`     | Include assistant turns (text + tool USE inputs)                         |
+| `captureToolResults`     | `false`    | Include tool result output (noisy — off by default)                      |
+| `captureToolMaxChars`    | `1000000`  | Guard cap on one tool part's `tool_output`; the server externalizes oversized output |
+| `commitTokenThreshold`   | `20000`    | Pending-token threshold for client-driven commit                         |
+| `commitKeepRecentCount`  | `10`       | Live tail kept after commit                                              |
+
+### Context takeover
+
+Takeover is enabled by default. OpenViking commits archived history, polls the
+session overview, then the `context` hook replaces covered conversation turns
+with a synthetic `[OpenViking Session Context]` user message while keeping the
+recent live tail.
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `takeover.enabled`       | `true`     | Let OpenViking own long-term context through the `context` hook           |
+| `takeover.tokenThreshold`| `30000`    | Synced-token pressure that triggers commit and boundary advance           |
+| `takeover.keepRecentTurns`| `3`       | Recent user turns retained in full fidelity                              |
+| `takeover.overviewBudget`| `3000`    | Token budget for the injected archive overview                           |
+| `takeover.overviewPollMs`| `2000`    | Delay between overview polling attempts after commit                     |
+| `takeover.overviewPollMax`| `15`     | Max overview polling attempts before fail-open                           |
+
+### Injection tuning
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `profileTokenBudget`     | `10000`    | Token budget for user profile block                                      |
+| `resumeContextBudget`    | `32000`    | Token budget for archive overview on session resume                      |
+
+### Misc
+
+| Field                    | Default    | Description                                                              |
+|--------------------------|------------|--------------------------------------------------------------------------|
+| `bypassPatterns`         | `[]`       | Glob patterns to skip extension processing                               |
+| `logLevel`               | `"error"`  | `"silent"`, `"error"`, or `"info"`                                      |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Pi Coding Agent                    │
+│                                                      │
+│  session_start  before_agent_start  context  turn_end│
+│  session_before_compact  session_shutdown            │
+└────────┬──────────────────┬───────────┬──────────────┘
+         │                  │           │
+         │  ┌───────────────▼───────────▼────────┐
+         │  │   extension modules (.ts)           │
+         │  │   client / sync / recall / tools    │──────►  OpenViking
+         │  └─────────────────────────────────────┘        Server
+         │                                                (HTTP API)
+         │  ┌──────────────────────────────────────┐
+         └──►  7 registered LLM tools              │
+            │  viking_search / viking_read / …     │
+            └──────────────────────────────────────┘
+```
+
+The extension is a single directory of TypeScript files loaded by pi's `jiti` transpiler — no build step, no npm dependencies, no MCP server. All communication goes over HTTP to the OpenViking REST API.
+
+### Event Flow
+
+| Pi Event               | Extension Action                                                                 |
+|------------------------|----------------------------------------------------------------------------------|
+| `session_start`        | Health check → derive OV session → build profile context → restore takeover state |
+| `before_agent_start`   | Idempotent startup for `pi -c` + queue the current prompt for recall              |
+| `context`              | Run current-prompt recall after UI rendering, then inject takeover and recall context |
+| `turn_end`             | Extract branch entries → write or pending-queue OV messages → maybe advance boundary |
+| `session_before_compact`| Takeover mode returns OV overview as pi compaction summary; otherwise commits pending messages |
+| `session_shutdown`     | Persist takeover state or final non-takeover commit                              |
+
+### Recall: Synchronous, Not Stale
+
+Unlike Hermes's stale prefetch (recall from previous turn's query, injected one turn late), this extension searches OpenViking with the **current** user prompt via pi's `context` event. Pi renders the submitted user message before this hook, so recall latency does not hold the message off-screen. Results are still injected into the same model turn as `<openviking-context>` blocks. This means:
+
+- **First turn** of a session gets relevant context immediately
+- **Topic switches** within a session get correct recall
+- No waiting for the next turn to see relevant memories
+
+### Memory Pollution Prevention
+
+Before pushing turns to OpenViking, shared capture sanitization strips injected context blocks such as `<openviking-context>` to prevent a self-referential pollution loop where recall context is captured back as user messages.
+
+In takeover mode the adapter uses faithful capture: acknowledgments and short
+turns are retained because they may later be represented only through the OV
+archive overview. Empty text, slash commands, and OpenViking status messages
+remain filtered.
+
+### Tool Use Preservation
+
+Tool capture preserves structured tool parts with bounded inputs and outputs. The memory extractor sees what the agent did without indexing unbounded raw output.
+
+## LLM Tools
+
+The extension registers 7 tools that pi's model can invoke on demand:
+
+| Tool                     | Description                                                |
+|--------------------------|------------------------------------------------------------|
+| `viking_search`          | Semantic search across memories, resources, and skills     |
+| `viking_read`            | Read a `viking://` URI at abstract / overview / full level |
+| `viking_browse`          | List directory contents or stat a `viking://` URI          |
+| `viking_remember`        | Store a fact or preference into long-term memory           |
+| `viking_forget`          | Delete a memory by URI or search query                     |
+| `viking_add_resource`    | Ingest a URL into OpenViking for indexed retrieval         |
+| `viking_archive_expand`  | Expand an archived session back into raw conversation      |
+
+The canonical `/viking` command (type `/viking` in pi's chat) displays connection status, session info, and accepts `commit` for manual synchronous commit.
+
+## Compared to Pi's Built-in Memory
+
+Pi has a built-in `MEMORY.md` file system. This extension **complements** it:
+
+| Feature      | Built-in `MEMORY.md`              | OpenViking extension                              |
+|--------------|-----------------------------------|---------------------------------------------------|
+| Storage      | Flat markdown                     | Vector DB + structured extraction                 |
+| Search       | Loaded into context wholesale     | Semantic similarity + ranking + token budget      |
+| Scope        | Per-project                       | Cross-project, cross-session, cross-agent         |
+| Capacity     | Context-limited                    | Unlimited (server-side storage)                   |
+| Extraction   | Manual rules                      | LLM-powered entity / preference / event extraction|
+| Subagents    | Same as parent                    | Isolated session + typed agent namespace          |
+
+## Compared to Claude Code Plugin
+
+Both plugins share the same core design (informed by each other):
+
+| Feature             | Claude Code Plugin                     | Pi Extension                           |
+|---------------------|----------------------------------------|----------------------------------------|
+| Architecture        | Hook scripts (.mjs) + MCP delegation   | Native TypeScript extension            |
+| Recall timing       | Synchronous (UserPromptSubmit hook)     | Synchronous (context event)            |
+| Tool delivery       | OV server's MCP endpoint (16 tools)     | pi.registerTool() (7 tools)            |
+| Write path          | Detached worker (async)                 | Async promise (pi's event loop)        |
+| Installation        | `claude plugin install` + setup script  | Copy directory → auto-discovered       |
+| Memory index        | None (flashlight search model)          | Built (map model — model sees what OV knows) |
+| Subagent isolation  | Explicit hook management                | Natural process-level isolation        |
+
+## Extension Structure
+
+See [DESIGN.md](./DESIGN.md) for the full design specification — comparison of all three OV plugins, detailed event flow, design rationale, and implementation guidance useful for building OV extensions for any agent harness.
+
+```
+pi-coding-agent-extension/
+├── config.json          # Default configuration (edit to customize)
+├── config.ts            # Config loader (defaults + config.json merge)
+├── client.ts            # OpenViking HTTP client (fetch + response envelope)
+├── sync.ts              # Turn capture, write queue, session lifecycle
+├── recall.ts            # Synchronous recall with ranking + budget
+├── takeover.ts          # Thin pi binding around lib/takeover-core.mjs
+├── tools.ts             # 7 registered LLM tools + /viking command
+├── lib/takeover-core.mjs # Pure context-takeover state machine
+├── index.ts             # Extension entry point (event handlers)
+├── TAKEOVER.md          # Context-takeover design
+└── README.md
+```
+
+All TypeScript files are loaded directly by pi's built-in `jiti` transpiler — zero dependencies beyond Node.js.
+
+## Troubleshooting
+
+| Symptom                                 | Cause                                                | Fix                                                         |
+|-----------------------------------------|------------------------------------------------------|-------------------------------------------------------------|
+| Extension not loading                   | `enabled: false` in config.json                      | Set `"enabled": true`                                       |
+| No recall on first prompt               | OpenViking server not running or wrong URL           | `curl http://localhost:1933/health`                         |
+| Tools not showing after `pi -c` resume  | Known pi issue (tools not re-registered on resume)   | Workaround built in — tools register in `before_agent_start`|
+| Extension crashes on load               | Wrong OV server URL or network issue                 | Check `logLevel` and server accessibility                   |
+| No memories extracted                   | Wrong embedding/extraction model in OV config        | Check OV's `embedding` / `vlm` configuration                |
+| Takeover never advances                  | Pending addMessage replay, commit, or overview polling failed | Set `OV_DEBUG_LOG=/tmp/ov-pi.log` and retry `/viking commit` |
+
+## License
+
+Apache-2.0 — same as [OpenViking](https://github.com/volcengine/OpenViking).

--- a/examples/pi-coding-agent-extension/config.ts
+++ b/examples/pi-coding-agent-extension/config.ts
@@ -1,0 +1,198 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
+import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
+
+/** Hand-maintained: this extension ships no manifest to read a version from. */
+export const EXTENSION_VERSION = "0.1.0";
+
+export interface OVConfig {
+  enabled: boolean;
+  endpoint: string;
+  apiKey: string;
+  account: string;
+  user: string;
+  peerId: string;
+  userAgent: string;
+  workspacePeer: boolean;
+  recallPeerScope: "actor" | "all";
+  recallQueryExpansion: "auto" | "off";
+  recallQueryExpansionConfigured: boolean;
+  syncTurns: boolean;
+  recallTokenBudget: number;
+  recallMaxContentChars: number;
+  recallPreferAbstract: boolean;
+  recallLimit: number;
+  recallLimitConfigured: boolean;
+  recallLedger: boolean;
+  scoreThreshold: number;
+  minQueryLength: number;
+  profileTokenBudget: number;
+  resumeContextBudget: number;
+  commitTokenThreshold: number;
+  commitKeepRecentCount: number;
+  takeoverEnabled: boolean;
+  takeoverTokenThreshold: number;
+  takeoverKeepRecentTurns: number;
+  takeoverOverviewBudget: number;
+  takeoverOverviewPollMs: number;
+  takeoverOverviewPollMax: number;
+  captureToolResults: boolean;
+  captureMode: "semantic" | "keyword";
+  captureMaxLength: number;
+  captureToolMaxChars: number;
+  captureAssistantTurns: boolean;
+  bypassPatterns: string[];
+  logLevel: "silent" | "error" | "info";
+}
+
+const DEFAULT_CONFIG: OVConfig = {
+  enabled: true,
+  endpoint: "http://127.0.0.1:1933",
+  apiKey: "",
+  account: "",
+  user: "",
+  peerId: "",
+  userAgent: "",
+  workspacePeer: true,
+  recallPeerScope: "all",
+  // Server-side query expansion costs a model call before retrieval starts, so
+  // it has to be switchable from the client that pays the latency.
+  recallQueryExpansion: "auto",
+  recallQueryExpansionConfigured: false,
+  syncTurns: true,
+  recallTokenBudget: 2000,
+  recallMaxContentChars: 500,
+  recallPreferAbstract: true,
+  recallLimit: 10,
+  recallLimitConfigured: false,
+  // Persist injected recall blocks and re-apply them to historical user
+  // messages so provider prompt-prefix caches keep hitting (#4137).
+  recallLedger: true,
+  scoreThreshold: 0.35,
+  minQueryLength: 3,
+  profileTokenBudget: 10000,
+  resumeContextBudget: 32000,
+  commitTokenThreshold: 20000,
+  commitKeepRecentCount: 10,
+  takeoverEnabled: true,
+  takeoverTokenThreshold: 30000,
+  takeoverKeepRecentTurns: 3,
+  takeoverOverviewBudget: 3000,
+  takeoverOverviewPollMs: 2000,
+  takeoverOverviewPollMax: 15,
+  captureToolResults: false,
+  captureMode: "semantic",
+  captureMaxLength: 24000,
+  captureToolMaxChars: 1000000,
+  captureAssistantTurns: true,
+  bypassPatterns: [],
+  logLevel: "error",
+};
+
+export function loadConfigFromModuleUrl(moduleUrl: string): OVConfig {
+  return loadConfig(dirname(fileURLToPath(moduleUrl)));
+}
+
+export function loadConfig(extensionDir: string): OVConfig {
+  const configPath = join(extensionDir, "config.json");
+  let file: any = {};
+  try {
+    if (existsSync(configPath)) file = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    file = {};
+  }
+
+  const takeover = file.takeover && typeof file.takeover === "object" ? file.takeover : {};
+  const creds = resolveOpenVikingCredentials();
+  const config: OVConfig = {
+    ...DEFAULT_CONFIG,
+    ...file,
+    endpoint: creds.baseUrl,
+    apiKey: creds.apiKey,
+    account: creds.account,
+    user: creds.user,
+    peerId: creds.peerId,
+    userAgent: buildUserAgent("pi", EXTENSION_VERSION),
+    recallLimitConfigured: Object.prototype.hasOwnProperty.call(file, "recallLimit"),
+    recallQueryExpansionConfigured: Object.prototype.hasOwnProperty.call(file, "recallQueryExpansion"),
+    recallTokenBudget: file.recallTokenBudget ?? file.recallBudget ?? DEFAULT_CONFIG.recallTokenBudget,
+    scoreThreshold: file.scoreThreshold ?? file.recallScoreThreshold ?? DEFAULT_CONFIG.scoreThreshold,
+    minQueryLength: file.minQueryLength ?? file.recallMinQueryLength ?? DEFAULT_CONFIG.minQueryLength,
+    profileTokenBudget: file.profileTokenBudget ?? file.profileBudget ?? DEFAULT_CONFIG.profileTokenBudget,
+    takeoverEnabled: takeover.enabled ?? file.takeoverEnabled ?? DEFAULT_CONFIG.takeoverEnabled,
+    takeoverTokenThreshold: takeover.tokenThreshold ?? file.takeoverTokenThreshold ?? DEFAULT_CONFIG.takeoverTokenThreshold,
+    takeoverKeepRecentTurns: takeover.keepRecentTurns ?? file.takeoverKeepRecentTurns ?? DEFAULT_CONFIG.takeoverKeepRecentTurns,
+    takeoverOverviewBudget: takeover.overviewBudget ?? file.takeoverOverviewBudget ?? DEFAULT_CONFIG.takeoverOverviewBudget,
+    takeoverOverviewPollMs: takeover.overviewPollMs ?? file.takeoverOverviewPollMs ?? DEFAULT_CONFIG.takeoverOverviewPollMs,
+    takeoverOverviewPollMax: takeover.overviewPollMax ?? file.takeoverOverviewPollMax ?? DEFAULT_CONFIG.takeoverOverviewPollMax,
+  };
+
+  if (process.env.OPENVIKING_URL || process.env.OPENVIKING_BASE_URL) config.endpoint = creds.baseUrl;
+  if (process.env.OPENVIKING_API_KEY || process.env.OPENVIKING_BEARER_TOKEN) config.apiKey = creds.apiKey;
+  if (process.env.OPENVIKING_ACCOUNT) config.account = creds.account;
+  if (process.env.OPENVIKING_USER) config.user = creds.user;
+  if (process.env.OPENVIKING_PEER_ID) config.peerId = creds.peerId;
+  if (process.env.OPENVIKING_WORKSPACE_PEER !== undefined) {
+    config.workspacePeer = envBool(process.env.OPENVIKING_WORKSPACE_PEER, config.workspacePeer);
+  }
+  if (process.env.OPENVIKING_RECALL_PEER_SCOPE) {
+    config.recallPeerScope = process.env.OPENVIKING_RECALL_PEER_SCOPE === "actor" ? "actor" : "all";
+  }
+  if (process.env.OPENVIKING_RECALL_LIMIT) {
+    config.recallLimit = Number(process.env.OPENVIKING_RECALL_LIMIT);
+    config.recallLimitConfigured = true;
+  }
+  if (process.env.OPENVIKING_RECALL_QUERY_EXPANSION) {
+    config.recallQueryExpansion = process.env.OPENVIKING_RECALL_QUERY_EXPANSION === "off" ? "off" : "auto";
+    config.recallQueryExpansionConfigured = true;
+  }
+  if (process.env.OPENVIKING_RECALL_LEDGER !== undefined) {
+    config.recallLedger = envBool(process.env.OPENVIKING_RECALL_LEDGER, config.recallLedger);
+  }
+
+  config.recallLimit = clampInt(config.recallLimit, 1, 50, DEFAULT_CONFIG.recallLimit);
+  config.recallMaxContentChars = clampInt(config.recallMaxContentChars, 100, 5000, DEFAULT_CONFIG.recallMaxContentChars);
+  config.recallTokenBudget = clampInt(config.recallTokenBudget, 200, 50000, DEFAULT_CONFIG.recallTokenBudget);
+  config.scoreThreshold = clampNumber(config.scoreThreshold, 0, 1, DEFAULT_CONFIG.scoreThreshold);
+  config.minQueryLength = clampInt(config.minQueryLength, 1, 64, DEFAULT_CONFIG.minQueryLength);
+  config.profileTokenBudget = clampInt(config.profileTokenBudget, 500, 50000, DEFAULT_CONFIG.profileTokenBudget);
+  config.resumeContextBudget = clampInt(config.resumeContextBudget, 1024, 128000, DEFAULT_CONFIG.resumeContextBudget);
+  config.commitTokenThreshold = clampInt(config.commitTokenThreshold, 1000, 1000000, DEFAULT_CONFIG.commitTokenThreshold);
+  config.commitKeepRecentCount = clampInt(config.commitKeepRecentCount, 0, 1000, DEFAULT_CONFIG.commitKeepRecentCount);
+  config.takeoverEnabled = config.takeoverEnabled !== false;
+  config.takeoverTokenThreshold = clampInt(config.takeoverTokenThreshold, 1, 1000000, DEFAULT_CONFIG.takeoverTokenThreshold);
+  config.takeoverKeepRecentTurns = clampInt(config.takeoverKeepRecentTurns, 0, 100, DEFAULT_CONFIG.takeoverKeepRecentTurns);
+  config.takeoverOverviewBudget = clampInt(config.takeoverOverviewBudget, 100, 50000, DEFAULT_CONFIG.takeoverOverviewBudget);
+  config.takeoverOverviewPollMs = clampInt(config.takeoverOverviewPollMs, 0, 60000, DEFAULT_CONFIG.takeoverOverviewPollMs);
+  config.takeoverOverviewPollMax = clampInt(config.takeoverOverviewPollMax, 1, 120, DEFAULT_CONFIG.takeoverOverviewPollMax);
+  config.captureMaxLength = clampInt(config.captureMaxLength, 200, 100000, DEFAULT_CONFIG.captureMaxLength);
+  config.captureToolMaxChars = clampInt(config.captureToolMaxChars, 200, 1000000, DEFAULT_CONFIG.captureToolMaxChars);
+  config.captureMode = config.captureMode === "keyword" ? "keyword" : "semantic";
+  config.recallPeerScope = config.recallPeerScope === "actor" ? "actor" : "all";
+  config.recallQueryExpansion = config.recallQueryExpansion === "off" ? "off" : "auto";
+  config.recallLedger = config.recallLedger !== false;
+  if (!Array.isArray(config.bypassPatterns)) config.bypassPatterns = [];
+  config.peerId = resolveEffectivePeerId({ cfg: config as any, cwd: process.cwd() }).peerId;
+  return config;
+}
+
+function envBool(value: string, fallback: boolean): boolean {
+  const lower = String(value || "").trim().toLowerCase();
+  if (lower === "0" || lower === "false" || lower === "no" || lower === "off") return false;
+  if (lower === "1" || lower === "true" || lower === "yes" || lower === "on") return true;
+  return fallback;
+}
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const next = Math.round(Number(value));
+  if (!Number.isFinite(next)) return fallback;
+  return Math.max(min, Math.min(max, next));
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const next = Number(value);
+  if (!Number.isFinite(next)) return fallback;
+  return Math.max(min, Math.min(max, next));
+}

--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -1,0 +1,365 @@
+/**
+ * Pi OpenViking Extension
+ *
+ * Integrates pi with an OpenViking context database for persistent,
+ * cross-session memory. Syncs conversation turns to OV, recalls
+ * relevant memories on each prompt, and commits sessions for long-term
+ * memory extraction.
+ *
+ * Design informed by: OpenClaw (synchronous recall), Claude Code plugin
+ * (most mature, production-hardened), Hermes (anti-pattern: stale prefetch).
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadConfigFromModuleUrl, type OVConfig } from "./config.js";
+import { OVClient } from "./client.js";
+import { RecallManager } from "./recall.js";
+import { RecallLedger } from "./shared/recall-ledger.mjs";
+import { SyncManager } from "./sync.js";
+import { buildProfileBlock } from "./shared/profile-inject.mjs";
+import { guardVikingUriToolCall } from "./lib/uri-guard-adapter.mjs";
+import { registerTools } from "./tools.js";
+import { createTakeoverManager } from "./takeover.js";
+
+export default async function (pi: ExtensionAPI) {
+  // --- Load config ---
+  const config = loadConfigFromModuleUrl(import.meta.url);
+  if (!config.enabled) return;
+
+  // Env overrides
+
+  // --- Initialize modules ---
+  const client = new OVClient(config);
+  const sync = new SyncManager(client, config);
+  const recall = new RecallManager(
+    client,
+    config,
+    () => sync.sessionId,
+    // The ledger keeps request prefixes byte-stable for provider prompt
+    // caches (#4137); it is per pi session and opened once the id is known.
+    config.recallLedger ? new RecallLedger() : null,
+  );
+  const debugLog = (message: string) => {
+    const file = process.env.OV_DEBUG_LOG;
+    if (!file) return;
+    try {
+      mkdirSync(dirname(file), { recursive: true });
+      appendFileSync(file, `${new Date().toISOString()} ${message}\n`);
+    } catch {
+      // Best effort; logging must never affect pi.
+    }
+  };
+  const takeover = createTakeoverManager({ pi, client, sync, config, log: debugLog });
+
+  // Session state
+  let connected = false;
+  let bypassed = false;
+  let profileBlock = "";
+  let archiveOverview = "";
+  let toolsRegistered = false;
+  let compacted = false;
+  let started = false;
+  let startPromise: Promise<void> | null = null;
+
+  // ================================================================
+  // Event Handlers
+  // ================================================================
+
+  const start = async (ctx: any): Promise<void> => {
+    if (started) return;
+    if (startPromise) return startPromise;
+
+    startPromise = (async () => {
+      // Bypass check
+      const cwd = process.cwd();
+      for (const pattern of config.bypassPatterns) {
+        if (matchBypass(cwd, pattern)) {
+          bypassed = true;
+          started = true;
+          return;
+        }
+      }
+
+      // Health check
+      connected = await client.health();
+      if (!connected) {
+        if (config.logLevel === "info") {
+          ctx.ui.notify("OpenViking: server not reachable", "warning");
+        }
+        return;
+      }
+
+      // Ensure OV session
+      const piSessionId = ctx.sessionManager.getSessionId();
+      recall.openLedger(piSessionId);
+      const ok = await sync.ensureSession(piSessionId);
+      if (!ok) {
+        if (config.logLevel !== "silent") {
+          ctx.ui.notify("OpenViking: failed to create session", "error");
+        }
+        return;
+      }
+      await sync.replayPending();
+
+      // Profile injection
+      profileBlock = await buildSessionProfileBlock(client, config);
+
+      const branch = typeof ctx.sessionManager.getBranch === "function"
+        ? ctx.sessionManager.getBranch()
+        : [];
+      if (config.takeoverEnabled) {
+        takeover.restore(branch);
+        sync.restoreWatermark(takeover.state.syncedEntryCount);
+      } else if (sync.sessionId) {
+        // Resume rehydration — fetch archive overview if session was previously committed.
+        archiveOverview = await fetchArchiveOverview(client, sync.sessionId, config);
+      }
+
+      // Register tools (also needed for pi -c continuations).
+      if (!toolsRegistered) {
+        registerTools(pi, client, sync);
+        toolsRegistered = true;
+      }
+      updateStatus(ctx, connected, 0, sync.sessionId, config, takeover.state);
+
+      started = true;
+      if (config.logLevel === "info") {
+        ctx.ui.notify(`OpenViking connected (${piSessionId.slice(0, 8)}...)`, "info");
+      }
+    })().finally(() => {
+      startPromise = null;
+    });
+
+    return startPromise;
+  };
+
+  // --- session_start ---
+  pi.on("session_start", async (event, ctx) => {
+    await start(ctx);
+  });
+
+  // --- before_agent_start ---
+  pi.on("before_agent_start", async (event, ctx) => {
+    // session_start doesn't fire for pi -c continuations.
+    await start(ctx);
+
+    if (!connected || bypassed) return;
+
+    // Queue recall for the context hook. Pi renders the user message before
+    // that hook, so recall latency does not delay the message appearing.
+    recall.queueSearch(event.prompt);
+
+    // Compose system prompt additions
+    const parts: string[] = [];
+    if (profileBlock) parts.push(profileBlock);
+    if (!config.takeoverEnabled && archiveOverview && (compacted || archiveOverview.trim())) {
+      parts.push(archiveOverview);
+    }
+    parts.push("OpenViking tools: viking_search, viking_read, viking_browse, viking_remember, viking_forget, viking_add_resource, viking_archive_expand.");
+
+    const additions = parts.join("\n\n");
+    if (!additions) return;
+
+    return {
+      systemPrompt: event.systemPrompt + "\n\n" + additions,
+    };
+  });
+
+  // --- context ---
+  pi.on("context", async (event, _ctx) => {
+    if (!connected || bypassed) return;
+
+    // Keep recall synchronous with the provider request so the current prompt
+    // still receives current-query memory, without blocking user-message UI.
+    await recall.searchPending();
+
+    const afterTakeover = config.takeoverEnabled
+      ? takeover.transformContext(event.messages as any)
+      : event.messages;
+    const messages = recall.injectRecall(afterTakeover);
+    return { messages };
+  });
+
+  // --- tool_call ---
+  pi.on("tool_call", async (event, _ctx) => {
+    const decision = guardVikingUriToolCall(event);
+    if (!decision) return;
+    return decision;
+  });
+
+  // --- turn_end ---
+  pi.on("turn_end", async (event, ctx) => {
+    if (!connected || bypassed || !config.syncTurns) return;
+
+    const branch = ctx.sessionManager.getBranch();
+    const result = await sync.syncBranch(branch);
+    debugLog(`turn_end: synced ${result.added} entries, ~${result.tokens} tokens`);
+    await takeover.onTurnSynced(result.tokens);
+    updateStatus(ctx, connected, result.added, sync.sessionId, config, takeover.state);
+  });
+
+  // --- session_before_compact ---
+  pi.on("session_before_compact", async (event, _ctx) => {
+    if (!connected || bypassed) return;
+
+    if (config.takeoverEnabled) {
+      const prep = (event as any)?.preparation ?? {};
+      return await takeover.handleBeforeCompact({
+        firstKeptEntryId: prep.firstKeptEntryId,
+        tokensBefore: prep.tokensBefore ?? 0,
+      });
+    }
+
+    const archiveId = await sync.commit();
+    compacted = true;
+
+    // Cache archive overview for rehydration after compaction
+    if (archiveId && sync.sessionId) {
+      archiveOverview = await fetchArchiveOverview(
+        client, sync.sessionId, config,
+      );
+    }
+    // Return nothing → pi proceeds with default compaction
+  });
+
+  // --- session_shutdown ---
+  pi.on("session_shutdown", async (_event, ctx) => {
+    if (!connected || bypassed) return;
+
+    await sync.shutdown();
+    if (config.takeoverEnabled) {
+      await takeover.shutdown();
+    } else {
+      await sync.commit();
+    }
+  });
+
+  // --- agent_end ---
+  pi.on("agent_end", async (_event, _ctx) => {
+    recall.invalidate();
+  });
+
+  // ================================================================
+  // Commands
+  // ================================================================
+
+  pi.registerCommand("viking", {
+    description: "OpenViking status and manual operations. Use 'commit' to force a sync.",
+    handler: async (args, ctx) => {
+      if (!connected) {
+        ctx.ui.notify("OpenViking: not connected", "warning");
+        return;
+      }
+
+      if (args?.trim() === "commit") {
+        await sync.shutdown();
+        const commitResult = config.takeoverEnabled ? null : await sync.commit();
+        const ok = config.takeoverEnabled
+          ? await takeover.commitAndAdvance()
+          : commitResult !== null;
+        if (ok) {
+          ctx.ui.notify(
+            "OpenViking: committed successfully" +
+              (commitResult?.trace_id ? ` (trace_id=${commitResult.trace_id})` : ""),
+            "info",
+          );
+        } else {
+          ctx.ui.notify("OpenViking: commit failed", "error");
+        }
+        return;
+      }
+
+      // Status
+      const sid = sync.sessionId ?? "none";
+      const t = takeover.state;
+      const takeoverInfo = config.takeoverEnabled
+        ? ` | takeover: ${t.coveredUserTurns}/${t.lastSeenUserTurns} turns archived, ~${t.pendingTokens} tokens pending`
+        : "";
+      ctx.ui.notify(
+        `OpenViking: ${connected ? "connected" : "disconnected"} | session: ${sid.slice(0, 12)}...${takeoverInfo}`,
+        "info",
+      );
+    },
+  });
+}
+
+// ================================================================
+// Helper Functions
+// ================================================================
+
+/** Simple bypass pattern matching (prefix and glob). */
+function matchBypass(cwd: string, pattern: string): boolean {
+  if (pattern.startsWith("*")) {
+    return cwd.endsWith(pattern.slice(1));
+  }
+  if (pattern.endsWith("*")) {
+    return cwd.startsWith(pattern.slice(0, -1));
+  }
+  return cwd === pattern || cwd.startsWith(pattern + "/");
+}
+
+/** Build the <openviking-context> profile block. */
+async function buildSessionProfileBlock(
+  client: OVClient, config: OVConfig,
+): Promise<string> {
+  try {
+    const profile = await buildProfileBlock(
+      (path: string, init?: any, options?: any) => client.fetchJSON(path, init, 10000),
+      config.profileTokenBudget,
+      config.peerId,
+    );
+    if (!profile?.block) return "";
+    return [
+      '<openviking-context source="session-start">',
+      profile.block,
+      "</openviking-context>",
+    ].join("\n");
+  } catch {
+    return "";
+  }
+}
+
+/** Fetch archive overview for rehydration using the session context API. */
+async function fetchArchiveOverview(
+  client: OVClient, sessionId: string, config: OVConfig,
+): Promise<string> {
+  try {
+    const ctx = await client.getSessionContext(sessionId, config.resumeContextBudget);
+    if (!ctx || !ctx.latest_archive_overview) return "";
+
+    return [
+      '<openviking-context source="session-archive">',
+      "<session-archive>",
+      ctx.latest_archive_overview,
+      "</session-archive>",
+      "</openviking-context>",
+    ].join("\n");
+  } catch {
+    return "";
+  }
+}
+
+function updateStatus(
+  ctx: any,
+  connected: boolean,
+  added: number,
+  sessionId: string | null,
+  config: OVConfig,
+  takeoverState?: { pendingTokens?: number; coveredUserTurns?: number },
+): void {
+  const setter = ctx?.ui?.setStatus;
+  if (typeof setter !== "function") return;
+  const threshold = config.takeoverEnabled
+    ? config.takeoverTokenThreshold
+    : config.commitTokenThreshold;
+  const pending = config.takeoverEnabled && takeoverState
+    ? ` · ctx ${takeoverState.coveredUserTurns ?? 0} · ~${takeoverState.pendingTokens ?? 0}/${threshold}`
+    : ` · ✎ ${threshold}`;
+  const status = `${connected ? "OV ✓" : "OV ✗"} · ↩${added}${pending} · ${sessionId ? sessionId.slice(0, 12) : "none"}`;
+  try {
+    setter(status);
+  } catch {
+    // Best effort; pi API shape may vary across fast-moving versions.
+  }
+}

--- a/examples/pi-coding-agent-extension/recall.ts
+++ b/examples/pi-coding-agent-extension/recall.ts
@@ -1,0 +1,150 @@
+import type { OVClient } from "./client.js";
+import type { OVConfig } from "./config.js";
+import { buildRecallBlock } from "./shared/recall-core.mjs";
+import { RecallLedger, ledgerKey } from "./shared/recall-ledger.mjs";
+
+export interface RecallCache {
+  block: string | null;
+  promptText: string;      // the query this cache is for
+}
+
+export class RecallManager {
+  private client: OVClient;
+  private config: OVConfig;
+  private cache: RecallCache = { block: null, promptText: "" };
+  private pendingPrompt = "";
+  // Read lazily: the session manager that owns this id is constructed after the
+  // recall manager, and the id only exists once a session has been opened.
+  private sessionId: () => string | null;
+  private ledger: RecallLedger | null;
+
+  constructor(
+    client: OVClient,
+    config: OVConfig,
+    sessionId: () => string | null = () => null,
+    ledger: RecallLedger | null = null,
+  ) {
+    this.client = client;
+    this.config = config;
+    this.sessionId = sessionId;
+    this.ledger = ledger;
+  }
+
+  /** Bind the injection ledger to the pi session (idempotent). */
+  openLedger(piSessionId: string): void {
+    this.ledger?.open(piSessionId);
+  }
+
+  queueSearch(userQuery: string): void {
+    this.pendingPrompt = userQuery;
+  }
+
+  async searchPending(): Promise<string | null> {
+    if (!this.pendingPrompt) return this.cache.block;
+
+    const userQuery = this.pendingPrompt;
+    this.pendingPrompt = "";
+    if (userQuery.trim().length < this.config.minQueryLength) {
+      this.cache = { block: null, promptText: userQuery };
+      return null;
+    }
+
+    const block = await buildRecallBlock(
+      // 10s is this extension's own budget for a bare retrieval; when the
+      // request also spends a server fuse the helper hands down a longer
+      // deadline, and ignoring it would abort a request still inside its fuse.
+      (path: string, init?: any, options?: any) =>
+        this.client.fetchJSON(path, init, options?.timeoutMs ?? 10000),
+      this.config as any,
+      userQuery,
+      {
+        actorPeerId: this.config.peerId,
+        // Passing the OV session id is what turns on server-side query
+        // expansion and the cross-turn dedup ledger.
+        sessionId: this.sessionId() ?? "",
+      },
+    );
+    this.cache = { block, promptText: userQuery };
+    return block;
+  }
+
+  // --- Injection ---
+
+  /**
+   * Inject recall into the deep-copied provider view of the session.
+   *
+   * Two passes keep the request prefix byte-identical across turns (#4137):
+   * historical user messages get the exact block the ledger says was sent
+   * with them before, and only the newest user message receives this turn's
+   * fresh block (which is then recorded for future re-injection).
+   */
+  injectRecall(messages: any[]): any[] {
+    const ledger = this.ledger?.isOpen ? this.ledger : null;
+    if (!this.cache.block && !ledger) return messages;
+
+    // Locate the newest user message; everything before it is history.
+    let lastUserIndex = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        lastUserIndex = i;
+        break;
+      }
+    }
+    if (lastUserIndex === -1) return messages;
+
+    let ordinal = 0;
+    for (let i = 0; i <= lastUserIndex; i++) {
+      const msg = messages[i];
+      if (msg.role !== "user") continue;
+      const content = textOf(msg);
+      const isNewest = i === lastUserIndex;
+
+      // Idempotency: never stack a second block onto an already-injected copy.
+      if (content.includes("<openviking-context")) {
+        ordinal++;
+        continue;
+      }
+
+      if (isNewest) {
+        const block = this.cache.block;
+        if (block) {
+          prependBlock(msg, block);
+          // Key by the ORIGINAL content: that is what the next turn's deep
+          // copy of this message will contain.
+          ledger?.record(ledgerKey(ordinal, content), block);
+        }
+      } else if (ledger) {
+        const block = ledger.get(ledgerKey(ordinal, content));
+        if (block) prependBlock(msg, block);
+      }
+      ordinal++;
+    }
+
+    ledger?.flush();
+    return messages;
+  }
+
+  invalidate(): void {
+    this.cache = { block: null, promptText: "" };
+    this.pendingPrompt = "";
+  }
+}
+
+function textOf(msg: any): string {
+  return typeof msg.content === "string"
+    ? msg.content
+    : Array.isArray(msg.content)
+      ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
+      : "";
+}
+
+function prependBlock(msg: any, block: string): void {
+  if (typeof msg.content === "string") {
+    msg.content = block + "\n" + msg.content;
+  } else if (Array.isArray(msg.content)) {
+    const textBlocks = msg.content.filter((b: any) => b.type === "text");
+    if (textBlocks.length > 0) {
+      (textBlocks[0] as any).text = block + "\n" + (textBlocks[0] as any).text;
+    }
+  }
+}

--- a/examples/pi-coding-agent-extension/shared/recall-ledger.d.mts
+++ b/examples/pi-coding-agent-extension/shared/recall-ledger.d.mts
@@ -1,0 +1,10 @@
+export declare function defaultLedgerDir(): string;
+export declare function ledgerKey(ordinal: number, originalContent: string): string;
+export declare class RecallLedger {
+  constructor(dir?: string);
+  open(sessionId: string): void;
+  get isOpen(): boolean;
+  get(key: string): string | null;
+  record(key: string, block: string): void;
+  flush(): void;
+}

--- a/examples/pi-coding-agent-extension/shared/recall-ledger.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-ledger.mjs
@@ -1,0 +1,126 @@
+/**
+ * Persistent per-session ledger of recall blocks injected into user messages.
+ *
+ * Pi's context hook hands extensions a deep copy of the session messages, so
+ * a block prepended to a user message is never written back to session
+ * storage. On the next request the history is rebuilt without it, and the
+ * request prefix no longer matches what the provider cached last turn —
+ * strict-prefix caches (DeepSeek and other OpenAI-compatible providers) then
+ * miss from the first divergent token (#4137).
+ *
+ * The ledger fixes that on the extension side: it records exactly which block
+ * was injected into which user message, keyed by the message's position and a
+ * hash of its ORIGINAL (un-injected) content. On every context event the
+ * recorded blocks are re-applied to the historical user messages in the fresh
+ * deep copy, so the bytes sent to the provider this turn are identical to the
+ * bytes sent last turn, and only the newest user message extends the prefix.
+ *
+ * Storage follows the pending-queue convention: one JSON file per pi session
+ * under `~/.openviking/pi-recall-ledger/` (0o700), overridable with
+ * OPENVIKING_RECALL_LEDGER_DIR. Losing the file (fresh machine, cleanup) only
+ * costs one cache miss per historical message; alignment resumes on the next
+ * turn because re-injection re-records as it goes.
+ */
+import { mkdirSync, readFileSync, writeFileSync, renameSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+
+const LEDGER_DIR_MODE = 0o700;
+const LEDGER_FILE_MODE = 0o600;
+/** Bounded so a very long session cannot grow the file without limit. */
+const MAX_ENTRIES = 500;
+const LEDGER_VERSION = 1;
+
+export function defaultLedgerDir() {
+  return process.env.OPENVIKING_RECALL_LEDGER_DIR
+    || join(homedir(), ".openviking", "pi-recall-ledger");
+}
+
+/**
+ * Key = user-message ordinal + hash of the original content. The ordinal
+ * disambiguates repeated identical prompts ("continue"); the hash guards
+ * against injecting into the wrong message after history is rewritten
+ * (compaction, takeover), where a stale ordinal must simply miss.
+ */
+export function ledgerKey(ordinal, originalContent) {
+  const digest = createHash("sha256").update(originalContent).digest("hex").slice(0, 16);
+  return `${ordinal}:${digest}`;
+}
+
+export class RecallLedger {
+  constructor(dir = defaultLedgerDir()) {
+    this.dir = dir;
+    this.sessionId = null;
+    this.entries = new Map();
+    this.loaded = false;
+    this.dirty = false;
+  }
+
+  /** Bind to a pi session and load its file. Safe to call repeatedly. */
+  open(sessionId) {
+    if (!sessionId || sessionId === this.sessionId) return;
+    this.sessionId = sessionId;
+    this.entries.clear();
+    this.loaded = false;
+    try {
+      const raw = readFileSync(this.filePath(), "utf-8");
+      const data = JSON.parse(raw);
+      if (data && data.version === LEDGER_VERSION && Array.isArray(data.entries)) {
+        for (const e of data.entries) {
+          if (typeof e?.key === "string" && typeof e?.block === "string") {
+            this.entries.set(e.key, e.block);
+          }
+        }
+      }
+    } catch {
+      // Missing or corrupt file: start empty. Costs one miss, never breaks pi.
+    }
+    this.loaded = true;
+  }
+
+  get isOpen() {
+    return this.loaded && this.sessionId !== null;
+  }
+
+  get(key) {
+    return this.entries.get(key) ?? null;
+  }
+
+  /** Record an injected block. Call flush() once per context event afterwards. */
+  record(key, block) {
+    if (this.entries.get(key) === block) return;
+    this.entries.set(key, block);
+    while (this.entries.size > MAX_ENTRIES) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+    this.dirty = true;
+  }
+
+  /** Atomic write (tmp + rename), same durability pattern as pending-queue. */
+  flush() {
+    if (!this.dirty || !this.sessionId) return;
+    try {
+      mkdirSync(this.dir, { recursive: true, mode: LEDGER_DIR_MODE });
+      try { chmodSync(this.dir, LEDGER_DIR_MODE); } catch { /* pre-existing dir */ }
+      const payload = JSON.stringify({
+        version: LEDGER_VERSION,
+        entries: [...this.entries].map(([key, block]) => ({ key, block })),
+      });
+      const tmp = this.filePath() + ".tmp";
+      writeFileSync(tmp, payload, { mode: LEDGER_FILE_MODE });
+      renameSync(tmp, this.filePath());
+      this.dirty = false;
+    } catch {
+      // Best effort; persistence failure degrades to the pre-ledger behaviour.
+    }
+  }
+
+  filePath() {
+    // Session ids are uuids today; sanitize anyway so a hostile id cannot escape the dir.
+    const safe = String(this.sessionId).replace(/[^A-Za-z0-9._-]/g, "_");
+    return join(this.dir, `${safe}.json`);
+  }
+}

--- a/examples/pi-coding-agent-extension/tests/recall-ledger.test.mjs
+++ b/examples/pi-coding-agent-extension/tests/recall-ledger.test.mjs
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RecallManager } from "../recall.ts";
+import { RecallLedger, ledgerKey } from "../shared/recall-ledger.mjs";
+
+function config(overrides = {}) {
+  return {
+    minQueryLength: 3,
+    recallLimit: 6,
+    recallMaxContentChars: 500,
+    recallTokenBudget: 2000,
+    scoreThreshold: 0.35,
+    peerId: "",
+    ...overrides,
+  };
+}
+
+function clientReturning(rendered) {
+  return { fetchJSON: async () => ({ ok: true, result: { rendered } }) };
+}
+
+/** One provider request: run recall for the newest prompt, then inject into a
+ * fresh deep copy of the history — exactly what pi's context hook sees. */
+async function turn(recall, block, history) {
+  recall.client = clientReturning(block);
+  const last = history[history.length - 1].content;
+  const prompt = typeof last === "string"
+    ? last
+    : last.filter((b) => b.type === "text").map((b) => b.text).join("");
+  recall.queueSearch(prompt);
+  await recall.searchPending();
+  const view = structuredClone(history);
+  return recall.injectRecall(view);
+}
+
+test("historical user messages get their original block back, so the request prefix is stable across turns (#4137)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-1");
+
+  // Turn 1: [u1] with recall block b1
+  const sent1 = await turn(recall, "- b1 memory", [
+    { role: "user", content: "u1 prompt" },
+  ]);
+  assert.match(sent1[0].content, /b1 memory/);
+
+  recall.invalidate(); // agent_end
+
+  // Turn 2: history rebuilt from storage WITHOUT b1; new block b2 for u2.
+  const sent2 = await turn(recall, "- b2 memory", [
+    { role: "user", content: "u1 prompt" },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: "u2 prompt" },
+  ]);
+
+  // The bytes for u1 this turn must equal the bytes sent last turn.
+  assert.equal(sent2[0].content, sent1[0].content, "u1 prefix must be byte-identical to turn 1");
+  assert.match(sent2[2].content, /b2 memory/);
+
+  recall.invalidate();
+
+  // Turn 3 after a process restart: a brand-new manager + ledger from disk.
+  const restarted = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  restarted.openLedger("session-1");
+  const sent3 = await turn(restarted, "- b3 memory", [
+    { role: "user", content: "u1 prompt" },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: "u2 prompt" },
+    { role: "assistant", content: "a2" },
+    { role: "user", content: "u3 prompt" },
+  ]);
+  assert.equal(sent3[0].content, sent1[0].content, "u1 survives restart");
+  assert.equal(sent3[2].content, sent2[2].content, "u2 survives restart");
+  assert.match(sent3[4].content, /b3 memory/);
+});
+
+test("repeated identical prompts keep distinct blocks via the ordinal in the key", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-2");
+
+  const sent1 = await turn(recall, "- first continue block", [
+    { role: "user", content: "continue" },
+  ]);
+  recall.invalidate();
+  const sent2 = await turn(recall, "- second continue block", [
+    { role: "user", content: "continue" },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: "continue" },
+  ]);
+
+  assert.equal(sent2[0].content, sent1[0].content);
+  assert.match(sent2[2].content, /second continue block/);
+  assert.doesNotMatch(sent2[2].content, /first continue block/);
+});
+
+test("a short prompt records nothing and history it appears in stays un-injected", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-3");
+
+  const sent1 = await turn(recall, "- unused", [{ role: "user", content: "x" }]);
+  assert.equal(sent1[0].content, "x");
+  recall.invalidate();
+
+  const sent2 = await turn(recall, "- b2", [
+    { role: "user", content: "x" },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: "real second prompt" },
+  ]);
+  assert.equal(sent2[0].content, "x", "no phantom block for a message that never had one");
+  assert.match(sent2[2].content, /b2/);
+});
+
+test("rewritten history (stale ordinals) misses cleanly instead of injecting into the wrong message", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-4");
+
+  await turn(recall, "- b1", [{ role: "user", content: "u1 prompt" }]);
+  recall.invalidate();
+
+  // Compaction dropped u1; a different message now sits at ordinal 0.
+  const sent = await turn(recall, "- b2", [
+    { role: "user", content: "totally different message" },
+    { role: "assistant", content: "a" },
+    { role: "user", content: "u2 prompt" },
+  ]);
+  assert.equal(sent[0].content, "totally different message");
+});
+
+test("array-content user messages round-trip through the ledger", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-5");
+
+  const sent1 = await turn(recall, "- b1", [
+    { role: "user", content: [{ type: "text", text: "u1 prompt" }] },
+  ]);
+  assert.match(sent1[0].content[0].text, /b1/);
+  recall.invalidate();
+
+  const sent2 = await turn(recall, "- b2", [
+    { role: "user", content: [{ type: "text", text: "u1 prompt" }] },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: [{ type: "text", text: "u2 prompt" }] },
+  ]);
+  assert.equal(sent2[0].content[0].text, sent1[0].content[0].text);
+  assert.match(sent2[2].content[0].text, /b2/);
+});
+
+test("a corrupt ledger file degrades to pre-ledger behaviour", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const ledgerA = new RecallLedger(dir);
+  ledgerA.open("session-6");
+  ledgerA.record(ledgerKey(0, "u1 prompt"), "- b1");
+  ledgerA.flush();
+
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  assert.equal(files.length, 1);
+  writeFileSync(join(dir, files[0]), "{not json");
+
+  const recall = new RecallManager(clientReturning(""), config(), () => null, new RecallLedger(dir));
+  recall.openLedger("session-6");
+  const sent = await turn(recall, "- b2", [
+    { role: "user", content: "u1 prompt" },
+    { role: "assistant", content: "a1" },
+    { role: "user", content: "u2 prompt" },
+  ]);
+  assert.equal(sent[0].content, "u1 prompt");
+  assert.match(sent[2].content, /b2/);
+});
+
+test("ledger file is written atomically with owner-only permissions", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ov-ledger-"));
+  const ledger = new RecallLedger(dir);
+  ledger.open("session-7");
+  ledger.record(ledgerKey(0, "u1"), "- b1");
+  ledger.flush();
+
+  const files = readdirSync(dir);
+  assert.deepEqual(files, ["session-7.json"]);
+  const data = JSON.parse(readFileSync(join(dir, "session-7.json"), "utf-8"));
+  assert.equal(data.version, 1);
+  assert.equal(data.entries.length, 1);
+});


### PR DESCRIPTION
## 起因 / 问题

#4137:pi 扩展的 recall 注入让 DeepSeek 等 OpenAI 兼容 provider 的前缀缓存命中率大跌。pi 的 context hook 给扩展的 `event.messages` 是 deep copy,`injectRecall()` 只改了这份拷贝,注入内容不落会话存储(实测 `~/.pi/agent/run-history.jsonl` 里没有任何 `<openviking-context>` 痕迹)。下一轮历史从存储重建,上一轮注入的 block 全部消失,只有最新一条消息带新 block:第 1 轮发 `[S, b1+u1]`,第 2 轮发 `[S, u1, a1, b2+u2]`。对严格前缀匹配的缓存,从 u1 起整段失效。

## 为什么是这个性质

不是检索或注入逻辑的问题,是"发出去的字节每轮都变"。issue 里腾讯插件(-12.4pp)和 Mem0(~1% 命中)是同类先例;Claude Code / Codex 插件因注入随消息持久化而无此问题,pi 的 deep copy 机制是特例。

## 改法

加一个注入台账(injection ledger),发送什么就记什么,下一轮原样补回:

- `shared/recall-ledger.mjs`(新):按 `user 消息序号 + 原始内容 hash` 记录每条 user 消息被注入过的 block,持久化到 `~/.openviking/pi-recall-ledger/<pi-session>.json`(0o700,tmp+rename 原子写,上限 500 条,沿用 pending-queue 的存储约定)。
- `recall.ts`:`injectRecall()` 改两段式——历史 user 消息按台账补回当年的 block,只有最新一条注入本轮新 block 并记账。每轮发出的前缀与上一轮字节级一致,同时保留逐轮动态检索(不用降级成 recallPerSession)。
- `config.ts` / `index.ts`:新增 `recallLedger` 开关(默认开,`OPENVIKING_RECALL_LEDGER=0` 可关),session start 时按 pi session id 绑定台账。

## 取舍 / 需要 reviewer 定夺的

- 台账键用 `序号+hash` 而不是只用 hash:重复的相同 prompt("continue")各自保留自己的 block;compaction/takeover 重写历史后旧序号整体 miss,行为退回现状(一次性 cache miss),不会注错消息。
- 选了"逐轮记账重放"而不是 issue 里的方案 1(会话级预取):预取牺牲每轮动态检索;方案 2(pi 落盘注入)要动 pi 上游。台账在扩展侧就能闭环。
- 台账文件丢失/损坏只损失一次命中,下一轮重新对齐;这是有意的降级路径,不报错。

## 没动什么,为什么

- 没动 takeover 的 transformContext:takeover 重写历史本身就会打断前缀缓存,属另一问题。
- 没动 system prompt 注入(profile/archive):session 内稳定,不影响前缀。
- 没动共享 recall-core:检索语义完全不变,只改注入的重放。

## 验证

- 单测 `tests/recall-ledger.test.mjs` 7 个用例全过(前缀跨轮/跨进程重启字节级一致、重复 prompt 区分、短 prompt 不记账、历史重写干净 miss、数组 content、损坏台账降级、原子写):`node --experimental-strip-types --test`,与既有 `recall-deferred.test.mjs` 3 例一起 10/10。
- e2e:pi 0.84.2(与 issue 同版本)+ 本扩展 + mock OV + mock OpenAI 兼容 provider 抓真实请求体,连续 3 轮(含跨进程 `-c` 续会):
  - ledger 开:req0→req1→req2,每轮请求都是上一轮的字节级前缀扩展(`prefix_stable=True`)。
  - `OPENVIKING_RECALL_LEDGER=0`(现状):从第 2 轮起在第一条注入过的 user 消息处分叉(`first divergence at msg[1] role=user`),复现 #4137。

Fixes #4137