### PR TITLE
fix(web-studio): avoid duplicate version prefix

### DIFF
--- a/web-studio/src/routes/monitoring/-lib/version.test.ts
+++ b/web-studio/src/routes/monitoring/-lib/version.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripVersionPrefix } from './version'
+
+describe('stripVersionPrefix', () => {
+  it('removes a leading version prefix', () => {
+    expect(stripVersionPrefix('v0.4.16')).toBe('0.4.16')
+    expect(stripVersionPrefix('V0.4.16')).toBe('0.4.16')
+  })
+
+  it('preserves versions without a prefix', () => {
+    expect(stripVersionPrefix('0.4.16')).toBe('0.4.16')
+  })
+})

--- a/web-studio/src/routes/monitoring/-lib/version.ts
+++ b/web-studio/src/routes/monitoring/-lib/version.ts
@@ -1,0 +1,3 @@
+export function stripVersionPrefix(version: string): string {
+  return version.replace(/^v/i, '')
+}

--- a/web-studio/src/routes/monitoring/route.tsx
+++ b/web-studio/src/routes/monitoring/route.tsx
@@ -32,6 +32,7 @@ import { useAppConnection } from '#/hooks/use-app-connection'
 import { getHealth, getObserverSystem, getOvResult } from '#/lib/ov-client'
 import { cn } from '#/lib/utils'
 import { parseObserverStatus } from './-lib/parse-status'
+import { stripVersionPrefix } from './-lib/version'
 
 export const Route = createFileRoute('/monitoring')({
   component: MonitoringRoute,
@@ -236,7 +237,9 @@ function MonitoringRoute() {
             </h1>
             {overview?.version ? (
               <Badge variant="outline" className="font-mono font-normal">
-                {t('version', { version: overview.version })}
+                {t('version', {
+                  version: stripVersionPrefix(overview.version),
+                })}
               </Badge>
             ) : null}
           </div>


### PR DESCRIPTION
## Description

Released Docker images can report `/health.version` as `v0.4.16`, while the monitoring translation already adds `v`. The badge then shows `vv0.4.16`.

This change removes one existing leading `v` before interpolation, so both `v0.4.16` and `0.4.16` display as `v0.4.16`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

No related issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Normalize an existing uppercase or lowercase `v` prefix in the monitoring version.
- Add regression coverage for prefixed and unprefixed version values.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="565" height="149" alt="image" src="https://github.com/user-attachments/assets/66f7ad90-c89f-45e8-bed0-3a1fd9024de3" />

The reported badge shows `vv0.4.16`; after this change it shows `v0.4.16`.

## Additional Notes

- `npm test -- src/routes/monitoring`: 2 test files and 4 tests passed.
- `npm run build`: passed.
- Targeted ESLint for the changed files: passed.
- The repository-wide `npm run lint` run was blocked by two unrelated `no-unnecessary-condition` errors in `web-studio/src/routes/tasks/-lib/task-pipeline.ts`.
