### PR TITLE
fix(parse): keep TypeScript sources out of video parsing

### DIFF
--- a/openviking/parse/parsers/media/constants.py
+++ b/openviking/parse/parsers/media/constants.py
@@ -9,7 +9,7 @@ IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".
 AUDIO_EXTENSIONS = [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a", ".opus", ".ac3"]
 
 # Video extensions supported by VideoParser
-VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv", ".ts"]
+VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"]
 
 # All media extensions combined
 MEDIA_EXTENSIONS = set(IMAGE_EXTENSIONS + AUDIO_EXTENSIONS + VIDEO_EXTENSIONS)

--- a/tests/parse/test_parser_router.py
+++ b/tests/parse/test_parser_router.py
@@ -1,10 +1,13 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from openviking.parse.accessors.base import LocalResource, SourceType
+from openviking.parse.accessors.http_accessor import URLType, URLTypeDetector
 from openviking.parse.parser_router import ParserRouter
+from openviking.parse.parsers.media.video import VideoParser
 from openviking.parse.parsers.media.utils import MPEG_TS_PACKET_SIZE, MPEG_TS_PROBE_BYTES
 from openviking.parse.registry import ParserRegistry
 from openviking.parse.understanding_api import PREPARED_RESPONSE_ID_ARG
@@ -173,6 +176,14 @@ def test_parser_registry_keeps_typescript_ts_on_text_fallback(tmp_path):
     path.write_text("export const answer: number = 42;\n")
 
     assert ParserRegistry().get_parser_for_file(path) is None
+
+
+def test_typescript_ts_extension_remains_text_for_url_detection():
+    assert URLTypeDetector.EXTENSION_MAP[".ts"] == URLType.DOWNLOAD_TXT
+
+
+def test_video_parser_does_not_claim_typescript_sources():
+    assert not VideoParser().can_parse(Path("source.ts"))
 
 
 def test_should_use_understanding_api_for_feishu_url(monkeypatch):


### PR DESCRIPTION
## Summary
- remove `.ts` from video parser extensions so TypeScript sources are not claimed as video
- add regression coverage for URL type detection and `VideoParser.can_parse()`

## Root cause
`.ts` is both a TypeScript source extension and an MPEG transport stream extension. It was present in `VIDEO_EXTENSIONS`, so parser routing and URL detection treated normal TypeScript files as video content.

## Validation
- `pytest tests/parse/test_parser_router.py -q`