### PR TITLE
fix(zcode): omit empty-string matchers from hooks template

### DIFF
--- a/examples/zcode-memory-plugin/README.md
+++ b/examples/zcode-memory-plugin/README.md
@@ -15,6 +15,8 @@ This package provides a ZCode lifecycle adapter for OpenViking long-term memory.
 
 ZCode does not support `PreCompact`/`SessionEnd`/`SubagentStart`/`SubagentStop`, so the commit-on-`Stop` strategy compensates for the absence of compact/end-of-session signals. The rollout file is the authoritative incremental transcript: stable host `turnId` values drive deduplication and allow a later Stop to recover missed turns. Hook stdin is only a fallback when the rollout file is unavailable.
 
+> Invariant: hook groups must OMIT the matcher key rather than writing `"matcher": ""`. Strict parsers treat an empty string as invalid and may silently drop the entire configuration source.
+
 ## Install
 
 Use the shared installer:

--- a/examples/zcode-memory-plugin/hooks/hooks.json
+++ b/examples/zcode-memory-plugin/hooks/hooks.json
@@ -13,7 +13,6 @@
     ],
     "UserPromptSubmit": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -37,7 +36,6 @@
     ],
     "Stop": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Problem

`examples/zcode-memory-plugin/hooks/hooks.json` ships two hook groups with `"matcher": ""`.
ZCode parses **config-file** hooks with a strict zod contract (verified against the v3.9.2 app
bundle): groups are `.strict()` and `matcher: string().min(1)`. An empty string therefore fails
`safeParse`, and the runner silently drops the ENTIRE user configuration-file source — all four
lifecycle hooks plus any other entries in the merged block never fire, with no error anywhere.

Live reproduction on ZCode 3.9.2 (macOS): official install → app relaunch → zero hook-state
files, zero MCP auto-connects; after removing the two empty matcher keys and relaunching,
SessionStart/UserPromptSubmit/Stop hooks and the stdio MCP proxy all activate immediately.

> Note the semantic trap: in plugin-manifest scope `"matcher": ""` is widely used as "match all".
> In config-file scope the equivalent is **omitting the key**.

## Change

- Remove the two `"matcher": ""` group keys from the shipped zcode template.
- One README sentence documenting the invariant so future templates don't regress.

Plugin suite: 40/40 green after the change.

## Maintainer options (not part of this diff)

- `examples/trae-memory-hooks/hooks/hooks.json` and
  `examples/claude-code-memory-plugin/hooks/hooks.json` contain the same pattern — harmless for
  their runtimes today, but worth an audit if those parsers ever stricten.
- A defensive sanitizer inside the installer merge step (drop empty matchers for every harness)
  would protect third-party templates too.

## Provenance

Incident + verification artifacts (operator workspace):
`projects/zcode-ov-dsh-plugin/docs/post-install-verification.md`,
schema extraction notes in its §8 and troubleshooting row "Hooks silently never fire".
