### PR TITLE
fix(zcode): make async stop test robust on slow CI runners

### DIFF
--- a/examples/zcode-memory-plugin/scripts/zcode-async.test.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-async.test.mjs
@@ -9,6 +9,12 @@ import { fileURLToPath } from "node:url";
 
 const hook = fileURLToPath(new URL("./auto-capture.mjs", import.meta.url));
 
+// Mirrors OPENVIKING_TIMEOUT_MS below: the parent must never stall this long.
+const HOOK_TIMEOUT_MS = 5000;
+// Slow CI runners need a generous budget for the detached worker to finish
+// (cold start + two delayed responses + state writes).
+const WORKER_WAIT_MS = 20000;
+
 function waitFor(predicate, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs;
   return new Promise((resolve, reject) => {
@@ -84,7 +90,7 @@ test("Stop returns before slow writes while detached worker finishes capture", a
       HOME: home,
       OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
       OPENVIKING_WRITE_PATH_ASYNC: "1",
-      OPENVIKING_TIMEOUT_MS: "5000",
+      OPENVIKING_TIMEOUT_MS: String(HOOK_TIMEOUT_MS),
     },
     stdio: ["pipe", "pipe", "pipe"],
   });
@@ -98,10 +104,17 @@ test("Stop returns before slow writes while detached worker finishes capture", a
 
   assert.equal(exitCode, 0, stderr);
   assert.equal(stdout, "");
+  // Core async-path guarantee, independent of wall-clock speed: every server
+  // response is delayed 700ms, so a parent that exits with zero completed
+  // responses provably never awaited the network. A synchronous fallback
+  // would have completed both responses before exiting.
   assert.equal(completedResponses, 0, "parent waited for a network response");
-  assert.ok(elapsedMs < 650, `parent hook took ${elapsedMs}ms`);
+  // Hang guard only (not a latency budget): the parent must exit well before
+  // the fetch timeout. Node cold start on a loaded CI runner can easily
+  // exceed any tighter wall-clock bound, which made this flaky.
+  assert.ok(elapsedMs < HOOK_TIMEOUT_MS, `parent hook took ${elapsedMs}ms`);
 
-  await waitFor(() => requests.some(({ url }) => url?.endsWith("/commit")));
+  await waitFor(() => requests.some(({ url }) => url?.endsWith("/commit")), WORKER_WAIT_MS);
   assert.equal(requests.length, 2);
   const batch = requests.find(({ url }) => url?.endsWith("/messages/batch"));
   assert.ok(batch);
@@ -113,7 +126,7 @@ test("Stop returns before slow writes while detached worker finishes capture", a
   });
 
   const statePath = join(home, ".openviking", "hook-state", "zcode", `${sessionId}.json`);
-  await waitFor(() => existsSync(statePath));
+  await waitFor(() => existsSync(statePath), WORKER_WAIT_MS);
   const state = JSON.parse(readFileSync(statePath, "utf8"));
   assert.equal(state.lastTurnId, "turn-001");
   assert.deepEqual(state.capturedTurnIds, [
@@ -168,7 +181,7 @@ test("400 failure does not advance state and successful retry prevents duplicate
     HOME: home,
     OPENVIKING_URL: `http://127.0.0.1:${server.address().port}`,
     OPENVIKING_WRITE_PATH_ASYNC: "0",
-    OPENVIKING_TIMEOUT_MS: "5000",
+    OPENVIKING_TIMEOUT_MS: String(HOOK_TIMEOUT_MS),
   };
 
   const first = await runHook({ session_id: sessionId, cwd: home }, env);


### PR DESCRIPTION
## Problem

`examples/zcode-memory-plugin/scripts/zcode-async.test.mjs` ("Stop returns before slow writes while detached worker finishes capture") is flaky on CI: it asserts the parent hook process exits within a hard-coded **650ms wall-clock budget**.

On a loaded/shared CI runner the node cold start plus ESM module-graph load alone can exceed that budget (observed 4.8s on a contended runner), so the test fails with `parent hook took 4857ms` even though the async detach behavior is completely correct. This shows up as `plugin-tests` failures on freshly-rebased PRs (e.g. #3540).

## Fix

Keep the async contract pinned by the assertions that are actually load-independent, and drop the wall-clock latency budget:

- **`completedResponses === 0` stays the core assertion.** Every server response is delayed 700ms, so a parent that exits having completed *zero* responses provably never awaited the network; a synchronous fallback would complete both responses before exiting. This is independent of machine speed.
- **`elapsed < OPENVIKING_TIMEOUT_MS` (5s) replaces the 650ms budget**, as a hang guard only — the parent must never stall until the fetch timeout.
- **`waitFor` budget for the detached worker raised 5s → 20s**: on a slow runner the worker needs cold start + two 700ms-delayed responses + state writes, which can exceed the old 5s default.
- Both timeouts now reference named constants (`HOOK_TIMEOUT_MS`, `WORKER_WAIT_MS`) shared with the env setup.

## Verification

- Local runs: 3/3 consecutive passes (previously failed on the same machine under load).
- **Detection capability preserved**: temporarily forcing `maybeDetach()` to return `false` (simulating a regression to the synchronous path) makes the test fail on exactly the `parent waited for a network response` assertion — the degenerate path is still caught after this change.
- Full `node --test examples/zcode-memory-plugin/scripts/*.test.mjs` suite passes (2/2).
