### PR TITLE
fix(dsh): launch MCP proxy with node command

### DIFF
--- a/examples/dsh-memory-plugin/mcp.mjs
+++ b/examples/dsh-memory-plugin/mcp.mjs
@@ -25,7 +25,7 @@ export function buildMcpConfig(config) {
   return {
     transport: "stdio",
     serverName: MCP_SERVER_NAME,
-    command: process.execPath,
+    command: "node",
     args: [PROXY_PATH],
     env,
     toolCallTimeoutMs: config.mcpToolCallTimeoutMs,

--- a/examples/dsh-memory-plugin/mcp.test.mjs
+++ b/examples/dsh-memory-plugin/mcp.test.mjs
@@ -18,7 +18,7 @@ test("the mount config validates against the pinned bridge's own schema", () => 
   // server through this same proxy, and it owns the transport quirks.
   assert.equal(parsed.transport, "stdio");
   assert.equal(parsed.serverName, "openviking");
-  assert.equal(parsed.command, process.execPath);
+  assert.equal(parsed.command, "node");
   assert.deepEqual(parsed.args, [PROXY_PATH]);
   assert.equal(parsed.toolCallTimeoutMs, 60000);
   // Startup must not be fatal: recall, capture, and commit keep working when


### PR DESCRIPTION
## Summary
- Start the DSH stdio MCP proxy with the stable `node` command instead of `process.execPath`.
- Keep the existing proxy path, credential env forwarding, timeout, and reconnect behavior unchanged.
- Update the MCP config contract test to prevent Electron desktop hosts from leaking their app executable into the proxy command.

Fixes #4189.

## Test plan
- `node --test mcp.test.mjs` -> 6 passed
- `npm test` in `examples/dsh-memory-plugin` -> 40 passed, 1 skipped