### PR TITLE
fix(queuefs): serialize session commit processing per session

### DIFF
--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -24,6 +24,7 @@ from .semantic_queue import SemanticQueue
 logger = get_logger(__name__)
 
 DEFAULT_MAX_CONCURRENT_SESSION_COMMIT = 8
+DEFAULT_MAX_DEFERRED_SESSION_COMMIT = 64
 
 # ========== Singleton Pattern ==========
 _instance: Optional["QueueManager"] = None
@@ -343,6 +344,7 @@ class QueueManager:
         """Concurrent SessionCommit worker with per-session in-process serialization."""
         poll_interval = self._SESSION_COMMIT_POLL_INTERVAL
         sem = asyncio.Semaphore(max_concurrent)
+        max_deferred = DEFAULT_MAX_DEFERRED_SESSION_COMMIT
         active_tasks: Set[asyncio.Task] = set()
         active_sessions: Set[str] = set()
         task_sessions: Dict[asyncio.Task, str] = {}
@@ -358,10 +360,16 @@ class QueueManager:
                     queue._on_process_error(str(e), data)
                     logger.error(f"[QueueManager] SessionCommit worker error: {e}")
 
-        def dispatch(data: Dict[str, Any], session_id: Optional[str]) -> None:
+        def dispatch(
+            data: Dict[str, Any],
+            session_id: Optional[str],
+            *,
+            counted: bool = False,
+        ) -> None:
             if session_id is not None:
                 active_sessions.add(session_id)
-            queue._on_dequeue_start()
+            if not counted:
+                queue._on_dequeue_start()
             task = asyncio.create_task(process_one(data))
             active_tasks.add(task)
             if session_id is not None:
@@ -382,7 +390,7 @@ class QueueManager:
                 if session_id is not None and session_id in active_sessions:
                     deferred.append(data)
                     continue
-                dispatch(data, session_id)
+                dispatch(data, session_id, counted=True)
                 return True
             return False
 
@@ -397,7 +405,7 @@ class QueueManager:
             while len(active_tasks) < max_concurrent and dispatch_deferred():
                 pass
 
-            while len(active_tasks) < max_concurrent:
+            while len(active_tasks) < max_concurrent and len(deferred) < max_deferred:
                 try:
                     queue_size = await queue.size()
                 except Exception:
@@ -409,11 +417,36 @@ class QueueManager:
                     break
                 session_id = _session_commit_session_id(data)
                 if session_id is not None and session_id in active_sessions:
+                    queue._on_dequeue_start()
                     deferred.append(data)
                     continue
                 dispatch(data, session_id)
 
             await asyncio.sleep(poll_interval)
