### PR TITLE
fix(web-studio): support viking links in directory overviews

### DIFF
--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -60,25 +60,51 @@ const file: VikingFsEntry = {
   uri: 'viking://resources/wiki/index.md',
 }
 
+const directory: VikingFsEntry = {
+  ...file,
+  isDir: true,
+  name: 'wiki',
+  overview: '',
+  uri: 'viking://resources/wiki',
+}
+
+function renderPreview(
+  entry: VikingFsEntry,
+  onNavigate: (uri: string) => void,
+  directoryOverview?: string,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  if (entry.isDir) {
+    queryClient.setQueryData(
+      ['viking-directory-level', entry.uri, 'abstract'],
+      '',
+    )
+    queryClient.setQueryData(
+      ['viking-directory-level', entry.uri, 'overview'],
+      directoryOverview,
+    )
+  }
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  return render(
+    <FilePreview
+      file={entry}
+      onClose={vi.fn()}
+      onNavigate={onNavigate}
+      showCloseButton={false}
+    />,
+    { wrapper },
+  )
+}
+
 describe('FilePreview Markdown links', () => {
   it('opens internal Markdown links in the resource preview', () => {
     const onNavigate = vi.fn()
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    })
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-
-    render(
-      <FilePreview
-        file={file}
-        onClose={vi.fn()}
-        onNavigate={onNavigate}
-        showCloseButton={false}
-      />,
-      { wrapper },
-    )
+    renderPreview(file, onNavigate)
 
     const link = screen.getByRole('link', { name: 'Target' })
     expect(link.getAttribute('href')).toBe('viking://resources/wiki/target.md')
@@ -87,5 +113,53 @@ describe('FilePreview Markdown links', () => {
 
     expect(onNavigate).toHaveBeenCalledOnce()
     expect(onNavigate).toHaveBeenCalledWith('viking://resources/wiki/target.md')
+  })
+
+  it('opens viking links from a directory overview', () => {
+    const onNavigate = vi.fn()
+    renderPreview(
+      directory,
+      onNavigate,
+      [
+        '[Target file](viking://resources/wiki/target.md)',
+        '[Target directory](viking://resources/wiki/target-directory)',
+      ].join('\n\n'),
+    )
+
+    const fileLink = screen.getByRole('link', { name: 'Target file' })
+    const directoryLink = screen.getByRole('link', {
+      name: 'Target directory',
+    })
+    expect(fileLink.getAttribute('href')).toBe(
+      'viking://resources/wiki/target.md',
+    )
+    expect(directoryLink.getAttribute('href')).toBe(
+      'viking://resources/wiki/target-directory',
+    )
+
+    fireEvent.click(fileLink)
+    fireEvent.click(directoryLink)
+
+    expect(onNavigate).toHaveBeenNthCalledWith(
+      1,
+      'viking://resources/wiki/target.md',
+    )
+    expect(onNavigate).toHaveBeenNthCalledWith(
+      2,
+      'viking://resources/wiki/target-directory',
+    )
+  })
+
+  it('decodes encoded viking links before navigating', () => {
+    const onNavigate = vi.fn()
+    renderPreview(
+      directory,
+      onNavigate,
+      '[目标](viking://resources/%E8%B5%84%E6%96%99/%E7%9B%AE%E6%A0%87.md)',
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '目标' }))
+
+    expect(onNavigate).toHaveBeenCalledWith('viking://resources/资料/目标.md')
   })
 })

--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -162,4 +162,36 @@ describe('FilePreview Markdown links', () => {
 
     expect(onNavigate).toHaveBeenCalledWith('viking://resources/资料/目标.md')
   })
