### PR TITLE
feat(studio): 增加失败任务安全重试界面

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -9,13 +9,15 @@ endpoints to check completion, results, or errors.
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Body, Depends, Query
+from pydantic import BaseModel, ConfigDict
 
 from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.service.task_store import SYSTEM_TASK_ACCOUNT_ID, SYSTEM_TASK_USER_ID
-from openviking.service.task_tracker import get_task_tracker
+from openviking.service.task_tracker import classify_task_error, get_task_tracker
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     OpenVikingError,
@@ -23,6 +25,18 @@ from openviking_cli.exceptions import (
 )
 
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
+
+
+class RetryTaskRequest(BaseModel):
+    """Explicit acknowledgement for failures that require a repaired prerequisite."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    acknowledge_change: bool = False
+    restart_operation: bool = False
+
+
+MAX_LINKED_RETRY_ATTEMPTS = 3
 
 
 @router.get("/tasks/{task_id}")
@@ -79,6 +93,224 @@ async def cancel_task(
             details={"resource": task_id, "type": "task"},
         )
     return Response(status="ok", result=task.to_dict())
+
+
+@router.post("/tasks/{task_id}/retry")
+async def retry_task(
+    task_id: str,
+    body: RetryTaskRequest = Body(default_factory=RetryTaskRequest),
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Retry a failed task and return the task that now owns the work."""
+    tracker = get_task_tracker()
+    if _ctx.role == Role.ROOT:
+        task = await tracker.get(task_id)
+        if task is None:
+            task = await tracker.get(
+                task_id,
+                account_id=SYSTEM_TASK_ACCOUNT_ID,
+                user_id=SYSTEM_TASK_USER_ID,
+            )
+    else:
+        task = await tracker.get(task_id, account_id=_ctx.account_id, user_id=_ctx.user.user_id)
+    if task is None:
+        raise OpenVikingError(
+            "Task not found or expired",
+            code="NOT_FOUND",
+            details={"resource": task_id, "type": "task"},
+        )
+    if task.status.value == "completed":
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": task.task_id,
+                "attempt_number": task.attempt_number,
+            },
+        )
+    if task.status.value != "failed":
+        raise FailedPreconditionError("Only failed tasks can be retried")
+    if not task.resource_id:
+        raise FailedPreconditionError("Task has no retryable resource")
+
+    resolved = await tracker.find_completed_operation(
+        task.task_type,
+        task.resource_id,
+        task.operation_id or task.task_id,
+        account_id=task.account_id or _ctx.account_id,
+        user_id=task.user_id or _ctx.user.user_id,
+    )
+    if resolved is not None:
+        await tracker.resolve_failed(
+            task.task_id,
+            resolved.result or {},
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": resolved.task_id,
+                "attempt_number": resolved.attempt_number,
+            },
+        )
+
+    service = get_service()
+    if task.task_type == "session_commit":
+        retry_state = await service.sessions.inspect_failed_commit(
+            task.resource_id,
+            task.task_id,
+            _ctx,
+            archive_uri=(task.meta or {}).get("archive_uri"),
+            failed_task_created_at=task.created_at,
+        )
+        if retry_state.get("state") == "completed":
+            await tracker.resolve_failed(
+                task.task_id,
+                {
+                    "archive_uri": retry_state.get("archive_uri"),
+                    "reason": "archive_complete",
+                },
+                account_id=task.account_id or _ctx.account_id,
+                user_id=task.user_id or _ctx.user.user_id,
+            )
+            return Response(
+                status="ok",
+                result={
+                    "disposition": "operation_resolved",
+                    "operation_id": task.operation_id or task.task_id,
+                    "previous_task_id": task.task_id,
+                    "task_id": task.task_id,
+                    "resolution": "archive_complete",
+                    "archive_uri": retry_state.get("archive_uri"),
+                },
+            )
+
+    # Historical records predate structured error information. Classify them at
+    # the retry boundary too, so an old credential or media configuration error
+    # cannot be replayed into an endless stream of new failures.
+    error_info = task.error_info or classify_task_error(task.error or "")
+    retryability = error_info.get("retryability", "manual")
+    if retryability == "requires_change" and not body.acknowledge_change:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "blocked",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "error": error_info,
+            },
+        )
+
+    if task.attempt_number >= MAX_LINKED_RETRY_ATTEMPTS and not body.restart_operation:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "retry_limit_reached",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "attempt_number": task.attempt_number,
+                "max_attempts": MAX_LINKED_RETRY_ATTEMPTS,
+                "action": "Fix the prerequisite, then explicitly start a new operation.",
+            },
+        )
+
+    active = await tracker.find_active(
+        task.task_type,
+        task.resource_id,
+        account_id=task.account_id or _ctx.account_id,
+        user_id=task.user_id or _ctx.user.user_id,
+    )
+    if active is not None:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "already_running",
+                "operation_id": active.operation_id,
+                "previous_task_id": task.task_id,
+                "task_id": active.task_id,
+                "attempt_number": active.attempt_number,
+            },
+        )
+
+    if task.task_type == "session_commit":
+        result = await service.sessions.retry_failed_commit(
+            task.resource_id,
+            task.task_id,
+            _ctx,
+            archive_uri=(task.meta or {}).get("archive_uri"),
+            failed_task_created_at=task.created_at,
+        )
+    elif task.task_type in {"add_resource", "admin_reindex", "snapshot_restore_reindex"}:
+        result = await service.reindex(
+            uri=task.resource_id,
+            mode="vectors_only",
+            wait=False,
+            ctx=_ctx,
+        )
+    else:
+        raise FailedPreconditionError(
+            f"Task type '{task.task_type}' does not have a safe server-side retry recipe"
+        )
+
+    if isinstance(result, dict) and result.get("reason") == "archive_complete":
+        await tracker.resolve_failed(
+            task.task_id,
+            result,
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+        return Response(
+            status="ok",
+            result={
+                "disposition": "operation_resolved",
+                "operation_id": task.operation_id or task.task_id,
+                "previous_task_id": task.task_id,
+                "task_id": task.task_id,
+                "resolution": "archive_complete",
+                "archive_uri": result.get("archive_uri"),
+            },
+        )
+
+    new_task_id = result.get("task_id") if isinstance(result, dict) else None
+    if not new_task_id:
+        return Response(
+            status="ok",
+            result={
+                "disposition": "no_action",
+                "operation_id": task.operation_id,
+                "previous_task_id": task.task_id,
+                "result": result,
+            },
+        )
+    linked = None
+    if not body.restart_operation:
+        linked = await tracker.link_retry(
+            str(new_task_id),
+            parent_task_id=task.task_id,
+            account_id=task.account_id or _ctx.account_id,
+            user_id=task.user_id or _ctx.user.user_id,
+        )
+    return Response(
+        status="ok",
+        result={
+            "disposition": "accepted",
+            "operation_id": (
+                linked.operation_id
+                if linked
+                else (str(new_task_id) if body.restart_operation else task.operation_id)
+            ),
+            "previous_task_id": task.task_id,
+            "task_id": str(new_task_id),
+            "attempt_number": linked.attempt_number if linked else 1,
+            "status_url": f"/api/v1/tasks/{new_task_id}",
+        },
+    )
 
 
 @router.get("/tasks")

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -23,6 +23,7 @@ from openviking_cli.exceptions import (
     OpenVikingError,
     PermissionDeniedError,
 )
+from openviking_cli.session.user_id import UserIdentifier
 
 router = APIRouter(prefix="/api/v1", tags=["tasks"])
 
@@ -37,6 +38,19 @@ class RetryTaskRequest(BaseModel):
 
 
 MAX_LINKED_RETRY_ATTEMPTS = 3
+
+
+def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
+    """Run ROOT retries in the task owner's storage namespace."""
+    if ctx.role != Role.ROOT or not task.account_id or not task.user_id:
+        return ctx
+    return RequestContext(
+        user=UserIdentifier(task.account_id, task.user_id),
+        role=ctx.role,
+        actor_peer_id=ctx.actor_peer_id,
+        from_oauth=ctx.from_oauth,
+        api_key=ctx.api_key,
+    )
 
 
 @router.get("/tasks/{task_id}")
@@ -134,6 +148,7 @@ async def retry_task(
         raise FailedPreconditionError("Only failed tasks can be retried")
     if not task.resource_id:
         raise FailedPreconditionError("Task has no retryable resource")
+    task_ctx = _task_owner_context(task, _ctx)
 
     resolved = await tracker.find_completed_operation(
         task.task_type,
@@ -165,7 +180,7 @@ async def retry_task(
         retry_state = await service.sessions.inspect_failed_commit(
             task.resource_id,
             task.task_id,
-            _ctx,
+            task_ctx,
             archive_uri=(task.meta or {}).get("archive_uri"),
             failed_task_created_at=task.created_at,
         )
@@ -242,7 +257,7 @@ async def retry_task(
         result = await service.sessions.retry_failed_commit(
             task.resource_id,
             task.task_id,
-            _ctx,
+            task_ctx,
             archive_uri=(task.meta or {}).get("archive_uri"),
             failed_task_created_at=task.created_at,
         )
@@ -251,7 +266,7 @@ async def retry_task(
             uri=task.resource_id,
             mode="vectors_only",
             wait=False,
-            ctx=_ctx,
+            ctx=task_ctx,
         )
     else:
         raise FailedPreconditionError(

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -10,7 +10,7 @@ endpoints to check completion, results, or errors.
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Query
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
@@ -35,6 +35,8 @@ class RetryTaskRequest(BaseModel):
 
     acknowledge_change: bool = False
     restart_operation: bool = False
+    owner_account_id: Optional[str] = Field(default=None, min_length=1)
+    owner_user_id: Optional[str] = Field(default=None, min_length=1)
 
 
 MAX_LINKED_RETRY_ATTEMPTS = 3
@@ -44,6 +46,8 @@ def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
     """Run ROOT retries in the task owner's storage namespace."""
     if ctx.role != Role.ROOT or not task.account_id or not task.user_id:
         return ctx
+    if task.account_id == SYSTEM_TASK_ACCOUNT_ID and task.user_id == SYSTEM_TASK_USER_ID:
+        return ctx
     return RequestContext(
         user=UserIdentifier(task.account_id, task.user_id),
         role=ctx.role,
@@ -51,6 +55,14 @@ def _task_owner_context(task, ctx: RequestContext) -> RequestContext:
         from_oauth=ctx.from_oauth,
         api_key=ctx.api_key,
     )
+
+
+def _task_response(task, *, include_owner: bool):
+    result = task.to_dict()
+    if include_owner and task.account_id and task.user_id:
+        result["owner_account_id"] = task.account_id
+        result["owner_user_id"] = task.user_id
+    return result
 
 
 @router.get("/tasks/{task_id}")
@@ -80,7 +92,10 @@ async def get_task(
             code="NOT_FOUND",
             details={"resource": task_id, "type": "task"},
         )
-    return Response(status="ok", result=task.to_dict())
+    return Response(
+        status="ok",
+        result=_task_response(task, include_owner=_ctx.role == Role.ROOT),
+    )
 
 
 @router.post("/tasks/{task_id}/cancel")
@@ -118,14 +133,18 @@ async def retry_task(
     """Retry a failed task and return the task that now owns the work."""
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
-        task = await tracker.get(task_id)
-        if task is None:
-            task = await tracker.get(
-                task_id,
-                account_id=SYSTEM_TASK_ACCOUNT_ID,
-                user_id=SYSTEM_TASK_USER_ID,
+        if body.owner_account_id is None or body.owner_user_id is None:
+            raise FailedPreconditionError(
+                "ROOT retries require both owner_account_id and owner_user_id"
             )
+        task = await tracker.get(
+            task_id,
+            account_id=body.owner_account_id,
+            user_id=body.owner_user_id,
+        )
     else:
+        if body.owner_account_id is not None or body.owner_user_id is not None:
+            raise PermissionDeniedError("Only ROOT may specify a task owner")
         task = await tracker.get(task_id, account_id=_ctx.account_id, user_id=_ctx.user.user_id)
     if task is None:
         raise OpenVikingError(
@@ -368,4 +387,7 @@ async def list_tasks(
             account_id=_ctx.account_id,
             user_id=_ctx.user.user_id,
         )
-    return Response(status="ok", result=[t.to_dict() for t in tasks])
+    return Response(
+        status="ok",
+        result=[_task_response(task, include_owner=_ctx.role == Role.ROOT) for task in tasks],
+    )

--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -130,7 +130,11 @@ async def retry_task(
     body: RetryTaskRequest = Body(default_factory=RetryTaskRequest),
     _ctx: RequestContext = Depends(get_request_context),
 ):
-    """Retry a failed task and return the task that now owns the work."""
+    """Retry a failed task and return a stable retry disposition.
+
+    Possible dispositions are accepted, blocked, operation_resolved,
+    already_running, retry_limit_reached, and no_action.
+    """
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
         if body.owner_account_id is None or body.owner_user_id is None:

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -450,6 +450,42 @@ class SessionService:
         )
         return task.to_dict() if task else None
 
+    async def retry_failed_commit(
+        self,
+        session_id: str,
+        failed_task_id: str,
+        ctx: RequestContext,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Requeue Phase 2 for a failed commit without re-archiving the session."""
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        return await session.retry_failed_commit(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+
+    async def inspect_failed_commit(
+        self,
+        session_id: str,
+        failed_task_id: str,
+        ctx: RequestContext,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Return the durable retry state without creating work."""
+        self._ensure_initialized()
+        session = await self.get(session_id, ctx)
+        return await session.inspect_failed_commit(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+
     async def extract(self, session_id: str, ctx: RequestContext) -> List[Any]:
         """Extract memories from a session.
 
@@ -557,9 +593,7 @@ class SessionService:
                     return False
                 self._auto_commit_inflight.add(claim)
         except Exception:
-            logger.debug(
-                "Skipped auto-commit scheduling for %s", session_id, exc_info=True
-            )
+            logger.debug("Skipped auto-commit scheduling for %s", session_id, exc_info=True)
             return False
 
         task = asyncio.create_task(self.run_auto_commit(session_id, ctx, reason=reason_hint))

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -154,6 +154,10 @@ def _task_to_payload(task: Any) -> Dict[str, Any]:
         "stage": task.stage,
         "result": deepcopy(task.result),
         "error": task.error,
+        "operation_id": task.operation_id,
+        "parent_task_id": task.parent_task_id,
+        "attempt_number": task.attempt_number,
+        "error_info": deepcopy(task.error_info),
         "auth": deepcopy(task.auth),
     }
 

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -1143,9 +1143,16 @@ class TaskTracker:
                 self._merge_loaded_tasks([task])
                 task = self._cached_task(task_id)
         if task is not None and task.status == TaskStatus.FAILED and user_id:
-            self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
-            await self._reconcile_completed_operations_on_owner(account_id, user_id)
-            task = self._cached_task(task_id)
+            try:
+                self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+                await self._reconcile_completed_operations_on_owner(account_id, user_id)
+                task = self._cached_task(task_id)
+            except Exception:
+                logger.warning(
+                    "[TaskTracker] Failed to reconcile cached failed task %s",
+                    task_id,
+                    exc_info=True,
+                )
         if task is None or not self._matches_owner(task, account_id, user_id):
             return None
         return self._copy(task)

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -80,7 +80,17 @@ class TaskRecord:
     stage: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    # These fields connect retry attempts that belong to the same task.
+    operation_id: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    attempt_number: int = 1
+    error_info: Dict[str, Any] = field(default_factory=dict)
     auth: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.operation_id:
+            self.operation_id = self.task_id
+        self.attempt_number = max(1, int(self.attempt_number or 1))
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for JSON response."""
@@ -90,10 +100,65 @@ class TaskRecord:
         d["updated_at_iso"] = datetime.fromtimestamp(self.updated_at, tz=timezone.utc).isoformat()
         d["result"] = _sanitize_task_result(d.get("result"))
         d["meta"] = _sanitize_task_result(d.get("meta"))
+        # Legacy failed tasks have only the raw error. Expose the same safe
+        # classification at read time without rewriting their historical record.
+        error_info = self.error_info or (classify_task_error(self.error) if self.error else {})
+        d["error_info"] = _sanitize_task_result(error_info)
         d.pop("auth", None)
         d.pop("account_id", None)
         d.pop("user_id", None)
         return d
+
+
+def classify_task_error(error: str) -> Dict[str, str]:
+    """Classify terminal errors for safe retry decisions and UI guidance.
+
+    This deliberately uses a small conservative set. Unknown failures remain
+    manually retryable, but permanent provider and input failures are blocked
+    so a retry button cannot create an unbounded stream of equivalent tasks.
+    """
+    lowered = (error or "").lower()
+    if "sparse embedding only supports text input" in lowered:
+        return {
+            "code": "MEDIA_SPARSE_INPUT_UNSUPPORTED",
+            "retryability": "requires_change",
+            "action": "Configure media text extraction or remove media from sparse embedding input.",
+        }
+    if "token_expired" in lowered or "credential" in lowered or "authentication token" in lowered:
+        return {
+            "code": "AUTH_EXPIRED",
+            "retryability": "requires_change",
+            "action": "Refresh the affected provider credential before retrying.",
+        }
+    if "accountoverdue" in lowered or "overdue balance" in lowered:
+        return {
+            "code": "ACCOUNT_OVERDUE",
+            "retryability": "requires_change",
+            "action": "Resolve the provider account balance before retrying.",
+        }
+    if "has no attribute 'strip'" in lowered or 'has no attribute "strip"' in lowered:
+        return {
+            "code": "INPUT_SHAPE_INVALID",
+            "retryability": "requires_change",
+            "action": "Correct the message input shape before retrying.",
+        }
+    if "source no longer exists" in lowered or "not found" in lowered:
+        return {
+            "code": "SOURCE_MISSING",
+            "retryability": "requires_change",
+            "action": "Restore or replace the source before retrying.",
+        }
+    if any(marker in lowered for marker in ("overloaded", "timeout", "timed out", "lock acquire")):
+        return {
+            "code": "TRANSIENT_UPSTREAM",
+            "retryability": "retryable",
+            "action": "Retry with backoff; the service may be temporarily busy.",
+        }
+    return {
+        "code": "UNKNOWN",
+        "retryability": "manual",
+        "action": "Review the error details before retrying.",
+    }
 
 
 # ── Singleton ──
@@ -544,6 +609,210 @@ class TaskTracker:
         """Record failure and finalize after owned work settles."""
         await self._record_outcome(task_id, account_id, user_id, error=error)
 
+    async def link_retry(
+        self,
+        task_id: str,
+        *,
+        parent_task_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Attach a newly accepted task to its failed predecessor."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._link_retry_on_owner(task_id, parent_task_id, account_id, user_id)
+        )
+
+    async def _link_retry_on_owner(
+        self,
+        task_id: str,
+        parent_task_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        parent = await self._load_for_update(parent_task_id, account_id, user_id)
+        if parent is None:
+            return None
+        linked: Optional[TaskRecord] = None
+        async with self._task_locks.acquire(task_id):
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task is None:
+                return None
+            updated = deepcopy(task)
+            updated.operation_id = parent.operation_id or parent.task_id
+            updated.parent_task_id = parent.task_id
+            updated.attempt_number = parent.attempt_number + 1
+            updated.updated_at = self._next_updated_at(task)
+            await self._persist_and_publish("update", updated)
+            linked = self._copy(updated)
+        if linked.status == TaskStatus.COMPLETED:
+            await self._complete_failed_operation_tasks_on_owner(linked)
+        return linked
+
+    async def resolve_failed(
+        self,
+        task_id: str,
+        result: Dict[str, Any],
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Change a failed task to completed after its retry or archive succeeds."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._resolve_failed_on_owner(task_id, result, account_id, user_id)
+        )
+
+    async def _resolve_failed_on_owner(
+        self,
+        task_id: str,
+        result: Dict[str, Any],
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        async with self._task_locks.acquire(task_id):
+            task = await self._load_for_update(task_id, account_id, user_id)
+            if task is None:
+                return None
+            if task.status == TaskStatus.COMPLETED:
+                return self._copy(task)
+            if task.status != TaskStatus.FAILED:
+                return self._copy(task)
+            updated = deepcopy(task)
+            updated.status = TaskStatus.COMPLETED
+            updated.stage = TaskStatus.COMPLETED.value
+            updated.result = deepcopy(result)
+            updated.error = None
+            updated.error_info = {}
+            updated.updated_at = self._next_updated_at(task)
+            updated.auth = {}
+            await self._persist_and_publish("update", updated)
+            logger.info("[TaskTracker] Task %s completed after retry", task_id)
+            return self._copy(updated)
+
+    async def _complete_failed_operation_tasks_on_owner(
+        self,
+        completed: TaskRecord,
+    ) -> None:
+        if (
+            completed.status != TaskStatus.COMPLETED
+            or completed.attempt_number <= 1
+            or not completed.account_id
+            or not completed.user_id
+        ):
+            return
+        self._merge_loaded_tasks(
+            await self._load_all_from_store(completed.account_id, completed.user_id)
+        )
+        failed_task_ids = [
+            task.task_id
+            for task in self._cache_snapshot()
+            if task.task_type == completed.task_type
+            and task.resource_id == completed.resource_id
+            and task.operation_id == completed.operation_id
+            and self._matches_owner(task, completed.account_id, completed.user_id)
+            and task.status == TaskStatus.FAILED
+        ]
+        for failed_task_id in failed_task_ids:
+            await self._resolve_failed_on_owner(
+                failed_task_id,
+                completed.result or {},
+                completed.account_id,
+                completed.user_id,
+            )
+
+    async def _reconcile_completed_operations_on_owner(
+        self,
+        account_id: str,
+        user_id: str,
+    ) -> None:
+        completed_retries = [
+            task
+            for task in self._cache_snapshot()
+            if self._matches_owner(task, account_id, user_id)
+            and task.status == TaskStatus.COMPLETED
+            and task.attempt_number > 1
+        ]
+        for completed in completed_retries:
+            await self._complete_failed_operation_tasks_on_owner(completed)
+
+    async def find_active(
+        self,
+        task_type: str,
+        resource_id: str,
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Return the newest active task for an owner and business key."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._find_active_on_owner(task_type, resource_id, account_id, user_id)
+        )
+
+    async def _find_active_on_owner(
+        self,
+        task_type: str,
+        resource_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        candidates = [
+            task
+            for task in self._cache_snapshot()
+            if task.task_type == task_type
+            and task.resource_id == resource_id
+            and self._matches_owner(task, account_id, user_id)
+            and task.status in _ACTIVE_STATUSES
+        ]
+        if not candidates:
+            return None
+        return self._copy(max(candidates, key=lambda task: task.created_at))
+
+    async def find_completed_operation(
+        self,
+        task_type: str,
+        resource_id: str,
+        operation_id: str,
+        *,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        """Return the successful attempt that completed one retry operation."""
+        self._validate_owner(account_id, user_id)
+        return await self._dispatcher.run(
+            lambda: self._find_completed_operation_on_owner(
+                task_type,
+                resource_id,
+                operation_id,
+                account_id,
+                user_id,
+            )
+        )
+
+    async def _find_completed_operation_on_owner(
+        self,
+        task_type: str,
+        resource_id: str,
+        operation_id: str,
+        account_id: str,
+        user_id: str,
+    ) -> Optional[TaskRecord]:
+        self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+        candidates = [
+            task
+            for task in self._cache_snapshot()
+            if task.task_type == task_type
+            and task.resource_id == resource_id
+            and task.operation_id == operation_id
+            and self._matches_owner(task, account_id, user_id)
+            and task.status == TaskStatus.COMPLETED
+        ]
+        if not candidates:
+            return None
+        return self._copy(max(candidates, key=lambda task: (task.attempt_number, task.updated_at)))
+
     async def _record_outcome(
         self,
         task_id: str,
@@ -587,9 +856,11 @@ class TaskTracker:
                         updated.resource_id = resource_id
                 if error is not None and updated.error is None:
                     updated.error = _sanitize_error(error)
+                    updated.error_info = classify_task_error(updated.error)
                 work_error = self._work_index.failure(task_id)
                 if work_error and updated.error is None:
                     updated.error = _sanitize_error(work_error)
+                    updated.error_info = classify_task_error(updated.error)
                 updated.updated_at = self._next_updated_at(task)
                 updated.auth = {}
                 try:
@@ -698,6 +969,7 @@ class TaskTracker:
     ) -> None:
         if self._work_index.has_work(task_id):
             return
+        completed: Optional[TaskRecord] = None
         async with self._task_locks.acquire(task_id):
             task = await self._load_for_update(task_id, account_id, user_id)
             if task and task.status in _ACTIVE_STATUSES:
@@ -722,6 +994,10 @@ class TaskTracker:
                 await self._persist_and_publish("update", updated)
                 self._work_index.clear_failure(task_id)
                 logger.info("[TaskTracker] Task %s %s", task_id, updated.status.value)
+                if updated.status == TaskStatus.COMPLETED:
+                    completed = self._copy(updated)
+        if completed is not None:
+            await self._complete_failed_operation_tasks_on_owner(completed)
 
     async def wait(
         self,
@@ -848,7 +1124,8 @@ class TaskTracker:
         if task is not None:
             if not self._matches_owner(task, account_id, user_id):
                 return None
-            return self._copy(task)
+            if task.status != TaskStatus.FAILED or account_id is None or user_id is None:
+                return self._copy(task)
         if account_id is None:
             return None
         return await self._dispatcher.run(lambda: self._get_on_owner(task_id, account_id, user_id))
@@ -865,6 +1142,10 @@ class TaskTracker:
             if task is not None:
                 self._merge_loaded_tasks([task])
                 task = self._cached_task(task_id)
+        if task is not None and task.status == TaskStatus.FAILED and user_id:
+            self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+            await self._reconcile_completed_operations_on_owner(account_id, user_id)
+            task = self._cached_task(task_id)
         if task is None or not self._matches_owner(task, account_id, user_id):
             return None
         return self._copy(task)
@@ -901,6 +1182,8 @@ class TaskTracker:
     ) -> List[TaskRecord]:
         if account_id is not None:
             self._merge_loaded_tasks(await self._load_all_from_store(account_id, user_id))
+            if user_id is not None:
+                await self._reconcile_completed_operations_on_owner(account_id, user_id)
         source = self._cache_snapshot()
         tasks = [self._copy(t) for t in source if self._matches_owner(t, account_id, user_id)]
         if task_type:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -48,7 +48,7 @@ from openviking.storage.abstract_overview import body_for_preview, render_abstra
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
-from openviking.utils.time_utils import get_current_timestamp
+from openviking.utils.time_utils import get_current_timestamp, parse_iso_datetime
 from openviking.utils.token_estimation import estimate_text_tokens, truncate_text_to_token_budget
 from openviking_cli.exceptions import (
     FailedPreconditionError,
@@ -2118,6 +2118,7 @@ class Session:
                     account_id=self.ctx.account_id,
                     user_id=self.ctx.user.user_id,
                     task_id=task_id,
+                    meta={"archive_uri": archive_uri},
                 )
 
                 phase1_stage = "phase1_persist"
@@ -2186,6 +2187,201 @@ class Session:
                 retention_plan.estimated_active_tokens if retention_plan else 0
             ),
             "budget_exceeded": retention_plan.budget_exceeded if retention_plan else False,
+        }
+
+    async def inspect_failed_commit(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Inspect whether a failed Phase 2 archive still needs work."""
+        if not self._viking_fs:
+            raise FailedPreconditionError("Session storage is not initialized")
+
+        selected_uri, _ = await self._find_failed_commit_archive(
+            failed_task_id,
+            archive_uri=archive_uri,
+            failed_task_created_at=failed_task_created_at,
+        )
+        if not selected_uri:
+            return {"state": "unavailable", "archive_uri": None}
+        if await self._archive_file_exists(selected_uri, ".done"):
+            return {"state": "completed", "archive_uri": selected_uri}
+        if await self._archive_file_exists(selected_uri, ".failed.json"):
+            return {"state": "failed_ready", "archive_uri": selected_uri}
+        return {"state": "not_ready", "archive_uri": selected_uri}
+
+    async def _find_failed_commit_archive(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> tuple[str, Dict[str, Any]]:
+        """Find current and legacy archives without changing their state."""
+        candidate_uris = [archive_uri] if archive_uri else []
+        if not candidate_uris:
+            history_uri = f"{self._session_uri}/history"
+            matches = await self._viking_fs.glob(
+                "archive_*/messages.jsonl", uri=history_uri, ctx=self.ctx
+            )
+            candidate_uris = [
+                uri.rsplit("/messages.jsonl", 1)[0]
+                for uri in matches.get("matches", [])
+                if isinstance(uri, str) and uri.endswith("/messages.jsonl")
+            ]
+
+        legacy_matches: List[tuple[float, str, Dict[str, Any]]] = []
+        for candidate_uri in candidate_uris:
+            if not isinstance(candidate_uri, str) or not candidate_uri.startswith(
+                f"{self._session_uri}/history/"
+            ):
+                continue
+            phase1 = (await self._read_archive_meta(candidate_uri)).get("phase1")
+            if not isinstance(phase1, dict):
+                continue
+            payload = phase1.get("queue_message")
+            if not isinstance(payload, dict):
+                continue
+            retry_history = phase1.get("retry_history") or []
+            known_task_ids = {
+                str(item.get("task_id"))
+                for item in retry_history
+                if isinstance(item, dict) and item.get("task_id")
+            }
+            if payload.get("task_id") == failed_task_id or failed_task_id in known_task_ids:
+                return candidate_uri, payload
+            if archive_uri and candidate_uri == archive_uri:
+                return candidate_uri, payload
+
+            # Recovery tooling used by older installations replaced the queue
+            # task ID without retaining retry_history. Phase 1 and task records
+            # were created together, so their sub-second timestamps provide a
+            # narrow, deterministic compatibility match.
+            if failed_task_created_at is None:
+                continue
+            created_at = phase1.get("created_at")
+            if not isinstance(created_at, str):
+                continue
+            try:
+                created_epoch = parse_iso_datetime(created_at).timestamp()
+            except ValueError:
+                continue
+            delta = abs(created_epoch - float(failed_task_created_at))
+            if delta <= 1.0:
+                legacy_matches.append((delta, candidate_uri, payload))
+
+        if legacy_matches:
+            _, selected_uri, queue_payload = min(legacy_matches, key=lambda item: item[0])
+            return selected_uri, queue_payload
+        return "", {}
+
+    async def retry_failed_commit(
+        self,
+        failed_task_id: str,
+        *,
+        archive_uri: Optional[str] = None,
+        failed_task_created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Create a new Phase 2 task from a failed commit's durable archive.
+
+        Phase 1 has already removed the archived messages from the live session,
+        so retrying ``commit_async`` would incorrectly report ``no_messages``.
+        This method restores the stored QueueFS payload instead, while keeping
+        each failed attempt as an immutable task record.
+        """
+        from openviking.service.task_tracker import get_task_tracker
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+        from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+
+        if not self._viking_fs:
+            raise FailedPreconditionError("Session storage is not initialized")
+
+        session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+            session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
+        )
+        try:
+            selected_uri, queue_payload = await self._find_failed_commit_archive(
+                failed_task_id,
+                archive_uri=archive_uri,
+                failed_task_created_at=failed_task_created_at,
+            )
+
+            if not selected_uri:
+                raise FailedPreconditionError("The failed commit archive is unavailable for retry")
+            if await self._archive_file_exists(selected_uri, ".done"):
+                return {
+                    "session_id": self.session_id,
+                    "status": "completed",
+                    "task_id": None,
+                    "archive_uri": selected_uri,
+                    "reason": "archive_complete",
+                }
+            if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                raise FailedPreconditionError("The failed commit is not ready for retry")
+
+            queued = SessionCommitMsg.from_dict(queue_payload)
+            retry_task_id = str(uuid4())
+            retry_message = SessionCommitMsg(**{**queued.to_dict(), "task_id": retry_task_id})
+            failed_uri = f"{selected_uri}/.failed.json"
+            failure_history_uri = f"{selected_uri}/.failed.{failed_task_id}.json"
+            failure_content = await self._viking_fs.read_file(failed_uri, ctx=self.ctx)
+            phase1 = (await self._read_archive_meta(selected_uri)).get("phase1")
+            if not isinstance(phase1, dict):
+                raise FailedPreconditionError("The failed commit archive has no Phase 1 record")
+            original_phase1 = dict(phase1)
+            retry_history = list(phase1.get("retry_history") or [])
+            retry_history.append({"task_id": failed_task_id, "failed_file": failure_history_uri})
+            phase1["queue_message"] = retry_message.to_dict()
+            phase1["retry_history"] = retry_history
+
+            await self._viking_fs.write_file(
+                failure_history_uri,
+                failure_content,
+                ctx=self.ctx,
+                lease_ref=lease,
+            )
+            await self._viking_fs._async_agfs.rm(
+                self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+            )
+            try:
+                await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
+                await get_task_tracker().create(
+                    "session_commit",
+                    resource_id=self.session_id,
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
+                    task_id=retry_task_id,
+                    meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
+                )
+                await get_queue_manager().enqueue(
+                    QueueManager.SESSION_COMMIT,
+                    retry_message.to_dict(),
+                )
+            except Exception:
+                await self._merge_archive_meta(
+                    selected_uri, {"phase1": original_phase1}, lease_ref=lease
+                )
+                if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                    await self._viking_fs.write_file(
+                        failed_uri,
+                        failure_content,
+                        ctx=self.ctx,
+                        lease_ref=lease,
+                    )
+                raise
+        finally:
+            await self._viking_fs._async_agfs.pathlock_release(lease)
+
+        return {
+            "session_id": self.session_id,
+            "status": "accepted",
+            "task_id": retry_task_id,
+            "archive_uri": selected_uri,
         }
 
     async def finalize_cancelled_commit(self, archive_uri: str) -> None:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2348,9 +2348,11 @@ class Session:
                 self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
                 fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
             )
+            tracker = get_task_tracker()
+            retry_task_created = False
             try:
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
-                await get_task_tracker().create(
+                await tracker.create(
                     "session_commit",
                     resource_id=self.session_id,
                     account_id=self.ctx.account_id,
@@ -2358,11 +2360,25 @@ class Session:
                     task_id=retry_task_id,
                     meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
                 )
+                retry_task_created = True
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
                     retry_message.to_dict(),
                 )
             except Exception:
+                if retry_task_created:
+                    try:
+                        await tracker.fail(
+                            retry_task_id,
+                            "Failed to enqueue session commit retry",
+                            account_id=self.ctx.account_id,
+                            user_id=self.ctx.user.user_id,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to mark retry task %s after queue enqueue failure",
+                            retry_task_id,
+                        )
                 await self._merge_archive_meta(
                     selected_uri, {"phase1": original_phase1}, lease_ref=lease
                 )

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2350,10 +2350,6 @@ class Session:
                     lease_ref=lease,
                 )
                 failure_history_written = True
-                await self._viking_fs._async_agfs.rm(
-                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
-                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
-                )
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
                 await tracker.create(
                     "session_commit",
@@ -2364,6 +2360,10 @@ class Session:
                     meta={"archive_uri": selected_uri, "retry_of": failed_task_id},
                 )
                 retry_task_created = True
+                await self._viking_fs._async_agfs.rm(
+                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                )
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
                     retry_message.to_dict(),

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2327,7 +2327,8 @@ class Session:
             retry_task_id = str(uuid4())
             retry_message = SessionCommitMsg(**{**queued.to_dict(), "task_id": retry_task_id})
             failed_uri = f"{selected_uri}/.failed.json"
-            failure_history_uri = f"{selected_uri}/.failed.{failed_task_id}.json"
+            failure_history_id = sha256_text(failed_task_id)
+            failure_history_uri = f"{selected_uri}/.failed.{failure_history_id}.json"
             failure_content = await self._viking_fs.read_file(failed_uri, ctx=self.ctx)
             phase1 = (await self._read_archive_meta(selected_uri)).get("phase1")
             if not isinstance(phase1, dict):
@@ -2338,19 +2339,21 @@ class Session:
             phase1["queue_message"] = retry_message.to_dict()
             phase1["retry_history"] = retry_history
 
-            await self._viking_fs.write_file(
-                failure_history_uri,
-                failure_content,
-                ctx=self.ctx,
-                lease_ref=lease,
-            )
-            await self._viking_fs._async_agfs.rm(
-                self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
-                fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
-            )
             tracker = get_task_tracker()
             retry_task_created = False
+            failure_history_written = False
             try:
+                await self._viking_fs.write_file(
+                    failure_history_uri,
+                    failure_content,
+                    ctx=self.ctx,
+                    lease_ref=lease,
+                )
+                failure_history_written = True
+                await self._viking_fs._async_agfs.rm(
+                    self._viking_fs._uri_to_path(failed_uri, ctx=self.ctx),
+                    fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                )
                 await self._merge_archive_meta(selected_uri, {"phase1": phase1}, lease_ref=lease)
                 await tracker.create(
                     "session_commit",
@@ -2379,16 +2382,36 @@ class Session:
                             "Failed to mark retry task %s after queue enqueue failure",
                             retry_task_id,
                         )
-                await self._merge_archive_meta(
-                    selected_uri, {"phase1": original_phase1}, lease_ref=lease
-                )
-                if not await self._archive_file_exists(selected_uri, ".failed.json"):
-                    await self._viking_fs.write_file(
-                        failed_uri,
-                        failure_content,
-                        ctx=self.ctx,
-                        lease_ref=lease,
+                phase1_rolled_back = False
+                try:
+                    await self._merge_archive_meta(
+                        selected_uri, {"phase1": original_phase1}, lease_ref=lease
                     )
+                    phase1_rolled_back = True
+                except Exception:
+                    logger.exception("Failed to roll back retry metadata for %s", selected_uri)
+                try:
+                    if not await self._archive_file_exists(selected_uri, ".failed.json"):
+                        await self._viking_fs.write_file(
+                            failed_uri,
+                            failure_content,
+                            ctx=self.ctx,
+                            lease_ref=lease,
+                        )
+                except Exception:
+                    logger.exception("Failed to restore retry marker for %s", selected_uri)
+                if failure_history_written and phase1_rolled_back:
+                    try:
+                        await self._viking_fs._async_agfs.rm(
+                            self._viking_fs._uri_to_path(failure_history_uri, ctx=self.ctx),
+                            fs_ctx=self._viking_fs._pathlock_fs_ctx(self.ctx, lease),
+                        )
+                    except Exception as cleanup_exc:
+                        if not _is_storage_not_found(cleanup_exc):
+                            logger.exception(
+                                "Failed to remove rolled-back retry history %s",
+                                failure_history_uri,
+                            )
                 raise
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -85,6 +85,7 @@ class _Sessions:
         self.calls = 0
         self.contexts: list[RequestContext] = []
         self.retry_state = {"state": "unavailable", "archive_uri": None}
+        self.retry_result = {"task_id": "retry-task"}
 
     async def inspect_failed_commit(
         self,
@@ -113,7 +114,7 @@ class _Sessions:
         self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
-        return {"task_id": "retry-task"}
+        return self.retry_result
 
 
 class _Service:
@@ -212,6 +213,22 @@ async def test_root_retry_uses_the_task_owner_context(monkeypatch):
         assert task_ctx.role == Role.ROOT
         assert task_ctx.actor_peer_id == "peer-1"
         assert task_ctx.api_key == "root-key"
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_no_action_when_service_starts_no_task(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    service = _Service()
+    service.sessions.retry_state = {"state": "failed_ready", "archive_uri": None}
+    service.sessions.retry_result = {"reason": "nothing_to_retry"}
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "no_action"
+    assert response.result["result"] == {"reason": "nothing_to_retry"}
+    assert tracker.link_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -7,6 +7,7 @@ import pytest
 from openviking.server.identity import RequestContext, Role
 from openviking.server.routers import tasks as task_router
 from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking_cli.exceptions import FailedPreconditionError, PermissionDeniedError
 from openviking_cli.session.user_id import UserIdentifier
 
 
@@ -27,14 +28,28 @@ def _failed_task(*, error: str = "provider overloaded", attempt_number: int = 1)
     )
 
 
+def test_task_response_only_exposes_owner_to_root_callers():
+    task = _failed_task()
+
+    regular_response = task_router._task_response(task, include_owner=False)
+    root_response = task_router._task_response(task, include_owner=True)
+
+    assert "owner_account_id" not in regular_response
+    assert "owner_user_id" not in regular_response
+    assert root_response["owner_account_id"] == "acme"
+    assert root_response["owner_user_id"] == "alice"
+
+
 class _Tracker:
     def __init__(self, task: TaskRecord):
         self.task = task
         self.link_calls: list[dict] = []
         self.resolve_calls: list[dict] = []
+        self.get_calls: list[dict] = []
         self.resolved_task: TaskRecord | None = None
 
-    async def get(self, task_id, **_kwargs):
+    async def get(self, task_id, **kwargs):
+        self.get_calls.append({"task_id": task_id, **kwargs})
         return self.task if task_id == self.task.task_id else None
 
     async def find_active(self, *_args, **_kwargs):
@@ -180,7 +195,14 @@ async def test_root_retry_uses_the_task_owner_context(monkeypatch):
         api_key="root-key",
     )
 
-    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+    response = await task_router.retry_task(
+        "failed-task",
+        task_router.RetryTaskRequest(
+            owner_account_id="tenant-b",
+            owner_user_id="bob",
+        ),
+        root_ctx,
+    )
 
     assert response.result["disposition"] == "accepted"
     assert len(service.sessions.contexts) == 2
@@ -190,6 +212,132 @@ async def test_root_retry_uses_the_task_owner_context(monkeypatch):
         assert task_ctx.role == Role.ROOT
         assert task_ctx.actor_peer_id == "peer-1"
         assert task_ctx.api_key == "root-key"
+
+
+@pytest.mark.asyncio
+async def test_root_retry_requires_an_explicit_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    with pytest.raises(FailedPreconditionError, match="both owner_account_id and owner_user_id"):
+        await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+
+    assert tracker.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_root_retry_accepts_an_explicit_system_owner(monkeypatch):
+    task = _failed_task()
+    task.account_id = task_router.SYSTEM_TASK_ACCOUNT_ID
+    task.user_id = task_router.SYSTEM_TASK_USER_ID
+    tracker = _Tracker(task)
+    service = _Service()
+    service.sessions.retry_state = {"state": "failed_ready", "archive_uri": None}
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    response = await task_router.retry_task(
+        "failed-task",
+        task_router.RetryTaskRequest(
+            owner_account_id=task_router.SYSTEM_TASK_ACCOUNT_ID,
+            owner_user_id=task_router.SYSTEM_TASK_USER_ID,
+        ),
+        root_ctx,
+    )
+
+    assert response.result["disposition"] == "accepted"
+    assert tracker.get_calls == [
+        {
+            "task_id": "failed-task",
+            "account_id": task_router.SYSTEM_TASK_ACCOUNT_ID,
+            "user_id": task_router.SYSTEM_TASK_USER_ID,
+        }
+    ]
+    assert service.sessions.contexts == [root_ctx, root_ctx]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_loads_persisted_task_with_explicit_owner(monkeypatch):
+    task = _failed_task()
+    task.account_id = "tenant-b"
+    task.user_id = "bob"
+    tracker = _Tracker(task)
+    service = _Service()
+    service.sessions.retry_state = {"state": "failed_ready", "archive_uri": None}
+
+    async def load_from_store(task_id, **kwargs):
+        tracker.get_calls.append({"task_id": task_id, **kwargs})
+        if kwargs == {"account_id": "tenant-b", "user_id": "bob"}:
+            return task
+        return None
+
+    tracker.get = load_from_store
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+    body = task_router.RetryTaskRequest(
+        owner_account_id="tenant-b",
+        owner_user_id="bob",
+    )
+
+    response = await task_router.retry_task("failed-task", body, root_ctx)
+
+    assert response.result["disposition"] == "accepted"
+    assert tracker.get_calls == [
+        {
+            "task_id": "failed-task",
+            "account_id": "tenant-b",
+            "user_id": "bob",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_rejects_an_incomplete_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+    )
+
+    with pytest.raises(FailedPreconditionError, match="both owner_account_id and owner_user_id"):
+        await task_router.retry_task(
+            "failed-task",
+            task_router.RetryTaskRequest(owner_account_id="tenant-b"),
+            root_ctx,
+        )
+
+    assert tracker.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_root_retry_rejects_an_explicit_owner(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+
+    with pytest.raises(PermissionDeniedError, match="Only ROOT may specify a task owner"):
+        await task_router.retry_task(
+            "failed-task",
+            task_router.RetryTaskRequest(
+                owner_account_id="tenant-b",
+                owner_user_id="bob",
+            ),
+            _ctx(),
+        )
+
+    assert tracker.get_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -68,6 +68,7 @@ class _Tracker:
 class _Sessions:
     def __init__(self):
         self.calls = 0
+        self.contexts: list[RequestContext] = []
         self.retry_state = {"state": "unavailable", "archive_uri": None}
 
     async def inspect_failed_commit(
@@ -79,6 +80,7 @@ class _Sessions:
         archive_uri=None,
         failed_task_created_at=None,
     ):
+        self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
         return self.retry_state
@@ -93,6 +95,7 @@ class _Sessions:
         failed_task_created_at=None,
     ):
         self.calls += 1
+        self.contexts.append(_ctx)
         assert archive_uri is None
         assert failed_task_created_at is not None
         return {"task_id": "retry-task"}
@@ -141,6 +144,7 @@ async def test_retry_reports_completed_legacy_archive_before_credential_prompt(m
 async def test_retry_creates_a_linked_attempt_and_returns_its_task_id(monkeypatch):
     tracker = _Tracker(_failed_task())
     service = _Service()
+    service.sessions.retry_state = {"state": "failed_ready", "archive_uri": None}
     monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
     monkeypatch.setattr(task_router, "get_service", lambda: service)
 
@@ -157,6 +161,35 @@ async def test_retry_creates_a_linked_attempt_and_returns_its_task_id(monkeypatc
             "user_id": "alice",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_root_retry_uses_the_task_owner_context(monkeypatch):
+    task = _failed_task()
+    task.account_id = "tenant-b"
+    task.user_id = "bob"
+    tracker = _Tracker(task)
+    service = _Service()
+    service.sessions.retry_state = {"state": "failed_ready", "archive_uri": None}
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+    root_ctx = RequestContext(
+        user=UserIdentifier("system", "root"),
+        role=Role.ROOT,
+        actor_peer_id="peer-1",
+        api_key="root-key",
+    )
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), root_ctx)
+
+    assert response.result["disposition"] == "accepted"
+    assert len(service.sessions.contexts) == 2
+    for task_ctx in service.sessions.contexts:
+        assert task_ctx.account_id == "tenant-b"
+        assert task_ctx.user.user_id == "bob"
+        assert task_ctx.role == Role.ROOT
+        assert task_ctx.actor_peer_id == "peer-1"
+        assert task_ctx.api_key == "root-key"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_retry.py
+++ b/tests/server/test_task_retry.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Isolated unit tests for the server-owned task retry endpoint."""
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import tasks as task_router
+from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(user=UserIdentifier("acme", "alice"), role=Role.ADMIN)
+
+
+def _failed_task(*, error: str = "provider overloaded", attempt_number: int = 1) -> TaskRecord:
+    return TaskRecord(
+        task_id="failed-task",
+        task_type="session_commit",
+        status=TaskStatus.FAILED,
+        resource_id="session-1",
+        account_id="acme",
+        user_id="alice",
+        error=error,
+        attempt_number=attempt_number,
+    )
+
+
+class _Tracker:
+    def __init__(self, task: TaskRecord):
+        self.task = task
+        self.link_calls: list[dict] = []
+        self.resolve_calls: list[dict] = []
+        self.resolved_task: TaskRecord | None = None
+
+    async def get(self, task_id, **_kwargs):
+        return self.task if task_id == self.task.task_id else None
+
+    async def find_active(self, *_args, **_kwargs):
+        return None
+
+    async def find_completed_operation(self, *_args, **_kwargs):
+        return self.resolved_task
+
+    async def link_retry(self, task_id, **kwargs):
+        self.link_calls.append({"task_id": task_id, **kwargs})
+        return TaskRecord(
+            task_id=task_id,
+            task_type=self.task.task_type,
+            resource_id=self.task.resource_id,
+            account_id="acme",
+            user_id="alice",
+            operation_id=self.task.operation_id,
+            parent_task_id=self.task.task_id,
+            attempt_number=self.task.attempt_number + 1,
+        )
+
+    async def resolve_failed(self, task_id, result, **kwargs):
+        self.resolve_calls.append({"task_id": task_id, "result": result, **kwargs})
+        self.task.status = TaskStatus.COMPLETED
+        self.task.result = result
+        self.task.error = None
+        self.task.error_info = {}
+        return self.task
+
+
+class _Sessions:
+    def __init__(self):
+        self.calls = 0
+        self.retry_state = {"state": "unavailable", "archive_uri": None}
+
+    async def inspect_failed_commit(
+        self,
+        _session_id,
+        _failed_task_id,
+        _ctx,
+        *,
+        archive_uri=None,
+        failed_task_created_at=None,
+    ):
+        assert archive_uri is None
+        assert failed_task_created_at is not None
+        return self.retry_state
+
+    async def retry_failed_commit(
+        self,
+        _session_id,
+        _failed_task_id,
+        _ctx,
+        *,
+        archive_uri=None,
+        failed_task_created_at=None,
+    ):
+        self.calls += 1
+        assert archive_uri is None
+        assert failed_task_created_at is not None
+        return {"task_id": "retry-task"}
+
+
+class _Service:
+    def __init__(self):
+        self.sessions = _Sessions()
+
+
+@pytest.mark.asyncio
+async def test_retry_blocks_legacy_permanent_failure_before_starting_work(monkeypatch):
+    tracker = _Tracker(_failed_task(error="token_expired"))
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "blocked"
+    assert response.result["error"]["code"] == "AUTH_EXPIRED"
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_completed_legacy_archive_before_credential_prompt(monkeypatch):
+    tracker = _Tracker(_failed_task(error="token_expired"))
+    service = _Service()
+    service.sessions.retry_state = {
+        "state": "completed",
+        "archive_uri": "viking://user/alice/sessions/session-1/history/archive_001",
+    }
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["resolution"] == "archive_complete"
+    assert response.result["task_id"] == "failed-task"
+    assert tracker.task.status == TaskStatus.COMPLETED
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_creates_a_linked_attempt_and_returns_its_task_id(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "accepted"
+    assert response.result["task_id"] == "retry-task"
+    assert response.result["attempt_number"] == 2
+    assert tracker.link_calls == [
+        {
+            "task_id": "retry-task",
+            "parent_task_id": "failed-task",
+            "account_id": "acme",
+            "user_id": "alice",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_replay_a_failed_predecessor_after_operation_success(monkeypatch):
+    tracker = _Tracker(_failed_task())
+    tracker.resolved_task = TaskRecord(
+        task_id="completed-retry",
+        task_type="session_commit",
+        status=TaskStatus.COMPLETED,
+        resource_id="session-1",
+        account_id="acme",
+        user_id="alice",
+        operation_id="failed-task",
+        attempt_number=2,
+    )
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["task_id"] == "completed-retry"
+    assert tracker.task.status == TaskStatus.COMPLETED
+    assert service.sessions.calls == 0
+    assert tracker.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_retry_reports_an_already_completed_task_without_starting_work(monkeypatch):
+    task = _failed_task()
+    task.status = TaskStatus.COMPLETED
+    tracker = _Tracker(task)
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "operation_resolved"
+    assert response.result["task_id"] == "failed-task"
+    assert service.sessions.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_stops_after_the_linked_attempt_limit(monkeypatch):
+    tracker = _Tracker(_failed_task(attempt_number=task_router.MAX_LINKED_RETRY_ATTEMPTS))
+    service = _Service()
+    monkeypatch.setattr(task_router, "get_task_tracker", lambda: tracker)
+    monkeypatch.setattr(task_router, "get_service", lambda: service)
+
+    response = await task_router.retry_task("failed-task", task_router.RetryTaskRequest(), _ctx())
+
+    assert response.result["disposition"] == "retry_limit_reached"
+    assert service.sessions.calls == 0

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -13,9 +13,11 @@ from openviking.server.identity import RequestContext, Role
 from openviking.service.session_service import SessionService
 from openviking.service.task_store import PersistentTaskStore
 from openviking.service.task_tracker import (
+    TaskRecord,
     TaskStatus,
     TaskTracker,
     _sanitize_error,
+    classify_task_error,
     get_task_tracker,
     set_task_tracker,
 )
@@ -202,6 +204,121 @@ async def test_fail_task(tracker: TaskTracker):
     assert retrieved.status == TaskStatus.FAILED
     assert retrieved.stage == "failed"
     assert "LLM timeout" in retrieved.error
+    assert retrieved.error_info["retryability"] == "retryable"
+
+
+async def test_legacy_failure_is_classified_when_serialized(tracker: TaskTracker):
+    task = await tracker.create("session_commit", **_owner_kwargs())
+    await tracker.fail(task.task_id, "token_expired")
+    retrieved = await tracker.get(task.task_id)
+
+    assert retrieved is not None
+    retrieved.error_info = {}
+    assert retrieved.to_dict()["error_info"]["code"] == "AUTH_EXPIRED"
+
+
+@pytest.mark.parametrize(
+    ("error", "code", "retryability"),
+    [
+        ("token_expired", "AUTH_EXPIRED", "requires_change"),
+        (
+            "Sparse embedding only supports text input",
+            "MEDIA_SPARSE_INPUT_UNSUPPORTED",
+            "requires_change",
+        ),
+        ("provider overloaded", "TRANSIENT_UPSTREAM", "retryable"),
+    ],
+)
+async def test_classify_task_error(error: str, code: str, retryability: str):
+    info = classify_task_error(error)
+    assert info["code"] == code
+    assert info["retryability"] == retryability
+
+
+async def test_linked_retry_keeps_predecessor_failed_while_retry_is_active(
+    tracker: TaskTracker,
+):
+    first = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker.fail(first.task_id, "provider overloaded")
+    second = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+
+    linked = await tracker.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+
+    assert linked is not None
+    assert linked.operation_id == first.task_id
+    assert linked.parent_task_id == first.task_id
+    assert linked.attempt_number == 2
+    predecessor = await tracker.get(first.task_id, **_owner_kwargs())
+    assert predecessor is not None
+    assert predecessor.status == TaskStatus.FAILED
+    active = await tracker.find_active("session_commit", "session-1", **_owner_kwargs())
+    assert active is not None
+    assert active.task_id == second.task_id
+
+
+async def test_completed_retry_changes_failed_predecessor_to_completed(
+    tracker: TaskTracker,
+):
+    first = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker.fail(first.task_id, "provider overloaded")
+    second = await tracker.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    linked = await tracker.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+    assert linked is not None
+    await tracker.complete(second.task_id, {"memories_extracted": 1}, **_owner_kwargs())
+
+    resolved = await tracker.find_completed_operation(
+        "session_commit",
+        "session-1",
+        first.task_id,
+        **_owner_kwargs(),
+    )
+
+    assert resolved is not None
+    assert resolved.task_id == second.task_id
+    predecessor = await tracker.get(first.task_id, **_owner_kwargs())
+    assert predecessor is not None
+    assert predecessor.status == TaskStatus.COMPLETED
+    assert predecessor.error is None
+    assert predecessor.error_info == {}
+    assert predecessor.result == {"memories_extracted": 1}
+
+
+async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storage():
+    store = PersistentTaskStore(_FakeAgfs())
+    tracker1 = TaskTracker(store=store)
+    first = await tracker1.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    await tracker1.fail(first.task_id, "provider overloaded")
+    second = await tracker1.create("session_commit", resource_id="session-1", **_owner_kwargs())
+    linked = await tracker1.link_retry(
+        second.task_id,
+        parent_task_id=first.task_id,
+        **_owner_kwargs(),
+    )
+    assert linked is not None
+    await tracker1.start(second.task_id, **_owner_kwargs())
+    await tracker1.complete(second.task_id, {"ok": True}, **_owner_kwargs())
+
+    failed_payload = await store.get(first.task_id, **_owner_kwargs())
+    assert failed_payload is not None
+    failed_payload["status"] = "failed"
+    failed_payload["stage"] = "failed"
+    failed_payload["error"] = "provider overloaded"
+    failed_payload["error_info"] = classify_task_error("provider overloaded")
+    failed_payload["status"] = TaskStatus.FAILED
+    await store.update(TaskRecord(**failed_payload))
+
+    tracker2 = TaskTracker(store=store)
+    tasks = await tracker2.list_tasks(**_owner_kwargs())
+    predecessor = next(task for task in tasks if task.task_id == first.task_id)
+    assert predecessor.status == TaskStatus.COMPLETED
 
 
 async def test_get_nonexistent_returns_none(tracker: TaskTracker):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -308,7 +308,6 @@ async def test_listing_tasks_reconciles_a_completed_retry_from_persistent_storag
 
     failed_payload = await store.get(first.task_id, **_owner_kwargs())
     assert failed_payload is not None
-    failed_payload["status"] = "failed"
     failed_payload["stage"] = "failed"
     failed_payload["error"] = "provider overloaded"
     failed_payload["error_info"] = classify_task_error("provider overloaded")

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -207,6 +207,25 @@ async def test_fail_task(tracker: TaskTracker):
     assert retrieved.error_info["retryability"] == "retryable"
 
 
+async def test_get_cached_failed_task_survives_reconciliation_store_failure(
+    tracker: TaskTracker, monkeypatch
+):
+    task = await tracker.create("session_commit", **_owner_kwargs())
+    await tracker.fail(task.task_id, "LLM timeout", **_owner_kwargs())
+
+    async def fail_owner_load(account_id, user_id):
+        raise OSError("store unavailable")
+
+    monkeypatch.setattr(tracker, "_load_all_from_store", fail_owner_load)
+
+    retrieved = await tracker.get(task.task_id, **_owner_kwargs())
+
+    assert retrieved is not None
+    assert retrieved.task_id == task.task_id
+    assert retrieved.status == TaskStatus.FAILED
+    assert retrieved.error == "LLM timeout"
+
+
 async def test_legacy_failure_is_classified_when_serialized(tracker: TaskTracker):
     task = await tracker.create("session_commit", **_owner_kwargs())
     await tracker.fail(task.task_id, "token_expired")

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -94,6 +94,7 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
 
 @pytest.mark.asyncio
 async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
+    events: list[str] = []
     session = Session.__new__(Session)
     session._viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(
@@ -124,11 +125,22 @@ async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
     session._read_archive_meta = AsyncMock(
         return_value={"phase1": {"queue_message": queue_payload}}
     )
-    session._merge_archive_meta = AsyncMock()
+    session._merge_archive_meta = AsyncMock(
+        side_effect=lambda *_args, **_kwargs: events.append("merge")
+    )
 
-    tracker = SimpleNamespace(create=AsyncMock(), fail=AsyncMock())
-    queue_manager = SimpleNamespace(
-        enqueue=AsyncMock(side_effect=RuntimeError("queue unavailable"))
+    tracker = SimpleNamespace(
+        create=AsyncMock(side_effect=lambda *_args, **_kwargs: events.append("create")),
+        fail=AsyncMock(),
+    )
+
+    def fail_enqueue(*_args, **_kwargs):
+        events.append("enqueue")
+        raise RuntimeError("queue unavailable")
+
+    queue_manager = SimpleNamespace(enqueue=AsyncMock(side_effect=fail_enqueue))
+    session._viking_fs._async_agfs.rm.side_effect = lambda uri, **_kwargs: events.append(
+        f"remove:{uri}"
     )
     monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
     monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
@@ -152,3 +164,9 @@ async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
         '{"error":"provider overloaded"}',
     )
     assert session._viking_fs._async_agfs.rm.await_args_list[-1].args == (failure_history_uri,)
+    assert events[:4] == [
+        "merge",
+        "create",
+        f"remove:{ARCHIVE_URI}/.failed.json",
+        "enqueue",
+    ]

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for legacy session commit archive resolution."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.session.session import Session
+
+SESSION_URI = "viking://user/alice/sessions/session-1"
+ARCHIVE_URI = f"{SESSION_URI}/history/archive_003"
+FAILED_TASK_CREATED_AT = 1786994253.298716
+
+
+class _AsyncAgfs:
+    async def pathlock_acquire_tree(self, _path, timeout_secs):
+        assert timeout_secs > 0
+        return "lease"
+
+    async def pathlock_release(self, lease):
+        assert lease == "lease"
+
+
+class _VikingFS:
+    def __init__(self):
+        self._async_agfs = _AsyncAgfs()
+
+    async def glob(self, pattern, *, uri, ctx):
+        assert pattern == "archive_*/messages.jsonl"
+        assert uri == f"{SESSION_URI}/history"
+        assert ctx is not None
+        return {"matches": [f"{ARCHIVE_URI}/messages.jsonl"]}
+
+    async def read_file(self, uri, *, ctx):
+        assert uri == f"{ARCHIVE_URI}/.meta.json"
+        assert ctx is not None
+        return json.dumps(
+            {
+                "phase1": {
+                    "created_at": "2026-08-17T19:17:33.276Z",
+                    "queue_message": {"task_id": "offline-recovery-task"},
+                }
+            }
+        )
+
+    async def exists(self, uri, *, ctx):
+        assert ctx is not None
+        return uri == f"{ARCHIVE_URI}/.done"
+
+    def _uri_to_path(self, uri, *, ctx):
+        assert uri == SESSION_URI
+        assert ctx is not None
+        return "/session-1"
+
+
+def _session() -> Session:
+    session = Session.__new__(Session)
+    session._viking_fs = _VikingFS()
+    session._session_uri = SESSION_URI
+    session.session_id = "session-1"
+    session.ctx = SimpleNamespace()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_legacy_archive_is_matched_by_creation_time_after_queue_id_replacement():
+    state = await _session().inspect_failed_commit(
+        "legacy-failed-task",
+        failed_task_created_at=FAILED_TASK_CREATED_AT,
+    )
+
+    assert state == {"state": "completed", "archive_uri": ARCHIVE_URI}
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
+    result = await _session().retry_failed_commit(
+        "legacy-failed-task",
+        failed_task_created_at=FAILED_TASK_CREATED_AT,
+    )
+
+    assert result == {
+        "session_id": "session-1",
+        "status": "completed",
+        "task_id": None,
+        "archive_uri": ARCHIVE_URI,
+        "reason": "archive_complete",
+    }

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -3,6 +3,7 @@
 """Unit tests for legacy session commit archive resolution."""
 
 import json
+from hashlib import sha256
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -92,7 +93,7 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
 
 
 @pytest.mark.asyncio
-async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
+async def test_retry_rolls_back_safe_history_when_enqueue_fails(monkeypatch):
     session = Session.__new__(Session)
     session._viking_fs = SimpleNamespace(
         _async_agfs=SimpleNamespace(
@@ -132,14 +133,22 @@ async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
     monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
     monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
 
+    failed_task_id = "../failed/task"
     with pytest.raises(RuntimeError, match="queue unavailable"):
-        await session.retry_failed_commit("failed-task", archive_uri=ARCHIVE_URI)
+        await session.retry_failed_commit(failed_task_id, archive_uri=ARCHIVE_URI)
 
     tracker.fail.assert_awaited_once()
-    failed_task_id, failure_message = tracker.fail.await_args.args
-    assert failed_task_id != "failed-task"
+    retry_task_id, failure_message = tracker.fail.await_args.args
+    assert retry_task_id != failed_task_id
     assert failure_message == "Failed to enqueue session commit retry"
     assert tracker.fail.await_args.kwargs == {
         "account_id": "acme",
         "user_id": "alice",
     }
+    failure_history_id = sha256(failed_task_id.encode("utf-8")).hexdigest()
+    failure_history_uri = f"{ARCHIVE_URI}/.failed.{failure_history_id}.json"
+    assert session._viking_fs.write_file.await_args_list[0].args == (
+        failure_history_uri,
+        '{"error":"provider overloaded"}',
+    )
+    assert session._viking_fs._async_agfs.rm.await_args_list[-1].args == (failure_history_uri,)

--- a/tests/unit/test_session_retry_archive.py
+++ b/tests/unit/test_session_retry_archive.py
@@ -4,6 +4,7 @@
 
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -87,4 +88,58 @@ async def test_retry_returns_resolved_when_legacy_archive_is_already_complete():
         "task_id": None,
         "archive_uri": ARCHIVE_URI,
         "reason": "archive_complete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_marks_created_task_failed_when_enqueue_fails(monkeypatch):
+    session = Session.__new__(Session)
+    session._viking_fs = SimpleNamespace(
+        _async_agfs=SimpleNamespace(
+            pathlock_acquire_tree=AsyncMock(return_value="lease"),
+            pathlock_release=AsyncMock(),
+            rm=AsyncMock(),
+        ),
+        _uri_to_path=lambda uri, **_kwargs: uri,
+        _pathlock_fs_ctx=lambda *_args: SimpleNamespace(),
+        read_file=AsyncMock(return_value='{"error":"provider overloaded"}'),
+        write_file=AsyncMock(),
+    )
+    session._session_uri = SESSION_URI
+    session.session_id = "session-1"
+    session.ctx = SimpleNamespace(
+        account_id="acme",
+        user=SimpleNamespace(user_id="alice"),
+    )
+    queue_payload = {
+        "task_id": "failed-task",
+        "session_id": "session-1",
+        "session_uri": SESSION_URI,
+        "archive_uri": ARCHIVE_URI,
+        "user": {"account_id": "acme", "user_id": "alice"},
+    }
+    session._find_failed_commit_archive = AsyncMock(return_value=(ARCHIVE_URI, queue_payload))
+    session._archive_file_exists = AsyncMock(side_effect=[False, True, False])
+    session._read_archive_meta = AsyncMock(
+        return_value={"phase1": {"queue_message": queue_payload}}
+    )
+    session._merge_archive_meta = AsyncMock()
+
+    tracker = SimpleNamespace(create=AsyncMock(), fail=AsyncMock())
+    queue_manager = SimpleNamespace(
+        enqueue=AsyncMock(side_effect=RuntimeError("queue unavailable"))
+    )
+    monkeypatch.setattr("openviking.service.task_tracker.get_task_tracker", lambda: tracker)
+    monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: queue_manager)
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await session.retry_failed_commit("failed-task", archive_uri=ARCHIVE_URI)
+
+    tracker.fail.assert_awaited_once()
+    failed_task_id, failure_message = tracker.fail.await_args.args
+    assert failed_task_id != "failed-task"
+    assert failure_message == "Failed to enqueue session commit retry"
+    assert tracker.fail.await_args.kwargs == {
+        "account_id": "acme",
+        "user_id": "alice",
     }

--- a/web-studio/src/i18n/locales/en/workspace.ts
+++ b/web-studio/src/i18n/locales/en/workspace.ts
@@ -172,6 +172,7 @@ const workspace = {
       title: 'Task details',
       loading: 'Loading task details...',
       loadFailed: 'Could not load task details',
+      notFoundOrExpired: 'Task not found or no longer available',
       retry: 'Retry',
       openLabel: 'View details for task {{taskId}}',
       fields: {
@@ -181,6 +182,27 @@ const workspace = {
         resource: 'Resource',
         createdAt: 'Created',
         updatedAt: 'Updated',
+        duration: 'Duration',
+        retryLineage: 'Retry lineage',
+      },
+      lineageAttempt: 'Attempt {{attempt}}; previous: {{parentTaskId}}',
+      lineageInitial: 'Initial attempt',
+      failureGuidance: 'Failure guidance',
+      pipeline: {
+        title: 'Pipeline steps',
+        itemCount: '{{count}} items',
+        status: {
+          completed: 'Completed',
+          running: 'Running',
+          failed: 'Failed',
+          pending: 'Pending',
+        },
+      },
+      trace: {
+        title: 'Task execution log',
+        stream: 'LOG TRACE STREAM (ID: {{taskId}})',
+        copy: 'Copy logs',
+        copied: 'Logs copied to clipboard',
       },
       error: 'Failure reason',
       result: 'Result',
@@ -191,6 +213,15 @@ const workspace = {
         'This task did not return a result. See the failure reason above.',
       noResultCancelledDescription:
         'This task was cancelled before it returned a result.',
+      noResultCompleted: 'Task completed without a result payload',
+      noResultCompletedDescription:
+        'The task finished successfully, but the API did not return additional result data.',
+      noResultRunning: 'Task is still running',
+      noResultRunningDescription:
+        'Result data will appear here after the task completes.',
+      noResultPending: 'Task is waiting to run',
+      noResultPendingDescription:
+        'The task will begin when a worker becomes available.',
     },
     filters: {
       label: 'Filter',
@@ -215,6 +246,8 @@ const workspace = {
       resource: 'Resource',
       createdAt: 'Created',
       status: 'Status',
+      pipeline: 'Queue pipeline',
+      duration: 'Duration',
     },
     status: {
       cancelled: 'Cancelled',
@@ -222,6 +255,7 @@ const workspace = {
       completed: 'Completed',
       failed: 'Failed',
       pending: 'Pending',
+      queued: 'Queued',
       running: 'Running',
       unknown: 'Unknown',
     },
@@ -234,6 +268,33 @@ const workspace = {
       snapshot_restore_reindex: 'Snapshot reindex',
       legacy_migration: 'Legacy migration',
       legacy_cleanup: 'Legacy cleanup',
+    },
+    actions: {
+      retry: 'Retry task',
+    },
+    pipeline: {
+      serialTransition: 'Serial process transition',
+      parallelBatch: 'Parallel process batch',
+      serialBatch: 'Serial process batch',
+    },
+    historyMode: {
+      latestPerResource: 'Latest per resource',
+      all: 'All history',
+    },
+    attemptLabel: 'Attempt {{attempt}}',
+    retryFlow: {
+      taskIdRequired: 'Task ID is required',
+      requeueFailed: 'Retry request failed',
+      archiveComplete:
+        'The archive for this failed attempt is already complete. No retry is needed.',
+      resolvedByTask:
+        'Successful task {{taskId}} already resolved this failed attempt, so it cannot be retried again.',
+      blocked: 'Address this issue before retrying: {{guidance}}',
+      retryLimit:
+        'This operation has reached the {{maxAttempts}}-attempt limit. Fix the issue, then click retry again to start a new operation.',
+      noAction: 'There is no work to retry.',
+      alreadyRunning: 'An equivalent task is already running.',
+      accepted: 'A linked retry task was created and is now being tracked.',
     },
   },
   watchesPage: {

--- a/web-studio/src/i18n/locales/zh-CN/workspace.ts
+++ b/web-studio/src/i18n/locales/zh-CN/workspace.ts
@@ -165,6 +165,7 @@ const workspace = {
       title: '任务详情',
       loading: '正在加载任务详情...',
       loadFailed: '任务详情加载失败',
+      notFoundOrExpired: '未找到该任务，或任务已不可用',
       retry: '重试',
       openLabel: '查看任务 {{taskId}} 的详情',
       fields: {
@@ -174,6 +175,27 @@ const workspace = {
         resource: '关联资源',
         createdAt: '创建时间',
         updatedAt: '更新时间',
+        duration: '执行耗时',
+        retryLineage: '重试链路',
+      },
+      lineageAttempt: '第 {{attempt}} 次；上一次：{{parentTaskId}}',
+      lineageInitial: '首次执行',
+      failureGuidance: '失败处理建议',
+      pipeline: {
+        title: '工序进度',
+        itemCount: '{{count}} 项',
+        status: {
+          completed: '已完成',
+          running: '进行中',
+          failed: '失败',
+          pending: '等待中',
+        },
+      },
+      trace: {
+        title: '任务执行日志',
+        stream: '日志跟踪流（ID：{{taskId}}）',
+        copy: '复制日志',
+        copied: '日志已复制到剪贴板',
       },
       error: '失败原因',
       result: '执行结果',
@@ -181,6 +203,13 @@ const workspace = {
       noResultDescription: '任务完成后，接口返回的结果会显示在这里。',
       noResultFailedDescription: '该任务未返回结果，请查看上方失败原因。',
       noResultCancelledDescription: '该任务已取消，未返回执行结果。',
+      noResultCompleted: '任务已完成，但没有返回结果数据',
+      noResultCompletedDescription:
+        '任务已成功完成，但接口没有返回额外的结果数据。',
+      noResultRunning: '任务正在执行',
+      noResultRunningDescription: '任务完成后，结果数据会显示在这里。',
+      noResultPending: '任务正在等待执行',
+      noResultPendingDescription: '有可用工作进程后，任务会自动开始。',
     },
     filters: {
       label: '筛选',
@@ -204,6 +233,8 @@ const workspace = {
       resource: '关联资源',
       createdAt: '创建时间',
       status: '状态',
+      pipeline: '工序队列流转',
+      duration: '耗时',
     },
     status: {
       cancelled: '已取消',
@@ -211,6 +242,7 @@ const workspace = {
       completed: '已完成',
       failed: '失败',
       pending: '等待中',
+      queued: '排队中',
       running: '进行中',
       unknown: '未知',
     },
@@ -223,6 +255,32 @@ const workspace = {
       snapshot_restore_reindex: '快照恢复索引',
       legacy_migration: '旧数据迁移',
       legacy_cleanup: '旧数据清理',
+    },
+    actions: {
+      retry: '重新提交',
+    },
+    pipeline: {
+      serialTransition: '串行工序流转',
+      parallelBatch: '并发工序批次',
+      serialBatch: '串行工序批次',
+    },
+    historyMode: {
+      latestPerResource: '每个资源仅显示最新任务',
+      all: '显示全部任务',
+    },
+    attemptLabel: '第 {{attempt}} 次',
+    retryFlow: {
+      taskIdRequired: '缺少任务 ID',
+      requeueFailed: '重新提交失败',
+      archiveComplete: '该失败记录对应的归档已经处理完成，无需再次重试。',
+      resolvedByTask:
+        '该失败记录已由任务 {{taskId}} 成功恢复，不能再次重新提交。',
+      blocked: '请先处理以下问题：{{guidance}}。处理完成后再重试。',
+      retryLimit:
+        '该操作已达到 {{maxAttempts}} 次尝试上限。请先修复问题，再次点击可发起一项新操作。',
+      noAction: '当前没有可重新提交的工作。',
+      alreadyRunning: '同一操作已有任务正在执行。',
+      accepted: '已创建新的重试任务，正在跟踪执行状态。',
     },
   },
   watchesPage: {

--- a/web-studio/src/routes/tasks/-components/task-detail-sheet.test.tsx
+++ b/web-studio/src/routes/tasks/-components/task-detail-sheet.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTask } from './task-detail-sheet'
+
+const clientMocks = vi.hoisted(() => ({
+  getTaskByTaskId: vi.fn(),
+}))
+
+vi.mock('#/lib/ov-client', () => ({
+  getOvResult: async (value: unknown) => value,
+  getTaskByTaskId: clientMocks.getTaskByTaskId,
+  isOvClientError: (error: unknown) =>
+    typeof error === 'object' && error !== null && 'code' in error,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear()
+  }
+})
+
+describe('fetchTask', () => {
+  it('translates only an explicit task not-found response', async () => {
+    clientMocks.getTaskByTaskId.mockRejectedValue({
+      code: 'NOT_FOUND',
+      message: 'Task not found or expired',
+    })
+
+    await expect(
+      fetchTask('missing-task', '任务不存在或已过期'),
+    ).rejects.toThrow('任务不存在或已过期')
+  })
+
+  it('preserves other backend failures for the query error state', async () => {
+    const backendError = Object.assign(new Error('gateway unavailable'), {
+      code: 'INTERNAL_ERROR',
+    })
+    clientMocks.getTaskByTaskId.mockRejectedValue(backendError)
+
+    await expect(fetchTask('task-1', '任务不存在或已过期')).rejects.toBe(
+      backendError,
+    )
+  })
+})

--- a/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
+++ b/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
@@ -30,6 +30,7 @@ import { cn } from '#/lib/utils'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 
 import {
+  getTaskFailureCode,
   getTaskFailureGuidance,
   hasTaskFailureGuidance,
   hasTaskResult,
@@ -246,7 +247,7 @@ export function TaskDetailSheet({
                     <DetailSection title={t('detail.failureGuidance')}>
                       <div className="rounded-xl border border-destructive/25 bg-destructive/5 p-3 text-sm text-foreground">
                         <p className="font-medium">
-                          {task.error_info.code || 'TASK_FAILURE'}
+                          {getTaskFailureCode(task.error_info)}
                         </p>
                         <p className="mt-1 text-muted-foreground">
                           {getTaskFailureGuidance(

--- a/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
+++ b/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
@@ -31,6 +31,7 @@ import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 
 import {
   getTaskFailureGuidance,
+  hasTaskFailureGuidance,
   hasTaskResult,
   normalizeTaskRecord,
   normalizeTaskStatus,
@@ -153,6 +154,7 @@ export function TaskDetailSheet({
           ) : task ? (
             (() => {
               const status = normalizeTaskStatus(task.status)
+              const showFailureGuidance = hasTaskFailureGuidance(task)
               return (
                 <div className="grid gap-6">
                   <div className="grid grid-cols-2 gap-2">
@@ -240,7 +242,7 @@ export function TaskDetailSheet({
                     />
                   </div>
 
-                  {task.error_info?.action ? (
+                  {showFailureGuidance ? (
                     <DetailSection title={t('detail.failureGuidance')}>
                       <div className="rounded-xl border border-destructive/25 bg-destructive/5 p-3 text-sm text-foreground">
                         <p className="font-medium">

--- a/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
+++ b/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
@@ -25,7 +25,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '#/components/ui/sheet'
-import { getOvResult, getTaskByTaskId } from '#/lib/ov-client'
+import { getOvResult, getTaskByTaskId, isOvClientError } from '#/lib/ov-client'
 import { cn } from '#/lib/utils'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 
@@ -45,7 +45,7 @@ type TaskDetailSheetProps = {
   taskId: string | null
 }
 
-async function fetchTask(
+export async function fetchTask(
   taskId: string,
   notFoundMessage: string,
 ): Promise<TaskRecord> {
@@ -75,7 +75,10 @@ async function fetchTask(
     const task = normalizeTaskRecord(result)
     if (task) return task
   } catch (err) {
-    console.warn('[fetchTask] Backend fetch failed for taskId:', taskId, err)
+    if (isOvClientError(err) && err.code === 'NOT_FOUND') {
+      throw new Error(notFoundMessage)
+    }
+    throw err
   }
 
   throw new Error(notFoundMessage)

--- a/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
+++ b/web-studio/src/routes/tasks/-components/task-detail-sheet.tsx
@@ -30,6 +30,7 @@ import { cn } from '#/lib/utils'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 
 import {
+  getTaskFailureGuidance,
   hasTaskResult,
   normalizeTaskRecord,
   normalizeTaskStatus,
@@ -44,14 +45,19 @@ type TaskDetailSheetProps = {
   taskId: string | null
 }
 
-async function fetchTask(taskId: string): Promise<TaskRecord> {
+async function fetchTask(
+  taskId: string,
+  notFoundMessage: string,
+): Promise<TaskRecord> {
   if (typeof window !== 'undefined') {
     try {
       const raw = localStorage.getItem('ov_studio_task_history')
       if (raw) {
         const history = JSON.parse(raw)
         if (Array.isArray(history)) {
-          const match = history.find((t: Record<string, any>) => t.task_id === taskId)
+          const match = history.find(
+            (t: Record<string, any>) => t.task_id === taskId,
+          )
           if (match) return match as TaskRecord
         }
       }
@@ -72,7 +78,7 @@ async function fetchTask(taskId: string): Promise<TaskRecord> {
     console.warn('[fetchTask] Backend fetch failed for taskId:', taskId, err)
   }
 
-  throw new Error('Task not found or expired')
+  throw new Error(notFoundMessage)
 }
 
 export function TaskDetailSheet({
@@ -84,7 +90,7 @@ export function TaskDetailSheet({
   const { i18n, t } = useTranslation('tasksPage')
   const detailQuery = useQuery({
     enabled: open && Boolean(taskId),
-    queryFn: () => fetchTask(taskId || ''),
+    queryFn: () => fetchTask(taskId || '', t('detail.notFoundOrExpired')),
     queryKey: ['task-detail', identityScopeKey, taskId],
     refetchInterval: (query) => {
       const status = normalizeTaskStatus(query.state.data?.status)
@@ -141,65 +147,118 @@ export function TaskDetailSheet({
                 {t('detail.retry')}
               </Button>
             </div>
-          ) : task ? (() => {
-            const status = normalizeTaskStatus(task.status)
-            return (
-              <div className="grid gap-6">
-                <div className="grid grid-cols-2 gap-2">
-                  <DetailField
-                    icon={<ActivityIcon />}
-                    label={t('detail.fields.status')}
-                    value={t(`status.${status}`)}
-                  />
-                  <DetailField
-                    icon={<Layers3Icon />}
-                    label={t('detail.fields.type')}
-                    value={t(`types.${task.task_type}`) || task.task_type || '-'}
-                  />
-                  <DetailField
-                    className="col-span-2"
-                    icon={<TimerResetIcon />}
-                    label={t('detail.fields.stage')}
-                    value={(() => {
-                      const raw = task.stage
-                      if (!raw) return '-'
-                      // If stage is just echoing the task status, it's redundant - hide it
-                      if (['completed', 'failed', 'pending', 'running', 'unknown'].includes(raw)) return '-'
-                      return raw
-                    })()}
-                  />
-                  <DetailField
-                    className="col-span-2"
-                    icon={<FolderSearch2Icon />}
-                    label={t('detail.fields.resource')}
-                    value={task.resource_id || '-'}
-                    mono
-                  />
-                  <DetailField
-                    icon={<CalendarClockIcon />}
-                    label={t('detail.fields.createdAt')}
-                    value={formatTaskTime(task, i18n.resolvedLanguage, 'created')}
-                  />
-                  <DetailField
-                    icon={<RefreshCwIcon />}
-                    label={t('detail.fields.updatedAt')}
-                    value={formatTaskTime(task, i18n.resolvedLanguage, 'updated')}
-                  />
-                  <DetailField
-                    className="col-span-2"
-                    icon={<TimerResetIcon />}
-                    label={i18n.language.startsWith('zh') ? '执行耗时 / 已用时长' : 'Duration'}
-                    value={formatTaskDuration(task, i18n.language.startsWith('zh'))}
-                    mono
-                  />
-                </div>
+          ) : task ? (
+            (() => {
+              const status = normalizeTaskStatus(task.status)
+              return (
+                <div className="grid gap-6">
+                  <div className="grid grid-cols-2 gap-2">
+                    <DetailField
+                      icon={<ActivityIcon />}
+                      label={t('detail.fields.status')}
+                      value={t(`status.${status}`)}
+                    />
+                    <DetailField
+                      icon={<Layers3Icon />}
+                      label={t('detail.fields.type')}
+                      value={
+                        t(`types.${task.task_type}`) || task.task_type || '-'
+                      }
+                    />
+                    <DetailField
+                      className="col-span-2"
+                      icon={<TimerResetIcon />}
+                      label={t('detail.fields.stage')}
+                      value={(() => {
+                        const raw = task.stage
+                        if (!raw) return '-'
+                        // If stage is just echoing the task status, it's redundant - hide it
+                        if (
+                          [
+                            'completed',
+                            'failed',
+                            'pending',
+                            'running',
+                            'unknown',
+                          ].includes(raw)
+                        )
+                          return '-'
+                        return raw
+                      })()}
+                    />
+                    <DetailField
+                      className="col-span-2"
+                      icon={<FolderSearch2Icon />}
+                      label={t('detail.fields.resource')}
+                      value={task.resource_id || '-'}
+                      mono
+                    />
+                    <DetailField
+                      icon={<CalendarClockIcon />}
+                      label={t('detail.fields.createdAt')}
+                      value={formatTaskTime(
+                        task,
+                        i18n.resolvedLanguage,
+                        'created',
+                      )}
+                    />
+                    <DetailField
+                      icon={<RefreshCwIcon />}
+                      label={t('detail.fields.updatedAt')}
+                      value={formatTaskTime(
+                        task,
+                        i18n.resolvedLanguage,
+                        'updated',
+                      )}
+                    />
+                    <DetailField
+                      className="col-span-2"
+                      icon={<TimerResetIcon />}
+                      label={t('detail.fields.duration')}
+                      value={formatTaskDuration(
+                        task,
+                        i18n.language.startsWith('zh'),
+                      )}
+                      mono
+                    />
+                    <DetailField
+                      className="col-span-2"
+                      icon={<RefreshCwIcon />}
+                      label={t('detail.fields.retryLineage')}
+                      value={
+                        task.attempt_number && task.attempt_number > 1
+                          ? t('detail.lineageAttempt', {
+                              attempt: task.attempt_number,
+                              parentTaskId: task.parent_task_id || '-',
+                            })
+                          : t('detail.lineageInitial')
+                      }
+                      mono
+                    />
+                  </div>
+
+                  {task.error_info?.action ? (
+                    <DetailSection title={t('detail.failureGuidance')}>
+                      <div className="rounded-xl border border-destructive/25 bg-destructive/5 p-3 text-sm text-foreground">
+                        <p className="font-medium">
+                          {task.error_info.code || 'TASK_FAILURE'}
+                        </p>
+                        <p className="mt-1 text-muted-foreground">
+                          {getTaskFailureGuidance(
+                            task.error_info,
+                            i18n.language,
+                          )}
+                        </p>
+                      </div>
+                    </DetailSection>
+                  ) : null}
 
                   {/* Worker Sub-Queue Pipeline Diagram (Type-Aware) */}
                   {(() => {
                     const steps = getTaskPipelineSteps(task, i18n.language)
 
                     return (
-                      <DetailSection title={i18n.language.startsWith('zh') ? '工序进度' : 'Pipeline Steps'}>
+                      <DetailSection title={t('detail.pipeline.title')}>
                         <div className="rounded-xl border bg-muted/20 p-3 text-xs">
                           <div className="grid gap-1.5">
                             {steps.map((st, i) => {
@@ -207,14 +266,41 @@ export function TaskDetailSheet({
                               const isRun = st.state === 'running'
                               const isFail = st.state === 'failed'
                               return (
-                                <div key={i} className="flex items-center justify-between rounded-lg border bg-background/60 px-3 py-2">
-                                  <span className="font-medium text-foreground">{i + 1}. {st.name}</span>
+                                <div
+                                  key={i}
+                                  className="flex items-center justify-between rounded-lg border bg-background/60 px-3 py-2"
+                                >
+                                  <span className="font-medium text-foreground">
+                                    {i + 1}. {st.name}
+                                  </span>
                                   <span className="flex items-center gap-2 text-[11px]">
                                     {st.count !== undefined && (
-                                      <span className="font-mono text-muted-foreground">{st.count} 项</span>
+                                      <span className="font-mono text-muted-foreground">
+                                        {t('detail.pipeline.itemCount', {
+                                          count: st.count,
+                                        })}
+                                      </span>
                                     )}
-                                    <span className={isDone ? 'text-foreground' : isFail ? 'text-destructive' : 'text-muted-foreground'}>
-                                      {isDone ? '已完成' : isRun ? '进行中' : isFail ? '失败' : '等待中'}
+                                    <span
+                                      className={
+                                        isDone
+                                          ? 'text-foreground'
+                                          : isFail
+                                            ? 'text-destructive'
+                                            : 'text-muted-foreground'
+                                      }
+                                    >
+                                      {t(
+                                        `detail.pipeline.status.${
+                                          isDone
+                                            ? 'completed'
+                                            : isRun
+                                              ? 'running'
+                                              : isFail
+                                                ? 'failed'
+                                                : 'pending'
+                                        }`,
+                                      )}
                                     </span>
                                   </span>
                                 </div>
@@ -226,99 +312,118 @@ export function TaskDetailSheet({
                     )
                   })()}
 
-                {/* Execution Log Section */}
-                <DetailSection title={i18n.language.startsWith('zh') ? '📜 任务执行日志' : 'Execution Trace Log'}>
-                  <div className="relative rounded-xl border border-border/60 bg-muted/30 p-3 font-mono text-[11px] leading-relaxed">
-                    <div className="flex items-center justify-between border-b border-border/40 pb-2 mb-2 text-[10px] text-muted-foreground font-mono">
-                      <span>LOG TRACE STREAM (ID: {task.task_id})</span>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        className="h-5 px-1.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-muted/60 cursor-pointer"
-                        onClick={() => {
-                          const logLines = generateStepLogs(task, i18n.language)
-                          navigator.clipboard.writeText(logLines.join('\n'))
-                          toast.success(i18n.language.startsWith('zh') ? '日志已成功复制到剪贴板' : 'Logs copied to clipboard')
-                        }}
-                      >
-                        <CopyIcon className="size-3 mr-1" />
-                        {i18n.language.startsWith('zh') ? '复制日志' : 'Copy Logs'}
-                      </Button>
+                  {/* Execution Log Section */}
+                  <DetailSection title={t('detail.trace.title')}>
+                    <div className="relative rounded-xl border border-border/60 bg-muted/30 p-3 font-mono text-[11px] leading-relaxed">
+                      <div className="flex items-center justify-between border-b border-border/40 pb-2 mb-2 text-[10px] text-muted-foreground font-mono">
+                        <span>
+                          {t('detail.trace.stream', { taskId: task.task_id })}
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="h-5 px-1.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-muted/60 cursor-pointer"
+                          onClick={() => {
+                            const logLines = generateStepLogs(
+                              task,
+                              i18n.language,
+                            )
+                            navigator.clipboard.writeText(logLines.join('\n'))
+                            toast.success(t('detail.trace.copied'))
+                          }}
+                        >
+                          <CopyIcon className="size-3 mr-1" />
+                          {t('detail.trace.copy')}
+                        </Button>
+                      </div>
+                      <div className="space-y-1 overflow-x-auto max-h-48">
+                        {generateStepLogs(task, i18n.language).map(
+                          (line, idx) => {
+                            const isErr =
+                              line.includes('[ERROR]') ||
+                              line.includes('[FATAL]')
+                            const isSucc = line.includes('[SUCCESS]')
+                            const isWarn = line.includes('[WARN]')
+                            return (
+                              <div
+                                key={idx}
+                                className={cn(
+                                  'whitespace-pre-wrap',
+                                  isErr
+                                    ? 'text-rose-600 dark:text-rose-400 font-medium'
+                                    : isSucc
+                                      ? 'text-cyan-600 dark:text-cyan-400 font-medium'
+                                      : isWarn
+                                        ? 'text-amber-600 dark:text-amber-400'
+                                        : 'text-muted-foreground',
+                                )}
+                              >
+                                {line}
+                              </div>
+                            )
+                          },
+                        )}
+                      </div>
                     </div>
-                    <div className="space-y-1 overflow-x-auto max-h-48">
-                      {generateStepLogs(task, i18n.language).map((line, idx) => {
-                        const isErr = line.includes('[ERROR]') || line.includes('[FATAL]')
-                        const isSucc = line.includes('[SUCCESS]')
-                        const isWarn = line.includes('[WARN]')
-                        return (
-                          <div key={idx} className={cn(
-                            'whitespace-pre-wrap',
-                            isErr ? 'text-rose-600 dark:text-rose-400 font-medium' : isSucc ? 'text-cyan-600 dark:text-cyan-400 font-medium' : isWarn ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground'
-                          )}>
-                            {line}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </div>
-                </DetailSection>
-
-                {task.error ? (
-                  <DetailSection title={t('detail.error')}>
-                    <p className="whitespace-pre-wrap rounded-xl border border-destructive/25 bg-destructive/5 p-4 font-mono text-xs leading-5 text-destructive">
-                      {task.error}
-                    </p>
                   </DetailSection>
-                ) : null}
 
-                {status === 'completed' ? (
-                  hasTaskResult(task.result) ? (
-                    <DetailSection title={t('detail.result')}>
-                      <pre className="min-h-[200px] max-h-[400px] overflow-auto rounded-xl border bg-muted/30 p-4 font-mono text-xs leading-5">
-                        {formatTaskResult(task.result)}
-                      </pre>
+                  {task.error ? (
+                    <DetailSection title={t('detail.error')}>
+                      <p className="whitespace-pre-wrap rounded-xl border border-destructive/25 bg-destructive/5 p-4 font-mono text-xs leading-5 text-destructive">
+                        {task.error}
+                      </p>
                     </DetailSection>
-                  ) : (
-                    <div className="flex items-start gap-3 rounded-xl border border-dashed bg-muted/10 p-4">
-                      <FileJson2Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  ) : null}
+
+                  {status === 'completed' ? (
+                    hasTaskResult(task.result) ? (
+                      <DetailSection title={t('detail.result')}>
+                        <pre className="min-h-[200px] max-h-[400px] overflow-auto rounded-xl border bg-muted/30 p-4 font-mono text-xs leading-5">
+                          {formatTaskResult(task.result)}
+                        </pre>
+                      </DetailSection>
+                    ) : (
+                      <div className="flex items-start gap-3 rounded-xl border border-dashed bg-muted/10 p-4">
+                        <FileJson2Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <div className="grid gap-0.5">
+                          <p className="text-sm font-medium">
+                            {t('detail.noResultCompleted')}
+                          </p>
+                          <p className="text-xs leading-5 text-muted-foreground">
+                            {t('detail.noResultCompletedDescription')}
+                          </p>
+                        </div>
+                      </div>
+                    )
+                  ) : status === 'running' ? (
+                    <div className="flex items-start gap-3 rounded-xl border border-sky-500/30 bg-sky-500/5 p-4">
+                      <LoaderCircleIcon className="mt-0.5 size-4 shrink-0 animate-spin text-sky-500" />
                       <div className="grid gap-0.5">
-                        <p className="text-sm font-medium">
-                          {t('detail.noResultCompleted')}
+                        <p className="text-sm font-medium text-sky-600 dark:text-sky-400">
+                          {t('detail.noResultRunning')}
                         </p>
                         <p className="text-xs leading-5 text-muted-foreground">
-                          {t('detail.noResultCompletedDescription')}
+                          {t('detail.noResultRunningDescription')}
                         </p>
                       </div>
                     </div>
-                  )
-                ) : status === 'running' ? (
-                  <div className="flex items-start gap-3 rounded-xl border border-sky-500/30 bg-sky-500/5 p-4">
-                    <LoaderCircleIcon className="mt-0.5 size-4 shrink-0 animate-spin text-sky-500" />
-                    <div className="grid gap-0.5">
-                      <p className="text-sm font-medium text-sky-600 dark:text-sky-400">
-                        {t('detail.noResultRunning')}
-                      </p>
-                      <p className="text-xs leading-5 text-muted-foreground">
-                        {t('detail.noResultRunningDescription')}
-                      </p>
+                  ) : status === 'pending' ? (
+                    <div className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
+                      <CircleDashedIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
+                      <div className="grid gap-0.5">
+                        <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                          {t('detail.noResultPending')}
+                        </p>
+                        <p className="text-xs leading-5 text-muted-foreground">
+                          {t('detail.noResultPendingDescription')}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                ) : status === 'pending' ? (
-                  <div className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
-                    <CircleDashedIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
-                    <div className="grid gap-0.5">
-                      <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
-                        {t('detail.noResultPending')}
-                      </p>
-                      <p className="text-xs leading-5 text-muted-foreground">
-                        {t('detail.noResultPendingDescription')}
-                      </p>
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            )
-          })() : null}
+                  ) : null}
+                </div>
+              )
+            })()
+          ) : null}
         </div>
       </SheetContent>
     </Sheet>
@@ -409,34 +514,56 @@ function generateStepLogs(task: TaskRecord, lang?: string): string[] {
   const createdAtStr = formatTaskTime(task, lang, 'created')
   const status = normalizeTaskStatus(task.status)
 
-  logs.push(`[${createdAtStr}] [INFO] [TaskPool] 任务已登记入队: ID=${task.task_id} Type=${task.task_type || 'generic'}`)
+  logs.push(
+    `[${createdAtStr}] [INFO] [TaskPool] 任务已登记入队: ID=${task.task_id} Type=${task.task_type || 'generic'}`,
+  )
   if (task.resource_id) {
-    logs.push(`[${createdAtStr}] [INFO] [ResourcePipeline] 关联物理资源路径: ${task.resource_id}`)
+    logs.push(
+      `[${createdAtStr}] [INFO] [ResourcePipeline] 关联物理资源路径: ${task.resource_id}`,
+    )
   }
 
   if (status === 'pending') {
-    logs.push(`[${createdAtStr}] [DEBUG] [WorkerThread] 任务就绪，正等待队列空闲分配 worker...`)
+    logs.push(
+      `[${createdAtStr}] [DEBUG] [WorkerThread] 任务就绪，正等待队列空闲分配 worker...`,
+    )
   } else if (status === 'running') {
-    logs.push(`[${createdAtStr}] [INFO] [WorkerThread-01] 已由可用 Worker 抢占分发，初始化解构环境`)
-    logs.push(`[${createdAtStr}] [INFO] [EmbeddingService] 物理向量索引计算落盘中...`)
+    logs.push(
+      `[${createdAtStr}] [INFO] [WorkerThread-01] 已由可用 Worker 抢占分发，初始化解构环境`,
+    )
+    logs.push(
+      `[${createdAtStr}] [INFO] [EmbeddingService] 物理向量索引计算落盘中...`,
+    )
   } else if (status === 'completed') {
-    logs.push(`[${createdAtStr}] [INFO] [WorkerThread-01] 物理工序 100% 结算完毕，校验物理一致性契约通过`)
+    logs.push(
+      `[${createdAtStr}] [INFO] [WorkerThread-01] 物理工序 100% 结算完毕，校验物理一致性契约通过`,
+    )
     if (task.result && typeof task.result === 'object') {
       const resObj = task.result as Record<string, any>
       if (resObj.reindexed_items) {
-        logs.push(`[${createdAtStr}] [SUCCESS] [ReindexWorker] 重置构建向量索引项: ${resObj.reindexed_items} 项`)
+        logs.push(
+          `[${createdAtStr}] [SUCCESS] [ReindexWorker] 重置构建向量索引项: ${resObj.reindexed_items} 项`,
+        )
       }
       if (resObj.processed) {
-        logs.push(`[${createdAtStr}] [SUCCESS] [DataProcessor] 文本分片处理完成: ${resObj.processed} 块`)
+        logs.push(
+          `[${createdAtStr}] [SUCCESS] [DataProcessor] 文本分片处理完成: ${resObj.processed} 块`,
+        )
       }
     }
-    logs.push(`[${createdAtStr}] [SUCCESS] 任务状态自愈闭环无缝更新为 [completed]`)
+    logs.push(
+      `[${createdAtStr}] [SUCCESS] 任务状态自愈闭环无缝更新为 [completed]`,
+    )
   } else if (status === 'failed') {
-    logs.push(`[${createdAtStr}] [ERROR] [WorkerThread-01] 工序处理触发异常中断`)
+    logs.push(
+      `[${createdAtStr}] [ERROR] [WorkerThread-01] 工序处理触发异常中断`,
+    )
     if (task.error) {
       logs.push(`[${createdAtStr}] [FATAL] Error Traceback: ${task.error}`)
     }
-    logs.push(`[${createdAtStr}] [WARN] 可随时点击 [重新入队/自愈] 触发自愈流水线二次重试`)
+    logs.push(
+      `[${createdAtStr}] [WARN] 可随时点击 [重新入队/自愈] 触发自愈流水线二次重试`,
+    )
   }
   return logs
 }

--- a/web-studio/src/routes/tasks/-lib/task-pipeline.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-pipeline.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTaskPipelineSteps } from './task-pipeline'
+
+describe('task pipeline helpers', () => {
+  it('handles a queue status without a Semantic entry', () => {
+    const steps = getTaskPipelineSteps({
+      result: {
+        queue_status: {
+          Embedding: { processed: 2 },
+        },
+      },
+      status: 'running',
+      task_type: 'resource_import',
+    })
+
+    expect(steps[1]?.count).toBeUndefined()
+    expect(steps[2]?.count).toBe(2)
+  })
+
+  it('handles a queue status without an Embedding entry', () => {
+    const steps = getTaskPipelineSteps({
+      result: {
+        queue_status: {
+          Semantic: { processed: 3 },
+        },
+      },
+      status: 'running',
+      task_type: 'resource_import',
+    })
+
+    expect(steps[1]?.count).toBe(3)
+    expect(steps[2]?.count).toBeUndefined()
+  })
+})

--- a/web-studio/src/routes/tasks/-lib/task-pipeline.ts
+++ b/web-studio/src/routes/tasks/-lib/task-pipeline.ts
@@ -12,13 +12,15 @@ export type PipelineGroup =
   | { type: 'serial'; step: PipelineStep }
   | { type: 'parallel'; steps: PipelineStep[] }
 
+type QueueStatus = Partial<
+  Record<string, { error_count?: number; processed?: number }>
+>
+
 function inferState(
   qKey: string | null,
   fallback: StepState,
   status: string | undefined,
-  qStatus:
-    | Record<string, { error_count?: number; processed?: number }>
-    | undefined,
+  qStatus: QueueStatus | undefined,
 ): StepState {
   if (status === 'pending') return 'pending'
   if (qKey && qStatus?.[qKey]) {
@@ -42,9 +44,7 @@ export function getTaskPipelineSteps(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as
-    | Record<string, { error_count?: number; processed?: number }>
-    | undefined
+  const qStatus = resObj.queue_status as QueueStatus | undefined
 
   if (type === 'session_commit') {
     return [
@@ -118,7 +118,7 @@ export function getTaskPipelineSteps(
         status,
         qStatus,
       ),
-      count: qStatus?.Semantic.processed,
+      count: qStatus?.Semantic?.processed,
     },
     {
       name: isZh ? '嵌入向量' : 'Vector Embedding',
@@ -128,7 +128,7 @@ export function getTaskPipelineSteps(
         status,
         qStatus,
       ),
-      count: qStatus?.Embedding.processed,
+      count: qStatus?.Embedding?.processed,
     },
   ]
 }
@@ -145,9 +145,7 @@ export function getTaskPipelineGroups(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as
-    | Record<string, { error_count?: number; processed?: number }>
-    | undefined
+  const qStatus = resObj.queue_status as QueueStatus | undefined
 
   if (type === 'session_commit') {
     return [

--- a/web-studio/src/routes/tasks/-lib/task-pipeline.ts
+++ b/web-studio/src/routes/tasks/-lib/task-pipeline.ts
@@ -16,7 +16,9 @@ function inferState(
   qKey: string | null,
   fallback: StepState,
   status: string | undefined,
-  qStatus: Record<string, { error_count?: number; processed?: number }> | undefined,
+  qStatus:
+    | Record<string, { error_count?: number; processed?: number }>
+    | undefined,
 ): StepState {
   if (status === 'pending') return 'pending'
   if (qKey && qStatus?.[qKey]) {
@@ -40,7 +42,9 @@ export function getTaskPipelineSteps(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as Record<string, { error_count?: number; processed?: number }> | undefined
+  const qStatus = resObj.queue_status as
+    | Record<string, { error_count?: number; processed?: number }>
+    | undefined
 
   if (type === 'session_commit') {
     return [
@@ -59,7 +63,12 @@ export function getTaskPipelineSteps(
       },
       {
         name: isZh ? '嵌入向量' : 'Vector Embedding',
-        state: inferState('Embedding', status === 'completed' ? 'completed' : (status as StepState), status, qStatus),
+        state: inferState(
+          'Embedding',
+          status === 'completed' ? 'completed' : (status as StepState),
+          status,
+          qStatus,
+        ),
         count: resObj.reindexed_items,
       },
     ]
@@ -69,9 +78,29 @@ export function getTaskPipelineSteps(
     const preState: StepState = status === 'pending' ? 'pending' : 'completed'
     return [
       { name: isZh ? '连接器鉴权' : 'Connector Auth', state: preState },
-      { name: isZh ? '资源拉取' : 'Resource Fetching', state: preState, count: resObj.downloaded_files },
-      { name: isZh ? '外部解析' : 'Document Parsing', state: inferState('Semantic', status === 'completed' ? 'completed' : (status as StepState), status, qStatus) },
-      { name: isZh ? '嵌入向量' : 'Vector Embedding', state: inferState('Embedding', status === 'completed' ? 'completed' : (status as StepState), status, qStatus) },
+      {
+        name: isZh ? '资源拉取' : 'Resource Fetching',
+        state: preState,
+        count: resObj.downloaded_files,
+      },
+      {
+        name: isZh ? '外部解析' : 'Document Parsing',
+        state: inferState(
+          'Semantic',
+          status === 'completed' ? 'completed' : (status as StepState),
+          status,
+          qStatus,
+        ),
+      },
+      {
+        name: isZh ? '嵌入向量' : 'Vector Embedding',
+        state: inferState(
+          'Embedding',
+          status === 'completed' ? 'completed' : (status as StepState),
+          status,
+          qStatus,
+        ),
+      },
     ]
   }
 
@@ -83,13 +112,23 @@ export function getTaskPipelineSteps(
     },
     {
       name: isZh ? '语义处理' : 'Semantic Processing',
-      state: inferState('Semantic', status === 'completed' ? 'completed' : (status as StepState), status, qStatus),
-      count: qStatus?.Semantic?.processed,
+      state: inferState(
+        'Semantic',
+        status === 'completed' ? 'completed' : (status as StepState),
+        status,
+        qStatus,
+      ),
+      count: qStatus?.Semantic.processed,
     },
     {
       name: isZh ? '嵌入向量' : 'Vector Embedding',
-      state: inferState('Embedding', status === 'completed' ? 'completed' : (status as StepState), status, qStatus),
-      count: qStatus?.Embedding?.processed,
+      state: inferState(
+        'Embedding',
+        status === 'completed' ? 'completed' : (status as StepState),
+        status,
+        qStatus,
+      ),
+      count: qStatus?.Embedding.processed,
     },
   ]
 }
@@ -106,7 +145,9 @@ export function getTaskPipelineGroups(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as Record<string, { error_count?: number; processed?: number }> | undefined
+  const qStatus = resObj.queue_status as
+    | Record<string, { error_count?: number; processed?: number }>
+    | undefined
 
   if (type === 'session_commit') {
     return [
@@ -122,19 +163,61 @@ export function getTaskPipelineGroups(
 
   if (type === 'admin_reindex' || type === 'snapshot_restore_reindex') {
     const purgeState: StepState = status === 'pending' ? 'pending' : 'completed'
-    const rebuildState = inferState('Embedding', status === 'completed' ? 'completed' : (status as StepState), status, qStatus)
+    const rebuildState = inferState(
+      'Embedding',
+      status === 'completed' ? 'completed' : (status as StepState),
+      status,
+      qStatus,
+    )
     return [
-      { type: 'serial', step: { name: isZh ? '外部解析' : 'Document Parsing', state: purgeState } },
-      { type: 'serial', step: { name: isZh ? '嵌入向量' : 'Vector Embedding', state: rebuildState } },
+      {
+        type: 'serial',
+        step: {
+          name: isZh ? '外部解析' : 'Document Parsing',
+          state: purgeState,
+        },
+      },
+      {
+        type: 'serial',
+        step: {
+          name: isZh ? '嵌入向量' : 'Vector Embedding',
+          state: rebuildState,
+        },
+      },
     ]
   }
 
   if (type === 'connector_import') {
     const preState: StepState = status === 'pending' ? 'pending' : 'completed'
-    const semState = inferState('Semantic', status === 'completed' ? 'completed' : status === 'running' ? 'running' : status === 'failed' ? 'failed' : 'pending', status, qStatus)
-    const embState = inferState('Embedding', status === 'completed' ? 'completed' : status === 'running' ? 'running' : status === 'failed' ? 'failed' : 'pending', status, qStatus)
+    const semState = inferState(
+      'Semantic',
+      status === 'completed'
+        ? 'completed'
+        : status === 'running'
+          ? 'running'
+          : status === 'failed'
+            ? 'failed'
+            : 'pending',
+      status,
+      qStatus,
+    )
+    const embState = inferState(
+      'Embedding',
+      status === 'completed'
+        ? 'completed'
+        : status === 'running'
+          ? 'running'
+          : status === 'failed'
+            ? 'failed'
+            : 'pending',
+      status,
+      qStatus,
+    )
     return [
-      { type: 'serial', step: { name: isZh ? '外部解析' : 'Document Parsing', state: preState } },
+      {
+        type: 'serial',
+        step: { name: isZh ? '外部解析' : 'Document Parsing', state: preState },
+      },
       {
         type: 'parallel',
         steps: [
@@ -147,10 +230,35 @@ export function getTaskPipelineGroups(
 
   // Default resource ingestion pipeline: 外部解析 -> (语义处理 + 嵌入向量)
   const parseState: StepState = status === 'pending' ? 'pending' : 'completed'
-  const semState = inferState('Semantic', status === 'completed' ? 'completed' : status === 'running' ? 'running' : status === 'failed' ? 'failed' : 'pending', status, qStatus)
-  const embState = inferState('Embedding', status === 'completed' ? 'completed' : status === 'running' ? 'running' : status === 'failed' ? 'failed' : 'pending', status, qStatus)
+  const semState = inferState(
+    'Semantic',
+    status === 'completed'
+      ? 'completed'
+      : status === 'running'
+        ? 'running'
+        : status === 'failed'
+          ? 'failed'
+          : 'pending',
+    status,
+    qStatus,
+  )
+  const embState = inferState(
+    'Embedding',
+    status === 'completed'
+      ? 'completed'
+      : status === 'running'
+        ? 'running'
+        : status === 'failed'
+          ? 'failed'
+          : 'pending',
+    status,
+    qStatus,
+  )
   return [
-    { type: 'serial', step: { name: isZh ? '外部解析' : 'Document Parsing', state: parseState } },
+    {
+      type: 'serial',
+      step: { name: isZh ? '外部解析' : 'Document Parsing', state: parseState },
+    },
     {
       type: 'parallel',
       steps: [

--- a/web-studio/src/routes/tasks/-lib/task-record.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-record.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getTaskFailureCode,
   getTaskFailureGuidance,
   hasTaskFailureGuidance,
   hasTaskResult,
@@ -43,6 +44,11 @@ describe('task record helpers', () => {
     expect(
       hasTaskFailureGuidance({ error_info: { code: 'AUTH_EXPIRED' } }),
     ).toBe(true)
+  })
+
+  it('uses a fallback failure code for legacy tasks', () => {
+    expect(getTaskFailureCode(undefined)).toBe('TASK_FAILURE')
+    expect(getTaskFailureCode({ code: 'AUTH_EXPIRED' })).toBe('AUTH_EXPIRED')
   })
 
   it('keeps backend guidance for unknown Chinese error codes', () => {

--- a/web-studio/src/routes/tasks/-lib/task-record.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-record.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getTaskFailureGuidance,
+  hasTaskFailureGuidance,
   hasTaskResult,
   isActiveTaskStatus,
   normalizeTaskRecord,
@@ -33,6 +35,23 @@ describe('task record helpers', () => {
     expect(hasTaskResult({})).toBe(false)
     expect(hasTaskResult([])).toBe(false)
     expect(hasTaskResult({ archive_uri: 'viking://archive' })).toBe(true)
+  })
+
+  it('shows failure guidance only when the task has a failure signal', () => {
+    expect(hasTaskFailureGuidance({ error_info: {} })).toBe(false)
+    expect(hasTaskFailureGuidance({ error: 'legacy failure' })).toBe(true)
+    expect(
+      hasTaskFailureGuidance({ error_info: { code: 'AUTH_EXPIRED' } }),
+    ).toBe(true)
+  })
+
+  it('keeps backend guidance for unknown Chinese error codes', () => {
+    expect(
+      getTaskFailureGuidance(
+        { action: 'Run the repair first.', code: 'NEW_FAILURE' },
+        'zh-CN',
+      ),
+    ).toBe('Run the repair first.')
   })
 
   it('recognizes task statuses that still require polling', () => {

--- a/web-studio/src/routes/tasks/-lib/task-record.ts
+++ b/web-studio/src/routes/tasks/-lib/task-record.ts
@@ -17,6 +17,8 @@ export type TaskRecord = TaskTimestamp & {
     retryability?: 'manual' | 'requires_change' | 'retryable'
   } | null
   operation_id?: string | null
+  owner_account_id?: string | null
+  owner_user_id?: string | null
   parent_task_id?: string | null
   attempt_number?: number
   resource_id?: string | null
@@ -81,6 +83,10 @@ export function hasTaskResult(result: unknown): boolean {
   return true
 }
 
+export function hasTaskFailureGuidance(task: TaskRecord): boolean {
+  return Boolean(task.error || task.error_info?.code || task.error_info?.action)
+}
+
 export function getTaskFailureGuidance(
   errorInfo: TaskRecord['error_info'],
   language: string,
@@ -99,5 +105,9 @@ export function getTaskFailureGuidance(
     SOURCE_MISSING: '原始来源已不存在。请恢复或替换来源后再重试。',
     TRANSIENT_UPSTREAM: '上游服务暂时繁忙或超时，可稍后重试。',
   }
-  return localized[errorInfo?.code || ''] || '请先查看失败详情并处理后再重试。'
+  return (
+    localized[errorInfo?.code || ''] ||
+    errorInfo?.action ||
+    '请先查看失败详情并处理后再重试。'
+  )
 }

--- a/web-studio/src/routes/tasks/-lib/task-record.ts
+++ b/web-studio/src/routes/tasks/-lib/task-record.ts
@@ -11,6 +11,14 @@ export type TaskStatus =
 
 export type TaskRecord = TaskTimestamp & {
   error?: string | null
+  error_info?: {
+    action?: string
+    code?: string
+    retryability?: 'manual' | 'requires_change' | 'retryable'
+  } | null
+  operation_id?: string | null
+  parent_task_id?: string | null
+  attempt_number?: number
   resource_id?: string | null
   result?: unknown
   stage?: string | null
@@ -71,4 +79,25 @@ export function hasTaskResult(result: unknown): boolean {
     return Object.keys(result).length > 0
   }
   return true
+}
+
+export function getTaskFailureGuidance(
+  errorInfo: TaskRecord['error_info'],
+  language: string,
+): string {
+  if (!language.startsWith('zh')) {
+    return errorInfo?.action || 'Review the error details before retrying.'
+  }
+
+  const localized: Record<string, string> = {
+    AUTH_EXPIRED:
+      '模型服务凭据已过期。请更新对应供应商的 API Key 或令牌、重启服务使配置生效后，再重试。',
+    ACCOUNT_OVERDUE: '模型服务商账户余额或账单异常。请处理后再重试。',
+    MEDIA_SPARSE_INPUT_UNSUPPORTED:
+      '稀疏向量仅支持文本输入。请先完成媒体文本提取或调整向量配置后再重试。',
+    INPUT_SHAPE_INVALID: '会话消息格式不正确。请修正输入后再重试。',
+    SOURCE_MISSING: '原始来源已不存在。请恢复或替换来源后再重试。',
+    TRANSIENT_UPSTREAM: '上游服务暂时繁忙或超时，可稍后重试。',
+  }
+  return localized[errorInfo?.code || ''] || '请先查看失败详情并处理后再重试。'
 }

--- a/web-studio/src/routes/tasks/-lib/task-record.ts
+++ b/web-studio/src/routes/tasks/-lib/task-record.ts
@@ -87,6 +87,12 @@ export function hasTaskFailureGuidance(task: TaskRecord): boolean {
   return Boolean(task.error || task.error_info?.code || task.error_info?.action)
 }
 
+export function getTaskFailureCode(
+  errorInfo: TaskRecord['error_info'],
+): string {
+  return errorInfo?.code || 'TASK_FAILURE'
+}
+
 export function getTaskFailureGuidance(
   errorInfo: TaskRecord['error_info'],
   language: string,

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -152,6 +152,8 @@ function TasksRoute() {
         `/api/v1/tasks/${encodeURIComponent(task.task_id)}/retry`,
         {
           acknowledge_change: retryAcknowledgementTaskId === task.task_id,
+          owner_account_id: task.owner_account_id,
+          owner_user_id: task.owner_user_id,
           restart_operation: restartOperationTaskId === task.task_id,
         },
       )

--- a/web-studio/src/routes/tasks/route.tsx
+++ b/web-studio/src/routes/tasks/route.tsx
@@ -44,12 +44,13 @@ import {
 } from '#/components/ui/table'
 import { useAppConnection } from '#/hooks/use-app-connection'
 import { ovClient } from '#/lib/ov-client'
-import { postResources } from '#/gen/ov-client'
-import { commitSession } from '#/lib/sessions/api'
 import { cn } from '#/lib/utils'
 import { QueueStatusCard } from '#/routes/monitoring/-components/queue-status-card'
 import { TaskDetailSheet } from '#/routes/tasks/-components/task-detail-sheet'
-import { normalizeTaskStatus } from '#/routes/tasks/-lib/task-record'
+import {
+  getTaskFailureGuidance,
+  normalizeTaskStatus,
+} from '#/routes/tasks/-lib/task-record'
 import type { TaskRecord } from '#/routes/tasks/-lib/task-record'
 import { formatTaskDuration, getTaskDate } from '#/routes/tasks/-lib/task-time'
 import { fetchTasks, getEffectiveTaskStatus, MAX_TASKS } from './-lib/task-list'
@@ -59,6 +60,22 @@ import { getTaskPipelineGroups } from './-lib/task-pipeline'
 export const Route = createFileRoute('/tasks')({
   component: TasksRoute,
 })
+
+type RetryTaskResult = {
+  action?: string
+  attempt_number?: number
+  disposition:
+    | 'accepted'
+    | 'already_running'
+    | 'blocked'
+    | 'no_action'
+    | 'operation_resolved'
+    | 'retry_limit_reached'
+  error?: TaskRecord['error_info']
+  max_attempts?: number
+  resolution?: 'archive_complete'
+  task_id?: string
+}
 
 const DEFAULT_PAGE_SIZE = 20
 const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
@@ -94,6 +111,11 @@ function TasksRoute() {
   const [selectedTaskId, setSelectedTaskId] = React.useState<string | null>(
     null,
   )
+  const [retryAcknowledgementTaskId, setRetryAcknowledgementTaskId] =
+    React.useState<string | null>(null)
+  const [restartOperationTaskId, setRestartOperationTaskId] = React.useState<
+    string | null
+  >(null)
   const tasksQuery = useQuery({
     queryFn: () => fetchTasks(taskType, statusFilter),
     queryKey: ['tasks', identityScopeKey, taskType, statusFilter],
@@ -120,86 +142,70 @@ function TasksRoute() {
   const retryMutation = useMutation({
     mutationFn: async (task: TaskRecord) => {
       if (task.task_id?.startsWith('mock_task_')) {
-        return { res: { ok: true }, task }
+        return {
+          disposition: 'accepted',
+          task_id: task.task_id,
+        } as RetryTaskResult
       }
-      if (!task.resource_id) {
-        throw new Error(
-          i18n.language.startsWith('zh')
-            ? '任务缺少关联资源 ID，无法重新入队'
-            : 'Missing resource ID for task',
-        )
-      }
-
-      // ── 1. task_type 精确匹配优先（不受 URI 前缀干扰）──────────────────────
-      if (task.task_type === 'session_commit') {
-        const res = await commitSession(task.resource_id)
-        const resAny = res as any
-        if (resAny?.result?.reason === 'no_messages' || resAny?.reason === 'no_messages') {
-          toast.info(
-            i18n.language.startsWith('zh')
-              ? '该会话无未提交消息，已无需重复入队'
-              : 'Session has no pending uncommitted messages',
-          )
-        }
-        return { res, task }
-      }
-      const resourceUri = task.resource_id || ''
-
-      if (resourceUri.startsWith('viking://')) {
-        const resp = await ovClient.instance.post('/api/v1/content/reindex', {
-          uri: resourceUri,
-          wait: false,
-        })
-        const json = resp.data
-        if (json.status === 'error' || json.error) {
-          throw new Error(
-            json.error?.message ||
-              json.message ||
-              (i18n.language.startsWith('zh')
-                ? '重新入队失败'
-                : 'Re-queue failed'),
-          )
-        }
-        return { res: json, task }
-      }
-
-      if (
-        resourceUri.startsWith('http://') ||
-        resourceUri.startsWith('https://')
-      ) {
-        const res = await postResources({
-          body: {
-            url: resourceUri,
-            reason: `Re-queued task: ${task.task_id}`,
-          } as any,
-        })
-        return { res, task }
-      }
-
-      const resp = await ovClient.instance.post('/api/v1/content/reindex', {
-        uri: resourceUri,
-        wait: false,
-      })
+      if (!task.task_id) throw new Error(t('retryFlow.taskIdRequired'))
+      const resp = await ovClient.instance.post(
+        `/api/v1/tasks/${encodeURIComponent(task.task_id)}/retry`,
+        {
+          acknowledge_change: retryAcknowledgementTaskId === task.task_id,
+          restart_operation: restartOperationTaskId === task.task_id,
+        },
+      )
       const json = resp.data
       if (json.status === 'error' || json.error) {
         throw new Error(
-          json.error?.message ||
-            json.message ||
-            (i18n.language.startsWith('zh')
-              ? '重新入队失败'
-              : 'Re-queue failed'),
+          json.error?.message || json.message || t('retryFlow.requeueFailed'),
         )
       }
-      return { res: json, task }
+      return (json.result || json) as RetryTaskResult
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : String(error))
     },
-    onSuccess: async () => {
+    onSuccess: async (result, task) => {
+      if (result.disposition === 'operation_resolved') {
+        toast.info(
+          result.resolution === 'archive_complete'
+            ? t('retryFlow.archiveComplete')
+            : t('retryFlow.resolvedByTask', {
+                taskId: result.task_id || '-',
+              }),
+        )
+        await queryClient.invalidateQueries({ queryKey: ['tasks'] })
+        return
+      }
+      if (result.disposition === 'blocked') {
+        setRetryAcknowledgementTaskId(task.task_id || null)
+        toast.warning(
+          t('retryFlow.blocked', {
+            guidance: getTaskFailureGuidance(result.error, i18n.language),
+          }),
+        )
+        return
+      }
+      if (result.disposition === 'retry_limit_reached') {
+        setRestartOperationTaskId(task.task_id || null)
+        toast.warning(
+          t('retryFlow.retryLimit', {
+            maxAttempts: result.max_attempts || 3,
+          }),
+        )
+        return
+      }
+      if (result.disposition === 'no_action') {
+        toast.info(t('retryFlow.noAction'))
+        return
+      }
+      setRetryAcknowledgementTaskId(null)
+      setRestartOperationTaskId(null)
       toast.success(
-        i18n.language.startsWith('zh')
-          ? '重新入队请求已发送，后端正在处理新任务！'
-          : 'Re-queue request submitted successfully!',
+        result.disposition === 'already_running'
+          ? t('retryFlow.alreadyRunning')
+          : t('retryFlow.accepted'),
       )
       await queryClient.invalidateQueries({ queryKey: ['tasks'] })
     },
@@ -230,7 +236,10 @@ function TasksRoute() {
     if (status === 'pending') return 0
 
     // Extract real queue metrics from task.result
-    const resObj = (task.result && typeof task.result === 'object') ? (task.result as Record<string, any>) : {}
+    const resObj =
+      task.result && typeof task.result === 'object'
+        ? (task.result as Record<string, any>)
+        : {}
     const qStatus = resObj.queue_status
     const embeddingProcessed = qStatus?.Embedding?.processed
     const semanticProcessed = qStatus?.Semantic?.processed
@@ -239,14 +248,14 @@ function TasksRoute() {
       const totalEmbedding = 20
       const embedRatio = Math.min(1, embeddingProcessed / totalEmbedding)
       // Step 1 (20%) + Step 2 (30%) + Step 3 (50% * embedRatio)
-      return Math.round(20 + 30 + (50 * embedRatio))
+      return Math.round(20 + 30 + 50 * embedRatio)
     }
 
     if (typeof semanticProcessed === 'number') {
       const totalSemantic = 5
       const semRatio = Math.min(1, semanticProcessed / totalSemantic)
       // Step 1 (20%) + Step 2 (30% * semRatio)
-      return Math.round(20 + (30 * semRatio))
+      return Math.round(20 + 30 * semRatio)
     }
 
     const stage = task.stage?.toLowerCase()
@@ -258,7 +267,8 @@ function TasksRoute() {
 
   const getTaskTotalSteps = (taskType?: string): number => {
     if (taskType === 'session_commit') return 1
-    if (taskType === 'admin_reindex' || taskType === 'snapshot_restore_reindex') return 2
+    if (taskType === 'admin_reindex' || taskType === 'snapshot_restore_reindex')
+      return 2
     if (taskType === 'connector_import') return 4
     return 3
   }
@@ -269,7 +279,8 @@ function TasksRoute() {
     const effStatus = getEffectiveTaskStatus(task, allTasks)
     const status = normalizeTaskStatus(effStatus)
     const pct = getTaskProgressPct(task)
-    const isRetrying = retryMutation.isPending && retryMutation.variables.task_id === taskId
+    const isRetrying =
+      retryMutation.isPending && retryMutation.variables.task_id === taskId
     const Icon =
       status === 'completed'
         ? CheckCircle2Icon
@@ -298,21 +309,17 @@ function TasksRoute() {
           }
         />
         <span>
-          {status === 'pending'
-            ? (i18n.language.startsWith('zh') ? '队首等待中' : 'Queued')
-            : t(`status.${status}`)}
+          {status === 'pending' ? t('status.queued') : t(`status.${status}`)}
         </span>
         {status === 'running' && (
-          <span className="font-mono font-semibold ml-0.5">
-            {pct}%
-          </span>
+          <span className="font-mono font-semibold ml-0.5">{pct}%</span>
         )}
         {status === 'failed' && (
           <button
             type="button"
             disabled={isRetrying}
             className="ml-1 inline-flex items-center justify-center rounded p-0.5 hover:bg-white/25 active:scale-95 transition-all cursor-pointer text-destructive-foreground disabled:opacity-50"
-            title={i18n.language.startsWith('zh') ? '重新发起任务' : 'Re-trigger Task'}
+            title={t('actions.retry')}
             onClick={(e) => {
               e.stopPropagation()
               retryMutation.mutate(task)
@@ -352,13 +359,20 @@ function TasksRoute() {
           return (
             <React.Fragment key={i}>
               {i > 0 && (
-                <span title="串行工序流转" className="inline-flex shrink-0">
+                <span
+                  title={t('pipeline.serialTransition')}
+                  className="inline-flex shrink-0"
+                >
                   <ChevronRightIcon className="size-3 text-muted-foreground/40" />
                 </span>
               )}
               <span
                 className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium leading-none shrink-0 border border-border/60 bg-secondary/80 text-foreground shadow-2xs transition-all"
-                title={grp.type === 'parallel' ? '并发执行工序批次' : '串行工序批次'}
+                title={t(
+                  grp.type === 'parallel'
+                    ? 'pipeline.parallelBatch'
+                    : 'pipeline.serialBatch',
+                )}
               >
                 {stepsInGroup.map((st: StepItem, j: number) => {
                   const isDone = st.state === 'completed'
@@ -371,10 +385,18 @@ function TasksRoute() {
                       key={j}
                       className="inline-flex items-center gap-1 shrink-0 transition-colors text-foreground/90 font-medium"
                     >
-                      {isDone && <CheckIcon className="size-3 text-foreground/75 shrink-0" />}
-                      {isRun && <LoaderCircleIcon className="size-3 text-foreground/75 animate-spin shrink-0" />}
-                      {isPend && <CircleDashedIcon className="size-3 text-foreground/75 shrink-0" />}
-                      {isFail && <XIcon className="size-3 text-foreground/75 shrink-0" />}
+                      {isDone && (
+                        <CheckIcon className="size-3 text-foreground/75 shrink-0" />
+                      )}
+                      {isRun && (
+                        <LoaderCircleIcon className="size-3 text-foreground/75 animate-spin shrink-0" />
+                      )}
+                      {isPend && (
+                        <CircleDashedIcon className="size-3 text-foreground/75 shrink-0" />
+                      )}
+                      {isFail && (
+                        <XIcon className="size-3 text-foreground/75 shrink-0" />
+                      )}
                       <span>{st.name}</span>
                     </span>
                   )
@@ -538,7 +560,9 @@ function TasksRoute() {
 
     const baseTypeRows = Object.entries(typeCounts)
       .map(([typeKey, count]) => {
-        const matchingTasks = allTasks.filter((taskItem) => taskItem.task_type === typeKey)
+        const matchingTasks = allTasks.filter(
+          (taskItem) => taskItem.task_type === typeKey,
+        )
         const processing = matchingTasks.filter(
           (taskItem) => normalizeTaskStatus(taskItem.status) === 'running',
         ).length
@@ -566,7 +590,10 @@ function TasksRoute() {
       ...baseTypeRows,
       {
         name: 'TOTAL',
-        processing: baseTypeRows.reduce((sum, item) => sum + item.processing, 0),
+        processing: baseTypeRows.reduce(
+          (sum, item) => sum + item.processing,
+          0,
+        ),
         pending: baseTypeRows.reduce((sum, item) => sum + item.pending, 0),
         completed: baseTypeRows.reduce((sum, item) => sum + item.completed, 0),
         errors: baseTypeRows.reduce((sum, item) => sum + item.errors, 0),
@@ -697,7 +724,11 @@ function TasksRoute() {
         {/* 左侧 (50% 宽度 - 优先看上层任务): 任务队列状态 (Task Queues) */}
         <div>
           <QueueStatusCard
-            title={i18n.language.startsWith('zh') ? '任务队列状态' : 'Task Queue Status'}
+            title={
+              i18n.language.startsWith('zh')
+                ? '任务队列状态'
+                : 'Task Queue Status'
+            }
             customRows={kpiData.typeRows}
             isHealthy={kpiData.failed === 0}
           />
@@ -706,7 +737,11 @@ function TasksRoute() {
         {/* 右侧 (50% 宽度 - 拆分出的下层工序): 工序队列状态 (Process Queues) */}
         <div>
           <QueueStatusCard
-            title={i18n.language.startsWith('zh') ? '工序队列状态' : 'Process Queue Status'}
+            title={
+              i18n.language.startsWith('zh')
+                ? '工序队列状态'
+                : 'Process Queue Status'
+            }
             customRows={queueRows}
             isHealthy={kpiData.failed === 0}
           />
@@ -794,13 +829,11 @@ function TasksRoute() {
           onClick={() => setDedupByResource((prev) => !prev)}
         >
           <LayersIcon className="size-3.5 text-muted-foreground" />
-          {i18n.language.startsWith('zh')
-            ? dedupByResource
-              ? '按资源收敛 (最新)'
-              : '逐条任务'
-            : dedupByResource
-              ? 'Latest per Resource'
-              : 'Individual Tasks'}
+          {t(
+            dedupByResource
+              ? 'historyMode.latestPerResource'
+              : 'historyMode.all',
+          )}
         </Button>
       </div>
 
@@ -850,9 +883,9 @@ function TasksRoute() {
                   <TableHead>{t('table.task')}</TableHead>
                   <TableHead>{t('table.type')}</TableHead>
                   <TableHead>{t('table.resource')}</TableHead>
-                  <TableHead>{i18n.language.startsWith('zh') ? '工序队列流转' : 'Queue Pipeline'}</TableHead>
+                  <TableHead>{t('table.pipeline')}</TableHead>
                   <TableHead>{t('table.status')}</TableHead>
-                  <TableHead>{i18n.language.startsWith('zh') ? '耗时' : 'Duration'}</TableHead>
+                  <TableHead>{t('table.duration')}</TableHead>
                   <TableHead className="text-right">
                     {t('table.createdAt')}
                   </TableHead>
@@ -890,6 +923,13 @@ function TasksRoute() {
                           <code className="min-w-0 truncate text-xs">
                             {taskId || `#${pageOffset + index + 1}`}
                           </code>
+                          {task.attempt_number && task.attempt_number > 1 ? (
+                            <span className="shrink-0 text-xs text-muted-foreground">
+                              {t('attemptLabel', {
+                                attempt: task.attempt_number,
+                              })}
+                            </span>
+                          ) : null}
                           {taskId ? (
                             <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
                           ) : null}
@@ -908,7 +948,10 @@ function TasksRoute() {
                       <TableCell>{renderQueuePipeline(task)}</TableCell>
                       <TableCell>{renderStatus(task)}</TableCell>
                       <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-                        {formatTaskDuration(task, i18n.language.startsWith('zh'))}
+                        {formatTaskDuration(
+                          task,
+                          i18n.language.startsWith('zh'),
+                        )}
                       </TableCell>
                       <TableCell className="whitespace-nowrap text-right text-muted-foreground">
                         {formatTime(task)}


### PR DESCRIPTION
## 说明

本 PR 为 Studio 增加失败任务的安全重试流程。界面调用受控重试接口，根据当前语言显示阻断原因，并展示重试链路。重试提交成功后，页面会原地刷新当前筛选结果，不会自动打开任务详情。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue 与 PR

Fixes #2356

依赖 #4295。

参考现有 PR #3340。

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [x] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [ ] 测试更新

## 主要变更

- 使用受控任务重试接口，替换原先直接调用会话提交和资源重建索引的方式。
- 正确处理阻断、已解决、已有任务运行、无需操作和达到尝试上限等返回结果，避免重复创建任务。
- 在任务界面显示尝试链路、失败处理建议、工序进度、执行耗时和运行详情。
- 重试提交成功后保留在任务列表页面，并原地刷新当前筛选结果。

## 测试

- [ ] 已添加能够验证修复或功能的测试
- [x] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

50 个测试文件、192 项测试全部通过。Studio 生产构建、Prettier 检查和针对性 ESLint 检查也已通过。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [x] 已为较难理解的代码补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [ ] 依赖变更已经合并并发布

## 截图

未提供。

## 补充说明

在后端依赖合并前，本 PR 保持 Draft。当前分支包含后端提交；#4295 合并后，本 PR 的差异会只剩 Studio 相关修改。
