### PR TITLE
fix(web-studio): respect task API limits

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTasks, MAX_TASKS } from './task-list'
+
+const clientMocks = vi.hoisted(() => ({
+  getTasks: vi.fn(),
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  getOvResult: async (value: unknown) => value,
+  getTasks: clientMocks.getTasks,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-20T12:00:00Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('task list requests', () => {
+  it('uses the server limit and filters the 24-hour scope locally', async () => {
+    clientMocks.getTasks.mockResolvedValue([
+      {
+        created_at: Date.parse('2026-08-20T11:00:00Z') / 1000,
+        task_id: 'recent-task',
+      },
+      {
+        created_at: Date.parse('2026-08-18T11:00:00Z') / 1000,
+        task_id: 'old-task',
+      },
+    ])
+
+    await expect(fetchTasks('all', 'all', '24h')).resolves.toEqual([
+      expect.objectContaining({ task_id: 'recent-task' }),
+    ])
+    expect(clientMocks.getTasks).toHaveBeenCalledWith({
+      query: { limit: MAX_TASKS },
+    })
+    expect(MAX_TASKS).toBe(200)
+  })
+
+  it('keeps the all-time scope within the same API contract', async () => {
+    clientMocks.getTasks.mockResolvedValue([
+      { created_at: 1, task_id: 'old-task' },
+      { created_at: 2, task_id: 'new-task' },
+    ])
+
+    await expect(fetchTasks('all', 'all', 'all')).resolves.toEqual([
+      expect.objectContaining({ task_id: 'new-task' }),
+      expect.objectContaining({ task_id: 'old-task' }),
+    ])
+    expect(clientMocks.getTasks).toHaveBeenCalledWith({
+      query: { limit: MAX_TASKS },
+    })
+  })
+
+  it('uses the generated client contract for task-type filters', async () => {
+    clientMocks.getTasks.mockResolvedValue([])
+
+    await fetchTasks('session_commit', 'all', 'all')
+
+    expect(clientMocks.getTasks).toHaveBeenCalledWith({
+      query: {
+        limit: MAX_TASKS,
+        task_type: 'session_commit',
+      },
+    })
+  })
+
+  it('keeps effective status filtering on the client', async () => {
+    clientMocks.getTasks.mockResolvedValue(
+      Array.from({ length: 9 }, (_, index) => ({
+        created_at: index + 1,
+        status: 'running',
+        task_id: `task-${index + 1}`,
+      })),
+    )
+
+    await expect(fetchTasks('all', 'pending', 'all')).resolves.toEqual([
+      expect.objectContaining({ task_id: 'task-9' }),
+    ])
+    expect(clientMocks.getTasks).toHaveBeenCalledWith({
+      query: { limit: MAX_TASKS },
+    })
+  })
+
+  it('propagates request failures to the query error state', async () => {
+    clientMocks.getTasks.mockRejectedValue(new Error('request failed'))
+
+    await expect(fetchTasks('all', 'all', 'all')).rejects.toThrow(
+      'request failed',
+    )
+  })
+})

--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fetchTasks, MAX_TASKS } from './task-list'
 
@@ -13,43 +13,22 @@ vi.mock('#/lib/ov-client', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.useFakeTimers()
-  vi.setSystemTime(new Date('2026-08-20T12:00:00Z'))
-})
-
-afterEach(() => {
-  vi.useRealTimers()
 })
 
 describe('task list requests', () => {
-  it('uses the server limit and filters the 24-hour scope locally', async () => {
+  it('uses the server limit without filtering older tasks locally', async () => {
     clientMocks.getTasks.mockResolvedValue([
       {
-        created_at: Date.parse('2026-08-20T11:00:00Z') / 1000,
-        task_id: 'recent-task',
+        created_at: 2,
+        task_id: 'new-task',
       },
       {
-        created_at: Date.parse('2026-08-18T11:00:00Z') / 1000,
+        created_at: 1,
         task_id: 'old-task',
       },
     ])
 
-    await expect(fetchTasks('all', 'all', '24h')).resolves.toEqual([
-      expect.objectContaining({ task_id: 'recent-task' }),
-    ])
-    expect(clientMocks.getTasks).toHaveBeenCalledWith({
-      query: { limit: MAX_TASKS },
-    })
-    expect(MAX_TASKS).toBe(200)
-  })
-
-  it('keeps the all-time scope within the same API contract', async () => {
-    clientMocks.getTasks.mockResolvedValue([
-      { created_at: 1, task_id: 'old-task' },
-      { created_at: 2, task_id: 'new-task' },
-    ])
-
-    await expect(fetchTasks('all', 'all', 'all')).resolves.toEqual([
+    await expect(fetchTasks('all', 'all')).resolves.toEqual([
       expect.objectContaining({ task_id: 'new-task' }),
       expect.objectContaining({ task_id: 'old-task' }),
     ])
@@ -61,7 +40,7 @@ describe('task list requests', () => {
   it('uses the generated client contract for task-type filters', async () => {
     clientMocks.getTasks.mockResolvedValue([])
 
-    await fetchTasks('session_commit', 'all', 'all')
+    await fetchTasks('session_commit', 'all')
 
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
       query: {
@@ -80,7 +59,7 @@ describe('task list requests', () => {
       })),
     )
 
-    await expect(fetchTasks('all', 'pending', 'all')).resolves.toEqual([
+    await expect(fetchTasks('all', 'pending')).resolves.toEqual([
       expect.objectContaining({ task_id: 'task-9' }),
     ])
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
@@ -91,8 +70,6 @@ describe('task list requests', () => {
   it('propagates request failures to the query error state', async () => {
     clientMocks.getTasks.mockRejectedValue(new Error('request failed'))
 
-    await expect(fetchTasks('all', 'all', 'all')).rejects.toThrow(
-      'request failed',
-    )
+    await expect(fetchTasks('all', 'all')).rejects.toThrow('request failed')
   })
 })

--- a/web-studio/src/routes/tasks/-lib/task-list.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.test.ts
@@ -35,6 +35,7 @@ describe('task list requests', () => {
     expect(clientMocks.getTasks).toHaveBeenCalledWith({
       query: { limit: MAX_TASKS },
     })
+    expect(MAX_TASKS).toBe(200)
   })
 
   it('uses the generated client contract for task-type filters', async () => {

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -1,0 +1,76 @@
+import { getOvResult, getTasks } from '#/lib/ov-client'
+import {
+  normalizeTasks,
+  normalizeTaskStatus,
+} from '#/routes/tasks/-lib/task-record'
+import type { TaskRecord, TaskStatus } from '#/routes/tasks/-lib/task-record'
+
+export type TaskStatusFilter = Exclude<TaskStatus, 'unknown'> | 'all'
+
+export type TaskTypeFilter =
+  | 'add_resource'
+  | 'add_skill'
+  | 'admin_reindex'
+  | 'connector_import'
+  | 'legacy_cleanup'
+  | 'legacy_migration'
+  | 'session_commit'
+  | 'snapshot_restore_reindex'
+  | 'all'
+
+export type TaskDataScope = '24h' | 'all'
+
+export const MAX_TASKS = 200
+const MAX_EFFECTIVE_RUNNING_TASKS = 8
+
+export function getEffectiveTaskStatus(
+  taskItem: TaskRecord,
+  list: TaskRecord[],
+): TaskStatus {
+  const rawStatus = normalizeTaskStatus(taskItem.status)
+  if (rawStatus !== 'running') {
+    return rawStatus
+  }
+  const runningList = list
+    .filter((task) => normalizeTaskStatus(task.status) === 'running')
+    .sort(
+      (left, right) =>
+        Number(left.created_at || 0) - Number(right.created_at || 0),
+    )
+  const index = runningList.findIndex(
+    (task) => task.task_id === taskItem.task_id,
+  )
+  return index >= MAX_EFFECTIVE_RUNNING_TASKS ? 'pending' : 'running'
+}
+
+export async function fetchTasks(
+  taskType: TaskTypeFilter,
+  status: TaskStatusFilter,
+  dataScope: TaskDataScope = '24h',
+): Promise<TaskRecord[]> {
+  const result = await getOvResult<unknown>(
+    getTasks({
+      query: {
+        limit: MAX_TASKS,
+        ...(taskType === 'all' ? {} : { task_type: taskType }),
+      },
+    }),
+  )
+  let fetched = normalizeTasks(result).sort(
+    (left, right) =>
+      Number(right.created_at || 0) - Number(left.created_at || 0),
+  )
+  if (dataScope === '24h') {
+    const nowSec = Math.floor(Date.now() / 1000)
+    fetched = fetched.filter((task) => {
+      const timestamp = Number(task.created_at || task.updated_at || 0)
+      return timestamp > 0 && nowSec - timestamp <= 86_400
+    })
+  }
+  if (status !== 'all') {
+    fetched = fetched.filter(
+      (task) => getEffectiveTaskStatus(task, fetched) === status,
+    )
+  }
+  return fetched
+}

--- a/web-studio/src/routes/tasks/-lib/task-list.ts
+++ b/web-studio/src/routes/tasks/-lib/task-list.ts
@@ -18,8 +18,6 @@ export type TaskTypeFilter =
   | 'snapshot_restore_reindex'
   | 'all'
 
-export type TaskDataScope = '24h' | 'all'
-
 export const MAX_TASKS = 200
 const MAX_EFFECTIVE_RUNNING_TASKS = 8
 
@@ -46,7 +44,6 @@ export function getEffectiveTaskStatus(
 export async function fetchTasks(
   taskType: TaskTypeFilter,
   status: TaskStatusFilter,
-  dataScope: TaskDataScope = '24h',
 ): Promise<TaskRecord[]> {
   const result = await getOvResult<unknown>(
     getTasks({
@@ -56,19 +53,12 @@ export async function fetchTasks(
       },
     }),
   )
-  let fetched = normalizeTasks(result).sort(
+  const fetched = normalizeTasks(result).sort(
     (left, right) =>
       Number(right.created_at || 0) - Number(left.created_at || 0),
   )
-  if (dataScope === '24h') {
-    const nowSec = Math.floor(Date.now() / 1000)
-    fetched = fetched.filter((task) => {
-      const timestamp = Number(task.created_at || task.updated_at || 0)
-      return timestamp > 0 && nowSec - timestamp <= 86_400
-    })
-  }
   if (status !== 'all') {
-    fetched = fetched.filter(
+    return fetched.filter(
       (task) => getEffectiveTaskStatus(task, fetched) === status,
     )
   }

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -43,39 +43,28 @@ import {
   TableRow,
 } from '#/components/ui/table'
 import { useAppConnection } from '#/hooks/use-app-connection'
-import { getOvResult, getTasks, ovClient } from '#/lib/ov-client'
+import { ovClient } from '#/lib/ov-client'
 import { postResources } from '#/gen/ov-client'
 import { commitSession } from '#/lib/sessions/api'
 import { cn } from '#/lib/utils'
 import { QueueStatusCard } from '#/routes/monitoring/-components/queue-status-card'
 import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
-import {
-  normalizeTasks,
-  normalizeTaskStatus,
-} from '#/routes/tasks/-lib/task-record'
-import type { TaskRecord, TaskStatus } from '#/routes/tasks/-lib/task-record'
+import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
+import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
+import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
+import type {
+  TaskDataScope,
+  TaskStatusFilter,
+  TaskTypeFilter,
+} from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
 export const Route = createFileRoute('/tasks')({
   component: TasksRoute,
 })
 
-type TaskStatusFilter = Exclude<TaskStatus, 'unknown'> | 'all'
-
-type TaskTypeFilter =
-  | 'add_resource'
-  | 'add_skill'
-  | 'admin_reindex'
-  | 'connector_import'
-  | 'legacy_cleanup'
-  | 'legacy_migration'
-  | 'session_commit'
-  | 'snapshot_restore_reindex'
-  | 'all'
-
 const DEFAULT_PAGE_SIZE = 20
-const MAX_TASKS = 300
 const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
 const TASK_TYPE_OPTIONS: Exclude<TaskTypeFilter, 'all'>[] = [
   'session_commit',
@@ -95,74 +84,6 @@ const TASK_STATUS_OPTIONS: Exclude<TaskStatusFilter, 'all'>[] = [
   'failed',
   'cancelled',
 ]
-
-// 根据 8 并发物理上限计算任务的物理有效状态 (前 8 个 running, 第 9 个及以后 pending)
-export function getEffectiveTaskStatus(taskItem: any, list: any[]): string {
-  const rawStatus = normalizeTaskStatus(taskItem.status)
-  if (rawStatus !== 'running') {
-    return rawStatus
-  }
-  const runningList = list
-    .filter((t) => normalizeTaskStatus(t.status) === 'running')
-    .sort((a, b) => Number(a.created_at || 0) - Number(b.created_at || 0))
-  const idx = runningList.findIndex((t) => t.task_id === taskItem.task_id)
-  return idx >= 8 ? 'pending' : 'running'
-}
-
-export type TaskDataScope = '24h' | 'all'
-
-async function fetchTasks(
-  taskType: TaskTypeFilter,
-  status: TaskStatusFilter,
-  dataScope: TaskDataScope = '24h',
-): Promise<TaskRecord[]> {
-  const query = {
-    limit: dataScope === 'all' ? 10000 : MAX_TASKS,
-    status: undefined,
-    task_type: taskType === 'all' ? undefined : taskType,
-    include_archived: dataScope === 'all' ? true : undefined,
-  }
-  try {
-    const result = await getOvResult<unknown>(
-      getTasks({
-        query: query as any,
-      }),
-    )
-    let fetched = normalizeTasks(result).sort(
-      (a, b) => Number(b.created_at || 0) - Number(a.created_at || 0),
-    )
-    if (dataScope === '24h') {
-      const nowSec = Math.floor(Date.now() / 1000)
-      fetched = fetched.filter((t) => {
-        const timeVal = Number(t.created_at || t.updated_at || 0)
-        return timeVal > 0 && nowSec - timeVal <= 86400
-      })
-    }
-    // 根据 8 并发物理上限计算任务的物理有效状态 (前 8 个 running, 第 9 个及以后 pending)
-    const getEffectiveTaskStatus = (taskItem: any, list: any[]): string => {
-      const rawStatus = normalizeTaskStatus(taskItem.status)
-      if (rawStatus !== 'running') {
-        return rawStatus
-      }
-      const runningList = list
-        .filter((t) => normalizeTaskStatus(t.status) === 'running')
-        .sort((a, b) => Number(a.created_at || 0) - Number(b.created_at || 0))
-      const idx = runningList.findIndex((t) => t.task_id === taskItem.task_id)
-      return idx >= 8 ? 'pending' : 'running'
-    }
-
-    if (status !== 'all') {
-      fetched = fetched.filter((t) => getEffectiveTaskStatus(t, fetched) === status)
-    }
-    if (taskType !== 'all') {
-      fetched = fetched.filter((t) => t.task_type === taskType)
-    }
-    return fetched
-  } catch (err) {
-    console.warn('[fetchTasks] Backend fetch failed:', err)
-    return []
-  }
-}
 
 function TasksRoute() {
   const { i18n, t } = useTranslation('tasksPage')
@@ -353,7 +274,7 @@ function TasksRoute() {
     const effStatus = getEffectiveTaskStatus(task, allTasks)
     const status = normalizeTaskStatus(effStatus)
     const pct = getTaskProgressPct(task)
-    const isRetrying = retryMutation.isPending && retryMutation.variables?.task_id === taskId
+    const isRetrying = retryMutation.isPending && retryMutation.variables.task_id === taskId
     const Icon =
       status === 'completed'
         ? CheckCircle2Icon
@@ -470,29 +391,6 @@ function TasksRoute() {
       </div>
     )
   }
-
-  const taskStatsQuery = useQuery({
-    queryFn: async () => {
-      try {
-        const resp = await ovClient.instance.get('/api/v1/tasks/stats')
-        const json = resp.data
-        if (json.result) {
-          return json.result as {
-            total: number
-            completed: number
-            pending: number
-            running: number
-            failed: number
-          }
-        }
-      } catch {
-        // Fallback to local counts if endpoint fails
-      }
-      return null
-    },
-    queryKey: ['taskStats', identityScopeKey],
-    refetchInterval: 5_000,
-  })
 
   const queueRows = React.useMemo(() => {
     const map: Record<
@@ -711,18 +609,11 @@ function TasksRoute() {
             type="button"
             variant="outline"
             size="sm"
-            disabled={tasksQuery.isFetching || taskStatsQuery.isFetching}
-            onClick={() => {
-              void tasksQuery.refetch()
-              void taskStatsQuery.refetch()
-            }}
+            disabled={tasksQuery.isFetching}
+            onClick={() => void tasksQuery.refetch()}
           >
             <RefreshCwIcon
-              className={
-                tasksQuery.isFetching || taskStatsQuery.isFetching
-                  ? 'animate-spin'
-                  : undefined
-              }
+              className={tasksQuery.isFetching ? 'animate-spin' : undefined}
             />
             {t('refresh')}
           </Button>

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -53,11 +53,7 @@ import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
-import type {
-  TaskDataScope,
-  TaskStatusFilter,
-  TaskTypeFilter,
-} from './-lib/task-list'
+import type { TaskStatusFilter, TaskTypeFilter } from './-lib/task-list'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
 export const Route = createFileRoute('/tasks')({
@@ -94,14 +90,13 @@ function TasksRoute() {
   const [taskType, setTaskType] = React.useState<TaskTypeFilter>('all')
   const [statusFilter, setStatusFilter] =
     React.useState<TaskStatusFilter>('all')
-  const [dataScope, setDataScope] = React.useState<TaskDataScope>('24h')
   const [dedupByResource, setDedupByResource] = React.useState<boolean>(true)
   const [selectedTaskId, setSelectedTaskId] = React.useState<string | null>(
     null,
   )
   const tasksQuery = useQuery({
-    queryFn: () => fetchTasks(taskType, statusFilter, dataScope),
-    queryKey: ['tasks', identityScopeKey, taskType, statusFilter, dataScope],
+    queryFn: () => fetchTasks(taskType, statusFilter),
+    queryKey: ['tasks', identityScopeKey, taskType, statusFilter],
     refetchInterval: 10_000,
   })
   const rawTasks = tasksQuery.data ?? []
@@ -723,29 +718,6 @@ function TasksRoute() {
           {t('filters.label')}
         </span>
         <Select
-          value={dataScope}
-          onValueChange={(value) => {
-            setDataScope(value as TaskDataScope)
-            setPage(1)
-          }}
-        >
-          <SelectTrigger
-            size="sm"
-            className="min-w-32 bg-background font-medium"
-            aria-label={t('filters.scope')}
-          >
-            <SelectValue>
-              {dataScope === '24h'
-                ? t('filters.scope24h')
-                : t('filters.scopeAll')}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="24h">{t('filters.scope24h')}</SelectItem>
-            <SelectItem value="all">{t('filters.scopeAll')}</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select
           value={taskType}
           onValueChange={(value) => {
             setTaskType(value as TaskTypeFilter)
@@ -799,7 +771,7 @@ function TasksRoute() {
             ))}
           </SelectContent>
         </Select>
-        {hasActiveFilters || dataScope !== '24h' ? (
+        {hasActiveFilters ? (
           <Button
             type="button"
             variant="ghost"
@@ -808,7 +780,6 @@ function TasksRoute() {
             onClick={() => {
               setTaskType('all')
               setStatusFilter('all')
-              setDataScope('24h')
               setPage(1)
             }}
           >
@@ -826,10 +797,10 @@ function TasksRoute() {
           {i18n.language.startsWith('zh')
             ? dedupByResource
               ? '按资源收敛 (最新)'
-              : '全部历史记录'
+              : '逐条任务'
             : dedupByResource
               ? 'Latest per Resource'
-              : 'All History Logs'}
+              : 'Individual Tasks'}
         </Button>
       </div>
 


### PR DESCRIPTION
## Description

Fix a Web Studio Tasks page regression introduced in #3828, which began generating invalid requests against a healthy OpenViking server. This restores the task-list API contract: requests are capped at 200, the unsupported `/api/v1/tasks/stats` poll and time-scope selector are removed, and task-list failures reach the existing error state instead of appearing as an empty list.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Related PR: #3828

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Request up to the server-supported maximum of 200 tasks through the generated client.
- Remove the unsupported 24-hour/all-time selector and its client-side time filtering; Web Studio now displays the task records returned by the server.
- Remove the `/api/v1/tasks/stats` poll; the displayed metrics already derive from the task list.
- Rename the task grouping toggle's ungrouped state from "All History Logs" to "Individual Tasks."
- Propagate task-list errors to the existing error state and add focused request, filtering, and error regression tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `npm test` with Node.js 22: 47 files and 182 tests passed.
- `npm run build` with Node.js 22.
- Focused ESLint and Prettier checks on the changed files.
- Real local OpenViking server contract: `GET /api/v1/tasks?limit=200` returned 200, `limit=300` returned 400, and `/api/v1/tasks/stats` returned 404.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not included. The Tasks filter row now contains task type, task status, and the grouping toggle; the unsupported time-scope selector is removed.

## Additional Notes

The server does not expose complete task history through this endpoint, so this PR does not label the returned task set as 24-hour or all-time data.

Repository-wide lint still reports two pre-existing errors in `task-pipeline.ts`; that file is unchanged from `upstream/main`. Focused lint for this change passes with no errors.
