### PR TITLE
fix(api-keys): hide deleting users from list

### DIFF
--- a/docs/en/api/08-admin.md
+++ b/docs/en/api/08-admin.md
@@ -636,11 +636,11 @@ ov admin register-user acme bob-private --role user \
 
 #### 1. API Implementation Overview
 
-List all users in a workspace.
+List active users in a workspace. Users with deletion in progress are omitted.
 
 **Processing Flow:**
 1. Verify requester has ROOT privileges or is an ADMIN of the account
-2. Call API Key Manager to get users list
+2. Call API Key Manager to get active users list
 3. Apply optional filters (name, role) and pagination limit
 4. Return users list (trusted mode omits user_key)
 
@@ -663,6 +663,7 @@ List all users in a workspace.
 **Notes:**
 - ADMIN can only list users in their own account
 - In `trusted` mode, `user_key` is omitted from the response
+- Users whose deletion has started are no longer returned
 
 #### 3. Usage Examples
 
@@ -741,16 +742,17 @@ ov --sudo admin list-users acme
 
 #### 1. API Implementation Overview
 
-Remove a user from a workspace. The user's API key is deleted immediately.
+Remove a user from a workspace. The user's API key is revoked immediately, and owned data cleanup runs asynchronously.
 
 **Processing Flow:**
 1. Verify requester has ROOT privileges or is an ADMIN of the account
-2. Call API Key Manager to delete user and their API key
-3. Return deletion confirmation
+2. Write a deletion fence and revoke the user's API key
+3. Enqueue a durable cleanup task for the user's owned data
+4. Return the deletion task ID
 
 **Code Entry Points:**
 - `openviking/server/routers/admin.py:remove_user` - HTTP route
-- `openviking/server/api_keys/new.py:APIKeyManager.remove_user` - Core implementation
+- `openviking/service/user_deletion.py:UserDeletionService.delete_user` - Core implementation
 - `openviking_cli/client/sync_http.py:SyncHTTPClient.admin_remove_user` - Python SDK
 
 #### 2. Interface and Parameters
@@ -765,6 +767,7 @@ Remove a user from a workspace. The user's API key is deleted immediately.
 **Notes:**
 - ADMIN can only remove users in their own account
 - Cannot delete the last admin user of an account
+- After deletion starts, the user key is invalid and list_users omits the user
 
 #### 3. Usage Examples
 
@@ -788,7 +791,7 @@ client = ov.SyncHTTPClient(api_key="<root-or-admin-key>")
 client.initialize()
 
 result = client.admin_remove_user("acme", "bob")
-print(f"User deleted: {result['deleted']}")
+print(f"User deletion task: {result['task_id']}")
 ```
 
 **TypeScript SDK**
@@ -804,7 +807,7 @@ result, err := client.AdminRemoveUser(ctx, "acme", "bob")
 if err != nil {
     return err
 }
-fmt.Println(result["deleted"])
+fmt.Println(result["task_id"])
 ```
 
 **CLI**
@@ -823,7 +826,10 @@ ov --sudo admin remove-user acme bob
 {
   "status": "ok",
   "result": {
-    "deleted": true
+    "account_id": "acme",
+    "user_id": "bob",
+    "status": "deleting",
+    "task_id": "..."
   },
   "time": 0.1
 }

--- a/docs/zh/api/08-admin.md
+++ b/docs/zh/api/08-admin.md
@@ -628,11 +628,11 @@ ov admin register-user acme bob-private --role user \
 
 #### 1. API 实现介绍
 
-列出工作区中的所有用户。
+列出工作区中的活跃用户。正在删除中的用户不会返回。
 
 **处理流程：**
 1. 验证请求者具有 ROOT 权限，或为本账户的 ADMIN
-2. 调用 API Key Manager 获取用户列表
+2. 调用 API Key Manager 获取活跃用户列表
 3. 应用可选的过滤条件（name、role）和分页限制
 4. 返回用户列表（trusted 模式下不包含 user_key）
 
@@ -655,6 +655,7 @@ ov admin register-user acme bob-private --role user \
 **说明：**
 - ADMIN 只能列出自己所属的 account 中的用户
 - 在 `trusted` 模式下，响应中不会包含 `user_key` 字段
+- 用户删除开始后，不再出现在该列表中
 
 #### 3. 使用示例
 
@@ -732,16 +733,17 @@ ov --sudo admin list-users acme
 
 #### 1. API 实现介绍
 
-从工作区中移除用户，同时删除其 API Key。
+从工作区中移除用户。用户 API Key 会立即失效，其拥有的数据清理异步执行。
 
 **处理流程：**
 1. 验证请求者具有 ROOT 权限，或为本账户的 ADMIN
