### PR TITLE
fix(dsh): scope URI guard to path arguments

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/codex-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/dsh-memory-plugin/README.md
+++ b/examples/dsh-memory-plugin/README.md
@@ -152,7 +152,7 @@ The patch can also carry plugin config:
 - `session/event` captures user, assistant, and optionally tool-result messages without scraping a transcript.
 - `turn/end` checks the OpenViking pending-token threshold and commits when required.
 - Failed writes enter the shared OpenViking pending queue for replay at the next session start.
-- `tools/pre-execute` blocks DSH filesystem and shell tools from treating `viking://` URIs as local paths, pointing the model at the bridged `mcp__openviking__*` tools instead.
+- `tools/pre-execute` blocks DSH filesystem tools from using `viking://` URIs in path arguments and blocks shell commands that contain them, pointing the model at the bridged `mcp__openviking__*` tools instead. File content, edit replacement text, grep query patterns, and descriptive metadata may mention `viking://` URIs without being treated as paths; shell commands remain conservatively checked as a whole, without token-level interpretation.
 
 Each DSH session maps to `dsh-<session-id>` in OpenViking. Workspace-derived actor peers are resolved per session and sent on every session-specific request.
 

--- a/examples/dsh-memory-plugin/shared/uri-guard.mjs
+++ b/examples/dsh-memory-plugin/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/dsh-memory-plugin/uri-guard.mjs
+++ b/examples/dsh-memory-plugin/uri-guard.mjs
@@ -1,36 +1,45 @@
 import { MCP_SERVER_NAME } from "./config.mjs";
-import { buildGuardMessage, findVikingUri } from "./shared/uri-guard.mjs";
+import { buildGuardMessage, findVikingUriInKeys } from "./shared/uri-guard.mjs";
 
 /** Model-facing name of a bridged OpenViking MCP tool. */
 const mcp = rawName => `mcp__${MCP_SERVER_NAME}__${rawName}`;
 
