### PR TITLE
fix(memory): expose reasons for skipped empty-URI operations

### DIFF
--- a/docs/design/traj-exp-experience-learning-redesign.md
+++ b/docs/design/traj-exp-experience-learning-redesign.md
@@ -650,6 +650,7 @@ merge 输入/输出日志通过 `tracer.info(..., console=False)` 记录，避�
   "trace_id": "...",
   "extracted_at": "...",
   "operations": {...},
+  "skipped_operations": [...],
   "summary": {...}
 }
 ```

--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -1612,10 +1612,19 @@ When long-term memory extraction runs successfully, the commit writes a `memory_
       }
     ]
   },
+  "skipped_operations": [
+    {
+      "memory_type": "events",
+      "page_id": 101,
+      "reason_code": "invalid_ranges",
+      "reason": "No valid event range could be resolved"
+    }
+  ],
   "summary": {
     "total_adds": 1,
     "total_updates": 1,
-    "total_deletes": 1
+    "total_deletes": 1,
+    "total_skipped": 1
   }
 }
 ```
@@ -1627,11 +1636,13 @@ When long-term memory extraction runs successfully, the commit writes a `memory_
 | `operations.adds` | array | New memories created (`uri`, `memory_type`, `after`) |
 | `operations.updates` | array | Modified memories (`uri`, `memory_type`, `before`, `after`) |
 | `operations.deletes` | array | Deleted memories (`uri`, `memory_type`, `deleted_content`) |
+| `skipped_operations` | array | Intentionally skipped operations and their stable reason codes; these do not represent file changes |
 | `summary.total_adds` | int | Number of new memories |
 | `summary.total_updates` | int | Number of modified memories |
 | `summary.total_deletes` | int | Number of deleted memories |
+| `summary.total_skipped` | int | Number of intentionally skipped operations |
 
-An empty `memory_diff.json` (all counts zero) is written when long-term memory extraction runs but produces no memory operations.
+An empty `memory_diff.json` (all counts zero) is written when long-term memory extraction runs but produces no applied or intentionally skipped operations.
 
 <a id="built-in-memory-types"></a>
 

--- a/docs/en/concepts/08-session.md
+++ b/docs/en/concepts/08-session.md
@@ -205,10 +205,19 @@ Each `session.commit()` writes a `memory_diff.json` to the archive directory, re
       }
     ]
   },
+  "skipped_operations": [
+    {
+      "memory_type": "events",
+      "page_id": 101,
+      "reason_code": "invalid_ranges",
+      "reason": "No valid event range could be resolved"
+    }
+  ],
   "summary": {
     "total_adds": 1,
     "total_updates": 1,
-    "total_deletes": 1
+    "total_deletes": 1,
+    "total_skipped": 1
   }
 }
 ```
@@ -220,9 +229,10 @@ Each `session.commit()` writes a `memory_diff.json` to the archive directory, re
 | `operations.adds` | New memories created (no `before`) |
 | `operations.updates` | Modified memories (with `before` and `after`) |
 | `operations.deletes` | Deleted memories (with `deleted_content`) |
+| `skipped_operations` | Intentionally skipped operations and their stable reason codes; these are not file changes |
 | `summary` | Counts per operation type |
 
-An empty `memory_diff.json` (all counts zero) is written even when no memory operations occurred.
+An empty `memory_diff.json` (all counts zero) is written when no applied or intentionally skipped operations occurred.
 
 ## Storage Structure
 

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -1584,10 +1584,19 @@ viking://user/{user_id}/sessions/{session_id}/
       }
     ]
   },
+  "skipped_operations": [
+    {
+      "memory_type": "events",
+      "page_id": 101,
+      "reason_code": "invalid_ranges",
+      "reason": "无法解析出有效的事件范围"
+    }
+  ],
   "summary": {
     "total_adds": 1,
     "total_updates": 1,
-    "total_deletes": 1
+    "total_deletes": 1,
+    "total_skipped": 1
   }
 }
 ```
@@ -1599,11 +1608,13 @@ viking://user/{user_id}/sessions/{session_id}/
 | `operations.adds` | array | 新增记忆（`uri`、`memory_type`、`after`） |
 | `operations.updates` | array | 修改记忆（`uri`、`memory_type`、`before`、`after`） |
 | `operations.deletes` | array | 删除记忆（`uri`、`memory_type`、`deleted_content`） |
+| `skipped_operations` | array | 策略性跳过的操作及稳定原因码；不代表文件变更 |
 | `summary.total_adds` | int | 新增记忆数 |
 | `summary.total_updates` | int | 修改记忆数 |
 | `summary.total_deletes` | int | 删除记忆数 |
+| `summary.total_skipped` | int | 策略性跳过的操作数 |
 
-如果长记忆抽取已运行但没有产生记忆操作，也会写入空结构的 `memory_diff.json`（所有计数为零）。
+如果长记忆抽取已运行但没有产生实际变更或策略性跳过，也会写入空结构的 `memory_diff.json`（所有计数为零）。
 
 <a id="内置记忆类型"></a>
 

--- a/docs/zh/concepts/08-session.md
+++ b/docs/zh/concepts/08-session.md
@@ -205,10 +205,19 @@ LLM 去重决策 → candidate(skip/create/none) + item(merge/delete)
       }
     ]
   },