-2. 调用 API Key Manager 删除用户及其 API Key
-3. 返回删除确认
+2. 写入删除 fence，并使用户 API Key 失效
+3. 提交一个持久化清理任务，删除该用户拥有的数据
+4. 返回删除任务 ID
 
 **代码入口：**
 - `openviking/server/routers/admin.py:remove_user` - HTTP 路由
-- `openviking/server/api_keys/new.py:APIKeyManager.remove_user` - 核心实现
+- `openviking/service/user_deletion.py:UserDeletionService.delete_user` - 核心实现
 - `openviking_cli/client/sync_http.py:SyncHTTPClient.admin_remove_user` - Python SDK
 
 #### 2. 接口和参数说明
@@ -756,6 +758,7 @@ ov --sudo admin list-users acme
 **说明：**
 - ADMIN 只能移除自己所属的 account 中的用户
 - 不能删除账户的最后一个 admin 用户
+- 删除开始后，用户 key 立即失效，list_users 不再返回该用户
 
 #### 3. 使用示例
 
@@ -779,7 +782,7 @@ client = ov.SyncHTTPClient(api_key="<root-or-admin-key>")
 client.initialize()
 
 result = client.admin_remove_user("acme", "bob")
-print(f"User deleted: {result['deleted']}")
+print(f"User deletion task: {result['task_id']}")
 ```
 
 **TypeScript SDK**
@@ -795,7 +798,7 @@ result, err := client.AdminRemoveUser(ctx, "acme", "bob")
 if err != nil {
     return err
 }
-fmt.Println(result["deleted"])
+fmt.Println(result["task_id"])
 ```
 
 **CLI**
@@ -814,7 +817,10 @@ ov --sudo admin remove-user acme bob
 {
   "status": "ok",
   "result": {
-    "deleted": true
+    "account_id": "acme",
+    "user_id": "bob",
+    "status": "deleting",
+    "task_id": "..."
   },
   "time": 0.1
 }

--- a/openviking/server/api_keys/legacy.py
+++ b/openviking/server/api_keys/legacy.py
@@ -677,6 +677,9 @@ class LegacyAPIKeyManager:
         result = []
         count = 0
         for user_id, user_info in account.users.items():
+            if user_info.get("deletion"):
+                continue
+
             user_role = user_info.get("role", "user")
 
             # Apply name filter if provided

--- a/tests/server/test_api_key_manager.py
+++ b/tests/server/test_api_key_manager.py
@@ -347,6 +347,16 @@ async def test_get_users(manager: APIKeyManager):
     assert roles["alice"] == "admin"
     assert roles["bob"] == "user"
 
+    await manager.begin_user_deletion(
+        acct,
+        "bob",
+        task_id="delete-bob",
+        owner_account_id=acct,
+        owner_user_id="alice",
+    )
+    users = manager.get_users(acct)
+    assert {u["user_id"] for u in users} == {"alice"}
+
 
 # ---- Persistence tests ----
 


### PR DESCRIPTION
## Description

Fixes the admin user listing behavior after user deletion becomes asynchronous.

**Before:** `DELETE /api/v1/admin/accounts/acme/users/bob` immediately revoked Bob's key and wrote a deletion fence, but `GET /api/v1/admin/accounts/acme/users` still returned Bob until the background cleanup task finished.

**After:** once deletion starts, Bob's key is invalid and `list_users` omits Bob immediately. The registry entry remains only as the internal deletion fence until cleanup finishes.

**Example:**

1. Register `alice` and `bob` in account `acme`.
2. Delete `bob`; the response returns `{"status": "deleting", "task_id": "..."}`.
3. List users for `acme`.

Before this PR, the list could include:

```json
[{"user_id": "alice", "role": "admin"}, {"user_id": "bob", "role": "user"}]
```

After this PR, the list returns only active users:

```json
[{"user_id": "alice", "role": "admin"}]
```

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Filter users with a deletion fence from the API key manager's `get_users` result.
- Extend the existing API key manager user-list contract test to cover deletion-in-progress users.
- Update English and Chinese admin API docs to describe async user deletion and immediate list omission.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```bash
OPENVIKING_CONFIG_FILE=ov.conf .venv/bin/pytest tests/server/test_api_key_manager.py::test_get_users -q
OPENVIKING_CONFIG_FILE=ov.conf .venv/bin/pytest tests/server/test_admin_api.py::test_list_users tests/server/test_admin_api.py::test_remove_user -q
```

Both focused test commands passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A

## Additional Notes

<!-- Add any additional notes or context about the PR -->

The initial focused test run without `OPENVIKING_CONFIG_FILE=ov.conf` failed during fixture setup because the OpenViking config file was not resolved. Re-running the same tests with the repo config passed.
