### PR TITLE
fix(docker): 补充 Studio 校验诊断信息

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
-RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); locations = list(spec.submodule_search_locations or ()) if spec else []; root = Path('/app/.venv').resolve(); p = (Path(locations[0]).resolve() / 'dist/index.html').resolve() if len(locations) == 1 else None; valid = p is not None and p.is_file() and p.is_relative_to(root); raise SystemExit(0 if valid else f'missing or misplaced Studio bundle: {p}')"
+RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); locations = list(spec.submodule_search_locations or ()) if spec else []; root = Path('/app/.venv').resolve(); p = (Path(locations[0]).resolve() / 'dist/index.html').resolve() if len(locations) == 1 else None; valid = p is not None and p.is_file() and p.is_relative_to(root); raise SystemExit(0 if valid else f'missing or misplaced Studio bundle: spec_found={spec is not None}, locations={locations!r}, resource={p}')"
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health
 RUN mkdir -p /app/.openviking \


### PR DESCRIPTION
## 问题

跟进 #4340 的审查意见。现有 Docker 运行时校验在找不到 `openviking.web_studio`，或检测到的包目录数量不是 1 时，只会输出 `missing or misplaced Studio bundle: None`，无法区分具体原因。

## 修改

失败信息增加 `spec_found`、`locations` 和 `resource`。校验条件和退出行为保持不变。

## 验证

- `git diff --check`
- `docker buildx build --check .`
- 完整 Linux/amd64 Docker 镜像构建
- 在 `-I -O` 下，现有资源检查返回 0
- 模拟包不存在和资源不存在均返回 1，并输出对应诊断

原审查意见：https://github.com/volcengine/OpenViking/pull/4340#discussion_r3859774862