### PR TITLE
fix(pi): pass status key to setStatus so the status line renders

### DIFF
--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -378,7 +378,7 @@ function updateStatus(
     : ` · ✎ ${threshold}`;
   const status = `${connected ? "OV ✓" : "OV ✗"} · ↩${added}${pending} · ${sessionId ? sessionId.slice(0, 12) : "none"}`;
   try {
-    setter(status);
+    setter("openviking", status);
   } catch {
     // Best effort; pi API shape may vary across fast-moving versions.
   }


### PR DESCRIPTION
## Bug

`updateStatus()` in `examples/pi-coding-agent-extension/index.ts` calls the pi status API with a single argument:

```ts
const setter = ctx?.ui?.setStatus;
// ...
setter(status);
```

But the pi extension API signature is `setStatus(key, text)` (see pi's `docs/tui.md`, "Pattern 4: Persistent Status Indicator"). With a single argument the status string is treated as the **key** and the text is `undefined` — which is the documented way to *clear* a status entry. The result: the OpenViking status line (`OV ✓ · ↩N · ...`) never renders, silently, with no error thrown.

## Fix

Pass an explicit key:

```ts
setter("openviking", status);
```

Verified locally on pi 0.84.3: the status line now renders in the footer after `/reload`.
