### PR TITLE
fix(embedding): name the missing package instead of calling None (#4200)

### DIFF
--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -736,8 +736,21 @@ class EmbeddingConfig(BaseModel):
             VoyageDenseEmbedder,
         )
 
-        if provider == "litellm" and LiteLLMDenseEmbedder is None:
-            raise ValueError("LiteLLM is not installed. Install it with: pip install litellm")
+        # Providers whose dependency is optional export None from
+        # `openviking.models.embedder` when the package is missing. Calling that
+        # None is where doctor's "invalid embedding config: 'NoneType' object is
+        # not callable" came from — an error that named neither the provider nor
+        # the missing package (#4200). Answer with the install command instead.
+        optional_providers = {
+            "litellm": (LiteLLMDenseEmbedder, "LiteLLM", "litellm"),
+            "gemini": (GeminiDenseEmbedder, "google-genai", "openviking[gemini]"),
+        }
+        optional = optional_providers.get(provider)
+        if optional is not None and optional[0] is None:
+            _embedder_class, dependency, install_target = optional
+            raise ValueError(
+                f"{dependency} is not installed. Install it with: pip install {install_target}"
+            )
 
         # Factory registry: (provider, type) -> (embedder_class, param_builder)
         runtime_config = {

--- a/tests/misc/test_embedding_optional_provider_deps.py
+++ b/tests/misc/test_embedding_optional_provider_deps.py
@@ -1,0 +1,84 @@
+"""#4200 — a missing optional dependency surfaced as "'NoneType' object is not callable".
+
+`openviking.models.embedder` exports `GeminiDenseEmbedder = None` when
+`google-genai` is not installed. `_create_embedder()` looked the class up in
+its factory registry and called it, so on a machine without the package the
+doctor printed
+
+    Embedding: FAIL  gemini/gemini-embedding-2-preview dimension=3072
+              (invalid embedding config: 'NoneType' object is not callable)
+              Fix: Fix embedding.dense provider/model/api_base/dimension in ov.conf
+
+— an error that names neither the provider nor the missing package, and a
+remediation line pointing at a config that is in fact correct.
+
+`litellm` already had the guard this adds for `gemini`.
+"""
+
+import pytest
+
+from openviking_cli.utils.config.embedding_config import EmbeddingConfig, EmbeddingModelConfig
+
+GEMINI_DENSE = EmbeddingModelConfig(
+    provider="gemini",
+    model="gemini-embedding-2-preview",
+    api_key="not-a-real-key",
+    dimension=3072,
+)
+
+
+def _uninstall(monkeypatch, name: str) -> None:
+    """Make one optional embedder look absent, the way its ImportError does."""
+    import openviking.models.embedder as embedder_pkg
+
+    monkeypatch.setattr(embedder_pkg, name, None)
+
+
+def test_missing_google_genai_names_the_package(monkeypatch):
+    _uninstall(monkeypatch, "GeminiDenseEmbedder")
+
+    with pytest.raises(ValueError) as excinfo:
+        EmbeddingConfig(dense=GEMINI_DENSE).get_embedder()
+
+    message = str(excinfo.value)
+    assert "google-genai" in message
+    assert "pip install openviking[gemini]" in message
+    assert "NoneType" not in message
+
+
+def test_missing_litellm_message_is_unchanged(monkeypatch):
+    _uninstall(monkeypatch, "LiteLLMDenseEmbedder")
+
+    with pytest.raises(ValueError) as excinfo:
+        EmbeddingConfig(
+            dense=EmbeddingModelConfig(
+                provider="litellm", model="whatever", api_key="k", dimension=768
+            )
+        ).get_embedder()
+
+    assert str(excinfo.value) == "LiteLLM is not installed. Install it with: pip install litellm"
+
+
+def test_installed_provider_is_not_diverted(monkeypatch):
+    """The guard must fire on absence only, never on a provider that is present."""
+    import openviking.models.embedder as embedder_pkg
+
+    if embedder_pkg.GeminiDenseEmbedder is None:
+        pytest.skip("google-genai is not installed in this environment")
+
+    embedder = EmbeddingConfig(dense=GEMINI_DENSE).get_embedder()
+
+    assert type(embedder).__name__ == "GeminiDenseEmbedder"
+
+
+def test_a_provider_without_an_optional_dependency_is_untouched():
+    embedder = EmbeddingConfig(
+        dense=EmbeddingModelConfig(
+            provider="openai",
+            model="text-embedding-3-small",
+            api_key="not-a-real-key",
+            dimension=1536,
+        )
+    ).get_embedder()
+
+    assert type(embedder).__name__ == "OpenAIDenseEmbedder"


### PR DESCRIPTION
Fixes #4200.

## Root cause

The reporter's `ov.conf` is fine. `openviking/models/embedder/__init__.py` degrades an optional embedder to `None`:

```python
try:
    from openviking.models.embedder.gemini_embedders import GeminiDenseEmbedder
except ImportError:
    GeminiDenseEmbedder = None  # google-genai not installed
```

`_create_embedder()` looks the class up in its factory registry and calls it, so on a machine without `google-genai` that call is `None(**params)`:

```
TypeError: 'NoneType' object is not callable
```

which `doctor` catches and renders as

```
Embedding: FAIL  gemini/gemini-embedding-2-preview dimension=3072
                 (invalid embedding config: 'NoneType' object is not callable)
                 Fix: Fix embedding.dense provider/model/api_base/dimension in ov.conf
```

The message names neither the provider nor the missing package, and the remediation line sends the user to edit a config that is already correct — which matches the report exactly (Windows, no WSL, so `google-genai` was never pulled in).

`litellm` is the same shape and already had a guard two lines above; `gemini` never got one. Those are the only two `None`-on-ImportError exports in that module today.

## The change

Both providers now go through one table, so the next optional embedder cannot regress the same way:

```python
optional_providers = {
    "litellm": (LiteLLMDenseEmbedder, "LiteLLM", "litellm"),
    "gemini": (GeminiDenseEmbedder, "google-genai", "openviking[gemini]"),
}
```

The litellm message is byte-identical to what it was. The gemini one points at the extra that already exists in `pyproject.toml` (`gemini = ["google-genai>=1.0.0"]`) rather than at the bare package, so the install matches how the project declares it.

## Tests

`tests/misc/test_embedding_optional_provider_deps.py` — 4 tests, driven through the real `EmbeddingConfig.get_embedder()` with the optional export monkeypatched to `None`, so they reproduce the missing-package state on a machine that has the package.

Against `main` with only `embedding_config.py` reverted:

```
E   TypeError: 'NoneType' object is not callable
FAILED test_missing_google_genai_names_the_package
1 failed, 2 passed, 1 skipped
```

That is the reported failure, reproduced in a unit test. With the change: **3 passed, 1 skipped**.

The skip is `test_installed_provider_is_not_diverted`, which asserts the guard never fires on a provider that *is* installed — it skips here because this environment has no `google-genai`, i.e. the same environment as the report. It will run on any machine or CI job that installs the `gemini` extra.

`ruff check` and `ruff format --check` clean on both files.
