### PR TITLE
fix(agent-evolution): recognize plugin-namespaced MCP reads

### DIFF
--- a/openviking/session/memory/experience_lineage.py
+++ b/openviking/session/memory/experience_lineage.py
@@ -22,7 +22,10 @@ _READ_TOOL_OPERATIONS = {
     "ov_read": "read",
     "ov_multi_read": "multi_read",
 }
-_MCP_OPENVIKING_READ_RE = re.compile(r"^mcp__openviking__(read|multi_read)$")
+_MCP_OPENVIKING_READ_RE = re.compile(
+    r"^mcp__(?:openviking|plugin_.+_openviking)__(read|multi_read)$",
+    re.IGNORECASE,
+)
 TRAJECTORY_OUTCOMES = ("success", "failure", "partial", "unknown", "unfinished")
 
 
@@ -154,7 +157,7 @@ def _read_operation(tool_name: str) -> str | None:
     if operation is not None:
         return operation
     match = _MCP_OPENVIKING_READ_RE.fullmatch(name)
-    return match.group(1) if match is not None else None
+    return match.group(1).lower() if match is not None else None
 
 
 def _load_value(value: Any) -> Any:

--- a/openviking/usage_reporter/extractors.py
+++ b/openviking/usage_reporter/extractors.py
@@ -36,7 +36,10 @@ _INJECTION_TOOL_OPERATIONS: dict[str, ToolOperation] = {
     "ov_read": "read",
     "ov_multi_read": "multi_read",
 }
-_MCP_OPENVIKING_TOOL_RE = re.compile(r"^mcp__openviking__(find|search|list|read|multi_read)$")
+_MCP_OPENVIKING_TOOL_RE = re.compile(
+    r"^mcp__(?:openviking|plugin_.+_openviking)__(find|search|list|read|multi_read)$",
+    re.IGNORECASE,
+)
 _MCP_SEARCH_RESULT_RE = re.compile(r"^- \[[^]]+\]\s+(viking://.+?)\s*$")
 _OPENVIKING_SEARCH_TABLE_ROW_RE = re.compile(
     r"^\s*\d+\s{2,}(?:memory|resource|skill)\s{2,}"
@@ -90,7 +93,7 @@ def _tool_usage(tool_name: str) -> tuple[UsageKind, ToolOperation] | None:
     match = _MCP_OPENVIKING_TOOL_RE.fullmatch(name)
     if match is None:
         return None
-    operation = cast(ToolOperation, match.group(1))
+    operation = cast(ToolOperation, match.group(1).lower())
     if operation in {"find", "search", "list"}:
         return "recall", operation
     return "injection", operation

--- a/tests/unit/session/memory/test_experience_lineage.py
+++ b/tests/unit/session/memory/test_experience_lineage.py
@@ -80,7 +80,42 @@ def test_collect_read_experience_uris_supports_generic_openviking_reads():
     assert collect_read_experience_uris(messages, ctx=_ctx()) == [uri, opencode_uri]
 
 
-@pytest.mark.parametrize("tool_name", ["multi_read", "openviking_multi_read"])
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "mcp__plugin_openviking-memory_openviking__read",
+        "mcp__PLUGIN_openviking-memory_OpenViking__READ",
+    ],
+)
+def test_collect_read_experience_uris_supports_plugin_namespaced_reads(tool_name):
+    uri = "viking://user/alice/memories/experiences/plugin-read.md"
+    messages = [
+        Message(
+            id="plugin-read",
+            role="user",
+            parts=[
+                ToolPart(
+                    tool_id="plugin-read-1",
+                    tool_name=tool_name,
+                    tool_input={"uri": uri},
+                    tool_status="completed",
+                )
+            ],
+        )
+    ]
+
+    assert collect_read_experience_uris(messages, ctx=_ctx()) == [uri]
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "multi_read",
+        "openviking_multi_read",
+        "mcp__plugin_openviking-memory_openviking__multi_read",
+        "mcp__PLUGIN_openviking-memory_OpenViking__MULTI_READ",
+    ],
+)
 def test_collect_read_experience_uris_filters_failed_multi_read_results(tool_name):
     first_uri = "viking://user/alice/memories/experiences/first.md"
     failed_uri = "viking://user/alice/memories/experiences/failed.md"
@@ -105,6 +140,25 @@ def test_collect_read_experience_uris_filters_failed_multi_read_results(tool_nam
     ]
 
     assert collect_read_experience_uris(messages, ctx=_ctx()) == [first_uri]
