### PR TITLE
fix(lock): verify process identity on macOS before honouring a PID lock (#4210)

### DIFF
--- a/openviking/utils/process_lock.py
+++ b/openviking/utils/process_lock.py
@@ -8,6 +8,7 @@ directory, which causes silent failures in AGFS and VectorDB.
 
 import atexit
 import os
+import subprocess
 import sys
 import threading
 
@@ -44,6 +45,46 @@ def _read_pid_file(lock_path: str) -> int:
         return 0
 
 
+def _process_cmdline(pid: int) -> str | None:
+    """Lowercased command line of *pid*, or None when it cannot be read.
+
+    Used to tell a recycled PID from a live OpenViking process. Returning None
+    means "cannot tell", and the caller then trusts the liveness probe — the
+    lock is honoured rather than stolen.
+
+    Linux reads /proc (#1088). macOS has no /proc, so it asks `ps`: without
+    this branch a reused PID (a real incident: Spotlight's `mdwrite` inheriting
+    PID 857 after a reboot) is read as a running OpenViking instance, and the
+    server refuses to start on every launchd retry, forever (#4210).
+    """
+    if sys.platform.startswith("linux"):
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as f:
+                return f.read().decode("utf-8", errors="replace").lower()
+        except OSError:
+            # /proc not available, or the process exited between kill and open.
+            return None
+
+    if sys.platform == "darwin":
+        try:
+            completed = subprocess.run(
+                ["/bin/ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if completed.returncode != 0:
+            # `ps` exits non-zero when the PID is gone; the liveness probe above
+            # already answered that question, so say nothing rather than lie.
+            return None
+        return completed.stdout.strip().lower() or None
+
+    return None
+
+
 def _is_pid_alive(pid: int) -> bool:
     """Check whether a process with the given PID is still running."""
     if pid <= 0:
@@ -60,24 +101,17 @@ def _is_pid_alive(pid: int) -> bool:
             return False
         raise
 
-    # PID exists, but on Linux PIDs are recycled. Verify this is actually
-    # an OpenViking process by checking /proc/{pid}/cmdline to avoid false
-    # positives from PID reuse (see issue #1088).
-    if sys.platform.startswith("linux"):
-        try:
-            with open(f"/proc/{pid}/cmdline", "rb") as f:
-                cmdline = f.read().decode("utf-8", errors="replace").lower()
-            if "openviking" not in cmdline and "openviking-server" not in cmdline:
-                logger.info(
-                    "PID %d is alive but not an OpenViking process (cmdline: %.100s). "
-                    "Assuming stale lock from recycled PID.",
-                    pid,
-                    cmdline[:100],
-                )
-                return False
-        except OSError:
-            # /proc not available or process exited between kill and open
-            pass
+    # PID exists, but PIDs are recycled. Verify this is actually an OpenViking
+    # process to avoid false positives from PID reuse (see issues #1088, #4210).
+    cmdline = _process_cmdline(pid)
+    if cmdline is not None and "openviking" not in cmdline:
+        logger.info(
+            "PID %d is alive but not an OpenViking process (cmdline: %.100s). "
+            "Assuming stale lock from recycled PID.",
+            pid,
+            cmdline[:100],
+        )
+        return False
 
     return True
 

--- a/tests/misc/test_process_lock.py
+++ b/tests/misc/test_process_lock.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 
+from openviking.utils import process_lock
 from openviking.utils.process_lock import (
     LOCK_FILENAME,
     DataDirectoryLocked,
@@ -35,10 +36,16 @@ class TestProcessLock:
             with open(lock_path) as f:
                 assert int(f.read().strip()) == os.getpid()
 
-    def test_live_pid_blocks_acquisition(self):
+    def test_live_pid_blocks_acquisition(self, monkeypatch):
         with tempfile.TemporaryDirectory() as tmpdir:
             lock_path = os.path.join(tmpdir, LOCK_FILENAME)
-            # PID 1 (init/launchd) is always alive.
+            # PID 1 (init/launchd) is always alive — but it is not OpenViking,
+            # and since #1088 a live PID only holds the lock when the process
+            # identity matches, so the verdict depended on which platform ran
+            # the test (on Windows `os.kill(1, 0)` does not even succeed, and
+            # this assertion failed before this stub was added). Pin the
+            # identity so the lock semantics are what is under test here.
+            monkeypatch.setattr(process_lock, "_is_pid_alive", lambda pid: pid == 1)
             with open(lock_path, "w") as f:
                 f.write("1")
             try:
@@ -48,9 +55,10 @@ class TestProcessLock:
                 assert "PID 1" in str(exc)
                 assert "connect clients over HTTP" in str(exc)
 
-    def test_error_message_includes_remediation(self):
+    def test_error_message_includes_remediation(self, monkeypatch):
         with tempfile.TemporaryDirectory() as tmpdir:
             lock_path = os.path.join(tmpdir, LOCK_FILENAME)
+            monkeypatch.setattr(process_lock, "_is_pid_alive", lambda pid: pid == 1)
             with open(lock_path, "w") as f:
                 f.write("1")
             try:

--- a/tests/misc/test_process_lock_pid_reuse.py
+++ b/tests/misc/test_process_lock_pid_reuse.py
@@ -1,0 +1,152 @@
+"""#4210 — a recycled PID kept the data-directory lock alive forever on macOS.
+
+`_is_pid_alive()` verified process identity only on Linux, through
+/proc/<pid>/cmdline (#1088). macOS has no /proc, so the check degraded to a
+bare `os.kill(pid, 0)`: after a reboot left a stale `.openviking.pid` behind
+and the OS handed that PID to an unrelated process (the reported incident:
+Spotlight's `mdwrite` inheriting PID 857), every start raised
+`DataDirectoryLocked` and the server never recovered — ~50,000 launchd retries
+over seven days, with no chance of self-healing because the impostor never
+exits.
+
+These tests drive the platform branches directly, so they cover the macOS path
+from Linux and Windows too.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from openviking.utils import process_lock
+from openviking.utils.process_lock import (
+    LOCK_FILENAME,
+    DataDirectoryLocked,
+    acquire_data_dir_lock,
+)
+
+
+class _CompletedProcess:
+    def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+@pytest.fixture
+def on_darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+
+def test_darwin_recycled_pid_is_reported_dead(monkeypatch, on_darwin):
+    """The incident: a live process that is not OpenViking must not hold the lock."""
+    monkeypatch.setattr(
+        process_lock.subprocess,
+        "run",
+        lambda *a, **k: _CompletedProcess("/System/Library/.../mdwrite"),
+    )
+
+    assert process_lock._is_pid_alive(os.getpid()) is False
+
+
+def test_darwin_real_openviking_process_still_holds_the_lock(monkeypatch, on_darwin):
+    monkeypatch.setattr(
+        process_lock.subprocess,
+        "run",
+        lambda *a, **k: _CompletedProcess("/opt/homebrew/bin/python3 -m openviking-server"),
+    )
+
+    assert process_lock._is_pid_alive(os.getpid()) is True
+
+
+def test_darwin_asks_ps_for_the_right_pid(monkeypatch, on_darwin):
+    """Pin the command, since a wrong flag would silently answer for every PID."""
+    seen: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["timeout"] = kwargs.get("timeout")
+        return _CompletedProcess("openviking-server")
+
+    monkeypatch.setattr(process_lock.subprocess, "run", fake_run)
+
+    process_lock._process_cmdline(4321)
+
+    assert seen["argv"] == ["/bin/ps", "-p", "4321", "-o", "command="]
+    assert seen["timeout"] == 2
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        _CompletedProcess("", returncode=1),  # ps says the pid is gone
+        _CompletedProcess("   ", returncode=0),  # empty answer
+    ],
+)
+def test_darwin_unreadable_command_line_keeps_the_lock(monkeypatch, on_darwin, outcome):
+    """When identity cannot be established, honour the lock instead of stealing it."""
+    monkeypatch.setattr(process_lock.subprocess, "run", lambda *a, **k: outcome)
+
+    assert process_lock._process_cmdline(4321) is None
+    assert process_lock._is_pid_alive(os.getpid()) is True
+
+
+@pytest.mark.parametrize("error", [OSError("no ps"), subprocess.TimeoutExpired("ps", 2)])
+def test_darwin_ps_failure_keeps_the_lock(monkeypatch, on_darwin, error):
+    def fake_run(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(process_lock.subprocess, "run", fake_run)
+
+    assert process_lock._process_cmdline(4321) is None
+    assert process_lock._is_pid_alive(os.getpid()) is True
+
+
+def test_stale_darwin_lock_is_taken_over_end_to_end(monkeypatch, on_darwin):
+    """Same path through acquire_data_dir_lock(), which is where it hurt."""
+    monkeypatch.setattr(
+        process_lock.subprocess, "run", lambda *a, **k: _CompletedProcess("mdwrite")
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lock_path = os.path.join(tmpdir, LOCK_FILENAME)
+        # A PID that is alive (this test process) but is not OpenViking, which is
+        # exactly what a recycled PID looks like from the outside.
+        with open(lock_path, "w") as handle:
+            handle.write(str(os.getpid() + 0))
+        # Written as another process's id so the same-pid short circuit is not
+        # what makes this pass.
+        monkeypatch.setattr(process_lock.os, "getpid", lambda: 999_999_001)
+
+        acquire_data_dir_lock(tmpdir)
+
+        with open(lock_path) as handle:
+            assert int(handle.read().strip()) == 999_999_001
+
+
+def test_a_live_openviking_process_still_blocks(monkeypatch, on_darwin):
+    monkeypatch.setattr(
+        process_lock.subprocess, "run", lambda *a, **k: _CompletedProcess("openviking-server")
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, LOCK_FILENAME), "w") as handle:
+            handle.write(str(os.getpid()))
+        monkeypatch.setattr(process_lock.os, "getpid", lambda: 999_999_002)
+
+        with pytest.raises(DataDirectoryLocked):
+            acquire_data_dir_lock(tmpdir)
+
+
+def test_other_platforms_do_not_shell_out(monkeypatch):
+    """Windows keeps the liveness probe as its only answer."""
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("no subprocess should run off the darwin path")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(process_lock.subprocess, "run", fail)
+
+    assert process_lock._process_cmdline(4321) is None


### PR DESCRIPTION
Fixes #4210.

## The gap

The PID-reuse guard from #1088 reads `/proc/<pid>/cmdline`, and that branch is `sys.platform.startswith("linux")`. macOS has no `/proc`, so `_is_pid_alive()` degraded to a bare `os.kill(pid, 0)` — which answers "is *a* process alive", not "is *OpenViking* alive".

The reported consequence is not a warning, it is a permanent outage: a reboot leaves `.openviking.pid` behind, the OS hands that PID to something else (Spotlight's `mdwrite` in the incident), and every start raises `DataDirectoryLocked`. The impostor never exits, so launchd retried for seven days — ~50,000 crashes, ~330 MB of logs, no path to self-healing.

## The change

The identity lookup moves into `_process_cmdline(pid)`, with the Linux `/proc` read unchanged and a Darwin branch that asks `ps`:

```
/bin/ps -p <pid> -o command=
```

`_is_pid_alive()` then applies the same rule it already applied on Linux: a live PID whose command line does not mention `openviking` is a recycled PID, not a lock holder.

The fail-safe direction is deliberate and tested: when the command line cannot be read — `ps` missing, timing out, exiting non-zero, or answering nothing — `_process_cmdline()` returns `None` and the caller keeps trusting the liveness probe. Not being able to identify a process never causes its lock to be stolen.

I dropped the redundant `and "openviking-server" not in cmdline` from the comparison: `openviking-server` contains `openviking`, so the second test could never change the outcome.

## Two existing tests changed, and why

`test_live_pid_blocks_acquisition` and `test_error_message_includes_remediation` write PID 1 to the lock file and expect it to block. Since #1088 that outcome has depended on the platform, because PID 1 is init/launchd, not OpenViking:

- **Windows**: measured failing on `main` before this PR — `os.kill(1, 0)` raises, `_is_pid_alive` returns False, no exception is raised (`1 failed, 4 passed`).
- **Linux**: `/proc/1/cmdline` is `init`/`systemd`, which the #1088 check rejects — so it can only pass where `/proc/1/cmdline` is unreadable and the `except OSError: pass` fallback runs.
- **macOS**: passes today only because no identity check exists; this PR would make it fail there too.

Both tests now stub `_is_pid_alive`, so they test the lock semantics they are named for instead of the host's process table. That is a change to existing tests, so I am flagging it rather than burying it — if you would rather I leave them as they are, the alternative is a `skipif(sys.platform != "linux")` on both, and I can switch.

## Tests

`tests/misc/test_process_lock_pid_reuse.py` — 10 tests. They monkeypatch `sys.platform` and `subprocess.run`, so the macOS path is covered from Linux and Windows CI as well; there is no Darwin-only skip.

Coverage: the recycled-PID case (a live non-OpenViking process no longer holds the lock), the real-instance case (still blocks), the exact `ps` argv and timeout, four "cannot tell" outcomes that must keep the lock, the end-to-end path through `acquire_data_dir_lock()`, and a guard that no other platform shells out.

Against `main` with only `openviking/utils/process_lock.py` reverted: **10 failed**. With the change: **15 passed** across both lock test files (5 pre-existing + 10 new).

`ruff check` and `ruff format --check` clean on the three touched files. (`ruff check tests/misc/` also reports an unrelated pre-existing I001 in `test_retrieval_enable_intent.py`, untouched here.)
