### PR TITLE
fix(serialization): JSON 编码前净化孤立代理项 lone surrogate（#4238）

### DIFF
--- a/bot/vikingbot/agent/loop.py
+++ b/bot/vikingbot/agent/loop.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from openviking.storage.vectordb.utils.json_safety import safe_json_dumps, sanitize_unicode_for_json
 from vikingbot.agent.context import ContextBuilder
 from vikingbot.agent.memory import MemoryStore
 from vikingbot.agent.remote_skills import SkillRuntimeContext
@@ -1518,7 +1519,7 @@ class AgentLoop:
                     return idx, tool_call, outcome, tool_execute_duration
 
                 for tool_call in response.tool_calls:
-                    args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
+                    args_str = safe_json_dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info(f"[TOOL_CALL]: {tool_call.name}({args_str[:200]})")
                     if publish_events:
                         await self.bus.publish_outbound(
@@ -1595,8 +1596,11 @@ class AgentLoop:
                 # Stage 3: Process results sequentially in original order
                 turn_tools: list[dict[str, Any]] = []
                 for _idx, tool_call, outcome, tool_execute_duration in results:
-                    result = outcome.result
-                    args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
+                    # Tool output can carry lone surrogates (mangled filenames etc.).
+                    # Neutralize them before the result enters the message list or the
+                    # persisted tool dict, so the next json.dumps(...) encode cannot crash.
+                    result = sanitize_unicode_for_json(outcome.result)
+                    args_str = safe_json_dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info(f"[RESULT]: {str(result)[:600]}")
 
                     if publish_events:
@@ -1615,7 +1619,7 @@ class AgentLoop:
                         "tool_call_id": tool_call.id,
                         "tool_name": tool_call.name,
                         "args": args_str,
-                        "resolved_args": outcome.effective_params,
+                        "resolved_args": sanitize_unicode_for_json(outcome.effective_params),
                         "result": result,
                         "duration": tool_execute_duration,
                         "execute_success": _is_tool_result_success(result),

--- a/bot/vikingbot/session/manager.py
+++ b/bot/vikingbot/session/manager.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, TypeVar
 
 from loguru import logger
 
+from openviking.storage.vectordb.utils.json_safety import safe_json_dumps
 from vikingbot.config.schema import SessionKey
 from vikingbot.providers.registry import find_by_name
 from vikingbot.sandbox.manager import SandboxManager
@@ -323,10 +324,10 @@ class SessionManager:
                     "updated_at": session.updated_at.isoformat(),
                     "metadata": session.metadata,
                 }
-                f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
+                f.write(safe_json_dumps(metadata_line, ensure_ascii=False) + "\n")
 
                 for msg in session.messages:
-                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                    f.write(safe_json_dumps(msg, ensure_ascii=False) + "\n")
             temporary.replace(path)
         finally:
             temporary.unlink(missing_ok=True)

