### PR TITLE
perf(storage): 减少云存储冗余请求

### DIFF
--- a/crates/ragfs/src/core/multibackend_wrapper.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper.rs
@@ -1221,24 +1221,16 @@ impl MultiWriteWrappedFS {
         let source_path = src_path.to_string();
         let destination_path = dst_path.to_string();
 
-        let source_exists_on_primary = FS_CTX
-            .scope(ctx.clone(), async {
-                inner.primary().backend.exists(&source_path).await
-            })
+        let source_info = FS_CTX
+            .scope(ctx.clone(), inner.primary().backend.stat(&source_path))
             .await;
-        if !source_exists_on_primary {
+        let Ok(source_info) = source_info else {
             return Ok(false);
+        };
+        if source_info.is_dir {
+            return Err(Error::IsADirectory(source_path.clone()));
         }
-
-        let source_size = FS_CTX
-            .scope(ctx.clone(), async {
-                let source_info = inner.primary().backend.stat(&source_path).await?;
-                if source_info.is_dir {
-                    return Err(Error::IsADirectory(source_path.clone()));
-                }
-                Ok::<u64, Error>(source_info.size)
-            })
-            .await?;
+        let source_size = source_info.size;
 
         if inner
             .check_redirect(&destination_path, source_size)
@@ -1356,7 +1348,7 @@ impl FileSystem for MultiWriteWrappedFS {
         if is_hidden_internal_name(file_name(path)) {
             return self.inner.primary().backend.read(path, offset, size).await;
         }
-        if let Some(fs) = self.inner.resolve_read_backend(path).await {
+        if let Some((fs, _)) = self.inner.resolve_read_route(path).await {
             return fs.read(path, offset, size).await;
         }
         Err(Error::not_found(path))
@@ -1448,8 +1440,8 @@ impl FileSystem for MultiWriteWrappedFS {
         if is_hidden_internal_name(file_name(path)) {
             return self.inner.primary().backend.stat(path).await;
         }
-        if let Some(fs) = self.inner.resolve_read_backend(path).await {
-            return fs.stat(path).await;
+        if let Some((_, info)) = self.inner.resolve_read_route(path).await {
+            return Ok(info);
         }
         Err(Error::not_found(path))
     }
@@ -1618,7 +1610,7 @@ impl FileSystem for MultiWriteWrappedFS {
                 if is_excluded_grep_path(&entry.path, exclude_owned.as_deref()) {
                     continue;
                 }
-                let Some(read_backend) = inner.resolve_read_backend(&entry.path).await else {
+                let Some((read_backend, _)) = inner.resolve_read_route(&entry.path).await else {
                     continue;
                 };
                 let rel_path = relative_match_file(&path_owned, &entry.path);

--- a/crates/ragfs/src/core/multibackend_wrapper/routing.rs
+++ b/crates/ragfs/src/core/multibackend_wrapper/routing.rs
@@ -56,28 +56,31 @@ impl Inner {
         FileInfo::new_file(name.to_string(), 0, 0o644)
     }
 
-    /// Resolve the read backend for a path using the fallback chain.
-    pub(super) async fn resolve_read_backend(&self, path: &str) -> Option<Arc<dyn FileSystem>> {
+    /// Resolve the read backend and metadata for a path using the fallback chain.
+    pub(super) async fn resolve_read_route(
+        &self,
+        path: &str,
+    ) -> Option<(Arc<dyn FileSystem>, FileInfo)> {
         let normalized = normalize_prefix_path(path);
         let read_backups = self.read_backups_sorted();
-        let backup_exists = futures::future::join_all(read_backups.iter().map(|backup| async {
+        let backup_stats = futures::future::join_all(read_backups.iter().map(|backup| async {
             (
                 backup.name.clone(),
                 backup.backend.clone(),
-                backup.backend.exists(&normalized).await,
+                backup.backend.stat(&normalized).await,
             )
         }))
         .await;
-        for (_name, backend, exists) in backup_exists {
-            if exists {
+        for (_name, backend, info) in backup_stats {
+            if let Ok(info) = info {
                 self.record_read_route(ReadRouteSource::Backup);
-                return Some(backend);
+                return Some((backend, info));
             }
         }
 
-        if self.primary().backend.exists(&normalized).await {
+        if let Ok(info) = self.primary().backend.stat(&normalized).await {
             self.record_read_route(ReadRouteSource::Primary);
-            return Some(self.primary().backend.clone());
+            return Some((self.primary().backend.clone(), info));
         }
 
         if self.redirects.is_empty() {
@@ -100,20 +103,20 @@ impl Inner {
                             .map(|be| (be.name.clone(), be.backend.clone()))
                     })
                     .collect();
-                let redirect_exists = futures::future::join_all(redirect_targets.iter().map(
+                let redirect_stats = futures::future::join_all(redirect_targets.iter().map(
                     |(target_name, backend)| async {
                         (
                             target_name.clone(),
                             backend.clone(),
-                            backend.exists(&normalized).await,
+                            backend.stat(&normalized).await,
                         )
                     },
                 ))
                 .await;
-                for (_target_name, backend, exists) in redirect_exists {
-                    if exists {
+                for (_target_name, backend, info) in redirect_stats {
+                    if let Ok(info) = info {
                         self.record_read_route(ReadRouteSource::Redirect);
-                        return Some(backend);
+                        return Some((backend, info));
                     }
                 }
             }

--- a/crates/ragfs/src/plugins/localfs/mod.rs
+++ b/crates/ragfs/src/plugins/localfs/mod.rs
@@ -970,7 +970,7 @@ impl FileSystem for LocalFileSystem {
         let metadata = fs::metadata(&local_path).map_err(|_| Error::NotFound(path.to_string()))?;
 
         if metadata.is_dir() {
-            return Err(Error::plugin(format!("is a directory: {}", path)));
+            return Err(Error::IsADirectory(path.to_string()));
         }
 
         // Read file

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -473,13 +473,7 @@ impl FileSystem for S3FileSystem {
         let normalized = Self::normalize_path(path);
         let key = self.client.build_key(&normalized);
 
-        // Check if already exists
-        if self.client.head_object(&key).await?.is_some() {
-            return Err(Error::already_exists(&normalized));
-        }
-
-        // Create empty file
-        self.client.put_object(&key, Vec::new()).await?;
+        self.client.put_object_create_new(&key, Vec::new()).await?;
 
         // Invalidate caches
         self.dir_cache.invalidate_parent(&normalized).await;
@@ -579,21 +573,25 @@ impl FileSystem for S3FileSystem {
         let normalized = Self::normalize_path(path);
         let key = self.client.build_key(&normalized);
 
-        // Check if it's a directory
-        if key.ends_with('/') || self.client.directory_exists(&normalized).await? {
-            // Try to read as file first
-            if self.client.head_object(&key).await?.is_none() {
-                return Err(Error::IsADirectory(normalized));
-            }
+        if normalized == "/" {
+            return Err(Error::IsADirectory(normalized));
         }
 
-        if offset == 0 && size == 0 {
+        let result = if offset == 0 && size == 0 {
             // Full read
             self.client.get_object(&key).await
         } else {
             // Range read
             self.client.get_object_range(&key, offset, size).await
+        };
+
+        if matches!(&result, Err(Error::NotFound(_)))
+            && self.client.directory_exists(&normalized).await?
+        {
+            return Err(Error::IsADirectory(normalized));
         }
+
+        result
     }
 
     async fn write(&self, path: &str, data: &[u8], _offset: u64, flags: WriteFlag) -> Result<u64> {

--- a/openviking/parse/parsers/media/utils.py
+++ b/openviking/parse/parsers/media/utils.py
@@ -419,7 +419,7 @@ async def _generate_media_summary(
     result = {"name": original_filename, "summary": ""}
 
     viking_fs = get_viking_fs()
-    stat = await viking_fs.stat(media_uri, ctx=ctx, skip_count=True)
+    stat = await viking_fs.stat_metadata(media_uri, ctx=ctx)
     size_bytes = int((stat or {}).get("size", 0))
     if not vlm.supports_media(
         media_type=media_type,

--- a/openviking/parse/tree_builder.py
+++ b/openviking/parse/tree_builder.py
@@ -126,7 +126,7 @@ class TreeBuilder:
                         f"Parent URI does not exist: {effective_parent_uri}. "
                         f"Use --parent-auto-create/-p to automatically create it."
                     )
-            stat_result = await viking_fs.stat(effective_parent_uri, ctx=ctx, skip_count=True)
+            stat_result = await viking_fs.stat_metadata(effective_parent_uri, ctx=ctx)
             if not stat_result.get("isDir"):
                 raise ValueError(f"Parent URI is not a directory: {effective_parent_uri}")
             base_uri = effective_parent_uri

--- a/openviking/privacy/service.py
+++ b/openviking/privacy/service.py
@@ -40,10 +40,8 @@ class UserPrivacyConfigService:
 
     async def exists(self, ctx: RequestContext, category: str, target_key: str) -> bool:
         try:
-            await self._viking_fs.stat(
-                self.get_config_root(ctx, category, target_key),
-                ctx=ctx,
-                skip_count=True,
+            await self._viking_fs.stat_metadata(
+                self.get_config_root(ctx, category, target_key), ctx=ctx
             )
             return True
         except (NotFoundError, FileNotFoundError):

--- a/openviking/pyagfs/helpers.py
+++ b/openviking/pyagfs/helpers.py
@@ -373,42 +373,7 @@ def _ensure_remote_parent_dir(
     fs_ctx: dict[str, str] | None = None,
 ) -> None:
     """Ensure the parent directory exists for a remote path."""
-    parent = "/".join(path.rstrip("/").split("/")[:-1])
-    if parent and parent != "/":
-        # Try to create parent directory (and its parents)
-        _ensure_remote_dir_recursive(client, parent, fs_ctx=fs_ctx)
-
-
-def _ensure_remote_dir_recursive(
-    client: AGFSSyncClientProtocol,
-    path: str,
-    *,
-    fs_ctx: dict[str, str] | None = None,
-) -> None:
-    """Recursively ensure a directory exists in AGFS."""
-    if not path or path == "/":
-        return
-
-    # Check if directory already exists
-    try:
-        info = _call_with_optional_ctx(client.stat, path, ctx=fs_ctx)
-        if info.get("isDir", False):
-            return  # Directory exists
-    except Exception:
-        # Directory doesn't exist, need to create it
-        pass
-
-    # Ensure parent exists first
-    parent = "/".join(path.rstrip("/").split("/")[:-1])
-    if parent and parent != "/":
-        _ensure_remote_dir_recursive(client, parent, fs_ctx=fs_ctx)
-
-    # Create this directory
-    try:
-        _call_with_optional_ctx(client.mkdir, path, ctx=fs_ctx)
-    except Exception:
-        # Might already exist due to race condition, ignore
-        pass
+    _call_with_optional_ctx(client.ensure_parent_dirs, path, ctx=fs_ctx)
 
 
 def _iter_file_bytes(data: bytes | AGFSByteStream) -> AGFSByteStream:

--- a/openviking/resource/watch_scheduler.py
+++ b/openviking/resource/watch_scheduler.py
@@ -586,7 +586,7 @@ class WatchScheduler:
         if self._viking_fs is None:
             return True
         try:
-            await self._viking_fs.stat(uri, ctx=ctx, skip_count=True)
+            await self._viking_fs.stat_metadata(uri, ctx=ctx)
             return True
         except NotFoundError:
             return False

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -518,7 +518,7 @@ async def read(uris: str | list[str]) -> str | list[ContentBlock]:
                 return resolved_uri, None, None
 
             async with semaphore:
-                stat = await service.fs.stat(resolved_uri, ctx=ctx, skip_count=True)
+                stat = await service.fs.stat_metadata(resolved_uri, ctx=ctx)
             if stat.get("isDir"):
                 return (
                     resolved_uri,

--- a/openviking/server/routers/content.py
+++ b/openviking/server/routers/content.py
@@ -215,7 +215,7 @@ async def download(
     # Try to get filename from stat
     filename = "download"
     try:
-        stat = await service.fs.stat(uri, ctx=_ctx, skip_count=True)
+        stat = await service.fs.stat_metadata(uri, ctx=_ctx)
         if stat and "name" in stat:
             filename = stat["name"]
     except Exception:

--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -208,7 +208,7 @@ async def attrs(
     service = get_service()
     uri = validate_request_viking_uri(resolve_path_variables(uri), _ctx)
     try:
-        stat_result = await service.fs.stat(uri, ctx=_ctx, skip_count=True)
+        stat_result = await service.fs.stat_metadata(uri, ctx=_ctx)
         result = {
             "uri": uri,
             "context_type": context_type_for_uri(uri),

--- a/openviking/server/routers/skills.py
+++ b/openviking/server/routers/skills.py
@@ -159,7 +159,7 @@ async def _entry_looks_like_skill(service, ctx: RequestContext, entry: Dict[str,
     # directory actually contains a SKILL.md file before listing it.  Any
     # error (including NotFound) means we cannot confirm it is a skill.
     try:
-        skill_md_stat = await service.fs.stat(_skill_md_uri(entry_uri), ctx=ctx, skip_count=True)
+        skill_md_stat = await service.fs.stat_metadata(_skill_md_uri(entry_uri), ctx=ctx)
     except Exception:
         return False
     if not skill_md_stat or skill_md_stat.get("isDir", False):
@@ -266,7 +266,7 @@ async def _require_skill(
     if target_uri:
         root_uri = _skill_root_uri(ctx, skill_name, target_uri)
         try:
-            stat = await service.fs.stat(root_uri, ctx=ctx, skip_count=True)
+            stat = await service.fs.stat_metadata(root_uri, ctx=ctx)
             if stat and stat.get("isDir", False):
                 return root_uri
         except NotFoundError:
@@ -276,7 +276,7 @@ async def _require_skill(
 
     user_root_uri = _skill_root_uri(ctx, skill_name)
     try:
-        stat = await service.fs.stat(user_root_uri, ctx=ctx, skip_count=True)
+        stat = await service.fs.stat_metadata(user_root_uri, ctx=ctx)
         if stat and stat.get("isDir", False):
             return user_root_uri
     except NotFoundError:
@@ -286,7 +286,7 @@ async def _require_skill(
 
     agent_root_uri = _skill_root_uri(ctx, skill_name, "viking://agent/skills")
     try:
-        stat = await service.fs.stat(agent_root_uri, ctx=ctx, skip_count=True)
+        stat = await service.fs.stat_metadata(agent_root_uri, ctx=ctx)
         if stat and stat.get("isDir", False):
             return agent_root_uri
     except NotFoundError:

--- a/openviking/server/routers/webdav.py
+++ b/openviking/server/routers/webdav.py
@@ -179,7 +179,7 @@ async def _write_text_resource(service, uri: str, content: str, ctx: RequestCont
 
 async def _safe_stat(service, uri: str, ctx: RequestContext) -> Optional[dict[str, Any]]:
     try:
-        return await service.fs.stat(uri, ctx=ctx, skip_count=True)
+        return await service.fs.stat_metadata(uri, ctx=ctx)
     except (FileNotFoundError, NotFoundError):
         return None
 

--- a/openviking/service/agent_evolution_service.py
+++ b/openviking/service/agent_evolution_service.py
@@ -122,7 +122,7 @@ class AgentEvolutionService:
             )
 
         viking_fs = self._ensure_initialized()
-        stat = await viking_fs.stat(canonical_uri, ctx=ctx, skip_count=True)
+        stat = await viking_fs.stat_metadata(canonical_uri, ctx=ctx)
         if stat.get("isDir", False):
             raise InvalidArgumentError("experience_uri must identify an Experience file")
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -638,7 +638,7 @@ class OpenVikingService:
             raise NotInitializedError("VikingFS")
 
         effective_ctx = ctx or RequestContext(user=self.user, role=Role.ROOT)
-        stat = await self._viking_fs.stat(uri, ctx=effective_ctx, skip_count=True)
+        stat = await self._viking_fs.stat_metadata(uri, ctx=effective_ctx)
         if not stat.get("isDir", False):
             raise InvalidArgumentError("Consistency check only supports directory URIs.")
         entries = await self._viking_fs.tree(

--- a/openviking/service/fs_service.py
+++ b/openviking/service/fs_service.py
@@ -928,10 +928,15 @@ class FSService:
             result, ctx, None, include_tags or "tags" in (extra_fields or [])
         )
 
-    async def stat(self, uri: str, ctx: RequestContext, skip_count: bool = False) -> Dict[str, Any]:
+    async def stat(self, uri: str, ctx: RequestContext) -> Dict[str, Any]:
         """Get resource status."""
         viking_fs = self._ensure_initialized()
-        return await viking_fs.stat(uri, ctx=ctx, skip_count=skip_count)
+        return await viking_fs.stat(uri, ctx=ctx)
+
+    async def stat_metadata(self, uri: str, ctx: RequestContext) -> Dict[str, Any]:
+        """Get storage metadata without lock or vector-index enrichment."""
+        viking_fs = self._ensure_initialized()
+        return await viking_fs.stat_metadata(uri, ctx=ctx)
 
     async def system_sync_status(self, uri: str, ctx: RequestContext) -> Dict[str, Any]:
         """Return multi-write sync status for one Viking URI subtree."""

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -509,7 +509,7 @@ class ReindexExecutor:
 
         acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_tree
         if mode != "prune_orphans" or await service.viking_fs.exists(uri, ctx=ctx):
-            stat = await service.viking_fs.stat(uri, ctx=ctx, skip_count=True)
+            stat = await service.viking_fs.stat_metadata(uri, ctx=ctx)
             if not stat.get("isDir", stat.get("is_dir")):
                 acquire_lock = service.viking_fs._async_agfs.pathlock_acquire_exact
         lease = await acquire_lock(path)
@@ -1009,7 +1009,7 @@ class ReindexExecutor:
         counters = run.counters
         ctx = run.ctx
         if mode == "semantic_and_vectors":
-            stat = await get_viking_fs().stat(uri, ctx=ctx, skip_count=True)
+            stat = await get_viking_fs().stat_metadata(uri, ctx=ctx)
             if stat.get("isDir", stat.get("is_dir")):
                 semantic_kwargs = {
                     "uri": uri,
@@ -1078,7 +1078,7 @@ class ReindexExecutor:
         try:
             if not await viking_fs.exists(uri, ctx=ctx):
                 raise NotFoundError(uri, "resource")
-            stat = await viking_fs.stat(uri, ctx=ctx, skip_count=True)
+            stat = await viking_fs.stat_metadata(uri, ctx=ctx)
             is_dir = stat.get("isDir", stat.get("is_dir")) if isinstance(stat, dict) else False
             if is_dir and recursive:
                 entries = await self._tree_all(viking_fs, uri, show_all_hidden=True, ctx=ctx)
@@ -1582,7 +1582,7 @@ class ReindexExecutor:
     ) -> None:
         viking_fs = get_viking_fs()
         if await viking_fs.exists(uri, ctx=ctx):
-            stat = await viking_fs.stat(uri, ctx=ctx, skip_count=True)
+            stat = await viking_fs.stat_metadata(uri, ctx=ctx)
             if stat.get("isDir", stat.get("is_dir")):
                 entries = (
                     await self._tree_all(viking_fs, uri, show_all_hidden=False, ctx=ctx)
@@ -1931,8 +1931,6 @@ class ReindexExecutor:
     async def _safe_read_text(self, uri: str, *, ctx: RequestContext) -> str:
         viking_fs = get_viking_fs()
         try:
-            if not await viking_fs.exists(uri, ctx=ctx):
-                return ""
             content = await viking_fs.read_file(uri, ctx=ctx)
             if isinstance(content, bytes):
                 return content.decode("utf-8", errors="replace")

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -598,7 +598,7 @@ class ResourceService:
         try:
             if not await self._viking_fs.exists(root_uri, ctx=ctx):
                 return True
-            stat = await self._viking_fs.stat(root_uri, ctx=ctx, skip_count=True)
+            stat = await self._viking_fs.stat_metadata(root_uri, ctx=ctx)
             if not isinstance(stat, dict) or not stat.get("isDir"):
                 return False
             entries = await self._viking_fs.ls(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -806,7 +806,7 @@ class Session:
     async def exists(self) -> bool:
         """Check whether this session already exists in storage."""
         try:
-            await self._viking_fs.stat(self._session_uri, ctx=self.ctx, skip_count=True)
+            await self._viking_fs.stat_metadata(self._session_uri, ctx=self.ctx)
             return True
         except Exception as exc:
             if not _is_storage_not_found(exc):
@@ -816,7 +816,7 @@ class Session:
     async def is_materialized(self) -> bool:
         """Check whether the session's authoritative live-message file exists."""
         try:
-            await self._viking_fs.stat(
+            await self._viking_fs.stat_metadata(
                 f"{self._session_uri}/messages.jsonl",
                 ctx=self.ctx,
             )

--- a/openviking/storage/content_write.py
+++ b/openviking/storage/content_write.py
@@ -1029,7 +1029,7 @@ class ContentWriteCoordinator:
         self, uri: str, *, ctx: RequestContext, allow_not_found: bool = False
     ) -> Dict[str, Any]:
         try:
-            return await self._viking_fs.stat(uri, ctx=ctx, skip_count=True)
+            return await self._viking_fs.stat_metadata(uri, ctx=ctx)
         except Exception as exc:
             if self._is_not_found(exc):
                 if allow_not_found:

--- a/openviking/storage/index_consistency.py
+++ b/openviking/storage/index_consistency.py
@@ -100,8 +100,6 @@ def _leaf_name(uri_or_path: str) -> str:
 
 async def _read_text_if_exists(viking_fs, uri: str, ctx: RequestContext) -> str:
     try:
-        if not await viking_fs.exists(uri, ctx=ctx):
-            return ""
         content = await viking_fs.read_file(uri, ctx=ctx)
         return content.decode("utf-8") if isinstance(content, bytes) else str(content)
     except Exception:

--- a/openviking/storage/ovpack/index.py
+++ b/openviking/storage/ovpack/index.py
@@ -87,8 +87,6 @@ async def call_vector_filter(
 
 async def read_text_if_exists(viking_fs, uri: str, ctx: RequestContext) -> str:
     try:
-        if not await viking_fs.exists(uri, ctx=ctx):
-            return ""
         content = await viking_fs.read_file(uri, ctx=ctx)
         return content.decode("utf-8") if isinstance(content, bytes) else content
     except Exception:

--- a/openviking/storage/ovpack/operations.py
+++ b/openviking/storage/ovpack/operations.py
@@ -118,7 +118,7 @@ async def _root_exists(viking_fs, root_uri: str, ctx: RequestContext) -> bool:
 
 async def _ensure_parent_exists(viking_fs, parent: str, ctx: RequestContext) -> None:
     try:
-        await viking_fs.stat(parent, ctx=ctx, skip_count=True)
+        await viking_fs.stat_metadata(parent, ctx=ctx)
     except Exception:
         await viking_fs.mkdir(parent, ctx=ctx)
 
@@ -699,7 +699,7 @@ async def restore_ovpack(
                 continue
 
             try:
-                target_stat = await viking_fs.stat(target_uri, ctx=ctx, skip_count=True)
+                target_stat = await viking_fs.stat_metadata(target_uri, ctx=ctx)
             except (NotFoundError, FileNotFoundError):
                 target_stat = None
 

--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -635,8 +635,8 @@ class SemanticDagExecutor:
         if not target_path:
             return True
         try:
-            current_stat = await self._viking_fs.stat(file_path, ctx=self._ctx, skip_count=True)
-            target_stat = await self._viking_fs.stat(target_path, ctx=self._ctx, skip_count=True)
+            current_stat = await self._viking_fs.stat_metadata(file_path, ctx=self._ctx)
+            target_stat = await self._viking_fs.stat_metadata(target_path, ctx=self._ctx)
             current_size = current_stat.get("size") if isinstance(current_stat, dict) else None
             target_size = target_stat.get("size") if isinstance(target_stat, dict) else None
             if current_size is not None and target_size is not None and current_size != target_size:

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -931,7 +931,7 @@ class SemanticProcessor(DequeueHandlerBase):
                     else f"{target_prefix}/{mapping_name}"
                 )
                 try:
-                    await viking_fs.stat(target_mapping, ctx=ctx, skip_count=True)
+                    await viking_fs.stat_metadata(target_mapping, ctx=ctx)
                     continue  # already carried over
                 except Exception:
                     pass

--- a/openviking/storage/viking_fs/_grep.py
+++ b/openviking/storage/viking_fs/_grep.py
@@ -60,10 +60,7 @@ class _GrepMixin:
         Returns:
             Dict with matches, count, match_count, files_scanned
         """
-        await self._ensure_access(uri, ctx)
-        # Skip vector_store.count() — the count field is not needed for grep,
-        # and avoiding it saves one VikingDB API call.
-        await self.stat(uri, ctx=ctx, skip_count=True)
+        await self.stat_metadata(uri, ctx=ctx)
 
         # Read engine and threshold from grep_config (ov.conf)
         engine = self.grep_config.engine if self.grep_config else "auto"
@@ -659,7 +656,7 @@ class _GrepMixin:
             logger.debug(f"Skipping excluded uri during grep: {normalized_uri}")
             return file_uris
         try:
-            root_stat = await self.stat(normalized_uri, ctx=ctx, skip_count=True)
+            root_stat = await self.stat_metadata(normalized_uri, ctx=ctx)
         except Exception:
             return file_uris
         if not root_stat.get("isDir", False):

--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -18,6 +18,7 @@ from openviking.pyagfs.exceptions import (
     AGFSClientError,
     AGFSDirectoryNotEmptyError,
     AGFSHTTPError,
+    AGFSIsADirectoryError,
 )
 from openviking.resource.watch_storage import is_watch_task_control_uri
 from openviking.server.error_mapping import is_not_found_error, map_exception
@@ -994,8 +995,61 @@ class _OpsMixin:
             raise NotFoundError(uri_or_id, "file", reason=missing_reason)
         return resolved
 
+    async def _stat_metadata(
+        self,
+        uri: str,
+        ctx: Optional[RequestContext] = None,
+    ) -> tuple[Dict[str, Any], str, str, RequestContext]:
+        """Resolve a URI and return its storage metadata and backing path."""
+        real_ctx = self._ctx_or_default(ctx)
+        uri = await self.resolve_uri(uri, real_ctx)
+        await self._ensure_access(uri, ctx)
+        primary_path = self._uri_to_path(uri, ctx=ctx)
+        path = primary_path
+        last_not_found: Optional[Exception] = None
+        for candidate_path in self._read_paths(uri, ctx=ctx):
+            if not await self._read_path_visible(uri, candidate_path, primary_path, real_ctx):
+                continue
+            try:
+                result = await self._async_agfs.stat(candidate_path)
+                path = candidate_path
+                break
+            except Exception as exc:
+                if is_not_found_error(exc):
+                    last_not_found = exc
+                    continue
+                raise
+        else:
+            if self._is_session_root_uri(uri):
+                now = datetime.now(timezone.utc).isoformat()
+                return (
+                    {
+                        "name": "session",
+                        "size": 0,
+                        "mode": 0o755,
+                        "modTime": now,
+                        "isDir": True,
+                    },
+                    primary_path,
+                    uri,
+                    real_ctx,
+                )
+            raise NotFoundError(uri, "file") from last_not_found
+        return result, path, uri, real_ctx
+
+    async def stat_metadata(
+        self,
+        uri: str,
+        ctx: Optional[RequestContext] = None,
+    ) -> Dict[str, Any]:
+        """Return storage metadata without path-lock or vector-index fields."""
+        result, _, resolved_uri, _ = await self._stat_metadata(uri, ctx=ctx)
+        if isinstance(result, dict):
+            result["uri"] = resolved_uri
+        return result
+
     async def stat(
-        self, uri: str, ctx: Optional[RequestContext] = None, skip_count: bool = False
+        self, uri: str, ctx: Optional[RequestContext] = None
     ) -> Dict[str, Any]:
         """
         File/directory information.
@@ -1020,42 +1074,13 @@ class _OpsMixin:
         Args:
             uri: Viking URI, or a 32-char hex vector record id (resolves to URI via vector store)
             ctx: Request context
-            skip_count: If True, skip the vector_store.count() call for directories.
-                Use this when the count field is not needed (e.g. in grep) to avoid
-                an extra VikingDB API call.
         """
-        real_ctx = self._ctx_or_default(ctx)
-        uri = await self.resolve_uri(uri, real_ctx)
-        await self._ensure_access(uri, ctx)
-        primary_path = self._uri_to_path(uri, ctx=ctx)
-        path = primary_path
-        last_not_found: Optional[Exception] = None
-        for candidate_path in self._read_paths(uri, ctx=ctx):
-            if not await self._read_path_visible(uri, candidate_path, primary_path, real_ctx):
-                continue
-            try:
-                result = await self._async_agfs.stat(candidate_path)
-                path = candidate_path
-                break
-            except Exception as exc:
-                if is_not_found_error(exc):
-                    last_not_found = exc
-                    continue
-                raise
-        else:
-            if self._is_session_root_uri(uri):
-                now = datetime.now(timezone.utc).isoformat()
-                return {
-                    "name": "session",
-                    "size": 0,
-                    "mode": 0o755,
-                    "modTime": now,
-                    "isDir": True,
-                    "isLocked": False,
-                }
-            raise NotFoundError(uri, "file") from last_not_found
+        result, path, uri, real_ctx = await self._stat_metadata(uri, ctx=ctx)
         if isinstance(result, dict):
             result["uri"] = uri
+            if self._is_session_root_uri(uri):
+                result["isLocked"] = False
+                return result
             result["isLocked"] = await self._is_path_locked_async(path)
             # Add deterministic vector record id for files (level 2).
             # This matches the ID used in VikingDB so callers can cross-reference
@@ -1063,7 +1088,7 @@ class _OpsMixin:
             if not result.get("isDir", False):
                 result["id"] = vector_record_id(real_ctx.account_id, uri, level=2)
             # Add count for directories if vector store available
-            if not skip_count and result.get("isDir", False):
+            if result.get("isDir", False):
                 try:
                     vector_store = self._get_vector_store()
                     if vector_store:
@@ -1174,7 +1199,7 @@ class _OpsMixin:
                     continue
                 if return_entries:
                     try:
-                        entry_stat = await self.stat(entry_uri, ctx=ctx, skip_count=True)
+                        entry_stat = await self.stat_metadata(entry_uri, ctx=ctx)
                     except NotFoundError:
                         name = entry.get("name") or entry["path"].rsplit("/", 1)[-1]
                         entry_stat = {
@@ -1621,46 +1646,15 @@ class _OpsMixin:
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        real_ctx = self._ctx_or_default(ctx)
-        uri = await self.resolve_uri(uri, real_ctx)
-        await self._ensure_access(uri, ctx)
-        primary_path = self._uri_to_path(uri, ctx=ctx)
-        # Verify the file exists before reading, because AGFS read returns
-        # empty bytes for non-existent files instead of raising an error.
-        last_not_found: Optional[Exception] = None
-        for path in self._read_paths(uri, ctx=ctx):
-            if not await self._read_path_visible(uri, path, primary_path, real_ctx):
-                continue
-            try:
-                stat = await self._async_agfs.stat(path)
-                break
-            except Exception as exc:
-                if is_not_found_error(exc):
-                    last_not_found = exc
-                    continue
-                raise
-        else:
-            raise NotFoundError(uri, "file") from last_not_found
-        if isinstance(stat, dict) and stat.get("isDir", False):
+        try:
+            raw = await self.read(uri, ctx=ctx)
+        except AGFSIsADirectoryError as exc:
             raise InvalidArgumentError(
                 f"Directory URI is not readable as a file: {uri}. "
                 "List it first, then read a file URI.",
                 details={"resource": uri, "expected": "file", "actual": "directory"},
-            )
-        try:
-            content = await self._async_agfs.read(path)
-            if isinstance(content, bytes):
-                raw = content
-            elif content is not None and hasattr(content, "content"):
-                raw = content.content
-            else:
-                raw = b""
-
-            text = self._decode_bytes(raw)
-        except Exception as exc:
-            if is_not_found_error(exc):
-                raise NotFoundError(uri, "file") from exc
-            raise
+            ) from exc
+        text = self._decode_bytes(raw)
 
         if offset == 0 and limit == -1:
             return text
@@ -1673,37 +1667,14 @@ class _OpsMixin:
         uri: str,
         ctx: Optional[RequestContext] = None,
     ) -> bytes:
-        """Read single binary file. Accepts a Viking URI or a 32-char hex vector record id."""
-        real_ctx = self._ctx_or_default(ctx)
-        uri = await self.resolve_uri(uri, real_ctx)
-        await self._ensure_access(uri, ctx)
-        primary_path = self._uri_to_path(uri, ctx=ctx)
-        last_not_found: Optional[Exception] = None
-        for path in self._read_paths(uri, ctx=ctx):
-            if not await self._read_path_visible(uri, path, primary_path, real_ctx):
-                continue
-            try:
-                stat = await self._async_agfs.stat(path)
-                break
-            except Exception as exc:
-                if is_not_found_error(exc):
-                    last_not_found = exc
-                    continue
-                raise
-        else:
-            raise NotFoundError(uri, "file") from last_not_found
-        if isinstance(stat, dict) and stat.get("isDir", False):
+        """Read single binary file. Accepts a Viking URI or vector record ID."""
+        try:
+            return await self.read(uri, ctx=ctx)
+        except AGFSIsADirectoryError as exc:
             raise InvalidArgumentError(
                 f"Cannot read directory as file: {uri}",
                 details={"resource": uri, "expected": "file", "actual": "directory"},
-            )
-        try:
-            raw = self._handle_agfs_read(await self._async_agfs.read(path))
-            return raw
-        except Exception as exc:
-            if is_not_found_error(exc):
-                raise NotFoundError(uri, "file") from exc
-            raise
+            ) from exc
 
     async def write_file_bytes(
         self,

--- a/openviking/storage/viking_fs/_sync.py
+++ b/openviking/storage/viking_fs/_sync.py
@@ -110,8 +110,8 @@ class _SyncMixin:
 
         async def default_is_changed(root_file: str, target_file: str) -> bool:
             try:
-                current_stat = await self.stat(root_file, ctx=ctx, skip_count=True)
-                target_stat = await self.stat(target_file, ctx=ctx, skip_count=True)
+                current_stat = await self.stat_metadata(root_file, ctx=ctx)
+                target_stat = await self.stat_metadata(target_file, ctx=ctx)
                 current_size = current_stat.get("size") if isinstance(current_stat, dict) else None
                 target_size = target_stat.get("size") if isinstance(target_stat, dict) else None
                 if (

--- a/openviking/utils/embedding_utils.py
+++ b/openviking/utils/embedding_utils.py
@@ -165,7 +165,7 @@ async def _resolve_context_timestamps(
 ) -> tuple[datetime, datetime]:
     updated_at = datetime.now(timezone.utc)
     try:
-        stat_result = await get_viking_fs().stat(uri, ctx=ctx, skip_count=True)
+        stat_result = await get_viking_fs().stat_metadata(uri, ctx=ctx)
         stat_mod_time = _coerce_datetime((stat_result or {}).get("modTime"))
         if stat_mod_time is not None:
             updated_at = stat_mod_time

--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -439,7 +439,7 @@ class ResourceProcessor:
                         target_preexisting = await viking_fs.exists(root_uri, ctx=ctx)
                         if target_preexisting:
                             try:
-                                stat = await viking_fs.stat(root_uri, ctx=ctx, skip_count=True)
+                                stat = await viking_fs.stat_metadata(root_uri, ctx=ctx)
                                 if isinstance(stat, dict) and stat.get("isDir"):
                                     entries = await viking_fs.ls(
                                         root_uri,

--- a/tests/misc/test_media_processor_zip_root.py
+++ b/tests/misc/test_media_processor_zip_root.py
@@ -88,7 +88,7 @@ class _FakeVikingFS:
             )
         return out
 
-    async def stat(self, uri: str, **_: Any) -> Dict[str, Any]:
+    async def stat_metadata(self, uri: str, **_: Any) -> Dict[str, Any]:
         if uri in self.dirs:
             return {"name": uri.rstrip("/").split("/")[-1], "isDir": True}
         if uri in self.files:

--- a/tests/misc/test_ovpack_import_policy.py
+++ b/tests/misc/test_ovpack_import_policy.py
@@ -36,8 +36,7 @@ class FakeVikingFS:
         self.existing_roots = existing_roots or set()
         self.removed_roots: list[str] = []
 
-    async def stat(self, uri: str, ctx=None, skip_count=False):
-        assert skip_count is True
+    async def stat_metadata(self, uri: str, ctx=None):
         return {"uri": uri, "isDir": True}
 
     async def mkdir(self, uri: str, exist_ok: bool = False, ctx=None):
@@ -676,7 +675,7 @@ async def test_backup_restore_contract(
 
     fake_fs = FakeVikingFS()
     fake_fs.ls = AsyncMock(return_value=[])
-    fake_fs.stat = AsyncMock(side_effect=FileNotFoundError())
+    fake_fs.stat_metadata = AsyncMock(side_effect=FileNotFoundError())
     fake_fs.rm = AsyncMock()
     assert (
         await PackService(fake_fs).restore_ovpack(

--- a/tests/misc/test_tree_builder_dedup.py
+++ b/tests/misc/test_tree_builder_dedup.py
@@ -29,7 +29,7 @@ class TestFinalizeFromTemp:
             return uri in existing_uris
 
         fs.ls = AsyncMock(side_effect=_ls)
-        fs.stat = AsyncMock(side_effect=_stat)
+        fs.stat_metadata = AsyncMock(side_effect=_stat)
         fs.exists = AsyncMock(side_effect=_exists)
         return fs
 

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -756,7 +756,7 @@ async def test_uat_producer_cancellation_respects_queue_ownership(
     service = ResourceService(
         viking_fs=SimpleNamespace(
             exists=AsyncMock(return_value=False),
-            stat=AsyncMock(return_value={"isDir": True}),
+            stat_metadata=AsyncMock(return_value={"isDir": True}),
             ls=AsyncMock(return_value=[]),
             rm=AsyncMock(),
             _uri_to_path=lambda _uri, ctx: "/resources/fixed",

--- a/tests/parse/test_markdown_link_rewrite.py
+++ b/tests/parse/test_markdown_link_rewrite.py
@@ -266,7 +266,7 @@ class FakeVikingFS:
     async def rm(self, uri, **kw):
         self.files.pop(uri, None)
 
-    async def stat(self, uri, **kw):
+    async def stat_metadata(self, uri, **kw):
         if uri not in self.files:
             raise FileNotFoundError(uri)
         return {"name": uri.rsplit("/", 1)[-1], "isDir": False}

--- a/tests/parse/test_media_understanding_summary.py
+++ b/tests/parse/test_media_understanding_summary.py
@@ -20,7 +20,7 @@ def _stub_media_prompt(monkeypatch):
 class _FS:
     def __init__(self, content=b"media"):
         self.content = content
-        self.stat = AsyncMock(return_value={"size": len(content)})
+        self.stat_metadata = AsyncMock(return_value={"size": len(content)})
 
     async def read(self, _uri, offset=0, size=-1, ctx=None):
         if offset >= len(self.content):
@@ -39,7 +39,7 @@ class _BlockingReadFS:
         self.two_reads_entered = asyncio.Event()
         self.release_reads = asyncio.Event()
 
-    async def stat(self, *_args, **_kwargs):
+    async def stat_metadata(self, *_args, **_kwargs):
         return {"size": 5}
 
     async def read(self, _uri, offset=0, size=-1, ctx=None):
@@ -232,7 +232,7 @@ async def test_unknown_size_media_stops_at_hard_staging_limit(
     monkeypatch,
 ):
     fs = _FS()
-    fs.stat.return_value = {"size": 0}
+    fs.stat_metadata.return_value = {"size": 0}
     fs.read = AsyncMock(side_effect=[b"a" * 4, b"b" * 4, b"c", b""])
     client = _CapturingPathClient()
     model_config = SimpleNamespace(get_client_instance=lambda: client)
@@ -274,10 +274,9 @@ async def test_media_summary_stat_skips_directory_vector_count(monkeypatch):
         "clip.mp4",
     )
 
-    fs.stat.assert_awaited_once_with(
+    fs.stat_metadata.assert_awaited_once_with(
         "viking://resources/video/clip.mp4",
         ctx=None,
-        skip_count=True,
     )
 
 

--- a/tests/resource/test_watch_scheduler.py
+++ b/tests/resource/test_watch_scheduler.py
@@ -136,8 +136,7 @@ class TestWatchSchedulerResourceExistence:
         from openviking_cli.exceptions import NotFoundError
 
         class FakeVikingFS:
-            async def stat(self, uri, ctx=None, skip_count=False):
-                assert skip_count is True
+            async def stat_metadata(self, uri, ctx=None):
                 raise NotFoundError(uri, "resource")
 
         class FakeResourceService(ResourceService):
@@ -178,8 +177,7 @@ class TestWatchSchedulerResourceExistence:
     @pytest.mark.asyncio
     async def test_target_uri_check_error_does_not_deactivate_task(self, tmp_path):
         class FakeVikingFS:
-            async def stat(self, uri, ctx=None, skip_count=False):
-                assert skip_count is True
+            async def stat_metadata(self, uri, ctx=None):
                 raise RuntimeError("temporary stat failure")
 
         class FakeResourceService(ResourceService):

--- a/tests/server/test_admin_rebuild_api.py
+++ b/tests/server/test_admin_rebuild_api.py
@@ -458,7 +458,7 @@ async def test_reindex_file_target_uses_exact_lock(monkeypatch):
         def _uri_to_path(self, uri, ctx):
             return "/local/default/resources/demo.md"
 
-        async def stat(self, uri, ctx):
+        async def stat_metadata(self, uri, ctx):
             return {"isDir": False}
 
     executor = ReindexExecutor()
@@ -525,7 +525,7 @@ async def test_reindex_prune_existing_file_uses_exact_lock(monkeypatch):
         async def exists(self, uri, ctx):
             return True
 
-        async def stat(self, uri, ctx):
+        async def stat_metadata(self, uri, ctx):
             return {"isDir": False}
 
     executor = ReindexExecutor()
@@ -1396,7 +1396,7 @@ async def test_reindex_memory_semantic_and_vectors_rebuilds_full_subtree(monkeyp
         seen["vectors"].append(uri)
 
     class FakeVikingFS:
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
     monkeypatch.setattr(ReindexExecutor, "_run_semantic_processor", fake_run_semantic_processor)
@@ -1463,7 +1463,7 @@ async def test_reindex_memory_non_recursive_limits_semantics_and_vectors(monkeyp
         seen["vectors"] = kwargs
 
     class FakeVikingFS:
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
     monkeypatch.setattr(ReindexExecutor, "_run_semantic_processor", fake_run_semantic_processor)
@@ -1552,7 +1552,7 @@ async def test_reindex_resource_vectors_non_recursive_skips_tree(monkeypatch):
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
     async def fail_tree_all(*args, **kwargs):
@@ -2043,7 +2043,7 @@ async def test_reindex_resource_vectors_parallelize_files_and_isolate_failures(m
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
         async def tree(
@@ -2249,7 +2249,7 @@ async def test_reindex_resource_l2_falls_back_to_vector_text_when_summary_missin
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
         async def tree(
@@ -2448,7 +2448,7 @@ async def test_reindex_memory_fallback_reads_existing_record_as_uri_owner(monkey
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": False}
 
     async def fake_read_memory_body(self, uri, *, ctx):
@@ -2496,7 +2496,7 @@ async def test_reindex_memory_skips_fallback_when_body_read_fails(monkeypatch):
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": False}
 
         async def read_file(self, uri, ctx=None):
@@ -2570,7 +2570,7 @@ async def test_reindex_resource_vectors_accepts_single_file_uri(monkeypatch):
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": False}
 
         async def tree(self, *args, **kwargs):
@@ -2626,7 +2626,7 @@ async def test_reindex_memory_l2_falls_back_to_body_when_abstract_missing(monkey
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": False}
 
     seen = {}
@@ -2677,7 +2677,7 @@ async def test_reindex_memory_l2_strips_memory_fields_from_abstract(monkeypatch)
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": False}
 
     seen = {}
@@ -2739,7 +2739,7 @@ async def test_reindex_memory_vectors_walks_deep_subtree(monkeypatch):
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
         async def tree(
@@ -2814,7 +2814,7 @@ async def test_reindex_memory_vectors_rebuilds_directory_levels_without_regenera
         async def exists(self, uri, ctx=None):
             return True
 
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             return {"isDir": True}
 
         async def tree(

--- a/tests/server/test_content_batch_write.py
+++ b/tests/server/test_content_batch_write.py
@@ -49,9 +49,8 @@ class _VFS:
         del ctx
         return "/virtual/" + uri.removeprefix("viking://")
 
-    async def stat(self, uri, ctx=None, skip_count=False):
+    async def stat_metadata(self, uri, ctx=None):
         del ctx
-        assert skip_count is True
         if uri == self.root:
             return {"uri": uri, "isDir": True}
         if uri in self.files:

--- a/tests/server/test_content_write_service.py
+++ b/tests/server/test_content_write_service.py
@@ -464,9 +464,8 @@ class _FakeVikingFS:
         self.tree_entries = []
         self._async_agfs = _FakePathLock()
 
-    async def stat(self, uri: str, ctx=None, skip_count=False):
+    async def stat_metadata(self, uri: str, ctx=None):
         del ctx
-        assert skip_count is True
         if uri == self._file_uri or uri in self.content:
             return {"isDir": False}
         if uri == self._root_uri:
@@ -876,9 +875,8 @@ class _FakeVikingFSForCreate:
         self.existing_dirs = set({root_uri} if existing_dirs is None else existing_dirs)
         self._async_agfs = _FakePathLock()
 
-    async def stat(self, uri: str, ctx=None, skip_count=False):
+    async def stat_metadata(self, uri: str, ctx=None):
         del ctx
-        assert skip_count is True
         if uri == self._file_uri:
             if self._file_exists:
                 return {"isDir": False}
@@ -1220,9 +1218,8 @@ class _AnyDirVikingFS:
     def __init__(self, file_uri: str):
         self._file_uri = file_uri
 
-    async def stat(self, uri: str, ctx=None, skip_count=False):
+    async def stat_metadata(self, uri: str, ctx=None):
         del ctx
-        assert skip_count is True
         return {"isDir": uri != self._file_uri}
 
 

--- a/tests/server/test_filesystem_router.py
+++ b/tests/server/test_filesystem_router.py
@@ -189,7 +189,7 @@ async def test_attrs_returns_memory_fields_and_tags(monkeypatch):
         filesystem,
         "get_service",
         lambda: SimpleNamespace(
-            fs=SimpleNamespace(stat=fake_stat, read=fake_read),
+            fs=SimpleNamespace(stat_metadata=fake_stat, read=fake_read),
             vikingdb_manager=FakeVectorManager(),
         ),
     )

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -645,7 +645,7 @@ async def test_read_image_returns_native_mcp_content(monkeypatch, uri, image_byt
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=read_visible,
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -673,7 +673,7 @@ async def test_read_mixed_batch_preserves_source_order(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=read_visible,
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -712,7 +712,7 @@ async def test_read_audio_returns_native_mcp_content(monkeypatch, uri, audio_byt
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=AsyncMock(),
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -737,7 +737,7 @@ async def test_read_video_returns_unsupported_hint(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=AsyncMock(),
                 read_visible=read_visible,
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -749,7 +749,6 @@ async def test_read_video_returns_unsupported_hint(monkeypatch):
     stat.assert_awaited_once_with(
         "viking://resources/demo.mp4",
         ctx=DEFAULT_CTX,
-        skip_count=True,
     )
     read_visible.assert_not_awaited()
 
@@ -764,7 +763,7 @@ async def test_read_video_nonexistent_uri_preserves_not_found(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=AsyncMock(),
                 read_visible=read_visible,
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -776,7 +775,6 @@ async def test_read_video_nonexistent_uri_preserves_not_found(monkeypatch):
     stat.assert_awaited_once_with(
         "viking://resources/missing.mp4",
         ctx=DEFAULT_CTX,
-        skip_count=True,
     )
     read_visible.assert_not_awaited()
 
@@ -791,7 +789,7 @@ async def test_read_video_directory_uri_preserves_directory_hint(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=AsyncMock(),
                 read_visible=read_visible,
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )
@@ -803,7 +801,6 @@ async def test_read_video_directory_uri_preserves_directory_hint(monkeypatch):
     stat.assert_awaited_once_with(
         "viking://resources/archive.mp4",
         ctx=DEFAULT_CTX,
-        skip_count=True,
     )
     read_visible.assert_not_awaited()
 
@@ -817,7 +814,7 @@ async def test_read_rejects_spoofed_image_extension(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=AsyncMock(),
-                stat=AsyncMock(return_value={"size": 12, "isDir": False}),
+                stat_metadata=AsyncMock(return_value={"size": 12, "isDir": False}),
             )
         ),
     )
@@ -837,7 +834,7 @@ async def test_read_rejects_images_too_large_for_common_clients(monkeypatch):
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=AsyncMock(),
-                stat=AsyncMock(return_value={"size": oversized, "isDir": False}),
+                stat_metadata=AsyncMock(return_value={"size": oversized, "isDir": False}),
             )
         ),
     )
@@ -863,7 +860,7 @@ async def test_read_rejects_media_batch_over_aggregate_limit_before_read(monkeyp
             fs=SimpleNamespace(
                 read_file_bytes=read_file_bytes,
                 read_visible=AsyncMock(),
-                stat=stat,
+                stat_metadata=stat,
             )
         ),
     )

--- a/tests/server/test_privacy_config_service.py
+++ b/tests/server/test_privacy_config_service.py
@@ -131,7 +131,7 @@ async def test_privacy_config_concurrent_updates_keep_every_version():
 @pytest.mark.asyncio
 async def test_privacy_config_exists_propagates_storage_errors():
     class FailingStorage:
-        async def stat(self, *_args, **_kwargs):
+        async def stat_metadata(self, *_args, **_kwargs):
             raise RuntimeError("storage unavailable")
 
     privacy = UserPrivacyConfigService(FailingStorage())

--- a/tests/server/test_request_wait_tracking.py
+++ b/tests/server/test_request_wait_tracking.py
@@ -52,7 +52,7 @@ class _FakeVikingFS:
             pathlock_release=lambda lease: None,
         )
 
-    async def stat(self, uri: str, ctx=None):
+    async def stat_metadata(self, uri: str, ctx=None):
         del ctx
         if uri == self._file_uri:
             return {"isDir": False}

--- a/tests/service/test_agent_evolution_service.py
+++ b/tests/service/test_agent_evolution_service.py
@@ -25,7 +25,7 @@ def _ctx() -> RequestContext:
 async def test_list_trajectories_by_experience_uses_exact_scalar_filter_and_pagination():
     experience_uri = "viking://user/alice/memories/experiences/exchange.md"
     viking_fs = Mock()
-    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    viking_fs.stat_metadata = AsyncMock(return_value={"isDir": False})
     vikingdb = Mock()
     vikingdb.filter = AsyncMock(
         return_value=[
@@ -96,7 +96,7 @@ async def test_list_trajectories_by_experience_rejects_other_user_uri():
 async def test_list_trajectories_by_experience_filters_created_at_by_utc_date():
     experience_uri = "viking://user/alice/memories/experiences/exchange.md"
     viking_fs = Mock()
-    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    viking_fs.stat_metadata = AsyncMock(return_value={"isDir": False})
     vikingdb = Mock()
     vikingdb.filter = AsyncMock(return_value=[])
     vikingdb.count = AsyncMock(return_value=0)
@@ -155,7 +155,7 @@ async def test_list_trajectories_by_experience_rejects_limit_above_1000():
 async def test_list_trajectories_by_experience_accepts_1000_and_paginates_all_results():
     experience_uri = "viking://user/alice/memories/experiences/exchange.md"
     viking_fs = Mock()
-    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    viking_fs.stat_metadata = AsyncMock(return_value={"isDir": False})
     vikingdb = Mock()
     vikingdb.filter = AsyncMock(
         side_effect=[
@@ -192,7 +192,7 @@ async def test_list_trajectories_by_experience_accepts_1000_and_paginates_all_re
 async def test_get_experience_outcome_distribution_counts_two_tags_on_same_list_field():
     experience_uri = "viking://user/alice/memories/experiences/exchange.md"
     viking_fs = Mock()
-    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    viking_fs.stat_metadata = AsyncMock(return_value={"isDir": False})
     vikingdb = Mock()
     vikingdb.count = AsyncMock(side_effect=[4, 2, 1, 0, 3])
     service = AgentEvolutionService(viking_fs=viking_fs, vikingdb=vikingdb)
@@ -233,7 +233,7 @@ async def test_get_experience_outcome_distribution_counts_two_tags_on_same_list_
 async def test_get_experience_outcome_distribution_filters_created_at_by_utc_date():
     experience_uri = "viking://user/alice/memories/experiences/exchange.md"
     viking_fs = Mock()
-    viking_fs.stat = AsyncMock(return_value={"isDir": False})
+    viking_fs.stat_metadata = AsyncMock(return_value={"isDir": False})
     vikingdb = Mock()
     vikingdb.count = AsyncMock(return_value=0)
     service = AgentEvolutionService(viking_fs=viking_fs, vikingdb=vikingdb)

--- a/tests/service/test_fs_service.py
+++ b/tests/service/test_fs_service.py
@@ -54,21 +54,16 @@ class _FakeVikingFS:
 
 
 @pytest.mark.asyncio
-async def test_stat_forwards_skip_count_without_changing_default(request_context):
-    viking_fs = SimpleNamespace(stat=AsyncMock(return_value={"isDir": True}))
+async def test_stat_metadata_uses_lightweight_viking_fs_path(request_context):
+    viking_fs = SimpleNamespace(stat_metadata=AsyncMock(return_value={"isDir": True}))
     service = FSService(viking_fs=viking_fs)
 
-    await service.stat("viking://resources", request_context, skip_count=True)
-    await service.stat("viking://resources", request_context)
+    result = await service.stat_metadata("viking://resources", request_context)
 
-    assert viking_fs.stat.await_args_list[0].kwargs == {
-        "ctx": request_context,
-        "skip_count": True,
-    }
-    assert viking_fs.stat.await_args_list[1].kwargs == {
-        "ctx": request_context,
-        "skip_count": False,
-    }
+    assert result == {"isDir": True}
+    viking_fs.stat_metadata.assert_awaited_once_with(
+        "viking://resources", ctx=request_context
+    )
 
 
 class _FakeMutationCoordinator:

--- a/tests/service/test_reindex_file_lock.py
+++ b/tests/service/test_reindex_file_lock.py
@@ -23,9 +23,8 @@ class _FakeVikingFS:
     async def exists(self, uri: str, ctx=None):
         return uri == self._uri
 
-    async def stat(self, uri: str, ctx=None, skip_count=False):
+    async def stat_metadata(self, uri: str, ctx=None):
         assert uri == self._uri
-        assert skip_count is True
         return {"isDir": False}
 
     async def read_file(self, uri: str, ctx=None):

--- a/tests/service/test_resource_service_connector.py
+++ b/tests/service/test_resource_service_connector.py
@@ -941,7 +941,7 @@ async def test_connector_watch_keeps_running_when_target_is_missing():
     from openviking_cli.exceptions import NotFoundError
 
     class MissingTargetFS:
-        async def stat(self, uri, ctx=None):
+        async def stat_metadata(self, uri, ctx=None):
             raise NotFoundError(uri, "resource")
 
     service = ResourceService()

--- a/tests/service/test_resource_service_reserved_target_cleanup.py
+++ b/tests/service/test_resource_service_reserved_target_cleanup.py
@@ -31,7 +31,7 @@ async def test_cleanup_reserved_target_removes_only_empty_directory():
     ctx = _ctx()
     viking_fs = SimpleNamespace(
         exists=AsyncMock(return_value=True),
-        stat=AsyncMock(return_value={"isDir": True}),
+        stat_metadata=AsyncMock(return_value={"isDir": True}),
         ls=AsyncMock(return_value=[]),
         rm=AsyncMock(),
     )
@@ -50,10 +50,9 @@ async def test_cleanup_reserved_target_removes_only_empty_directory():
         ctx=ctx,
         lease_ref=lock,
     )
-    viking_fs.stat.assert_awaited_once_with(
+    viking_fs.stat_metadata.assert_awaited_once_with(
         "viking://resources/empty",
         ctx=ctx,
-        skip_count=True,
     )
 
 
@@ -62,7 +61,7 @@ async def test_cleanup_reserved_target_preserves_nonempty_directory():
     ctx = _ctx()
     viking_fs = SimpleNamespace(
         exists=AsyncMock(return_value=True),
-        stat=AsyncMock(return_value={"isDir": True}),
+        stat_metadata=AsyncMock(return_value={"isDir": True}),
         ls=AsyncMock(return_value=[{"name": "document.md", "isDir": False}]),
         rm=AsyncMock(),
     )
@@ -76,10 +75,9 @@ async def test_cleanup_reserved_target_preserves_nonempty_directory():
 
     assert removed is False
     viking_fs.rm.assert_not_awaited()
-    viking_fs.stat.assert_awaited_once_with(
+    viking_fs.stat_metadata.assert_awaited_once_with(
         "viking://resources/nonempty",
         ctx=ctx,
-        skip_count=True,
     )
 
 

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -158,15 +158,16 @@ class TestSessionExists:
 
     async def test_session_exists_skips_directory_vector_count(self):
         session = Session.__new__(Session)
-        session._viking_fs = SimpleNamespace(stat=AsyncMock(return_value={"isDir": True}))
+        session._viking_fs = SimpleNamespace(
+            stat_metadata=AsyncMock(return_value={"isDir": True})
+        )
         session._session_uri = "viking://user/alice/sessions/session-1"
         session.ctx = SimpleNamespace()
 
         assert await session.exists() is True
-        session._viking_fs.stat.assert_awaited_once_with(
+        session._viking_fs.stat_metadata.assert_awaited_once_with(
             session._session_uri,
             ctx=session.ctx,
-            skip_count=True,
         )
 
     async def test_session_exists_true_after_create(

--- a/tests/storage/test_content_write_processing_mode.py
+++ b/tests/storage/test_content_write_processing_mode.py
@@ -50,14 +50,13 @@ class _FakeVikingFS:
 @pytest.mark.asyncio
 async def test_content_write_stat_skips_directory_vector_count(ctx):
     fake_fs = _FakeVikingFS()
-    fake_fs.stat = AsyncMock(return_value={"isDir": True})
+    fake_fs.stat_metadata = AsyncMock(return_value={"isDir": True})
     coordinator = ContentWriteCoordinator(viking_fs=fake_fs)
 
     assert await coordinator._safe_stat("viking://resources/demo", ctx=ctx) == {"isDir": True}
-    fake_fs.stat.assert_awaited_once_with(
+    fake_fs.stat_metadata.assert_awaited_once_with(
         "viking://resources/demo",
         ctx=ctx,
-        skip_count=True,
     )
 
 

--- a/tests/storage/test_ingest_ls_node_limit.py
+++ b/tests/storage/test_ingest_ls_node_limit.py
@@ -48,7 +48,7 @@ class _TruncatingVikingFS:
     async def read_file(self, uri, ctx=None):
         return ""
 
-    async def stat(self, uri, ctx=None):
+    async def stat_metadata(self, uri, ctx=None):
         return {"size": 0}
 
     async def mv(self, src, dst, ctx=None, lease_ref=None):

--- a/tests/storage/test_semantic_dag_incremental.py
+++ b/tests/storage/test_semantic_dag_incremental.py
@@ -37,7 +37,7 @@ class _FakeVikingFS:
     async def ls(self, uri, node_limit=None, ctx=None):
         return self._tree.get(self._norm(uri), [])
 
-    async def stat(self, uri, ctx=None):
+    async def stat_metadata(self, uri, ctx=None):
         content = self._file_contents.get(self._norm(uri), "")
         return {"size": len(content)}
 

--- a/tests/storage/test_semantic_processor_target_preexisting.py
+++ b/tests/storage/test_semantic_processor_target_preexisting.py
@@ -51,7 +51,7 @@ class _SyncWrapperVikingFS:
     async def read_file(self, uri, ctx=None):
         return "{}"
 
-    async def stat(self, uri, ctx=None):
+    async def stat_metadata(self, uri, ctx=None):
         raise FileNotFoundError(uri)
 
     async def write_file(self, uri, content, ctx=None, lease_ref=None):

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -52,7 +52,7 @@ class _MemoryVikingFS:
     def __init__(self) -> None:
         self.files: dict[str, str] = {}
 
-    async def stat(self, uri, ctx=None):
+    async def stat_metadata(self, uri, ctx=None):
         return {"path": uri}
 
     async def write_file(self, uri, content, ctx=None, lease_ref=None):

--- a/tests/storage/test_viking_fs_glob.py
+++ b/tests/storage/test_viking_fs_glob.py
@@ -315,7 +315,7 @@ async def test_glob_directory_metadata_uses_is_dir_instead_of_trailing_slash(mon
     async def fake_stat(*_args, **_kwargs):
         raise NotFoundError("viking://resources/folder", "file")
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
+    monkeypatch.setattr(fs, "stat_metadata", fake_stat)
 
     result = await fs.glob(
         "**/*",

--- a/tests/storage/test_viking_fs_grep.py
+++ b/tests/storage/test_viking_fs_grep.py
@@ -13,7 +13,8 @@ from openviking_cli.utils.config.grep_config import GrepConfig
 
 
 class _DummyAgfs:
-    pass
+    def stat(self, path, ctx=None):
+        return {"name": path.rsplit("/", 1)[-1], "isDir": True}
 
 
 class _DummyVectorStore:
@@ -46,7 +47,6 @@ class _KeywordFailingButTagFilterWorkingStore:
 @pytest.fixture
 def fs(monkeypatch):
     viking_fs = VikingFS(agfs=_DummyAgfs())
-    monkeypatch.setattr(viking_fs, "stat", _fake_stat)
     monkeypatch.setattr(
         viking_fs,
         "_uri_to_path",
@@ -58,25 +58,6 @@ def fs(monkeypatch):
         lambda path, ctx=None: path.replace("/", "viking://", 1),
     )
     return viking_fs
-
-
-async def _fake_stat(uri, ctx=None, skip_count=False):
-    return {"name": uri.rsplit("/", 1)[-1], "isDir": True}
-
-
-@pytest.mark.asyncio
-async def test_collect_grep_files_skips_directory_vector_count(monkeypatch):
-    viking_fs = VikingFS(agfs=_DummyAgfs())
-    stat = AsyncMock(return_value={"isDir": True})
-    monkeypatch.setattr(viking_fs, "stat", stat)
-    monkeypatch.setattr(viking_fs, "ls", AsyncMock(return_value=[]))
-
-    assert await viking_fs._collect_grep_files(
-        "viking://resources",
-        excluded_prefix=None,
-        level_limit=1,
-    ) == []
-    stat.assert_awaited_once_with("viking://resources", ctx=None, skip_count=True)
 
 
 def test_grep_config_default_switch_to_remote_threshold_is_10000():
@@ -366,9 +347,6 @@ async def test_grep_vikingdb_pushes_tag_filter_into_bm25_request(monkeypatch):
 async def test_grep_preserves_dfs_order_and_node_limit(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         entries = {
             "viking://resources": [
@@ -393,7 +371,6 @@ async def test_grep_preserves_dfs_order_and_node_limit(monkeypatch):
         }
         return contents[path].encode()
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -429,9 +406,6 @@ async def test_grep_preserves_dfs_order_and_node_limit(monkeypatch):
 async def test_grep_allowed_uris_filters_before_node_limit(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         return [
             {"name": "untagged.md", "isDir": False},
@@ -441,7 +415,6 @@ async def test_grep_allowed_uris_filters_before_node_limit(monkeypatch):
     def fake_agfs_read(path, offset=0, size=-1):
         return b"match"
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -467,9 +440,6 @@ async def test_grep_allowed_uris_filters_before_node_limit(monkeypatch):
 async def test_grep_applies_content_transform_before_matching(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         if uri == "viking://resources":
             return [{"name": "memory.md", "isDir": False}]
@@ -478,7 +448,6 @@ async def test_grep_applies_content_transform_before_matching(monkeypatch):
     def fake_agfs_read(path, offset=0, size=-1):
         return b'visible\n<!-- MEMORY_FIELDS {"secret":"hidden"} -->'
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -506,9 +475,6 @@ async def test_grep_applies_content_transform_before_matching(monkeypatch):
 async def test_grep_parallel_reads_respect_concurrency_limit(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         entries = {
             "viking://resources": [{"name": f"file{i}.md", "isDir": False} for i in range(12)]
@@ -526,7 +492,6 @@ async def test_grep_parallel_reads_respect_concurrency_limit(monkeypatch):
         active_reads -= 1
         return f"match from {path}".encode()
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -547,9 +512,6 @@ async def test_grep_parallel_reads_respect_concurrency_limit(monkeypatch):
 async def test_grep_parallel_reads_work_with_blocking_agfs_read(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         if uri == "viking://resources":
             return [{"name": f"file{i}.md", "isDir": False} for i in range(8)]
@@ -559,7 +521,6 @@ async def test_grep_parallel_reads_work_with_blocking_agfs_read(monkeypatch):
         time.sleep(0.05)
         return f"match from {path}".encode()
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -581,9 +542,6 @@ async def test_grep_parallel_reads_work_with_blocking_agfs_read(monkeypatch):
 async def test_grep_stops_scheduling_later_batches_after_node_limit(monkeypatch):
     fs = VikingFS(agfs=_DummyAgfs())
 
-    async def fake_stat(uri, ctx=None, skip_count=False):
-        return {"isDir": True}
-
     async def fake_ls(uri, ctx=None, **kwargs):
         if uri == "viking://resources":
             return [{"name": f"file{i}.md", "isDir": False} for i in range(6)]
@@ -603,7 +561,6 @@ async def test_grep_stops_scheduling_later_batches_after_node_limit(monkeypatch)
         }
         return contents[path].encode()
 
-    monkeypatch.setattr(fs, "stat", fake_stat)
     monkeypatch.setattr(fs, "ls", fake_ls)
     monkeypatch.setattr(
         fs,
@@ -617,7 +574,7 @@ async def test_grep_stops_scheduling_later_batches_after_node_limit(monkeypatch)
 
     assert result["count"] == 2
     assert result["files_scanned"] == 1
-    assert read_paths == ["/resources/file0.md", "/resources/file1.md"]
+    assert sorted(read_paths) == ["/resources/file0.md", "/resources/file1.md"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/service/test_core_consistency.py
+++ b/tests/unit/service/test_core_consistency.py
@@ -65,7 +65,7 @@ def _service_with_fs(stat_result: dict) -> tuple[OpenVikingService, AsyncMock]:
     service._user = UserIdentifier.the_default_user()
     service._vikingdb_manager = AsyncMock()
     service._viking_fs = AsyncMock()
-    service._viking_fs.stat.return_value = stat_result
+    service._viking_fs.stat_metadata.return_value = stat_result
     return service, service._viking_fs
 
 
@@ -100,10 +100,9 @@ async def test_check_consistency_preserves_directory_behavior() -> None:
         result = await service.check_consistency(uri="viking://resources", ctx=ctx)
 
     assert result == report.to_dict()
-    viking_fs.stat.assert_awaited_once_with(
+    viking_fs.stat_metadata.assert_awaited_once_with(
         "viking://resources",
         ctx=ctx,
-        skip_count=True,
     )
     viking_fs.tree.assert_awaited_once()
     check.assert_awaited_once()


### PR DESCRIPTION
## Description

云存储上的每次 `stat`、`HEAD`、`LIST` 和 `GET` 都有延迟和费用。本次只删除已经能从后续操作得到结果的重复探测，不增加批量删除、分页或其他新功能。

### 修改前后

| 场景 | 修改前 | 修改后 | 减少的访问 |
| --- | --- | --- | --- |
| VikingFS 读取一个存在的文件 | 先调用 AGFS `stat`，再 `read` | 直接 `read` | 1 次元数据请求 |
| 读取可选的 `.abstract.md` / `.overview.md` | `exists`，然后 `read_file`；`read_file` 内部还会再次 `stat` | 直接 `read_file`，不存在时沿用原来的空字符串结果 | 2 次 AGFS 调用 |
| S3 读取普通文件 | 先 `HEAD` 目录标记和 `LIST` 同名前缀，再 `GET` 文件 | 直接 `GET`；只有 `GET` 返回不存在时才判断它是否为目录 | 正常成功路径减少 1 次 `HEAD` 和 1 次 `LIST` |
| S3 创建空文件 | `HEAD` 判断不存在，再 `PUT` | 一次带 `If-None-Match: *` 的条件 `PUT` | 1 次 S3 请求，并保留“已存在则失败”语义 |
| MultiWrite `stat` | 路由时通过 `exists` 做一次 `stat`，选中后再次 `stat` | 路由直接返回第一次拿到的元数据 | 选中后端减少 1 次元数据请求 |
| 主后端内复制 | `exists` 和 `stat` 各查一次源文件 | 一次 `stat` 同时判断存在、目录和大小 | 1 次元数据请求 |
| VikingFS `exists` / grep 起始路径检查 | 复用完整公开 `stat`，额外查询 PathLock，目录 `exists` 还会统计向量数量 | 只读取判断所需的存储元数据 | 去掉无关的 PathLock / VikingDB 查询 |
| Python 创建远端父目录 | Python 逐级 `stat`、递归 `mkdir` | 一次调用 RAGFS `ensure_parent_dirs` | Python 到 AGFS 的调用从随目录深度增长收敛为 1 次 |

### 具体例子

读取 `viking://resources/docs/a.md`，且对应 S3 对象存在：

- **修改前：** VikingFS 先查文件元数据；进入 S3 读取后，S3 又通过目录 `HEAD` 和前缀 `LIST` 排除目录，最后才 `GET` 文件。
- **修改后：** VikingFS 直接发起读取，S3 直接 `GET` 文件。只有 `GET` 失败且对象不存在时，才补查目录信息，用于区分“目录”和“路径不存在”。

文件内容、MultiWrite 后备顺序以及目录读取的 `InvalidArgument` 结果不变。底层网络、权限等错误不再被 Python 文件读取接口统一伪装成 `NotFound`，而是保留原始错误分类。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 删除 VikingFS、reindex、索引一致性和 OVPack 读取前的重复 `exists/stat`。
- 让 S3 成功读取走单次 `GET`，创建文件走单次条件 `PUT`；复用 MultiWrite 路由已经取得的元数据。
- 将远端父目录创建交给 RAGFS 的 `ensure_parent_dirs`，并保留 LocalFS/S3 的明确目录错误，供 Python 层准确映射。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

已执行：

- `.venv/bin/python -m pytest -q --no-cov tests/storage/test_viking_fs_grep.py`：16 passed
- `cargo test -p ragfs core::multibackend_wrapper::tests`：18 passed
- `cargo test -p ragfs plugins::localfs::tests`：23 passed
- `.venv/bin/ruff check ...`：通过
- `cargo check -p ragfs-python`：通过

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

- 本次净减少 105 行代码：新增 100 行，删除 205 行。
- Rust 检查仍会输出仓库已有的缺少文档、未使用变量和 PyO3 废弃接口警告，本次没有新增这些警告。
- 本次没有实现批量删除、目录分页或新的公开接口。
