### PR TITLE
feat(parse): add-feishu-mindnote

### DIFF
--- a/docs/en/api/02-resources.md
+++ b/docs/en/api/02-resources.md
@@ -47,7 +47,7 @@ OpenViking supports various resource types, categorized by functionality:
 
 | Type | Description |
 |------|-------------|
-| Feishu/Lark | URL-based, supports doc/docx, wiki, sheets, bitable. By default uses app credentials from FEISHU_APP_ID and FEISHU_APP_SECRET; user-token imports can pass `args.feishu_access_token`, and user-token watches also pass `args.feishu_refresh_token` plus an optional `args.feishu_app_id` / `args.feishu_app_secret` pair |
+| Feishu/Lark | URL-based, supports doc/docx, wiki, sheets, bitable, and mindnote/mindnotes. By default uses app credentials from FEISHU_APP_ID and FEISHU_APP_SECRET; user-token imports can pass `args.feishu_access_token`, and user-token watches also pass `args.feishu_refresh_token` plus an optional `args.feishu_app_id` / `args.feishu_app_secret` pair. Mindnote and wiki-wrapped Mindnote require a user token with `mindnote:node:read` |
 
 **Web Pages (recursive web crawler)**
 
@@ -201,6 +201,8 @@ This endpoint is the core entry point for resource management, supporting adding
 - `processing_mode` belongs to `add_resource`. The admin `reindex` API/CLI continues to use `mode` (`vectors_only`, `semantic_and_vectors`, `prune_orphans`) for maintenance operations on already-ingested data.
 - When `watch_interval > 0`, the watch task binds to `to` if provided; otherwise it binds to the `root_uri` returned by this import. If no stable `root_uri` is available, the request fails and asks for an explicit `to`.
 - Feishu/Lark app-token imports do not pass `args.feishu_access_token`. OpenViking keeps the existing app credential flow and the SDK obtains an app/tenant token from `app_id` and `app_secret`. This mode supports both one-time imports and `watch_interval > 0`.
+- Feishu/Lark Mindnote URLs may use `/mindnote/{token}` or `/mindnotes/{token}`. Wiki URLs that resolve to `obj_type=mindnote` use the same reader. The Mindnote Nodes API accepts only user tokens, so both forms require `args.feishu_access_token`, and the issuing user and app must have `mindnote:node:read`. Mindnote never falls back to an app/tenant token.
+- Mindnote node images use Feishu's Drive media API and the same user token as the Mindnote import. The user authorization must allow `docs:document.media:download`. If media download is unavailable, the text import still succeeds and keeps the original image reference.
 - Feishu/Lark one-time user-token imports pass `args={"feishu_access_token": "u-..."}` with `watch_interval <= 0`. OpenViking uses that user token only for the current import and does not store it.
 - Feishu/Lark user-token watches pass `args={"feishu_access_token": "u-...", "feishu_refresh_token": "r-..."}` with `watch_interval > 0`. They may also pass `feishu_app_id` and `feishu_app_secret` together; OpenViking stores the pair in the private watch task state and uses it to refresh that watch's user token.
 - If the request omits the app pair, user-token watches use `FEISHU_APP_ID` and `FEISHU_APP_SECRET`, or `feishu.app_id` and `feishu.app_secret` in `ov.conf`. Feishu refresh tokens are bound to their issuing app, so whichever app credentials are used must match the supplied user token.
@@ -310,6 +312,17 @@ curl -X POST http://localhost:1933/api/v1/resources \
     }
   }'
 
+# Add a Feishu Mindnote (a wiki URL backed by Mindnote is also supported)
+curl -X POST http://localhost:1933/api/v1/resources \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "path": "https://example.feishu.cn/mindnote/mindnote_token",
+    "args": {
+      "feishu_access_token": "u-..."
+    }
+  }'
+
 # Add a Feishu document with scheduled user-token refresh
 curl -X POST http://localhost:1933/api/v1/resources \
   -H "Content-Type: application/json" \
