### PR TITLE
fix(queuefs): treat an ACL denial as permanent, not transient

### DIFF
--- a/openviking/utils/model_retry.py
+++ b/openviking/utils/model_retry.py
@@ -9,6 +9,7 @@ import time
 from typing import Awaitable, Callable, TypeVar
 
 from openviking.utils.exceptions import AllCredentialsFailedError
+from openviking_cli.exceptions import PermissionDeniedError
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,13 @@ QUOTA_EXCEEDED_PATTERNS = (
 )
 
 _PERMANENT_IO_ERRORS = (FileNotFoundError, PermissionError, IsADirectoryError, NotADirectoryError)
+
+# An ACL denial from OpenViking's own authorization layer. Deterministic: a retry
+# re-runs the same check for the same principal against the same resource, so a
+# queued message carrying one is poison, not transient. Distinct from
+# ERROR_CLASS_AUTH, which means "try a different model credential" — there is no
+# credential to switch to here.
+_PERMANENT_PERMISSION_ERRORS = (PermissionDeniedError,)
 
 TRANSIENT_API_ERROR_PATTERNS = (
     "429",
@@ -146,6 +154,9 @@ def classify_api_error(error: Exception) -> str:
       credential-level and may be resolved by switching credentials, whereas a
       400 is a request-level error that fails on every credential of the same
       model.
+    - a ``PermissionDeniedError`` from OpenViking's own ACL layer is ``permanent``,
+      not ``auth``: ``auth`` means the caller should try another model credential,
+      and an ACL denial has none to try.
     - ``quota_exceeded`` is checked before ``transient`` because quota errors
       typically include "429" / "TooManyRequests" which would otherwise match
       the transient category.
@@ -163,7 +174,7 @@ def classify_api_error(error: Exception) -> str:
         return ERROR_CLASS_UNKNOWN
 
     for exc in (error, getattr(error, "__cause__", None)):
-        if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS):
+        if exc is not None and isinstance(exc, _PERMANENT_IO_ERRORS + _PERMANENT_PERMISSION_ERRORS):
             return ERROR_CLASS_PERMANENT
 
     texts = [str(error)]

--- a/tests/unit/test_model_retry.py
+++ b/tests/unit/test_model_retry.py
@@ -13,9 +13,11 @@ from openviking.utils.model_retry import (
     ERROR_CLASS_QUOTA_EXCEEDED,
     ERROR_CLASS_TRANSIENT,
     classify_api_error,
+    is_retryable_api_error,
     retry_async,
     retry_sync,
 )
+from openviking_cli.exceptions import PermissionDeniedError as CliPermissionDeniedError
 
 
 def test_classify_api_error_recognizes_request_burst_too_fast():
@@ -250,3 +252,30 @@ def test_numeric_status_code_with_compact_error_code_context_still_matches():
     assert classify_api_error(RuntimeError("Error code:413-Payload Too Large")) == (
         ERROR_CLASS_INPUT_TOO_LARGE
     )
+
+
+def test_classify_cli_permission_denied_is_permanent():
+    """An ACL denial is deterministic — retrying re-runs the same check.
+
+    Left unclassified it fell through to ``unknown``, and SemanticProcessor's
+    handler re-enqueues everything that is not ``input_too_large`` or
+    ``permanent``. One denied message then re-enqueued every ~30s forever and
+    pinned the semantic queue (issue #4312).
+    """
+    assert classify_api_error(CliPermissionDeniedError()) == ERROR_CLASS_PERMANENT
+
+
+def test_classify_cli_permission_denied_with_resource_is_permanent():
+    err = CliPermissionDeniedError("Permission denied", resource="viking://user/.overview.md")
+    assert classify_api_error(err) == ERROR_CLASS_PERMANENT
+
+
+def test_classify_cli_permission_denied_as_cause_is_permanent():
+    """The ACL error usually reaches the handler wrapped by a caller."""
+    err = RuntimeError("failed to refresh parent overview")
+    err.__cause__ = CliPermissionDeniedError()
+    assert classify_api_error(err) == ERROR_CLASS_PERMANENT
+
+
+def test_classify_cli_permission_denied_is_not_retryable():
+    assert is_retryable_api_error(CliPermissionDeniedError()) is False


### PR DESCRIPTION
Closes #4312.

## Problem

`SemanticProcessor.on_dequeue` drops a message for exactly two error classes:

```python
error_class = classify_api_error(e)
if error_class == ERROR_CLASS_INPUT_TOO_LARGE:
    ...drop
elif error_class == ERROR_CLASS_PERMANENT:
    ...drop
else:
    # Transient or unknown — re-enqueue for retry
    logger.warning("Transient API error processing semantic message, re-enqueueing: %s", e)
```

`classify_api_error` does not recognise `openviking_cli.exceptions.PermissionDeniedError`. Checked against the current tip:

```python
>>> classify_api_error(PermissionDeniedError())
'unknown'
>>> classify_api_error(PermissionDeniedError("Permission denied", resource="viking://user/.overview.md"))
'unknown'
```

`unknown` takes the `else` branch, so the message is re-enqueued and the circuit breaker records another failure. Forever. @Yiipu saw it retry every ~30s for 14 hours on v0.4.16, with the breaker held open and all semantic processing for the user stalled; a restart did not clear it and the queue row had to be deleted from `queue.db` by hand.

A permission denial is deterministic. The retry re-runs the same ACL check for the same principal against the same resource, so it cannot start succeeding.

## Fix

```python
# An ACL denial from OpenViking's own authorization layer. Deterministic: a retry
# re-runs the same check for the same principal against the same resource, so a
# queued message carrying one is poison, not transient. Distinct from
# ERROR_CLASS_AUTH, which means "try a different model credential" — there is no
# credential to switch to here.
_PERMANENT_PERMISSION_ERRORS = (PermissionDeniedError,)
```

folded into the existing `isinstance` pass, which already walks `__cause__` — the ACL error normally reaches the handler wrapped by its caller.

**`permanent`, not `auth`, and that distinction matters here.** The docstring separates the two because `auth` means "this credential failed, another one may work". An ACL denial has no credential to switch to. It also would not fix the bug: in `on_dequeue` only `input_too_large` and `permanent` drop the message, so an `auth` classification would still land in the `else` branch and re-enqueue forever.

This lands in `classify_api_error` rather than in the handler so every consumer agrees — `models/embedder/base.py`, `models/vlm/base.py` and `storage/collection_schemas.py` all classify through the same function, and none of them should be retrying an ACL denial either.

#4254 removes the known trigger (`viking://user/.overview.md` from a parent refresh at a namespace root). This is the other half the issue asks for: the classification gap that turns *any* future ACL denial into a stuck queue.

## Deliberately not included

`UnauthenticatedError` — the sibling under the same "Authentication Errors" heading — classifies as `unknown` too, so it has the same poison-message property. I left it alone because a retry after a credential refresh could plausibly succeed, unlike an ACL denial, and that is your call rather than mine. Happy to add it if you want the whole heading treated the same way.

## Verification

Four tests appended to `tests/unit/test_model_retry.py`, next to the existing classification cases: bare, with a `resource`, reached through `__cause__`, and not retryable.

Removing `_PERMANENT_PERMISSION_ERRORS` from the isinstance check flips three of them:

```
FAILED tests/unit/test_model_retry.py::test_classify_cli_permission_denied_is_permanent
FAILED tests/unit/test_model_retry.py::test_classify_cli_permission_denied_with_resource_is_permanent
FAILED tests/unit/test_model_retry.py::test_classify_cli_permission_denied_as_cause_is_permanent
3 failed, 30 passed
```

The fourth (`is_retryable_api_error(...) is False`) passes either way — `unknown` is not `transient` — so it guards the direction the other three do not.

Every suite that touches the classifier, same command on both sides:

| | passed | failed |
|---|---|---|
| `origin/main` (3693171) | 160 | 3 |
| this branch | 164 | 3 |

(`tests/unit/test_model_retry.py`, `tests/unit/test_circuit_breaker.py`, `tests/utils/test_circuit_breaker.py`, `tests/unit/test_ordered_credential_switcher.py`, `tests/storage/test_memory_semantic_stall.py`, `tests/storage/test_collection_schemas.py`.)

The 3 failures are identical on both sides and pre-existing. Two of them are worth a look on their own: `tests/utils/test_circuit_breaker.py::test_classify_permanent_errors` asserts `403 Forbidden` is `permanent`, while `tests/unit/test_model_retry.py::test_classify_403_is_auth` asserts it is `auth`. They contradict each other, and the code has followed the `auth` reading since the classes were split. The third, `test_embedding_handler_open_breaker_logs_summary_instead_of_per_item_warning`, is also red on a clean checkout. All three are outside the scope of this change, so I have not touched them.

`import` note: `openviking_cli/exceptions.py` imports only `typing`, so pulling it into `openviking/utils/model_retry.py` adds no cycle.