### PR TITLE
fix(sdk): align batch writes with server mode

### DIFF
--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -637,6 +637,18 @@ func TestBatchWriteAndDownloadBytes(t *testing.T) {
 			if body["root_uri"] != "viking://resources/project" || body["future_flag"] != float64(0) {
 				t.Fatalf("body = %#v", body)
 			}
+			operations, ok := body["operations"].([]any)
+			if !ok || len(operations) != 1 {
+				t.Fatalf("operations = %#v", body["operations"])
+			}
+			operation, ok := operations[0].(map[string]any)
+			if !ok || !reflect.DeepEqual(operation, map[string]any{
+				"uri":     "viking://resources/project/a.txt",
+				"content": "hello",
+				"mode":    "upsert",
+			}) {
+				t.Fatalf("operation = %#v", operations[0])
+			}
 			writeOK(t, w, map[string]any{"updated": 1})
 		case "GET /api/v1/content/download":
 			if r.URL.Query().Get("uri") != "viking://resources/project/a.txt" {
@@ -653,9 +665,7 @@ func TestBatchWriteAndDownloadBytes(t *testing.T) {
 		{
 			URI:     "resources/project/a.txt",
 			Content: String("hello"),
-			Precondition: BatchWritePrecondition{
-				Kind: "create_if_absent",
-			},
+			Mode:    "upsert",
 		},
 	}, &BatchWriteOptions{Extra: map[string]any{"future_flag": 0}}); err != nil {
 		t.Fatal(err)

--- a/sdk/go/filesystem.go
+++ b/sdk/go/filesystem.go
@@ -208,7 +208,7 @@ func (c *Client) Write(ctx context.Context, uri string, content string, opts *Wr
 	return result, err
 }
 
-// BatchWrite applies preconditioned file writes in one request.
+// BatchWrite applies file writes in one request and refreshes their indexes once.
 func (c *Client) BatchWrite(
 	ctx context.Context,
 	rootURI string,

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -186,18 +186,12 @@ type WriteOptions struct {
 	Extra          map[string]any
 }
 
-// BatchWritePrecondition protects one batch write operation.
-type BatchWritePrecondition struct {
-	Kind     string  `json:"kind"`
-	BaseHash *string `json:"base_hash,omitempty"`
-}
-
-// BatchWriteOperation is one preconditioned file write.
+// BatchWriteOperation is one file write in a batch.
 type BatchWriteOperation struct {
-	URI           string                 `json:"uri"`
-	Content       *string                `json:"content,omitempty"`
-	ContentBase64 *string                `json:"content_base64,omitempty"`
-	Precondition  BatchWritePrecondition `json:"precondition"`
+	URI           string  `json:"uri"`
+	Content       *string `json:"content,omitempty"`
+	ContentBase64 *string `json:"content_base64,omitempty"`
+	Mode          string  `json:"mode,omitempty"`
 }
 
 // BatchWriteOptions controls BatchWrite.

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -583,7 +583,7 @@ export class OpenVikingClient {
       body: mergeExtra(body, options.extra),
     });
   }
-  /** Apply preconditioned file writes in one request. */
+  /** Apply file writes in one request and refresh their indexes once. */
   batchWrite(
     rootUri: string,
     operations: BatchWriteOperation[],
@@ -596,10 +596,7 @@ export class OpenVikingClient {
           uri: normalizeURI(operation.uri),
           content: operation.content,
           content_base64: operation.contentBase64,
-          precondition: compact({
-            kind: operation.precondition.kind,
-            base_hash: operation.precondition.baseHash,
-          }),
+          mode: operation.mode,
         }),
       ),
       wait: options.wait,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -98,17 +98,12 @@ export interface WriteOptions extends WaitOptions {
   processingMode?: ProcessingMode;
   extra?: JsonObject;
 }
-/** One batch-write precondition. */
-export interface BatchWritePrecondition {
-  kind: "create_if_absent" | "replace_if_hash";
-  baseHash?: string;
-}
-/** One preconditioned batch-write operation. */
+/** One file write in a batch. */
 export interface BatchWriteOperation {
   uri: string;
   content?: string;
   contentBase64?: string;
-  precondition: BatchWritePrecondition;
+  mode?: "replace" | "append" | "create" | "upsert";
 }
 /** Batch-write request options. */
 export interface BatchWriteOptions extends WaitOptions {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -429,7 +429,7 @@ describe("OpenVikingClient", () => {
         {
           uri: "resources/project/a.txt",
           content: "hello",
-          precondition: { kind: "create_if_absent" },
+          mode: "upsert",
         },
       ],
       { extra: { future_flag: 0 } },
@@ -442,10 +442,18 @@ describe("OpenVikingClient", () => {
       extra: { future_flag: false },
     });
 
-    expect(JSON.parse(String(fetcher.mock.calls[0]![1]?.body))).toMatchObject({
+    const batchWriteBody = JSON.parse(String(fetcher.mock.calls[0]![1]?.body));
+    expect(batchWriteBody).toMatchObject({
       root_uri: "viking://resources/project",
       future_flag: 0,
     });
+    expect(batchWriteBody.operations).toEqual([
+      {
+        uri: "viking://resources/project/a.txt",
+        content: "hello",
+        mode: "upsert",
+      },
+    ]);
     expect(
       new URL(String(fetcher.mock.calls[1]![0])).searchParams.get("uri"),
     ).toBe("viking://resources/project/a.txt");


### PR DESCRIPTION
## Description

The Go and TypeScript SDKs still modeled `batch-write` operations with the removed `precondition` request shape, while the current Server accepts only `mode` (`replace`, `append`, `create`, or `upsert`). This made both SDK methods send a request that the Server rejects as an unknown field.

### Before

For the same `a.txt` batch write, the SDKs exposed and serialized:

```json
{
  "uri": "viking://resources/project/a.txt",
  "content": "hello",
  "precondition": {"kind": "create_if_absent"}
}
```

The Server's strict request schema rejects `precondition`, so the SDK call cannot complete.

### After

The SDKs expose and serialize the Server's supported request shape:

```json
{
  "uri": "viking://resources/project/a.txt",
  "content": "hello",
  "mode": "upsert"
}
```

The caller supplies a batch operation, the SDK normalizes its URI and sends `mode`, and the Server applies the same write semantics already used by its `batch-write` API. Server and Python SDK behavior is unchanged.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

None.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- Remove the obsolete Go and TypeScript `BatchWritePrecondition` public types.
- Add `mode` to both SDKs' batch operation types and serialize it in TypeScript requests.
- Update the existing SDK contract tests to assert the supported `mode` request body.

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```text
cd sdk/go && go test ./...
cd sdk/typescript && npm test
cd sdk/typescript && npm run typecheck
cd sdk/typescript && npm run build
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

Not applicable.

## Additional Notes

This intentionally removes an unusable SDK request shape. The Server already removed `precondition` and accepts only `mode`; Python already passes the correct operation shape. No new test case or test file was added—the existing batch-write contract tests were updated so they compile against and verify the corrected public API.
