### PR TITLE
fix(storage): clean orphan child vectors when rm() target path is gone (#3064)

### DIFF
--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -163,13 +163,24 @@ class _OpsMixin:
                 if mapped is not None:
                     raise mapped from exc
                 raise
-            # Path does not exist: clean up any orphan index records and return
-            uris_to_delete = await self._collect_uris(path, recursive, ctx=ctx)
-            uris_to_delete.append(target_uri)
+            # Path does not exist: clean up any orphan index records and return.
+            # The AGFS listing is gone, so discover descendant URIs from the
+            # vector index itself; otherwise exact-match deletion removes only
+            # the target URI record and leaves every child record behind as an
+            # orphan (#3064).
             real_ctx = self._ctx_or_default(ctx)
+            if recursive:
+                uris_to_delete = await self._collect_orphan_uris(target_uri, ctx=real_ctx)
+            else:
+                uris_to_delete = []
+            if target_uri not in uris_to_delete:
+                uris_to_delete.append(target_uri)
             estimated_count = await _estimate_deleted_count(path, real_ctx)
             await self._delete_from_vector_store(uris_to_delete, ctx=ctx)
-            logger.info(f"[VikingFS] rm target not found, cleaned orphan index: {uri}")
+            logger.info(
+                f"[VikingFS] rm target not found, cleaned orphan index: {uri} "
+                f"({len(uris_to_delete)} URIs)"
+            )
             return {"estimated_deleted_count": estimated_count}
 
         if is_dir:
@@ -844,6 +855,42 @@ class _OpsMixin:
                     uris.append(self._path_to_uri(full_path, ctx=ctx))
 
         await _collect(path)
+        return uris
+
+    async def _collect_orphan_uris(
+        self, uri: str, ctx: Optional[RequestContext] = None
+    ) -> List[str]:
+        """Collect a URI and all its descendants from the vector index.
+
+        Used by ``rm()`` when the backing AGFS path no longer exists: the
+        filesystem listing is unavailable, so the index is the only source
+        of truth for which child records still need cleanup.
+        """
+        vector_store = self._get_vector_store()
+        if not vector_store:
+            return []
+
+        real_ctx = self._ctx_or_default(ctx)
+        try:
+            records = await vector_store.filter(
+                filter=PathScope("uri", uri, depth=-1),
+                limit=100000,
+                offset=0,
+                output_fields=["uri"],
+                ctx=real_ctx,
+            )
+        except Exception as e:
+            logger.warning(f"[VikingFS] Failed to collect orphan URIs under {uri}: {e}")
+            return []
+
+        uris: List[str] = []
+        seen: set = set()
+        for record in records:
+            child_uri = record.get("uri") if isinstance(record, dict) else None
+            if not isinstance(child_uri, str) or not child_uri or child_uri in seen:
+                continue
+            seen.add(child_uri)
+            uris.append(child_uri)
         return uris
 
     # ========== Parent Directory Creation ==========

--- a/tests/misc/test_vikingfs_rm_orphan_cleanup.py
+++ b/tests/misc/test_vikingfs_rm_orphan_cleanup.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for orphan index cleanup in VikingFS.rm() (#3064).
+
+When ``rm()`` targets a URI whose backing AGFS path no longer exists, the
+filesystem listing is unavailable. The cleanup must therefore discover
+descendant URIs from the vector index itself instead of relying on
+``_collect_uris`` (which silently returns nothing for a missing path) plus
+exact-match deletion, which left every child record behind as an orphan.
+"""
+
+import contextvars
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.storage.expr import PathScope
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _make_viking_fs(vector_store=None) -> VikingFS:
+    """Create a VikingFS instance with a mocked AGFS backend."""
+    fs = VikingFS.__new__(VikingFS)
+    fs.agfs = AsyncMock()
+    fs._async_agfs = fs.agfs
+    fs.query_embedder = None
+    fs.rerank_config = None
+    fs.grep_config = None
+    fs.vector_store = vector_store
+    fs._encryptor = None
+    fs._bound_ctx = contextvars.ContextVar("vikingfs_bound_ctx_test", default=None)
+    return fs
+
+
+def _user_ctx(
+    account_id: str = "acct1",
+    user_id: str = "alice",
+    role: Role = Role.USER,
+) -> RequestContext:
+    return RequestContext(
+        user=UserIdentifier(account_id=account_id, user_id=user_id),
+        role=role,
+    )
+
+
+class TestRmOrphanIndexCleanup:
+    """rm() on a non-existent path must clean child records from the index."""
+
+    @pytest.mark.asyncio
+    async def test_recursive_rm_cleans_orphan_children_from_index(self) -> None:
+        target_uri = "viking://resources/docs"
+        orphan_uris = [
+            "viking://resources/docs/a.md",
+            "viking://resources/docs/",
+            "viking://resources/docs/sub/.abstract.md",
+        ]
+        vector_store = MagicMock()
+        vector_store.filter = AsyncMock(return_value=[{"uri": uri} for uri in orphan_uris])
+        vector_store.count = AsyncMock(return_value=4)
+        fs = _make_viking_fs(vector_store)
+        fs.agfs.stat = AsyncMock(side_effect=FileNotFoundError(f"not found: {target_uri}"))
+        fs._delete_from_vector_store = AsyncMock()
+
+        result = await fs.rm(f"{target_uri}/", recursive=True, ctx=_user_ctx())
+
+        # Descendants are discovered from the index via a full-depth scope.
+        vector_store.filter.assert_awaited_once()
+        kwargs = vector_store.filter.await_args.kwargs
+        scope = kwargs["filter"]
+        assert isinstance(scope, PathScope)
+        assert scope.path == target_uri
+        assert scope.depth == -1
+
+        # Every discovered orphan plus the target itself gets deleted.
+        deleted_uris = fs._delete_from_vector_store.await_args.args[0]
+        assert sorted(deleted_uris) == sorted(orphan_uris + [target_uri])
+        assert deleted_uris.count(target_uri) == 1
+        assert result["estimated_deleted_count"] == 4
+        fs.agfs.rm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_recursive_rm_deletes_target_only(self) -> None:
+        target_uri = "viking://resources/docs/notes.md"
+        vector_store = MagicMock()
+        vector_store.filter = AsyncMock()
+        vector_store.count = AsyncMock(return_value=1)
+        fs = _make_viking_fs(vector_store)
+        fs.agfs.stat = AsyncMock(side_effect=FileNotFoundError("gone"))
+        fs._delete_from_vector_store = AsyncMock()
+
+        result = await fs.rm(target_uri, recursive=False, ctx=_user_ctx())
+
+        vector_store.filter.assert_not_awaited()
+        deleted_uris = fs._delete_from_vector_store.await_args.args[0]
+        assert deleted_uris == [target_uri]
+        assert result["estimated_deleted_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_recursive_rm_dedupes_and_skips_records_without_uri(self) -> None:
+        target_uri = "viking://user/alice/memories/topics"
+        vector_store = MagicMock()
+        vector_store.filter = AsyncMock(
+            return_value=[
+                {"uri": "viking://user/alice/memories/topics/t1"},
+                {"uri": "viking://user/alice/memories/topics/t1"},
+                {"level": 2},
+                {"uri": ""},
+                {"uri": target_uri},
+            ]
+        )
+        vector_store.count = AsyncMock(return_value=3)
+        fs = _make_viking_fs(vector_store)
+        fs.agfs.stat = AsyncMock(side_effect=FileNotFoundError("gone"))
+        fs._delete_from_vector_store = AsyncMock()
+
+        result = await fs.rm(target_uri, recursive=True, ctx=_user_ctx())
+
+        deleted_uris = fs._delete_from_vector_store.await_args.args[0]
+        assert deleted_uris == [
+            "viking://user/alice/memories/topics/t1",
+            target_uri,
+        ]
+        assert result["estimated_deleted_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_orphan_cleanup_without_vector_store_still_succeeds(self) -> None:
+        target_uri = "viking://resources/docs"
+        fs = _make_viking_fs(vector_store=None)
+        fs.agfs.stat = AsyncMock(side_effect=FileNotFoundError("gone"))
+        fs._delete_from_vector_store = AsyncMock()
+
+        result = await fs.rm(target_uri, recursive=True, ctx=_user_ctx())
+
+        deleted_uris = fs._delete_from_vector_store.await_args.args[0]
+        assert deleted_uris == [target_uri]
+        assert result["estimated_deleted_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_index_discovery_failure_falls_back_to_target_only(self) -> None:
+        target_uri = "viking://resources/docs"
+        vector_store = MagicMock()
+        vector_store.filter = AsyncMock(side_effect=RuntimeError("backend down"))
+        vector_store.count = AsyncMock(return_value=9)
+        fs = _make_viking_fs(vector_store)
+        fs.agfs.stat = AsyncMock(side_effect=FileNotFoundError("gone"))
+        fs._delete_from_vector_store = AsyncMock()
+
+        result = await fs.rm(target_uri, recursive=True, ctx=_user_ctx())
+
+        deleted_uris = fs._delete_from_vector_store.await_args.args[0]
+        assert deleted_uris == [target_uri]
+        assert result["estimated_deleted_count"] == 9


### PR DESCRIPTION
## Summary

When `VikingFS.rm()` is called on a URI whose backing AGFS path no longer exists (e.g. files were deleted directly on the filesystem and then `ov rm --recursive` is run on the missing parent), the orphan-cleanup branch failed to remove any child vector records:

- `_collect_uris()` silently returns `[]` when the path doesn't exist, so only the target URI was passed on.
- `delete_uris()` matches **exact** URIs only (`Eq("uri", ...) or In("uri", [f"{uri}/"])`), so child records like `viking://resources/foo/child.md` were never deleted.

Consequences: stale search hits pointing at deleted files, wasted vector storage (~9% of records in the reporter's case), and a misleading `estimated_deleted_count`.

This PR fixes the root cause on the delete path: when the target path is gone and `recursive=True`, the descendant URIs are now discovered **from the vector index itself** via `PathScope("uri", target_uri, depth=-1)` — the same mechanism already used by `_estimate_deleted_count()` in the very same code path — and all discovered records plus the target are deleted through the existing tenant-safe `_delete_from_vector_store()`.

Behavior notes:
- Non-recursive `rm()` on a missing path keeps its previous target-only semantics.
- If index discovery fails, cleanup falls back to the previous target-only behavior instead of breaking `rm()`'s idempotent-delete contract (a warning is logged).
- The normal (path-exists) rm flow is untouched.

## Type of Change

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Other

## Testing

New regression suite in `tests/misc/test_vikingfs_rm_orphan_cleanup.py` (mocked AGFS + vector store, same style as `tests/misc/test_vikingfs_uri_guard.py`):

- recursive `rm()` on a non-existent directory deletes every discovered orphan child URI + the target, requests them via `PathScope(depth=-1)`, and reports the accurate `estimated_deleted_count`
- non-recursive `rm()` on a non-existent path still deletes only the target
- duplicate/blank/URI-less index records are deduped/skipped; the target appears exactly once
- no vector store configured → idempotent success with target-only cleanup
- index-discovery failure → graceful fallback to target-only cleanup

Local results:

```
tests/misc/test_vikingfs_rm_orphan_cleanup.py  5 passed
tests/misc/                                    398 passed (18 pre-existing env failures identical on upstream/main)
tests/storage/                                 396 passed / 16 pre-existing failures identical on upstream/main
ruff check / ruff format                       clean on changed lines (pinned ruff 0.15.5)
```

The 18+16 unrelated failures reproduce identically on a pristine `upstream/main` checkout on this Windows machine (native RAGFS binding not built), so they are environmental, not introduced by this change.

## Related Issues

- Fixes #3064

## Checklist

- [x] Code follows project style guidelines (Conventional Commit title, line width, double quotes)
- [x] Tests added for new functionality
- [ ] Documentation updated (not needed — behavior now matches the documented idempotent-rm contract)
- [x] All tests pass (no regressions vs. upstream/main baseline)
