### PR TITLE
fix(memory-plugin): setup wizard first-run path, proxy hint, config source reporting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
             examples/codex-memory-plugin/scripts/auto-recall.test.mjs \
             examples/codex-memory-plugin/scripts/session-start-commit.test.mjs \
             examples/claude-code-memory-plugin/scripts/auto-capture.test.mjs \
+            examples/claude-code-memory-plugin/scripts/config.test.mjs \
             examples/claude-code-memory-plugin/scripts/marketplace.test.mjs \
             examples/claude-code-memory-plugin/scripts/skill-experience.test.mjs \
             examples/claude-code-memory-plugin/scripts/uri-guard.test.mjs \
@@ -58,6 +59,7 @@ jobs:
             examples/memory-plugin-shared/install-opencode-jsonc.test.mjs \
             examples/memory-plugin-shared/install-tui.test.mjs \
             examples/memory-plugin-shared/release-marketplace.test.mjs \
+            examples/memory-plugin-shared/setup-wizard.test.mjs \
             examples/memory-plugin-shared/sync.test.mjs \
             examples/memory-plugin-shared/mcp-proxy-config.test.mjs \
             examples/memory-plugin-shared/recall-compress-core.test.mjs \

--- a/agent-plugins/servers/shared/credentials.mjs
+++ b/agent-plugins/servers/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/agent-plugins/servers/shared/mcp-proxy-core.mjs
+++ b/agent-plugins/servers/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/claude-code-memory-plugin/scripts/config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.mjs
@@ -167,11 +167,31 @@ export function loadConfig() {
 
   // apiKey: env → ovcli.api_key → cc.apiKey → server.root_api_key
   // Accepts OPENVIKING_BEARER_TOKEN or OPENVIKING_API_KEY (sent as Bearer either way).
-  const apiKey = str(process.env.OPENVIKING_BEARER_TOKEN, null)
-    || str(process.env.OPENVIKING_API_KEY, null)
+  const envApiKey = str(process.env.OPENVIKING_BEARER_TOKEN, null)
+    || str(process.env.OPENVIKING_API_KEY, null);
+  const apiKey = envApiKey
     || str(cliFile.api_key, null)
     || str(cc.apiKey, null)
     || str(server.root_api_key, "");
+
+  // Which source actually supplied the api_key. `configPath` only reports the
+  // file that parsed, so debug logs and 401 hints pointed at the wrong file
+  // whenever both configs existed.
+  const ccApiKeyFromCli = hasOwn(pluginSettings, "apiKey");
+  let credentialSource = "none";
+  let credentialPath = null;
+  if (envApiKey) {
+    credentialSource = "env";
+  } else if (str(cliFile.api_key, null)) {
+    credentialSource = "ovcli";
+    credentialPath = cliConf?.configPath || null;
+  } else if (str(cc.apiKey, null)) {
+    credentialSource = ccApiKeyFromCli ? "ovcli" : "ov";
+    credentialPath = (ccApiKeyFromCli ? cliConf?.configPath : ovConf?.configPath) || null;
+  } else if (str(server.root_api_key, null)) {
+    credentialSource = "ov";
+    credentialPath = ovConf?.configPath || null;
+  }
 
   // accountId: env → ovcli.account → cc.accountId → ""
   const accountId = str(process.env.OPENVIKING_ACCOUNT, null)
@@ -225,6 +245,8 @@ export function loadConfig() {
 
   return {
     configPath,
+    credentialSource,
+    credentialPath,
     baseUrl,
     apiKey,
     accountId,

--- a/examples/claude-code-memory-plugin/scripts/config.test.mjs
+++ b/examples/claude-code-memory-plugin/scripts/config.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { loadConfig } from "./config.mjs";
+
+const OVERRIDES = [
+  "OPENVIKING_CONFIG_FILE",
+  "OPENVIKING_CLI_CONFIG_FILE",
+  "OPENVIKING_API_KEY",
+  "OPENVIKING_BEARER_TOKEN",
+];
+
+/**
+ * Run loadConfig() against a throwaway ~/.openviking pair, with the env vars
+ * that feed the credential chain reset to exactly what the case needs.
+ */
+function withConfigs({ ov, cli, env = {} }, fn) {
+  const dir = mkdtempSync(join(tmpdir(), "cc-config-"));
+  const ovPath = join(dir, "ov.conf");
+  const cliPath = join(dir, "ovcli.conf");
+  const saved = Object.fromEntries(OVERRIDES.map((key) => [key, process.env[key]]));
+  try {
+    for (const key of OVERRIDES) delete process.env[key];
+    if (ov) writeFileSync(ovPath, JSON.stringify(ov));
+    if (cli) writeFileSync(cliPath, JSON.stringify(cli));
+    process.env.OPENVIKING_CONFIG_FILE = ovPath;
+    process.env.OPENVIKING_CLI_CONFIG_FILE = cliPath;
+    Object.assign(process.env, env);
+    return fn({ ovPath, cliPath });
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("an ovcli.conf api_key is reported as the credential source", () => {
+  withConfigs({
+    ov: { server: { host: "127.0.0.1", port: 1933 } },
+    cli: { url: "http://127.0.0.1:1933", api_key: "sk-cli" },
+  }, ({ ovPath, cliPath }) => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "sk-cli");
+    assert.equal(cfg.credentialSource, "ovcli");
+    assert.equal(cfg.credentialPath, cliPath);
+    // configPath stays "whichever file parsed" for backward compat.
+    assert.equal(cfg.configPath, ovPath);
+  });
+});
+
+test("an ov.conf root_api_key is reported even when ovcli.conf exists", () => {
+  withConfigs({
+    ov: { server: { root_api_key: "sk-root" } },
+    cli: { url: "http://127.0.0.1:1933" },
+  }, ({ ovPath }) => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "sk-root");
+    assert.equal(cfg.credentialSource, "ov");
+    assert.equal(cfg.credentialPath, ovPath);
+  });
+});
+
+test("an ov.conf claude_code.apiKey is reported as ov.conf", () => {
+  withConfigs({
+    ov: { claude_code: { apiKey: "sk-cc" } },
+    cli: { url: "http://127.0.0.1:1933" },
+  }, ({ ovPath }) => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "sk-cc");
+    assert.equal(cfg.credentialSource, "ov");
+    assert.equal(cfg.credentialPath, ovPath);
+  });
+});
+
+test("an ovcli.conf plugin.claude_code.apiKey is reported as ovcli.conf", () => {
+  withConfigs({
+    ov: { server: {} },
+    cli: { url: "http://127.0.0.1:1933", plugin: { claude_code: { apiKey: "sk-plugin" } } },
+  }, ({ cliPath }) => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "sk-plugin");
+    assert.equal(cfg.credentialSource, "ovcli");
+    assert.equal(cfg.credentialPath, cliPath);
+  });
+});
+
+test("an env api_key wins and carries no path", () => {
+  withConfigs({
+    ov: { server: { root_api_key: "sk-root" } },
+    cli: { url: "http://127.0.0.1:1933", api_key: "sk-cli" },
+    env: { OPENVIKING_API_KEY: "sk-env" },
+  }, () => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "sk-env");
+    assert.equal(cfg.credentialSource, "env");
+    assert.equal(cfg.credentialPath, null);
+  });
+});
+
+test("no api_key anywhere reports no source", () => {
+  withConfigs({
+    ov: { server: { host: "127.0.0.1" } },
+    cli: { url: "http://127.0.0.1:1933" },
+  }, () => {
+    const cfg = loadConfig();
+    assert.equal(cfg.apiKey, "");
+    assert.equal(cfg.credentialSource, "none");
+    assert.equal(cfg.credentialPath, null);
+  });
+});

