### PR TITLE
feat(fs): create default L0 for mkdir directories

### DIFF
--- a/docs/en/api/03-filesystem.md
+++ b/docs/en/api/03-filesystem.md
@@ -429,7 +429,7 @@ Create a directory.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | uri | str | Yes | - | Viking URI for the new directory |
-| description | str | No | `null` | Initial directory description. When provided, it is written to `.abstract.md` and queued for L0 vectorization. |
+| description | str | No | `null` | Initial directory description. When omitted, the directory name is used as the default L0; when provided, this description is used. Both forms write `.abstract.md` and queue L0 vectorization. |
 
 
 **Python HTTP SDK**

--- a/docs/en/concepts/03-context-layers.md
+++ b/docs/en/concepts/03-context-layers.md
@@ -12,7 +12,7 @@ OpenViking uses a three-layer information model to balance retrieval efficiency,
 
 L0 and L1 are **directory-level semantic sidecars**. They describe a directory; OpenViking does not create a matching L0/L1 sidecar for every ordinary file. File summaries are inputs aggregated into the containing directory's L1.
 
-L0 and L1 are normally generated together, but either one may exist independently. For example, `mkdir(description=...)` initially creates only L0, so a directory with `.abstract.md` but no `.overview.md` is valid. Reads and vector rebuilds process only the levels that actually exist.
+L0 and L1 are normally generated together, but either one may exist independently. For example, `mkdir()` initially creates only L0: it uses the directory name as the default body when `description` is omitted, or the provided description otherwise. A directory with `.abstract.md` but no `.overview.md` is therefore valid. Reads and vector rebuilds process only the levels that actually exist.
 
 The body limits are configured by `semantic.abstract_max_chars` and `semantic.overview_max_chars`; the table shows their defaults. These limits apply to the Markdown body only and do not truncate sidecar metadata.
 

--- a/docs/zh/api/03-filesystem.md
+++ b/docs/zh/api/03-filesystem.md
@@ -430,7 +430,7 @@ openviking attrs set-tags viking://resources/docs --tags team=search --mode appe
 | 参数 | 类型 | 必填 | 默认值 | 说明 |
 |------|------|------|--------|------|
 | uri | str | 是 | - | 新目录的 Viking URI |
-| description | str | 否 | `null` | 目录初始说明。传入后会写入 `.abstract.md`，并进入目录 L0 向量化队列。 |
+| description | str | 否 | `null` | 目录初始说明。未传入时使用目录名作为默认 L0；传入后使用该说明。两种情况都会写入 `.abstract.md` 并进入 L0 向量化队列。 |
 
 
 **Python HTTP SDK**

--- a/docs/zh/concepts/03-context-layers.md
+++ b/docs/zh/concepts/03-context-layers.md
@@ -12,7 +12,7 @@ OpenViking 使用三层信息模型，在检索效率、导航能力和原始内
 
 L0/L1 是**目录级语义 sidecar**。它们描述一个目录，不是为每个普通文件创建的同名伴生文件。文件摘要会作为输入，聚合到所在目录的 L1 中。
 
