### PR TITLE
fix(docker): 在运行时校验 Studio 安装包

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
-RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); assert spec and spec.origin, 'missing Studio package'; root = Path('/app/.venv').resolve(); p = (Path(spec.origin).resolve().parent / 'dist/index.html').resolve(); assert p.is_file() and p.is_relative_to(root), f'missing or misplaced Studio bundle: {p}'"
+RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); locations = list(spec.submodule_search_locations or ()) if spec else []; root = Path('/app/.venv').resolve(); p = (Path(locations[0]).resolve() / 'dist/index.html').resolve() if len(locations) == 1 else None; valid = p is not None and p.is_file() and p.is_relative_to(root); raise SystemExit(0 if valid else f'missing or misplaced Studio bundle: {p}')"
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health
 RUN mkdir -p /app/.openviking \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
-RUN /app/.venv/bin/python -I -c "from importlib.resources import files; from pathlib import Path; p = Path(files('openviking.web_studio').joinpath('dist/index.html')).resolve(); root = Path('/app/.venv').resolve(); assert p.is_file() and p.is_relative_to(root), f'missing or misplaced Studio bundle: {p}'"
+RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); assert spec and spec.origin, 'missing Studio package'; root = Path('/app/.venv').resolve(); p = (Path(spec.origin).resolve().parent / 'dist/index.html').resolve(); assert p.is_file() and p.is_relative_to(root), f'missing or misplaced Studio bundle: {p}'"
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health
 RUN mkdir -p /app/.openviking \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-${TARGETPLATFORM} \
             echo "Unsupported UV_LOCK_STRATEGY: ${UV_LOCK_STRATEGY}" >&2; \
             exit 2 \
             ;; \
-    esac && \
-    python -c "from importlib.resources import files; p = files('openviking.web_studio').joinpath('dist/index.html'); assert p.is_file(), f'missing Studio bundle: {p}'"
+    esac
 
 # Stage 4: runtime
 FROM python:3.13-slim-trixie
@@ -111,6 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
+RUN /app/.venv/bin/python -I -c "from importlib.resources import files; from pathlib import Path; p = Path(files('openviking.web_studio').joinpath('dist/index.html')).resolve(); root = Path('/app/.venv').resolve(); assert p.is_file() and p.is_relative_to(root), f'missing or misplaced Studio bundle: {p}'"
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health
 RUN mkdir -p /app/.openviking \


### PR DESCRIPTION
## 说明

PR #4305 在 `uv sync` 后检查 Studio 资源，但该命令位于 `/app`，Python 会优先从当前目录导入 `openviking.web_studio`。如果 wheel 漏装 Studio，源码目录中的 `dist/index.html` 仍可能让检查通过，而最终镜像只复制 `.venv`。

本 PR 将检查移到 runtime stage。在复制 `.venv` 后，使用其中的 Python 以 `-I` 模式导入资源，并确认 `index.html` 实际位于 `/app/.venv`。这项修改对应 PR #4305 合并后留下的审查意见。

## 人工参与

- [x] 有人工参与本次实现或审查
- [ ] 本 PR 完全由 AI Agent 生成，没有人工参与

## 关联 Issue

补充修复 PR #4305 的审查意见：https://github.com/volcengine/OpenViking/pull/4305#discussion_r3850010649

## 变更类型

- [x] 缺陷修复（不破坏现有兼容性）
- [ ] 新功能（不破坏现有兼容性）
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（不改变功能）
- [ ] 性能优化
- [ ] 测试更新

## 主要变更

- 删除 py-builder 中可能被源码目录遮蔽的资源检查。
- 在 runtime stage 复制 `.venv` 后执行隔离检查，并确认资源解析到 `/app/.venv` 内。

## 测试

- [ ] 已添加能够验证修复或功能的测试
- [ ] 新增测试和现有单元测试在本地通过
- [x] 已在以下平台测试：
  - [x] Linux（linux/amd64 镜像）
  - [ ] macOS
  - [x] Windows（Docker Desktop 主机）

执行了以下检查：

```text
docker buildx build --check .
docker build --platform linux/amd64 --build-arg OPENVIKING_VERSION=0.0.0+pr4305.review -t openviking:pr4305-runtime-validation .
```

验证结果：

- Dockerfile 静态检查通过，没有警告。
- 完整 Linux/amd64 镜像构建成功，新的 runtime 检查实际执行通过。
- Studio 入口文件解析到 `/app/.venv/lib/python3.13/site-packages/openviking/web_studio/dist/index.html`。
- runtime 镜像中没有 `/app/openviking` 源码目录，也没有 Node 或 npm。
- 基于最新 `main` 重建后，全部 Docker layers 命中缓存。

## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自查
- [ ] 已为较难理解的构建步骤补充必要注释
- [ ] 已同步更新相关文档
- [x] 本次修改没有产生新的警告
- [x] 依赖变更已经合并并发布（本 PR 未修改依赖）

## 截图

不适用。

## 补充说明

本 PR 只调整 Docker 镜像的安装后检查，不改变 Studio 构建过程，也不改变普通 pip 安装的降级行为。
