### PR TITLE
fix(reindex): preserve namespace markers and oversized abstracts

### DIFF
--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -1891,7 +1891,7 @@ class ReindexExecutor:
             uri=uri,
             parent_uri=parent_uri,
             is_leaf=is_leaf,
-            abstract=abstract or "",
+            abstract=_truncate_abstract_bytes(abstract or ""),
             context_type=context_type,
             level=level,
             user=owner_ctx.user,

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -448,6 +448,21 @@ class ReindexExecutor:
         except Exception as exc:
             raise NotFoundError(uri, "resource") from exc
 
+        # tree() returns descendants only, so rebuild the namespace's own L0/L1
+        # markers explicitly before walking the individual skill roots.
+        await self._reindex_resource_vectors_from_entries(
+            **self._with_ingest_options(
+                {
+                    "root_uri": uri,
+                    "directories": [uri],
+                    "files": [],
+                    "counters": counters,
+                    "ctx": ctx,
+                },
+                run.ingest_options,
+            )
+        )
+
         skill_roots = []
         for entry in entries:
             entry_uri = entry.get("uri")
@@ -1331,11 +1346,26 @@ class ReindexExecutor:
                         mode=mode,
                         run=run,
                     )
+                # tree() does not include the requested container itself.
+                await self._reindex_resource_vectors_from_entries(
+                    **self._with_ingest_options(
+                        {
+                            "root_uri": target_root,
+                            "directories": [target_root],
+                            "files": [],
+                            "counters": counters,
+                            "ctx": ctx,
+                        },
+                        run.ingest_options,
+                    )
+                )
                 return
 
         memory_roots: list[str] = []
         skill_roots: list[str] = []