-L0 和 L1 通常成对生成，但系统允许只存在其中一个。例如，`mkdir(description=...)` 会先创建 L0，因此只有 `.abstract.md` 的目录也是合法状态。读取和向量重建只处理实际存在的层级。
+L0 和 L1 通常成对生成，但系统允许只存在其中一个。例如，`mkdir()` 会先创建 L0：未传入 `description` 时使用目录名作为默认正文，传入后使用该说明。因此只有 `.abstract.md` 的目录也是合法状态。读取和向量重建只处理实际存在的层级。
 
 正文上限由 `semantic.abstract_max_chars` 和 `semantic.overview_max_chars` 配置；上表是默认值。限制只作用于 Markdown 正文，不会截断 sidecar 元数据。
 

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -10,7 +10,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from openviking.core.context import ContextLevel
-from openviking.core.namespace import classify_uri, context_type_for_uri
+from openviking.core.namespace import classify_uri, context_type_for_uri, uri_leaf_name
 from openviking.privacy import (
     UserPrivacyConfigService,
     get_skill_name_from_uri,
@@ -194,11 +194,14 @@ class FSService:
         """Create directory."""
         viking_fs = self._ensure_initialized()
         await viking_fs.mkdir(uri, ctx=ctx)
-        abstract = self._normalize_directory_description(description)
-        if not abstract:
-            return
 
         directory_uri, abstract_uri = self._resolve_directory_uris(uri)
+        abstract = self._normalize_directory_description(description)
+        if not abstract:
+            if await viking_fs.exists(abstract_uri, ctx=ctx):
+                return
+            abstract = f"# {uri_leaf_name(directory_uri)}"
+
         await viking_fs.write_file(
             abstract_uri,
             render_abstract_overview(

--- a/tests/server/test_http_client_sdk.py
+++ b/tests/server/test_http_client_sdk.py
@@ -152,7 +152,11 @@ async def test_sdk_ls(http_client):
 
 async def test_sdk_mkdir_and_ls(http_client):
     client, _ = http_client
-    await client.mkdir("viking://resources/sdk_dir/")
+    uri = "viking://resources/sdk_dir/"
+
+    await client.mkdir(uri)
+
+    assert await client.abstract(uri) == "# sdk_dir"
     result = await client.ls("viking://resources/")
     assert isinstance(result, list)
 
@@ -164,8 +168,11 @@ async def test_sdk_mkdir_with_description_sets_abstract(http_client):
 
     await client.mkdir(uri, description=description)
 
-    abstract = await client.abstract(uri)
-    assert abstract == description
+    assert await client.abstract(uri) == description
+
+    await client.mkdir(uri)
+
+    assert await client.abstract(uri) == description
 
 
 async def test_sdk_tree(http_client):


### PR DESCRIPTION
## Description

`mkdir` now creates a minimal, searchable L0 even when callers omit `description`.

### Expected behavior

**Before:** `ov mkdir viking://resources/bob_files` created only the physical directory. It did not create `.abstract.md` or enqueue a directory L0 unless a description was supplied.

**After:** The same command writes a canonical `.abstract.md` whose visible body is `# bob_files`, then enqueues that body for L0 vectorization. `mkdir(..., description="Bob's files")` continues to use the supplied description. Repeating `mkdir` without a description leaves an existing abstract unchanged.

Flow: public `mkdir` request → create the directory → use the normalized description or the directory-name heading → write the OKF L0 sidecar → enqueue L0 vectorization. Creator ACL management semantics are intentionally outside this PR.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Create a directory-name L0 sidecar and enqueue vectorization when `description` is omitted or blank.
- Preserve an existing `.abstract.md` when an idempotent `mkdir` call does not provide a replacement description.
- Update the existing SDK contract coverage and bilingual filesystem/context-layer documentation.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `PYTHONPATH=sdk/python .venv/bin/python -m pytest tests/storage/test_abstract_overview_freshness.py tests/unit/test_vectorize_file_strategy.py -q --no-cov` — 37 passed.
- `.venv/bin/python -m ruff check openviking/service/fs_service.py tests/server/test_http_client_sdk.py`
- `.venv/bin/python -m ruff format --check openviking/service/fs_service.py tests/server/test_http_client_sdk.py`
- Focused behavior verification covered the default body, canonical `directory` metadata, L0 enqueue arguments, and preservation of an existing description.

The modified real-server HTTP/SDK tests could not complete locally because the existing Python 3.14 fixture fails during application startup with `owner event loop is already bound`, before any `mkdir` request is issued.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This PR keeps the existing asynchronous embedding behavior and current resource L1-to-L0 fallback contract unchanged. It does not grant the directory creator ACL `manage` permission.
