### PR TITLE
fix(docs): remove duplicate CLI API key block

### DIFF
--- a/docs/images/agents/zh/cli.md
+++ b/docs/images/agents/zh/cli.md
@@ -18,8 +18,6 @@ npm i -g @openviking/cli && ov config
 
 {{OPENVIKING_API_KEY_BLOCK}}
 
-{{OPENVIKING_API_KEY_BLOCK}}
-
 
 ### 步骤3：配置完成后，可运行以下命令查看 CLI 用法：
 


### PR DESCRIPTION
## Description

Remove the duplicated `OPENVIKING_API_KEY_BLOCK` placeholder from the Chinese OpenViking CLI connection guide. The duplicate was introduced when the API Key copy was refined while the previous placeholder remained, causing the rendered guide to show the API Key block twice.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Removed the stale duplicate API Key placeholder from `docs/images/agents/zh/cli.md`
- Kept the Chinese template aligned with the English template: one API Key block per guide

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- Verified the Chinese and English CLI templates each contain exactly one `OPENVIKING_API_KEY_BLOCK` placeholder
- `npm run test:theme`
- `npm run check:api`
- `DOCS_BASE=/ npm run docs:build`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

The reported rendered guide showed the API Key block twice; after this change the source template contains a single placeholder.

## Additional Notes

No runtime code or dependency changes.