+
+  it('preserves non-viking links in a directory overview', () => {
+    const onNavigate = vi.fn()
+    renderPreview(
+      directory,
+      onNavigate,
+      [
+        '[Relative](child.md)',
+        '[Protocol relative](//example.com/child.md)',
+        '[External](https://example.com/child.md)',
+        '[Data](data:text/html,unsafe)',
+        '[Blob](blob:https://example.com/id)',
+      ].join('\n\n'),
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Relative' }).getAttribute('href'),
+    ).toBe('child.md')
+    expect(
+      screen
+        .getByRole('link', { name: 'Protocol relative' })
+        .getAttribute('href'),
+    ).toBe('//example.com/child.md')
+    const externalLink = screen.getByRole('link', { name: 'External' })
+    expect(externalLink.getAttribute('href')).toBe(
+      'https://example.com/child.md',
+    )
+    expect(externalLink.getAttribute('target')).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Data' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Blob' })).toBeNull()
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
 })

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, lazy, Suspense } from 'react'
 import type { ComponentProps, ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import hljs from 'highlight.js/lib/core'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
@@ -327,6 +327,47 @@ function resolveMarkdownAssetUrl(assetPath: string, fileUri: string): string {
     return toDownloadUrl(target.value)
   }
   return target.value
+}
+
+function transformMarkdownUrl(url: string): string {
+  return /^(viking|data|blob):/i.test(url) ? url : defaultUrlTransform(url)
+}
+
+function MarkdownLink({
+  children,
+  fileUri,
+  href,
+  onNavigate,
+}: {
+  children?: ReactNode
+  fileUri: string
+  href?: string
+  onNavigate?: (uri: string) => void
+}) {
+  const target = href ? resolveMarkdownAssetTarget(String(href), fileUri) : null
+  const isInternal = target?.kind === 'viking' && Boolean(onNavigate)
+  const resolvedHref = target
+    ? isInternal
+      ? target.value
+      : resolveMarkdownAssetUrl(target.value, fileUri)
+    : ''
+  const isExternal = /^(https?:|mailto:|tel:)/i.test(resolvedHref)
+
+  return (
+    <a
+      href={resolvedHref}
+      onClick={(event) => {
+        if (target?.kind === 'viking' && onNavigate) {
+          event.preventDefault()
+          onNavigate(target.value)
+        }
+      }}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noreferrer noopener' : undefined}
+    >
+      {children}
+    </a>
+  )
 }
 
 function MarkdownImage({
@@ -1516,7 +1557,19 @@ export function FilePreview({
                         <article className="prose prose-sm max-w-none break-words rounded-md border bg-muted/20 p-3 dark:prose-invert dark:prose-pre:bg-muted-foreground/20">
                           <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
-                            components={markdownComponents}
+                            urlTransform={transformMarkdownUrl}
+                            components={{
+                              ...markdownComponents,
+                              a: ({ href, children }) => (
+                                <MarkdownLink
+                                  href={href}
+                                  fileUri={file.uri}
+                                  onNavigate={onNavigate}
+                                >
+                                  {children}
+                                </MarkdownLink>
+                              ),
+                            }}
                           >
                             {level.content}
                           </ReactMarkdown>
@@ -1604,7 +1657,7 @@ export function FilePreview({
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw, rehypeSanitize]}
-                  urlTransform={(url) => url}
+                  urlTransform={transformMarkdownUrl}
                   components={{
                     ...markdownComponents,
                     img: ({ src, alt }) => (
@@ -1614,36 +1667,15 @@ export function FilePreview({
                         fileUri={file.uri}
                       />
                     ),
-                    a: ({ href, children }) => {
-                      const target = href
-                        ? resolveMarkdownAssetTarget(String(href), file.uri)
-                        : null
-                      const isInternal =
-                        target?.kind === 'viking' && Boolean(onNavigate)
-                      const resolvedHref = target
-                        ? isInternal
-                          ? target.value
-                          : resolveMarkdownAssetUrl(target.value, file.uri)
-                        : ''
-                      const isExternal = /^(https?:|mailto:|tel:)/i.test(
-                        resolvedHref,
-                      )
-                      return (
-                        <a
-                          href={resolvedHref}
-                          onClick={(event) => {
-                            if (target?.kind === 'viking' && onNavigate) {
-                              event.preventDefault()
-                              onNavigate(target.value)
-                            }
-                          }}
-                          target={isExternal ? '_blank' : undefined}
-                          rel={isExternal ? 'noreferrer noopener' : undefined}
-                        >
-                          {children}
-                        </a>
-                      )
-                    },
+                    a: ({ href, children }) => (
+                      <MarkdownLink
+                        href={href}
+                        fileUri={file.uri}
+                        onNavigate={onNavigate}
+                      >
+                        {children}
+                      </MarkdownLink>
+                    ),
                   }}
                 >
                   {displayContent || emptyFileText}

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -329,8 +329,8 @@ function resolveMarkdownAssetUrl(assetPath: string, fileUri: string): string {
   return target.value
 }
 
-function transformMarkdownUrl(url: string): string {
-  return /^(viking|data|blob):/i.test(url) ? url : defaultUrlTransform(url)
+function transformDirectoryMarkdownUrl(url: string): string {
+  return url.startsWith(vikingPrefix) ? url : defaultUrlTransform(url)
 }
 
 function MarkdownLink({
@@ -367,6 +367,29 @@ function MarkdownLink({
     >
       {children}
     </a>
+  )
+}
+
+function DirectoryMarkdownLink({
+  children,
+  fileUri,
+  href,
+  onNavigate,
+}: {
+  children?: ReactNode
+  fileUri: string
+  href?: string
+  onNavigate?: (uri: string) => void
+}) {
+  const decodedHref = href ? safeDecodeUri(href.trim()) : ''
+  if (!decodedHref.startsWith(vikingPrefix)) {
+    return <a href={href}>{children}</a>
+  }
+
+  return (
+    <MarkdownLink href={decodedHref} fileUri={fileUri} onNavigate={onNavigate}>
+      {children}
+    </MarkdownLink>
   )
 }
 
@@ -1557,17 +1580,17 @@ export function FilePreview({
                         <article className="prose prose-sm max-w-none break-words rounded-md border bg-muted/20 p-3 dark:prose-invert dark:prose-pre:bg-muted-foreground/20">
                           <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
-                            urlTransform={transformMarkdownUrl}
+                            urlTransform={transformDirectoryMarkdownUrl}
                             components={{
                               ...markdownComponents,
                               a: ({ href, children }) => (
-                                <MarkdownLink
+                                <DirectoryMarkdownLink
                                   href={href}
                                   fileUri={file.uri}
                                   onNavigate={onNavigate}
                                 >
                                   {children}
-                                </MarkdownLink>
+                                </DirectoryMarkdownLink>
                               ),
                             }}
                           >
@@ -1657,7 +1680,7 @@ export function FilePreview({
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw, rehypeSanitize]}
-                  urlTransform={transformMarkdownUrl}
+                  urlTransform={(url) => url}
                   components={{
                     ...markdownComponents,
                     img: ({ src, alt }) => (


### PR DESCRIPTION
## Description

Enable viking:// links rendered in resource directory overviews to navigate directly to the corresponding file or directory in Web Studio, while preserving the existing behavior of regular Markdown links.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Follow-up to #4251.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Allow explicit viking:// links in directory overview Markdown rendering.
- Route viking links through the existing Web Studio resource navigation callback.
- Preserve relative, protocol-relative, HTTP, and HTTPS link behavior, while keeping unsafe data and blob links filtered.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validated with the focused FilePreview test suite, the full Web Studio test suite (192 tests), Web Studio production build, targeted ESLint and Prettier checks, and git diff --check.