### PR TITLE
fix(server): bound the tag list on set_tags and reindex (#4290)

### DIFF
--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Content endpoints for OpenViking HTTP Server."""
 
-from typing import Literal
+from typing import Annotated, Literal
 from urllib.parse import quote
 
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import Response as FastAPIResponse
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from openviking.core.namespace import (
     is_hidden_by_actor_peer_view,
@@ -73,13 +73,29 @@ class BatchWriteRequest(BaseModel):
     telemetry: TelemetryRequest = False
 
 
+# Bounds for caller-supplied search tags. Every tag becomes its own `must`
+# clause in build_search_tags_filter() and the whole list is stored on the
+# record, so an unbounded list turns one authenticated request into an
+# arbitrarily large filter and an arbitrarily large stored metadata field.
+#
+# Enforced on the request models rather than inside normalize_search_tags():
+# Experience lineage builds one tag per read Experience with the percent-escaped
+# URI as the key (session/memory/experience_lineage.py), so a cap in the shared
+# normalizer would silently drop data no caller ever supplied.
+MAX_SEARCH_TAGS = 64
+MAX_SEARCH_TAG_LENGTH = 1024
+
+SearchTag = Annotated[str, Field(max_length=MAX_SEARCH_TAG_LENGTH)]
+SearchTagList = Annotated[list[SearchTag], Field(max_length=MAX_SEARCH_TAGS)]
+
+
 class SetTagsRequest(BaseModel):
     """Request to set explicit k=v retrieval tags metadata for a file or directory."""
 
     model_config = ConfigDict(extra="forbid")
 
     uri: str
-    tags: list[str]
+    tags: SearchTagList
     mode: str = "replace"
     recursive: bool = False
     telemetry: TelemetryRequest = False
@@ -93,7 +109,7 @@ class ReindexRequest(BaseModel):
     wait: bool = True
     dry_run: bool = False
     recursive: bool = True
-    tags: list[str] | None = None
+    tags: SearchTagList | None = None
     tag_mode: str = "replace"
 
 

--- a/tests/server/test_api_set_tags_bounds.py
+++ b/tests/server/test_api_set_tags_bounds.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for #4290: unbounded `tags` on set_tags / reindex.
+
+`tags: list[str]` carried no length constraint, so one authenticated request
+could submit 10k entries or a single 10KB value. Every tag becomes its own
+`must` clause in `build_search_tags_filter()` and the whole list is stored on
+the record, so the cost lands on every later search as well as on the write.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers.content import (
+    MAX_SEARCH_TAG_LENGTH,
+    MAX_SEARCH_TAGS,
+    ReindexRequest,
+    SetTagsRequest,
+)
+from openviking.service.fs_service import FSService
+from openviking.service.session_service import SessionService
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.session.user_id import UserIdentifier
+from tests.utils.mock_agfs import MockLocalAGFS
+
+
+@pytest.fixture
+def service(temp_dir):
+    mock_agfs = MockLocalAGFS(root_path=temp_dir / "mock_agfs_root")
+    viking_fs = VikingFS(agfs=mock_agfs)
+    return SimpleNamespace(
+        fs=FSService(viking_fs=viking_fs),
+        sessions=SessionService(viking_fs=viking_fs),
+        viking_fs=viking_fs,
+    )
+
+
+def _tags(count, value="v"):
+    return [f"k{index}={value}" for index in range(count)]
+
+
+# ── Rejected ──
+
+
+@pytest.mark.parametrize("model", [SetTagsRequest, ReindexRequest])
+@pytest.mark.parametrize(
+    "tags,reason",
+    [
+        (_tags(MAX_SEARCH_TAGS + 1), "one over the count cap"),
+        (_tags(10_000), "the reported 10k list"),
+        (["k=" + "v" * MAX_SEARCH_TAG_LENGTH], "one over the length cap"),
+        (["k=" + "v" * 10_240], "the reported 10KB value"),
+    ],
+)
+def test_oversized_tags_are_rejected(model, tags, reason):
+    with pytest.raises(ValidationError):
+        model(uri="viking://resources/x", tags=tags)
+
+
+# ── Accepted ──
+
+
+@pytest.mark.parametrize("model", [SetTagsRequest, ReindexRequest])
+@pytest.mark.parametrize(
+    "tags",
+    [
+        ["topic=rag", "lang=python", "stage=draft", "owner=team"],
+        _tags(MAX_SEARCH_TAGS),
+        ["k=" + "v" * (MAX_SEARCH_TAG_LENGTH - 2)],
+        [],
+    ],
+)
+def test_realistic_tags_are_accepted(model, tags):
+    assert model(uri="viking://resources/x", tags=tags).tags == tags
+
+
+def test_reindex_tags_stay_optional():
+    assert ReindexRequest(uri="viking://resources/x").tags is None
+
+
+def test_caps_leave_room_for_experience_lineage_tags():
+    """Lineage builds one tag per read Experience, keyed on the escaped URI.
+
+    Those tags never pass through these request models, but the length cap has
+    to stay above them anyway — a number below this would be a trap for anyone
+    who later moves the check into the shared normalizer.
+    """
+    from openviking.session.memory.experience_lineage import experience_source_tag
+
+    uri = (
+        "viking://user/A-Very-Long-User-Id-With-Caps/memories/experiences/"
+        "2026-08-25-A-Rather-Long-Experience-Folder-Name-With-Caps/experience.md"
+    )
+    assert len(experience_source_tag(uri)) < MAX_SEARCH_TAG_LENGTH
+
+
+# ── Over HTTP: rejected before any write happens ──
+
+
+async def test_http_set_tags_rejects_an_oversized_list(client, service):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    uri = "viking://resources/set-tags-bounds"
+    await service.viking_fs.mkdir(uri, exist_ok=True, ctx=ctx)
+
+    response = await client.post(
+        "/api/v1/content/set_tags", json={"uri": uri, "tags": _tags(10_000)}
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+async def test_http_fs_attrs_set_tags_shares_the_same_bound(client, service):
+    """`/fs/attrs/set_tags` reuses SetTagsRequest, so it must be bounded too."""
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    uri = "viking://resources/set-tags-bounds-fs"
+    await service.viking_fs.mkdir(uri, exist_ok=True, ctx=ctx)
+
+    response = await client.post(
+        "/api/v1/fs/attrs/set_tags", json={"uri": uri, "tags": ["k=" + "v" * 10_240]}
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+async def test_http_set_tags_still_accepts_a_normal_list(client, service):
+    ctx = RequestContext(user=UserIdentifier.the_default_user(), role=Role.ROOT)
+    uri = "viking://resources/set-tags-bounds-ok"
+    await service.viking_fs.mkdir(uri, exist_ok=True, ctx=ctx)
+
+    response = await client.post(
+        "/api/v1/content/set_tags",
+        json={"uri": uri, "tags": ["topic=rag", "lang=python"]},
+    )
+    assert response.status_code != 400, response.text


### PR DESCRIPTION
Fixes #4290.

`tags: list[str]` carried no length constraint on either request model, so one authenticated request could submit 10k entries or a single 10KB value. The cost does not stop at the write — every tag becomes its own `must` clause in `build_search_tags_filter()`, and the whole list is stored on the record, so it lands on every later search that merges those tags.

## Bounds

| | value | default in tree |
| :-- | --: | :-- |
| `MAX_SEARCH_TAGS` | 64 per request | tests and real callers use ≤ 4 |
| `MAX_SEARCH_TAG_LENGTH` | 1024 per tag | longest real tag measured: 183 chars |

Applied through one shared `SearchTagList` alias, so `SetTagsRequest` — which `/content/set_tags` **and** `/fs/attrs/set_tags` both use — and `ReindexRequest` are bounded by a single definition rather than three copies.

## Why on the request models and not in `normalize_search_tags()`

That was my first instinct, since it would cover the MCP and CLI paths too. It is the wrong place, and the reason is worth recording.

`session/memory/experience_lineage.py` builds one lineage tag per read Experience, using the **percent-escaped URI as the key**:

```python
def experience_source_tag(experience_uri: str) -> str:
    uri_key = _escape_search_tag_key(str(experience_uri or "").strip())
    return normalize_search_tag(f"{uri_key}=1")
```

Measured on real URI shapes, that produces tags of **79 to 183 characters** — escaping expands every uppercase character to three. A key-length cap chosen from what an API caller "should" need would have truncated data no caller ever supplied. Those tags never pass through these request models, so bounding at the boundary leaves them alone.

`test_caps_leave_room_for_experience_lineage_tags` pins that relationship, so the number stays safe if anyone later moves the check into the shared normalizer.

## Tests

`tests/server/test_api_set_tags_bounds.py`, 21 cases:

- **Rejected**, on both models: one over the count cap, the reported 10k list, one over the length cap, the reported 10KB value.
- **Accepted**, on both models: a realistic 4-tag list, exactly `MAX_SEARCH_TAGS`, a tag at exactly the length cap, and an empty list. `ReindexRequest.tags` stays optional.
- **Over HTTP**: `/content/set_tags` and `/fs/attrs/set_tags` both return `400 / INVALID_ARGUMENT` for an oversized list, and a normal list is still accepted. Rejection happens in request validation, before any write is attempted.

`21 passed`. Mutation-tested: removing both caps fails **10** of them.

Neighbouring `tests/server/test_api_content_write.py` reports `1 passed, 19 errors` both with and without this change — pre-existing on `main` in this environment, verified by re-running the identical command on a clean tree. `ruff check` clean.

## Not included

The issue also mentions rate limiting (#4293) and charset/pattern validation for keys. Rate limiting is a different mechanism, and a charset restriction would have to reckon with the percent-escaped lineage keys above, so both belong in their own change.
