### PR TITLE
Fix/backup-restore-watch-control-files

### DIFF
--- a/docs/en/api/14-ovpack.md
+++ b/docs/en/api/14-ovpack.md
@@ -301,6 +301,9 @@ pure-dense vector snapshots; hybrid index types reject vector snapshot export.
 Backup reads live files and does not provide an atomic point-in-time snapshot.
 Callers that require strict consistency should pause writes during the backup window.
 
+Watch task schedules are instance-local and do not migrate: backup excludes
+their control files, and restore skips any that older packs contain.
+
 ```
 POST /api/v1/pack/backup
 ```

--- a/docs/zh/api/14-ovpack.md
+++ b/docs/zh/api/14-ovpack.md
@@ -298,6 +298,8 @@ ov import ./exports/my-project.ovpack viking://resources/imported/ --vector-mode
 
 备份是在线逐文件读取，不保证同一时刻的原子快照。需要严格一致性时，调用方应在备份窗口暂停写入。
 
+Watch 任务调度是实例本地的，不会随备份迁移：备份会排除其控制文件，restore 时若旧备份包中含有也会跳过。
+
 ```
 POST /api/v1/pack/backup
 ```

--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -14,6 +14,7 @@ from openviking.core.namespace import (
     is_session_uri,
     relative_uri_path,
 )
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.identity import RequestContext
 from openviking.storage.index_consistency import check_index_consistency
 from openviking.storage.ovpack.format import (
@@ -405,6 +406,8 @@ async def _backup_entries(viking_fs, ctx: RequestContext) -> list[dict[str, Any]
             scoped_entry = dict(entry)
             scoped_entry["rel_path"] = f"{scope}/{rel_path}"
             scoped_entry["uri"] = join_uri(scope_uri, rel_path)
+            if is_watch_task_control_uri(scoped_entry["uri"]):
+                continue
             entries.append(scoped_entry)
     return entries
 
@@ -654,7 +657,9 @@ async def restore_ovpack(
 
         manifest_entries = manifest_entries_by_path(manifest)
         backup_scopes = backup_scopes_from_manifest(manifest, manifest_entries)
-        members = validated_import_members(infolist, base_name, root_uri)
+        members = validated_import_members(
+            infolist, base_name, root_uri, skip_watch_control_files=True
+        )
 
         index_records = validate_manifest_content(zf, manifest, infolist, base_name)
         dense_vectors = read_dense_vectors(zf, manifest, base_name, index_records)

--- a/openviking/storage/ovpack/validation.py
+++ b/openviking/storage/ovpack/validation.py
@@ -8,6 +8,7 @@ import json
 import zipfile
 from typing import Any
 
+from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.storage.ovpack.format import (
     OVPACK_DENSE_PATH,
     OVPACK_INDEX_RECORDS_PATH,
@@ -30,6 +31,9 @@ from openviking.storage.ovpack.manifest import (
 )
 from openviking.storage.ovpack.policy import validate_import_target_uri
 from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def base_name_from_entries(infolist: list[zipfile.ZipInfo]) -> str:
@@ -484,8 +488,20 @@ def validate_manifest_content(
 
 
 def validated_import_members(
-    infolist: list[zipfile.ZipInfo], base_name: str, root_uri: str
+    infolist: list[zipfile.ZipInfo],
+    base_name: str,
+    root_uri: str,
+    *,
+    skip_watch_control_files: bool = False,
 ) -> list[tuple[zipfile.ZipInfo, str, str, str]]:
+    """Validate and classify every zip member for import/restore.
+
+    ``skip_watch_control_files`` is used by backup restore: backup packs
+    produced by older versions may carry ``viking://resources/.watch_tasks.json``
+    and friends, which are instance-local scheduling state and cannot be
+    imported. Skipping them (instead of rejecting the whole pack) lets those
+    packs round-trip.
+    """
     members: list[tuple[zipfile.ZipInfo, str, str, str]] = []
     for info in infolist:
         zip_path = info.filename
@@ -516,6 +532,9 @@ def validated_import_members(
             members.append((info, safe_zip_path, kind, rel_path))
             continue
         target_uri = join_uri(root_uri, rel_path)
+        if skip_watch_control_files and is_watch_task_control_uri(target_uri):
+            logger.warning(f"[ovpack] Skipping watch task control file: {target_uri}")
+            continue
         validate_import_target_uri(target_uri)
         members.append((info, safe_zip_path, kind, rel_path))
 

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -272,6 +272,43 @@ class MissingSidecarBackupVikingFS(FakeBackupVikingFS):
         )
 
 
+class WatchTaskBackupVikingFS(FakeBackupVikingFS):
+    def __init__(self) -> None:
+        super().__init__()
+        self.binary_files["viking://resources/.watch_tasks.json"] = b'{"tasks":[]}'
+
+    async def tree(
+        self,
+        uri: str,
+        show_all_hidden: bool = False,
+        node_limit=None,
+        level_limit=None,
+        ctx=None,
+    ):
+        if uri == "viking://resources":
+            return [
+                {
+                    "rel_path": "README.md",
+                    "uri": "viking://resources/README.md",
+                    "isDir": False,
+                    "size": 5,
+                },
+                {
+                    "rel_path": ".watch_tasks.json",
+                    "uri": "viking://resources/.watch_tasks.json",
+                    "isDir": False,
+                    "size": 13,
+                },
+            ]
+        return await super().tree(
+            uri,
+            show_all_hidden=show_all_hidden,
+            node_limit=node_limit,
+            level_limit=level_limit,
+            ctx=ctx,
+        )
+
+
 class FakeRestoreVectorVikingFS(FakeVikingFS):
     async def tree(self, uri: str, node_limit=None, level_limit=None, ctx=None):
         self.tree_calls.append(uri)
@@ -690,6 +727,83 @@ async def test_backup_skips_missing_semantic_sidecars(
     assert "openviking-backup/files/user/.overview.md" not in names
     assert "user/.overview.md" not in manifest_paths
     assert "user" in manifest_paths
+
+
+@pytest.mark.asyncio
+async def test_backup_excludes_watch_task_control_files(
+    temp_ovpack_path: Path,
+    request_ctx: RequestContext,
+):
+    await backup_ovpack(
+        WatchTaskBackupVikingFS(),
+        str(temp_ovpack_path),
+        ctx=request_ctx,
+    )
+
+    with zipfile.ZipFile(temp_ovpack_path, "r") as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("openviking-backup/_ovpack/manifest.json").decode("utf-8"))
+
+    manifest_paths = {entry["path"] for entry in manifest["entries"]}
+    assert "openviking-backup/files/resources/.watch_tasks.json" not in names
+    assert "resources/.watch_tasks.json" not in manifest_paths
+    assert "openviking-backup/files/resources/README.md" in names
+    assert "resources/README.md" in manifest_paths
+
+
+@pytest.mark.asyncio
+async def test_restore_skips_watch_task_control_files(
+    temp_ovpack_path: Path,
+    request_ctx: RequestContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    files = {
+        "resources/README.md": "hello",
+        "resources/.watch_tasks.json": '{"tasks":[]}',
+    }
+    manifest = _manifest_for_files("openviking-backup", files)
+    manifest["root"] = {
+        "name": "openviking-backup",
+        "uri": "viking://",
+        "scope": "root",
+        "package_type": "backup",
+    }
+    manifest["scopes"] = ["resources"]
+    entries_list: list[dict[str, object]] = manifest["entries"]  # type: ignore[assignment]
+    entries_list.insert(1, {"path": "resources", "kind": "directory"})
+    index_data = _set_manifest_index(manifest)
+    entries = {
+        "openviking-backup/": "",
+        "openviking-backup/files/": "",
+        "openviking-backup/files/resources/": "",
+        "openviking-backup/_ovpack/": "",
+        "openviking-backup/_ovpack/index_records.jsonl": index_data.decode("utf-8"),
+        "openviking-backup/_ovpack/manifest.json": json.dumps(manifest),
+    }
+    entries.update(
+        {f"openviking-backup/files/{rel_path}": content for rel_path, content in files.items()}
+    )
+    _write_ovpack(temp_ovpack_path, entries)
+
+    async def noop_vectorization(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "openviking.storage.ovpack.operations._enqueue_direct_vectorization",
+        noop_vectorization,
+    )
+
+    fake_fs = FakeVikingFS()
+    fake_fs.ls = AsyncMock(return_value=[])
+    fake_fs.stat = AsyncMock(side_effect=FileNotFoundError())
+    fake_fs.rm = AsyncMock()
+    result = await restore_ovpack(
+        fake_fs, str(temp_ovpack_path), request_ctx, on_conflict="overwrite"
+    )
+
+    assert result == "viking://"
+    assert fake_fs.written_files == ["viking://resources/README.md"]
+    fake_fs.rm.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -273,9 +273,16 @@ class MissingSidecarBackupVikingFS(FakeBackupVikingFS):
 
 
 class WatchTaskBackupVikingFS(FakeBackupVikingFS):
+    WATCH_CONTROL_FILES = {
+        ".watch_tasks.json": b'{"tasks":[]}',
+        ".watch_tasks.json.bak": b'{"backup":true}',
+        ".watch_tasks.json.tmp": b'{"tmp":true}',
+    }
+
     def __init__(self) -> None:
         super().__init__()
-        self.binary_files["viking://resources/.watch_tasks.json"] = b'{"tasks":[]}'
+        for name, data in self.WATCH_CONTROL_FILES.items():
+            self.binary_files[f"viking://resources/{name}"] = data
 
     async def tree(
         self,
@@ -286,20 +293,24 @@ class WatchTaskBackupVikingFS(FakeBackupVikingFS):
         ctx=None,
     ):
         if uri == "viking://resources":
-            return [
+            entries = [
                 {
                     "rel_path": "README.md",
                     "uri": "viking://resources/README.md",
                     "isDir": False,
                     "size": 5,
-                },
-                {
-                    "rel_path": ".watch_tasks.json",
-                    "uri": "viking://resources/.watch_tasks.json",
-                    "isDir": False,
-                    "size": 13,
-                },
+                }
             ]
+            entries.extend(
+                {
+                    "rel_path": name,
+                    "uri": f"viking://resources/{name}",
+                    "isDir": False,
+                    "size": len(data),
+                }
+                for name, data in self.WATCH_CONTROL_FILES.items()
+            )
+            return entries
         return await super().tree(
             uri,
             show_all_hidden=show_all_hidden,
@@ -745,8 +756,9 @@ async def test_backup_excludes_watch_task_control_files(
         manifest = json.loads(zf.read("openviking-backup/_ovpack/manifest.json").decode("utf-8"))
 
     manifest_paths = {entry["path"] for entry in manifest["entries"]}
-    assert "openviking-backup/files/resources/.watch_tasks.json" not in names
-    assert "resources/.watch_tasks.json" not in manifest_paths
+    for name in (".watch_tasks.json", ".watch_tasks.json.bak", ".watch_tasks.json.tmp"):
+        assert f"openviking-backup/files/resources/{name}" not in names
+        assert f"resources/{name}" not in manifest_paths
     assert "openviking-backup/files/resources/README.md" in names
     assert "resources/README.md" in manifest_paths
 
@@ -760,6 +772,8 @@ async def test_restore_skips_watch_task_control_files(
     files = {
         "resources/README.md": "hello",
         "resources/.watch_tasks.json": '{"tasks":[]}',
+        "resources/.watch_tasks.json.bak": '{"backup":true}',
+        "resources/.watch_tasks.json.tmp": '{"tmp":true}',
     }
     manifest = _manifest_for_files("openviking-backup", files)
     manifest["root"] = {


### PR DESCRIPTION
## Description

Backup of a workspace with an active watch task fails to round-trip: `ov backup` packs `viking://resources/.watch_tasks.json` (and `.bak`), but `ov restore` rejects the resulting pack with `cannot import watch task control file`, so any user with a watch task can neither backup nor restore.

Two root causes, both fixed:
- Backup runs under a ROOT maintenance context, which bypasses the watch-task control file filter in `_is_accessible`, so the control files end up in the pack.
- Restore validates every member with `validate_import_target_uri`, which unconditionally rejects watch control files, failing the entire pack.

Fix both sides:
- **Backup**: exclude watch-task control files from the backup walk (`_backup_entries`).
- **Restore**: skip (instead of reject) watch control members when restoring a backup, so packs created by older versions still round-trip. Import keeps rejecting them.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4139

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `openviking/storage/ovpack/operations.py`: skip `is_watch_task_control_uri` entries in `_backup_entries`; pass `skip_watch_control_files=True` from `restore_ovpack`.
- `openviking/storage/ovpack/validation.py`: add `skip_watch_control_files` keyword to `validated_import_members`; when set, log a warning and skip watch control members instead of validating/rejecting them.
- `tests/misc/test_ovpack_import_policy.py`: `test_backup_excludes_watch_task_control_files` (regression for the backup side) and `test_restore_skips_watch_task_control_files` (a pre-fix pack containing `.watch_tasks.json` restores successfully, skipping the control file).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] Windows

Local verification on Windows:
- `tests/misc/test_ovpack_import_policy.py`: 20 passed (incl. both new tests).
- `ruff check` / `ruff format --check` clean on all three changed files; `mypy` clean on both changed source files.
- Live end-to-end on a running server (reproduced issue #4139 first): `ov restore` of the previously-failing pack now succeeds, server logs `[ovpack] Skipping watch task control file: viking://resources/.watch_tasks.json` (and `.bak`) then `Successfully restored backup`; a fresh `ov backup` no longer contains the control files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The fix is additive and non-breaking: the default behavior of `validated_import_members` (used by `import_ovpack`) is unchanged — import still rejects watch control files; only the backup-restore path opts into skipping them.
