### PR TITLE
fix(embedding): pass dimensions to OpenAI-compatible backends

### DIFF
--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -89,9 +89,11 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
                        non-symmetric mode with query_param/document_param.
             api_key: API key, if None will read from env vars (OPENVIKING_EMBEDDING_API_KEY or OPENAI_API_KEY)
             api_base: API base URL, optional. Required for third-party OpenAI-compatible APIs.
-            dimension: Target dimension for output vectors. If specified and the model returns vectors
-                      with a different dimension, the output will be truncated to this dimension.
-                      If None, uses the model's default dimension without truncation.
+            dimension: Target dimension for output vectors. For custom OpenAI-compatible
+                      backends this is sent to the API when api_base is configured; otherwise,
+                      if the model returns vectors with a different dimension, the output will
+                      be truncated to this dimension. If None, uses the model's default dimension
+                      without truncation.
             query_param: Parameter for query-side embeddings. Supports simple values (e.g., 'query')
                          or key=value format (e.g., 'input_type=query,task=search'). Defaults to None.
                          Setting this (or document_param) activates non-symmetric mode.
@@ -292,7 +294,7 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         # Preserve existing behavior for official OpenAI embeddings: only custom
         # OpenAI-compatible backends and Azure send explicit dimensions.
         if self._provider == "openai":
-            return False
+            return bool(self.api_base)
         return bool(self.api_base)
 
     def _get_async_client(self):

--- a/tests/unit/test_openai_embedder.py
+++ b/tests/unit/test_openai_embedder.py
@@ -35,6 +35,31 @@ class TestOpenAIDenseEmbedder:
         assert "dimensions" not in call_kwargs
 
     @patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
+    def test_openai_compatible_api_base_sends_dimensions(self, mock_openai_class):
+        """OpenAI-compatible backends should receive explicit dimensions."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = [0.1] * 1024
+
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = OpenAIDenseEmbedder(
+            model_name="Qwen/Qwen3-Embedding-8B",
+            api_key="test-api-key",
+            api_base="https://api.siliconflow.cn/v1",
+            dimension=1024,
+        )
+
+        embedder.embed("Hello world")
+
+        call_kwargs = mock_client.embeddings.create.call_args[1]
+        assert call_kwargs["dimensions"] == 1024
+
+    @patch("openviking.models.embedder.openai_embedders.openai.OpenAI")
     def test_embed_with_input_type_none(self, mock_openai_class):
         """OpenAI embed should not include extra_body when input_type is None"""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary

- Send the configured `dimensions` value when the OpenAI embedder is pointed at a custom `api_base`.
- Preserve the existing official OpenAI default path, where no explicit `dimensions` parameter is sent unless the request is using an OpenAI-compatible backend URL.
- Add regression coverage for SiliconFlow-style OpenAI-compatible embedding endpoints.

## Root cause

`OpenAIDenseEmbedder._should_send_dimensions()` returned `False` for every `provider="openai"` configuration. That preserved official OpenAI behavior, but it also blocked OpenAI-compatible gateways such as SiliconFlow from receiving their supported native projection parameter. OpenViking then had to accept full-size vectors and truncate locally, losing information instead of letting the model generate the requested dimension.

Fixes #4201.

## Test plan

- `OV_PREBUILT_BIN_DIR=/tmp/openviking-ov-prebuilt OV_SKIP_RAGFS_BUILD=1 uv run --extra test pytest --no-cov tests/unit/test_openai_embedder.py::TestOpenAIDenseEmbedder::test_openai_compatible_api_base_sends_dimensions`
  - Red before the implementation: `KeyError: 'dimensions'`
  - Green after the implementation: `1 passed, 4 warnings`
- `OV_PREBUILT_BIN_DIR=/tmp/openviking-ov-prebuilt OV_SKIP_RAGFS_BUILD=1 uv run --extra test pytest --no-cov tests/unit/test_openai_embedder.py`
  - `8 passed, 4 warnings`

Local note: this machine has no Cargo, so the Python tests used a temporary prebuilt `ov` placeholder through `OV_PREBUILT_BIN_DIR` to satisfy the editable build artifact check.