### PR TITLE
fix(memory): tolerate incomplete case templates

### DIFF
--- a/openviking/prompts/templates/memory/cases.yaml
+++ b/openviking/prompts/templates/memory/cases.yaml
@@ -38,17 +38,17 @@ content_template: |
   {%- endif %}
   {%- endfor %}
 embedding_template: |-
-  {{ case_name }}
+  {{ case_name|default("", true) }}
 
-  {{ task_signature }}
+  {{ task_signature|default("", true) }}
 
-  {{ input }}
+  {{ input|default(content, true) }}
 
-  {{ rubric }}
+  {{ rubric|default("", true) }}
 overview_template: |-
   # Cases Overview
   {% for item in items %}
-  - [{{ item.file_content.case_name }}](./{{ item.file_name }}) — {{ item.file_content.task_signature }}
+  - [{{ item.file_content.case_name|default(item.file_name|replace(".md", ""), true) }}](./{{ item.file_name }}){% if item.file_content.task_signature|default("", true) %} — {{ item.file_content.task_signature }}{% endif %}
   {% endfor %}
 
 fields:

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -1439,25 +1439,18 @@ class MemoryUpdater:
                     if schema and schema.embedding_template:
                         template_vars = dict(mf.extra_fields)
                         template_vars["content"] = abstract
-                        missing_vars = TemplateUtils.find_missing_variables(
-                            schema.embedding_template,
-                            template_vars,
-                        )
-                        if missing_vars:
-                            logger.warning(
-                                f"Missing embedding template variables for {uri}, falling back to plain content: {sorted(missing_vars)}"
+                        try:
+                            rendered_embedding_text = TemplateUtils.render(
+                                schema.embedding_template,
+                                template_vars,
+                                extract_context=extract_context,
                             )
-                        else:
-                            try:
-                                embedding_text = render_template(
-                                    schema.embedding_template,
-                                    template_vars,
-                                    extract_context=extract_context,
-                                )
-                            except Exception as e:
-                                logger.warning(
-                                    f"Failed to render embedding template for {uri}, falling back to plain content: {e}"
-                                )
+                            if rendered_embedding_text:
+                                embedding_text = rendered_embedding_text
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to render embedding template for {uri}, falling back to plain content: {e}"
+                            )
 
                 # Get parent URI
                 from openviking_cli.utils.uri import VikingURI

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -383,6 +383,48 @@ class TestMemoryUpdater:
         assert "- [workflow.md](./workflow.md)" in viking_fs.store[preference_overview_uri]
 
     @pytest.mark.asyncio
+    async def test_generate_cases_overview_uses_filename_when_case_fields_missing(self):
+        registry = MemoryTypeRegistry(load_schemas=False)
+        registry.load_from_yaml("openviking/prompts/templates/memory/cases.yaml")
+
+        case_dir = "viking://user/alice/memories/cases"
+        case_uri = f"{case_dir}/mem_plain.md"
+        overview_uri = f"{case_dir}/.overview.md"
+
+        class FakeVikingFS:
+            def __init__(self):
+                self.store = {
+                    case_uri: MemoryFileUtils.write(
+                        MemoryFile(
+                            uri=case_uri,
+                            memory_type="cases",
+                            content="Remember API plain case note.",
+                            extra_fields={"version": 1},
+                        )
+                    )
+                }
+
+            async def ls(self, uri, show_all_hidden=False, ctx=None):
+                return [{"name": "mem_plain.md", "isDir": False}]
+
+            async def read_file(self, uri, ctx=None):
+                return self.store[uri]
+
+            async def write_file(self, uri, content, ctx=None, **kwargs):
+                self.store[uri] = content
+
+        viking_fs = FakeVikingFS()
+        updater = MemoryUpdater(registry=registry)
+        updater._get_viking_fs = MagicMock(return_value=viking_fs)
+        ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+        await updater.generate_overview("cases", case_dir, ctx, extract_context=None)
+
+        document = parse_abstract_overview(viking_fs.store[overview_uri])
+        assert "- [mem_plain](./mem_plain.md)" in document.body
+        assert "- [](./mem_plain.md)" not in document.body
+
+    @pytest.mark.asyncio
     async def test_apply_operations_preserves_pre_resolved_multi_uris_for_new_page_ids(self):
         registry = MagicMock()
         registry.get.return_value = MemoryTypeSchema(

--- a/tests/unit/session/memory/test_embedding_template.py
+++ b/tests/unit/session/memory/test_embedding_template.py
@@ -447,6 +447,52 @@ class TestEmbeddingTextConstruction:
         assert vector_text == "Trip summary"
 
     @pytest.mark.asyncio
+    async def test_plain_case_memory_uses_content_without_missing_variable_warning(self):
+        registry = MemoryTypeRegistry(load_schemas=False)
+        memory_dir = PromptManager._get_bundled_templates_dir() / "memory"
+        registry.load_from_yaml(str(memory_dir / "cases.yaml"))
+
+        case_uri = "viking://user/alice/memories/cases/mem_plain.md"
+        updater = MemoryUpdater(registry=registry, vikingdb=Mock())
+        updater._viking_fs = Mock()
+        updater._viking_fs.read_file = AsyncMock(
+            return_value=MemoryFileUtils.write(
+                MemoryFile(
+                    uri=case_uri,
+                    memory_type="cases",
+                    content="Remember API plain case note.",
+                    extra_fields={"version": 1},
+                )
+            )
+        )
+        updater._vikingdb.enqueue_embedding_msg = AsyncMock(return_value=True)
+
+        result = MemoryUpdateResult()
+        result.add_written(case_uri)
+        ctx = SimpleNamespace(user=None, account_id="default")
+
+        with (
+            patch.object(EmbeddingMsgConverter, "from_context") as mock_from_context,
+            patch("openviking.session.memory.memory_updater.logger.warning") as mock_warning,
+        ):
+            mock_from_context.side_effect = lambda context: SimpleNamespace(
+                telemetry_id=None, id="msg-1", message=context.get_vectorization_text()
+            )
+            await updater._vectorize_memories(
+                result,
+                ctx,
+                extract_context=None,
+                uri_memory_type_map={case_uri: "cases"},
+            )
+
+        vector_text = mock_from_context.call_args[0][0].get_vectorization_text()
+        assert vector_text == "Remember API plain case note."
+        assert not any(
+            "Missing embedding template variables" in str(call.args[0])
+            for call in mock_warning.call_args_list
+        )
+
+    @pytest.mark.asyncio
     async def test_memory_abstract_truncated_to_50000_bytes_before_vector_write(self):
         registry = MemoryTypeRegistry(load_schemas=False)
         registry._types["events"] = registry._parse_memory_type(


### PR DESCRIPTION
## Summary
- Render case embedding templates even when optional structured fields are missing.
- Add defaults for case memory embedding and overview templates so plain remember API notes still produce useful text and links.
- Add regression coverage for plain case memories and overview generation.

Fixes #4112

## Test plan
- [x] `OV_PREBUILT_BIN_DIR=<tmpdir> python -m pytest tests/unit/session/memory/test_embedding_template.py::TestEmbeddingTextConstruction::test_plain_case_memory_uses_content_without_missing_variable_warning tests/session/memory/test_memory_updater.py::TestMemoryUpdater::test_generate_cases_overview_uses_filename_when_case_fields_missing`

🤖 Generated with Claude Code