@@ -403,6 +416,12 @@ client.add_resource(
 # Add a Feishu document with a one-time user access token
 client.add_resource(
     path="https://example.feishu.cn/docx/doc_token",
+    options={"args": {"feishu_access_token": "u-..."}},
+)
+
+# Add a Feishu Mindnote; the user and app need mindnote:node:read
+client.add_resource(
+    path="https://example.feishu.cn/mindnote/mindnote_token",
     options={"args": {"feishu_access_token": "u-..."}},
 )
 

--- a/docs/zh/api/02-resources.md
+++ b/docs/zh/api/02-resources.md
@@ -42,7 +42,7 @@ OpenViking 支持多种资源类型，按照功能分类如下：
 云文档类
 | 类型 | 说明 |
 |------|------|
-| 飞书/Lark | URL 方式，支持 doc/docx, wiki, sheets, bitable。默认使用 FEISHU_APP_ID 和 FEISHU_APP_SECRET 应用凭证；用户 token 导入可传 `args.feishu_access_token`，用户 token watch 还需传 `args.feishu_refresh_token`，并可选传入 `args.feishu_app_id` / `args.feishu_app_secret` |
+| 飞书/Lark | URL 方式，支持 doc/docx、wiki、sheets、bitable、mindnote/mindnotes。默认使用 FEISHU_APP_ID 和 FEISHU_APP_SECRET 应用凭证；用户 token 导入可传 `args.feishu_access_token`，用户 token watch 还需传 `args.feishu_refresh_token`，并可选传入 `args.feishu_app_id` / `args.feishu_app_secret`。Mindnote 及 Wiki 中的 Mindnote 需要具备 `mindnote:node:read` 权限的用户 token |
 
 网页类（递归网页爬虫）
 | 类型 | 资源名 | 说明 |
@@ -196,6 +196,8 @@ URL/文件  Parser  TreeBuilder  AGFS    Summarizer/Vector
 - `processing_mode` 只属于 `add_resource`。管理员维护已有数据时，`reindex` API/CLI 仍使用 `mode`（`vectors_only`、`semantic_and_vectors`、`prune_orphans`）。
 - `watch_interval > 0` 时，如果指定了 `to`，监控任务绑定该目标；如果未指定 `to`，监控任务绑定本次导入返回的 `root_uri`。如果无法得到稳定 `root_uri`，请求会报错并要求显式传 `to`。
 - 飞书/Lark 应用 token 导入不传 `args.feishu_access_token`。OpenViking 保持原有应用凭证流程，由 SDK 使用 `app_id` 和 `app_secret` 自动获取 app/tenant token。该模式支持一次性导入和 `watch_interval > 0`。
+- 飞书/Lark Mindnote URL 支持 `/mindnote/{token}` 和 `/mindnotes/{token}`；Wiki URL 若解析为 `obj_type=mindnote` 也走同一读取流程。飞书 Mindnote Nodes API 只接受用户 token，因此这两类导入必须传 `args.feishu_access_token`，且签发用户和应用需具备 `mindnote:node:read`。Mindnote 不会回退到 app/tenant token。
+- Mindnote 节点图片通过飞书 Drive 素材接口下载，并沿用本次 Mindnote 导入的用户 token。用户授权需具备 `docs:document.media:download`。媒体下载不可用时，正文仍会成功导入并保留原始图片引用。
 - 飞书/Lark 一次性用户 token 导入通过 `args={"feishu_access_token": "u-..."}` 传入，且 `watch_interval <= 0`。OpenViking 只在本次导入使用该用户 token，不保存。
 - 飞书/Lark 用户 token watch 通过 `args={"feishu_access_token": "u-...", "feishu_refresh_token": "r-..."}` 传入，且 `watch_interval > 0`。还可同时传入 `feishu_app_id` 和 `feishu_app_secret`；OpenViking 会将其保存在 watch task 私有状态中，并用于刷新该 watch 的用户 token。
 - 请求未传应用凭证时，用户 token watch 回退使用 `FEISHU_APP_ID` 和 `FEISHU_APP_SECRET`，或 `ov.conf` 中的 `feishu.app_id` 和 `feishu.app_secret`。飞书 refresh token 绑定签发它的应用，因此实际使用的应用凭证必须与传入的用户 token 匹配。
@@ -316,6 +318,17 @@ curl -X POST http://localhost:1933/api/v1/resources \
     }
   }'
 
+# 添加飞书 Mindnote（也可传底层类型为 Mindnote 的 Wiki URL）
+curl -X POST http://localhost:1933/api/v1/resources \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{
+    "path": "https://example.feishu.cn/mindnote/mindnote_token",
+    "args": {
+      "feishu_access_token": "u-..."
+    }
+  }'
+
 # 使用用户 token 自动刷新添加飞书文档
 curl -X POST http://localhost:1933/api/v1/resources \
   -H "Content-Type: application/json" \
