### PR TITLE
fix(observer): ignore drained queue errors in health

### DIFF
--- a/openviking/storage/observers/queue_observer.py
+++ b/openviking/storage/observers/queue_observer.py
@@ -122,4 +122,15 @@ class QueueObserver(BaseObserver):
         return not self.has_errors()
 
     def has_errors(self) -> bool:
-        return self._queue_manager.has_errors()
+        return run_async(self.has_active_errors_async())
+
+    async def has_active_errors_async(self) -> bool:
+        statuses = await self._queue_manager.check_status()
+        return self._has_active_errors(statuses)
+
+    @staticmethod
+    def _has_active_errors(statuses: Dict[str, QueueStatus]) -> bool:
+        return any(
+            status.error_count > 0 and not status.is_complete
+            for status in statuses.values()
+        )

--- a/tests/storage/test_queue_observer.py
+++ b/tests/storage/test_queue_observer.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for QueueObserver health semantics."""
+
+from openviking.storage.observers.queue_observer import QueueObserver
+from openviking.storage.queuefs.named_queue import QueueStatus
+
+
+class _FakeQueueManager:
+    SEMANTIC = "Semantic"
+
+    def __init__(self, statuses: dict[str, QueueStatus]):
+        self._statuses = statuses
+        self._queues = {}
+
+    async def check_status(self) -> dict[str, QueueStatus]:
+        return self._statuses
+
+
+def test_historical_queue_errors_do_not_make_drained_queue_unhealthy() -> None:
+    observer = QueueObserver(
+        _FakeQueueManager(
+            {
+                "Semantic": QueueStatus(
+                    pending=0,
+                    in_progress=0,
+                    processed=69,
+                    requeue_count=1,
+                    error_count=1,
+                )
+            }
+        )
+    )
+
+    assert observer.has_errors() is False
+    assert observer.is_healthy() is True
+
+    table = observer.get_status_table()
+    assert "Semantic" in table
+    assert "Warnings:" not in table
+
+
+def test_queue_errors_make_pending_queue_unhealthy() -> None:
+    observer = QueueObserver(
+        _FakeQueueManager(
+            {
+                "Semantic": QueueStatus(
+                    pending=1,
+                    in_progress=0,
+                    processed=69,
+                    error_count=1,
+                )
+            }
+        )
+    )
+
+    assert observer.has_errors() is True
+    assert observer.is_healthy() is False
+
+    table = observer.get_status_table()
+    assert "Warnings:" not in table
+
+
+def test_queue_errors_make_in_progress_queue_unhealthy() -> None:
+    observer = QueueObserver(
+        _FakeQueueManager(
+            {
+                "Semantic": QueueStatus(
+                    pending=0,
+                    in_progress=1,
+                    processed=69,
+                    error_count=1,
+                )
+            }
+        )
+    )
+
+    assert observer.has_errors() is True
+    assert observer.is_healthy() is False


### PR DESCRIPTION
## 根因与修复

- Queue observer 之前把累计 `error_count > 0` 直接视为当前错误。
- Semantic queue 中已 drop/ACK 的历史失败会在 `Pending=0`、`In Progress=0` 时继续把 queue/system 标成 unhealthy。
- 修复后只有队列未完成且存在错误计数时才算 queue has errors；队列已 drain 的历史错误仍在表格 `Errors` 列展示，但不再让 system unhealthy。

## 范围与已知现状

- 本 PR 不新增 ACK 或 reset endpoint。
- 本 PR 不追加解释性 warning 文案；observer 输出以组件 health 和 status 表格为准。
- `error_count > 0` 且 `pending` 或 `in_progress` 非 0 时仍按 unhealthy 处理，这是排障视角下更保守的状态展示。

## 验证

- `.venv/bin/python -m pytest tests/storage/test_queue_observer.py -q`（3 passed）
- `ruff check openviking/storage/observers/queue_observer.py tests/storage/test_queue_observer.py`（All checks passed）