--- a/examples/claude-code-memory-plugin/scripts/ov-status.mjs
+++ b/examples/claude-code-memory-plugin/scripts/ov-status.mjs
@@ -133,10 +133,10 @@ async function main() {
     : (cliConf?.url) ? cliShort
     : (ovConf?.server?.url) ? ovShort
     : "default";
-  const keySrc = (process.env.OPENVIKING_API_KEY || process.env.OPENVIKING_BEARER_TOKEN) ? "env"
-    : (cliConf?.api_key) ? cliShort
-    : (ovConf?.claude_code?.apiKey) ? ovShort
-    : (ovConf?.server?.root_api_key) ? ovShort
+  // Taken from loadConfig() so this line and the MCP proxy always name the
+  // same file.
+  const keySrc = cfg.credentialSource === "env" ? "env"
+    : cfg.credentialPath ? homeShort(cfg.credentialPath)
     : "(none)";
   console.log(`Auth: url from ${urlSrc}, api_key from ${keySrc}`);
 }

--- a/examples/claude-code-memory-plugin/scripts/shared/credentials.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/claude-code-memory-plugin/scripts/shared/setup-wizard.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/claude-code-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/claude-code-memory-plugin/servers/mcp-proxy.mjs
@@ -29,9 +29,9 @@ function readProxyConfig() {
     timeoutMs: cfg.timeoutMs,
     debug: cfg.debug,
     debugLogPath: cfg.debugLogPath,
-    credentialSource: cfg.configPath?.endsWith("ovcli.conf") ? "ovcli" : "auto",
-    credentialPath: cfg.configPath,
-    watchedPaths: [cfg.configPath],
+    credentialSource: cfg.credentialSource,
+    credentialPath: cfg.credentialPath || "",
+    watchedPaths: [cfg.credentialPath, cfg.configPath].filter(Boolean),
   });
 }
 

