### PR TITLE
fix(rerank): allow bypassing environment proxy settings

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -963,6 +963,7 @@ Reranking model for search result refinement. Supports VikingDB (Volcengine), Co
 | `api_base` | str | Endpoint URL (for `openai` provider) |
 | `model` | str | Model name (for `openai` providers) |
 | `timeout` | float | HTTP request timeout in seconds for OpenAI-compatible providers. Increase for slow or cold-starting local rerank servers. Default: `30.0` |
+| `trust_env` | bool | Whether to use proxy and authentication settings from the process environment. Set `false` for trusted LAN endpoints that must bypass ambient proxy discovery. Default: `true` |
 | `max_input_tokens` | int | Maximum estimated raw-text tokens in each query-document pair sent to the reranker. Oversized inputs retain their beginning and end. `0` disables truncation. Default: `0` |
 | `threshold` | float | Score threshold between `0.0` and `1.0`; results below this are filtered out. Default: `0.1` |
 | `extra_headers` | object | Custom HTTP headers (for OpenAI-compatible providers, optional) |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -931,6 +931,7 @@ PDF 解析配置。支持三种策略：`local`（本地 pdfplumber）、`mineru
 | `api_base` | str | 接口地址（用于 `openai` 提供方） |
 | `model` | str | 模型名称（用于 `openai` 提供方） |
 | `timeout` | float | OpenAI 兼容 provider 的 HTTP 请求超时时间，单位为秒。对于较慢或冷启动的本地 rerank 服务可适当增大。默认：`30.0` |
+| `trust_env` | bool | 是否使用进程环境中的代理和认证设置。对于需要绕过环境代理发现的受信任局域网端点，设为 `false`。默认：`true` |
 | `max_input_tokens` | int | 每个 query-document 对发送给 reranker 的最大估算原始文本 token 数；超长输入会保留开头和结尾。`0` 表示不截断。默认：`0` |
 | `threshold` | float | 分数阈值，范围为 `0.0` 到 `1.0`。低于此值的结果会被过滤。默认：`0.1` |
 | `extra_headers` | object | 自定义 HTTP 请求头（OpenAI 兼容 provider 可用，可选） |

--- a/openviking/models/rerank/openai_rerank.py
+++ b/openviking/models/rerank/openai_rerank.py
@@ -51,6 +51,7 @@ class OpenAIRerankClient(RerankBase):
         model_name: str,
         extra_headers: Optional[Dict[str, str]] = None,
         timeout: float = 30.0,
+        trust_env: bool = True,
     ) -> None:
         """
         Initialize OpenAI-compatible rerank client.
@@ -62,6 +63,9 @@ class OpenAIRerankClient(RerankBase):
             extra_headers: Optional extra headers for API requests
             timeout: HTTP request timeout in seconds. Defaults to 30. Increase for
                 local LLM servers that incur model cold-start latency on the first call.
+            trust_env: Whether to use proxy and authentication settings from the
+                process environment. Set False for trusted LAN endpoints that must
+                bypass ambient proxy discovery.
         """
         super().__init__()
         self.api_key = api_key
@@ -69,6 +73,7 @@ class OpenAIRerankClient(RerankBase):
         self.model_name = model_name
         self.extra_headers = extra_headers or {}
         self.timeout = timeout
+        self.trust_env = trust_env
         self.provider = "openai"
         self._uses_nested_envelope = _uses_nested_envelope(api_base)
 
@@ -140,12 +145,25 @@ class OpenAIRerankClient(RerankBase):
             if self.extra_headers:
                 headers.update(self.extra_headers)
 
-            response = requests.post(
-                url=self.api_base,
-                headers=headers,
-                json=req_body,
-                timeout=self.timeout,
-            )
+            if self.trust_env:
+                response = requests.post(
+                    url=self.api_base,
+                    headers=headers,
+                    json=req_body,
+                    timeout=self.timeout,
+                )
+            else:
+                session = requests.Session()
+                try:
+                    session.trust_env = False
+                    response = session.post(
+                        url=self.api_base,
+                        headers=headers,
+                        json=req_body,
+                        timeout=self.timeout,
+                    )
+                finally:
+                    session.close()
             response.raise_for_status()
             result = response.json()
 
@@ -204,4 +222,5 @@ class OpenAIRerankClient(RerankBase):
             model_name=config.model or "qwen3-rerank",
             extra_headers=config.extra_headers,
             timeout=config.timeout,
+            trust_env=config.trust_env,
         )

--- a/openviking_cli/utils/config/rerank_config.py
+++ b/openviking_cli/utils/config/rerank_config.py
@@ -43,6 +43,15 @@ class RerankConfig(BaseModel):
         ),
     )
 
+    trust_env: bool = Field(
+        default=True,
+        description=(
+            "Whether OpenAI-compatible rerank calls use proxy and authentication settings "
+            "from the process environment. Set false for trusted LAN endpoints that must "
+            "bypass ambient proxy discovery."
+        ),
+    )
+
     threshold: float = Field(
         default=0.1, description="Relevance threshold (score > threshold is relevant)"
     )

--- a/tests/unit/models/rerank/test_openai_rerank_timeout.py
+++ b/tests/unit/models/rerank/test_openai_rerank_timeout.py
@@ -69,6 +69,21 @@ def test_openai_rerank_from_config_default_timeout():
     assert client.timeout == 30.0
 
 
+def test_openai_rerank_from_config_can_disable_environment_proxy_lookup():
+    """from_config passes trust_env through to the client."""
+    config = RerankConfig(
+        model="qwen3-rerank",
+        api_key="test-key",
+        api_base="http://rerank.internal:8081/v1/rerank",
+        trust_env=False,
+    )
+
+    client = OpenAIRerankClient.from_config(config)
+
+    assert client is not None
+    assert client.trust_env is False
+
+
 @patch("openviking.models.rerank.openai_rerank.requests.post")
 def test_rerank_batch_uses_configured_timeout(mock_post):
     """rerank_batch passes the configured timeout to requests.post."""
@@ -108,3 +123,24 @@ def test_rerank_batch_uses_default_timeout(mock_post):
 
     assert mock_post.called
     assert mock_post.call_args.kwargs["timeout"] == 30.0
+
+
+@patch("openviking.models.rerank.openai_rerank.requests.Session")
+def test_rerank_batch_can_disable_environment_proxy_lookup(mock_session):
+    """A LAN endpoint can opt out of proxy environment discovery."""
+    response = Mock()
+    response.json.return_value = {"results": [{"index": 0, "relevance_score": 0.9}]}
+    session = mock_session.return_value
+    session.post.return_value = response
+
+    client = OpenAIRerankClient(
+        api_key="test-key",
+        api_base="http://rerank.internal:8081/v1/rerank",
+        model_name="qwen3-rerank",
+        trust_env=False,
+    )
+
+    assert client.rerank_batch(query="test query", documents=["doc1"]) == [0.9]
+    assert session.trust_env is False
+    session.post.assert_called_once()
+    session.close.assert_called_once()


### PR DESCRIPTION
## Summary
- add `rerank.trust_env` for OpenAI-compatible rerank endpoints
- use a short-lived `requests.Session` with `trust_env=False` when configured, bypassing ambient proxy/auth discovery for trusted LAN endpoints
- document the setting in English and Chinese and cover configuration + request behavior with unit tests

## Motivation
Long-running deployments can need a direct route to a trusted LAN rerank endpoint even when the process environment has proxy configuration. This opt-in setting preserves the existing default (`true`) and avoids changing proxy behavior for existing deployments.

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest tests/unit/models/rerank/test_openai_rerank_timeout.py -q --no-cov` (9 passed)
- `.venv/bin/ruff check openviking/models/rerank/openai_rerank.py openviking_cli/utils/config/rerank_config.py tests/unit/models/rerank/test_openai_rerank_timeout.py`