### PR TITLE
fix(tasks): 从归档恢复失败的会话提交

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -10,7 +10,7 @@ endpoints to check completion, results, or errors.
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Query
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
@@ -35,6 +35,8 @@ class RetryTaskRequest(BaseModel):
 
     acknowledge_change: bool = False
     restart_operation: bool = False
+    owner_account_id: Optional[str] = Field(default=None, min_length=1)
+    owner_user_id: Optional[str] = Field(default=None, min_length=1)
 
 
 MAX_LINKED_RETRY_ATTEMPTS = 3
@@ -44,6 +46,8 @@ def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
     """Run ROOT retries in the task owner's storage namespace."""
     if ctx.role != Role.ROOT or not task.account_id or not task.user_id:
         return ctx
+    if task.account_id == SYSTEM_TASK_ACCOUNT_ID and task.user_id == SYSTEM_TASK_USER_ID:
+        return ctx
     return RequestContext(
         user=UserIdentifier(task.account_id, task.user_id),
         role=ctx.role,
@@ -51,6 +55,14 @@ def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
         from_oauth=ctx.from_oauth,
         api_key=ctx.api_key,
     )
+
+
+def _task_response(task, *, include_owner: bool):
+    result = task.to_dict()
+    if include_owner and task.account_id and task.user_id:
+        result["owner_account_id"] = task.account_id
+        result["owner_user_id"] = task.user_id
+    return result
 
 
 @router.get("/tasks/{task_id}")
@@ -80,7 +92,10 @@ async def get_task(
             code="NOT_FOUND",
             details={"resource": task_id, "type": "task"},
         )
-    return Response(status="ok", result=task.to_dict())
+    return Response(
+        status="ok",
+        result=_task_response(task, include_owner=_ctx.role == Role.ROOT),
+    )
 
 
 @router.post("/tasks/{task_id}/cancel")
