### PR TITLE
feat(task): 支持开放 compile 任务队列

### DIFF
--- a/openviking/server/app.py
+++ b/openviking/server/app.py
@@ -50,6 +50,7 @@ from openviking.server.routers import (
     snapshot_router,
     stats_router,
     system_router,
+    task_queues_router,
     tasks_router,
     user_settings_router,
     watches_router,
@@ -624,6 +625,7 @@ def create_app(
     app.include_router(observer_router)
     app.include_router(openviking_assets_router)
     app.include_router(metrics_router)
+    app.include_router(task_queues_router)
     app.include_router(tasks_router)
     app.include_router(user_settings_router)
     app.include_router(watches_router)

--- a/openviking/server/routers/__init__.py
+++ b/openviking/server/routers/__init__.py
@@ -21,6 +21,7 @@ from openviking.server.routers.skills import router as skills_router
 from openviking.server.routers.snapshot import router as snapshot_router
 from openviking.server.routers.stats import router as stats_router
 from openviking.server.routers.system import router as system_router
+from openviking.server.routers.task_queues import router as task_queues_router
 from openviking.server.routers.tasks import router as tasks_router
 from openviking.server.routers.user_settings import router as user_settings_router
 from openviking.server.routers.watches import router as watches_router
@@ -46,6 +47,7 @@ __all__ = [
     "metrics_router",
     "observer_router",
     "openviking_assets_router",
+    "task_queues_router",
     "tasks_router",
     "user_settings_router",
     "watches_router",

--- a/openviking/server/routers/task_queues.py
+++ b/openviking/server/routers/task_queues.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""External task queue endpoints for OpenViking HTTP Server."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+
+from openviking.server.auth import get_request_context
+from openviking.server.dependencies import get_service
+from openviking.server.identity import RequestContext
+from openviking.server.models import Response
+from openviking.service.open_task_queue import OpenTaskQueueService, open_task_to_dict
+from openviking_cli.exceptions import FailedPreconditionError
+
+router = APIRouter(prefix="/api/v1/task-queues/compile", tags=["task-queues"])
+
+
+class CompileOpenTaskRequest(BaseModel):
+    """Task payload accepted by the open compile queue."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    from_: list[str] = Field(alias="from", min_length=1)
+    to: str = Field(min_length=1)
+    skill: str = Field(min_length=1)
+    reason: Optional[str] = None
+    runtime_timeout_seconds: Optional[float] = Field(
+        default=None,
+        gt=0,
+        allow_inf_nan=False,
+    )
+
+
+class LeasedTaskRequest(BaseModel):
+    """Task owner plus the active QueueFS lease."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    account_id: str = Field(min_length=1)
+    user_id: str = Field(min_length=1)
+    lease_id: str = Field(min_length=1)
+
+
+class TaskUpdateRequest(LeasedTaskRequest):
+    """Progress update from the worker that owns the active lease."""
+
+    stage: Optional[str] = Field(default=None, min_length=1)
+    progress: Optional[float] = Field(default=None, ge=0, le=1, allow_inf_nan=False)
+    message: Optional[str] = None
+    details: Optional[dict[str, Any]] = None
+
+
+class CompleteTaskRequest(LeasedTaskRequest):
+    """Terminal success update from the worker that owns the active lease."""
+
+    result: dict[str, Any] = Field(default_factory=dict)
+
+
+class FailTaskError(BaseModel):
+    """Terminal failure payload from an external worker."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+
+
+class FailTaskRequest(LeasedTaskRequest):
+    """Terminal failure update from the worker that owns the active lease."""
+
+    error: FailTaskError
+
+
+class AckTaskRequest(LeasedTaskRequest):
+    """Worker acknowledgement for a terminal task."""
+
+
+def _open_task_queue_service() -> OpenTaskQueueService:
+    service = get_service()
+    viking_fs = getattr(service, "viking_fs", None)
+    agfs = getattr(viking_fs, "agfs", None) if viking_fs is not None else None
+    if agfs is None:
+        raise FailedPreconditionError("Open task queue requires initialized storage")
+    return OpenTaskQueueService(agfs)
+
+
+@router.post("/tasks")
+async def create_compile_task(
+    request: CompileOpenTaskRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Create a compile task for the caller and enqueue it to the shared queue."""
+    service = _open_task_queue_service()
+    task = await service.create_compile_task(
+        account_id=_ctx.account_id,
+        user_id=_ctx.user.user_id,
+        payload=request.model_dump(by_alias=True, exclude_none=True),
+    )
+    return Response(status="ok", result=open_task_to_dict(task))
+
+
+@router.post("/claim")
+async def claim_compile_task(
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Claim the oldest available open compile task from the shared QueueFS queue."""
+    service = _open_task_queue_service()
+    task = await service.claim_compile_task(
+        worker_account_id=_ctx.account_id,
+        worker_user_id=_ctx.user.user_id,
+    )
+    return Response(
+        status="ok",
+        result=None if task is None else open_task_to_dict(task, include_lease_id=True),
+    )
+
+
+@router.patch("/tasks/{task_id}")
+async def update_compile_task(
+    task_id: str,
+    request: TaskUpdateRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Update progress for the task lease owner and renew the lease."""
+    service = _open_task_queue_service()
+    updates = request.model_dump(
+        exclude={"account_id", "user_id", "lease_id"},
+        exclude_unset=True,
+        exclude_none=True,
+    )
+    task = await service.update_task(
+        account_id=request.account_id,
+        user_id=request.user_id,
+        task_id=task_id,
+        lease_id=request.lease_id,
+        updates=updates,
+    )
+    return Response(status="ok", result=open_task_to_dict(task, include_lease_id=True))
+
+
+@router.post("/tasks/{task_id}/complete")
+async def complete_compile_task(
+    task_id: str,
+    request: CompleteTaskRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Mark a leased open compile task completed."""
+    service = _open_task_queue_service()
+    task = await service.complete_task(
+        account_id=request.account_id,
+        user_id=request.user_id,
+        task_id=task_id,
+        lease_id=request.lease_id,
+        result=request.result,
+    )
+    return Response(status="ok", result=open_task_to_dict(task, include_lease_id=True))
+
+
+@router.post("/tasks/{task_id}/fail")
+async def fail_compile_task(
+    task_id: str,
+    request: FailTaskRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Mark a leased open compile task failed."""
+    service = _open_task_queue_service()
+    task = await service.fail_task(
+        account_id=request.account_id,
+        user_id=request.user_id,
+        task_id=task_id,
+        lease_id=request.lease_id,
+        error=request.error.model_dump(),
+    )
+    return Response(status="ok", result=open_task_to_dict(task, include_lease_id=True))
+
+
+@router.post("/tasks/{task_id}/ack")
+async def ack_compile_task(
+    task_id: str,
+    request: AckTaskRequest,
+    _ctx: RequestContext = Depends(get_request_context),
+):
+    """Acknowledge a terminal open compile task without deleting its record."""
+    service = _open_task_queue_service()
+    task = await service.ack_task(
+        account_id=request.account_id,
+        user_id=request.user_id,
+        task_id=task_id,
+        lease_id=request.lease_id,
+        ack_by_account_id=_ctx.account_id,
+        ack_by_user_id=_ctx.user.user_id,
+    )
+    return Response(status="ok", result=open_task_to_dict(task, include_lease_id=True))

--- a/openviking/service/open_task_queue.py
+++ b/openviking/service/open_task_queue.py
@@ -1,0 +1,520 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""QueueFS-backed external compile task queue."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable, Optional
+from uuid import uuid4
+
+from openviking.core.identifiers import validate_account_id, validate_user_id
+from openviking.pyagfs import AsyncAGFSClient
+from openviking.pyagfs.exceptions import AGFSNotFoundError
+from openviking.service.task_store import PersistentTaskStore, task_record_path
+from openviking.service.task_tracker import TaskRecord, TaskStatus
+from openviking.storage.queuefs.named_queue import NamedQueue
+from openviking_cli.exceptions import (
+    ConflictError,
+    FailedPreconditionError,
+    InvalidArgumentError,
+    NotFoundError,
+)
+
+DEFAULT_LEASE_SECONDS = 600.0
+QUEUE_MOUNT_POINT = "/queue"
+OPEN_COMPILE_QUEUE = "OpenCompileTask"
+OPEN_TASK_AUTH_KEY = "open_task_queue"
+OPEN_TASK_META_KEY = "__open_task_queue"
+MAX_CLAIM_DEQUEUE_ATTEMPTS = 100
+
+_COMPILE_TASK_TYPE = "compile"
+_TERMINAL_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
+
+
+@dataclass(frozen=True)
+class _ClaimResult:
+    task: Optional[TaskRecord]
+    ack_message: bool = False
+
+
+class OpenTaskQueueService:
+    """Open compile queue API backed by QueueFS and standard task records."""
+
+    def __init__(
+        self,
+        agfs: Any,
+        *,
+        lease_seconds: float = DEFAULT_LEASE_SECONDS,
+        queue_factory: Optional[Callable[[str], Any]] = None,
+    ) -> None:
+        if isinstance(agfs, AsyncAGFSClient):
+            self._agfs = agfs
+            sync_agfs = agfs._client
+        else:
+            sync_agfs = agfs
+            self._agfs = AsyncAGFSClient(agfs)
+        self._store = PersistentTaskStore(self._agfs)
+        self._lease_seconds = float(lease_seconds)
+        self._queue = (
+            queue_factory(OPEN_COMPILE_QUEUE)
+            if queue_factory is not None
+            else NamedQueue(sync_agfs, QUEUE_MOUNT_POINT, OPEN_COMPILE_QUEUE)
+        )
+
+    async def create_compile_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        payload: dict[str, Any],
+    ) -> TaskRecord:
+        _validate_owner(account_id, user_id)
+        task = TaskRecord(
+            task_id=str(uuid4()),
+            task_type=_COMPILE_TASK_TYPE,
+            status=TaskStatus.PENDING,
+            account_id=account_id,
+            user_id=user_id,
+            stage="queued",
+            meta={
+                OPEN_TASK_META_KEY: OPEN_COMPILE_QUEUE,
+                "payload": deepcopy(payload),
+                "attempt": 0,
+            },
+        )
+        await self._store.create(task)
+        try:
+            await self._queue.enqueue(_queue_delivery_payload(task))
+        except Exception as exc:
+            await self._mark_enqueue_failed(task, exc)
+            raise
+        return task
+
+    async def claim_compile_task(
+        self,
+        *,
+        worker_account_id: str,
+        worker_user_id: str,
+    ) -> Optional[TaskRecord]:
+        _validate_owner(worker_account_id, worker_user_id)
+        for _ in range(MAX_CLAIM_DEQUEUE_ATTEMPTS):
+            message = await self._queue.dequeue_raw()
+            if message is None:
+                return None
+
+            parsed = _parse_queue_message(message)
+            if parsed is None:
+                await self._ack_malformed_message(message)
+                continue
+            msg_id, payload = parsed
+
+            if payload.get("task_type") != _COMPILE_TASK_TYPE:
+                await self._queue.ack(msg_id, message)
+                continue
+
+            owner = _queue_owner(payload)
+            if owner is None:
+                await self._queue.ack(msg_id, message)
+                continue
+
+            claim = await self._claim_task(
+                account_id=owner[0],
+                user_id=owner[1],
+                claimed_by_account_id=worker_account_id,
+                claimed_by_user_id=worker_user_id,
+                task_id=str(payload.get("task_id", "")),
+                queue_message_id=msg_id,
+            )
+            if claim.task is not None:
+                return claim.task
+            if claim.ack_message:
+                await self._queue.ack(msg_id, message)
+        return None
+
+    async def update_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        updates: dict[str, Any],
+    ) -> TaskRecord:
+        if not updates:
+            raise InvalidArgumentError("At least one task update field is required")
+
+        def apply(task: TaskRecord, now: float) -> None:
+            if task.status != TaskStatus.RUNNING:
+                raise FailedPreconditionError("Task is not running")
+            for field_name in ("message", "progress", "details"):
+                if field_name in updates:
+                    task.meta[field_name] = updates[field_name]
+            if "stage" in updates:
+                task.stage = updates["stage"]
+            task.meta["lease_expires_at"] = now + self._lease_seconds
+
+        return await self._mutate_with_lease(
+            account_id=account_id,
+            user_id=user_id,
+            task_id=task_id,
+            lease_id=lease_id,
+            mutate=apply,
+        )
+
+    async def complete_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        result: dict[str, Any],
+    ) -> TaskRecord:
+        return await self._finish_task(
+            account_id=account_id,
+            user_id=user_id,
+            task_id=task_id,
+            lease_id=lease_id,
+            status=TaskStatus.COMPLETED,
+            result=result,
+            error=None,
+        )
+
+    async def fail_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        error: dict[str, Any],
+    ) -> TaskRecord:
+        return await self._finish_task(
+            account_id=account_id,
+            user_id=user_id,
+            task_id=task_id,
+            lease_id=lease_id,
+            status=TaskStatus.FAILED,
+            result=None,
+            error=error,
+        )
+
+    async def ack_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        ack_by_account_id: str,
+        ack_by_user_id: str,
+    ) -> TaskRecord:
+        queue_message_id = ""
+
+        def mark_acked(task: TaskRecord, now: float) -> None:
+            nonlocal queue_message_id
+            if task.status not in _TERMINAL_STATUSES:
+                raise FailedPreconditionError("Only completed or failed tasks can be acked")
+            queue_message_id = str(_task_auth(task).get("queue_message_id") or "")
+            if not queue_message_id:
+                raise FailedPreconditionError("Task has no QueueFS delivery to ack")
+            task.meta["acknowledged_at"] = task.meta.get("acknowledged_at") or now
+            task.meta["ack_by_account_id"] = task.meta.get("ack_by_account_id") or ack_by_account_id
+            task.meta["ack_by"] = task.meta.get("ack_by") or ack_by_user_id
+
+        task = await self._mutate_with_lease(
+            account_id=account_id,
+            user_id=user_id,
+            task_id=task_id,
+            lease_id=lease_id,
+            mutate=mark_acked,
+            require_running=False,
+        )
+        await self._queue.ack(queue_message_id, _queue_delivery_payload(task))
+        return task
+
+    async def _finish_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        status: TaskStatus,
+        result: Optional[dict[str, Any]],
+        error: Optional[dict[str, Any]],
+    ) -> TaskRecord:
+        def finish(task: TaskRecord, now: float) -> None:
+            if task.status != TaskStatus.RUNNING:
+                raise FailedPreconditionError("Task is not running")
+            task.status = status
+            task.stage = status.value
+            task.result = deepcopy(result)
+            task.error = error.get("message") if error else None
+            task.meta["error"] = deepcopy(error)
+            task.meta["lease_expires_at"] = now + self._lease_seconds
+            if status == TaskStatus.COMPLETED:
+                task.meta["progress"] = 1.0
+
+        return await self._mutate_with_lease(
+            account_id=account_id,
+            user_id=user_id,
+            task_id=task_id,
+            lease_id=lease_id,
+            mutate=finish,
+        )
+
+    async def _claim_task(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        claimed_by_account_id: str,
+        claimed_by_user_id: str,
+        task_id: str,
+        queue_message_id: str,
+    ) -> _ClaimResult:
+        try:
+            _validate_owner(account_id, user_id)
+            _validate_task_id(task_id)
+        except InvalidArgumentError:
+            return _ClaimResult(None, ack_message=True)
+
+        now = time.time()
+        async with self._locked_task(account_id, user_id, task_id):
+            task = await self._read_task(account_id, user_id, task_id)
+            if task is None or not _is_open_compile_task(task):
+                return _ClaimResult(None, ack_message=True)
+            if task.meta.get("acknowledged_at") is not None:
+                return _ClaimResult(None, ack_message=True)
+            if task.status == TaskStatus.RUNNING and not _lease_expired(task, now):
+                return _ClaimResult(None)
+
+            updated = deepcopy(task)
+            updated.auth[OPEN_TASK_AUTH_KEY] = {
+                "lease_id": f"lease_{uuid4().hex}",
+                "queue_message_id": queue_message_id,
+            }
+            updated.meta["lease_expires_at"] = now + self._lease_seconds
+            updated.meta["claimed_by_account_id"] = claimed_by_account_id
+            updated.meta["claimed_by_user_id"] = claimed_by_user_id
+            if updated.status not in _TERMINAL_STATUSES:
+                updated.status = TaskStatus.RUNNING
+                updated.stage = "running"
+                updated.meta["attempt"] = int(updated.meta.get("attempt") or 0) + 1
+            updated.updated_at = _next_updated_at(task, now=now)
+            await self._store.update(updated)
+            return _ClaimResult(updated)
+
+    async def _mutate_with_lease(
+        self,
+        *,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+        lease_id: str,
+        mutate: Callable[[TaskRecord, float], None],
+        require_running: bool = True,
+    ) -> TaskRecord:
+        _validate_owner(account_id, user_id)
+        _validate_task_id(task_id)
+        if not lease_id:
+            raise InvalidArgumentError("lease_id is required")
+
+        now = time.time()
+        async with self._locked_task(account_id, user_id, task_id):
+            task = await self._read_task(account_id, user_id, task_id)
+            if task is None or not _is_open_compile_task(task):
+                raise NotFoundError(task_id, "task")
+            self._check_lease(task, lease_id, now)
+            if require_running and task.status != TaskStatus.RUNNING:
+                raise FailedPreconditionError("Task is not running")
+
+            updated = deepcopy(task)
+            mutate(updated, now)
+            updated.updated_at = _next_updated_at(task, now=now)
+            await self._store.update(updated)
+            return updated
+
+    async def _mark_enqueue_failed(self, task: TaskRecord, error: Exception) -> None:
+        async with self._locked_task(task.account_id or "", task.user_id or "", task.task_id):
+            latest = await self._read_task(task.account_id or "", task.user_id or "", task.task_id)
+            if latest is None:
+                return
+            updated = deepcopy(latest)
+            updated.status = TaskStatus.FAILED
+            updated.stage = TaskStatus.FAILED.value
+            updated.error = str(error)
+            updated.meta["error"] = {
+                "code": "QUEUE_ENQUEUE_FAILED",
+                "message": str(error),
+            }
+            updated.updated_at = _next_updated_at(latest)
+            await self._store.update(updated)
+
+    async def _read_task(
+        self,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+    ) -> Optional[TaskRecord]:
+        payload = await self._store.get(task_id, account_id=account_id, user_id=user_id)
+        if payload is None:
+            return None
+        data = dict(payload)
+        data["status"] = TaskStatus(data["status"])
+        return TaskRecord(**data)
+
+    async def _ack_malformed_message(self, message: Any) -> None:
+        msg_id = _queue_message_id(message)
+        if msg_id:
+            await self._queue.ack(msg_id, message)
+
+    @staticmethod
+    def _check_lease(task: TaskRecord, lease_id: str, now: float) -> None:
+        if _task_auth(task).get("lease_id") != lease_id:
+            raise ConflictError("Task lease does not match", resource=task.task_id)
+        if _lease_expired(task, now):
+            raise ConflictError("Task lease has expired", resource=task.task_id)
+
+    @asynccontextmanager
+    async def _locked_task(
+        self,
+        account_id: str,
+        user_id: str,
+        task_id: str,
+    ) -> AsyncIterator[None]:
+        try:
+            lease = await self._agfs.pathlock_acquire_exact(
+                task_record_path(account_id, user_id, task_id),
+                timeout_secs=10.0,
+            )
+        except AGFSNotFoundError:
+            yield
+            return
+        try:
+            yield
+        finally:
+            await self._agfs.pathlock_release(lease)
+
+
+def open_task_to_dict(task: TaskRecord, *, include_lease_id: bool = False) -> dict[str, Any]:
+    meta = task.meta
+    data = task.to_dict()
+    data.pop("meta", None)
+    data["account_id"] = task.account_id
+    data["user_id"] = task.user_id
+    data["created_by_user_id"] = task.user_id
+    data["payload"] = deepcopy(meta.get("payload") or {})
+    data["progress"] = meta.get("progress")
+    data["message"] = meta.get("message")
+    data["details"] = deepcopy(meta.get("details") or {})
+    data["attempt"] = int(meta.get("attempt") or 0)
+    data["lease_expires_at"] = meta.get("lease_expires_at")
+    data["claimed_by_account_id"] = meta.get("claimed_by_account_id")
+    data["claimed_by_user_id"] = meta.get("claimed_by_user_id")
+    data["acknowledged_at"] = meta.get("acknowledged_at")
+    data["ack_by_account_id"] = meta.get("ack_by_account_id")
+    data["ack_by"] = meta.get("ack_by")
+    if meta.get("error") is not None:
+        data["error"] = deepcopy(meta["error"])
+    if include_lease_id:
+        data["lease_id"] = _task_auth(task).get("lease_id")
+    return data
+
+
+def _queue_delivery_payload(task: TaskRecord) -> dict[str, Any]:
+    return {
+        "task_id": task.task_id,
+        "task_type": task.task_type,
+        "account_id": task.account_id,
+        "user_id": task.user_id,
+        "created_at": task.created_at,
+    }
+
+
+def _parse_queue_message(message: Any) -> Optional[tuple[str, dict[str, Any]]]:
+    msg_id = _queue_message_id(message)
+    payload = _queue_payload(message)
+    if not msg_id or not isinstance(payload, dict):
+        return None
+    return msg_id, payload
+
+
+def _queue_message_id(message: Any) -> str:
+    if not isinstance(message, dict):
+        return ""
+    msg_id = message.get("id")
+    return str(msg_id) if msg_id else ""
+
+
+def _queue_payload(message: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(message, dict):
+        return None
+    payload: Any = message.get("data", message)
+    if isinstance(payload, bytes):
+        payload = payload.decode("utf-8")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (TypeError, ValueError):
+            return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _queue_owner(payload: dict[str, Any]) -> Optional[tuple[str, str]]:
+    account_id = payload.get("account_id")
+    user_id = payload.get("user_id")
+    if not isinstance(account_id, str) or not isinstance(user_id, str):
+        return None
+    try:
+        _validate_owner(account_id, user_id)
+    except InvalidArgumentError:
+        return None
+    return account_id, user_id
+
+
+def _task_auth(task: TaskRecord) -> dict[str, Any]:
+    auth = task.auth.get(OPEN_TASK_AUTH_KEY)
+    return auth if isinstance(auth, dict) else {}
+
+
+def _is_open_compile_task(task: TaskRecord) -> bool:
+    return (
+        task.task_type == _COMPILE_TASK_TYPE
+        and task.meta.get(OPEN_TASK_META_KEY) == OPEN_COMPILE_QUEUE
+    )
+
+
+def _lease_expired(task: TaskRecord, now: float) -> bool:
+    expires_at = task.meta.get("lease_expires_at")
+    return expires_at is not None and float(expires_at) <= now
+
+
+def _next_updated_at(task: TaskRecord, *, now: Optional[float] = None) -> float:
+    current = time.time() if now is None else now
+    return max(current, math.nextafter(task.updated_at, math.inf))
+
+
+def _validate_account(account_id: str) -> None:
+    error = validate_account_id(account_id)
+    if error:
+        raise InvalidArgumentError(error)
+
+
+def _validate_owner(account_id: str, user_id: str) -> None:
+    _validate_account(account_id)
+    error = validate_user_id(user_id)
+    if error:
+        raise InvalidArgumentError(error)
+
+
+def _validate_task_id(task_id: str) -> None:
+    if not isinstance(task_id, str) or not task_id or "/" in task_id or "\\" in task_id:
+        raise InvalidArgumentError("Invalid task id")

--- a/openviking/service/task_store.py
+++ b/openviking/service/task_store.py
@@ -15,6 +15,19 @@ SYSTEM_TASK_ACCOUNT_ID = "_system"
 SYSTEM_TASK_USER_ID = "root"
 
 
+def task_user_dir_path(account_id: str, user_id: str) -> str:
+    system_dir = (
+        f"/local/{account_id}"
+        if account_id == SYSTEM_TASK_ACCOUNT_ID
+        else f"/local/{account_id}/_system"
+    )
+    return f"{system_dir}/tasks/{user_id}"
+
+
+def task_record_path(account_id: str, user_id: str, task_id: str) -> str:
+    return f"{task_user_dir_path(account_id, user_id)}/{task_id}.json"
+
+
 class TaskStore(Protocol):
     async def create(self, task: Any) -> None: ...
 
@@ -133,10 +146,10 @@ class PersistentTaskStore:
         return f"{self._system_dir(account_id)}/{self.TASKS_DIRNAME}"
 
     def _task_dir(self, account_id: str, user_id: str) -> str:
-        return f"{self._task_root_dir(account_id)}/{user_id}"
+        return task_user_dir_path(account_id, user_id)
 
     def _task_path(self, account_id: str, user_id: str, task_id: str) -> str:
-        return f"{self._task_dir(account_id, user_id)}/{task_id}.json"
+        return task_record_path(account_id, user_id, task_id)
 
 
 def _task_to_payload(task: Any) -> Dict[str, Any]:

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -21,7 +21,10 @@ from openviking.server.config import (
 from openviking.server.dependencies import set_service
 from openviking.server.identity import RequestContext, Role
 from openviking.server.routers import sessions as sessions_router
+from openviking.server.routers import task_queues as task_queues_router
+from openviking.service.open_task_queue import OpenTaskQueueService, open_task_to_dict
 from openviking.session.session import Session
+from openviking_cli.exceptions import ConflictError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config import OPENVIKING_CONFIG_ENV
 from openviking_cli.utils.config.memory_config import SessionAutoCommitConfig
@@ -48,6 +51,68 @@ def _message_request(
     if peer_id is not _UNSET and peer_id is not None:
         payload["peer_id"] = peer_id
     return payload
+
+
+def _compile_open_task_request() -> dict:
+    return {
+        "from": ["viking://resources/project"],
+        "to": "viking://resources/wiki",
+        "skill": "viking://user/default/skills/wiki",
+        "reason": "Generate wiki pages",
+        "runtime_timeout_seconds": 3600,
+    }
+
+
+class _FakeOpenTaskQueue:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.pending: list[dict] = []
+        self.processing: dict[str, dict] = {}
+        self.acked: list[str] = []
+        self._next_id = 0
+
+    async def enqueue(self, data):
+        self._next_id += 1
+        msg_id = f"msg_{self._next_id}"
+        message = {"id": msg_id, "data": json.dumps(dict(data))}
+        self.pending.append(message)
+        return msg_id
+
+    async def dequeue_raw(self):
+        if not self.pending:
+            return None
+        message = self.pending.pop(0)
+        self.processing[message["id"]] = message
+        return message
+
+    async def ack(self, msg_id, message=None):
+        del message
+        self.processing.pop(msg_id, None)
+        self.acked.append(msg_id)
+
+    def recover_processing(self) -> None:
+        messages = list(self.processing.values())
+        self.processing.clear()
+        self.pending.extend(messages)
+
+
+def _install_fake_open_task_queue(monkeypatch, service, *, lease_seconds: float = 600.0):
+    queues: dict[str, _FakeOpenTaskQueue] = {}
+
+    def queue_factory(name: str) -> _FakeOpenTaskQueue:
+        queue = queues.get(name)
+        if queue is None:
+            queue = _FakeOpenTaskQueue(name)
+            queues[name] = queue
+        return queue
+
+    queue_service = OpenTaskQueueService(
+        service.viking_fs.agfs,
+        lease_seconds=lease_seconds,
+        queue_factory=queue_factory,
+    )
+    monkeypatch.setattr(task_queues_router, "_open_task_queue_service", lambda: queue_service)
+    return queue_service, queues
 
 
 @pytest.fixture(autouse=True)
@@ -1481,3 +1546,187 @@ async def test_commit_failed_when_summary_fails_does_not_block_next_commit(
     body = resp.json()
     assert body["status"] == "ok"
     assert body["result"]["archived"] is True
+
+
+async def test_compile_open_task_queue_claim_complete_ack_with_worker_identity(
+    client: httpx.AsyncClient,
+    service,
+    monkeypatch,
+):
+    _queue_service, queues = _install_fake_open_task_queue(monkeypatch, service)
+    owner_headers = {"X-OpenViking-Account": "queue-acct", "X-OpenViking-User": "alice"}
+    worker_headers = {"X-OpenViking-Account": "worker-acct", "X-OpenViking-User": "bob"}
+    task_owner = {"account_id": "queue-acct", "user_id": "alice"}
+
+    create_resp = await client.post(
+        "/api/v1/task-queues/compile/tasks",
+        json=_compile_open_task_request(),
+        headers=owner_headers,
+    )
+
+    assert create_resp.status_code == 200, create_resp.text
+    created = create_resp.json()["result"]
+    task_id = created["task_id"]
+    assert task_id
+    assert created["task_type"] == "compile"
+    assert created["status"] == "pending"
+    assert created["created_by_user_id"] == "alice"
+    assert created["user_id"] == "alice"
+    assert created["payload"]["from"] == ["viking://resources/project"]
+    assert "lease_id" not in created
+    assert "queue_name" not in created
+    assert "queue_message_id" not in created
+    assert service.viking_fs.agfs.exists(f"/local/queue-acct/_system/tasks/alice/{task_id}.json")
+    assert not service.viking_fs.agfs.exists(
+        f"/local/queue-acct/_system/open_task_queue/compile/{task_id}/task.json"
+    )
+    queue = queues["OpenCompileTask"]
+    assert len(queue.pending) == 1
+    assert queue.processing == {}
+
+    forbidden_connection = await client.post(
+        "/api/v1/task-queues/compile/tasks",
+        json={
+            **_compile_open_task_request(),
+            "openviking_connection": {"api_key": "secret"},
+        },
+        headers=owner_headers,
+    )
+    assert forbidden_connection.status_code == 400
+
+    claim_resp = await client.post(
+        "/api/v1/task-queues/compile/claim",
+        headers=worker_headers,
+    )
+    assert claim_resp.status_code == 200, claim_resp.text
+    claimed = claim_resp.json()["result"]
+    lease_id = claimed["lease_id"]
+    assert claimed["task_id"] == task_id
+    assert claimed["status"] == "running"
+    assert claimed["attempt"] == 1
+    assert claimed["account_id"] == "queue-acct"
+    assert claimed["user_id"] == "alice"
+    assert claimed["claimed_by_account_id"] == "worker-acct"
+    assert claimed["claimed_by_user_id"] == "bob"
+    assert queue.pending == []
+    assert set(queue.processing) == {"msg_1"}
+
+    no_more_work = await client.post(
+        "/api/v1/task-queues/compile/claim",
+        headers=owner_headers,
+    )
+    assert no_more_work.status_code == 200
+    assert no_more_work.json()["result"] is None
+
+    update_resp = await client.patch(
+        f"/api/v1/task-queues/compile/tasks/{task_id}",
+        json={
+            **task_owner,
+            "lease_id": lease_id,
+            "stage": "generating",
+            "progress": 0.4,
+            "message": "Generating pages",
+            "details": {"pages": 3},
+        },
+        headers=worker_headers,
+    )
+    assert update_resp.status_code == 200, update_resp.text
+    updated = update_resp.json()["result"]
+    assert updated["stage"] == "generating"
+    assert updated["progress"] == 0.4
+    assert updated["details"] == {"pages": 3}
+
+    wrong_lease = await client.patch(
+        f"/api/v1/task-queues/compile/tasks/{task_id}",
+        json={**task_owner, "lease_id": "lease_wrong", "progress": 0.6},
+        headers=worker_headers,
+    )
+    assert wrong_lease.status_code == 409
+
+    complete_resp = await client.post(
+        f"/api/v1/task-queues/compile/tasks/{task_id}/complete",
+        json={
+            **task_owner,
+            "lease_id": lease_id,
+            "result": {
+                "from": ["viking://resources/project"],
+                "to": "viking://resources/wiki",
+                "skill": "viking://user/default/skills/wiki",
+                "created": ["viking://resources/wiki/intro.md"],
+                "updated": [],
+                "unchanged": [],
+                "page_count": 1,
+                "link_count": 0,
+                "warnings": [],
+            },
+        },
+        headers=worker_headers,
+    )
+    assert complete_resp.status_code == 200, complete_resp.text
+    completed = complete_resp.json()["result"]
+    assert completed["status"] == "completed"
+    assert completed["stage"] == "completed"
+    assert completed["progress"] == 1.0
+    assert completed["result"]["created"] == ["viking://resources/wiki/intro.md"]
+    assert set(queue.processing) == {"msg_1"}
+    assert queue.acked == []
+
+    ack_resp = await client.post(
+        f"/api/v1/task-queues/compile/tasks/{task_id}/ack",
+        json={**task_owner, "lease_id": lease_id},
+        headers=worker_headers,
+    )
+    assert ack_resp.status_code == 200, ack_resp.text
+    acked = ack_resp.json()["result"]
+    assert acked["ack_by_account_id"] == "worker-acct"
+    assert acked["ack_by"] == "bob"
+    assert acked["acknowledged_at"] is not None
+    assert queue.processing == {}
+    assert queue.acked == ["msg_1"]
+
+
+async def test_compile_open_task_queue_recovered_expired_lease_can_be_claimed_again(
+    service,
+    monkeypatch,
+):
+    queue_service, queues = _install_fake_open_task_queue(
+        monkeypatch,
+        service,
+        lease_seconds=-1.0,
+    )
+    created = await queue_service.create_compile_task(
+        account_id="lease-acct",
+        user_id="alice",
+        payload=_compile_open_task_request(),
+    )
+    queue = queues["OpenCompileTask"]
+    first_claim = await queue_service.claim_compile_task(
+        worker_account_id="lease-acct",
+        worker_user_id="alice",
+    )
+
+    assert first_claim is not None
+    first_claimed = open_task_to_dict(first_claim, include_lease_id=True)
+    assert first_claimed["lease_id"] is not None
+    with pytest.raises(ConflictError):
+        await queue_service.update_task(
+            account_id="lease-acct",
+            user_id="alice",
+            task_id=created.task_id,
+            lease_id=first_claimed["lease_id"],
+            updates={"progress": 0.2},
+        )
+
+    queue.recover_processing()
+    second_claim = await queue_service.claim_compile_task(
+        worker_account_id="worker-acct",
+        worker_user_id="bob",
+    )
+
+    assert second_claim is not None
+    second_claimed = open_task_to_dict(second_claim, include_lease_id=True)
+    assert second_claim.task_id == created.task_id
+    assert second_claimed["attempt"] == 2
+    assert second_claimed["claimed_by_account_id"] == "worker-acct"
+    assert second_claimed["claimed_by_user_id"] == "bob"
+    assert second_claimed["lease_id"] != first_claimed["lease_id"]


### PR DESCRIPTION
## Description

这个 PR 增加第一版开放 compile 任务队列协议。它只解决一件事：外部系统把 compile 工作注册进 OpenViking，外部 worker 从共享 QueueFS 队列 claim，之后按标准 task.json 更新状态、完成、失败和 ACK。

### Before

OpenViking 现有 `/api/v1/tasks` 只能查询已有后台任务状态；外部系统没有公开协议可以把 compile 工作注册进队列，也没有 claim / update / complete / fail / ack 这套生命周期入口。

如果外部系统想提交下面这个 compile 输入：

```json
{
  "from": ["viking://resources/project"],
  "to": "viking://resources/wiki",
  "skill": "viking://user/default/skills/wiki"
}
```

之前没有对应的公开队列。系统不能给它生成标准 task record，也不能通过 QueueFS 给 worker 做可恢复投递。

### After

新增 `/api/v1/task-queues/compile` 这组接口，只支持 compile 任务。

流程如下：

1. 外部系统调用 `POST /api/v1/task-queues/compile/tasks` 注册任务。
2. Server 生成 `task_id`，写标准任务记录：`/local/{account}/_system/tasks/{user_id}/{task_id}.json`。
3. Server 往共享 QueueFS 队列 `/queue/OpenCompileTask` 写调度消息，消息只带定位信息：`task_id`、`task_type`、`account_id`、`user_id`、`created_at`。
4. 外部 worker 调用 `POST /api/v1/task-queues/compile/claim`。Server 从 QueueFS `dequeue_raw()` 获取消息，不扫描 task 目录。
5. claim 成功后，Server 按消息里的 `account_id/user_id/task_id` 找到 task record，把状态改为 `running`，写入 `lease_id`、`attempt`、`claimed_by_account_id`、`claimed_by_user_id`，并返回任务 payload。
6. worker 执行过程中调用 `PATCH /api/v1/task-queues/compile/tasks/{task_id}` 更新 `stage`、`progress`、`message`、`details`，请求体必须带任务 owner 的 `account_id/user_id` 和 `lease_id`。这里的 owner 来自 claim 返回值，不从 worker 当前身份推导。
7. worker 调用 `complete` 或 `fail` 只把 task record 写成终态，不 ACK QueueFS。这样 worker 在完成写 task.json 后如果还没 ACK 就崩溃，QueueFS 仍能恢复投递。
8. worker 最后调用 `ack`，Server 校验终态和 lease 后调用 QueueFS `ack(queue_message_id)`，并在 task record 写入 `acknowledged_at`、`ack_by_account_id`、`ack_by`。

这版没有新建 `/open_task_queue/.../task.json`，也没有按 account 建 `OpenCompileTask.{account}`。QueueFS 队列是共享的 `/queue/OpenCompileTask`；任务状态仍然走现有 `_system/tasks` 记录。

### Example

注册任务：

```json
{
  "from": ["viking://resources/project"],
  "to": "viking://resources/wiki",
  "skill": "viking://user/default/skills/wiki"
}
```

返回：

```json
{
  "task_id": "uuid-abc",
  "task_type": "compile",
  "status": "pending",
  "account_id": "queue-acct",
  "user_id": "alice",
  "payload": {
    "from": ["viking://resources/project"],
    "to": "viking://resources/wiki",
    "skill": "viking://user/default/skills/wiki"
  }
}
```

worker claim 后返回：

```json
{
  "task_id": "uuid-abc",
  "task_type": "compile",
  "status": "running",
  "account_id": "queue-acct",
  "user_id": "alice",
  "attempt": 1,
  "lease_id": "lease_xyz",
  "claimed_by_account_id": "worker-acct",
  "claimed_by_user_id": "bob",
  "payload": {
    "from": ["viking://resources/project"],
    "to": "viking://resources/wiki",
    "skill": "viking://user/default/skills/wiki"
  }
}
```

worker 后续更新用 claim 返回的 owner 和 lease：

```json
{
  "account_id": "queue-acct",
  "user_id": "alice",
  "lease_id": "lease_xyz",
  "stage": "generating",
  "progress": 0.4,
  "message": "Generating pages"
}
```

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Added an open compile task queue service backed by the shared QueueFS named queue `OpenCompileTask`.
- Added HTTP endpoints for compile task registration, claim, progress update, completion, failure, and ACK.
- Reused the existing persistent task record layout under `_system/tasks`.
- Kept worker identity separate from task owner identity; claim returns the owner fields that later updates use to locate task.json.
- Added focused coverage in the existing server API test file for cross-worker claim/update/complete/ack and expired lease recovery.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands run:

```bash
.venv/bin/ruff check openviking/service/task_store.py openviking/service/open_task_queue.py openviking/server/routers/task_queues.py tests/server/test_api_sessions.py
.venv/bin/python -m py_compile openviking/service/task_store.py openviking/service/open_task_queue.py openviking/server/routers/task_queues.py
.venv/bin/pytest tests/server/test_api_sessions.py -k "compile_open_task_queue" -q --no-cov
git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The task queue flow is described in this PR body instead of adding task API documentation in this change.
