### PR TITLE
perf(cli): stream ov get downloads into a sibling temp file

### DIFF
--- a/crates/ov_cli/src/client.rs
+++ b/crates/ov_cli/src/client.rs
@@ -542,6 +542,14 @@ impl HttpClient {
 
     /// Download file as raw bytes
     pub async fn get_bytes(&self, uri: &str) -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        self.get_stream(uri, &mut bytes).await?;
+        Ok(bytes)
+    }
+
+    /// Stream a download body into `sink` chunk by chunk and return the number
+    /// of bytes written, so caller memory stays bounded regardless of size.
+    pub async fn get_stream<W: std::io::Write>(&self, uri: &str, sink: &mut W) -> Result<u64> {
         let url = format!("{}/api/v1/content/download", self.base.base_url);
         let params = vec![
             ("uri".to_string(), uri.to_string()),
@@ -554,7 +562,7 @@ impl HttpClient {
             .get(&url)
             .headers(self.base.build_headers())
             .query(&params);
-        let response = self
+        let mut response = self
             .base
             .send_request(request, "HTTP request failed")
             .await?;
@@ -569,11 +577,16 @@ impl HttpClient {
             return Err(crate::base_client::api_error_from_body(&bytes, status));
         }
 
-        response
-            .bytes()
+        let mut written = 0u64;
+        while let Some(chunk) = response
+            .chunk()
             .await
-            .map(|b| b.to_vec())
-            .map_err(|e| Error::from_reqwest("Failed to read response bytes", e))
+            .map_err(|e| Error::from_reqwest("Failed to read download chunk", e))?
+        {
+            sink.write_all(&chunk)?;
+            written += chunk.len() as u64;
+        }
+        Ok(written)
     }
 
     // ============ Filesystem Methods ============

--- a/crates/ov_cli/src/commands/content.rs
+++ b/crates/ov_cli/src/commands/content.rs
@@ -111,33 +111,36 @@ pub async fn get(client: &HttpClient, uri: &str, local_path: &str) -> Result<()>
 
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
 
-    // Download file
-    let bytes = client.get_bytes(uri).await?;
+    // Stream into a sibling temp file so memory stays bounded and a partial
+    // download never occupies the requested target; publish via hard link so
+    // the target appears atomically and an existing target is never replaced.
+    // The temp file must live in the target's own directory: link(2) does not
+    // cross filesystems.
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
 
-    // Write to local file
-    let mut file = create_download_target(path, local_path)?;
-    file.write_all(&bytes)?;
+    let written = client.get_stream(uri, &mut file).await?;
     file.flush()?;
 
-    println!("Downloaded {} bytes to {}", bytes.len(), local_path);
-    Ok(())
-}
+    let display = path.display().to_string();
+    file.persist_noclobber(path).map_err(|error| {
+        if error.error.kind() == std::io::ErrorKind::AlreadyExists {
+            crate::error::Error::Client(format!("File already exists: {display}"))
+        } else {
+            crate::error::Error::Io(error.error)
+        }
+    })?;
 
-fn create_download_target(path: &Path, local_path: &str) -> Result<std::fs::File> {
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .map_err(|error| {
-            if error.kind() == std::io::ErrorKind::AlreadyExists {
-                crate::error::Error::Client(format!("File already exists: {local_path}"))
-            } else {
-                crate::error::Error::Io(error)
-            }
-        })
+    println!("Downloaded {written} bytes to {display}");
+    Ok(())
 }
 
 fn output_content_result(result: Value, output_format: OutputFormat, compact: bool) -> Result<()> {
@@ -306,18 +309,142 @@ mod tests {
         );
     }
 
-    #[test]
-    fn download_target_creation_does_not_truncate_an_existing_file() {
-        let dir = tempfile::tempdir().expect("tempdir should be created");
-        let path = dir.path().join("result.bin");
-        std::fs::write(&path, b"existing").expect("fixture should be written");
+    enum DownloadBody {
+        Complete(Vec<u8>),
+        /// Advertise `declared` bytes but send only `sent`, then close: the
+        /// client must treat the transfer as failed mid-body.
+        Truncated { declared: usize, sent: Vec<u8> },
+    }
 
-        let error = super::create_download_target(&path, &path.to_string_lossy())
-            .expect_err("existing targets must be rejected atomically");
+    async fn spawn_download_server(body: DownloadBody) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have an address");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("download request should arrive");
+            // Drain the request head; a GET with no body arrives in one read.
+            let mut buffer = vec![0u8; 8192];
+            let _ = socket.read(&mut buffer).await;
+
+            let (declared, sent, truncate) = match body {
+                DownloadBody::Complete(bytes) => (bytes.len(), bytes, false),
+                DownloadBody::Truncated { declared, sent } => (declared, sent, true),
+            };
+            let head = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {declared}\r\nconnection: close\r\n\r\n"
+            );
+            socket
+                .write_all(head.as_bytes())
+                .await
+                .expect("response head should write");
+            socket.write_all(&sent).await.expect("body should write");
+            if truncate {
+                socket.shutdown().await.expect("socket should shut down");
+            }
+        });
+        format!("http://{address}")
+    }
+
+    fn download_client(base_url: String) -> crate::client::HttpClient {
+        crate::client::HttpClient::new(base_url, None, None, None, None, 5.0, false, None)
+    }
+
+    #[tokio::test]
+    async fn get_streams_body_and_publishes_target_atomically() {
+        let body: Vec<u8> = (0..300_000u32).map(|i| (i % 251) as u8).collect();
+        let base_url = spawn_download_server(DownloadBody::Complete(body.clone())).await;
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let target = dir.path().join("download.bin");
+
+        super::get(
+            &download_client(base_url),
+            "viking://resources/file.bin",
+            &target.to_string_lossy(),
+        )
+        .await
+        .expect("download should succeed");
+
+        assert_eq!(
+            std::fs::read(&target).expect("published file should be readable"),
+            body
+        );
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("target directory should be listable")
+            .map(|entry| entry.expect("entry should be readable"))
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "no temp file should remain after success: {entries:?}"
+        );
+        assert!(entries[0].path().ends_with("download.bin"));
+    }
+
+    #[tokio::test]
+    async fn get_interrupted_transfer_leaves_no_target_and_no_partial_files() {
+        let base_url = spawn_download_server(DownloadBody::Truncated {
+            declared: 4096,
+            sent: vec![7u8; 512],
+        })
+        .await;
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let target = dir.path().join("download.bin");
+
+        let error = super::get(
+            &download_client(base_url),
+            "viking://resources/file.bin",
+            &target.to_string_lossy(),
+        )
+        .await
+        .expect_err("a truncated body must fail the download");
+
+        assert!(
+            matches!(
+                error,
+                Error::Network(_) | Error::Timeout(_) | Error::Parse(_) | Error::Io(_)
+            ),
+            "unexpected error variant: {error:?}"
+        );
+        assert!(
+            !target.exists(),
+            "the requested target must never appear from a failed transfer"
+        );
+        let residue: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("target directory should be listable")
+            .collect();
+        assert!(
+            residue.is_empty(),
+            "the partial temp file must be removed on error: {residue:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_refuses_to_overwrite_existing_target() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let target = dir.path().join("download.bin");
+        std::fs::write(&target, b"existing").expect("fixture should be written");
+
+        // No server needed: the preflight check rejects before any request.
+        let client = download_client("http://127.0.0.1:1".into());
+        let error = super::get(
+            &client,
+            "viking://resources/file.bin",
+            &target.to_string_lossy(),
+        )
+        .await
+        .expect_err("existing targets must be rejected");
 
         assert!(matches!(error, Error::Client(_)));
         assert_eq!(
-            std::fs::read(&path).expect("existing file should remain readable"),
+            std::fs::read(&target).expect("existing file should remain readable"),
             b"existing"
         );
     }


### PR DESCRIPTION
## What

Follow-up on #4294 (file-only scope, see note below): `ov get` read the entire response body into memory (`response.bytes()`) before writing the local file, so CLI memory scaled linearly with download size, and a cancelled transfer had no atomic-publish story between the preflight check and the final write.

This PR:

- adds `HttpClient::get_stream`, which streams the download body chunk by chunk into any `std::io::Write` sink and returns the byte count; error responses keep the existing `api_error_from_body` handling
- rewrites `commands::content::get` to stream into a `tempfile::NamedTempFile` created **in the target's own directory** (same filesystem, so publish is a hard link), then publish with `persist_noclobber`:
  - the target appears atomically after a successful transfer
  - an existing target is never replaced (the `create_new` / no-overwrite behavior from before is preserved, now race-free at publish time)
  - a failed or cancelled transfer drops the temp file, so no partial file survives
- `get_bytes` now delegates to the same streaming path, so buffering callers (`read`, TUI) are unchanged

## Scope note on the issue's third bullet

The issue also asks for server-side TTL cleanup of orphaned `openviking-download-*.zip` archives. Directory downloads were reverted in #4320, and current `main` serves downloads from memory with no temporary archive files, so there is nothing to reap — that part is intentionally not addressed here. When directory download comes back, the same streaming client can serve it.

## Testing

- `cargo test --bin ov`: **474 passed, 0 failed** (includes 36 `client::` tests unchanged, confirming `get_bytes` behavior is identical)
- New tests in `commands::content`:
  - `get_streams_body_and_publishes_target_atomically` — 300 KB body lands byte-identical on disk, exactly one directory entry remains (no temp residue)
  - `get_interrupted_transfer_leaves_no_target_and_no_partial_files` — server advertises 4096 bytes, sends 512, closes; download fails, target absent, directory empty
  - `get_refuses_to_overwrite_existing_target` — pre-existing target is rejected without any request and its contents survive

Fixes #4294 (streaming + interrupted-cleanup bullets; archive-TTL bullet is moot after #4320).