### PR TITLE
fix(memory): repair multi-block patch regression

### DIFF
--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -9,6 +9,7 @@ from openviking.session.memory.merge_op.base import (
     FieldType,
     MergeOp,
     MergeOpBase,
+    SearchReplaceBlock,
     StrPatch,
     get_python_type_for_field,
 )

--- a/tests/unit/session/memory/test_patch_no_original_multiblock.py
+++ b/tests/unit/session/memory/test_patch_no_original_multiblock.py
@@ -19,10 +19,11 @@ from openviking.session.memory.merge_op.base import FieldType, SearchReplaceBloc
 from openviking.session.memory.merge_op.patch import PatchOp
 
 
+@pytest.mark.asyncio
 class TestNewMemoryMultiBlockPatch:
     """PatchOp: all blocks must survive when writing a new memory."""
 
-    def test_strpatch_multiblock_no_silent_loss(self):
+    async def test_strpatch_multiblock_no_silent_loss(self):
         """All StrPatch blocks are joined when current_value is None."""
         op = PatchOp(FieldType.STRING)
         patch = StrPatch(
@@ -31,11 +32,11 @@ class TestNewMemoryMultiBlockPatch:
                 SearchReplaceBlock(search="", replace="Fact B: user is in Tokyo."),
             ]
         )
-        result = op.apply(None, patch)
+        result = await op.apply(None, patch)
         assert "Fact A" in result, "block 0 content should be present"
         assert "Fact B" in result, "block 1 content was silently dropped before the fix"
 
-    def test_dict_form_multiblock_no_silent_loss(self):
+    async def test_dict_form_multiblock_no_silent_loss(self):
         """dict-form blocks (the actual JSON-parsed LLM path) are all joined."""
         op = PatchOp(FieldType.STRING)
         patch_value = {
@@ -44,23 +45,28 @@ class TestNewMemoryMultiBlockPatch:
                 {"search": "", "replace": "Line 2 fact"},
             ]
         }
-        result = op.apply(None, patch_value)
+        result = await op.apply(None, patch_value)
         assert "Line 1" in result
         assert "Line 2" in result, "second dict block was silently dropped before the fix"
 
-    def test_single_block_behaviour_unchanged(self):
+    async def test_dict_form_accepts_model_blocks(self):
+        """Model block objects in a dict-form patch are supported."""
+        op = PatchOp(FieldType.STRING)
+        patch_value = {"blocks": [SearchReplaceBlock(search="", replace="Model block")]}
+        result = await op.apply(None, patch_value)
+        assert result == "Model block"
+
+    async def test_single_block_behaviour_unchanged(self):
         """The common single-block case is unaffected by this change."""
         op = PatchOp(FieldType.STRING)
         patch = StrPatch(blocks=[SearchReplaceBlock(search="", replace="Only fact.")])
-        result = op.apply(None, patch)
+        result = await op.apply(None, patch)
         assert result == "Only fact."
 
-    def test_existing_content_path_unaffected(self):
+    async def test_existing_content_path_unaffected(self):
         """When current_value is NOT None the existing search/replace path runs."""
         op = PatchOp(FieldType.STRING)
-        patch = StrPatch(
-            blocks=[SearchReplaceBlock(search="old text", replace="new text")]
-        )
-        result = op.apply("some old text here", patch)
+        patch = StrPatch(blocks=[SearchReplaceBlock(search="old text", replace="new text")])
+        result = await op.apply("some old text here", patch)
         assert "new text" in result
         assert "old text" not in result


### PR DESCRIPTION
## Description

Repair the multi-block new-memory regression added in #3682 so its tests exercise the asynchronous `PatchOp.apply()` API and its model-block branch no longer raises `NameError`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4286

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Import `SearchReplaceBlock` for the implementation branch introduced in #3682.
- Convert all four new-memory regression tests to async tests and await `PatchOp.apply()`.
- Add coverage for dict-form patches containing `SearchReplaceBlock` model objects.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

```text
uv run --no-sync ruff check openviking/session/memory/merge_op/patch.py tests/unit/session/memory/test_patch_no_original_multiblock.py
# All checks passed

uv run --no-sync pytest -q --no-cov tests/unit/session/memory/test_patch_no_original_multiblock.py tests/session/memory/test_merge_ops.py
# 59 passed

git diff --check
# passed
```

Before the change, the targeted new-memory test file failed 4/4 with unawaited-coroutine warnings. The model-block reproduction separately raised `NameError`; it now returns the expected replacement.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

No user-facing behavior or documentation contract changes; this makes the intended #3682 behavior executable and tested. There are no dependencies.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The scope is limited to the two files changed/introduced by #3682.