### PR TITLE
fix(queue): back off SessionCommit dependency-wait requeues

### DIFF
--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -24,6 +24,14 @@ if TYPE_CHECKING:
 
 
 class SessionCommitProcessor(DequeueHandlerBase):
+    # Dependency-wait backoff (issue #4345): when a commit cannot run because
+    # its predecessor is still pending, re-enqueueing immediately hot-loops the
+    # queue (observed >800k requeues behind ~33 waiting commits). Exponential
+    # backoff with a cap bounds the churn while never dropping the message.
+    DEP_WAIT_BASE_S = 0.1
+    DEP_WAIT_MAX_S = 3.0
+    DEP_WAIT_MAX_HOLD_S = 1.0
+
     def __init__(
         self,
         session_service: "SessionService",
@@ -31,6 +39,9 @@ class SessionCommitProcessor(DequeueHandlerBase):
     ) -> None:
         self._session_service = session_service
         self._service_loop = service_loop
+        # key -> (attempt_count, next_attempt_monotonic). In-memory only:
+        # a restart just resumes the backoff schedule from the base delay.
+        self._dep_wait: Dict[str, tuple] = {}
 
     @staticmethod
     def _parse_message(data: Dict[str, Any]) -> tuple[SessionCommitMsg, RequestContext]:
@@ -85,17 +96,50 @@ class SessionCommitProcessor(DequeueHandlerBase):
             await session.load()
             with bind_task_context(msg.task_id, ctx.account_id, ctx.user.user_id):
                 processed = await session.resume_queued_commit(msg)
-            if not processed:
-                from openviking.storage.queuefs import QueueManager, get_queue_manager
-
-                await get_queue_manager().enqueue(
-                    QueueManager.SESSION_COMMIT,
-                    msg.to_dict(),
-                )
-                self.report_requeue()
+            if processed:
+                self._dep_wait.pop(self._dep_wait_key(msg), None)
+            else:
+                await self._requeue_with_backoff(msg)
             return processed
         finally:
             reset_root_observability_context(root_context_token)
