### PR TITLE
docs(embedding): clarify DashScope endpoint configuration

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -474,7 +474,8 @@ Get your API key at https://aistudio.google.com/apikey
       "provider": "dashscope",
       "api_key": "${DASHSCOPE_API_KEY}",
       "model": "text-embedding-v4",
-      "dimension": 1024
+      "dimension": 1024,
+      "input": "text"
     }
   }
 }
@@ -491,11 +492,11 @@ Get your API key at https://aistudio.google.com/apikey
 | `qwen3-vl-embedding` | 2560 | multimodal | Text + image + video |
 | `qwen2.5-vl-embedding` | 1024 | multimodal | Text + image + video |
 
-**Multimodal parameters** (text+image/video models only):
+**Input and multimodal parameters**:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `input_type` | str | `"multimodal"` or `"text"` | Embedding mode (default: `"multimodal"`) |
+| `input` | str | `"multimodal"` | Embedding mode: `"text"` or `"multimodal"` |
 | `enable_fusion` | bool | `false` | Enable fusion vectors for `tongyi-embedding-vision-*` models |
 | `res_level` | int | `2` | Image resolution level (1=high, 2=medium, 3=low) |
 | `max_video_frames` | int | `16` | Maximum video frames to embed |
@@ -507,7 +508,11 @@ Get your API key at https://aistudio.google.com/apikey
 | China | `https://dashscope.aliyuncs.com` (default) | Recommended for users in mainland China |
 | International | `https://dashscope-intl.aliyuncs.com` | For users outside China |
 
-Custom endpoint URLs are also supported by setting a full URL.
+For a custom gateway, set `api_base` to the gateway's base URL. OpenViking
+appends the mode-specific endpoint path automatically, so do not include
+`/compatible-mode/v1` (text mode) or
+`/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding`
+(multimodal mode) in `api_base`.
 
 Get your API key at https://dashscope.console.aliyun.com/api-key
 

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -444,7 +444,8 @@ openviking-server doctor
       "provider": "dashscope",
       "api_key": "${DASHSCOPE_API_KEY}",
       "model": "text-embedding-v4",
-      "dimension": 1024
+      "dimension": 1024,
+      "input": "text"
     }
   }
 }
@@ -461,11 +462,11 @@ openviking-server doctor
 | `qwen3-vl-embedding` | 2560 | multimodal | 文本 + 图像 + 视频 |
 | `qwen2.5-vl-embedding` | 1024 | multimodal | 文本 + 图像 + 视频 |
 
-**多模态参数**（仅文本+图像/视频模型支持）:
+**输入和多模态参数**:
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `input_type` | str | `"multimodal"` 或 `"text"` | 嵌入模式（默认: `"multimodal"`） |
+| `input` | str | `"multimodal"` | 嵌入模式：`"text"` 或 `"multimodal"` |
 | `enable_fusion` | bool | `false` | 为 `tongyi-embedding-vision-*` 模型启用融合向量 |
 | `res_level` | int | `2` | 图像分辨率级别（1=高，2=中，3=低） |
 | `max_video_frames` | int | `16` | 视频最大嵌入帧数 |
@@ -477,7 +478,11 @@ openviking-server doctor
 | 中国 | `https://dashscope.aliyuncs.com`（默认） | 推荐中国大陆用户使用 |
 | 国际 | `https://dashscope-intl.aliyuncs.com` | 推荐中国境外用户使用 |
 
-也支持设置完整 URL 来自定义端点地址。
+如果使用自定义网关，`api_base` 应填写网关根地址。OpenViking 会根据
+输入模式自动追加 endpoint 路径，因此不要在 `api_base` 中包含
+`/compatible-mode/v1`（文本模式）或
+`/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding`
+（多模态模式）。
 
 获取 API Key: https://dashscope.console.aliyun.com/api-key
 


### PR DESCRIPTION
## Description

The DashScope embedding guide did not match the current configuration contract:
the text model example omitted `input: "text"`, the parameter table used
`input_type` instead of the `ov.conf` key `input`, and the endpoint note told
users to provide a complete endpoint URL even though the embedder appends the
mode-specific path itself. These mismatches can lead to an invalid URL or send
a text-only model through the multimodal path.

This PR aligns the English and Chinese guides with the current implementation.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4132

## Type of Change

- [ ] Bug fix (non-breaking change that fixes a bug)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add `input: "text"` to the `text-embedding-v4` examples.
- Document the actual `input` configuration key.
- Clarify that `api_base` must not include the mode-specific endpoint suffixes
  appended by OpenViking.
- Keep the English and Chinese guidance equivalent.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

Validation performed:

- `git diff --check`
- Targeted assertions confirmed both localized examples use `input: "text"`,
  both tables use `input`, and the endpoint suffix guidance is present.
- The VitePress build was attempted but could not start because `npm ci --prefix docs` timed out while downloading dependencies.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A; this change updates text-only configuration guidance.

## Additional Notes

This PR intentionally does not change runtime URL construction or provider
behavior. Supporting arbitrary full endpoint URLs would require a separate
runtime contract for the text and multimodal paths.
