### PR TITLE
feat(zcode): glyph badges in OV context injections

### DIFF
--- a/examples/zcode-memory-plugin/README.md
+++ b/examples/zcode-memory-plugin/README.md
@@ -15,6 +15,8 @@ This package provides a ZCode lifecycle adapter for OpenViking long-term memory.
 
 ZCode does not support `PreCompact`/`SessionEnd`/`SubagentStart`/`SubagentStop`, so the commit-on-`Stop` strategy compensates for the absence of compact/end-of-session signals. The rollout file is the authoritative incremental transcript: stable host `turnId` values drive deduplication and allow a later Stop to recover missed turns. Hook stdin is only a fallback when the rollout file is unavailable.
 
+> Invariant: hook groups must OMIT the matcher key rather than writing `"matcher": ""`. Strict parsers treat an empty string as invalid and may silently drop the entire configuration source.
+
 ## Install
 
 Use the shared installer:

--- a/examples/zcode-memory-plugin/hooks/hooks.json
+++ b/examples/zcode-memory-plugin/hooks/hooks.json
@@ -13,7 +13,6 @@
     ],
     "UserPromptSubmit": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -37,7 +36,6 @@
     ],
     "Stop": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -344,7 +344,7 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   const lines = [
     "<openviking-context>",
     `✧ OV · recall ×${items.length}`,
-    "When a recalled item is used in your reply, cite it inline with glyphs: ✧ recall · ⌕ search · ▤ read (omit if none used).",
+    "Match the glyph to HOW you got it: remembered without tools → ✧; used viking search → ⌕; used the read tool → ▤. Format: <glyph> <fact> — viking://uri. Cite only items you actually used; omit glyphs otherwise.",
   ];
   let contentCount = 0;
   let hintCount = 0;

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -343,6 +343,7 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let budgetRemaining = Math.max(200, Number(cfg.recallTokenBudget || 2000));
   const lines = [
     "<openviking-context>",
+    `🦞 OV · recall ×${items.length}`,
     "Relevant context from OpenViking. Use the read MCP tool to expand URIs.",
   ];
   let contentCount = 0;
@@ -423,8 +424,10 @@ function looksLikeUnknownField(res) {
 }
 
 function wrapContext(body) {
+  const n = (body.match(/\[[^\]]*%\]/g) || []).length;
   return [
     "<openviking-context>",
+    "🦞 OV · recall ×" + n,
     "Relevant memory from OpenViking. Use the search/read MCP tools to expand URIs.",
     body,
     "</openviking-context>",

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -343,7 +343,7 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   let budgetRemaining = Math.max(200, Number(cfg.recallTokenBudget || 2000));
   const lines = [
     "<openviking-context>",
-    `🦞 OV · recall ×${items.length}`,
+    `✧ OV · recall ×${items.length}`,
     "Relevant context from OpenViking. Use the read MCP tool to expand URIs.",
   ];
   let contentCount = 0;
@@ -424,10 +424,11 @@ function looksLikeUnknownField(res) {
 }
 
 function wrapContext(body) {
-  const n = (body.match(/\[[^\]]*%\]/g) || []).length;
+  const n = (body.match(/<memory\b/g) || []).length
+    || (body.match(/\[[^\]]*%\]/g) || []).length;
   return [
     "<openviking-context>",
-    "🦞 OV · recall ×" + n,
+    "✧ OV · recall ×" + n,
     "Relevant memory from OpenViking. Use the search/read MCP tools to expand URIs.",
     body,
     "</openviking-context>",

--- a/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/recall-core.mjs
@@ -344,7 +344,7 @@ async function buildFallbackInjectionBlock(fetchJSON, items, cfg, actorPeerId = 
   const lines = [
     "<openviking-context>",
     `✧ OV · recall ×${items.length}`,
-    "Relevant context from OpenViking. Use the read MCP tool to expand URIs.",
+    "When a recalled item is used in your reply, cite it inline with glyphs: ✧ recall · ⌕ search · ▤ read (omit if none used).",
   ];
   let contentCount = 0;
   let hintCount = 0;
@@ -429,7 +429,7 @@ function wrapContext(body) {
   return [
     "<openviking-context>",
     "✧ OV · recall ×" + n,
-    "Relevant memory from OpenViking. Use the search/read MCP tools to expand URIs.",
+    "When a recalled item is used in your reply, cite it inline with glyphs: ✧ recall · ⌕ search · ▤ read, e.g. ✧ name — viking://...(omit if none used).",
     body,
     "</openviking-context>",
   ].join("\n");

--- a/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
@@ -90,7 +90,7 @@ async function main() {
       });
     });
     outputContext(
-      profile ? `<openviking-context source="session-start">\n${profile}\n</openviking-context>` : "",
+      profile ? `🦞 OV · index\n<openviking-context source="session-start">\n${profile}\n</openviking-context>` : "",
       "SessionStart",
     );
     return;

--- a/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
+++ b/examples/zcode-memory-plugin/scripts/zcode-hook.mjs
@@ -90,7 +90,7 @@ async function main() {
       });
     });
     outputContext(
-      profile ? `🦞 OV · index\n<openviking-context source="session-start">\n${profile}\n</openviking-context>` : "",
+      profile ? `☰ OV · index\n<openviking-context source="session-start">\n${profile}\n</openviking-context>` : "",
       "SessionStart",
     );
     return;


### PR DESCRIPTION
## What

Adds one glanceable header line inside the plugin's own context injections:

- recall injections: `✧ OV · recall ×N` (N = memory hits; counted for both the
  context-face `score="…"` format and the legacy `[type 53%]` format)
- session-start index injection: `☰ OV · index`

## Why

KB traffic becomes visible at a glance in harnesses that render hook context as
plain text (no DOM/SVG available there). Glyph set mirrors the line-style legend
used by the dsh web-UI visualization (star/lines), keeping cross-harness
semantics identical. Purely additive text inside blocks the plugin already
emits; no renderer, manifest, or schema changes.

Complements #4391 (same vendored tree, independent change).

## Testing

Plugin suite: 40/40 green. Live dry-drive against a real server shows
`✧ OV · recall ×10` with the count matching `<memory …>` entries 1:1.
