### PR TITLE
fix(server): bound the listing limits on /api/v1/fs/ls and /tree (#4289)

### DIFF
--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -25,6 +25,17 @@ from openviking_cli.exceptions import NotFoundError
 
 router = APIRouter(prefix="/api/v1/fs", tags=["filesystem"])
 
+# Ceilings for caller-supplied listing limits. Without them one authenticated
+# request can ask the server to collect and serialize an arbitrarily large tree
+# in memory (`node_limit=1000000&level_limit=100`), stalling the event loop for
+# every other tenant. Each ceiling sits above the largest value anything in the
+# tree asks for over HTTP -- the MCP tools and the agent file tool cap
+# themselves at 1000, the WebDAV PROPFIND path asks for 10000 -- so raising a
+# limit stays useful; it just cannot be unbounded. Same pattern as
+# routers/debug.py, which already caps its scroll `limit` with `le=1000`.
+MAX_NODE_LIMIT = 10_000
+MAX_LEVEL_LIMIT = 32
+MAX_ABS_LIMIT = 4_096
 
 _ATTR_INDEX_FIELDS = ["level", "search_tags"]
 
@@ -72,10 +83,14 @@ async def ls(
     simple: bool = Query(False, description="Return only relative path list"),
     recursive: bool = Query(False, description="List all subdirectories recursively"),
     output: str = Query("agent", description="Output format: original or agent"),
-    abs_limit: int = Query(256, description="Abstract limit (only for agent output)"),
+    abs_limit: int = Query(
+        256, ge=0, le=MAX_ABS_LIMIT, description="Abstract limit (only for agent output)"
+    ),
     show_all_hidden: bool = Query(False, description="List all hidden files, like -a"),
-    node_limit: int = Query(1000, description="Maximum number of nodes to list"),
-    limit: Optional[int] = Query(None, description="Alias for node_limit"),
+    node_limit: int = Query(
+        1000, ge=1, le=MAX_NODE_LIMIT, description="Maximum number of nodes to list"
+    ),
+    limit: Optional[int] = Query(None, ge=1, le=MAX_NODE_LIMIT, description="Alias for node_limit"),
     sort_by: Optional[Literal["name", "mtime"]] = Query(
         None,
         description="Sort directory and file groups before applying node_limit",
@@ -115,11 +130,17 @@ async def ls(
 async def tree(
     uri: str = Query(..., description="Viking URI"),
     output: str = Query("agent", description="Output format: original or agent"),
-    abs_limit: int = Query(256, description="Abstract limit (only for agent output)"),
+    abs_limit: int = Query(
+        256, ge=0, le=MAX_ABS_LIMIT, description="Abstract limit (only for agent output)"
+    ),
     show_all_hidden: bool = Query(False, description="List all hidden files, like -a"),
-    node_limit: int = Query(1000, description="Maximum number of nodes to list"),
-    limit: Optional[int] = Query(None, description="Alias for node_limit"),
-    level_limit: int = Query(3, description="Maximum depth level to traverse"),
+    node_limit: int = Query(
+        1000, ge=1, le=MAX_NODE_LIMIT, description="Maximum number of nodes to list"
+    ),
+    limit: Optional[int] = Query(None, ge=1, le=MAX_NODE_LIMIT, description="Alias for node_limit"),
+    level_limit: int = Query(
+        3, ge=1, le=MAX_LEVEL_LIMIT, description="Maximum depth level to traverse"
+    ),
     _ctx: RequestContext = Depends(get_request_context),
 ):
     """Get directory tree."""

--- a/tests/server/test_api_fs_listing_limits.py
+++ b/tests/server/test_api_fs_listing_limits.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for #4289: unbounded listing limits on /api/v1/fs.
+
+`node_limit`, `limit`, `level_limit`, and `abs_limit` were declared with a
+default but no `ge`/`le`, so one authenticated request could ask the server to
+collect and serialize an arbitrarily large tree in memory. These assert the
+ceilings are enforced by request validation -- before the handler runs, so no
+listing work is done -- and that every value the shipped clients actually use
+still passes.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers.filesystem import (
+    MAX_ABS_LIMIT,
+    MAX_LEVEL_LIMIT,
+    MAX_NODE_LIMIT,
+)
+from openviking.service.fs_service import FSService
+from openviking.service.session_service import SessionService
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.session.user_id import UserIdentifier
+from tests.utils.mock_agfs import MockLocalAGFS
+
+
+@pytest.fixture
+def service(temp_dir):
+    mock_agfs = MockLocalAGFS(root_path=temp_dir / "mock_agfs_root")
+    viking_fs = VikingFS(agfs=mock_agfs)
+    return SimpleNamespace(
+        fs=FSService(viking_fs=viking_fs),
+        sessions=SessionService(viking_fs=viking_fs),
+        viking_fs=viking_fs,
+    )
+
+
+async def _make_dir(service, uri):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    await service.viking_fs.mkdir(uri, exist_ok=True, ctx=ctx)
+    return uri
+
+
+# ── Rejected: above the ceiling ──
+
+
+@pytest.mark.parametrize(
+    "endpoint,params",
+    [
+        # The exact shape from the report.
+        ("/api/v1/fs/tree", {"node_limit": 1_000_000, "level_limit": 100}),
+        ("/api/v1/fs/ls", {"node_limit": MAX_NODE_LIMIT + 1}),
+        ("/api/v1/fs/tree", {"node_limit": MAX_NODE_LIMIT + 1}),
+        # The alias must be capped too, or it is a way around node_limit.
+        ("/api/v1/fs/ls", {"limit": MAX_NODE_LIMIT + 1}),
+        ("/api/v1/fs/tree", {"limit": MAX_NODE_LIMIT + 1}),
+        ("/api/v1/fs/tree", {"level_limit": MAX_LEVEL_LIMIT + 1}),
+        ("/api/v1/fs/ls", {"abs_limit": MAX_ABS_LIMIT + 1}),
+        ("/api/v1/fs/tree", {"abs_limit": MAX_ABS_LIMIT + 1}),
+    ],
+)
+async def test_over_ceiling_is_rejected_by_validation(client, service, endpoint, params):
+    uri = await _make_dir(service, "viking://resources/limit-bounds")
+    response = await client.get(endpoint, params={"uri": uri, **params})
+    # The app maps FastAPI's RequestValidationError onto 400/INVALID_ARGUMENT.
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+@pytest.mark.parametrize(
+    "endpoint,params",
+    [
+        ("/api/v1/fs/ls", {"node_limit": 0}),
+        ("/api/v1/fs/ls", {"node_limit": -1}),
+        ("/api/v1/fs/ls", {"limit": 0}),
+        ("/api/v1/fs/tree", {"level_limit": 0}),
+        ("/api/v1/fs/ls", {"abs_limit": -1}),
+    ],
+)
+async def test_non_positive_limits_are_rejected(client, service, endpoint, params):
+    uri = await _make_dir(service, "viking://resources/limit-bounds-low")
+    response = await client.get(endpoint, params={"uri": uri, **params})
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+# ── Accepted: everything real callers ask for ──
+
+
+@pytest.mark.parametrize(
+    "endpoint,params",
+    [
+        # Defaults.
+        ("/api/v1/fs/ls", {}),
+        ("/api/v1/fs/tree", {}),
+        # What the MCP tools and the agent file tool ask for.
+        ("/api/v1/fs/ls", {"node_limit": 1000}),
+        ("/api/v1/fs/tree", {"node_limit": 1000, "level_limit": 3}),
+        # What the WebDAV PROPFIND path asks for, and the ceilings themselves.
+        ("/api/v1/fs/ls", {"node_limit": 10_000}),
+        ("/api/v1/fs/ls", {"node_limit": MAX_NODE_LIMIT, "abs_limit": MAX_ABS_LIMIT}),
+        ("/api/v1/fs/tree", {"node_limit": MAX_NODE_LIMIT, "level_limit": MAX_LEVEL_LIMIT}),
+        ("/api/v1/fs/ls", {"limit": MAX_NODE_LIMIT}),
+        # abs_limit=0 stays allowed: an empty abstract cannot cost anything.
+        ("/api/v1/fs/ls", {"abs_limit": 0}),
+    ],
+)
+async def test_values_real_callers_use_are_accepted(client, service, endpoint, params):
+    uri = await _make_dir(service, "viking://resources/limit-bounds-ok")
+    response = await client.get(endpoint, params={"uri": uri, "output": "original", **params})
+    # The assertion is about validation, not about the handler: the request must
+    # reach it. (`/tree` returns 500 under MockLocalAGFS on `main` as well, with
+    # or without limits, so asserting 200 there would test the mock, not the cap.)
+    assert response.status_code != 400, response.text
+    if endpoint.endswith("/ls"):
+        assert response.status_code == 200, response.text
+
+
+async def test_listing_still_truncates_at_the_requested_limit(client, service):
+    """The cap is a ceiling on the request, not a change to listing behaviour."""
+    uri = await _make_dir(service, "viking://resources/limit-bounds-trunc")
+    for index in range(12):
+        await _make_dir(service, f"{uri}/d-{index:02d}")
+
+    response = await client.get(
+        "/api/v1/fs/ls", params={"uri": uri, "output": "original", "node_limit": 5}
+    )
+    assert response.status_code == 200, response.text
+    assert len(response.json()["result"]) == 5
+
+
+async def test_ceilings_stay_above_every_default():
+    """A ceiling below its own default would reject the no-argument request."""
+    assert MAX_NODE_LIMIT > 1000
+    assert MAX_LEVEL_LIMIT > 3
+    assert MAX_ABS_LIMIT > 256


### PR DESCRIPTION
Fixes #4289.

`node_limit`, its `limit` alias, `level_limit`, and `abs_limit` were declared with a default but no `ge`/`le`. `routers/debug.py:39` already caps its scroll `limit` with `ge=1, le=1000`; these two endpoints never got the same treatment, so one authenticated request could ask the server to collect and serialize an arbitrarily large tree in memory.

## The ceilings

Named constants at the top of the router, so they are adjustable in one place:

| parameter | default | ceiling |
| :-- | --: | --: |
| `node_limit` | 1000 | `MAX_NODE_LIMIT = 10_000` |
| `limit` (alias) | — | `MAX_NODE_LIMIT` |
| `level_limit` | 3 | `MAX_LEVEL_LIMIT = 32` |
| `abs_limit` | 256 | `MAX_ABS_LIMIT = 4_096` |

I picked each one by finding the largest value anything in the tree actually asks for, rather than by feel:

- The MCP `tree` / `list` tools and `bot`'s agent file tool (`_MAX_FILES = 1000`) cap themselves at **1000**, and the MCP `tree` docstring tells the model it may *raise* `node_limit`, so the ceiling has to leave real headroom above the default.
- `webdav.py:242` asks for **10000** — but it calls `service.fs.ls` in process, as do the `LS_ALL_NODES` (`2**31 - 1`) callers in `parse/parsers/directory.py` and the `node_limit=1000000` caller in `session/memory/graph_view.py`. **None of them cross this router**, so none are affected by the cap; 10 000 is simply the largest number the codebase treats as a sane listing size.
- Across the whole test suite the largest values used are `node_limit=1000`, `level_limit=10`, `abs_limit=1024` — all comfortably inside.

The `limit` alias is bounded identically. Capping only `node_limit` would leave a documented parameter as the way around it. `abs_limit` keeps `ge=0`: an empty abstract cannot cost anything.

## Out of scope

`/grep` and `/glob` take `node_limit` through a **POST body model** (`search.py`, `node_limit: Optional[int] = 256`), not a `Query`. Bounding those is a different validation surface with its own compatibility questions, so I left it out rather than bundle it. Happy to follow up.

## Tests

`tests/server/test_api_fs_listing_limits.py`, 24 cases, all passing:

- **Rejected** — the exact `node_limit=1000000&level_limit=100` from the report, plus each parameter one over its ceiling on both endpoints, plus non-positive values. Asserted as `400 / INVALID_ARGUMENT`, which is what the app's `RequestValidationError` handler produces, and it happens *before* the handler runs, so no listing work is done.
- **Accepted** — the defaults, the values the MCP tools / agent tool / WebDAV path use, each ceiling exactly, and `abs_limit=0`.
- **Behaviour unchanged** — `node_limit=5` against a 12-entry directory still returns 5.
- A guard that no ceiling can be set below its own default, which would silently break the no-argument request.

Mutation-tested:

- drop the `le=` ceilings (keep `ge=1`) → **8 failures**
- cap `node_limit` but not its `limit` alias → **3 failures**

Run against `tests/server/test_api_fs_{listing_limits,ls_sort,content_endpoint_suite}.py` and `test_filesystem_router.py`, the failure set is identical to `origin/main`'s. One note on that comparison: `test_api_fs_ls_sort.py` is **timing-flaky in this environment** — over three runs each it failed 1/3 with the change and 2/3 without, on identical commands — so I isolated it rather than count it either way. `ruff check` clean.