+
+        drain_deadline = time.monotonic() + 5.0
+        while active_tasks or deferred:
+            done_tasks = {task for task in active_tasks if task.done()}
+            if not done_tasks and active_tasks:
+                timeout = max(0.0, drain_deadline - time.monotonic())
+                if timeout == 0.0:
+                    break
+                done_tasks, _ = await asyncio.wait(
+                    active_tasks,
+                    timeout=timeout,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done_tasks:
+                    break
+
+            for task in done_tasks:
+                active_tasks.discard(task)
+                session_id = task_sessions.pop(task, None)
+                if session_id is not None:
+                    active_sessions.discard(session_id)
+
+            while len(active_tasks) < max_concurrent and dispatch_deferred():
+                pass
 
         if active_tasks:
             try:
@@ -429,6 +462,11 @@ class QueueManager:
                 for t in active_tasks:
                     t.cancel()
                 await asyncio.gather(*active_tasks, return_exceptions=True)
+        if deferred:
+            logger.warning(
+                "[QueueManager] SessionCommit worker stopped with "
+                f"{len(deferred)} deferred message(s) left for stale recovery"
+            )
 
     def stop(self) -> None:
         """Stop QueueManager and release resources."""

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -7,9 +7,11 @@ All queues are managed through NamedQueue.
 
 import asyncio
 import atexit
+import json
 import threading
 import time
 import traceback
+from collections import deque
 from typing import Any, Dict, Optional, Set, Union
 
 from openviking.service.task_work_index import TaskWorkIndex
@@ -25,6 +27,20 @@ DEFAULT_MAX_CONCURRENT_SESSION_COMMIT = 8
 
 # ========== Singleton Pattern ==========
 _instance: Optional["QueueManager"] = None
+
+
+def _session_commit_session_id(data: Dict[str, Any]) -> Optional[str]:
+    payload = data.get("data")
+    if not isinstance(payload, str):
+        return None
+    try:
+        message = json.loads(payload)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(message, dict):
+        return None
+    session_id = message.get("session_id")
+    return str(session_id) if session_id else None
 
 
 def init_queue_manager(
@@ -223,7 +239,11 @@ class QueueManager:
             else self._poll_interval
         )
         try:
-            if max_concurrent > 1:
+            if queue.name == self.SESSION_COMMIT and max_concurrent > 1:
+                loop.run_until_complete(
+                    self._worker_async_session_fifo(queue, stop_event, max_concurrent)
+                )
+            elif max_concurrent > 1:
                 loop.run_until_complete(
                     self._worker_async_concurrent(queue, stop_event, max_concurrent)
                 )
@@ -311,6 +331,99 @@ class QueueManager:
             except asyncio.TimeoutError:
                 logger.warning(
                     f"[QueueManager] Drain timeout for {queue.name}, "
+                    f"cancelling {len(active_tasks)} in-flight task(s)"
+                )
+                for t in active_tasks:
+                    t.cancel()
+                await asyncio.gather(*active_tasks, return_exceptions=True)
+
+    async def _worker_async_session_fifo(
+        self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int
+    ) -> None:
+        """Concurrent SessionCommit worker with per-session in-process serialization."""
+        poll_interval = self._SESSION_COMMIT_POLL_INTERVAL
+        sem = asyncio.Semaphore(max_concurrent)
+        active_tasks: Set[asyncio.Task] = set()
+        active_sessions: Set[str] = set()
+        task_sessions: Dict[asyncio.Task, str] = {}
+        deferred: deque[Dict[str, Any]] = deque()
+
+        async def process_one(data: Dict[str, Any]) -> None:
+            async with sem:
+                msg_id = data.get("id", "") if isinstance(data, dict) else ""
+                try:
+                    await queue.process_dequeued(data)
+                    await queue.ack(msg_id, data)
+                except Exception as e:
+                    queue._on_process_error(str(e), data)
+                    logger.error(f"[QueueManager] SessionCommit worker error: {e}")
+
+        def dispatch(data: Dict[str, Any], session_id: Optional[str]) -> None:
+            if session_id is not None:
+                active_sessions.add(session_id)
+            queue._on_dequeue_start()
+            task = asyncio.create_task(process_one(data))
+            active_tasks.add(task)
+            if session_id is not None:
+                task_sessions[task] = session_id
+            logger.debug(
+                "[QueueManager] Dispatched SessionCommit task "
+                "(session_id=%s, active=%s)",
+                session_id,
+                len(active_tasks),
+            )
+
+        def dispatch_deferred() -> bool:
+            if not deferred:
+                return False
+            for _ in range(len(deferred)):
+                data = deferred.popleft()
+                session_id = _session_commit_session_id(data)
+                if session_id is not None and session_id in active_sessions:
+                    deferred.append(data)
+                    continue
+                dispatch(data, session_id)
+                return True
+            return False
+
+        while not stop_event.is_set():
+            done_tasks = {task for task in active_tasks if task.done()}
+            for task in done_tasks:
+                active_tasks.discard(task)
+                session_id = task_sessions.pop(task, None)
+                if session_id is not None:
+                    active_sessions.discard(session_id)
+
+            while len(active_tasks) < max_concurrent and dispatch_deferred():
+                pass
+
+            while len(active_tasks) < max_concurrent:
+                try:
+                    queue_size = await queue.size()
+                except Exception:
+                    break
+                if not queue.has_dequeue_handler() or queue_size == 0:
+                    break
+                data = await queue.dequeue_raw()
+                if data is None:
+                    break
+                session_id = _session_commit_session_id(data)
+                if session_id is not None and session_id in active_sessions:
+                    deferred.append(data)
+                    continue
+                dispatch(data, session_id)
+
+            await asyncio.sleep(poll_interval)
+
+        if active_tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*active_tasks, return_exceptions=True),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[QueueManager] Drain timeout for SessionCommit, "
                     f"cancelling {len(active_tasks)} in-flight task(s)"
                 )
                 for t in active_tasks:

