### PR TITLE
fix(claude-code-memory-plugin): recall against older servers

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/lib/recall-compat.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/lib/recall-compat.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { buildServerAssembledBlock, fetchAssembledContext, unknownBodyFields } from "../shared/recall-core.mjs";
+
+const EXTRA_FORBIDDEN = (...fields) => ({
+  ok: false,
+  status: 400,
+  error: {
+    code: "INVALID_ARGUMENT",
+    message: "Invalid request parameters",
+    details: {
+      validation_errors: fields.map((field) => ({
+        loc: ["body", field],
+        message: "Extra inputs are not permitted",
+        type: "extra_forbidden",
+      })),
+    },
+  },
+});
+
+test("unknownBodyFields reads the fields a validation error names", () => {
+  const res = EXTRA_FORBIDDEN("mode", "purpose", "max_tokens");
+  assert.deepEqual(unknownBodyFields(res), ["mode", "purpose", "max_tokens"]);
+});
+
+test("unknownBodyFields ignores non-extra errors and never strips query", () => {
+  const res = {
+    ok: false,
+    status: 400,
+    error: {
+      details: {
+        validation_errors: [
+          { loc: ["body", "query"], message: "Extra inputs are not permitted", type: "extra_forbidden" },
+          { loc: ["body", "score_threshold"], message: "Input should be a number", type: "float_parsing" },
+        ],
+      },
+    },
+  };
+  assert.deepEqual(unknownBodyFields(res), []);
+});
+
+test("fetchAssembledContext strips rejected fields and retries instead of going legacy", async () => {
+  const legacyCachePath = join(mkdtempSync(join(tmpdir(), "ov-compat-")), "context-face.json");
+  const bodies = [];
+  const fetchJSON = async (path, init) => {
+    const body = JSON.parse(init.body);
+    bodies.push(body);
+    const extras = ["mode", "purpose", "dedup_turns"].filter((field) => field in body);
+    if (extras.length) return EXTRA_FORBIDDEN(...extras);
+    return {
+      ok: true,
+      status: 200,
+      result: {
+        rendered: "remembered",
+        entries: [{ uri: "viking://user/alice/memories/note.md", category: "memory", text: "remembered" }],
+        stats: { used_tokens: 5 },
+      },
+    };
+  };
+
+  const events = [];
+  const out = await fetchAssembledContext(
+    fetchJSON,
+    {},
+    "what did we decide?",
+    { sessionId: "s1", legacyCachePath, log: (stage, data) => events.push([stage, data]) },
+  );
+
+  assert.equal(out.rendered, "remembered");
+  assert.equal(bodies.length, 2, "one strip pass, then success");
+  assert.equal(bodies[1].mode, undefined);
+  assert.equal(bodies[1].purpose, undefined);
+  assert.equal(bodies[1].query, "what did we decide?");
+  const stripEvents = events.filter(([stage]) => stage === "recall_context_face_fields_stripped");
+  assert.equal(stripEvents.length, 1);
+  assert.deepEqual(stripEvents[0][1].stripped.sort(), ["dedup_turns", "mode", "purpose"]);
+
+  // A second call must not have been poisoned by a legacy marker.
+  const again = await fetchAssembledContext(fetchJSON, {}, "again", { legacyCachePath });
+  assert.ok(again, "the context face stays supported after a successful strip-retry");
+});
+
+test("fetchAssembledContext still goes legacy when the error names nothing strippable", async () => {
+  const legacyCachePath = join(mkdtempSync(join(tmpdir(), "ov-compat-")), "context-face.json");
+  const fetchJSON = async () => ({
+    ok: false,
+    status: 400,
+    error: { message: "unexpected mode value" },
+  });
+  const events = [];
+  const out = await fetchAssembledContext(
+    fetchJSON,
+    {},
+    "query",
+    { legacyCachePath, log: (stage) => events.push(stage) },
+  );
+  assert.equal(out, null);
+  assert.ok(events.includes("recall_context_face_unsupported"));
+});
+
+test("fetchAssembledContext adapts the older memories shape into entries", async () => {
+  const legacyCachePath = join(mkdtempSync(join(tmpdir(), "ov-compat-")), "context-face.json");
+  const fetchJSON = async () => ({
+    ok: true,
+    status: 200,
+    result: {
+      memories: [
+        { uri: "viking://user/alice/memories/skills/Build.md", context_type: "memory",
+          abstract: "Skill: Build", score: 0.44 },
+      ],
+    },
+  });
+  const out = await fetchAssembledContext(fetchJSON, {}, "build", { legacyCachePath });
+  assert.equal(out.entries.length, 1);
+  assert.equal(out.entries[0].category, "memory");
+  assert.equal(out.entries[0].text, "Skill: Build");
+});
+
+test("buildServerAssembledBlock renders old-shape memories into an injection block", async () => {
+  const legacyCachePath = join(mkdtempSync(join(tmpdir(), "ov-compat-")), "context-face.json");
+  const fetchJSON = async (path) => {
+    if (path === "/api/v1/search/search") {
+      return {
+        ok: true,
+        status: 200,
+        result: {
+          memories: [
+            { uri: "viking://user/alice/memories/skills/Build.md", context_type: "memory",
+              abstract: "Skill: Build — prefer make targets over raw scripts", score: 0.52 },
+          ],
+        },
+      };
+    }
+    return { ok: false, status: 404 };
+  };
+  const block = await buildServerAssembledBlock(fetchJSON, {}, "how do we build?", { legacyCachePath });
+  assert.ok(block.includes("<openviking-context>"));
+  assert.ok(block.includes("viking://user/alice/memories/skills/Build.md"));
+  assert.ok(block.includes("prefer make targets"));
+});