--- a/bot/vikingbot/tests/unit/test_agent_loop_surrogates.py
+++ b/bot/vikingbot/tests/unit/test_agent_loop_surrogates.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Lone-surrogate (U+D800-U+DFFF) safety for tool results entering the agent loop (#4238)."""
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from vikingbot.agent.context import ContextBuilder
+from vikingbot.agent.loop import AgentLoop
+from vikingbot.agent.tools.registry import ToolExecutionResult
+from vikingbot.config.schema import SessionKey
+
+
+class _FakeResponse:
+    def __init__(self, tool_calls, content=""):
+        self.has_tool_calls = bool(tool_calls)
+        self.tool_calls = tool_calls
+        self.content = content
+        self.reasoning_content = None
+        self.usage = None
+
+
+class _FakeProvider:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def chat_stream(self, **kwargs):
+        yield SimpleNamespace(type="response", response=self._responses.pop(0))
+
+
+class _FakeRegistry:
+    def __init__(self, result, arguments):
+        self._result = result
+        self._arguments = arguments
+
+    def get_definitions(self, **kwargs):
+        return [
+            {
+                "type": "function",
+                "function": {"name": "list", "parameters": {"type": "object", "properties": {}}},
+            }
+        ]
+
+    async def execute_detailed(self, name, arguments, **kwargs):
+        return ToolExecutionResult(result=self._result, effective_params=dict(arguments))
+
+
+def _build_loop(tmp_path: Path, provider, registry) -> AgentLoop:
+    loop = AgentLoop.__new__(AgentLoop)
+    loop.max_iterations = 2
+    loop.context = ContextBuilder(tmp_path, enable_subagents=False)
+    loop.provider = provider
+    loop.bus = None
+    loop.sandbox_manager = None
+    loop.sessions = None
+    loop.tools = registry
+    loop.model = "fake-model"
+    loop.temperature = 0.0
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_tool_result_surrogate_is_sanitized_in_message_flow(tmp_path: Path):
+    surrogate_args = {"uri": "viking://resources/\ud800bad_name"}
+    provider = _FakeProvider(
+        [
+            _FakeResponse(
+                tool_calls=[
+                    SimpleNamespace(
+                        id="call_1", name="list", arguments=surrogate_args, tokens=None
+                    )
+                ]
+            ),
+            _FakeResponse(tool_calls=[], content="done"),
+        ]
+    )
+    registry = _FakeRegistry(
+        result="listed viking://resources/\ud800bad_name", arguments=surrogate_args
+    )
+    loop = _build_loop(tmp_path, provider, registry)
+    key = SessionKey(type="test", channel_id="channel", chat_id="chat")
+    messages: list = []
+    captured_turns: list = []
+
+    final_content, _, tools_used, _, _ = await loop._run_agent_loop(
+        messages=messages,
+        session_key=key,
+        publish_events=False,
+        ov_tools_enable=False,
+        inject_write_experience=False,
+        tool_registry=registry,
+        captured_turns=captured_turns,
+    )
+
+    assert final_content == "done"
+
+    # The tool result that flows back into the transcript must be surrogate-free.
+    tool_messages = [m for m in messages if m.get("role") == "tool"]
+    assert tool_messages, "expected a tool message in the transcript"
+    content = tool_messages[0]["content"]
+    assert "\ud800" not in content
+    assert "�" in content
+
+    # The persisted tool-use dict (stored into session JSONL via agent_turns)
+    # must be surrogate-free as well, including the echoed arguments.
+    assert len(captured_turns) == 1
+    record = captured_turns[0]["tool_calls"][0]
+    assert "\ud800" not in record["result"]
+    assert "�" in record["result"]
+    assert "\ud800" not in record["resolved_args"]["uri"]
+    assert "�" in record["resolved_args"]["uri"]
+
+    # tools_used also holds the sanitized result.
+    assert "\ud800" not in tools_used[0]["result"]

--- a/bot/vikingbot/tests/unit/test_session_manager_surrogates.py
+++ b/bot/vikingbot/tests/unit/test_session_manager_surrogates.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Lone-surrogate (U+D800-U+DFFF) safety when persisting sessions (#4238)."""
+
+from pathlib import Path
+
+import pytest
+
+from vikingbot.config.schema import SessionKey
+from vikingbot.session.manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_save_session_with_surrogate_in_message_does_not_crash(tmp_path: Path):
+    manager = SessionManager(bot_data_path=tmp_path)
+    key = SessionKey(type="test", channel_id="channel", chat_id="chat")
+    session = manager.get_or_create(key)
+    session.add_message("tool", "listed viking://resources/\ud800bad_name")
+
+    await manager.save(session)
+
+    persisted = manager._load(key)
+    assert persisted is not None
+    content = persisted.messages[0]["content"]
+    assert "\ud800" not in content
+    assert "�" in content
+
+
+@pytest.mark.asyncio
+async def test_save_session_with_surrogate_in_metadata_does_not_crash(tmp_path: Path):
+    manager = SessionManager(bot_data_path=tmp_path)
+    key = SessionKey(type="test", channel_id="channel", chat_id="chat")
+    session = manager.get_or_create(key)
+    session.metadata["note"] = "file \udfff found"
+    session.add_message("user", "hello")
+
+    await manager.save(session)
+
+    persisted = manager._load(key)
+    assert persisted is not None
+    assert "\udfff" not in persisted.metadata["note"]
+
+
+@pytest.mark.asyncio
+async def test_save_session_roundtrip_preserves_valid_non_bmp(tmp_path: Path):
+    manager = SessionManager(bot_data_path=tmp_path)
+    key = SessionKey(type="test", channel_id="channel", chat_id="chat")
+    session = manager.get_or_create(key)
+    session.add_message("user", "wave \U0001F600")
+
+    await manager.save(session)
+
+    persisted = manager._load(key)
+    assert persisted.messages[0]["content"] == "wave \U0001F600"

--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -13,11 +13,12 @@ from typing import Callable, Optional
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.exceptions import ExceptionMiddleware
 
 from openviking.observability.http_error_context import capture_public_http_error
+from openviking.server.responses import SurrogateSafeJSONResponse
 from openviking.server.config import (
     ServerConfig,
     load_bot_gateway_token,
@@ -397,6 +398,10 @@ def create_app(
         description="OpenViking HTTP Server - Agent-native context database",
         version="0.1.0",
         lifespan=lifespan,
+        # Route handlers often return plain dicts (e.g. the success path of
+        # response_from_result). Make the framework's default JSON renderer
+        # tolerate lone surrogate code points from mangled filenames.
+        default_response_class=SurrogateSafeJSONResponse,
     )
 
     app.state.config = config
@@ -489,7 +494,7 @@ def create_app(
     async def openviking_error_handler(request: Request, exc: OpenVikingError):
         http_status = ERROR_CODE_TO_HTTP_STATUS.get(exc.code, 500)
         capture_public_http_error(code=exc.code, message=exc.message, details=exc.details)
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=http_status,
             content=Response(
                 status="error",
@@ -512,7 +517,7 @@ def create_app(
             message=message,
             details=details,
         )
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=ERROR_CODE_TO_HTTP_STATUS[code],
             content=Response(
                 status="error",
@@ -535,7 +540,7 @@ def create_app(
             details = {"original_http_status_code": exc.status_code}
         message = _message_from_http_detail(exc.detail)
         capture_public_http_error(code=code, message=message, details=details)
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=response_status,
             headers=exc.headers,
             content=Response(
@@ -558,7 +563,7 @@ def create_app(
                 extra={"error_code": mapped.code, "error_message": mapped.message},
                 exc_info=exc,
             )
-            return JSONResponse(
+            return SurrogateSafeJSONResponse(
                 status_code=http_status,
                 content=Response(
                     status="error",
@@ -571,7 +576,7 @@ def create_app(
             )
 
         logger.exception("Unhandled exception")
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=500,
             content=Response(
                 status="error",

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -27,7 +27,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, Field
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from openviking.server.responses import SurrogateSafeJSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from openviking.core.path_variables import resolve_path_variables
@@ -183,7 +183,7 @@ class _IdentityASGIMiddleware:
                     headers["WWW-Authenticate"] = (
                         f'Bearer resource_metadata="{origin}/.well-known/oauth-protected-resource"'
                     )
-            resp = JSONResponse(
+            resp = SurrogateSafeJSONResponse(
                 {"jsonrpc": "2.0", "id": None, "error": {"code": -32001, "message": str(exc)}},
                 status_code=status,
                 headers=headers,

--- a/openviking/server/oauth/router.py
+++ b/openviking/server/oauth/router.py
@@ -28,12 +28,13 @@ from typing import Optional
 from urllib.parse import urlencode, urlparse
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse
 from mcp.shared.auth import ProtectedResourceMetadata
 from pydantic import AnyHttpUrl, BaseModel, Field
 
 from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext
+from openviking.server.responses import SurrogateSafeJSONResponse
 from openviking.server.oauth.provider import MCP_SCOPE, OpenVikingOAuthProvider
 from openviking.server.oauth.storage import OAuthStore
 from openviking_cli.exceptions import (
@@ -222,7 +223,7 @@ def _public_origin(request: Request) -> str:
 
 
 @router.get("/.well-known/oauth-protected-resource")
-async def oauth_protected_resource(request: Request) -> JSONResponse:
+async def oauth_protected_resource(request: Request) -> SurrogateSafeJSONResponse:
     """RFC 9728 — protected resource metadata for /mcp.
 
     MCP clients reach this URL via the ``WWW-Authenticate: Bearer
@@ -241,7 +242,7 @@ async def oauth_protected_resource(request: Request) -> JSONResponse:
         bearer_methods_supported=["header"],
         resource_name="OpenViking MCP",
     )
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         metadata.model_dump(mode="json", exclude_none=True),
         headers={"Cache-Control": "public, max-age=3600"},
     )
@@ -275,7 +276,7 @@ async def authorize_page_get(request: Request, pending: str = "") -> HTMLRespons
 
 
 @router.get("/oauth/authorize/page/status")
-async def authorize_page_status(request: Request, pending: str = "") -> JSONResponse:
+async def authorize_page_status(request: Request, pending: str = "") -> SurrogateSafeJSONResponse:
     """Polled by the authorize page until verification + auth-code mint.
 
     Status values:
@@ -285,14 +286,14 @@ async def authorize_page_status(request: Request, pending: str = "") -> JSONResp
     """
     store, provider = _get_store_and_provider(request)
     if not pending:
-        return JSONResponse({"status": "expired"}, status_code=410)
+        return SurrogateSafeJSONResponse({"status": "expired"}, status_code=410)
 
     record = await store.load_pending_authorization(pending)
     if record is None:
-        return JSONResponse({"status": "expired"}, status_code=410)
+        return SurrogateSafeJSONResponse({"status": "expired"}, status_code=410)
 
     if not record["verified"]:
-        return JSONResponse({"status": "pending"}, headers={"Cache-Control": "no-store"})
+        return SurrogateSafeJSONResponse({"status": "pending"}, headers={"Cache-Control": "no-store"})
 
     # Verified — mint auth code and tear down pending row.
     auth_code = provider.mint_authorization_code()
@@ -319,7 +320,7 @@ async def authorize_page_status(request: Request, pending: str = "") -> JSONResp
     if record.get("state"):
         params["state"] = record["state"]
     sep = "&" if "?" in record["redirect_uri"] else "?"
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         {
             "status": "approved",
             "redirect_url": f"{record['redirect_uri']}{sep}{urlencode(params)}",
@@ -356,18 +357,18 @@ class OAuthPendingInfo(BaseModel):
     "/api/v1/auth/oauth/pending/{pending_id}",
     response_model=OAuthPendingInfo,
 )
-async def oauth_pending_info(request: Request, pending_id: str) -> JSONResponse:
+async def oauth_pending_info(request: Request, pending_id: str) -> SurrogateSafeJSONResponse:
     """Return public-safe metadata about a pending OAuth authorization."""
     store, provider = _get_store_and_provider(request)
     record = await store.load_pending_authorization(pending_id)
     if record is None:
-        return JSONResponse({"error": "expired"}, status_code=404)
+        return SurrogateSafeJSONResponse({"error": "expired"}, status_code=404)
 
     client = await provider.get_client(record["client_id"])
     redirect_uri = record.get("redirect_uri") or ""
     redirect_host = urlparse(redirect_uri).netloc or None
 
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         OAuthPendingInfo(
             client_id=record["client_id"],
             client_name=client.client_name if client else None,
@@ -414,7 +415,7 @@ async def oauth_verify(
     request: Request,
     body: OAuthVerifyRequest,
     ctx: RequestContext = Depends(get_request_context),
-) -> JSONResponse:
+) -> SurrogateSafeJSONResponse:
     """Bind the caller's identity to a pending OAuth authorization.
 
     Two entry points converge here:
@@ -465,7 +466,7 @@ async def oauth_verify(
 
     if decision == "deny":
         await store.delete_pending_authorization(record["pending_id"])
-        return JSONResponse({"status": "denied"})
+        return SurrogateSafeJSONResponse({"status": "denied"})
 
     # Bind the verifier's current API-key fingerprint into the pending row.
     # The fp is propagated through auth_code → access/refresh tokens, and
@@ -496,7 +497,7 @@ async def oauth_verify(
         raise InvalidArgumentError("Verification raced — please restart from the authorize page")
 
     client = await provider.get_client(record["client_id"])
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         {
             "status": "approved",
             "client_id": record["client_id"],

--- a/openviking/server/profile_middleware.py
+++ b/openviking/server/profile_middleware.py
@@ -12,9 +12,11 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from fastapi import Request
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse
 from starlette.responses import Response as StarletteResponse
 from starlette.responses import StreamingResponse
+
+from openviking.server.responses import SurrogateSafeJSONResponse
 
 PROFILE_TRUE_VALUES = {"1", "true", "yes", "on"}
 PROFILE_SORT_BY = "cumulative"
@@ -201,7 +203,7 @@ async def inject_profile_into_response(response, profile_lines: list[str]):
         )
 
     payload["profile"] = profile_lines
-    rebuilt = JSONResponse(status_code=response.status_code, content=payload)
+    rebuilt = SurrogateSafeJSONResponse(status_code=response.status_code, content=payload)
     for key, value in response.headers.items():
         if key.lower() not in {"content-length", "content-type"}:
             rebuilt.headers[key] = value

--- a/openviking/server/request_id.py
+++ b/openviking/server/request_id.py
@@ -10,9 +10,9 @@ import re
 import time
 import uuid
 
-from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from openviking.server.responses import SurrogateSafeJSONResponse
 from openviking_cli.utils.logger import bind_log_request_id
 
 REQUEST_ID_HEADER = "X-Request-ID"
@@ -80,7 +80,7 @@ class RequestIdMiddleware:
         with bind_log_request_id(request_id):
             try:
                 if invalid:
-                    response = JSONResponse(
+                    response = SurrogateSafeJSONResponse(
                         status_code=400,
                         content={
                             "status": "error",

--- a/openviking/server/responses.py
+++ b/openviking/server/responses.py
@@ -8,6 +8,26 @@ from fastapi.responses import JSONResponse
 
 from openviking.observability.http_error_context import capture_public_http_error
 from openviking.server.models import ERROR_CODE_TO_HTTP_STATUS, ErrorInfo, Response
+from openviking.storage.vectordb.utils.json_safety import sanitize_unicode_for_json
+
+
+class SurrogateSafeJSONResponse(JSONResponse):
+    """``JSONResponse`` that tolerates lone surrogate code points in the payload.
+
+    Filesystem names and tool results can carry isolated UTF-16 surrogates
+    (U+D800-U+DFFF) after Python decodes non-UTF-8 bytes with ``surrogateescape``.
+    Starlette's ``render`` calls ``json.dumps(..., ensure_ascii=False)`` and then
+    encodes to UTF-8, which raises ``UnicodeEncodeError`` for those characters.
+    On that failure we re-render the sanitized payload (lone surrogates become
+    U+FFFD), so the response envelope stays well-formed instead of truncating
+    into a 500. Normal responses are byte-for-byte identical and pay no cost.
+    """
+
+    def render(self, content: Any) -> bytes:
+        try:
+            return super().render(content)
+        except UnicodeEncodeError:
+            return super().render(sanitize_unicode_for_json(content))
 
 
 def _message_from_business_error(result: Dict[str, Any]) -> str:
@@ -61,7 +81,7 @@ def response_from_result(
             error=error,
             telemetry=telemetry,
         ).model_dump(exclude_none=True)
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=ERROR_CODE_TO_HTTP_STATUS.get(code, 500),
             content=content,
         )
@@ -87,7 +107,7 @@ def error_response(
         error=ErrorInfo(code=code, message=message, details=details),
         telemetry=telemetry,
     ).model_dump(exclude_none=True)
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         status_code=ERROR_CODE_TO_HTTP_STATUS.get(code, 500),
         content=content,
     )

--- a/openviking/server/routers/bot.py
+++ b/openviking/server/routers/bot.py
@@ -9,7 +9,9 @@ from typing import AsyncGenerator, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
+
+from openviking.server.responses import SurrogateSafeJSONResponse
 
 from openviking.server.auth import _auth_mode, get_request_context
 from openviking.server.config import get_server_url_from_server_data
@@ -207,7 +209,7 @@ async def create_compile(
         ) from exc
     if not response.is_success:
         _raise_compile_proxy_error(response)
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         status_code=status.HTTP_202_ACCEPTED,
         content=Response(status="ok", result=response.json()).model_dump(mode="json"),
     )

--- a/openviking/server/routers/system.py
+++ b/openviking/server/routers/system.py
@@ -6,11 +6,11 @@ import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.uri_validation import validate_request_viking_uri
+from openviking.server.responses import SurrogateSafeJSONResponse
 from openviking.pyagfs.exceptions import AGFSInvalidOperationError, AGFSNotSupportedError
 from openviking.server.auth import get_request_context, require_role
 from openviking.server.dependencies import get_service
@@ -118,13 +118,13 @@ async def readiness_check(request: Request):
     try:
         service = get_service()
         if not service._initialized:
-            return JSONResponse(
+            return SurrogateSafeJSONResponse(
                 status_code=503,
                 content={"status": "not_ready", "reason": "initializing"},
             )
     except RuntimeError:
         # get_service() raises RuntimeError when service not yet set
-        return JSONResponse(
+        return SurrogateSafeJSONResponse(
             status_code=503,
             content={"status": "not_ready", "reason": "initializing"},
         )
@@ -194,7 +194,7 @@ async def readiness_check(request: Request):
 
     all_ok = all(_is_ready_check_ok(v) for v in checks.values())
     status_code = 200 if all_ok else 503
-    return JSONResponse(
+    return SurrogateSafeJSONResponse(
         status_code=status_code,
         content={"status": "ready" if all_ok else "not_ready", "checks": checks},
     )

--- a/tests/server/test_surrogate_safe_responses.py
+++ b/tests/server/test_surrogate_safe_responses.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Lone-surrogate (U+D800-U+DFFF) safety at the HTTP response boundary (#4238)."""
+
+import json
+
+from fastapi.responses import JSONResponse
+
+from openviking.server.responses import (
+    SurrogateSafeJSONResponse,
+    error_response,
+    response_from_result,
+)
+
+
+def test_surrogate_safe_json_response_replaces_lone_surrogates():
+    content = {
+        "uri": "viking://resources/\ud800bad_name",
+        "nested": {"paths": ["\udfff", "ok"]},
+    }
+    response = SurrogateSafeJSONResponse(status_code=200, content=content)
+    body = response.render(content)
+    decoded = json.loads(body)
+    assert "\ud800" not in decoded["uri"]
+    assert "\udfff" not in decoded["nested"]["paths"][0]
+    assert "�" in decoded["uri"]
+
+
+def test_surrogate_safe_json_response_keeps_valid_non_bmp_characters():
+    content = {"name": "emoji \U0001F600 preserved"}
+    response = SurrogateSafeJSONResponse(content=content)
+    body = response.render(content)
+    assert "\U0001F600" in json.loads(body)["name"]
+
+
+def test_surrogate_safe_json_response_accepts_clean_content():
+    content = {"status": "ok", "count": 3, "flag": True, "none": None}
+    response = SurrogateSafeJSONResponse(content=content)
+    body = response.render(content)
+    assert json.loads(body) == content
+
+
+def test_clean_content_is_byte_identical_to_plain_json_response():
+    # The happy path must not pay the sanitizer cost or change the output.
+    content = {"uri": "viking://resources/ok_name", "nested": [1, 2, {"k": "v"}]}
+    safe = SurrogateSafeJSONResponse(content=content).render(content)
+    plain = JSONResponse(content=content).render(content)
+    assert safe == plain
+
+
+def test_error_response_with_surrogate_message_renders():
+    response = error_response("NOT_FOUND", "viking://resources/\ud800bad_name missing")
+    assert isinstance(response, SurrogateSafeJSONResponse)
+    assert response.status_code == 404
+    body = response.body
+    assert b"\xed\xb2\x80" not in body  # no raw surrogate bytes in UTF-8
+    assert b"\xef\xbf\xbd" in body  # replacement character present
+
+
+def test_response_from_result_error_path_renders_with_surrogate():
+    response = response_from_result(
+        {
+            "status": "error",
+            "code": "PROCESSING_ERROR",
+            "message": "listed viking://resources/\ud800bad_name",
+        }
+    )
+    assert isinstance(response, SurrogateSafeJSONResponse)
+    body = response.body
+    assert b"\xed\xb2\x80" not in body
+    assert b"\xef\xbf\xbd" in body
+
+
+def test_response_from_result_success_path_is_surrogate_safe_default():
+    # The success path returns a plain dict, which the FastAPI app serializes with
+    # the surrogate-safe default response class. Replicate that class's render on
+    # the returned dict to prove the whole envelope stays well-formed.
+    result = response_from_result({"uri": "viking://resources/\ud800x"})
+    assert isinstance(result, dict)
+    response = SurrogateSafeJSONResponse(status_code=200, content=result)
+    body = response.render(result)
+    assert b"\xed\xb2\x80" not in body
+    assert b"\xef\xbf\xbd" in body


### PR DESCRIPTION
## Description

修复 #4238：非 UTF-8 文件名经 `surrogateescape` 解码后会产生孤立代理项（lone surrogate，U+D800–U+DFFF）。这类字符串在内存中无害，但 `json.dumps(..., ensure_ascii=False)` 之后的 `.encode("utf-8")` 会抛出 `UnicodeEncodeError: surrogates not allowed`，导致 HTTP 响应、会话 JSONL 持久化、Agent 工具结果回流三处崩溃。

仓库已有现成的净化工具 `sanitize_unicode_for_json` / `safe_json_dumps`（位于 `openviking.storage.vectordb.utils.json_safety`），但此前只在 vectordb 存储层使用，未接入上述三处出口边界。本 PR 将净化逻辑接入这些边界，行为是**纯增量**的：正常响应逐字节不变，仅在失败路径触发净化。

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

Fixes #4238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **HTTP 响应边界**
  - `openviking/server/responses.py`：新增 `SurrogateSafeJSONResponse(JSONResponse)`，`render` 用 try/except 回退——先走原渲染，捕获 `UnicodeEncodeError` 后再对净化后的 payload 重新渲染（正常响应零开销、字节级一致）。
  - `openviking/server/app.py`：将其设为 FastAPI 的 `default_response_class`，并把 5 处异常处理器由 `JSONResponse` 改为 `SurrogateSafeJSONResponse`。
  - `oauth/router.py`、`mcp_endpoint.py`、`profile_middleware.py`、`request_id.py`、`routers/bot.py`、`routers/system.py`：所有显式 `JSONResponse` 站点统一替换。
- **会话持久化边界**：`bot/vikingbot/session/manager.py` 在写会话元数据与消息时用 `safe_json_dumps` 替代 `json.dumps`。
- **工具结果边界**：`bot/vikingbot/agent/loop.py` 在工具结果与 `resolved_args` 回流进消息列表 / 持久化工具字典前先 `sanitize_unicode_for_json`。
- **回归测试**：新增 11 个测试，覆盖 HTTP、会话、Agent 循环三条路径。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

验证结果：

- 新增回归测试全部通过：HTTP 边界 7 项、会话持久化 3 项、Agent 循环 1 项。
- `bot/vikingbot/tests/unit/` 完整套件 69 项通过。
- `tests/server/test_error_mapping.py`、`test_error_envelope_status_codes.py`（部分）等共 18 项通过；另有 7 项因 app fixture 缺少本地配置文件在 setup 阶段报错，经 `git stash` 验证为**预先存在**的环境问题，与本改动无关。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- 本 PR 复用了仓库已有的 `sanitize_unicode_for_json` / `safe_json_dumps`，未引入任何新逻辑或新依赖。
- 采用 issue 建议的 try/except 回退方案，正常响应路径不承担任何额外序列化开销。
