### PR TITLE
feat(uri): add viking://~ home alias for the caller's user root

### DIFF
--- a/docs/en/concepts/04-viking-uri.md
+++ b/docs/en/concepts/04-viking-uri.md
@@ -30,6 +30,27 @@ under `viking://user/{user_id}/sessions`.
 `temp`, `queue`, and `upload` are internal implementation
 scopes and cannot be addressed directly through public API URI parameters.
 
+### Home Alias `~`
+
+`~` is a server-side alias for the caller's own user root. `viking://~` expands to
+`viking://user/{user_id}`, and `viking://~/memories/note.md` to
+`viking://user/{user_id}/memories/note.md`, where `{user_id}` comes from the request's
+authenticated identity — the same string therefore points at a different directory for
+each caller.
+
+- Universal: accepted by every control plane (REST API, `ov` CLI, SDKs, MCP), anywhere a
+  public-scope URI is accepted.
+- First segment only: `viking://resources/~/x` and `viking://user/alice/~/x` keep `~` as
+  a literal path segment.
+- Accepted, not advertised: `~` is not part of the public scope list, so the
+  `Invalid scope ... Must be one of:` error message never mentions it.
+- Responses always echo the expanded canonical URI, never `viking://~`, and persisted
+  data (vector records, watch keys) stays canonical as well.
+- Requires an authenticated user identity. Expansion happens at the request boundary for
+  user and admin callers; root-role and unauthenticated contexts, along with places that
+  demand an already-canonical URI (internal storage paths, background tasks), reject the
+  alias instead of guessing a user.
+
 ## Initial Directory Structure
 
 Moving away from traditional flat database thinking, all context is organized as a filesystem. Agents no longer just find data through vector search, but can locate and browse data through deterministic paths and standard filesystem commands. Each context or directory is assigned a unique URI identifier string in the format viking://{scope}/{path}, allowing the system to precisely locate and access resources stored in different locations.

--- a/docs/en/guides/06-mcp-integration.md
+++ b/docs/en/guides/06-mcp-integration.md
@@ -155,6 +155,12 @@ For MCP tools, `viking://user` is the authenticated user's workspace. For exampl
 extension. Canonical URIs containing that exact current user id are also accepted;
 MCP does not use this shorthand for cross-user access.
 
+`viking://~` is a separate, universal alias for the caller's user root: it expands to
+`viking://user/<current-user>` on every control plane (REST API, `ov` CLI, SDKs, and
+MCP alike), and responses always echo the expanded canonical URI. The
+`viking://user/<path>` shorthand above stays MCP-only. See
+[Viking URI](../concepts/04-viking-uri.md) for details.
+
 > **Note**: MCP exposes the minimum closure for watch management (`list_watches` + `cancel_watch`). Pause / resume / trigger and the unified `update` verb are intentionally not exposed here — use the REST `/api/v1/watches/*` endpoints or the `ov task watch` CLI for those operations.
 
 > Feishu/Lark imports without `args.feishu_access_token` keep the existing app/tenant-token behavior and can be watched. Feishu/Lark one-time user-token imports pass only `args.feishu_access_token`; Feishu/Lark user-token watches must also pass `args.feishu_refresh_token` and require the same Feishu app credentials configured on the OpenViking server.

--- a/docs/zh/concepts/04-viking-uri.md
+++ b/docs/zh/concepts/04-viking-uri.md
@@ -28,6 +28,21 @@ viking://{scope}/{path}
 新 session 数据位于 `viking://user/{user_id}/sessions`。
 `temp`、`queue` 和 `upload` 是内部实现作用域，不能通过公开 API 的 URI 参数直接访问。
 
+### Home 别名 `~`
+
+`~` 是当前调用方用户根目录的服务端别名。`viking://~` 展开为 `viking://user/{user_id}`，
+`viking://~/memories/note.md` 展开为 `viking://user/{user_id}/memories/note.md`，
+其中 `{user_id}` 取自请求的认证身份——同一个字符串对不同调用方指向不同目录。
+
+- 通用：所有控制面（REST API、`ov` CLI、SDK、MCP）都接受，可用于任何接受公开作用域 URI 的位置。
+- 仅识别第 0 段：`viking://resources/~/x` 和 `viking://user/alice/~/x` 中的 `~` 仍是字面路径段。
+- 接受但不宣传：`~` 不属于公开作用域列表，`Invalid scope ... Must be one of:` 错误信息中不会出现它。
+- 响应始终回显展开后的 canonical URI，不会返回 `viking://~`；持久化数据（向量记录、watch key）
+  同样保持 canonical 形式。
+- 需要认证用户身份。展开发生在 user / admin 调用方的请求入口；root 角色与未认证上下文，
+  以及要求 URI 已是 canonical 形式的场景（内部存储路径、后台任务），会直接拒绝该别名，
+  而不会猜测用户。
+
 ## 初始目录
 
 摒弃传统的扁平化数据库思维，将所有上下文组织为一套文件系统。Agent 不再仅是通过向量搜索来找数据，而是可以通过确定性的路径和标准文件系统指令来定位和浏览数据。每个上下文或目录分配唯一的 URI 标识字符串，格式为 viking://{scope}/{path}，让系统能精准定位并访问存储在不同位置的资源。

