### PR TITLE
fix(observability): fall back instead of 500 on a malformed ?timezone=

### DIFF
--- a/openviking/observability/usage_audit/time.py
+++ b/openviking/observability/usage_audit/time.py
@@ -10,6 +10,14 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
 
+# `ZoneInfo()` rejects a bad key in two different ways: an unknown-but-well-formed
+# name raises `ZoneInfoNotFoundError`, while a malformed one — absolute (`/UTC`),
+# non-normalized (`Asia/`), or traversing (`..`) — raises `ValueError` before any
+# lookup happens. Both mean "this is not a usable timezone", and both must fall
+# back rather than propagate: the value reaches here straight from an untrusted
+# `?timezone=` query parameter.
+_INVALID_TIMEZONE = (ZoneInfoNotFoundError, ValueError)
+
 
 def resolve_usage_timezone(timezone_name: str) -> tzinfo:
     """Resolve the server-default Usage/Audit timezone with local fallback.
@@ -21,21 +29,24 @@ def resolve_usage_timezone(timezone_name: str) -> tzinfo:
         return datetime.now().astimezone().tzinfo or timezone.utc
     try:
         return ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError:
-        logger.warning("Unknown usage_audit timezone %s; falling back to local", timezone_name)
+    except (*_INVALID_TIMEZONE, TypeError):
+        # TypeError as well here: this value comes from the config file, where a
+        # bare `timezone: 8` parses as an int and would otherwise abort startup.
+        logger.warning("Unknown usage_audit timezone %r; falling back to local", timezone_name)
         return datetime.now().astimezone().tzinfo or timezone.utc
 
 
 def resolve_user_timezone(timezone_name: str | None, *, fallback: tzinfo) -> tzinfo:
     """Resolve a request-supplied IANA tz name with a server-side fallback.
 