--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -423,6 +423,31 @@ function looksLikeUnknownField(res) {
   return text.includes("extra") || text.includes("mode") || text.includes("unexpected");
 }
 
+/**
+ * Extract the top-level body fields a validation error names as unknown, so the
+ * request can be retried without them. Older servers (e.g. v0.4.x) reject the
+ * newer context-face fields one by one with `extra_forbidden` entries like
+ * `{loc: ["body", "max_tokens"], type: "extra_forbidden"}`; each name here is a
+ * field the caller can drop and retry, instead of writing the whole context
+ * face off as unsupported.
+ */
+export function unknownBodyFields(res) {
+  const details = res?.error?.details ?? res?.error ?? {};
+  const errors = Array.isArray(details.validation_errors) ? details.validation_errors : [];
+  const fields = [];
+  for (const err of errors) {
+    const type = String(err?.type || "").toLowerCase();
+    const message = String(err?.message || "").toLowerCase();
+    if (!type.includes("extra") && !message.includes("extra inputs")) continue;
+    const loc = Array.isArray(err?.loc) ? err.loc : [];
+    const field = loc[loc.length - 1];
+    if (typeof field === "string" && field && field !== "body" && field !== "query") {
+      fields.push(field);
+    }
+  }
+  return [...new Set(fields)];
+}
+
 function wrapContext(body) {
   return [
     "<openviking-context>",
@@ -459,10 +484,25 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   const body = buildContextSearchBody(cfg, options);
   body.query = query;
-  const res = await fetchJSON("/api/v1/search/search", {
-    method: "POST",
-    body: JSON.stringify(body),
-  }, { actorPeerId, timeoutMs: contextRequestTimeoutMs(cfg, body) });
+
+  // An older server rejects newer optional fields one by one (extra_forbidden), and it names
+  // them. Strip exactly what it names and retry, instead of marking the whole context face
+  // legacy on the first 400: a v0.4.x server that rejects `mode`/`purpose` still assembles
+  // context perfectly well from the fields it does know.
+  let res;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    res = await fetchJSON("/api/v1/search/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }, { actorPeerId, timeoutMs: contextRequestTimeoutMs(cfg, body) });
+    if (res.ok) break;
+    const status = res.status || 0;
+    if (status !== 400 && status !== 422) break;
+    const stripped = unknownBodyFields(res).filter((field) => field in body);
+    if (!stripped.length) break;
+    for (const field of stripped) delete body[field];
+    log("recall_context_face_fields_stripped", { attempt: attempt + 1, stripped });
+  }
 
   if (!res.ok) {
     const status = res.status || 0;
@@ -477,15 +517,28 @@ export async function fetchAssembledContext(fetchJSON, cfg, query, options = {})
 
   const result = res.result || {};
   const stats = result.stats || {};
+  let entries = Array.isArray(result.entries) ? result.entries : [];
+  if (!entries.length && Array.isArray(result.memories) && result.memories.length) {
+    // Older servers answer this endpoint with `memories` (context_type/abstract) instead of
+    // assembled `entries` (category/text). Same information, earlier shape; adapt it so a
+    // strip-retried request on an old server still yields recall instead of an empty block.
+    entries = result.memories.map((memory) => ({
+      uri: memory?.uri || "",
+      category: memory?.context_type || "memory",
+      text: String(memory?.abstract || memory?.overview || "").trim(),
+      score: memory?.score,
+    }));
+    log("recall_context_memories_shape", { entries: entries.length });
+  }
   log("recall_context_assembled", {
-    entries: Array.isArray(result.entries) ? result.entries.length : 0,
+    entries: entries.length,
     usedTokens: stats.used_tokens || 0,
     tiers: stats.tier_counts || {},
     rewrite: stats.rewrite || "off",
   });
   return {
     rendered: String(result.rendered || "").trim(),
-    entries: Array.isArray(result.entries) ? result.entries : [],
+    entries,
     digest: String(result.digest || "").trim(),
     stats,
   };
@@ -538,7 +591,27 @@ async function recallViaContextFace(fetchJSON, cfg, query, options, log) {
     }
   }
 
-  const injected = digest || rendered;
+  // Older servers return entries (or the memories shape adapted above) without any
+  // server-side `rendered` string. Render them locally rather than discarding recall
+  // the endpoint already paid for.
+  let fallbackRendered = rendered;
+  if (!fallbackRendered && entries.length) {
+    const maxContentChars = Math.max(
+      80,
+      Math.floor(Number(cfg.recallMaxContentChars || 500)),
+    );
+    fallbackRendered = entries
+      .map(normalizeContextEntry)
+      .filter((entry) => entry.uri || entry.text)
+      .map((entry) => {
+        const text = entry.text ? entry.text.slice(0, maxContentChars) : "";
+        return text ? `- ${entry.uri}\n  ${text}` : `- ${entry.uri}`;
+      })
+      .join("\n");
+    log("recall_context_rendered_locally", { entries: entries.length });
+  }
+
+  const injected = digest || fallbackRendered;
   if (!injected) return "";
   return wrapContext(injected);
 }


### PR DESCRIPTION
## Summary

Auto-recall fails against servers that predate the context-face request fields (observed on a v0.4.9 deployment; v0.4.16 is unaffected). Capture works. The failure is silent. Three defects in `recall-core.mjs` cause this. This PR fixes all three.

**1. One unknown-field error disables the context face permanently.**
A v0.4.9 server rejects the context-face body fields with `extra_forbidden`: `mode`, `purpose`, `dedup_turns`, `max_tokens`, `quotas`, and `rewrite`. On v0.4.16 the same fields are valid when `mode: "context"` accompanies them, which the plugin always sends. The plugin always sends `mode` and `purpose`. The first request therefore returns 400. The plugin then writes the legacy marker (a 6-hour TTL). After each expiry, the next request fails again and renews the marker. Recall on these servers is therefore dead in steady state.
Fix: read the field names from `validation_errors[].loc`. Remove those fields from the body. Retry, up to 3 passes. Write the legacy marker only when the error names no removable field. The `query` field is never removed.

**2. The older response shape is discarded.**
Older servers return `result.memories` with `context_type` and `abstract`. The plugin reads only `result.entries` with `category` and `text`.
Fix: adapt `memories` into `entries`. The log stage is `recall_context_memories_shape`.

**3. An empty `rendered` string injects nothing.**
Older servers return no `rendered` string. A successful call therefore injected no context.
Fix: render the entries locally as URI plus content-capped abstract. The log stage is `recall_context_rendered_locally`.

The legacy fallback path does not change. One behavior change exists on current servers: when a response carries entries but no rendered text, the plugin now renders the entries locally instead of injecting nothing.

## Test plan

- [x] `node --test scripts/lib/*.test.mjs`: 15 tests pass. The new file `recall-compat.test.mjs` adds 6 tests: field extraction from real `validation_errors` shapes, strip-and-retry without a legacy marker, the legacy fallback when no field is removable, the `memories` shape adapter, and block rendering through `buildServerAssembledBlock`.
- [x] Verified against a local v0.4.16 server (Docker image, dev auth): the plugin's combined body is accepted, the response carries `entries`/`rendered`, and none of the three new code paths fires (no strip pass, no shape adaptation, no local rendering). The patch is inert on current servers.
- [x] Verified against a live v0.4.9 deployment with `auth_mode: api_key`. Before the patch: the hook logs `recall_context_face_unsupported` and injects nothing. After the patch: one strip pass removes `mode`, `purpose`, and `dedup_turns`, and the hook injects an `<openviking-context>` block with stored memory.

AI assisted with this change. A human reviewed it.