--- a/docs/zh/guides/06-mcp-integration.md
+++ b/docs/zh/guides/06-mcp-integration.md
@@ -146,6 +146,11 @@ claude mcp add --transport http openviking \
 `viking://user/<当前用户>/notes/todo.md`，不依赖文件名或扩展名判断。工具返回的、
 包含当前用户 ID 的 canonical URI 也可以直接使用；这套简写不用于跨用户访问。
 
+`viking://~` 是另一个通用别名，表示调用方的用户根目录：它在所有控制面（REST API、`ov` CLI、
+SDK 和 MCP）上都会展开为 `viking://user/<当前用户>`，且响应始终回显展开后的 canonical URI。
+上面的 `viking://user/<path>` 简写则仍是 MCP 专属。详见
+[Viking URI](../concepts/04-viking-uri.md)。
+
 > **注**：MCP 仅暴露 watch 管理的最小闭包（`list_watches` + `cancel_watch`）。pause / resume / trigger 和统一的 `update` 动作刻意不在此处暴露，请通过 REST `/api/v1/watches/*` 接口或 `ov task watch` CLI 使用上述操作。
 
 > 未传 `args.feishu_access_token` 的飞书/Lark 导入保持现有应用/tenant token 行为，也支持 watch。飞书/Lark 一次性用户 token 导入只传 `args.feishu_access_token`；飞书/Lark 用户 token watch 还必须传 `args.feishu_refresh_token`，并要求 OpenViking 服务端配置同一个飞书应用凭证。

