### PR TITLE
fix(parse): probe MPEG-TS magic bytes for .ts URLs before routing as video

### DIFF
--- a/openviking/parse/accessors/http_accessor.py
+++ b/openviking/parse/accessors/http_accessor.py
@@ -23,12 +23,13 @@ from typing import Any, Dict, Mapping, Optional, Tuple, Union
 from urllib.parse import unquote, urlparse
 
 from openviking.parse.base import lazy_import
-from openviking.parse.parsers.constants import CODE_EXTENSIONS
+from openviking.parse.parsers.constants import CODE_EXTENSIONS, TYPESCRIPT_MPEG_TS_EXTENSION
 from openviking.parse.parsers.media.constants import (
     AUDIO_EXTENSIONS,
     IMAGE_EXTENSIONS,
     VIDEO_EXTENSIONS,
 )
+from openviking.parse.parsers.media.utils import MPEG_TS_PROBE_BYTES, is_mpeg_ts
 from openviking.utils import is_code_hosting_blob_url
 from openviking.utils.network_guard import build_httpx_request_validation_hooks
 from openviking_cli.exceptions import PermissionDeniedError
@@ -694,6 +695,18 @@ class HTTPAccessor(DataAccessor):
             meta["detected_by"] = "magic_bytes"
             meta["magic_extension"] = magic_ext
             meta["refined_by_magic_bytes"] = True
+        elif (
+            url_type == URLType.DOWNLOAD_VIDEO
+            and meta.get("extension") == TYPESCRIPT_MPEG_TS_EXTENSION
+            and not self._looks_like_mpeg_ts(content)
+        ):
+            # A ".ts" extension is ambiguous: MPEG-TS video stream or TypeScript
+            # source. Extension-based detection alone routes it to DOWNLOAD_VIDEO,
+            # so verify the content; fall back to text when the bytes are not an
+            # MPEG-TS stream (fixes #3266).
+            url_type = URLType.DOWNLOAD_TXT
+            meta["detected_by"] = "mpeg_ts_probe"
+            meta["refined_by_mpeg_ts_probe"] = True
 
         meta["resolved_url_type"] = url_type
         if meta.get("refined_by_magic_bytes") and magic_ext:
@@ -733,6 +746,13 @@ class HTTPAccessor(DataAccessor):
             URLType.DOWNLOAD_TXT,
             URLType.DOWNLOAD_HTML,
         }
+
+    @staticmethod
+    def _looks_like_mpeg_ts(content: bytes) -> bool:
+        """Check whether downloaded bytes start with MPEG-TS packet sync bytes."""
+        if len(content) < MPEG_TS_PROBE_BYTES:
+            return False
+        return is_mpeg_ts(content[:MPEG_TS_PROBE_BYTES])
 
     @staticmethod
     def _detect_from_magic_bytes(content: bytes) -> Tuple[URLType, Optional[str]]:

