### PR TITLE
fix(session): resolve skill patch-merge schemas from the skill_extract registry (#4368)

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -78,6 +78,10 @@ from openviking.session.train import (
     get_streaming_policy_trainer,
     make_streaming_policy_trainer_key,
 )
+from openviking.session.skill.session_skill_context_provider import (
+    SESSION_SKILL_MEMORY_TYPE,
+    load_skill_extract_registry,
+)
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking_cli.utils import get_logger
@@ -837,6 +841,12 @@ class SessionCompressorV3:
             policy_optimizer=PatchMergePolicyOptimizer(
                 viking_fs=viking_fs,
                 memory_type="skills",
+                # Gradients carry the trainer-level type "skills", but that
+                # schema only exists (as "session_skills") in the dedicated
+                # skill_extract registry — the general registry raises
+                # "Memory schema not found or disabled: skills" (issue #4368).
+                registry_factory=load_skill_extract_registry,
+                schema_memory_type=SESSION_SKILL_MEMORY_TYPE,
             ),
             policy_updater=SkillPolicyUpdater(
                 skill_processor=self.skill_processor,

--- a/openviking/session/memory/patch_merge_context_provider.py
+++ b/openviking/session/memory/patch_merge_context_provider.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, MemoryTypeSchema
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
@@ -121,12 +122,19 @@ class PatchMergeContextProvider(SessionExtractContextProvider):
         patches: list[PatchMergePatch],
         required_file_uris: list[str] | None = None,
         output_language: str | None = None,
+        registry_factory: Any = None,
+        schema_memory_type: str | None = None,
     ):
         super().__init__(messages=[])
         self.memory_type = memory_type
         self.required_file_uris = list(required_file_uris or [])
         self.patches = list(patches)
         self._output_language = output_language or _resolve_patch_output_language(self.patches)
+        self._registry_factory = registry_factory
+        # Schema-registry key when it differs from the trainer-level memory_type
+        # (e.g. gradients carry "skills" while the skill registry registers
+        # "session_skills"; see compressor_v3's session-skill trainer).
+        self._schema_memory_type = schema_memory_type
 
     def instruction(self) -> str:
         output_language = self._output_language
@@ -153,10 +161,19 @@ is an existing file, put it in delete_ids; if it is only a new proposal, omit it
 
     def get_memory_schemas(self, ctx: RequestContext) -> list[MemoryTypeSchema]:
         del ctx
-        schema = self._get_registry().get(self.memory_type)
+        schema_key = self._schema_memory_type or self.memory_type
+        schema = self._get_registry().get(schema_key)
         if schema is None or not schema.enabled:
-            raise ValueError(f"Memory schema not found or disabled: {self.memory_type}")
+            raise ValueError(f"Memory schema not found or disabled: {schema_key}")
         return [schema]
+
+    def _get_registry(self) -> "MemoryTypeRegistry":
+        if self._registry is None:
+            if self._registry_factory is not None:
+                self._registry = self._registry_factory()
+            else:
+                self._registry = MemoryTypeRegistry(load_schemas=True)
+        return self._registry
 
     async def prefetch(self) -> list[dict[str, Any]]:
         messages: list[dict[str, Any]] = []

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -48,6 +48,13 @@ class PatchMergePolicyOptimizer:
     viking_fs: Any = None
     vlm: Any = None
     memory_type: str = "experiences"
+    # Optional override for the memory-schema registry the provider queries
+    # (default: general MemoryTypeRegistry). The session-skill trainer passes
+    # load_skill_extract_registry because its schema only exists there.
+    registry_factory: Any = None
+    # Registry lookup key when it differs from memory_type ("skills" gradients
+    # resolve against the "session_skills" schema key).
+    schema_memory_type: str | None = None
 
     @tracer(
         "train.policy_optimizer.patch_merge.plan",
@@ -130,6 +137,8 @@ class PatchMergePolicyOptimizer:
             memory_type=self.memory_type,
             required_file_uris=_required_file_uris(gradients, policy_set),
             patches=[_gradient_to_merge_patch(gradient) for gradient in gradients],
+            registry_factory=self.registry_factory,
+            schema_memory_type=self.schema_memory_type,
         )
         provider._ctx = context.request_context
         provider._viking_fs = viking_fs

--- a/tests/session/test_patch_merge_skill_registry.py
+++ b/tests/session/test_patch_merge_skill_registry.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Session-skill patch-merge must resolve schemas from the skill registry (issue #4368).
+
+`Compressor._get_session_skill_trainer` builds a `PatchMergePolicyOptimizer`
+with the trainer-level ``memory_type="skills"``. Gradients from
+``_skill_operations_to_gradients`` carry the same value, but the schema
+describing skills only exists (under the key ``session_skills``) in the
+dedicated ``skill_extract`` registry — the general ``MemoryTypeRegistry``
+never contains it, so the default provider raised
+``Memory schema not found or disabled: skills`` on every commit that reached
+skill extraction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openviking.session.memory.dataclass import MemoryFile
+from openviking.session.memory.patch_merge_context_provider import (
+    PatchMergeContextProvider,
+    PatchMergePatch,
+)
+from openviking.session.skill.session_skill_context_provider import (
+    SESSION_SKILL_MEMORY_TYPE,
+    load_skill_extract_registry,
+)
+from openviking.session.train.components.policy_optimizer import (
+    PatchMergePolicyOptimizer,
+)
+
+
+def _skill_patch() -> PatchMergePatch:
+    return PatchMergePatch(
+        before_file=None,
+        after_file=MemoryFile(
+            uri="viking://memories/default/user/skills/pdf-merge/SKILL.md",
+            content="Merge PDFs with a single command.",
+            memory_type="skills",
+            extra_fields={"memory_type": "skills", "skill_name": "pdf-merge"},
+        ),
+    )
+
+
+def test_skill_provider_resolves_schema_from_skill_registry() -> None:
+    """The skill path must query the skill registry under 'session_skills'."""
+    provider = PatchMergeContextProvider(
+        memory_type="skills",
+        patches=[_skill_patch()],
+        registry_factory=load_skill_extract_registry,
+        schema_memory_type=SESSION_SKILL_MEMORY_TYPE,
+    )
+    schemas = provider.get_memory_schemas(None)
+    assert len(schemas) == 1
+    assert schemas[0].memory_type == SESSION_SKILL_MEMORY_TYPE
+    assert schemas[0].enabled
+
+
+def test_skill_provider_default_registry_still_raises() -> None:
+    """Guard: without injection the general registry has no 'skills' entry.
+
+    If this ever starts passing because 'skills' became a first-class general
+    schema, the injection in ``_get_session_skill_trainer`` can be dropped.
+    """
+    provider = PatchMergeContextProvider(
+        memory_type="skills",
+        patches=[_skill_patch()],
+    )
+    with pytest.raises(ValueError, match="skills"):
+        provider.get_memory_schemas(None)
+
+
+def test_default_experiences_path_is_unchanged() -> None:
+    """No injection → general registry + memory_type key, exactly as before."""
+    provider = PatchMergeContextProvider(
+        memory_type="experiences",
+        patches=[],
+    )
+    schemas = provider.get_memory_schemas(None)
+    assert len(schemas) == 1
+    assert schemas[0].memory_type == "experiences"
+    assert schemas[0].enabled
+
+
+def test_optimizer_defaults_preserve_legacy_construction() -> None:
+    """Existing call sites (experiences) construct the optimizer unchanged."""
+    optimizer = PatchMergePolicyOptimizer(viking_fs=None, memory_type="experiences")
+    assert optimizer.registry_factory is None
+    assert optimizer.schema_memory_type is None
+
+
+def test_optimizer_passes_registry_config_to_provider() -> None:
+    """The optimizer forwards the registry override into the provider it builds."""
+    optimizer = PatchMergePolicyOptimizer(
+        viking_fs=None,
+        memory_type="skills",
+        registry_factory=load_skill_extract_registry,
+        schema_memory_type=SESSION_SKILL_MEMORY_TYPE,
+    )
+    provider = PatchMergeContextProvider(
+        memory_type=optimizer.memory_type,
+        patches=[],
+        registry_factory=optimizer.registry_factory,
+        schema_memory_type=optimizer.schema_memory_type,
+    )
+    # Same wiring _run_merge_extract_loop uses; must resolve, not raise.
+    schemas = provider.get_memory_schemas(None)
+    assert schemas[0].memory_type == SESSION_SKILL_MEMORY_TYPE


### PR DESCRIPTION
Fixes #4368.

## Problem

With `memory.session_skill_extraction_enabled: true`, every session commit that reaches the skill-extraction step fails with `ValueError: Memory schema not found or disabled: skills`, and the whole `session_commit` task is marked failed.

Root cause (as diagnosed in the issue): the trainer-level memory type `"skills"` (what `_skill_operations_to_gradients` stamps onto gradients and what `Compressor._get_session_skill_trainer` passes to `PatchMergePolicyOptimizer`) is not a key in the general `MemoryTypeRegistry(load_schemas=True)` — the skill schema only exists under `"session_skills"` in the dedicated `skill_extract` registry (`load_skill_extract_registry()`). `PatchMergeContextProvider.get_memory_schemas()` always queried the general registry, so the skill path could never resolve a schema.

## Fix

Follows the issue's suggested option 1 — inject the registry instead of changing either registry's contents:

- `PatchMergeContextProvider` accepts optional `registry_factory` (callable returning a `MemoryTypeRegistry`; default unchanged → general registry) and `schema_memory_type` (registry lookup key when it differs from the trainer-level `memory_type`).
- `PatchMergePolicyOptimizer` gains the same two optional fields and forwards them to the provider it builds.
- `Compressor._get_session_skill_trainer` now passes `registry_factory=load_skill_extract_registry, schema_memory_type=SESSION_SKILL_MEMORY_TYPE` while keeping `memory_type="skills"` everywhere else in the trainer pipeline (gradient filtering, isolation handler, plan-item metadata), so no other behavior changes.

The experiences path (default construction) is byte-for-byte unchanged: both new fields default to `None` and `_get_registry` falls back to the original `MemoryTypeRegistry(load_schemas=True)`.

## Tests

`tests/session/test_patch_merge_skill_registry.py` (new):

- skill provider resolves the `session_skills` schema via the injected registry (previously raised);
- guard test: without injection the general registry still has no `"skills"` entry (documents *why* the injection is required);
- default `experiences` path unchanged;
- optimizer defaults preserve legacy construction, and the optimizer→provider wiring resolves.

Validated locally: `python -m pytest tests/session/test_patch_merge_skill_registry.py -q` — 5 passed.
