### PR TITLE
fix(task): bound wait_for_descendants so orphaned work cannot hang tasks

### DIFF
--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -173,7 +173,13 @@ class TaskTracker:
     TTL_FAILED = 604_800  # 7 days
     CLEANUP_INTERVAL = 300  # 5 minutes
 
-    def __init__(self, store: TaskStore, *, max_concurrent_store_io: int = 8) -> None:
+    def __init__(
+        self,
+        store: TaskStore,
+        *,
+        max_concurrent_store_io: int = 8,
+        descendant_wait_timeout_s: Optional[float] = 600.0,
+    ) -> None:
         self._store = store
         self._tasks: Dict[str, TaskRecord] = {}
         self._lock = threading.Lock()
@@ -184,6 +190,9 @@ class TaskTracker:
         self._business_locks = KeyedAsyncLockPool[tuple[str, str, str, str]]()
         self._store_io = StoreIOLimiter(max_concurrent_store_io)
         self._cleanup_task: Optional[asyncio.Task] = None
+        # Upper bound for wait_for_descendants. ``None`` or ``<= 0`` restores the
+        # legacy unbounded wait.
+        self._descendant_wait_timeout_s = descendant_wait_timeout_s
         self._work_index = TaskWorkIndex()
         self._install_work_index_callbacks()
         logger.info(
@@ -816,8 +825,35 @@ class TaskTracker:
         return deleted
 
     async def wait_for_descendants(self, task_id: str, current_work_id: str) -> None:
-        """Wait on the same durable work index used by completion and cancellation."""
+        """Wait on the same durable work index used by completion and cancellation.
+
+        Bounded by ``descendant_wait_timeout_s`` (default 600s): when descendant
+        work never reaches a terminal ACK — orphaned in-memory entry, rollback
+        without retry, worker crash window — the parent proceeds instead of
+        spinning forever and leaving the task stuck in ``processing``. QueueFS
+        remains the source of truth; late descendant ACKs still run their own
+        finalization path.
+        """
+        timeout_s = self._descendant_wait_timeout_s
+        if timeout_s is None or timeout_s <= 0:
+            while self._work_index.has_work(task_id, exclude_work_id=current_work_id):
+                await asyncio.sleep(0.05)
+            return
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s
         while self._work_index.has_work(task_id, exclude_work_id=current_work_id):
+            if loop.time() >= deadline:
+                orphaned = self._work_index.work_ids(task_id, exclude_work_id=current_work_id)
+                logger.warning(
+                    "[TaskTracker] wait_for_descendants timed out after %.0fs for task %s: "
+                    "%d descendant work item(s) never reached a terminal ACK %s; "
+                    "proceeding so the parent task can complete",
+                    timeout_s,
+                    task_id,
+                    len(orphaned),
+                    [f"{queue}:{work}" for queue, work in orphaned[:5]],
+                )
+                return
             await asyncio.sleep(0.05)
 
     def has_work(self, task_id: str) -> bool:

--- a/openviking/service/task_work_index.py
+++ b/openviking/service/task_work_index.py
@@ -276,6 +276,25 @@ class TaskWorkIndex:
                 )
             return bool(self._work.get(task_id) or self._active.get(task_id))
 
+    def work_ids(
+        self,
+        task_id: str,
+        exclude_work_id: Optional[str] = None,
+    ) -> tuple[tuple[str, str], ...]:
+        """Snapshot the queued work entries owned by a task.
+
+        Used for diagnostics when descendant work never reaches a terminal ACK.
+        """
+        with self._lock:
+            entries = self._work.get(task_id)
+            if not entries:
+                return ()
+            return tuple(
+                (queue_name, work_id)
+                for queue_name, work_id in sorted(entries)
+                if work_id != exclude_work_id
+            )
+
     def cancellation_requested(self, task_id: str) -> bool:
         callback = self._is_cancellation_requested
         return bool(callback is not None and callback(task_id))