--- a/openviking/tests/parse/accessors/test_http_accessor_ts_routing.py
+++ b/openviking/tests/parse/accessors/test_http_accessor_ts_routing.py
@@ -1,0 +1,75 @@
+from openviking.parse.accessors.http_accessor import HTTPAccessor, URLType
+from openviking.parse.parsers.media.utils import MPEG_TS_PACKET_SIZE, MPEG_TS_PROBE_BYTES
+
+
+def mpeg_ts_probe() -> bytes:
+    content = bytearray(MPEG_TS_PROBE_BYTES)
+    for offset in range(0, MPEG_TS_PROBE_BYTES, MPEG_TS_PACKET_SIZE):
+        content[offset] = 0x47
+    return bytes(content)
+
+
+def typescript_content() -> bytes:
+    return b"export const answer: number = 42;\n"
+
+
+def finalize_for_ts(accessor: HTTPAccessor, url: str, content: bytes) -> URLType:
+    meta = accessor._finalize_download_metadata(
+        url=url,
+        initial_url_type=URLType.DOWNLOAD_VIDEO,
+        initial_meta={"url": url, "detected_by": "extension", "extension": ".ts"},
+        response_headers={},
+        content=content,
+    )
+    assert meta["extension"] == ".ts"
+    return meta["resolved_url_type"]
+
+
+def test_finalize_downgrades_typescript_ts_url_to_text():
+    accessor = HTTPAccessor()
+
+    resolved = finalize_for_ts(
+        accessor, "https://cdn.example.com/lib/source.ts", typescript_content()
+    )
+
+    assert resolved == URLType.DOWNLOAD_TXT
+
+
+def test_finalize_keeps_mpeg_ts_video_for_real_stream():
+    accessor = HTTPAccessor()
+
+    resolved = finalize_for_ts(
+        accessor, "https://cdn.example.com/lib/video.ts", mpeg_ts_probe()
+    )
+
+    assert resolved == URLType.DOWNLOAD_VIDEO
+
+
+def test_finalize_downgrades_short_ts_payload_to_text():
+    accessor = HTTPAccessor()
+
+    resolved = finalize_for_ts(
+        accessor, "https://cdn.example.com/lib/x.ts", b"\x47\x00\x01"
+    )
+
+    # Shorter than an MPEG-TS probe window: cannot be a valid stream.
+    assert resolved == URLType.DOWNLOAD_TXT
+
+
+def test_finalize_does_not_probe_non_ts_video_urls():
+    accessor = HTTPAccessor()
+    content = b"not really a video"
+
+    meta = accessor._finalize_download_metadata(
+        url="https://cdn.example.com/lib/movie.mp4",
+        initial_url_type=URLType.DOWNLOAD_VIDEO,
+        initial_meta={
+            "url": "https://cdn.example.com/lib/movie.mp4",
+            "detected_by": "extension",
+            "extension": ".mp4",
+        },
+        response_headers={},
+        content=content,
+    )
+
+    assert meta["resolved_url_type"] == URLType.DOWNLOAD_VIDEO


### PR DESCRIPTION
## Summary

Fixes #3266

A URL ending in `.ts` is ambiguous: it may be an **MPEG-TS video stream** or a **TypeScript source file**. Local file paths already handle this correctly — `get_media_type()` and `ParserRegistry.get_parser_for_file()` verify the content with `is_mpeg_ts()` magic-byte probing (`0x47` sync bytes at 188-byte packet boundaries).

URL-based detection did not have this guard. `HTTPAccessor.URLTypeDetector` maps `VIDEO_EXTENSIONS` (which includes `.ts`) to `DOWNLOAD_VIDEO` by extension alone, and `_should_use_magic_bytes()` deliberately skips refinement for extension-based detections. As a result, importing a TypeScript source file from a URL routed it through the video understanding pipeline.

### Root cause

```
http_accessor.py EXTENSION_MAP:
    VIDEO_EXTENSIONS -> DOWNLOAD_VIDEO        # .ts included
_finalize_download_metadata():
    extension-based result is never verified against content
```

### Fix

In `_finalize_download_metadata` (which already has the downloaded bytes available), refine the extension-based result:

- If the resolved type is `DOWNLOAD_VIDEO`, the detected extension is `.ts`, and the content does **not** pass an MPEG-TS probe → fall back to `DOWNLOAD_TXT`.
- Real MPEG-TS streams keep the video route unchanged.
- Non-`.ts` video URLs are untouched.

The probe reuses the existing `is_mpeg_ts()` / `MPEG_TS_PROBE_BYTES` helpers, so the local-path and URL paths now agree on how ambiguity is resolved.

## Test plan

- [x] New tests in `openviking/tests/parse/accessors/test_http_accessor_ts_routing.py`:
  - TypeScript content on a `.ts` URL resolves to `DOWNLOAD_TXT`
  - A real MPEG-TS stream on a `.ts` URL stays `DOWNLOAD_VIDEO`
  - Payloads shorter than one MPEG-TS probe window fall back to `DOWNLOAD_TXT`
  - `.mp4` URLs bypass the probe entirely
- [x] Existing suites pass with no regressions: `tests/misc/test_mpeg_ts_media_utils.py` (6), `tests/unit/test_accessors_http.py` (30), plus the 4 new tests — 40 passed
- [x] Verified first-pass detection behavior is intentionally unchanged (`.ts` still maps to `DOWNLOAD_VIDEO` pre-download); refinement happens post-download where content is available