### PR TITLE
fix(docker): 显式构建并校验 Studio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,12 @@
 __pycache__
 *.py[cod]
 .pytest_cache
+.ruff_cache
 .coverage
 htmlcov
+target/
+src/build/
+docs/.vitepress/dist/
 web-studio/node_modules
 web-studio/dist
 openviking/web_studio/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,24 @@
 # ragfs-python's default S3-enabled dependency set currently requires rustc >= 1.91.1.
 FROM rust:1.91.1-trixie AS rust-toolchain
 
-# Stage 2: build Python environment with uv (builds Rust CLI + C++ extension + web-studio from source)
+# Stage 2: build Studio separately so npm failures stop the Docker build.
+FROM node:24-trixie-slim AS web-studio-builder
+ARG TARGETPLATFORM
+WORKDIR /app/web-studio
+
+# Keep npm install cached when only Studio sources change.
+COPY web-studio/package.json web-studio/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm,id=npm-${TARGETPLATFORM} npm ci
+COPY web-studio/ ./
+RUN npm run build -- --base=/studio/ \
+ && test -f dist/index.html
+
+# Stage 3: build Python environment with uv (builds Rust CLI + C++ extension)
 FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS py-builder
 
 # Reuse Rust toolchain from stage 1 so setup.py can compile ov CLI in-place.
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
-# Provide Node.js so setup.py build_py can build web-studio SPA in-tree.
-COPY --from=node:24-trixie-slim /usr/local/bin/node /usr/local/bin/
-COPY --from=node:24-trixie-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
-RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
- && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="/app/.venv/bin:/usr/local/cargo/bin:${PATH}"
@@ -50,26 +57,21 @@ COPY build_support/ build_support/
 COPY bot/ bot/
 COPY crates/ crates/
 COPY openviking/ openviking/
+COPY --from=web-studio-builder /app/web-studio/dist/ openviking/web_studio/dist/
 COPY openviking_cli/ openviking_cli/
 COPY src/ src/
 COPY third_party/ third_party/
-COPY web-studio/ web-studio/
 
-# Install project and dependencies (triggers setup.py build_py → web-studio
-# SPA build + build_ext → native extensions).
+# Install project and dependencies. setup.py packages the copied Studio bundle
+# without running npm again, while build_ext still builds native extensions.
 # Default to auto-refreshing uv.lock inside the ephemeral build context when it is
 # stale, so Docker builds stay unblocked after dependency changes. Set
 # UV_LOCK_STRATEGY=locked to keep fail-fast reproducibility checks.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
-    --mount=type=cache,target=/root/.npm,id=npm-${TARGETPLATFORM} \
     --mount=type=cache,target=/cargo-target,id=cargo-target-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM} \
     --mount=type=cache,target=/root/.ccache,id=ccache-${TARGETPLATFORM} \
-    # The source checkout may contain a previously generated Studio bundle.
-    # Remove it so setup.py rebuilds the SPA from the current TypeScript source
-    # instead of silently packaging stale browser code into the image.
-    rm -rf openviking/web_studio/dist; \
     if [ -n "${OPENVIKING_VERSION:-}" ]; then \
         export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENVIKING="${OPENVIKING_VERSION}"; \
     elif [ -f openviking/_version.py ]; then \
@@ -92,9 +94,10 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
             echo "Unsupported UV_LOCK_STRATEGY: ${UV_LOCK_STRATEGY}" >&2; \
             exit 2 \
             ;; \
-    esac
+    esac && \
+    python -c "from importlib.resources import files; p = files('openviking.web_studio').joinpath('dist/index.html'); assert p.is_file(), f'missing Studio bundle: {p}'"
 
-# Stage 3: runtime
+# Stage 4: runtime
 FROM python:3.13-slim-trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## 说明

PR #4299 已让 Docker 镜像从当前源码重新生成 Studio，但 Studio 仍由 setup.py 的 build_py 钩子隐式构建。该钩子在 npm 或 Vite 失败时只打印 warning，镜像仍可能构建成功并缺少 /studio。

本 PR 将 Docker 中的 Studio 构建改为独立 Node stage。前端构建失败会直接终止 Docker build，Python builder 只打包已经通过校验的 bundle。setup.py 在普通 pip 安装时的降级行为保持不变。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue

本 PR 补充 @yufeng201 在 https://github.com/volcengine/OpenViking/pull/4299#issuecomment-5404541782 中提出的构建建议
## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [ ] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [ ] 测试更新

## 主要变更

- 使用独立 Node stage 运行 npm ci 和 Studio 生产构建；依赖文件与前端源码分层复制。
- 将生成的 dist 复制到 Python package tree，并在 uv sync 后检查安装包内的 index.html。
- Python builder 不再安装 Node 或复制 Studio 源码；保留 --reinstall-package openviking，避免持久化 uv 缓存复用旧 wheel。
- 在 .dockerignore 中补充 Rust、C++、Ruff 和 Vite 的本地构建目录。

## 测试

- [ ] 已添加能够验证修复或功能的测试
- [ ] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [x] Linux
  - [ ] macOS
  - [x] Windows

在 Windows Docker Desktop 上完成 Linux/amd64 镜像的完整构建：

    docker build --progress=plain \
      --build-arg OPENVIKING_VERSION=0.0.0+pr4299followup \
      --build-arg UV_LOCK_STRATEGY=locked \
      -t openviking-pr4299-followup:test .

验证结果：

- Dockerfile 静态检查通过，没有 lint warning。
- 完整镜像构建成功，包含 Rust CLI、C++ 扩展、Python wheel 和 Studio bundle。
- 最终镜像中的 index.html 位于已安装包内，并使用 /studio/ 基础路径。
- runtime 镜像中没有 Node 或 npm。
- 相同参数再次构建时，全部 Docker layers 命中缓存。
- 基于最新 main 重建。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [x] 已为较难理解的构建步骤补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布（本 PR 未修改依赖）

## 截图

不适用。

## 补充说明

本 PR 不把 setup.py 改成全局 fail-fast。普通 pip 安装环境仍可在没有 Node 时跳过 Studio；Docker 镜像则把 Studio 作为必需产物。