### PR TITLE
fix(semantic): skip thematic breaks when extracting directory abstracts

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -57,6 +57,20 @@ from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# CommonMark thematic break: three or more matching -, _ or * chars,
+# optionally separated by spaces or tabs (---, * * *, ___).
+_THEMATIC_BREAK_RE = re.compile(r"^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$")
+_HEADING_RE = re.compile(r"^#{1,6}[ \t]+(.*)$")
+# Label prefix of a heading that carries its body inline, e.g.
+# "Brief Description: This directory contains ..." (also fullwidth colon).
+_HEADING_LABEL_RE = re.compile(r"^([^:：]{1,48})[:：][ \t]*(\S.*)$")
+
+
+def _split_heading_label(inline_text: str) -> Optional[str]:
+    """Return the body carried inline after a heading label, if any."""
+    match = _HEADING_LABEL_RE.match(inline_text.strip())
+    return match.group(2).strip() if match else None
+
 
 class RequestQueueStats:
     processed: int = 0
@@ -993,22 +1007,31 @@ class SemanticProcessor(DequeueHandlerBase):
         """Extract an abstract from the Markdown overview brief description."""
         lines = overview_content.split("\n")
 
-        # Skip header lines (starting with #)
-        content_lines = []
+        content_lines: List[str] = []
         in_header = True
 
         for line in lines:
-            if in_header and line.startswith("#"):
+            if _THEMATIC_BREAK_RE.match(line):
+                # Structural, never content: a leading thematic break must not
+                # end the header block nor be collected as the abstract (#4336).
                 continue
-            elif in_header and line.strip():
-                in_header = False
 
-            if not in_header:
-                # Stop at first ##
-                if line.startswith("##"):
+            heading = _HEADING_RE.match(line)
+            if heading:
+                if not in_header:
+                    # The brief-description body has ended at the next heading.
                     break
-                if line.strip():
-                    content_lines.append(line.strip())
+                # A heading line that itself carries the brief text
+                # ("#### Brief Description: ...") yields the text after the label.
+                inline_brief = _split_heading_label(heading.group(1))
+                if inline_brief:
+                    content_lines.append(inline_brief)
+                    in_header = False
+                continue
+
+            if line.strip():
+                in_header = False
+                content_lines.append(line.strip())
 
         return "\n".join(content_lines).strip()
 

