### PR TITLE
feat(dsh): skip automatic memory for subagent sessions

### DIFF
--- a/examples/dsh-memory-plugin/README.md
+++ b/examples/dsh-memory-plugin/README.md
@@ -141,6 +141,7 @@ The patch can also carry plugin config:
             recallTokenBudget: 2000
             scoreThreshold: 0.35
             captureToolResults: false
+            skipSubagentSessions: true
             commitTokenThreshold: 20000
             mcpToolCallTimeoutMs: 60000
 ```
@@ -151,6 +152,7 @@ The patch can also carry plugin config:
 - `agent/pre-step` retrieves with the current step input and appends a durable plugin message to that same step.
 - `session/event` captures user, assistant, and optionally tool-result messages without scraping a transcript.
 - `turn/end` checks the OpenViking pending-token threshold and commits when required.
+- `skipSubagentSessions: true` excludes sessions marked with `header.origin: subagent` from automatic profile, recall, capture, and commit; it defaults to `false`.
 - Failed writes enter the shared OpenViking pending queue for replay at the next session start.
 - `tools/pre-execute` blocks DSH filesystem and shell tools from treating `viking://` URIs as local paths, pointing the model at the bridged `mcp__openviking__*` tools instead.
 

--- a/examples/dsh-memory-plugin/config.mjs
+++ b/examples/dsh-memory-plugin/config.mjs
@@ -1,7 +1,7 @@
 import { buildUserAgent, resolveOpenVikingCredentials } from "./shared/credentials.mjs";
 import { resolveEffectivePeerId } from "./shared/workspace-peer.mjs";
 