--- a/openviking/core/namespace.py
+++ b/openviking/core/namespace.py
@@ -241,6 +241,12 @@ def resolve_uri(
         return _resolve_user_uri(parts)
     if scope == "agent":
         return ResolvedNamespace(uri=canonical_uri, scope=scope)
+    if scope == "~":
+        # The home alias is expanded at the request boundary only. Reaching the
+        # canonical parser with it (root-role requests, internal callers, storage
+        # paths) means no identity is available, so fail closed instead of
+        # creating a literal '~' namespace.
+        raise NamespaceShapeError(f"Home alias URI is not canonical: {'/'.join(parts)}")
     if scope == "session":
         raise NamespaceShapeError(f"Legacy session URI is not canonical: {'/'.join(parts)}")
     if scope in {"resources", "temp", "queue", "upload"}:
@@ -260,6 +266,11 @@ def resolve_current_user_uri(uri: str, ctx: RequestContext) -> str:
     parts = uri_parts(uri)
     if not parts:
         return "viking://"
+
+    if parts[0] == "~":
+        if len(parts) == 1:
+            return canonical_user_root(ctx)
+        return f"{canonical_user_root(ctx)}/{'/'.join(parts[1:])}"
 
     if parts[0] == "session":
         if len(parts) == 1:

--- a/openviking/core/uri_validation.py
+++ b/openviking/core/uri_validation.py
@@ -14,7 +14,9 @@ from openviking.core.namespace import (
 from openviking_cli.exceptions import InvalidURIError, PermissionDeniedError
 from openviking_cli.utils.uri import VikingURI
 
-_PUBLIC_API_SCOPES = frozenset({"", *VikingURI.PUBLIC_SCOPES, *VikingURI.LEGACY_SCOPES})
+_PUBLIC_API_SCOPES = frozenset(
+    {"", *VikingURI.PUBLIC_SCOPES, *VikingURI.LEGACY_SCOPES, *VikingURI.ALIAS_SCOPES}
+)
 _ALL_API_SCOPES = frozenset({"", *VikingURI.VISITABLE_SCOPES})
 
 
@@ -49,7 +51,10 @@ def validate_viking_uri(
 
     scopes = _allowed_api_scopes(allow_internal=allow_internal, allowed_scopes=allowed_scopes)
     if parsed.scope not in scopes:
-        scope_names = ", ".join(sorted(scope for scope in scopes if scope))
+        # Alias scopes are accepted but never advertised in scope error messages.
+        scope_names = ", ".join(
+            sorted(scope for scope in scopes if scope and scope not in VikingURI.ALIAS_SCOPES)
+        )
         if not parsed.scope:
             reason = f"URI must include one of: {scope_names}"
         else:

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -260,7 +260,7 @@ async def find(
     level: Optional[List[int]] = None,
     context_type: Optional[Union[str, List[str]]] = None,
 ) -> str:
-    """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
+    """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score. viking://~ expands server-side to your user root (viking://user/<your-id>)."""
     service = get_service()
     ctx = _get_ctx()
     if target_uri:
@@ -307,7 +307,7 @@ async def search(
     abstract, and score. ``mode="context"`` returns an injection-ready,
     token-budgeted context block and supports category quotas, purpose presets,
     detail tiers, cross-turn deduplication, peer scoping, and optional rewriting.
-    ``target_uri`` is only supported in list mode.
+    ``target_uri`` is only supported in list mode. ``viking://~`` expands server-side to your user root (``viking://user/<your-id>``).
     """
     service = get_service()
     ctx = _get_ctx()
@@ -324,6 +324,11 @@ async def search(
                 "other_peer_penalty cannot be combined with other_peer_penalties "
                 "in mode='context'"
             )
+        # Resolve exclusions with the same strictness as the REST search router,
+        # so alias/shorthand URIs match the canonical URIs they are compared against.
+        resolved_exclude_uris = [
+            _resolve_mcp_workspace_uri(exclude_uri, ctx) for exclude_uri in (exclude_uris or ())
+        ]
         result = await assemble_context(
             service=service,
             ctx=ctx,
@@ -339,7 +344,7 @@ async def search(
                 purpose=purpose,
                 detail=detail_by_category or (None if detail == "auto" else detail),
                 dedup_turns=dedup_turns,
-                exclude_uris=exclude_uris or (),
+                exclude_uris=resolved_exclude_uris,
                 peer_scope=peer_scope,
                 other_peer_penalty=other_peer_penalties or other_peer_penalty,
                 rewrite=rewrite == "auto",
@@ -405,7 +410,7 @@ def _format_search_result(result) -> str:
 
 @mcp.tool()
 async def read(uris: str | list[str]) -> str:
-    """Read full content from one or more viking:// file URIs. Pass a single URI string or a list for batch reads. For directory listing, use the list tool instead."""
+    """Read full content from one or more viking:// file URIs. Pass a single URI string or a list for batch reads. viking://~ expands server-side to your user root (viking://user/<your-id>). For directory listing, use the list tool instead."""
     import asyncio
 
     service = get_service()
@@ -437,7 +442,7 @@ async def read(uris: str | list[str]) -> str:
 
 @mcp.tool(name="list")
 async def ls(uri: str, recursive: bool = False) -> str:
-    """List files and subdirectories under a viking:// directory URI. Use recursive=true for deep listing."""
+    """List files and subdirectories under a viking:// directory URI. Use recursive=true for deep listing. viking://~ expands server-side to your user root (viking://user/<your-id>)."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -468,7 +473,7 @@ async def tree(
     node_limit: int = 1000,
     include_abstract: bool = False,
 ) -> str:
-    """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories)."""
+    """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -556,7 +561,7 @@ async def write(
     - Any new file (whether created by "replace" or "create") must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
-    Writable scopes: viking://resources/, viking://user/{user_id}/, viking://agent/. Documented current-user roots such as viking://user/resources are expanded at this MCP boundary. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
+    Writable scopes: viking://resources/, viking://user/{user_id}/, viking://agent/. Documented current-user roots such as viking://user/resources are expanded at this MCP boundary. viking://~ expands server-side to your user root (viking://user/<your-id>). The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
     service = get_service()
     ctx = _get_ctx()
     uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -592,7 +597,7 @@ async def edit(
 ) -> str:
     """Replace an exact string with new text in an existing viking:// file. Use this for targeted changes instead of rewriting the whole file with the write tool. old_string must match the file's current content exactly, including indentation and newlines; use the read tool first to see it. The edit fails and the file is left unchanged if old_string is not found, or if it matches more than once and replace_all is false (pass more surrounding context to make it unique, or set replace_all=true to replace every occurrence). Pass new_string="" to delete old_string.
 
-    Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change)."""
+    Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
     service = get_service()
     ctx = _get_ctx()
     uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -758,6 +763,8 @@ async def add_resource(
     Local file: pass ``path`` as a filesystem path (e.g. ``/tmp/foo.pdf``). The response is an
     upload instruction — HTTP POST the file to the returned URL and the server ingests it
     automatically; you do NOT need to call this tool again.
+
+    In any target URI, ``viking://~`` expands server-side to your user root (``viking://user/<your-id>``).
 
     Args:
         path: Remote URL or local filesystem path. Required unless ``temp_file_id`` is set.
@@ -1019,7 +1026,7 @@ async def list_watches() -> str:
 
 @mcp.tool()
 async def cancel_watch(to_uri: str) -> str:
-    """Cancel a watch task by its target URI (e.g. "viking://resources/volcengine/OpenViking")."""
+    """Cancel a watch task by its target URI (e.g. "viking://resources/volcengine/OpenViking"). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
     from openviking.resource import watch_manager as _wm_mod
 
     service = get_service()
@@ -1064,7 +1071,7 @@ async def cancel_watch(to_uri: str) -> str:
 async def grep(
     uri: str, pattern: str | list[str], case_insensitive: bool = False, node_limit: int = 10
 ) -> str:
-    """Search content in viking:// files using regex patterns (like grep). Supports multiple patterns searched concurrently. Use this for exact text matching; use the search tool for semantic retrieval."""
+    """Search content in viking:// files using regex patterns (like grep). Supports multiple patterns searched concurrently. viking://~ expands server-side to your user root (viking://user/<your-id>). Use this for exact text matching; use the search tool for semantic retrieval."""
     import asyncio
 
     service = get_service()
@@ -1114,7 +1121,7 @@ async def grep(
 
 @mcp.tool()
 async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> str:
-    """Find viking:// files matching a glob pattern (e.g. **/*.md, *.py). Use this for filename matching; use the search tool for content-based retrieval."""
+    """Find viking:// files matching a glob pattern (e.g. **/*.md, *.py). viking://~ expands server-side to your user root (viking://user/<your-id>). Use this for filename matching; use the search tool for content-based retrieval."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -1140,7 +1147,7 @@ async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> s
 
 @mcp.tool()
 async def forget(uri: str, recursive: bool = False) -> str:
-    """Permanently delete a viking:// URI from OpenViking. Irreversible — confirm with user before calling."""
+    """Permanently delete a viking:// URI from OpenViking. viking://~ expands server-side to your user root (viking://user/<your-id>). Irreversible — confirm with user before calling."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -260,7 +260,7 @@ async def find(
     level: Optional[List[int]] = None,
     context_type: Optional[Union[str, List[str]]] = None,
 ) -> str:
-    """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score. viking://~ expands server-side to your user root (viking://user/<your-id>)."""
+    """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
     ctx = _get_ctx()
     if target_uri:
@@ -307,7 +307,7 @@ async def search(
     abstract, and score. ``mode="context"`` returns an injection-ready,
     token-budgeted context block and supports category quotas, purpose presets,
     detail tiers, cross-turn deduplication, peer scoping, and optional rewriting.
-    ``target_uri`` is only supported in list mode. ``viking://~`` expands server-side to your user root (``viking://user/<your-id>``).
+    ``target_uri`` is only supported in list mode.
     """
     service = get_service()
     ctx = _get_ctx()
@@ -410,7 +410,7 @@ def _format_search_result(result) -> str:
 
 @mcp.tool()
 async def read(uris: str | list[str]) -> str:
-    """Read full content from one or more viking:// file URIs. Pass a single URI string or a list for batch reads. viking://~ expands server-side to your user root (viking://user/<your-id>). For directory listing, use the list tool instead."""
+    """Read full content from one or more viking:// file URIs. Pass a single URI string or a list for batch reads. For directory listing, use the list tool instead."""
     import asyncio
 
     service = get_service()
@@ -442,7 +442,7 @@ async def read(uris: str | list[str]) -> str:
 
 @mcp.tool(name="list")
 async def ls(uri: str, recursive: bool = False) -> str:
-    """List files and subdirectories under a viking:// directory URI. Use recursive=true for deep listing. viking://~ expands server-side to your user root (viking://user/<your-id>)."""
+    """List files and subdirectories under a viking:// directory URI. Use recursive=true for deep listing."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -473,7 +473,7 @@ async def tree(
     node_limit: int = 1000,
     include_abstract: bool = False,
 ) -> str:
-    """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
+    """Show the recursive directory tree under a viking:// URI, indented by depth, so you can understand the whole layout at a glance. Use this when you need a full picture of the file tree; use list for a single directory level, glob for filename patterns, and grep for content. level_limit caps the depth (default 3); node_limit caps the total entries. Set include_abstract=true to also see each file's summary (slower, but useful for orientation in unfamiliar directories)."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -561,7 +561,7 @@ async def write(
     - Any new file (whether created by "replace" or "create") must end in one of: .md .txt .json .yaml .yml .toml .py .js .ts
     - mode="append": append to the end of an existing file; fails if the file does not exist.
 
-    Writable scopes: viking://resources/, viking://user/{user_id}/, viking://agent/. Documented current-user roots such as viking://user/resources are expanded at this MCP boundary. viking://~ expands server-side to your user root (viking://user/<your-id>). The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
+    Writable scopes: viking://resources/, viking://user/{user_id}/, viking://agent/. Documented current-user roots such as viking://user/resources are expanded at this MCP boundary. The managed user subtrees skills/, peers/, privacy/ and sessions/ are read-only. After a write, semantic search indexes refresh in the background; pass wait=true to block until search reflects the change."""
     service = get_service()
     ctx = _get_ctx()
     uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -597,7 +597,7 @@ async def edit(
 ) -> str:
     """Replace an exact string with new text in an existing viking:// file. Use this for targeted changes instead of rewriting the whole file with the write tool. old_string must match the file's current content exactly, including indentation and newlines; use the read tool first to see it. The edit fails and the file is left unchanged if old_string is not found, or if it matches more than once and replace_all is false (pass more surrounding context to make it unique, or set replace_all=true to replace every occurrence). Pass new_string="" to delete old_string.
 
-    Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
+    Editing a memory file preserves its metadata; after an edit, search indexes refresh in the background (pass wait=true to block until search reflects the change)."""
     service = get_service()
     ctx = _get_ctx()
     uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -763,8 +763,6 @@ async def add_resource(
     Local file: pass ``path`` as a filesystem path (e.g. ``/tmp/foo.pdf``). The response is an
     upload instruction — HTTP POST the file to the returned URL and the server ingests it
     automatically; you do NOT need to call this tool again.
-
-    In any target URI, ``viking://~`` expands server-side to your user root (``viking://user/<your-id>``).
 
     Args:
         path: Remote URL or local filesystem path. Required unless ``temp_file_id`` is set.
@@ -1026,7 +1024,7 @@ async def list_watches() -> str:
 
 @mcp.tool()
 async def cancel_watch(to_uri: str) -> str:
-    """Cancel a watch task by its target URI (e.g. "viking://resources/volcengine/OpenViking"). viking://~ expands server-side to your user root (viking://user/<your-id>)."""
+    """Cancel a watch task by its target URI (e.g. "viking://resources/volcengine/OpenViking")."""
     from openviking.resource import watch_manager as _wm_mod
 
     service = get_service()
@@ -1071,7 +1069,7 @@ async def cancel_watch(to_uri: str) -> str:
 async def grep(
     uri: str, pattern: str | list[str], case_insensitive: bool = False, node_limit: int = 10
 ) -> str:
-    """Search content in viking:// files using regex patterns (like grep). Supports multiple patterns searched concurrently. viking://~ expands server-side to your user root (viking://user/<your-id>). Use this for exact text matching; use the search tool for semantic retrieval."""
+    """Search content in viking:// files using regex patterns (like grep). Supports multiple patterns searched concurrently. Use this for exact text matching; use the search tool for semantic retrieval."""
     import asyncio
 
     service = get_service()
@@ -1121,7 +1119,7 @@ async def grep(
 
 @mcp.tool()
 async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> str:
-    """Find viking:// files matching a glob pattern (e.g. **/*.md, *.py). viking://~ expands server-side to your user root (viking://user/<your-id>). Use this for filename matching; use the search tool for content-based retrieval."""
+    """Find viking:// files matching a glob pattern (e.g. **/*.md, *.py). Use this for filename matching; use the search tool for content-based retrieval."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)
@@ -1147,7 +1145,7 @@ async def glob(pattern: str, uri: str = "viking://", node_limit: int = 100) -> s
 
 @mcp.tool()
 async def forget(uri: str, recursive: bool = False) -> str:
-    """Permanently delete a viking:// URI from OpenViking. viking://~ expands server-side to your user root (viking://user/<your-id>). Irreversible — confirm with user before calling."""
+    """Permanently delete a viking:// URI from OpenViking. Irreversible — confirm with user before calling."""
     service = get_service()
     ctx = _get_ctx()
     resolved_uri = _resolve_mcp_workspace_uri(uri, ctx)

--- a/openviking_cli/utils/uri.py
+++ b/openviking_cli/utils/uri.py
@@ -25,6 +25,7 @@ class VikingURI:
     - session: Legacy alias for user sessions (viking://session/{session_id}/...)
     - agent: Agent capabilities scope (viking://agent/skills/..., viking://agent/endpoints/...)
     - queue: Queue scope (viking://queue/...)
+    - ~: Server-side alias for the caller's user root, expanded to viking://user/{user_id}
 
     Examples:
     - viking://resources/my_project/docs/api
@@ -43,9 +44,12 @@ class VikingURI:
     PUBLIC_SCOPES = frozenset(LISTABLE_SCOPES)
     LEGACY_SCOPES = frozenset({"session"})
     INTERNAL_SCOPES = frozenset({"temp", "queue", "upload"})
+    # Server-side alias for the caller's user namespace root. Only valid as segment 0,
+    # and never persisted or echoed back: the server always expands it to viking://user/{user_id}.
+    ALIAS_SCOPES = frozenset({"~"})
     # All valid scopes that can be addressed by the URI parser/storage internals.
     # Public API handlers must not use this as their external whitelist.
-    VISITABLE_SCOPES = PUBLIC_SCOPES | LEGACY_SCOPES | INTERNAL_SCOPES
+    VISITABLE_SCOPES = PUBLIC_SCOPES | LEGACY_SCOPES | INTERNAL_SCOPES | ALIAS_SCOPES
 
     def __init__(self, uri: str):
         """
@@ -81,7 +85,8 @@ class VikingURI:
         # Parse scope
         scope = path.split("/")[0]
         if scope not in self.VISITABLE_SCOPES:
-            scope_names = ", ".join(sorted(self.VISITABLE_SCOPES))
+            # Alias scopes are accepted but never advertised in scope error messages.
+            scope_names = ", ".join(sorted(self.VISITABLE_SCOPES - self.ALIAS_SCOPES))
             raise ValueError(f"Invalid scope '{scope}'. Must be one of: {scope_names}")
 
         return {
@@ -195,7 +200,8 @@ class VikingURI:
         Returns:
             Viking URI string
         """
-        if scope not in VikingURI.VISITABLE_SCOPES:
+        # Alias scopes are inputs only: the server never mints a '~' URI.
+        if scope not in VikingURI.VISITABLE_SCOPES or scope in VikingURI.ALIAS_SCOPES:
             raise ValueError(f"Invalid scope '{scope}'")
 
         parts = [scope] + list(path_parts)

--- a/tests/server/test_api_watches.py
+++ b/tests/server/test_api_watches.py
@@ -244,3 +244,42 @@ async def test_patch_partial_preserves_unset_fields(client: httpx.AsyncClient, w
     body = resp.json()
     assert body["result"]["watch_interval"] == original_interval
     assert body["result"]["is_active"] is False
+
+
+async def test_home_alias_to_uri_resolves_to_canonically_keyed_task(
+    app, client: httpx.AsyncClient, watch_manager
+):
+    """`?to_uri=viking://~/...` addresses the task stored under the canonical key.
+
+    Watch tasks are keyed on the canonical URI, and the router canonicalizes
+    ``to_uri`` at the request boundary, so the alias resolves to the same task
+    and the response keeps echoing the stored canonical key. The dev auth plugin
+    resolves test requests to root, which never expands the alias, so this test
+    overrides the request context with a user-role identity.
+    """
+    from openviking.server.auth import get_request_context
+    from openviking.server.identity import RequestContext, Role
+    from openviking_cli.session.user_id import UserIdentifier
+
+    canonical = "viking://user/default/resources/home-alias"
+    task = await _seed(watch_manager, to_uri=canonical)
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier(account_id="default", user_id="default"),
+        role=Role.USER,
+    )
+    try:
+        resp = await client.get(
+            "/api/v1/watches", params={"to_uri": "viking://~/resources/home-alias"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["result"]["task_id"] == task.task_id
+        assert resp.json()["result"]["to_uri"] == canonical
+
+        resp = await client.delete(
+            "/api/v1/watches", params={"to_uri": "viking://~/resources/home-alias"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["result"]["deleted"] is True
+        assert resp.json()["result"]["to_uri"] == canonical
+    finally:
+        app.dependency_overrides.pop(get_request_context, None)

--- a/tests/server/test_filesystem_router.py
+++ b/tests/server/test_filesystem_router.py
@@ -83,3 +83,25 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         "memory_type": "preferences",
     }
     assert attrs["tags"] == ["team=search"]
+
+
+@pytest.mark.asyncio
+async def test_mkdir_echoes_canonical_home_alias(monkeypatch):
+    seen = {}
+
+    async def fake_mkdir(uri, ctx=None, description=None):
+        seen["uri"] = uri
+
+    monkeypatch.setattr(
+        filesystem,
+        "get_service",
+        lambda: SimpleNamespace(fs=SimpleNamespace(mkdir=fake_mkdir)),
+    )
+
+    response = await filesystem.mkdir(
+        filesystem.MkdirRequest(uri="viking://~/resources/notes"),
+        _ctx=RequestContext(user=UserIdentifier("acct", "alice"), role=Role.USER),
+    )
+
+    assert seen["uri"] == "viking://user/alice/resources/notes"
+    assert response.result["uri"] == "viking://user/alice/resources/notes"

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -44,6 +44,7 @@ from openviking_cli.exceptions import (
     AlreadyExistsError,
     FailedPreconditionError,
     InvalidArgumentError,
+    InvalidURIError,
     NotFoundError,
     PermissionDeniedError,
     UnauthenticatedError,
@@ -1225,6 +1226,30 @@ async def test_edit_memory_file_preserves_metadata(service):
     assert "coffee" in raw_after
     visible = await service.fs.read_visible(uri, ctx=DEFAULT_CTX)
     assert visible.strip() == "likes: coffee"
+
+
+async def test_write_home_alias_uri(service):
+    """`viking://~/...` writes into the caller's canonical user root."""
+    user_ctx = RequestContext(DEFAULT_CTX.user, Role.USER)
+    canonical = f"viking://user/{DEFAULT_CTX.user.user_id}/memories/preferences/home_alias.md"
+    token = _mcp_ctx.set(user_ctx)
+    try:
+        result = await write(uri="viking://~/memories/preferences/home_alias.md", content="x")
+        listing = await list_tool(uri="viking://~/memories/preferences")
+    finally:
+        _mcp_ctx.reset(token)
+    # Responses echo the expanded canonical URI, never the alias.
+    assert canonical in result
+    assert "viking://~" not in result
+    assert "home_alias.md" in listing
+    visible = await service.fs.read_visible(canonical, ctx=DEFAULT_CTX)
+    assert visible.strip() == "x"
+
+
+async def test_home_alias_rejected_for_root_role(service):
+    """Root-role MCP calls skip current-user resolution, so the alias fails closed."""
+    with pytest.raises(InvalidURIError, match="Home alias URI is not canonical"):
+        await list_tool(uri="viking://~/memories")
 
 
 async def test_write_user_shorthand_uri(service):

--- a/tests/unit/test_namespace_uri_classification.py
+++ b/tests/unit/test_namespace_uri_classification.py
@@ -5,6 +5,7 @@
 import pytest
 
 from openviking.core.namespace import (
+    NamespaceShapeError,
     canonical_session_uri,
     classify_uri,
     context_type_for_uri,
@@ -15,7 +16,10 @@ from openviking.core.namespace import (
     resolve_uri,
     visible_roots,
 )
-from openviking.core.uri_validation import validate_content_target_uri
+from openviking.core.uri_validation import (
+    validate_content_target_uri,
+    validate_request_viking_uri,
+)
 from openviking.server.identity import RequestContext, Role
 from openviking_cli.exceptions import InvalidURIError
 from openviking_cli.session.user_id import UserIdentifier
@@ -191,9 +195,14 @@ def test_request_boundary_expands_current_user_content_roots():
 
 
 def test_unreserved_user_root_segment_keeps_canonical_meaning():
-    # The generic namespace parser stays canonical-first. Callers that expose
-    # a current-user workspace dialect (such as MCP) must opt into that policy
-    # at their boundary instead of guessing from file extensions or server state.
+    # The generic namespace parser stays canonical-first for user id segments: an
+    # unreserved segment under viking://user/ is a peer user id, never a shorthand.
+    # The '~' home alias does not weaken that rule -- it is a reserved token that
+    # cannot be a valid user id (see identifiers.validate_user_id), and it is only
+    # recognized as segment 0, so it never competes with a canonical user segment.
+    # Callers that expose a current-user workspace dialect (such as MCP) must still
+    # opt into that policy at their boundary instead of guessing from file
+    # extensions or server state.
     assert resolve_uri("viking://user/notes/todo.md").uri == "viking://user/notes/todo.md"
     assert (
         resolve_uri("viking://user/bob/zeus-persona.md").uri
@@ -217,3 +226,76 @@ def test_unreserved_user_root_segment_keeps_canonical_meaning():
         resolve_uri("viking://user/alice/notes/todo.md").uri
         == "viking://user/alice/notes/todo.md"
     )
+
+
+def test_home_alias_expands_to_current_user_root_at_request_boundary():
+    for role in (Role.USER, Role.ADMIN):
+        ctx = RequestContext(
+            user=UserIdentifier(account_id="acct", user_id="alice"),
+            role=role,
+        )
+
+        assert resolve_request_uri("viking://~", ctx) == "viking://user/alice"
+        assert resolve_request_uri("viking://~/", ctx) == "viking://user/alice"
+        assert (
+            resolve_request_uri("viking://~/memories/preferences/p.md", ctx)
+            == "viking://user/alice/memories/preferences/p.md"
+        )
+        assert (
+            resolve_request_uri("viking://~/resources/docs/", ctx)
+            == "viking://user/alice/resources/docs"
+        )
+        assert (
+            validate_request_viking_uri("viking://~/resources/docs", ctx)
+            == "viking://user/alice/resources/docs"
+        )
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="alice"),
+        role=Role.USER,
+    )
+    expanded = resolve_request_uri("viking://~/memories", ctx)
+    # The expanded alias is field-for-field identical to the explicit form.
+    assert resolve_uri(expanded) == resolve_uri("viking://user/alice/memories")
+    assert context_type_for_uri(resolve_request_uri("viking://~/memories/m.md", ctx)) == "memory"
+    assert is_content_root_uri(resolve_request_uri("viking://~/resources", ctx), kind="resource")
+    assert (
+        validate_content_target_uri("viking://~/resources", ctx, kind="resource")
+        == "viking://user/alice/resources"
+    )
+
+
+def test_home_alias_fails_closed_without_current_user_resolution():
+    root_ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="root-actor"),
+        role=Role.ROOT,
+    )
+
+    # Root-role requests skip current-user resolution, so the alias never becomes
+    # a literal '~' namespace -- it is rejected instead of guessing a user.
+    with pytest.raises(NamespaceShapeError, match="Home alias URI is not canonical"):
+        resolve_request_uri("viking://~/resources/docs", root_ctx)
+    with pytest.raises(InvalidURIError, match="Home alias URI is not canonical"):
+        validate_request_viking_uri("viking://~/resources/docs", root_ctx)
+
+    # Every internal consumer of the canonical parser is protected the same way.
+    with pytest.raises(NamespaceShapeError, match="Home alias URI is not canonical"):
+        resolve_uri("viking://~")
+    with pytest.raises(NamespaceShapeError, match="Home alias URI is not canonical"):
+        resolve_uri("viking://~/x")
+    assert not is_content_root_uri("viking://~/resources", kind="resource")
+
+
+def test_home_alias_is_only_recognized_as_first_segment():
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="alice"),
+        role=Role.USER,
+    )
+
+    # '~' is not a valid user id, so it can never shadow a real user namespace.
+    with pytest.raises(NamespaceShapeError, match="Invalid user_id"):
+        resolve_request_uri("viking://user/~/x", ctx)
+
+    # Anywhere else it stays a literal path segment.
+    assert resolve_request_uri("viking://resources/~/x", ctx) == "viking://resources/~/x"
+    assert resolve_request_uri("viking://user/alice/~/x", ctx) == "viking://user/alice/~/x"

--- a/tests/unit/test_uri_short_format.py
+++ b/tests/unit/test_uri_short_format.py
@@ -49,6 +49,35 @@ class TestVikingURIExplicitFormat:
         with pytest.raises(ValueError, match="Invalid scope"):
             VikingURI("viking://invalid_scope/foo")
 
+    def test_home_alias_is_parsable(self):
+        """'viking://~' should parse with the home alias scope."""
+        uri = VikingURI("viking://~")
+        assert uri.uri == "viking://~"
+        assert uri.scope == "~"
+
+    def test_home_alias_with_suffix_is_parsable(self):
+        """'viking://~/notes' keeps the alias scope and its suffix."""
+        uri = VikingURI("viking://~/notes")
+        assert uri.uri == "viking://~/notes"
+        assert uri.scope == "~"
+        assert uri.full_path == "~/notes"
+
+    def test_invalid_scope_error_copy_hides_home_alias(self):
+        """The parser's own scope enumeration never advertises the alias."""
+        with pytest.raises(ValueError, match="Invalid scope") as exc_info:
+            VikingURI("viking://invalid_scope/foo")
+        message = str(exc_info.value)
+        assert "Must be one of:" in message
+        assert "~" not in message.split("Must be one of:", 1)[1]
+
+    def test_build_rejects_home_alias_scope(self):
+        """build() must never mint an alias URI: responses stay canonical."""
+        with pytest.raises(ValueError, match="Invalid scope"):
+            VikingURI.build("~")
+        with pytest.raises(ValueError, match="Invalid scope"):
+            VikingURI.build("~", "notes")
+        assert VikingURI.build("user", "alice") == "viking://user/alice"
+
     @pytest.mark.parametrize(
         "value,scope",
         [

--- a/tests/unit/test_uri_validation.py
+++ b/tests/unit/test_uri_validation.py
@@ -16,6 +16,8 @@ from openviking_cli.exceptions import InvalidURIError
         "viking://session/s1",
         "viking://agent/code-agent/memories/facts/project.md",
         "viking://",
+        "viking://~",
+        "viking://~/memories/x",
     ],
 )
 def test_validate_viking_uri_accepts_supported_forms(uri: str):
@@ -53,6 +55,24 @@ def test_validate_viking_uri_reports_explicit_scheme_requirement():
     assert "frozenset" not in message
 
 
+def test_validate_viking_uri_hides_home_alias_in_public_scope_list():
+    with pytest.raises(InvalidURIError) as exc_info:
+        validate_viking_uri("viking://temp/generated")
+
+    reason = exc_info.value.details["reason"]
+    scope_list = reason.split("Must be one of:", 1)[1]
+    assert "resources" in scope_list
+    # The home alias is accepted but never advertised in the public scope list.
+    assert "~" not in scope_list
+
+    with pytest.raises(InvalidURIError) as exc_info:
+        validate_viking_uri("viking://", allowed_scopes={"resources"})
+
+    reason = exc_info.value.details["reason"]
+    assert reason.startswith("URI must include one of:")
+    assert "~" not in reason
+
+
 def test_validate_viking_uri_supports_internal_and_operation_scopes():
     assert validate_viking_uri("viking://temp/generated", allow_internal=True)
 
@@ -70,3 +90,24 @@ def test_validate_viking_uri_supports_internal_and_operation_scopes():
             "viking://invalid_scope/doc",
             allowed_scopes={"invalid_scope"},
         )
+
+
+def test_validate_viking_uri_hides_home_alias_for_unknown_scopes():
+    # Unknown scopes fail at the parser, whose message also enumerates scopes.
+    with pytest.raises(InvalidURIError) as exc_info:
+        validate_viking_uri("viking://bogus/x")
+
+    reason = exc_info.value.details["reason"]
+    assert "~" not in reason.split("Must be one of:", 1)[1]
+
+
+def test_validate_viking_uri_rejects_home_alias_for_restricted_scopes():
+    with pytest.raises(InvalidURIError) as exc_info:
+        validate_viking_uri("viking://~", allowed_scopes={"resources"})
+
+    reason = exc_info.value.details["reason"]
+    assert reason.startswith("Invalid scope '~'")
+    # Only the echoed offending scope may mention '~'; the advertised list must not.
+    scope_list = reason.split("Must be one of:", 1)[1]
+    assert "resources" in scope_list
+    assert "~" not in scope_list


### PR DESCRIPTION
## Description

Adds `viking://~` (and `viking://~/<suffix>`) as a server-side **home alias** for the authenticated caller's user namespace root: `viking://~/memories/note.md` resolves to `viking://user/<user_id>/memories/note.md`, with `<user_id>` inferred from the request identity (API key / OAuth / headers per auth mode).

The alias rides the request-boundary resolution introduced by #4048: expansion happens in `resolve_current_user_uri` for USER/ADMIN identities (same roles as the existing current-user shorthand, per #4145), so every entry point that already calls `validate_request_viking_uri` — REST routers and the MCP endpoint — supports it with **zero client changes** (`ov` CLI, SDKs, and MCP proxies pass URIs through verbatim).

Why `~` is safe where the generic user-root shorthand of #3936 wasn't: `~` can never be a valid `user_id` (`validate_user_id`'s charset excludes it), so segment-0 aliasing never competes with a canonical user segment. The design note in `test_namespace_uri_classification.py` is amended accordingly.

Fail-closed by construction:
- The canonical parser `resolve_uri` **rejects** the alias (mirroring the legacy-session handling), so ROOT-role requests (unbound identity), internal callers, and storage paths error out instead of materializing a literal `~` directory.
- `VikingURI.build` refuses to mint `~`; responses and persisted data always carry the expanded canonical URI.
- The alias is accepted but never advertised: the `Must be one of: ...` scope error copy filters it at both the parser and the public validator.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `openviking_cli/utils/uri.py`: new `ALIAS_SCOPES = {"~"}` folded into `VISITABLE_SCOPES` only (kept out of `LISTABLE_SCOPES`/`PUBLIC_SCOPES`, so `~` never appears in root `ls` or advertised scope lists); `build()` rejects alias scopes; parser error copy filters them.
- `openviking/core/uri_validation.py`: `_PUBLIC_API_SCOPES` accepts the alias; the inline scope-name join keeps it out of error messages.
- `openviking/core/namespace.py`: `resolve_current_user_uri` gains the `~` branch (bare `viking://~` → user root; suffix appended verbatim); `resolve_uri` raises `NamespaceShapeError` for the alias, adjacent to the legacy-session raise.
- `openviking/server/mcp_endpoint.py`: `search` (mode=context) now resolves `exclude_uris` through `_resolve_mcp_workspace_uri`, matching the REST search router's `_resolve_uri_list` strictness. Tool docstrings deliberately do NOT mention the alias: agents pass it through verbatim and responses echo the canonical form, so it is self-explanatory on contact, and carrying it in 12 descriptions would cost every MCP session tokens.
- Docs: "Home Alias `~`" subsection in `docs/{en,zh}/concepts/04-viking-uri.md`; universal-alias note beside the MCP `viking://user` dialect in `docs/{en,zh}/guides/06-mcp-integration.md`.

## Testing

- Unit: `tests/unit/test_uri_short_format.py`, `test_uri_validation.py`, `test_namespace_uri_classification.py` — parse/build/validate acceptance, USER + ADMIN expansion, ROOT rejection, `resolve_uri` fail-closed, segment-0-only literalness (`viking://resources/~/x`, `viking://user/alice/~/x` unchanged, `viking://user/~/x` still invalid), and error-copy assertions covering both the parser-level and validator-level `Must be one of:` paths (52 passed).
- Server: `test_mcp_endpoint.py` (112 passed — includes MCP alias ls/write, ROOT rejection, exclude_uris resolution), `test_api_watches.py` (13 passed — alias `to_uri` hits the canonically keyed task, response echoes the canonical key), `test_filesystem_router.py` (mkdir echoes the canonical URI; the one pre-existing failure `test_attrs_returns_memory_fields_and_tags` reproduces identically on a clean checkout of the base commit), `test_api_search_context.py` + `tests/retrieve/` (69 passed), `tests/misc/test_vikingfs_uri_guard.py` + `tests/service/test_fs_service.py` (58 passed).
- `uvx ruff check` clean on all touched files.