--- a/tests/test_task_tracker_descendant_wait.py
+++ b/tests/test_task_tracker_descendant_wait.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""wait_for_descendants must be bounded so orphaned descendant work cannot hang
+the parent AddResource task in ``processing`` forever (issue #4341)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from openviking.service.task_tracker import TaskTracker
+from openviking.service.task_work_index import QueueTaskMetadata
+
+
+class _StubStore:
+    """TaskTracker only touches the store's class name during __init__."""
+
+    def __getattr__(self, name: str) -> Any:
+        raise AttributeError(f"stub store has no {name}")
+
+
+def _tracker(descendant_wait_timeout_s: float | None) -> TaskTracker:
+    return TaskTracker(
+        _StubStore(),  # type: ignore[arg-type]
+        descendant_wait_timeout_s=descendant_wait_timeout_s,
+    )
+
+
+def _meta(task_id: str, work_id: str) -> QueueTaskMetadata:
+    return QueueTaskMetadata(task_id=task_id, work_id=work_id)
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_immediately_when_no_other_work() -> None:
+    tracker = _tracker(descendant_wait_timeout_s=5.0)
+    tracker._work_index.register("AddResource", _meta("t1", "w-self"))
+    start = time.monotonic()
+    await tracker.wait_for_descendants("t1", current_work_id="w-self")
+    assert time.monotonic() - start < 1.0
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_when_descendant_reaches_terminal_ack() -> None:
+    tracker = _tracker(descendant_wait_timeout_s=5.0)
+    index = tracker._work_index
+    index.register("AddResource", _meta("t2", "w-self"))
+    index.register("Semantic", _meta("t2", "w-child"))
+
+    async def ack_child_after(delay: float) -> None:
+        await asyncio.sleep(delay)
+        await index.prepare_ack("Semantic", _meta("t2", "w-child"))
+
+    acker = asyncio.create_task(ack_child_after(0.2))
+    start = time.monotonic()
+    await tracker.wait_for_descendants("t2", current_work_id="w-self")
+    elapsed = time.monotonic() - start
+    assert 0.1 < elapsed < 4.0, "should return shortly after the descendant ACKs"
+    await acker
+
+
+@pytest.mark.asyncio
+async def test_orphaned_descendant_times_out_and_parent_proceeds() -> None:
+    tracker = _tracker(descendant_wait_timeout_s=0.15)
+    index = tracker._work_index
+    index.register("AddResource", _meta("t3", "w-self"))
+    # Simulate an orphan: registered but its finalization callback never fires.
+    index.register("Embedding", _meta("t3", "w-orphan"))
+
+    start = time.monotonic()
+    await tracker.wait_for_descendants("t3", current_work_id="w-self")
+    elapsed = time.monotonic() - start
+    assert 0.1 < elapsed < 3.0, "must return after the bounded timeout, not hang"
+
+
+@pytest.mark.asyncio
+async def test_timeout_logs_orphaned_work_ids() -> None:
+    tracker = _tracker(descendant_wait_timeout_s=0.05)
+    index = tracker._work_index
+    index.register("AddResource", _meta("t4", "w-self"))
+    index.register("Semantic", _meta("t4", "w-orphan"))
+
+    await tracker.wait_for_descendants("t4", current_work_id="w-self")
+
+    assert index.work_ids("t4", exclude_work_id="w-self") == (
+        ("Semantic", "w-orphan"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_unbounded_legacy_mode_still_waits_until_ack() -> None:
+    tracker = _tracker(descendant_wait_timeout_s=None)
+    index = tracker._work_index
+    index.register("AddResource", _meta("t5", "w-self"))
+    index.register("Semantic", _meta("t5", "w-child"))
+
+    async def ack_child_after() -> None:
+        await asyncio.sleep(0.2)
+        await index.prepare_ack("Semantic", _meta("t5", "w-child"))
+
+    acker = asyncio.create_task(ack_child_after())
+    await tracker.wait_for_descendants("t5", current_work_id="w-self")
+    await acker
+    assert not index.has_work("t5", exclude_work_id="w-self")


### PR DESCRIPTION
Fixes #4341 (defense-in-depth layer).

## Problem

AddResource tasks whose descendant queue work (Semantic/Embedding) never reaches a terminal ACK stay stuck in `processing` forever: `wait_for_descendants` spins on the in-memory `TaskWorkIndex._work` with no timeout, so the parent never completes and never ACKs. ~21 zombie tasks/day observed on a healthy instance (see issue).

## Change

- `TaskTracker(descendant_wait_timeout_s=600.0)` bounds the wait; `None`/`<=0` restores the legacy unbounded behavior
- on timeout the remaining `(queue, work_id)` entries are logged (warning) and the parent proceeds — QueueFS stays the source of truth, late descendant ACKs still run their own finalization
- new `TaskWorkIndex.work_ids()` snapshot accessor for the timeout diagnostics

This is deliberately a bounded-wait safety net on top of the root-cause investigation in the issue discussion (repeatedly failing Embedding child). It converts an invisible hang into a loud, diagnosable event and unblocks the queue.

## Tests

`tests/test_task_tracker_descendant_wait.py` — 5 cases: immediate return / return on descendant ACK / orphan timeout proceeds / diagnostics content / unbounded legacy mode. All pass (`pytest --noconftest -o addopts=""`).