-export const PLUGIN_VERSION = "0.2.1";
+export const PLUGIN_VERSION = "0.3.0";
 
 /**
  * Namespace for the bridged OpenViking MCP tools. DSH publishes every MCP tool
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG = Object.freeze({
   captureMaxLength: 24000,
   captureToolMaxChars: 1000000,
   captureAssistantTurns: true,
+  skipSubagentSessions: false,
   requestTimeoutMs: 10000,
   mcpToolCallTimeoutMs: 60000,
 });
@@ -152,6 +153,7 @@ export function resolveConfig(input = {}, env = process.env, cwd = process.cwd()
   config.syncTurns = config.syncTurns !== false;
   config.captureAssistantTurns = config.captureAssistantTurns !== false;
   config.captureToolResults = config.captureToolResults === true;
+  config.skipSubagentSessions = config.skipSubagentSessions === true;
   return config;
 }
 

--- a/examples/dsh-memory-plugin/index.mjs
+++ b/examples/dsh-memory-plugin/index.mjs
@@ -13,6 +13,9 @@ export function apply(ctx, input = {}) {
   const config = resolveConfig(input);
   const client = new OpenVikingClient(config);
   const runtime = new OpenVikingRuntime(client, config, ctx.logger);
+  const skipMemory = session => (
+    config.skipSubagentSessions && session?.header?.origin === "subagent"
+  );
   ctx.provide("openvikingMemory", runtime);
   ctx.effect(
     () => () => runtime.disposeAll(),
@@ -20,6 +23,7 @@ export function apply(ctx, input = {}) {
   );
 
   ctx.on("agent/session-start", ({ agent }) => {
+    if (skipMemory(agent.session)) return false;
     agent.ctx.effect(
       () => () => runtime.dispose(agent.session),
       "openvikingMemory.disposeSession()",
@@ -31,6 +35,7 @@ export function apply(ctx, input = {}) {
   // the final claimed batch and appends after every other contributor.
   ctx.on("agent/pre-step", async ({ agent, messages, signal }, next) => {
     const decision = await next();
+    if (skipMemory(agent.session)) return decision;
     if (decision.kind !== "enter" || signal.aborted) return decision;
     const profile = await runtime.profileMessage(agent);
     if (signal.aborted) return decision;
@@ -43,11 +48,13 @@ export function apply(ctx, input = {}) {
   }, { prepend: true });
 
   ctx.on("session/event", (session, event) => {
+    if (skipMemory(session)) return;
     runtime.capture(session, event);
     runtime.maybeCommit(session, event);
   });
 
   ctx.on("session/flush", async session => {
+    if (skipMemory(session)) return;
     await runtime.flush(session);
   });
 

--- a/examples/dsh-memory-plugin/index.test.mjs
+++ b/examples/dsh-memory-plugin/index.test.mjs
@@ -2,11 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { apply } from "./index.mjs";
 
-test("pre-step recalls from the final downstream message batch", async () => {
+test("session filtering skips subagents without changing main-session recall", async () => {
   const handlers = new Map();
+  let memoryRuntime;
   const ctx = {
     logger: { debug() {} },
-    provide() {},
+    provide(name, value) {
+      if (name === "openvikingMemory") memoryRuntime = value;
+    },
     effect(execute) {
       execute();
       return async () => {};
@@ -20,6 +23,7 @@ test("pre-step recalls from the final downstream message batch", async () => {
   apply(ctx, {
     endpoint: "http://127.0.0.1:1933",
     workspacePeer: false,
+    skipSubagentSessions: true,
   });
 
   const agent = {
@@ -31,8 +35,8 @@ test("pre-step recalls from the final downstream message batch", async () => {
       },
     },
   };
-  const runtime = handlers.get("agent/session-start");
-  assert.equal(typeof runtime, "function");
+  const sessionStart = handlers.get("agent/session-start");
+  assert.equal(typeof sessionStart, "function");
 
   const preStep = handlers.get("agent/pre-step");
   const initial = [message("initial input")];
@@ -57,6 +61,38 @@ test("pre-step recalls from the final downstream message batch", async () => {
       messages: initial,
       signal: new AbortController().signal,
     }, async () => ({ kind: "enter", messages: downstream }));
+
+    const child = {
+      status: "idle",
+      session: {
+        id: "dsh-derived-child",
+        header: { cwd: "/workspace", origin: "subagent" },
+      },
+      inject() {
+        assert.fail("subagent profile must not be injected");
+      },
+      ctx: {
+        effect() {
+          assert.fail("subagent teardown commit must not be registered");
+        },
+      },
+    };
+    assert.equal(await sessionStart({ agent: child }), false);
+    const childMessages = [message("derived worker input")];
+    const childDecision = await preStep({
+      agent: child,
+      messages: childMessages,
+      signal: new AbortController().signal,
+    }, async () => ({ kind: "enter", messages: childMessages }));
+    handlers.get("session/event")(child.session, {
+      type: "user/message",
+      data: message("derived exploration chatter"),
+    });
+    handlers.get("session/event")(child.session, { type: "turn/end", data: {} });
+    await handlers.get("session/flush")(child.session);
+
+    assert.deepEqual(childDecision.messages, childMessages);
+    assert.equal(memoryRuntime.states.has(child.session.id), false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/examples/dsh-memory-plugin/package-lock.json
+++ b/examples/dsh-memory-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openviking/dsh-memory-plugin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openviking/dsh-memory-plugin",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deepseek-ai/dsh-llm": "0.1.0-rc.6",

--- a/examples/dsh-memory-plugin/package.json
+++ b/examples/dsh-memory-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openviking/dsh-memory-plugin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "OpenViking memory and context bundle for DeepSeek Harness",
   "type": "module",
   "main": "index.mjs",


### PR DESCRIPTION
## Description

Adds an opt-in `skipSubagentSessions` boundary to the DSH memory plugin. When enabled, sessions classified by DSH as `header.origin: subagent` do not enter automatic profile, recall, capture, threshold-commit, flush, or teardown-commit paths. The default remains `false`, preserving existing installations.

The filter stays at the plugin hook boundary: `agent/pre-step` still awaits downstream listeners, and the URI guard plus process-wide MCP/skill surfaces remain unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Addresses #4170

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a default-off `skipSubagentSessions` config and normalize it as a strict boolean.
- Skip automatic memory lifecycle hooks only for `header.origin === "subagent"`, without creating runtime state or registering teardown commits.
- Preserve main-session recall, document the option, and bump the publishable plugin to `0.3.0`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands and results:

- Node 22.19.0: focused test plus `npm run check`, `npm test`, and `npm pack --dry-run` passed.
- Node 24.16.0: `npm ci`, `npm run check`, and `npm test` passed (42 passed, 1 environment-gated E2E skipped, 0 failed).
- Repository memory-plugin PR matrix: 341 passed, 1 environment-gated E2E skipped, 0 failed.
- Independent code review: APPROVE, with no findings at any severity.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This intentionally uses DSH's authoritative `origin: subagent` classification. It does not classify unmarked timer/cron sessions, and it does not remove the process-wide OpenViking MCP tools from child agents. Those broader behaviors require separate host metadata or tool-surface policy.

The raw diff is 63 changed lines across six files.
