### PR TITLE
fix(memory): preserve extracted replace fields

### DIFF
--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -424,7 +424,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                             immutable_fields = {
                                 field.name
                                 for field in schema.fields
-                                if field.merge_op != MergeOp.PATCH
+                                if field.merge_op == MergeOp.IMMUTABLE
                             }
                             for field_name in immutable_fields:
                                 if field_name in old_content.extra_fields:

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -32,6 +32,8 @@ class TestResolveOperations:
             filename_template="{{ name }}.md",
             fields=[
                 MemoryField(name="name", field_type=FieldType.STRING, merge_op=MergeOp.IMMUTABLE),
+                MemoryField(name="owner", field_type=FieldType.STRING, merge_op=MergeOp.REPLACE),
+                MemoryField(name="count", field_type=FieldType.INT64, merge_op=MergeOp.SUM),
                 MemoryField(name="content", field_type=FieldType.STRING, merge_op=MergeOp.PATCH),
             ],
         )
@@ -40,7 +42,7 @@ class TestResolveOperations:
             uri=existing_uri,
             content="old content",
             memory_type="entities",
-            extra_fields={"name": "Melanie"},
+            extra_fields={"name": "Melanie", "owner": "Alice", "count": 2},
         )
 
         context_provider = Mock()
@@ -73,8 +75,60 @@ class TestResolveOperations:
         assert operation.uris == [existing_uri]
         assert operation.old_memory_file_content is old_file
         assert operation.memory_fields["name"] == "Melanie"
+        assert "owner" not in operation.memory_fields
+        assert "count" not in operation.memory_fields
         assert operation.memory_fields["content"] == "new content"
         isolation_handler.calculate_memory_uris.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_existing_page_id_keeps_new_replace_and_sum_values(self):
+        schema = MemoryTypeSchema(
+            memory_type="entities",
+            description="entity memory",
+            fields=[
+                MemoryField(name="name", field_type=FieldType.STRING, merge_op=MergeOp.IMMUTABLE),
+                MemoryField(name="owner", field_type=FieldType.STRING, merge_op=MergeOp.REPLACE),
+                MemoryField(name="count", field_type=FieldType.INT64, merge_op=MergeOp.SUM),
+            ],
+        )
+        existing_uri = "viking://user/alice/memories/entities/Melanie.md"
+        old_file = MemoryFile(
+            uri=existing_uri,
+            content="old content",
+            memory_type="entities",
+            extra_fields={"name": "Melanie", "owner": "Alice", "count": 2},
+        )
+
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {existing_uri: old_file}
+
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, role_scope=None: item
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(
+            page_id_map=SimpleNamespace(resolve=lambda page_id: existing_uri)
+        )
+
+        operations, _ = await loop.resolve_operations(
+            AttrDict(
+                entities=[
+                    {"name": "Ignored", "owner": "Bob", "count": 3, "page_id": 7}
+                ]
+            )
+        )
+
+        operation = operations.upsert_operations[0]
+        assert operation.memory_fields["name"] == "Melanie"
+        assert operation.memory_fields["owner"] == "Bob"
+        assert operation.memory_fields["count"] == 3
 
     def test_unresolved_page_ids_are_ignored(self):
         loop = ExtractLoop(vlm=Mock(model="test-model"), viking_fs=Mock(), context_provider=Mock())


### PR DESCRIPTION
## Summary

Fix Memory V2 updates overwriting newly extracted values for existing fields configured with `merge_op: replace` or `merge_op: sum`. Only `merge_op: immutable` fields should be restored from the existing memory before merge processing.

## Type of Change

- [x] Bug fix (fix)
- [x] Tests added for new functionality

## Testing

- [x] `python3 -m py_compile openviking/session/memory/extract_loop.py tests/unit/session/memory/test_extract_loop_match_text.py`
- [x] `pytest tests/unit/session/memory/test_extract_loop_match_text.py::TestResolveOperations -q` (3 passed)
- The complete focused file reports 5 passed and 3 unrelated existing fixture failures in `TestPageIdInstruction` and `TestFinalOperationsHydration` because mocked operation models lack `model_fields`.

## Related Issues

Fixes #4193

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (not needed)
- [ ] All tests pass