### PR TITLE
fix(search): filter invalid result tags

### DIFF
--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -26,6 +26,7 @@ from openviking.storage.expr import FilterExpr
 from openviking.storage.semantic_sidecar import body_for_preview
 from openviking.storage.vikingdb_manager import VikingDBManager, VikingDBManagerProxy
 from openviking.telemetry import get_current_telemetry
+from openviking.utils.tags import normalize_search_tags
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking.utils.token_estimation import (
     estimate_text_tokens,
@@ -621,7 +622,9 @@ class HierarchicalRetriever:
                     abstract=abstract,
                     category=c.get("category", ""),
                     score=final_score,
-                    search_tags=list(c.get("search_tags") or []),
+                    search_tags=normalize_search_tags(
+                        c.get("search_tags"), discard_invalid=True
+                    ),
                 )
             )
 

--- a/openviking_cli/retrieve/types.py
+++ b/openviking_cli/retrieve/types.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from openviking.utils.tags import normalize_search_tags
+
 
 class ContextType(str, Enum):
     """Context type for retrieval."""
@@ -377,7 +379,7 @@ class FindResult:
             "level": ctx.level,
             "score": ctx.score,
             "abstract": ctx.abstract,
-            "tags": ctx.search_tags,
+            "tags": normalize_search_tags(ctx.search_tags, discard_invalid=True),
         }
 
     def _query_to_dict(self, q: TypedQuery) -> Dict[str, Any]:

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -639,7 +639,7 @@ async def test_convert_to_matched_contexts_propagates_search_tags():
                 "viking://resources/file-a",
                 1.0,
                 abstract="child A",
-                search_tags=["team=infra", "project=viking"],
+                search_tags=["default", "team=infra", "bad=", "project=viking"],
             )
         ],
         ctx=_ctx(),

--- a/tests/retrieve/test_provenance.py
+++ b/tests/retrieve/test_provenance.py
@@ -107,6 +107,21 @@ class TestMatchedContextSearchTags:
         assert d["resources"][0]["tags"] == ["team=infra", "project=viking"]
         assert "search_tags" not in d["resources"][0]
 
+    def test_context_to_dict_discards_legacy_invalid_tags(self):
+        ctx = MatchedContext(
+            uri="viking://resources/docs/arch.md",
+            context_type=ContextType.RESOURCE,
+            level=2,
+            search_tags=["default", "team=infra", "bad=", "project=viking"],
+        )
+
+        result = FindResult(memories=[], resources=[ctx], skills=[])
+
+        assert result.to_dict()["resources"][0]["tags"] == [
+            "team=infra",
+            "project=viking",
+        ]
+
     def test_context_to_dict_defaults_empty_tags(self):
         ctx = MatchedContext(
             uri="viking://resources/docs/arch.md",

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -14,6 +14,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.exceptions import InvalidArgumentError
+from openviking_cli.retrieve import ContextType, FindResult, MatchedContext
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -53,6 +54,41 @@ async def test_find_basic(client_with_resource):
     assert body["result"] is not None
     assert "usage" not in body
     assert "telemetry" not in body
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "service_method"),
+    [
+        ("/api/v1/search/find", "find"),
+        ("/api/v1/search/search", "search"),
+    ],
+)
+async def test_search_endpoints_filter_invalid_result_tags(
+    client: httpx.AsyncClient, service, monkeypatch, endpoint: str, service_method: str
+):
+    async def fake_search(**kwargs):
+        del kwargs
+        return FindResult(
+            memories=[],
+            resources=[
+                MatchedContext(
+                    uri="viking://resources/legacy-tags.md",
+                    context_type=ContextType.RESOURCE,
+                    search_tags=["default", "team=infra", "bad=", "project=viking"],
+                )
+            ],
+            skills=[],
+        )
+
+    monkeypatch.setattr(service.search, service_method, fake_search)
+
+    response = await client.post(endpoint, json={"query": "legacy tags"})
+
+    assert response.status_code == 200
+    assert response.json()["result"]["resources"][0]["tags"] == [
+        "team=infra",
+        "project=viking",
+    ]
 
 
 @pytest.mark.parametrize("endpoint", ["/api/v1/search/find", "/api/v1/search/search"])


### PR DESCRIPTION
## 变更说明

- 修正 session 自动提交策略的默认值，使其与发布配置保持一致：
  - `pending_token_threshold`: `150000`
  - `message_count_threshold`: `100`
  - `keep_recent_count`: `0`
- 读取历史向量记录的标签时，仅展示严格 `key=value` 格式的业务标签。
  - `fs/attrs`、`/api/v1/search/find` 和默认 list 模式的 `/api/v1/search/search` 都会过滤裸标签（例如 `default`）和非法标签（例如 `bad=`）。
  - 合法标签会保持原有规范化行为；该改动只影响读取结果，不会回写或迁移存量向量数据。
- 补充检索转换、公共结果序列化及两个 HTTP 搜索接口的回归测试。

## 验证

- `uv run --active pytest tests/retrieve/test_hierarchical_retriever_rerank.py tests/retrieve/test_provenance.py tests/server/test_api_search.py::test_search_endpoints_filter_invalid_result_tags -q`
  - `32 passed`
- `uv run --active ruff check openviking/retrieve/hierarchical_retriever.py openviking_cli/retrieve/types.py tests/retrieve/test_hierarchical_retriever_rerank.py tests/retrieve/test_provenance.py tests/server/test_api_search.py`
- `git diff --check`
