### PR TITLE
fix(storage): make sync_tree additive by default (issue #4217)

### DIFF
--- a/openviking/storage/viking_fs/_sync.py
+++ b/openviking/storage/viking_fs/_sync.py
@@ -36,10 +36,12 @@ class SyncDiff:
 class _SyncMixin:
     """Top-down recursive tree diff-and-merge primitive.
 
-    Moves (not copies) visible children of ``root_uri`` into ``target_uri``
-    so the target ends up mirroring the source, returning a :class:`SyncDiff`
-    describing what changed.  Hidden files (``.``-prefixed) are skipped —
-    callers that need to carry over parser sidecars (e.g.
+    Moves (not copies) visible children of ``root_uri`` into ``target_uri``,
+    returning a :class:`SyncDiff` describing what changed.  The merge is
+    additive by default: entries that exist only in the target are left
+    untouched.  Pass ``delete_missing=True`` to ``sync_tree`` to make the
+    target mirror the source exactly.  Hidden files (``.``-prefixed) are
+    skipped — callers that need to carry over parser sidecars (e.g.
     ``.image_mappings.json``) do so explicitly after the sync.
     """
 
@@ -52,6 +54,7 @@ class _SyncMixin:
         file_change_status: Optional[Dict[str, bool]] = None,
         lease_ref: Optional[Dict[str, Any]] = None,
         delete_temp_after: bool = False,
+        delete_missing: bool = False,
         is_changed: Optional[Callable[[str, str, "RequestContext"], "bool"]] = None,
     ) -> SyncDiff:
         """Recursively merge ``root_uri`` into ``target_uri``.
@@ -59,6 +62,11 @@ class _SyncMixin:
         Hidden entries (names starting with ``.``) are skipped on both sides.
         Name conflicts (file vs. directory at the same name) are resolved by
         deleting the target-side entry before moving the source in place.
+
+        The merge is additive: files and directories that exist only in the
+        target are kept unless ``delete_missing`` is set.  This keeps
+        add-resource style syncs (a temp tree holding only the newly-added
+        resource) from deleting pre-existing siblings.
 
         Args:
             root_uri: Source (typically a temp/staging tree). Must exist.
@@ -74,6 +82,9 @@ class _SyncMixin:
             delete_temp_after: If ``True``, call ``delete_temp(root_uri)``
                 after a successful sync into an existing target (the
                 whole-tree mv path already consumes the source).
+            delete_missing: If ``True``, entries that exist only in the
+                target are deleted so it mirrors the source exactly.  Default
+                ``False`` (additive merge) — target-only entries are kept.
             is_changed: Optional async predicate ``(root_file, target_file,
                 ctx) -> bool`` used to decide if an existing file needs to
                 be replaced.  Defaults to a stat-size shortcut followed by
@@ -163,7 +174,7 @@ class _SyncMixin:
                         )
                     continue
 
-                if target_file and not root_file:
+                if delete_missing and target_file and not root_file:
                     try:
                         await self.rm(target_file, ctx=ctx, lease_ref=lease_ref)
                         diff.deleted_files.append(target_file)
@@ -240,7 +251,7 @@ class _SyncMixin:
                         )
                     target_subdir = None
 
-                if target_subdir and not root_subdir:
+                if delete_missing and target_subdir and not root_subdir:
                     try:
                         await self.rm(
                             target_subdir,

--- a/tests/storage/test_sync_tree_additive.py
+++ b/tests/storage/test_sync_tree_additive.py
@@ -1,0 +1,150 @@
+"""Regression: sync_tree must be additive by default (issue #4217).
+
+add-resource into an EXISTING directory used to mirror the temp source tree
+over the target, deleting every target-only sibling (the temp tree holds only
+the newly-added resource, so N adds to one directory left 1 survivor).
+
+The fix gates the two destructive branches behind ``delete_missing`` (default
+``False`` = additive merge): target-only files and directories are retained
+unless a caller explicitly asks for a full mirror (``delete_missing=True``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from openviking.storage.viking_fs._sync import _SyncMixin
+
+
+class _MemNode:
+    def __init__(self, kind: str, content: str = "") -> None:
+        self.kind = kind  # "file" | "dir"
+        self.content = content
+        self.children: Dict[str, str] = {}  # name -> uri
+
+
+class _MemoryVikingFS(_SyncMixin):
+    """In-memory VikingFS fake backing the real ``_SyncMixin.sync_tree`` logic."""
+
+    def __init__(self) -> None:
+        self.tree: Dict[str, _MemNode] = {}
+        self._ensure_dir("viking:")
+
+    # -- seeding helpers ---------------------------------------------------
+
+    def _ensure_dir(self, uri: str) -> None:
+        if uri in self.tree:
+            return
+        parent_uri, name = (uri.rsplit("/", 1) + [""])[:2] if "/" in uri else ("", uri)
+        if parent_uri and name:
+            self._ensure_dir(parent_uri)
+        node = _MemNode("dir")
+        self.tree[uri] = node
+        if parent_uri in self.tree and name:
+            self.tree[parent_uri].children[name] = uri
+
+    def add_file(self, uri: str, content: str = "") -> None:
+        parent_uri, name = uri.rsplit("/", 1)
+        self._ensure_dir(parent_uri)
+        self.tree[uri] = _MemNode("file", content)
+        self.tree[parent_uri].children[name] = uri
+
+    # -- VikingFS interface used by sync_tree -----------------------------
+
+    async def exists(self, uri: str, ctx=None) -> bool:
+        return uri in self.tree
+
+    async def ls(self, uri: str, show_all_hidden=False, node_limit=None, ctx=None):
+        node = self.tree.get(uri)
+        if node is None or node.kind != "dir":
+            return []
+        entries = []
+        for name, child_uri in node.children.items():
+            child = self.tree.get(child_uri)
+            if child is None:
+                continue
+            entries.append({"name": name, "isDir": child.kind == "dir"})
+        return entries
+
+    async def stat(self, uri: str, ctx=None) -> Dict[str, Any]:
+        return {"size": len(self.tree.get(uri, _MemNode("file")).content)}
+
+    async def read_file(self, uri: str, ctx=None) -> str:
+        node = self.tree.get(uri)
+        return node.content if node else ""
+
+    async def mv(self, src: str, dst: str, ctx=None, lease_ref=None) -> None:
+        node = self.tree.pop(src, None)
+        if node is None:
+            return
+        old_parent, old_name = src.rsplit("/", 1)
+        if old_parent in self.tree and old_name in self.tree[old_parent].children:
+            del self.tree[old_parent].children[old_name]
+        self.tree[dst] = node
+        new_parent, new_name = dst.rsplit("/", 1)
+        if new_parent in self.tree and new_name:
+            self.tree[new_parent].children[new_name] = dst
+
+    async def rm(self, uri: str, recursive=False, ctx=None, lease_ref=None) -> None:
+        node = self.tree.pop(uri, None)
+        if node is None:
+            return
+        for child_uri in list(node.children.values()):
+            await self.rm(child_uri, recursive=True)
+        parent, name = uri.rsplit("/", 1)
+        if parent in self.tree and name in self.tree[parent].children:
+            del self.tree[parent].children[name]
+
+    async def mkdir(self, uri: str, exist_ok=False, ctx=None, lease_ref=None) -> None:
+        self._ensure_dir(uri)
+
+    async def delete_temp(self, uri: str, ctx=None, lease_ref=None) -> None:
+        await self.rm(uri, recursive=True)
+
+
+def _seed() -> _MemoryVikingFS:
+    """Target holds a pre-existing file + subdir; source holds only one new file."""
+    fs = _MemoryVikingFS()
+    fs._ensure_dir("viking://resources/test")
+    fs.add_file("viking://resources/test/a.md", "existing file")
+    fs._ensure_dir("viking://resources/test/sub")
+    fs.add_file("viking://resources/test/sub/x.md", "nested file")
+    fs._ensure_dir("viking://temp/new")
+    fs.add_file("viking://temp/new/b.md", "new file")
+    return fs
+
+
+async def test_sync_tree_additive_keeps_target_only_entries():
+    """Default (delete_missing=False): sync adds the new file, deletes nothing."""
+    fs = _seed()
+
+    diff = await fs.sync_tree("viking://temp/new", "viking://resources/test")
+
+    # Prior target entries survive.
+    assert await fs.exists("viking://resources/test/a.md")
+    assert await fs.exists("viking://resources/test/sub/x.md")
+    # The new file lands.
+    assert await fs.exists("viking://resources/test/b.md")
+    assert await fs.read_file("viking://resources/test/b.md") == "new file"
+    # Diff reports the add only — nothing deleted.
+    assert diff.added_files == ["viking://resources/test/b.md"]
+    assert diff.deleted_files == []
+    assert diff.deleted_dirs == []
+
+
+async def test_sync_tree_delete_missing_mirrors_source():
+    """delete_missing=True restores the old mirror behaviour explicitly."""
+    fs = _seed()
+
+    diff = await fs.sync_tree(
+        "viking://temp/new",
+        "viking://resources/test",
+        delete_missing=True,
+    )
+
+    # Target-only entries removed, new file present.
+    assert not await fs.exists("viking://resources/test/a.md")
+    assert not await fs.exists("viking://resources/test/sub")
+    assert await fs.exists("viking://resources/test/b.md")
+    assert "viking://resources/test/a.md" in diff.deleted_files
+    assert "viking://resources/test/sub" in diff.deleted_dirs


### PR DESCRIPTION
## Summary

`add-resource` into an existing directory was deleting every pre-existing
sibling resource. The add-resource path syncs a temp tree (holding only the
newly-added resource) over the target via `VikingFS.sync_tree`, which used to
mirror the source onto the target — so N adds to one directory left 1 survivor.

This PR makes `sync_tree` **additive by default**: target-only files and
directories are kept unless the caller explicitly asks for a full mirror.

## Root cause

`SemanticProcessor.on_dequeue` sees `msg.uri != msg.target_uri` and calls
`_sync_topdown_recursive(source=temp, target=existing_dir)`, which delegates to
`sync_tree`. `sync_tree` unconditionally removed every target entry missing
from the source temp tree:

```python
if target_file and not root_file:        # -> rm(target_file)
if target_subdir and not root_subdir:    # -> rm(target_subdir, recursive=True)
```

The `target_preexisting` flag is threaded through `SemanticMsg` but was never
consumed to switch merge-vs-replace.

## Change

- `openviking/storage/viking_fs/_sync.py`:
  - Add `delete_missing: bool = False` to `sync_tree`.
  - Gate the two destructive branches on it (default `False` = additive merge).
  - Update docstrings: the target mirrors the source only when
    `delete_missing=True`.
- `tests/storage/test_sync_tree_additive.py`: new focused unit tests proving
  (a) additive default keeps all target-only entries and adds the new file,
  (b) `delete_missing=True` restores the mirror behaviour (target-only entries
  removed).

Caller audit: `sync_tree` has exactly one caller —
`SemanticProcessor._sync_topdown_recursive` — used only by the add-resource /
semantic-sync paths, which are intentionally left additive (no flag passed).
No other caller needs replace semantics today; the mirror behaviour remains
available behind `delete_missing=True` for any future full-replace caller.

## Type of Change

- [x] Bug fix (fix)

## Testing

- [x] Unit tests pass
  - `pytest tests/storage/ -q` → 408 passed, 10 failed, 1 skipped
  - The 10 failures are pre-existing upstream test drift, reproduced
    identically on `main` without this change (prompt-template text,
    memory-directory mock signature, vectordb mock backend, volcengine client
    tests — none touch `sync_tree`).
  - New tests: `tests/storage/test_sync_tree_additive.py` → 2 passed.

## Related Issues

- Fixes #4217

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (if needed)
- [x] All tests pass (except pre-existing failures listed above)
