### PR TITLE
fix(ingest): wait for a busy target tree lock instead of failing instantly (#4337)

### DIFF
--- a/openviking/utils/resource_processor.py
+++ b/openviking/utils/resource_processor.py
@@ -48,6 +48,10 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 _MAX_FILE_VECTORIZATION_CONCURRENCY = 64
 VECTORDB_MAX_QUERY_LIMIT = 100_000
+# Ingesting into a busy directory (e.g. a sibling upload still holding the
+# tree lock through its extraction) waits for the lock instead of failing
+# with CONFLICT immediately (#4337). 0 restores the old zero-wait behavior.
+RESOURCE_LOCK_ACQUIRE_WAIT_SECS = 60.0
 
 
 class ResourceProcessor:
@@ -463,6 +467,7 @@ class ResourceProcessor:
                                 dst_path,
                                 uri=root_uri,
                                 root_is_file=root_is_file,
+                                timeout=RESOURCE_LOCK_ACQUIRE_WAIT_SECS,
                             )
                     if not target_preexisting:
                         await viking_fs.persist_temp_tree(

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -85,6 +85,9 @@ class _FakeVikingFS:
         self.persist_calls = []
         self.delete_temp_calls = []
 
+    async def _ensure_access(self, uri, ctx=None, action=None):
+        return None
+
     def bind_request_context(self, ctx):
         return _CtxMgr()
 

--- a/tests/misc/test_resource_processor_mv.py
+++ b/tests/misc/test_resource_processor_mv.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from openviking.utils.resource_processor import RESOURCE_LOCK_ACQUIRE_WAIT_SECS
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
@@ -351,7 +353,12 @@ async def test_resource_processor_allows_flat_root_only_for_single_no_split_sour
 
     assert result["status"] == "success"
     assert result["root_uri"] == root_uri
-    assert fake_fs._async_agfs.exact_attempts == [("/mock/resources/神雕_副本.md", 0.0)]
+    # Auto-named candidates skip to the next name on contention (0-wait);
+    # a caller-specified target waits for a busy lock instead (#4337).
+    expected_timeout = 0.0 if auto_candidate else RESOURCE_LOCK_ACQUIRE_WAIT_SECS
+    assert fake_fs._async_agfs.exact_attempts == [
+        ("/mock/resources/神雕_副本.md", expected_timeout)
+    ]
     assert fake_fs._async_agfs.tree_attempts == []
     assert rp.tree_builder.finalize_from_temp.await_args.kwargs["flatten_single_file"] is True
 

--- a/tests/unit/test_resource_reservation.py
+++ b/tests/unit/test_resource_reservation.py
@@ -93,3 +93,57 @@ async def test_reservation_returns_first_available_lock(monkeypatch):
 
     assert uri == "viking://resources/report_1"
     assert acquired is lease
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_forwards_wait_timeout_to_backend(monkeypatch):
+    """Ingest into a busy directory must wait for the tree lock (#4337)."""
+    from types import SimpleNamespace
+
+    viking_fs = _FakeVikingFS()
+    viking_fs._async_agfs = SimpleNamespace(
+        pathlock_acquire_tree=AsyncMock(return_value={"lease_ref": "tree"}),
+        pathlock_acquire_exact=AsyncMock(return_value={"lease_ref": "exact"}),
+    )
+    monkeypatch.setattr(resource_processor_module, "get_viking_fs", lambda: viking_fs)
+
+    await ResourceProcessor.acquire_resource_lock(
+        "/agfs/resources/docs", uri="viking://resources/docs", timeout=60.0
+    )
+    viking_fs._async_agfs.pathlock_acquire_tree.assert_awaited_once_with(
+        "/agfs/resources/docs", timeout_secs=60.0
+    )
+    viking_fs._async_agfs.pathlock_acquire_exact.assert_not_awaited()
+
+    await ResourceProcessor.acquire_resource_lock(
+        "/agfs/resources/docs/file.md",
+        uri="viking://resources/docs/file.md",
+        timeout=60.0,
+        root_is_file=True,
+    )
+    viking_fs._async_agfs.pathlock_acquire_exact.assert_awaited_once_with(
+        "/agfs/resources/docs/file.md", timeout_secs=60.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_still_maps_busy_after_wait(monkeypatch):
+    """A lock that stays busy past the wait maps to a retryable busy error."""
+    from types import SimpleNamespace
+
+    from openviking.storage.errors import LockAcquisitionError
+
+    viking_fs = _FakeVikingFS()
+    viking_fs._async_agfs = SimpleNamespace(
+        pathlock_acquire_tree=AsyncMock(
+            side_effect=LockAcquisitionError("lock acquire timed out after 60000ms")
+        ),
+    )
+    monkeypatch.setattr(resource_processor_module, "get_viking_fs", lambda: viking_fs)
+
+    with pytest.raises(ResourceBusyError) as exc_info:
+        await ResourceProcessor.acquire_resource_lock(
+            "/agfs/resources/docs", uri="viking://resources/docs", timeout=60.0
+        )
+    assert exc_info.value.retryable is True
+    assert exc_info.value.conflict_type == "path_busy"


### PR DESCRIPTION
## Summary

Fixes #4337.

Uploading several files into one directory raced on the target directory's tree lock: the first ingest acquired it and held it through the whole LLM extraction, while every sibling ingest acquired the same tree lock with the zero-wait default and failed immediately with `CONFLICT lock acquire timed out after 0ms`. A UI that uploads N files at once therefore degraded to a single-file upload.

## Change

- `ResourceProcessor.process_resource` now acquires the caller-specified target's lock with a bounded wait (`RESOURCE_LOCK_ACQUIRE_WAIT_SECS = 60.0`) instead of the zero-wait default. The wait happens inside the pathlock backend (`timeout_secs`), so siblings queue on the lock and proceed as each holder finishes, rather than failing instantly.
- Auto-named candidate reservation (`reserve_unique_candidate`) intentionally keeps the zero-wait behavior: on contention it skips to the next candidate name, which is cheaper than waiting.
- Tests: new cases assert the wait timeout is forwarded to the backend for both exact and tree locks and that a lock still busy after the wait maps to the existing retryable `path_busy` error; the flat-root ingest test now locks in the new expected timeout per path (wait for caller-specified, zero-wait for auto-named).

## Notes

- The 60s budget covers the "tens of seconds" extraction window reported in the issue; it is a module-level constant rather than a config knob because the config schema lives in the external `openviking_cli` package.
- Local verification: `tests/unit/test_resource_reservation.py`, `tests/misc/test_resource_processor_mv.py`, `tests/utils/` green (3 pre-existing environment failures unrelated to this change, verified identical on a clean baseline).