### PR TITLE
fix(retrieve): accept array intent planner responses

### DIFF
--- a/openviking/retrieve/intent_analyzer.py
+++ b/openviking/retrieve/intent_analyzer.py
@@ -91,6 +91,14 @@ class IntentAnalyzer:
         if not parsed:
             raise ValueError("Failed to parse intent analysis response")
 
+        if isinstance(parsed, list):
+            parsed = {"reasoning": "", "queries": parsed}
+        elif not isinstance(parsed, dict):
+            raise ValueError(
+                "Intent analysis response must be a JSON object or array, got "
+                f"{type(parsed).__name__}"
+            )
+
         reasoning = parsed.get("reasoning", "")
         if not isinstance(reasoning, str):
             reasoning = str(reasoning)
@@ -98,6 +106,8 @@ class IntentAnalyzer:
         # Build QueryPlan
         queries = []
         for q in parsed.get("queries", []):
+            if not isinstance(q, dict):
+                continue
             try:
                 context_type = ContextType(q.get("context_type", "resource"))
             except ValueError:

--- a/tests/retrieve/test_intent_analyzer_query_planner.py
+++ b/tests/retrieve/test_intent_analyzer_query_planner.py
@@ -136,6 +136,34 @@ async def test_intent_analyzer_normalizes_non_string_reasoning(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_intent_analyzer_handles_bare_array_response(monkeypatch):
+    planner = RecordingModel(
+        """[
+          {
+            "query": "bare array query",
+            "context_type": "memory",
+            "intent": "test intent",
+            "priority": 1
+          }
+        ]"""
+    )
+    config = SimpleNamespace(get_query_planner=lambda: planner)
+
+    monkeypatch.setattr(intent_module, "get_openviking_config", lambda: config)
+    monkeypatch.setattr(intent_module, "render_prompt", lambda prompt_id, variables: "prompt")
+
+    result = await IntentAnalyzer().analyze(
+        compression_summary="",
+        messages=[],
+        current_message="where is my preference?",
+    )
+
+    assert len(result.queries) == 1
+    assert result.queries[0].query == "bare array query"
+    assert result.reasoning == ""
+
+
+@pytest.mark.asyncio
 async def test_intent_analyzer_uses_model_specific_prompt(monkeypatch):
     planner = RecordingModel(
         _query_plan_response("planned query"),


### PR DESCRIPTION
## Summary
- Normalize bare JSON array responses from the query planner into the expected `queries` payload shape.
- Reject non-object top-level responses with a clear error and skip malformed query items.
- Add regression coverage for #4022 so a bare array no longer crashes intent analysis.

Fixes #4022

## Test plan
- [x] `OPENVIKING_CONFIG_FILE=/tmp/openviking-empty.toml python -m pytest tests/retrieve/test_intent_analyzer_query_planner.py::test_intent_analyzer_handles_bare_array_response -q` failed before the fix with `AttributeError: 'list' object has no attribute 'get'`
- [x] `OPENVIKING_CONFIG_FILE=/tmp/openviking-empty.toml python -m pytest tests/retrieve/test_intent_analyzer_query_planner.py -q`
- [x] `python -m ruff check openviking/retrieve/intent_analyzer.py tests/retrieve/test_intent_analyzer_query_planner.py`