### PR TITLE
fix(ragfs): normalize localfs mkdir already exists

### DIFF
--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 use std::process::{Command, Stdio};
 
 use grep_regex::RegexMatcher;
@@ -905,11 +905,13 @@ impl FileSystem for LocalFileSystem {
             }
         }
 
-        // Create directory
-        fs::create_dir(&local_path)
-            .map_err(|e| Error::plugin(format!("failed to create directory: {}", e)))?;
-
-        Ok(())
+        match fs::create_dir(&local_path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                Err(Error::AlreadyExists(path.to_string()))
+            }
+            Err(e) => Err(Error::plugin(format!("failed to create directory: {}", e))),
+        }
     }
 
     async fn remove(&self, path: &str) -> Result<()> {


### PR DESCRIPTION
## Description

Fix localfs mkdir error classification for a concurrent create race.

**Before:** when two callers tried to create the same localfs directory, the loser could receive an OS `AlreadyExists` from `fs::create_dir()`. localfs wrapped that as a plugin error:

```text
plugin error: failed to create directory: File exists (os error 17)
```

That bypassed existing idempotent callers such as `PersistentTaskStore._mkdir_if_missing()`, so a normal session commit could return 503 while creating the task tracker directory.

**After:** localfs maps `std::io::ErrorKind::AlreadyExists` from `fs::create_dir()` to the existing domain error `Error::AlreadyExists(path)`. Existing upper layers continue to handle already-existing directories through the supported `AGFSAlreadyExistsError` path.

**Example:** for the same path `/local/acme/_system/tasks/alice`, a concurrent second mkdir now reports `AlreadyExists("/local/acme/_system/tasks/alice")` instead of `Plugin("failed to create directory: File exists (os error 17)")`, allowing task tracker directory ensure to continue.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

N/A

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Normalize localfs `fs::create_dir()` `AlreadyExists` errors into `Error::AlreadyExists`.
- Keep other mkdir backend errors as plugin errors with their original message.
- Leave task tracker and API-layer behavior unchanged so existing idempotent directory handling remains the single owner.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```text
cargo test -p ragfs localfs
uv run python -m pytest -q -o addopts='' tests/test_task_tracker.py::test_persistent_store_ignores_existing_task_dirs
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A

## Additional Notes

<!-- Add any additional notes or context about the PR -->

No new tests were added. The existing task tracker contract test already covers the intended upper-layer behavior for already-existing task directories.
