### PR TITLE
fix(dsh): run MCP proxy as Node under Electron

### DIFF
--- a/examples/dsh-memory-plugin/mcp.mjs
+++ b/examples/dsh-memory-plugin/mcp.mjs
@@ -16,7 +16,10 @@ export const PROXY_PATH = fileURLToPath(new URL("./servers/mcp-proxy.mjs", impor
  * already resolved have to be passed explicitly.
  */
 export function buildMcpConfig(config) {
-  const env = {};
+  // In DSH Desktop, process.execPath is Electron's executable rather than a
+  // standalone Node binary. This tells Electron to run the proxy script as
+  // Node instead of attempting to launch a second Desktop instance.
+  const env = { ELECTRON_RUN_AS_NODE: "1" };
   if (config.endpoint) env.OPENVIKING_URL = config.endpoint;
   if (config.apiKey) env.OPENVIKING_API_KEY = config.apiKey;
   if (config.account) env.OPENVIKING_ACCOUNT = config.account;

--- a/examples/dsh-memory-plugin/mcp.test.mjs
+++ b/examples/dsh-memory-plugin/mcp.test.mjs
@@ -20,6 +20,7 @@ test("the mount config validates against the pinned bridge's own schema", () => 
   assert.equal(parsed.serverName, "openviking");
   assert.equal(parsed.command, process.execPath);
   assert.deepEqual(parsed.args, [PROXY_PATH]);
+  assert.equal(parsed.env.ELECTRON_RUN_AS_NODE, "1");
   assert.equal(parsed.toolCallTimeoutMs, 60000);
   // Startup must not be fatal: recall, capture, and commit keep working when
   // only the MCP endpoint is down, and the bridge reconnects on its own.
@@ -42,6 +43,7 @@ test("credentials resolved by the plugin reach the proxy through the child env",
   const { env } = buildMcpConfig(config);
 
   assert.deepEqual(env, {
+    ELECTRON_RUN_AS_NODE: "1",
     OPENVIKING_URL: "http://ov.example.com",
     OPENVIKING_API_KEY: "secret",
     OPENVIKING_ACCOUNT: "acme",
@@ -69,7 +71,10 @@ test("an anonymous local server forwards no credential env", () => {
     mcpToolCallTimeoutMs: 60000,
   });
 
-  assert.deepEqual(env, { OPENVIKING_URL: "http://127.0.0.1:1933" });
+  assert.deepEqual(env, {
+    ELECTRON_RUN_AS_NODE: "1",
+    OPENVIKING_URL: "http://127.0.0.1:1933",
+  });
 });
 
 test("mounting passes the bridge plugin and its config to the host context", () => {


### PR DESCRIPTION
## Description

Fixes #4197.

When this plugin runs inside DSH Desktop, `process.execPath` is Electron's executable rather than a standalone Node binary. The MCP client reuses that executable to start the stdio proxy; without `ELECTRON_RUN_AS_NODE=1`, reconnect attempts start a second Desktop instance instead of the proxy.

This change sets `ELECTRON_RUN_AS_NODE=1` in the child environment and adds regression coverage. Existing credential forwarding is preserved.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4197

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Run the MCP stdio proxy as Node when the host executable is Electron.
- Cover the Electron runtime flag in the plugin configuration tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local verification:

- `npm test`: 40 passed, 1 live integration test skipped.
- `npm run check` and `git diff --check` passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The local Node runtime was v20.20.2, while the plugin declares Node 22.19+ or 24+; npm emitted an engine warning, but the full test suite and syntax checks passed.