### PR TITLE
fix(server): bound the limits on /api/v1/search find, grep, and glob (#4289)

### DIFF
--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import math
-from typing import Any, Dict, List, Literal, Optional, Sequence, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Sequence, Union
 
 from fastapi import APIRouter, Depends
 from fastapi import Response as FastAPIResponse
@@ -60,6 +60,24 @@ def _sanitize_floats(obj: Any) -> Any:
 
 
 router = APIRouter(prefix="/api/v1/search", tags=["search"])
+
+# Ceilings for caller-supplied search limits. `_resolve_search_limit` prefers
+# `node_limit` over `limit`, so bounding only one would leave the other as the
+# documented way around it.
+#
+# grep and glob are directory traversals and carry traversal bounds; semantic
+# search returns a result page, which is what routers/debug.py already caps with
+# le=1000. The traversal numbers match the ones proposed for routers/filesystem.py
+# in #4289 deliberately — if that lands, the two definitions should collapse into
+# one shared pair rather than drift.
+MAX_SEARCH_LIMIT = 1_000
+MAX_NODE_LIMIT = 10_000
+MAX_LEVEL_LIMIT = 32
+
+SearchLimit = Annotated[int, Field(ge=1, le=MAX_SEARCH_LIMIT)]
+TraversalNodeLimit = Annotated[int, Field(ge=1, le=MAX_NODE_LIMIT)]
+TraversalLevelLimit = Annotated[int, Field(ge=1, le=MAX_LEVEL_LIMIT)]
+
 TimeField = Literal["updated_at", "created_at"]
 
 
@@ -128,8 +146,8 @@ class FindRequest(BaseModel):
     image_url: Optional[str] = None
     target_uri: Union[str, List[str]] = ""
     context_type: Optional[Union[str, List[str]]] = None
-    limit: int = DEFAULT_LIMIT
-    node_limit: Optional[int] = None
+    limit: SearchLimit = DEFAULT_LIMIT
+    node_limit: Optional[SearchLimit] = None
     score_threshold: Optional[float] = None
     filter: Optional[Dict[str, Any]] = None
     include_provenance: bool = False
@@ -189,8 +207,8 @@ class SearchRequest(BaseModel):
     target_uri: Union[str, List[str]] = ""
     context_type: Optional[Union[str, List[str]]] = None
     session_id: Optional[str] = None
-    limit: int = DEFAULT_LIMIT
-    node_limit: Optional[int] = None
+    limit: SearchLimit = DEFAULT_LIMIT
+    node_limit: Optional[SearchLimit] = None
     score_threshold: Optional[float] = None
     filter: Optional[Dict[str, Any]] = None
     include_provenance: bool = False
@@ -308,8 +326,8 @@ class GrepRequest(BaseModel):
     exclude_uri: Optional[str] = None
     pattern: str
     case_insensitive: bool = False
-    node_limit: Optional[int] = 256
-    level_limit: int = 10
+    node_limit: Optional[TraversalNodeLimit] = 256
+    level_limit: TraversalLevelLimit = 10
 
 
 class GlobRequest(BaseModel):
@@ -317,7 +335,7 @@ class GlobRequest(BaseModel):
 
     pattern: str
     uri: str = "viking://"
-    node_limit: Optional[int] = 256
+    node_limit: Optional[TraversalNodeLimit] = 256
 
 
 @router.post("/find")

--- a/tests/server/test_api_search_limit_bounds.py
+++ b/tests/server/test_api_search_limit_bounds.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Regression tests for #4289 (search half): unbounded limits on /api/v1/search.
+
+`/find`, `/grep`, and `/glob` take their limits through POST body models rather
+than `Query`, so the bounds added to the filesystem router do not reach them.
+`_resolve_search_limit` prefers `node_limit` over `limit`, which means bounding
+only one of the pair leaves the other as a documented way around it.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from openviking.server.routers.search import (
+    MAX_LEVEL_LIMIT,
+    MAX_NODE_LIMIT,
+    MAX_SEARCH_LIMIT,
+    FindRequest,
+    GlobRequest,
+    GrepRequest,
+    _resolve_search_limit,
+)
+from openviking.service.fs_service import FSService
+from openviking.service.session_service import SessionService
+from openviking.storage.viking_fs import VikingFS
+from tests.utils.mock_agfs import MockLocalAGFS
+
+
+@pytest.fixture
+def service(temp_dir):
+    mock_agfs = MockLocalAGFS(root_path=temp_dir / "mock_agfs_root")
+    viking_fs = VikingFS(agfs=mock_agfs)
+    return SimpleNamespace(
+        fs=FSService(viking_fs=viking_fs),
+        sessions=SessionService(viking_fs=viking_fs),
+        viking_fs=viking_fs,
+    )
+
+
+DEFAULTS = {
+    FindRequest: {"query": "x"},
+    GrepRequest: {"uri": "viking://resources/x", "pattern": "p"},
+    GlobRequest: {"pattern": "*"},
+}
+
+
+def _build(model, **overrides):
+    return model(**{**DEFAULTS[model], **overrides})
+
+
+# ── Rejected ──
+
+
+@pytest.mark.parametrize("field", ["limit", "node_limit"])
+@pytest.mark.parametrize("value", [MAX_SEARCH_LIMIT + 1, 1_000_000, 0, -1])
+def test_find_rejects_out_of_range_result_counts(field, value):
+    with pytest.raises(ValidationError):
+        _build(FindRequest, **{field: value})
+
+
+@pytest.mark.parametrize("model", [GrepRequest, GlobRequest])
+@pytest.mark.parametrize("value", [MAX_NODE_LIMIT + 1, 1_000_000, 0, -1])
+def test_traversals_reject_out_of_range_node_limits(model, value):
+    with pytest.raises(ValidationError):
+        _build(model, node_limit=value)
+
+
+@pytest.mark.parametrize("value", [MAX_LEVEL_LIMIT + 1, 100, 0, -1])
+def test_grep_rejects_out_of_range_level_limits(value):
+    with pytest.raises(ValidationError):
+        _build(GrepRequest, level_limit=value)
+
+
+# ── Accepted ──
+
+
+@pytest.mark.parametrize("value", [1, 10, 50, MAX_SEARCH_LIMIT])
+def test_find_accepts_what_real_callers_ask_for(value):
+    """The plugins in examples/ ask for 1-50; 10 is DEFAULT_LIMIT."""
+    assert _build(FindRequest, limit=value).limit == value
+    assert _build(FindRequest, node_limit=value).node_limit == value
+
+
+@pytest.mark.parametrize("model", [GrepRequest, GlobRequest])
+def test_traversals_accept_their_defaults_and_their_ceiling(model):
+    assert _build(model).node_limit == 256
+    assert _build(model, node_limit=MAX_NODE_LIMIT).node_limit == MAX_NODE_LIMIT
+    assert _build(model, node_limit=None).node_limit is None
+
+
+def test_grep_accepts_its_default_and_ceiling_depth():
+    assert _build(GrepRequest).level_limit == 10
+    assert _build(GrepRequest, level_limit=MAX_LEVEL_LIMIT).level_limit == MAX_LEVEL_LIMIT
+
+
+# ── The pair has to be bounded together ──
+
+
+def test_node_limit_is_the_one_that_wins():
+    """Why bounding only `limit` would not be enough."""
+    assert _resolve_search_limit(10, 500) == 500
+    assert _resolve_search_limit(10, None) == 10
+
+
+def test_ceilings_stay_above_every_default():
+    """A ceiling below its own default would reject the no-argument request."""
+    assert MAX_SEARCH_LIMIT > _build(FindRequest).limit
+    assert MAX_NODE_LIMIT > 256
+    assert MAX_LEVEL_LIMIT > 10
+
+
+# ── Over HTTP ──
+
+
+async def test_http_find_rejects_an_out_of_range_limit(client, service):
+    response = await client.post(
+        "/api/v1/search/find", json={"query": "x", "limit": 1_000_000}
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+async def test_http_grep_rejects_an_out_of_range_node_limit(client, service):
+    response = await client.post(
+        "/api/v1/search/grep",
+        json={"uri": "viking://resources", "pattern": "p", "node_limit": 1_000_000},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"
+
+
+async def test_http_glob_rejects_an_out_of_range_node_limit(client, service):
+    response = await client.post(
+        "/api/v1/search/glob", json={"pattern": "*", "node_limit": 1_000_000}
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "INVALID_ARGUMENT"


### PR DESCRIPTION
Part of #4289 — the half #4318 explicitly left out.

#4318 bounds the filesystem router through `Query` constraints. Those do not reach `/find`, `/grep`, and `/glob`, which take their limits through **POST body models**, so `node_limit=1000000&level_limit=100` is still accepted on the search surface. This closes that.

## Bounds

| model | field | default | ceiling |
| :-- | :-- | --: | --: |
| `FindRequest`, session variant | `limit`, `node_limit` | 10 | `MAX_SEARCH_LIMIT = 1_000` |
| `GrepRequest`, `GlobRequest` | `node_limit` | 256 | `MAX_NODE_LIMIT = 10_000` |
| `GrepRequest` | `level_limit` | 10 | `MAX_LEVEL_LIMIT = 32` |

Two different numbers because these are two different things. Semantic search returns a **result page** — `routers/debug.py` already caps its scroll page with `le=1000`, and the plugins in `examples/` ask for 1–50. `grep` and `glob` are **directory traversals**, so they get the traversal bounds, not the page bound.

## Why `limit` and `node_limit` are bounded together

```python
def _resolve_search_limit(limit: int, node_limit: Optional[int]) -> int:
    return node_limit if node_limit is not None else limit
```

`node_limit` wins when set, so capping only `limit` would leave the other as a documented way around it — the same trap as the `limit` alias in #4318. `test_node_limit_is_the_one_that_wins` pins that relationship directly rather than just asserting the two caps exist, so the reason survives a refactor of the helper.

## Relationship to #4318

The traversal numbers match the ones proposed there **deliberately**. If both land, the two definitions should collapse into one shared pair rather than drift, and I am happy to do that in whichever merges second. I kept them local here rather than importing across routers so this PR stands alone and neither blocks the other.

## Tests

`tests/server/test_api_search_limit_bounds.py`, 32 cases:

- **Rejected** — one over each ceiling, the reported `1_000_000`, and non-positive values, across all three models and both fields of the pair.
- **Accepted** — 1 / 10 / 50 / the ceiling for search; the defaults, the ceiling, and explicit `None` for the traversals.
- **Guards** — `node_limit` is the field that wins; no ceiling sits below its own default.
- **Over HTTP** — all three endpoints return `400 / INVALID_ARGUMENT`, in request validation, before any search or traversal runs.

`32 passed`. Mutation-tested: removing the three constraints fails **23**.

`tests/server/test_api_search{,_context}.py` report `75 errors` both with and without this change — pre-existing in this environment, verified by re-running the identical command on a clean tree. `ruff check` clean.
