### PR TITLE
fix(cli): keep logging alive after rotation failures

### DIFF
--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -10,6 +10,7 @@ import logging
 import queue
 import sys
 import threading
+import time
 from contextlib import contextmanager
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
@@ -97,7 +98,20 @@ class _RustAwareTimedRotatingFileHandler(TimedRotatingFileHandler):
 
     def doRollover(self) -> None:
         """Rotate the active Python log file and then refresh the Rust writer."""
-        super().doRollover()
+        try:
+            super().doRollover()
+        except Exception as exc:
+            if self.stream is None and not self.delay:
+                self.stream = self._open()
+
+            current_time = int(time.time())
+            rollover_at = self.computeRollover(current_time)
+            while rollover_at <= current_time:
+                rollover_at += self.interval
+            self.rolloverAt = rollover_at
+            sys.stderr.write(f"Warning: log rotation failed; continuing with active log file: {exc}\n")
+            return
+
         _reopen_rust_tracing_file()
 
 

--- a/tests/test_logger_rotation.py
+++ b/tests/test_logger_rotation.py
@@ -1,0 +1,56 @@
+import logging
+
+from openviking_cli.utils import logger as logger_module
+
+
+def test_timed_rotation_failure_keeps_file_logging_alive(tmp_path, monkeypatch, capsys):
+    log_path = tmp_path / "server.log"
+    handler = logger_module._RustAwareTimedRotatingFileHandler(
+        log_path,
+        when="midnight",
+        backupCount=7,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.rolloverAt = 0
+
+    def fail_rollover(_self):
+        if _self.stream is not None:
+            _self.stream.close()
+            _self.stream = None
+        raise OSError("simulated Windows rename failure")
+
+    monkeypatch.setattr(
+        logger_module.TimedRotatingFileHandler,
+        "doRollover",
+        fail_rollover,
+    )
+
+    try:
+        handler.emit(logging.makeLogRecord({"levelno": logging.INFO, "msg": "first"}))
+        handler.emit(logging.makeLogRecord({"levelno": logging.INFO, "msg": "second"}))
+        handler.flush()
+    finally:
+        handler.close()
+
+    assert log_path.read_text(encoding="utf-8") == "first\nsecond\n"
+    assert "log rotation failed" in capsys.readouterr().err
+
+
+def test_timed_rotation_still_reopens_rust_tracing_on_success(tmp_path, monkeypatch):
+    calls = []
+    handler = logger_module._RustAwareTimedRotatingFileHandler(
+        tmp_path / "server.log",
+        when="midnight",
+        backupCount=7,
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(logger_module, "_reopen_rust_tracing_file", lambda: calls.append("reopened"))
+
+    try:
+        handler.doRollover()
+    finally:
+        handler.close()
+
+    assert calls == ["reopened"]


### PR DESCRIPTION
## Summary
- Recover the timed rotating file handler when rollover fails after closing the active stream.
- Keep writing to the original log file and advance the next retry window instead of letting `emit()` silently drop every record.
- Add focused regression coverage for the failure path and the existing Rust tracing reopen behavior on successful rotation.

## Root cause
`TimedRotatingFileHandler.doRollover()` can close `self.stream` before the file rename/removal step. If that step fails, especially on Windows file sharing errors, the exception is swallowed by logging's `emit()` path and the handler remains unable to write subsequent records.

Fixes #3669.

## Validation
- `PYTHONPATH=. python3 -m pytest tests/test_logger_rotation.py -q --no-cov`
- `PYTHONPATH=. python3 -m pytest tests/test_config_loader.py tests/test_logger_rotation.py -q --no-cov`
- `PYTHONPATH=. python3 -m ruff check openviking_cli/utils/logger.py tests/test_logger_rotation.py`

Note: `uv run pytest tests/test_logger_rotation.py -q --no-cov` did not reach pytest in this fresh worktree because editable wheel setup failed while building the bundled Rust `ov` CLI artifact (`openviking/bin/ov` missing). I used `PYTHONPATH=.` for the focused Python logger tests.