### PR TITLE
fix(sdk/go): forward remote sources on Windows

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -687,6 +687,33 @@ func TestAddResourceExtra(t *testing.T) {
 	}
 }
 
+func TestAddResourceForwardsRemoteSources(t *testing.T) {
+	remoteSources := []string{
+		"http://example.com/a.md",
+		"https://example.com/a.md",
+		"git@example.com:team/docs.git",
+		"ssh://git@example.com/team/docs.git",
+		"git://example.com/team/docs.git",
+	}
+
+	for _, source := range remoteSources {
+		t.Run(source, func(t *testing.T) {
+			client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body := readJSONBody(t, r)
+				if body["path"] != source {
+					t.Fatalf("path = %#v, want %q", body["path"], source)
+				}
+				writeOK(t, w, map[string]any{"root_uri": "viking://resources/a"})
+			}))
+			defer closeServer()
+
+			if _, err := client.AddResource(context.Background(), source, nil); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestAddResourceSendsAddTypeAndProcessingMode(t *testing.T) {
 	client, closeServer := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := readJSONBody(t, r)

--- a/sdk/go/upload.go
+++ b/sdk/go/upload.go
@@ -141,6 +141,13 @@ func (c *Client) uploadTempFile(ctx context.Context, filePath string) (string, e
 }
 
 func (c *Client) addLocalUpload(ctx context.Context, payload map[string]any, path string, includeSourceName bool) error {
+	for _, prefix := range []string{"http://", "https://", "git@", "ssh://", "git://"} {
+		if strings.HasPrefix(path, prefix) {
+			payload["path"] = path
+			return nil
+		}
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Description

Make the standalone Go SDK forward documented remote resource sources without attempting to inspect them as local filesystem paths first. This fixes `AddResource` on Windows, where `os.Stat("https://...")` returns an invalid-path error instead of an `IsNotExist` error.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4284

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Recognize the documented `http://`, `https://`, `git@`, `ssh://`, and `git://` remote source forms before local filesystem inspection.
- Preserve the existing temporary-upload flow for local files and directories.
- Add request-body coverage for every supported remote source form.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

```text
cd sdk/go
go test ./...
# ok github.com/volcengine/OpenViking/sdk/go
# examples/basic_usage: no test files

go vet ./...
# passed

git diff --check
# passed
```

Before the change, the same Windows test run failed four existing `AddResource` tests with a `CreateFile https://...` filesystem syntax error.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Existing Go SDK and bilingual user documentation already describe remote URLs as supported, so no documentation text changes are needed. The new source check is intentionally direct and has no non-obvious algorithm requiring an inline comment. This change has no dependencies.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The change is internal to the SDK and does not add a dependency or alter any exported type or method signature.