@@ -115,17 +130,25 @@ async def retry_task(
     body: RetryTaskRequest = Body(default_factory=RetryTaskRequest),
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Retry a failed task and return the task that now owns the work."""
+    """Retry a failed task and return a stable retry disposition.
+
+    Possible dispositions are accepted, blocked, operation_resolved,
+    already_running, retry_limit_reached, and no_action.
+    """
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
-        task = await tracker.get(task_id)
-        if task is None:
-            task = await tracker.get(
-                task_id,
-                account_id=SYSTEM_TASK_ACCOUNT_ID,
-                user_id=SYSTEM_TASK_USER_ID,
+        if body.owner_account_id is None or body.owner_user_id is None:
+            raise FailedPreconditionError(
+                "ROOT retries require both owner_account_id and owner_user_id"
             )
+        task = await tracker.get(
+            task_id,
+            account_id=body.owner_account_id,
+            user_id=body.owner_user_id,
+        )
     else:
+        if body.owner_account_id is not None or body.owner_user_id is not None:
+            raise PermissionDeniedError("Only ROOT may specify a task owner")
         task = await tracker.get(task_id, account_id=_ctx.account_id, user_id=_ctx.user.user_id)
     if task is None:
         raise OpenVikingError(
@@ -393,4 +416,7 @@ async def list_tasks(
             account_id=_ctx.account_id,
             user_id=_ctx.user.user_id,
         )
-    return Response(status="ok", result=[t.to_dict() for t in tasks])
+    return Response(
+        status="ok",
+        result=[_task_response(task, include_owner=_ctx.role == Role.ROOT) for task in tasks],
+    )

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -169,7 +169,8 @@ async def retry_task(
             archive_uri=(task.meta or {}).get("archive_uri"),
             failed_task_created_at=task.created_at,
         )
-        if retry_state.get("state") == "completed":
+        archive_state = retry_state.get("state")
+        if archive_state == "completed":
             await tracker.resolve_failed(
                 task.task_id,
                 {
@@ -188,6 +189,30 @@ async def retry_task(
                     "task_id": task.task_id,
                     "resolution": "archive_complete",
                     "archive_uri": retry_state.get("archive_uri"),
+                },
+            )
+        if archive_state != "failed_ready":
+            archive_error = (
+                {
+                    "code": "RETRY_ARCHIVE_UNAVAILABLE",
+                    "retryability": "manual",
+                    "action": "Restore the failed commit archive before retrying.",
+                }
+                if archive_state == "unavailable"
+                else {
+                    "code": "RETRY_ARCHIVE_NOT_READY",
+                    "retryability": "manual",
+                    "action": "Wait for the failed commit archive to reach a retryable state.",
+                }
+            )
+            return Response(
+                status="ok",
+                result={
+                    "disposition": "blocked",
+                    "operation_id": task.operation_id or task.task_id,
+                    "previous_task_id": task.task_id,
+                    "archive_state": archive_state,
+                    "error": archive_error,
                 },
             )
 

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -9,13 +9,15 @@ endpoints to check completion, results, or errors.
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Body, Depends, Query
+from pydantic import BaseModel, ConfigDict
 
 from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
-from openviking.service.task_tracker import get_task_tracker
+from openviking.service.task_tracker import classify_task_error, get_task_tracker
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     OpenVikingError,
@@ -23,6 +25,18 @@ from openviking_cli.exceptions import (
 )
 
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
+
+
+class RetryTaskRequest(BaseModel):
+    """Explicit acknowledgement for failures that require a repaired prerequisite."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    acknowledge_change: bool = False
+    restart_operation: bool = False
+
+
+MAX_LINKED_RETRY_ATTEMPTS = 3
 
 
 @router.get("/tasks/{task_id}")
@@ -79,6 +93,224 @@ async def cancel_task(
             details={"resource": task_id, "type": "task"},
         )
     return Response(status="ok", result=task.to_dict())
+
+
+@router.post("/tasks/{task_id}/retry")
+async def retry_task(
+    task_id: str,
+    body: RetryTaskRequest = Body(default_factory=RetryTaskRequest),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Retry a failed task and return the task that now owns the work."""
+    tracker = get_task_tracker()
+    if _ctx.role == Role.ROOT:
+        task = await tracker.get(task_id)
+        if task is None:
+            task = await tracker.get(
+                task_id,
+                account_id=SYSTEM_TASK_ACCOUNT_ID,
+                user_id=SYSTEM_TASK_USER_ID,
+            )
+    else:
+        task = await tracker.get(task_id, account_id=_ctx.account_id, user_id=_ctx.user.user_id)
+    if task is None:
+        raise OpenVikingError(
+            "Task not found or expired",
+            code="NOT_FOUND",
+            details={"resource": task_id, "type": "task"},
+        )
+    if task.status.value == "completed":
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": task.task_id,
+                "attempt_number": task.attempt_number,
+            },
+        )
+    if task.status.value != "failed":
+        raise FailedPreconditionError("Only failed tasks can be retried")
+    if not task.resource_id:
+        raise FailedPreconditionError("Task has no retryable resource")
+
+    resolved = await tracker.find_completed_operation(
+        task.task_type,
+        task.resource_id,
+        task.operation_id or task.task_id,
+        account_id=task.account_id or _ctx.account_id,
+        user_id=task.user_id or _ctx.user.user_id,
+    )
+    if resolved is not None:
+        await tracker.resolve_failed(
+            task.task_id,
+            resolved.result or {},
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": resolved.task_id,
+                "attempt_number": resolved.attempt_number,
+            },
+        )
+
+    service = get_service()
+    if task.task_type == "session_commit":
+        retry_state = await service.sessions.inspect_failed_commit(
+            task.resource_id,
+            task.task_id,
+            _ctx,
+            archive_uri=(task.meta or {}).get("archive_uri"),
+            failed_task_created_at=task.created_at,
+        )
+        if retry_state.get("state") == "completed":
+            await tracker.resolve_failed(
+                task.task_id,
+                {
+                    "archive_uri": retry_state.get("archive_uri"),
+                    "reason": "archive_complete",
+                },
+                account_id=task.account_id or _ctx.account_id,
+                user_id=task.user_id or _ctx.user.user_id,
+            )
+            return Response(
+                status="ok",
+                result={
+                    "disposition": "operation_resolved",
+                    "operation_id": task.operation_id or task.task_id,
+                    "previous_task_id": task.task_id,
+                    "task_id": task.task_id,
+                    "resolution": "archive_complete",
+                    "archive_uri": retry_state.get("archive_uri"),
+                },
+            )
+
+    # Historical records predate structured error information. Classify them at
+    # the retry boundary too, so an old credential or media configuration error
+    # cannot be replayed into an endless stream of new failures.
+    error_info = task.error_info or classify_task_error(task.error or "")
+    retryability = error_info.get("retryability", "manual")
+    if retryability == "requires_change" and not body.acknowledge_change:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "blocked",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "error": error_info,
+            },
+        )
+
+    if task.attempt_number >= MAX_LINKED_RETRY_ATTEMPTS and not body.restart_operation:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "retry_limit_reached",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "attempt_number": task.attempt_number,
+                "max_attempts": MAX_LINKED_RETRY_ATTEMPTS,
+                "action": "Fix the prerequisite, then explicitly start a new operation.",
+            },
+        )
+
+    active = await tracker.find_active(
+        task.task_type,
+        task.resource_id,
+        account_id=task.account_id or _ctx.account_id,
+        user_id=task.user_id or _ctx.user.user_id,
+    )
+    if active is not None:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "already_running",
+                "operation_id": active.operation_id,
+                "previous_task_id": task.task_id,
+                "task_id": active.task_id,
+                "attempt_number": active.attempt_number,
+            },
+        )
+
+    if task.task_type == "session_commit":
+        result = await service.sessions.retry_failed_commit(
+            task.resource_id,
+            task.task_id,
+            _ctx,
+            archive_uri=(task.meta or {}).get("archive_uri"),
+            failed_task_created_at=task.created_at,
+        )
+    elif task.task_type in {"add_resource", "admin_reindex", "snapshot_restore_reindex"}:
+        result = await service.reindex(
+            uri=task.resource_id,
+            mode="vectors_only",
+            wait=False,
+            ctx=_ctx,
+        )
+    else:
+        raise FailedPreconditionError(
+            f"Task type '{task.task_type}' does not have a safe server-side retry recipe"
+        )
+
+    if isinstance(result, dict) and result.get("reason") == "archive_complete":
+        await tracker.resolve_failed(
+            task.task_id,
+            result,
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": task.task_id,
+                "resolution": "archive_complete",
+                "archive_uri": result.get("archive_uri"),
+            },
+        )
+
+    new_task_id = result.get("task_id") if isinstance(result, dict) else None
+    if not new_task_id:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "no_action",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "result": result,
+            },
+        )
+    linked = None
+    if not body.restart_operation:
+        linked = await tracker.link_retry(
+            str(new_task_id),
+            parent_task_id=task.task_id,
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+    return Response(
+        status="ok",
+        result={
+            "disposition": "accepted",
+            "operation_id": (
+                linked.operation_id
+                if linked
+                else (str(new_task_id) if body.restart_operation else task.operation_id)
+            ),
+            "previous_task_id": task.task_id,
+            "task_id": str(new_task_id),
+            "attempt_number": linked.attempt_number if linked else 1,
+            "status_url": f"/api/v1/tasks/{new_task_id}",
+        },
+    )
 
 
 @router.get("/tasks")

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -23,6 +23,7 @@ from openviking_cli.exceptions import (
     OpenVikingError,
     PermissionDeniedError,
 )
+from openviking_cli.session.user_id import UserIdentifier
 
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
 
@@ -37,6 +38,19 @@ class RetryTaskRequest(BaseModel):
 
 
 MAX_LINKED_RETRY_ATTEMPTS = 3
+
+
+def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
+    """Run ROOT retries in the task owner's storage namespace."""
+    if ctx.role != Role.ROOT or not task.account_id or not task.user_id:
+        return ctx
+    return RequestContext(
+        user=UserIdentifier(task.account_id, task.user_id),
+        role=ctx.role,
+        actor_peer_id=ctx.actor_peer_id,
+        from_oauth=ctx.from_oauth,
+        api_key=ctx.api_key,
+    )
 
 
 @router.get("/tasks/{task_id}")
@@ -134,6 +148,7 @@ async def retry_task(
         raise FailedPreconditionError("Only failed tasks can be retried")
     if not task.resource_id:
         raise FailedPreconditionError("Task has no retryable resource")
+    task_ctx = _task_owner_context(task, _ctx)
 
     resolved = await tracker.find_completed_operation(
         task.task_type,
@@ -165,7 +180,7 @@ async def retry_task(
         retry_state = await service.sessions.inspect_failed_commit(
             task.resource_id,
             task.task_id,
-            _ctx,
+            task_ctx,
             archive_uri=(task.meta or {}).get("archive_uri"),
             failed_task_created_at=task.created_at,
         )
@@ -267,7 +282,7 @@ async def retry_task(
         result = await service.sessions.retry_failed_commit(
             task.resource_id,
             task.task_id,
-            _ctx,
+            task_ctx,
             archive_uri=(task.meta or {}).get("archive_uri"),
             failed_task_created_at=task.created_at,
         )
@@ -276,7 +291,7 @@ async def retry_task(
             uri=task.resource_id,
             mode="vectors_only",
             wait=False,
-            ctx=_ctx,
+            ctx=task_ctx,
         )
     else:
         raise FailedPreconditionError(

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -450,6 +450,42 @@ class SessionService:
         )
         return task.to_dict() if task else None
 
+    async def retry_failed_commit(
+        self,
+        session_id: str,
+        failed_task_id: str,
+        ctx: RequestContext,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Requeue Phase 2 for a failed commit without re-archiving the session."""
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        return await session.retry_failed_commit(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+
+    async def inspect_failed_commit(
+        self,
+        session_id: str,
+        failed_task_id: str,
+        ctx: RequestContext,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Return the durable retry state without creating work."""
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        return await session.inspect_failed_commit(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+
     async def extract(self, session_id: str, ctx: RequestContext) -> List[Any]:
         """Extract memories from a session.
 
@@ -557,9 +593,7 @@ class SessionService:
                     return False
                 self._auto_commit_inflight.add(claim)
         except Exception:
-            logger.debug(
-                "Skipped auto-commit scheduling for %s", session_id, exc_info=True
-            )
+            logger.debug("Skipped auto-commit scheduling for %s", session_id, exc_info=True)
             return False
 
         task = asyncio.create_task(self.run_auto_commit(session_id, ctx, reason=reason_hint))

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -154,6 +154,10 @@ def _task_to_payload(task: Any) -> Dict[str, Any]:
         "stage": task.stage,
         "result": deepcopy(task.result),
         "error": task.error,
+        "operation_id": task.operation_id,
+        "parent_task_id": task.parent_task_id,
+        "attempt_number": task.attempt_number,
+        "error_info": deepcopy(task.error_info),
         "auth": deepcopy(task.auth),
     }
 

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -1149,9 +1149,16 @@ class TaskTracker:
                 self._merge_loaded_tasks([task])
                 task = self._cached_task(task_id)
         if task is not None and task.status == TaskStatus.FAILED and user_id:
-            self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
-            await self._reconcile_completed_operations_on_owner(account_id, user_id)
-            task = self._cached_task(task_id)
+            try:
+                self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+                await self._reconcile_completed_operations_on_owner(account_id, user_id)
+                task = self._cached_task(task_id)
+            except Exception:
+                logger.warning(
+                    "[TaskTracker] Failed to reconcile cached failed task %s",
+                    task_id,
+                    exc_info=True,
+                )
         if task is None or not self._matches_owner(task, account_id, user_id):
             return None
         return self._copy(task)

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -80,7 +80,17 @@ class TaskRecord:
     stage: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    # These fields connect retry attempts that belong to the same task.
+    operation_id: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    attempt_number: int = 1
+    error_info: Dict[str, Any] = field(default_factory=dict)
     auth: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.operation_id:
+            self.operation_id = self.task_id
+        self.attempt_number = max(1, int(self.attempt_number or 1))
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for JSON response."""
@@ -90,10 +100,65 @@ class TaskRecord:
         d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
         d["result"] = _sanitize_task_result(d.get("result"))
         d["meta"] = _sanitize_task_result(d.get("meta"))
+        # Legacy failed tasks have only the raw error. Expose the same safe
+        # classification at read time without rewriting their historical record.
+        error_info = self.error_info or (classify_task_error(self.error) if self.error else {})
+        d["error_info"] = _sanitize_task_result(error_info)
         d.pop("auth", None)
         d.pop("account_id", None)
         d.pop("user_id", None)
         return d
+
+
+def classify_task_error(error: str) -> Dict[str, str]:
+    """Classify terminal errors for safe retry decisions and UI guidance.
+
+    This deliberately uses a small conservative set. Unknown failures remain
+    manually retryable, but permanent provider and input failures are blocked
+    so a retry button cannot create an unbounded stream of equivalent tasks.
+    """
+    lowered = (error or "").lower()
+    if "sparse embedding only supports text input" in lowered:
+        return {
+            "code": "MEDIA_SPARSE_INPUT_UNSUPPORTED",
+            "retryability": "requires_change",
+            "action": "Configure media text extraction or remove media from sparse embedding input.",
+        }
+    if "token_expired" in lowered or "credential" in lowered or "authentication token" in lowered:
+        return {
+            "code": "AUTH_EXPIRED",
+            "retryability": "requires_change",
+            "action": "Refresh the affected provider credential before retrying.",
+        }
+    if "accountoverdue" in lowered or "overdue balance" in lowered:
+        return {
+            "code": "ACCOUNT_OVERDUE",
+            "retryability": "requires_change",
+            "action": "Resolve the provider account balance before retrying.",
+        }
+    if "has no attribute 'strip'" in lowered or 'has no attribute "strip"' in lowered:
+        return {
+            "code": "INPUT_SHAPE_INVALID",
+            "retryability": "requires_change",
+            "action": "Correct the message input shape before retrying.",
+        }
+    if "source no longer exists" in lowered or "not found" in lowered:
+        return {
+            "code": "SOURCE_MISSING",
+            "retryability": "requires_change",
+            "action": "Restore or replace the source before retrying.",
+        }
+    if any(marker in lowered for marker in ("overloaded", "timeout", "timed out", "lock acquire")):
+        return {
+            "code": "TRANSIENT_UPSTREAM",
+            "retryability": "retryable",
+            "action": "Retry with backoff; the service may be temporarily busy.",
+        }
+    return {
+        "code": "UNKNOWN",
+        "retryability": "manual",
+        "action": "Review the error details before retrying.",
+    }
 
 
 # ── Singleton ──
@@ -544,6 +609,210 @@ class TaskTracker:
         """Record failure and finalize after owned work settles."""
         await self._record_outcome(task_id, account_id, user_id, error=error)
 
+    async def link_retry(
+        self,
+        task_id: str,
+        *,
+        parent_task_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Attach a newly accepted task to its failed predecessor."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._link_retry_on_owner(task_id, parent_task_id, account_id, user_id)
+        )
+
+    async def _link_retry_on_owner(
+        self,
+        task_id: str,
+        parent_task_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        parent = await self._load_for_update(parent_task_id, account_id, user_id)
+        if parent is None:
+            return None
+        linked: Optional[TaskRecord] = None
+        async with self._task_locks.acquire(task_id):
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task is None:
+                return None
+            updated = deepcopy(task)
+            updated.operation_id = parent.operation_id or parent.task_id
+            updated.parent_task_id = parent.task_id
+            updated.attempt_number = parent.attempt_number + 1
+            updated.updated_at = self._next_updated_at(task)
+            await self._persist_and_publish("update", updated)
+            linked = self._copy(updated)
+        if linked.status == TaskStatus.COMPLETED:
+            await self._complete_failed_operation_tasks_on_owner(linked)
+        return linked
+
+    async def resolve_failed(
+        self,
+        task_id: str,
+        result: Dict[str, Any],
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Change a failed task to completed after its retry or archive succeeds."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._resolve_failed_on_owner(task_id, result, account_id, user_id)
+        )
+
+    async def _resolve_failed_on_owner(
+        self,
+        task_id: str,
+        result: Dict[str, Any],
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        async with self._task_locks.acquire(task_id):
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task is None:
+                return None
+            if task.status == TaskStatus.COMPLETED:
+                return self._copy(task)
+            if task.status != TaskStatus.FAILED:
+                return self._copy(task)
+            updated = deepcopy(task)
+            updated.status = TaskStatus.COMPLETED
+            updated.stage = TaskStatus.COMPLETED.value
+            updated.result = deepcopy(result)
+            updated.error = None
+            updated.error_info = {}
+            updated.updated_at = self._next_updated_at(task)
+            updated.auth = {}
+            await self._persist_and_publish("update", updated)
+            logger.info("[TaskTracker] Task %s completed after retry", task_id)
+            return self._copy(updated)
+
+    async def _complete_failed_operation_tasks_on_owner(
+        self,
+        completed: TaskRecord,
+    ) -> None:
+        if (
+            completed.status != TaskStatus.COMPLETED
+            or completed.attempt_number <= 1
+            or not completed.account_id
+            or not completed.user_id
+        ):
+            return
+        self._merge_loaded_tasks(
+            await self._load_all_from_store(completed.account_id, completed.user_id)
+        )
+        failed_task_ids = [
+            task.task_id
+            for task in self._cache_snapshot()
+            if task.task_type == completed.task_type
+            and task.resource_id == completed.resource_id
+            and task.operation_id == completed.operation_id
+            and self._matches_owner(task, completed.account_id, completed.user_id)
+            and task.status == TaskStatus.FAILED
+        ]
+        for failed_task_id in failed_task_ids:
+            await self._resolve_failed_on_owner(
+                failed_task_id,
+                completed.result or {},
+                completed.account_id,
+                completed.user_id,
+            )
+
+    async def _reconcile_completed_operations_on_owner(
+        self,
+        account_id: str,
+        user_id: str,
+    ) -> None:
+        completed_retries = [
+            task
+            for task in self._cache_snapshot()
+            if self._matches_owner(task, account_id, user_id)
+            and task.status == TaskStatus.COMPLETED
+            and task.attempt_number > 1
+        ]
+        for completed in completed_retries:
+            await self._complete_failed_operation_tasks_on_owner(completed)
+
+    async def find_active(
+        self,
+        task_type: str,
+        resource_id: str,
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Return the newest active task for an owner and business key."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._find_active_on_owner(task_type, resource_id, account_id, user_id)
+        )
+
+    async def _find_active_on_owner(
+        self,
+        task_type: str,
+        resource_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        candidates = [
+            task
+            for task in self._cache_snapshot()
+            if task.task_type == task_type
+            and task.resource_id == resource_id
+            and self._matches_owner(task, account_id, user_id)
+            and task.status in _ACTIVE_STATUSES
+        ]
+        if not candidates:
+            return None
+        return self._copy(max(candidates, key=lambda task: task.created_at))
+
+    async def find_completed_operation(
+        self,
+        task_type: str,
+        resource_id: str,
+        operation_id: str,
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Return the successful attempt that completed one retry operation."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._find_completed_operation_on_owner(
+                task_type,
+                resource_id,
+                operation_id,
+                account_id,
+                user_id,
+            )
+        )
+
+    async def _find_completed_operation_on_owner(
+        self,
+        task_type: str,
+        resource_id: str,
+        operation_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        candidates = [
+            task
+            for task in self._cache_snapshot()
+            if task.task_type == task_type
+            and task.resource_id == resource_id
+            and task.operation_id == operation_id
+            and self._matches_owner(task, account_id, user_id)
+            and task.status == TaskStatus.COMPLETED
+        ]
+        if not candidates:
+            return None
+        return self._copy(max(candidates, key=lambda task: (task.attempt_number, task.updated_at)))
+
     async def _record_outcome(
         self,
         task_id: str,
@@ -587,9 +856,11 @@ class TaskTracker:
                         updated.resource_id = resource_id
                 if error is not None and updated.error is None:
                     updated.error = _sanitize_error(error)
+                    updated.error_info = classify_task_error(updated.error)
                 work_error = self._work_index.failure(task_id)
                 if work_error and updated.error is None:
                     updated.error = _sanitize_error(work_error)
+                    updated.error_info = classify_task_error(updated.error)
                 updated.updated_at = self._next_updated_at(task)
                 updated.auth = {}
                 try:
@@ -698,6 +969,7 @@ class TaskTracker:
     ) -> None:
         if self._work_index.has_work(task_id):
             return
+        completed: Optional[TaskRecord] = None
         async with self._task_locks.acquire(task_id):
             task = await self._load_for_update(task_id, account_id, user_id)
             if task and task.status in _ACTIVE_STATUSES:
@@ -722,6 +994,10 @@ class TaskTracker:
                 await self._persist_and_publish("update", updated)
                 self._work_index.clear_failure(task_id)
                 logger.info("[TaskTracker] Task %s %s", task_id, updated.status.value)
+                if updated.status == TaskStatus.COMPLETED:
+                    completed = self._copy(updated)
+        if completed is not None:
+            await self._complete_failed_operation_tasks_on_owner(completed)
 
     async def wait(
         self,
@@ -848,7 +1124,8 @@ class TaskTracker:
         if task is not None:
             if not self._matches_owner(task, account_id, user_id):
                 return None
-            return self._copy(task)
+            if task.status != TaskStatus.FAILED or account_id is None or user_id is None:
+                return self._copy(task)
         if account_id is None:
             return None
         return await self._dispatcher.run(lambda: self._get_on_owner(task_id, account_id, user_id))
@@ -865,6 +1142,10 @@ class TaskTracker:
             if task is not None:
                 self._merge_loaded_tasks([task])
                 task = self._cached_task(task_id)
+        if task is not None and task.status == TaskStatus.FAILED and user_id:
+            self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+            await self._reconcile_completed_operations_on_owner(account_id, user_id)
+            task = self._cached_task(task_id)
         if task is None or not self._matches_owner(task, account_id, user_id):
             return None
         return self._copy(task)
@@ -901,6 +1182,8 @@ class TaskTracker:
     ) -> List[TaskRecord]:
         if account_id is not None:
             self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+            if user_id is not None:
+                await self._reconcile_completed_operations_on_owner(account_id, user_id)
         source = self._cache_snapshot()
         tasks = [self._copy(t) for t in source if self._matches_owner(t, account_id, user_id)]
         if task_type:

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -693,6 +693,8 @@ class TaskTracker:
     async def _complete_failed_operation_tasks_on_owner(
         self,
         completed: TaskRecord,
+        *,
+        refresh_from_store: bool = True,
     ) -> None:
         if (
             completed.status != TaskStatus.COMPLETED
@@ -701,9 +703,10 @@ class TaskTracker:
             or not completed.user_id
         ):
             return
-        self._merge_loaded_tasks(
-            await self._load_all_from_store(completed.account_id, completed.user_id)
-        )
+        if refresh_from_store:
+            self._merge_loaded_tasks(
+                await self._load_all_from_store(completed.account_id, completed.user_id)
+            )
         failed_task_ids = [
             task.task_id
             for task in self._cache_snapshot()
@@ -734,7 +737,10 @@ class TaskTracker:
             and task.attempt_number > 1
         ]
         for completed in completed_retries:
-            await self._complete_failed_operation_tasks_on_owner(completed)
+            await self._complete_failed_operation_tasks_on_owner(
+                completed,
+                refresh_from_store=False,
+            )
 
     async def find_active(
         self,

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -48,7 +48,7 @@ from openviking.storage.abstract_overview import body_for_preview, render_abstra
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
-from openviking.utils.time_utils import get_current_timestamp
+from openviking.utils.time_utils import get_current_timestamp, parse_iso_datetime
 from openviking.utils.token_estimation import estimate_text_tokens, truncate_text_to_token_budget
 from openviking_cli.exceptions import (
     FailedPreconditionError,
@@ -2118,6 +2118,7 @@ class Session:
                     account_id=self.ctx.account_id,
                     user_id=self.ctx.user.user_id,
                     task_id=task_id,
+                    meta={"archive_uri": archive_uri},
                 )
 
                 phase1_stage = "phase1_persist"
@@ -2186,6 +2187,201 @@ class Session:
                 retention_plan.estimated_active_tokens if retention_plan else 0
             ),
             "budget_exceeded": retention_plan.budget_exceeded if retention_plan else False,
+        }
+
+    async def inspect_failed_commit(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Inspect whether a failed Phase 2 archive still needs work."""
+        if not self._viking_fs:
+            raise FailedPreconditionError("Session storage is not initialized")
+
+        selected_uri, _ = await self._find_failed_commit_archive(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+        if not selected_uri:
+            return {"state": "unavailable", "archive_uri": None}
+        if await self._archive_file_exists(selected_uri, ".done"):
+            return {"state": "completed", "archive_uri": selected_uri}
+        if await self._archive_file_exists(selected_uri, ".failed.json"):
+            return {"state": "failed_ready", "archive_uri": selected_uri}
+        return {"state": "not_ready", "archive_uri": selected_uri}
+
+    async def _find_failed_commit_archive(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> tuple[str, Dict[str, Any]]:
+        """Find current and legacy archives without changing their state."""
+        candidate_uris = [archive_uri] if archive_uri else []
+        if not candidate_uris:
+            history_uri = f"{self._session_uri}/history"
+            matches = await self._viking_fs.glob(
+                "archive_*/messages.jsonl", uri=history_uri, ctx=self.ctx
+            )
+            candidate_uris = [
+                uri.rsplit("/messages.jsonl", 1)[0]
+                for uri in matches.get("matches", [])
+                if isinstance(uri, str) and uri.endswith("/messages.jsonl")
+            ]
+
+        legacy_matches: List[tuple[float, str, Dict[str, Any]]] = []
+        for candidate_uri in candidate_uris:
+            if not isinstance(candidate_uri, str) or not candidate_uri.startswith(
+                f"{self._session_uri}/history/"
+            ):
+                continue
+            phase1 = (await self._read_archive_meta(candidate_uri)).get("phase1")
+            if not isinstance(phase1, dict):
+                continue
+            payload = phase1.get("queue_message")
+            if not isinstance(payload, dict):
+                continue
+            retry_history = phase1.get("retry_history") or []
+            known_task_ids = {
+                str(item.get("task_id"))
+                for item in retry_history
+                if isinstance(item, dict) and item.get("task_id")
+            }
+            if payload.get("task_id") == failed_task_id or failed_task_id in known_task_ids:
+                return candidate_uri, payload
+            if archive_uri and candidate_uri == archive_uri:
+                return candidate_uri, payload
+
+            # Recovery tooling used by older installations replaced the queue
+            # task ID without retaining retry_history. Phase 1 and task records
+            # were created together, so their sub-second timestamps provide a
+            # narrow, deterministic compatibility match.
+            if failed_task_created_at is None:
+                continue
+            created_at = phase1.get("created_at")
+            if not isinstance(created_at, str):
+                continue
+            try:
+                created_epoch = parse_iso_datetime(created_at).timestamp()
+            except ValueError:
+                continue
+            delta = abs(created_epoch - float(failed_task_created_at))
+            if delta <= 1.0:
+                legacy_matches.append((delta, candidate_uri, payload))
+
+        if legacy_matches:
+            _, selected_uri, queue_payload = min(legacy_matches, key=lambda item: item[0])
+            return selected_uri, queue_payload
+        return "", {}
+
+    async def retry_failed_commit(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Create a new Phase 2 task from a failed commit's durable archive.
+
+        Phase 1 has already removed the archived messages from the live session,
+        so retrying ``commit_async`` would incorrectly report ``no_messages``.
+        This method restores the stored QueueFS payload instead, while keeping
+        each failed attempt as an immutable task record.
+        """
+        from openviking.service.task_tracker import get_task_tracker
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+        from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+
+        if not self._viking_fs:
+            raise FailedPreconditionError("Session storage is not initialized")
+
+        session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+            session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
+        )
+        try:
+            selected_uri, queue_payload = await self._find_failed_commit_archive(
+                failed_task_id,
+                archive_uri=archive_uri,
+                failed_task_created_at=failed_task_created_at,
+            )
+
+            if not selected_uri:
+                raise FailedPreconditionError("The failed commit archive is unavailable for retry")
+            if await self._archive_file_exists(selected_uri, ".done"):
+                return {
+                    "session_id": self.session_id,
+                    "status": "completed",
+                    "task_id": None,
+                    "archive_uri": selected_uri,
+                    "reason": "archive_complete",
+                }
+            if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                raise FailedPreconditionError("The failed commit is not ready for retry")
+
+            queued = SessionCommitMsg.from_dict(queue_payload)
+            retry_task_id = str(uuid4())
+            retry_message = SessionCommitMsg(**{**queued.to_dict(), "task_id": retry_task_id})
+            failed_uri = f"{selected_uri}/.failed.json"
+            failure_history_uri = f"{selected_uri}/.failed.{failed_task_id}.json"
+            failure_content = await self._viking_fs.read_file(failed_uri, ctx=self.ctx)
+            phase1 = (await self._read_archive_meta(selected_uri)).get("phase1")
+            if not isinstance(phase1, dict):
+                raise FailedPreconditionError("The failed commit archive has no Phase 1 record")
+            original_phase1 = dict(phase1)
+            retry_history = list(phase1.get("retry_history") or [])
+            retry_history.append({"task_id": failed_task_id, "failed_file": failure_history_uri})
+            phase1["queue_message"] = retry_message.to_dict()
+            phase1["retry_history"] = retry_history
+
+            await self._viking_fs.write_file(
+                failure_history_uri,
+                failure_content,
+                ctx=self.ctx,
+                lease_ref=lease,
+            )
+            await self._viking_fs._async_agfs.rm(
+                self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+            )
+            try:
+                await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
+                await get_task_tracker().create(
+                    "session_commit",
+                    resource_id=self.session_id,
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
+                    task_id=retry_task_id,
+                    meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
+                )
+                await get_queue_manager().enqueue(
+                    QueueManager.SESSION_COMMIT,
+                    retry_message.to_dict(),
+                )
+            except Exception:
+                await self._merge_archive_meta(
+                    selected_uri, {"phase1": original_phase1}, lease_ref=lease
+                )
+                if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                    await self._viking_fs.write_file(
+                        failed_uri,
+                        failure_content,
+                        ctx=self.ctx,
+                        lease_ref=lease,
+                    )
+                raise
+        finally:
+            await self._viking_fs._async_agfs.pathlock_release(lease)
+
+        return {
+            "session_id": self.session_id,
+            "status": "accepted",
+            "task_id": retry_task_id,
+            "archive_uri": selected_uri,
         }
 
     async def finalize_cancelled_commit(self, archive_uri: str) -> None:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2348,9 +2348,11 @@ class Session:
                 self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
                 fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
             )
+            tracker = get_task_tracker()
+            retry_task_created = False
             try:
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
-                await get_task_tracker().create(
+                await tracker.create(
                     "session_commit",
                     resource_id=self.session_id,
                     account_id=self.ctx.account_id,
@@ -2358,11 +2360,25 @@ class Session:
                     task_id=retry_task_id,
                     meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
                 )
+                retry_task_created = True
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
                     retry_message.to_dict(),
                 )
             except Exception:
+                if retry_task_created:
+                    try:
+                        await tracker.fail(
+                            retry_task_id,
+                            "Failed to enqueue session commit retry",
+                            account_id=self.ctx.account_id,
+                            user_id=self.ctx.user.user_id,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to mark retry task %s after queue enqueue failure",
+                            retry_task_id,
+                        )
                 await self._merge_archive_meta(
                     selected_uri, {"phase1": original_phase1}, lease_ref=lease
                 )

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2350,10 +2350,6 @@ class Session:
                     lease_ref=lease,
                 )
                 failure_history_written = True
-                await self._viking_fs._async_agfs.rm(
-                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
-                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
-                )
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
                 await tracker.create(
                     "session_commit",
@@ -2364,6 +2360,10 @@ class Session:
                     meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
                 )
                 retry_task_created = True
+                await self._viking_fs._async_agfs.rm(
+                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                )
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
                     retry_message.to_dict(),

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2327,7 +2327,8 @@ class Session:
             retry_task_id = str(uuid4())
             retry_message = SessionCommitMsg(**{**queued.to_dict(), "task_id": retry_task_id})
             failed_uri = f"{selected_uri}/.failed.json"
-            failure_history_uri = f"{selected_uri}/.failed.{failed_task_id}.json"
+            failure_history_id = sha256_text(failed_task_id)
+            failure_history_uri = f"{selected_uri}/.failed.{failure_history_id}.json"
             failure_content = await self._viking_fs.read_file(failed_uri, ctx=self.ctx)
             phase1 = (await self._read_archive_meta(selected_uri)).get("phase1")
             if not isinstance(phase1, dict):
@@ -2338,19 +2339,21 @@ class Session:
             phase1["queue_message"] = retry_message.to_dict()
             phase1["retry_history"] = retry_history
 
-            await self._viking_fs.write_file(
-                failure_history_uri,
-                failure_content,
-                ctx=self.ctx,
-                lease_ref=lease,
-            )
-            await self._viking_fs._async_agfs.rm(
-                self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
-                fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
-            )
             tracker = get_task_tracker()
             retry_task_created = False
+            failure_history_written = False
             try:
+                await self._viking_fs.write_file(
+                    failure_history_uri,
+                    failure_content,
+                    ctx=self.ctx,
+                    lease_ref=lease,
+                )
+                failure_history_written = True
+                await self._viking_fs._async_agfs.rm(
+                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                )
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
                 await tracker.create(
                     "session_commit",
@@ -2379,16 +2382,36 @@ class Session:
                             "Failed to mark retry task %s after queue enqueue failure",
                             retry_task_id,
                         )
-                await self._merge_archive_meta(
-                    selected_uri, {"phase1": original_phase1}, lease_ref=lease
-                )
-                if not await self._archive_file_exists(selected_uri, ".failed.json"):
-                    await self._viking_fs.write_file(
-                        failed_uri,
-                        failure_content,
-                        ctx=self.ctx,
-                        lease_ref=lease,
+                phase1_rolled_back = False
+                try:
+                    await self._merge_archive_meta(
+                        selected_uri, {"phase1": original_phase1}, lease_ref=lease
                     )
+                    phase1_rolled_back = True
+                except Exception:
+                    logger.exception("Failed to roll back retry metadata for %s", selected_uri)
+                try:
+                    if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                        await self._viking_fs.write_file(
+                            failed_uri,
+                            failure_content,
+                            ctx=self.ctx,
+                            lease_ref=lease,
+                        )
+                except Exception:
+                    logger.exception("Failed to restore retry marker for %s", selected_uri)
+                if failure_history_written and phase1_rolled_back:
+                    try:
+                        await self._viking_fs._async_agfs.rm(
+                            self._viking_fs._uri_to_path(failure_history_uri, ctx=self.ctx),
+                            fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                        )
+                    except Exception as cleanup_exc:
+                        if not _is_storage_not_found(cleanup_exc):
+                            logger.exception(
+                                "Failed to remove rolled-back retry history %s",
+                                failure_history_uri,
+                            )
                 raise
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -68,6 +68,7 @@ class _Tracker:
 class _Sessions:
     def __init__(self):
         self.calls = 0
+        self.contexts: list[RequestContext] = []
         self.retry_state = {"state": "failed_ready", "archive_uri": None}
 
     async def inspect_failed_commit(
@@ -79,6 +80,7 @@ class _Sessions:
         archive_uri=None,
         failed_task_created_at=None,
     ):
+        self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
         return self.retry_state
@@ -93,6 +95,7 @@ class _Sessions:
         failed_task_created_at=None,
     ):
         self.calls += 1
+        self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
         return {"task_id": "retry-task"}
@@ -185,6 +188,34 @@ async def test_retry_creates_a_linked_attempt_and_returns_its_task_id(monkeypatc
             "user_id": "alice",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_uses_the_task_owner_context(monkeypatch):
+    task = _failed_task()
+    task.account_id = "tenant-b"
+    task.user_id = "bob"
+    tracker = _Tracker(task)
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+        actor_peer_id="peer-1",
+        api_key="root-key",
+    )
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+
+    assert response.result["disposition"] == "accepted"
+    assert len(service.sessions.contexts) == 2
+    for task_ctx in service.sessions.contexts:
+        assert task_ctx.account_id == "tenant-b"
+        assert task_ctx.user.user_id == "bob"
+        assert task_ctx.role == Role.ROOT
+        assert task_ctx.actor_peer_id == "peer-1"
+        assert task_ctx.api_key == "root-key"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -68,7 +68,7 @@ class _Tracker:
 class _Sessions:
     def __init__(self):
         self.calls = 0
-        self.retry_state = {"state": "unavailable", "archive_uri": None}
+        self.retry_state = {"state": "failed_ready", "archive_uri": None}
 
     async def inspect_failed_commit(
         self,
@@ -135,6 +135,34 @@ async def test_retry_reports_completed_legacy_archive_before_credential_prompt(m
     assert response.result["task_id"] == "failed-task"
     assert tracker.task.status == TaskStatus.COMPLETED
     assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("archive_state", "error_code"),
+    [
+        ("unavailable", "RETRY_ARCHIVE_UNAVAILABLE"),
+        ("not_ready", "RETRY_ARCHIVE_NOT_READY"),
+    ],
+)
+async def test_retry_blocks_when_commit_archive_is_not_retryable(
+    monkeypatch,
+    archive_state,
+    error_code,
+):
+    tracker = _Tracker(_failed_task())
+    service = _Service()
+    service.sessions.retry_state = {"state": archive_state, "archive_uri": None}
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "blocked"
+    assert response.result["archive_state"] == archive_state
+    assert response.result["error"]["code"] == error_code
+    assert service.sessions.calls == 0
+    assert tracker.link_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -7,6 +7,7 @@ import pytest
 from openviking.server.identity import RequestContext, Role
 from openviking.server.routers import tasks as task_router
 from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking_cli.exceptions import FailedPreconditionError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -27,14 +28,28 @@ def _failed_task(*, error: str = "provider overloaded", attempt_number: int = 1)
     )
 
 
+def test_task_response_only_exposes_owner_to_root_callers():
+    task = _failed_task()
+
+    regular_response = task_router._task_response(task, include_owner=False)
+    root_response = task_router._task_response(task, include_owner=True)
+
+    assert "owner_account_id" not in regular_response
+    assert "owner_user_id" not in regular_response
+    assert root_response["owner_account_id"] == "acme"
+    assert root_response["owner_user_id"] == "alice"
+
+
 class _Tracker:
     def __init__(self, task: TaskRecord):
         self.task = task
         self.link_calls: list[dict] = []
         self.resolve_calls: list[dict] = []
+        self.get_calls: list[dict] = []
         self.resolved_task: TaskRecord | None = None
 
-    async def get(self, task_id, **_kwargs):
+    async def get(self, task_id, **kwargs):
+        self.get_calls.append({"task_id": task_id, **kwargs})
         return self.task if task_id == self.task.task_id else None
 
     async def find_active(self, *_args, **_kwargs):
@@ -70,6 +85,7 @@ class _Sessions:
         self.calls = 0
         self.contexts: list[RequestContext] = []
         self.retry_state = {"state": "failed_ready", "archive_uri": None}
+        self.retry_result = {"task_id": "retry-task"}
 
     async def inspect_failed_commit(
         self,
@@ -98,7 +114,7 @@ class _Sessions:
         self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
-        return {"task_id": "retry-task"}
+        return self.retry_result
 
 
 class _Service:
@@ -206,7 +222,14 @@ async def test_root_retry_uses_the_task_owner_context(monkeypatch):
         api_key="root-key",
     )
 
-    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+    response = await task_router.retry_task(
+        "failed-task",
+        task_router.RetryTaskRequest(
+            owner_account_id="tenant-b",
+            owner_user_id="bob",
+        ),
+        root_ctx,
+    )
 
     assert response.result["disposition"] == "accepted"
     assert len(service.sessions.contexts) == 2
@@ -216,6 +239,145 @@ async def test_root_retry_uses_the_task_owner_context(monkeypatch):
         assert task_ctx.role == Role.ROOT
         assert task_ctx.actor_peer_id == "peer-1"
         assert task_ctx.api_key == "root-key"
+
+
+@pytest.mark.asyncio
+async def test_root_retry_requires_an_explicit_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    with pytest.raises(FailedPreconditionError, match="both owner_account_id and owner_user_id"):
+        await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+
+    assert tracker.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_root_retry_accepts_an_explicit_system_owner(monkeypatch):
+    task = _failed_task()
+    task.account_id = task_router.SYSTEM_TASK_ACCOUNT_ID
+    task.user_id = task_router.SYSTEM_TASK_USER_ID
+    tracker = _Tracker(task)
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    response = await task_router.retry_task(
+        "failed-task",
+        task_router.RetryTaskRequest(
+            owner_account_id=task_router.SYSTEM_TASK_ACCOUNT_ID,
+            owner_user_id=task_router.SYSTEM_TASK_USER_ID,
+        ),
+        root_ctx,
+    )
+
+    assert response.result["disposition"] == "accepted"
+    assert tracker.get_calls == [
+        {
+            "task_id": "failed-task",
+            "account_id": task_router.SYSTEM_TASK_ACCOUNT_ID,
+            "user_id": task_router.SYSTEM_TASK_USER_ID,
+        }
+    ]
+    assert service.sessions.contexts == [root_ctx, root_ctx]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_loads_persisted_task_with_explicit_owner(monkeypatch):
+    task = _failed_task()
+    task.account_id = "tenant-b"
+    task.user_id = "bob"
+    tracker = _Tracker(task)
+    service = _Service()
+
+    async def load_from_store(task_id, **kwargs):
+        tracker.get_calls.append({"task_id": task_id, **kwargs})
+        if kwargs == {"account_id": "tenant-b", "user_id": "bob"}:
+            return task
+        return None
+
+    tracker.get = load_from_store
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+    body = task_router.RetryTaskRequest(
+        owner_account_id="tenant-b",
+        owner_user_id="bob",
+    )
+
+    response = await task_router.retry_task("failed-task", body, root_ctx)
+
+    assert response.result["disposition"] == "accepted"
+    assert tracker.get_calls == [
+        {
+            "task_id": "failed-task",
+            "account_id": "tenant-b",
+            "user_id": "bob",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_rejects_an_incomplete_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    with pytest.raises(FailedPreconditionError, match="both owner_account_id and owner_user_id"):
+        await task_router.retry_task(
+            "failed-task",
+            task_router.RetryTaskRequest(owner_account_id="tenant-b"),
+            root_ctx,
+        )
+
+    assert tracker.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_root_retry_rejects_an_explicit_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+
+    with pytest.raises(PermissionDeniedError, match="Only ROOT may specify a task owner"):
+        await task_router.retry_task(
+            "failed-task",
+            task_router.RetryTaskRequest(
+                owner_account_id="tenant-b",
+                owner_user_id="bob",
+            ),
+            _ctx(),
+        )
+
+    assert tracker.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_no_action_when_service_starts_no_task(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    service = _Service()
+    service.sessions.retry_result = {"reason": "nothing_to_retry"}
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "no_action"
+    assert response.result["result"] == {"reason": "nothing_to_retry"}
+    assert tracker.link_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Isolated unit tests for the server-owned task retry endpoint."""
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import tasks as task_router
+from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
+
+
+def _failed_task(*, error: str = "provider overloaded", attempt_number: int = 1) -> TaskRecord:
+    return TaskRecord(
+        task_id="failed-task",
+        task_type="session_commit",
+        status=TaskStatus.FAILED,
+        resource_id="session-1",
+        account_id="acme",
+        user_id="alice",
+        error=error,
+        attempt_number=attempt_number,
+    )
+
+
+class _Tracker:
+    def __init__(self, task: TaskRecord):
+        self.task = task
+        self.link_calls: list[dict] = []
+        self.resolve_calls: list[dict] = []
+        self.resolved_task: TaskRecord | None = None
+
+    async def get(self, task_id, **_kwargs):
+        return self.task if task_id == self.task.task_id else None
+
+    async def find_active(self, *_args, **_kwargs):
+        return None
+
+    async def find_completed_operation(self, *_args, **_kwargs):
+        return self.resolved_task
+
+    async def link_retry(self, task_id, **kwargs):
+        self.link_calls.append({"task_id": task_id, **kwargs})
+        return TaskRecord(
+            task_id=task_id,
+            task_type=self.task.task_type,
+            resource_id=self.task.resource_id,
+            account_id="acme",
+            user_id="alice",
+            operation_id=self.task.operation_id,
+            parent_task_id=self.task.task_id,
+            attempt_number=self.task.attempt_number + 1,
+        )
+
+    async def resolve_failed(self, task_id, result, **kwargs):
+        self.resolve_calls.append({"task_id": task_id, "result": result, **kwargs})
+        self.task.status = TaskStatus.COMPLETED
+        self.task.result = result
+        self.task.error = None
+        self.task.error_info = {}
+        return self.task
+
+
+class _Sessions:
+    def __init__(self):
+        self.calls = 0
+        self.retry_state = {"state": "unavailable", "archive_uri": None}
+
+    async def inspect_failed_commit(
+        self,
+        _session_id,
+        _failed_task_id,
+        _ctx,
+        *,
+        archive_uri=None,
+        failed_task_created_at=None,
+    ):
+        assert archive_uri is None
+        assert failed_task_created_at is not None
+        return self.retry_state
+
+    async def retry_failed_commit(
+        self,
+        _session_id,
+        _failed_task_id,
+        _ctx,
+        *,
+        archive_uri=None,
+        failed_task_created_at=None,
+    ):
+        self.calls += 1
+        assert archive_uri is None
+        assert failed_task_created_at is not None
+        return {"task_id": "retry-task"}
+
+
+class _Service:
+    def __init__(self):
+        self.sessions = _Sessions()
+
+
+@pytest.mark.asyncio
+async def test_retry_blocks_legacy_permanent_failure_before_starting_work(monkeypatch):
+    tracker = _Tracker(_failed_task(error="token_expired"))
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "blocked"
+    assert response.result["error"]["code"] == "AUTH_EXPIRED"
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_completed_legacy_archive_before_credential_prompt(monkeypatch):
+    tracker = _Tracker(_failed_task(error="token_expired"))
+    service = _Service()
+    service.sessions.retry_state = {
+        "state": "completed",
+        "archive_uri": "viking://user/alice/sessions/session-1/history/archive_001",
+    }
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["resolution"] == "archive_complete"
+    assert response.result["task_id"] == "failed-task"
+    assert tracker.task.status == TaskStatus.COMPLETED
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_creates_a_linked_attempt_and_returns_its_task_id(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "accepted"
+    assert response.result["task_id"] == "retry-task"
+    assert response.result["attempt_number"] == 2
+    assert tracker.link_calls == [
+        {
+            "task_id": "retry-task",
+            "parent_task_id": "failed-task",
+            "account_id": "acme",
+            "user_id": "alice",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_replay_a_failed_predecessor_after_operation_success(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    tracker.resolved_task = TaskRecord(
+        task_id="completed-retry",
+        task_type="session_commit",
+        status=TaskStatus.COMPLETED,
+        resource_id="session-1",
+        account_id="acme",
+        user_id="alice",
+        operation_id="failed-task",
+        attempt_number=2,
+    )
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["task_id"] == "completed-retry"
+    assert tracker.task.status == TaskStatus.COMPLETED
+    assert service.sessions.calls == 0
+    assert tracker.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_an_already_completed_task_without_starting_work(monkeypatch):
+    task = _failed_task()
+    task.status = TaskStatus.COMPLETED
+    tracker = _Tracker(task)
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["task_id"] == "failed-task"
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_stops_after_the_linked_attempt_limit(monkeypatch):
+    tracker = _Tracker(_failed_task(attempt_number=task_router.MAX_LINKED_RETRY_ATTEMPTS))
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "retry_limit_reached"
+    assert service.sessions.calls == 0

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -13,9 +13,11 @@ from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
 from openviking.service.task_store import PersistentTaskStore
 from openviking.service.task_tracker import (
+    TaskRecord,
     TaskStatus,
     TaskTracker,
     _sanitize_error,
+    classify_task_error,
     get_task_tracker,
     set_task_tracker,
 )
@@ -202,6 +204,121 @@ async def test_fail_task(tracker: TaskTracker):
     assert retrieved.status == TaskStatus.FAILED
     assert retrieved.stage == "failed"
     assert "LLM timeout" in retrieved.error
+    assert retrieved.error_info["retryability"] == "retryable"
+
+
+async def test_legacy_failure_is_classified_when_serialized(tracker: TaskTracker):
+    task = await tracker.create("session_commit", **_owner_kwargs())
+    await tracker.fail(task.task_id, "token_expired")
+    retrieved = await tracker.get(task.task_id)
+
+    assert retrieved is not None
+    retrieved.error_info = {}
+    assert retrieved.to_dict()["error_info"]["code"] == "AUTH_EXPIRED"
+
+
+@pytest.mark.parametrize(
+    ("error", "code", "retryability"),
+    [
+        ("token_expired", "AUTH_EXPIRED", "requires_change"),
+        (
+            "Sparse embedding only supports text input",
+            "MEDIA_SPARSE_INPUT_UNSUPPORTED",
+            "requires_change",
+        ),
+        ("provider overloaded", "TRANSIENT_UPSTREAM", "retryable"),
+    ],
+)
+async def test_classify_task_error(error: str, code: str, retryability: str):
+    info = classify_task_error(error)
+    assert info["code"] == code
+    assert info["retryability"] == retryability
+
+
+async def test_linked_retry_keeps_predecessor_failed_while_retry_is_active(
+    tracker: TaskTracker,
+):
+    first = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker.fail(first.task_id, "provider overloaded")
+    second = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+
+    linked = await tracker.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+
+    assert linked is not None
+    assert linked.operation_id == first.task_id
+    assert linked.parent_task_id == first.task_id
+    assert linked.attempt_number == 2
+    predecessor = await tracker.get(first.task_id, **_owner_kwargs())
+    assert predecessor is not None
+    assert predecessor.status == TaskStatus.FAILED
+    active = await tracker.find_active("session_commit", "session-1", **_owner_kwargs())
+    assert active is not None
+    assert active.task_id == second.task_id
+
+
+async def test_completed_retry_changes_failed_predecessor_to_completed(
+    tracker: TaskTracker,
+):
+    first = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker.fail(first.task_id, "provider overloaded")
+    second = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    linked = await tracker.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+    assert linked is not None
+    await tracker.complete(second.task_id, {"memories_extracted": 1}, **_owner_kwargs())
+
+    resolved = await tracker.find_completed_operation(
+        "session_commit",
+        "session-1",
+        first.task_id,
+        **_owner_kwargs(),
+    )
+
+    assert resolved is not None
+    assert resolved.task_id == second.task_id
+    predecessor = await tracker.get(first.task_id, **_owner_kwargs())
+    assert predecessor is not None
+    assert predecessor.status == TaskStatus.COMPLETED
+    assert predecessor.error is None
+    assert predecessor.error_info == {}
+    assert predecessor.result == {"memories_extracted": 1}
+
+
+async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storage():
+    store = PersistentTaskStore(_FakeAgfs())
+    tracker1 = TaskTracker(store=store)
+    first = await tracker1.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker1.fail(first.task_id, "provider overloaded")
+    second = await tracker1.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    linked = await tracker1.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+    assert linked is not None
+    await tracker1.start(second.task_id, **_owner_kwargs())
+    await tracker1.complete(second.task_id, {"ok": True}, **_owner_kwargs())
+
+    failed_payload = await store.get(first.task_id, **_owner_kwargs())
+    assert failed_payload is not None
+    failed_payload["status"] = "failed"
+    failed_payload["stage"] = "failed"
+    failed_payload["error"] = "provider overloaded"
+    failed_payload["error_info"] = classify_task_error("provider overloaded")
+    failed_payload["status"] = TaskStatus.FAILED
+    await store.update(TaskRecord(**failed_payload))
+
+    tracker2 = TaskTracker(store=store)
+    tasks = await tracker2.list_tasks(**_owner_kwargs())
+    predecessor = next(task for task in tasks if task.task_id == first.task_id)
+    assert predecessor.status == TaskStatus.COMPLETED
 
 
 async def test_get_nonexistent_returns_none(tracker: TaskTracker):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -291,7 +291,7 @@ async def test_completed_retry_changes_failed_predecessor_to_completed(
     assert predecessor.result == {"memories_extracted": 1}
 
 
-async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storage():
+async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storage(monkeypatch):
     store = PersistentTaskStore(_FakeAgfs())
     tracker1 = TaskTracker(store=store)
     first = await tracker1.create("session_commit", resource_id="session-1", **_owner_kwargs())
@@ -308,7 +308,6 @@ async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storag
 
     failed_payload = await store.get(first.task_id, **_owner_kwargs())
     assert failed_payload is not None
-    failed_payload["status"] = "failed"
     failed_payload["stage"] = "failed"
     failed_payload["error"] = "provider overloaded"
     failed_payload["error_info"] = classify_task_error("provider overloaded")
@@ -316,9 +315,19 @@ async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storag
     await store.update(TaskRecord(**failed_payload))
 
     tracker2 = TaskTracker(store=store)
+    load_calls = 0
+    original_load_all = tracker2._load_all_from_store
+
+    async def counted_load_all(account_id, user_id):
+        nonlocal load_calls
+        load_calls += 1
+        return await original_load_all(account_id, user_id)
+
+    monkeypatch.setattr(tracker2, "_load_all_from_store", counted_load_all)
     tasks = await tracker2.list_tasks(**_owner_kwargs())
     predecessor = next(task for task in tasks if task.task_id == first.task_id)
     assert predecessor.status == TaskStatus.COMPLETED
+    assert load_calls == 1
 
 
 async def test_get_nonexistent_returns_none(tracker: TaskTracker):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -207,6 +207,25 @@ async def test_fail_task(tracker: TaskTracker):
     assert retrieved.error_info["retryability"] == "retryable"
 
 
+async def test_get_cached_failed_task_survives_reconciliation_store_failure(
+    tracker: TaskTracker, monkeypatch
+):
+    task = await tracker.create("session_commit", **_owner_kwargs())
+    await tracker.fail(task.task_id, "LLM timeout", **_owner_kwargs())
+
+    async def fail_owner_load(account_id, user_id):
+        raise OSError("store unavailable")
+
+    monkeypatch.setattr(tracker, "_load_all_from_store", fail_owner_load)
+
+    retrieved = await tracker.get(task.task_id, **_owner_kwargs())
+
+    assert retrieved is not None
+    assert retrieved.task_id == task.task_id
+    assert retrieved.status == TaskStatus.FAILED
+    assert retrieved.error == "LLM timeout"
+
+
 async def test_legacy_failure_is_classified_when_serialized(tracker: TaskTracker):
     task = await tracker.create("session_commit", **_owner_kwargs())
     await tracker.fail(task.task_id, "token_expired")

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -94,6 +94,7 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
 
 @pytest.mark.asyncio
 async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
+    events: list[str] = []
     session = Session.__new__(Session)
     session._viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(
@@ -124,11 +125,22 @@ async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
     session._read_archive_meta = AsyncMock(
         return_value={"phase1": {"queue_message": queue_payload}}
     )
-    session._merge_archive_meta = AsyncMock()
+    session._merge_archive_meta = AsyncMock(
+        side_effect=lambda *_args, **_kwargs: events.append("merge")
+    )
 
-    tracker = SimpleNamespace(create=AsyncMock(), fail=AsyncMock())
-    queue_manager = SimpleNamespace(
-        enqueue=AsyncMock(side_effect=RuntimeError("queue unavailable"))
+    tracker = SimpleNamespace(
+        create=AsyncMock(side_effect=lambda *_args, **_kwargs: events.append("create")),
+        fail=AsyncMock(),
+    )
+
+    def fail_enqueue(*_args, **_kwargs):
+        events.append("enqueue")
+        raise RuntimeError("queue unavailable")
+
+    queue_manager = SimpleNamespace(enqueue=AsyncMock(side_effect=fail_enqueue))
+    session._viking_fs._async_agfs.rm.side_effect = lambda uri, **_kwargs: events.append(
+        f"remove:{uri}"
     )
     monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
     monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
@@ -152,3 +164,9 @@ async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
         '{"error":"provider overloaded"}',
     )
     assert session._viking_fs._async_agfs.rm.await_args_list[-1].args == (failure_history_uri,)
+    assert events[:4] == [
+        "merge",
+        "create",
+        f"remove:{ARCHIVE_URI}/.failed.json",
+        "enqueue",
+    ]

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for legacy session commit archive resolution."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.session.session import Session
+
+SESSION_URI = "viking://user/alice/sessions/session-1"
+ARCHIVE_URI = f"{SESSION_URI}/history/archive_003"
+FAILED_TASK_CREATED_AT = 1786994253.298716
+
+
+class _AsyncAgfs:
+    async def pathlock_acquire_tree(self, _path, timeout_secs):
+        assert timeout_secs > 0
+        return "lease"
+
+    async def pathlock_release(self, lease):
+        assert lease == "lease"
+
+
+class _VikingFS:
+    def __init__(self):
+        self._async_agfs = _AsyncAgfs()
+
+    async def glob(self, pattern, *, uri, ctx):
+        assert pattern == "archive_*/messages.jsonl"
+        assert uri == f"{SESSION_URI}/history"
+        assert ctx is not None
+        return {"matches": [f"{ARCHIVE_URI}/messages.jsonl"]}
+
+    async def read_file(self, uri, *, ctx):
+        assert uri == f"{ARCHIVE_URI}/.meta.json"
+        assert ctx is not None
+        return json.dumps(
+            {
+                "phase1": {
+                    "created_at": "2026-08-17T19:17:33.276Z",
+                    "queue_message": {"task_id": "offline-recovery-task"},
+                }
+            }
+        )
+
+    async def exists(self, uri, *, ctx):
+        assert ctx is not None
+        return uri == f"{ARCHIVE_URI}/.done"
+
+    def _uri_to_path(self, uri, *, ctx):
+        assert uri == SESSION_URI
+        assert ctx is not None
+        return "/session-1"
+
+
+def _session() -> Session:
+    session = Session.__new__(Session)
+    session._viking_fs = _VikingFS()
+    session._session_uri = SESSION_URI
+    session.session_id = "session-1"
+    session.ctx = SimpleNamespace()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_legacy_archive_is_matched_by_creation_time_after_queue_id_replacement():
+    state = await _session().inspect_failed_commit(
+        "legacy-failed-task",
+        failed_task_created_at=FAILED_TASK_CREATED_AT,
+    )
+
+    assert state == {"state": "completed", "archive_uri": ARCHIVE_URI}
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
+    result = await _session().retry_failed_commit(
+        "legacy-failed-task",
+        failed_task_created_at=FAILED_TASK_CREATED_AT,
+    )
+
+    assert result == {
+        "session_id": "session-1",
+        "status": "completed",
+        "task_id": None,
+        "archive_uri": ARCHIVE_URI,
+        "reason": "archive_complete",
+    }

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -3,6 +3,7 @@
 """Unit tests for legacy session commit archive resolution."""
 
 import json
+from hashlib import sha256
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -92,7 +93,7 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
 
 
 @pytest.mark.asyncio
-async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
+async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
     session = Session.__new__(Session)
     session._viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(
@@ -132,14 +133,22 @@ async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
     monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
     monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
 
+    failed_task_id = "../failed/task"
     with pytest.raises(RuntimeError, match="queue unavailable"):
-        await session.retry_failed_commit("failed-task", archive_uri=ARCHIVE_URI)
+        await session.retry_failed_commit(failed_task_id, archive_uri=ARCHIVE_URI)
 
     tracker.fail.assert_awaited_once()
-    failed_task_id, failure_message = tracker.fail.await_args.args
-    assert failed_task_id != "failed-task"
+    retry_task_id, failure_message = tracker.fail.await_args.args
+    assert retry_task_id != failed_task_id
     assert failure_message == "Failed to enqueue session commit retry"
     assert tracker.fail.await_args.kwargs == {
         "account_id": "acme",
         "user_id": "alice",
     }
+    failure_history_id = sha256(failed_task_id.encode("utf-8")).hexdigest()
+    failure_history_uri = f"{ARCHIVE_URI}/.failed.{failure_history_id}.json"
+    assert session._viking_fs.write_file.await_args_list[0].args == (
+        failure_history_uri,
+        '{"error":"provider overloaded"}',
+    )
+    assert session._viking_fs._async_agfs.rm.await_args_list[-1].args == (failure_history_uri,)

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -4,6 +4,7 @@
 
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -87,4 +88,58 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
         "task_id": None,
         "archive_uri": ARCHIVE_URI,
         "reason": "archive_complete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
+    session = Session.__new__(Session)
+    session._viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(
+            pathlock_acquire_tree=AsyncMock(return_value="lease"),
+            pathlock_release=AsyncMock(),
+            rm=AsyncMock(),
+        ),
+        _uri_to_path=lambda uri, **_kwargs: uri,
+        _pathlock_fs_ctx=lambda *_args: SimpleNamespace(),
+        read_file=AsyncMock(return_value='{"error":"provider overloaded"}'),
+        write_file=AsyncMock(),
+    )
+    session._session_uri = SESSION_URI
+    session.session_id = "session-1"
+    session.ctx = SimpleNamespace(
+        account_id="acme",
+        user=SimpleNamespace(user_id="alice"),
+    )
+    queue_payload = {
+        "task_id": "failed-task",
+        "session_id": "session-1",
+        "session_uri": SESSION_URI,
+        "archive_uri": ARCHIVE_URI,
+        "user": {"account_id": "acme", "user_id": "alice"},
+    }
+    session._find_failed_commit_archive = AsyncMock(return_value=(ARCHIVE_URI, queue_payload))
+    session._archive_file_exists = AsyncMock(side_effect=[False, True, False])
+    session._read_archive_meta = AsyncMock(
+        return_value={"phase1": {"queue_message": queue_payload}}
+    )
+    session._merge_archive_meta = AsyncMock()
+
+    tracker = SimpleNamespace(create=AsyncMock(), fail=AsyncMock())
+    queue_manager = SimpleNamespace(
+        enqueue=AsyncMock(side_effect=RuntimeError("queue unavailable"))
+    )
+    monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
+    monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await session.retry_failed_commit("failed-task", archive_uri=ARCHIVE_URI)
+
+    tracker.fail.assert_awaited_once()
+    failed_task_id, failure_message = tracker.fail.await_args.args
+    assert failed_task_id != "failed-task"
+    assert failure_message == "Failed to enqueue session commit retry"
+    assert tracker.fail.await_args.kwargs == {
+        "account_id": "acme",
+        "user_id": "alice",
     }


### PR DESCRIPTION
## 说明

本 PR 完善了后台失败任务的重试机制，并记录每次重试之间的关联。会话提交失败后，系统会读取第一阶段保存的队列消息，从归档中继续执行第二阶段，不再对已经归档的活动会话重复提交。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue 与 PR

为 #2356 提供后端支持。

参考现有 PR #3340。

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [x] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [x] 测试更新

## 主要变更

- 新增受控重试接口，明确返回 `accepted`、`blocked`、`operation_resolved`、`already_running` 和 `retry_limit_reached` 等结果。
- 保存操作链路、尝试次数、上一个任务 ID 和结构化失败处理建议。
- 会话提交失败后，从第一阶段归档的队列消息继续执行；关联重试成功时，将之前的失败任务更新为已完成。
- 同一操作最多连续尝试 3 次。修复根因后，用户可以明确发起一项新操作。

## 测试

- [x] 已添加能够验证修复或功能的测试
- [x] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

针对性测试共 59 项，全部通过。所有改动过的 Python 文件也通过了 Ruff 检查和格式验证。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [x] 已为较难理解的代码补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布

## 截图

不适用。

## 补充说明

#3340 针对较早版本的直接提取流程，目前与 `main` 存在冲突。本实现使用当前的 QueueFS 流程，重新提交第一阶段已经归档的队列消息。

#4240 会修改任务跟踪内部实现。如果该 PR 先合并，则本 PR 需要重新检查兼容性。
