### PR TITLE
fix(session): 避免 Session 锁阻塞归档写入

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -813,7 +813,7 @@ class Session:
         """Update mutable session config without overwriting concurrent meta changes."""
         update_auto_commit_policy = update_auto_commit_policy or auto_commit_policy is not None
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
-        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
@@ -835,7 +835,7 @@ class Session:
                     existing = dict(self._meta.auto_commit_policy or {})
                     existing.update(auto_commit_policy)
                     self._meta.auto_commit_policy = AutoCommitPolicy.from_dict(existing).to_dict()
-            await self._save_meta(lease_ref=lease)
+            await self._save_meta()
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)
 
@@ -1252,7 +1252,7 @@ class Session:
             return
 
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
-        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
@@ -1283,16 +1283,14 @@ class Session:
                     f"{self._session_uri}/messages.jsonl",
                     batch_content,
                     ctx=self.ctx,
-                    lease_ref=lease,
                 )
             else:
                 await self._viking_fs.append_file(
                     f"{self._session_uri}/messages.jsonl",
                     batch_content,
                     ctx=self.ctx,
-                    lease_ref=lease,
                 )
-            await self._save_meta(lease_ref=lease)
+            await self._save_meta()
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)
 
@@ -1671,7 +1669,7 @@ class Session:
             return False
 
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
-        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
@@ -1692,7 +1690,6 @@ class Session:
                     archive_uri,
                     stage="phase1_recovery",
                     error=error,
-                    lease_ref=lease,
                 )
                 if task_id:
                     await tracker.fail(
@@ -1718,7 +1715,6 @@ class Session:
                     archive_uri,
                     stage="phase1_recovery",
                     error=f"Cannot verify Phase 1 state: {exc}",
-                    lease_ref=lease,
                 )
                 return False
 
@@ -1732,7 +1728,6 @@ class Session:
                     archive_uri,
                     stage="phase1_recovery",
                     error="Root rewrite was not durably completed before process interruption",
-                    lease_ref=lease,
                 )
                 return False
 
@@ -1763,8 +1758,8 @@ class Session:
             )
             self._meta.last_commit_at = get_current_timestamp()
             self._rebuild_pending_tokens()
-            await self._save_meta(lease_ref=lease)
-            await self._write_phase1_ready_marker(archive_uri, lease_ref=lease)
+            await self._save_meta()
+            await self._write_phase1_ready_marker(archive_uri)
             logger.warning("Recovered interrupted Session Phase 1: %s", archive_uri)
             return True
         finally:
@@ -1896,11 +1891,11 @@ class Session:
         )
 
         # ===== Phase 1: authoritative snapshot + split (path-lock protected) =====
-        # Use a waiting filesystem lock and reload inside it. Different workers
-        # can hold stale Session objects, so in-memory emptiness is never a
-        # correctness boundary.
+        # The exact lock on the Session directory is the mutex for root Session
+        # state and archive-number allocation. Child files use their own exact
+        # locks, so Phase 2 can keep writing an earlier archive concurrently.
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
-        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
@@ -1979,7 +1974,7 @@ class Session:
                     retained_message_token_budget=effective_token_budget if turn_mode else 0,
                     min_raw_tail_steps=effective_min_tail,
                 )
-                await self._save_meta(lease_ref=lease)
+                await self._save_meta()
                 get_current_telemetry().set("memory.extracted", 0)
                 return {
                     "session_id": self.session_id,
@@ -2019,7 +2014,7 @@ class Session:
             # remember the policy for subsequent add_message accounting.
             if not messages_to_archive:
                 self._messages = retained_messages
-                await self._write_to_agfs_async(messages=self._messages, lease_ref=lease)
+                await self._write_to_agfs_async(messages=self._messages)
                 self._meta.pending_tokens = 0
                 self._meta.message_count = total
                 self._remember_retention_policy(
@@ -2029,7 +2024,7 @@ class Session:
                     retained_message_token_budget=effective_token_budget if turn_mode else 0,
                     min_raw_tail_steps=effective_min_tail,
                 )
-                await self._save_meta(lease_ref=lease)
+                await self._save_meta()
                 get_current_telemetry().set("memory.extracted", 0)
                 return {
                     "session_id": self.session_id,
@@ -2078,7 +2073,6 @@ class Session:
                     min_raw_tail_steps=effective_min_tail,
                     agent_evolution_enabled=agent_evolution_enabled,
                     agent_memory_skip_reason=agent_memory_skip_reason,
-                    lease_ref=lease,
                 )
 
                 # Archive raw remains durable and recoverable before any live
@@ -2089,7 +2083,6 @@ class Session:
                         uri=f"{archive_uri}/messages.jsonl",
                         content="\n".join(lines) + "\n",
                         ctx=self.ctx,
-                        lease_ref=lease,
                     )
                     if retention_plan is not None:
                         await self._merge_archive_meta(
@@ -2102,7 +2095,6 @@ class Session:
                                     min_raw_tail_steps=effective_min_tail,
                                 )
                             },
-                            lease_ref=lease,
                         )
 
                 phase1_stage = "queue_enqueue"
@@ -2122,7 +2114,7 @@ class Session:
 
                 phase1_stage = "phase1_persist"
                 self._messages = retained_messages