--- a/openviking/storage/queuefs/semantic_sidecar.py
+++ b/openviking/storage/queuefs/semantic_sidecar.py
@@ -2,12 +2,33 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Shared writeback for semantic sidecar files."""
 
+import re
 from typing import Any, Callable, Dict, Optional
 
 from openviking.server.identity import RequestContext
 from openviking_cli.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_THEMATIC_BREAK_RE = re.compile(r"^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$")
+
+
+def has_retrievable_abstract_text(text: str) -> bool:
+    """True if the abstract contains at least one non-structural text line.
+
+    A bare thematic break (``---``) or heading-only content would persist a
+    structurally invalid sidecar: the reader treats a leading ``---`` as an
+    opening frontmatter delimiter and fails with "frontmatter is not closed"
+    (#4336). Such content must not be written at all.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or _THEMATIC_BREAK_RE.match(stripped):
+            continue
+        if stripped.startswith("#"):
+            continue
+        return True
+    return False
 
 
 async def write_semantic_sidecars(
@@ -60,6 +81,13 @@ async def _write_sidecars(
         ctx=ctx,
         lease_ref=lease_ref,
     )
+    if not has_retrievable_abstract_text(abstract):
+        logger.warning(
+            "[SemanticSidecar] Skipping content-free abstract for %s "
+            "(no retrievable text; would break sidecar parsing)",
+            dir_uri,
+        )
+        return
     await viking_fs.write_file(
         f"{dir_uri}/.abstract.md",
         abstract,

--- a/tests/storage/test_semantic_processor_l0_l1.py
+++ b/tests/storage/test_semantic_processor_l0_l1.py
@@ -50,6 +50,78 @@ def test_markdown_overview_extracts_multiline_brief_description(monkeypatch):
     assert abstract == "This is the first abstract line.\nThis is the second abstract line."
 
 
+def test_abstract_extraction_skips_leading_thematic_break(monkeypatch):
+    """A leading thematic break must never become the abstract (#4336)."""
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = (
+        "### Directory\n"
+        "#### wiki\n"
+        "---\n"
+        "#### Brief Description: This directory contains public-service and legal-aid documents.\n"
+    )
+
+    _, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == "This directory contains public-service and legal-aid documents."
+
+
+def test_abstract_extraction_skips_thematic_break_before_body(monkeypatch):
+    """Thematic break variants are structural, not abstract content (#4336)."""
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = (
+        "# docs\n"
+        "***\n"
+        "_ _ _\n"
+        "-  -  -\n"
+        "The real brief description sentence.\n\n"
+        "## Quick Navigation\n"
+    )
+
+    _, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == "The real brief description sentence."
+
+
+def test_abstract_extraction_returns_empty_for_structure_only_overview(monkeypatch):
+    """Heading/break-only output must yield an empty abstract, not '---' (#4336)."""
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = "### Directory\n#### wiki\n---\n#### Brief Description\n"
+
+    _, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == ""
+
+
+def test_abstract_extraction_fullwidth_colon_heading_label(monkeypatch):
+    """Chinese '简要描述：<正文>' headings also yield their inline body."""
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = "### 目录\n#### wiki\n---\n#### 简要描述：本目录包含公共服务与法律援助文档。\n"
+
+    _, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == "本目录包含公共服务与法律援助文档。"
+
+
+def test_abstract_extraction_stops_at_heading_after_body(monkeypatch):
+    """Any heading after the brief body ends the abstract section."""
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = (
+        "# README\n\n"
+        "Brief body line.\n\n"
+        "### A nested section heading\n"
+        "Text that must not be collected.\n"
+    )
+
+    _, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == "Brief body line."
+
+
 def test_index_references_are_replaced_inside_markdown_overview(monkeypatch):
     _patch_semantic_limits(monkeypatch)
     processor = SemanticProcessor()

--- a/tests/storage/test_semantic_sidecar_content_free.py
+++ b/tests/storage/test_semantic_sidecar_content_free.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+"""Content-free abstracts must not be persisted as .abstract.md sidecars (#4336)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openviking.storage.queuefs.semantic_sidecar import (
+    has_retrievable_abstract_text,
+    write_semantic_sidecars,
+)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("---", False),
+        ("***", False),
+        ("___", False),
+        ("- - -", False),
+        ("", False),
+        ("   \n", False),
+        ("# Heading only\n---\n", False),
+        ("This directory contains documents.", True),
+        ("---\nSecond line is real text.", True),
+        ("# Heading\nFollowed by a real body line.", True),
+    ],
+)
+def test_has_retrievable_abstract_text(text, expected):
+    assert has_retrievable_abstract_text(text) is expected
+
+
+@pytest.mark.asyncio
+async def test_write_semantic_sidecars_skips_content_free_abstract():
+    viking_fs = MagicMock()
+    viking_fs._uri_to_path = MagicMock(return_value="/tmp/ignored")
+    viking_fs._async_agfs.pathlock_acquire_exact_batch = AsyncMock(return_value={"lease": 1})
+    viking_fs._async_agfs.pathlock_release = AsyncMock()
+    viking_fs.write_file = AsyncMock()
+
+    wrote = await write_semantic_sidecars(
+        viking_fs=viking_fs,
+        dir_uri="viking://resources/x",
+        overview="# Overview\n\nBody",
+        abstract="---",
+        ctx=None,
+        is_stale=lambda: False,
+    )
+
+    assert wrote is True
+    written_paths = [call.args[0] for call in viking_fs.write_file.await_args_list]
+    assert "viking://resources/x/.overview.md" in written_paths
+    assert "viking://resources/x/.abstract.md" not in written_paths
+
+
+@pytest.mark.asyncio
+async def test_write_semantic_sidecars_writes_real_abstract():
+    viking_fs = MagicMock()
+    viking_fs._uri_to_path = MagicMock(return_value="/tmp/ignored")
+    viking_fs._async_agfs.pathlock_acquire_exact_batch = AsyncMock(return_value={"lease": 1})
+    viking_fs._async_agfs.pathlock_release = AsyncMock()
+    viking_fs.write_file = AsyncMock()
+
+    wrote = await write_semantic_sidecars(
+        viking_fs=viking_fs,
+        dir_uri="viking://resources/x",
+        overview="# Overview\n\nBody",
+        abstract="Real abstract text.",
+        ctx=None,
+        is_stale=lambda: False,
+    )
+
+    assert wrote is True
+    written_paths = [call.args[0] for call in viking_fs.write_file.await_args_list]
+    assert "viking://resources/x/.abstract.md" in written_paths


### PR DESCRIPTION
## Problem

A directory overview that contains a Markdown thematic break (`---`) between its leading headings and the brief description made `_extract_abstract_from_overview()` treat the break as the first content line and stop at the following heading. The generated `.abstract.md` then contained exactly `---` (3 bytes).

The semantic-sidecar reader parses a leading `---` as an opening YAML frontmatter delimiter; with no closing delimiter, every `find`/`search` against the affected resource subtree fails with:

```
InvalidArgumentError: semantic sidecar frontmatter is not closed
```

Reproducer (from #4336):

```python
overview = (
    "### Directory\n"
    "#### wiki\n"
    "---\n"
    "#### Brief Description: This directory contains public-service and legal-aid documents.\n"
)
# before: _extract_abstract_from_overview(overview) == "---"
# after:  == "This directory contains public-service and legal-aid documents."
```

## Fix (two layers)

**1. Extraction — `semantic_processor._extract_abstract_from_overview`**
- Thematic breaks (`---`/`***`/`___`, including spaced variants, per CommonMark) are structural: they neither end the leading-header block nor get collected as content.
- A heading line that carries its body inline (`#### Brief Description: <body>`, also fullwidth `：` for zh overviews) yields the text after the label, so the real prose is extracted instead of nothing.
- Once the brief body has started, any heading ends the abstract section (previously only `##` did).

**2. Writeback guard — `semantic_sidecar.write_semantic_sidecars`**
- A content-free abstract (empty, bare thematic break, headings only) is no longer persisted at all, so a structurally invalid sidecar can never ship. Readers already guard with `exists()` and degrade to an empty abstract, so a missing `.abstract.md` is safe.

## Tests

- `tests/storage/test_semantic_processor_l0_l1.py`: 5 new regressions (issue reproducer, thematic-break variants, structure-only overview → empty, fullwidth-colon zh heading, heading-after-body stops collection). Existing brief-description tests unchanged and passing.
- `tests/storage/test_semantic_sidecar_content_free.py`: new — 10 parametrized cases for `has_retrievable_abstract_text` + async write/skip behavior of `write_semantic_sidecars`.

Fixes #4336