### PR TITLE
fix(session): repair session skill patch merge

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -53,6 +53,10 @@ from openviking.session.memory.streaming_memory_updater import (
 from openviking.session.memory.utils.json_parser import JsonUtils
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.memory.utils.uri import generate_uri
+from openviking.session.skill.session_skill_context_provider import (
+    SESSION_SKILL_MEMORY_TYPE,
+    load_skill_extract_registry,
+)
 from openviking.session.train import (
     Case,
     ExperienceGradientContext,
@@ -61,6 +65,7 @@ from openviking.session.train import (
     MemoryFilePolicyUpdater,
     PatchMergePolicyOptimizer,
     PatchMergePolicyOptimizerContext,
+    PatchMergeSchemaBinding,
     PipelineContext,
     PolicyApplyResult,
     PolicyPlanItem,
@@ -837,6 +842,10 @@ class SessionCompressorV3:
             policy_optimizer=PatchMergePolicyOptimizer(
                 viking_fs=viking_fs,
                 memory_type="skills",
+                schema_binding=PatchMergeSchemaBinding(
+                    memory_type=SESSION_SKILL_MEMORY_TYPE,
+                    registry=load_skill_extract_registry(),
+                ),
             ),
             policy_updater=SkillPolicyUpdater(
                 skill_processor=self.skill_processor,

--- a/openviking/session/memory/patch_merge_context_provider.py
+++ b/openviking/session/memory/patch_merge_context_provider.py
@@ -10,9 +10,11 @@ from typing import Any
 
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, MemoryTypeSchema
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
+from openviking.session.memory.utils import add_line_numbers, line_count
 from openviking.session.memory.utils.language import resolve_output_language_from_text
 
 _SYSTEM_HIDDEN_FIELDS = {
@@ -74,6 +76,14 @@ class PatchMergePatch:
         return "unknown"
 
 
+@dataclass(frozen=True, slots=True)
+class PatchMergeSchemaBinding:
+    """Bind one extraction memory type to the registry that defines it."""
+
+    memory_type: str
+    registry: MemoryTypeRegistry
+
+
 def _resolve_patch_output_language(patches: list[PatchMergePatch]) -> str:
     return resolve_output_language_from_text(_patch_language_text(patches), fallback_language="en")
 
@@ -117,16 +127,22 @@ class PatchMergeContextProvider(SessionExtractContextProvider):
     def __init__(
         self,
         *,
-        memory_type: str,
         patches: list[PatchMergePatch],
+        memory_type: str | None = None,
+        schema_binding: PatchMergeSchemaBinding | None = None,
         required_file_uris: list[str] | None = None,
         output_language: str | None = None,
     ):
+        if (memory_type is None) == (schema_binding is None):
+            raise ValueError("PatchMergeContextProvider requires exactly one schema source")
         super().__init__(messages=[])
-        self.memory_type = memory_type
+        self.memory_type = (
+            schema_binding.memory_type if schema_binding is not None else str(memory_type)
+        )
         self.required_file_uris = list(required_file_uris or [])
         self.patches = list(patches)
         self._output_language = output_language or _resolve_patch_output_language(self.patches)
+        self._registry = schema_binding.registry if schema_binding is not None else None
 
     def instruction(self) -> str:
         output_language = self._output_language
@@ -157,6 +173,31 @@ is an existing file, put it in delete_ids; if it is only a new proposal, omit it
         if schema is None or not schema.enabled:
             raise ValueError(f"Memory schema not found or disabled: {self.memory_type}")
         return [schema]
+
+    async def read_file(self, uri: str) -> dict[str, Any] | None:
+        """Render a seeded policy snapshot without reparsing its storage format."""
+        # Optimizers seed typed snapshots before ExtractLoop starts. Reading the
+        # URI through the generic memory reader would reinterpret specialized
+        # formats such as SKILL.md and break patch materialization.
+        memory_file = self.read_file_contents.get(uri)
+        if memory_file is None:
+            return await super().read_file(uri)
+
+        result = memory_file.to_metadata()
+        result.pop("links", None)
+        result.pop("backlinks", None)
+        for hidden_field in _SYSTEM_HIDDEN_FIELDS:
+            result.pop(hidden_field, None)
+        result["page_id"] = self.get_extract_context().page_id_map.get_page_id(uri)
+        plain_content = memory_file.plain_content() or ""
+        if plain_content:
+            result["content"] = add_line_numbers(plain_content, start_line=1)
+        elif line_count(plain_content) == 0:
+            result["content"] = (
+                "<system-reminder>Warning: the file exists but the contents are empty."
+                "</system-reminder>"
+            )
+        return result
 
     async def prefetch(self) -> list[dict[str, Any]]:
         messages: list[dict[str, Any]] = []

--- a/openviking/session/skill/session_skill_context_provider.py
+++ b/openviking/session/skill/session_skill_context_provider.py
@@ -41,11 +41,14 @@ def parse_skill_extract_file(raw_content: str) -> Dict[str, Any]:
     try:
         parsed = SkillLoader.parse(raw_content)
         return {
+            "memory_type": SESSION_SKILL_MEMORY_TYPE,
             "name": parsed.get("name", ""),
             "description": parsed.get("description", ""),
             "content": parsed.get("content", ""),
             "allowed_tools": parsed.get("allowed_tools", []),
+            "allowed_tools_declared": parsed.get("allowed_tools_declared", False),
             "tags": parsed.get("tags", []),
+            **({"metadata": parsed["metadata"]} if "metadata" in parsed else {}),
         }
     except Exception:
         return parse_memory_file_with_fields(raw_content)

--- a/openviking/session/skill/skill_operation_updater.py
+++ b/openviking/session/skill/skill_operation_updater.py
@@ -14,8 +14,8 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import ResolvedOperation, ResolvedOperations
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.merge_op import MergeOpFactory
+from openviking.session.skill.skill_state_adapter import SkillStateAdapter
 from openviking.storage.abstract_overview import body_for_preview
-from openviking.storage.content_write import ContentWriteCoordinator
 from openviking.storage.viking_fs import VikingFS, get_viking_fs
 from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.exceptions import NotFoundError
@@ -52,10 +52,12 @@ class SkillOperationUpdater:
         registry: MemoryTypeRegistry,
         skill_processor: SkillProcessor,
         viking_fs: Optional[VikingFS] = None,
+        transaction_handle: Any = None,
     ):
         self._registry = registry
         self._skill_processor = skill_processor
         self._viking_fs = viking_fs or get_viking_fs()
+        self._transaction_handle = transaction_handle
 
     async def apply_operations(
         self,
@@ -105,6 +107,7 @@ class SkillOperationUpdater:
                 viking_fs=self._viking_fs,
                 ctx=ctx,
                 allow_local_path_resolution=False,
+                lease_ref=self._transaction_handle,
             )
             created_root_uri = (
                 processor_result.get("root_uri") or processor_result.get("uri") or root_uri
@@ -118,15 +121,17 @@ class SkillOperationUpdater:
                 "name": merged_skill["name"],
             }
 
-        merged_skill = await self._skill_processor.sanitize_skill_privacy(merged_skill, ctx)
-        serialized = SkillLoader.to_skill_md(merged_skill)
-        write_result = await ContentWriteCoordinator(self._viking_fs).write(
-            uri=skill_md_uri,
-            content=serialized,
+        skills_root_uri = root_uri.rsplit("/", 1)[0]
+        processor_result = await self._skill_processor.process_skill(
+            data=merged_skill,
+            viking_fs=self._viking_fs,
             ctx=ctx,
-            mode="replace",
+            allow_local_path_resolution=False,
+            privacy_change_reason="auto-extracted from session skill update",
+            target_uri=skills_root_uri,
+            lease_ref=self._transaction_handle,
         )
-        updated_root_uri = write_result.get("root_uri") or root_uri
+        updated_root_uri = processor_result.get("root_uri") or root_uri
         return {
             "status": "success",
             "action": "update",
@@ -145,17 +150,16 @@ class SkillOperationUpdater:
         if not schema:
             raise ValueError(f"Unknown session skill schema: {operation.memory_type}")
 
-        skill = {
-            "name": (existing_skill or {}).get("name")
-            or operation.memory_fields.get("skill_name", ""),
-            "description": (existing_skill or {}).get("description", ""),
-            "content": (existing_skill or {}).get("content"),
-            "allowed_tools": list((existing_skill or {}).get("allowed_tools") or []),
-            "tags": list(
-                (existing_skill or {}).get("tags")
-                or (["session-derived"] if existing_skill is None else [])
+        source_fields = existing_skill or operation.memory_fields
+        skill = SkillStateAdapter.skill_payload(
+            name=str(
+                (existing_skill or {}).get("name") or operation.memory_fields.get("skill_name", "")
             ),
-        }
+            content=(existing_skill or {}).get("content"),
+            metadata=source_fields,
+        )
+        if existing_skill is None and not skill.get("tags"):
+            skill["tags"] = ["session-derived"]
 
         for schema_field in schema.fields:
             if schema_field.name not in operation.memory_fields:

--- a/openviking/session/skill/skill_state_adapter.py
+++ b/openviking/session/skill/skill_state_adapter.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Canonical conversions between SKILL.md fields and training policy state."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+class SkillStateAdapter:
+    """Keep Skill frontmatter intact across extraction, planning, and writes."""
+
+    _NON_FRONTMATTER_KEYS = {
+        "content",
+        "memory_type",
+        "name",
+        "skill_name",
+        "source_path",
+        "status",
+        "version",
+    }
+
+    @classmethod
+    def _copy_frontmatter(cls, fields: Mapping[str, Any] | None) -> dict[str, Any]:
+        return {
+            key: deepcopy(value)
+            for key, value in dict(fields or {}).items()
+            if key not in cls._NON_FRONTMATTER_KEYS and not key.startswith("_")
+        }
+
+    @classmethod
+    def policy_metadata(cls, fields: Mapping[str, Any] | None) -> dict[str, Any]:
+        metadata = cls._copy_frontmatter(fields)
+        metadata["memory_type"] = "skills"
+        return metadata
+
+    @classmethod
+    def merge_policy_metadata(
+        cls,
+        base: Mapping[str, Any] | None,
+        fields: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        metadata = deepcopy(dict(base or {}))
+        updates = cls.policy_metadata(fields)
+        updates = {key: value for key, value in updates.items() if value is not None}
+        if updates.get("description") == "":
+            updates.pop("description")
+        metadata.update(updates)
+        return metadata
+
+    @classmethod
+    def skill_payload(
+        cls,
+        *,
+        name: str,
+        content: str | None,
+        metadata: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        payload = cls._copy_frontmatter(metadata)
+        payload["name"] = name
+        payload["description"] = payload.get("description", "")
+        payload["content"] = content
+        payload.setdefault("allowed_tools", [])
+        payload.setdefault("tags", [])
+        return payload
+
+    @classmethod
+    def operation_fields(cls, policy: Any) -> dict[str, Any]:
+        payload = cls.skill_payload(
+            name=str(policy.name),
+            content=str(policy.content),
+            metadata=policy.metadata,
+        )
+        payload["skill_name"] = payload.pop("name")
+        return payload

--- a/openviking/session/train/__init__.py
+++ b/openviking/session/train/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Session training framework for trajectory/experience policy optimization."""
 
+from openviking.session.memory.patch_merge_context_provider import PatchMergeSchemaBinding
 from openviking.session.train.batch_runner import (
     BatchTrainEvalConfig,
     BatchTrainEvalReport,
@@ -132,6 +133,7 @@ __all__ = [
     "TrajectoryAnalyzerContext",
     "PatchMergePolicyOptimizer",
     "PatchMergePolicyOptimizerContext",
+    "PatchMergeSchemaBinding",
     "PolicyTrainer",
     "PipelineLifecycleHook",
     "PipelineReportBuilder",

--- a/openviking/session/train/components/memory_store.py
+++ b/openviking/session/train/components/memory_store.py
@@ -10,6 +10,7 @@ from typing import Any
 from openviking.core.skill_loader import SkillLoader
 from openviking.server.identity import RequestContext
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.session.skill.skill_state_adapter import SkillStateAdapter
 from openviking.session.train.domain import Policy, PolicySet, PolicyStatus
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import tracer
@@ -78,6 +79,7 @@ class ExperienceSetLoader:
             metadata={"source": "memory_store"},
             viking_fs=viking_fs,
             request_context=ctx,
+            loader=self,
         )
 
 
@@ -170,12 +172,7 @@ class SkillSetLoader:
 
             version = 1
             status: PolicyStatus = "production"
-            metadata: dict[str, Any] = {
-                "memory_type": "skills",
-                "description": skill.get("description", ""),
-                "allowed_tools": list(skill.get("allowed_tools") or []),
-                "tags": list(skill.get("tags") or []),
-            }
+            metadata = SkillStateAdapter.policy_metadata(skill)
             policies.append(
                 Policy(
                     name=str(skill.get("name") or dir_name),
@@ -196,4 +193,5 @@ class SkillSetLoader:
             metadata={"source": "skill_store"},
             viking_fs=viking_fs,
             request_context=ctx,
+            loader=self,
         )

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -14,9 +14,11 @@ from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.extract_loop import ExtractLoop
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.memory_updater import ExtractContext
+from openviking.session.memory.merge_op import MergeOpFactory
 from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
+    PatchMergeSchemaBinding,
 )
 from openviking.session.train.domain import (
     Policy,
@@ -47,7 +49,9 @@ class PatchMergePolicyOptimizer:
 
     viking_fs: Any = None
     vlm: Any = None
+    # Policy/updater type can differ from the schema used by ExtractLoop.
     memory_type: str = "experiences"
+    schema_binding: PatchMergeSchemaBinding | None = None
 
     @tracer(
         "train.policy_optimizer.patch_merge.plan",
@@ -80,11 +84,12 @@ class PatchMergePolicyOptimizer:
             policy_set=policy_set,
             context=context,
         )
-        items = _operations_to_plan_items(
+        items = await _operations_to_plan_items(
             operations=operations,
             gradients=patch_gradients,
             policy_set=policy_set,
             memory_type=self.memory_type,
+            schema_binding=self.schema_binding,
         )
         _log_merge_output(
             target="all",
@@ -126,8 +131,12 @@ class PatchMergePolicyOptimizer:
             raise RuntimeError("VikingFS is required for patch-merge policy optimization")
 
         extract_context = ExtractContext(list(context.messages or []))
+        schema_memory_type = (
+            self.schema_binding.memory_type if self.schema_binding is not None else self.memory_type
+        )
         provider = PatchMergeContextProvider(
-            memory_type=self.memory_type,
+            memory_type=self.memory_type if self.schema_binding is None else None,
+            schema_binding=self.schema_binding,
             required_file_uris=_required_file_uris(gradients, policy_set),
             patches=[_gradient_to_merge_patch(gradient) for gradient in gradients],
         )
@@ -138,7 +147,7 @@ class PatchMergePolicyOptimizer:
         isolation_handler = MemoryIsolationHandler(
             context.request_context,
             extract_context,
-            allowed_memory_types={self.memory_type},
+            allowed_memory_types={schema_memory_type},
         )
         isolation_handler.prepare_messages()
         provider._isolation_handler = isolation_handler
@@ -384,34 +393,38 @@ def _policy_to_memory_file(policy: Policy, *, memory_type: str = "experiences") 
         extra_fields=extra_fields,
     )
 
-def _operations_to_plan_items(
+async def _operations_to_plan_items(
     *,
     operations: Any,
     gradients: list[SemanticGradient],
     policy_set: PolicySet,
     memory_type: str,
+    schema_binding: PatchMergeSchemaBinding | None = None,
 ) -> list[PolicyPlanItem]:
+    operation_memory_type = (
+        schema_binding.memory_type if schema_binding is not None else memory_type
+    )
     items: list[PolicyPlanItem] = []
     source_links_by_target = _source_trajectory_links_by_target(gradients, policy_set)
     superseded_policies = _superseded_policies_for_gradients(gradients, policy_set)
     confidence_values = [float(gradient.confidence) for gradient in gradients]
     confidence = max(confidence_values) if confidence_values else None
-    name_field = _name_field_for_memory_type(memory_type)
+    name_field = _name_field_for_memory_type(operation_memory_type)
 
-    upsert_output_count = _upsert_output_count(operations, memory_type=memory_type)
+    upsert_output_count = _upsert_output_count(
+        operations,
+        memory_type=operation_memory_type,
+    )
     replacement_source_uris_by_target = _replacement_source_uris_by_target(operations)
     upsert_target_uris: set[str] = set()
     for op in getattr(operations, "upsert_operations", []) or []:
-        if getattr(op, "memory_type", None) != memory_type:
+        if getattr(op, "memory_type", None) != operation_memory_type:
             continue
         fields = dict(getattr(op, "memory_fields", {}) or {})
-        after_content = str(fields.get("content") or "")
-        if not after_content.strip():
-            continue
         target_name = str(
             fields.get(name_field)
             or fields.get("name")
-            or _fallback_policy_name(op, memory_type=memory_type)
+            or _fallback_policy_name(op, memory_type=operation_memory_type)
         )
         target_uri = first_uri(getattr(op, "uris", []) or [])
         old_file = getattr(op, "old_memory_file_content", None)
@@ -419,6 +432,14 @@ def _operations_to_plan_items(
         if before_content is None and target_uri:
             policy = _find_policy_by_uri(policy_set, target_uri)
             before_content = policy.content if policy is not None else None
+        after_content = await _materialize_content_field(
+            fields.get("content"),
+            before_content=before_content,
+            schema_binding=schema_binding,
+        )
+        if not after_content.strip():
+            continue
+        fields["content"] = after_content
         items.append(
             PolicyPlanItem(
                 kind="upsert",
@@ -521,11 +542,29 @@ def _operations_to_plan_items(
     return items
 
 
+async def _materialize_content_field(
+    value: Any,
+    *,
+    before_content: str | None,
+    schema_binding: PatchMergeSchemaBinding | None,
+) -> str:
+    if schema_binding is None:
+        return str(value or "")
+    schema = schema_binding.registry.get(schema_binding.memory_type)
+    if schema is None:
+        return str(value or "")
+    content_field = next((field for field in schema.fields if field.name == "content"), None)
+    if content_field is None:
+        return str(value or "")
+    merged = await MergeOpFactory.from_field(content_field).apply(before_content, value)
+    return str(merged or "")
+
+
 def _name_field_for_memory_type(memory_type: str) -> str:
     """Return the extra_fields key for the policy name in a given memory type."""
     if memory_type == "experiences":
         return "experience_name"
-    if memory_type == "skills":
+    if memory_type in {"skills", "session_skills"}:
         return "skill_name"
     if memory_type.endswith("s"):
         return f"{memory_type[:-1]}_name"
@@ -536,7 +575,7 @@ def _fallback_policy_name(op: Any, *, memory_type: str) -> str:
     uri = first_uri(getattr(op, "uris", []) or [])
     if uri:
         # For skills: path/to/skills/my_skill/SKILL.md → my_skill
-        if memory_type == "skills" and uri.endswith("/SKILL.md"):
+        if memory_type in {"skills", "session_skills"} and uri.endswith("/SKILL.md"):
             parts = uri.rstrip("/").split("/")
             if len(parts) >= 2:
                 return parts[-2]

--- a/openviking/session/train/components/policy_updater.py
+++ b/openviking/session/train/components/policy_updater.py
@@ -139,13 +139,7 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
 
         if item.kind == "delete":
             existing = policies_by_uri.get(uri) or _find_policy(
-                PolicySet(
-                    policy_set.root_uri,
-                    result,
-                    metadata=dict(policy_set.metadata),
-                    viking_fs=policy_set.viking_fs,
-                    request_context=policy_set.request_context,
-                ),
+                result,
                 uri=None,
                 name=item.target_name,
             )
@@ -162,13 +156,7 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
         if item.kind != "upsert" or item.after_content is None:
             continue
         existing = policies_by_uri.get(uri) or _find_policy(
-            PolicySet(
-                policy_set.root_uri,
-                result,
-                metadata=dict(policy_set.metadata),
-                viking_fs=policy_set.viking_fs,
-                request_context=policy_set.request_context,
-            ),
+            result,
             uri=None,
             name=item.target_name,
         )
@@ -194,22 +182,16 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
         policies_by_uri[uri] = updated
 
     result.sort(key=lambda policy: policy.uri)
-    return PolicySet(
-        root_uri=policy_set.root_uri,
-        policies=result,
-        metadata=dict(policy_set.metadata),
-        viking_fs=policy_set.viking_fs,
-        request_context=policy_set.request_context,
-    )
+    return policy_set.with_policies(result)
 
 
 def _find_policy(
-    policy_set: PolicySet,
+    policies: list[Policy],
     *,
     uri: str | None,
     name: str,
 ) -> Policy | None:
-    for policy in policy_set.policies:
+    for policy in policies:
         if uri and policy.uri == uri:
             return policy
         if not uri and policy.name == name:
@@ -236,7 +218,7 @@ def _plan_to_resolved_operations(
 
     for item in plan.items:
         uri = _target_uri(item, policy_set.root_uri)
-        current = _find_policy(policy_set, uri=uri, name=item.target_name)
+        current = _find_policy(policy_set.policies, uri=uri, name=item.target_name)
         if (
             current is not None
             and item.before_content is not None
@@ -258,7 +240,7 @@ def _plan_to_resolved_operations(
             errors.append(f"missing after_content for {item.target_name}")
             continue
 
-        updated = _find_policy(updated_policy_set, uri=uri, name=item.target_name)
+        updated = _find_policy(updated_policy_set.policies, uri=uri, name=item.target_name)
         if updated is None:
             errors.append(f"planned policy not found after simulation: {item.target_name}")
             continue

--- a/openviking/session/train/components/skill_policy_updater.py
+++ b/openviking/session/train/components/skill_policy_updater.py
@@ -19,6 +19,7 @@ from openviking.session.skill.session_skill_context_provider import (
     SESSION_SKILL_MEMORY_TYPE,
     load_skill_extract_registry,
 )
+from openviking.session.skill.skill_state_adapter import SkillStateAdapter
 from openviking.session.train.domain import (
     Policy,
     PolicyApplyResult,
@@ -38,10 +39,8 @@ logger = get_logger(__name__)
 class SkillPolicyUpdater:
     """PolicyUpdater that writes skill files to a skills directory.
 
-    For new skills (no existing file) the full ``SkillProcessor.process_skill``
-    pipeline is used (validation, privacy, overview, index).  For existing
-    skills, the merged content is serialized to SKILL.md and written via
-    ``ContentWriteCoordinator``.
+    New and existing skills both use the full ``SkillProcessor.process_skill``
+    pipeline (validation, privacy, SKILL.md/sidecars, and index refresh).
 
     ``delete`` operations remove the entire skill subdirectory.
     """
@@ -88,6 +87,7 @@ class SkillPolicyUpdater:
             registry=registry,
             skill_processor=processor,
             viking_fs=viking_fs,
+            transaction_handle=transaction_handle,
         )
         result = await updater.apply_operations(operations, ctx)
 
@@ -166,7 +166,8 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
         )
         metadata = dict(existing.metadata) if existing is not None else {}
         metadata.update(item.metadata.get("patch_metadata", {}))
-        metadata.setdefault("memory_type", item.memory_type or "skills")
+        merge_memory_fields = item.metadata.get("merge_memory_fields", {})
+        metadata = SkillStateAdapter.merge_policy_metadata(metadata, merge_memory_fields)
         version = (existing.version + 1) if existing is not None else 1
         updated = Policy(
             name=item.target_name,
@@ -185,13 +186,7 @@ def _apply_items_to_snapshot(items: list[PolicyPlanItem], policy_set: PolicySet)
         policies_by_uri[uri] = updated
 
     result.sort(key=lambda policy: policy.uri)
-    return PolicySet(
-        root_uri=policy_set.root_uri,
-        policies=result,
-        metadata=dict(policy_set.metadata),
-        viking_fs=policy_set.viking_fs,
-        request_context=policy_set.request_context,
-    )
+    return policy_set.with_policies(result)
 
 
 def _find_policy(policy_set: PolicySet, *, uri: str | None, name: str) -> Policy | None:
@@ -243,16 +238,7 @@ def _plan_to_resolved_operations(
         old_mf = _policy_to_memory_file(current) if current is not None else None
         # Build memory_fields in the shape expected by SkillOperationUpdater.
         # Skill schema uses "skill_name" / "description" / "content" fields.
-        memory_fields: dict[str, Any] = {
-            "skill_name": updated.name,
-            "content": updated.content,
-            "description": updated.metadata.get("description", ""),
-        }
-        # Carry over other metadata
-        for key in ("allowed_tools", "tags"):
-            value = updated.metadata.get(key)
-            if value is not None:
-                memory_fields[key] = value
+        memory_fields = SkillStateAdapter.operation_fields(updated)
 
         upserts.append(
             ResolvedOperation(
@@ -275,13 +261,11 @@ def _policy_to_memory_file(policy: Policy | None) -> MemoryFile | None:
     if policy is None:
         return None
     # Serialize policy content + metadata into a SKILL.md-shaped MemoryFile.
-    skill_dict = {
-        "name": policy.name,
-        "description": policy.metadata.get("description", ""),
-        "content": policy.content,
-        "allowed_tools": policy.metadata.get("allowed_tools", []),
-        "tags": policy.metadata.get("tags", []),
-    }
+    skill_dict = SkillStateAdapter.skill_payload(
+        name=policy.name,
+        content=policy.content,
+        metadata=policy.metadata,
+    )
     serialized = SkillLoader.to_skill_md(skill_dict)
     return MemoryFile(
         uri=policy.uri,

--- a/openviking/session/train/domain.py
+++ b/openviking/session/train/domain.py
@@ -11,7 +11,7 @@ changing the current extraction pipeline.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal
 
 from openviking.message import Message
@@ -51,10 +51,10 @@ Experience = Policy
 class PolicySet:
     """Snapshot of all policies under a policy root directory.
 
-    ``viking_fs`` and ``request_context`` are runtime storage dependencies used
-    for concurrency-safe policy updates.  They are intentionally excluded from
-    equality/repr so the domain snapshot still behaves like policy data in
-    tests and diagnostics.
+    ``viking_fs``, ``request_context``, and ``loader`` are runtime storage
+    dependencies used for concurrency-safe policy updates.  They are
+    intentionally excluded from equality/repr so the domain snapshot still
+    behaves like policy data in tests and diagnostics.
     """
 
     root_uri: str
@@ -62,6 +62,16 @@ class PolicySet:
     metadata: dict[str, Any] = field(default_factory=dict)
     viking_fs: Any | None = field(default=None, repr=False, compare=False)
     request_context: Any | None = field(default=None, repr=False, compare=False)
+    loader: Any | None = field(default=None, repr=False, compare=False)
+
+    def with_policies(self, policies: list[Policy]) -> "PolicySet":
+        """Return a new snapshot while preserving its runtime dependencies."""
+
+        return replace(
+            self,
+            policies=list(policies),
+            metadata=dict(self.metadata),
+        )
 
     @asynccontextmanager
     async def lock(self):
@@ -95,9 +105,12 @@ class PolicySet:
         if self.request_context is None:
             raise RuntimeError("PolicySet.request_context is required for policy reload")
 
-        from openviking.session.train.components.memory_store import ExperienceSetLoader
+        loader = self.loader
+        if loader is None:
+            from openviking.session.train.components.memory_store import ExperienceSetLoader
 
-        return await ExperienceSetLoader(viking_fs=self.viking_fs).load(
+            loader = ExperienceSetLoader(viking_fs=self.viking_fs)
+        return await loader.load(
             self.root_uri,
             ctx=self.request_context,
         )

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -3,7 +3,7 @@
 """Semantic retrieval mixin for VikingFS."""
 
 import asyncio
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openviking.core.context import ContextLevel
 from openviking.core.retrieval_targets import resolve_retrieval_targets
@@ -432,23 +432,31 @@ class _SemanticMixin:
         content_filename: str = "content.md",
         is_leaf: bool = False,
         ctx: Optional[RequestContext] = None,
+        lease_ref: Dict[str, Any] | str | None = None,
     ) -> None:
         """Write context to AGFS (L0/L1/L2)."""
 
         self._ensure_mutable_access(uri, ctx)
         path = self._uri_to_path(uri, ctx=ctx)
+        lease_kwargs = {"lease_ref": lease_ref} if lease_ref is not None else {}
 
         try:
-            await self._ensure_parent_dirs(path, ctx=ctx)
+            await self._ensure_parent_dirs(path, ctx=ctx, **lease_kwargs)
             try:
-                await self._async_agfs.mkdir(path)
+                if lease_ref is None:
+                    await self._async_agfs.mkdir(path)
+                else:
+                    await self._async_agfs.mkdir(
+                        path,
+                        fs_ctx=self._pathlock_fs_ctx(ctx, lease_ref),
+                    )
             except Exception as e:
                 if "exist" not in str(e).lower():
                     raise
 
             if content:
                 content_uri = f"{uri}/{content_filename}"
-                await self.write_file(content_uri, content, ctx=ctx)
+                await self.write_file(content_uri, content, ctx=ctx, **lease_kwargs)
 
             if abstract:
                 abstract_uri = f"{uri}/.abstract.md"
@@ -466,6 +474,7 @@ class _SemanticMixin:
                         },
                     ),
                     ctx=ctx,
+                    **lease_kwargs,
                 )
 
             if overview:
@@ -484,6 +493,7 @@ class _SemanticMixin:
                         },
                     ),
                     ctx=ctx,
+                    **lease_kwargs,
                 )
 
         except Exception as e:

--- a/openviking/utils/skill_processor.py
+++ b/openviking/utils/skill_processor.py
@@ -27,9 +27,9 @@ from openviking.privacy import (
 )
 from openviking.server.identity import RequestContext
 from openviking.server.local_input_guard import deny_direct_local_skill_input
-from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.storage.queuefs.embedding_msg_converter import EmbeddingMsgConverter
 from openviking.storage.viking_fs import VikingFS
+from openviking.storage.vikingdb_manager import VikingDBManager
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.path_safety import safe_join_viking_uri
@@ -119,6 +119,7 @@ class SkillProcessor:
         apply_privacy: bool = True,
         privacy_change_reason: str = "auto-extracted from add_skill",
         target_uri: Optional[str] = None,
+        lease_ref: Any = None,
     ) -> Dict[str, Any]:
         """
         Process and store a skill.
@@ -155,6 +156,7 @@ class SkillProcessor:
             apply_privacy=apply_privacy,
             privacy_change_reason=privacy_change_reason,
             target_uri=target_uri,
+            lease_ref=lease_ref,
         )
 
     async def process_prepared_skill(
@@ -166,6 +168,7 @@ class SkillProcessor:
         apply_privacy: bool = True,
         privacy_change_reason: str = "auto-extracted from add_skill",
         target_uri: Optional[str] = None,
+        lease_ref: Any = None,
     ) -> Dict[str, Any]:
         config = get_openviking_config()
         cleanup_path = preparation.cleanup_path
@@ -221,6 +224,7 @@ class SkillProcessor:
                 abstract=skill_abstract,
                 overview=overview,
                 ctx=ctx,
+                lease_ref=lease_ref,
             )
 
             await self._write_auxiliary_files(
@@ -229,6 +233,7 @@ class SkillProcessor:
                 base_path=base_path,
                 skill_dir_uri=skill_dir_uri,
                 ctx=ctx,
+                lease_ref=lease_ref,
             )
             telemetry.set(
                 "skill.write.duration_ms", round((time.perf_counter() - write_start) * 1000, 3)
@@ -539,8 +544,10 @@ class SkillProcessor:
         abstract: str,
         overview: str,
         ctx: RequestContext,
+        lease_ref: Any = None,
     ):
         """Write main skill content to VikingFS."""
+        lease_kwargs = {"lease_ref": lease_ref} if lease_ref is not None else {}
         await viking_fs.write_context(
             uri=skill_dir_uri,
             content=SkillLoader.to_skill_md(skill_dict),
@@ -549,6 +556,7 @@ class SkillProcessor:
             content_filename="SKILL.md",
             is_leaf=False,
             ctx=ctx,
+            **lease_kwargs,
         )
 
     async def _write_auxiliary_files(
@@ -558,8 +566,10 @@ class SkillProcessor:
         base_path: Optional[Path],
         skill_dir_uri: str,
         ctx: RequestContext,
+        lease_ref: Any = None,
     ):
         """Write auxiliary files to VikingFS."""
+        lease_kwargs = {"lease_ref": lease_ref} if lease_ref is not None else {}
         for aux_file in auxiliary_files:
             if base_path:
                 rel_path = aux_file.relative_to(base_path)
@@ -576,9 +586,19 @@ class SkillProcessor:
                 is_text = False
 
             if is_text:
-                await viking_fs.write_file(aux_uri, file_bytes.decode("utf-8"), ctx=ctx)
+                await viking_fs.write_file(
+                    aux_uri,
+                    file_bytes.decode("utf-8"),
+                    ctx=ctx,
+                    **lease_kwargs,
+                )
             else:
-                await viking_fs.write_file_bytes(aux_uri, file_bytes, ctx=ctx)
+                await viking_fs.write_file_bytes(
+                    aux_uri,
+                    file_bytes,
+                    ctx=ctx,
+                    **lease_kwargs,
+                )
 
     async def _index_skill(self, context: Context, skill_dir_uri: str):
         """Write skill directory vector via async queue as L0."""

--- a/tests/session/memory/test_patch_merge_context_provider.py
+++ b/tests/session/memory/test_patch_merge_context_provider.py
@@ -13,6 +13,7 @@ from openviking.session.memory.dataclass import MemoryFile, MemoryTypeSchema
 from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
+    PatchMergeSchemaBinding,
 )
 
 
@@ -77,6 +78,56 @@ async def test_patch_merge_context_provider_prefetch_reads_originals_and_renders
     assert "    +new line" in messages[1]["content"]
     assert "     keep line" in messages[1]["content"]  # n=1 context line
     assert "  status:" not in messages[1]["content"]
+
+
+async def test_patch_merge_context_provider_uses_seeded_typed_snapshot(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.resolve_output_language",
+        lambda _text: "en",
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: SimpleNamespace(
+            memory=SimpleNamespace(eager_prefetch=True, prefetch_search_topn=5, link_enabled=False)
+        ),
+    )
+    uri = "viking://user/u/skills/code-review/SKILL.md"
+    provider = PatchMergeContextProvider(
+        memory_type="skills",
+        required_file_uris=[uri],
+        output_language="en",
+        patches=[
+            PatchMergePatch(
+                before_file=_memory_file(
+                    name="code-review",
+                    uri=uri,
+                    content="Read changed files.",
+                    memory_type="skills",
+                ),
+                after_file=_memory_file(
+                    name="code-review",
+                    uri=uri,
+                    content="Read changed files before commenting.",
+                    memory_type="skills",
+                ),
+            )
+        ],
+    )
+    provider._viking_fs = SimpleNamespace(
+        read_file=AsyncMock(side_effect=AssertionError("must not re-read storage format"))
+    )
+    provider.read_file_contents[uri] = _memory_file(
+        name="code-review",
+        uri=uri,
+        content="Read changed files.",
+        memory_type="skills",
+    )
+
+    result = await provider.read_file(uri)
+
+    provider._viking_fs.read_file.assert_not_awaited()
+    assert result["content"] == "1\tRead changed files."
+    assert result["page_id"] == 1
 
 
 @pytest.mark.asyncio
@@ -146,7 +197,9 @@ async def test_patch_merge_context_provider_skips_extra_candidates_for_existing_
             )
         ],
     )
-    provider.search_files = AsyncMock(return_value=["viking://user/u/memories/experiences/other.md"])
+    provider.search_files = AsyncMock(
+        return_value=["viking://user/u/memories/experiences/other.md"]
+    )
     provider.read_file = AsyncMock(
         return_value={
             "memory_type": "experiences",
@@ -340,6 +393,42 @@ def test_patch_merge_context_provider_get_memory_schema_single_type(monkeypatch)
     provider._registry = SimpleNamespace(get=lambda name: schema if name == "experiences" else None)
 
     assert provider.get_memory_schemas(ctx=None) == [schema]
+
+
+def test_patch_merge_context_provider_accepts_one_bound_schema_source(monkeypatch):
+    monkeypatch.setattr(PatchMergeContextProvider, "_detect_language", lambda self: "en")
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: SimpleNamespace(memory=None),
+    )
+    schema = MemoryTypeSchema(
+        memory_type="session_skills",
+        description="Session skills",
+        directory="viking://user/{{ user_space }}/skills",
+        filename_template="{{ skill_name }}/SKILL.md",
+        fields=[],
+    )
+    binding = PatchMergeSchemaBinding(
+        memory_type="session_skills",
+        registry=SimpleNamespace(get=lambda name: schema if name == "session_skills" else None),
+    )
+
+    provider = PatchMergeContextProvider(
+        schema_binding=binding,
+        required_file_uris=[],
+        patches=[],
+        output_language="en",
+    )
+
+    assert provider.get_memory_schemas(ctx=None) == [schema]
+    with pytest.raises(ValueError, match="exactly one schema source"):
+        PatchMergeContextProvider(
+            memory_type="skills",
+            schema_binding=binding,
+            required_file_uris=[],
+            patches=[],
+            output_language="en",
+        )
 
 
 def test_patch_merge_context_provider_get_memory_schema_raises_for_missing_type():

--- a/tests/session/test_commit_skill_inference.py
+++ b/tests/session/test_commit_skill_inference.py
@@ -250,7 +250,7 @@ async def test_skill_operation_updater_creates_skill_with_session_defaults():
 
 
 @pytest.mark.asyncio
-async def test_skill_operation_updater_updates_existing_skill(monkeypatch):
+async def test_skill_operation_updater_updates_existing_skill():
     existing_skill_md = """---
 name: code-review
 description: Review code carefully
@@ -258,6 +258,11 @@ allowed-tools:
 - Read
 tags:
 - session-derived
+metadata:
+  vikingbot:
+    requires:
+      bins:
+      - git
 ---
 
 ## 核心规范
@@ -265,26 +270,13 @@ tags:
 """
     viking_fs = MagicMock()
     viking_fs.read_file = AsyncMock(return_value=existing_skill_md)
-    write_calls = {}
-
-    class _FakeContentWriter:
-        def __init__(self, _viking_fs):
-            self._viking_fs = _viking_fs
-
-        async def write(self, **kwargs):
-            write_calls.update(kwargs)
-            return {
-                "uri": kwargs["uri"],
-                "root_uri": kwargs["uri"].rsplit("/SKILL.md", 1)[0],
-            }
-
-    monkeypatch.setattr(
-        "openviking.session.skill.skill_operation_updater.ContentWriteCoordinator",
-        _FakeContentWriter,
-    )
-
     processor = MagicMock()
-    processor.sanitize_skill_privacy = AsyncMock(side_effect=lambda skill_dict, _ctx: skill_dict)
+    processor.process_skill = AsyncMock(
+        return_value={
+            "root_uri": "viking://user/default/skills/code-review",
+            "uri": "viking://user/default/skills/code-review",
+        }
+    )
     updater = SkillOperationUpdater(
         registry=_build_skill_registry(),
         skill_processor=processor,
@@ -323,16 +315,25 @@ tags:
     assert result.written_uris == []
     assert result.edited_uris == [uri]
     assert result.operation_results[0]["action"] == "update"
-    assert write_calls["uri"] == uri
-    assert write_calls["mode"] == "replace"
-    assert "allowed-tools:" in write_calls["content"]
-    assert "tags:" in write_calls["content"]
-    assert "Review code from evidence" in write_calls["content"]
-    assert "- 基于证据总结问题" in write_calls["content"]
+    processor.process_skill.assert_awaited_once()
+    call = processor.process_skill.await_args.kwargs
+    assert call["target_uri"] == "viking://user/default/skills"
+    assert call["allow_local_path_resolution"] is False
+    assert call["data"]["allowed_tools"] == ["Read"]
+    assert call["data"]["tags"] == ["session-derived"]
+    assert call["data"]["metadata"] == {
+        "vikingbot": {"requires": {"bins": ["git"]}},
+    }
+    assert call["data"]["description"] == "Review code from evidence"
+    assert "- 基于证据总结问题" in call["data"]["content"]
 
 
 @pytest.mark.asyncio
 async def test_skill_operation_updater_sanitizes_existing_skill_updates(monkeypatch):
+    monkeypatch.setattr(
+        "openviking.utils.skill_processor.get_openviking_config",
+        lambda: SimpleNamespace(),
+    )
     existing_skill_md = """---
 name: code-review
 description: Review code carefully
@@ -340,6 +341,11 @@ allowed-tools:
 - Read
 tags:
 - session-derived
+metadata:
+  vikingbot:
+    requires:
+      bins:
+      - git
 ---
 
 ## 核心规范
@@ -347,23 +353,7 @@ tags:
 """
     viking_fs = MagicMock()
     viking_fs.read_file = AsyncMock(return_value=existing_skill_md)
-    write_calls = {}
-
-    class _FakeContentWriter:
-        def __init__(self, _viking_fs):
-            self._viking_fs = _viking_fs
-
-        async def write(self, **kwargs):
-            write_calls.update(kwargs)
-            return {
-                "uri": kwargs["uri"],
-                "root_uri": kwargs["uri"].rsplit("/SKILL.md", 1)[0],
-            }
-
-    monkeypatch.setattr(
-        "openviking.session.skill.skill_operation_updater.ContentWriteCoordinator",
-        _FakeContentWriter,
-    )
+    viking_fs.write_context = AsyncMock()
 
     async def _fake_extract_skill_privacy_values(*, skill_name, skill_description, content):
         assert skill_name == "code-review"
@@ -384,14 +374,18 @@ tags:
 
     privacy_config_service = MagicMock()
     privacy_config_service.upsert = AsyncMock()
+    vikingdb = MagicMock()
+    vikingdb.enqueue_embedding_msg = AsyncMock(return_value=True)
     processor = SkillProcessor(
-        vikingdb=MagicMock(),
+        vikingdb=vikingdb,
         privacy_config_service=privacy_config_service,
     )
+    processor._generate_overview = AsyncMock(return_value="Updated skill overview")
     updater = SkillOperationUpdater(
         registry=_build_skill_registry(),
         skill_processor=processor,
         viking_fs=viking_fs,
+        transaction_handle="skill-policy-lease",
     )
     uri = "viking://user/default/skills/code-review/SKILL.md"
     operations = ResolvedOperations(
@@ -424,15 +418,21 @@ tags:
     assert result.written_uris == []
     assert result.edited_uris == [uri]
     assert result.operation_results[0]["action"] == "update"
-    assert "secret-xyz" not in write_calls["content"]
-    assert "{{ov_privacy:skill:code-review:api_key}}" in write_calls["content"]
+    viking_fs.write_context.assert_awaited_once()
+    assert viking_fs.write_context.await_args.kwargs["lease_ref"] == "skill-policy-lease"
+    written_content = viking_fs.write_context.await_args.kwargs["content"]
+    assert "secret-xyz" not in written_content
+    assert "{{ov_privacy:skill:code-review:api_key}}" in written_content
+    assert SkillLoader.parse(written_content)["metadata"] == {
+        "vikingbot": {"requires": {"bins": ["git"]}},
+    }
     privacy_config_service.upsert.assert_awaited_once_with(
         ctx=ctx,
         category="skill",
         target_key="code-review",
         values={"api_key": "secret-xyz"},
         updated_by=ctx.user.user_id,
-        change_reason="auto-extracted from add_skill",
+        change_reason="auto-extracted from session skill update",
     )
 
 

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import inspect
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+from openviking.core.skill_loader import SkillLoader
 from openviking.message import Message, TextPart
 from openviking.server.identity import RequestContext, Role
 from openviking.session import create_session_compressor
@@ -33,6 +35,7 @@ from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.train import (
     Case,
     ExperienceSet,
+    PatchSemanticGradient,
     PolicyApplyResult,
     PolicyPlanItem,
     PolicyUpdatePlan,
@@ -46,6 +49,7 @@ from openviking.session.train import (
     Trajectory,
 )
 from openviking.session.train.components.session_commit import _case_spec_message_to_request
+from openviking.utils.skill_processor import SkillProcessor
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -301,6 +305,245 @@ async def test_v3_skill_only_extraction_submits_gradients_without_agent_memories
         "skill_submitted": 1,
         "skill_uris": [skill_uri],
     }
+
+
+@pytest.mark.parametrize(
+    "skill_case",
+    ["new", "existing"],
+)
+async def test_session_skill_trainer_optimizes_gradients_with_session_skill_schema(
+    monkeypatch, skill_case
+):
+    existing_skill = skill_case == "existing"
+
+    class FakeVLM:
+        model = "test-model"
+
+        def __init__(self):
+            self.messages = []
+
+        async def get_completion_async(self, **kwargs):
+            self.messages.append(list(kwargs["messages"]))
+            return json.dumps(
+                {
+                    "session_skills": [
+                        {
+                            "page_id": 1 if existing_skill else 100,
+                            "skill_name": "code-review",
+                            "description": "Review code changes",
+                            "content": {
+                                "blocks": [
+                                    {
+                                        "search": ("Read changed files." if existing_skill else ""),
+                                        "replace": "Read changed files before commenting.",
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            )
+
+    class FakeAsyncAGFS:
+        async def pathlock_acquire_tree(self, path, timeout_secs):
+            del path, timeout_secs
+            return "skill-policy-lease"
+
+        async def pathlock_release(self, lease):
+            assert lease == "skill-policy-lease"
+
+    class FakeVikingFS:
+        def __init__(self, files):
+            self._async_agfs = FakeAsyncAGFS()
+            self.files = files
+            self.write_context_calls = []
+
+        def _uri_to_path(self, uri, ctx=None):
+            del ctx
+            return f"/local/default/{uri.removeprefix('viking://')}"
+
+        async def ls(self, uri, output="original", ctx=None):
+            del ctx
+            assert output == "original"
+            if existing_skill and uri == "viking://user/u/skills":
+                return [
+                    {
+                        "name": "code-review",
+                        "uri": "viking://user/u/skills/code-review",
+                        "isDir": True,
+                    }
+                ]
+            return []
+
+        async def read_file(self, uri, ctx=None):
+            del ctx
+            if uri not in self.files:
+                raise FileNotFoundError(uri)
+            return self.files[uri]
+
+        async def write_context(
+            self,
+            *,
+            uri,
+            content,
+            abstract,
+            overview,
+            content_filename,
+            is_leaf,
+            ctx,
+            lease_ref,
+        ):
+            del abstract, overview, is_leaf, ctx
+            assert content_filename == "SKILL.md"
+            assert lease_ref == "skill-policy-lease"
+            self.write_context_calls.append((uri, lease_ref))
+            self.files[f"{uri}/SKILL.md"] = content
+
+        async def search(self, query, **kwargs):
+            del query, kwargs
+            return []
+
+    class FakeVikingDB:
+        async def enqueue_embedding_msg(self, _message):
+            return True
+
+    vlm = FakeVLM()
+    config = SimpleNamespace(
+        memory=SimpleNamespace(
+            custom_templates_dir="",
+            eager_prefetch=True,
+            experimental_memory_switch=False,
+            link_enabled=False,
+            prefetch_search_topn=5,
+        ),
+        prompts=SimpleNamespace(templates_dir=""),
+        vlm=SimpleNamespace(get_vlm_instance=lambda: vlm),
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.prompts.manager.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.extract_loop.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.train.components.policy_optimizer.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.utils.skill_processor.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3._skill_trainer_key",
+        lambda _ctx: object(),
+    )
+
+    ctx = _ctx()
+    skill_uri = "viking://user/u/skills/code-review/SKILL.md"
+    existing_skill_data = {
+        "name": "code-review",
+        "description": "Review code changes",
+        "content": "Read changed files.",
+        "allowed_tools": ["Read"],
+        "allowed_tools_declared": True,
+        "metadata": {"vikingbot": {"requires": {"bins": ["git"]}}},
+    }
+    files = {skill_uri: SkillLoader.to_skill_md(existing_skill_data)} if existing_skill else {}
+    fs = FakeVikingFS(files)
+    gradient = PatchSemanticGradient(
+        before_file=(
+            MemoryFile(
+                uri=skill_uri,
+                content="Read changed files.",
+                memory_type="skills",
+                extra_fields={
+                    "memory_type": "skills",
+                    "skill_name": "code-review",
+                    "description": "Review code changes",
+                    "allowed_tools": ["Read"],
+                    "allowed_tools_declared": True,
+                    "metadata": {"vikingbot": {"requires": {"bins": ["git"]}}},
+                },
+            )
+            if existing_skill
+            else None
+        ),
+        after_file=MemoryFile(
+            uri=skill_uri,
+            content="## Workflow\n- Read changed files before commenting.",
+            memory_type="skills",
+            extra_fields={
+                "memory_type": "skills",
+                "skill_name": "code-review",
+                "description": "Review code changes",
+            },
+        ),
+        base_version=None,
+        rationale="Preserve the verified review workflow.",
+        links=[],
+        confidence=0.9,
+        metadata={},
+    )
+    skill_processor = SkillProcessor(vikingdb=FakeVikingDB())
+    skill_processor._generate_overview = AsyncMock(return_value="Review workflow overview")
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        rollout_analyzer=SimpleNamespace(),
+        skill_processor=skill_processor,
+        streaming_trainer_config=StreamingPolicyTrainerConfig(
+            max_gradients_per_update=1,
+            max_wait_seconds=60,
+        ),
+    )
+    trainer = await compressor._get_session_skill_trainer(
+        viking_fs=fs,
+        ctx=ctx,
+        messages=_messages(),
+        strict_extract_errors=True,
+        archive_uri="viking://user/u/sessions/s1/history/archive_001",
+    )
+
+    try:
+        result = await trainer.submit_gradients([gradient])
+    finally:
+        await trainer.close()
+
+    assert result.apply_result.errors == []
+    assert result.apply_result.written_uris == [skill_uri]
+    assert result.plan.items[0].after_content == "Read changed files before commenting."
+    assert fs.write_context_calls == [("viking://user/u/skills/code-review", "skill-policy-lease")]
+    written_skill = SkillLoader.parse(fs.files[skill_uri])
+    assert written_skill["description"] == "Review code changes"
+    assert written_skill["content"] == "Read changed files before commenting."
+    if existing_skill:
+        assert written_skill["allowed_tools"] == ["Read"]
+        assert written_skill["allowed_tools_declared"] is True
+        assert written_skill["metadata"] == {"vikingbot": {"requires": {"bins": ["git"]}}}
+        assert result.apply_result.updated_policy_set.policies[0].metadata["metadata"] == {
+            "vikingbot": {"requires": {"bins": ["git"]}}
+        }
+    assert result.plan.metadata["chunks"][0]["memory_type"] == "skills"
+    system_prompt = next(
+        message["content"]
+        for messages in vlm.messages
+        for message in messages
+        if message["role"] == "system"
+    )
+    assert '"session_skills"' in system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/session/train/test_train_components.py
+++ b/tests/session/train/test_train_components.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from test_fakes import fake_request_context
 
+from openviking.core.skill_loader import SkillLoader
 from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.train import (
@@ -20,7 +21,10 @@ from openviking.session.train import (
     PatchMergePolicyOptimizer,
     PatchMergePolicyOptimizerContext,
     PatchSemanticGradient,
+    PolicyPlanItem,
     PolicyUpdatePlan,
+    SkillPolicyUpdater,
+    SkillSetLoader,
 )
 
 
@@ -47,13 +51,13 @@ class FakeVikingFS:
     async def read_file(self, uri: str, ctx=None):
         return self.files[uri]
 
-    async def write_file(self, uri: str, content: str, ctx=None, lock_handle=None):
-        self.write_lock_handles.append((uri, lock_handle))
+    async def write_file(self, uri: str, content: str, ctx=None, lease_ref=None):
+        self.write_lock_handles.append((uri, lease_ref))
         self.files[uri] = content
 
-    async def rm(self, uri: str, recursive: bool = False, ctx=None, lock_handle=None):
+    async def rm(self, uri: str, recursive: bool = False, ctx=None, lease_ref=None):
         del recursive, ctx
-        self.rm_lock_handles.append(lock_handle)
+        self.rm_lock_handles.append(lease_ref)
         self.files.pop(uri, None)
         return {"estimated_deleted_count": 1}
 
@@ -226,6 +230,133 @@ async def test_experience_set_loader_requires_request_context():
 
     with pytest.raises(ValueError, match="requires request_context ctx"):
         await ExperienceSetLoader(viking_fs=fs).load(root)
+
+
+async def test_skill_policy_set_reload_preserves_skill_loader():
+    root = "viking://user/u/skills"
+    skill_uri = f"{root}/code-review/SKILL.md"
+    raw_skill = """---
+name: code-review
+description: Review code changes
+allowed-tools:
+- Read
+metadata:
+  vikingbot:
+    requires:
+      bins:
+      - git
+---
+Read changed files before commenting.
+"""
+
+    class FakeSkillVikingFS:
+        async def ls(self, uri, output="original", ctx=None):
+            del ctx
+            assert uri == root
+            assert output == "original"
+            return [
+                {
+                    "name": "code-review",
+                    "uri": f"{root}/code-review",
+                    "isDir": True,
+                }
+            ]
+
+        async def read_file(self, uri, ctx=None):
+            del ctx
+            assert uri == skill_uri
+            return raw_skill
+
+    ctx = fake_request_context()
+    loaded = await SkillSetLoader(viking_fs=FakeSkillVikingFS()).load(root, ctx=ctx)
+
+    updated = loaded.with_policies([])
+    reloaded = await updated.reload()
+
+    assert reloaded.metadata["source"] == "skill_store"
+    assert [policy.name for policy in reloaded.policies] == ["code-review"]
+    policy = reloaded.policies[0]
+    assert policy.metadata["allowed_tools"] == ["Read"]
+    assert policy.metadata["allowed_tools_declared"] is True
+    assert policy.metadata["metadata"] == {"vikingbot": {"requires": {"bins": ["git"]}}}
+
+
+async def test_skill_policy_updater_preserves_omitted_existing_description():
+    root = "viking://user/u/skills"
+    skill_uri = f"{root}/code-review/SKILL.md"
+    original_description = "Review code changes"
+
+    class FakeSkillProcessor:
+        async def process_skill(
+            self,
+            *,
+            data,
+            viking_fs,
+            ctx,
+            allow_local_path_resolution,
+            privacy_change_reason,
+            target_uri,
+            lease_ref,
+        ):
+            del ctx
+            assert allow_local_path_resolution is False
+            assert privacy_change_reason == "auto-extracted from session skill update"
+            assert lease_ref is None
+            skill_root_uri = f"{target_uri.rstrip('/')}/{data['name']}"
+            viking_fs.files[f"{skill_root_uri}/SKILL.md"] = SkillLoader.to_skill_md(data)
+            return {"root_uri": skill_root_uri}
+
+    fs = FakeVikingFS(
+        {
+            skill_uri: SkillLoader.to_skill_md(
+                {
+                    "name": "code-review",
+                    "description": original_description,
+                    "content": "Read changed files.",
+                }
+            )
+        }
+    )
+    policy_set = ExperienceSet(
+        root_uri=root,
+        policies=[
+            Experience(
+                name="code-review",
+                uri=skill_uri,
+                version=1,
+                status="production",
+                content="Read changed files.",
+                metadata={"description": original_description, "memory_type": "skills"},
+            )
+        ],
+    )
+    plan = PolicyUpdatePlan(
+        items=[
+            PolicyPlanItem(
+                kind="upsert",
+                memory_type="skills",
+                target_name="code-review",
+                target_uri=skill_uri,
+                before_content="Read changed files.",
+                after_content="Read changed files before commenting.",
+                metadata={
+                    "merge_memory_fields": {
+                        "description": None,
+                        "content": "Read changed files before commenting.",
+                    }
+                },
+            )
+        ]
+    )
+
+    result = await SkillPolicyUpdater(
+        skill_processor=FakeSkillProcessor(),
+        viking_fs=fs,
+    ).apply(plan, policy_set, fake_request_context())
+
+    assert result.errors == []
+    assert result.updated_policy_set.policies[0].metadata["description"] == original_description
+    assert SkillLoader.parse(fs.files[skill_uri])["description"] == original_description
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_viking_fs_write_locking.py
+++ b/tests/storage/test_viking_fs_write_locking.py
@@ -56,6 +56,16 @@ class _AsyncAppendAGFS:
         return len(data)
 
 
+class _AsyncContextAGFS:
+    """Async AGFS stub that records context-directory creation."""
+
+    def __init__(self):
+        self.mkdir_calls = []
+
+    async def mkdir(self, path, fs_ctx=None):
+        self.mkdir_calls.append((path, fs_ctx))
+
+
 class _AsyncMoveAGFS:
     """Async AGFS stub that records move lock ownership and release."""
 
@@ -190,6 +200,49 @@ async def test_append_file_holds_exact_lease_across_read_and_write(monkeypatch):
     )
     assert fake.events[3][3]["lease_ref"] == "lease-1"
     assert fake.events[4] == ("release", {"lease_ref": "lease-1"})
+
+
+async def test_write_context_propagates_outer_lease_to_directory_and_files(monkeypatch):
+    """Context writes must remain inside an outer policy tree-lock lease."""
+    fake = _AsyncContextAGFS()
+    fs = VikingFS(agfs=_FakeAGFS())
+    fs._async_agfs = fake  # type: ignore[assignment]
+    outer_lease = "skill-policy-lease"
+
+    ensure_parent_dirs = AsyncMock()
+    write_file = AsyncMock()
+    monkeypatch.setattr(fs, "_ensure_parent_dirs", ensure_parent_dirs)
+    monkeypatch.setattr(fs, "write_file", write_file)
+    monkeypatch.setattr(fs, "_ensure_mutable_access", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        fs,
+        "_uri_to_path",
+        lambda _uri, **_kwargs: "/local/default/user/default/skills/code-review",
+    )
+
+    await fs.write_context(
+        "viking://user/default/skills/code-review",
+        content="Skill body",
+        abstract="Skill abstract",
+        overview="Skill overview",
+        content_filename="SKILL.md",
+        ctx=_default_ctx(),
+        lease_ref=outer_lease,
+    )
+
+    ensure_parent_dirs.assert_awaited_once_with(
+        "/local/default/user/default/skills/code-review",
+        ctx=_default_ctx(),
+        lease_ref=outer_lease,
+    )
+    assert fake.mkdir_calls == [
+        (
+            "/local/default/user/default/skills/code-review",
+            {"account_id": "default", "lease_ref": outer_lease},
+        )
+    ]
+    assert write_file.await_count == 3
+    assert all(call.kwargs["lease_ref"] == outer_lease for call in write_file.await_args_list)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -34,6 +34,11 @@ class TestResolveOperations:
                 MemoryField(name="name", field_type=FieldType.STRING, merge_op=MergeOp.IMMUTABLE),
                 MemoryField(name="owner", field_type=FieldType.STRING, merge_op=MergeOp.REPLACE),
                 MemoryField(name="count", field_type=FieldType.INT64, merge_op=MergeOp.SUM),
+                MemoryField(
+                    name="description",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.REPLACE,
+                ),
                 MemoryField(name="content", field_type=FieldType.STRING, merge_op=MergeOp.PATCH),
             ],
         )
@@ -42,7 +47,12 @@ class TestResolveOperations:
             uri=existing_uri,
             content="old content",
             memory_type="entities",
-            extra_fields={"name": "Melanie", "owner": "Alice", "count": 2},
+            extra_fields={
+                "name": "Melanie",
+                "owner": "Alice",
+                "count": 2,
+                "description": "old description",
+            },
         )
 
         context_provider = Mock()
@@ -66,7 +76,13 @@ class TestResolveOperations:
 
         operations, _ = await loop.resolve_operations(
             AttrDict(
-                entities=[{"content": "new content", "page_id": 7}],
+                entities=[
+                    {
+                        "description": "new description",
+                        "content": "new content",
+                        "page_id": 7,
+                    }
+                ],
                 delete_uris=[],
             )
         )
@@ -77,6 +93,7 @@ class TestResolveOperations:
         assert operation.memory_fields["name"] == "Melanie"
         assert "owner" not in operation.memory_fields
         assert "count" not in operation.memory_fields
+        assert operation.memory_fields["description"] == "new description"
         assert operation.memory_fields["content"] == "new content"
         isolation_handler.calculate_memory_uris.assert_not_called()
 


### PR DESCRIPTION
## Summary

- bind session-skill patch merging to the dedicated enabled `session_skills` schema and registry while preserving the external `skills` policy type
- materialize PATCH operations against existing `SKILL.md` content before producing policy updates
- preserve skill loader state, frontmatter metadata, and transaction leases throughout the Trainer → Optimizer → Updater → SkillProcessor write path
- add regression coverage for both new and existing skills using the real session-skill training pipeline

## Root Cause

When session skill extraction produced a gradient, `PatchMergePolicyOptimizer` passed `memory_type="skills"` to `PatchMergeContextProvider`.

The provider resolved that name against the default memory registry, where the legacy `skills` schema is disabled. This caused:

`ValueError: Memory schema not found or disabled: skills`

before `SkillPolicyUpdater` could write the generated `SKILL.md`.

Session skills use a separate enabled `session_skills` schema and registry, so the optimizer now receives an explicit schema binding for that extraction model.

## Validation

- Ruff passed for all changed Python files
- 15 targeted regression tests passed
- `git diff --check upstream/main...HEAD` passed
- merge-tree validation against the latest `upstream/main` completed without conflicts
- real new-skill and existing-skill Trainer → Optimizer → Updater → SkillProcessor paths are covered

Closes #4186
