### PR TITLE
fix(memory-plugin): resolve the viking://~ home alias client-side (#4314)

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/dsh-memory-plugin/shared/recall-core.mjs
+++ b/examples/dsh-memory-plugin/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/memory-plugin-shared/lib/recall-core.mjs
+++ b/examples/memory-plugin-shared/lib/recall-core.mjs
@@ -271,9 +271,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/memory-plugin-shared/recall-core.test.mjs
+++ b/examples/memory-plugin-shared/recall-core.test.mjs
@@ -281,3 +281,33 @@ test("buildRecallBlock falls back to find when neither context endpoint works", 
   assert.match(block, /^<openviking-context>/);
   assert.match(block, /\[memory 90%\]/);
 });
+
+test("recall resolves the viking://~ home alias client-side (#4314)", async () => {
+  // A server in the default dev auth mode resolves every request as ROOT and
+  // rejects viking://~ with INVALID_URI, which took recall down on local
+  // deployments while profile injection kept working.
+  const seen = [];
+  const fetchJSON = async (pathname, init = {}) => {
+    if (pathname.startsWith("/api/v1/system/status")) return { ok: true, result: { user: "default" } };
+    if (pathname.startsWith("/api/v1/fs/ls")) return { ok: true, result: [{ name: "default", isDir: true }] };
+    if (pathname === "/api/v1/search/find") {
+      const body = JSON.parse(init.body);
+      seen.push(body.target_uri);
+      // The dev-mode server: the home alias is not canonical for ROOT.
+      if (body.target_uri.includes("viking://~")) return { ok: false, error: { code: "INVALID_URI" } };
+      return {
+        ok: true,
+        result: { memories: [{ uri: `${body.target_uri}/m.md`, score: 0.9, content: "hello world" }], skills: [] },
+      };
+    }
+    return { ok: false, status: 404 };
+  };
+
+  const block = await buildRecallBlock(fetchJSON, { recallLimit: 5, scoreThreshold: 0 }, "hello");
+
+  assert.deepEqual(seen, [
+    "viking://user/default/memories",
+    "viking://user/default/skills",
+  ]);
+  assert.ok(block, "recall must return a block against a server that rejects viking://~");
+});

--- a/examples/opencode-plugin/lib/shared/recall-core.mjs
+++ b/examples/opencode-plugin/lib/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/pi-coding-agent-extension/shared/recall-core.mjs
+++ b/examples/pi-coding-agent-extension/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -272,9 +272,22 @@ async function resolveUserSpace(fetchJSON, actorPeerId = "") {
 
 async function resolveTargetUri(fetchJSON, targetUri, actorPeerId = "") {
   const trimmed = targetUri.trim().replace(/\/+$/, "");
-  // viking://~ is the home alias: the server expands it to the caller's own user
-  // space, so it needs no client-side rewrite.
-  if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
+  // The viking://~ home alias is expanded server-side for USER and ADMIN, but a
+  // server in the default dev auth mode resolves every request as ROOT and
+  // rejects it outright ("Home alias URI is not canonical"), which took recall
+  // down on local deployments while profile injection kept working. Resolve the
+  // reserved home directories here instead, exactly as the uid-less branch below
+  // already does — an explicit-uid URI is accepted by every role.
+  const home = trimmed.match(/^viking:\/\/~\/(.*)$/);
+  if (home) {
+    const homeParts = (home[1] ?? "").trim().split("/").filter(Boolean);
+    if (homeParts.length > 0 && USER_RESERVED_DIRS.has(homeParts[0])) {
+      const homeSpace = await resolveUserSpace(fetchJSON, actorPeerId);
+      return `viking://user/${homeSpace}/${homeParts.join("/")}`;
+    }
+    return trimmed;
+  }
+  if (trimmed === "viking://~") return trimmed;
   // Legacy compat: uid-less viking://user/<reserved> URIs may still sit in plugin
   // configs. Newer servers reject them, so rewrite to an explicit-uid URI here.
   const m = trimmed.match(/^viking:\/\/user(?:\/(.*))?$/);


### PR DESCRIPTION
Fixes #4314.

## Root cause

`resolveTargetUri` returned `viking://~/...` untouched, on the stated grounds that the server expands it:

```js
// viking://~ is the home alias: the server expands it to the caller's own user
// space, so it needs no client-side rewrite.
if (trimmed === "viking://~" || trimmed.startsWith("viking://~/")) return trimmed;
```

That comment is true for USER and ADMIN and false for ROOT. A server in the **default dev auth mode** — no `root_api_key`, no `auth_mode`, i.e. what you get from an untouched `ov.conf` — resolves every request as ROOT and rejects the alias:

```
[INVALID_URI] Home alias URI is not canonical: ~/memories/profile.md
```

Recall searches `viking://~/memories` and `viking://~/skills`, so on a stock local deployment it returned nothing while profile injection kept working. Nothing surfaced to the user — recall just came back empty.

## The fix

The same function already resolves the uid-less `viking://user/<reserved>` form client-side through `resolveUserSpace()`, and the reporter confirmed that path works under dev mode. `viking://~/<reserved>` now gets the same treatment. The result is an explicit-uid URI, which every role accepts, so this is not a dev-mode special case — it is one URI shape for all of them.

Deliberately narrow: bare `viking://~` and any non-reserved subpath still pass through untouched, so only the two directories that were broken change. `resolveUserSpace()` caches per process, so this adds no per-recall request after the first.

I picked this over the issue's option 1 (rewrite the hardcoded `SOURCES`) because it fixes every caller of `resolveTargetUri` rather than two constants, and over option 2 (expand `~` for ROOT server-side) because what `~` should mean for ROOT is your call, not a client's.

## Verified

Against `buildRecallBlock` with a stubbed server that rejects the alias exactly as dev mode does:

```
before   dev-mode(reject viking://~)=true   target_uri=["viking://~/memories","viking://~/skills"]                 recall=EMPTY
         dev-mode(reject viking://~)=false  target_uri=["viking://~/memories","viking://~/skills"]                 recall=OK

after    dev-mode(reject viking://~)=true   target_uri=["viking://user/default/memories","…/skills"]               recall=OK
         dev-mode(reject viking://~)=false  target_uri=["viking://user/default/memories","…/skills"]               recall=OK
```

## Scope — this is seven plugins, not one

The issue reports it against `pi-coding-agent-extension`, but `recall-core.mjs` is a generated file: six copies were byte-identical and every one carried the same `SOURCES` and the same passthrough. So the change is made in `examples/memory-plugin-shared/lib/recall-core.mjs` and propagated with `examples/memory-plugin-shared/sync.mjs`; the six copies are identical again afterwards (verified by checksum). Editing only the reported copy would have been reverted by the next sync, and `sync.test.mjs` would have caught it in CI.

## Tests

New case in `examples/memory-plugin-shared/recall-core.test.mjs`, next to the existing recall tests. It stubs a dev-mode server, asserts the exact `target_uri` values that reach `/api/v1/search/find`, and asserts recall returns a block against a server that refuses `viking://~`.

- `recall-core.test.mjs`: **14 pass, 0 fail**
- `sync.test.mjs`: **2 pass, 0 fail**
- Mutation-tested: restoring the passthrough fails **1** (`# pass 13 / # fail 1`).
- `recall-compress-core.test.mjs` + `recall-session-wiring.test.mjs`: 12 pass, 1 fail — `pi wires the sync manager into the recall manager`, which fails identically on a clean tree, verified by re-running with the change stashed.
