### PR TITLE
fix(memory): recall actor peer trees in legacy fallback

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -199,7 +199,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(query, perSourceLimit, actorPeerId = "", peerScope = "") {

--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -119,7 +119,7 @@ function dedupeItems(items) {
 // User URI space resolution
 // ---------------------------------------------------------------------------
 
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
 let _userSpaceCache = "";
 
 async function resolveUserSpace(actorPeerId = "") {
@@ -174,7 +174,7 @@ async function resolveTargetUri(targetUri, actorPeerId = "") {
 // cross-namespace leakage; use MCP search(scope="resources") explicitly)
 // ---------------------------------------------------------------------------
 
-const SOURCES = [
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories",  bucket: "memories" },
   { type: "skill",  uri: "viking://~/skills",    bucket: "skills"   },
 ];
@@ -191,11 +191,23 @@ async function searchOneSource(query, source, limit, actorPeerId = "") {
   return items.map(item => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(query, perSourceLimit, actorPeerId = "") {
-  const results = await Promise.all(SOURCES.map(src => searchOneSource(query, src, perSourceLimit, actorPeerId)));
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(query, perSourceLimit, actorPeerId = "", peerScope = "") {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
+  const results = await Promise.all(sources.map(src => searchOneSource(query, src, perSourceLimit, actorPeerId)));
   const all = results.flat();
   log("search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -412,7 +424,12 @@ async function main() {
   }
 
   const perSourceLimit = Math.max(cfg.recallLimit * 2, 8);
-  const raw = await searchAllSources(userPrompt, perSourceLimit, effectivePeer.peerId);
+  const raw = await searchAllSources(
+    userPrompt,
+    perSourceLimit,
+    effectivePeer.peerId,
+    cfg.recallPeerScope,
+  );
   if (raw.length === 0) {
     log("skip", { reason: "no results" });
     writeRecallState({ count: 0, reason: "no_results", cc_session_id: sessionId });

--- a/examples/claude-code-memory-plugin/scripts/auto-recall.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+function writeJson(res, statusCode, value) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(value));
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      try {
+        resolve(raw ? JSON.parse(raw) : null);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+async function withMockOpenViking(handler, fn) {
+  const server = http.createServer((req, res) => {
+    handler(req, res).catch((err) => {
+      writeJson(res, 500, { status: "error", error: String(err?.stack || err) });
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function runAutoRecall(input, env) {
+  return new Promise((resolve, reject) => {
+    const cleanEnv = { ...process.env };
+    for (const key of Object.keys(cleanEnv)) {
+      if (key.startsWith("OPENVIKING_")) delete cleanEnv[key];
+    }
+    const child = spawn(process.execPath, [join(SCRIPT_DIR, "auto-recall.mjs")], {
+      env: { ...cleanEnv, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`auto-recall exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+function hookEnv(root, baseUrl, peerScope = "all") {
+  return {
+    HOME: root,
+    TMPDIR: root,
+    OPENVIKING_AUTO_RECALL: "1",
+    OPENVIKING_CONFIG_FILE: join(root, "missing-ov.conf"),
+    OPENVIKING_CLI_CONFIG_FILE: join(root, "missing-ovcli.conf"),
+    OPENVIKING_MEMORY_ENABLED: "1",
+    OPENVIKING_PEER_ID: "peer-123",
+    OPENVIKING_RECALL_COMPRESS: "off",
+    OPENVIKING_RECALL_PEER_SCOPE: peerScope,
+    OPENVIKING_STATE_DIR: join(root, "state"),
+    OPENVIKING_TIMEOUT_MS: "5000",
+    OPENVIKING_URL: baseUrl,
+  };
+}
+
+async function runFallbackRecall(peerScope) {
+  const root = await mkdtemp(join(tmpdir(), "ov-cc-recall-peer-"));
+  const calls = [];
+  try {
+    await withMockOpenViking(async (req, res) => {
+      const url = new URL(req.url, "http://127.0.0.1");
+      const body = req.method === "POST" ? await readRequestBody(req) : null;
+      calls.push({ path: url.pathname, body });
+
+      if (req.method === "GET" && url.pathname === "/health") {
+        writeJson(res, 200, { status: "ok", result: { healthy: true } });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/v1/search/search") {
+        writeJson(res, 400, {
+          status: "error",
+          error: { message: "Extra inputs: mode" },
+        });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/v1/search/recall") {
+        writeJson(res, 404, { status: "error", error: { code: "NOT_FOUND" } });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/v1/system/status") {
+        writeJson(res, 200, { status: "ok", result: { user: "default" } });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/v1/fs/ls") {
+        writeJson(res, 200, { status: "ok", result: [] });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/v1/search/find") {
+        writeJson(res, 200, {
+          status: "ok",
+          result: { memories: [], skills: [] },
+        });
+        return;
+      }
+      writeJson(res, 404, { status: "error", error: { code: "NOT_FOUND" } });
+    }, async (baseUrl) => {
+      await runAutoRecall(
+        { session_id: `recall-${peerScope}`, cwd: root, prompt: "find peer memory" },
+        hookEnv(root, baseUrl, peerScope),
+      );
+    });
+    return calls;
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("raw fallback searches qualified actor peer memories and skills", async () => {
+  const calls = await runFallbackRecall("all");
+  const searchCalls = calls.filter((call) => call.path.startsWith("/api/v1/search/"));
+
+  assert.deepEqual(
+    searchCalls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    searchCalls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://~/memories",
+      "viking://~/peers/peer-123/memories",
+      "viking://~/peers/peer-123/skills",
+      "viking://~/skills",
+    ],
+  );
+});
+
+test("raw actor-scoped fallback searches only qualified actor peer trees", async () => {
+  const calls = await runFallbackRecall("actor");
+  const searchCalls = calls.filter((call) => call.path.startsWith("/api/v1/search/"));
+
+  assert.deepEqual(
+    searchCalls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    searchCalls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://~/peers/peer-123/memories",
+      "viking://~/peers/peer-123/skills",
+    ],
+  );
+});

--- a/examples/claude-code-memory-plugin/scripts/auto-recall.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.test.mjs
@@ -71,7 +71,7 @@ function runAutoRecall(input, env) {
   });
 }
 
-function hookEnv(root, baseUrl, peerScope = "all") {
+function hookEnv(root, baseUrl, peerScope = "all", actorPeerId = "peer-123") {
   return {
     HOME: root,
     TMPDIR: root,
@@ -79,16 +79,17 @@ function hookEnv(root, baseUrl, peerScope = "all") {
     OPENVIKING_CONFIG_FILE: join(root, "missing-ov.conf"),
     OPENVIKING_CLI_CONFIG_FILE: join(root, "missing-ovcli.conf"),
     OPENVIKING_MEMORY_ENABLED: "1",
-    OPENVIKING_PEER_ID: "peer-123",
+    ...(actorPeerId ? { OPENVIKING_PEER_ID: actorPeerId } : {}),
     OPENVIKING_RECALL_COMPRESS: "off",
     OPENVIKING_RECALL_PEER_SCOPE: peerScope,
     OPENVIKING_STATE_DIR: join(root, "state"),
     OPENVIKING_TIMEOUT_MS: "5000",
     OPENVIKING_URL: baseUrl,
+    OPENVIKING_WORKSPACE_PEER: "0",
   };
 }
 
-async function runFallbackRecall(peerScope) {
+async function runFallbackRecall(peerScope, actorPeerId = "peer-123") {
   const root = await mkdtemp(join(tmpdir(), "ov-cc-recall-peer-"));
   const calls = [];
   try {
@@ -131,7 +132,7 @@ async function runFallbackRecall(peerScope) {
     }, async (baseUrl) => {
       await runAutoRecall(
         { session_id: `recall-${peerScope}`, cwd: root, prompt: "find peer memory" },
-        hookEnv(root, baseUrl, peerScope),
+        hookEnv(root, baseUrl, peerScope, actorPeerId),
       );
     });
     return calls;
@@ -176,6 +177,25 @@ test("raw actor-scoped fallback searches only qualified actor peer trees", async
     [
       "viking://~/peers/peer-123/memories",
       "viking://~/peers/peer-123/skills",
+    ],
+  );
+});
+
+test("raw actor-scoped fallback preserves qualified user trees without actorPeerId", async () => {
+  const calls = await runFallbackRecall("actor", "");
+  const searchCalls = calls.filter((call) => call.path.startsWith("/api/v1/search/"));
+
+  assert.deepEqual(
+    searchCalls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    searchCalls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://user/default/memories",
+      "viking://user/default/skills",
     ],
   );
 });

--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -307,7 +307,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -11,8 +11,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -299,13 +299,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -593,7 +612,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -281,3 +281,79 @@ test("buildRecallBlock falls back to find when neither context endpoint works", 
   assert.match(block, /^<openviking-context>/);
   assert.match(block, /\[memory 90%\]/);
 });
+
+test("raw fallback searches qualified actor peer trees when actorPeerId is set", async () => {
+  const calls = [];
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path, init) => {
+    calls.push({ path, body: init?.body ? JSON.parse(init.body) : null });
+    if (path === "/api/v1/search/search") {
+      return { ok: false, status: 400, error: { message: "Extra inputs: mode" } };
+    }
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") {
+      return { ok: true, result: { memories: [], skills: [] } };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, {}, "peer memory", {
+    actorPeerId: "peer-123",
+    legacyCachePath,
+  });
+
+  assert.deepEqual(
+    calls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    calls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://~/memories",
+      "viking://~/peers/peer-123/memories",
+      "viking://~/peers/peer-123/skills",
+      "viking://~/skills",
+    ],
+  );
+});
+
+test("raw actor-scoped fallback searches only qualified actor peer trees", async () => {
+  const calls = [];
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path, init) => {
+    calls.push({ path, body: init?.body ? JSON.parse(init.body) : null });
+    if (path === "/api/v1/search/search") {
+      return { ok: false, status: 400, error: { message: "Extra inputs: mode" } };
+    }
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") {
+      return { ok: true, result: { memories: [], skills: [] } };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, { recallPeerScope: "actor" }, "peer memory", {
+    actorPeerId: "peer-123",
+    legacyCachePath,
+  });
+
+  assert.deepEqual(
+    calls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    calls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://~/peers/peer-123/memories",
+      "viking://~/peers/peer-123/skills",
+    ],
+  );
+});

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -357,3 +357,39 @@ test("raw actor-scoped fallback searches only qualified actor peer trees", async
     ],
   );
 });
+
+test("raw actor-scoped fallback preserves qualified user trees without actorPeerId", async () => {
+  const calls = [];
+  const legacyCachePath = await tempPath("context-face.json");
+  const fetchJSON = async (path, init) => {
+    calls.push({ path, body: init?.body ? JSON.parse(init.body) : null });
+    if (path === "/api/v1/search/search") {
+      return { ok: false, status: 400, error: { message: "Extra inputs: mode" } };
+    }
+    if (path === "/api/v1/search/recall") return { ok: false, status: 404 };
+    if (path === "/api/v1/system/status") return { ok: true, result: { user: "default" } };
+    if (path.startsWith("/api/v1/fs/ls")) return { ok: true, result: [] };
+    if (path === "/api/v1/search/find") {
+      return { ok: true, result: { memories: [], skills: [] } };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  await buildRecallBlock(fetchJSON, { recallPeerScope: "actor" }, "user memory", {
+    legacyCachePath,
+  });
+
+  assert.deepEqual(
+    calls.slice(0, 2).map((call) => call.path),
+    ["/api/v1/search/search", "/api/v1/search/recall"],
+  );
+  assert.deepEqual(
+    calls.filter((call) => call.path === "/api/v1/search/find")
+      .map((call) => call.body.target_uri)
+      .sort(),
+    [
+      "viking://~/memories",
+      "viking://~/skills",
+    ],
+  );
+});

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -12,8 +12,8 @@ const STOPWORDS = new Set([
   "what", "when", "where", "which", "who", "whom", "whose", "why", "how", "did", "does",
   "is", "are", "was", "were", "the", "and", "for", "with", "from", "that", "this", "your", "you",
 ]);
-const USER_RESERVED_DIRS = new Set(["memories", "skills"]);
-const SOURCES = [
+const USER_RESERVED_DIRS = new Set(["memories", "skills", "peers"]);
+const USER_SOURCES = [
   { type: "memory", uri: "viking://~/memories", bucket: "memories" },
   { type: "skill", uri: "viking://~/skills", bucket: "skills" },
 ];
@@ -300,13 +300,32 @@ async function searchOneSource(fetchJSON, query, source, limit, actorPeerId = ""
   return items.map((item) => ({ ...item, _sourceType: source.type }));
 }
 
-async function searchAllSources(fetchJSON, query, perSourceLimit, actorPeerId = "", log = () => {}) {
+function buildFallbackSources(actorPeerId = "", peerScope = "") {
+  const peerId = String(actorPeerId).trim();
+  const peerSources = peerId
+    ? USER_SOURCES.map((source) => ({
+      ...source,
+      uri: `viking://~/peers/${peerId}/${source.bucket}`,
+    }))
+    : [];
+  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+}
+
+async function searchAllSources(
+  fetchJSON,
+  query,
+  perSourceLimit,
+  actorPeerId = "",
+  peerScope = "",
+  log = () => {},
+) {
+  const sources = buildFallbackSources(actorPeerId, peerScope);
   const results = await Promise.all(
-    SOURCES.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
+    sources.map((src) => searchOneSource(fetchJSON, query, src, perSourceLimit, actorPeerId)),
   );
   const all = results.flat();
   log("recall_search_summary", {
-    counts: SOURCES.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
+    counts: sources.map((src, i) => ({ type: src.type, uri: src.uri, count: results[i].length })),
     total: all.length,
   });
   return all;
@@ -594,7 +613,14 @@ export async function buildRecallBlock(fetchJSON, cfg, query, options = {}) {
 
   const recallLimit = Math.max(1, Number(cfg.recallLimit || DEFAULT_CONTEXT_LIMIT));
   const perSourceLimit = Math.max(recallLimit * 2, 8);
-  const raw = await searchAllSources(fetchJSON, trimmed, perSourceLimit, actorPeerId, log);
+  const raw = await searchAllSources(
+    fetchJSON,
+    trimmed,
+    perSourceLimit,
+    actorPeerId,
+    cfg.recallPeerScope,
+    log,
+  );
   if (raw.length === 0) return null;
 
   const profile = buildQueryProfile(trimmed);

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -308,7 +308,7 @@ function buildFallbackSources(actorPeerId = "", peerScope = "") {
       uri: `viking://~/peers/${peerId}/${source.bucket}`,
     }))
     : [];
-  return peerScope === "actor" ? peerSources : [...USER_SOURCES, ...peerSources];
+  return peerScope === "actor" && peerId ? peerSources : [...USER_SOURCES, ...peerSources];
 }
 
 async function searchAllSources(


### PR DESCRIPTION
## Summary
- include qualified actor peer memory and skill roots in raw-find fallback recall
- honor `recallPeerScope: actor` as peer-trees-only while preserving user fallback when no actor is present
- update shared vendored modules and the Claude inline fallback
- add regression coverage for the context -> recall -> find degradation ladder

Fixes #4140

## Test plan
- [x] `node --test examples/memory-plugin-shared/recall-core.test.mjs examples/memory-plugin-shared/sync.test.mjs examples/claude-code-memory-plugin/scripts/auto-recall.test.mjs` (21 passed)
- [x] `git diff --check origin/main...HEAD`

🤖 Generated with Claude Code