### PR TITLE
fix(auth): reject mismatched OAuth user headers

### DIFF
--- a/openviking/server/auth/plugins/api_key.py
+++ b/openviking/server/auth/plugins/api_key.py
@@ -146,6 +146,16 @@ class ApiKeyAuthPlugin(AuthPlugin):
 
         role = Role(record.role)
 
+        if role == Role.USER:
+            if x_openviking_account and x_openviking_account != record.account_id:
+                raise PermissionDeniedError(
+                    "OAuth token identity does not match X-OpenViking-Account"
+                )
+            if x_openviking_user and x_openviking_user != record.user_id:
+                raise PermissionDeniedError(
+                    "OAuth token identity does not match X-OpenViking-User"
+                )
+
         # Role downgrade protection
         if api_key_manager is not None and hasattr(api_key_manager, "get_user_role"):
             try:

--- a/tests/server/oauth/test_auth_integration.py
+++ b/tests/server/oauth/test_auth_integration.py
@@ -227,6 +227,25 @@ async def test_oauth_user_role_rejects_account_override(provider, store):
 
 
 @pytest.mark.asyncio
+async def test_oauth_user_role_rejects_user_override(provider, store):
+    """A USER OAuth token cannot impersonate another user via header."""
+    token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="user")
+    request = _make_request(
+        bearer=token,
+        api_key_manager=_StubKeyManager(),
+        oauth_provider=provider,
+        extra_headers={"x-openviking-user": "bob"},
+    )
+    with pytest.raises(PermissionDeniedError):
+        await resolve_identity(
+            request,
+            x_api_key=None,
+            authorization=f"Bearer {token}",
+            x_openviking_user="bob",
+        )
+
+
+@pytest.mark.asyncio
 async def test_oauth_root_can_be_used_without_explicit_tenant_headers(provider, store):
     """ROOT OAuth tokens carry account/user in claims — no header requirement."""
     token = await _mint_token(provider, store, account_id="tenant-a", user_id="alice", role="root")


### PR DESCRIPTION
## Summary
- Reject USER OAuth tokens when `X-OpenViking-Account` or `X-OpenViking-User` conflicts with the token-bound identity.
- Preserve the existing behavior for matching headers and privileged OAuth tokens.
- Add regression coverage for user-header mismatch in addition to the existing account-header mismatch case.

Fixes #3801.

## Test plan
- `pytest tests/server/oauth/test_auth_integration.py::test_oauth_user_role_rejects_account_override tests/server/oauth/test_auth_integration.py::test_oauth_user_role_rejects_user_override` -> 2 passed, 4 warnings
- `pytest tests/server/oauth/test_auth_integration.py` -> 13 passed, 4 warnings