### PR TITLE
fix(memory): index generated directory overviews

### DIFF
--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -1666,6 +1666,16 @@ class MemoryUpdater:
                 ctx=ctx,
                 lease_ref=lease_ref,
             )
+            from openviking.utils.embedding_utils import vectorize_directory_meta
+
+            await vectorize_directory_meta(
+                uri=directory,
+                abstract="",
+                overview=rendered,
+                context_type="memory",
+                ctx=ctx,
+                include_abstract=False,
+            )
             return True
         except Exception as e:
             tracer.error(f"Failed to write overview {overview_path}: {e}")

--- a/tests/session/memory/test_memory_updater.py
+++ b/tests/session/memory/test_memory_updater.py
@@ -317,7 +317,27 @@ class TestMemoryUpdater:
         updater._get_viking_fs = MagicMock(return_value=viking_fs)
         ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
 
-        await updater.generate_overview("events", directory, ctx, extract_context=None)
+        with patch(
+            "openviking.utils.embedding_utils.vectorize_directory_meta",
+            new_callable=AsyncMock,
+        ) as vectorize_directory_meta:
+            generated = await updater.generate_overview(
+                "events", directory, ctx, extract_context=None
+            )
+
+        assert generated is True
+        vectorize_directory_meta.assert_awaited_once_with(
+            uri=directory,
+            abstract="",
+            overview=(
+                "# Events Overview\n\n"
+                "- [kept event](./kept_event.md)\n\n"
+                "- [plain_event.md](./plain_event.md)"
+            ),
+            context_type="memory",
+            ctx=ctx,
+            include_abstract=False,
+        )
 
         document = parse_abstract_overview(viking_fs.store[overview_uri])
         assert document.metadata["generated_by"] == {
@@ -373,8 +393,16 @@ class TestMemoryUpdater:
         updater._get_viking_fs = MagicMock(return_value=viking_fs)
         ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
 
-        await updater.generate_overview("entities", entity_dir, ctx, extract_context=None)
-        await updater.generate_overview("preferences", preference_dir, ctx, extract_context=None)
+        with patch(
+            "openviking.utils.embedding_utils.vectorize_directory_meta",
+            new_callable=AsyncMock,
+        ) as vectorize_directory_meta:
+            await updater.generate_overview("entities", entity_dir, ctx, extract_context=None)
+            await updater.generate_overview(
+                "preferences", preference_dir, ctx, extract_context=None
+            )
+
+        assert vectorize_directory_meta.await_count == 2
 
         assert "**Category:** 动漫角色" in viking_fs.store[entity_overview_uri]
         assert "- [越前龙马.md](./越前龙马.md)" in viking_fs.store[entity_overview_uri]


### PR DESCRIPTION
## Description

Ensure generated memory `.overview.md` sidecars are also queued as L1 directory metadata. The updater now reuses the existing `vectorize_directory_meta` path immediately after persisting an overview, without creating an extra L0 abstract record.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4280

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Queue the rendered directory overview as memory L1 metadata after the sidecar is written.
- Avoid generating an L0 abstract record for memory subdirectories.
- Assert the vectorization contract in the existing overview tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Focused validation:

- `pytest -q --no-cov tests/session/memory/test_memory_updater.py -k generate_overview` (3 passed)
- `ruff check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py`
- `ruff format --check openviking/session/memory/memory_updater.py tests/session/memory/test_memory_updater.py`

The complete test module reached 23 passing tests; 10 unrelated tests could not initialize because this local environment has no `OPENVIKING_CONFIG_FILE`.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No public API, configuration, dependency, or schema changes.