### PR TITLE
fix(storage): exclude watch control files from backups

### DIFF
--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -14,6 +14,7 @@ from openviking.core.namespace import (
     is_session_uri,
     relative_uri_path,
 )
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.index_consistency import check_index_consistency
 from openviking.storage.ovpack.format import (
@@ -405,6 +406,8 @@ async def _backup_entries(viking_fs, ctx: RequestContext) -> list[dict[str, Any]
             scoped_entry = dict(entry)
             scoped_entry["rel_path"] = f"{scope}/{rel_path}"
             scoped_entry["uri"] = join_uri(scope_uri, rel_path)
+            if is_watch_task_control_uri(scoped_entry["uri"]):
+                continue
             entries.append(scoped_entry)
     return entries
 

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -181,6 +181,9 @@ class FakeBackupVikingFS:
     def __init__(self) -> None:
         self.binary_files = {
             "viking://resources/README.md": b"hello",
+            "viking://resources/.watch_tasks.json": b"{}",
+            "viking://resources/.watch_tasks.json.bak": b"{}",
+            "viking://resources/.watch_tasks.json.tmp": b"{}",
             "viking://user/resources/sessions/sess_1/.meta.json": b'{"session_id":"sess_1"}',
         }
         self.tree_contexts: list[tuple[str, RequestContext]] = []
@@ -204,7 +207,25 @@ class FakeBackupVikingFS:
                     "uri": "viking://resources/README.md",
                     "isDir": False,
                     "size": 5,
-                }
+                },
+                {
+                    "rel_path": ".watch_tasks.json",
+                    "uri": "viking://resources/.watch_tasks.json",
+                    "isDir": False,
+                    "size": 2,
+                },
+                {
+                    "rel_path": ".watch_tasks.json.bak",
+                    "uri": "viking://resources/.watch_tasks.json.bak",
+                    "isDir": False,
+                    "size": 2,
+                },
+                {
+                    "rel_path": ".watch_tasks.json.tmp",
+                    "uri": "viking://resources/.watch_tasks.json.tmp",
+                    "isDir": False,
+                    "size": 2,
+                },
             ]
         if uri == "viking://user":
             return [
@@ -614,8 +635,15 @@ async def test_backup_restore_contract(
         names = set(zf.namelist())
         manifest = json.loads(zf.read("openviking-backup/_ovpack/manifest.json").decode("utf-8"))
 
+    manifest_paths = {entry["path"] for entry in manifest["entries"]}
     assert "openviking-backup/files/resources/README.md" in names
     assert "openviking-backup/files/user/resources/sessions/sess_1/.meta.json" in names
+    assert "openviking-backup/files/resources/.watch_tasks.json" not in names
+    assert "openviking-backup/files/resources/.watch_tasks.json.bak" not in names
+    assert "openviking-backup/files/resources/.watch_tasks.json.tmp" not in names
+    assert "resources/.watch_tasks.json" not in manifest_paths
+    assert "resources/.watch_tasks.json.bak" not in manifest_paths
+    assert "resources/.watch_tasks.json.tmp" not in manifest_paths
     assert all(ctx.role == Role.ROOT for _, ctx in backup_fs.tree_contexts)
     assert manifest["root"] == {
         "name": "openviking-backup",


### PR DESCRIPTION
## Description

Fix backup and restore round trips when a workspace contains watch tasks.

`ov backup` previously included `.watch_tasks.json` and its temporary/backup variants, while restore correctly rejects these internal control files. This produced backup packages that could not be restored.

Watch control files are now excluded from backups. Restore-side validation remains unchanged.

## Related Issue

Fixes #4139

## Changes Made

- Exclude watch task control files from `_backup_entries()`.
- Keep instance-local scheduler state out of portable backup packages.
- Add regression coverage to verify that the files are absent from both the archive and manifest, and that the backup can be restored.

## Testing

```bash
PYTHONPATH=. .venv/bin/python -m pytest --no-cov \
  tests/misc/test_ovpack_import_policy.py -v

.venv/bin/ruff format --check \
  openviking/storage/ovpack/operations.py \
  tests/misc/test_ovpack_import_policy.py

.venv/bin/ruff check \
  openviking/storage/ovpack/operations.py \
  tests/misc/test_ovpack_import_policy.py

git diff --check