### PR TITLE
fix(release): align bundled CLI version with wheels

### DIFF
--- a/.github/scripts/smoke_test_wheel_version.py
+++ b/.github/scripts/smoke_test_wheel_version.py
@@ -1,0 +1,42 @@
+"""Verify that an installed wheel exposes one consistent version."""
+
+import importlib.metadata
+import os
+import subprocess
+from pathlib import Path
+
+import openviking
+
+
+def main() -> None:
+    wheel_version = importlib.metadata.version("openviking")
+    package_version = openviking.__version__
+    if wheel_version != package_version:
+        raise SystemExit(
+            f"Wheel metadata version ({wheel_version}) does not match "
+            f"openviking.__version__ ({package_version})"
+        )
+
+    binary_name = "ov.exe" if os.name == "nt" else "ov"
+    bundled_cli = Path(openviking.__file__).resolve().parent / "bin" / binary_name
+    if not bundled_cli.is_file():
+        raise SystemExit(f"Bundled Rust CLI was not installed at {bundled_cli}")
+
+    output = subprocess.run(
+        [str(bundled_cli), "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    cli_version = output.split()[-1]
+    if cli_version != wheel_version:
+        raise SystemExit(
+            f"Bundled Rust CLI version ({cli_version}) does not match "
+            f"wheel metadata version ({wheel_version})"
+        )
+
+    print(f"Verified wheel, package, and CLI version: {wheel_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -3,6 +3,11 @@ name: 15. _Build Distribution
 on:
   workflow_call:
     inputs:
+      version:
+        description: 'Release tag (e.g. v0.4.16)'
+        required: false
+        type: string
+        default: ''
       os_json:
         description: 'JSON string of runner labels to build on (ubuntu-24.04=x86_64, ubuntu-24.04-arm=aarch64, macos-14=arm64, macos-15-intel=x86_64, windows-latest=x86_64)'
         required: false
@@ -82,6 +87,11 @@ jobs:
         # For sdist, ensure local runtime binaries are not packaged even if present
         # Ignore uv.lock changes to avoid dirty state in setuptools_scm
         git update-index --assume-unchanged uv.lock || true
+
+    - name: Configure OpenViking version
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: uv run --frozen python -m build_support.release_version
 
     - name: Debug Git and SCM
       shell: bash
@@ -227,14 +237,10 @@ jobs:
     - name: Install build dependencies
       run: uv pip install setuptools setuptools_scm cmake wheel build
 
-    - name: Resolve OpenViking version for Rust CLI (Linux)
-      shell: bash
-      run: |
-        OPENVIKING_VERSION=$(
-          uv run --frozen python -c "from build_support.versioning import resolve_openviking_version; print(resolve_openviking_version())"
-        )
-        echo "OPENVIKING_VERSION=$OPENVIKING_VERSION" >> "$GITHUB_ENV"
-        echo "Resolved OpenViking version: $OPENVIKING_VERSION"
+    - name: Configure OpenViking version (Linux)
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: uv run --frozen python -m build_support.release_version
 
     - name: Build Rust CLI (Linux)
       run: cargo build --release --target ${{ matrix.arch == 'aarch64' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }} -p ov_cli
@@ -302,6 +308,7 @@ jobs:
         "$PYTHON_BIN" -m pip install --force-reinstall dist/*.whl
 
         cd "$RUNNER_TEMP"
+        "$PYTHON_BIN" "$GITHUB_WORKSPACE/.github/scripts/smoke_test_wheel_version.py"
         "$PYTHON_BIN" - <<'PY'
         import importlib
         import importlib.util
@@ -461,14 +468,10 @@ jobs:
       shell: bash
       run: echo "OV_REQUIRE_RAGFS_BUILD=1" >> "$GITHUB_ENV"
 
-    - name: Resolve OpenViking version for Rust CLI (macOS/Windows)
-      shell: bash
-      run: |
-        OPENVIKING_VERSION=$(
-          uv run --frozen python -c "from build_support.versioning import resolve_openviking_version; print(resolve_openviking_version())"
-        )
-        echo "OPENVIKING_VERSION=$OPENVIKING_VERSION" >> "$GITHUB_ENV"
-        echo "Resolved OpenViking version: $OPENVIKING_VERSION"
+    - name: Configure OpenViking version (macOS/Windows)
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: uv run --frozen python -m build_support.release_version
 
     - name: Build Rust CLI (macOS/Windows)
       shell: bash
@@ -528,6 +531,7 @@ jobs:
         python -m pip install --force-reinstall dist/*.whl
 
         cd "$RUNNER_TEMP"
+        python "$GITHUB_WORKSPACE/.github/scripts/smoke_test_wheel_version.py"
         python - <<'PY'
         import importlib.util
         from importlib.resources import files
@@ -565,6 +569,7 @@ jobs:
         python -m pip install --force-reinstall dist/*.whl
 
         cd "$RUNNER_TEMP"
+        python "$GITHUB_WORKSPACE/.github/scripts/smoke_test_wheel_version.py"
         python - <<'PY'
         import importlib.util
         from importlib.resources import files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     uses: ./.github/workflows/_build.yml
     with:
+      version: ${{ github.event.release.tag_name || '' }}
       os_json: ${{ inputs.os_json || '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-14", "macos-15-intel", "windows-latest"]' }}
       python_json: ${{ inputs.python_json || '["3.10"]' }}
       build_sdist: ${{ github.event_name == 'release' || inputs.build_sdist != false }}

--- a/build_support/release_version.py
+++ b/build_support/release_version.py
@@ -1,0 +1,59 @@
+"""Configure the version shared by release build consumers."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Collection
+from pathlib import Path
+
+from build_support.versioning import resolve_openviking_version
+
+RELEASE_TAG_PATTERN = re.compile(r"^v([0-9]+\.[0-9]+\.[0-9]+)$")
+
+
+def build_environment(
+    input_version: str, scm_version: str, head_tags: Collection[str]
+) -> dict[str, str]:
+    """Return the environment shared by Python and Rust build consumers."""
+    match = RELEASE_TAG_PATTERN.fullmatch(input_version) if input_version else None
+    if input_version and match is None:
+        raise ValueError(f"Invalid release tag {input_version!r}; expected vX.Y.Z")
+    if input_version and input_version not in head_tags:
+        raise ValueError(f"Release tag {input_version!r} does not point at HEAD")
+
+    version = match.group(1) if match else scm_version
+    entries = {"OPENVIKING_VERSION": version}
+    if match:
+        entries["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING"] = version
+    return entries
+
+
+def main() -> None:
+    input_version = os.environ.get("INPUT_VERSION", "").strip()
+    head_tags = (
+        subprocess.run(
+            ["git", "tag", "--points-at", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        if input_version
+        else ()
+    )
+    entries = build_environment(
+        input_version,
+        "" if input_version else resolve_openviking_version(),
+        head_tags,
+    )
+
+    github_env = Path(os.environ["GITHUB_ENV"])
+    with github_env.open("a", encoding="utf-8") as env_file:
+        for key, value in entries.items():
+            env_file.write(f"{key}={value}\n")
+    print(f"Configured OpenViking version: {entries['OPENVIKING_VERSION']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -2813,9 +2813,21 @@ fn render_pre_language_help_request(args: &[OsString]) -> Option<String> {
     help_ui::render_command_help_request(args).or_else(|| Some(error.to_string()))
 }
 
+fn render_pre_language_version_request(args: &[OsString]) -> Option<&'static str> {
+    if args.len() == 2 && matches!(args[1].to_str(), Some("--version" | "-V")) {
+        Some(concat!("openviking ", env!("OPENVIKING_CLI_VERSION")))
+    } else {
+        None
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args = preprocess_cli_args(std::env::args_os().collect());
+    if let Some(version) = render_pre_language_version_request(&args) {
+        println!("{version}");
+        return;
+    }
     let command_display = error_ui::display_command(&args);
     let (pre_parse_output_format, pre_parse_compact) = pre_parse_output_options(&args);
     if let Some(help) = render_pre_language_help_request(&args) {
@@ -3621,7 +3633,8 @@ mod tests {
         language_command_can_run_picker, language_gate_action, language_required_message,
         legacy_upload_option_error, plain_help_misuse, pre_parse_output_options,
         pre_parse_requires_cli_config_file, preprocess_cli_args, preprocess_privacy_args,
-        render_pre_language_help_request, resolve_output_format,
+        render_pre_language_help_request, render_pre_language_version_request,
+        resolve_output_format,
     };
     use crate::config::{Config, DEFAULT_CUSTOM_URL};
     use crate::output::OutputFormat;
@@ -4871,6 +4884,16 @@ mod tests {
         assert_eq!(
             language_gate_action(&os_args(&["ov", "status"]), false, false),
             LanguageGateAction::ExitNonInteractive
+        );
+    }
+
+    #[test]
+    fn version_flags_render_before_language_setup() {
+        for flag in ["--version", "-V"] {
+            assert!(render_pre_language_version_request(&os_args(&["ov", flag])).is_some());
+        }
+        assert!(
+            render_pre_language_version_request(&os_args(&["ov", "status", "--version"])).is_none()
         );
     }
 

--- a/tests/misc/test_release_tag_selection.py
+++ b/tests/misc/test_release_tag_selection.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -44,3 +46,29 @@ def test_build_support_versioning_uses_main_release_tags_only(monkeypatch) -> No
         captured_kwargs["git_describe_command"]
         == "git describe --dirty --tags --long --match v[0-9]*"
     )
+
+
+def test_release_version_must_be_an_exact_head_tag() -> None:
+    from build_support.release_version import build_environment
+
+    with pytest.raises(ValueError, match="expected vX.Y.Z"):
+        build_environment("0.4.16", "", {"v0.4.16"})
+    with pytest.raises(ValueError, match="does not point at HEAD"):
+        build_environment("v0.4.16", "", {"v0.4.15"})
+
+
+def test_non_release_build_keeps_scm_version() -> None:
+    from build_support.release_version import build_environment
+
+    assert build_environment("", "0.4.17.dev3", ()) == {
+        "OPENVIKING_VERSION": "0.4.17.dev3"
+    }
+
+
+def test_release_build_configures_python_and_cli_versions() -> None:
+    from build_support.release_version import build_environment
+
+    assert build_environment("v0.4.16", "", {"v0.4.16"}) == {
+        "OPENVIKING_VERSION": "0.4.16",
+        "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING": "0.4.16",
+    }


### PR DESCRIPTION
## Summary

- pass the published release tag into the reusable distribution workflow
- configure one validated version for Python packages and the bundled Rust CLI while preserving SCM-derived development versions for manual builds
- verify installed wheel metadata, `openviking.__version__`, and the bundled CLI version on every wheel platform
- allow `ov --version` and `ov -V` to run before first-use language configuration

## Root cause

The release workflow resolved the Rust CLI version after dependency setup had made the checkout dirty, but built Python wheel metadata after cleaning the checkout. The two build stages therefore derived different versions from the same release commit.

## Validation

- `actionlint .github/workflows/_build.yml .github/workflows/release.yml`
- `python -m pytest -o addopts= tests/misc/test_release_tag_selection.py -q`
- `cargo test -p ov_cli tests::version_flags_render_before_language_setup -- --exact --nocapture`
- `cargo build --release -p ov_cli`
- fresh configuration: `target/release/ov.exe --version` outputs `openviking 0.4.16`
- `git diff --check upstream/main`

Closes #4208
