### PR TITLE
feat(cc-plugin): optional toast feedback on context injection

### DIFF
--- a/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
+++ b/examples/claude-code-memory-plugin/scripts/auto-recall.mjs
@@ -35,9 +35,13 @@ function output(obj) {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
-function approve(msg) {
+function approve(msg, systemMessage) {
   const out = { decision: "approve" };
-  if (msg) out.hookSpecificOutput = { hookEventName: "UserPromptSubmit", additionalContext: msg };
+  if (msg) {
+    out.hookSpecificOutput = { hookEventName: "UserPromptSubmit", additionalContext: msg };
+    // Optional one-line toast so the user sees how much was recalled.
+    if (systemMessage) out.systemMessage = systemMessage;
+  }
   output(out);
 }
 
@@ -398,8 +402,9 @@ async function main() {
       approve();
       return;
     }
+    const recalledCount = new Set(endpointBlock.match(/viking:\/\/[^\s<>"')\]]+/g) || []).size;
     writeRecallState({
-      count: new Set(endpointBlock.match(/viking:\/\/[^\s<>"')\]]+/g) || []).size,
+      count: recalledCount,
       content_items: 1,
       hint_items: 0,
       tokens_used: estimateTokens(endpointBlock),
@@ -407,7 +412,7 @@ async function main() {
       cc_session_id: sessionId,
       reason: "ok",
     });
-    approve(endpointBlock);
+    approve(endpointBlock, cfg.toast ? `🧠 OpenViking recall: ${recalledCount} memories` : null);
     return;
   }
 
@@ -449,7 +454,7 @@ async function main() {
     cc_session_id: sessionId,
     reason: "ok",
   });
-  approve(built?.block);
+  approve(built?.block, cfg.toast ? `🧠 OpenViking recall: ${picked.length} memories` : null);
 }
 
 main().catch((err) => { logError("uncaught", err); approve(); });

--- a/examples/claude-code-memory-plugin/scripts/config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.mjs
@@ -202,6 +202,11 @@ export function loadConfig() {
   const defaultLogPath = join(homedir(), ".openviking", "logs", "cc-hooks.log");
   const debugLogPath = str(process.env.OPENVIKING_DEBUG_LOG, defaultLogPath);
 
+  // Injected-context toast: a one-line systemMessage alongside additionalContext
+  // so the user can see the plugin is alive and how much it recalled. Opt-out
+  // via OPENVIKING_TOAST=0 or cc.toast=false.
+  const toast = envBool("OPENVIKING_TOAST") ?? (cc.toast !== false);
+
   const timeoutMs = Math.max(1000, Math.floor(num(
     process.env.OPENVIKING_TIMEOUT_MS,
     num(cc.timeoutMs, 15000),
@@ -233,6 +238,7 @@ export function loadConfig() {
     workspacePeer,
     timeoutMs,
     userAgent: USER_AGENT,
+    toast,
 
     // Recall
     autoRecall: envBool("OPENVIKING_AUTO_RECALL") ?? (cc.autoRecall !== false),

--- a/examples/claude-code-memory-plugin/scripts/session-start.mjs
+++ b/examples/claude-code-memory-plugin/scripts/session-start.mjs
@@ -50,13 +50,15 @@ function output(obj) {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
-function approve(additionalContext) {
+function approve(additionalContext, systemMessage) {
   const out = { decision: "approve" };
   if (additionalContext) {
     out.hookSpecificOutput = {
       hookEventName: "SessionStart",
       additionalContext,
     };
+    // Optional one-line toast so the user sees the plugin injected context.
+    if (systemMessage) out.systemMessage = systemMessage;
   }
   output(out);
 }
@@ -188,6 +190,12 @@ async function main() {
   const composed = `<openviking-context source="${source}">\n${sections.join("\n")}\n</openviking-context>`;
   writeLastInject(composed);
 
+  const toast = cfg.toast
+    ? `🧠 OpenViking ${source}: injected ${
+        profile ? `${profile.prefCount} preferences + ${profile.entCount} entities` : "context"
+      }${archiveSection ? " + session archive" : ""}`
+    : null;
+
   if (cfg.debug) {
     process.stderr.write(
       `[ov] session-start injected ~${composed.length} chars / ~${estimateTokens(composed)} tokens` +
@@ -211,7 +219,7 @@ async function main() {
     },
     archive: Boolean(archiveSection),
   });
-  approve(composed);
+  approve(composed, toast);
 }
 
 main().catch((err) => { logError("uncaught", err); approve(); });


### PR DESCRIPTION
## Motivation

Context injections (session-start profile/archive, auto-recall memories) are currently fully silent: the hook returns `additionalContext` only, so the user has no way to tell whether the memory plugin is working at all. A misconfigured server, an unreachable endpoint, and "no memories matched" all look identical — you have to go read `~/.openviking/last_inject.md` to distinguish them.

This PR adds an optional one-line `systemMessage` toast next to the injected context, so Claude Code surfaces what happened:

- `🧠 OpenViking startup: injected 256 preferences + 2 entities`
- `🧠 OpenViking recall: 3 memories`

This also doubles as a troubleshooting aid: when recall sources are misconfigured, the absence/presence of the toast immediately shows whether the hook ran and whether it found anything.

## Changes

- `scripts/config.mjs`: new `toast` flag, resolved the same way as existing tuning fields — `OPENVIKING_TOAST` env → `cc.toast` → default **on** (`cc.toast !== false`).
- `scripts/session-start.mjs`: `approve()` accepts an optional `systemMessage`; the injection site builds a toast from `source` + preference/entity counts + archive presence.
- `scripts/auto-recall.mjs`: same `approve()` extension; both injection paths (server-assembled endpoint block and local recall) toast the recalled item count. The URI-count regex for the endpoint path is reused from the adjacent `writeRecallState` call.

No-op behavior when nothing is injected is unchanged. With `toast` disabled the output is byte-identical to before.

## Testing

Ran the hooks against a live local server (0.4.16):

- `session-start` (source=startup): toast `🧠 OpenViking startup: injected 256 preferences + 2 entities`, injected 8858 chars.
- `auto-recall` (query hitting memories): toast `🧠 OpenViking recall: 3 memories`, 1250 chars context.
- `OPENVIKING_TOAST=0`: no `systemMessage`, injection unchanged.
- `node --check` passes on all three files.