### PR TITLE
docs: add Windows CLI PATH troubleshooting

### DIFF
--- a/docs/en/getting-started/02-quickstart.md
+++ b/docs/en/getting-started/02-quickstart.md
@@ -40,6 +40,26 @@ pipx upgrade openviking
 
 After installation, use `ov` as the client command (`openviking` is an alias) and `openviking-server` as the server command.
 
+#### Windows: `openviking-server` is not recognized
+
+The Python wheel installs `openviking-server.exe` in Python's Scripts directory. If PowerShell or Command Prompt cannot find the command, first verify that the same Python interpreter can launch the server entry point directly:
+
+```powershell
+py -m openviking_cli.server_bootstrap --help
+```
+
+Then print the Scripts directory used by that interpreter:
+
+```powershell
+py -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+```
+
+Add the printed directory to your user `PATH`, open a new terminal, and retry `openviking-server --help`. If the first command reports `No module named openviking_cli`, install OpenViking with the same interpreter and retry:
+
+```powershell
+py -m pip install openviking --upgrade --force-reinstall
+```
+
 ### Option 2: Start via Docker (As an independent service)
 
 If you prefer to run OpenViking as a standalone service, Docker is recommended.


### PR DESCRIPTION
## Summary

- explain why Windows may not find the installed `openviking-server` launcher
- document the PATH-independent module entry point
- show how to find the active interpreter's Scripts directory and recover from an interpreter mismatch

Closes #4171

## Verification

- confirmed the published `openviking 0.4.15` Windows wheel declares the `openviking-server` entry point
- confirmed a clean Python 3.14 virtual environment creates `Scripts\openviking-server.exe`
- `npm run test:theme` (13 passed)
- `npm run test:search` (4 passed)
- `npm run check:api`
- `npm run docs:build`
