### PR TITLE
fix(semantic): stop parent refresh at namespace roots

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -255,7 +255,7 @@ class SemanticProcessor(DequeueHandlerBase):
         parent_uri = parent.uri.rstrip("/")
         if (
             not parent_uri
-            or parent_uri in {"viking://", "viking:"}
+            or parent_uri in {"viking://", "viking:", "viking://user", "viking://agent"}
             or parent_uri == uri.rstrip("/")
         ):
             return

--- a/tests/storage/test_semantic_parent_bubbling.py
+++ b/tests/storage/test_semantic_parent_bubbling.py
@@ -66,3 +66,92 @@ async def test_non_recursive_reindex_does_not_bubble_to_parent(monkeypatch):
     )
 
     plan.assert_not_awaited()
+
+@pytest.mark.parametrize(
+    ("uri", "context_type"),
+    [
+        ("viking://user/alice", "resource"),
+        ("viking://agent/skills", "skill"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_parent_refresh_stops_at_nonsemantic_namespace_root(
+    monkeypatch, uri, context_type
+):
+    plan = AsyncMock(
+        side_effect=AssertionError("non-semantic namespace root must not be refreshed")
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.plan_abstract_overview_refresh",
+        plan,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            semantic=SimpleNamespace(
+                overview_sample_limit=32,
+                freshness_refresh_ratio=0.10,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+
+    msg = SemanticMsg(uri=uri, context_type=context_type)
+    await SemanticProcessor()._enqueue_parent_refresh(
+        msg,
+        msg.uri,
+        l0_body_changed=True,
+    )
+
+    plan.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("uri", "context_type", "expected_parent"),
+    [
+        ("viking://resources/project", "resource", "viking://resources"),
+        ("viking://user/alice/resources", "resource", "viking://user/alice"),
+        ("viking://agent/skills/demo", "skill", "viking://agent/skills"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_parent_refresh_preserves_semantic_roots(
+    monkeypatch, uri, context_type, expected_parent
+):
+    plan = AsyncMock(
+        return_value=FreshnessDecision(
+            FreshnessAction.NOOP,
+            pending_after=0,
+            total_entries=1,
+        )
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.plan_abstract_overview_refresh",
+        plan,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            semantic=SimpleNamespace(
+                overview_sample_limit=32,
+                freshness_refresh_ratio=0.10,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+
+    msg = SemanticMsg(uri=uri, context_type=context_type)
+    await SemanticProcessor()._enqueue_parent_refresh(
+        msg,
+        msg.uri,
+        l0_body_changed=True,
+    )
+
+    plan.assert_awaited_once()
+    assert plan.await_args.kwargs["dir_uri"] == expected_parent


### PR DESCRIPTION
## Description

Prevent semantic parent refresh from targeting non-semantic namespace roots.

On the current `main`, `_enqueue_parent_refresh()` uses the freshness-aware
parent aggregation path. When a changed resource or skill is a direct child of
a bare namespace container, the computed parent can be `viking://user` or
`viking://agent`.

Passing those roots to `plan_abstract_overview_refresh()` can construct invalid
semantic sidecar paths such as `viking://user/.overview.md`, which may fail with
`PermissionDeniedError` and leave deterministic work in the semantic retry
loop.

This change stops parent bubbling at those two non-semantic namespace roots
while preserving parent refresh for valid semantic directories.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4219

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Stop `_enqueue_parent_refresh()` when the computed parent is:
  - `viking://user`
  - `viking://agent`
- Keep the existing scheme-root guards unchanged.
- Preserve semantic parent refresh for valid roots including:
  - `viking://resources`
  - `viking://user/{user_id}`
  - `viking://agent/skills`
- Add regression coverage for both the rejected namespace roots and the
  semantic roots that must continue to refresh.

## Testing

- `python -m pytest tests/storage/test_semantic_parent_bubbling.py -q`
  - `7 passed`
- `python -m pytest tests/unit/test_namespace_uri_classification.py -q`
  - `24 passed`
- `python -m ruff check openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_parent_bubbling.py`
  - passed
- `git diff --check`
  - passed

The focused tests are fully offline and do not require an LLM, embedding
provider, API key, or external service.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] The targeted regression tests pass locally
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings attributable to this patch
- [ ] Any dependent changes have been merged and published

## Additional Notes

This intentionally does not change the global semantic retry classifier or add
a general retry limit. PR #2596 addresses retry bounding separately.

The fix is kept at the parent-refresh eligibility boundary so invalid
namespace-root semantic work is not created in the first place.