### PR TITLE
fix(semantic): ignore ordered list markers when truncating abstracts

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1097,6 +1097,11 @@ class SemanticProcessor(DequeueHandlerBase):
         first_sentence_end = None
         last_sentence_end_within_limit = None
         for sentence_end_match in re.finditer(r"\.(?!\d)(?=\s|$)|[!?](?=\s|$)|[。？！]", text):
+            if sentence_end_match.group(0) == ".":
+                line_start = text.rfind("\n", 0, sentence_end_match.start()) + 1
+                prefix = text[line_start : sentence_end_match.start()]
+                if re.fullmatch(r"\s*\d+", prefix):
+                    continue
             sentence_end = sentence_end_match.end()
             if first_sentence_end is None:
                 first_sentence_end = sentence_end

--- a/tests/storage/test_semantic_processor_l0_l1.py
+++ b/tests/storage/test_semantic_processor_l0_l1.py
@@ -183,3 +183,19 @@ def test_abstract_truncation_accepts_sentence_period_after_number(monkeypatch):
     _, abstract = processor._enforce_size_limits("# README\n\nBody", abstract)
 
     assert abstract == "This import check was generated at 16:55."
+
+
+def test_abstract_truncation_ignores_ordered_list_marker(monkeypatch):
+    _patch_semantic_limits(monkeypatch, abstract_max_chars=80)
+    processor = SemanticProcessor()
+    abstract = (
+        "1. **Project Overview**\n\n"
+        "This directory contains generated architecture notes and implementation "
+        "details that need to stay discoverable in semantic recall."
+    )
+
+    _, abstract = processor._enforce_size_limits("# overview\n\nBody", abstract)
+
+    assert abstract != "1."
+    assert abstract.startswith("1. **Project Overview**")
+    assert "This directory contains generated architecture notes" in abstract


### PR DESCRIPTION
## Summary
- Skip ordered list markers such as `1.` when detecting sentence boundaries during generated abstract/overview truncation.
- Add a regression test so abstracts that start with numbered Markdown sections are not reduced to only the list marker.

## Root cause
The truncation helper treated any period followed by whitespace as a sentence boundary. For generated Markdown abstracts beginning with `1. **Project Overview**`, that made `1.` look like a complete first sentence.

## Validation
- `python -m pytest tests/storage/test_semantic_processor_l0_l1.py -q`