### PR TITLE
fix(queuefs): stop semantic parent refresh at namespace roots

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -8,6 +8,7 @@ import threading
 from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from openviking.core.namespace import NamespaceShapeError, resolve_uri, uri_parts
 from openviking.observability.context import (
     bind_root_observability_context,
     reset_root_observability_context,
@@ -66,6 +67,28 @@ from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_NAMESPACE_SCOPE_ROOTS = frozenset({"user", "agent"})
+
+
+def _is_namespace_scope_root(uri: str) -> bool:
+    """Return True when uri is a tenant container, not a content directory.
+
+    ``viking://user`` and ``viking://agent`` are namespace containers. Parent
+    refresh used to treat them as ordinary directories and then read
+    ``viking://user/.overview.md``, which ACL parses as another user id.
+    """
+    canonical = (uri or "").rstrip("/")
+    if canonical in {"", "viking://", "viking:"}:
+        return True
+    try:
+        resolved = resolve_uri(canonical)
+    except NamespaceShapeError:
+        return True
+    if resolved.is_container:
+        return True
+    parts = uri_parts(canonical)
+    return len(parts) == 1 and parts[0] in _NAMESPACE_SCOPE_ROOTS
 
 
 class RequestQueueStats:
@@ -253,11 +276,7 @@ class SemanticProcessor(DequeueHandlerBase):
         if parent is None:
             return
         parent_uri = parent.uri.rstrip("/")
-        if (
-            not parent_uri
-            or parent_uri in {"viking://", "viking:"}
-            or parent_uri == uri.rstrip("/")
-        ):
+        if _is_namespace_scope_root(parent_uri) or parent_uri == uri.rstrip("/"):
             return
         semantic_config = get_openviking_config().semantic
         decision = await plan_abstract_overview_refresh(
@@ -348,8 +367,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     # maintenance. Let the newest message aggregate while this
                     # one still summarizes/vectorizes its changed files.
                     logger.info(
-                        "Downgrading stale semantic message to file-only work: "
-                        "uri=%s version=%s",
+                        "Downgrading stale semantic message to file-only work: uri=%s version=%s",
                         msg.uri,
                         msg.coalesce_version,
                     )
@@ -766,10 +784,7 @@ class SemanticProcessor(DequeueHandlerBase):
         if msg.skip_vectorization:
             logger.info(f"Skipping vectorization for {dir_uri} (requested via SemanticMsg)")
             return
-        if not (
-            wrote_semantics.overview_body_changed
-            or wrote_semantics.abstract_body_changed
-        ):
+        if not (wrote_semantics.overview_body_changed or wrote_semantics.abstract_body_changed):
             logger.info(
                 "Skipping directory vectorization for %s (visible semantics unchanged)",
                 dir_uri,

--- a/tests/storage/test_semantic_parent_bubbling.py
+++ b/tests/storage/test_semantic_parent_bubbling.py
@@ -33,14 +33,10 @@ async def test_unchanged_l0_does_not_mark_or_enqueue_parent(monkeypatch):
         lambda: SimpleNamespace(),
     )
     get_queue_manager = AsyncMock(side_effect=AssertionError("parent must not be enqueued"))
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.get_queue_manager", get_queue_manager
-    )
+    monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", get_queue_manager)
 
     msg = SemanticMsg(uri="viking://resources/root/child", context_type="resource")
-    await SemanticProcessor()._enqueue_parent_refresh(
-        msg, msg.uri, l0_body_changed=False
-    )
+    await SemanticProcessor()._enqueue_parent_refresh(msg, msg.uri, l0_body_changed=False)
 
     assert plan.await_args.kwargs["l0_body_changed"] is False
     assert plan.await_args.kwargs["force_refresh"] is False
@@ -61,8 +57,74 @@ async def test_non_recursive_reindex_does_not_bubble_to_parent(monkeypatch):
         generation_trigger="reindex",
         propagate_to_parent=False,
     )
-    await SemanticProcessor()._enqueue_parent_refresh(
-        msg, msg.uri, l0_body_changed=True
-    )
+    await SemanticProcessor()._enqueue_parent_refresh(msg, msg.uri, l0_body_changed=True)
 
     plan.assert_not_awaited()
+
+
+def _patch_parent_plan(monkeypatch, plan):
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.plan_abstract_overview_refresh",
+        plan,
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_openviking_config",
+        lambda: SimpleNamespace(
+            semantic=SimpleNamespace(overview_sample_limit=32, freshness_refresh_ratio=0.10)
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_processor.get_viking_fs",
+        lambda: SimpleNamespace(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_user_namespace_container_is_not_parent_refresh_target(monkeypatch):
+    plan = AsyncMock(side_effect=AssertionError("viking://user has no directory sidecars"))
+    _patch_parent_plan(monkeypatch, plan)
+
+    msg = SemanticMsg(
+        uri="viking://user/kb_1116",
+        context_type="resource",
+        role="user",
+        user_id="kb_1116",
+        generation_trigger="parent_refresh",
+    )
+    await SemanticProcessor()._enqueue_parent_refresh(msg, msg.uri, l0_body_changed=True)
+
+    plan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_scope_root_is_not_parent_refresh_target(monkeypatch):
+    plan = AsyncMock(side_effect=AssertionError("viking://agent has no directory sidecars"))
+    _patch_parent_plan(monkeypatch, plan)
+
+    msg = SemanticMsg(
+        uri="viking://agent/skills",
+        context_type="skill",
+        generation_trigger="parent_refresh",
+    )
+    await SemanticProcessor()._enqueue_parent_refresh(msg, msg.uri, l0_body_changed=True)
+
+    plan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_user_home_still_receives_parent_refresh(monkeypatch):
+    plan = AsyncMock(
+        return_value=FreshnessDecision(FreshnessAction.NOOP, pending_after=1, total_entries=4)
+    )
+    _patch_parent_plan(monkeypatch, plan)
+
+    msg = SemanticMsg(
+        uri="viking://user/kb_1116/resources",
+        context_type="resource",
+        role="user",
+        user_id="kb_1116",
+    )
+    await SemanticProcessor()._enqueue_parent_refresh(msg, msg.uri, l0_body_changed=True)
+
+    plan.assert_awaited_once()
+    assert plan.await_args.kwargs["dir_uri"] == "viking://user/kb_1116"


### PR DESCRIPTION
Parent bubbling treated viking://user and viking://agent as ordinary directories, then read viking://user/.overview.md. ACL parses that sidecar name as another user id, denies access, and the job is retried forever. Skip tenant containers so bubbling stops at the user home.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
