### PR TITLE
fix(memory): Event memory writes reusing existing page IDs

### DIFF
--- a/openviking/session/memory/dataclass.py
+++ b/openviking/session/memory/dataclass.py
@@ -180,6 +180,7 @@ class MemoryOperationSkipCode(str, Enum):
     INVALID_RANGES = "invalid_ranges"
     AMBIGUOUS_TARGET = "ambiguous_target"
     NO_WRITABLE_TARGET = "no_writable_target"
+    PAGE_ID_TYPE_MISMATCH = "page_id_type_mismatch"
 
 
 class MemoryOperationSkip(BaseModel):

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -26,6 +26,7 @@ from openviking.session.memory.dataclass import (
 )
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.merge_op import FieldType, MergeOp, PatchOp
+from openviking.session.memory.page_id_map import ResponsePageIdAllocator
 from openviking.session.memory.schema_model_generator import SchemaModelGenerator
 from openviking.session.memory.tools import (
     MEMORY_TOOLS_REGISTRY,
@@ -328,7 +329,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 if resolution_issues and resolution_repair_count == 0:
                     resolution_repair_count += 1
                     pending_resolution_repair = (final_operations, raw_links)
-                    self._release_retryable_event_page_ids(final_operations)
                     max_iterations += 1
                     self._disable_tools_for_iteration = True
                     messages.append(
@@ -523,15 +523,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
             and operation.resolution_skip.reason_code in _EVENT_RETRYABLE_RESOLUTION_SKIP_CODES
         )
 
-    def _release_retryable_event_page_ids(self, operations: ResolvedOperations) -> None:
-        page_id_map = getattr(self._extract_context, "page_id_map", None)
-        release_page_id = getattr(page_id_map, "release_new_page_id", None)
-        if not callable(release_page_id):
-            return
-        for operation in operations.upsert_operations:
-            if self._is_retryable_event_operation(operation):
-                release_page_id(operation.page_id)
-
     @classmethod
     def _event_resolution_repair_subset(
         cls,
@@ -632,7 +623,27 @@ The final output of the model must strictly follow the JSON Schema format shown 
         )
 
     @staticmethod
-    def _normalize_event_links(
+    def _normalize_page_id_reference(
+        raw_page_id: Optional[int],
+        page_id_assignments: Dict[int, List[int]],
+        page_id_map: Any,
+    ) -> Tuple[Optional[int], bool]:
+        """Return the normalized response ID and whether the reference is ambiguous."""
+        if raw_page_id is None:
+            return None, False
+        assigned_ids = page_id_assignments.get(raw_page_id, [])
+        if not assigned_ids:
+            return raw_page_id, False
+
+        unique_ids = list(dict.fromkeys(assigned_ids))
+        existing_uri = page_id_map.resolve(raw_page_id) if page_id_map else None
+        if len(unique_ids) != 1 or (existing_uri is not None and unique_ids[0] != raw_page_id):
+            return None, True
+        return unique_ids[0], False
+
+    @classmethod
+    def _normalize_operation_links(
+        cls,
         raw_links: List[WikiLink],
         page_id_assignments: Dict[int, List[int]],
         page_id_map: Any,
@@ -646,27 +657,78 @@ The final output of the model must strictly follow the JSON Schema format shown 
             ambiguous = False
             for field_name in ("f", "t"):
                 raw_page_id = getattr(link, field_name, None)
-                assigned_ids = page_id_assignments.get(raw_page_id, [])
-                if not assigned_ids:
-                    continue
-                unique_ids = list(dict.fromkeys(assigned_ids))
-                existing_uri = page_id_map.resolve(raw_page_id) if page_id_map else None
-                if len(unique_ids) != 1 or (
-                    existing_uri is not None and unique_ids[0] != raw_page_id
-                ):
+                normalized_page_id, is_ambiguous = cls._normalize_page_id_reference(
+                    raw_page_id,
+                    page_id_assignments,
+                    page_id_map,
+                )
+                if is_ambiguous:
                     ambiguous = True
                     break
-                updates[field_name] = unique_ids[0]
+                if normalized_page_id != raw_page_id:
+                    updates[field_name] = normalized_page_id
             if ambiguous:
                 logger.warning(
-                    "Skipping ambiguous memory link after event page_id normalization: "
-                    "f=%s, t=%s",
+                    "Skipping ambiguous memory link after page_id normalization: f=%s, t=%s",
                     link.f,
                     link.t,
                 )
                 continue
             normalized_links.append(link.model_copy(update=updates) if updates else link)
         return normalized_links
+
+    def _assign_response_page_ids(
+        self,
+        operations: Any,
+        schemas: List[Any],
+        page_id_map: Any,
+    ) -> Tuple[Dict[Tuple[int, int], int], Dict[int, List[int]]]:
+        """Assign unique IDs to new logical operations within one candidate response."""
+        entries: List[Tuple[int, int, Optional[int], bool]] = []
+        for schema_index, schema in enumerate(schemas):
+            value = getattr(operations, schema.memory_type, None)
+            if value is None:
+                continue
+            items = value if isinstance(value, list) else [value]
+            is_event = self._is_event_schema(schema)
+            for item_index, item in enumerate(items):
+                requested_page_id = dict(item).get("page_id")
+                entries.append((schema_index, item_index, requested_page_id, is_event))
+
+        assigned_page_ids: Dict[Tuple[int, int], int] = {}
+        page_id_assignments: Dict[int, List[int]] = {}
+        page_id_allocator = None
+
+        # Preserve non-Event behavior where possible. Events are always new and therefore
+        # allocate after every other memory type has claimed its response-local ID.
+        for event_phase in (False, True):
+            for schema_index, item_index, requested_page_id, is_event in entries:
+                if is_event != event_phase:
+                    continue
+                existing_uri = None
+                if requested_page_id is not None and page_id_map is not None:
+                    existing_uri = page_id_map.resolve(requested_page_id)
+                if not is_event and existing_uri is not None:
+                    page_id = requested_page_id
+                else:
+                    if page_id_allocator is None:
+                        allocator_factory = getattr(
+                            page_id_map,
+                            "new_page_id_allocator",
+                            None,
+                        )
+                        page_id_allocator = (
+                            allocator_factory()
+                            if callable(allocator_factory)
+                            else ResponsePageIdAllocator()
+                        )
+                    page_id = page_id_allocator.allocate(requested_page_id)
+
+                assigned_page_ids[(schema_index, item_index)] = page_id
+                if requested_page_id is not None:
+                    page_id_assignments.setdefault(requested_page_id, []).append(page_id)
+
+        return assigned_page_ids, page_id_assignments
 
     async def resolve_operations(self, operations) -> tuple[ResolvedOperations, List]:
         tracer.info(f"operations={JsonUtils.dumps(operations)}")
@@ -676,9 +738,14 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         role_scope = self._isolation_handler.get_read_scope()
         page_id_map = getattr(self._extract_context, "page_id_map", None)
-        event_page_id_assignments: Dict[int, List[int]] = {}
+        schemas = list(self.context_provider.get_memory_schemas(self.ctx))
+        assigned_page_ids, page_id_assignments = self._assign_response_page_ids(
+            operations,
+            schemas,
+            page_id_map,
+        )
 
-        for schema in self.context_provider.get_memory_schemas(self.ctx):
+        for schema_index, schema in enumerate(schemas):
             memory_type = schema.memory_type
             value = getattr(operations, memory_type, None)
             if value is None:
@@ -686,7 +753,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
             items = value if isinstance(value, list) else [value]
 
-            for item in items:
+            for item_index, item in enumerate(items):
                 item_dict = dict(item)
                 item_dict["memory_type"] = memory_type
                 identity_resolution_skip = None
@@ -721,15 +788,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     identity_resolution_skip = None
 
                 requested_page_id = item_dict.pop("page_id", None)
-                page_id = requested_page_id
+                page_id = assigned_page_ids[(schema_index, item_index)]
                 is_event = self._is_event_schema(schema)
-                if is_event:
-                    if page_id_map is not None:
-                        page_id = page_id_map.allocate_new_page_id(requested_page_id)
-                    elif page_id is None or page_id < 100:
-                        page_id = 100
-                    if requested_page_id is not None:
-                        event_page_id_assignments.setdefault(requested_page_id, []).append(page_id)
                 resolved_op = ResolvedOperation(
                     old_memory_file_content=None,
                     memory_fields=item_dict,
@@ -747,8 +807,8 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         operation=resolved_op,
                         extract_context=self._extract_context,
                     )
-                elif page_id is not None and page_id_map is not None:
-                    resolved_uri = page_id_map.resolve(page_id)
+                elif requested_page_id is not None and page_id_map is not None:
+                    resolved_uri = page_id_map.resolve(requested_page_id)
                     if resolved_uri:
                         old_content = self.context_provider.read_file_contents.get(resolved_uri)
                         belongs_to_schema = self._uri_belongs_to_schema(resolved_uri, schema)
@@ -805,24 +865,37 @@ The final output of the model must strictly follow the JSON Schema format shown 
             old_content = self.context_provider.read_file_contents.get(delete_uri)
             if not old_content:
                 continue
-            delete_file_contents.append(old_content)
-
             replacement_page_id = delete_id.replacement_page_id
-            if replacement_page_id is None:
-                continue
-            replacement_uri = page_id_map.resolve(replacement_page_id)
-            if not replacement_uri:
-                for op in upsert_operations:
-                    if op.page_id == replacement_page_id and op.uris:
-                        replacement_uri = op.uris[0]
-                        break
+            replacement_uri = None
+            if replacement_page_id is not None:
+                replacement_page_id, ambiguous = self._normalize_page_id_reference(
+                    replacement_page_id,
+                    page_id_assignments,
+                    page_id_map,
+                )
+                if ambiguous:
+                    logger.warning(
+                        "Skipping delete with ambiguous replacement page_id: "
+                        "delete_page_id=%s, replacement_page_id=%s",
+                        delete_id.delete_page_id,
+                        delete_id.replacement_page_id,
+                    )
+                    continue
+                replacement_uri = page_id_map.resolve(replacement_page_id)
+                if not replacement_uri:
+                    for op in upsert_operations:
+                        if op.page_id == replacement_page_id and op.uris:
+                            replacement_uri = op.uris[0]
+                            break
+
+            delete_file_contents.append(old_content)
             if replacement_uri and replacement_uri != delete_uri:
                 delete_replacements[delete_uri] = replacement_uri
 
         raw_links = getattr(operations, "links", None) or []
-        raw_links = self._normalize_event_links(
+        raw_links = self._normalize_operation_links(
             raw_links,
-            event_page_id_assignments,
+            page_id_assignments,
             page_id_map,
         )
         resolved = ResolvedOperations(
@@ -840,7 +913,6 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     break
 
         return resolved, raw_links
-
 
     def _normalize_delete_ids(self, raw_delete_ids: List[Any]) -> List[DeleteId]:
         delete_ids: List[DeleteId] = []

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -735,6 +735,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
         upsert_operations: List[ResolvedOperation] = []
         delete_file_contents: List[MemoryFile] = []
         errors: List[str] = []
+        invalid_reference_page_ids: set[int] = set()
 
         role_scope = self._isolation_handler.get_read_scope()
         page_id_map = getattr(self._extract_context, "page_id_map", None)
@@ -813,6 +814,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
                         old_content = self.context_provider.read_file_contents.get(resolved_uri)
                         belongs_to_schema = self._uri_belongs_to_schema(resolved_uri, schema)
                         if belongs_to_schema is False:
+                            invalid_reference_page_ids.add(requested_page_id)
                             existing_memory_type = self._memory_type_for_uri(resolved_uri)
                             resolved_op.resolution_skip = MemoryOperationSkip(
                                 reason_code=MemoryOperationSkipCode.PAGE_ID_TYPE_MISMATCH,
@@ -868,6 +870,14 @@ The final output of the model must strictly follow the JSON Schema format shown 
             replacement_page_id = delete_id.replacement_page_id
             replacement_uri = None
             if replacement_page_id is not None:
+                if replacement_page_id in invalid_reference_page_ids:
+                    logger.warning(
+                        "Skipping delete with type-mismatched replacement page_id: "
+                        "delete_page_id=%s, replacement_page_id=%s",
+                        delete_id.delete_page_id,
+                        delete_id.replacement_page_id,
+                    )
+                    continue
                 replacement_page_id, ambiguous = self._normalize_page_id_reference(
                     replacement_page_id,
                     page_id_assignments,
@@ -893,6 +903,13 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 delete_replacements[delete_uri] = replacement_uri
 
         raw_links = getattr(operations, "links", None) or []
+        if invalid_reference_page_ids:
+            raw_links = [
+                link
+                for link in raw_links
+                if link.f not in invalid_reference_page_ids
+                and link.t not in invalid_reference_page_ids
+            ]
         raw_links = self._normalize_operation_links(
             raw_links,
             page_id_assignments,

--- a/openviking/session/memory/extract_loop.py
+++ b/openviking/session/memory/extract_loop.py
@@ -9,6 +9,7 @@ Reference: bot/vikingbot/agent/loop.py AgentLoop structure
 import asyncio
 import json
 import re
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from openviking.models.vlm.base import ToolCall, VLMBase
@@ -17,9 +18,11 @@ from openviking.session.memory.dataclass import (
     DeleteId,
     MemoryFile,
     MemoryOperationSkip,
+    MemoryOperationSkipCode,
     ResolvedOperation,
     ResolvedOperations,
     StoredLink,
+    WikiLink,
 )
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
 from openviking.session.memory.merge_op import FieldType, MergeOp, PatchOp
@@ -39,6 +42,23 @@ from openviking_cli.utils import get_logger
 from openviking_cli.utils.config import get_openviking_config
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class _EventRepairOperations:
+    """Server-filtered operation set accepted from one Event repair response."""
+
+    events: List[Dict[str, Any]]
+    delete_ids: List[Any] = field(default_factory=list)
+    links: List[WikiLink] = field(default_factory=list)
+
+
+_EVENT_RETRYABLE_RESOLUTION_SKIP_CODES = {
+    MemoryOperationSkipCode.INVALID_PEER_ID,
+    MemoryOperationSkipCode.INVALID_RANGES,
+    MemoryOperationSkipCode.AMBIGUOUS_TARGET,
+    MemoryOperationSkipCode.NO_WRITABLE_TARGET,
+}
 
 
 _CANNED_REFUSAL_RE = re.compile(
@@ -158,6 +178,8 @@ class ExtractLoop:
         # Reset format retry counter for each run
         self._format_retry_count = 0
         patch_repair_count = 0
+        resolution_repair_count = 0
+        pending_resolution_repair: Optional[Tuple[ResolvedOperations, List]] = None
 
         # 从 provider 获取 schemas（内部自动加载 registry）
         schemas = self.context_provider.get_memory_schemas(self.ctx)
@@ -285,7 +307,42 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
             # If model returned final operations, check if refetch is needed
             if operations is not None:
-                final_operations, raw_links = await self.resolve_operations(operations)
+                if pending_resolution_repair is not None:
+                    operations = self._event_resolution_repair_subset(
+                        operations,
+                        pending_resolution_repair[0],
+                    )
+                candidate_operations, candidate_links = await self.resolve_operations(operations)
+                if pending_resolution_repair is not None:
+                    base_operations, base_links = pending_resolution_repair
+                    final_operations = self._merge_event_resolution_repair(
+                        base_operations,
+                        candidate_operations,
+                    )
+                    raw_links = base_links
+                    pending_resolution_repair = None
+                else:
+                    final_operations = candidate_operations
+                    raw_links = candidate_links
+                resolution_issues = self._retryable_resolution_issues(final_operations)
+                if resolution_issues and resolution_repair_count == 0:
+                    resolution_repair_count += 1
+                    pending_resolution_repair = (final_operations, raw_links)
+                    self._release_retryable_event_page_ids(final_operations)
+                    max_iterations += 1
+                    self._disable_tools_for_iteration = True
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": self._build_resolution_repair_instruction(resolution_issues),
+                        }
+                    )
+                    tracer.info(
+                        "Extended max_iterations to "
+                        f"{max_iterations} for retry memory target resolution",
+                        console=True,
+                    )
+                    continue
                 # Check if any write_uris target existing files that weren't read
                 refetch_uris = await self._check_unread_existing_files(final_operations)
                 if refetch_uris:
@@ -336,6 +393,15 @@ The final output of the model must strictly follow the JSON Schema format shown 
             # If it's the last iteration, treat unparseable response as
             # "no memory operations" rather than failing hard.
             if iteration >= max_iterations:
+                if pending_resolution_repair is not None:
+                    final_operations, raw_links = pending_resolution_repair
+                    pending_resolution_repair = None
+                    tracer.info(
+                        "Event resolution repair response could not be parsed; "
+                        "keeping the first-pass operations",
+                        console=True,
+                    )
+                    break
                 tracer.info(
                     "Memory extraction final response could not be parsed as JSON operations "
                     f"after {max_iterations} iterations — treating as no operations "
@@ -368,6 +434,240 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         return final_operations, tools_used
 
+    def _retryable_resolution_issues(self, operations: ResolvedOperations) -> List[Dict[str, Any]]:
+        issues: List[Dict[str, Any]] = []
+        for operation in operations.upsert_operations:
+            resolution_skip = operation.resolution_skip
+            if (
+                operation.uris
+                or operation.memory_type != "events"
+                or resolution_skip is None
+                or resolution_skip.reason_code not in _EVENT_RETRYABLE_RESOLUTION_SKIP_CODES
+            ):
+                continue
+            if resolution_skip.reason_code == MemoryOperationSkipCode.NO_WRITABLE_TARGET and (
+                not self.ctx or not self.ctx.user
+            ):
+                continue
+            issue = {
+                "memory_type": operation.memory_type,
+                "page_id": operation.page_id,
+                "reason_code": resolution_skip.reason_code.value,
+                "reason": resolution_skip.reason,
+                "operation": operation.memory_fields,
+            }
+            issues.append(issue)
+        return issues
+
+    @staticmethod
+    def _build_resolution_repair_instruction(issues: List[Dict[str, Any]]) -> str:
+        details = json.dumps(issues, ensure_ascii=False, indent=2)
+        return (
+            "Some event operations could not resolve a safe write target. "
+            "Return only corrected event operations for the failed items below; leave every "
+            "other memory-type field, delete_ids, and links empty. The server has preserved "
+            "all successful operations from the previous response. "
+            "Reuse exactly the page_id shown for each failed event. "
+            "For event ranges, use valid in-bounds message indexes and include the user-role "
+            "message that establishes the event so its owner can be resolved. "
+            "Do not target a disallowed or ambiguous peer. Output ONLY one JSON object matching "
+            "the required schema.\n\n"
+            f"Resolution issues:\n{details}"
+        )
+
+    @staticmethod
+    def _is_event_schema(schema: Any) -> bool:
+        return (
+            getattr(schema, "memory_type", None) == "events"
+            and getattr(schema, "operation_mode", None) == "add_only"
+        )
+
+    def _uri_belongs_to_schema(self, uri: str, schema: Any) -> Optional[bool]:
+        """Return a path-based ownership result without trusting file metadata."""
+        render_directories = getattr(self._isolation_handler, "render_schema_directories", None)
+        if not callable(render_directories):
+            return None
+        try:
+            directories = render_directories(schema)
+        except Exception:
+            return None
+        if not isinstance(directories, (list, tuple, set)):
+            return None
+        directories = [
+            directory.rstrip("/") for directory in directories if isinstance(directory, str)
+        ]
+        if not directories:
+            return None
+        filename_template = str(getattr(schema, "filename_template", "") or "").lstrip("/")
+        if not filename_template:
+            return None
+        if schema.filename_has_variables():
+            return any(uri.startswith(f"{directory}/") for directory in directories)
+        return any(uri == f"{directory}/{filename_template}" for directory in directories)
+
+    def _memory_type_for_uri(self, uri: str) -> Optional[str]:
+        matches = [
+            schema.memory_type
+            for schema in self.context_provider.get_memory_schemas(self.ctx)
+            if self._uri_belongs_to_schema(uri, schema) is True
+        ]
+        unique_matches = list(dict.fromkeys(matches))
+        return unique_matches[0] if len(unique_matches) == 1 else None
+
+    @staticmethod
+    def _is_retryable_event_operation(operation: ResolvedOperation) -> bool:
+        return bool(
+            operation.memory_type == "events"
+            and not operation.uris
+            and operation.resolution_skip is not None
+            and operation.resolution_skip.reason_code in _EVENT_RETRYABLE_RESOLUTION_SKIP_CODES
+        )
+
+    def _release_retryable_event_page_ids(self, operations: ResolvedOperations) -> None:
+        page_id_map = getattr(self._extract_context, "page_id_map", None)
+        release_page_id = getattr(page_id_map, "release_new_page_id", None)
+        if not callable(release_page_id):
+            return
+        for operation in operations.upsert_operations:
+            if self._is_retryable_event_operation(operation):
+                release_page_id(operation.page_id)
+
+    @classmethod
+    def _event_resolution_repair_subset(
+        cls,
+        operations: Any,
+        original: ResolvedOperations,
+    ) -> _EventRepairOperations:
+        """Keep only one range repair for each failed Event and preserve its original fields."""
+        failed_events = {
+            operation.page_id: operation
+            for operation in original.upsert_operations
+            if cls._is_retryable_event_operation(operation) and operation.page_id is not None
+        }
+        candidates: Dict[int, List[Dict[str, Any]]] = {}
+        for item in getattr(operations, "events", None) or []:
+            item_dict = dict(item)
+            page_id = item_dict.get("page_id")
+            if page_id in failed_events:
+                candidates.setdefault(page_id, []).append(item_dict)
+
+        repaired_items: List[Dict[str, Any]] = []
+        for page_id, failed_operation in failed_events.items():
+            page_candidates = candidates.get(page_id, [])
+            if len(page_candidates) != 1:
+                if page_candidates:
+                    logger.warning(
+                        "Ignoring ambiguous Event repair response for page_id=%s: count=%s",
+                        page_id,
+                        len(page_candidates),
+                    )
+                continue
+
+            candidate = page_candidates[0]
+            expected_name = failed_operation.memory_fields.get("event_name")
+            if candidate.get("event_name") != expected_name or candidate.get("ranges") is None:
+                logger.warning(
+                    "Ignoring mismatched Event repair response for page_id=%s",
+                    page_id,
+                )
+                continue
+
+            repaired_item = {
+                key: value
+                for key, value in failed_operation.memory_fields.items()
+                if key not in {"memory_type", "user_id"}
+            }
+            repaired_item["ranges"] = candidate["ranges"]
+            repaired_item["page_id"] = page_id
+            repaired_items.append(repaired_item)
+
+        return _EventRepairOperations(events=repaired_items)
+
+    @classmethod
+    def _merge_event_resolution_repair(
+        cls,
+        original: ResolvedOperations,
+        repair: ResolvedOperations,
+    ) -> ResolvedOperations:
+        """Replace only failed Events; preserve every other first-pass operation."""
+        failed_page_ids = {
+            operation.page_id
+            for operation in original.upsert_operations
+            if cls._is_retryable_event_operation(operation)
+        }
+        failed_event_names = {
+            operation.page_id: operation.memory_fields.get("event_name")
+            for operation in original.upsert_operations
+            if cls._is_retryable_event_operation(operation)
+        }
+        repaired_events: Dict[int, ResolvedOperation] = {}
+        duplicate_page_ids = set()
+        for operation in repair.upsert_operations:
+            if (
+                operation.memory_type != "events"
+                or operation.page_id not in failed_page_ids
+                or operation.memory_fields.get("event_name")
+                != failed_event_names.get(operation.page_id)
+            ):
+                continue
+            if operation.page_id in repaired_events:
+                duplicate_page_ids.add(operation.page_id)
+                continue
+            repaired_events[operation.page_id] = operation
+        for page_id in duplicate_page_ids:
+            repaired_events.pop(page_id, None)
+
+        merged_operations: List[ResolvedOperation] = []
+        for operation in original.upsert_operations:
+            if cls._is_retryable_event_operation(operation):
+                repaired_operation = repaired_events.get(operation.page_id)
+                merged_operations.append(repaired_operation or operation)
+                continue
+            merged_operations.append(operation)
+
+        return original.model_copy(
+            update={
+                "upsert_operations": merged_operations,
+            }
+        )
+
+    @staticmethod
+    def _normalize_event_links(
+        raw_links: List[WikiLink],
+        page_id_assignments: Dict[int, List[int]],
+        page_id_map: Any,
+    ) -> List[WikiLink]:
+        if not raw_links or not page_id_assignments:
+            return raw_links
+
+        normalized_links: List[WikiLink] = []
+        for link in raw_links:
+            updates: Dict[str, int] = {}
+            ambiguous = False
+            for field_name in ("f", "t"):
+                raw_page_id = getattr(link, field_name, None)
+                assigned_ids = page_id_assignments.get(raw_page_id, [])
+                if not assigned_ids:
+                    continue
+                unique_ids = list(dict.fromkeys(assigned_ids))
+                existing_uri = page_id_map.resolve(raw_page_id) if page_id_map else None
+                if len(unique_ids) != 1 or (
+                    existing_uri is not None and unique_ids[0] != raw_page_id
+                ):
+                    ambiguous = True
+                    break
+                updates[field_name] = unique_ids[0]
+            if ambiguous:
+                logger.warning(
+                    "Skipping ambiguous memory link after event page_id normalization: "
+                    "f=%s, t=%s",
+                    link.f,
+                    link.t,
+                )
+                continue
+            normalized_links.append(link.model_copy(update=updates) if updates else link)
+        return normalized_links
+
     async def resolve_operations(self, operations) -> tuple[ResolvedOperations, List]:
         tracer.info(f"operations={JsonUtils.dumps(operations)}")
         upsert_operations: List[ResolvedOperation] = []
@@ -376,6 +676,7 @@ The final output of the model must strictly follow the JSON Schema format shown 
 
         role_scope = self._isolation_handler.get_read_scope()
         page_id_map = getattr(self._extract_context, "page_id_map", None)
+        event_page_id_assignments: Dict[int, List[int]] = {}
 
         for schema in self.context_provider.get_memory_schemas(self.ctx):
             memory_type = schema.memory_type
@@ -419,7 +720,16 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 if not isinstance(identity_resolution_skip, MemoryOperationSkip):
                     identity_resolution_skip = None
 
-                page_id = item_dict.pop("page_id", None)
+                requested_page_id = item_dict.pop("page_id", None)
+                page_id = requested_page_id
+                is_event = self._is_event_schema(schema)
+                if is_event:
+                    if page_id_map is not None:
+                        page_id = page_id_map.allocate_new_page_id(requested_page_id)
+                    elif page_id is None or page_id < 100:
+                        page_id = 100
+                    if requested_page_id is not None:
+                        event_page_id_assignments.setdefault(requested_page_id, []).append(page_id)
                 resolved_op = ResolvedOperation(
                     old_memory_file_content=None,
                     memory_fields=item_dict,
@@ -429,16 +739,35 @@ The final output of the model must strictly follow the JSON Schema format shown 
                     resolution_skip=identity_resolution_skip,
                 )
 
-                if page_id is not None and page_id_map is not None:
+                if is_event:
+                    # Event page_ids are temporary link anchors. They must never select an
+                    # existing memory file; URI collision handling remains unchanged downstream.
+                    resolved_op.uris = self._isolation_handler.calculate_memory_uris(
+                        memory_type_schema=schema,
+                        operation=resolved_op,
+                        extract_context=self._extract_context,
+                    )
+                elif page_id is not None and page_id_map is not None:
                     resolved_uri = page_id_map.resolve(page_id)
                     if resolved_uri:
-                        resolved_op.uris = [resolved_uri]
-                        # Existing page IDs retain their historical precedence over
-                        # an invalid peer hint. Keep the hint runtime-only and do
-                        # not persist it into memory metadata.
-                        resolved_op.resolution_skip = None
                         old_content = self.context_provider.read_file_contents.get(resolved_uri)
-                        if old_content is not None:
+                        belongs_to_schema = self._uri_belongs_to_schema(resolved_uri, schema)
+                        if belongs_to_schema is False:
+                            existing_memory_type = self._memory_type_for_uri(resolved_uri)
+                            resolved_op.resolution_skip = MemoryOperationSkip(
+                                reason_code=MemoryOperationSkipCode.PAGE_ID_TYPE_MISMATCH,
+                                reason=(
+                                    f"page_id {page_id} belongs to memory type "
+                                    f"{existing_memory_type or 'another schema'}, not {memory_type}"
+                                ),
+                            )
+                        else:
+                            resolved_op.uris = [resolved_uri]
+                            # Existing page IDs retain their historical precedence over
+                            # an invalid peer hint. Keep the hint runtime-only and do
+                            # not persist it into memory metadata.
+                            resolved_op.resolution_skip = None
+                        if old_content is not None and resolved_op.uris:
                             resolved_op.old_memory_file_content = old_content
                             immutable_fields = {
                                 field.name
@@ -491,6 +820,11 @@ The final output of the model must strictly follow the JSON Schema format shown 
                 delete_replacements[delete_uri] = replacement_uri
 
         raw_links = getattr(operations, "links", None) or []
+        raw_links = self._normalize_event_links(
+            raw_links,
+            event_page_id_assignments,
+            page_id_map,
+        )
         resolved = ResolvedOperations(
             upsert_operations=upsert_operations,
             delete_file_contents=delete_file_contents,

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -906,6 +906,7 @@ class MemoryUpdater:
                 if resolution_skip.reason_code in {
                     MemoryOperationSkipCode.INVALID_PEER_ID,
                     MemoryOperationSkipCode.INVALID_RANGES,
+                    MemoryOperationSkipCode.PAGE_ID_TYPE_MISMATCH,
                 }:
                     logger.warning(message)
                 else:

--- a/openviking/session/memory/page_id_map.py
+++ b/openviking/session/memory/page_id_map.py
@@ -14,11 +14,41 @@ page_id information is injected into LLM context by annotating read results
 with [page_id: N], not by generating a separate mapping table.
 """
 
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional
 
 from openviking_cli.utils import get_logger
 
 logger = get_logger(__name__)
+
+
+class ResponsePageIdAllocator:
+    """Allocate unique new-page IDs for one candidate LLM response."""
+
+    def __init__(self, registered_page_ids: Iterable[int] = ()):
+        self._registered_page_ids = set(registered_page_ids)
+        self._allocated_page_ids: set[int] = set()
+        self._next_page_id = 100
+
+    def allocate(self, requested_page_id: Optional[int]) -> int:
+        if (
+            requested_page_id is not None
+            and requested_page_id >= 100
+            and requested_page_id not in self._registered_page_ids
+            and requested_page_id not in self._allocated_page_ids
+        ):
+            page_id = requested_page_id
+        else:
+            page_id = self._next_page_id
+            while page_id in self._registered_page_ids or page_id in self._allocated_page_ids:
+                page_id += 1
+
+        self._allocated_page_ids.add(page_id)
+        while (
+            self._next_page_id in self._registered_page_ids
+            or self._next_page_id in self._allocated_page_ids
+        ):
+            self._next_page_id += 1
+        return page_id
 
 
 class PageIdMap:
@@ -26,10 +56,8 @@ class PageIdMap:
 
     def __init__(self):
         self._next_id: int = 1
-        self._next_new_id: int = 100
         self._id_to_uri: Dict[int, str] = {}
         self._uri_to_id: Dict[str, int] = {}
-        self._reserved_new_ids: set[int] = set()
 
     def get_page_id(self, uri: str) -> int:
         """Register an existing page (from prefetch/read). Returns page_id in 1-99 range."""
@@ -43,36 +71,11 @@ class PageIdMap:
 
     def register_new_page_id(self, uri: str, page_id: int) -> None:
         self._id_to_uri[page_id] = uri
-        if page_id >= 100:
-            self._reserved_new_ids.add(page_id)
-            self._next_new_id = max(self._next_new_id, page_id + 1)
         if uri not in self._uri_to_id:
             self._uri_to_id[uri] = page_id
 
-    def allocate_new_page_id(self, requested_page_id: Optional[int] = None) -> int:
-        """Reserve a unique ID in the new-page range, honoring a valid request when possible."""
-        if (
-            requested_page_id is not None
-            and requested_page_id >= 100
-            and requested_page_id not in self._id_to_uri
-            and requested_page_id not in self._reserved_new_ids
-        ):
-            page_id = requested_page_id
-        else:
-            page_id = self._next_new_id
-            while page_id in self._id_to_uri or page_id in self._reserved_new_ids:
-                page_id += 1
-
-        self._reserved_new_ids.add(page_id)
-        self._next_new_id = max(self._next_new_id, page_id + 1)
-        return page_id
-
-    def release_new_page_id(self, page_id: Optional[int]) -> None:
-        """Release an unregistered reservation so a repair attempt can reuse its ID."""
-        if page_id is None or page_id < 100 or page_id in self._id_to_uri:
-            return
-        self._reserved_new_ids.discard(page_id)
-        self._next_new_id = min(self._next_new_id, page_id)
+    def new_page_id_allocator(self) -> ResponsePageIdAllocator:
+        return ResponsePageIdAllocator(self._id_to_uri)
 
     def resolve(self, page_id: int) -> Optional[str]:
         """Resolve page_id to URI."""

--- a/openviking/session/memory/page_id_map.py
+++ b/openviking/session/memory/page_id_map.py
@@ -26,8 +26,10 @@ class PageIdMap:
 
     def __init__(self):
         self._next_id: int = 1
+        self._next_new_id: int = 100
         self._id_to_uri: Dict[int, str] = {}
         self._uri_to_id: Dict[str, int] = {}
+        self._reserved_new_ids: set[int] = set()
 
     def get_page_id(self, uri: str) -> int:
         """Register an existing page (from prefetch/read). Returns page_id in 1-99 range."""
@@ -41,8 +43,36 @@ class PageIdMap:
 
     def register_new_page_id(self, uri: str, page_id: int) -> None:
         self._id_to_uri[page_id] = uri
+        if page_id >= 100:
+            self._reserved_new_ids.add(page_id)
+            self._next_new_id = max(self._next_new_id, page_id + 1)
         if uri not in self._uri_to_id:
             self._uri_to_id[uri] = page_id
+
+    def allocate_new_page_id(self, requested_page_id: Optional[int] = None) -> int:
+        """Reserve a unique ID in the new-page range, honoring a valid request when possible."""
+        if (
+            requested_page_id is not None
+            and requested_page_id >= 100
+            and requested_page_id not in self._id_to_uri
+            and requested_page_id not in self._reserved_new_ids
+        ):
+            page_id = requested_page_id
+        else:
+            page_id = self._next_new_id
+            while page_id in self._id_to_uri or page_id in self._reserved_new_ids:
+                page_id += 1
+
+        self._reserved_new_ids.add(page_id)
+        self._next_new_id = max(self._next_new_id, page_id + 1)
+        return page_id
+
+    def release_new_page_id(self, page_id: Optional[int]) -> None:
+        """Release an unregistered reservation so a repair attempt can reuse its ID."""
+        if page_id is None or page_id < 100 or page_id in self._id_to_uri:
+            return
+        self._reserved_new_ids.discard(page_id)
+        self._next_new_id = min(self._next_new_id, page_id)
 
     def resolve(self, page_id: int) -> Optional[str]:
         """Resolve page_id to URI."""

--- a/openviking/session/memory/schema_model_generator.py
+++ b/openviking/session/memory/schema_model_generator.py
@@ -153,11 +153,17 @@ class SchemaModelGenerator:
                 ),
             )
 
+        page_id_json_schema = {"type": "integer"}
+        page_id_description = "Temporary page_id for identifying the target memory item."
+        if memory_type.memory_type == "events" and memory_type.operation_mode == "add_only":
+            page_id_json_schema["minimum"] = 100
+            page_id_description = "Unique page_id for this new event; it MUST be at least 100."
+
         field_definitions["page_id"] = (
-            Annotated[int, WithJsonSchema({"type": "integer"})],
+            Annotated[int, WithJsonSchema(page_id_json_schema)],
             Field(
                 ...,
-                description="Temporary page_id for identifying the target memory item.",
+                description=page_id_description,
             ),
         )
 

--- a/tests/session/memory/test_schema_models.py
+++ b/tests/session/memory/test_schema_models.py
@@ -273,6 +273,46 @@ class TestSchemaModelGenerator:
             "Temporary page_id for identifying the target memory item."
         )
 
+    def test_event_page_id_schema_requires_new_page_range(self):
+        memory_type = MemoryTypeSchema(
+            memory_type="events",
+            operation_mode="add_only",
+            filename_template="{{ event_name }}.md",
+            directory="viking://user/{{ user_space }}/memories/events",
+            fields=[
+                MemoryField(
+                    name="event_name",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.IMMUTABLE,
+                )
+            ],
+        )
+
+        model = SchemaModelGenerator([memory_type]).create_flat_data_model(memory_type)
+        schema = model.model_json_schema()
+
+        assert schema["properties"]["page_id"]["minimum"] == 100
+        assert "MUST be at least 100" in schema["properties"]["page_id"]["description"]
+        # Runtime resolution normalizes bad model output instead of dropping the event.
+        assert model.model_validate({"page_id": 5, "event_name": "demo"}).page_id == 5
+
+    def test_non_event_add_only_page_id_schema_is_unchanged(self):
+        memory_type = MemoryTypeSchema(
+            memory_type="trajectories",
+            operation_mode="add_only",
+            filename_template="{{ trajectory_name }}.md",
+            directory="viking://user/{{ user_space }}/memories/trajectories",
+            fields=[],
+        )
+
+        model = SchemaModelGenerator([memory_type]).create_flat_data_model(memory_type)
+        page_id_schema = model.model_json_schema()["properties"]["page_id"]
+
+        assert "minimum" not in page_id_schema
+        assert page_id_schema["description"] == (
+            "Temporary page_id for identifying the target memory item."
+        )
+
     def test_existing_patch_can_omit_immutable_fields_but_new_item_cannot(
         self, real_registry
     ):

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -168,6 +168,77 @@ class TestResolveOperations:
         isolation_handler.calculate_memory_uris.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_type_mismatched_page_id_is_rejected_from_links_and_replacements(self):
+        entity_schema = MemoryTypeSchema(
+            memory_type="entities",
+            directory="viking://user/{{ user_space }}/memories/entities",
+            filename_template="{{ name }}.md",
+            fields=[],
+        )
+        experience_schema = MemoryTypeSchema(
+            memory_type="experiences",
+            directory="viking://user/{{ user_space }}/memories/experiences",
+            filename_template="{{ experience_name }}.md",
+            fields=[],
+        )
+        profile_uri = "viking://user/alice/memories/profile.md"
+        old_entity_uri = "viking://user/alice/memories/entities/old-project.md"
+        experience_uri = "viking://user/alice/memories/experiences/trip.md"
+        page_id_map = PageIdMap()
+        assert page_id_map.get_page_id(profile_uri) == 1
+        assert page_id_map.get_page_id(old_entity_uri) == 2
+
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [entity_schema, experience_schema]
+        context_provider.read_file_contents = {
+            profile_uri: MemoryFile(uri=profile_uri, memory_type="profile", content="profile"),
+            old_entity_uri: MemoryFile(
+                uri=old_entity_uri,
+                memory_type="entities",
+                content="old entity",
+            ),
+        }
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.render_schema_directories.side_effect = lambda schema: [
+            schema.directory.replace("{{ user_space }}", "alice")
+        ]
+        isolation_handler.calculate_memory_uris.return_value = [experience_uri]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+        loop._link_enabled = True
+
+        operations, raw_links = await loop.resolve_operations(
+            AttrDict(
+                entities=[{"page_id": 1, "name": "wrong-project"}],
+                experiences=[{"page_id": 100, "experience_name": "trip"}],
+                links=[WikiLink(f=1, t=100, link_type="related_to", match_text=None)],
+                delete_ids=[{"delete_page_id": 2, "replacement_page_id": 1}],
+            )
+        )
+
+        mismatched_operation = operations.upsert_operations[0]
+        assert mismatched_operation.uris == []
+        assert mismatched_operation.resolution_skip is not None
+        assert (
+            mismatched_operation.resolution_skip.reason_code
+            == MemoryOperationSkipCode.PAGE_ID_TYPE_MISMATCH
+        )
+        assert raw_links == []
+        assert operations.delete_file_contents == []
+        assert operations.delete_replacements == {}
+
+        await loop.finalize_operations(operations, raw_links)
+        assert operations.resolved_links == []
+
+    @pytest.mark.asyncio
     async def test_existing_page_id_uses_path_when_metadata_is_dirty(self):
         schema = MemoryTypeSchema(
             memory_type="profile",

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -241,6 +241,171 @@ class TestResolveOperations:
         assert operation.uris == [trajectory_uri]
 
     @pytest.mark.asyncio
+    async def test_new_page_ids_are_unique_across_memory_types(self):
+        event_schema = self._event_schema()
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        entity_schema = MemoryTypeSchema(
+            memory_type="entities",
+            directory="viking://user/{{ user_space }}/memories/entities",
+            filename_template="{{ name }}.md",
+            fields=[],
+        )
+        uris = {
+            "events": "viking://user/alice/memories/events/demo.md",
+            "profile": "viking://user/alice/memories/profile.md",
+            "entities": "viking://user/alice/memories/entities/target.md",
+        }
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [
+            event_schema,
+            profile_schema,
+            entity_schema,
+        ]
+        context_provider.read_file_contents = {}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.side_effect = lambda **kwargs: [
+            uris[kwargs["memory_type_schema"].memory_type]
+        ]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=PageIdMap())
+        loop._link_enabled = True
+        raw_operations = AttrDict(
+            events=[{"event_name": "demo", "ranges": "0", "page_id": 100}],
+            profile=[{"summary": "profile", "page_id": 100}],
+            entities=[{"name": "target", "page_id": 101}],
+            links=[WikiLink(f=100, t=101, match_text=None)],
+        )
+
+        operations, raw_links = await loop.resolve_operations(raw_operations)
+        assert [operation.page_id for operation in operations.upsert_operations] == [102, 100, 101]
+        assert raw_links == []
+
+        repeated_operations, repeated_links = await loop.resolve_operations(raw_operations)
+        assert [operation.page_id for operation in repeated_operations.upsert_operations] == [
+            102,
+            100,
+            101,
+        ]
+        assert repeated_links == []
+
+        await loop.finalize_operations(operations, raw_links)
+        assert operations.resolved_links == []
+
+    @pytest.mark.asyncio
+    async def test_duplicate_non_event_page_ids_are_normalized(self):
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        entity_schema = MemoryTypeSchema(
+            memory_type="entities",
+            directory="viking://user/{{ user_space }}/memories/entities",
+            filename_template="{{ name }}.md",
+            fields=[],
+        )
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [profile_schema, entity_schema]
+        context_provider.read_file_contents = {}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.side_effect = lambda **kwargs: [
+            (
+                "viking://user/alice/memories/profile.md"
+                if kwargs["memory_type_schema"].memory_type == "profile"
+                else f"viking://user/alice/memories/entities/{kwargs['operation'].memory_fields['name']}.md"
+            )
+        ]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=PageIdMap())
+
+        operations, raw_links = await loop.resolve_operations(
+            AttrDict(
+                profile=[{"summary": "profile", "page_id": 100}],
+                entities=[
+                    {"name": "duplicate", "page_id": 100},
+                    {"name": "target", "page_id": 102},
+                ],
+                links=[WikiLink(f=100, t=102, match_text=None)],
+            )
+        )
+
+        assert [operation.page_id for operation in operations.upsert_operations] == [100, 101, 102]
+        assert raw_links == []
+
+    @pytest.mark.asyncio
+    async def test_delete_with_ambiguous_new_replacement_page_id_is_skipped(self):
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        entity_schema = MemoryTypeSchema(
+            memory_type="entities",
+            directory="viking://user/{{ user_space }}/memories/entities",
+            filename_template="{{ name }}.md",
+            fields=[],
+        )
+        deleted_uri = "viking://user/alice/memories/entities/deleted.md"
+        deleted_file = MemoryFile(uri=deleted_uri, memory_type="entities", content="deleted")
+        page_id_map = PageIdMap()
+        assert page_id_map.get_page_id(deleted_uri) == 1
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [profile_schema, entity_schema]
+        context_provider.read_file_contents = {deleted_uri: deleted_file}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.side_effect = lambda **kwargs: [
+            (
+                "viking://user/alice/memories/profile.md"
+                if kwargs["memory_type_schema"].memory_type == "profile"
+                else "viking://user/alice/memories/entities/replacement.md"
+            )
+        ]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+
+        operations, _ = await loop.resolve_operations(
+            AttrDict(
+                profile=[{"summary": "profile", "page_id": 100}],
+                entities=[{"name": "replacement", "page_id": 100}],
+                delete_ids=[{"delete_page_id": 1, "replacement_page_id": 100}],
+            )
+        )
+
+        assert operations.delete_file_contents == []
+        assert operations.delete_replacements == {}
+
+    @pytest.mark.asyncio
     async def test_existing_page_id_keeps_existing_uri_and_identity_fields(self):
         schema = MemoryTypeSchema(
             memory_type="entities",
@@ -367,11 +532,11 @@ class TestResolveOperations:
 
 
 class TestResolveLinksMultiUri:
-    def test_normalize_event_links_remaps_unregistered_low_page_id(self):
+    def test_normalize_operation_links_remaps_unregistered_low_page_id(self):
         page_id_map = PageIdMap()
         links = [WikiLink(f=5, t=7, match_text="event")]
 
-        normalized = ExtractLoop._normalize_event_links(
+        normalized = ExtractLoop._normalize_operation_links(
             links,
             {5: [100]},
             page_id_map,
@@ -381,13 +546,13 @@ class TestResolveLinksMultiUri:
         assert normalized[0].f == 100
         assert normalized[0].t == 7
 
-    def test_normalize_event_links_drops_collision_with_existing_page(self):
+    def test_normalize_operation_links_drops_collision_with_existing_page(self):
         page_id_map = PageIdMap()
         for index in range(5):
             page_id_map.get_page_id(f"viking://user/alice/memories/existing-{index}.md")
         links = [WikiLink(f=5, t=7, match_text="ambiguous")]
 
-        normalized = ExtractLoop._normalize_event_links(
+        normalized = ExtractLoop._normalize_operation_links(
             links,
             {5: [100]},
             page_id_map,

--- a/tests/unit/session/memory/test_extract_loop_match_text.py
+++ b/tests/unit/session/memory/test_extract_loop_match_text.py
@@ -9,8 +9,11 @@ import pytest
 from openviking.session.memory.dataclass import (
     MemoryField,
     MemoryFile,
+    MemoryOperationSkip,
+    MemoryOperationSkipCode,
     MemoryTypeSchema,
     ResolvedOperation,
+    ResolvedOperations,
     WikiLink,
 )
 from openviking.session.memory.extract_loop import ExtractLoop
@@ -23,6 +26,220 @@ class AttrDict(dict):
 
 
 class TestResolveOperations:
+    @staticmethod
+    def _event_schema():
+        return MemoryTypeSchema(
+            memory_type="events",
+            description="event memory",
+            directory="viking://user/{{ user_space }}/memories/events",
+            filename_template="{{ event_name }}.md",
+            operation_mode="add_only",
+            fields=[
+                MemoryField(
+                    name="event_name",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.IMMUTABLE,
+                ),
+                MemoryField(
+                    name="ranges",
+                    field_type=FieldType.STRING,
+                    merge_op=MergeOp.IMMUTABLE,
+                ),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_event_low_page_id_never_reuses_existing_profile(self):
+        schema = self._event_schema()
+        page_id_map = PageIdMap()
+        for index in range(4):
+            page_id_map.get_page_id(f"viking://user/alice/memories/filler-{index}.md")
+        profile_uri = "viking://user/alice/memories/profile.md"
+        assert page_id_map.get_page_id(profile_uri) == 5
+        profile = MemoryFile(uri=profile_uri, memory_type="profile", content="profile")
+        event_uri = "viking://user/alice/memories/events/2026/08/27/demo.md"
+
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {profile_uri: profile}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.return_value = [event_uri]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+
+        operations, _ = await loop.resolve_operations(
+            AttrDict(events=[{"event_name": "demo", "ranges": "0", "page_id": 5}])
+        )
+
+        operation = operations.upsert_operations[0]
+        assert operation.page_id == 100
+        assert operation.uris == [event_uri]
+        assert operation.old_memory_file_content is None
+        assert page_id_map.resolve(5) == profile_uri
+        isolation_handler.calculate_memory_uris.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_event_unknown_low_page_id_is_normalized_and_written(self):
+        schema = self._event_schema()
+        page_id_map = PageIdMap()
+        event_uri = "viking://user/alice/memories/events/2026/08/27/demo.md"
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.return_value = [event_uri]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+
+        operations, _ = await loop.resolve_operations(
+            AttrDict(events=[{"event_name": "demo", "ranges": "0", "page_id": 5}])
+        )
+
+        operation = operations.upsert_operations[0]
+        assert operation.page_id == 100
+        assert operation.uris == [event_uri]
+        assert operation.resolution_skip is None
+
+    @pytest.mark.asyncio
+    async def test_existing_page_id_from_other_memory_type_is_rejected(self):
+        schema = MemoryTypeSchema(
+            memory_type="entities",
+            directory="viking://user/{{ user_space }}/memories/entities",
+            filename_template="{{ name }}.md",
+            fields=[],
+        )
+        profile_uri = "viking://user/alice/memories/profile.md"
+        profile = MemoryFile(uri=profile_uri, memory_type="profile", content="profile")
+        page_id_map = PageIdMap()
+        assert page_id_map.get_page_id(profile_uri) == 1
+        context_provider = Mock()
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        context_provider.get_memory_schemas.return_value = [schema, profile_schema]
+        context_provider.read_file_contents = {profile_uri: profile}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.render_schema_directories.side_effect = lambda current_schema: [
+            (
+                "viking://user/alice/memories/entities"
+                if current_schema.memory_type == "entities"
+                else "viking://user/alice/memories"
+            )
+        ]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+
+        operations, _ = await loop.resolve_operations(AttrDict(entities=[{"page_id": 1}]))
+
+        operation = operations.upsert_operations[0]
+        assert operation.uris == []
+        assert operation.old_memory_file_content is None
+        assert operation.resolution_skip is not None
+        assert (
+            operation.resolution_skip.reason_code == MemoryOperationSkipCode.PAGE_ID_TYPE_MISMATCH
+        )
+        isolation_handler.calculate_memory_uris.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_existing_page_id_uses_path_when_metadata_is_dirty(self):
+        schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        profile_uri = "viking://user/alice/memories/profile.md"
+        dirty_profile = MemoryFile(
+            uri=profile_uri,
+            memory_type="events",
+            content="profile",
+        )
+        page_id_map = PageIdMap()
+        assert page_id_map.get_page_id(profile_uri) == 1
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {profile_uri: dirty_profile}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.render_schema_directories.return_value = ["viking://user/alice/memories"]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=page_id_map)
+
+        operations, _ = await loop.resolve_operations(AttrDict(profile=[{"page_id": 1}]))
+
+        operation = operations.upsert_operations[0]
+        assert operation.uris == [profile_uri]
+        assert operation.old_memory_file_content is dirty_profile
+        assert operation.resolution_skip is None
+
+    @pytest.mark.asyncio
+    async def test_non_event_add_only_resolution_is_unchanged(self):
+        schema = MemoryTypeSchema(
+            memory_type="trajectories",
+            directory="viking://user/{{ user_space }}/memories/trajectories",
+            filename_template="{{ trajectory_name }}.md",
+            operation_mode="add_only",
+            fields=[],
+        )
+        trajectory_uri = "viking://user/alice/memories/trajectories/demo.md"
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema]
+        context_provider.read_file_contents = {}
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        isolation_handler.calculate_memory_uris.return_value = [trajectory_uri]
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._extract_context = SimpleNamespace(page_id_map=PageIdMap())
+
+        operations, _ = await loop.resolve_operations(
+            AttrDict(trajectories=[{"trajectory_name": "demo", "page_id": 105}])
+        )
+
+        operation = operations.upsert_operations[0]
+        assert operation.page_id == 105
+        assert operation.uris == [trajectory_uri]
+
     @pytest.mark.asyncio
     async def test_existing_page_id_keeps_existing_uri_and_identity_fields(self):
         schema = MemoryTypeSchema(
@@ -150,6 +367,34 @@ class TestResolveOperations:
 
 
 class TestResolveLinksMultiUri:
+    def test_normalize_event_links_remaps_unregistered_low_page_id(self):
+        page_id_map = PageIdMap()
+        links = [WikiLink(f=5, t=7, match_text="event")]
+
+        normalized = ExtractLoop._normalize_event_links(
+            links,
+            {5: [100]},
+            page_id_map,
+        )
+
+        assert len(normalized) == 1
+        assert normalized[0].f == 100
+        assert normalized[0].t == 7
+
+    def test_normalize_event_links_drops_collision_with_existing_page(self):
+        page_id_map = PageIdMap()
+        for index in range(5):
+            page_id_map.get_page_id(f"viking://user/alice/memories/existing-{index}.md")
+        links = [WikiLink(f=5, t=7, match_text="ambiguous")]
+
+        normalized = ExtractLoop._normalize_event_links(
+            links,
+            {5: [100]},
+            page_id_map,
+        )
+
+        assert normalized == []
+
     def test_shared_page_id_pairs_matching_user_uris_only(self):
         loop = ExtractLoop(vlm=Mock(model="test-model"), viking_fs=Mock(), context_provider=Mock())
         loop._extract_context = Mock()
@@ -214,6 +459,453 @@ class TestResolveLinksMultiUri:
         ]
 
         assert loop._resolve_links(raw_links, upsert_operations=upsert_operations) == []
+
+
+class TestResolutionRepair:
+    @staticmethod
+    def _loop(ctx=None):
+        return ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=Mock(),
+            isolation_handler=Mock(),
+            ctx=ctx,
+        )
+
+    def test_retryable_resolution_issues_include_ranges(self):
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={"ranges": "99"},
+                    memory_type="events",
+                    uris=[],
+                    page_id=100,
+                    resolution_skip=MemoryOperationSkip(
+                        reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                        reason="Message ranges are malformed or out of bounds",
+                    ),
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        issues = self._loop()._retryable_resolution_issues(operations)
+
+        assert issues == [
+            {
+                "memory_type": "events",
+                "page_id": 100,
+                "reason_code": "invalid_ranges",
+                "reason": "Message ranges are malformed or out of bounds",
+                "operation": {"ranges": "99"},
+            }
+        ]
+        instruction = ExtractLoop._build_resolution_repair_instruction(issues)
+        assert "valid in-bounds message indexes" in instruction
+        assert '"reason_code": "invalid_ranges"' in instruction
+        assert "server has preserved all successful operations" in instruction
+
+    def test_policy_skip_is_not_retried(self):
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={},
+                    memory_type="events",
+                    uris=[],
+                    page_id=100,
+                    resolution_skip=MemoryOperationSkip(
+                        reason_code=MemoryOperationSkipCode.PEER_MEMORY_DISABLED,
+                        reason="Peer memory writes are disabled",
+                    ),
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        assert self._loop()._retryable_resolution_issues(operations) == []
+
+    def test_non_event_resolution_skip_is_not_retried(self):
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={"ranges": "99"},
+                    memory_type="trajectories",
+                    uris=[],
+                    page_id=100,
+                    resolution_skip=MemoryOperationSkip(
+                        reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                        reason="Message ranges are malformed or out of bounds",
+                    ),
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        assert self._loop()._retryable_resolution_issues(operations) == []
+
+    def test_missing_request_context_is_not_retried(self):
+        operations = ResolvedOperations(
+            upsert_operations=[
+                ResolvedOperation(
+                    memory_fields={"ranges": "0"},
+                    memory_type="events",
+                    uris=[],
+                    page_id=100,
+                    resolution_skip=MemoryOperationSkip(
+                        reason_code=MemoryOperationSkipCode.NO_WRITABLE_TARGET,
+                        reason="No writable memory target could be resolved",
+                    ),
+                )
+            ],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        assert self._loop(ctx=None)._retryable_resolution_issues(operations) == []
+
+    @pytest.mark.asyncio
+    async def test_run_repairs_only_failed_event_and_preserves_successful_profile(self):
+        schema = TestResolveOperations._event_schema()
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        event_uri = "viking://user/alice/memories/events/2026/08/27/demo.md"
+        profile_uri = "viking://user/alice/memories/profile.md"
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [schema, profile_schema]
+        context_provider.get_output_language.return_value = "zh-CN"
+        context_provider.get_tools.return_value = []
+        context_provider.get_extract_context.return_value = SimpleNamespace(page_id_map=PageIdMap())
+        context_provider.prefetch = AsyncMock(return_value=[])
+        context_provider.read_file_contents = {}
+        context_provider.instruction.return_value = "base instruction"
+
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+        event_resolution_attempts = 0
+
+        def calculate_memory_uris(*, memory_type_schema, operation, **kwargs):
+            nonlocal event_resolution_attempts
+            if memory_type_schema.memory_type == "profile":
+                return [profile_uri]
+            event_resolution_attempts += 1
+            if event_resolution_attempts == 1:
+                operation.resolution_skip = MemoryOperationSkip(
+                    reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                    reason="Message ranges are malformed or out of bounds",
+                )
+                return []
+            operation.resolution_skip = None
+            return [event_uri]
+
+        isolation_handler.calculate_memory_uris.side_effect = calculate_memory_uris
+
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+        )
+        loop._call_llm = AsyncMock(
+            side_effect=[
+                (
+                    [],
+                    AttrDict(
+                        events=[{"event_name": "demo", "ranges": "99", "page_id": 5}],
+                        profile=[{"page_id": 101, "summary": "keep me"}],
+                    ),
+                ),
+                (
+                    [],
+                    AttrDict(events=[{"event_name": "demo", "ranges": "0", "page_id": 100}]),
+                ),
+            ]
+        )
+        loop._check_unread_existing_files = AsyncMock(return_value=[])
+        loop._validate_patch_operations = AsyncMock(return_value=[])
+        loop.finalize_operations = AsyncMock()
+
+        with (
+            patch("openviking.session.memory.extract_loop.get_openviking_config") as mock_config,
+            patch(
+                "openviking.session.memory.extract_loop.SchemaModelGenerator.generate_all_models"
+            ),
+            patch(
+                "openviking.session.memory.extract_loop.SchemaModelGenerator.create_structured_operations_model"
+            ) as mock_create_model,
+        ):
+            mock_config.return_value = SimpleNamespace(memory=SimpleNamespace(link_enabled=False))
+            mock_create_model.return_value = SimpleNamespace(
+                model_fields={"events": None},
+                model_json_schema=lambda: {},
+            )
+
+            final_operations, _ = await loop.run()
+
+        assert loop._call_llm.await_count == 2
+        assert event_resolution_attempts == 2
+        assert len(final_operations.upsert_operations) == 2
+        assert final_operations.upsert_operations[0].uris == [event_uri]
+        assert final_operations.upsert_operations[0].page_id == 100
+        assert final_operations.upsert_operations[1].memory_type == "profile"
+        assert final_operations.upsert_operations[1].uris == [profile_uri]
+        assert final_operations.upsert_operations[1].memory_fields["summary"] == "keep me"
+        repair_messages = [
+            message["content"]
+            for message in loop._call_llm.await_args_list[-1].args[0]
+            if message["role"] == "user" and "Resolution issues:" in message["content"]
+        ]
+        assert len(repair_messages) == 1
+        assert '"reason_code": "invalid_ranges"' in repair_messages[0]
+        assert '"event_name": "demo"' in repair_messages[0]
+
+    def test_merge_event_repair_ignores_unrequested_memory_types(self):
+        original_profile = ResolvedOperation(
+            memory_fields={"summary": "original"},
+            memory_type="profile",
+            uris=["viking://user/alice/memories/profile.md"],
+            page_id=1,
+        )
+        failed_event = ResolvedOperation(
+            memory_fields={"ranges": "99"},
+            memory_type="events",
+            uris=[],
+            page_id=100,
+            resolution_skip=MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                reason="invalid",
+            ),
+        )
+        repaired_event = ResolvedOperation(
+            memory_fields={"ranges": "0"},
+            memory_type="events",
+            uris=["viking://user/alice/memories/events/demo.md"],
+            page_id=100,
+        )
+        hallucinated_profile = original_profile.model_copy(
+            update={"memory_fields": {"summary": "changed"}}
+        )
+
+        merged = ExtractLoop._merge_event_resolution_repair(
+            ResolvedOperations(
+                upsert_operations=[original_profile, failed_event],
+                delete_file_contents=[],
+                errors=[],
+            ),
+            ResolvedOperations(
+                upsert_operations=[repaired_event, hallucinated_profile],
+                delete_file_contents=[],
+                errors=[],
+            ),
+        )
+
+        assert merged.upsert_operations == [original_profile, repaired_event]
+
+    def test_event_repair_subset_filters_extra_events_and_preserves_failed_id(self):
+        successful_event = ResolvedOperation(
+            memory_fields={"event_name": "success", "ranges": "0", "summary": "success"},
+            memory_type="events",
+            uris=["viking://user/alice/memories/events/success.md"],
+            page_id=100,
+        )
+        failed_event = ResolvedOperation(
+            memory_fields={"event_name": "failed", "ranges": "99", "summary": "original"},
+            memory_type="events",
+            uris=[],
+            page_id=101,
+            resolution_skip=MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                reason="invalid",
+            ),
+        )
+        original = ResolvedOperations(
+            upsert_operations=[successful_event, failed_event],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        subset = ExtractLoop._event_resolution_repair_subset(
+            AttrDict(
+                events=[
+                    {
+                        "event_name": "success",
+                        "ranges": "0",
+                        "summary": "duplicate",
+                        "page_id": 100,
+                    },
+                    {
+                        "event_name": "failed",
+                        "ranges": "0",
+                        "summary": "changed",
+                        "page_id": 999,
+                    },
+                    {
+                        "event_name": "failed",
+                        "ranges": "0",
+                        "summary": "changed",
+                        "page_id": 101,
+                    },
+                ],
+                profile=[{"page_id": 1, "summary": "ignore"}],
+            ),
+            original,
+        )
+
+        assert subset.events == [
+            {
+                "event_name": "failed",
+                "ranges": "0",
+                "summary": "original",
+                "page_id": 101,
+            }
+        ]
+        assert subset.delete_ids == []
+        assert subset.links == []
+
+    def test_merge_event_repair_rejects_changed_or_duplicate_page_id(self):
+        failed_event = ResolvedOperation(
+            memory_fields={"event_name": "failed", "ranges": "99"},
+            memory_type="events",
+            uris=[],
+            page_id=101,
+            resolution_skip=MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                reason="invalid",
+            ),
+        )
+        changed_id = failed_event.model_copy(
+            update={
+                "uris": ["viking://user/alice/memories/events/changed.md"],
+                "page_id": 102,
+                "resolution_skip": None,
+            }
+        )
+        duplicate_a = failed_event.model_copy(
+            update={
+                "uris": ["viking://user/alice/memories/events/a.md"],
+                "resolution_skip": None,
+            }
+        )
+        duplicate_b = duplicate_a.model_copy(
+            update={"uris": ["viking://user/alice/memories/events/b.md"]}
+        )
+        original = ResolvedOperations(
+            upsert_operations=[failed_event],
+            delete_file_contents=[],
+            errors=[],
+        )
+
+        changed_id_result = ExtractLoop._merge_event_resolution_repair(
+            original,
+            ResolvedOperations(
+                upsert_operations=[changed_id],
+                delete_file_contents=[],
+                errors=[],
+            ),
+        )
+        duplicate_result = ExtractLoop._merge_event_resolution_repair(
+            original,
+            ResolvedOperations(
+                upsert_operations=[duplicate_a, duplicate_b],
+                delete_file_contents=[],
+                errors=[],
+            ),
+        )
+
+        assert changed_id_result.upsert_operations == [failed_event]
+        assert duplicate_result.upsert_operations == [failed_event]
+
+    @pytest.mark.asyncio
+    async def test_run_keeps_first_pass_when_event_repair_cannot_be_parsed(self):
+        event_schema = TestResolveOperations._event_schema()
+        profile_schema = MemoryTypeSchema(
+            memory_type="profile",
+            directory="viking://user/{{ user_space }}/memories",
+            filename_template="profile.md",
+            fields=[],
+        )
+        profile_uri = "viking://user/alice/memories/profile.md"
+        context_provider = Mock()
+        context_provider.get_memory_schemas.return_value = [event_schema, profile_schema]
+        context_provider.get_output_language.return_value = "zh-CN"
+        context_provider.get_tools.return_value = []
+        context_provider.get_extract_context.return_value = SimpleNamespace(
+            page_id_map=PageIdMap()
+        )
+        context_provider.prefetch = AsyncMock(return_value=[])
+        context_provider.read_file_contents = {}
+        context_provider.instruction.return_value = "base instruction"
+
+        isolation_handler = Mock()
+        isolation_handler.get_read_scope.return_value = None
+        isolation_handler.fill_identity_fields.side_effect = lambda item, **kwargs: item
+
+        def calculate_memory_uris(*, memory_type_schema, operation, **kwargs):
+            if memory_type_schema.memory_type == "profile":
+                return [profile_uri]
+            operation.resolution_skip = MemoryOperationSkip(
+                reason_code=MemoryOperationSkipCode.INVALID_RANGES,
+                reason="Message ranges are malformed or out of bounds",
+            )
+            return []
+
+        isolation_handler.calculate_memory_uris.side_effect = calculate_memory_uris
+        loop = ExtractLoop(
+            vlm=Mock(model="test-model"),
+            viking_fs=Mock(),
+            context_provider=context_provider,
+            isolation_handler=isolation_handler,
+            max_iterations=1,
+        )
+        loop._call_llm = AsyncMock(
+            side_effect=[
+                (
+                    [],
+                    AttrDict(
+                        events=[{"event_name": "demo", "ranges": "99", "page_id": 5}],
+                        profile=[{"page_id": 101, "summary": "keep me"}],
+                    ),
+                ),
+                ([], None),
+                ([], None),
+            ]
+        )
+        loop.finalize_operations = AsyncMock()
+
+        with (
+            patch("openviking.session.memory.extract_loop.get_openviking_config") as mock_config,
+            patch(
+                "openviking.session.memory.extract_loop.SchemaModelGenerator.generate_all_models"
+            ),
+            patch(
+                "openviking.session.memory.extract_loop.SchemaModelGenerator.create_structured_operations_model"
+            ) as mock_create_model,
+        ):
+            mock_config.return_value = SimpleNamespace(memory=SimpleNamespace(link_enabled=False))
+            mock_create_model.return_value = SimpleNamespace(
+                model_fields={"events": None, "profile": None},
+                model_json_schema=lambda: {},
+            )
+
+            final_operations, _ = await loop.run()
+
+        assert loop._call_llm.await_count == 3
+        assert len(final_operations.upsert_operations) == 2
+        assert final_operations.upsert_operations[0].memory_type == "events"
+        assert (
+            final_operations.upsert_operations[0].resolution_skip.reason_code
+            == MemoryOperationSkipCode.INVALID_RANGES
+        )
+        assert final_operations.upsert_operations[1].memory_type == "profile"
+        assert final_operations.upsert_operations[1].uris == [profile_uri]
+        assert final_operations.errors == []
 
 
 class TestPageIdInstruction:

--- a/tests/unit/session/memory/test_page_id_map.py
+++ b/tests/unit/session/memory/test_page_id_map.py
@@ -58,37 +58,30 @@ class TestPageIdMap:
         assert pim.resolve(existing_id) == "viking://profile.md"
         assert pim.resolve(100) == "viking://profile.md"
 
-    def test_allocate_new_page_id_normalizes_low_requested_id(self):
+    def test_response_allocator_normalizes_low_requested_id(self):
         pim = PageIdMap()
         pim.get_page_id("viking://user/a/memories/profile.md")
+        allocator = pim.new_page_id_allocator()
 
-        assert pim.allocate_new_page_id(1) == 100
+        assert allocator.allocate(1) == 100
 
-    def test_allocate_new_page_id_preserves_available_new_id(self):
+    def test_response_allocator_preserves_available_new_id(self):
         pim = PageIdMap()
+        allocator = pim.new_page_id_allocator()
 
-        assert pim.allocate_new_page_id(105) == 105
-        assert pim.allocate_new_page_id(105) == 106
+        assert allocator.allocate(105) == 105
+        assert allocator.allocate(105) == 100
 
-    def test_allocate_new_page_id_skips_registered_and_reserved_ids(self):
-        pim = PageIdMap()
-        pim.register_new_page_id("viking://new-item", 100)
-
-        assert pim.allocate_new_page_id() == 101
-        assert pim.allocate_new_page_id() == 102
-
-    def test_release_new_page_id_allows_repair_to_reuse_reservation(self):
-        pim = PageIdMap()
-
-        assert pim.allocate_new_page_id(5) == 100
-        pim.release_new_page_id(100)
-
-        assert pim.allocate_new_page_id(100) == 100
-
-    def test_release_new_page_id_does_not_release_registered_id(self):
+    def test_response_allocator_skips_registered_and_allocated_ids(self):
         pim = PageIdMap()
         pim.register_new_page_id("viking://new-item", 100)
+        allocator = pim.new_page_id_allocator()
 
-        pim.release_new_page_id(100)
+        assert allocator.allocate(None) == 101
+        assert allocator.allocate(None) == 102
 
-        assert pim.allocate_new_page_id(100) == 101
+    def test_new_response_can_reuse_unregistered_page_id(self):
+        pim = PageIdMap()
+
+        assert pim.new_page_id_allocator().allocate(100) == 100
+        assert pim.new_page_id_allocator().allocate(100) == 100

--- a/tests/unit/session/memory/test_page_id_map.py
+++ b/tests/unit/session/memory/test_page_id_map.py
@@ -57,3 +57,38 @@ class TestPageIdMap:
         assert pim.get_page_id("viking://profile.md") == existing_id
         assert pim.resolve(existing_id) == "viking://profile.md"
         assert pim.resolve(100) == "viking://profile.md"
+
+    def test_allocate_new_page_id_normalizes_low_requested_id(self):
+        pim = PageIdMap()
+        pim.get_page_id("viking://user/a/memories/profile.md")
+
+        assert pim.allocate_new_page_id(1) == 100
+
+    def test_allocate_new_page_id_preserves_available_new_id(self):
+        pim = PageIdMap()
+
+        assert pim.allocate_new_page_id(105) == 105
+        assert pim.allocate_new_page_id(105) == 106
+
+    def test_allocate_new_page_id_skips_registered_and_reserved_ids(self):
+        pim = PageIdMap()
+        pim.register_new_page_id("viking://new-item", 100)
+
+        assert pim.allocate_new_page_id() == 101
+        assert pim.allocate_new_page_id() == 102
+
+    def test_release_new_page_id_allows_repair_to_reuse_reservation(self):
+        pim = PageIdMap()
+
+        assert pim.allocate_new_page_id(5) == 100
+        pim.release_new_page_id(100)
+
+        assert pim.allocate_new_page_id(100) == 100
+
+    def test_release_new_page_id_does_not_release_registered_id(self):
+        pim = PageIdMap()
+        pim.register_new_page_id("viking://new-item", 100)
+
+        pim.release_new_page_id(100)
+
+        assert pim.allocate_new_page_id(100) == 101


### PR DESCRIPTION
## 问题是什么

模型在生成记忆时，会给每条记忆一个临时编号 `page_id`。后面的记忆关系和删除操作通过这个编号找到对应的记忆。

旧逻辑有三个问题：

- Event 可能误用已有 Profile 等记忆的编号，服务端会把它当成修改已有记忆，结果 `memories/events` 没有新增文件。
- 模型可能给不同的新记忆相同的编号。例如 Profile 和 Event 都使用 100，服务端就无法确定关系里的 100 到底指哪一条记忆。
- 当 Entity 错用了 Profile 的编号时，Entity 内容虽然会被拒绝，但使用这个编号的关系和删除迁移仍可能写到 Profile 上。

## 怎么修复

- Event 不再通过模型给的编号查找已有记忆，而是直接根据 Event 内容确定它在 `memories/events` 下的文件。
- 服务端会一起检查本次模型返回的所有新记忆。已有记忆使用 1–99，新记忆最终都使用不重复的 >=100 编号。模型给的编号可用就保留；已经被占用就改成下一个空闲编号。其他记忆先保留合法编号，Event 再使用剩余编号，尽量不改变原有行为。
- 例如模型同时返回 Profile=100、Event=100，服务端会调整为 Profile=100、Event=101，保证两条记忆最终编号不同。
- 如果一条关系仍然只写“100”，服务端无法知道模型想指 Profile 还是 Event。此时不猜测目标，直接丢弃这条关系；删除旧记忆时如果也无法确定关系应该迁移给谁，就跳过这次删除。这个场景不会再调用一次模型。
- 如果某个编号实际属于 Profile，模型却拿它修改 Entity，则拒绝 Entity 内容，同时丢弃使用该编号的关系，并跳过要把关系迁移给该编号的删除。
- Event 中消息范围不合法、无法确定写入目标等可修复问题，最多让模型修正一次。该修正只处理失败的 Event，不改动第一轮已经成功的其他记忆。

编号检查只处理当前这一次模型返回的内容。重新提取或重试时会重新计算，不会沿用上一次的编号占用状态。没有为编号冲突增加模型调用，也没有改变写入锁和 I/O 链路。

## 验证

- 覆盖 Event 误用已有编号、不同记忆使用相同编号、错误编号产生关系和删除迁移、Event 修正及重试隔离。
- Memory 测试：450/456 通过；其余 6 项为改动前已有的失败。
- React、Updater、Isolation、Trajectory 相关测试：91/91 通过。
- Ruff、compileall、`git diff --check` 通过。