--- a/tests/storage/test_queue_manager.py
+++ b/tests/storage/test_queue_manager.py
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Focused tests for QueueManager concurrency selection."""
 
+import asyncio
+import json
 import os
 import subprocess
 import sys
+import threading
+from collections import deque
+from typing import Any, Dict, Optional
 
 from openviking.storage.queuefs.queue_manager import QueueManager
 
@@ -34,3 +39,129 @@ def test_queue_concurrency_uses_separate_configured_values() -> None:
     assert manager._max_concurrent_for_queue(manager.EXTERNAL_PARSE) == 9
     assert manager._max_concurrent_for_queue(manager.ADD_RESOURCE) == 7
     assert manager._max_concurrent_for_queue(manager.SESSION_COMMIT) == 5
+
+
+def _session_commit_queue_item(msg_id: str, session_id: str) -> Dict[str, Any]:
+    return {
+        "id": msg_id,
+        "data": json.dumps(
+            {
+                "task_id": msg_id,
+                "session_id": session_id,
+                "session_uri": f"viking://user/alice/sessions/{session_id}",
+                "archive_uri": f"viking://user/alice/sessions/{session_id}/history/archive_001",
+                "user": {"account_id": "acme", "user_id": "alice"},
+            }
+        ),
+    }
+
+
+class _FakeSessionCommitQueue:
+    name = QueueManager.SESSION_COMMIT
+
+    def __init__(
+        self,
+        messages: list[Dict[str, Any]],
+        *,
+        block_first: bool = False,
+    ) -> None:
+        self._messages = deque(messages)
+        self.block_first = block_first
+        self.started: list[str] = []
+        self.acked: list[str] = []
+        self.in_progress_count = 0
+        self.errors: list[str] = []
+        self.first_started = asyncio.Event()
+        self.second_started = asyncio.Event()
+        self.release_first = asyncio.Event()
+
+    def has_dequeue_handler(self) -> bool:
+        return True
+
+    async def size(self) -> int:
+        return len(self._messages)
+
+    async def dequeue_raw(self) -> Optional[Dict[str, Any]]:
+        if not self._messages:
+            return None
+        return self._messages.popleft()
+
+    async def process_dequeued(self, data: Dict[str, Any]) -> None:
+        msg_id = str(data["id"])
+        self.started.append(msg_id)
+        if len(self.started) == 1:
+            self.first_started.set()
+            if self.block_first:
+                await self.release_first.wait()
+        elif len(self.started) == 2:
+            self.second_started.set()
+
+    async def ack(self, msg_id: str, message: Optional[Dict[str, Any]] = None) -> None:
+        self.acked.append(msg_id)
+
+    def _on_dequeue_start(self) -> None:
+        self.in_progress_count += 1
+
+    def _on_process_error(self, error_msg: str, data: Optional[Dict[str, Any]] = None) -> None:
+        self.errors.append(error_msg)
+
+
+async def test_session_commit_worker_serializes_same_session() -> None:
+    manager = QueueManager(agfs=object())
+    manager._SESSION_COMMIT_POLL_INTERVAL = 0.01
+    queue = _FakeSessionCommitQueue(
+        [
+            _session_commit_queue_item("commit-1", "session-a"),
+            _session_commit_queue_item("commit-2", "session-a"),
+        ],
+        block_first=True,
+    )
+    stop_event = threading.Event()
+    worker = asyncio.create_task(
+        manager._worker_async_session_fifo(queue, stop_event, max_concurrent=2)
+    )
+
+    await asyncio.wait_for(queue.first_started.wait(), timeout=1.0)
+    await asyncio.sleep(0.05)
+
+    assert queue.started == ["commit-1"]
+    assert queue.in_progress_count == 1
+    assert queue.acked == []
+    assert queue.errors == []
+
+    queue.release_first.set()
+    await asyncio.wait_for(queue.second_started.wait(), timeout=1.0)
+    stop_event.set()
+    await asyncio.wait_for(worker, timeout=1.0)
+
+    assert queue.started == ["commit-1", "commit-2"]
+    assert queue.acked == ["commit-1", "commit-2"]
+
+
+async def test_session_commit_worker_allows_different_sessions_concurrently() -> None:
+    manager = QueueManager(agfs=object())
+    manager._SESSION_COMMIT_POLL_INTERVAL = 0.01
+    queue = _FakeSessionCommitQueue(
+        [
+            _session_commit_queue_item("commit-1", "session-a"),
+            _session_commit_queue_item("commit-2", "session-b"),
+        ],
+        block_first=True,
+    )
+    stop_event = threading.Event()
+    worker = asyncio.create_task(
+        manager._worker_async_session_fifo(queue, stop_event, max_concurrent=2)
+    )
+
+    await asyncio.wait_for(queue.second_started.wait(), timeout=1.0)
+
+    assert queue.started == ["commit-1", "commit-2"]
+    assert queue.in_progress_count == 2
+    assert queue.acked == ["commit-2"]
+    assert queue.errors == []
+
+    queue.release_first.set()
+    stop_event.set()
+    await asyncio.wait_for(worker, timeout=1.0)
+
+    assert queue.acked == ["commit-2", "commit-1"]

--- a/tests/storage/test_queue_manager.py
+++ b/tests/storage/test_queue_manager.py
@@ -11,6 +11,7 @@ import threading
 from collections import deque
 from typing import Any, Dict, Optional
 
+from openviking.storage.queuefs.named_queue import QueueStatus
 from openviking.storage.queuefs.queue_manager import QueueManager
 
 
@@ -70,6 +71,8 @@ class _FakeSessionCommitQueue:
         self.started: list[str] = []
         self.acked: list[str] = []
         self.in_progress_count = 0
+        self.processed_count = 0
+        self.error_count = 0
         self.errors: list[str] = []
         self.first_started = asyncio.Event()
         self.second_started = asyncio.Event()
@@ -95,6 +98,7 @@ class _FakeSessionCommitQueue:
                 await self.release_first.wait()
         elif len(self.started) == 2:
             self.second_started.set()
+        self._on_process_success()
 
     async def ack(self, msg_id: str, message: Optional[Dict[str, Any]] = None) -> None:
         self.acked.append(msg_id)
@@ -102,8 +106,22 @@ class _FakeSessionCommitQueue:
     def _on_dequeue_start(self) -> None:
         self.in_progress_count += 1
 
+    def _on_process_success(self) -> None:
+        self.in_progress_count -= 1
+        self.processed_count += 1
+
     def _on_process_error(self, error_msg: str, data: Optional[Dict[str, Any]] = None) -> None:
+        self.in_progress_count -= 1
+        self.error_count += 1
         self.errors.append(error_msg)
+
+    async def get_status(self) -> QueueStatus:
+        return QueueStatus(
+            pending=len(self._messages),
+            in_progress=self.in_progress_count,
+            processed=self.processed_count,
+            error_count=self.error_count,
+        )
 
 
 async def test_session_commit_worker_serializes_same_session() -> None:
@@ -125,9 +143,11 @@ async def test_session_commit_worker_serializes_same_session() -> None:
     await asyncio.sleep(0.05)
 
     assert queue.started == ["commit-1"]
-    assert queue.in_progress_count == 1
+    assert queue.in_progress_count == 2
     assert queue.acked == []
     assert queue.errors == []
+    manager._queues[manager.SESSION_COMMIT] = queue
+    assert not await manager.is_all_complete(manager.SESSION_COMMIT)
 
     queue.release_first.set()
     await asyncio.wait_for(queue.second_started.wait(), timeout=1.0)
@@ -136,6 +156,7 @@ async def test_session_commit_worker_serializes_same_session() -> None:
 
     assert queue.started == ["commit-1", "commit-2"]
     assert queue.acked == ["commit-1", "commit-2"]
+    assert queue.in_progress_count == 0
 
 
 async def test_session_commit_worker_allows_different_sessions_concurrently() -> None:
@@ -156,7 +177,7 @@ async def test_session_commit_worker_allows_different_sessions_concurrently() ->
     await asyncio.wait_for(queue.second_started.wait(), timeout=1.0)
 
     assert queue.started == ["commit-1", "commit-2"]
-    assert queue.in_progress_count == 2
+    assert queue.in_progress_count == 1
     assert queue.acked == ["commit-2"]
     assert queue.errors == []
 
@@ -165,3 +186,66 @@ async def test_session_commit_worker_allows_different_sessions_concurrently() ->
     await asyncio.wait_for(worker, timeout=1.0)
 
     assert queue.acked == ["commit-2", "commit-1"]
+    assert queue.in_progress_count == 0
+
+
+async def test_session_commit_worker_lookahead_reaches_later_different_session() -> None:
+    manager = QueueManager(agfs=object())
+    manager._SESSION_COMMIT_POLL_INTERVAL = 0.01
+    queue = _FakeSessionCommitQueue(
+        [
+            _session_commit_queue_item("commit-a1", "session-a"),
+            _session_commit_queue_item("commit-a2", "session-a"),
+            _session_commit_queue_item("commit-a3", "session-a"),
+            _session_commit_queue_item("commit-b1", "session-b"),
+        ],
+        block_first=True,
+    )
+    stop_event = threading.Event()
+    worker = asyncio.create_task(
+        manager._worker_async_session_fifo(queue, stop_event, max_concurrent=3)
+    )
+
+    await asyncio.wait_for(queue.second_started.wait(), timeout=1.0)
+
+    assert queue.started == ["commit-a1", "commit-b1"]
+    assert queue.in_progress_count == 3
+    assert queue.acked == ["commit-b1"]
+    assert len(queue._messages) == 0
+
+    queue.release_first.set()
+    stop_event.set()
+    await asyncio.wait_for(worker, timeout=1.0)
+
+    assert queue.started == ["commit-a1", "commit-b1", "commit-a2", "commit-a3"]
+    assert queue.acked == ["commit-b1", "commit-a1", "commit-a2", "commit-a3"]
+    assert queue.in_progress_count == 0
+
+
+async def test_session_commit_worker_bounds_deferred_messages() -> None:
+    manager = QueueManager(agfs=object())
+    manager._SESSION_COMMIT_POLL_INTERVAL = 0.01
+    queue = _FakeSessionCommitQueue(
+        [_session_commit_queue_item(f"commit-{i}", "session-a") for i in range(70)],
+        block_first=True,
+    )
+    stop_event = threading.Event()
+    worker = asyncio.create_task(
+        manager._worker_async_session_fifo(queue, stop_event, max_concurrent=3)
+    )
+
+    await asyncio.wait_for(queue.first_started.wait(), timeout=1.0)
+    await asyncio.sleep(0.05)
+
+    assert queue.started == ["commit-0"]
+    assert queue.in_progress_count == 65
+    assert len(queue._messages) == 5
+
+    queue.release_first.set()
+    stop_event.set()
+    await asyncio.wait_for(worker, timeout=1.0)
+
+    assert len(queue.started) == 65
+    assert len(queue.acked) == 65
+    assert queue.in_progress_count == 0
+    assert len(queue._messages) == 5


### PR DESCRIPTION
## Description

修复同一 session 下多个 Session Phase 2 commit 并发消费时可能触发的 requeue storm。  
本 PR 在 `SessionCommit` 队列 worker 层增加 per-session FIFO 调度：同一个 session 的 commit 串行处理，不同 session 仍可并发处理，并通过有界 lookahead 避免队头同 session backlog 阻塞后续不同 session 的可运行任务。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4345

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 为 `SessionCommit` 队列增加专用 per-session FIFO worker，避免同一 session 的后续 commit 在前驱仍 pending 时进入 processor。
- 增加 `DEFAULT_MAX_DEFERRED_SESSION_COMMIT = 64`，通过有界 lookahead 暂存同 session blocked 消息，保持 QueueFS 原有单队列数据布局不变。
- deferred 消息计入 in-progress，避免 `wait_complete()` 在消息已 dequeue 但未处理时提前返回。
- graceful stop 时 drain 已经取出的 active/deferred 消息，减少依赖 stale recovery 的正常停机场景。
- 补充单元测试覆盖同 session 串行、不同 session 并发、lookahead 命中后续不同 session、deferred 上限和状态计数闭环。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

测试命令：

```bash
OPENVIKING_CONFIG_FILE=/tmp/openviking-no-config-for-test.json .venv/bin/python -m pytest --no-cov -q tests/storage/test_queue_manager.py
OPENVIKING_CONFIG_FILE=/tmp/openviking-no-config-for-test.json .venv/bin/python -m pytest --no-cov -q tests/storage/test_session_commit_processor_identity.py
.venv/bin/python -m py_compile openviking/storage/queuefs/queue_manager.py tests/storage/test_queue_manager.py
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本 PR 不改变 QueueFS 的持久化路径或数据布局，仍使用原有 `/queue/SessionCommit` 单队列。  
`lookahead` 上限当前为 64，用于在不引入 breaking change 的前提下缓解全局 FIFO 队列中的同 session 队头阻塞。