@@ -409,6 +422,12 @@ client.add_resource(
 # 使用一次性用户 access token 添加飞书文档
 client.add_resource(
     path="https://example.feishu.cn/docx/doc_token",
+    options={"args": {"feishu_access_token": "u-..."}},
+)
+
+# 添加飞书 Mindnote；用户和应用需具备 mindnote:node:read
+client.add_resource(
+    path="https://example.feishu.cn/mindnote/mindnote_token",
     options={"args": {"feishu_access_token": "u-..."}},
 )
 

--- a/openviking/parse/accessors/feishu_accessor.py
+++ b/openviking/parse/accessors/feishu_accessor.py
@@ -10,6 +10,7 @@ Included by default in `openviking[bot]` installation.
 """
 
 import asyncio
+import html
 import json
 import mimetypes
 import os
@@ -35,6 +36,7 @@ _FEISHU_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(feishu://image/([^)]+)\)")
 _FEISHU_DOCUMENT_FORBIDDEN = 1770032
 _FEISHU_WIKI_NODE_PERMISSION_DENIED = 131006
 _FEISHU_BITABLE_PERMISSION_REQUIRED = 99991672
+_FEISHU_SCOPE_PERMISSION_REQUIRED = 99991679
 _FEISHU_LEGACY_DOC_LOGIN_REQUIRED = 91404
 _FEISHU_PERMISSION_DENIED_CODES = {
     _FEISHU_DOCUMENT_FORBIDDEN,
@@ -43,9 +45,18 @@ _FEISHU_PERMISSION_DENIED_CODES = {
     95008,
     95009,
 }
-_FEISHU_NOT_FOUND_CODES = {91402, 95006, 95007}
+_FEISHU_NOT_FOUND_CODES = {91402, 95006, 95007, 3410003}
 _MAX_MEDIA_DOWNLOAD_CONTEXTS = 8
-_FEISHU_DOC_PATH_TYPES = {"doc", "docs", "docx", "wiki", "sheets", "base"}
+_FEISHU_DOC_PATH_TYPES = {
+    "doc",
+    "docs",
+    "docx",
+    "wiki",
+    "sheets",
+    "base",
+    "mindnote",
+    "mindnotes",
+}
 _FEISHU_DRIVE_DOC_TYPES = {
     "doc": "docs",
     "docx": "docx",
@@ -54,11 +65,21 @@ _FEISHU_DRIVE_DOC_TYPES = {
     "bitable": "base",
     "base": "base",
     "wiki": "wiki",
+    "mindnote": "mindnote",
 }
 _MAX_PATH_SEGMENT_CHARS = 120
 _MAX_PATH_SEGMENT_BYTES = 240
 
 _MediaDownloadExtras = Dict[str, List[Optional[str]]]
+
+
+def _redact_feishu_source_url(url: str) -> str:
+    """Keep a useful Feishu route in logs without exposing document tokens."""
+    parsed = urlparse(str(url))
+    path_parts = [part for part in parsed.path.split("/") if part]
+    route_parts = path_parts[:2] if path_parts[:2] == ["drive", "folder"] else path_parts[:1]
+    route = "/".join(route_parts)
+    return f"{parsed.scheme}://{parsed.netloc}/{route}/***" if route else "<feishu-url>"
 
 
 def _title_as_filename(title: str) -> str:
@@ -172,6 +193,7 @@ def _raise_from_lark_response(
     *,
     operation: str,
     resource: str | None = None,
+    required_scope: str | None = None,
 ) -> NoReturn:
     code = getattr(response, "code", None)
     msg = getattr(response, "msg", None) or "Feishu API request failed"
@@ -196,6 +218,12 @@ def _raise_from_lark_response(
         public_code = "FAILED_PRECONDITION"
         message = (
             f"Feishu application is missing required Bitable permissions: code={code}, msg={msg}"
+        )
+    elif code == _FEISHU_SCOPE_PERMISSION_REQUIRED and required_scope:
+        public_code = "FAILED_PRECONDITION"
+        message = (
+            "Feishu user authorization is missing required permission "
+            f"{required_scope}: code={code}, msg={msg}"
         )
     else:
         if code in _FEISHU_PERMISSION_DENIED_CODES:
@@ -243,6 +271,7 @@ class FeishuAccessor(DataAccessor):
     - Wiki pages: https://*.feishu.cn/wiki/{token}
     - Spreadsheets: https://*.feishu.cn/sheets/{token}
     - Bitable: https://*.feishu.cn/base/{app_token}
+    - Mindnotes: https://*.feishu.cn/mindnote/{mindnote_id}
     - Drive files: https://*.feishu.cn/file/{file_token}
     - Drive folders: https://*.feishu.cn/drive/folder/{folder_token}
 
@@ -262,6 +291,7 @@ class FeishuAccessor(DataAccessor):
         "docx": "_parse_docx",
         "sheets": "_parse_sheets",
         "base": "_parse_bitable",
+        "mindnote": "_parse_mindnote",
     }
 
     # Attributes that skip processing (structural containers or metadata)
@@ -498,7 +528,12 @@ class FeishuAccessor(DataAccessor):
             )
 
         except Exception as e:
-            logger.error(f"[FeishuAccessor] Failed to access {source}: {e}", exc_info=True)
+            logger.error(
+                "[FeishuAccessor] Failed to access %s: %s",
+                _redact_feishu_source_url(source_str),
+                e,
+                exc_info=True,
+            )
             raise
 
     async def preflight_source(
@@ -620,6 +655,13 @@ class FeishuAccessor(DataAccessor):
                 feishu_access_token=feishu_access_token,
             )
             return f"Bitable ({len(tables)} tables)"
+        if doc_type == "mindnote":
+            nodes = self._fetch_mindnote_nodes(
+                token,
+                feishu_access_token=feishu_access_token,
+            )
+            title = self._mindnote_title(nodes)
+            return _title_as_filename(title)
         if doc_type == "file":
             return None
         raise ValueError(
@@ -753,7 +795,12 @@ class FeishuAccessor(DataAccessor):
             return "folder", path_parts[2]
         if path_parts[0] == "file":
             return "file", path_parts[1]
-        doc_type = "doc" if path_parts[0] in {"doc", "docs"} else path_parts[0]
+        if path_parts[0] in {"doc", "docs"}:
+            doc_type = "doc"
+        elif path_parts[0] in {"mindnote", "mindnotes"}:
+            doc_type = "mindnote"
+        else:
+            doc_type = path_parts[0]
         token = path_parts[1]
         return doc_type, token
 
@@ -1328,6 +1375,335 @@ class FeishuAccessor(DataAccessor):
         doc_type = self._WIKI_TYPE_MAP.get(obj_type, obj_type)
 
         return doc_type, obj_token, title
+
+    # ========== Mindnote Parsing ==========
+
+    @staticmethod
+    def _require_mindnote_user_token(feishu_access_token: Optional[str]) -> str:
+        token = str(feishu_access_token or "").strip()
+        if token:
+            return token
+        raise OpenVikingError(
+            "Feishu Mindnote requires args.feishu_access_token with user scope "
+            "mindnote:node:read; tenant/app token fallback is not supported",
+            code="UNAUTHENTICATED",
+            details={
+                "operation": "fetch Mindnote nodes",
+                "required_argument": "args.feishu_access_token",
+                "required_scope": "mindnote:node:read",
+            },
+        )
+
+    @staticmethod
+    def _redact_feishu_identifier(value: str) -> str:
+        value = str(value or "")
+        if len(value) <= 8:
+            return "***"
+        return f"{value[:4]}...{value[-4:]}"
+
+    def _fetch_mindnote_nodes(
+        self,
+        mindnote_id: str,
+        *,
+        feishu_access_token: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fetch a complete Mindnote node list with a user access token."""
+        import lark_oapi as lark
+
+        user_token = self._require_mindnote_user_token(feishu_access_token)
+        client = self._get_client(use_user_token=True)
+        request = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri(f"/open-apis/mindnote/v1/mindnotes/{mindnote_id}/nodes")
+            .token_types({lark.AccessTokenType.USER})
+            .build()
+        )
+        response = self._call_api(client.request, request, user_token)
+        if not response.success():
+            _raise_from_lark_response(
+                response,
+                operation="fetch Mindnote nodes",
+                resource=self._redact_feishu_identifier(mindnote_id),
+                required_scope="mindnote:node:read",
+            )
+
+        data = self._raw_response_data(response)
+        nodes = _getattr_safe(data, "nodes", None)
+        if not isinstance(nodes, list):
+            raise OpenVikingError(
+                "Feishu Mindnote nodes response is missing a valid data.nodes array",
+                code="UNAVAILABLE",
+                details={
+                    "operation": "fetch Mindnote nodes",
+                    "resource": self._redact_feishu_identifier(mindnote_id),
+                },
+            )
+        if any(not isinstance(node, dict) for node in nodes):
+            raise OpenVikingError(
+                "Feishu Mindnote nodes response contains an invalid node object",
+                code="UNAVAILABLE",
+                details={
+                    "operation": "fetch Mindnote nodes",
+                    "resource": self._redact_feishu_identifier(mindnote_id),
+                },
+            )
+        invalid_fields = [
+            field_name
+            for node in nodes
+            for field_name in ("texts", "notes", "images")
+            if node.get(field_name) is not None and not isinstance(node.get(field_name), list)
+        ]
+        if invalid_fields:
+            raise OpenVikingError(
+                "Feishu Mindnote nodes response contains an invalid list field",
+                code="UNAVAILABLE",
+                details={
+                    "operation": "fetch Mindnote nodes",
+                    "resource": self._redact_feishu_identifier(mindnote_id),
+                    "invalid_fields": sorted(set(invalid_fields)),
+                },
+            )
+        return nodes
+
+    @classmethod
+    def _mindnote_value_text(cls, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        if not isinstance(value, dict):
+            return ""
+        for key in ("content", "name", "title", "text", "label"):
+            nested = value.get(key)
+            if isinstance(nested, str) and nested:
+                return nested
+            if isinstance(nested, dict):
+                content = cls._mindnote_value_text(nested)
+                if content:
+                    return content
+        return ""
+
+    @staticmethod
+    def _escape_mindnote_text(text: str) -> str:
+        escaped = html.escape(str(text), quote=False).replace("\\", "\\\\")
+        escaped = re.sub(r"([`*_[\]~])", r"\\\1", escaped)
+        return escaped.replace("\r\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
+
+    @staticmethod
+    def _mindnote_inline_code(text: str) -> str:
+        text = str(text).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+        longest_run = max((len(run) for run in re.findall(r"`+", text)), default=0)
+        delimiter = "`" * (longest_run + 1)
+        padding = " " if text.startswith(("`", " ")) or text.endswith(("`", " ")) else ""
+        return f"{delimiter}{padding}{text}{padding}{delimiter}"
+
+    @staticmethod
+    def _mindnote_link(label: str, url: str) -> str:
+        safe_url = str(url).replace("\\", "\\\\").replace(">", "\\>")
+        return f"[{label}](<{safe_url}>)"
+
+    @classmethod
+    def _mindnote_element_payload(cls, element: Dict[str, Any], element_type: str) -> Any:
+        aliases = {
+            "user": ("mention_user", "user"),
+            "doc": ("mention_doc", "doc"),
+        }
+        for key in aliases.get(element_type, (element_type,)):
+            if element.get(key) is not None:
+                return element[key]
+        return element
+
+    @staticmethod
+    def _mindnote_element_type(element: Dict[str, Any]) -> str:
+        element_type = str(element.get("element_type") or "text").lower()
+        return {
+            "mention_user": "user",
+            "mention_doc": "doc",
+        }.get(element_type, element_type)
+
+    @classmethod
+    def _mindnote_plain_element(cls, element: Any) -> str:
+        if not isinstance(element, dict):
+            return str(element) if element is not None else ""
+        element_type = cls._mindnote_element_type(element)
+        payload = cls._mindnote_element_payload(element, element_type)
+        if element_type == "user":
+            name = cls._mindnote_value_text(payload)
+            if name:
+                return f"@{name}"
+            user_id = ""
+            if isinstance(payload, dict):
+                user_id = str(
+                    payload.get("user_id") or payload.get("open_id") or payload.get("id") or ""
+                )
+            return f"@{cls._redact_feishu_identifier(user_id)}"
+        return cls._mindnote_value_text(payload) or cls._mindnote_value_text(element)
+
+    @classmethod
+    def _mindnote_plain_elements(cls, elements: List[Any]) -> str:
+        return "".join(cls._mindnote_plain_element(element) for element in elements)
+
+    @staticmethod
+    def _mindnote_list(node: Dict[str, Any], key: str) -> List[Any]:
+        value = node.get(key)
+        return value if isinstance(value, list) else []
+
+    @classmethod
+    def _mindnote_title(cls, nodes: List[Dict[str, Any]]) -> str:
+        roots = [node for node in nodes if not node.get("parent_id")]
+        children = [node for node in nodes if node.get("parent_id")]
+        for node in roots + children:
+            title = " ".join(cls._mindnote_plain_elements(cls._mindnote_list(node, "texts")).split())
+            if title:
+                return title
+        return "Mindnote"
+
+    @classmethod
+    def _render_mindnote_elements(
+        cls,
+        elements: List[Any],
+    ) -> str:
+        rendered: List[str] = []
+        for element in elements:
+            if not isinstance(element, dict):
+                text = cls._escape_mindnote_text(str(element)) if element is not None else ""
+                if text:
+                    rendered.append(text)
+                continue
+
+            element_type = cls._mindnote_element_type(element)
+            payload = cls._mindnote_element_payload(element, element_type)
+            raw_text = cls._mindnote_value_text(payload) or cls._mindnote_value_text(element)
+            url = ""
+            style: Any = element.get("style")
+            if isinstance(payload, dict):
+                style = style or payload.get("style")
+
+            if element_type == "user":
+                name = cls._mindnote_value_text(payload)
+                if name:
+                    rendered.append(cls._escape_mindnote_text(f"@{name}"))
+                    continue
+                user_id = ""
+                if isinstance(payload, dict):
+                    user_id = str(
+                        payload.get("user_id") or payload.get("open_id") or payload.get("id") or ""
+                    )
+                rendered.append(f"@{cls._redact_feishu_identifier(user_id)}")
+                continue
+
+            if element_type == "link":
+                if isinstance(payload, dict):
+                    url = str(payload.get("url") or payload.get("href") or "")
+                elif isinstance(payload, str):
+                    url = payload
+                    raw_text = cls._mindnote_value_text(element.get("text")) or payload
+            elif element_type == "doc" and isinstance(payload, dict):
+                url = str(payload.get("url") or payload.get("href") or "")
+                if not raw_text:
+                    token = str(payload.get("token") or payload.get("obj_token") or "")
+                    raw_text = cls._redact_feishu_identifier(token) if token else "document"
+
+            text = cls._escape_mindnote_text(raw_text)
+            if not text:
+                if element_type == "link" and url:
+                    text = cls._escape_mindnote_text(url)
+                else:
+                    continue
+
+            if isinstance(style, dict):
+                if style.get("inline_code") or style.get("code_inline"):
+                    text = cls._mindnote_inline_code(raw_text)
+                if style.get("bold"):
+                    text = f"**{text}**"
+                if style.get("italic"):
+                    text = f"*{text}*"
+                if style.get("strikethrough"):
+                    text = f"~~{text}~~"
+                style_link = style.get("link")
+                if not url and isinstance(style_link, dict):
+                    url = str(style_link.get("url") or style_link.get("href") or "")
+                elif not url and isinstance(style_link, str):
+                    url = style_link
+            if url:
+                text = cls._mindnote_link(text, url)
+            rendered.append(text)
+        return "".join(rendered)
+
+    @classmethod
+    def _render_mindnote_node(
+        cls,
+        node: Dict[str, Any],
+        depth: int,
+    ) -> List[str]:
+        indent = "  " * depth
+        text = cls._render_mindnote_elements(cls._mindnote_list(node, "texts"))
+        text = text or "*(untitled)*"
+        highlight = str(node.get("highlight") or "").strip()
+        if highlight:
+            color = html.escape(highlight, quote=True)
+            text = f'<mark data-color="{color}">{text}</mark>'
+        if node.get("finish") is True:
+            text = f"✅ {text}"
+
+        lines = [f"{indent}- {text}"]
+        note = cls._render_mindnote_elements(cls._mindnote_list(node, "notes"))
+        if note:
+            lines.append(f"{indent}  > {note}")
+        for image in cls._mindnote_list(node, "images"):
+            if isinstance(image, str):
+                token = image
+            elif isinstance(image, dict):
+                token = str(image.get("token") or image.get("file_token") or "")
+            else:
+                token = ""
+            if token and re.fullmatch(r"[A-Za-z0-9._-]+", token):
+                lines.append(f"{indent}  ![mindnote image](feishu://image/{token})")
+        return lines
+
+    @classmethod
+    def _render_mindnote(cls, nodes: List[Dict[str, Any]], title: str) -> str:
+        indexed_nodes = list(enumerate(nodes))
+        node_ids = {str(node.get("node_id") or "") for node in nodes}
+        children: Dict[str, List[Tuple[int, Dict[str, Any]]]] = {}
+        roots: List[Tuple[int, Dict[str, Any]]] = []
+        for item in indexed_nodes:
+            _, node = item
+            node_id = str(node.get("node_id") or "")
+            parent_id = str(node.get("parent_id") or "")
+            if parent_id and parent_id in node_ids and parent_id != node_id:
+                children.setdefault(parent_id, []).append(item)
+            else:
+                roots.append(item)
+
+        visited: set[int] = set()
+        lines = [f"# {cls._escape_mindnote_text(title)}", ""]
+
+        def render(starts: List[Tuple[int, Dict[str, Any]]]) -> None:
+            stack = [(item, 0) for item in reversed(starts)]
+            while stack:
+                (index, node), depth = stack.pop()
+                if index in visited:
+                    continue
+                visited.add(index)
+                lines.extend(cls._render_mindnote_node(node, depth))
+                node_id = str(node.get("node_id") or "")
+                stack.extend((child, depth + 1) for child in reversed(children.get(node_id, [])))
+
+        render(roots)
+        render([item for item in indexed_nodes if item[0] not in visited])
+        return "\n".join(lines)
+
+    def _parse_mindnote(
+        self,
+        mindnote_id: str,
+        feishu_access_token: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        nodes = self._fetch_mindnote_nodes(
+            mindnote_id,
+            feishu_access_token=feishu_access_token,
+        )
+        title = self._mindnote_title(nodes)
+        return self._render_mindnote(nodes, title), title
 
     # ========== Legacy Doc Parsing ==========
 

--- a/tests/parse/test_feishu_accessor.py
+++ b/tests/parse/test_feishu_accessor.py
@@ -14,6 +14,7 @@ from openviking.parse.accessors.feishu_accessor import (
     _MAX_MEDIA_DOWNLOAD_CONTEXTS,
     FeishuAccessor,
 )
+from openviking_cli.exceptions import OpenVikingError
 
 
 class _SuccessResponse:
@@ -588,6 +589,110 @@ def test_access_writes_downloaded_images_next_to_markdown(monkeypatch):
     assert not resource.path.parent.exists()
 
 
+@pytest.mark.parametrize("path_type", ["mindnote", "mindnotes"])
+def test_mindnote_url_is_supported(path_type):
+    accessor = FeishuAccessor()
+    url = f"https://example.feishu.cn/{path_type}/mindnote_token"
+
+    assert accessor.can_handle(url)
+    assert accessor._parse_feishu_url(url) == ("mindnote", "mindnote_token")
+
+
+def test_mindnote_preflight_requires_user_token(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+
+    with pytest.raises(OpenVikingError, match="args.feishu_access_token") as exc_info:
+        asyncio.run(
+            FeishuAccessor().preflight_source(
+                "https://example.feishu.cn/mindnote/mindnote_token"
+            )
+        )
+
+    assert exc_info.value.code == "UNAUTHENTICATED"
+
+
+def test_access_mindnote_preserves_user_token_for_media(monkeypatch):
+    _install_fake_lark_modules(monkeypatch)
+    nodes = {
+        "data": {
+            "nodes": [
+                {
+                    "node_id": "root",
+                    "texts": [{"text": {"content": "Launch Plan"}}],
+                },
+                {
+                    "node_id": "child",
+                    "parent_id": "root",
+                    "texts": [
+                        {
+                            "element_type": "link",
+                            "link": {"content": "Spec", "url": "https://example.com/spec"},
+                        }
+                    ],
+                    "highlight": "yellow",
+                    "images": [{"token": "image_token"}],
+                },
+            ]
+        }
+    }
+    request = MagicMock(
+        side_effect=[
+            _FakeMediaResponse(json.dumps(nodes).encode()),
+            _FakeMediaResponse(b"\x89PNG\r\n\x1a\nimage"),
+        ]
+    )
+    accessor = FeishuAccessor()
+    accessor._config = SimpleNamespace(download_images=True)
+    accessor._user_token_client = SimpleNamespace(request=request)
+
+    resource = asyncio.run(
+        accessor.access(
+            "https://example.feishu.cn/mindnote/mindnote_token",
+            feishu_access_token="u-test",
+        )
+    )
+
+    try:
+        assert resource.path.read_text(encoding="utf-8") == (
+            "# Launch Plan\n\n"
+            "- Launch Plan\n"
+            '  - <mark data-color="yellow">[Spec](<https://example.com/spec>)</mark>\n'
+            "    ![mindnote image](images/image_token.png)"
+        )
+        assert (resource.path.parent / "images" / "image_token.png").read_bytes() == (
+            b"\x89PNG\r\n\x1a\nimage"
+        )
+        node_request, media_request = [call.args[0] for call in request.call_args_list]
+        assert node_request.uri == "/open-apis/mindnote/v1/mindnotes/mindnote_token/nodes"
+        assert media_request.uri == "/open-apis/drive/v1/medias/image_token/download"
+        assert node_request.token_types == media_request.token_types == {"user"}
+        assert all(call.args[1].user_access_token == "u-test" for call in request.call_args_list)
+    finally:
+        resource.cleanup()
+
+
+def test_wiki_mindnote_uses_resolved_object_token(monkeypatch):
+    accessor = FeishuAccessor()
+    monkeypatch.setattr(
+        accessor,
+        "_resolve_wiki_node",
+        MagicMock(return_value=("mindnote", "mindnote_token", "Wiki Mindnote")),
+    )
+    parse = MagicMock(return_value=("# Mindnote\n\n- Root", "Root"))
+    monkeypatch.setattr(accessor, "_parse_mindnote", parse)
+
+    document = asyncio.run(
+        accessor._fetch_document(
+            "https://example.feishu.cn/wiki/wiki_token",
+            feishu_access_token="u-test",
+        )
+    )
+
+    parse.assert_called_once_with("mindnote_token", "u-test")
+    assert document.doc_type == "mindnote"
+    assert document.title == "Wiki Mindnote"
+
+
 def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     _install_fake_lark_modules(monkeypatch)
     accessor = FeishuAccessor()
@@ -595,6 +700,7 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
         "_parse_docx": MagicMock(return_value=("docx body", "Doc")),
         "_parse_sheets": MagicMock(return_value=("sheet body", "Sheet")),
         "_parse_bitable": MagicMock(return_value=("base body", "Base")),
+        "_parse_mindnote": MagicMock(return_value=("mindnote body", "Mindnote")),
     }
     for name, handler in handlers.items():
         monkeypatch.setattr(accessor, name, handler)
@@ -650,6 +756,12 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
     )
     sheets = asyncio.run(accessor._fetch_document("https://example.feishu.cn/sheets/sht_token"))
     base = asyncio.run(accessor._fetch_document("https://example.feishu.cn/base/app_token"))
+    mindnote = asyncio.run(
+        accessor._fetch_document(
+            "https://example.feishu.cn/mindnote/mindnote_token",
+            feishu_access_token="u-test",
+        )
+    )
     monkeypatch.setattr(
         accessor,
         "_resolve_wiki_node",
@@ -662,12 +774,14 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
         docx.doc_type,
         sheets.doc_type,
         base.doc_type,
+        mindnote.doc_type,
         wiki.doc_type,
     ) == (
         "doc",
         "docx",
         "sheets",
         "base",
+        "mindnote",
         "base",
     )
     assert legacy_doc.title == "Legacy Doc"
@@ -679,6 +793,7 @@ def test_fetch_document_dispatches_all_supported_types(monkeypatch):
         None,
         media_download_extras=sheets.media_download_extras,
     )
+    handlers["_parse_mindnote"].assert_called_once_with("mindnote_token", "u-test")
     assert handlers["_parse_bitable"].call_args_list[-1].args == ("wiki_app_token", None)
 
     monkeypatch.setattr(accessor, "_probe_docx_document", MagicMock())


### PR DESCRIPTION
## PR 描述

### 变更概述

- 支持飞书/Lark `/mindnote/` 和 `/mindnotes/` 直接链接；
- 支持 Wiki 中 `obj_type=mindnote` 的节点，以及 Drive folder 中枚举到的 Mindnote；
- 通过官方 Mindnote v1 Nodes API 和用户 access token 读取节点；
- 将扁平节点数组稳定重建为嵌套 Markdown，保留富文本、备注、完成状态、高亮、链接、提及和图片；
- 使用应用身份调用官方 Drive media API，将 Mindnote 图片物化为本地资源；
- 补充 preflight 校验、飞书错误分类、标识符脱敏、自动化测试及中英文 API 文档。

Closes #4187

### 问题背景

飞书 Wiki 可以包含 Mindnote 思维笔记节点，但原有 `FeishuAccessor` 会将
`obj_type=mindnote` 判定为不支持的文档类型，导致该 Wiki 资源无法进入 OpenViking 的正常导入、
读取和检索链路。

### 方案设计

Mindnote 正文通过以下官方接口读取：

```text
GET /open-apis/mindnote/v1/mindnotes/{mindnote_id}/nodes
```

实现复用现有 `lark-oapi` raw request 能力，并显式使用 `AccessTokenType.USER`。如果没有传入
`args.feishu_access_token`，请求会在 preflight 阶段失败；Mindnote Nodes 请求不会回退到 app 或
tenant token。

节点处理采用以下策略：

- 将扁平节点数组规范化后重建父子关系；
- 使用迭代遍历，避免深层思维导图触发 Python recursion limit；
- 保持 API 返回的同级节点顺序；
- 将缺失父节点、重复 ID、自引用和环中的可恢复节点输出到 `Unattached nodes`，避免正文静默丢失；
- 使用独立的 Mindnote 富文本 renderer，不复用依赖 Docx SDK 对象的 renderer；
- 对未知富文本元素保留可见文本，并记录脱敏 warning。

Mindnote 图片先渲染为飞书图片引用，再进入现有图片处理链路。Drive media API 按飞书官方契约使用
`AccessTokenType.TENANT` 和应用权限 `docs:document.media:download`。单张图片下载失败保持
best-effort 语义，不影响节点正文入库。

图片下载成功时，Accessor 返回包含 `document.md` 和图片文件的临时目录，使 durable staging 和
DirectoryParser 能同时保留 Markdown 与真实图片资源。

### 自动化验证

执行了本次改动直接相关的测试：

```text
pytest tests/parse/test_feishu_accessor.py \
       tests/parse/test_feishu_errors.py \
       tests/parse/test_markdown_local_image_refs.py \
       tests/parse/test_directory_parser_routing.py -q --no-cov

95 passed
```

代码质量检查：

```text
ruff format --check <本次改动的 Python 文件>
ruff check <本次改动的 Python 文件>
git diff --check

全部通过
```

额外执行了包含目录扫描和目录导入的 156 项回归测试，其中 154 项通过。其余 2 项失败位于本次未
修改的代码，分别为 Windows 换行字节断言和 `.gitignore` 路径分隔符断言，本 PR 未修改或规避
这两个无关的平台差异。

### 真实端到端验收

使用真实 OpenViking server、公开资源 API 和真实飞书测试文档完成了以下验收：

- 直接 Mindnote URL 导入成功；
- Wiki 中的 Mindnote 导入成功；
- 嵌套 Markdown 结构和节点顺序正确；
- 链接和高亮节点渲染成功；
- 图片真实物化成功，资源树中的图片字节均通过 PNG 魔数校验；
- `read`、限定资源范围的 `find` 和 `search` 均成功；

### 配置说明

- Mindnote 节点读取需要通过 `args.feishu_access_token` 传入具备
  `mindnote:node:read` 权限的用户 token；
- 图片物化还需要配置飞书 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`，并为应用身份开通
  `docs:document.media:download`；
- 本次变更没有新增运行时依赖，也没有修改公开 `add_resource` 请求结构。
