### PR TITLE
fix(mcp): stop trusting request headers for signed upload URLs

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import contextvars
+import ipaddress
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -840,6 +841,50 @@ def _indexing_hint(result: Dict[str, Any]) -> str:
 _DEFAULT_UPLOAD_TTL_SECONDS = 600
 
 
+def _is_loopback_authority(authority: str) -> bool:
+    """Return True for syntactically safe localhost/loopback Host authorities.
+
+    ``authority`` may include a numeric port (``localhost:1933``) or a bracketed
+    IPv6 literal (``[::1]:1933``). Non-loopback request authorities are not
+    trusted for signed upload URLs because they can be supplied by the client.
+    """
+    host = authority.strip()
+    if not host:
+        return False
+    # Reject characters that can change URL authority interpretation when the
+    # value is interpolated into ``http://{host}`` (userinfo, paths, fragments,
+    # queries, whitespace/control chars, or scheme-relative forms).
+    if any(ch in host for ch in "@/?#\\") or any(ch.isspace() for ch in host):
+        return False
+
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            return False
+        addr = host[1:end]
+        rest = host[end + 1 :]
+        if rest:
+            if not rest.startswith(":") or not rest[1:].isdigit():
+                return False
+        host = addr
+    elif ":" in host:
+        # Host headers with a single colon are host:port. Multiple colons without
+        # brackets are IPv6 literals; leave them intact for ipaddress parsing.
+        if host.count(":") == 1:
+            name, port = host.rsplit(":", 1)
+            if not port.isdigit():
+                return False
+            host = name
+
+    host = host.rstrip(".").lower()
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def _resolve_public_base_url() -> tuple[str, str]:
     """Pick the URL the agent should POST uploads to. Returns ``(base_url, source)``.
 
@@ -848,16 +893,15 @@ def _resolve_public_base_url() -> tuple[str, str]:
     1. ``env`` — ``OPENVIKING_PUBLIC_BASE_URL`` environment variable. Operator-set,
        always wins.
     2. ``config`` — ``ServerConfig.public_base_url``. Operator-set baseline in ov.conf.
-    3. ``forwarded`` — ``X-Forwarded-Host`` (+ ``X-Forwarded-Proto``) from the request.
-       Set by reverse proxies (nginx, ALB, ingress controllers, MCP proxies). Reliable
-       when the proxy chain forwards these headers, which is the standard default.
-    4. ``host`` — the raw ``Host`` header from a direct connection. Reliable for
-       same-host MCP clients (e.g. local Claude Code talking to localhost server).
-    5. ``listen`` — ``http://{listen_host}:{listen_port}`` last-resort fallback.
-       Only produces an agent-reachable URL when the server is bound to a routable
-       address; commonly wrong behind reverse proxies.
+    3. ``host`` — a raw ``Host`` header only when it names localhost/loopback.
+       This preserves direct local MCP clients (e.g. Claude Code talking to a
+       localhost server) without letting an arbitrary request authority control
+       signed upload destinations.
+    4. ``listen`` — ``http://{listen_host}:{listen_port}`` last-resort fallback.
+       Reverse-proxy deployments that need an externally reachable upload URL
+       should set ``OPENVIKING_PUBLIC_BASE_URL`` or ``server.public_base_url``.
 
-    Sources 1 and 2 are "explicit" — operator vouched for the URL. Sources 3-5 are
+    Sources 1 and 2 are "explicit" — operator vouched for the URL. Sources 3-4 are
     inferred and may be wrong when the proxy chain doesn't forward request headers.
     Callers should append a "set OPENVIKING_PUBLIC_BASE_URL if upload fails" hint
     in that case.
@@ -880,13 +924,12 @@ def _resolve_public_base_url() -> tuple[str, str]:
             head = value.split(",", 1)[0].strip()
             return head or None
 
-        xfh = _first(url_info.get("x_forwarded_host"))
-        xfp = _first(url_info.get("x_forwarded_proto"))
+        # Do not infer signed upload destinations from X-Forwarded-*: an
+        # untrusted client can usually set those headers itself unless the
+        # deployment normalizes them. Operators behind a proxy should configure
+        # a public base URL explicitly.
         host_hdr = _first(url_info.get("host"))
-        if xfh:
-            proto = xfp or "https"
-            return f"{proto}://{xfh}", "forwarded"
-        if host_hdr:
+        if host_hdr and _is_loopback_authority(host_hdr):
             return f"http://{host_hdr}", "host"
 
     if config is not None:

--- a/tests/server/test_mcp_endpoint.py
+++ b/tests/server/test_mcp_endpoint.py
@@ -1038,7 +1038,7 @@ async def test_add_resource_local_path_uses_config_when_env_unset(service, monke
     upload_token_store.clear()
 
 
-async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, monkeypatch):
+async def test_add_resource_local_path_ignores_untrusted_forwarded_headers(service, monkeypatch):
     from openviking.server.mcp_endpoint import _request_url_ctx
     from openviking.server.upload_token_store import upload_token_store
 
@@ -1048,7 +1048,7 @@ async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, 
     token = _request_url_ctx.set(
         {
             "x_forwarded_proto": "https",
-            "x_forwarded_host": "ov.public.example.com",
+            "x_forwarded_host": "attacker.example.com",
             "host": "internal:1933",
         }
     )
@@ -1057,8 +1057,59 @@ async def test_add_resource_local_path_infers_from_x_forwarded_headers(service, 
     finally:
         _request_url_ctx.reset(token)
 
-    assert "https://ov.public.example.com/api/v1/resources/temp_upload?token=" in result
+    assert "attacker.example.com" not in result
+    assert "http://127.0.0.1:1933/api/v1/resources/temp_upload?token=" in result
     # Inferred → hint must appear
+    assert "OPENVIKING_PUBLIC_BASE_URL" in result
+    upload_token_store.clear()
+
+
+async def test_add_resource_local_path_ignores_untrusted_host_header(service, monkeypatch):
+    from openviking.server.mcp_endpoint import _request_url_ctx
+    from openviking.server.upload_token_store import upload_token_store
+
+    upload_token_store.clear()
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "attacker.example.com",
+        }
+    )
+    try:
+        result = await add_resource(path="/tmp/x.pdf")
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert "attacker.example.com" not in result
+    assert "http://127.0.0.1:1933/api/v1/resources/temp_upload?token=" in result
+    assert "OPENVIKING_PUBLIC_BASE_URL" in result
+    upload_token_store.clear()
+
+
+async def test_add_resource_local_path_allows_loopback_host_for_local_clients(service, monkeypatch):
+    from openviking.server.mcp_endpoint import _request_url_ctx
+    from openviking.server.upload_token_store import upload_token_store
+
+    upload_token_store.clear()
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example.com",
+            "host": "localhost:1933",
+        }
+    )
+    try:
+        result = await add_resource(path="/tmp/x.pdf")
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert "attacker.example.com" not in result
+    assert "http://localhost:1933/api/v1/resources/temp_upload?token=" in result
     assert "OPENVIKING_PUBLIC_BASE_URL" in result
     upload_token_store.clear()
 

--- a/tests/unit/test_mcp_public_base_url_trust.py
+++ b/tests/unit/test_mcp_public_base_url_trust.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for MCP upload URL host trust."""
+
+from __future__ import annotations
+
+from openviking.server import dependencies
+from openviking.server.config import ServerConfig
+from openviking.server.mcp_endpoint import (
+    _is_loopback_authority,
+    _request_url_ctx,
+    _resolve_public_base_url,
+)
+
+
+def _set_config(monkeypatch, **kwargs) -> ServerConfig:
+    config = ServerConfig(**kwargs)
+    monkeypatch.setattr(dependencies, "_server_config", config)
+    return config
+
+
+def test_mcp_upload_url_does_not_trust_forwarded_host_without_public_base_url(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="127.0.0.1", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example",
+            "host": "openviking.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://127.0.0.1:1933"
+    assert source == "listen"
+
+
+def test_mcp_upload_url_does_not_trust_external_host_header_without_public_base_url(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="0.0.0.0", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "attacker.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://127.0.0.1:1933"
+    assert source == "listen"
+
+
+def test_mcp_upload_url_keeps_explicit_public_base_url_authoritative(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, public_base_url="https://openviking.example")
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": "https",
+            "x_forwarded_host": "attacker.example",
+            "host": "attacker.example",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "https://openviking.example"
+    assert source == "config"
+
+
+def test_mcp_upload_url_allows_loopback_host_for_local_clients(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_PUBLIC_BASE_URL", raising=False)
+    _set_config(monkeypatch, host="127.0.0.1", port=1933, public_base_url=None)
+    token = _request_url_ctx.set(
+        {
+            "x_forwarded_proto": None,
+            "x_forwarded_host": None,
+            "host": "localhost:1933",
+        }
+    )
+    try:
+        base_url, source = _resolve_public_base_url()
+    finally:
+        _request_url_ctx.reset(token)
+
+    assert base_url == "http://localhost:1933"
+    assert source == "host"
+
+
+def test_loopback_authority_rejects_url_authority_confusion():
+    assert _is_loopback_authority("localhost:1933")
+    assert _is_loopback_authority("127.0.0.1:1933")
+    assert _is_loopback_authority("[::1]:1933")
+    assert not _is_loopback_authority("localhost:1933@attacker.example")
+    assert not _is_loopback_authority("localhost/path")
+    assert not _is_loopback_authority("localhost?next=attacker")
+    assert not _is_loopback_authority("localhost#attacker")
+    assert not _is_loopback_authority("localhost:not-a-port")
+    assert not _is_loopback_authority("[::1]extra")


### PR DESCRIPTION
Rewrite of #2319 (original work by @Hinotoi-agent) against current `main`, trimmed to the production change plus its tests. Not a literal cherry-pick: the original patch no longer applies, so only the `_is_loopback_authority` helper is carried over verbatim and everything else was redone against current code. Attribution is in the commit trailer.

### The problem
流程：
1. Agent（已认证）调 add_resource(path=本地文件) → 服务器签发一个 upload token，返回一句话："把文件 POST 到 https://{host}/api/v1/resources/temp_upload?token=XXX"
2. Agent 照做，把文件 POST 到那个 URL

{host} 原来直接取 X-Forwarded-Host/Host 请求头。谁能改这两个头，谁就能把第 2 步的目标换成 attacker.example，于是 agent 把文件内容 + token 一起送过去了。

攻击者拿到后能干嘛：
- 文件本身（用户要上传的私有内容）
- token：temp_upload?token= 是免 APIKey 的（resources.py:168-174，token 本身就是凭证，且绑定了 to/reason），拿去对真服务器重放，就能以受害者身份灌入自己的内容（比如投毒 memory）

真正的场景是链路中间的 confused deputy——MCP 网关/中继、会 append 而不是 replace X-Forwarded-Host 的 ingress、多级代理。它们能设头但本不该拿到文件。所以定位是 defense-in-depth，不是权限绕过。

修法：不信 X-Forwarded-*，Host 只在是 loopback 时采信；反代部署必须显式配 OPENVIKING_PUBLIC_BASE_URL。

