### PR TITLE
fix(bot): use user-scoped resources URI in VikingSearchTool

### DIFF
--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -2558,6 +2558,7 @@ async def test_openviking_search_uses_user_namespace(monkeypatch):
     assert "sender-1/memories" in result
     assert calls == [
         ("viking://resources/", None),
+        ("viking://user/sender-1/resources/", "sender-1"),
         ("viking://user/sender-1/memories/", "sender-1"),
         ("viking://user/sender-1/skills/", "sender-1"),
     ]
@@ -2591,6 +2592,10 @@ async def test_openviking_search_user_key_mode_uses_current_user_namespace(monke
     assert "sender-1/memories" in result
     assert calls == [
         ("viking://resources/", None),
+        ("viking://~/resources/", None),
+        ("viking://~/peers/sender-0/resources/", None),
+        ("viking://~/peers/sender-1/resources/", None),
+        ("viking://~/peers/sender-2/resources/", None),
         ("viking://~/memories/", None),
         ("viking://~/skills/", None),
         ("viking://~/peers/sender-0/memories/", None),
@@ -2644,6 +2649,10 @@ async def test_openviking_search_actor_client_expands_current_peer_scope(monkeyp
     assert "sender-0/memories" in result
     assert calls == [
         ("viking://resources/", None),
+        ("viking://~/resources/", None),
+        ("viking://~/peers/sender-0/resources/", None),
+        ("viking://~/peers/sender-1/resources/", None),
+        ("viking://~/peers/sender-2/resources/", None),
         ("viking://~/memories/", None),
         ("viking://~/skills/", None),
         ("viking://~/peers/sender-0/memories/", None),
@@ -2726,7 +2735,8 @@ async def test_openviking_list_default_memory_expands_current_peer(monkeypatch):
             )
             return uris
 
-        async def list_resources(self, path=None, recursive=False):
+        async def list_resources(self, path=None, recursive=False, node_limit=1000):
+            del node_limit
             calls.append((path, recursive))
             return []
 
@@ -2780,6 +2790,8 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
 
     assert calls == [
         ("*.md", "viking://resources/"),
+        ("*.md", "viking://~/resources/"),
+        ("*.md", "viking://user/default/peers/sender-0/resources/"),
         ("*.md", "viking://~/memories/"),
         ("*.md", "viking://~/skills/"),
         ("*.md", "viking://user/default/peers/sender-0/memories/"),
@@ -2818,6 +2830,8 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
 
     assert calls == [
         ("*.md", "viking://resources/"),
+        ("*.md", "viking://user/admin/resources/"),
+        ("*.md", "viking://user/admin/peers/sender-0/resources/"),
         ("*.md", "viking://user/admin/memories/"),
         ("*.md", "viking://user/admin/skills/"),
         ("*.md", "viking://user/admin/peers/sender-0/memories/"),

--- a/bot/tests/test_openviking_api_key_type.py
+++ b/bot/tests/test_openviking_api_key_type.py
@@ -2555,12 +2555,12 @@ async def test_openviking_search_uses_user_namespace(monkeypatch):
     tool_context = SimpleNamespace(workspace_id="workspace", memory_owner_user_ids=["sender-1"])
     result = await tool.execute(tool_context, query="hello")
 
-    assert "sender-1/memories" in result
+    assert "memories" in result
     assert calls == [
         ("viking://resources/", None),
-        ("viking://user/sender-1/resources/", "sender-1"),
-        ("viking://user/sender-1/memories/", "sender-1"),
-        ("viking://user/sender-1/skills/", "sender-1"),
+        ("viking://~/resources/", "sender-1"),
+        ("viking://~/memories/", "sender-1"),
+        ("viking://~/skills/", "sender-1"),
     ]
 
 
@@ -2593,9 +2593,6 @@ async def test_openviking_search_user_key_mode_uses_current_user_namespace(monke
     assert calls == [
         ("viking://resources/", None),
         ("viking://~/resources/", None),
-        ("viking://~/peers/sender-0/resources/", None),
-        ("viking://~/peers/sender-1/resources/", None),
-        ("viking://~/peers/sender-2/resources/", None),
         ("viking://~/memories/", None),
         ("viking://~/skills/", None),
         ("viking://~/peers/sender-0/memories/", None),
@@ -2650,9 +2647,6 @@ async def test_openviking_search_actor_client_expands_current_peer_scope(monkeyp
     assert calls == [
         ("viking://resources/", None),
         ("viking://~/resources/", None),
-        ("viking://~/peers/sender-0/resources/", None),
-        ("viking://~/peers/sender-1/resources/", None),
-        ("viking://~/peers/sender-2/resources/", None),
         ("viking://~/memories/", None),
         ("viking://~/skills/", None),
         ("viking://~/peers/sender-0/memories/", None),
@@ -2791,7 +2785,6 @@ async def test_openviking_glob_root_adds_current_peer_memory(monkeypatch):
     assert calls == [
         ("*.md", "viking://resources/"),
         ("*.md", "viking://~/resources/"),
-        ("*.md", "viking://user/default/peers/sender-0/resources/"),
         ("*.md", "viking://~/memories/"),
         ("*.md", "viking://~/skills/"),
         ("*.md", "viking://user/default/peers/sender-0/memories/"),
@@ -2830,10 +2823,9 @@ async def test_openviking_glob_root_uses_namespaced_self_targets_for_root_key(mo
 
     assert calls == [
         ("*.md", "viking://resources/"),
-        ("*.md", "viking://user/admin/resources/"),
-        ("*.md", "viking://user/admin/peers/sender-0/resources/"),
-        ("*.md", "viking://user/admin/memories/"),
-        ("*.md", "viking://user/admin/skills/"),
+        ("*.md", "viking://~/resources/"),
+        ("*.md", "viking://~/memories/"),
+        ("*.md", "viking://~/skills/"),
         ("*.md", "viking://user/admin/peers/sender-0/memories/"),
     ]
 

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 import httpx
 from loguru import logger
 
+from openviking.core.namespace import uri_parts
 from vikingbot.agent.tools.base import Tool, ToolContext
 from vikingbot.openviking_mount.ov_server import VikingClient
 
@@ -149,17 +150,16 @@ class OVFileTool(Tool, ABC):
     def _current_memory_uri(self, client: VikingClient) -> str:
         return client._memory_target_uri(None)
 
-    def _current_skill_uri(self, client: VikingClient) -> str:
-        memory_uri = self._current_memory_uri(client).rstrip("/")
-        if memory_uri.endswith("/memories"):
-            return f"{memory_uri[: -len('/memories')]}/skills/"
-        return "viking://~/skills/"
+    @staticmethod
+    def _memory_sibling_uri(memory_uri: str, segment: str) -> str | None:
+        parts = uri_parts(memory_uri)
+        if not parts or parts[-1] != "memories":
+            return None
+        parts[-1] = segment
+        return f"viking://{'/'.join(parts)}/"
 
-    def _current_resources_uri(self, client: VikingClient) -> str:
-        memory_uri = self._current_memory_uri(client).rstrip("/")
-        if memory_uri.endswith("/memories"):
-            return f"{memory_uri[: -len('/memories')]}/resources/"
-        return "viking://~/resources/"
+    def _current_skill_uri(self, client: VikingClient) -> str:
+        return self._memory_sibling_uri(self._current_memory_uri(client), "skills") or ""
 
     def _fs_retrieval_uris(
         self,
@@ -178,11 +178,19 @@ class OVFileTool(Tool, ABC):
             if not self._is_default_root_uri(uri):
                 return [uri or ""]
 
+            current_memory_uri = self._current_memory_uri(client)
+            peer_memory_uris = self._peer_memory_uris(client, tool_context)
+            resource_uris = ["viking://resources/"]
+            for memory_uri in [current_memory_uri, *peer_memory_uris]:
+                resource_uri = self._memory_sibling_uri(memory_uri, "resources")
+                if resource_uri:
+                    resource_uris.append(resource_uri)
+
             target_uris = [
-                self._current_resources_uri(client),
-                self._current_memory_uri(client),
+                *resource_uris,
+                current_memory_uri,
                 self._current_skill_uri(client),
-                *self._peer_memory_uris(client, tool_context),
+                *peer_memory_uris,
             ]
             return self._dedupe_strings(target_uris)
 
@@ -462,15 +470,16 @@ class VikingSearchTool(OVFileTool):
                 and (memory_owner_user_ids or legacy_memory_user_ids)
             ):
                 user_ids = memory_owner_user_ids or legacy_memory_user_ids
-                search_targets: list[tuple[str, str | None]] = [(self._current_resources_uri(client), None)]
+                search_targets: list[tuple[str, str | None]] = [("viking://resources/", None)]
                 for user_id in self._dedupe_strings(list(user_ids or [])):
                     memory_uri = client._memory_target_uri(user_id)
-                    skill_uri = (
-                        f"{memory_uri.rstrip('/')[: -len('/memories')]}/skills/"
-                        if memory_uri.rstrip("/").endswith("/memories")
-                        else "viking://~/skills/"
+                    resource_uri = self._memory_sibling_uri(memory_uri, "resources")
+                    skill_uri = self._memory_sibling_uri(memory_uri, "skills")
+                    search_targets.extend(
+                        (target, user_id)
+                        for target in (resource_uri, memory_uri, skill_uri)
+                        if target
                     )
-                    search_targets.extend([(memory_uri, user_id), (skill_uri, user_id)])
             else:
                 peer_ids = self._memory_peer_ids(tool_context)
                 if not target_uri:
@@ -478,12 +487,23 @@ class VikingSearchTool(OVFileTool):
                     if actor_peer_id and not peer_ids:
                         peer_ids = [actor_peer_id]
                     if actor_peer_id or peer_ids:
+                        current_memory_uri = self._current_memory_uri(client)
+                        peer_memory_uris = self._peer_memory_uris(
+                            client,
+                            tool_context,
+                            peer_ids=peer_ids,
+                        )
+                        resource_uris = ["viking://resources/"]
+                        for memory_uri in [current_memory_uri, *peer_memory_uris]:
+                            resource_uri = self._memory_sibling_uri(memory_uri, "resources")
+                            if resource_uri:
+                                resource_uris.append(resource_uri)
                         target_uris = self._dedupe_strings(
                             [
-                                self._current_resources_uri(client),
-                                self._current_memory_uri(client),
+                                *resource_uris,
+                                current_memory_uri,
                                 self._current_skill_uri(client),
-                                *self._peer_memory_uris(client, tool_context, peer_ids=peer_ids),
+                                *peer_memory_uris,
                             ]
                         )
                     else:

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -155,6 +155,12 @@ class OVFileTool(Tool, ABC):
             return f"{memory_uri[: -len('/memories')]}/skills/"
         return "viking://~/skills/"
 
+    def _current_resources_uri(self, client: VikingClient) -> str:
+        memory_uri = self._current_memory_uri(client).rstrip("/")
+        if memory_uri.endswith("/memories"):
+            return f"{memory_uri[: -len('/memories')]}/resources/"
+        return "viking://~/resources/"
+
     def _fs_retrieval_uris(
         self,
         client: VikingClient,
@@ -173,7 +179,7 @@ class OVFileTool(Tool, ABC):
                 return [uri or ""]
 
             target_uris = [
-                "viking://resources/",
+                self._current_resources_uri(client),
                 self._current_memory_uri(client),
                 self._current_skill_uri(client),
                 *self._peer_memory_uris(client, tool_context),
@@ -456,7 +462,7 @@ class VikingSearchTool(OVFileTool):
                 and (memory_owner_user_ids or legacy_memory_user_ids)
             ):
                 user_ids = memory_owner_user_ids or legacy_memory_user_ids
-                search_targets: list[tuple[str, str | None]] = [("viking://resources/", None)]
+                search_targets: list[tuple[str, str | None]] = [(self._current_resources_uri(client), None)]
                 for user_id in self._dedupe_strings(list(user_ids or [])):
                     memory_uri = client._memory_target_uri(user_id)
                     skill_uri = (
@@ -474,7 +480,7 @@ class VikingSearchTool(OVFileTool):
                     if actor_peer_id or peer_ids:
                         target_uris = self._dedupe_strings(
                             [
-                                "viking://resources/",
+                                self._current_resources_uri(client),
                                 self._current_memory_uri(client),
                                 self._current_skill_uri(client),
                                 *self._peer_memory_uris(client, tool_context, peer_ids=peer_ids),

--- a/bot/vikingbot/agent/tools/ov_file.py
+++ b/bot/vikingbot/agent/tools/ov_file.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 import httpx
 from loguru import logger
 
-from openviking.core.namespace import uri_parts
 from vikingbot.agent.tools.base import Tool, ToolContext
 from vikingbot.openviking_mount.ov_server import VikingClient
 
@@ -118,17 +117,12 @@ class OVFileTool(Tool, ABC):
             ]
         )
 
-    def _is_default_memory_uri(self, client: VikingClient, uri: str | None) -> bool:
+    def _is_default_memory_uri(self, uri: str | None) -> bool:
         normalized = self._normalize_uri(uri)
         # ``viking://user/memories`` is the legacy spelling of the current-user default
         # target; it is still accepted here because it survives in stored bot configs and
         # LLM output. New emissions always use the ``viking://~`` home alias.
-        if normalized in {"", "viking://user/memories", "viking://~/memories"}:
-            return True
-        try:
-            return normalized == self._normalize_uri(client._memory_target_uri(None))
-        except Exception:
-            return False
+        return normalized in {"", "viking://user/memories", "viking://~/memories"}
 
     def _is_default_root_uri(self, uri: str | None) -> bool:
         return self._normalize_uri(uri) in {"", "viking://", "viking://user", "viking://~"}
@@ -147,20 +141,6 @@ class OVFileTool(Tool, ABC):
             include_self=False,
         )
 
-    def _current_memory_uri(self, client: VikingClient) -> str:
-        return client._memory_target_uri(None)
-
-    @staticmethod
-    def _memory_sibling_uri(memory_uri: str, segment: str) -> str | None:
-        parts = uri_parts(memory_uri)
-        if not parts or parts[-1] != "memories":
-            return None
-        parts[-1] = segment
-        return f"viking://{'/'.join(parts)}/"
-
-    def _current_skill_uri(self, client: VikingClient) -> str:
-        return self._memory_sibling_uri(self._current_memory_uri(client), "skills") or ""
-
     def _fs_retrieval_uris(
         self,
         client: VikingClient,
@@ -170,27 +150,20 @@ class OVFileTool(Tool, ABC):
         if getattr(client, "actor_peer_id", None):
             if self._is_default_root_uri(uri):
                 return [uri or "viking://"]
-            if self._is_default_memory_uri(client, uri):
-                return [uri or self._current_memory_uri(client)]
+            if self._is_default_memory_uri(uri):
+                return [uri or "viking://~/memories/"]
             return [uri or ""]
 
-        if not self._is_default_memory_uri(client, uri):
+        if not self._is_default_memory_uri(uri):
             if not self._is_default_root_uri(uri):
                 return [uri or ""]
 
-            current_memory_uri = self._current_memory_uri(client)
-            peer_memory_uris = self._peer_memory_uris(client, tool_context)
-            resource_uris = ["viking://resources/"]
-            for memory_uri in [current_memory_uri, *peer_memory_uris]:
-                resource_uri = self._memory_sibling_uri(memory_uri, "resources")
-                if resource_uri:
-                    resource_uris.append(resource_uri)
-
             target_uris = [
-                *resource_uris,
-                current_memory_uri,
-                self._current_skill_uri(client),
-                *peer_memory_uris,
+                "viking://resources/",
+                "viking://~/resources/",
+                "viking://~/memories/",
+                "viking://~/skills/",
+                *self._peer_memory_uris(client, tool_context),
             ]
             return self._dedupe_strings(target_uris)
 
@@ -472,13 +445,12 @@ class VikingSearchTool(OVFileTool):
                 user_ids = memory_owner_user_ids or legacy_memory_user_ids
                 search_targets: list[tuple[str, str | None]] = [("viking://resources/", None)]
                 for user_id in self._dedupe_strings(list(user_ids or [])):
-                    memory_uri = client._memory_target_uri(user_id)
-                    resource_uri = self._memory_sibling_uri(memory_uri, "resources")
-                    skill_uri = self._memory_sibling_uri(memory_uri, "skills")
                     search_targets.extend(
-                        (target, user_id)
-                        for target in (resource_uri, memory_uri, skill_uri)
-                        if target
+                        [
+                            ("viking://~/resources/", user_id),
+                            ("viking://~/memories/", user_id),
+                            ("viking://~/skills/", user_id),
+                        ]
                     )
             else:
                 peer_ids = self._memory_peer_ids(tool_context)
@@ -487,29 +459,23 @@ class VikingSearchTool(OVFileTool):
                     if actor_peer_id and not peer_ids:
                         peer_ids = [actor_peer_id]
                     if actor_peer_id or peer_ids:
-                        current_memory_uri = self._current_memory_uri(client)
-                        peer_memory_uris = self._peer_memory_uris(
-                            client,
-                            tool_context,
-                            peer_ids=peer_ids,
-                        )
-                        resource_uris = ["viking://resources/"]
-                        for memory_uri in [current_memory_uri, *peer_memory_uris]:
-                            resource_uri = self._memory_sibling_uri(memory_uri, "resources")
-                            if resource_uri:
-                                resource_uris.append(resource_uri)
                         target_uris = self._dedupe_strings(
                             [
-                                *resource_uris,
-                                current_memory_uri,
-                                self._current_skill_uri(client),
-                                *peer_memory_uris,
+                                "viking://resources/",
+                                "viking://~/resources/",
+                                "viking://~/memories/",
+                                "viking://~/skills/",
+                                *self._peer_memory_uris(
+                                    client,
+                                    tool_context,
+                                    peer_ids=peer_ids,
+                                ),
                             ]
                         )
                     else:
                         target_uris = [""]
                 elif (
-                    self._is_default_memory_uri(client, target_uri)
+                    self._is_default_memory_uri(target_uri)
                     and not getattr(client, "actor_peer_id", None)
                     and peer_ids
                 ):


### PR DESCRIPTION
## Summary

`VikingSearchTool` hardcoded `viking://resources/` (shared namespace) as the search target for resources, but user-uploaded resources are stored under `viking://user/<user_id>/resources/`. The server correctly treats `resources` as a standalone scope without user-path resolution (only `~`, `session`, and `user` prefixes go through `resolve_current_user_uri()`), so the shared URI returned **zero results** in user API key mode.

This patch adds `_current_resources_uri()` — mirroring the existing `_current_skill_uri()` pattern — to derive the user-scoped resources URI from the current memory URI. All three hardcoded sites are replaced:

1. `_fs_retrieval_uris()` — default root retrieval list
2. `VikingSearchTool.execute()` — sender-fanout branch  
3. `VikingSearchTool.execute()` — actor-peer-id branch

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Manual testing completed — Vikingbot chat API search for resources now returns correct results instead of empty arrays
- [ ] Unit tests pass

### Reproduction

Before the fix (user API key mode):
```bash
curl -s -X POST http://127.0.0.1:1933/api/v1/search/find \
  -H "Authorization: Bearer <user_key>" \
  -d '{"query": "test", "target_uri": "viking://resources/", "limit": 5}'
# → resources: []  (empty)
```

After the fix:
```bash
# Vikingbot now derives viking://user/<user_id>/resources/ automatically
curl -s -X POST http://127.0.0.1:18790/bot/v1/chat \
  -H "Authorization: Bearer <user_key>" \
  -d '{"message": "search for resources", "session_id": "test"}'
# → returns correct resource results
```

## Root Cause Analysis

| URI | Scope | Behavior |
|-----|-------|----------|
| `viking://resources/` | `resources` (shared) | Treated as standalone scope, **no user-path resolution** |
| `viking://user/<id>/resources/` | `user` | Resolved to user namespace, correct results |
| `viking://~/resources/` | `~` (alias) | Expanded to `viking://user/<id>/resources/` at request boundary |

The existing `_current_memory_uri()` and `_current_skill_uri()` already use user-scoped paths. The `viking://resources/` hardcode was an oversight — it should have followed the same pattern.

## Checklist

- [x] Code follows project style guidelines (ruff, 100 char width, double quotes)
- [ ] Tests added for new functionality
- [ ] Documentation updated (if needed)
- [ ] All tests pass