### PR TITLE
perf(retrieval): reuse context assembler query embeddings

### DIFF
--- a/openviking/retrieve/context_assembler/gather.py
+++ b/openviking/retrieve/context_assembler/gather.py
@@ -21,6 +21,7 @@ from openviking.retrieve.context_assembler.params import (
     OTHER_PEER_OVERFETCH,
     REPORTED_CATEGORY_KEYS,
 )
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.server.identity import RequestContext
 from openviking.utils.search_filters import merge_context_type_filter
 from openviking_cli.exceptions import InvalidArgumentError
@@ -222,6 +223,7 @@ async def gather_candidates(
 
     searched: Dict[str, int] = {}
     retrieval_errors: List[str] = []
+    query_embedding_cache = QueryEmbeddingCache()
     excluded_count = 0
 
     def _build(items: Sequence[Tuple[Any, Optional[str]]]) -> List[Candidate]:
@@ -285,6 +287,7 @@ async def gather_candidates(
             filter=find_filter if find_filter is not None else filter,
             image_url=image_url,
             level=None,
+            query_embedding_cache=query_embedding_cache,
         )
 
     async def gather_bucket(bucket: str, quota: int) -> List[Candidate]:
@@ -399,6 +402,7 @@ async def gather_candidates(
         "origins": origins,
         "peer_scope": peer_scope,
         "quotas": dict(quotas) if quotas is not None else None,
+        "query_embeddings": query_embedding_cache.size,
     }
     if retrieval_errors:
         stats["retrieval_errors"] = retrieval_errors[:5]

--- a/openviking/retrieve/hierarchical_retriever.py
+++ b/openviking/retrieve/hierarchical_retriever.py
@@ -20,6 +20,7 @@ from openviking.core.retrieval_targets import default_target_directories
 from openviking.models.embedder.base import EmbedResult, embed_compat
 from openviking.models.rerank import RerankClient
 from openviking.retrieve.memory_lifecycle import hotness_score
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.retrieve.retrieval_stats import get_stats_collector
 from openviking.server.identity import RequestContext
 from openviking.storage.abstract_overview import body_for_preview
@@ -108,6 +109,7 @@ class HierarchicalRetriever:
         score_gte: bool = False,
         scope_dsl: Optional[FilterExpr | Dict[str, Any]] = None,
         level: Optional[List[int]] = None,
+        query_embedding_cache: Optional[QueryEmbeddingCache] = None,
     ) -> QueryResult:
         """
         Execute hierarchical retrieval.
@@ -118,6 +120,7 @@ class HierarchicalRetriever:
             score_gte: True uses >=, False uses >
             scope_dsl: Additional scope constraints passed from public find/search filter
             level: Optional result level filter (0=L0, 1=L1, 2=L2)
+            query_embedding_cache: Request-local cache shared across retrieval scopes
         """
         t0 = time.monotonic()
         telemetry = get_current_telemetry()
@@ -152,15 +155,27 @@ class HierarchicalRetriever:
         if self.embedder:
             if image_query and not getattr(self.embedder, "supports_multimodal", False):
                 raise InvalidArgumentError("Image search requires a multimodal embedding model.")
-            with telemetry.measure("search.embed_query"):
-                embedding_input = getattr(query, "embedding_input", None) or query.query
-                result: EmbedResult = await embed_compat(
-                    self.embedder,
-                    embedding_input,
-                    is_query=True,
+
+            embedding_input = getattr(query, "embedding_input", None) or query.query
+
+            async def _embed_query() -> EmbedResult:
+                with telemetry.measure("search.embed_query"):
+                    return await embed_compat(
+                        self.embedder,
+                        embedding_input,
+                        is_query=True,
+                    )
+
+            if query_embedding_cache is None:
+                result = await _embed_query()
+            else:
+                result = await query_embedding_cache.get_or_create(
+                    embedder=self.embedder,
+                    embedding_input=embedding_input,
+                    factory=_embed_query,
                 )
-                query_vector = result.dense_vector
-                sparse_query_vector = result.sparse_vector
+            query_vector = result.dense_vector
+            sparse_query_vector = result.sparse_vector
 
         # Step 1: Determine starting directories based on explicit target dirs.
         if target_dirs:
@@ -622,9 +637,7 @@ class HierarchicalRetriever:
                     abstract=abstract,
                     category=c.get("category", ""),
                     score=final_score,
-                    search_tags=normalize_search_tags(
-                        c.get("search_tags"), discard_invalid=True
-                    ),
+                    search_tags=normalize_search_tags(c.get("search_tags"), discard_invalid=True),
                 )
             )
 

