### PR TITLE
fix(embedder): 稀疏嵌入仅提交文本输入

### DIFF
--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -407,12 +407,12 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
     def supports_multimodal(self) -> bool:
         """Sparse vectors require text-only input even on the multimodal endpoint.
 
-        The provider accepts the request at the endpoint level, but rejects an
-        image part whenever ``sparse_embedding`` is enabled. Returning ``False``
-        makes the common embedder guard retain the extracted text and drop image
-        parts before the provider call. Image-only search remains unsupported and
-        is rejected by the retrieval capability check instead of embedding empty
-        text.
+        The provider accepts the request at the endpoint level, but rejects
+        non-text parts (images and videos) whenever ``sparse_embedding`` is
+        enabled. Returning ``False`` makes the common embedder guard retain the
+        extracted text and drop those parts before the provider call. Image-only
+        search remains unsupported and is rejected by the retrieval capability
+        check instead of embedding empty text.
         """
         return False
 

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -410,7 +410,9 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
         The provider accepts the request at the endpoint level, but rejects an
         image part whenever ``sparse_embedding`` is enabled. Returning ``False``
         makes the common embedder guard retain the extracted text and drop image
-        parts before the provider call.
+        parts before the provider call. Image-only search remains unsupported and
+        is rejected by the retrieval capability check instead of embedding empty
+        text.
         """
         return False
 
@@ -499,7 +501,8 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
 
         A hybrid provider request enables sparse embedding, for which image and
         video parts are unsupported. The base guard performs a deterministic
-        text-only downgrade instead of submitting a request that must fail.
+        text-only downgrade for mixed content. Image-only search remains
+        unsupported because dropping its only input would produce an empty query.
         """
         return False
 

--- a/openviking/models/embedder/volcengine_embedders.py
+++ b/openviking/models/embedder/volcengine_embedders.py
@@ -405,8 +405,14 @@ class VolcengineSparseEmbedder(SparseEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        """Multimodal inputs are supported when using the multimodal endpoint."""
-        return self.input_type == "multimodal"
+        """Sparse vectors require text-only input even on the multimodal endpoint.
+
+        The provider accepts the request at the endpoint level, but rejects an
+        image part whenever ``sparse_embedding`` is enabled. Returning ``False``
+        makes the common embedder guard retain the extracted text and drop image
+        parts before the provider call.
+        """
+        return False
 
 
 class VolcengineHybridEmbedder(HybridEmbedderBase):
@@ -489,8 +495,13 @@ class VolcengineHybridEmbedder(HybridEmbedderBase):
 
     @property
     def supports_multimodal(self) -> bool:
-        """Hybrid embeddings always use the multimodal endpoint."""
-        return True
+        """Hybrid vectors include sparse output and therefore require text input.
+
+        A hybrid provider request enables sparse embedding, for which image and
+        video parts are unsupported. The base guard performs a deterministic
+        text-only downgrade instead of submitting a request that must fail.
+        """
+        return False
 
     def embed(self, content: "EmbeddingInput", is_query: bool = False) -> EmbedResult:
         """Perform hybrid embedding on text or multimodal content

--- a/tests/unit/test_volcengine_embedder_input.py
+++ b/tests/unit/test_volcengine_embedder_input.py
@@ -12,6 +12,7 @@ from openviking.models.embedder.volcengine_embedders import (
 _MULTIMODAL_INPUT = [
     {"type": "text", "text": "diagram of a heat exchanger"},
     {"type": "image_url", "image_url": {"url": "https://example.test/image.png"}},
+    {"type": "video_url", "video_url": {"url": "https://example.test/video.mp4"}},
 ]
 
 

--- a/tests/unit/test_volcengine_embedder_input.py
+++ b/tests/unit/test_volcengine_embedder_input.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Input-guard tests for Volcengine sparse-capable embedding modes."""
+
+from unittest.mock import patch
+
+from openviking.models.embedder.volcengine_embedders import (
+    VolcengineHybridEmbedder,
+    VolcengineSparseEmbedder,
+)
+
+_MULTIMODAL_INPUT = [
+    {"type": "text", "text": "diagram of a heat exchanger"},
+    {"type": "image_url", "image_url": {"url": "https://example.test/image.png"}},
+]
+
+
+@patch("openviking.models.embedder.volcengine_embedders.volcenginesdkarkruntime.Ark")
+def test_sparse_embedder_downgrades_multimodal_input_to_text(_mock_ark):
+    embedder = VolcengineSparseEmbedder(model_name="test", api_key="test-key")
+
+    assert embedder.supports_multimodal is False
+    assert embedder.prepare_embedding_input(_MULTIMODAL_INPUT) == "diagram of a heat exchanger"
+
+
+@patch("openviking.models.embedder.volcengine_embedders.volcenginesdkarkruntime.Ark")
+def test_hybrid_embedder_downgrades_multimodal_input_to_text(_mock_ark):
+    embedder = VolcengineHybridEmbedder(model_name="test", api_key="test-key")
+
+    assert embedder.supports_multimodal is False
+    assert embedder.prepare_embedding_input(_MULTIMODAL_INPUT) == "diagram of a heat exchanger"


### PR DESCRIPTION
## 说明

Volcengine 的稀疏嵌入接口只接受文本。本 PR 调整了多模态输入处理：保留已经提取出的文本，忽略接口不支持的图片和视频部分，避免向稀疏嵌入接口发送无效输入。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue

未发现可由本 PR 完整解决的开放 Issue。

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [ ] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [x] 测试更新

## 主要变更

- 将 Volcengine 稀疏嵌入器和混合嵌入器标记为仅支持文本输入。
- 规范化混合输入时保留已提取文本，不再传递图片和视频部分。
- 添加图片和视频输入的针对性测试。

## 测试

- [x] 已添加能够验证修复或功能的测试
- [x] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

2 项针对性测试全部通过，Ruff 检查和格式验证通过。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [x] 已为较难理解的代码补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布

## 截图

不适用。

## 补充说明

本 PR 没有新增生产依赖，也没有修改 API 契约。