+
+
+def test_collect_read_experience_uris_ignores_other_plugin_read_tools():
+    messages = [
+        Message(
+            id="other-plugin-read",
+            role="user",
+            parts=[
+                ToolPart(
+                    tool_id="other-plugin-read-1",
+                    tool_name="mcp__plugin_other-memory_other__read",
+                    tool_input={"uri": "viking://user/alice/memories/experiences/other.md"},
+                    tool_status="completed",
+                )
+            ],
+        )
+    ]
+
+    assert collect_read_experience_uris(messages, ctx=_ctx()) == []
 
 
 def test_collect_read_experience_uris_ignores_removed_dedicated_tool():

--- a/tests/unit/usage_reporter/test_memory_usage_extractor.py
+++ b/tests/unit/usage_reporter/test_memory_usage_extractor.py
@@ -240,7 +240,7 @@ async def test_memory_usage_extractor_parses_mcp_text_search_and_list_results():
             parts=[
                 ToolPart(
                     tool_id="call-find",
-                    tool_name="mcp__openviking__find",
+                    tool_name="mcp__plugin_openviking-memory_openviking__find",
                     tool_status="completed",
                     tool_output=(
                         "Found 2 item(s):\n\n"
@@ -352,6 +352,10 @@ async def test_memory_usage_extractor_canonicalizes_home_alias_list_uri():
             "mcp__openviking__read",
             {"uris": "viking://user/test/memories/experiences/read.md"},
         ),
+        (
+            "mcp__plugin_openviking-memory_openviking__read",
+            {"uris": "viking://user/test/memories/experiences/read.md"},
+        ),
     ],
 )
 async def test_memory_usage_extractor_recognizes_generic_read_tools(tool_name, tool_input):
@@ -387,6 +391,8 @@ async def test_memory_usage_extractor_recognizes_generic_read_tools(tool_name, t
         "openviking_multi_read",
         "ov_multi_read",
         "mcp__openviking__multi_read",
+        "mcp__plugin_openviking-memory_openviking__multi_read",
+        "mcp__PLUGIN_openviking-memory_OpenViking__MULTI_READ",
     ],
 )
 async def test_memory_usage_extractor_multi_read_counts_only_successful_experiences(tool_name):
@@ -440,6 +446,12 @@ async def test_memory_usage_extractor_does_not_fuzzy_match_other_mcp_tools():
                 ToolPart(
                     tool_id="call-read",
                     tool_name="mcp__other__read",
+                    tool_status="completed",
+                    tool_input={"uri": experience_uri},
+                ),
+                ToolPart(
+                    tool_id="call-plugin-read",
+                    tool_name="mcp__plugin_other-memory_other__read",
                     tool_status="completed",
                     tool_input={"uri": experience_uri},
                 ),


### PR DESCRIPTION
## Description

Recognize OpenViking MCP tools namespaced by agent plugins so explicit Experience reads from the official Claude Code plugin populate Agent Evolution lineage and usage reporting.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Addresses problem 1 in #4330.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Accept `mcp__plugin_<plugin-name>_openviking__read` and `multi_read`, case-insensitively, while retaining the existing `mcp__openviking__*` names.
- Keep matching anchored to the OpenViking MCP server so unrelated plugin `read` tools and Claude Code's native `Read` are not attributed as Experience consumption.
- Apply the same namespace handling to memory usage reporting and add positive and negative regression coverage.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

- `.venv/bin/python -m pytest tests/unit/session/memory/test_experience_lineage.py tests/unit/usage_reporter/test_memory_usage_extractor.py -q` (54 passed)
- `.venv/bin/python -m pytest tests/service/test_agent_evolution_service.py tests/session/train/test_trajectory_analyzer_component.py -q` (12 passed)
- `.venv/bin/ruff check openviking/session/memory/experience_lineage.py openviking/usage_reporter/extractors.py tests/unit/session/memory/test_experience_lineage.py tests/unit/usage_reporter/test_memory_usage_extractor.py`
- `.venv/bin/ruff format --check openviking/session/memory/experience_lineage.py openviking/usage_reporter/extractors.py tests/unit/session/memory/test_experience_lineage.py tests/unit/usage_reporter/test_memory_usage_extractor.py`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- This intentionally addresses only explicit tool-call lineage from issue #4330.
- Auto recall remains uncounted because it emits no `ToolPart`, and the injected context is stripped before capture. Retrieval/injection provenance requires a separate design.
- The targeted tests emit pre-existing Pydantic deprecation warnings unrelated to this change.
- This change has no dependent changes.
