### PR TITLE
docs: use connect agent template tokens

### DIFF
--- a/docs/images/agents/en/agent-cli.md
+++ b/docs/images/agents/en/agent-cli.md
@@ -5,7 +5,7 @@ First ask the user for the OpenViking API Key and store it as OPENVIKING_API_KEY
 
 Write the following content to ~/.openviking/ovcli.conf, replacing ${OPENVIKING_API_KEY} with the actual value provided by the user:
 {
-  "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+  "url": "{{OPENVIKING_BASE_URL}}",
   "api_key": "${OPENVIKING_API_KEY}"
 }
 

--- a/docs/images/agents/en/api.md
+++ b/docs/images/agents/en/api.md
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import requests
 
-url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-api_key = "[TODO]your-api-key"
+url = "{{OPENVIKING_BASE_URL}}"
+api_key = "{{OPENVIKING_API_KEY}}"
 file_path = Path("[TODO]your-file-path")  # e.g. test.txt
 resource_to = "[TODO]your-resource-path"  # e.g. viking://resources/test.txt
 reason = "[TODO]your-reason"  # e.g. External API documentation

--- a/docs/images/agents/en/cli.md
+++ b/docs/images/agents/en/cli.md
@@ -15,6 +15,8 @@ https://api.vikingdb.cn-beijing.volces.com/openviking
 
 - API Key: Copy the API Key shown on the page into your terminal
 
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ### Step 3: After configuration, run the following command to view CLI usage:
 
 ```bash

--- a/docs/images/agents/en/cli.md
+++ b/docs/images/agents/en/cli.md
@@ -10,7 +10,7 @@ npm i -g @openviking/cli && ov config
 
 - Base URL: Copy the following Base URL into your terminal
 ```text
-https://api.vikingdb.cn-beijing.volces.com/openviking
+{{OPENVIKING_BASE_URL}}
 ```
 
 - API Key: Copy the API Key shown on the page into your terminal

--- a/docs/images/agents/en/cursor.md
+++ b/docs/images/agents/en/cursor.md
@@ -6,6 +6,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 Select **Volcengine OpenViking Cloud**. Paste the API key from this page.
 
+API Key: Copy the API Key shown on the page and paste it when the installer prompts for it.
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## Verify
 
 1. Restart Cursor and start a new Agent session.

--- a/docs/images/agents/en/deerflow-mcp.md
+++ b/docs/images/agents/en/deerflow-mcp.md
@@ -5,7 +5,7 @@ DeerFlow can connect to OpenViking through an MCP Server. MCP integration lets D
 Edit the `.env` file in the DeerFlow project root and add the API key from this page:
 
 ```bash