+const FILE_PATH_KEYS = ["filePath", "file_path", "filepath", "path"];
+
 const GUARDED_TOOLS = {
   read: {
+    keys: FILE_PATH_KEYS,
     tool: mcp("read"),
     example: uri => `${mcp("read")}(uris="${uri}")`,
   },
   glob: {
+    keys: [...FILE_PATH_KEYS, "pattern"],
     tool: mcp("list"),
     example: uri => `${mcp("list")}(uri="${uri}")`,
   },
   grep: {
+    keys: FILE_PATH_KEYS,
     tool: mcp("grep"),
     example: (uri, args) =>
       `${mcp("grep")}(pattern="${escapeText(args?.pattern)}", uri="${uri}")`,
   },
   bash: {
+    keys: ["command"],
     tool: `${mcp("read")} or ${mcp("search")}`,
     example: uri => `${mcp("read")}(uris="${uri}")`,
   },
   edit: {
+    keys: FILE_PATH_KEYS,
     tool: mcp("edit"),
     example: uri => `${mcp("edit")}(uri="${uri}", old_string="...", new_string="...")`,
   },
   write: {
+    keys: FILE_PATH_KEYS,
     tool: mcp("write"),
     example: uri => `${mcp("write")}(uri="${uri}", content="...")`,
   },
   str_replace_editor: {
+    keys: FILE_PATH_KEYS,
     tool: "the OpenViking MCP tools",
     example: uri => `${mcp("read")}(uris="${uri}")`,
   },
@@ -39,7 +48,7 @@ const GUARDED_TOOLS = {
 export async function guardVikingUri(exec, next) {
   const hint = GUARDED_TOOLS[exec.name];
   if (!hint) return next();
-  const uri = findVikingUri(exec.arguments);
+  const uri = findVikingUriInKeys(exec.arguments, hint.keys);
   if (!uri) return next();
   return {
     kind: "deny",

--- a/examples/dsh-memory-plugin/uri-guard.test.mjs
+++ b/examples/dsh-memory-plugin/uri-guard.test.mjs
@@ -2,53 +2,146 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { guardVikingUri } from "./uri-guard.mjs";
 
-test("uri guard blocks every DSH filesystem and shell tool that accepts paths", async () => {
+const VIKING_FILE = "viking://user/default/memories/profile.md";
+
+async function evaluate(name, args, nextResult = { kind: "allow", marker: true }) {
+  let delegated = 0;
+  const exec = { name, arguments: args };
+  const argumentsSnapshot = structuredClone(args);
+  const decision = await guardVikingUri(exec, async () => {
+    delegated += 1;
+    return nextResult;
+  });
+  assert.deepEqual(exec.arguments, argumentsSnapshot, `${name} arguments`);
+  return { decision, delegated, exec };
+}
+
+test("uri guard blocks Viking URIs in DSH filesystem path fields", async () => {
+  const pathKeys = ["filePath", "file_path", "filepath", "path"];
+  const toolHints = {
+    read: "mcp__openviking__read",
+    write: "mcp__openviking__write",
+    edit: "mcp__openviking__edit",
+    glob: "mcp__openviking__list",
+    grep: "mcp__openviking__grep",
+    str_replace_editor: "OpenViking MCP tools",
+  };
+  const cases = Object.entries(toolHints).flatMap(([name, hint]) =>
+    pathKeys.map(key => [name, { [key]: VIKING_FILE }, hint]),
+  );
+  cases.push(["glob", { pattern: VIKING_FILE }, toolHints.glob]);
+
+  for (const [name, args, hint] of cases) {
+    const { decision, delegated } = await evaluate(name, args);
+    const label = `${name}.${Object.keys(args)[0]}`;
+    assert.equal(delegated, 0, label);
+    assert.equal(decision.kind, "deny", label);
+    assert.match(decision.reason, /viking:\/\/ URIs are OpenViking virtual paths/, label);
+    assert.match(decision.reason, new RegExp(hint), label);
+  }
+});
+
+test("uri guard allows Viking URIs in write and edit content fields", async () => {
   const cases = [
-    ["read", { file_path: "viking://user/default/memories/profile.md" }],
-    ["write", { file_path: "viking://user/default/memories/profile.md" }],
-    ["edit", { file_path: "viking://user/default/memories/profile.md" }],
-    ["glob", { path: "viking://user/default/memories" }],
-    ["grep", { path: "viking://user/default/memories", pattern: "profile" }],
-    ["bash", { command: "cat viking://user/default/memories/profile.md" }],
+    ["write", { file_path: "/tmp/notes.md", content: `Document ${VIKING_FILE}` }],
+    ["edit", { file_path: "/tmp/notes.md", old_string: VIKING_FILE, new_string: "local" }],
+    ["edit", { file_path: "/tmp/notes.md", old_string: "local", new_string: VIKING_FILE }],
     ["str_replace_editor", {
-      command: "view",
-      path: "viking://user/default/memories/profile.md",
+      command: "str_replace",
+      path: "/tmp/notes.md",
+      old_str: "local",
+      new_str: VIKING_FILE,
     }],
   ];
 
   for (const [name, args] of cases) {
-    let delegated = false;
-    const decision = await guardVikingUri({
-      name,
-      arguments: args,
-    }, async () => {
-      delegated = true;
-      return { kind: "allow" };
-    });
-
-    assert.equal(delegated, false, name);
-    assert.equal(decision.kind, "deny", name);
-    assert.match(decision.reason, /viking:\/\/ URIs are OpenViking virtual paths/, name);
-    assert.match(decision.reason, /mcp__openviking__/, name);
+    const { decision, delegated } = await evaluate(name, args);
+    assert.equal(delegated, 1, name);
+    assert.deepEqual(decision, { kind: "allow", marker: true }, name);
   }
 });
 
-test("uri guard delegates the bridged OpenViking tools and ordinary filesystem paths", async () => {
-  const next = async () => ({ kind: "allow", marker: true });
-  assert.deepEqual(
-    await guardVikingUri({ name: "read", arguments: { file_path: "/tmp/a" } }, next),
-    { kind: "allow", marker: true },
-  );
-  // The bridge publishes every OpenViking tool under an `mcp__openviking__`
-  // name, so the guard's bare `read` / `grep` / `write` keys never shadow them.
-  for (const name of ["read", "grep", "glob", "write", "edit"]) {
-    assert.deepEqual(
-      await guardVikingUri({
-        name: `mcp__openviking__${name}`,
-        arguments: { uri: "viking://user/default/memories/profile.md" },
-      }, next),
-      { kind: "allow", marker: true },
-      name,
-    );
+test("uri guard allows grep queries and metadata to mention Viking URIs", async () => {
+  const cases = [
+    ["grep", { path: "/tmp", pattern: VIKING_FILE }],
+    ["write", {
+      file_path: "/tmp/notes.md",
+      content: "ordinary",
+      metadata: { source: VIKING_FILE },
+    }],
+    ["read", { file_path: "/tmp/notes.md", description: VIKING_FILE }],
+  ];
+
+  for (const [name, args] of cases) {
+    const { decision, delegated } = await evaluate(name, args);
+    assert.equal(delegated, 1, name);
+    assert.deepEqual(decision, { kind: "allow", marker: true }, name);
+  }
+});
+
+test("uri guard keeps the conservative shell command check", async () => {
+  const { decision, delegated } = await evaluate("bash", {
+    command: `cat ${VIKING_FILE}`,
+    description: "local command",
+  });
+
+  assert.equal(delegated, 0);
+  assert.equal(decision.kind, "deny");
+  assert.match(decision.reason, /mcp__openviking__/);
+});
+
+test("uri guard ignores non-command bash metadata", async () => {
+  const { decision, delegated } = await evaluate("bash", {
+    command: "pwd",
+    description: VIKING_FILE,
+  });
+
+  assert.equal(delegated, 1);
+  assert.deepEqual(decision, { kind: "allow", marker: true });
+});
+
+test("uri guard handles empty arguments and nested selected path values", async () => {
+  for (const args of [null, {}, undefined]) {
+    const { decision, delegated } = await evaluate("write", args);
+    assert.equal(delegated, 1);
+    assert.deepEqual(decision, { kind: "allow", marker: true });
+  }
+
+  const { decision, delegated } = await evaluate("read", {
+    path: ["/tmp/a", { nested: VIKING_FILE }],
+  });
+  assert.equal(delegated, 0);
+  assert.equal(decision.kind, "deny");
+});
+
+test("uri guard reports the selected path URI without leaking content URIs", async () => {
+  const pathUri = "viking://resources/path-target.md";
+  const contentUri = "viking://user/private/content-only.md";
+  const { decision, delegated } = await evaluate("write", {
+    file_path: pathUri,
+    content: contentUri,
+  });
+
+  assert.equal(delegated, 0);
+  assert.equal(decision.kind, "deny");
+  assert.match(decision.reason, /viking:\/\/resources\/path-target\.md/);
+  assert.doesNotMatch(decision.reason, /content-only/);
+});
+
+test("uri guard delegates bridged OpenViking and non-guarded tools", async () => {
+  for (const name of [
+    "mcp__openviking__read",
+    "mcp__openviking__grep",
+    "mcp__openviking__glob",
+    "mcp__openviking__write",
+    "mcp__openviking__edit",
+    "custom_tool",
+  ]) {
+    const { decision, delegated } = await evaluate(name, {
+      uri: VIKING_FILE,
+      content: VIKING_FILE,
+    });
+    assert.equal(delegated, 1, name);
+    assert.deepEqual(decision, { kind: "allow", marker: true }, name);
   }
 });

--- a/examples/memory-plugin-shared/lib/uri-guard.mjs
+++ b/examples/memory-plugin-shared/lib/uri-guard.mjs
@@ -14,12 +14,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/memory-plugin-shared/uri-guard.test.mjs
+++ b/examples/memory-plugin-shared/uri-guard.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { buildGuardMessage, findVikingUri, findVikingUriInValue, normalizeToolName } from "./lib/uri-guard.mjs"
+import {
+  buildGuardMessage,
+  findVikingUri,
+  findVikingUriInKeys,
+  findVikingUriInValue,
+  normalizeToolName,
+} from "./lib/uri-guard.mjs"
 
 test("findVikingUri detects common path and URI argument keys", () => {
   assert.equal(findVikingUri({ filePath: "viking://resources/a.md" }), "viking://resources/a.md")
@@ -16,6 +22,33 @@ test("findVikingUri detects nested command strings", () => {
   )
   assert.equal(
     findVikingUriInValue(["grep", "needle", "viking://resources/project/"]),
+    "viking://resources/project/",
+  )
+  assert.equal(
+    findVikingUri("viking://resources/direct-value.md"),
+    "viking://resources/direct-value.md",
+  )
+})
+
+test("findVikingUriInKeys scans only explicitly selected argument fields", () => {
+  const args = {
+    file_path: "/tmp/notes.md",
+    content: "Read viking://resources/docs/ later",
+    metadata: { source: "viking://resources/metadata/" },
+  }
+
+  assert.equal(findVikingUriInKeys(args, ["file_path"]), null)
+  assert.equal(findVikingUriInKeys(args, ["content"]), "viking://resources/docs/")
+  assert.equal(findVikingUriInKeys(null, ["file_path"]), null)
+  assert.equal(findVikingUriInKeys("viking://resources/a.md", ["file_path"]), null)
+})
+
+test("findVikingUriInKeys preserves recursive scanning inside a selected field", () => {
+  assert.equal(
+    findVikingUriInKeys(
+      { path: ["/tmp/a", { nested: "viking://resources/project/" }] },
+      ["path"],
+    ),
     "viking://resources/project/",
   )
 })

--- a/examples/opencode-plugin/lib/shared/uri-guard.mjs
+++ b/examples/opencode-plugin/lib/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/pi-coding-agent-extension/shared/uri-guard.mjs
+++ b/examples/pi-coding-agent-extension/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {

--- a/examples/zcode-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/uri-guard.mjs
@@ -15,12 +15,18 @@ export function normalizeToolName(value) {
 }
 
 export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+  const uri = findVikingUriInKeys(args, keys);
+  if (uri) return uri;
+  return findVikingUriInValue(args);
+}
+
+export function findVikingUriInKeys(args = {}, keys = []) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return null;
 }
 
 export function findVikingUriInValue(value) {


### PR DESCRIPTION
## Description

This PR fixes false denials in the DSH memory plugin URI guard. Filesystem tools now inspect only
arguments with path semantics, so local file content, replacement text, grep query patterns, and
descriptive metadata may mention `viking://` URIs without being treated as local paths.

Real Viking URI path arguments remain blocked, and `bash.command` retains its conservative
whole-command check.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

The contributor selected the issue, requested the requirement, implementation plan, and acceptance
documents, selected the branch, directed implementation, and reviewed the PR workflow.

## Related Issue

Fixes #4188

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added `findVikingUriInKeys()` for exact selected-field scanning while preserving the existing
  `findVikingUri()` behavior for other integrations.
- Added an explicit per-tool argument policy to the DSH guard for read, write, edit, glob, grep,
  str-replace editor, and bash tools.
- Excluded file content, replacement text, `grep.pattern`, and unknown metadata from filesystem-path
  checks while retaining path aliases and recursive selected-value scanning.
- Preserved conservative checking of `bash.command` and existing OpenViking replacement guidance.
- Added deterministic regression coverage for allow/deny behavior, path aliases, nested values,
  `next()` call counts, unchanged arguments, and deny-message privacy.
- Updated the DSH README and synchronized all generated shared URI guard copies.

## Backward Compatibility

- Existing `findVikingUri()` callers retain their whole-arguments fallback behavior.
- Only the DSH adapter uses the new exact-key helper, so other plugin guards keep their current
  runtime behavior.
- OpenViking MCP tools and tools outside the DSH guarded-tool allowlist continue directly to
  `next()`.
- No runtime dependency, package lock, hook registration, authentication, or server API changes are
  introduced.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands and results:

```text
Real DSH 0.1.1-rc.2 URI-guard E2E:           passed
Focused URI guard and synchronization tests:  16 passed
Shared URI guard consumer regression tests:    14 passed
Unaffected DSH tests excluding live/baseline:  41 passed
DSH full suite:                                44 passed, 1 skipped, 1 failed
Modified/generated MJS syntax checks:          passed
Shared synchronization idempotence check:      passed
Plugin version consistency check:              passed
git diff --check:                              passed
```

The focused tests cover issue #4188's write/edit reproductions, grep query literals, unknown
metadata, every supported filesystem path alias, glob path expressions, nested selected values,
shell commands, OpenViking tools, delegation counts, argument immutability, and deny-message privacy.

The URI-guard E2E installed official `@deepseek-ai/dsh@0.1.1-rc.2`, initialized an isolated
`headless` profile, linked the current source checkout with `dsh plugin`, confirmed that the
composed profile contained `@openviking/dsh-memory-plugin`, and used actual model-driven DSH tool
calls to verify:

- `write` accepts a local path whose content contains a Viking URI and creates the expected file.
- `edit` accepts Viking URIs in `old_string` and `new_string` and performs the local replacement.
- `str_replace_editor` accepts a Viking URI in its real `new_str` argument and performs the local
  replacement.
- `grep` accepts a Viking URI as its query `pattern` under a local path and returns the expected
  match.
- `read` rejects a Viking URI in `file_path` before filesystem access and returns the OpenViking MCP
  guidance.

This E2E exercises the real DSH `tools/pre-execute` lifecycle and real local filesystem tools.