### PR TITLE
fix(langchain): support separator-containing store keys

### DIFF
--- a/integrations/langchain/src/langchain_openviking/store.py
+++ b/integrations/langchain/src/langchain_openviking/store.py
@@ -52,10 +52,6 @@ else:
 
 logger = logging.getLogger(__name__)
 
-_PATH_KEY_MARKER = "__openviking_path_key_v1__"
-_ABSOLUTE_PATH_KIND = "abs"
-_RELATIVE_PATH_KIND = "rel"
-
 
 class OpenVikingStore(BaseStore):
     """LangGraph ``BaseStore`` persisted and indexed through OpenViking.
@@ -63,9 +59,9 @@ class OpenVikingStore(BaseStore):
     Values are stored as JSON records under ``<root_uri>/data``. A separate
     markdown projection under ``<root_uri>/index`` gives OpenViking semantic
     retrieval a compact document to index for query-based ``search`` calls.
-    Keys without slashes keep the original one-segment URI layout. Absolute
-    and relative POSIX path keys use a versioned hierarchy so separators are
-    represented as URI path segments instead of the rejected ``%2F`` escape.
+    Every key remains one URI path segment. Encoded slash and backslash
+    separators use adapter-level escape tokens because OpenViking rejects
+    ``%2F`` and ``%5C`` within a URI segment.
 
     Args:
         root_uri: Base URI for the store. Defaults to the ``viking://~`` home alias,
@@ -151,14 +147,9 @@ class OpenVikingStore(BaseStore):
         return await asyncio.to_thread(lambda: self.batch(list(ops)))
 
     def get(self, namespace: tuple[str, ...], key: str, *, refresh_ttl: Any = None) -> Any:
-        record = None
-        for uri in self._data_uri_candidates(namespace, key):
-            try:
-                record = self._read_record(uri)
-                break
-            except Exception:
-                continue
-        if record is None:
+        try:
+            record = self._read_record(self._data_uri(namespace, key))
+        except Exception:
             return None
         return Item(
             namespace=tuple(record["namespace"]),
@@ -195,10 +186,8 @@ class OpenVikingStore(BaseStore):
         self._write(index_uri, self._index_document(record, effective_index))
 
     def delete(self, namespace: tuple[str, ...], key: str) -> None:
-        for uri in self._data_uri_candidates(namespace, key):
-            self._remove(uri)
-        for uri in self._index_uri_candidates(namespace, key):
-            self._remove(uri)
+        self._remove(self._data_uri(namespace, key))
+        self._remove(self._index_uri(namespace, key))
 
     def search(
         self,
@@ -384,12 +373,6 @@ class OpenVikingStore(BaseStore):
     def _index_uri(self, namespace: tuple[str, ...], key: str) -> str:
         return _record_uri(self._index_prefix_uri(namespace), key, ".md")
 
-    def _data_uri_candidates(self, namespace: tuple[str, ...], key: str) -> tuple[str, ...]:
-        return _record_uri_candidates(self._data_prefix_uri(namespace), key, ".json")
-
-    def _index_uri_candidates(self, namespace: tuple[str, ...], key: str) -> tuple[str, ...]:
-        return _record_uri_candidates(self._index_prefix_uri(namespace), key, ".md")
-
     def _data_prefix_uri(self, namespace: tuple[str, ...]) -> str:
         return _join_uri(self.root_uri, "data", *namespace)
 
@@ -464,38 +447,17 @@ def _join_uri(root: str, *segments: str) -> str:
 
 
 def _record_uri(prefix: str, key: str, suffix: str) -> str:
-    path = _path_key_parts(key)
-    if path is None:
-        return f"{prefix}/{_segment(key)}{suffix}"
-    kind, parts = path
-    return _join_uri(
-        prefix,
-        _PATH_KEY_MARKER,
-        kind,
-        *parts[:-1],
-        f"{parts[-1]}{suffix}",
-    )
+    return f"{prefix}/{_encode_key_segment(key)}{suffix}"
 
 
-def _record_uri_candidates(prefix: str, key: str, suffix: str) -> tuple[str, ...]:
-    uri = _record_uri(prefix, key, suffix)
-    if "/" not in key:
-        return (uri,)
-    legacy_uri = f"{prefix}/{_segment(key)}{suffix}"
-    return (uri, legacy_uri) if legacy_uri != uri else (uri,)
+def _encode_key_segment(key: str) -> str:
+    # quote(..., safe="") encodes a literal "!" as "%21", leaving bare "!"
+    # available as an unambiguous adapter escape marker.
+    return _segment(key).replace("%2F", "!s").replace("%5C", "!b")
 
 
-def _path_key_parts(key: str) -> tuple[str, tuple[str, ...]] | None:
-    if "/" not in key:
-        return None
-    kind = _ABSOLUTE_PATH_KIND if key.startswith("/") else _RELATIVE_PATH_KIND
-    parts = tuple(key.split("/")[1:] if kind == _ABSOLUTE_PATH_KIND else key.split("/"))
-    if not parts or any(not part or part in {".", ".."} or "\\" in part for part in parts):
-        raise ValueError(
-            "OpenVikingStore path keys must be canonical POSIX paths without "
-            "empty, '.', '..', or backslash segments."
-        )
-    return kind, parts
+def _decode_key_segment(segment: str) -> str:
+    return unquote(segment.replace("!s", "%2F").replace("!b", "%5C"))
 
 
 def _parse_canonicalized_record_uri(
@@ -542,26 +504,8 @@ def _identity_relative_root_tail(classification: UriClassification) -> tuple[str
 def _parse_record_parts(parts: list[str]) -> tuple[tuple[str, ...], str] | None:
     if not parts or not parts[-1]:
         return None
-    decoded = [unquote(part) for part in parts]
-    try:
-        marker_index = decoded.index(_PATH_KEY_MARKER)
-    except ValueError:
-        namespace = tuple(decoded[:-1])
-        key = decoded[-1]
-        return namespace, key
-
-    if marker_index + 2 >= len(decoded):
-        return tuple(decoded[:-1]), decoded[-1]
-    kind = decoded[marker_index + 1]
-    if kind not in {_ABSOLUTE_PATH_KIND, _RELATIVE_PATH_KIND}:
-        return tuple(decoded[:-1]), decoded[-1]
-    key_parts = decoded[marker_index + 2 :]
-    if any(not part or part in {".", ".."} or "\\" in part for part in key_parts):
-        return None
-    namespace = tuple(decoded[:marker_index])
-    key = "/".join(key_parts)
-    if kind == _ABSOLUTE_PATH_KIND:
-        key = f"/{key}"
+    namespace = tuple(unquote(part) for part in parts[:-1])
+    key = _decode_key_segment(parts[-1])
     return namespace, key
 
 

--- a/integrations/langchain/src/langchain_openviking/store.py
+++ b/integrations/langchain/src/langchain_openviking/store.py
@@ -52,6 +52,10 @@ else:
 
 logger = logging.getLogger(__name__)
 
+_PATH_KEY_MARKER = "__openviking_path_key_v1__"
+_ABSOLUTE_PATH_KIND = "abs"
+_RELATIVE_PATH_KIND = "rel"
+
 
 class OpenVikingStore(BaseStore):
     """LangGraph ``BaseStore`` persisted and indexed through OpenViking.
