### PR TITLE
Revert "fix(dsh): launch MCP proxy with node command (#4263)"

### DIFF
--- a/examples/dsh-memory-plugin/mcp.mjs
+++ b/examples/dsh-memory-plugin/mcp.mjs
@@ -28,7 +28,7 @@ export function buildMcpConfig(config) {
   return {
     transport: "stdio",
     serverName: MCP_SERVER_NAME,
-    command: "node",
+    command: process.execPath,
     args: [PROXY_PATH],
     env,
     toolCallTimeoutMs: config.mcpToolCallTimeoutMs,

--- a/examples/dsh-memory-plugin/mcp.test.mjs
+++ b/examples/dsh-memory-plugin/mcp.test.mjs
@@ -18,7 +18,7 @@ test("the mount config validates against the pinned bridge's own schema", () => 
   // server through this same proxy, and it owns the transport quirks.
   assert.equal(parsed.transport, "stdio");
   assert.equal(parsed.serverName, "openviking");
-  assert.equal(parsed.command, "node");
+  assert.equal(parsed.command, process.execPath);
   assert.deepEqual(parsed.args, [PROXY_PATH]);
   assert.equal(parsed.env.ELECTRON_RUN_AS_NODE, "1");
   assert.equal(parsed.toolCallTimeoutMs, 60000);


### PR DESCRIPTION
Reverts the `command` change from #4263 (`26aae04a`) and restores the form #4272 landed: `command: process.execPath` together with `ELECTRON_RUN_AS_NODE: "1"`.

### Why

**The bug #4263 targets was already fixed, differently.** Under DSH Desktop, `process.execPath` is Electron's binary rather than a standalone Node, so spawning the stdio proxy with it would launch a second Desktop instance. #4272 (`Fixes #4197`) fixed that by keeping `process.execPath` and setting `ELECTRON_RUN_AS_NODE=1`, which makes Electron run the script as Node. That fix was verified on a real DSH Desktop install and does not depend on `PATH`.

**The two fixes landed concurrently and left `main` inconsistent.** `mcp.mjs` on `main` currently sets `command: "node"` while still exporting `ELECTRON_RUN_AS_NODE: "1"`, and the comment immediately above it still explains the `process.execPath`/Electron handling. The implementation and its documented rationale disagree.

**`process.execPath` is a deliberate, load-bearing choice.** #3308 reported that on Windows, spawning a bare command name hits npm's POSIX shim and fails with `EPERM`; the fix was to launch through the currently running interpreter, since a name on `PATH` may resolve to something else while `process.execPath` is always available. Every memory plugin follows the same shape: an external config may enter via `node`, but once inside we re-enter through `process.execPath` rather than betting on `PATH`.

**A bare `node` adds a new requirement.** It assumes the GUI process's `PATH` contains a standalone `node`. On trimmed Linux desktops, or any host where the runtime ships its own Node, this fails with `ENOENT` — a regression for hosts that work today.

#4263 references #4189, which carries no reproduction details, and overlaps with #4272's verified fix.

### Follow-up

If a distribution is found that disables `ELECTRON_RUN_AS_NODE`, the right fix is an explicit capability probe with a documented fallback, not defaulting to `PATH` lookup.