### PR TITLE
fix(memory-plugin): stop the uri-guard from reading file content as a path (#4188)

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/codex-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/dsh-memory-plugin/shared/uri-guard.mjs
+++ b/examples/dsh-memory-plugin/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/dsh-memory-plugin/uri-guard.test.mjs
+++ b/examples/dsh-memory-plugin/uri-guard.test.mjs
@@ -52,3 +52,58 @@ test("uri guard delegates the bridged OpenViking tools and ordinary filesystem p
     );
   }
 });
+
+// #4188 — the guard scanned every argument value, so a local write or edit whose
+// CONTENT merely mentioned a viking URI was denied and no file was created.
+// Measured before the fix, with an ordinary local file_path:
+//
+//   write { content: "docs say viking://user/default/ is virtual" } -> deny
+//   edit  { new_string: "see viking://user/default/" }              -> deny
+test("uri guard ignores a viking URI that appears in file content", async () => {
+  const next = async () => ({ kind: "allow", marker: true });
+  const cases = [
+    ["write", { file_path: "/home/me/notes.md", content: "docs say viking://user/default/ is virtual" }],
+    ["edit", {
+      file_path: "/home/me/notes.md",
+      old_string: "old",
+      new_string: "see viking://user/default/memories/",
+    }],
+    ["str_replace_editor", {
+      command: "create",
+      path: "/tmp/notes.md",
+      file_text: "viking://user/default/",
+    }],
+  ];
+
+  for (const [name, args] of cases) {
+    assert.deepEqual(
+      await guardVikingUri({ name, arguments: args }, next),
+      { kind: "allow", marker: true },
+      name,
+    );
+  }
+});
+
+test("uri guard still denies a viking URI used as a location", async () => {
+  const next = async () => ({ kind: "allow" });
+  const cases = [
+    // Same tools as above, with the URI where a path belongs — content is
+    // skipped by key name, so the path argument still decides.
+    ["write", { file_path: "viking://user/default/memories/p.md", content: "harmless text" }],
+    ["edit", {
+      file_path: "viking://user/default/memories/p.md",
+      old_string: "a",
+      new_string: "b",
+    }],
+    // A path key the list does not know about is still swept, so the fallback
+    // keeps its reason to exist.
+    ["glob", { targets: { primary: "viking://user/default/memories" } }],
+    // bash carries its path inside `command`, which is not content.
+    ["bash", { command: "cat viking://user/default/memories/p.md" }],
+  ];
+
+  for (const [name, args] of cases) {
+    const decision = await guardVikingUri({ name, arguments: args }, next);
+    assert.equal(decision.kind, "deny", name);
+  }
+});

--- a/examples/memory-plugin-shared/lib/uri-guard.mjs
+++ b/examples/memory-plugin-shared/lib/uri-guard.mjs
@@ -13,30 +13,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/opencode-plugin/lib/shared/uri-guard.mjs
+++ b/examples/opencode-plugin/lib/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/pi-coding-agent-extension/shared/uri-guard.mjs
+++ b/examples/pi-coding-agent-extension/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }

--- a/examples/zcode-memory-plugin/scripts/shared/uri-guard.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/uri-guard.mjs
@@ -14,30 +14,52 @@ export function normalizeToolName(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS) {
+// Arguments that carry file CONTENT rather than a location. The sweep below
+// looks past the known path keys so an unusual one (`paths`, a nested target)
+// is still caught, but text a tool is asked to WRITE is not a path: a local
+// `write` whose body merely mentions viking://user/default/ was denied, and no
+// file was created. Skipped by name at any depth.
+const DEFAULT_CONTENT_KEYS = [
+  "content",
+  "contents",
+  "text",
+  "body",
+  "old_string",
+  "oldString",
+  "new_string",
+  "newString",
+  "old_str",
+  "new_str",
+  "file_text",
+  "insert_line",
+  "replacement",
+];
+
+export function findVikingUri(args = {}, keys = DEFAULT_URI_KEYS, contentKeys = DEFAULT_CONTENT_KEYS) {
   if (!args || typeof args !== "object") return null;
   for (const key of keys) {
     const uri = findVikingUriInValue(args[key]);
     if (uri) return uri;
   }
-  return findVikingUriInValue(args);
+  return findVikingUriInValue(args, new Set(contentKeys));
 }
 
-export function findVikingUriInValue(value) {
+export function findVikingUriInValue(value, skipKeys) {
   if (typeof value === "string") {
     const match = value.match(/\bviking:\/\/[^\s"'`<>)]*/i);
     return match?.[0] || null;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      const uri = findVikingUriInValue(item);
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
     return null;
   }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) {
-      const uri = findVikingUriInValue(item);
+    for (const [key, item] of Object.entries(value)) {
+      if (skipKeys?.has(key)) continue;
+      const uri = findVikingUriInValue(item, skipKeys);
       if (uri) return uri;
     }
   }


### PR DESCRIPTION
Fixes #4188.

## Reproduced

Through the real `guardVikingUri()`, with an ordinary **local** `file_path`:

```
write (content mentions a URI)     -> deny
edit  (new_string mentions a URI)  -> deny
str_replace_editor (file_text)     -> deny
write (clean)                      -> allow
```

`findVikingUri()` checks the path-like keys first and then sweeps every remaining argument value, so the regex matched the URI inside the text the tool was asked to write. The write is denied and no file is created — documenting OpenViking in a local file is enough to trigger it.

## The change

The sweep stays, because it is what catches a path key the list does not know about (a nested `targets.primary`, a `paths` array). It now skips arguments that carry **content** rather than a location: `content`, `contents`, `text`, `body`, `old_string`/`new_string` (and the `_str` / `file_text` spellings `str_replace_editor` uses), `replacement`, `insert_line`.

The issue suggested dropping the fallback entirely. I kept it because that would also stop catching URIs in unusual path keys, and `bash` carries its path inside `command` — which is not content and must keep denying. Skipping by key name fixes the false positive without narrowing what the guard was built to catch.

Measured after:

```
write (content mentions a URI)     -> allow
edit  (new_string mentions a URI)  -> allow
str_replace_editor (file_text)     -> allow
write (real viking path)           -> deny
bash  (URI as a path)              -> deny
glob  (nested unusual key)         -> deny
```

## Tests

Two tests added to `examples/dsh-memory-plugin/uri-guard.test.mjs`: one for the three content shapes that must now pass through, one pinning the four location shapes that must still deny — including the nested unknown key, so a later "simplify" cannot quietly delete the fallback.

With only `shared/uri-guard.mjs` reverted to `main`:

```
not ok 3 - uri guard ignores a viking URI that appears in file content
# pass 3  # fail 1
```

With the fix: **4 passed, 0 failed** (2 pre-existing + 2 new).

## Vendored copies

`uri-guard.mjs` is generated into seven plugin directories from `examples/memory-plugin-shared/lib`. I edited the source and re-ran `node examples/memory-plugin-shared/sync.mjs`, so the six other harnesses (claude-code, codex, opencode, pi-coding-agent, zcode, agent-plugins) carry the identical fix rather than drifting from it.