+  "skipped_operations": [
+    {
+      "memory_type": "events",
+      "page_id": 101,
+      "reason_code": "invalid_ranges",
+      "reason": "无法解析出有效的事件范围"
+    }
+  ],
   "summary": {
     "total_adds": 1,
     "total_updates": 1,
-    "total_deletes": 1
+    "total_deletes": 1,
+    "total_skipped": 1
   }
 }
 ```
@@ -220,9 +229,10 @@ LLM 去重决策 → candidate(skip/create/none) + item(merge/delete)
 | `operations.adds` | 新增的记忆（无 `before`） |
 | `operations.updates` | 修改的记忆（含 `before` 和 `after`） |
 | `operations.deletes` | 删除的记忆（含 `deleted_content`） |
+| `skipped_operations` | 策略性跳过的操作及稳定原因码；不代表文件变更 |
 | `summary` | 各操作类型的计数 |
 
-即使没有记忆操作，也会写入空结构的 `memory_diff.json`（所有计数为零）。
+如果没有实际变更或策略性跳过，也会写入空结构的 `memory_diff.json`（所有计数为零）。
 
 ## 存储结构
 

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -361,6 +361,7 @@ class SessionCompressorV3:
         allowed_memory_types: Optional[set[str]] = None,
         agent_evolution_enabled: bool = True,
         allow_self_memory: bool = True,
+        peer_memory_enabled: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
         event_search_tags: Optional[List[str]] = None,
     ):
@@ -400,6 +401,7 @@ class SessionCompressorV3:
                 archive_uri=archive_uri,
                 allowed_memory_types=allowed_memory_types,
                 allow_self_memory=allow_self_memory,
+                peer_memory_enabled=peer_memory_enabled,
                 allowed_peer_ids=allowed_peer_ids,
                 event_search_tags=event_search_tags,
             )
@@ -453,6 +455,7 @@ class SessionCompressorV3:
                 contexts=result.contexts,
                 train_result=train_result,
                 archive_uri=archive_uri or "",
+                skipped_operations=getattr(result, "skipped_operations", []),
             )
         except Exception:
             if strict_extract_errors:
@@ -601,6 +604,7 @@ class SessionCompressorV3:
         archive_uri: Optional[str] = None,
         allowed_memory_types: Optional[set[str]] = None,
         allow_self_memory: bool = True,
+        peer_memory_enabled: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
         event_search_tags: Optional[List[str]] = None,
     ) -> "_V3ExtractionResult":
@@ -642,6 +646,7 @@ class SessionCompressorV3:
             allowed_memory_types=allowed_memory_types,
             allow_self=allow_self_memory,
             allowed_peer_ids=allowed_peer_ids,
+            peer_memory_enabled=peer_memory_enabled,
         )
         isolation_handler.prepare_messages()
         context_provider._isolation_handler = isolation_handler
@@ -682,6 +687,7 @@ class SessionCompressorV3:
                     "allowed_memory_types": allowed_memory_types,
                     "allow_self": allow_self_memory,
                     "allowed_peer_ids": allowed_peer_ids,
+                    "peer_memory_enabled": peer_memory_enabled,
                 },
                 metadata={
                     "source_extraction_id": extraction_id,
@@ -719,6 +725,10 @@ class SessionCompressorV3:
             cases=canonical_cases,
             memory_diff=memory_diff,
             case_uri_by_name=_case_uri_by_name(canonical_cases, patch_operations, result),
+            skipped_operations=[
+                item.model_dump(mode="json", exclude_none=True)
+                for item in getattr(result, "skipped_operations", [])
+            ],
         )
 
     def _session_skill_extraction_enabled(self) -> bool:
@@ -1223,6 +1233,7 @@ class _V3ExtractionResult:
     cases: list[Case] = field(default_factory=list)
     memory_diff: dict[str, Any] | None = None
     case_uri_by_name: dict[str, str] = field(default_factory=dict)
+    skipped_operations: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -2046,15 +2057,15 @@ def _v3_extraction_response(
     contexts: list[Context],
     train_result: Any,
     archive_uri: str,
+    skipped_operations: Optional[list[dict[str, Any]]] = None,
 ) -> list[Context] | dict[str, Any]:
     """Build the extraction response.
 
     Historically ``extract_long_term_memories`` returned ``list[Context]`` and
     a number of direct callers still index/compare the return value as a list.
-    Commit orchestration now also understands the execution-memory style
-    ``{"contexts": ..., "session_skills": ...}`` shape so it can count
-    session skills.  Preserve the old list shape unless there are actual
-    session skills to report.
+    Commit orchestration also understands a structured response for session
+    skills and intentionally skipped operations. Preserve the old list shape
+    unless either field has content.
     """
     skill_dicts: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -2064,9 +2075,13 @@ def _v3_extraction_response(
             if uri_str and uri_str not in seen:
                 seen.add(uri_str)
                 skill_dicts.append({"uri": uri_str, "archive_uri": archive_uri})
-    if not skill_dicts:
+    public_skips = list(skipped_operations or [])
+    if not skill_dicts and not public_skips:
         return contexts
-    return {"contexts": contexts, "session_skills": skill_dicts}
+    response: dict[str, Any] = {"contexts": contexts, "session_skills": skill_dicts}
+    if public_skips:
+        response["skipped_operations"] = public_skips
+    return response
 
 
 def _make_memory_diff(

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -361,9 +361,9 @@ class SessionCompressorV3:
         allowed_memory_types: Optional[set[str]] = None,
         agent_evolution_enabled: bool = True,
         allow_self_memory: bool = True,
-        peer_memory_enabled: bool = True,
         allowed_peer_ids: Optional[set[str]] = None,
         event_search_tags: Optional[List[str]] = None,
+        peer_memory_enabled: bool = True,
     ):
         if not agent_evolution_enabled:
             effective_types = (

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -346,6 +346,9 @@ class SessionCompressorV3:
             adds=adds,
             updates=updates,
             deletes=deletes,
+            skipped_operations=_serialize_skipped_operations(
+                getattr(result, "skipped_operations", [])
+            ),
         )
 
     @tracer(ignore_result=True)
@@ -725,10 +728,9 @@ class SessionCompressorV3:
             cases=canonical_cases,
             memory_diff=memory_diff,
             case_uri_by_name=_case_uri_by_name(canonical_cases, patch_operations, result),
-            skipped_operations=[
-                item.model_dump(mode="json", exclude_none=True)
-                for item in getattr(result, "skipped_operations", [])
-            ],
+            skipped_operations=_serialize_skipped_operations(
+                getattr(result, "skipped_operations", [])
+            ),
         )
 
     def _session_skill_extraction_enabled(self) -> bool:
@@ -2052,6 +2054,22 @@ def _same_memory_file(before: Optional[MemoryFile], after: Optional[MemoryFile])
     )
 
 
+def _serialize_skipped_operations(items: Any) -> list[dict[str, Any]]:
+    serialized: list[dict[str, Any]] = []
+    for item in list(items or []):
+        if isinstance(item, dict):
+            payload = dict(item)
+        else:
+            model_dump = getattr(item, "model_dump", None)
+            if not callable(model_dump):
+                continue
+            payload = model_dump(mode="json", exclude_none=True)
+        if isinstance(payload, dict):
+            payload.pop("source", None)
+            serialized.append(payload)
+    return serialized
+
+
 def _v3_extraction_response(
     *,
     contexts: list[Context],
@@ -2090,7 +2108,9 @@ def _make_memory_diff(
     adds: list[dict[str, Any]],
     updates: list[dict[str, Any]],
     deletes: list[dict[str, Any]],
+    skipped_operations: Optional[list[dict[str, Any]]] = None,
 ) -> dict[str, Any]:
+    skipped = list(skipped_operations or [])
     return {
         "archive_uri": archive_uri,
         "trace_id": tracer.get_trace_id() or None,
@@ -2100,10 +2120,12 @@ def _make_memory_diff(
             "updates": list(updates),
             "deletes": list(deletes),
         },
+        "skipped_operations": skipped,
         "summary": {
             "total_adds": len(adds),
             "total_updates": len(updates),
             "total_deletes": len(deletes),
+            "total_skipped": len(skipped),
         },
     }
 
@@ -2116,12 +2138,16 @@ def _merge_memory_diffs(
     adds: list[dict[str, Any]] = []
     updates: list[dict[str, Any]] = []
     deletes: list[dict[str, Any]] = []
+    skipped_operations: list[dict[str, Any]] = []
     trace_id = tracer.get_trace_id() or None
     for diff in diffs:
         if not isinstance(diff, dict):
             continue
         if trace_id is None and diff.get("trace_id"):
             trace_id = str(diff.get("trace_id"))
+        skipped_operations.extend(
+            item for item in diff.get("skipped_operations", []) if isinstance(item, dict)
+        )
         operations = diff.get("operations")
         if not isinstance(operations, dict):
             continue
@@ -2133,6 +2159,7 @@ def _merge_memory_diffs(
         adds=adds,
         updates=updates,
         deletes=deletes,
+        skipped_operations=skipped_operations,
     )
     merged["trace_id"] = trace_id
     return merged
@@ -2145,7 +2172,8 @@ def _memory_diff_has_changes(diff: Any) -> bool:
     if not isinstance(summary, dict):
         return False
     return any(
-        int(summary.get(key) or 0) > 0 for key in ("total_adds", "total_updates", "total_deletes")
+        int(summary.get(key) or 0) > 0
+        for key in ("total_adds", "total_updates", "total_deletes", "total_skipped")
     )
 
 

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -458,7 +458,6 @@ class SessionCompressorV3:
                 contexts=result.contexts,
                 train_result=train_result,
                 archive_uri=archive_uri or "",
-                skipped_operations=getattr(result, "skipped_operations", []),
             )
         except Exception:
             if strict_extract_errors:
@@ -2075,15 +2074,14 @@ def _v3_extraction_response(
     contexts: list[Context],
     train_result: Any,
     archive_uri: str,
-    skipped_operations: Optional[list[dict[str, Any]]] = None,
 ) -> list[Context] | dict[str, Any]:
     """Build the extraction response.
 
     Historically ``extract_long_term_memories`` returned ``list[Context]`` and
     a number of direct callers still index/compare the return value as a list.
     Commit orchestration also understands a structured response for session
-    skills and intentionally skipped operations. Preserve the old list shape
-    unless either field has content.
+    skills. Preserve the old list shape unless there are actual session skills
+    to report.
     """
     skill_dicts: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -2093,13 +2091,9 @@ def _v3_extraction_response(
             if uri_str and uri_str not in seen:
                 seen.add(uri_str)
                 skill_dicts.append({"uri": uri_str, "archive_uri": archive_uri})
-    public_skips = list(skipped_operations or [])
-    if not skill_dicts and not public_skips:
+    if not skill_dicts:
         return contexts
-    response: dict[str, Any] = {"contexts": contexts, "session_skills": skill_dicts}
-    if public_skips:
-        response["skipped_operations"] = public_skips
-    return response
+    return {"contexts": contexts, "session_skills": skill_dicts}
 
 
 def _make_memory_diff(

--- a/openviking/session/memory/dataclass.py
+++ b/openviking/session/memory/dataclass.py
@@ -169,6 +169,40 @@ class MemoryOperationSource(BaseModel):
     extracted_at: Optional[str] = None
 
 
+class MemoryOperationSkipCode(str, Enum):
+    """Stable reason codes for intentionally skipped memory operations."""
+
+    MEMORY_TYPE_FILTERED = "memory_type_filtered"
+    SELF_MEMORY_DISABLED = "self_memory_disabled"
+    PEER_MEMORY_DISABLED = "peer_memory_disabled"
+    INVALID_PEER_ID = "invalid_peer_id"
+    PEER_NOT_ALLOWED = "peer_not_allowed"
+    INVALID_RANGES = "invalid_ranges"
+    AMBIGUOUS_TARGET = "ambiguous_target"
+    NO_WRITABLE_TARGET = "no_writable_target"
+    DEPENDENT_DELETE_SUPPRESSED = "dependent_delete_suppressed"
+
+
+class MemoryOperationSkip(BaseModel):
+    """Internal policy/validation decision explaining why no URI was produced."""
+
+    reason_code: MemoryOperationSkipCode
+    reason: str
+
+
+class SkippedMemoryOperation(BaseModel):
+    """Structured, task-visible record for one intentionally skipped operation."""
+
+    memory_type: str
+    page_id: Optional[int] = None
+    uri: Optional[str] = None
+    reason_code: MemoryOperationSkipCode
+    reason: str
+    # Source is used only to scope shared streaming-batch results back to the
+    # submitting commit. It must never be serialized into the public task result.
+    source: Optional[MemoryOperationSource] = Field(default=None, exclude=True)
+
+
 # ============================================================================
 # Memory Field and Schema Definitions
 # ============================================================================
@@ -298,6 +332,9 @@ class ResolvedOperation(BaseModel):
     uris: List[str]
     page_id: Optional[int] = None  # Temporary page_id for link resolution (not persisted)
     source: Optional[MemoryOperationSource] = None
+    # Runtime-only resolution decision. It is deliberately excluded from model
+    # serialization so it cannot enter later LLM merge prompts or memory files.
+    resolution_skip: Optional[MemoryOperationSkip] = Field(default=None, exclude=True)
     # Custom scalar tags (already normalized as "key=value") to attach to this
     # operation's memories in the vector index. None means "no tags"; used by
     # event-memory auto-tagging. Not persisted in the memory file content.

--- a/openviking/session/memory/dataclass.py
+++ b/openviking/session/memory/dataclass.py
@@ -180,7 +180,6 @@ class MemoryOperationSkipCode(str, Enum):
     INVALID_RANGES = "invalid_ranges"
     AMBIGUOUS_TARGET = "ambiguous_target"
     NO_WRITABLE_TARGET = "no_writable_target"
-    DEPENDENT_DELETE_SUPPRESSED = "dependent_delete_suppressed"
 
 
 class MemoryOperationSkip(BaseModel):

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -16,6 +16,7 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import (
     DeleteId,
     MemoryFile,
+    MemoryOperationSkip,
     ResolvedOperation,
     ResolvedOperations,
     StoredLink,
@@ -387,6 +388,17 @@ The final output of the model must strictly follow the JSON Schema format shown 
             for item in items:
                 item_dict = dict(item)
                 item_dict["memory_type"] = memory_type
+                identity_resolution_skip = None
+                classify_identity_fields = getattr(
+                    self._isolation_handler,
+                    "_classify_identity_fields",
+                    None,
+                )
+                if callable(classify_identity_fields):
+                    identity_resolution_skip = classify_identity_fields(
+                        item_dict,
+                        memory_type_schema=schema,
+                    )
                 try:
                     self._isolation_handler.fill_identity_fields(
                         item_dict,
@@ -404,6 +416,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         item_dict,
                         role_scope=role_scope,
                     )
+                if not isinstance(identity_resolution_skip, MemoryOperationSkip):
+                    identity_resolution_skip = None
 
                 page_id = item_dict.pop("page_id", None)
                 resolved_op = ResolvedOperation(
@@ -412,12 +426,17 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     memory_type=memory_type,
                     uris=[],
                     page_id=page_id,
+                    resolution_skip=identity_resolution_skip,
                 )
 
                 if page_id is not None and page_id_map is not None:
                     resolved_uri = page_id_map.resolve(page_id)
                     if resolved_uri:
                         resolved_op.uris = [resolved_uri]
+                        # Existing page IDs retain their historical precedence over
+                        # an invalid peer hint. Keep the hint runtime-only and do
+                        # not persist it into memory metadata.
+                        resolved_op.resolution_skip = None
                         old_content = self.context_provider.read_file_contents.get(resolved_uri)
                         if old_content is not None:
                             resolved_op.old_memory_file_content = old_content

--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -7,7 +7,12 @@ from typing import Any, Dict, List, Optional, Set
 
 from openviking.core.peer_id import safe_peer_id
 from openviking.server.identity import RequestContext
-from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+from openviking.session.memory.dataclass import (
+    MemoryOperationSkip,
+    MemoryOperationSkipCode,
+    MemoryTypeSchema,
+    ResolvedOperation,
+)
 from openviking.session.memory.memory_updater import ExtractContext
 from openviking.session.memory.utils.uri import generate_uri, render_template
 from openviking_cli.utils import get_logger
@@ -16,6 +21,30 @@ logger = get_logger(__name__)
 
 _INTERNAL_MEMORY_TYPES = {"session_skills"}
 _SELF_PEER_ID = "__self"
+_INVALID_PEER_MARKER = "_memory_resolution_invalid_peer_id"
+
+_SKIP_REASON_MESSAGES = {
+    MemoryOperationSkipCode.MEMORY_TYPE_FILTERED: (
+        "Memory type is outside the allowed extraction scope"
+    ),
+    MemoryOperationSkipCode.SELF_MEMORY_DISABLED: "Self memory writes are disabled",
+    MemoryOperationSkipCode.PEER_MEMORY_DISABLED: "Peer memory writes are disabled",
+    MemoryOperationSkipCode.INVALID_PEER_ID: "Target peer ID is invalid",
+    MemoryOperationSkipCode.PEER_NOT_ALLOWED: ("Target peer is outside the allowed memory scope"),
+    MemoryOperationSkipCode.INVALID_RANGES: "Message ranges are malformed or out of bounds",
+    MemoryOperationSkipCode.AMBIGUOUS_TARGET: "Memory ownership cannot be resolved uniquely",
+    MemoryOperationSkipCode.NO_WRITABLE_TARGET: "No writable memory target could be resolved",
+}
+
+_SKIP_REASON_PRIORITY = {
+    MemoryOperationSkipCode.INVALID_PEER_ID: 0,
+    MemoryOperationSkipCode.INVALID_RANGES: 1,
+    MemoryOperationSkipCode.PEER_MEMORY_DISABLED: 2,
+    MemoryOperationSkipCode.PEER_NOT_ALLOWED: 3,
+    MemoryOperationSkipCode.SELF_MEMORY_DISABLED: 4,
+    MemoryOperationSkipCode.AMBIGUOUS_TARGET: 5,
+    MemoryOperationSkipCode.NO_WRITABLE_TARGET: 6,
+}
 
 
 @dataclass
@@ -24,6 +53,12 @@ class RoleScope:
 
     user_ids: List[str]
     peer_ids: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _TargetResolution:
+    target_ids: List[str] = field(default_factory=list)
+    skip_code: Optional[MemoryOperationSkipCode] = None
 
 
 def peer_user_space(user_space: str, peer_id: str) -> str:
@@ -43,6 +78,7 @@ class MemoryIsolationHandler:
         allowed_memory_types: Optional[Set[str]] = None,
         allow_self: bool = True,
         allowed_peer_ids: Optional[Set[str]] = None,
+        peer_memory_enabled: Optional[bool] = None,
     ):
         self.ctx = ctx
         self._extract_context = extract_context
@@ -58,6 +94,9 @@ class MemoryIsolationHandler:
         }
         self.allow_self = bool(allow_self)
         self.allowed_peer_ids = peer_ids
+        self.peer_memory_enabled = (
+            bool(peer_memory_enabled) if peer_memory_enabled is not None else True
+        )
         self.allow_peer = bool(peer_ids)
 
     def prepare_messages(self) -> None:
@@ -69,15 +108,29 @@ class MemoryIsolationHandler:
         return messages if isinstance(messages, list) else []
 
     def _message_target_id(self, msg: Any) -> Optional[str]:
+        resolution = self._message_target_resolution(msg)
+        return resolution.target_ids[0] if resolution.target_ids else None
+
+    def _message_target_resolution(self, msg: Any) -> _TargetResolution:
         if not self._is_peer_owner_message(msg):
-            return None
+            return _TargetResolution()
         raw_peer_id = getattr(msg, "peer_id", None)
+        if raw_peer_id in (None, ""):
+            if self.allow_self:
+                return _TargetResolution([_SELF_PEER_ID])
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.SELF_MEMORY_DISABLED)
         peer_id = safe_peer_id(raw_peer_id)
-        if peer_id and self._can_write_peer(peer_id):
-            return peer_id
-        if raw_peer_id in (None, "") and self.allow_self:
-            return _SELF_PEER_ID
-        return None
+        if not peer_id:
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_PEER_ID)
+        if peer_id == _SELF_PEER_ID:
+            if self.allow_self:
+                return _TargetResolution([_SELF_PEER_ID])
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.SELF_MEMORY_DISABLED)
+        if not self.peer_memory_enabled:
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED)
+        if not self._can_write_peer(peer_id):
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.PEER_NOT_ALLOWED)
+        return _TargetResolution([peer_id])
 
     @staticmethod
     def _is_peer_owner_message(msg: Any) -> bool:
@@ -115,11 +168,14 @@ class MemoryIsolationHandler:
             item_dict.pop("peer_id", None)
             return
 
-        peer_id = safe_peer_id(item_dict.get("peer_id"))
+        raw_peer_id = item_dict.get("peer_id")
+        peer_id = safe_peer_id(raw_peer_id)
         if peer_id and peer_id != _SELF_PEER_ID:
             item_dict["peer_id"] = peer_id
         else:
             item_dict.pop("peer_id", None)
+            if raw_peer_id not in (None, "", _SELF_PEER_ID):
+                item_dict[_INVALID_PEER_MARKER] = True
 
     def allows_schema(self, memory_type_schema: MemoryTypeSchema) -> bool:
         memory_type = getattr(memory_type_schema, "memory_type", "")
@@ -134,23 +190,11 @@ class MemoryIsolationHandler:
     def _can_write_peer(self, peer_id: str) -> bool:
         return self.allow_peer and peer_id in self.allowed_peer_ids
 
-    def _unique_peer_target_id_in_messages(self) -> Optional[str]:
-        targets = [
-            peer_id
-            for msg in self._messages()
-            if (peer_id := safe_peer_id(getattr(msg, "peer_id", None)))
-            and self._is_peer_owner_message(msg)
-            and self._can_write_peer(peer_id)
-        ]
-        peer_ids = list(dict.fromkeys(targets))
-        return peer_ids[0] if len(peer_ids) == 1 else None
-
-    def _unique_target_id_in_messages(self) -> Optional[str]:
+    def _target_ids_in_messages(self) -> List[str]:
         targets = [
             target_id for msg in self._messages() if (target_id := self._message_target_id(msg))
         ]
-        target_ids = list(dict.fromkeys(targets))
-        return target_ids[0] if len(target_ids) == 1 else None
+        return list(dict.fromkeys(targets))
 
     def _range_is_fully_in_bounds(self, ranges: Any) -> bool:
         parts = str(ranges).split(",")
@@ -197,41 +241,93 @@ class MemoryIsolationHandler:
             )
         return directories
 
-    def _range_targets(self, ranges: Any) -> tuple[List[str], bool]:
+    @staticmethod
+    def _preferred_skip_code(
+        skip_codes: List[MemoryOperationSkipCode],
+    ) -> MemoryOperationSkipCode:
+        if not skip_codes:
+            return MemoryOperationSkipCode.NO_WRITABLE_TARGET
+        return min(skip_codes, key=lambda code: _SKIP_REASON_PRIORITY.get(code, 999))
+
+    def _range_targets(self, ranges: Any) -> _TargetResolution:
         if not ranges or not self._extract_context:
-            return [], False
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
         range_is_fully_in_bounds = self._range_is_fully_in_bounds(ranges)
+        if not range_is_fully_in_bounds:
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
         try:
             msg_range = self._extract_context.read_message_ranges(str(ranges))
         except Exception:
             logger.warning("Failed to parse memory ranges for peer memory: %s", ranges)
-            return [], False
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
 
         target_ids = []
         has_message = False
         has_user_message = False
+        skip_codes: List[MemoryOperationSkipCode] = []
         for msg_group in getattr(msg_range, "elements", []) or []:
             for msg in msg_group:
                 has_message = True
                 if self._is_peer_owner_message(msg):
                     has_user_message = True
-                target_id = self._message_target_id(msg)
-                if target_id:
-                    target_ids.append(target_id)
-        can_fallback = range_is_fully_in_bounds and has_message and not has_user_message
-        return list(dict.fromkeys(target_ids)), can_fallback
+                resolution = self._message_target_resolution(msg)
+                target_ids.extend(resolution.target_ids)
+                if resolution.skip_code is not None:
+                    skip_codes.append(resolution.skip_code)
+        target_ids = list(dict.fromkeys(target_ids))
+        if target_ids:
+            return _TargetResolution(target_ids)
+        if has_user_message:
+            return _TargetResolution(skip_code=self._preferred_skip_code(skip_codes))
+        if has_message:
+            fallback_targets = self._target_ids_in_messages()
+            if len(fallback_targets) == 1:
+                return _TargetResolution(fallback_targets)
+            if len(fallback_targets) > 1:
+                return _TargetResolution(skip_code=MemoryOperationSkipCode.AMBIGUOUS_TARGET)
+        return _TargetResolution(skip_code=MemoryOperationSkipCode.NO_WRITABLE_TARGET)
 
-    def _resolve_operation_target_id(self, raw_peer_id: Any) -> Optional[str]:
-        peer_id = safe_peer_id(raw_peer_id)
-        if peer_id == _SELF_PEER_ID and self.allow_self:
-            return _SELF_PEER_ID
-        if peer_id and self._can_write_peer(peer_id):
-            return peer_id
+    def _resolve_operation_target(self, raw_peer_id: Any) -> _TargetResolution:
         if raw_peer_id not in (None, ""):
-            return None
+            peer_id = safe_peer_id(raw_peer_id)
+            if not peer_id:
+                return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_PEER_ID)
+            if peer_id == _SELF_PEER_ID:
+                if self.allow_self:
+                    return _TargetResolution([_SELF_PEER_ID])
+                return _TargetResolution(skip_code=MemoryOperationSkipCode.SELF_MEMORY_DISABLED)
+            if not self.peer_memory_enabled:
+                return _TargetResolution(skip_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED)
+            if not self._can_write_peer(peer_id):
+                return _TargetResolution(skip_code=MemoryOperationSkipCode.PEER_NOT_ALLOWED)
+            return _TargetResolution([peer_id])
         if self.allow_self:
-            return _SELF_PEER_ID
-        return self._unique_peer_target_id_in_messages()
+            return _TargetResolution([_SELF_PEER_ID])
+        peer_targets = list(
+            dict.fromkeys(
+                target
+                for msg in self._messages()
+                for target in self._message_target_resolution(msg).target_ids
+                if target != _SELF_PEER_ID
+            )
+        )
+        if len(peer_targets) == 1:
+            return _TargetResolution(peer_targets)
+        if len(peer_targets) > 1:
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.AMBIGUOUS_TARGET)
+        return _TargetResolution(skip_code=MemoryOperationSkipCode.NO_WRITABLE_TARGET)
+
+    @staticmethod
+    def _skip_operation(
+        operation: ResolvedOperation,
+        reason_code: MemoryOperationSkipCode,
+    ) -> List[str]:
+        operation.memory_fields.pop(_INVALID_PEER_MARKER, None)
+        operation.resolution_skip = MemoryOperationSkip(
+            reason_code=reason_code,
+            reason=_SKIP_REASON_MESSAGES[reason_code],
+        )
+        return []
 
     def calculate_memory_uris(
         self,
@@ -239,8 +335,14 @@ class MemoryIsolationHandler:
         operation: ResolvedOperation,
         extract_context: ExtractContext,
     ):
+        operation.resolution_skip = None
         if not self.allows_schema(memory_type_schema):
-            return []
+            reason_code = (
+                MemoryOperationSkipCode.SELF_MEMORY_DISABLED
+                if not self.allow_self and not getattr(memory_type_schema, "peer_enabled", True)
+                else MemoryOperationSkipCode.MEMORY_TYPE_FILTERED
+            )
+            return self._skip_operation(operation, reason_code)
 
         if not self.ctx or not self.ctx.user:
             return []
@@ -249,25 +351,31 @@ class MemoryIsolationHandler:
         operation.memory_fields["user_id"] = user_id
 
         target_ids: List[str] = []
+        skip_code: Optional[MemoryOperationSkipCode] = None
         has_ranges = operation.memory_fields.get("ranges") is not None
         if not getattr(memory_type_schema, "peer_enabled", True):
             operation.memory_fields.pop("peer_id", None)
-            target_ids = [_SELF_PEER_ID] if self.allow_self else []
+            if self.allow_self:
+                target_ids = [_SELF_PEER_ID]
+            else:
+                skip_code = MemoryOperationSkipCode.SELF_MEMORY_DISABLED
         elif operation.memory_fields.get("ranges") is not None:
-            target_ids, can_fallback = self._range_targets(
+            resolution = self._range_targets(
                 operation.memory_fields.get("ranges"),
             )
-            if not target_ids and can_fallback:
-                fallback_target = self._unique_target_id_in_messages()
-                if fallback_target:
-                    target_ids = [fallback_target]
+            target_ids = resolution.target_ids
+            skip_code = resolution.skip_code
             operation.memory_fields.pop("peer_id", None)
         else:
-            target_id = self._resolve_operation_target_id(
-                operation.memory_fields.get("peer_id"),
+            invalid_peer_id = bool(operation.memory_fields.pop(_INVALID_PEER_MARKER, False))
+            resolution = (
+                _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_PEER_ID)
+                if invalid_peer_id
+                else self._resolve_operation_target(operation.memory_fields.get("peer_id"))
             )
-            if target_id:
-                target_ids = [target_id]
+            target_ids = resolution.target_ids
+            skip_code = resolution.skip_code
+            target_id = target_ids[0] if len(target_ids) == 1 else None
             if target_id == _SELF_PEER_ID:
                 operation.memory_fields.pop("peer_id", None)
             elif target_id:
@@ -276,7 +384,10 @@ class MemoryIsolationHandler:
                 operation.memory_fields.pop("peer_id", None)
 
         if not target_ids:
-            return []
+            return self._skip_operation(
+                operation,
+                skip_code or MemoryOperationSkipCode.NO_WRITABLE_TARGET,
+            )
 
         # 文件
         uris = set()

--- a/openviking/session/memory/memory_isolation_handler.py
+++ b/openviking/session/memory/memory_isolation_handler.py
@@ -21,7 +21,6 @@ logger = get_logger(__name__)
 
 _INTERNAL_MEMORY_TYPES = {"session_skills"}
 _SELF_PEER_ID = "__self"
-_INVALID_PEER_MARKER = "_memory_resolution_invalid_peer_id"
 
 _SKIP_REASON_MESSAGES = {
     MemoryOperationSkipCode.MEMORY_TYPE_FILTERED: (
@@ -123,9 +122,10 @@ class MemoryIsolationHandler:
         if not peer_id:
             return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_PEER_ID)
         if peer_id == _SELF_PEER_ID:
-            if self.allow_self:
-                return _TargetResolution([_SELF_PEER_ID])
-            return _TargetResolution(skip_code=MemoryOperationSkipCode.SELF_MEMORY_DISABLED)
+            # ``__self`` is an internal operation-target sentinel, not a valid
+            # message peer. Preserve the legacy behavior: an explicit message
+            # peer with this value does not resolve to a writable target.
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.NO_WRITABLE_TARGET)
         if not self.peer_memory_enabled:
             return _TargetResolution(skip_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED)
         if not self._can_write_peer(peer_id):
@@ -168,14 +168,29 @@ class MemoryIsolationHandler:
             item_dict.pop("peer_id", None)
             return
 
-        raw_peer_id = item_dict.get("peer_id")
-        peer_id = safe_peer_id(raw_peer_id)
+        peer_id = safe_peer_id(item_dict.get("peer_id"))
         if peer_id and peer_id != _SELF_PEER_ID:
             item_dict["peer_id"] = peer_id
         else:
             item_dict.pop("peer_id", None)
-            if raw_peer_id not in (None, "", _SELF_PEER_ID):
-                item_dict[_INVALID_PEER_MARKER] = True
+
+    @staticmethod
+    def _classify_identity_fields(
+        item_dict: Dict[str, Any],
+        memory_type_schema: Optional[MemoryTypeSchema] = None,
+    ) -> Optional[MemoryOperationSkip]:
+        """Capture a diagnostic hint without changing identity-field normalization."""
+        if memory_type_schema is not None and not memory_type_schema.peer_enabled:
+            return None
+        raw_peer_id = item_dict.get("peer_id")
+        if raw_peer_id not in (None, "", _SELF_PEER_ID):
+            if safe_peer_id(raw_peer_id):
+                return None
+            return MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.INVALID_PEER_ID,
+                reason=_SKIP_REASON_MESSAGES[MemoryOperationSkipCode.INVALID_PEER_ID],
+            )
+        return None
 
     def allows_schema(self, memory_type_schema: MemoryTypeSchema) -> bool:
         memory_type = getattr(memory_type_schema, "memory_type", "")
@@ -253,8 +268,6 @@ class MemoryIsolationHandler:
         if not ranges or not self._extract_context:
             return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
         range_is_fully_in_bounds = self._range_is_fully_in_bounds(ranges)
-        if not range_is_fully_in_bounds:
-            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
         try:
             msg_range = self._extract_context.read_message_ranges(str(ranges))
         except Exception:
@@ -277,14 +290,17 @@ class MemoryIsolationHandler:
         target_ids = list(dict.fromkeys(target_ids))
         if target_ids:
             return _TargetResolution(target_ids)
-        if has_user_message:
-            return _TargetResolution(skip_code=self._preferred_skip_code(skip_codes))
-        if has_message:
+        can_fallback = range_is_fully_in_bounds and has_message and not has_user_message
+        if can_fallback:
             fallback_targets = self._target_ids_in_messages()
             if len(fallback_targets) == 1:
                 return _TargetResolution(fallback_targets)
             if len(fallback_targets) > 1:
                 return _TargetResolution(skip_code=MemoryOperationSkipCode.AMBIGUOUS_TARGET)
+        if not range_is_fully_in_bounds:
+            return _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_RANGES)
+        if has_user_message:
+            return _TargetResolution(skip_code=self._preferred_skip_code(skip_codes))
         return _TargetResolution(skip_code=MemoryOperationSkipCode.NO_WRITABLE_TARGET)
 
     def _resolve_operation_target(self, raw_peer_id: Any) -> _TargetResolution:
@@ -322,7 +338,6 @@ class MemoryIsolationHandler:
         operation: ResolvedOperation,
         reason_code: MemoryOperationSkipCode,
     ) -> List[str]:
-        operation.memory_fields.pop(_INVALID_PEER_MARKER, None)
         operation.resolution_skip = MemoryOperationSkip(
             reason_code=reason_code,
             reason=_SKIP_REASON_MESSAGES[reason_code],
@@ -335,6 +350,7 @@ class MemoryIsolationHandler:
         operation: ResolvedOperation,
         extract_context: ExtractContext,
     ):
+        identity_resolution_skip = operation.resolution_skip
         operation.resolution_skip = None
         if not self.allows_schema(memory_type_schema):
             reason_code = (
@@ -367,14 +383,11 @@ class MemoryIsolationHandler:
             skip_code = resolution.skip_code
             operation.memory_fields.pop("peer_id", None)
         else:
-            invalid_peer_id = bool(operation.memory_fields.pop(_INVALID_PEER_MARKER, False))
-            resolution = (
-                _TargetResolution(skip_code=MemoryOperationSkipCode.INVALID_PEER_ID)
-                if invalid_peer_id
-                else self._resolve_operation_target(operation.memory_fields.get("peer_id"))
-            )
+            resolution = self._resolve_operation_target(operation.memory_fields.get("peer_id"))
             target_ids = resolution.target_ids
             skip_code = resolution.skip_code
+            if not target_ids and identity_resolution_skip is not None:
+                skip_code = identity_resolution_skip.reason_code
             target_id = target_ids[0] if len(target_ids) == 1 else None
             if target_id == _SELF_PEER_ID:
                 operation.memory_fields.pop("peer_id", None)

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -736,7 +736,6 @@ class MemoryUpdateResult:
             f"Written: {len(self.written_uris)}, "
             f"Edited: {len(self.edited_uris)}, "
             f"Deleted: {len(self.deleted_uris)}, "
-            f"Skipped: {len(self.skipped_operations)}, "
             f"Errors: {len(self.errors)}"
         )
 
@@ -880,7 +879,6 @@ class MemoryUpdater:
 
         applicable_upserts: List[ResolvedOperation] = []
         has_unresolved_upserts = False
-        has_unexplained_unresolved_upserts = False
         for resolved_op in operations.upsert_operations:
             if resolved_op.uris:
                 applicable_upserts.append(resolved_op)
@@ -889,6 +887,8 @@ class MemoryUpdater:
             error_target = f"{resolved_op.memory_type}(page_id={resolved_op.page_id})"
             resolution_skip = getattr(resolved_op, "resolution_skip", None)
             if resolution_skip is not None:
+                # Reporting-only: the operation remains unresolved, preserving
+                # the legacy delete-suppression behavior for direct mixed batches.
                 skipped = SkippedMemoryOperation(
                     memory_type=resolved_op.memory_type,
                     page_id=resolved_op.page_id,
@@ -911,7 +911,6 @@ class MemoryUpdater:
                 else:
                     tracer.info(message)
                 continue
-            has_unexplained_unresolved_upserts = True
             resolution_error = ValueError("Missing resolved URI")
             result.add_error(error_target, resolution_error)
             tracer.error(
@@ -965,28 +964,6 @@ class MemoryUpdater:
         for file_content in operations.delete_file_contents:
             delete_uri = file_content.uri
             if has_unresolved_upserts:
-                if not has_unexplained_unresolved_upserts:
-                    skip = SkippedMemoryOperation(
-                        memory_type=(
-                            file_content.memory_type
-                            or file_content.extra_fields.get("memory_type")
-                            or self.memory_type_from_uri(delete_uri)
-                            or "unknown"
-                        ),
-                        uri=delete_uri,
-                        reason_code=MemoryOperationSkipCode.DEPENDENT_DELETE_SUPPRESSED,
-                        reason=(
-                            "Delete was suppressed because the batch contains an "
-                            "intentionally skipped upsert"
-                        ),
-                    )
-                    result.add_skipped(skip)
-                    tracer.info(
-                        "Skipping dependent memory delete by resolution policy: "
-                        f"memory_type={skip.memory_type} "
-                        "reason_code=dependent_delete_suppressed"
-                    )
-                    continue
                 delete_error = ValueError(
                     "Skipped delete because batch contains unresolved upsert URIs"
                 )

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -22,8 +22,10 @@ from openviking.message.part import TextPart
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import (
     MemoryFile,
+    MemoryOperationSkipCode,
     ResolvedOperation,
     ResolvedOperations,
+    SkippedMemoryOperation,
     StoredLink,
 )
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
@@ -711,6 +713,7 @@ class MemoryUpdateResult:
         self.written_uris: List[str] = []
         self.edited_uris: List[str] = []
         self.deleted_uris: List[str] = []
+        self.skipped_operations: List[SkippedMemoryOperation] = []
         self.errors: List[Tuple[str, Exception]] = []
 
     def add_written(self, uri: str) -> None:
@@ -725,11 +728,15 @@ class MemoryUpdateResult:
     def add_error(self, uri: str, error: Exception) -> None:
         self.errors.append((uri, error))
 
+    def add_skipped(self, operation: SkippedMemoryOperation) -> None:
+        self.skipped_operations.append(operation)
+
     def summary(self) -> str:
         return (
             f"Written: {len(self.written_uris)}, "
             f"Edited: {len(self.edited_uris)}, "
             f"Deleted: {len(self.deleted_uris)}, "
+            f"Skipped: {len(self.skipped_operations)}, "
             f"Errors: {len(self.errors)}"
         )
 
@@ -873,12 +880,38 @@ class MemoryUpdater:
 
         applicable_upserts: List[ResolvedOperation] = []
         has_unresolved_upserts = False
+        has_unexplained_unresolved_upserts = False
         for resolved_op in operations.upsert_operations:
             if resolved_op.uris:
                 applicable_upserts.append(resolved_op)
                 continue
             has_unresolved_upserts = True
             error_target = f"{resolved_op.memory_type}(page_id={resolved_op.page_id})"
+            resolution_skip = getattr(resolved_op, "resolution_skip", None)
+            if resolution_skip is not None:
+                skipped = SkippedMemoryOperation(
+                    memory_type=resolved_op.memory_type,
+                    page_id=resolved_op.page_id,
+                    reason_code=resolution_skip.reason_code,
+                    reason=resolution_skip.reason,
+                    source=resolved_op.source,
+                )
+                result.add_skipped(skipped)
+                message = (
+                    "Skipping memory operation by resolution policy: "
+                    f"memory_type={resolved_op.memory_type} "
+                    f"page_id={resolved_op.page_id} "
+                    f"reason_code={resolution_skip.reason_code.value}"
+                )
+                if resolution_skip.reason_code in {
+                    MemoryOperationSkipCode.INVALID_PEER_ID,
+                    MemoryOperationSkipCode.INVALID_RANGES,
+                }:
+                    logger.warning(message)
+                else:
+                    tracer.info(message)
+                continue
+            has_unexplained_unresolved_upserts = True
             resolution_error = ValueError("Missing resolved URI")
             result.add_error(error_target, resolution_error)
             tracer.error(
@@ -932,6 +965,28 @@ class MemoryUpdater:
         for file_content in operations.delete_file_contents:
             delete_uri = file_content.uri
             if has_unresolved_upserts:
+                if not has_unexplained_unresolved_upserts:
+                    skip = SkippedMemoryOperation(
+                        memory_type=(
+                            file_content.memory_type
+                            or file_content.extra_fields.get("memory_type")
+                            or self.memory_type_from_uri(delete_uri)
+                            or "unknown"
+                        ),
+                        uri=delete_uri,
+                        reason_code=MemoryOperationSkipCode.DEPENDENT_DELETE_SUPPRESSED,
+                        reason=(
+                            "Delete was suppressed because the batch contains an "
+                            "intentionally skipped upsert"
+                        ),
+                    )
+                    result.add_skipped(skip)
+                    tracer.info(
+                        "Skipping dependent memory delete by resolution policy: "
+                        f"memory_type={skip.memory_type} "
+                        "reason_code=dependent_delete_suppressed"
+                    )
+                    continue
                 delete_error = ValueError(
                     "Skipped delete because batch contains unresolved upsert URIs"
                 )

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -616,16 +616,12 @@ def split_request_by_merge_group(
             group_key = MemoryMergeGroupKey(peer_id=peer_id, memory_type=single_uri_op.memory_type)
             upsert_groups.setdefault(group_key, []).append(single_uri_op)
 
-    # Keep deletes in the same apply group as unresolved upserts so MemoryUpdater
-    # can observe both operations and suppress delete execution when an upsert is
-    # intentionally skipped.
-    if not passthrough_upserts:
-        for file in list(operations.delete_file_contents or []):
-            group_key = MemoryMergeGroupKey(
-                peer_id=_peer_id_for_memory_file(file),
-                memory_type=file.memory_type or "",
-            )
-            delete_groups.setdefault(group_key, []).append(file)
+    for file in list(operations.delete_file_contents or []):
+        group_key = MemoryMergeGroupKey(
+            peer_id=_peer_id_for_memory_file(file),
+            memory_type=file.memory_type or "",
+        )
+        delete_groups.setdefault(group_key, []).append(file)
 
     group_keys = list(dict.fromkeys(list(upsert_groups.keys()) + list(delete_groups.keys())))
     grouped_requests: list[tuple[MemoryMergeGroupKey, MemoryUpdateRequest]] = []
@@ -658,7 +654,9 @@ def split_request_by_merge_group(
         )
 
     if passthrough_upserts:
-        passthrough_deletes = list(operations.delete_file_contents or [])
+        # Unresolved upserts keep their original standalone passthrough group.
+        # Deletes remain in their normal peer/type groups, including replacement
+        # metadata, so diagnostics cannot change write/delete ordering.
         group_key = MemoryMergeGroupKey(peer_id=None, memory_type="")
         grouped_requests.append(
             (
@@ -667,19 +665,10 @@ def split_request_by_merge_group(
                     request,
                     operations=ResolvedOperations(
                         upsert_operations=passthrough_upserts,
-                        delete_file_contents=passthrough_deletes,
+                        delete_file_contents=[],
                         errors=list(operations.errors or []),
                         resolved_links=[],
-                        delete_replacements={
-                            file.uri: replacement_uri
-                            for file in passthrough_deletes
-                            if file.uri
-                            if (
-                                replacement_uri := (
-                                    getattr(operations, "delete_replacements", {}) or {}
-                                ).get(file.uri)
-                            )
-                        },
+                        delete_replacements={},
                     ),
                 ),
             )
@@ -1772,12 +1761,18 @@ def _skipped_operation_matches_scope(
     scoped_uris: set[str],
 ) -> bool:
     source = getattr(operation, "source", None)
-    if scope.extraction_id and getattr(source, "extraction_id", None) == scope.extraction_id:
-        return True
-    if scope.archive_uri and getattr(source, "archive_uri", None) == scope.archive_uri:
-        return True
-    if scope.session_id and getattr(source, "session_id", None) == scope.session_id:
-        return True
+    source_extraction_id = _optional_str(getattr(source, "extraction_id", None))
+    if scope.extraction_id and source_extraction_id:
+        return source_extraction_id == scope.extraction_id
+
+    source_archive_uri = _optional_str(getattr(source, "archive_uri", None))
+    if scope.archive_uri and source_archive_uri:
+        return source_archive_uri == scope.archive_uri
+
+    source_session_id = _optional_str(getattr(source, "session_id", None))
+    if scope.session_id and source_session_id:
+        return source_session_id == scope.session_id
+
     uri = str(getattr(operation, "uri", None) or "")
     return bool(uri and uri in scoped_uris)
 

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -26,6 +26,7 @@ from openviking.session.memory.dataclass import (
     MemoryTypeSchema,
     ResolvedOperation,
     ResolvedOperations,
+    SkippedMemoryOperation,
     StoredLink,
 )
 from openviking.session.memory.extract_loop import ExtractLoop
@@ -208,6 +209,7 @@ class StreamingMemoryUpdater:
             f"written_uris={scoped_result.apply_result.written_uris} "
             f"edited_uris={scoped_result.apply_result.edited_uris} "
             f"deleted_uris={scoped_result.apply_result.deleted_uris} "
+            f"skipped_reason_codes={_skipped_reason_codes(scoped_result.apply_result)} "
             f"errors={scoped_result.apply_result.errors}",
             console=self.config.trace_console,
         )
@@ -398,6 +400,7 @@ class StreamingMemoryUpdater:
             f"written_uris={apply_result.written_uris} "
             f"edited_uris={apply_result.edited_uris} "
             f"deleted_uris={apply_result.deleted_uris} "
+            f"skipped_reason_codes={_skipped_reason_codes(apply_result)} "
             f"errors={apply_result.errors}",
             console=self.config.trace_console,
         )
@@ -449,6 +452,7 @@ class StreamingMemoryUpdater:
             f"written_uris={apply_result.written_uris} "
             f"edited_uris={apply_result.edited_uris} "
             f"deleted_uris={apply_result.deleted_uris} "
+            f"skipped_reason_codes={_skipped_reason_codes(apply_result)} "
             f"errors={apply_result.errors}",
             console=self.config.trace_console,
         )
@@ -612,12 +616,16 @@ def split_request_by_merge_group(
             group_key = MemoryMergeGroupKey(peer_id=peer_id, memory_type=single_uri_op.memory_type)
             upsert_groups.setdefault(group_key, []).append(single_uri_op)
 
-    for file in list(operations.delete_file_contents or []):
-        group_key = MemoryMergeGroupKey(
-            peer_id=_peer_id_for_memory_file(file),
-            memory_type=file.memory_type or "",
-        )
-        delete_groups.setdefault(group_key, []).append(file)
+    # Keep deletes in the same apply group as unresolved upserts. MemoryUpdater
+    # can then fail closed: an intentionally skipped replacement must not let
+    # its old file be deleted by a separate group.
+    if not passthrough_upserts:
+        for file in list(operations.delete_file_contents or []):
+            group_key = MemoryMergeGroupKey(
+                peer_id=_peer_id_for_memory_file(file),
+                memory_type=file.memory_type or "",
+            )
+            delete_groups.setdefault(group_key, []).append(file)
 
     group_keys = list(dict.fromkeys(list(upsert_groups.keys()) + list(delete_groups.keys())))
     grouped_requests: list[tuple[MemoryMergeGroupKey, MemoryUpdateRequest]] = []
@@ -650,6 +658,7 @@ def split_request_by_merge_group(
         )
 
     if passthrough_upserts:
+        passthrough_deletes = list(operations.delete_file_contents or [])
         group_key = MemoryMergeGroupKey(peer_id=None, memory_type="")
         grouped_requests.append(
             (
@@ -658,10 +667,19 @@ def split_request_by_merge_group(
                     request,
                     operations=ResolvedOperations(
                         upsert_operations=passthrough_upserts,
-                        delete_file_contents=[],
+                        delete_file_contents=passthrough_deletes,
                         errors=list(operations.errors or []),
                         resolved_links=[],
-                        delete_replacements={},
+                        delete_replacements={
+                            file.uri: replacement_uri
+                            for file in passthrough_deletes
+                            if file.uri
+                            if (
+                                replacement_uri := (
+                                    getattr(operations, "delete_replacements", {}) or {}
+                                ).get(file.uri)
+                            )
+                        },
                     ),
                 ),
             )
@@ -1610,6 +1628,7 @@ def scope_memory_update_result_to_submitter(
     scoped_apply_result = _scope_apply_result_to_uris(
         result.apply_result,
         scoped_uris=scoped_uris,
+        scope=scope,
     )
     metadata = dict(result.metadata or {})
     metadata.update(
@@ -1717,6 +1736,7 @@ def _scope_apply_result_to_uris(
     apply_result: MemoryUpdateResult,
     *,
     scoped_uris: set[str],
+    scope: _MemorySubmitterScope,
 ) -> MemoryUpdateResult:
     scoped = MemoryUpdateResult()
     scoped.written_uris = [
@@ -1733,7 +1753,33 @@ def _scope_apply_result_to_uris(
         for error in list(getattr(apply_result, "errors", []) or [])
         if _apply_error_matches_scoped_uris(error, scoped_uris=scoped_uris)
     ]
+    scoped.skipped_operations = [
+        operation
+        for operation in list(getattr(apply_result, "skipped_operations", []) or [])
+        if _skipped_operation_matches_scope(
+            operation,
+            scope=scope,
+            scoped_uris=scoped_uris,
+        )
+    ]
     return scoped
+
+
+def _skipped_operation_matches_scope(
+    operation: SkippedMemoryOperation,
+    *,
+    scope: _MemorySubmitterScope,
+    scoped_uris: set[str],
+) -> bool:
+    source = getattr(operation, "source", None)
+    if scope.extraction_id and getattr(source, "extraction_id", None) == scope.extraction_id:
+        return True
+    if scope.archive_uri and getattr(source, "archive_uri", None) == scope.archive_uri:
+        return True
+    if scope.session_id and getattr(source, "session_id", None) == scope.session_id:
+        return True
+    uri = str(getattr(operation, "uri", None) or "")
+    return bool(uri and uri in scoped_uris)
 
 
 def _operation_matches_scope(op: ResolvedOperation, *, scope: _MemorySubmitterScope) -> bool:
@@ -1894,6 +1940,7 @@ def combine_streaming_memory_results(
         combined_apply_result.written_uris.extend(result.apply_result.written_uris)
         combined_apply_result.edited_uris.extend(result.apply_result.edited_uris)
         combined_apply_result.deleted_uris.extend(result.apply_result.deleted_uris)
+        combined_apply_result.skipped_operations.extend(result.apply_result.skipped_operations)
         combined_apply_result.errors.extend(result.apply_result.errors)
         for key in ("batch_id", "batch_trace_id"):
             if result.metadata.get(key):
@@ -1965,11 +2012,19 @@ def _make_isolation_handler(
         allowed_memory_types=options.get("allowed_memory_types"),
         allow_self=options.get("allow_self", True),
         allowed_peer_ids=options.get("allowed_peer_ids"),
+        peer_memory_enabled=options.get("peer_memory_enabled"),
     )
 
 
 def _operation_count(operations: ResolvedOperations) -> int:
     return len(operations.upsert_operations or []) + len(operations.delete_file_contents or [])
+
+
+def _skipped_reason_codes(result: MemoryUpdateResult) -> list[str]:
+    return [
+        operation.reason_code.value
+        for operation in list(getattr(result, "skipped_operations", []) or [])
+    ]
 
 
 def _operation_lock_paths(

--- a/openviking/session/memory/streaming_memory_updater.py
+++ b/openviking/session/memory/streaming_memory_updater.py
@@ -616,9 +616,9 @@ def split_request_by_merge_group(
             group_key = MemoryMergeGroupKey(peer_id=peer_id, memory_type=single_uri_op.memory_type)
             upsert_groups.setdefault(group_key, []).append(single_uri_op)
 
-    # Keep deletes in the same apply group as unresolved upserts. MemoryUpdater
-    # can then fail closed: an intentionally skipped replacement must not let
-    # its old file be deleted by a separate group.
+    # Keep deletes in the same apply group as unresolved upserts so MemoryUpdater
+    # can observe both operations and suppress delete execution when an upsert is
+    # intentionally skipped.
     if not passthrough_upserts:
         for file in list(operations.delete_file_contents or []):
             group_key = MemoryMergeGroupKey(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -184,6 +184,7 @@ def _message_peer_ids(messages: List[Message]) -> set[str]:
 @dataclass(frozen=True)
 class _MemoryExtractionScope:
     allow_self_memory: bool
+    peer_memory_enabled: bool
     allowed_peer_ids: set[str]
     include_session_skills: bool
     memory_types: Optional[set[str]]
@@ -201,6 +202,7 @@ def _resolve_memory_extraction_scope(
 
     return _MemoryExtractionScope(
         allow_self_memory=allow_self_memory,
+        peer_memory_enabled=policy.peer_enabled,
         allowed_peer_ids=allowed_peer_ids,
         include_session_skills=config_session_skill_extraction_enabled and allow_self_memory,
         memory_types=policy.memory_types,
@@ -2367,6 +2369,7 @@ class Session:
         memories_extracted: Dict[str, int] = {}
         usage_events_extracted = 0
         extracted_skill_results: list[dict] = []
+        skipped_memory_operations: list[dict[str, Any]] = []
         active_count_updated = 0
         memory_diff_uri: Optional[str] = None
         completed_memory_steps: Dict[str, set[str]] = {}
@@ -2551,6 +2554,7 @@ class Session:
                         ),
                     )
                     self_memory_enabled = extraction_scope.allow_self_memory
+                    peer_memory_enabled = extraction_scope.peer_memory_enabled
                     allowed_peer_ids = extraction_scope.allowed_peer_ids
                     long_term_memory_types = extraction_scope.memory_types
 
@@ -2598,6 +2602,7 @@ class Session:
                                     allowed_memory_types=long_term_memory_types,
                                     agent_evolution_enabled=agent_evolution_enabled,
                                     allow_self_memory=self_memory_enabled,
+                                    peer_memory_enabled=peer_memory_enabled,
                                     allowed_peer_ids=allowed_peer_ids,
                                     event_search_tags=event_search_tags,
                                 )
@@ -2650,9 +2655,11 @@ class Session:
                             if isinstance(result, dict):
                                 target_contexts = list(result.get("contexts", []))
                                 target_skills = list(result.get("session_skills", []))
+                                target_skips = list(result.get("skipped_operations", []))
                             else:
                                 target_contexts = list(result or [])
                                 target_skills = []
+                                target_skips = []
                             logger.info(
                                 "Extracted %s memories for %s",
                                 len(target_contexts),
@@ -2664,6 +2671,9 @@ class Session:
                                 memories_extracted[cat] = memories_extracted.get(cat, 0) + 1
                             if target_skills:
                                 extracted_skill_results.extend(target_skills)
+                            skipped_memory_operations.extend(
+                                item for item in target_skips if isinstance(item, dict)
+                            )
 
                         if total_extracted:
                             self._stats.memories_extracted += total_extracted
@@ -2754,6 +2764,10 @@ class Session:
                     for item in extracted_skill_results
                     if isinstance(item, dict) and (item.get("uri") or item.get("root_uri"))
                 ],
+                "memory_extraction": {
+                    "skipped": len(skipped_memory_operations),
+                    "skipped_operations": skipped_memory_operations,
+                },
                 "usage_events_extracted": usage_events_extracted,
                 "active_count_updated": active_count_updated,
                 "effective_memory_types": sorted(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2640,14 +2640,6 @@ class Session:
                         if extraction_error is not None:
                             raise extraction_error
 
-                        if long_term_has_work and self._viking_fs:
-                            candidate_memory_diff_uri = f"{archive_uri}/memory_diff.json"
-                            if await self._viking_fs.exists(
-                                candidate_memory_diff_uri,
-                                ctx=self.ctx,
-                            ):
-                                memory_diff_uri = candidate_memory_diff_uri
-
                         total_extracted = 0
                         for label, result in zip(extraction_labels, _results, strict=True):
                             if label == "archive_summary":
@@ -2655,11 +2647,9 @@ class Session:
                             if isinstance(result, dict):
                                 target_contexts = list(result.get("contexts", []))
                                 target_skills = list(result.get("session_skills", []))
-                                target_skips = list(result.get("skipped_operations", []))
                             else:
                                 target_contexts = list(result or [])
                                 target_skills = []
-                                target_skips = []
                             logger.info(
                                 "Extracted %s memories for %s",
                                 len(target_contexts),
@@ -2671,9 +2661,6 @@ class Session:
                                 memories_extracted[cat] = memories_extracted.get(cat, 0) + 1
                             if target_skills:
                                 extracted_skill_results.extend(target_skills)
-                            skipped_memory_operations.extend(
-                                item for item in target_skips if isinstance(item, dict)
-                            )
 
                         if total_extracted:
                             self._stats.memories_extracted += total_extracted
@@ -2695,6 +2682,35 @@ class Session:
                             )
                         else:
                             await _run_archive_summary()
+
+                    # A recovered Phase 2 run may have already completed the
+                    # long-term step before a sibling step failed. Reuse its
+                    # persisted diff instead of reporting an empty task result.
+                    if completed_memory_steps.get("long_term") and self._viking_fs:
+                        candidate_memory_diff_uri = f"{archive_uri}/memory_diff.json"
+                        if await self._viking_fs.exists(
+                            candidate_memory_diff_uri,
+                            ctx=self.ctx,
+                        ):
+                            memory_diff_uri = candidate_memory_diff_uri
+                            try:
+                                raw_memory_diff = await self._viking_fs.read_file(
+                                    candidate_memory_diff_uri,
+                                    ctx=self.ctx,
+                                )
+                                memory_diff = json.loads(raw_memory_diff or "{}")
+                                if isinstance(memory_diff, dict):
+                                    skipped_memory_operations.extend(
+                                        item
+                                        for item in memory_diff.get("skipped_operations", [])
+                                        if isinstance(item, dict)
+                                    )
+                            except Exception as exc:
+                                logger.warning(
+                                    "Failed to read skipped memory operations from %s: %s",
+                                    candidate_memory_diff_uri,
+                                    exc,
+                                )
 
                     # Update active_count (using snapshot, not self._usage_records)
                     if self._vikingdb_manager:

--- a/tests/session/memory/test_memory_diff.py
+++ b/tests/session/memory/test_memory_diff.py
@@ -477,7 +477,14 @@ class TestMemoryDiffStructure:
     def test_memory_diff_structure(self):
         """Verify memory_diff.json structure."""
         # This test validates the expected structure
-        expected_keys = ["archive_uri", "trace_id", "extracted_at", "operations", "summary"]
+        expected_keys = [
+            "archive_uri",
+            "trace_id",
+            "extracted_at",
+            "operations",
+            "skipped_operations",
+            "summary",
+        ]
 
         # We verify this through the actual implementation tests above
         # This is a placeholder for documentation
@@ -487,6 +494,7 @@ class TestMemoryDiffStructure:
                 "trace_id",
                 "extracted_at",
                 "operations",
+                "skipped_operations",
                 "summary",
             }
         )

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -11,6 +11,7 @@ import pytest
 from openviking.message.message import Message
 from openviking.message.part import TextPart
 from openviking.server.identity import RequestContext, Role
+from openviking.session.memory.dataclass import MemoryOperationSkipCode
 from openviking.session.memory.memory_isolation_handler import (
     MemoryIsolationHandler,
 )
@@ -876,8 +877,75 @@ class TestCalculateMemoryUris:
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
         assert uris == []
+        assert operation.resolution_skip is not None
+        assert operation.resolution_skip.reason_code == MemoryOperationSkipCode.PEER_NOT_ALLOWED
         assert "peer_id" not in operation.memory_fields
         mock_generate_uri.assert_not_called()
+
+    def test_calculate_memory_uris_classifies_peer_policy_skip(self):
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        ctx = create_ctx(user_id="support_bot")
+        extract_ctx = create_mock_extract_context(
+            [create_message("user", peer_id="web-visitor-alice")]
+        )
+        handler = MemoryIsolationHandler(
+            ctx,
+            extract_ctx,
+            allow_self=False,
+            allowed_peer_ids=set(),
+            peer_memory_enabled=False,
+        )
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"peer_id": "web-visitor-alice"},
+            memory_type="preferences",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(
+            MemoryTypeSchema(
+                memory_type="preferences",
+                filename_template="preferences.md",
+                directory="viking://user/{user_space}/memories",
+            ),
+            operation,
+            extract_ctx,
+        )
+
+        assert uris == []
+        assert operation.resolution_skip is not None
+        assert operation.resolution_skip.reason_code == (
+            MemoryOperationSkipCode.PEER_MEMORY_DISABLED
+        )
+
+    def test_calculate_memory_uris_classifies_invalid_ranges(self):
+        from openviking.session.memory.dataclass import MemoryTypeSchema, ResolvedOperation
+
+        ctx = create_ctx(user_id="support_bot")
+        extract_ctx = create_mock_extract_context([create_message("user")])
+        handler = MemoryIsolationHandler(ctx, extract_ctx)
+        operation = ResolvedOperation(
+            old_memory_file_content=None,
+            memory_fields={"ranges": "10-20"},
+            memory_type="preferences",
+            uris=[],
+        )
+
+        uris = handler.calculate_memory_uris(
+            MemoryTypeSchema(
+                memory_type="preferences",
+                filename_template="preferences.md",
+                directory="viking://user/{user_space}/memories",
+            ),
+            operation,
+            extract_ctx,
+        )
+
+        assert uris == []
+        assert operation.resolution_skip is not None
+        assert operation.resolution_skip.reason_code == MemoryOperationSkipCode.INVALID_RANGES
+        extract_ctx.read_message_ranges.assert_not_called()
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_calculate_memory_uris_missing_peer_id_prefers_self_when_allowed(
@@ -1196,5 +1264,7 @@ class TestCalculateMemoryUris:
         uris = handler.calculate_memory_uris(schema, operation, extract_ctx)
 
         assert uris == []
+        assert operation.resolution_skip is not None
+        assert operation.resolution_skip.reason_code == MemoryOperationSkipCode.INVALID_PEER_ID
         assert "peer_id" not in operation.memory_fields
         mock_generate_uri.assert_not_called()

--- a/tests/session/memory/test_memory_isolation_handler.py
+++ b/tests/session/memory/test_memory_isolation_handler.py
@@ -84,6 +84,14 @@ class TestGetReadScope:
         assert scope.user_ids == ["user_a"]
         assert scope.peer_ids == []
 
+    def test_explicit_self_sentinel_message_is_not_a_writable_target(self):
+        ctx = create_ctx()
+        message = create_message("user", peer_id="__self")
+        extract_ctx = create_mock_extract_context([message])
+        handler = MemoryIsolationHandler(ctx, extract_ctx, allow_self=True)
+
+        assert handler._message_target_id(message) is None
+
     def test_deduplicate_users(self):
         """Test that duplicate users are deduplicated."""
         ctx = create_ctx()
@@ -292,6 +300,21 @@ class TestFillIdentityFields:
 
         assert item_dict["user_id"] == "user_a"
         assert item_dict["peer_id"] == "web-visitor-alice"
+
+    def test_invalid_peer_classification_does_not_change_identity_field_semantics(self):
+        ctx = create_ctx()
+        extract_ctx = create_mock_extract_context([create_message("user")])
+        handler = MemoryIsolationHandler(ctx, extract_ctx)
+        role_scope = handler.get_read_scope()
+
+        item_dict = {"peer_id": "web/visitor/alice"}
+        resolution_skip = handler._classify_identity_fields(item_dict)
+        result = handler.fill_identity_fields(item_dict, role_scope)
+
+        assert resolution_skip is not None
+        assert resolution_skip.reason_code == MemoryOperationSkipCode.INVALID_PEER_ID
+        assert result is None
+        assert item_dict == {"user_id": "user_a"}
 
 
 class TestPrepareMessages:
@@ -945,7 +968,7 @@ class TestCalculateMemoryUris:
         assert uris == []
         assert operation.resolution_skip is not None
         assert operation.resolution_skip.reason_code == MemoryOperationSkipCode.INVALID_RANGES
-        extract_ctx.read_message_ranges.assert_not_called()
+        extract_ctx.read_message_ranges.assert_called_once_with("10-20")
 
     @patch("openviking.session.memory.memory_isolation_handler.generate_uri")
     def test_calculate_memory_uris_missing_peer_id_prefers_self_when_allowed(

--- a/tests/session/memory/test_memory_react.py
+++ b/tests/session/memory/test_memory_react.py
@@ -7,6 +7,7 @@ Tests for memory ExtractLoop orchestrator.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import BaseModel, Field
 
 from openviking.session.memory.dataclass import (
     MemoryFile,
@@ -17,6 +18,7 @@ from openviking.session.memory.dataclass import (
 from openviking.session.memory.extract_loop import (
     ExtractLoop,
 )
+from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.merge_op import SearchReplaceBlock, StrPatch
 from openviking.session.memory.schema_model_generator import SchemaModelGenerator
 
@@ -159,6 +161,89 @@ class TestAllowedDirectoriesList:
 
 
 class TestExtractLoopFinalJsonRetry:
+    @staticmethod
+    def _invalid_peer_resolution_loop(target_uri=None):
+        schema = MemoryTypeSchema(
+            memory_type="preferences",
+            description="Preferences",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="preferences.md",
+            fields=[],
+        )
+        context_provider = MagicMock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {}
+
+        ctx = MagicMock()
+        ctx.user.user_id = "user_a"
+        extract_context = MagicMock()
+        extract_context.messages = []
+        extract_context.page_id_map.resolve.return_value = target_uri
+
+        extract_loop = object.__new__(ExtractLoop)
+        extract_loop.ctx = ctx
+        extract_loop.context_provider = context_provider
+        extract_loop._extract_context = extract_context
+        extract_loop._isolation_handler = MemoryIsolationHandler(ctx, extract_context)
+        return extract_loop
+
+    @pytest.mark.asyncio
+    async def test_existing_page_id_keeps_write_target_without_invalid_peer_metadata(self):
+        class PreferenceItem(BaseModel):
+            page_id: int
+            peer_id: str
+
+        class Operations(BaseModel):
+            preferences: list[PreferenceItem]
+            delete_ids: list = Field(default_factory=list)
+
+        target_uri = "viking://user/user_a/memories/preferences.md"
+        extract_loop = self._invalid_peer_resolution_loop(target_uri)
+
+        resolved, _ = await extract_loop.resolve_operations(
+            Operations(
+                preferences=[
+                    PreferenceItem(page_id=7, peer_id="web/visitor/alice"),
+                ]
+            )
+        )
+
+        operation = resolved.upsert_operations[0]
+        assert operation.uris == [target_uri]
+        assert operation.resolution_skip is None
+        assert operation.memory_fields == {
+            "memory_type": "preferences",
+            "user_id": "user_a",
+        }
+
+    @pytest.mark.asyncio
+    async def test_invalid_peer_hint_preserves_legacy_self_write_fallback(self):
+        class PreferenceItem(BaseModel):
+            page_id: int
+            peer_id: str
+
+        class Operations(BaseModel):
+            preferences: list[PreferenceItem]
+            delete_ids: list = Field(default_factory=list)
+
+        extract_loop = self._invalid_peer_resolution_loop()
+
+        resolved, _ = await extract_loop.resolve_operations(
+            Operations(
+                preferences=[
+                    PreferenceItem(page_id=101, peer_id="web/visitor/alice"),
+                ]
+            )
+        )
+
+        operation = resolved.upsert_operations[0]
+        assert operation.uris == ["viking://user/user_a/memories/preferences.md"]
+        assert operation.resolution_skip is None
+        assert operation.memory_fields == {
+            "memory_type": "preferences",
+            "user_id": "user_a",
+        }
+
     @pytest.mark.asyncio
     async def test_structured_parser_preserves_delete_ids(self):
         class FakeContextProvider:

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -580,7 +580,7 @@ class TestMemoryUpdater:
         updater._apply_delete.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_apply_operations_safely_suppresses_delete_for_expected_uri_skip(self):
+    async def test_apply_operations_preserves_legacy_delete_suppression_for_expected_skip(self):
         updater = MemoryUpdater(registry=MagicMock())
         updater._get_viking_fs = MagicMock(return_value=MagicMock())
         updater._apply_upsert = AsyncMock(return_value=None)
@@ -611,12 +611,12 @@ class TestMemoryUpdater:
 
         result = await updater.apply_operations(operations=operations, ctx=ctx)
 
-        assert result.errors == []
+        assert [(target, str(error)) for target, error in result.errors] == [
+            (old_uri, "Skipped delete because batch contains unresolved upsert URIs")
+        ]
         assert [item.reason_code for item in result.skipped_operations] == [
             MemoryOperationSkipCode.INVALID_RANGES,
-            MemoryOperationSkipCode.DEPENDENT_DELETE_SUPPRESSED,
         ]
-        assert result.skipped_operations[1].memory_type == "preferences"
         updater._apply_delete.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -15,6 +15,8 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.dataclass import (
     MemoryField,
     MemoryFile,
+    MemoryOperationSkip,
+    MemoryOperationSkipCode,
     MemoryOperationSource,
     MemoryTypeSchema,
     ResolvedOperation,
@@ -481,6 +483,49 @@ class TestMemoryUpdater:
         )
 
     @pytest.mark.asyncio
+    async def test_apply_operations_reports_expected_empty_uri_as_skip(self):
+        updater = MemoryUpdater(registry=MagicMock())
+        updater._get_viking_fs = MagicMock(return_value=MagicMock())
+        updater._apply_upsert = AsyncMock(return_value=None)
+        updater._sync_resource_refs_for_result = AsyncMock()
+        updater._vectorize_memories = AsyncMock()
+        updater.generate_overview = AsyncMock()
+        operation = ResolvedOperation(
+            memory_fields={"peer_id": "web-visitor-alice"},
+            memory_type="preferences",
+            uris=[],
+            page_id=102,
+            resolution_skip=MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.PEER_NOT_ALLOWED,
+                reason="Target peer is outside the allowed memory scope",
+            ),
+        )
+        operations = ResolvedOperations(
+            upsert_operations=[operation],
+            delete_file_contents=[],
+            errors=[],
+        )
+        ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+        with (
+            patch("openviking.session.memory.memory_updater.tracer.info") as tracer_info,
+            patch("openviking.session.memory.memory_updater.tracer.error") as tracer_error,
+        ):
+            result = await updater.apply_operations(operations=operations, ctx=ctx)
+
+        assert result.errors == []
+        assert len(result.skipped_operations) == 1
+        assert result.skipped_operations[0].reason_code == (
+            MemoryOperationSkipCode.PEER_NOT_ALLOWED
+        )
+        updater._apply_upsert.assert_not_awaited()
+        tracer_error.assert_not_called()
+        tracer_info.assert_any_call(
+            "Skipping memory operation by resolution policy: "
+            "memory_type=preferences page_id=102 reason_code=peer_not_allowed"
+        )
+
+    @pytest.mark.asyncio
     async def test_apply_operations_skips_deletes_when_replacement_uri_is_unresolved(self):
         registry = MagicMock()
         registry.get.return_value = MemoryTypeSchema(
@@ -532,6 +577,46 @@ class TestMemoryUpdater:
             ("events(page_id=102)", "Missing resolved URI"),
             (old_uri, "Skipped delete because batch contains unresolved upsert URIs"),
         ]
+        updater._apply_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_apply_operations_safely_suppresses_delete_for_expected_uri_skip(self):
+        updater = MemoryUpdater(registry=MagicMock())
+        updater._get_viking_fs = MagicMock(return_value=MagicMock())
+        updater._apply_upsert = AsyncMock(return_value=None)
+        updater._apply_delete = AsyncMock()
+        updater._sync_resource_refs_for_result = AsyncMock()
+        updater._vectorize_memories = AsyncMock()
+        updater.generate_overview = AsyncMock()
+        old_uri = "viking://user/alice/memories/preferences/old.md"
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={"ranges": "99"},
+                    memory_type="preferences",
+                    uris=[],
+                    page_id=102,
+                    resolution_skip=MemoryOperationSkip(
+                        reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                        reason="Message ranges are malformed or out of bounds",
+                    ),
+                )
+            ],
+            delete_file_contents=[
+                MemoryFile(uri=old_uri, extra_fields={"memory_type": "preferences"})
+            ],
+            errors=[],
+        )
+        ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+        result = await updater.apply_operations(operations=operations, ctx=ctx)
+
+        assert result.errors == []
+        assert [item.reason_code for item in result.skipped_operations] == [
+            MemoryOperationSkipCode.INVALID_RANGES,
+            MemoryOperationSkipCode.DEPENDENT_DELETE_SUPPRESSED,
+        ]
+        assert result.skipped_operations[1].memory_type == "preferences"
         updater._apply_delete.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/session/memory/test_streaming_memory_updater.py
+++ b/tests/session/memory/test_streaming_memory_updater.py
@@ -801,7 +801,10 @@ def test_scope_memory_update_result_to_submitter_filters_shared_batch_by_source(
             memory_type="preferences",
             reason_code=MemoryOperationSkipCode.PEER_NOT_ALLOWED,
             reason="Target peer is outside the allowed memory scope",
-            source=MemoryOperationSource(extraction_id="extract_a"),
+            source=MemoryOperationSource(
+                extraction_id="extract_a",
+                session_id="session_a",
+            ),
         )
     )
     apply_result.add_skipped(
@@ -809,7 +812,10 @@ def test_scope_memory_update_result_to_submitter_filters_shared_batch_by_source(
             memory_type="preferences",
             reason_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED,
             reason="Peer memory writes are disabled",
-            source=MemoryOperationSource(extraction_id="extract_b"),
+            source=MemoryOperationSource(
+                extraction_id="extract_b",
+                session_id="session_a",
+            ),
         )
     )
     batch_result = StreamingMemoryUpdateResult(
@@ -887,15 +893,17 @@ def test_split_request_by_merge_group_groups_by_peer_and_memory_type():
     ]
 
 
-def test_split_request_keeps_deletes_with_unresolved_upserts():
-    unresolved = _note_op("replacement")
+def test_split_request_keeps_unresolved_upserts_separate_from_delete_groups():
+    replacement = _note_op("replacement")
+    unresolved = _note_op("skipped")
     unresolved.uris = []
     old_file = _note_delete_file("old")
     request = MemoryUpdateRequest(
         operations=ResolvedOperations(
-            upsert_operations=[unresolved],
+            upsert_operations=[replacement, unresolved],
             delete_file_contents=[old_file],
             errors=[],
+            delete_replacements={old_file.uri: replacement.uris[0]},
         ),
         messages=[],
         ctx=_ctx(),
@@ -903,11 +911,18 @@ def test_split_request_keeps_deletes_with_unresolved_upserts():
 
     grouped = split_request_by_merge_group(request)
 
-    assert len(grouped) == 1
-    group_key, group_request = grouped[0]
-    assert group_key == MemoryMergeGroupKey(peer_id=None, memory_type="")
-    assert group_request.operations.upsert_operations == [unresolved]
-    assert group_request.operations.delete_file_contents == [old_file]
+    assert len(grouped) == 2
+    replacement_key, replacement_request = grouped[0]
+    assert replacement_key == MemoryMergeGroupKey(peer_id=None, memory_type="notes")
+    assert replacement_request.operations.upsert_operations == [replacement]
+    assert replacement_request.operations.delete_file_contents == [old_file]
+    assert replacement_request.operations.delete_replacements == {old_file.uri: replacement.uris[0]}
+
+    unresolved_key, unresolved_request = grouped[1]
+    assert unresolved_key == MemoryMergeGroupKey(peer_id=None, memory_type="")
+    assert unresolved_request.operations.upsert_operations == [unresolved]
+    assert unresolved_request.operations.delete_file_contents == []
+    assert unresolved_request.operations.delete_replacements == {}
 
 
 def test_split_request_by_merge_group_infers_peer_from_uri_when_field_missing():

--- a/tests/session/memory/test_streaming_memory_updater.py
+++ b/tests/session/memory/test_streaming_memory_updater.py
@@ -13,10 +13,12 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.memory.dataclass import (
     MemoryField,
     MemoryFile,
+    MemoryOperationSkipCode,
     MemoryOperationSource,
     MemoryTypeSchema,
     ResolvedOperation,
     ResolvedOperations,
+    SkippedMemoryOperation,
     StoredLink,
 )
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
@@ -715,8 +717,7 @@ async def test_merge_requests_merges_cross_session_operation_kinds_in_parallel(m
         else:
             kind = "update"
             assert all(
-                op.old_memory_file_content is not None
-                for op in operations.upsert_operations
+                op.old_memory_file_content is not None for op in operations.upsert_operations
             )
         assert kwargs["force_merge"] is True
         entered.add(kind)
@@ -795,6 +796,22 @@ def test_scope_memory_update_result_to_submitter_filters_shared_batch_by_source(
     apply_result = MemoryUpdateResult()
     apply_result.add_written(op_a.uris[0])
     apply_result.add_written(op_b.uris[0])
+    apply_result.add_skipped(
+        SkippedMemoryOperation(
+            memory_type="preferences",
+            reason_code=MemoryOperationSkipCode.PEER_NOT_ALLOWED,
+            reason="Target peer is outside the allowed memory scope",
+            source=MemoryOperationSource(extraction_id="extract_a"),
+        )
+    )
+    apply_result.add_skipped(
+        SkippedMemoryOperation(
+            memory_type="preferences",
+            reason_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED,
+            reason="Peer memory writes are disabled",
+            source=MemoryOperationSource(extraction_id="extract_b"),
+        )
+    )
     batch_result = StreamingMemoryUpdateResult(
         operations=ResolvedOperations(
             upsert_operations=[op_a, op_b],
@@ -822,6 +839,10 @@ def test_scope_memory_update_result_to_submitter_filters_shared_batch_by_source(
     assert scoped.metadata["batch_request_count"] == 2
     assert scoped.metadata["scoped_to_source_extraction_id"] == "extract_a"
     assert scoped.apply_result.written_uris == [op_a.uris[0]]
+    assert len(scoped.apply_result.skipped_operations) == 1
+    assert scoped.apply_result.skipped_operations[0].reason_code == (
+        MemoryOperationSkipCode.PEER_NOT_ALLOWED
+    )
     assert scoped.operations.upsert_operations == [op_a]
     assert scoped.metadata["unscoped_written_uris"] == [op_a.uris[0], op_b.uris[0]]
 
@@ -864,6 +885,29 @@ def test_split_request_by_merge_group_groups_by_peer_and_memory_type():
         0,
         0,
     ]
+
+
+def test_split_request_keeps_deletes_with_unresolved_upserts():
+    unresolved = _note_op("replacement")
+    unresolved.uris = []
+    old_file = _note_delete_file("old")
+    request = MemoryUpdateRequest(
+        operations=ResolvedOperations(
+            upsert_operations=[unresolved],
+            delete_file_contents=[old_file],
+            errors=[],
+        ),
+        messages=[],
+        ctx=_ctx(),
+    )
+
+    grouped = split_request_by_merge_group(request)
+
+    assert len(grouped) == 1
+    group_key, group_request = grouped[0]
+    assert group_key == MemoryMergeGroupKey(peer_id=None, memory_type="")
+    assert group_request.operations.upsert_operations == [unresolved]
+    assert group_request.operations.delete_file_contents == [old_file]
 
 
 def test_split_request_by_merge_group_infers_peer_from_uri_when_field_missing():

--- a/tests/session/test_commit_skill_inference.py
+++ b/tests/session/test_commit_skill_inference.py
@@ -77,6 +77,27 @@ def test_v3_extraction_response_returns_session_skills():
     }
 
 
+def test_v3_extraction_response_returns_skipped_operations():
+    skipped = {
+        "memory_type": "preferences",
+        "reason_code": "invalid_ranges",
+        "reason": "Message ranges are malformed or out of bounds",
+    }
+
+    result = _v3_extraction_response(
+        contexts=[],
+        train_result={},
+        archive_uri="viking://sessions/s1/history/archive_001",
+        skipped_operations=[skipped],
+    )
+
+    assert result == {
+        "contexts": [],
+        "session_skills": [],
+        "skipped_operations": [skipped],
+    }
+
+
 def test_session_skill_operations_dedup_duplicate_creates():
     result = dedup_session_skill_operations(_build_duplicate_session_skill_operations())
 

--- a/tests/session/test_commit_skill_inference.py
+++ b/tests/session/test_commit_skill_inference.py
@@ -77,27 +77,6 @@ def test_v3_extraction_response_returns_session_skills():
     }
 
 
-def test_v3_extraction_response_returns_skipped_operations():
-    skipped = {
-        "memory_type": "preferences",
-        "reason_code": "invalid_ranges",
-        "reason": "Message ranges are malformed or out of bounds",
-    }
-
-    result = _v3_extraction_response(
-        contexts=[],
-        train_result={},
-        archive_uri="viking://sessions/s1/history/archive_001",
-        skipped_operations=[skipped],
-    )
-
-    assert result == {
-        "contexts": [],
-        "session_skills": [],
-        "skipped_operations": [skipped],
-    }
-
-
 def test_session_skill_operations_dedup_duplicate_creates():
     result = dedup_session_skill_operations(_build_duplicate_session_skill_operations())
 

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -22,8 +22,10 @@ from openviking.session.compressor_v3 import (
 )
 from openviking.session.memory.dataclass import (
     MemoryFile,
+    MemoryOperationSkipCode,
     ResolvedOperation,
     ResolvedOperations,
+    SkippedMemoryOperation,
     StoredLink,
 )
 from openviking.session.memory.memory_updater import MemoryUpdateResult
@@ -107,6 +109,51 @@ def test_extract_long_term_memories_preserves_legacy_positional_parameter_order(
         "event_search_tags",
         "peer_memory_enabled",
     ]
+
+
+@pytest.mark.asyncio
+async def test_memory_diff_includes_intentionally_skipped_operations(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+    compressor = SessionCompressorV3(vikingdb=None)
+    result = MemoryUpdateResult()
+    result.add_skipped(
+        SkippedMemoryOperation(
+            memory_type="events",
+            page_id=101,
+            reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+            reason="No valid event range could be resolved",
+        )
+    )
+
+    diff = await compressor._build_memory_diff(
+        result=result,
+        operations=ResolvedOperations(
+            upsert_operations=[],
+            delete_file_contents=[],
+            errors=[],
+        ),
+        viking_fs=SimpleNamespace(),
+        ctx=_ctx(),
+        archive_uri="viking://user/u/sessions/s1/history/archive_001",
+    )
+
+    assert diff["skipped_operations"] == [
+        {
+            "memory_type": "events",
+            "page_id": 101,
+            "reason_code": "invalid_ranges",
+            "reason": "No valid event range could be resolved",
+        }
+    ]
+    assert diff["summary"] == {
+        "total_adds": 0,
+        "total_updates": 0,
+        "total_deletes": 0,
+        "total_skipped": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -1093,7 +1140,20 @@ async def test_v3_fast_path_writes_final_memory_diff_with_case_traj_and_exp(monk
                     "updates": [],
                     "deletes": [],
                 },
-                "summary": {"total_adds": 1, "total_updates": 0, "total_deletes": 0},
+                "skipped_operations": [
+                    {
+                        "memory_type": "preferences",
+                        "page_id": 102,
+                        "reason_code": "peer_not_allowed",
+                        "reason": "Target peer is outside the allowed memory scope",
+                    }
+                ],
+                "summary": {
+                    "total_adds": 1,
+                    "total_updates": 0,
+                    "total_deletes": 0,
+                    "total_skipped": 1,
+                },
             },
         )
 
@@ -1146,7 +1206,20 @@ async def test_v3_fast_path_writes_final_memory_diff_with_case_traj_and_exp(monk
         "trajectories",
     ]
     assert [item["memory_type"] for item in diff["operations"]["updates"]] == ["experiences"]
-    assert diff["summary"] == {"total_adds": 2, "total_updates": 1, "total_deletes": 0}
+    assert diff["skipped_operations"] == [
+        {
+            "memory_type": "preferences",
+            "page_id": 102,
+            "reason_code": "peer_not_allowed",
+            "reason": "Target peer is outside the allowed memory scope",
+        }
+    ]
+    assert diff["summary"] == {
+        "total_adds": 2,
+        "total_updates": 1,
+        "total_deletes": 0,
+        "total_skipped": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -1218,7 +1291,12 @@ async def test_v3_builds_training_memory_diff_from_streaming_result(monkeypatch)
         archive_uri=archive_uri,
     )
 
-    assert diff["summary"] == {"total_adds": 1, "total_updates": 1, "total_deletes": 0}
+    assert diff["summary"] == {
+        "total_adds": 1,
+        "total_updates": 1,
+        "total_deletes": 0,
+        "total_skipped": 0,
+    }
     assert diff["operations"]["adds"][0]["memory_type"] == "trajectories"
     update = diff["operations"]["updates"][0]
     assert update["memory_type"] == "experiences"
@@ -1315,7 +1393,12 @@ async def test_v3_training_memory_diff_filters_batch_items_by_current_analysis_t
         archive_uri=archive_uri,
     )
 
-    assert diff["summary"] == {"total_adds": 2, "total_updates": 0, "total_deletes": 0}
+    assert diff["summary"] == {
+        "total_adds": 2,
+        "total_updates": 0,
+        "total_deletes": 0,
+        "total_skipped": 0,
+    }
     assert [op["uri"] for op in diff["operations"]["adds"]] == [traj_a, exp_a]
 
 

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -93,6 +94,19 @@ def test_factory_ignores_deprecated_memory_version():
         create_session_compressor(vikingdb=None, memory_version="unsupported"),
         SessionCompressorV3,
     )
+
+
+def test_extract_long_term_memories_preserves_legacy_positional_parameter_order():
+    parameter_names = list(
+        inspect.signature(SessionCompressorV3.extract_long_term_memories).parameters
+    )
+
+    assert parameter_names[-4:] == [
+        "allow_self_memory",
+        "allowed_peer_ids",
+        "event_search_tags",
+        "peer_memory_enabled",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -189,13 +189,7 @@ async def test_v3_skips_agent_training_when_agent_evolution_is_disabled(monkeypa
     )
 
     compressor.train_from_extracted_cases.assert_not_awaited()
-    assert result["skipped_operations"] == [
-        {
-            "memory_type": "profile",
-            "reason_code": "peer_memory_disabled",
-            "reason": "Peer memory writes are disabled",
-        }
-    ]
+    assert result == []
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -108,12 +108,19 @@ async def test_v3_skips_agent_training_when_agent_evolution_is_disabled(monkeypa
             cases=[_training_case()],
             memory_diff={"operations": {}},
             case_uri_by_name={},
+            skipped_operations=[
+                {
+                    "memory_type": "profile",
+                    "reason_code": "peer_memory_disabled",
+                    "reason": "Peer memory writes are disabled",
+                }
+            ],
         )
     )
     compressor.train_from_extracted_cases = AsyncMock()
     compressor._write_final_memory_diff = AsyncMock()
 
-    await compressor.extract_long_term_memories(
+    result = await compressor.extract_long_term_memories(
         messages=_messages(),
         ctx=_ctx(),
         allowed_memory_types={"cases", "profile"},
@@ -121,6 +128,13 @@ async def test_v3_skips_agent_training_when_agent_evolution_is_disabled(monkeypa
     )
 
     compressor.train_from_extracted_cases.assert_not_awaited()
+    assert result["skipped_operations"] == [
+        {
+            "memory_type": "profile",
+            "reason_code": "peer_memory_disabled",
+            "reason": "Peer memory writes are disabled",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -119,19 +119,36 @@ class TestCommit:
         self,
         session_with_messages: Session,
     ):
-        session_with_messages._session_compressor.extract_long_term_memories = AsyncMock(
-            return_value={
-                "contexts": [],
-                "session_skills": [],
-                "skipped_operations": [
+        async def extract_long_term_memories(**kwargs):
+            archive_uri = kwargs["archive_uri"]
+            await session_with_messages._viking_fs.write_file(
+                uri=f"{archive_uri}/memory_diff.json",
+                content=json.dumps(
                     {
-                        "memory_type": "preferences",
-                        "page_id": 102,
-                        "reason_code": "peer_not_allowed",
-                        "reason": "Target peer is outside the allowed memory scope",
+                        "archive_uri": archive_uri,
+                        "operations": {"adds": [], "updates": [], "deletes": []},
+                        "summary": {
+                            "total_adds": 0,
+                            "total_updates": 0,
+                            "total_deletes": 0,
+                            "total_skipped": 1,
+                        },
+                        "skipped_operations": [
+                            {
+                                "memory_type": "preferences",
+                                "page_id": 102,
+                                "reason_code": "peer_not_allowed",
+                                "reason": "Target peer is outside the allowed memory scope",
+                            }
+                        ],
                     }
-                ],
-            }
+                ),
+                ctx=session_with_messages.ctx,
+            )
+            return []
+
+        session_with_messages._session_compressor.extract_long_term_memories = AsyncMock(
+            side_effect=extract_long_term_memories
         )
 
         commit_result = await session_with_messages.commit_async()
@@ -150,6 +167,80 @@ class TestCommit:
                 }
             ],
         }
+
+    async def test_recovered_commit_task_reads_existing_skipped_memory_operations(
+        self,
+        session_with_messages: Session,
+        monkeypatch,
+    ):
+        original_prepare = Session._prepare_phase2_archive_messages
+
+        async def prepare_with_completed_long_term(self, archive_uri, current_messages):
+            (
+                messages,
+                coverage_start_archive,
+                coverage_end_archive,
+                covered_failed_archives,
+                completed_memory_steps,
+            ) = await original_prepare(self, archive_uri, current_messages)
+            completed_memory_steps.setdefault("long_term", set()).update(
+                message.id for message in messages
+            )
+            await self._viking_fs.write_file(
+                uri=f"{archive_uri}/memory_diff.json",
+                content=json.dumps(
+                    {
+                        "archive_uri": archive_uri,
+                        "operations": {"adds": [], "updates": [], "deletes": []},
+                        "summary": {
+                            "total_adds": 0,
+                            "total_updates": 0,
+                            "total_deletes": 0,
+                            "total_skipped": 1,
+                        },
+                        "skipped_operations": [
+                            {
+                                "memory_type": "preferences",
+                                "page_id": 102,
+                                "reason_code": "peer_not_allowed",
+                                "reason": "Target peer is outside the allowed memory scope",
+                            }
+                        ],
+                    }
+                ),
+                ctx=self.ctx,
+            )
+            return (
+                messages,
+                coverage_start_archive,
+                coverage_end_archive,
+                covered_failed_archives,
+                completed_memory_steps,
+            )
+
+        monkeypatch.setattr(
+            Session,
+            "_prepare_phase2_archive_messages",
+            prepare_with_completed_long_term,
+        )
+        session_with_messages._session_compressor.extract_long_term_memories = AsyncMock()
+
+        commit_result = await session_with_messages.commit_async()
+        task_result = await _wait_for_task(commit_result["task_id"])
+
+        assert task_result["status"] == "completed"
+        assert task_result["result"]["memory_extraction"] == {
+            "skipped": 1,
+            "skipped_operations": [
+                {
+                    "memory_type": "preferences",
+                    "page_id": 102,
+                    "reason_code": "peer_not_allowed",
+                    "reason": "Target peer is outside the allowed memory scope",
+                }
+            ],
+        }
+        session_with_messages._session_compressor.extract_long_term_memories.assert_not_awaited()
 
     async def test_commit_default_disables_agent_memory_but_keeps_archive(
         self, session_with_messages: Session

--- a/tests/session/test_session_commit.py
+++ b/tests/session/test_session_commit.py
@@ -115,6 +115,42 @@ class TestCommit:
         # Wait for semantic/embedding queues
         await service.resources.wait_processed(timeout=60.0)
 
+    async def test_commit_task_reports_intentionally_skipped_memory_operations(
+        self,
+        session_with_messages: Session,
+    ):
+        session_with_messages._session_compressor.extract_long_term_memories = AsyncMock(
+            return_value={
+                "contexts": [],
+                "session_skills": [],
+                "skipped_operations": [
+                    {
+                        "memory_type": "preferences",
+                        "page_id": 102,
+                        "reason_code": "peer_not_allowed",
+                        "reason": "Target peer is outside the allowed memory scope",
+                    }
+                ],
+            }
+        )
+
+        commit_result = await session_with_messages.commit_async()
+        task_result = await _wait_for_task(commit_result["task_id"])
+
+        assert commit_result["status"] == "accepted"
+        assert task_result["status"] == "completed"
+        assert task_result["result"]["memory_extraction"] == {
+            "skipped": 1,
+            "skipped_operations": [
+                {
+                    "memory_type": "preferences",
+                    "page_id": 102,
+                    "reason_code": "peer_not_allowed",
+                    "reason": "Target peer is outside the allowed memory scope",
+                }
+            ],
+        }
+
     async def test_commit_default_disables_agent_memory_but_keeps_archive(
         self, session_with_messages: Session
     ):
@@ -340,6 +376,7 @@ class TestCommit:
             ctx,
             allowed_memory_types,
             allow_self_memory=True,
+            peer_memory_enabled=True,
             allowed_peer_ids=None,
             **kwargs,
         ):
@@ -348,6 +385,7 @@ class TestCommit:
                 {
                     "allowed_memory_types": set(allowed_memory_types or set()),
                     "allow_self_memory": allow_self_memory,
+                    "peer_memory_enabled": peer_memory_enabled,
                     "allowed_peer_ids": set(allowed_peer_ids or set()),
                     "roles": [message.role for message in messages],
                     "peer_ids": [message.peer_id for message in messages],
@@ -386,6 +424,7 @@ class TestCommit:
                     "profile",
                 },
                 "allow_self_memory": False,
+                "peer_memory_enabled": True,
                 "allowed_peer_ids": {"web-visitor-alice"},
                 "roles": ["user", "assistant"],
                 "peer_ids": ["web-visitor-alice", "web-visitor-alice"],


### PR DESCRIPTION
## Summary

- classify policy- and validation-driven empty-URI memory operations with stable reason codes
- expose intentionally skipped operations in commit task results under `result.memory_extraction.skipped_operations`, include reason codes in logs, and persist them in `memory_diff.json` with `summary.total_skipped`
- scope skipped results by extraction source so concurrently batched commits do not see each other's skip reasons
- keep unresolved upserts in their existing standalone streaming group, preserving write, delete, and replacement ordering
- reuse the existing peer-memory policy without adding configuration, LLM calls, or telemetry

## Scope

- expected policy and validation skips do not fail the commit task
- unexplained empty URIs keep the existing behavior: they remain internal `MemoryUpdateResult.errors` and are not promoted to task errors, failed operations, or `memory_diff.json` skipped records
- `memory_diff.json` stores skipped operations as top-level audit metadata; `operations` continues to contain only applied file changes
- low-level `MemoryUpdater` handling of directly supplied mixed unresolved-upsert/delete batches is unchanged; this PR does not add replacement atomicity guarantees
- recovered Phase 2 tasks reuse the persisted `memory_diff.json` so skipped reasons remain visible through `get_task`

## Compatibility

- URI resolution and file mutation behavior are unchanged for the existing self/peer/range policy combinations
- unresolved upserts and deletes retain the pre-PR streaming grouping, so diagnostics do not change mutation ordering
- `peer_memory_enabled` propagates the existing `MemoryPolicy.peer_enabled` decision and is not a new configuration option
- the new parameter is appended to the public extraction signature, preserving existing positional bindings
- skip diagnostics use runtime-only fields and are not persisted into memory metadata
- skip-only extraction preserves the historical `list[Context]` public return shape

## Testing

- memory isolation/updater/streaming tests: `117 passed`
- compressor/commit task compatibility and propagation tests: `10 passed`
- memory-diff regression tests: `13 passed`
- merge-base differential check: 900 self/peer/range combinations produced no URI or `memory_fields` behavior changes
- `ruff check` and `git diff --check` pass for the touched files

Related to #4131