@@ -59,6 +63,9 @@ class OpenVikingStore(BaseStore):
     Values are stored as JSON records under ``<root_uri>/data``. A separate
     markdown projection under ``<root_uri>/index`` gives OpenViking semantic
     retrieval a compact document to index for query-based ``search`` calls.
+    Keys without slashes keep the original one-segment URI layout. Absolute
+    and relative POSIX path keys use a versioned hierarchy so separators are
+    represented as URI path segments instead of the rejected ``%2F`` escape.
 
     Args:
         root_uri: Base URI for the store. Defaults to the ``viking://~`` home alias,
@@ -144,9 +151,14 @@ class OpenVikingStore(BaseStore):
         return await asyncio.to_thread(lambda: self.batch(list(ops)))
 
     def get(self, namespace: tuple[str, ...], key: str, *, refresh_ttl: Any = None) -> Any:
-        try:
-            record = self._read_record(self._data_uri(namespace, key))
-        except Exception:
+        record = None
+        for uri in self._data_uri_candidates(namespace, key):
+            try:
+                record = self._read_record(uri)
+                break
+            except Exception:
+                continue
+        if record is None:
             return None
         return Item(
             namespace=tuple(record["namespace"]),
@@ -183,8 +195,10 @@ class OpenVikingStore(BaseStore):
         self._write(index_uri, self._index_document(record, effective_index))
 
     def delete(self, namespace: tuple[str, ...], key: str) -> None:
-        self._remove(self._data_uri(namespace, key))
-        self._remove(self._index_uri(namespace, key))
+        for uri in self._data_uri_candidates(namespace, key):
+            self._remove(uri)
+        for uri in self._index_uri_candidates(namespace, key):
+            self._remove(uri)
 
     def search(
         self,
@@ -365,10 +379,16 @@ class OpenVikingStore(BaseStore):
             pass
 
     def _data_uri(self, namespace: tuple[str, ...], key: str) -> str:
-        return f"{self._data_prefix_uri(namespace)}/{_segment(key)}.json"
+        return _record_uri(self._data_prefix_uri(namespace), key, ".json")
 
     def _index_uri(self, namespace: tuple[str, ...], key: str) -> str:
-        return f"{self._index_prefix_uri(namespace)}/{_segment(key)}.md"
+        return _record_uri(self._index_prefix_uri(namespace), key, ".md")
+
+    def _data_uri_candidates(self, namespace: tuple[str, ...], key: str) -> tuple[str, ...]:
+        return _record_uri_candidates(self._data_prefix_uri(namespace), key, ".json")
+
+    def _index_uri_candidates(self, namespace: tuple[str, ...], key: str) -> tuple[str, ...]:
+        return _record_uri_candidates(self._index_prefix_uri(namespace), key, ".md")
 
     def _data_prefix_uri(self, namespace: tuple[str, ...]) -> str:
         return _join_uri(self.root_uri, "data", *namespace)
@@ -443,6 +463,41 @@ def _join_uri(root: str, *segments: str) -> str:
     return root.rstrip("/") if not suffix else f"{root.rstrip('/')}/{suffix}"
 
 
+def _record_uri(prefix: str, key: str, suffix: str) -> str:
+    path = _path_key_parts(key)
+    if path is None:
+        return f"{prefix}/{_segment(key)}{suffix}"
+    kind, parts = path
+    return _join_uri(
+        prefix,
+        _PATH_KEY_MARKER,
+        kind,
+        *parts[:-1],
+        f"{parts[-1]}{suffix}",
+    )
+
+
+def _record_uri_candidates(prefix: str, key: str, suffix: str) -> tuple[str, ...]:
+    uri = _record_uri(prefix, key, suffix)
+    if "/" not in key:
+        return (uri,)
+    legacy_uri = f"{prefix}/{_segment(key)}{suffix}"
+    return (uri, legacy_uri) if legacy_uri != uri else (uri,)
+
+
+def _path_key_parts(key: str) -> tuple[str, tuple[str, ...]] | None:
+    if "/" not in key:
+        return None
+    kind = _ABSOLUTE_PATH_KIND if key.startswith("/") else _RELATIVE_PATH_KIND
+    parts = tuple(key.split("/")[1:] if kind == _ABSOLUTE_PATH_KIND else key.split("/"))
+    if not parts or any(not part or part in {".", ".."} or "\\" in part for part in parts):
+        raise ValueError(
+            "OpenVikingStore path keys must be canonical POSIX paths without "
+            "empty, '.', '..', or backslash segments."
+        )
+    return kind, parts
+
+
 def _parse_canonicalized_record_uri(
     *,
     root_uri: str,
@@ -487,8 +542,26 @@ def _identity_relative_root_tail(classification: UriClassification) -> tuple[str
 def _parse_record_parts(parts: list[str]) -> tuple[tuple[str, ...], str] | None:
     if not parts or not parts[-1]:
         return None
-    namespace = tuple(unquote(part) for part in parts[:-1])
-    key = unquote(parts[-1])
+    decoded = [unquote(part) for part in parts]
+    try:
+        marker_index = decoded.index(_PATH_KEY_MARKER)
+    except ValueError:
+        namespace = tuple(decoded[:-1])
+        key = decoded[-1]
+        return namespace, key
+
+    if marker_index + 2 >= len(decoded):
+        return tuple(decoded[:-1]), decoded[-1]
+    kind = decoded[marker_index + 1]
+    if kind not in {_ABSOLUTE_PATH_KIND, _RELATIVE_PATH_KIND}:
+        return tuple(decoded[:-1]), decoded[-1]
+    key_parts = decoded[marker_index + 2 :]
+    if any(not part or part in {".", ".."} or "\\" in part for part in key_parts):
+        return None
+    namespace = tuple(decoded[:marker_index])
+    key = "/".join(key_parts)
+    if kind == _ABSOLUTE_PATH_KIND:
+        key = f"/{key}"
     return namespace, key
 
 

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1224,6 +1224,81 @@ def test_langgraph_store_round_trip_and_semantic_search():
     assert store.list_namespaces(prefix=("users",)) == [("users", "ada")]
 
 
+def test_langgraph_store_round_trips_hierarchical_path_keys():
+    client = InMemoryOpenVikingClient()
+    store = OpenVikingStore(client=client)
+    namespace = ("filesystem", "user-a")
+
+    store.put(namespace, "/docs/readme.md", {"policy": "cobalt deployment"})
+    store.put(namespace, "notes/todo.md", {"task": "amber checklist"})
+
+    absolute_data_uri = (
+        "viking://~/memories/langgraph_store/data/filesystem/user-a/"
+        "__openviking_path_key_v1__/abs/docs/readme.md.json"
+    )
+    absolute_index_uri = (
+        "viking://~/memories/langgraph_store/index/filesystem/user-a/"
+        "__openviking_path_key_v1__/abs/docs/readme.md.md"
+    )
+    relative_data_uri = (
+        "viking://~/memories/langgraph_store/data/filesystem/user-a/"
+        "__openviking_path_key_v1__/rel/notes/todo.md.json"
+    )
+    assert absolute_data_uri in client.records
+    assert absolute_index_uri in client.records
+    assert relative_data_uri in client.records
+    assert all("%2F" not in uri for uri in client.records)
+
+    assert store.get(namespace, "/docs/readme.md").value["policy"] == "cobalt deployment"
+    assert store.get(namespace, "notes/todo.md").value["task"] == "amber checklist"
+    assert {item.key for item in store.search(namespace)} == {
+        "/docs/readme.md",
+        "notes/todo.md",
+    }
+    semantic = store.search(namespace, query="cobalt", limit=5)
+    assert [item.key for item in semantic] == ["/docs/readme.md"]
+    assert store.list_namespaces(prefix=("filesystem",)) == [namespace]
+
+    store.delete(namespace, "/docs/readme.md")
+    assert absolute_data_uri not in client.records
+    assert absolute_index_uri not in client.records
+
+
+def test_langgraph_store_reads_legacy_percent_encoded_path_key():
+    namespace = ("filesystem", "user-a")
+    key = "/AGENTS.md"
+    legacy_uri = "viking://~/memories/langgraph_store/data/filesystem/user-a/%2FAGENTS.md.json"
+    now = "2026-08-26T00:00:00+00:00"
+    client = InMemoryOpenVikingClient(
+        {
+            legacy_uri: json.dumps(
+                {
+                    "namespace": list(namespace),
+                    "key": key,
+                    "value": {"content": "legacy record"},
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+        }
+    )
+    store = OpenVikingStore(client=client)
+
+    item = store.get(namespace, key)
+
+    assert item is not None
+    assert item.key == key
+    assert item.value["content"] == "legacy record"
+
+
+@pytest.mark.parametrize("key", ["/", "/docs//readme.md", "/docs/../readme.md", r"/docs\readme.md"])
+def test_langgraph_store_rejects_noncanonical_path_keys(key):
+    store = OpenVikingStore(client=InMemoryOpenVikingClient())
+
+    with pytest.raises(ValueError, match="canonical POSIX paths"):
+        store.put(("filesystem",), key, {"content": "invalid"})
+
+
 def test_langgraph_store_semantic_search_keeps_peer_id_out_of_retrieval():
     client = InMemoryOpenVikingClient()
     store = OpenVikingStore(client=client, actor_peer_id="peer-store")

--- a/tests/unit/test_langchain_integration.py
+++ b/tests/unit/test_langchain_integration.py
@@ -1224,79 +1224,108 @@ def test_langgraph_store_round_trip_and_semantic_search():
     assert store.list_namespaces(prefix=("users",)) == [("users", "ada")]
 
 
-def test_langgraph_store_round_trips_hierarchical_path_keys():
+def test_langgraph_store_round_trips_separator_keys_as_single_uri_segments():
     client = InMemoryOpenVikingClient()
     store = OpenVikingStore(client=client)
     namespace = ("filesystem", "user-a")
+    cases = {
+        "profile": "profile",
+        "/docs/readme.md": "!sdocs!sreadme.md",
+        "notes/todo.md": "notes!stodo.md",
+        "/": "!s",
+        "/docs/": "!sdocs!s",
+        "docs//readme.md": "docs!s!sreadme.md",
+        r"docs\readme.md": "docs!breadme.md",
+        "!sAGENTS.md": "%21sAGENTS.md",
+        "!bAGENTS.md": "%21bAGENTS.md",
+        "%2F": "%252F",
+        ".": ".",
+        "..": "..",
+        "中/文": "%E4%B8%AD!s%E6%96%87",
+    }
 
-    store.put(namespace, "/docs/readme.md", {"policy": "cobalt deployment"})
-    store.put(namespace, "notes/todo.md", {"task": "amber checklist"})
+    for key, encoded in cases.items():
+        policy = "cobalt deployment" if key == "/docs/readme.md" else "amber checklist"
+        store.put(namespace, key, {"key": key, "policy": policy})
+        data_uri = f"viking://~/memories/langgraph_store/data/filesystem/user-a/{encoded}.json"
+        index_uri = f"viking://~/memories/langgraph_store/index/filesystem/user-a/{encoded}.md"
+        assert data_uri in client.records
+        assert index_uri in client.records
 
-    absolute_data_uri = (
-        "viking://~/memories/langgraph_store/data/filesystem/user-a/"
-        "__openviking_path_key_v1__/abs/docs/readme.md.json"
-    )
-    absolute_index_uri = (
-        "viking://~/memories/langgraph_store/index/filesystem/user-a/"
-        "__openviking_path_key_v1__/abs/docs/readme.md.md"
-    )
-    relative_data_uri = (
-        "viking://~/memories/langgraph_store/data/filesystem/user-a/"
-        "__openviking_path_key_v1__/rel/notes/todo.md.json"
-    )
-    assert absolute_data_uri in client.records
-    assert absolute_index_uri in client.records
-    assert relative_data_uri in client.records
     assert all("%2F" not in uri for uri in client.records)
 
-    assert store.get(namespace, "/docs/readme.md").value["policy"] == "cobalt deployment"
-    assert store.get(namespace, "notes/todo.md").value["task"] == "amber checklist"
-    assert {item.key for item in store.search(namespace)} == {
-        "/docs/readme.md",
-        "notes/todo.md",
-    }
+    for key in cases:
+        item = store.get(namespace, key)
+        assert item is not None
+        assert item.key == key
+        assert item.value["key"] == key
+
+    assert {item.key for item in store.search(namespace, limit=100)} == set(cases)
     semantic = store.search(namespace, query="cobalt", limit=5)
     assert [item.key for item in semantic] == ["/docs/readme.md"]
     assert store.list_namespaces(prefix=("filesystem",)) == [namespace]
 
     store.delete(namespace, "/docs/readme.md")
-    assert absolute_data_uri not in client.records
-    assert absolute_index_uri not in client.records
+    assert (
+        "viking://~/memories/langgraph_store/data/filesystem/user-a/!sdocs!sreadme.md.json"
+    ) not in client.records
+    assert (
+        "viking://~/memories/langgraph_store/index/filesystem/user-a/!sdocs!sreadme.md.md"
+    ) not in client.records
 
 
-def test_langgraph_store_reads_legacy_percent_encoded_path_key():
-    namespace = ("filesystem", "user-a")
-    key = "/AGENTS.md"
-    legacy_uri = "viking://~/memories/langgraph_store/data/filesystem/user-a/%2FAGENTS.md.json"
-    now = "2026-08-26T00:00:00+00:00"
-    client = InMemoryOpenVikingClient(
-        {
-            legacy_uri: json.dumps(
-                {
-                    "namespace": list(namespace),
-                    "key": key,
-                    "value": {"content": "legacy record"},
-                    "created_at": now,
-                    "updated_at": now,
-                }
-            )
-        }
-    )
+def test_langgraph_store_distinguishes_separator_escapes_from_literal_markers():
+    client = InMemoryOpenVikingClient()
     store = OpenVikingStore(client=client)
+    namespace = ("filesystem", "user-a")
+    cases = {
+        "/AGENTS.md": "!sAGENTS.md",
+        "!sAGENTS.md": "%21sAGENTS.md",
+        r"\AGENTS.md": "!bAGENTS.md",
+        "!bAGENTS.md": "%21bAGENTS.md",
+    }
 
-    item = store.get(namespace, key)
+    for key in cases:
+        store.put(namespace, key, {"key": key})
 
-    assert item is not None
-    assert item.key == key
-    assert item.value["content"] == "legacy record"
+    expected_data_uris = {
+        f"viking://~/memories/langgraph_store/data/filesystem/user-a/{encoded}.json"
+        for encoded in cases.values()
+    }
+    assert expected_data_uris.issubset(client.records)
+    assert len(expected_data_uris) == len(cases)
+
+    for key in cases:
+        item = store.get(namespace, key)
+        assert item is not None
+        assert item.key == key
+        assert item.value["key"] == key
 
 
-@pytest.mark.parametrize("key", ["/", "/docs//readme.md", "/docs/../readme.md", r"/docs\readme.md"])
-def test_langgraph_store_rejects_noncanonical_path_keys(key):
-    store = OpenVikingStore(client=InMemoryOpenVikingClient())
+def test_langgraph_store_keeps_namespace_and_key_identity_collision_free():
+    client = InMemoryOpenVikingClient()
+    store = OpenVikingStore(client=client)
+    marker = "__openviking_path_key_v1__"
+    path_identity = (("filesystem", "user-a"), "/docs")
+    namespace_identity = (("filesystem", "user-a", marker, "abs"), "docs")
 
-    with pytest.raises(ValueError, match="canonical POSIX paths"):
-        store.put(("filesystem",), key, {"content": "invalid"})
+    store.put(*path_identity, {"identity": "path-key"})
+    store.put(*namespace_identity, {"identity": "namespace"})
+
+    path_uri = "viking://~/memories/langgraph_store/data/filesystem/user-a/!sdocs.json"
+    namespace_uri = (
+        "viking://~/memories/langgraph_store/data/filesystem/user-a/"
+        "__openviking_path_key_v1__/abs/docs.json"
+    )
+    assert path_uri in client.records
+    assert namespace_uri in client.records
+    assert path_uri != namespace_uri
+    assert store.get(*path_identity).value["identity"] == "path-key"
+    assert store.get(*namespace_identity).value["identity"] == "namespace"
+    assert store.list_namespaces(prefix=("filesystem",)) == [
+        ("filesystem", "user-a"),
+        ("filesystem", "user-a", marker, "abs"),
+    ]
 
 
 def test_langgraph_store_semantic_search_keeps_peer_id_out_of_retrieval():


### PR DESCRIPTION
## Description

Support slash- and backslash-containing LangGraph store keys without sending encoded path separators that OpenViking rejects.

The adapter keeps each BaseStore key as exactly one URI segment. It first applies the existing percent encoding, then translates encoded separators into adapter-level escape tokens:

```text
/AGENTS.md       -> !sAGENTS.md
notes/todo.md    -> notes!stodo.md
docs\guide.md    -> docs!bguide.md
!sAGENTS.md      -> %21sAGENTS.md
```

Because `quote(..., safe="")` encodes a literal `!` as `%21` before `!s` and `!b` are introduced, separator escapes remain distinct from literal marker text. Keys without separators retain their existing URI layout.

This preserves LangGraph's `(namespace, key)` boundary: namespace labels remain URI hierarchy, while the complete opaque key remains the final segment.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4334

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve ordinary key URI layouts.
- Encode `/` as `!s` and `\` as `!b` after percent encoding.
- Decode only the final key segment; namespace parsing remains unchanged.
- Support leading, trailing, and repeated separators, backslashes, Unicode, dot segments, percent text, and literal `!s`/`!b`.
- Remove the earlier versioned hierarchy and path-normalization restrictions.
- Add regression coverage for the namespace/key identity collision identified during review.

## Testing

- [x] I have added tests that prove the fix is effective
- [x] New and existing integration tests pass locally
- [x] Tested on:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

- `72 passed` in `tests/unit/test_langchain_integration.py`
- Ruff lint and format checks
- mypy for all 15 `langchain_openviking` source files
- `git diff --check`
- End-to-end against OpenViking 0.4.16: put/get, listing, semantic search, namespace listing, and isolated deletion
- Confirmed `/AGENTS.md` and literal `!sAGENTS.md` remain separate records through write/read/list/glob/search
- Exhaustive local round-trip check over 66,430 generated keys found no collisions

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review
- [x] I have commented the non-obvious encoding invariant
- [ ] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

This revision adopts the single-segment encoding suggested in the issue discussion. It avoids changing namespace semantics or introducing an internal URI hierarchy.