-                await self._write_to_agfs_async(messages=self._messages, lease_ref=lease)
+                await self._write_to_agfs_async(messages=self._messages)
                 self._meta.message_count = len(self._messages)
                 self._meta.pending_tokens = 0
                 self._remember_retention_policy(
@@ -2142,8 +2134,8 @@ class Session:
                     # commit boundary, so an idle scan and a concurrent worker
                     # never see a stale state.
                     self._meta.last_auto_commit_at = get_current_timestamp()
-                await self._save_meta(lease_ref=lease)
-                await self._write_phase1_ready_marker(archive_uri, lease_ref=lease)
+                await self._save_meta()
+                await self._write_phase1_ready_marker(archive_uri)
             except Exception as e:
                 logger.error(f"[commit] Failed during {phase1_stage}: {e}")
                 # Whether the queue write failed or a queued Phase 1 stopped
@@ -2154,7 +2146,6 @@ class Session:
                         archive_uri,
                         stage=phase1_stage,
                         error=str(e),
-                        lease_ref=lease,
                     )
                 except Exception:
                     logger.exception(
@@ -3967,7 +3958,7 @@ class Session:
     ) -> None:
         """Merge Phase 2 results without overwriting concurrent root updates."""
         session_path = self._viking_fs._uri_to_path(self._session_uri, ctx=self.ctx)
-        lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+        lease = await self._viking_fs._async_agfs.pathlock_acquire_exact(
             session_path, timeout_secs=_SESSION_PHASE1_LOCK_TIMEOUT_SECONDS
         )
         try:
@@ -4008,7 +3999,7 @@ class Session:
                 # a clean auto-commit even after Phase 2 reloads the latest meta.
                 latest_meta.last_auto_commit_at = get_current_timestamp()
             self._meta = latest_meta
-            await self._save_meta(lease_ref=lease)
+            await self._save_meta()
         finally:
             await self._viking_fs._async_agfs.pathlock_release(lease)
 

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -1542,7 +1542,7 @@ async def test_concurrent_stale_workers_append_without_losing_messages(
     ]
 
 
-async def test_phase2_meta_merge_serializes_with_concurrent_append(
+async def test_session_state_lock_serializes_root_meta_without_blocking_archive_write(
     client,
     monkeypatch,
 ):
@@ -1574,6 +1574,12 @@ async def test_phase2_meta_merge_serializes_with_concurrent_append(
     )
     await phase2_inside_save.wait()
 
+    memory_diff_uri = f"{initial._session_uri}/history/archive_001/memory_diff.json"
+    await asyncio.wait_for(
+        phase2._viking_fs.write_file(memory_diff_uri, "{}", ctx=phase2.ctx),
+        timeout=1.0,
+    )
+
     append_task = asyncio.create_task(
         appending.add_message_async("assistant", [TextPart("second")])
     )
@@ -1585,6 +1591,7 @@ async def test_phase2_meta_merge_serializes_with_concurrent_append(
 
     fresh = client(session_id=initial.session_id)
     await fresh.load()
+    assert await fresh._viking_fs.read_file(memory_diff_uri, ctx=fresh.ctx) == "{}"
     assert [message.content for message in fresh.messages] == ["first", "second"]
     assert fresh.meta.message_count == 2
     assert fresh.meta.total_message_count == 2

--- a/tests/unit/session/test_event_tag_concurrency.py
+++ b/tests/unit/session/test_event_tag_concurrency.py
@@ -15,7 +15,7 @@ class _PathLock:
         self.acquired = 0
         self.released = 0
 
-    async def pathlock_acquire_tree(self, path, timeout_secs):
+    async def pathlock_acquire_exact(self, path, timeout_secs):
         del path, timeout_secs
         self.acquired += 1
         return "lease-1"
@@ -133,6 +133,6 @@ async def test_update_config_updates_policy_and_tags_in_one_locked_write():
     assert saved_meta.message_count == 41
     assert saved_meta.pending_tokens == 8200
     assert len(viking_fs.writes) == 1
-    assert viking_fs.writes[0][2] == "lease-1"
+    assert viking_fs.writes[0][2] is None
     assert viking_fs._async_agfs.acquired == 1
     assert viking_fs._async_agfs.released == 1


### PR DESCRIPTION
## Description

修复连续 Session commit 时，后一个 Phase 1 的 Session Tree Lock 阻塞前一个 Phase 2 写入 archive 文件，导致 `wait=true` 长时间等待的问题。

### 修改前

输入场景：同一个 Session 连续创建 `archive_001` 和 `archive_002`。

- `archive_001` 的 Phase 2 写入 `history/archive_001/memory_diff.json`。
- `archive_002` 的 Phase 1 持有 `/session` Tree Lock。
- Tree Lock 覆盖整个 Session 子树，导致 `memory_diff.json` 的文件 Exact Lock 等待甚至超时。

### 修改后

相同场景下：

- Phase 1 仅持有 `/session` Exact Lock，用于串行化消息、根元数据和 archive 编号分配。
- Session 根 Lease 不再传给子文件；子文件继续使用 VikingFS 已有的目标文件锁。
- `archive_001` 的 Phase 2 可以与 `archive_002` 的 Phase 1 并行写 archive 文件；连续 Phase 1 和 add-message 仍然串行。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 将 Session 状态入口的 `/session` Tree Lock 恢复为 Exact Lock。
- 停止把 Session Exact Lease 传给不在其覆盖范围内的子文件。
- 扩展现有并发契约测试，验证 Session 状态仍然串行且 archive 文件写入不再被阻塞。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

该问题由历史上的 Session Tree Lock 范围过大引起，细粒度 Lease 控制使该冲突更容易复现。本 PR 基于 `main`，不修改 Queue、Task 或重试语义。
