### PR TITLE
feat(metrics): track memory extraction operation outcomes

### DIFF
--- a/openviking/metrics/collectors/telemetry_bridge.py
+++ b/openviking/metrics/collectors/telemetry_bridge.py
@@ -96,6 +96,11 @@ class TelemetryBridgeCollector(EventMetricCollector):
     MEMORY_EXTRACTED_TOTAL: ClassVar[str] = MetricCollector.metric_name(
         DOMAIN_MEMORY, "extracted", unit="total"
     )
+    # rule: <METRICS_NAMESPACE>_<DOMAIN_MEMORY>_operations_total
+    # e.g.: openviking_memory_operations_total
+    MEMORY_OPERATIONS_TOTAL: ClassVar[str] = MetricCollector.metric_name(
+        DOMAIN_MEMORY, "operations", unit="total"
+    )
     # rule: <METRICS_NAMESPACE>_<DOMAIN_RESOURCE>_stage_total
     # e.g.: openviking_resource_stage_total
     RESOURCE_STAGE_TOTAL: ClassVar[str] = MetricCollector.metric_name(
@@ -259,6 +264,31 @@ class TelemetryBridgeCollector(EventMetricCollector):
                 label_names=("operation",),
                 amount=extracted,
             )
+
+        extract = memory.get("extract") or {}
+        actions = extract.get("actions") or {}
+        if isinstance(actions, Mapping):
+            for action, result in (
+                ("created", "success"),
+                ("merged", "success"),
+                ("deleted", "success"),
+                ("skipped", "skipped"),
+                ("failed", "failed"),
+            ):
+                value = int(actions.get(action, 0) or 0)
+                if value <= 0:
+                    continue
+                metric_action = "updated" if action == "merged" else action
+                registry.inc_counter(
+                    self.MEMORY_OPERATIONS_TOTAL,
+                    labels={
+                        "operation": operation,
+                        "action": metric_action,
+                        "result": result,
+                    },
+                    label_names=("operation", "action", "result"),
+                    amount=value,
+                )
 
         resource = summary.get("resource") or {}
         if resource:

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -125,6 +125,7 @@ def _initialize_extraction_telemetry() -> None:
         "memory.extract.merged",
         "memory.extract.deleted",
         "memory.extract.skipped",
+        "memory.extract.failed",
     ):
         telemetry.set(name, 0)
 
@@ -138,7 +139,8 @@ def _report_extraction_telemetry(result: Any) -> None:
     telemetry.set("memory.extract.created", len(result.written_uris))
     telemetry.set("memory.extract.merged", len(result.edited_uris))
     telemetry.set("memory.extract.deleted", len(result.deleted_uris))
