### PR TITLE
fix(session): use session skill schema for skill training

### DIFF
--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -30,6 +30,7 @@ from openviking.session.memory.dataclass import (
 )
 from openviking.session.memory.memory_updater import MemoryUpdateResult
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.session.skill.session_skill_context_provider import SESSION_SKILL_MEMORY_TYPE
 from openviking.session.train import (
     Case,
     ExperienceSet,
@@ -301,6 +302,46 @@ async def test_v3_skill_only_extraction_submits_gradients_without_agent_memories
         "skill_submitted": 1,
         "skill_uris": [skill_uri],
     }
+
+
+@pytest.mark.asyncio
+async def test_session_skill_trainer_uses_session_skill_schema_registry(monkeypatch):
+    captured = {}
+
+    async def fake_load(self, root_uri, ctx=None):
+        del self, ctx
+        return ExperienceSet(root_uri=root_uri, policies=[])
+
+    async def fake_get_streaming_policy_trainer(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr("openviking.session.compressor_v3.SkillSetLoader.load", fake_load)
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_streaming_policy_trainer",
+        fake_get_streaming_policy_trainer,
+    )
+
+    compressor = SessionCompressorV3(
+        vikingdb=None,
+        rollout_analyzer=SimpleNamespace(),
+        skill_processor=SimpleNamespace(),
+    )
+
+    trainer = await compressor._get_session_skill_trainer(
+        viking_fs=SimpleNamespace(),
+        ctx=_ctx(),
+        messages=_messages(),
+        strict_extract_errors=False,
+        archive_uri="viking://user/u/sessions/s1/history/archive_001",
+    )
+
+    optimizer = captured["policy_optimizer"]
+    assert trainer is not None
+    assert optimizer.memory_type == SESSION_SKILL_MEMORY_TYPE
+    schema = optimizer.memory_registry.get(SESSION_SKILL_MEMORY_TYPE)
+    assert schema is not None
+    assert schema.enabled is True
 
 
 @pytest.mark.asyncio

--- a/tests/session/train/test_train_components.py
+++ b/tests/session/train/test_train_components.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -110,6 +111,38 @@ class FakeVikingDB:
     async def enqueue_embedding_msg(self, embedding_msg):
         self.embedding_messages.append(embedding_msg)
         return True
+
+
+@pytest.fixture(autouse=True)
+def _test_openviking_config(monkeypatch):
+    config = SimpleNamespace(
+        output_language_override="",
+        vlm=SimpleNamespace(get_vlm_instance=lambda: object()),
+        memory=SimpleNamespace(
+            custom_templates_dir="",
+            eager_prefetch=False,
+            experimental_memory_switch=False,
+            link_enabled=False,
+            prefetch_search_topn=5,
+        ),
+    )
+    monkeypatch.setattr(
+        "openviking.session.train.components.policy_optimizer.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.session_extract_context_provider.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking.session.memory.utils.language.get_openviking_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "openviking_cli.utils.config.get_openviking_config",
+        lambda: config,
+    )
+    return config
 
 
 def _experience_set() -> ExperienceSet:


### PR DESCRIPTION
## Summary
- Route session skill training through the dedicated `session_skills` memory type instead of the legacy `skills` type.
- Allow patch-merge planning to receive an explicit memory registry so session skill extraction resolves against the enabled session skill schema.
- Add regression coverage for the compressor trainer wiring and patch-merge optimizer schema resolution.

Fixes #4186.

## Test plan
- `pytest tests/session/test_compressor_v3.py::test_session_skill_trainer_uses_session_skill_schema_registry tests/session/train/test_train_components.py::test_patch_merge_policy_optimizer_uses_session_skill_registry` -> 2 passed, 4 warnings
- `pytest tests/session/train/test_train_components.py` -> 18 passed, 4 warnings

## Notes
- The broader `pytest tests/session/test_compressor_v3.py tests/session/train/test_train_components.py` command still hits existing local-environment failures unrelated to this patch: missing local OpenViking config / uninitialized VikingFS paths in other compressor tests.