### PR TITLE
fix(storage): 修复 ov add-resource在向量库返回4xx时吞异常问题

### DIFF
--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -1604,6 +1604,17 @@ class ResourceService:
             request_wait_tracker.cleanup(telemetry_id)
             unregister_telemetry(telemetry_id)
 
+    @staticmethod
+    def _raise_queue_status_errors(status: Dict[str, Any]) -> None:
+        failed = {
+            name: group
+            for name, group in status.items()
+            if isinstance(group, dict)
+            and (int(group.get("error_count", 0) or 0) > 0 or bool(group.get("errors")))
+        }
+        if failed:
+            raise InternalError(f"queue processing failed: {failed}")
+
     # ── Connector routing ──
 
     @property
@@ -1822,6 +1833,7 @@ class ResourceService:
                     round((time.perf_counter() - wait_start) * 1000, 3),
                 )
                 result["queue_status"] = status
+                self._raise_queue_status_errors(status)
             else:
                 from openviking.service.task_tracker import get_task_tracker
 

--- a/openviking/storage/__init__.py
+++ b/openviking/storage/__init__.py
@@ -17,6 +17,7 @@ from openviking.storage.errors import (
     RecordNotFoundError,
     SchemaError,
     StorageException,
+    VikingDBException,
 )
 
 if TYPE_CHECKING:
@@ -55,6 +56,7 @@ def __getattr__(name: str):
 
 __all__ = [
     # Exceptions
+    "VikingDBException",
     "StorageException",
     "CollectionNotFoundError",
     "RecordNotFoundError",

--- a/openviking/storage/errors.py
+++ b/openviking/storage/errors.py
@@ -6,6 +6,24 @@
 class VikingDBException(Exception):
     """Base exception for vector-store operations."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        error_type: str | None = None,
+        retryable: bool = False,
+        action: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        # 私有化下游需要结构化判定重试边界；默认值保持其他存储后端原有异常语义。
+        self.status_code = status_code
+        self.code = code
+        self.error_type = error_type
+        self.retryable = retryable
+        self.action = action
+
 
 class StorageException(VikingDBException):
     """Legacy alias for VikingDBException for backward compatibility."""

--- a/openviking/storage/vectordb/collection/vikingdb_clients.py
+++ b/openviking/storage/vectordb/collection/vikingdb_clients.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import requests
 
 import openviking
+from openviking.storage.errors import ConnectionError
 from openviking_cli.utils.logger import default_logger as logger
 
 # Default request timeout (seconds)
@@ -97,6 +98,11 @@ class VikingDBClient:
                 timeout=DEFAULT_TIMEOUT,
             )
             return response
-        except Exception as e:
+        except requests.RequestException as e:
             logger.error(f"Request to {url} failed: {e}")
-            raise e
+            raise ConnectionError(
+                f"Request to {path} failed: {e}",
+                error_type="connection_error",
+                retryable=True,
+                action=path,
+            ) from e

--- a/openviking/storage/vectordb/collection/vikingdb_collection.py
+++ b/openviking/storage/vectordb/collection/vikingdb_collection.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
+from openviking.storage.errors import VikingDBException
 from openviking.storage.vectordb.collection.collection import ICollection
 from openviking.storage.vectordb.collection.result import (
     AggregateResult,
@@ -38,6 +39,39 @@ class VikingDBCollection(ICollection):
         self.project_name = self.meta_data.get("ProjectName", "default")
         self.collection_name = self.meta_data.get("CollectionName", "")
 
+    @staticmethod
+    def _build_response_error(response: Any, action: str) -> VikingDBException:
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            result = {}
+
+        if isinstance(result, dict):
+            code = result.get("code")
+            message = (
+                result.get("message") or result.get("msg") or result.get("error") or response.text
+            )
+        else:
+            code = None
+            message = response.text
+
+        status_code = response.status_code
+        error_type = (
+            "http_client_error"
+            if 400 <= status_code < 500
+            else "http_server_error"
+            if status_code >= 500
+            else "http_error"
+        )
+        return VikingDBException(
+            f"Request to {action} failed: {status_code} {message}",
+            status_code=status_code,
+            code=str(code) if code is not None else None,
+            error_type=error_type,
+            retryable=status_code == 429 or status_code >= 500,
+            action=action,
+        )
+
     def _console_post(self, data: Dict[str, Any], action: str):
         path, method = VIKINGDB_APIS[action]
         response = self.client.do_req(method, path=path, req_body=data)
@@ -71,23 +105,23 @@ class VikingDBCollection(ICollection):
     def _data_post(self, path: str, data: Dict[str, Any]):
         response = self.client.do_req("POST", path, req_body=data)
         if response.status_code != 200:
-            logger.error(f"Request to {path} failed: {response.text}")
-            return {}
+            raise self._build_response_error(response, path)
         try:
             result = response.json()
             return result.get("result", {})
         except json.JSONDecodeError:
+            logger.warning("Invalid JSON response from %s", path)
             return {}
 
     def _data_get(self, path: str, params: Dict[str, Any]):
         response = self.client.do_req("GET", path, req_params=params)
         if response.status_code != 200:
-            logger.error(f"Request to {path} failed: {response.text}")
-            return {}
+            raise self._build_response_error(response, path)
         try:
             result = response.json()
             return result.get("result", {})
         except json.JSONDecodeError:
+            logger.warning("Invalid JSON response from %s", path)
             return {}
 
     def update(self, fields: Optional[Dict[str, Any]] = None, description: Optional[str] = None):

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -354,7 +354,7 @@ class _SingleAccountBackend:
                     ]
             except Exception as e:
                 logger.error("Error reading existing record before partial update: %s", e)
-                return ""
+                raise
 
             if existing_records:
                 existing = dict(existing_records[0])
@@ -665,7 +665,7 @@ class _SingleAccountBackend:
             return await self._async_adapter.call("count", filter=filter)
         except Exception as e:
             logger.error("Error counting records: %s", e)
-            return 0
+            raise
 
     async def clear(self) -> bool:
         try:

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -8,20 +8,27 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+import requests
 
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
 from openviking.server.identity import RequestContext, Role, UserIdentifier
+from openviking.service.resource_service import ResourceService
 from openviking.storage.collection_schemas import (
     CollectionSchemas,
     TextEmbeddingHandler,
     _build_embedding_metadata,
     init_context_collection,
 )
-from openviking.storage.errors import EmbeddingRebuildRequiredError
+from openviking.storage.errors import (
+    ConnectionError,
+    EmbeddingRebuildRequiredError,
+    VikingDBException,
+)
 from openviking.storage.expr import Eq
 from openviking.storage.queuefs.embedding_msg import EmbeddingMsg
 from openviking.storage.vectordb import engine as vectordb_engine
 from openviking.storage.vectordb.collection.result import UpsertDataResult
+from openviking.storage.vectordb.collection.vikingdb_clients import VikingDBClient
 from openviking.storage.vectordb.collection.vikingdb_collection import VikingDBCollection
 from openviking.storage.vectordb.collection.volcengine_api_key_collection import (
     VolcengineApiKeyCollection,
@@ -38,6 +45,7 @@ from openviking.storage.viking_vector_index_backend import (
     VikingVectorIndexBackend,
     _SingleAccountBackend,
 )
+from openviking_cli.exceptions import InternalError
 from openviking_cli.utils.config.vectordb_config import (
     VectorDBBackendConfig,
     VolcengineConfig,
@@ -804,6 +812,91 @@ def test_private_vikingdb_collection_ignores_unknown_fields_on_writes():
 
     assert calls[0][1]["ignore_unknown_fields"] is True
     assert calls[1][1]["ignore_unknown_fields"] is True
+
+
+def test_private_vikingdb_collection_raises_on_data_api_error(monkeypatch):
+    class _Response:
+        status_code = 403
+        text = '{"code":"AccessDenied","message":"license state Downgraded rejects data write"}'
+
+        def json(self):
+            return {
+                "code": "AccessDenied",
+                "message": "license state Downgraded rejects data write",
+            }
+
+    collection = VikingDBCollection(
+        host="https://vikingdb.example.com",
+        meta_data={"ProjectName": "default", "CollectionName": "context"},
+    )
+    monkeypatch.setattr(collection.client, "do_req", lambda *args, **kwargs: _Response())
+
+    with pytest.raises(VikingDBException, match="license state Downgraded") as exc_info:
+        collection.upsert_data([{"id": "rec-1", "content": "hello"}])
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "AccessDenied"
+    assert exc_info.value.error_type == "http_client_error"
+    assert exc_info.value.retryable is False
+    assert exc_info.value.action == "/api/vikingdb/data/upsert"
+
+
+def test_private_vikingdb_collection_marks_server_error_retryable(monkeypatch):
+    class _Response:
+        status_code = 503
+        text = '{"code":"ServiceUnavailable","message":"temporarily unavailable"}'
+
+        def json(self):
+            return {
+                "code": "ServiceUnavailable",
+                "message": "temporarily unavailable",
+            }
+
+    collection = VikingDBCollection(
+        host="https://vikingdb.example.com",
+        meta_data={"ProjectName": "default", "CollectionName": "context"},
+    )
+    monkeypatch.setattr(collection.client, "do_req", lambda *args, **kwargs: _Response())
+
+    with pytest.raises(VikingDBException) as exc_info:
+        collection.upsert_data([{"id": "rec-1", "content": "hello"}])
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "ServiceUnavailable"
+    assert exc_info.value.error_type == "http_server_error"
+    assert exc_info.value.retryable is True
+
+
+def test_private_vikingdb_client_wraps_connection_error(monkeypatch):
+    def _raise_connection_error(**kwargs):
+        del kwargs
+        raise requests.ConnectionError("connection refused")
+
+    monkeypatch.setattr(requests, "request", _raise_connection_error)
+
+    with pytest.raises(ConnectionError, match="connection refused") as exc_info:
+        VikingDBClient("https://vikingdb.example.com").do_req(
+            "POST",
+            "/api/vikingdb/data/upsert",
+            req_body={},
+        )
+
+    assert exc_info.value.status_code is None
+    assert exc_info.value.error_type == "connection_error"
+    assert exc_info.value.retryable is True
+    assert exc_info.value.action == "/api/vikingdb/data/upsert"
+
+
+def test_resource_service_raises_on_queue_status_errors():
+    status = {
+        "embedding": {"processed_count": 1, "error_count": 1, "errors": ["AccessDenied"]},
+        "indexing": {"processed_count": 0, "error_count": 0, "errors": []},
+    }
+
+    with pytest.raises(InternalError, match="queue processing failed") as exc_info:
+        ResourceService._raise_queue_status_errors(status)
+
+    assert "AccessDenied" in str(exc_info.value)
 
 
 def _exercise_fetch_and_search_apis(collection):
@@ -1870,7 +1963,7 @@ async def test_single_account_backend_upsert_partial_update_creates_when_record_
 
 
 @pytest.mark.asyncio
-async def test_single_account_backend_upsert_partial_update_returns_empty_when_get_fails():
+async def test_single_account_backend_upsert_partial_update_raises_when_get_fails():
     class _Adapter:
         mode = "local"
         USE_CONTENT_FIELD = False
@@ -1888,12 +1981,31 @@ async def test_single_account_backend_upsert_partial_update_returns_empty_when_g
         shared_adapter=_Adapter(),
     )
 
-    result = await backend.upsert(
-        {"id": "rec-1", "abstract": "patched"},
-        options=UpsertOptions(partial_update=True),
+    with pytest.raises(RuntimeError, match="backend exploded"):
+        await backend.upsert(
+            {"id": "rec-1", "abstract": "patched"},
+            options=UpsertOptions(partial_update=True),
+        )
+
+
+@pytest.mark.asyncio
+async def test_single_account_backend_count_raises_when_adapter_count_fails():
+    class _Adapter:
+        mode = "local"
+        USE_CONTENT_FIELD = False
+
+        def count(self, filter=None):
+            del filter
+            raise RuntimeError("count backend exploded")
+
+    backend = _SingleAccountBackend(
+        config=VectorDBBackendConfig(backend="local", name="context", dimension=2),
+        bound_account_id="acc1",
+        shared_adapter=_Adapter(),
     )
 
-    assert result == ""
+    with pytest.raises(RuntimeError, match="count backend exploded"):
+        await backend.count()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

修复 OpenViking 在下游向量库接口4xx时的假成功\吞异常问题。

之前 下游向量库 API 返回 4xx/5xx 时可能被降级为空结果，backend 部分路径也会把关键失败吞成空字符串或 0，导致 add-resource 任务显示成功，但实际写入数为 0。

本次改动：
- 为 VikingDBException 增加结构化字段：status_code、code、error_type、retryable、action
- VikingDB data API 非 200 响应改为抛 VikingDBException
- requests 连接异常继续抛 ConnectionError，用于区分真实连接问题
- backend 关键读/count 失败不再吞成空值
- add_resource wait 阶段发现 queue_status 包含 error_count/errors 时抛 InternalError
- 补充 403、503、连接失败、queue_status 错误抬升相关单测

## Type of Change

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

- [x] Unit tests pass
  - `.venv/bin/python -m pytest tests/storage/test_collection_schemas.py -q -k "private_vikingdb_collection_raises_on_data_api_error or private_vikingdb_collection_marks_server_error_retryable or private_vikingdb_client_wraps_connection_error or resource_service_raises_on_queue_status_errors"`

- [x] Manual testing completed

## Related Issues

- N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [ ] Documentation updated (if needed)
- [ ] All tests pass