### PR TITLE
fix(embedding): truncate LiteLLM async vectors

### DIFF
--- a/openviking/models/embedder/litellm_embedders.py
+++ b/openviking/models/embedder/litellm_embedders.py
@@ -206,6 +206,7 @@ class LiteLLMDenseEmbedder(DenseEmbedderBase):
             response = await litellm.aembedding(**kwargs)
             self._update_telemetry_token_usage(response)
             vector = response.data[0]["embedding"]
+            vector = self._truncate_vector(vector)
             return EmbedResult(dense_vector=vector)
 
         try:

--- a/tests/unit/test_litellm_embedder.py
+++ b/tests/unit/test_litellm_embedder.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Tests for LiteLLM Embedder and factory integration."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -42,6 +42,23 @@ class TestLiteLLMDenseEmbedder:
         call_kwargs = mock_litellm.embedding.call_args[1]
         assert call_kwargs["model"] == "openai/text-embedding-3-small"
         assert call_kwargs["api_key"] == "test-key"
+
+    @patch("openviking.models.embedder.litellm_embedders.litellm")
+    async def test_embed_async_truncates_vector_to_configured_dimension(self, mock_litellm):
+        """Async embedding should truncate vectors to the configured dimension."""
+        mock_litellm.aembedding = AsyncMock(
+            return_value=_mock_litellm_response(vectors=[[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        from openviking.models.embedder.litellm_embedders import LiteLLMDenseEmbedder
+
+        embedder = LiteLLMDenseEmbedder(
+            model_name="bedrock/amazon.titan-embed-text-v2:0",
+            dimension=3,
+        )
+        result = await embedder.embed_async("Hello world")
+
+        assert result.dense_vector == [0.1, 0.2, 0.3]
 
     @patch("openviking.models.embedder.litellm_embedders.litellm")
     def test_embed_with_api_base(self, mock_litellm):


### PR DESCRIPTION
## Summary
- apply the configured embedding dimension to LiteLLM async responses
- keep async behavior consistent with the existing synchronous path
- add a regression test for oversized provider vectors

Fixes #4134

## Test plan
- [x] `.venv/bin/pytest -q tests/unit/test_litellm_embedder.py` (17 passed)
- [x] `ruff check openviking/models/embedder/litellm_embedders.py tests/unit/test_litellm_embedder.py`
- [x] `ruff format --check openviking/models/embedder/litellm_embedders.py tests/unit/test_litellm_embedder.py`
- [x] `git diff --check origin/main...HEAD`

🤖 Generated with Claude Code