-    Accepts e.g. `Asia/Shanghai`, `America/New_York`, or `UTC`. An unknown or
-    empty value falls back to the server default and emits a debug log entry.
+    Accepts e.g. `Asia/Shanghai`, `America/New_York`, or `UTC`. An unknown,
+    malformed, or empty value falls back to the server default and emits a debug
+    log entry — the caller passes an untrusted query parameter straight through.
     """
     if not timezone_name:
         return fallback
     try:
         return ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError:
+    except _INVALID_TIMEZONE:
         logger.debug("Unknown request timezone %r; falling back to server default", timezone_name)
         return fallback

--- a/tests/observability/test_usage_audit_timezone.py
+++ b/tests/observability/test_usage_audit_timezone.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Timezone resolution for the Console usage/audit endpoints.
+
+`?timezone=` is an untrusted free-form query parameter (no `pattern=` on the
+route), and `ZoneInfo()` rejects a bad key in two different ways: an
+unknown-but-well-formed name raises `ZoneInfoNotFoundError`, a malformed one
+raises `ValueError` before any lookup happens. Only the first was handled, so a
+malformed value escaped as an unhandled exception instead of falling back.
+"""
+
+from __future__ import annotations
+
+from datetime import timezone
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from openviking.observability.usage_audit.api_service import UsageAuditQueryService
+from openviking.observability.usage_audit.time import (
+    resolve_usage_timezone,
+    resolve_user_timezone,
+)
+from openviking.server.auth import get_request_context
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers.console import router as console_router
+from openviking_cli.session.user_id import UserIdentifier
+
+# Malformed keys, each rejected by a different branch of ZoneInfo's validation.
+MALFORMED_TIMEZONES = [
+    "..",  # traverses out of TZPATH
+    "../../etc/passwd",
+    "/UTC",  # absolute path
+    "Asia/",  # non-normalized
+    ".",
+]
+
+
+@pytest.mark.parametrize("value", MALFORMED_TIMEZONES)
+def test_resolve_user_timezone_falls_back_on_a_malformed_name(value: str) -> None:
+    assert resolve_user_timezone(value, fallback=timezone.utc) is timezone.utc
+
+
+@pytest.mark.parametrize("value", MALFORMED_TIMEZONES)
+def test_resolve_usage_timezone_falls_back_on_a_malformed_name(value: str) -> None:
+    # Returns the local tz; the point is that it returns at all.
+    assert resolve_usage_timezone(value) is not None
+
+
+def test_resolve_usage_timezone_falls_back_on_a_non_string_config_value() -> None:
+    # `timezone: 8` in YAML parses as an int and used to abort startup.
+    assert resolve_usage_timezone(8) is not None  # type: ignore[arg-type]
+
+
+def test_resolve_user_timezone_still_resolves_a_valid_name() -> None:
+    assert resolve_user_timezone("Asia/Shanghai", fallback=timezone.utc) == ZoneInfo(
+        "Asia/Shanghai"
+    )
+
+
+def test_resolve_user_timezone_still_falls_back_on_an_unknown_name() -> None:
+    assert resolve_user_timezone("Not/AZone", fallback=timezone.utc) is timezone.utc
+
+
+def test_resolve_user_timezone_falls_back_on_an_empty_value() -> None:
+    assert resolve_user_timezone("", fallback=timezone.utc) is timezone.utc
+    assert resolve_user_timezone(None, fallback=timezone.utc) is timezone.utc
+
+
+class _StubStore:
+    async def get_today_tokens(self, **_kwargs):
+        return {}
+
+    async def get_today_retrievals(self, **_kwargs):
+        return {}
+
+
+class _StubInventory:
+    async def get_counts(self, _ctx):
+        return {}
+
+
+class _Runtime:
+    def __init__(self, api_service) -> None:
+        self.api_service = api_service
+
+
+def _app() -> FastAPI:
+    """Console router wired to the REAL query service, not a fake one.
+
+    The tz resolution under test lives in the service, so a fake service would
+    not exercise it.
+    """
+    app = FastAPI()
+    app.include_router(console_router)
+    app.state.usage_audit_runtime = _Runtime(
+        UsageAuditQueryService(
+            store=_StubStore(),  # type: ignore[arg-type]
+            inventory=_StubInventory(),  # type: ignore[arg-type]
+            timezone_name="UTC",
+        )
+    )
+    app.dependency_overrides[get_request_context] = lambda: RequestContext(
+        user=UserIdentifier(account_id="acct-1", user_id="user-1"),
+        role=Role.ADMIN,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", MALFORMED_TIMEZONES)
+async def test_dashboard_summary_survives_a_malformed_timezone_parameter(value: str) -> None:
+    transport = httpx.ASGITransport(app=_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/api/v1/console/dashboard/summary", params={"timezone": value})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Description

The three Console BFF endpoints (`/dashboard/summary`, `/tokens`, `/context-commits`) accept `?timezone=` as a free-form query parameter with no `pattern=`. A malformed value returns **HTTP 500** instead of falling back to the server default.

`ZoneInfo()` rejects a bad key in two different ways, and only one of them was handled:

| input | `ZoneInfo()` raises | before | after |
| --- | --- | --- | --- |
| `Asia/Shanghai` | — | 200 | 200 |
| `Not/AZone` | `ZoneInfoNotFoundError` | 200 (documented fallback) | 200 |
| `..` | `ValueError` | **500** | 200 |
| `../../etc/passwd` | `ValueError` | **500** | 200 |
| `/UTC` | `ValueError` | **500** | 200 |
| `Asia/` | `ValueError` | **500** | 200 |
| `.` | `ValueError` | **500** | 200 |

The malformed forms fail validation *before* any lookup — `ZoneInfoNotFoundError` is a `KeyError` subclass, so `except ZoneInfoNotFoundError` never sees them. `openviking/server/app.py` registers handlers for `OpenVikingError`, `RequestValidationError` and `StarletteHTTPException` but no generic `Exception` handler, so the `ValueError` reaches Starlette's `ServerErrorMiddleware`.

Status codes above are measured, driving the real router over `httpx.ASGITransport(..., raise_app_exceptions=False)`.

This is a robustness bug, not a path-traversal one — `ZoneInfo` is what rejects `../../etc/passwd`, and it rejects it correctly. The defect is that the rejection is not caught.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None — found while reading `usage_audit` for #4173.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `resolve_user_timezone()` now catches `ValueError` alongside `ZoneInfoNotFoundError`, matching what its docstring already promises for "an unknown or empty value".
- `resolve_usage_timezone()` catches the same pair **plus `TypeError`**. That value comes from the config file, where a bare `timezone: 8` parses as an `int`; `ZoneInfo(8)` raises `TypeError` and would abort startup instead of falling back with a warning. Kept separate from the request path, where FastAPI already guarantees `str | None`.
- The shared tuple is named `_INVALID_TIMEZONE` with a comment on why two exception types are needed, so the pair does not drift back apart.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

New `tests/observability/test_usage_audit_timezone.py` — 19 cases: the five malformed keys against both resolvers, the non-`str` config value, and one end-to-end pass per malformed key through the **real** `UsageAuditQueryService` mounted on the console router (a fake service would not exercise the resolver at all).

Reverting only `openviking/observability/usage_audit/time.py`:

```
16 failed, 3 passed
```

With the change: **19 passed**. The 3 that pass either way are the must-not-regress guards — a valid name still resolves, an unknown name still falls back, an empty value still falls back.

Whole directory: `pytest tests/observability/` → **49 passed**. `ruff check` and `ruff format --check` clean on both files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — the docstrings are the documentation here and are updated; no user-facing doc claims the old behaviour
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
