### PR TITLE
fix(web-studio): respect task list query limit

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-query.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-query.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildTaskQuery } from './task-query'
+
+describe('buildTaskQuery', () => {
+  it('keeps the recent task query within the server limit', () => {
+    expect(buildTaskQuery('24h', 'all').limit).toBe(200)
+  })
+
+  it('keeps the all-task query within the server limit', () => {
+    expect(buildTaskQuery('all', 'all').limit).toBe(200)
+  })
+})

--- a/web-studio/src/routes/tasks/-lib/task-query.ts
+++ b/web-studio/src/routes/tasks/-lib/task-query.ts
@@ -1,0 +1,13 @@
+export type TaskDataScope = '24h' | 'all'
+
+// The server validates this endpoint with `limit <= 200`.
+export const TASK_QUERY_LIMIT = 200
+
+export function buildTaskQuery(dataScope: TaskDataScope, taskType: string) {
+  return {
+    limit: TASK_QUERY_LIMIT,
+    status: undefined,
+    task_type: taskType === 'all' ? undefined : taskType,
+    include_archived: dataScope === 'all' ? true : undefined,
+  }
+}

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -55,6 +55,7 @@ import {
 } from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord, TaskStatus } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
+import { buildTaskQuery } from './-lib/task-query'
 import { getTaskPipelineGroups } from './-lib/task-pipeline'
 
 export const Route = createFileRoute('/tasks')({
@@ -75,7 +76,6 @@ type TaskTypeFilter =
   | 'all'
 
 const DEFAULT_PAGE_SIZE = 20
-const MAX_TASKS = 300
 const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
 const TASK_TYPE_OPTIONS: Exclude<TaskTypeFilter, 'all'>[] = [
   'session_commit',
@@ -116,12 +116,7 @@ async function fetchTasks(
   status: TaskStatusFilter,
   dataScope: TaskDataScope = '24h',
 ): Promise<TaskRecord[]> {
-  const query = {
-    limit: dataScope === 'all' ? 10000 : MAX_TASKS,
-    status: undefined,
-    task_type: taskType === 'all' ? undefined : taskType,
-    include_archived: dataScope === 'all' ? true : undefined,
-  }
+  const query = buildTaskQuery(dataScope, taskType)
   try {
     const result = await getOvResult<unknown>(
       getTasks({


### PR DESCRIPTION
## Description

Fix the Web Studio task page returning an empty list when connected to a server that enforces the task endpoint maximum of 200 results. The page requested `limit=300` for the default scope and `limit=10000` for the all-task scope, which caused HTTP 400 validation errors.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or refactoring

## Changes Made

- Centralize the task query limit at the server-supported value of 200.
- Use the same safe limit for both recent and all-task scopes.
- Add regression tests for both query paths.

## Testing

- [x] Added tests proving both task scopes use `limit=200`.
- [x] Web Studio test suite: 47 files, 180 tests passed.
- [x] Web Studio production build passed on macOS.
- [x] New helper and test pass lint and format checks.

The repository-wide lint/format commands still report pre-existing issues in unrelated task-page and monitoring files; this PR introduces no new lint errors.