### PR TITLE
fix(uri): expand current-user URIs for admins

### DIFF
--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from openviking.core.identifiers import validate_user_id
 from openviking.core.peer_id import normalize_peer_id
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.uri import VikingURI
 
@@ -250,7 +250,7 @@ def resolve_uri(
 
 def resolve_request_uri(uri: str, ctx: RequestContext) -> str:
     """Resolve supported current-user shorthands at an authenticated request boundary."""
-    if getattr(ctx.role, "value", ctx.role) == "user":
+    if ctx.role in {Role.USER, Role.ADMIN}:
         return resolve_current_user_uri(uri, ctx)
     return resolve_uri(uri).uri
 

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -173,6 +173,18 @@ def test_request_boundary_expands_current_user_content_roots():
     )
     assert (
         resolve_request_uri("viking://user/resources", admin_ctx)
+        == "viking://user/admin/resources"
+    )
+    assert (
+        resolve_request_uri("viking://user/skills", admin_ctx)
+        == "viking://user/admin/skills"
+    )
+    root_ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="root-actor"),
+        role=Role.ROOT,
+    )
+    assert (
+        resolve_request_uri("viking://user/resources", root_ctx)
         == "viking://user/resources"
     )
     assert is_content_root_uri("viking://resources", kind="resource")


### PR DESCRIPTION
## Description

Fixes the request-boundary URI normalization introduced by #4048 so admin actors keep the same current-user shorthand semantics as regular user actors.

**Before:** `resolve_request_uri()` expanded `viking://user/...` current-user shorthands only when `ctx.role` was `Role.USER`. For an admin request from user `test-user`, `viking://user/skills` stayed as `viking://user/skills`, was interpreted as user id `skills`, and later failed ACL checks against `test-user`.

**After:** `Role.ADMIN` and `Role.USER` both expand current-user shorthands at the authenticated request boundary. `Role.ROOT` still uses literal URI resolution.

**Example:** With `ctx.role = Role.ADMIN`, `ctx.user.user_id = "test-user"`, and input URI `viking://user/skills`:

- Before: `viking://user/skills` -> interpreted as `user_id = "skills"` -> `PERMISSION_DENIED`
- After: `viking://user/test-user/skills` -> accesses the current admin user's skills root

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related to #4048.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Expand request-boundary current-user URI shorthands for both `Role.USER` and `Role.ADMIN`.
- Remove the #4048 `getattr` role check and compare against `Role` constants directly.
- Update the existing namespace URI classification test to cover admin expansion for `resources` and `skills`, while keeping root literal resolution unchanged.

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Test command:

```bash
pytest tests/unit/test_namespace_uri_classification.py -q
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR intentionally limits the scope to the #4048 request URI normalization regression. It does not change pre-existing ACL or root-role behavior outside that path.