-        resource_directories: list[str] = []
+        # Include the requested user namespace itself; tree() only contributes
+        # descendants and would otherwise omit its L0/L1 vector records.
+        resource_directories: list[str] = [target_root]
         resource_files: list[str] = []
 
         for entry in entries:

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -748,6 +748,43 @@ async def test_reindex_upsert_uses_uri_owner_for_user_scoped_records(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_reindex_upsert_caps_oversized_abstract_by_utf8_bytes(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor
+
+    captured = {}
+
+    class FakeVikingDB:
+        async def enqueue_embedding_msg(self, msg):
+            captured["msg"] = msg
+            return True
+
+    fake_service = type("Svc", (), {"vikingdb_manager": FakeVikingDB()})()
+    monkeypatch.setattr("openviking.service.reindex_executor.get_service", lambda: fake_service)
+
+    service = ReindexExecutor()
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="acct", user_id="admin"),
+        role=Role.ROOT,
+    )
+    oversized_abstract = "א" * 60_000
+
+    await service._upsert_context(
+        uri="viking://user/bob/memories/events/large.md",
+        parent_uri="viking://user/bob/memories/events",
+        abstract=oversized_abstract,
+        vector_text="large memory",
+        is_leaf=True,
+        context_type="memory",
+        level=ContextLevel.DETAIL,
+        ctx=ctx,
+    )
+
+    abstract = captured["msg"].context_data["abstract"]
+    assert len(abstract.encode("utf-8")) == 50_000
+    assert abstract == oversized_abstract[:25_000]
+
+
+@pytest.mark.asyncio
 async def test_reindex_semantic_processor_uses_uri_owner_for_user_scoped_records(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor
 

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -1618,6 +1618,56 @@ async def test_reindex_executor_infers_user_namespace_root():
 
 
 @pytest.mark.asyncio
+async def test_reindex_user_container_reindexes_its_root_markers_after_children(monkeypatch):
+    from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+
+    class FakeVikingFS:
+        async def tree(
+            self,
+            uri,
+            output="original",
+            show_all_hidden=True,
+            node_limit=1000,
+            level_limit=None,
+            ctx=None,
+        ):
+            return [{"uri": "viking://user/default", "isDir": True}]
+
+    seen = {"users": [], "namespace": []}
+    reindex_user_container = ReindexExecutor._reindex_user_namespace
+
+    async def fake_reindex_user_namespace(self, *, uri, mode, run):
+        seen["users"].append((uri, mode))
+
+    async def fake_reindex_resource_vectors_from_entries(
+        self, *, root_uri, directories, files, counters, ctx
+    ):
+        seen["namespace"].append((root_uri, list(directories), list(files)))
+
+    monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
+    monkeypatch.setattr(ReindexExecutor, "_reindex_user_namespace", fake_reindex_user_namespace)
+    monkeypatch.setattr(
+        ReindexExecutor,
+        "_reindex_resource_vectors_from_entries",
+        fake_reindex_resource_vectors_from_entries,
+    )
+
+    ctx = RequestContext(
+        user=UserIdentifier(account_id="test", user_id="alice"),
+        role=Role.ROOT,
+    )
+    await reindex_user_container(
+        ReindexExecutor(),
+        uri="viking://user",
+        mode="vectors_only",
+        run=_make_reindex_run(ctx, _ReindexCounters()),
+    )
+
+    assert seen["users"] == [("viking://user/default", "vectors_only")]
+    assert seen["namespace"] == [("viking://user", ["viking://user"], [])]
+
+
+@pytest.mark.asyncio
 async def test_reindex_executor_rejects_deprecated_agent_namespace_root():
     from openviking.service.reindex_executor import ReindexExecutor
 
@@ -1840,8 +1890,9 @@ async def test_reindex_user_namespace_semantic_and_vectors_skips_uncovered_root_
 
 
 @pytest.mark.asyncio
-async def test_reindex_skill_namespace_reindexes_only_skill_roots(monkeypatch):
+async def test_reindex_skill_namespace_reindexes_root_markers_and_only_skill_roots(monkeypatch):
     from openviking.service.reindex_executor import ReindexExecutor, _ReindexCounters
+    from openviking.utils.ingest_options import IngestOptions
 
     class FakeVikingFS:
         async def tree(
@@ -1861,13 +1912,23 @@ async def test_reindex_skill_namespace_reindexes_only_skill_roots(monkeypatch):
                 {"uri": "viking://user/default/skills/my_skill/SKILL.md", "isDir": False},
             ]
 
-    seen = []
+    seen = {"namespace": [], "skills": []}
 
     async def fake_reindex_skill(self, *, uri, mode, run):
-        seen.append((uri, mode))
+        seen["skills"].append((uri, mode))
+
+    async def fake_reindex_resource_vectors_from_entries(
+        self, *, root_uri, directories, files, counters, ctx, ingest_options=None
+    ):
+        seen["namespace"].append((root_uri, list(directories), list(files), ingest_options))
 
     monkeypatch.setattr("openviking.service.reindex_executor.get_viking_fs", lambda: FakeVikingFS())
     monkeypatch.setattr(ReindexExecutor, "_reindex_skill", fake_reindex_skill)
+    monkeypatch.setattr(
+        ReindexExecutor,
+        "_reindex_resource_vectors_from_entries",
+        fake_reindex_resource_vectors_from_entries,
+    )
 
     service = ReindexExecutor()
     counters = _ReindexCounters()
@@ -1875,14 +1936,25 @@ async def test_reindex_skill_namespace_reindexes_only_skill_roots(monkeypatch):
         user=UserIdentifier(account_id="test", user_id="alice"),
         role=Role.ROOT,
     )
+    ingest_options = IngestOptions.from_search_tags(["team=search"], mode="replace")
+    run = _make_reindex_run(ctx, counters)
+    run.ingest_options = ingest_options
 
     await service._reindex_skill_namespace(
         uri="viking://user/default/skills",
         mode="semantic_and_vectors",
-        run=_make_reindex_run(ctx, counters),
+        run=run,
     )
 
-    assert seen == [("viking://user/default/skills/my_skill", "semantic_and_vectors")]
+    assert seen["namespace"] == [
+        (
+            "viking://user/default/skills",
+            ["viking://user/default/skills"],
+            [],
+            ingest_options,
+        )
+    ]
+    assert seen["skills"] == [("viking://user/default/skills/my_skill", "semantic_and_vectors")]
 
 
 @pytest.mark.asyncio
