### PR TITLE
fix(pyagfs): tolerate legacy rm bindings

### DIFF
--- a/openviking/pyagfs/async_client.py
+++ b/openviking/pyagfs/async_client.py
@@ -199,12 +199,15 @@ class AsyncAGFSClient:
             kwargs["recursive"] = recursive
         if not force:
             kwargs["force"] = force
-        return await self.run(
-            "rm",
-            path,
-            **kwargs,
-            ctx=_fs_ctx_with_auto_pathlock(path, fs_ctx, auto_pathlock),
-        )
+        ctx = _fs_ctx_with_auto_pathlock(path, fs_ctx, auto_pathlock)
+        try:
+            return await self.run("rm", path, **kwargs, ctx=ctx)
+        except TypeError as exc:
+            if "force" not in kwargs or "unexpected keyword argument 'force'" not in str(exc):
+                raise
+            legacy_kwargs = dict(kwargs)
+            legacy_kwargs.pop("force", None)
+            return await self.run("rm", path, **legacy_kwargs, ctx=ctx)
 
     async def stat(
         self, path: str, *, fs_ctx: Dict[str, str] | None = None, bypass_cache: bool = False

--- a/tests/agfs/test_async_client.py
+++ b/tests/agfs/test_async_client.py
@@ -27,6 +27,14 @@ class _SyncAGFS:
         return ("pathlock_is_locked", ctx, path, ignore_stale)
 
 
+class _LegacyRmAGFS:
+    """Synchronous binding stub with the older rm signature."""
+
+    def rm(self, path, recursive=False):
+        """Return remove call arguments without accepting force."""
+        return ("rm", path, recursive)
+
+
 @pytest.mark.asyncio
 async def test_async_agfs_client_hides_threadpool(monkeypatch):
     to_thread_calls = []
@@ -67,3 +75,19 @@ async def test_async_agfs_client_hides_threadpool(monkeypatch):
             {"recursive": True, "ctx": {"account_id": "_system"}},
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_agfs_client_rm_tolerates_legacy_binding_without_force(monkeypatch):
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(async_client.asyncio, "to_thread", fake_to_thread)
+
+    agfs = AsyncAGFSClient(_LegacyRmAGFS())
+
+    assert await agfs.rm("/redo/id", recursive=True, force=False) == (
+        "rm",
+        "/redo/id",
+        True,
+    )


### PR DESCRIPTION
## Summary
- Retry `AsyncAGFSClient.rm` without `force` when an older synchronous AGFS binding rejects the keyword.
- Add a regression test covering legacy `rm(path, recursive=False)` bindings.

## Why
Some installed AGFS bindings do not accept the newer `force` parameter. Calls such as `rm(..., force=False)` should remain compatible with those bindings instead of failing with `TypeError` before the remove operation can run.

Fixes #4016.

## Test plan
- `pytest tests/agfs/test_async_client.py -q`