-    telemetry.set("memory.extract.skipped", len(result.errors))
+    telemetry.set("memory.extract.skipped", len(result.skipped_operations))
+    telemetry.set("memory.extract.failed", len(result.errors))
 
 
 async def _commit_experience_snapshot(

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -80,6 +80,20 @@ _MEMORY_STEP_NAMES = ("long_term",)
 _CUMULATIVE_CHECKPOINT_VERSION = 2
 
 
+def _publish_telemetry_summary_best_effort(snapshot: Any) -> None:
+    """Publish a completed session telemetry summary without affecting the task outcome."""
+    if snapshot is None:
+        return
+    try:
+        from openviking.metrics.datasources.telemetry_bridge import (
+            TelemetryBridgeEventDataSource,
+        )
+
+        TelemetryBridgeEventDataSource.record_summary(snapshot.summary)
+    except Exception:
+        logger.debug("failed to publish session telemetry summary to metrics bridge", exc_info=True)
+
+
 class _ArchiveMessagesCorruptError(ValueError):
     """Raised when an archive messages file cannot be deserialized."""
 
@@ -2752,6 +2766,7 @@ class Session:
 
             # Phase 2 complete — update meta with telemetry and commit info
             snapshot = telemetry.finish("ok")
+            _publish_telemetry_summary_best_effort(snapshot)
             await self._merge_and_save_commit_meta(
                 archive_index=archive_index,
                 memories_extracted=memories_extracted,
@@ -2818,6 +2833,9 @@ class Session:
             )
             logger.info(f"Session {self.session_id} memory extraction completed")
         except asyncio.CancelledError:
+            telemetry.set_error("session.commit.phase2", "CANCELLED", "session commit cancelled")
+            snapshot = telemetry.finish("cancelled")
+            _publish_telemetry_summary_best_effort(snapshot)
             await self._write_failed_marker(
                 archive_uri,
                 stage="cancelled",
@@ -2825,6 +2843,9 @@ class Session:
             )
             raise
         except Exception as e:
+            telemetry.set_error("session.commit.phase2", type(e).__name__, str(e))
+            snapshot = telemetry.finish("error")
+            _publish_telemetry_summary_best_effort(snapshot)
             await self._write_failed_marker(
                 archive_uri,
                 stage="memory_extraction",

--- a/openviking/telemetry/operation.py
+++ b/openviking/telemetry/operation.py
@@ -371,6 +371,7 @@ class TelemetrySummaryBuilder:
                         "merged": cls._i(gauges.get("memory.extract.merged"), 0),
                         "deleted": cls._i(gauges.get("memory.extract.deleted"), 0),
                         "skipped": cls._i(gauges.get("memory.extract.skipped"), 0),
+                        "failed": cls._i(gauges.get("memory.extract.failed"), 0),
                     },
                     "stages": {
                         public_key: cls._f(gauges.get(metric_key), 0.0)

--- a/tests/metrics/integration/test_telemetry_bridge.py
+++ b/tests/metrics/integration/test_telemetry_bridge.py
@@ -28,7 +28,18 @@ def test_telemetry_bridge_records_operation_and_resource_metrics(registry, rende
                     },
                 },
                 "vector": {"searches": 1, "scored": 2, "passed": 2, "returned": 1, "scanned": 9},
-                "memory": {"extracted": 4},
+                "memory": {
+                    "extracted": 4,
+                    "extract": {
+                        "actions": {
+                            "created": 2,
+                            "merged": 1,
+                            "deleted": 1,
+                            "skipped": 3,
+                            "failed": 1,
+                        }
+                    },
+                },
                 "semantic_nodes": {"OK": 12},
                 "resource": {
                     "process": {
@@ -57,6 +68,26 @@ def test_telemetry_bridge_records_operation_and_resource_metrics(registry, rende
         )
         assert 'openviking_vector_searches_total{operation="resource.process"} 1' in text
         assert 'openviking_memory_extracted_total{operation="resource.process"} 4' in text
+        assert (
+            'openviking_memory_operations_total{action="created",operation="resource.process",result="success"} 2'
+            in text
+        )
+        assert (
+            'openviking_memory_operations_total{action="updated",operation="resource.process",result="success"} 1'
+            in text
+        )
+        assert (
+            'openviking_memory_operations_total{action="deleted",operation="resource.process",result="success"} 1'
+            in text
+        )
+        assert (
+            'openviking_memory_operations_total{action="skipped",operation="resource.process",result="skipped"} 3'
+            in text
+        )
+        assert (
+            'openviking_memory_operations_total{action="failed",operation="resource.process",result="failed"} 1'
+            in text
+        )
         assert (
             'openviking_semantic_nodes_total{status="OK"} 12' in text
             or 'openviking_semantic_nodes_total{status="OK"} 12.0' in text

--- a/tests/telemetry/test_execution.py
+++ b/tests/telemetry/test_execution.py
@@ -18,7 +18,8 @@ def test_operation_telemetry_summary_includes_memory_extract_breakdown():
     telemetry.set("memory.extract.created", 3)
     telemetry.set("memory.extract.merged", 1)
     telemetry.set("memory.extract.deleted", 0)
-    telemetry.set("memory.extract.skipped", 3)
+    telemetry.set("memory.extract.skipped", 2)
+    telemetry.set("memory.extract.failed", 1)
     telemetry.set("memory.extract.stage.prepare_inputs.duration_ms", 8.4)
     telemetry.set("memory.extract.stage.llm_extract.duration_ms", 410.2)
     telemetry.set("memory.extract.stage.normalize_candidates.duration_ms", 6.7)
@@ -44,7 +45,8 @@ def test_operation_telemetry_summary_includes_memory_extract_breakdown():
         "actions": {
             "created": 3,
             "merged": 1,
-            "skipped": 3,
+            "skipped": 2,
+            "failed": 1,
         },
         "stages": {
             "prepare_inputs_ms": 8.4,


### PR DESCRIPTION
## Summary

Add outcome-level metrics for session memory extraction and ensure the manually managed Session Commit Phase 2 telemetry is delivered to the existing telemetry metrics bridge.

This makes memory extraction observable as real create, update, delete, skip, and failure outcomes instead of reporting a single aggregate extraction count.

## Problem

The existing extraction telemetry had two gaps:

- `memory.extract.skipped` was populated from `result.errors`, conflating policy skips with failed writes.
- Session Commit Phase 2 constructs and finishes `OperationTelemetry` directly. Unlike paths using `run_with_telemetry`, its completed summary was not published as a `telemetry.summary` event, so the telemetry metrics bridge could not emit the new memory outcome counter.

## Changes

- Add `openviking_memory_operations_total` with bounded labels:

  ```text
  operation=session_commit_phase2
  action=created | updated | deleted | skipped | failed
  result=success | skipped | failed
  ```

- Keep the existing internal `merged` telemetry field for compatibility, while exporting it as `action=updated`.
- Correct outcome accounting in the session extractor:
  - `skipped` comes from `MemoryUpdateResult.skipped_operations`
  - `failed` comes from `MemoryUpdateResult.errors`
- Include `failed` in the memory extraction telemetry summary.
- Publish Session Commit Phase 2 telemetry summaries on success, failure, and cancellation through the existing `TelemetryBridgeEventDataSource`; publishing is best-effort and cannot affect task completion semantics.
- Extend telemetry bridge and summary tests for all five outcome classes.

## Validation

- `git diff --check`
- Python compilation check for the changed modules
- Telemetry bridge integration coverage verifies the generated `openviking_memory_operations_total` series for created, updated, deleted, skipped, and failed outcomes.

## Notes

The metric intentionally does not include session ID, account, user, URI, or error message labels, preventing high-cardinality series.