@@ -2964,13 +3036,14 @@ async def test_reindex_user_namespace_partitions_memory_skill_and_resource(monke
     )
 
     await service._reindex_user_namespace(
-        uri="viking://user/",
+        uri="viking://user/default",
         mode="vectors_only",
         run=_make_reindex_run(ctx, counters),
     )
 
     assert seen["memory"] == [("viking://user/default/memories", "vectors_only")]
     assert seen["skill"] == [("viking://user/default/skills/my_skill", "vectors_only")]
+    assert "viking://user/default" in seen["resource_dirs"]
     assert "viking://user/default/resources" in seen["resource_dirs"]
     assert "viking://user/default/memories" not in seen["resource_dirs"]
     assert "viking://user/default/skills" not in seen["resource_dirs"]


### PR DESCRIPTION
## Description

This fixes two `reindex` correctness failures reproduced during a live embedding-model migration:

1. Reindexing user and skill namespaces rebuilt descendants but omitted the requested namespace directory's own L0/L1 vector records.
2. Reindexing an existing memory with an abstract above the local vector store's 65,535-byte field limit failed the record, even though OpenViking already provides `_truncate_abstract_bytes()` for this boundary.

Both failures make a model migration incomplete: the first can leave missing namespace markers while the task reports no failed items; the second makes a valid historical memory permanently fail vectorization.

## Changes made

### Preserve namespace-root markers

- Rebuild a skill namespace's own L0/L1 markers before reindexing individual skill roots.
- Rebuild `viking://user` after fan-out to concrete users.
- Include each concrete user namespace root in its own directory-vector input.
- Forward the existing reindex tag options to these root-marker upserts.

`VikingFS.tree()` returns descendants, so the namespace orchestration must explicitly include the requested root instead of assuming it is present in the tree result.

### Cap reindexed abstracts at the vector-write boundary

- Apply the existing UTF-8 byte-safe `_truncate_abstract_bytes()` helper when `_upsert_context()` constructs any reindex `Context`.
- Add a regression test with 60,000 Hebrew characters, proving the persisted abstract is exactly 50,000 UTF-8 bytes and is not split mid-codepoint.

The common `_upsert_context()` boundary is intentional: resource, memory, skill, directory-marker, and fallback reindex paths all converge there, so a future caller cannot bypass the cap again. Embedding text remains unchanged; only the stored abstract scalar is bounded.

## Reproduction and live proof

The failures were reproduced on OpenViking 0.4.12 on macOS arm64 with Python 3.13 while moving an existing 1,024-dimensional collection between embedding models.

- Before the namespace fix, a completed root reindex omitted L0/L1 records for namespace roots.
- Before the abstract fix, a 107 KB historical memory failed with `string field 'fields' exceeds 65535 bytes`.
- With both fixes installed, the final global reindex scanned 14,026 records, rebuilt 13,454 semantic/vector records, and reported 0 failures.
- The strict consistency endpoint then reported 13,458 expected records and 0 missing.

## Testing

- `ruff format --check openviking/service/reindex_executor.py tests/server/test_admin_rebuild_api.py`
- `ruff check openviking/service/reindex_executor.py tests/server/test_admin_rebuild_api.py`
- Focused owner-routing and oversized-abstract tests: 2 passed
- Namespace-root regression tests cover skill roots, the public user container, concrete user roots, descendant partitioning, and tag propagation.
- On the previous commit, the hosted API/CLI integration suite, dependency check, and plugin tests passed; the updated head will rerun them.

The normal editable `uv run` path cannot build locally because this machine has no Cargo toolchain and therefore cannot produce the required native `ov` artifact. The repository's existing virtual environment runs the focused Python tests directly. Hosted CI provides the native build environment.

## Human involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Type of change

- [x] Bug fix (non-breaking)
- [x] Test update
- [ ] Breaking change
- [ ] Feature

## Safety and scope

- Non-destructive: all changes use the existing upsert path.
- No semantic generation, URI classification, prune behavior, or vector schema changes.
- No backend-specific size constant is duplicated; the existing shared helper remains the single limit definition.
- Documentation is unchanged because the current reindex contract already promises root-marker rebuilding and valid vector writes; these changes make implementation match that contract.
