### PR TITLE
fix(memory): strip Windows-unsafe trailing chars from generated memory URIs

### DIFF
--- a/openviking/session/memory/utils/uri.py
+++ b/openviking/session/memory/utils/uri.py
@@ -46,7 +46,7 @@ def generate_uri(
     fields: Dict[str, Any],
     user_space: str = "default",
     extract_context: Any = None,
-) -> tuple[str, str]:
+) -> str:
     """
     Generate a full URI from memory type schema and field values.
 
@@ -81,7 +81,37 @@ def generate_uri(
             raise ValueError(f"Template variable '{var}' has None value")
     # Render using unified render_template method (same as content_template)
     uri = render_template(uri_template, context, extract_context)
-    return uri
+    return sanitize_uri_path_segments(uri)
+
+
+# Win32 silently drops trailing spaces/dots when materializing a path, which
+# desynchronizes on-disk directories from RAGFS lock-token paths (#4308).
+_TRAILING_FS_UNSAFE_RE = re.compile(r"[\s.]+$")
+
+
+def sanitize_uri_path_segments(uri: str) -> str:
+    """Strip trailing spaces/dots from every path segment of a memory URI.
+
+    Windows filesystems cannot create names ending in spaces or dots: the OS
+    silently strips them, so a template-rendered segment like ``"Desktop "``
+    materializes as ``Desktop`` while the RAGFS lock-token path keeps the
+    space, and every subsequent write fails with a lock I/O error. Normalizing
+    segments at URI-generation time keeps the logical URI aligned with what
+    the filesystem can actually materialize on every platform. A non-empty
+    segment reduced to nothing falls back to ``_`` so paths never gain empty
+    components.
+    """
+    scheme_sep = "://"
+    if scheme_sep not in uri:
+        head, tail = "", uri
+    else:
+        scheme, _, rest = uri.partition(scheme_sep)
+        head, tail = f"{scheme}{scheme_sep}", rest
+    cleaned_segments = []
+    for segment in tail.split("/"):
+        stripped = _TRAILING_FS_UNSAFE_RE.sub("", segment)
+        cleaned_segments.append(stripped if stripped or not segment else "_")
+    return head + "/".join(cleaned_segments)
 
 
 def validate_uri_template(memory_type: MemoryTypeSchema) -> bool:

--- a/tests/session/memory/test_memory_utils.py
+++ b/tests/session/memory/test_memory_utils.py
@@ -141,6 +141,101 @@ class TestUriGeneration:
         with pytest.raises(ValueError, match="has None value"):
             generate_uri(memory_type, {"topic": None})
 
+    def test_generate_uri_strips_windows_unsafe_trailing_chars(self):
+        """Trailing spaces/dots in rendered segments are stripped (#4308).
+
+        Windows drops trailing spaces/dots when creating paths while RAGFS
+        lock-token paths keep them, which fails memory extraction with a lock
+        I/O error. The generated URI must already be materializable.
+        """
+        memory_type = MemoryTypeSchema(
+            memory_type="scratch",
+            description="Scratch memory",
+            directory="viking://user/{{ user_space }}/memories/scratch",
+            filename_template="{{ name }}",
+            fields=[],
+        )
+
+        uri = generate_uri(
+            memory_type,
+            {"name": "Desktop "},
+            user_space="default",
+        )
+
+        assert uri == "viking://user/default/memories/scratch/Desktop"
+
+    def test_generate_uri_strips_trailing_space_in_split_segment(self):
+        """A field containing '/' splits into segments, each one sanitized."""
+        memory_type = MemoryTypeSchema(
+            memory_type="events",
+            description="Event memory",
+            directory="viking://user/{{ user_space }}/memories/events",
+            filename_template="2026/07/30/{{ event_name }}.md",
+            fields=[],
+        )
+
+        uri = generate_uri(
+            memory_type,
+            {"event_name": "Desktop /new report"},
+            user_space="default",
+        )
+
+        assert (
+            uri == "viking://user/default/memories/events/2026/07/30/Desktop/new report.md"
+        )
+
+    def test_generate_uri_trailing_dots_stripped_in_directory_segment(self):
+        memory_type = MemoryTypeSchema(
+            memory_type="events",
+            description="Event memory",
+            directory="viking://user/{{ user_space }}/memories/events",
+            filename_template="2026/07/30/{{ event_name }}.md",
+            fields=[],
+        )
+
+        uri = generate_uri(
+            memory_type,
+            {"event_name": "release../summary"},
+            user_space="default",
+        )
+
+        assert uri == "viking://user/default/memories/events/2026/07/30/release/summary.md"
+
+    def test_generate_uri_segment_reduced_to_nothing_gets_placeholder(self):
+        memory_type = MemoryTypeSchema(
+            memory_type="events",
+            description="Event memory",
+            directory="viking://user/{{ user_space }}/memories/events",
+            filename_template="2026/07/30/{{ event_name }}.md",
+            fields=[],
+        )
+
+        uri = generate_uri(
+            memory_type,
+            {"event_name": "   /notes"},
+            user_space="default",
+        )
+
+        assert uri == "viking://user/default/memories/events/2026/07/30/_/notes.md"
+
+    def test_generate_uri_clean_values_unchanged(self):
+        """Normal field values keep producing identical URIs."""
+        memory_type = MemoryTypeSchema(
+            memory_type="preferences",
+            description="User preference memory",
+            directory="viking://user/{{ user_space }}/memories/preferences",
+            filename_template="{{ topic }}.md",
+            fields=[],
+        )
+
+        uri = generate_uri(
+            memory_type,
+            {"topic": "Python code style"},
+            user_space="default",
+        )
+
+        assert uri == "viking://user/default/memories/preferences/Python code style.md"
+
     def test_validate_uri_template_valid(self):
         """Test validating a valid URI template."""
         memory_type = MemoryTypeSchema(


### PR DESCRIPTION
## Problem

On Windows, session memory extraction fails deterministically when the LLM-generated event name produces a path segment ending with a space (#4308). Example: `event_name: "Desktop /new"` renders through `filename_template` (`{{ event_name }}.md`) into a `Desktop ` **directory** segment. Windows cannot materialize names ending in spaces/dots — the OS silently strips them — while the RAGFS lock-token path keeps the space (`.../Desktop /.exact.ovlock.overview.md.<token>`). Lock-token creation then fails with `lock I/O error` and the whole `memory_extraction` stage aborts. Retrying reproduces the identical failure (the extraction output is deterministic), so there is no retry-based workaround.

## Fix

Normalize each rendered segment inside `generate_uri()` (`openviking/session/memory/utils/uri.py`) — the single point where memory URIs are built from schema templates + LLM field values:

- strip trailing whitespace and trailing dots per path segment (both are silently dropped by Win32 when creating paths);
- a non-empty segment reduced to nothing falls back to `_` so paths never gain empty components.

This keeps the logical URI aligned with what the filesystem can actually materialize, on every platform — same direction as the #4023/#4162 family (don't change logical identity, fix the path component). Callers untouched: both `calculate_memory_uris()` and the merge-group path in `streaming_memory_updater` route through `generate_uri()`.

Also fixed the return annotation of `generate_uri` (`tuple[str, str]` → `str`, it always returned a single URI).

## Testing

5 new tests in `tests/session/memory/test_memory_utils.py`:

- trailing-space filename segment stripped (`"Desktop "` → `Desktop`);
- field containing `/` splits into segments, each sanitized (`"Desktop /new report"` → `Desktop/new report`, the exact #4308 repro shape);
- trailing dots in a directory segment stripped (`"release../summary"` → `release/summary`);
- all-whitespace segment gets `_` placeholder;
- clean values produce byte-identical URIs (regression guard).

`tests/session/memory`: 361 passed with the change vs 356 on the baseline; the 3 failing tests there and the wider `tests/session` failures/errors (missing optional deps in this env) are identical before/after via `git stash` baseline comparison — zero regressions introduced.

Fixes #4308