### PR TITLE
fix(semantic): skip thematic breaks when extracting directory abstracts

### DIFF
--- a/openviking/storage/abstract_overview.py
+++ b/openviking/storage/abstract_overview.py
@@ -490,18 +490,34 @@ async def write_abstract_overview(
             next_freshness["pending_child_changes"] = max(current_pending - consumed, 0)
             merged_metadata["freshness"] = next_freshness
 
-        overview_body_changed = existing_overview is None or semantic_body_digest(
-            existing_overview.body
-        ) != semantic_body_digest(overview)
-        abstract_body_changed = existing_abstract is None or semantic_body_digest(
-            existing_abstract.body
-        ) != semantic_body_digest(abstract)
+        overview_body_changed = (
+            existing_overview is None
+            or semantic_body_digest(existing_overview.body) != semantic_body_digest(overview)
+        )
+        # A content-free abstract must not be persisted: a bare structural
+        # marker (e.g. a thematic break) would be misparsed as unclosed YAML
+        # frontmatter and break semantic search for the subtree (issue #4336).
+        write_abstract = bool(abstract.strip())
+        if not write_abstract:
+            logger.info(
+                "%s Skipping empty abstract write for %s (no prose extracted)",
+                log_prefix,
+                dir_uri,
+            )
+        abstract_body_changed = write_abstract and (
+            existing_abstract is None
+            or semantic_body_digest(existing_abstract.body) != semantic_body_digest(abstract)
+        )
 
         rendered_overview = render_abstract_overview(
             ContextLevel.OVERVIEW, dir_uri, overview, merged_metadata
         )
-        rendered_abstract = render_abstract_overview(
-            ContextLevel.ABSTRACT, dir_uri, abstract, merged_metadata
+        rendered_abstract = (
+            render_abstract_overview(
+                ContextLevel.ABSTRACT, dir_uri, abstract, merged_metadata
+            )
+            if write_abstract
+            else ""
         )
         current_overview = await _raw_if_exists(viking_fs, overview_uri, ctx)
         current_abstract = await _raw_if_exists(viking_fs, abstract_uri, ctx)
@@ -510,7 +526,7 @@ async def write_abstract_overview(
             await viking_fs.write_file(
                 overview_uri, rendered_overview, ctx=ctx, lease_ref=sidecar_lease
             )
-        if current_abstract != rendered_abstract:
+        if write_abstract and current_abstract != rendered_abstract:
             await viking_fs.write_file(
                 abstract_uri, rendered_abstract, ctx=ctx, lease_ref=sidecar_lease
             )

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1133,27 +1133,42 @@ class SemanticProcessor(DequeueHandlerBase):
 
         return candidate + "..."
 
+    _THEMATIC_BREAK_RE = re.compile(r"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$")
+
     def _extract_abstract_from_overview(self, overview_content: str) -> str:
-        """Extract an abstract from the Markdown overview brief description."""
+        """Extract an abstract from the Markdown overview brief description.
+
+        Headings, blank lines and Markdown thematic breaks before the first
+        prose line are structural decoration (title block, separators) and are
+        skipped; extraction stops at the first ``##`` heading after prose has
+        started. This prevents a bare ``---`` separator from becoming the whole
+        abstract (issue #4336), which the semantic-sidecar parser would then
+        misread as unclosed YAML frontmatter.
+        """
         overview_content = body_for_preview(overview_content)
         lines = overview_content.split("\n")
 
-        # Skip header lines (starting with #)
-        content_lines = []
-        in_header = True
+        content_lines: List[str] = []
+        found_prose = False
 
         for line in lines:
-            if in_header and line.startswith("#"):
-                continue
-            elif in_header and line.strip():
-                in_header = False
+            stripped = line.strip()
+            is_heading = line.startswith("#")
+            is_break = bool(self._THEMATIC_BREAK_RE.match(line))
 
-            if not in_header:
-                # Stop at first ##
-                if line.startswith("##"):
-                    break
-                if line.strip():
-                    content_lines.append(line.strip())
+            if not found_prose:
+                if is_heading or is_break or not stripped:
+                    continue
+                found_prose = True
+                content_lines.append(stripped)
+                continue
+
+            # Stop at first ## after the brief description has started
+            if line.startswith("##"):
+                break
+            if is_break or not stripped:
+                continue
+            content_lines.append(stripped)
 
         return "\n".join(content_lines).strip()
 

--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1133,42 +1133,59 @@ class SemanticProcessor(DequeueHandlerBase):
 
         return candidate + "..."
 
-    _THEMATIC_BREAK_RE = re.compile(r"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$")
+    # CommonMark thematic break: three or more matching -, _ or * chars,
+    # optionally separated by spaces or tabs (---, * * *, ___).
+    _THEMATIC_BREAK_RE = re.compile(r"^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$")
+    _HEADING_RE = re.compile(r"^#{1,6}[ \t]+(.*)$")
+    # Label prefix of a heading that carries its body inline, e.g.
+    # "Brief Description: This directory contains ..." (also fullwidth colon).
+    _HEADING_LABEL_RE = re.compile(r"^([^:：]{1,48})[:：][ \t]*(\S.*)$")
+
+    @classmethod
+    def _inline_heading_body(cls, heading_text: str) -> Optional[str]:
+        """Return the body carried inline after a heading label, if any."""
+        match = cls._HEADING_LABEL_RE.match(heading_text.strip())
+        return match.group(2).strip() if match else None
 
     def _extract_abstract_from_overview(self, overview_content: str) -> str:
         """Extract an abstract from the Markdown overview brief description.
 
         Headings, blank lines and Markdown thematic breaks before the first
         prose line are structural decoration (title block, separators) and are
-        skipped; extraction stops at the first ``##`` heading after prose has
-        started. This prevents a bare ``---`` separator from becoming the whole
-        abstract (issue #4336), which the semantic-sidecar parser would then
-        misread as unclosed YAML frontmatter.
+        skipped; a heading that carries its brief inline
+        (``#### Brief Description: ...``) yields the text after the label.
+        Once prose has started, the next heading of any level ends the
+        abstract section. This prevents a bare ``---`` separator from becoming
+        the whole abstract (issue #4336), which the semantic-sidecar parser
+        would then misread as unclosed YAML frontmatter.
         """
         overview_content = body_for_preview(overview_content)
         lines = overview_content.split("\n")
 
         content_lines: List[str] = []
-        found_prose = False
+        in_header = True
 
         for line in lines:
+            if self._THEMATIC_BREAK_RE.match(line):
+                # Structural, never content: a leading thematic break must
+                # not end the header block nor be collected as the abstract.
+                continue
+
+            heading = self._HEADING_RE.match(line)
+            if heading:
+                if not in_header:
+                    # The brief-description body has ended at the next heading.
+                    break
+                inline_body = self._inline_heading_body(heading.group(1))
+                if inline_body:
+                    content_lines.append(inline_body)
+                    in_header = False
+                continue
+
             stripped = line.strip()
-            is_heading = line.startswith("#")
-            is_break = bool(self._THEMATIC_BREAK_RE.match(line))
-
-            if not found_prose:
-                if is_heading or is_break or not stripped:
-                    continue
-                found_prose = True
+            if stripped:
                 content_lines.append(stripped)
-                continue
-
-            # Stop at first ## after the brief description has started
-            if line.startswith("##"):
-                break
-            if is_break or not stripped:
-                continue
-            content_lines.append(stripped)
+                in_header = False
 
         return "\n".join(content_lines).strip()
 

--- a/tests/storage/test_abstract_thematic_break.py
+++ b/tests/storage/test_abstract_thematic_break.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Directory abstract extraction must not emit bare thematic breaks (issue #4336).
+
+A ``---`` separator between the overview headings and the brief description was
+treated as the first content line, so ``.abstract.md`` ended up containing
+exactly ``---`` and the semantic-sidecar parser failed with
+"frontmatter is not closed" for the whole subtree.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from openviking.storage.abstract_overview import write_abstract_overview
+from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+REPRO_OVERVIEW = """### Directory
+#### wiki
+
+---
+
+#### Brief Description:
+This directory contains public-service and legal-aid documents.
+
+## Details
+Other section.
+"""
+
+
+def _extract(content: str) -> str:
+    processor = object.__new__(SemanticProcessor)
+    return processor._extract_abstract_from_overview(content)
+
+
+def test_repro_thematic_break_before_brief_description() -> None:
+    abstract = _extract(REPRO_OVERVIEW)
+    assert abstract == "This directory contains public-service and legal-aid documents."
+
+
+def test_bare_thematic_break_only_overview_yields_empty_abstract() -> None:
+    assert _extract("### Directory\n#### wiki\n\n---\n") == ""
+
+
+def test_plain_overview_still_extracts_first_section() -> None:
+    content = "## Overview\nFirst paragraph.\nSecond line.\n\n## Next\nlater"
+    assert _extract(content) == "First paragraph.\nSecond line."
+
+
+def test_thematic_break_inside_brief_description_is_skipped() -> None:
+    content = "#### Brief Description:\nPart one.\n\n---\n\nPart two.\n\n## Next\nx"
+    assert _extract(content) == "Part one.\nPart two."
+
+
+class _RecordingFS:
+    """Minimal VikingFS double: records writes, no existing sidecars."""
+
+    def __init__(self) -> None:
+        self.writes: Dict[str, str] = {}
+
+    async def _uri_to_path(self, uri: str, ctx: Optional[Any] = None) -> str:
+        return uri
+
+    async def read_file(self, uri: str, ctx: Optional[Any] = None) -> str:
+        if uri in self.writes:
+            return self.writes[uri]
+        raise KeyError(uri)
+
+    async def write_file(self, uri: str, body: str, ctx: Optional[Any] = None, **_: Any) -> None:
+        self.writes[uri] = body
+
+
+class _NullLease:
+    pass
+
+
+class _StubAGFS:
+    async def pathlock_acquire_exact_batch(self, paths: List[str]) -> _NullLease:
+        return _NullLease()
+
+    async def pathlock_release(self, lease: _NullLease) -> None:
+        return None
+
+
+class _LockableFS(_RecordingFS):
+    def __init__(self) -> None:
+        super().__init__()
+        self._async_agfs = _StubAGFS()
+
+
+@pytest.mark.asyncio
+async def test_empty_abstract_is_not_persisted() -> None:
+    fs = _LockableFS()
+    result = await write_abstract_overview(
+        viking_fs=fs,
+        dir_uri="viking://user/u/resources/dir",
+        overview="Meaningful overview prose.",
+        abstract="",
+        ctx=None,
+        is_stale=lambda: False,
+    )
+    assert result.wrote is True
+    assert any(uri.endswith(".overview.md") for uri in fs.writes)
+    assert not any(uri.endswith(".abstract.md") for uri in fs.writes), (
+        "a content-free abstract must not be persisted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prose_abstract_is_still_persisted() -> None:
+    fs = _LockableFS()
+    await write_abstract_overview(
+        viking_fs=fs,
+        dir_uri="viking://user/u/resources/dir",
+        overview="Meaningful overview prose.",
+        abstract="A real abstract sentence.",
+        ctx=None,
+        is_stale=lambda: False,
+    )
+    assert any(uri.endswith(".abstract.md") for uri in fs.writes)

--- a/tests/storage/test_abstract_thematic_break.py
+++ b/tests/storage/test_abstract_thematic_break.py
@@ -49,6 +49,33 @@ def test_plain_overview_still_extracts_first_section() -> None:
     assert _extract(content) == "First paragraph.\nSecond line."
 
 
+def test_inline_brief_heading_yields_body_after_label() -> None:
+    content = "### Directory\n#### wiki\n\n---\n\n#### Brief Description: This directory contains public-service and legal-aid documents.\n"
+    assert _extract(content) == "This directory contains public-service and legal-aid documents."
+
+
+def test_inline_brief_heading_fullwidth_colon_zh() -> None:
+    content = "#### \u7b80\u8981\u63cf\u8ff0\uff1a\u672c\u76ee\u5f55\u5305\u542b\u516c\u5171\u670d\u52a1\u4e0e\u6cd5\u5f8b\u63f4\u52a9\u6587\u6863\u3002"
+    assert _extract(content) == "\u672c\u76ee\u5f55\u5305\u542b\u516c\u5171\u670d\u52a1\u4e0e\u6cd5\u5f8b\u63f4\u52a9\u6587\u6863\u3002"
+
+
+def test_heading_of_any_level_ends_abstract_section() -> None:
+    content = (
+        "#### Brief Description:\nPart one.\n\n#### Notes\nstray notes text\n"
+    )
+    assert _extract(content) == "Part one."
+
+
+def test_spaced_thematic_break_variant_is_skipped() -> None:
+    content = "### Directory\n#### wiki\n\n- - -\n\nFirst prose line.\n"
+    assert _extract(content) == "First prose line."
+
+
+def test_structural_headings_do_not_leak_into_abstract() -> None:
+    content = "### Directory\n#### wiki\n#### Brief Description:\nReal prose here.\n"
+    assert _extract(content) == "Real prose here."
+
+
 def test_thematic_break_inside_brief_description_is_skipped() -> None:
     content = "#### Brief Description:\nPart one.\n\n---\n\nPart two.\n\n## Next\nx"
     assert _extract(content) == "Part one.\nPart two."


### PR DESCRIPTION
Fixes #4336.

## Problem

`_extract_abstract_from_overview()` treated a Markdown thematic break (`---`) between the overview headings and the brief-description section as the first content line, then stopped at the following heading. The persisted `.abstract.md` contained exactly `---`, which the semantic-sidecar parser misreads as unclosed YAML frontmatter — `find`/`search` then fail with `InvalidArgumentError: semantic sidecar frontmatter is not closed` for the affected subtree.

## Change

- `_extract_abstract_from_overview` now treats headings, blank lines and thematic breaks (`---`/`***`/`___` variants) before the first prose line as structural decoration and skips them; extraction stops at the first `##` heading after prose has started. The brief-description text is captured instead of the separator.
- `write_abstract_overview` no longer persists a content-free abstract: when no prose was extracted, `.overview.md` is still written but the `.abstract.md` write is skipped, so structurally invalid sidecars cannot reach storage.

## Tests

`tests/storage/test_abstract_thematic_break.py` — 6 cases: the exact issue repro, bare-break-only overview → empty abstract, plain overview behavior unchanged, break inside the brief description, empty abstract not persisted, prose abstract still persisted. Also verified adjacent suites (`test_abstract_overview_freshness.py` 4/4, `test_semantic_dag_stats.py` 8/8).