### PR TITLE
修复 Understanding 解析空文件时返回 500 的问题

### DIFF
--- a/openviking/parse/understanding_api.py
+++ b/openviking/parse/understanding_api.py
@@ -37,6 +37,7 @@ from openviking.parse.parsers.media.constants import (
 )
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.utils.zip_safe import normalize_zip_filenames, safe_extract_zip
+from openviking_cli.exceptions import InvalidArgumentError
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -333,6 +334,8 @@ class UnderstandingAPI(BaseParser):
 
     async def _create_file(self, *, local_path: Path) -> Dict[str, Any]:
         file_size = local_path.stat().st_size
+        if file_size == 0:
+            raise InvalidArgumentError("Understanding parser does not support empty files.")
         if file_size > self._upload_simple_max_bytes:
             if not self._enable_resumable_upload:
                 raise ValueError(

--- a/tests/parse/test_understanding_api.py
+++ b/tests/parse/test_understanding_api.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from openviking.parse.understanding_api import UnderstandingAPI
+from openviking_cli.exceptions import InvalidArgumentError
 
 
 @pytest.mark.asyncio
@@ -56,10 +57,21 @@ async def test_parse_uses_downloaded_file_and_resolved_extension(monkeypatch, tm
 
 
 @pytest.mark.asyncio
-async def test_submit_file_returns_response_id(tmp_path):
+async def test_submit_file_validates_input_and_returns_response_id(tmp_path):
+    empty_source = tmp_path / "empty.pdf"
+    empty_source.touch()
+    api = UnderstandingAPI.__new__(UnderstandingAPI)
+
+    with pytest.raises(
+        InvalidArgumentError,
+        match="Understanding parser does not support empty files",
+    ) as exc_info:
+        await api.submit_file(empty_source)
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
     source = tmp_path / "download.pdf"
     source.write_bytes(b"%PDF-1.7")
-    api = UnderstandingAPI.__new__(UnderstandingAPI)
     api._create_file = AsyncMock(return_value={"id": "file-1"})
     api._create_response_for_file = AsyncMock(return_value={"id": "response-1"})
 


### PR DESCRIPTION
## 说明

修复使用 Understanding 解析器导入 0 字节文件时被错误返回为 HTTP 500 的问题。

修改前：上传一个 0 字节文件时，OpenViking 会继续请求 Understanding Files API；上游拒绝该文件后，异常进入通用解析失败分支，客户端收到 `PROCESSING_ERROR` 和 HTTP 500。

修改后：上传同一个 0 字节文件时，Understanding 上传边界会在请求上游前直接抛出 `InvalidArgumentError`；服务端沿用现有错误映射，返回 `INVALID_ARGUMENT` 和 HTTP 400。

## 人工参与

- [x] 有人工参与实现或评审
- [ ] 完全由 AI Agent 生成，没有人工参与

## 关联 Issue

无

## 变更类型

- [x] Bug 修复（不破坏兼容性）
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构（无功能变化）
- [ ] 性能优化
- [x] 测试更新

## 具体改动

- 在 Understanding Files API 上传边界校验文件大小，拒绝 0 字节文件，不再发送无效上游请求
- 使用现有 `InvalidArgumentError` 作为唯一错误来源，复用 `INVALID_ARGUMENT -> HTTP 400` 映射
- 将回归覆盖合入现有 `submit_file` 契约测试，同时保留正常文件提交覆盖

## 测试

- [x] 已补充能够验证修复有效的测试覆盖
- [x] 新旧单元测试在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证命令：

- `uv run --extra test pytest tests/parse/test_understanding_api.py -q`（2 passed）
- `uv run --extra dev ruff check openviking/parse/understanding_api.py tests/parse/test_understanding_api.py`
- `uv run --extra dev ruff format --check openviking/parse/understanding_api.py tests/parse/test_understanding_api.py`
- `git diff --check`

## 检查项

- [x] 代码符合项目风格
- [x] 已完成自查
- [ ] 已为难以理解的代码补充注释
- [ ] 已同步更新相关文档
- [x] 没有引入新的警告
- [ ] 依赖变更已经合入并发布

## 截图

无

## 补充说明

该校验只作用于配置为 Understanding 解析器的文件路径；内部解析器的空文件行为不变。