--- a/examples/codex-memory-plugin/scripts/ov-credentials.test.mjs
+++ b/examples/codex-memory-plugin/scripts/ov-credentials.test.mjs
@@ -92,3 +92,29 @@ test("ovcli source can be forced explicitly without inheriting env key", async (
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("credentialPath names the file that supplied the api_key", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-creds-path-"));
+  const cliPath = join(dir, "ovcli.conf");
+  const ovPath = join(dir, "ov.conf");
+  await writeFile(cliPath, JSON.stringify({ url: "http://127.0.0.1:1933", api_key: "cli-key" }));
+  await writeFile(ovPath, JSON.stringify({ server: { root_api_key: "root-key" } }));
+  const env = { OPENVIKING_CLI_CONFIG_FILE: cliPath, OPENVIKING_CONFIG_FILE: ovPath };
+  try {
+    assert.equal(resolveOpenVikingCredentials(env).credentialPath, cliPath);
+
+    // env beats both files, so no file is named.
+    assert.equal(
+      resolveOpenVikingCredentials({ ...env, OPENVIKING_API_KEY: "env-key" }).credentialPath,
+      "",
+    );
+
+    // A tuning-only ovcli.conf carries no credentials, so the chain lands on ov.conf.
+    await writeFile(cliPath, JSON.stringify({ plugin: { recallCompress: "off" } }));
+    const creds = resolveOpenVikingCredentials(env);
+    assert.equal(creds.apiKey, "root-key");
+    assert.equal(creds.credentialPath, ovPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/examples/codex-memory-plugin/scripts/shared/credentials.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/codex-memory-plugin/scripts/shared/setup-wizard.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/codex-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-proxy.mjs
@@ -34,7 +34,7 @@ function readProxyConfig() {
     debug: cfg.debug,
     debugLogPath: cfg.debugLogPath,
     credentialSource: creds.credentialSource,
-    credentialPath: creds.cliPath || creds.ovPath,
+    credentialPath: creds.credentialPath,
     watchedPaths: [creds.cliPath, creds.ovPath, creds.cliPathCandidate],
   });
 }

--- a/examples/dsh-memory-plugin/shared/credentials.mjs
+++ b/examples/dsh-memory-plugin/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/dsh-memory-plugin/shared/mcp-proxy-core.mjs
+++ b/examples/dsh-memory-plugin/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/dsh-memory-plugin/shared/setup-wizard.mjs
+++ b/examples/dsh-memory-plugin/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/memory-plugin-shared/lib/credentials.mjs
+++ b/examples/memory-plugin-shared/lib/credentials.mjs
@@ -191,9 +191,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
+++ b/examples/memory-plugin-shared/lib/mcp-proxy-core.mjs
@@ -294,7 +294,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/memory-plugin-shared/lib/setup-wizard.mjs
+++ b/examples/memory-plugin-shared/lib/setup-wizard.mjs
@@ -38,14 +38,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -88,22 +91,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/memory-plugin-shared/setup-wizard.test.mjs
+++ b/examples/memory-plugin-shared/setup-wizard.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import test from "node:test";
+import { runSetupWizard } from "./lib/setup-wizard.mjs";
+
+/**
+ * Drive the wizard with scripted answers: readline writes a prompt without a
+ * trailing newline, so every such chunk gets the next answer fed back.
+ */
+function scriptedIo(answers) {
+  const queue = [...answers];
+  const input = new PassThrough();
+  const written = [];
+  const output = new Writable({
+    write(chunk, _enc, cb) {
+      const text = chunk.toString();
+      written.push(text);
+      if (!text.endsWith("\n")) {
+        setImmediate(() => input.write(`${queue.shift() ?? ""}\n`));
+      }
+      cb();
+    },
+  });
+  return { input, output, transcript: () => written.join("") };
+}
+
+test("a missing config file is created at the candidate path", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-wizard-new-"));
+  const target = join(dir, "nested", "ovcli.conf");
+  try {
+    const io = scriptedIo(["1", "sk-test", "y"]);
+    const result = await runSetupWizard({
+      input: io.input,
+      output: io.output,
+      env: { OPENVIKING_CLI_CONFIG_FILE: target },
+    });
+
+    assert.equal(result.written, true);
+    assert.equal(result.path, target);
+    assert.match(io.transcript(), new RegExp(`Config file: ${target}`));
+    assert.deepEqual(JSON.parse(await readFile(target, "utf-8")), {
+      url: "http://127.0.0.1:1933",
+      api_key: "sk-test",
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("an existing config file keeps unknown fields and its secret", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-wizard-existing-"));
+  const target = join(dir, "ovcli.conf");
+  try {
+    await writeFile(
+      target,
+      JSON.stringify({ url: "https://old.example.com", api_key: "sk-old", account: "acct" }),
+    );
+    const io = scriptedIo(["1", "", "y"]);
+    const result = await runSetupWizard({
+      input: io.input,
+      output: io.output,
+      env: { OPENVIKING_CLI_CONFIG_FILE: target },
+    });
+
+    assert.equal(result.path, target);
+    assert.deepEqual(JSON.parse(await readFile(target, "utf-8")), {
+      url: "http://127.0.0.1:1933",
+      api_key: "sk-old",
+      account: "acct",
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("declining the confirmation writes nothing but still names the target", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ov-wizard-abort-"));
+  const target = join(dir, "missing", "ovcli.conf");
+  try {
+    await mkdir(join(dir, "missing"), { recursive: true });
+    const io = scriptedIo(["2", "sk-test", "n"]);
+    const result = await runSetupWizard({
+      input: io.input,
+      output: io.output,
+      env: { OPENVIKING_CLI_CONFIG_FILE: target },
+    });
+
+    assert.equal(result.written, false);
+    assert.equal(result.path, target);
+    await assert.rejects(() => readFile(target, "utf-8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/examples/opencode-plugin/lib/shared/credentials.mjs
+++ b/examples/opencode-plugin/lib/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
+++ b/examples/opencode-plugin/lib/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/opencode-plugin/lib/shared/setup-wizard.mjs
+++ b/examples/opencode-plugin/lib/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/pi-coding-agent-extension/shared/credentials.mjs
+++ b/examples/pi-coding-agent-extension/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/pi-coding-agent-extension/shared/setup-wizard.mjs
+++ b/examples/pi-coding-agent-extension/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }

--- a/examples/zcode-memory-plugin/scripts/shared/credentials.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/credentials.mjs
@@ -192,9 +192,20 @@ export function resolveOpenVikingCredentials(env = process.env) {
   const explicitMcpUrl = str(env.OPENVIKING_MCP_URL, "");
   const mcpUrl = (mode !== "cli" && explicitMcpUrl) ? explicitMcpUrl : `${baseUrl.replace(/\/+$/, "")}/mcp`;
 
+  // The file that actually supplied the api_key, following the same chain —
+  // empty when the key came from the environment or was never found.
+  let credentialPath = "";
+  if (apiKey) {
+    if (useCli) credentialPath = files.cliPath;
+    else if (str(env.OPENVIKING_BEARER_TOKEN, str(env.OPENVIKING_API_KEY, ""))) credentialPath = "";
+    else if (str(files.cliFile.api_key, "")) credentialPath = files.cliPath;
+    else credentialPath = files.ovPath;
+  }
+
   return {
     ...files,
     credentialSource: useCli ? "ovcli" : ((mode === "env" || envHasCredentials) ? "env" : "auto"),
+    credentialPath,
     baseUrl,
     mcpUrl,
     apiKey,

--- a/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-core.mjs
@@ -295,7 +295,7 @@ export function createOpenVikingMcpProxy({
     return errorResponse(
       id,
       -32001,
-      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that 'ov serve' is running.`,
+      `OpenViking MCP request failed. Check the configured URL (${proxyConfig.mcpUrl}) and that the OpenViking server (\`openviking-server\`) is reachable.`,
       { cause: msg },
     );
   }

--- a/examples/zcode-memory-plugin/scripts/shared/setup-wizard.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/setup-wizard.mjs
@@ -39,14 +39,17 @@ export async function runSetupWizard({
   output = process.stdout,
   env = process.env,
 } = {}) {
-  const { cliPath } = loadCredentialFiles(env);
-  const current = readJsonSafe(cliPath);
+  // cliPath is empty until the file exists; first-run writes go to the candidate
+  // path (OPENVIKING_CLI_CONFIG_FILE, else ~/.openviking/ovcli.conf).
+  const { cliPath, cliPathCandidate } = loadCredentialFiles(env);
+  const targetPath = cliPath || cliPathCandidate;
+  const current = readJsonSafe(targetPath);
   const rl = createInterface({ input, output });
   const say = (line = "") => output.write(`${line}\n`);
 
   try {
     say("OpenViking memory plugin setup");
-    say(`Config file: ${cliPath}`);
+    say(`Config file: ${targetPath}`);
     say("");
     say("Current values:");
     say(`  url:     ${current.url || "(not set)"}`);
@@ -89,22 +92,22 @@ export async function runSetupWizard({
     const confirm = (await rl.question("Write config? [Y/n] ")).trim().toLowerCase();
     if (confirm === "n" || confirm === "no") {
       say("Aborted; nothing written.");
-      return { written: false, path: cliPath };
+      return { written: false, path: targetPath };
     }
 
-    mkdirSync(dirname(cliPath), { recursive: true });
-    if (existsSync(cliPath)) {
-      copyFileSync(cliPath, `${cliPath}.bak.${Date.now()}`);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    if (existsSync(targetPath)) {
+      copyFileSync(targetPath, `${targetPath}.bak.${Date.now()}`);
     }
-    writeFileSync(cliPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(targetPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
     try {
-      chmodSync(cliPath, 0o600);
+      chmodSync(targetPath, 0o600);
     } catch {
       /* best effort on platforms without chmod semantics */
     }
-    say(`Written: ${cliPath}`);
+    say(`Written: ${targetPath}`);
     say("The stdio MCP proxy and hooks pick this up on the next harness start.");
-    return { written: true, path: cliPath };
+    return { written: true, path: targetPath };
   } finally {
     rl.close();
   }


### PR DESCRIPTION
## Description

Fixes three defects in the shared memory-plugin code: the setup wizard cannot create a config on a fresh machine, the MCP proxy's connection-failure hint names a subcommand that does not exist, and the Claude Code plugin reports the wrong file as the source of the API key.

### Defect 1 — the setup wizard cannot create a first-run config

**Root cause.** `runSetupWizard` in `examples/memory-plugin-shared/lib/setup-wizard.mjs` destructured `cliPath` from `loadCredentialFiles(env)`. In `examples/memory-plugin-shared/lib/credentials.mjs`, `cliPath` is deliberately `""` when the file does not exist (`let cliPath = cliFile ? cliPathCandidate : ""`), because callers use it as an "ovcli.conf is in play" signal; the path the user *should* write to is returned separately as `cliPathCandidate`. The wizard used the signal as if it were the path, so on a machine with no `~/.openviking/ovcli.conf` it read, printed, and wrote the empty string.

**Introduced in.** `f90556253` — `feat(plugins): stdio MCP proxy, remote marketplace install, and type-quota recall for memory plugins (#3039)`, which added both `setup-wizard.mjs` and the `cliPath` / `cliPathCandidate` split in `credentials.mjs` in the same commit. The wizard has never worked on a first run.

**Symptom.** `node examples/claude-code-memory-plugin/scripts/setup.mjs` on a fresh machine prints `Config file: ` with a blank path and then either exits silently without writing anything or fails with `ENOENT: no such file or directory, open ''`. This is the only supported configuration path for a pure-marketplace install with no installer script, so those users could not configure the plugin at all. Every harness that exposes the wizard is affected (Claude Code, Codex, opencode, pi).

**Fix.** Fall back to `cliPathCandidate` when `cliPath` is empty, which keeps honoring an explicit `OPENVIKING_CLI_CONFIG_FILE` and otherwise resolves to `~/.openviking/ovcli.conf`. The existing `mkdirSync(dirname(...), { recursive: true })` before the write now runs against a real path, so a missing `~/.openviking` directory is created.

**Verified.** New `examples/memory-plugin-shared/setup-wizard.test.mjs` drives the wizard with scripted stdin; the first-run case fails with `ENOENT ... open ''` against the pre-fix module and passes after. Also reproduced end to end: `printf 'y\n\n\n\ny\n' | OPENVIKING_CLI_CONFIG_FILE=<tmp>/.openviking/ovcli.conf node examples/claude-code-memory-plugin/scripts/setup.mjs` now prints the real target path instead of a blank one.

### Defect 2 — the proxy error hint names a command that does not exist

**Root cause.** The JSON-RPC `-32001` transport-failure path in `examples/memory-plugin-shared/lib/mcp-proxy-core.mjs` told the user to check that `'ov serve'` is running. There is no `ov serve` subcommand — `ov` is the Rust CLI, and the server is started with `openviking-server` (see the entry points in `pyproject.toml`).

**Introduced in.** `f90556253` — `feat(plugins): stdio MCP proxy, remote marketplace install, and type-quota recall for memory plugins (#3039)`, the commit that added `mcp-proxy-core.mjs`.

**Symptom.** Whenever the server is down or the URL is wrong, every harness's MCP tool call surfaces an error telling the user to run a command that does not exist; `ov serve` exits with an unknown-subcommand error, sending the user down a dead end during exactly the failure they are trying to diagnose.

**Fix.** The hint now reads `... and that the OpenViking server (\`openviking-server\`) is reachable.` A repo-wide grep for `ov serve` now returns nothing; all other occurrences were the generated copies of this same string, regenerated by `sync.mjs`.

### Defect 3 — `loadConfig().configPath` reports the wrong file

**Root cause.** `examples/claude-code-memory-plugin/scripts/config.mjs` set `configPath: ovConf?.configPath || cliConf?.configPath`, i.e. whichever config file merely *parsed*, with `ov.conf` unconditionally preferred. The actual credential chain is the opposite order and is per-field: env → `ovcli.conf` `api_key` → `ov.conf` `claude_code.apiKey` → `ov.conf` `server.root_api_key`. `servers/mcp-proxy.mjs` then derived `credentialSource` from `configPath.endsWith("ovcli.conf")` and passed `credentialPath: cfg.configPath`, so on any machine that has both files the proxy reported `ov.conf` even when the key came from `ovcli.conf`. `scripts/ov-status.mjs` re-implemented the real chain independently, so the two disagreed.

**Introduced in.** The `configPath` line dates to `8c01e97ee` — `feat(cc-memory-plugin): persistent session and recall redesign (#1615)`, the commit that added `ovcli.conf` as a credential source ahead of `ov.conf` in the api_key chain while leaving `configPath` preferring `ov.conf`. It became user-visible in `f90556253` (#3039), which introduced `servers/mcp-proxy.mjs` and derived `credentialSource` / `credentialPath` from that field.

**Symptom.** The proxy's debug `start` log line and the `data.credentialPath` in its 401 error point at `~/.openviking/ov.conf` while the key actually comes from `~/.openviking/ovcli.conf` — so an operator debugging a 401 edits the wrong file. On this machine, before the fix, `loadConfig().configPath` printed the `ov.conf` path while `ov-status.mjs` printed `api_key from ~/.openviking/ovcli.conf`. The Codex proxy had the same class of bug through `credentialPath: creds.cliPath || creds.ovPath`, which names `ovcli.conf` whenever that file exists even if the key came from `ov.conf`.

**Fix.** `loadConfig()` now also returns `credentialSource` (`env` / `ovcli` / `ov` / `none`) and `credentialPath`, computed by walking the same chain that produces `apiKey` — including the case where `apiKey` arrives through `ovcli.conf`'s `plugin.claude_code` section, which is reported as `ovcli`. `configPath` keeps its old meaning for backward compat. `servers/mcp-proxy.mjs` and `scripts/ov-status.mjs` both read the new fields, so they can no longer disagree. On the shared side, `resolveOpenVikingCredentials` gained the same `credentialPath` and the Codex proxy now uses it.

**Verified.** New `examples/claude-code-memory-plugin/scripts/config.test.mjs` covers all five branches of the chain against throwaway config pairs; `examples/codex-memory-plugin/scripts/ov-credentials.test.mjs` gained a case for the shared resolver. Confirmed live on a machine with both files: `loadConfig()` now reports `credentialSource: ovcli` / `credentialPath: ~/.openviking/ovcli.conf`, matching `ov-status.mjs`'s `api_key from ~/.openviking/ovcli.conf`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- `examples/memory-plugin-shared/lib/setup-wizard.mjs`: write to `cliPath || cliPathCandidate` so a first run creates `ovcli.conf` (and its parent directory) instead of writing to `""`.
- `examples/memory-plugin-shared/lib/mcp-proxy-core.mjs`: replace the nonexistent `'ov serve'` in the transport-failure hint with `openviking-server`.
- `examples/memory-plugin-shared/lib/credentials.mjs`: `resolveOpenVikingCredentials` now returns `credentialPath`, the file that actually supplied the `api_key` (empty for env-sourced keys).
- `examples/claude-code-memory-plugin/scripts/config.mjs`: `loadConfig()` returns `credentialSource` and `credentialPath` following the real api_key chain; `configPath` is unchanged for backward compat.
- `examples/claude-code-memory-plugin/servers/mcp-proxy.mjs` and `scripts/ov-status.mjs`: consume the new fields so the proxy log, the proxy's 401 payload and `/ov` all name the same file.
- `examples/codex-memory-plugin/servers/mcp-proxy.mjs`: use `creds.credentialPath` instead of `creds.cliPath || creds.ovPath`.
- New tests `examples/memory-plugin-shared/setup-wizard.test.mjs` and `examples/claude-code-memory-plugin/scripts/config.test.mjs`, plus a new case in `examples/codex-memory-plugin/scripts/ov-credentials.test.mjs`; both new files added to the `node --test` list in `.github/workflows/pr.yml`.
- Regenerated the `sync.mjs` copies of the three changed shared modules.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

`node examples/memory-plugin-shared/sync.mjs` followed by the workflow's `node --test` list: 221 tests, 221 passing.

The wizard test was run against the pre-fix module to confirm it reproduces the defect (`Error: ENOENT: no such file or directory, open ''`) before passing against the fix.

Two files in the workflow list, `install-agent-hooks.test.mjs` and `install-opencode-jsonc.test.mjs`, fail when run from a linked `git worktree` rather than a normal checkout: `install.sh`'s `resolve_self_checkout` tests `[ -d "$dir/../../.git" ]`, and in a worktree `.git` is a file, so `CHECKOUT_DIR` stays empty and the marketplace directory resolves to `/examples`. This is unrelated to these changes and does not affect CI, which runs on a normal checkout.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

`agent-plugins/servers/config.mjs` and `agent-plugins/servers/mcp-proxy.mjs` carry the same `configPath` / `credentialSource` pattern as defect 3. It is left alone here to keep this change scoped to the plugins named above.
