### PR TITLE
fix(docker): 从当前源码重新生成 Studio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ __pycache__
 htmlcov
 web-studio/node_modules
 web-studio/dist
+openviking/web_studio/dist
 web-studio/.vite
 node_modules
 *.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Local development artifacts are not needed by the runtime image and make the
+# build context unnecessarily large.
+.git
+.venv
+__pycache__
+*.py[cod]
+.pytest_cache
+.coverage
+htmlcov
+web-studio/node_modules
+web-studio/dist
+web-studio/.vite
+node_modules
+*.log
+*.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/root/.ccache,id=ccache-${TARGETPLATFORM} \
+    # The source checkout may contain a previously generated Studio bundle.
+    # Remove it so setup.py rebuilds the SPA from the current TypeScript source
+    # instead of silently packaging stale browser code into the image.
+    rm -rf openviking/web_studio/dist; \
     if [ -n "${OPENVIKING_VERSION:-}" ]; then \
         export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING="${OPENVIKING_VERSION}"; \
     elif [ -f openviking/_version.py ]; then \
@@ -76,13 +80,13 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
     fi; \
     case "${UV_LOCK_STRATEGY}" in \
         locked) \
-            uv sync --locked --no-editable --extra bot --extra gemini \
+            uv sync --locked --no-editable --reinstall-package openviking --extra bot --extra gemini \
             ;; \
         auto) \
             if ! uv lock --check; then \
                 uv lock; \
             fi; \
-            uv sync --locked --no-editable --extra bot --extra gemini \
+            uv sync --locked --no-editable --reinstall-package openviking --extra bot --extra gemini \
             ;; \
         *) \
             echo "Unsupported UV_LOCK_STRATEGY: ${UV_LOCK_STRATEGY}" >&2; \
@@ -107,6 +111,7 @@ COPY --from=py-builder /app/.venv /app/.venv
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health
 RUN mkdir -p /app/.openviking \
+ && sed -i 's/\r$//' /usr/local/bin/openviking-entrypoint /usr/local/bin/openviking-pending-health \
  && chmod +x /usr/local/bin/openviking-entrypoint /usr/local/bin/openviking-pending-health
 ENV HOME="/app" \
     PATH="/app/.venv/bin:$PATH" \


### PR DESCRIPTION
## 说明

本 PR 修复 Docker 镜像构建流程。镜像会从当前源码安装 OpenViking，并重新生成 Studio bundle，不再复用源码包中可能已经过期的 `dist` 目录。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue

未发现可由本 PR 完整解决的开放 Issue。

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [ ] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [ ] 测试更新

## 主要变更

- 同步依赖前删除已有的 Studio bundle，并强制重新安装当前源码中的 OpenViking 包。
- 统一运行时入口脚本和健康检查脚本的换行格式。
- 新增 `.dockerignore`，排除仓库元数据、本地虚拟环境、缓存和前端生成文件。

## 测试

- [ ] 已添加能够验证修复或功能的测试
- [ ] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [x] Linux
  - [ ] macOS
  - [x] Windows

已在 Windows Docker Desktop 上完成 Linux 镜像的完整构建。随后使用一次性测试容器确认：安装后的包包含重新生成的 Studio `index.html`，两个运行时脚本均存在，并且已经移除 CRLF 换行。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [ ] 已为较难理解的代码补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布

## 截图

不适用。

## 补充说明

无
