### PR TITLE
feat(vlm): preserve per-call thinking policy for OpenAI-compatible routes

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -730,6 +730,22 @@ For OpenAI-compatible providers that accept provider-specific JSON body fields, 
 }
 ```
 
+For LiteLLM routes with provider-specific reasoning controls, configure per-call fragments: `thinking=true` selects `enabled`, `thinking=false`
+selects `disabled`, and `thinking=None` leaves the static body or backend default unchanged:
+
+```json
+{
+  "vlm": {
+    "provider": "litellm", "model": "LocalModel",
+    "api_base": "http://localhost:4000/v1",
+    "thinking_extra_request_body": {
+      "enabled": {"chat_template_kwargs": {"enable_thinking": true}},
+      "disabled": {"chat_template_kwargs": {"enable_thinking": false}}
+    }
+  }
+}
+```
+
 **Streaming Mode**
 
 For OpenAI-compatible providers that return SSE (Server-Sent Events) format responses, enable `stream` mode:

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -698,6 +698,22 @@ LiteLLM 的 Bedrock bearer-token API-key 鉴权，请设置 `forward_api_key=tru
 }
 ```
 
+对于推理控制格式由 provider 自定义的 LiteLLM 路由，可以分别配置调用级片段：`thinking=true` 选择 `enabled`，`thinking=false` 选择 `disabled`；`thinking=None`
+不应用调用级片段，保留静态请求体或后端默认行为：
+
+```json
+{
+  "vlm": {
+    "provider": "litellm", "model": "LocalModel",
+    "api_base": "http://localhost:4000/v1",
+    "thinking_extra_request_body": {
+      "enabled": {"chat_template_kwargs": {"enable_thinking": true}},
+      "disabled": {"chat_template_kwargs": {"enable_thinking": false}}
+    }
+  }
+}
+```
+
 **流式模式**
 
 对于返回 SSE（Server-Sent Events）格式响应的 OpenAI 兼容 provider，启用 `stream` 模式：

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import time
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -137,6 +138,17 @@ NATIVE_AUTH_LITELLM_PREFIXES: tuple[str, ...] = (
 
 def _has_litellm_prefix(model: str, prefixes: tuple[str, ...]) -> bool:
     return model.lower().startswith(prefixes)
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Return a recursive merge without mutating either input."""
+    result = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
 
 
 def detect_provider_by_model(model: str) -> str | None:
@@ -298,8 +310,13 @@ class LiteLLMVLMProvider(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
-        if self.extra_request_body:
-            kwargs["extra_body"] = dict(self.extra_request_body)
+        extra_body = deepcopy(self.extra_request_body)
+        if thinking is not None:
+            policy = "enabled" if thinking else "disabled"
+            fragment = self.thinking_extra_request_body.get(policy, {})
+            extra_body = _deep_merge(extra_body, fragment)
+        if extra_body:
+            kwargs["extra_body"] = extra_body
 
         # Ollama-specific request options. Without an explicit num_ctx the server
         # truncates long prompts to its 4096-token default; thinking models left

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -75,6 +75,7 @@ class VLMBase(ABC):
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.extra_request_body = dict(config.get("extra_request_body") or {})
+        self.thinking_extra_request_body = dict(config.get("thinking_extra_request_body") or {})
         self.stream = config.get("stream", False)
         self.thinking = config.get("thinking", False)
 

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -5,9 +5,12 @@ import importlib
 import threading
 import weakref
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, TypeAdapter, ValidationError, model_validator
+
+ThinkingExtraRequestBody = Dict[Literal["enabled", "disabled"], Dict[str, Any]]
+_THINKING_EXTRA_REQUEST_BODY_ADAPTER = TypeAdapter(ThinkingExtraRequestBody)
 
 
 def _load_codex_auth_module():
@@ -45,6 +48,7 @@ class VLMCredential(BaseModel):
     extra_request_body: Optional[Dict[str, Any]] = Field(
         default=None, description="Extra JSON body fields"
     )
+    thinking_extra_request_body: Optional[ThinkingExtraRequestBody] = None
     stream: Optional[bool] = Field(default=None, description="Enable streaming mode")
     reasoning_effort: Optional[str] = Field(
         default=None,
@@ -163,6 +167,11 @@ class VLMConfig(BaseModel):
         ),
     )
 
+    thinking_extra_request_body: Optional[ThinkingExtraRequestBody] = Field(
+        default=None,
+        description="Request body fragments selected by the per-call thinking policy",
+    )
+
     stream: bool = Field(
         default=False, description="Enable streaming mode for OpenAI-compatible providers"
     )
@@ -218,6 +227,21 @@ class VLMConfig(BaseModel):
                             "Duplicate VLM provider config after normalization: "
                             f"{existing_name} and {name}"
                         )
+                    if (
+                        isinstance(config, dict)
+                        and config.get("thinking_extra_request_body") is not None
+                    ):
+                        config = dict(config)
+                        try:
+                            config["thinking_extra_request_body"] = (
+                                _THINKING_EXTRA_REQUEST_BODY_ADAPTER.validate_python(
+                                    config["thinking_extra_request_body"]
+                                )
+                            )
+                        except ValidationError as exc:
+                            raise ValueError(
+                                f"Invalid thinking_extra_request_body for VLM provider {name!r}"
+                            ) from exc
                     normalized[normalized_name] = config
                     provider_sources[normalized_name] = str(name)
                 data["providers"] = normalized
@@ -281,6 +305,7 @@ class VLMConfig(BaseModel):
             or self.api_base
             or self.extra_headers
             or self.extra_request_body
+            or self.thinking_extra_request_body
             or self.stream
             or self.reasoning_effort
             or self.forward_api_key is not None
@@ -303,6 +328,13 @@ class VLMConfig(BaseModel):
                 and "extra_request_body" not in self.providers[self.provider]
             ):
                 self.providers[self.provider]["extra_request_body"] = self.extra_request_body
+            if (
+                self.thinking_extra_request_body
+                and "thinking_extra_request_body" not in self.providers[self.provider]
+            ):
+                self.providers[self.provider]["thinking_extra_request_body"] = (
+                    self.thinking_extra_request_body
+                )
             if self.stream and "stream" not in self.providers[self.provider]:
                 self.providers[self.provider]["stream"] = self.stream
             if self.reasoning_effort and "reasoning_effort" not in self.providers[self.provider]:
@@ -340,6 +372,10 @@ class VLMConfig(BaseModel):
                 extra_request_body=(
                     primary_cfg.get("extra_request_body") or self.extra_request_body
                 ),
+                thinking_extra_request_body=(
+                    primary_cfg.get("thinking_extra_request_body")
+                    or self.thinking_extra_request_body
+                ),
                 stream=(
                     primary_cfg.get("stream")
                     if primary_cfg.get("stream") is not None
@@ -369,6 +405,10 @@ class VLMConfig(BaseModel):
                 extra_headers=backup_cfg.get("extra_headers") or self.backup.extra_headers,
                 extra_request_body=(
                     backup_cfg.get("extra_request_body") or self.backup.extra_request_body
+                ),
+                thinking_extra_request_body=(
+                    backup_cfg.get("thinking_extra_request_body")
+                    or self.backup.thinking_extra_request_body
                 ),
                 stream=(
                     backup_cfg.get("stream")
@@ -413,6 +453,10 @@ class VLMConfig(BaseModel):
                         extra_request_body=(
                             provider_cfg.get("extra_request_body") or self.extra_request_body
                         ),
+                        thinking_extra_request_body=(
+                            provider_cfg.get("thinking_extra_request_body")
+                            or self.thinking_extra_request_body
+                        ),
                         stream=(
                             provider_cfg.get("stream")
                             if provider_cfg.get("stream") is not None
@@ -449,6 +493,8 @@ class VLMConfig(BaseModel):
                 cred.extra_headers = self.extra_headers
             if not cred.extra_request_body:
                 cred.extra_request_body = self.extra_request_body
+            if not cred.thinking_extra_request_body:
+                cred.thinking_extra_request_body = self.thinking_extra_request_body
             if cred.stream is None:
                 cred.stream = self.stream
             if not cred.reasoning_effort:
@@ -504,6 +550,8 @@ class VLMConfig(BaseModel):
             config["extra_headers"] = self.extra_headers
         if self.extra_request_body and "extra_request_body" not in config:
             config["extra_request_body"] = self.extra_request_body
+        if self.thinking_extra_request_body and "thinking_extra_request_body" not in config:
+            config["thinking_extra_request_body"] = self.thinking_extra_request_body
         if self.stream and "stream" not in config:
             config["stream"] = self.stream
         if self.reasoning_effort and "reasoning_effort" not in config:
@@ -535,6 +583,8 @@ class VLMConfig(BaseModel):
             config["extra_headers"] = cred.extra_headers
         if cred.extra_request_body:
             config["extra_request_body"] = cred.extra_request_body
+        if cred.thinking_extra_request_body:
+            config["thinking_extra_request_body"] = cred.thinking_extra_request_body
         if cred.stream:
             config["stream"] = cred.stream
         if cred.reasoning_effort:
@@ -652,6 +702,8 @@ class VLMConfig(BaseModel):
             result["extra_headers"] = credential.extra_headers
         if credential.extra_request_body:
             result["extra_request_body"] = credential.extra_request_body
+        if credential.thinking_extra_request_body:
+            result["thinking_extra_request_body"] = credential.thinking_extra_request_body
         if credential.reasoning_effort:
             result["reasoning_effort"] = credential.reasoning_effort
 
@@ -690,6 +742,8 @@ class VLMConfig(BaseModel):
                 result["extra_headers"] = config.get("extra_headers")
             if config.get("extra_request_body"):
                 result["extra_request_body"] = config.get("extra_request_body")
+            if config.get("thinking_extra_request_body"):
+                result["thinking_extra_request_body"] = config.get("thinking_extra_request_body")
             if config.get("reasoning_effort"):
                 result["reasoning_effort"] = config.get("reasoning_effort")
 

--- a/tests/unit/test_extra_headers_vlm.py
+++ b/tests/unit/test_extra_headers_vlm.py
@@ -6,6 +6,9 @@ import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from pydantic import ValidationError
+
 from openviking.models.vlm.backends.litellm_vlm import (
     LiteLLMVLMProvider,
     detect_provider_by_model,
@@ -666,6 +669,51 @@ class TestVLMConfigExtraRequestBody:
 
         result = config._build_vlm_config_dict()
         assert result["extra_request_body"] == {"think": False}
+
+    def test_thinking_request_body_propagates_through_supported_config_shapes(self):
+        from openviking_cli.utils.config.vlm_config import VLMConfig
+
+        policy = {"enabled": {"reasoning": {"effort": "medium"}}}
+        configs = [
+            VLMConfig(model="LocalModel", provider="litellm", thinking_extra_request_body=policy),
+            VLMConfig(
+                model="LocalModel",
+                provider="litellm",
+                providers={"litellm": {"thinking_extra_request_body": policy}},
+            ),
+            VLMConfig(
+                model="LocalModel",
+                credentials=[{"provider": "litellm", "thinking_extra_request_body": policy}],
+            ),
+        ]
+        failover = VLMConfig(
+            model="LocalModel",
+            provider="litellm",
+            thinking_extra_request_body=policy,
+            backup={
+                "model": "BackupModel",
+                "provider": "litellm",
+                "thinking_extra_request_body": policy,
+            },
+        )
+
+        assert [
+            config._build_vlm_config_dict()["thinking_extra_request_body"] for config in configs
+        ] == [policy] * 3
+        assert all(item.thinking_extra_request_body == policy for item in failover.credentials)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"thinking_extra_request_body": {"enabled": ["invalid"]}},
+            {"providers": {"litellm": {"thinking_extra_request_body": {"other": {}}}}},
+        ],
+    )
+    def test_thinking_request_body_rejects_invalid_shapes(self, config):
+        from openviking_cli.utils.config.vlm_config import VLMConfig
+
+        with pytest.raises(ValidationError, match="thinking_extra_request_body"):
+            VLMConfig(model="LocalModel", provider="litellm", **config)
 
     def test_vlm_config_accepts_flat_extra_request_body(self):
         from openviking_cli.utils.config.vlm_config import VLMConfig

--- a/tests/unit/test_vlm_thinking_param.py
+++ b/tests/unit/test_vlm_thinking_param.py
@@ -67,6 +67,46 @@ class TestLiteLLMThinkingParam:
         extra_body = kwargs.get("extra_body", {})
         assert "enable_thinking" not in extra_body
 
+    def test_openai_compatible_route_maps_per_call_thinking_without_state_leaks(self):
+        static_body = {
+            "chat_template_kwargs": {"custom_option": "preserved", "mode": "static"},
+            "stops": ["static"],
+        }
+        thinking_body = {
+            "enabled": {
+                "chat_template_kwargs": {"enable_thinking": True, "mode": "dynamic"},
+                "stops": ["enabled"],
+            },
+            "disabled": {"chat_template_kwargs": {"enable_thinking": False}},
+        }
+        vlm = self._make_provider(
+            "LocalModel",
+            api_base="http://localhost:4000/v1",
+            extra_request_body=static_body,
+            thinking_extra_request_body=thinking_body,
+        )
+        model = vlm._resolve_model("LocalModel")
+        messages = [{"role": "user", "content": "hello"}]
+
+        disabled = vlm._build_kwargs(model, messages, thinking=False)["extra_body"]
+        enabled = vlm._build_kwargs(model, messages, thinking=True)["extra_body"]
+        defaulted = vlm._build_kwargs(model, messages, thinking=None)["extra_body"]
+
+        assert disabled["chat_template_kwargs"] == {
+            "custom_option": "preserved",
+            "mode": "static",
+            "enable_thinking": False,
+        }
+        assert enabled["chat_template_kwargs"] == {
+            "custom_option": "preserved",
+            "mode": "dynamic",
+            "enable_thinking": True,
+        }
+        assert enabled["stops"] == ["enabled"]
+        assert defaulted == static_body
+        assert vlm.extra_request_body == static_body
+        assert vlm.thinking_extra_request_body == thinking_body
+
     def test_litellm_anthropic_no_thinking_field(self):
         """Anthropic model should NOT have enable_thinking in extra_body."""
         vlm = self._make_provider("claude-3-opus")


### PR DESCRIPTION
## Description

Generic LiteLLM/OpenAI-compatible VLM routes could not preserve the per-call `thinking` choice in provider-specific request bodies. Static `extra_request_body` could express only one fixed policy, while the existing dynamic handling intentionally covered DashScope and Ollama only.

This PR adds an optional `thinking_extra_request_body` mapping with `enabled` and `disabled` fragments. The fragment selected by the per-call `thinking` value is recursively merged into a fresh copy of the static request body.

This implementation was AI-assisted. A human specified the change, reviewed the approach and results, and explicitly approved remote submission.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Closes #4066

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add validated `thinking_extra_request_body.enabled` and `.disabled` dictionaries to flat, provider, credential, backup, and failover VLM configuration paths.
- Deep-copy and recursively merge the selected per-call fragment after static `extra_request_body` and before existing provider-specific LiteLLM rules.
- Preserve existing DashScope `enable_thinking` and Ollama `think`/`num_ctx` behavior, and keep behavior unchanged when the new field is absent.
- Document the new configuration in the English and Chinese VLM guides.

Minimal example:

```json
{
  "thinking_extra_request_body": {
    "enabled": {"chat_template_kwargs": {"enable_thinking": true}},
    "disabled": {"chat_template_kwargs": {"enable_thinking": false}}
  }
}
```

`thinking=True` selects `enabled`, `thinking=False` selects `disabled`, and `thinking=None` selects neither fragment.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation run after rebasing onto `3693171661024f1d603c57ba1e233228b5c666b5`:

- `pytest -o addopts="" -q tests/unit/test_vlm_thinking_param.py tests/unit/test_extra_headers_vlm.py tests/unit/test_vlm_failover.py tests/misc/test_config_validation.py`: 149 passed, 6 pre-existing dependency/deprecation warnings
- Ruff format check: passed
- Ruff check: passed
- `git diff --check`: passed

The focused tests cover `True`, `False`, and `None`; recursive dictionary merge; scalar/list replacement; immutable configuration across sequential calls; DashScope/Ollama regressions; validation; and config/failover propagation.

The full suite was attempted locally but collection is currently blocked on Python 3.14 by unrelated Pydantic V1/langfuse compatibility errors in `test_vikingbot_chat_images.py` and `test_vikingbot_vlm_adapter_retry.py`. Repository-wide mypy also reports existing errors across the import graph. No live model service was used.

## Checklist

- [x] My code follows the project coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Merge priority is static `extra_request_body`, then the selected per-call fragment, then existing provider-specific rules. No model-name or server-format detection was added, and the direct OpenAI SDK backend remains unchanged.