--- a/openviking/retrieve/query_embedding_cache.py
+++ b/openviking/retrieve/query_embedding_cache.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Request-local cache for sharing query embeddings across retrieval scopes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Awaitable, Callable, Dict, Tuple
+
+from openviking.models.embedder.base import EmbeddingInput, EmbedResult
+
+
+class QueryEmbeddingCache:
+    """Share one in-flight embedding task for each query within a request."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[Tuple[int, str], asyncio.Task[EmbedResult]] = {}
+
+    @staticmethod
+    def _input_key(embedding_input: EmbeddingInput) -> str:
+        if isinstance(embedding_input, str):
+            return embedding_input
+        return json.dumps(
+            embedding_input,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    async def get_or_create(
+        self,
+        *,
+        embedder: object,
+        embedding_input: EmbeddingInput,
+        factory: Callable[[], Awaitable[EmbedResult]],
+    ) -> EmbedResult:
+        """Return the cached result, creating exactly one shared task on a miss."""
+        key = (id(embedder), self._input_key(embedding_input))
+        task = self._tasks.get(key)
+        if task is None:
+            task = asyncio.create_task(factory())
+            self._tasks[key] = task
+        return await task
+
+    @property
+    def size(self) -> int:
+        """Number of distinct query embeddings requested through this cache."""
+        return len(self._tasks)

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -8,6 +8,7 @@ Provides semantic search operations: search, find.
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.server.identity import RequestContext
 from openviking.storage.viking_fs import VikingFS
 from openviking.utils.image_search import (
@@ -132,6 +133,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        query_embedding_cache: Optional[QueryEmbeddingCache] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -158,5 +160,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            query_embedding_cache=query_embedding_cache,
         )
         return result

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Union
 
 from openviking.core.context import ContextLevel
 from openviking.core.retrieval_targets import resolve_retrieval_targets
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.server.error_mapping import is_not_found_error, map_exception
 from openviking.server.identity import RequestContext
 from openviking.storage.abstract_overview import body_for_preview, render_abstract_overview
@@ -190,6 +191,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        query_embedding_cache: Optional[QueryEmbeddingCache] = None,
     ):
         """Semantic search.
 
@@ -256,6 +258,7 @@ class _SemanticMixin:
             score_threshold=score_threshold,
             scope_dsl=filter,
             level=level,
+            query_embedding_cache=query_embedding_cache,
         )
 
         # Convert QueryResult to FindResult

--- a/tests/retrieve/test_context_assembler_pipeline.py
+++ b/tests/retrieve/test_context_assembler_pipeline.py
@@ -140,6 +140,7 @@ async def test_assembly_returns_readable_entries_within_budget():
 
 async def test_query_expansion_fans_out_planned_queries(monkeypatch):
     queries_seen = []
+    caches_seen = []
 
     async def fake_expand(*, query, session, mode, timeout_s=None):
         del session, mode, timeout_s
@@ -147,6 +148,7 @@ async def test_query_expansion_fans_out_planned_queries(monkeypatch):
 
     async def fake_find(**kwargs):
         queries_seen.append(kwargs["query"])
+        caches_seen.append(kwargs["query_embedding_cache"])
         return _FakeFindResult()
 
     async def fake_get(session_id, ctx, *, auto_create=False):
@@ -175,6 +177,7 @@ async def test_query_expansion_fans_out_planned_queries(monkeypatch):
     )
 
     assert queries_seen == ["short", "expanded query"]
+    assert len({id(cache) for cache in caches_seen}) == 1
     assert result.stats["query_expansion"] == "used"
 
 

--- a/tests/retrieve/test_hierarchical_retriever_rerank.py
+++ b/tests/retrieve/test_hierarchical_retriever_rerank.py
@@ -11,6 +11,7 @@ import pytest
 
 from openviking.core.context import ContextLevel
 from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever, RetrieverMode
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.abstract_overview import render_abstract_overview
 from openviking.utils.token_estimation import estimate_text_tokens
@@ -46,6 +47,16 @@ class DummyEmbedder:
 
     async def embed_async(self, text: str, is_query: bool = False) -> DummyEmbedResult:
         return self.embed(text, is_query=is_query)
+
+
+class CountingEmbedder(DummyEmbedder):
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def embed_async(self, text: str, is_query: bool = False) -> DummyEmbedResult:
+        self.calls.append((text, is_query))
+        await asyncio.sleep(0)
+        return DummyEmbedResult()
 
 
 class DummyStorage:
@@ -452,6 +463,45 @@ async def test_quick_mode_uses_single_vector_search_without_rerank_or_recursion(
     assert storage.search_calls[0]["level"] is None
     assert storage.child_search_calls == []
     assert fake_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_request_cache_shares_query_embedding_across_retrievers():
+    embedder = CountingEmbedder()
+    cache = QueryEmbeddingCache()
+    retrievers = [
+        HierarchicalRetriever(
+            storage=QuickSearchStorage([]),
+            embedder=embedder,
+            rerank_config=None,
+        )
+        for _ in range(3)
+    ]
+
+    await asyncio.gather(
+        *[
+            retriever.retrieve(
+                _query(),
+                ctx=_ctx(),
+                mode=RetrieverMode.QUICK,
+                query_embedding_cache=cache,
+            )
+            for retriever in retrievers
+        ]
+    )
+
+    assert embedder.calls == [("hello", True)]
+    assert cache.size == 1
+
+    await retrievers[0].retrieve(
+        TypedQuery(query="goodbye", context_type=ContextType.RESOURCE, intent=""),
+        ctx=_ctx(),
+        mode=RetrieverMode.QUICK,
+        query_embedding_cache=cache,
+    )
+
+    assert embedder.calls == [("hello", True), ("goodbye", True)]
+    assert cache.size == 2
 
 
 @pytest.mark.asyncio

--- a/tests/service/test_search_service_image.py
+++ b/tests/service/test_search_service_image.py
@@ -1,5 +1,6 @@
 import pytest
 
+from openviking.retrieve.query_embedding_cache import QueryEmbeddingCache
 from openviking.server.identity import RequestContext, Role
 from openviking.service.search_service import SearchService
 from openviking_cli.session.user_id import UserIdentifier
@@ -8,6 +9,7 @@ from openviking_cli.session.user_id import UserIdentifier
 class FakeVikingFS:
     def __init__(self):
         self.image_url = None
+        self.query_embedding_cache = None
 
     async def read_file_bytes(self, uri, ctx=None):
         assert uri == "viking://resources/cat.png"
@@ -15,6 +17,7 @@ class FakeVikingFS:
 
     async def find(self, **kwargs):
         self.image_url = kwargs["image_url"]
+        self.query_embedding_cache = kwargs["query_embedding_cache"]
         return {"ok": True}
 
 
@@ -23,12 +26,15 @@ async def test_search_service_resolves_viking_image_url_to_data_uri():
     fs = FakeVikingFS()
     service = SearchService(fs)
     ctx = RequestContext(user=UserIdentifier("acc", "user"), role=Role.USER)
+    cache = QueryEmbeddingCache()
 
     result = await service.find(
         query="",
         image_url="viking://resources/cat.png",
         ctx=ctx,
+        query_embedding_cache=cache,
     )
 
     assert result == {"ok": True}
     assert fs.image_url.startswith("data:image/png;base64,")
+    assert fs.query_embedding_cache is cache


### PR DESCRIPTION
## Description

Context assembly fans one planned query out across category, target, and peer scopes. Each scope currently creates a `HierarchicalRetriever` that embeds the identical query again. This change adds a request-local in-flight task cache so those searches share one query embedding while keeping their vector searches, filters, ranking, and result limits unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A - this is an isolated retrieval performance improvement.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Add a request-local cache keyed by embedder identity and canonical embedding input; concurrent misses share one `asyncio.Task`.
- Thread the cache from context assembly through `SearchService.find`, `VikingFS.find`, and `HierarchicalRetriever.retrieve`.
- Keep distinct query-expansion inputs isolated and expose the number of distinct query embeddings in assembly stats.
- Add regression coverage for cache propagation, concurrent reuse, and distinct-query separation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Local checks:

- `ruff format --check` and `ruff check` on all changed Python files
- `pytest -o addopts='' tests/service/test_search_service_image.py tests/retrieve -q` - 59 passed
- A deterministic 12-scope benchmark with a serialized 30 ms embedder reduced embedding calls from 12 to 1 and elapsed time from 377.3 ms to 32.0 ms

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not needed; internal behavior only)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (no dependencies)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The cache lives only for one context assembly request. Ordinary `find` callers that do not pass it retain the existing behavior. Embedding failures continue to propagate through the existing per-scope error handling, and the cache does not alter retrieval scores or result ordering.
