### PR TITLE
fix(embedding): route the ollama provider to Ollama's /v1 surface (#4302)

### DIFF
--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -735,6 +735,7 @@ class EmbeddingConfig(BaseModel):
             VolcengineSparseEmbedder,
             VoyageDenseEmbedder,
         )
+        from openviking_cli.utils.ollama import normalize_ollama_openai_base
 
         if provider == "litellm" and LiteLLMDenseEmbedder is None:
             raise ValueError("LiteLLM is not installed. Install it with: pip install litellm")
@@ -893,14 +894,16 @@ class EmbeddingConfig(BaseModel):
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),
                 },
             ),
-            # Ollama: local OpenAI-compatible embedding server, no real API key needed
+            # Ollama: local OpenAI-compatible embedding server, no real API key needed.
+            # normalize_ollama_openai_base() adds the /v1 prefix Ollama needs when
+            # api_base is a bare host, which is how the configuration guide shows it.
             ("ollama", "dense"): (
                 OpenAIDenseEmbedder,
                 lambda cfg: {
                     "model_name": cfg.model,
                     "api_key": cfg.api_key
                     or "no-key",  # Ollama ignores the key, but client requires non-empty
-                    "api_base": cfg.api_base or "http://localhost:11434/v1",
+                    "api_base": normalize_ollama_openai_base(cfg.api_base),
                     "dimension": cfg.dimension,
                     "configured_provider": "ollama",
                     "config": dict(runtime_config),

--- a/openviking_cli/utils/ollama.py
+++ b/openviking_cli/utils/ollama.py
@@ -30,6 +30,11 @@ from dataclasses import dataclass
 OLLAMA_DEFAULT_HOST = "localhost"
 OLLAMA_DEFAULT_PORT = 11434
 
+# Ollama serves its OpenAI-compatible surface under this prefix; the native API
+# lives under ``/api``. Nothing else is routed, so a request to ``/embeddings``
+# is answered with a plain-text ``404 page not found``.
+OLLAMA_OPENAI_PATH = "/v1"
+
 _LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 # ---------------------------------------------------------------------------
@@ -67,6 +72,33 @@ def parse_ollama_url(api_base: str | None) -> tuple[str, int]:
         return host, port
     except Exception:
         return OLLAMA_DEFAULT_HOST, OLLAMA_DEFAULT_PORT
+
+
+def normalize_ollama_openai_base(api_base: str | None) -> str:
+    """Return an *api_base* an OpenAI-compatible client can actually call.
+
+    The OpenAI client appends ``/embeddings`` to whatever base URL it is given,
+    so a bare ``http://127.0.0.1:11434`` — the form the configuration guide
+    shows — resolves to ``/embeddings`` and Ollama answers ``404 page not
+    found``. Append ``/v1`` when the base carries no path of its own; leave any
+    explicit path alone, so ``.../v1`` (what the setup wizard writes) and a
+    reverse-proxy prefix both keep working.
+    """
+    default = f"http://{OLLAMA_DEFAULT_HOST}:{OLLAMA_DEFAULT_PORT}{OLLAMA_OPENAI_PATH}"
+    if not api_base:
+        return default
+    base = api_base.strip().rstrip("/")
+    if not base:
+        return default
+    try:
+        # A base without a scheme ("host:11434") parses as scheme+path, so give
+        # urlparse a netloc to work with before asking whether a path is set.
+        parsed = urllib.parse.urlparse(base if "://" in base else "//" + base)
+    except Exception:
+        return base
+    if parsed.path:
+        return base
+    return base + OLLAMA_OPENAI_PATH
 
 
 # ---------------------------------------------------------------------------

--- a/tests/misc/test_ollama_embedding_api_base.py
+++ b/tests/misc/test_ollama_embedding_api_base.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for #4302: `embedding.provider: "ollama"` 404s on a bare api_base.
+
+Ollama routes its OpenAI-compatible surface under ``/v1`` and answers anything
+else with ``404 page not found``. The OpenAI client appends ``/embeddings`` to
+whatever base URL it is handed, so the bare ``http://127.0.0.1:11434`` shown in
+docs/*/guides/01-configuration.md produced a request to ``/embeddings`` — and a
+`doctor` probe failure — against a perfectly healthy server.
+"""
+
+from openviking_cli.utils.config.embedding_config import EmbeddingConfig, EmbeddingModelConfig
+
+
+def _ollama_embedder(api_base):
+    dense = EmbeddingModelConfig(
+        provider="ollama",
+        model="nomic-embed-text",
+        dimension=768,
+        **({"api_base": api_base} if api_base is not None else {}),
+    )
+    return EmbeddingConfig(dense=dense).get_embedder()
+
+
+class TestOllamaEmbedderApiBase:
+    def test_bare_host_is_routed_to_the_openai_surface(self):
+        """The documented config form must reach /v1/embeddings, not /embeddings."""
+        embedder = _ollama_embedder("http://127.0.0.1:11434")
+        assert embedder.api_base == "http://127.0.0.1:11434/v1"
+        # The client joins its base URL with "embeddings"; a base without the
+        # /v1 segment is what produced `404 page not found`.
+        assert str(embedder.client.base_url).rstrip("/").endswith("/v1")
+
+    def test_wizard_form_is_unchanged(self):
+        """setup_wizard writes .../v1 — it must not become .../v1/v1."""
+        embedder = _ollama_embedder("http://localhost:11434/v1")
+        assert embedder.api_base == "http://localhost:11434/v1"
+
+    def test_reverse_proxy_prefix_is_preserved(self):
+        embedder = _ollama_embedder("https://gpu.internal/ollama/v1")
+        assert embedder.api_base == "https://gpu.internal/ollama/v1"
+
+    def test_omitted_api_base_keeps_the_local_default(self):
+        embedder = _ollama_embedder(None)
+        assert embedder.api_base == "http://localhost:11434/v1"
+
+    def test_api_key_is_still_optional(self):
+        """Ollama ignores the key but the OpenAI client requires a non-empty one."""
+        embedder = _ollama_embedder("http://127.0.0.1:11434")
+        assert embedder.api_key == "no-key"

--- a/tests/unit/test_ollama_utils.py
+++ b/tests/unit/test_ollama_utils.py
@@ -9,6 +9,7 @@ from openviking_cli.utils.ollama import (
     OllamaStartResult,
     detect_ollama_in_config,
     ensure_ollama_for_server,
+    normalize_ollama_openai_base,
     parse_ollama_url,
     start_ollama,
 )
@@ -37,6 +38,53 @@ class TestParseOllamaUrl:
     def test_empty_returns_defaults(self):
         assert parse_ollama_url("") == ("localhost", 11434)
 
+
+# ---------------------------------------------------------------------------
+# normalize_ollama_openai_base (#4302)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOllamaOpenAIBase:
+    """The OpenAI client appends ``/embeddings`` to its base URL, so a bare
+    ``http://127.0.0.1:11434`` — the form docs/*/guides/01-configuration.md
+    shows — reaches ``/embeddings`` and Ollama answers ``404 page not found``.
+    """
+
+    def test_bare_host_gains_the_openai_prefix(self):
+        assert (
+            normalize_ollama_openai_base("http://127.0.0.1:11434")
+            == "http://127.0.0.1:11434/v1"
+        )
+
+    def test_trailing_slash_is_not_doubled(self):
+        assert (
+            normalize_ollama_openai_base("http://localhost:11434/")
+            == "http://localhost:11434/v1"
+        )
+
+    def test_existing_v1_is_left_alone(self):
+        assert (
+            normalize_ollama_openai_base("http://localhost:11434/v1")
+            == "http://localhost:11434/v1"
+        )
+
+    def test_reverse_proxy_prefix_is_left_alone(self):
+        # An explicit path is the operator's decision; do not rewrite it.
+        assert (
+            normalize_ollama_openai_base("https://gpu.internal/ollama/v1")
+            == "https://gpu.internal/ollama/v1"
+        )
+
+    def test_schemeless_host_is_still_recognised_as_pathless(self):
+        assert normalize_ollama_openai_base("localhost:11434") == "localhost:11434/v1"
+
+    def test_none_and_empty_fall_back_to_the_local_default(self):
+        assert normalize_ollama_openai_base(None) == "http://localhost:11434/v1"
+        assert normalize_ollama_openai_base("   ") == "http://localhost:11434/v1"
+
+    def test_result_is_idempotent(self):
+        once = normalize_ollama_openai_base("http://127.0.0.1:11434")
+        assert normalize_ollama_openai_base(once) == once
 
 # ---------------------------------------------------------------------------
 # detect_ollama_in_config


### PR DESCRIPTION
Fixes #4302.

## Root cause

Ollama routes its OpenAI-compatible API under `/v1` and its native API under `/api`; anything else gets a plain-text `404 page not found`. The OpenAI client appends `/embeddings` to whatever base URL it is handed, and the `("ollama", "dense")` factory entry passed `cfg.api_base` through untouched:

```python
"api_base": cfg.api_base or "http://localhost:11434/v1",
```

Only the *fallback* carried the `/v1` prefix. So the default worked and every explicit `api_base` — the thing anyone pointing at a non-default host, container, or port has to set — was sent to `/embeddings`.

That also explains why the reporter's `litellm` workaround succeeds against the same server: LiteLLM appends the Ollama route itself, so the bare host is correct there. The bare form is what the config guide shows for the neighbouring `vlm` / `query_planner` blocks, and there is no `provider: "ollama"` embedding example in the docs to show otherwise.

## Verification

Reproduced against a stub that routes exactly like Ollama — 200 on `/v1/embeddings`, `404 page not found` on everything else — with no network and no Ollama install:

**Before**

```
as documented (bare host):
  configured api_base : http://127.0.0.1:PORT
  client base_url     : http://127.0.0.1:PORT
  probe               : FAIL (RuntimeError: OpenAI API error: 404 page not found)
  path(s) requested   : ['/embeddings']

as the setup wizard writes it:
  configured api_base : http://127.0.0.1:PORT/v1
  probe               : ok (dimension=768)
  path(s) requested   : ['/v1/embeddings']
```

**After** — both forms request `/v1/embeddings` and return a 768-dim vector.

## The change

`normalize_ollama_openai_base()` lives next to `parse_ollama_url()` in `openviking_cli/utils/ollama.py` (stdlib-only, same as the rest of that module) and is applied in the factory.

| configured | result |
| :-- | :-- |
| `http://127.0.0.1:11434` | `http://127.0.0.1:11434/v1` |
| `http://localhost:11434/` | `http://localhost:11434/v1` |
| `http://localhost:11434/v1` | unchanged |
| `https://gpu.internal/ollama/v1` | unchanged |
| `localhost:11434` (no scheme) | `localhost:11434/v1` |
| absent | `http://localhost:11434/v1` (as before) |

Any explicit path is the operator's decision and is left alone — so `setup_wizard`'s `.../v1` never becomes `/v1/v1`, and a reverse-proxy prefix survives. The function is idempotent.

Scope is deliberately the dense-embedding factory only. `vlm` and `query_planner` reach Ollama through LiteLLM, which does its own routing; rewriting their base would break them.

## Tests

- `tests/unit/test_ollama_utils.py::TestNormalizeOllamaOpenAIBase` — 7 cases for the helper, alongside the existing `parse_ollama_url` tests.
- `tests/misc/test_ollama_embedding_api_base.py` — 5 cases driving the real `EmbeddingConfig.get_embedder()` factory and asserting the constructed OpenAI client's `base_url`, which is what the SDK joins `embeddings` onto.

`36 passed` for the two files. Across `test_ollama_utils`, `test_doctor`, `test_setup_wizard`, `test_embedding_input_type` and the new file: **216 passed, 3 failed — the same 3 failures `origin/main` produces** (`test_pass_with_utf8_bom_config`, `TestConfigWriting::test_write_new_config`, `TestConfigWriting::test_backup_existing`), verified by re-running the identical command on a clean tree. `ruff check` and `ruff format` clean.

Mutation-tested:

- factory back to `cfg.api_base or ".../v1"` → 1 failure (`test_bare_host_is_routed_to_the_openai_surface`)
- normalizer appends `/v1` unconditionally → 4 failures (the two reverse-proxy cases, the `.../v1` case, and idempotence)

## Follow-up, not included

The configuration guide has no `embedding.dense` + `provider: "ollama"` example at all. Happy to add one to `docs/en` and `docs/zh` in a separate PR if you want it — I left it out rather than guess at the Chinese wording.