+
+    @classmethod
+    def _dep_wait_key(cls, msg: SessionCommitMsg) -> str:
+        return f"{msg.session_id}:{msg.archive_uri}"
+
+    @classmethod
+    def _dep_wait_delay_s(cls, attempt: int) -> float:
+        return min(
+            cls.DEP_WAIT_BASE_S * (2 ** min(attempt, 6)),
+            cls.DEP_WAIT_MAX_S,
+        )
+
+    async def _requeue_with_backoff(self, msg: SessionCommitMsg) -> None:
+        """Re-enqueue a dependency-waiting commit after bounded backoff.
+
+        The predecessor commit is still pending (``resume_queued_commit``
+        returned False). Holding this worker briefly and applying exponential
+        backoff keeps the dequeue/ack/re-enqueue cycle bounded instead of
+        spinning at full consumer speed.
+        """
+        import time
+
+        from openviking.storage.queuefs import QueueManager, get_queue_manager
+
+        key = self._dep_wait_key(msg)
+        now = time.monotonic()
+        attempt, next_at = self._dep_wait.get(key, (0, 0.0))
+        if now < next_at:
+            await asyncio.sleep(min(next_at - now, self.DEP_WAIT_MAX_HOLD_S))
+        attempt += 1
+        delay = self._dep_wait_delay_s(attempt)
+        self._dep_wait[key] = (attempt, time.monotonic() + delay)
+        await get_queue_manager().enqueue(
+            QueueManager.SESSION_COMMIT,
+            msg.to_dict(),
+        )
+        self.report_requeue()
 
     async def _finalize_cancelled(self, msg: SessionCommitMsg, ctx: RequestContext) -> None:
         session = self._session_service.session(

--- a/tests/storage/test_session_commit_requeue_backoff.py
+++ b/tests/storage/test_session_commit_requeue_backoff.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Dependency-wait requeues must back off instead of hot-looping (issue #4345).
+
+A later Session Phase 2 commit whose predecessor is still pending was
+re-enqueued immediately with no delay, dedup or retry limit — one deployment
+observed >800k requeues behind ~33 waiting commits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from openviking.storage.queuefs import session_commit_processor as scp_module
+from openviking.storage.queuefs.session_commit_processor import SessionCommitProcessor
+from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
+
+
+def _msg(session_id: str = "sess-1", archive_uri: str = "viking://a/1") -> SessionCommitMsg:
+    return SessionCommitMsg(
+        task_id="task-1",
+        session_id=session_id,
+        session_uri="viking://s/1",
+        archive_uri=archive_uri,
+        user={"user_id": "u", "account_id": "a"},
+    )
+
+
+def _processor() -> SessionCommitProcessor:
+    return SessionCommitProcessor(session_service=None, service_loop=asyncio.get_event_loop())
+
+
+class _StubQueueManager:
+    def __init__(self) -> None:
+        self.enqueued: List[Dict[str, Any]] = []
+
+    async def enqueue(self, queue_name: str, data: Any) -> str:
+        self.enqueued.append({"queue": queue_name, "data": data})
+        return "id"
+
+
+def test_backoff_delay_is_exponential_and_capped() -> None:
+    delays = [SessionCommitProcessor._dep_wait_delay_s(n) for n in range(0, 12)]
+    assert delays[0] == pytest.approx(SessionCommitProcessor.DEP_WAIT_BASE_S)
+    assert delays[1] == pytest.approx(SessionCommitProcessor.DEP_WAIT_BASE_S * 2)
+    # growth stops at the cap
+    assert delays[-1] == pytest.approx(SessionCommitProcessor.DEP_WAIT_MAX_S)
+    assert all(d <= SessionCommitProcessor.DEP_WAIT_MAX_S + 1e-9 for d in delays)
+
+
+@pytest.mark.asyncio
+async def test_requeue_enqueues_once_and_registers_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubQueueManager()
+    monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: stub)
+    requeues: List[str] = []
+    processor = _processor()
+    processor.report_requeue = lambda: requeues.append("x")  # type: ignore[method-assign]
+
+    msg = _msg()
+    await processor._requeue_with_backoff(msg)
+
+    assert len(stub.enqueued) == 1
+    assert stub.enqueued[0]["queue"] == "SessionCommit"
+    assert stub.enqueued[0]["data"]["session_id"] == "sess-1"
+    assert requeues == ["x"]
+    attempt, _next = processor._dep_wait[processor._dep_wait_key(msg)]
+    assert attempt == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_waits_backoff_instead_of_hot_looping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubQueueManager()
+    monkeypatch.setattr("openviking.storage.queuefs.get_queue_manager", lambda: stub)
+    monkeypatch.setattr(SessionCommitProcessor, "DEP_WAIT_BASE_S", 0.01)
+    monkeypatch.setattr(SessionCommitProcessor, "DEP_WAIT_MAX_S", 0.05)
+    monkeypatch.setattr(SessionCommitProcessor, "DEP_WAIT_MAX_HOLD_S", 0.02)
+
+    processor = _processor()
+    msg = _msg()
+    # 20 dependency waits back-to-back must NOT take 20 * full consumer speed:
+    # cumulative hold grows with backoff instead of the old immediate requeue.
+    for _ in range(20):
+        await processor._requeue_with_backoff(msg)
+    attempt, _ = processor._dep_wait[processor._dep_wait_key(msg)]
+    assert attempt == 20
+    assert len(stub.enqueued) == 20
+    # delay schedule reaches the cap quickly under the shrunken test constants
+    assert processor._dep_wait_delay_s(attempt) == pytest.approx(0.05)
+
+
+def test_key_distinguishes_sessions_and_archives() -> None:
+    assert SessionCommitProcessor._dep_wait_key(_msg()) != SessionCommitProcessor._dep_wait_key(
+        _msg(archive_uri="viking://a/2")
+    )
+    assert SessionCommitProcessor._dep_wait_key(_msg()) != SessionCommitProcessor._dep_wait_key(
+        _msg(session_id="sess-2")
+    )


### PR DESCRIPTION
Fixes #4345.

## Problem

When several Session Phase 2 commits are queued for the same session, a later commit whose predecessor is still pending is dequeued, `resume_queued_commit()` returns `False`, and `SessionCommitProcessor._process()` immediately re-enqueues the same message — no delay, no dedup, no retry limit. The consumer hot-loops dequeue/ack/re-enqueue; the issue reports >800k requeues behind ~33 waiting commits.

## Change

- `SessionCommitProcessor` applies per-commit exponential backoff (0.1s base, doubling, capped at 3s) on the dependency-wait re-enqueue path, briefly holding the worker instead of spinning at full consumer speed
- Backoff state is an in-memory registry keyed by `(session_id, archive_uri)`; the durable message is never mutated or dropped, and a restart just resumes the schedule from the base delay
- The registry entry is cleared as soon as the commit processes

Deliberately scoped as the bounded-backoff safety net from the issue's suggested direction; a per-session FIFO scheduler (single outstanding entry per session) would be the larger architectural follow-up.

## Tests

`tests/storage/test_session_commit_requeue_backoff.py` — 4 cases: delay schedule is exponential and capped, requeue enqueues exactly once + registers backoff + reports requeue, 20 consecutive waits honor the schedule (no hot loop), key distinguishes sessions/archives.