### PR TITLE
fix(session-commit): pace the dependency wait instead of spinning (#4345)

### DIFF
--- a/openviking/storage/queuefs/session_commit_msg.py
+++ b/openviking/storage/queuefs/session_commit_msg.py
@@ -21,6 +21,10 @@ class SessionCommitMsg:
     # Resolved custom scalar tags to attach to event memories extracted in this
     # commit. Already normalized by the producer; empty means "no tags".
     event_search_tags: List[str] = field(default_factory=list)
+    # How many times this message has already been put back because an earlier
+    # commit for the same session had not reached a terminal state. Only the
+    # consumer sets it; producers leave it at 0.
+    dependency_wait_count: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -24,6 +24,16 @@ if TYPE_CHECKING:
 
 
 class SessionCommitProcessor(DequeueHandlerBase):
+    # A commit whose predecessor is still running is put back on the queue. With
+    # no delay that is a hot loop: the same messages are dequeued, found blocked,
+    # and re-enqueued as fast as the consumer can turn, which is how a queue of
+    # 33 waiters reached a requeue count in the hundreds of thousands without
+    # draining. The wait is paced instead, doubling from 50ms and holding at 2s
+    # so a long Phase 2 costs at most one poll every two seconds per waiter.
+    _DEPENDENCY_WAIT_BASE_DELAY = 0.05
+    _DEPENDENCY_WAIT_MAX_DELAY = 2.0
+    _DEPENDENCY_WAIT_MAX_DOUBLING = 8
+
     def __init__(
         self,
         session_service: "SessionService",
@@ -88,14 +98,27 @@ class SessionCommitProcessor(DequeueHandlerBase):
             if not processed:
                 from openviking.storage.queuefs import QueueManager, get_queue_manager
 
+                await asyncio.sleep(self._dependency_wait_delay(msg.dependency_wait_count))
+                payload = msg.to_dict()
+                payload["dependency_wait_count"] = msg.dependency_wait_count + 1
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
-                    msg.to_dict(),
+                    payload,
                 )
                 self.report_requeue()
             return processed
         finally:
             reset_root_observability_context(root_context_token)
+
+    @classmethod
+    def _dependency_wait_delay(cls, wait_count: int) -> float:
+        """Seconds to wait before putting a dependency-blocked commit back.
+
+        Doubles per attempt and then holds flat, so an unusually long Phase 2
+        cannot turn into an unbounded wait for the commits queued behind it.
+        """
+        doublings = min(max(wait_count, 0), cls._DEPENDENCY_WAIT_MAX_DOUBLING)
+        return min(cls._DEPENDENCY_WAIT_BASE_DELAY * (2**doublings), cls._DEPENDENCY_WAIT_MAX_DELAY)
 
     async def _finalize_cancelled(self, msg: SessionCommitMsg, ctx: RequestContext) -> None:
         session = self._session_service.session(

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -110,7 +110,9 @@ async def test_process_requeues_deferred_commit_and_resets_root_context(monkeypa
 
     await processor._process(_make_msg(), ctx)
 
-    assert queued == [("SessionCommit", _make_msg().to_dict())]
+    expected = _make_msg().to_dict()
+    expected["dependency_wait_count"] = 1
+    assert queued == [("SessionCommit", expected)]
     assert get_root_observability_context() is None
 
 
@@ -158,3 +160,67 @@ async def test_cancelled_queued_commit_writes_terminal_marker_before_success(mon
     assert marker["stage"] == "cancelled"
     assert marker["error"] == "session commit cancelled"
     on_success.assert_called_once_with()
+
+
+async def test_dependency_blocked_commit_is_paced_and_counts_its_waits(monkeypatch):
+    """A commit blocked behind its predecessor must not spin.
+
+    Without a delay the consumer dequeues the blocked message, finds it still
+    blocked and re-enqueues it as fast as it can turn, which is how a queue of
+    33 waiters reached a requeue count in the hundreds of thousands while its
+    depth never dropped. Assert both halves of the pacing: the worker actually
+    waits, and the wait it already served rides along on the message so the
+    next attempt waits longer instead of restarting from zero.
+    """
+    queued: list = []
+    slept: list = []
+
+    class _QueueManager:
+        async def enqueue(self, queue_name, data):
+            queued.append(data)
+
+    async def _record_sleep(delay):
+        slept.append(delay)
+
+    processor = SessionCommitProcessor(
+        _FakeSessionService({}, processed=False),
+        asyncio.get_running_loop(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: _QueueManager(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.session_commit_processor.asyncio.sleep",
+        _record_sleep,
+    )
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+    msg = _make_msg()
+    for _ in range(3):
+        await processor._process(msg, ctx)
+        msg = SessionCommitMsg.from_dict(queued[-1])
+
+    assert [item["dependency_wait_count"] for item in queued] == [1, 2, 3]
+    assert all(delay > 0 for delay in slept)
+    assert slept == sorted(slept)
+    assert slept[0] < slept[-1]
+
+
+def test_dependency_wait_delay_grows_then_holds_at_the_cap():
+    """The wait doubles, then stops growing.
+
+    A predecessor that runs for an hour must not push the commits behind it into
+    an hour-long poll interval, so the delay is capped rather than unbounded.
+    """
+    delays = [SessionCommitProcessor._dependency_wait_delay(n) for n in range(0, 14)]
+
+    assert delays[0] == SessionCommitProcessor._DEPENDENCY_WAIT_BASE_DELAY
+    assert delays == sorted(delays)
+    assert max(delays) == SessionCommitProcessor._DEPENDENCY_WAIT_MAX_DELAY
+    assert delays[-1] == delays[-2] == SessionCommitProcessor._DEPENDENCY_WAIT_MAX_DELAY
+    # A negative or absent counter from an older producer must not underflow.
+    assert (
+        SessionCommitProcessor._dependency_wait_delay(-5)
+        == SessionCommitProcessor._DEPENDENCY_WAIT_BASE_DELAY
+    )


### PR DESCRIPTION
Closes #4345.

## The problem

`SessionCommitProcessor._process` puts a dependency-blocked commit straight back on the queue:

```python
if not processed:
    await get_queue_manager().enqueue(QueueManager.SESSION_COMMIT, msg.to_dict())
    self.report_requeue()
```

`resume_queued_commit` returns `False` while an earlier commit for the same session is still pending, so the consumer dequeues the message, learns nothing has changed, and enqueues it again — as fast as it can turn. Nothing in that path waits, backs off, or counts. The report saw 33 waiters hold the queue depth at 33-34 while the requeue counter passed 800,000.

## The change

The wait is paced instead of spun. `_dependency_wait_delay` doubles from 50 ms and holds flat at 2 s, and the number of waits already served rides along on the message so the next attempt resumes the backoff instead of restarting it:

```python
await asyncio.sleep(self._dependency_wait_delay(msg.dependency_wait_count))
payload = msg.to_dict()
payload["dependency_wait_count"] = msg.dependency_wait_count + 1
```

`dependency_wait_count` is a new `SessionCommitMsg` field defaulting to `0`. Producers never set it, and `from_dict` already drops unknown keys, so a message written by an older producer — or one already sitting in a queue across an upgrade — loads at `0` and behaves exactly as before.

The cap matters as much as the growth. Without it a Phase 2 that runs for an hour would push the commits behind it into an hour-long poll interval; with it a waiter costs at most one dequeue every two seconds.

## What this does not do

#4345 also suggests per-`task_id` deduplication and per-session FIFO scheduling. This does neither. Both change how work is scheduled and are yours to decide; this is the smallest change that stops the spin, and it composes with either.

It is also worth being explicit about the trade-off I did pick: the `asyncio.sleep` runs inside the handler, so a blocked commit occupies its consumer for the length of the delay. That is strictly less consumer time than today, where the same commit occupies it continuously — but if you would rather the wait not hold a worker at all, the shape that needs is a delayed enqueue in `QueueManager`, and I am happy to send that instead.

## Evidence

`tests/storage/test_session_commit_processor_identity.py` — **3 of 5 fail on `main`, 5 pass with the change**:

```
main      3 failed, 2 passed
  test_process_requeues_deferred_commit_and_resets_root_context
  test_dependency_blocked_commit_is_paced_and_counts_its_waits    KeyError: 'dependency_wait_count'
  test_dependency_wait_delay_grows_then_holds_at_the_cap          AttributeError: _dependency_wait_delay

patched   5 passed
```

`test_dependency_blocked_commit_is_paced_and_counts_its_waits` drives `_process` three times, feeding each re-enqueued payload back in, and asserts the counter reaches `[1, 2, 3]`, that every wait was non-zero, and that the waits are non-decreasing. `test_dependency_wait_delay_grows_then_holds_at_the_cap` pins the curve and the cap, including that a negative counter from a malformed payload cannot underflow.

**One existing test changed.** `test_process_requeues_deferred_commit_and_resets_root_context` asserted the re-enqueued payload was byte-identical to the original:

```python
assert queued == [("SessionCommit", _make_msg().to_dict())]
```

It now expects the same payload plus `dependency_wait_count: 1`. The test is about the requeue happening and the observability context being reset, not about the payload being unchanged, and both of those assertions are untouched.

**Environment.** `tests/unit/session/test_session_commit_resume.py` passes. `tests/session/test_session_commit.py` and `test_session_commit_race.py` error on my Windows machine before they run anything:

```
ImportError: No compatible x86 engine backend was packaged in this wheel. Missing symbol: PersistStore
```

I checked that on a clean `main` with my changes stashed and got the identical error, so it is this wheel and not this diff — but it does mean I have not exercised those two files, and CI is more authoritative than I am here.