-OPENVIKING_API_KEY=[TODO]your-api-key
+OPENVIKING_API_KEY={{OPENVIKING_API_KEY}}
 ```
 
 ## Step 2: Create an MCP configuration file
@@ -26,7 +26,7 @@ Open `extensions_config.json` in the project root and add OpenViking under `mcpS
     "openviking": {
       "enabled": true,
       "type": "http",
-      "url": "https://api.vikingdb.cn-beijing.volces.com/openviking/mcp",
+      "url": "{{OPENVIKING_BASE_URL}}/mcp",
       "headers": {
         "X-API-Key": "$OPENVIKING_API_KEY"
       }

--- a/docs/images/agents/en/deerflow-memory-manager.md
+++ b/docs/images/agents/en/deerflow-memory-manager.md
@@ -5,7 +5,7 @@ DeerFlow can use OpenViking as a long-term memory backend through MemoryManager.
 Edit the `.env` file in the DeerFlow project root and add the API key from this page:
 
 ```bash
-OPENVIKING_API_KEY=[TODO]your-api-key
+OPENVIKING_API_KEY={{OPENVIKING_API_KEY}}
 ```
 
 ## Step 2: Update DeerFlow memory configuration
@@ -20,7 +20,7 @@ memory:
   manager_class: openviking
   mode: middleware
   backend_config:
-    base_url: https://api.vikingdb.cn-beijing.volces.com/openviking
+    base_url: {{OPENVIKING_BASE_URL}}
     owner_user_id: default
     api_key_env: OPENVIKING_API_KEY
     startup_policy: fail_fast
@@ -57,7 +57,7 @@ Successful log examples:
 
 ```text
 Memory manager resolved: OpenVikingMemoryManager (manager_class='openviking')
-HTTP Request: GET https://api.vikingdb.cn-beijing.volces.com/openviking/health "HTTP/1.1 200 OK"
+HTTP Request: GET {{OPENVIKING_BASE_URL}}/health "HTTP/1.1 200 OK"
 ```
 
 ## Step 5: Verify memory write and recall

--- a/docs/images/agents/en/hermes.md
+++ b/docs/images/agents/en/hermes.md
@@ -4,7 +4,9 @@
 hermes memory setup openviking
 ```
 
-Keep **OpenViking Service (VolcEngine Cloud)**. Paste the API key from this page.
+Keep **OpenViking Service (VolcEngine Cloud)**. Paste the API key from this page:
+
+{{OPENVIKING_API_KEY_BLOCK}}
 
 ## Verify
 

--- a/docs/images/agents/en/mcp.md
+++ b/docs/images/agents/en/mcp.md
@@ -4,9 +4,9 @@
 {
   "mcpServers": {
     "ov-mcp-server": {
-      "url": "https://api.vikingdb.cn-beijing.volces.com/openviking/mcp",
+      "url": "{{OPENVIKING_BASE_URL}}/mcp",
       "headers": {
-        "Authorization": "Bearer ZGVmYXV********YzdlZjhiMg"
+        "Authorization": "Bearer {{OPENVIKING_API_KEY}}"
       }
     }
   }

--- a/docs/images/agents/en/openclaw.md
+++ b/docs/images/agents/en/openclaw.md
@@ -1,5 +1,9 @@
 ## Install
 
+Copy the API key from this page:
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
 openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <API-key-from-this-page>

--- a/docs/images/agents/en/openclaw.md
+++ b/docs/images/agents/en/openclaw.md
@@ -6,7 +6,7 @@ Copy the API key from this page:
 
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
-openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <API-key-from-this-page>
+openclaw openviking setup --base-url {{OPENVIKING_BASE_URL}} --api-key <API-key-from-this-page>
 openclaw gateway restart
 ```
 

--- a/docs/images/agents/en/sdk.md
+++ b/docs/images/agents/en/sdk.md
@@ -13,8 +13,8 @@ Refer to the standard write example from GitHub and fill in the API Key and doma
 ```python
 from openviking.client import SyncHTTPClient
 
-url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-api_key = "[TODO]your-api-key"
+url = "{{OPENVIKING_BASE_URL}}"
+api_key = "{{OPENVIKING_API_KEY}}"
 
 client = SyncHTTPClient(
     url=url,

--- a/docs/images/agents/en/trae.md
+++ b/docs/images/agents/en/trae.md
@@ -10,6 +10,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 Select **Volcengine OpenViking Cloud**. Paste the API key from this page.
 
+API Key: Copy the API Key shown on the page and paste it when the installer prompts for it.
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## Verify
 
 Restart TRAE. Confirm `openviking` is connected in settings.

--- a/docs/images/agents/zh/agent-cli.md
+++ b/docs/images/agents/zh/agent-cli.md
@@ -6,7 +6,7 @@
 
 请在 ~/.openviking/ovcli.conf 写入以下内容：
 {
-  "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+  "url": "{{OPENVIKING_BASE_URL}}",
   "api_key": "${OPENVIKING_API_KEY}"
 }
 

--- a/docs/images/agents/zh/api.md
+++ b/docs/images/agents/zh/api.md
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import requests
 
-url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-api_key = "[TODO]your-api-key"
+url = "{{OPENVIKING_BASE_URL}}"
+api_key = "{{OPENVIKING_API_KEY}}"
 file_path = Path("[TODO]your-file-path") # e.g. test.txt
 resource_to = "[TODO]your-resource-path" # e.g. viking://resources/test.txt
 reason = "[TODO]your-reason" # e.g. External API documentation

--- a/docs/images/agents/zh/cli.md
+++ b/docs/images/agents/zh/cli.md
@@ -12,7 +12,7 @@ npm i -g @openviking/cli && ov config
 
 - Base URL: 复制以下 Base URL 到你的终端
 ```text
-https://api.vikingdb.cn-beijing.volces.com/openviking
+{{OPENVIKING_BASE_URL}}
 ```
 - API Key: 把本页展示的 API Key 粘贴到终端
 

--- a/docs/images/agents/zh/cli.md
+++ b/docs/images/agents/zh/cli.md
@@ -16,6 +16,8 @@ https://api.vikingdb.cn-beijing.volces.com/openviking
 ```
 - API Key: 把本页展示的 API Key 粘贴到终端
 
+{{OPENVIKING_API_KEY_BLOCK}}
+
 
 ### 步骤3：配置完成后，可运行以下命令查看 CLI 用法：
 

--- a/docs/images/agents/zh/cursor.md
+++ b/docs/images/agents/zh/cursor.md
@@ -6,6 +6,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 选 **火山引擎 OpenViking 云服务**，把本页 API Key 贴进去。
 
+API Key：复制页面中展示的 API Key，并在安装器提示时粘贴。
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## 验证
 
 1. 重启 Cursor，新建 Agent 会话。

--- a/docs/images/agents/zh/deerflow-mcp.md
+++ b/docs/images/agents/zh/deerflow-mcp.md
@@ -5,7 +5,7 @@ DeerFlow 支持通过 MCP Server 接入 OpenViking。MCP 接入的核心价值�
 在 DeerFlow 项目根目录下编辑 `.env` 文件，把本页的 API Key 填进去：
 
 ```bash
-OPENVIKING_API_KEY=[TODO]your-api-key
+OPENVIKING_API_KEY={{OPENVIKING_API_KEY}}
 ```
 
 ## 步骤 2：创建 MCP 配置文件
@@ -26,7 +26,7 @@ cp extensions_config.example.json extensions_config.json
     "openviking": {
       "enabled": true,
       "type": "http",
-      "url": "https://api.vikingdb.cn-beijing.volces.com/openviking/mcp",
+      "url": "{{OPENVIKING_BASE_URL}}/mcp",
       "headers": {
         "X-API-Key": "$OPENVIKING_API_KEY"
       }

--- a/docs/images/agents/zh/deerflow-memory-manager.md
+++ b/docs/images/agents/zh/deerflow-memory-manager.md
@@ -5,7 +5,7 @@ DeerFlow 支持通过 MemoryManager 接入 OpenViking 作为长期记忆后端�
 在 DeerFlow 项目根目录下编辑 `.env` 文件，把本页的 API Key 填进去：
 
 ```bash
-OPENVIKING_API_KEY=[TODO]your-api-key
+OPENVIKING_API_KEY={{OPENVIKING_API_KEY}}
 ```
 
 ## 步骤 2：修改 DeerFlow 的 memory 配置
@@ -20,7 +20,7 @@ memory:
   manager_class: openviking
   mode: middleware
   backend_config:
-    base_url: https://api.vikingdb.cn-beijing.volces.com/openviking
+    base_url: {{OPENVIKING_BASE_URL}}
     owner_user_id: default
     api_key_env: OPENVIKING_API_KEY
     startup_policy: fail_fast
@@ -57,7 +57,7 @@ grep -i "memory manager resolved\|openviking\|deermem" logs/gateway.log
 
 ```text
 Memory manager resolved: OpenVikingMemoryManager (manager_class='openviking')
-HTTP Request: GET https://api.vikingdb.cn-beijing.volces.com/openviking/health "HTTP/1.1 200 OK"
+HTTP Request: GET {{OPENVIKING_BASE_URL}}/health "HTTP/1.1 200 OK"
 ```
 
 ## 步骤 5：验证写入与召回

--- a/docs/images/agents/zh/hermes.md
+++ b/docs/images/agents/zh/hermes.md
@@ -4,7 +4,9 @@
 hermes memory setup openviking
 ```
 
-保持 **OpenViking Service (VolcEngine Cloud)**，把本页 API Key 贴进去。
+保持 **OpenViking Service (VolcEngine Cloud)**，把本页 API Key 贴进去：
+
+{{OPENVIKING_API_KEY_BLOCK}}
 
 ## 验证
 

--- a/docs/images/agents/zh/mcp.md
+++ b/docs/images/agents/zh/mcp.md
@@ -4,9 +4,9 @@
 {
   "mcpServers": {
     "ov-mcp-server": {
-      "url": "https://api.vikingdb.cn-beijing.volces.com/openviking/mcp",
+      "url": "{{OPENVIKING_BASE_URL}}/mcp",
       "headers": {
-        "Authorization": "Bearer ZGVmYXV********YzdlZjhiMg"
+        "Authorization": "Bearer {{OPENVIKING_API_KEY}}"
       }
     }
   }

--- a/docs/images/agents/zh/openclaw.md
+++ b/docs/images/agents/zh/openclaw.md
@@ -1,5 +1,9 @@
 ## 安装
 
+复制本页 API Key：
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
 openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <本页的-API-Key>

--- a/docs/images/agents/zh/openclaw.md
+++ b/docs/images/agents/zh/openclaw.md
@@ -6,7 +6,7 @@
 
 ```bash
 openclaw plugins install clawhub:@openviking/openclaw-plugin
-openclaw openviking setup --base-url https://api.vikingdb.cn-beijing.volces.com/openviking --api-key <本页的-API-Key>
+openclaw openviking setup --base-url {{OPENVIKING_BASE_URL}} --api-key <本页的-API-Key>
 openclaw gateway restart
 ```
 

--- a/docs/images/agents/zh/sdk.md
+++ b/docs/images/agents/zh/sdk.md
@@ -11,8 +11,8 @@ pip install openviking --upgrade --force-reinstall
 ```python
 from openviking.client import SyncHTTPClient
 
-url = "https://api.vikingdb.cn-beijing.volces.com/openviking"
-api_key = "[TODO]your-api-key"
+url = "{{OPENVIKING_BASE_URL}}"
+api_key = "{{OPENVIKING_API_KEY}}"
 
 client = SyncHTTPClient(
     url=url,

--- a/docs/images/agents/zh/trae.md
+++ b/docs/images/agents/zh/trae.md
@@ -10,6 +10,10 @@ bash <(curl -fsSL https://ovrelease.tos-cn-beijing.volces.com/memory-plugin-shar
 
 选 **火山引擎 OpenViking 云服务**，把本页 API Key 贴进去。
 
+API Key：复制页面中展示的 API Key，并在安装器提示时粘贴。
+
+{{OPENVIKING_API_KEY_BLOCK}}
+
 ## 验证
 
 重启 TRAE。在设置里确认 `openviking` 已连接。


### PR DESCRIPTION
## Description

This PR supersedes the previous unmerged Connect Agent docs PR and includes its changes.

It updates the Connect Agent GitHub markdown docs to use frontend-recognized template tokens instead of hardcoded OpenViking Cloud values or ad hoc API Key placeholders.

Frontend will replace these tokens at render time:
- `{{OPENVIKING_BASE_URL}}`
- `{{OPENVIKING_API_KEY}}`
- `{{OPENVIKING_API_KEY_BLOCK}}`

For `{{OPENVIKING_API_KEY}}`, the frontend displays a masked value on the page while preserving the full real key for copy actions.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Changes

- Replaces hardcoded OpenViking Cloud Base URL examples with `{{OPENVIKING_BASE_URL}}`.
- Replaces API Key placeholders in copyable examples with `{{OPENVIKING_API_KEY}}`.
- Keeps `{{OPENVIKING_API_KEY_BLOCK}}` for standalone API Key copy blocks.
- Keeps explicit manual API Key placeholders in shell commands where copying a real key into shell history would be unsafe.
- Updates both English and Chinese Connect Agent docs under `docs/images/agents`.

## Verification

- Confirmed `docs/images/agents` no longer contains the hardcoded OpenViking Cloud Base URL.
- Paired with frontend MR: https://code.byted.org/machinelearning/vikingdb-fe/merge_requests/420