### PR TITLE
fix(dsh): prevent duplicate profile injection after re-seed

### DIFF
--- a/examples/dsh-memory-plugin/runtime.mjs
+++ b/examples/dsh-memory-plugin/runtime.mjs
@@ -109,6 +109,10 @@ export class OpenVikingRuntime {
   async profileMessage(agent) {
     const state = await this.initialize(agent);
     if (!state.ready || !state.profileBlock || state.profileDelivered) return null;
+    if (hasStartupProfile(agent)) {
+      state.profileDelivered = true;
+      return null;
+    }
     state.profileDelivered = true;
     return pluginMessage(state.profileBlock, "instructions");
   }
@@ -313,4 +317,22 @@ function pluginMessage(content, form) {
       form,
     },
   });
+}
+
+function hasStartupProfile(agent) {
+  const session = agent.session;
+  const ownEvents = (session?.events || []).slice(session?.header?.seedLength ?? 0);
+  const inHistory = ownEvents.some(event => (
+    event?.type === "user/message" && isStartupProfile(event.data)
+  ));
+  if (inHistory) return true;
+  return [agent.inbox?.nextTurn, agent.inbox?.nextStep].some(messages => (
+    (messages || []).some(isStartupProfile)
+  ));
+}
+
+function isStartupProfile(message) {
+  return message?.source?.kind === "plugin"
+    && message.source.plugin === OPENVIKING_PLUGIN_SOURCE
+    && message.source.form === "instructions";
 }

--- a/examples/dsh-memory-plugin/runtime.test.mjs
+++ b/examples/dsh-memory-plugin/runtime.test.mjs
@@ -206,6 +206,64 @@ test("dispose waits for the final commit before deleting session state", async (
   assert.equal(runtime.states.has(session.id), false);
 });
 
+test("persisted profile delivery survives dispose and re-seed", async () => {
+  const runtime = new OpenVikingRuntime({
+    async commitSession() {
+      return { ok: true };
+    },
+  }, config(), { debug() {} });
+  const session = {
+    id: "profile-resume",
+    header: { cwd: "/workspace" },
+    events: [],
+  };
+  const firstState = runtime.stateFor(session);
+  firstState.ready = true;
+  firstState.profileBlock = "profile v1";
+
+  const profile = await runtime.profileMessage({ session });
+  assert.equal(profile?.source?.form, "instructions");
+  session.events.push({ type: "user/message", data: profile });
+  await runtime.dispose(session);
+
+  const resumedSession = {
+    id: session.id,
+    header: session.header,
+    events: [...session.events],
+  };
+  const resumedState = runtime.stateFor(resumedSession);
+  resumedState.ready = true;
+  resumedState.profileBlock = "profile v2";
+  assert.equal(await runtime.profileMessage({ session: resumedSession }), null);
+  assert.equal(resumedState.profileDelivered, true);
+
+  const pendingSession = {
+    id: "profile-pending",
+    header: { cwd: "/workspace" },
+    events: [],
+  };
+  const pendingState = runtime.stateFor(pendingSession);
+  pendingState.ready = true;
+  pendingState.profileBlock = "pending profile";
+  assert.equal(await runtime.profileMessage({
+    session: pendingSession,
+    inbox: { nextTurn: [], nextStep: [profile] },
+  }), null);
+
+  const otherSession = {
+    id: "profile-other",
+    header: { cwd: "/workspace", seedLength: 1 },
+    events: [{ type: "user/message", data: profile }],
+  };
+  const otherState = runtime.stateFor(otherSession);
+  otherState.ready = true;
+  otherState.profileBlock = "other profile";
+  assert.equal(
+    (await runtime.profileMessage({ session: otherSession }))?.source?.form,
+    "instructions",
+  );
+});
+
 test("disposeAll drains every live session", async () => {
   const committed = [];
   const runtime = new OpenVikingRuntime({


### PR DESCRIPTION
## Description

Prevent the DSH memory plugin from appending another startup profile when an existing session is de-seeded and later re-seeded.

Instead of retaining session ids in process memory, the runtime recovers the delivery decision from DSH's durable session events and current inbox. Events inherited from a parent session seed are excluded so child sessions still receive their own profile.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4226

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Detect an existing OpenViking instructions message in the session's own durable events.
- Detect a profile that is still pending in the agent inbox before injecting another copy.
- Add regression coverage for dispose/re-seed, pending inbox delivery, and child-session seed isolation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing DSH plugin unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands:

```console
npm test
npm run check
npm pack --dry-run
```

`npm test`: 40 passed, 0 failed, 1 live integration test skipped.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The full Windows DSH de-seed/re-seed flow was not reproduced locally. The regression test covers the confirmed runtime state transition using DSH's documented durable event and inbox contracts.
