### PR TITLE
[codex] fix server JSON surrogate rendering

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -13,7 +13,7 @@ from typing import Callable, Optional
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.exceptions import ExceptionMiddleware
 
@@ -30,6 +30,7 @@ from openviking.server.identity import Role
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
 from openviking.server.profile_middleware import create_profile_http_middleware
 from openviking.server.request_id import REQUEST_ID_HEADER, RequestIdMiddleware
+from openviking.server.responses import SafeJSONResponse
 from openviking.server.routers import (
     admin_router,
     agent_evolution_router,
@@ -397,6 +398,7 @@ def create_app(
         description="OpenViking HTTP Server - Agent-native context database",
         version="0.1.0",
         lifespan=lifespan,
+        default_response_class=SafeJSONResponse,
     )
 
     app.state.config = config
@@ -489,7 +491,7 @@ def create_app(
     async def openviking_error_handler(request: Request, exc: OpenVikingError):
         http_status = ERROR_CODE_TO_HTTP_STATUS.get(exc.code, 500)
         capture_public_http_error(code=exc.code, message=exc.message, details=exc.details)
-        return JSONResponse(
+        return SafeJSONResponse(
             status_code=http_status,
             content=Response(
                 status="error",
@@ -512,7 +514,7 @@ def create_app(
             message=message,
             details=details,
         )
-        return JSONResponse(
+        return SafeJSONResponse(
             status_code=ERROR_CODE_TO_HTTP_STATUS[code],
             content=Response(
                 status="error",
@@ -535,7 +537,7 @@ def create_app(
             details = {"original_http_status_code": exc.status_code}
         message = _message_from_http_detail(exc.detail)
         capture_public_http_error(code=code, message=message, details=details)
-        return JSONResponse(
+        return SafeJSONResponse(
             status_code=response_status,
             headers=exc.headers,
             content=Response(
@@ -558,7 +560,7 @@ def create_app(
                 extra={"error_code": mapped.code, "error_message": mapped.message},
                 exc_info=exc,
             )
-            return JSONResponse(
+            return SafeJSONResponse(
                 status_code=http_status,
                 content=Response(
                     status="error",
@@ -571,7 +573,7 @@ def create_app(
             )
 
         logger.exception("Unhandled exception")
-        return JSONResponse(
+        return SafeJSONResponse(
             status_code=500,
             content=Response(
                 status="error",

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -27,7 +27,6 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, Field
 from starlette.requests import Request
-from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from openviking.core.path_variables import resolve_path_variables
@@ -50,6 +49,7 @@ from openviking.server.local_input_guard import (
     is_remote_resource_source,
 )
 from openviking.server.resource_ingest import ingest_temp_upload
+from openviking.server.responses import SafeJSONResponse as JSONResponse
 from openviking.server.temp_upload_store import TempUploadStore
 from openviking.server.upload_token_store import upload_token_store
 from openviking.telemetry.span_models import update_root_span_identity

--- a/openviking/server/oauth/router.py
+++ b/openviking/server/oauth/router.py
@@ -28,7 +28,7 @@ from typing import Optional
 from urllib.parse import urlencode, urlparse
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse
 from mcp.shared.auth import ProtectedResourceMetadata
 from pydantic import AnyHttpUrl, BaseModel, Field
 
@@ -36,6 +36,7 @@ from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext
 from openviking.server.oauth.provider import MCP_SCOPE, OpenVikingOAuthProvider
 from openviking.server.oauth.storage import OAuthStore
+from openviking.server.responses import SafeJSONResponse as JSONResponse
 from openviking_cli.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,

--- a/openviking/server/request_id.py
+++ b/openviking/server/request_id.py
@@ -10,9 +10,9 @@ import re
 import time
 import uuid
 
-from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from openviking.server.responses import SafeJSONResponse as JSONResponse
 from openviking_cli.utils.logger import bind_log_request_id
 
 REQUEST_ID_HEADER = "X-Request-ID"

--- a/openviking/server/responses.py
+++ b/openviking/server/responses.py
@@ -8,6 +8,17 @@ from fastapi.responses import JSONResponse
 
 from openviking.observability.http_error_context import capture_public_http_error
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
+from openviking.storage.vectordb.utils.json_safety import sanitize_unicode_for_json
+
+
+class SafeJSONResponse(JSONResponse):
+    """JSON response that replaces lone surrogates before UTF-8 encoding."""
+
+    def render(self, content: Any) -> bytes:
+        try:
+            return super().render(content)
+        except UnicodeEncodeError:
+            return super().render(sanitize_unicode_for_json(content))
 
 
 def _message_from_business_error(result: Dict[str, Any]) -> str:
@@ -61,7 +72,7 @@ def response_from_result(
             error=error,
             telemetry=telemetry,
         ).model_dump(exclude_none=True)
-        return JSONResponse(
+        return SafeJSONResponse(
             status_code=ERROR_CODE_TO_HTTP_STATUS.get(code, 500),
             content=content,
         )
@@ -87,7 +98,7 @@ def error_response(
         error=ErrorInfo(code=code, message=message, details=details),
         telemetry=telemetry,
     ).model_dump(exclude_none=True)
-    return JSONResponse(
+    return SafeJSONResponse(
         status_code=ERROR_CODE_TO_HTTP_STATUS.get(code, 500),
         content=content,
     )

--- a/openviking/server/routers/bot.py
+++ b/openviking/server/routers/bot.py
@@ -9,12 +9,13 @@ from typing import AsyncGenerator, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 
 from openviking.server.auth import _auth_mode, get_request_context
 from openviking.server.config import get_server_url_from_server_data
 from openviking.server.identity import RequestContext
 from openviking.server.models import Response
+from openviking.server.responses import SafeJSONResponse as JSONResponse
 from openviking_cli.exceptions import OpenVikingError
 from openviking_cli.utils.logger import get_logger
 

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from openviking.core.path_variables import resolve_path_variables
@@ -16,6 +15,7 @@ from openviking.server.auth import get_request_context, require_role
 from openviking.server.dependencies import get_service
 from openviking.server.identity import AuthMode, RequestContext, Role
 from openviking.server.models import Response
+from openviking.server.responses import SafeJSONResponse as JSONResponse
 from openviking.storage.viking_fs import get_viking_fs
 from openviking_cli.utils import get_logger
 

--- a/tests/server/test_safe_json_response.py
+++ b/tests/server/test_safe_json_response.py
@@ -1,0 +1,38 @@
+import json
+
+from openviking.server.responses import SafeJSONResponse, error_response, response_from_result
+
+
+def test_safe_json_response_preserves_normal_unicode_rendering():
+    response = SafeJSONResponse({"message": "hello 世界 😀"})
+
+    assert response.body == b'{"message":"hello \xe4\xb8\x96\xe7\x95\x8c \xf0\x9f\x98\x80"}'
+
+
+def test_error_response_replaces_lone_surrogates_before_rendering():
+    response = error_response(
+        "NOT_FOUND",
+        "File not found: viking://resources/\ud800bad_name",
+        details={"uri": "viking://resources/\ud800bad_name"},
+    )
+
+    payload = json.loads(response.body.decode("utf-8"))
+
+    assert payload["error"]["message"] == "File not found: viking://resources/�bad_name"
+    assert payload["error"]["details"]["uri"] == "viking://resources/�bad_name"
+
+
+def test_business_error_response_replaces_lone_surrogates_before_rendering():
+    response = response_from_result(
+        {
+            "status": "error",
+            "code": "NOT_FOUND",
+            "message": "Missing viking://resources/\ud800bad_name",
+            "details": {"uri": "viking://resources/\ud800bad_name"},
+        }
+    )
+
+    payload = json.loads(response.body.decode("utf-8"))
+
+    assert payload["error"]["message"] == "Missing viking://resources/�bad_name"
+    assert payload["error"]["details"]["uri"] == "viking://resources/�bad_name"


### PR DESCRIPTION
## Summary
- Add `SafeJSONResponse` to retry JSON rendering after replacing lone Unicode surrogates with U+FFFD.
- Route server JSON error and API response paths through the safe response class.
- Add regression coverage for normal Unicode and malformed surrogate payloads.

## Root Cause
JSON encoding can raise `UnicodeEncodeError` when response content contains lone surrogate code points, for example from malformed file names or resource URIs. That can turn an otherwise valid error response into a server-side rendering failure.

## Validation
- `python -m ruff check openviking/server/app.py openviking/server/mcp_endpoint.py openviking/server/oauth/router.py openviking/server/request_id.py openviking/server/responses.py openviking/server/routers/bot.py openviking/server/routers/system.py tests/server/test_safe_json_response.py`
- `python -m pytest tests/server/test_safe_json_response.py -q`

## Notes
- `python -m pytest tests/server/test_safe_json_response.py tests/server/test_profile_middleware.py` passes the new safe JSON tests, but `tests/server/test_profile_middleware.py::test_profile_query_adds_profile_field_to_json_response` fails locally because the profiler top-N output contains framework/stdlib entries only and no `openviking/` or `tests/` path line in this Python 3.13/FastAPI environment.