### PR TITLE
fix(session): use session skill schema for patch merge

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -53,6 +53,10 @@ from openviking.session.memory.streaming_memory_updater import (
 from openviking.session.memory.utils.json_parser import JsonUtils
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.memory.utils.uri import generate_uri
+from openviking.session.skill.session_skill_context_provider import (
+    SESSION_SKILL_MEMORY_TYPE,
+    load_skill_extract_registry,
+)
 from openviking.session.train import (
     Case,
     ExperienceGradientContext,
@@ -836,7 +840,8 @@ class SessionCompressorV3:
             gradient_estimator=_NoopGradientEstimator(),
             policy_optimizer=PatchMergePolicyOptimizer(
                 viking_fs=viking_fs,
-                memory_type="skills",
+                memory_type=SESSION_SKILL_MEMORY_TYPE,
+                memory_registry=load_skill_extract_registry(),
             ),
             policy_updater=SkillPolicyUpdater(
                 skill_processor=self.skill_processor,

--- a/openviking/session/memory/patch_merge_context_provider.py
+++ b/openviking/session/memory/patch_merge_context_provider.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, MemoryTypeSchema
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
@@ -121,9 +122,11 @@ class PatchMergeContextProvider(SessionExtractContextProvider):
         patches: list[PatchMergePatch],
         required_file_uris: list[str] | None = None,
         output_language: str | None = None,
+        memory_registry: MemoryTypeRegistry | None = None,
     ):
         super().__init__(messages=[])
         self.memory_type = memory_type
+        self._registry = memory_registry
         self.required_file_uris = list(required_file_uris or [])
         self.patches = list(patches)
         self._output_language = output_language or _resolve_patch_output_language(self.patches)
@@ -153,7 +156,8 @@ is an existing file, put it in delete_ids; if it is only a new proposal, omit it
 
     def get_memory_schemas(self, ctx: RequestContext) -> list[MemoryTypeSchema]:
         del ctx
-        schema = self._get_registry().get(self.memory_type)
+        registry = self._get_registry()
+        schema = registry.get(self.memory_type)
         if schema is None or not schema.enabled:
             raise ValueError(f"Memory schema not found or disabled: {self.memory_type}")
         return [schema]

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -13,6 +13,7 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.extract_loop import ExtractLoop
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.memory_updater import ExtractContext
 from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
@@ -48,6 +49,7 @@ class PatchMergePolicyOptimizer:
     viking_fs: Any = None
     vlm: Any = None
     memory_type: str = "experiences"
+    memory_registry: MemoryTypeRegistry | None = None
 
     @tracer(
         "train.policy_optimizer.patch_merge.plan",
@@ -128,6 +130,7 @@ class PatchMergePolicyOptimizer:
         extract_context = ExtractContext(list(context.messages or []))
         provider = PatchMergeContextProvider(
             memory_type=self.memory_type,
+            memory_registry=self.memory_registry,
             required_file_uris=_required_file_uris(gradients, policy_set),
             patches=[_gradient_to_merge_patch(gradient) for gradient in gradients],
         )
@@ -525,7 +528,7 @@ def _name_field_for_memory_type(memory_type: str) -> str:
     """Return the extra_fields key for the policy name in a given memory type."""
     if memory_type == "experiences":
         return "experience_name"
-    if memory_type == "skills":
+    if memory_type in {"skills", "session_skills"}:
         return "skill_name"
     if memory_type.endswith("s"):
         return f"{memory_type[:-1]}_name"

--- a/tests/session/memory/test_patch_merge_context_provider.py
+++ b/tests/session/memory/test_patch_merge_context_provider.py
@@ -14,6 +14,7 @@ from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
 )
+from openviking.session.skill.session_skill_context_provider import load_skill_extract_registry
 
 
 def _memory_file(
@@ -352,6 +353,21 @@ def test_patch_merge_context_provider_get_memory_schema_raises_for_missing_type(
 
     with pytest.raises(ValueError, match="Memory schema not found or disabled: missing"):
         provider.get_memory_schemas(ctx=None)
+
+
+def test_patch_merge_context_provider_uses_registry_override_for_session_skills():
+    provider = PatchMergeContextProvider(
+        memory_type="session_skills",
+        memory_registry=load_skill_extract_registry(),
+        required_file_uris=[],
+        patches=[],
+    )
+
+    schemas = provider.get_memory_schemas(ctx=None)
+
+    assert len(schemas) == 1
+    assert schemas[0].memory_type == "session_skills"
+    assert schemas[0].enabled is True
 
 
 def test_patch_merge_context_provider_instruction_mentions_path_field_normalization():

--- a/tests/session/train/test_train_components.py
+++ b/tests/session/train/test_train_components.py
@@ -10,6 +10,10 @@ from test_fakes import fake_request_context
 
 from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.session.skill.session_skill_context_provider import (
+    SESSION_SKILL_MEMORY_TYPE,
+    load_skill_extract_registry,
+)
 from openviking.session.train import (
     ContentHashPolicySnapshotter,
     DryRunPolicyUpdater,
@@ -509,7 +513,10 @@ async def test_patch_merge_policy_optimizer_runs_patch_merge_extract_loop(monkey
                 [],
             )
 
-    monkeypatch.setattr("openviking.session.train.components.policy_optimizer.ExtractLoop", FakeExtractLoop)
+    monkeypatch.setattr(
+        "openviking.session.train.components.policy_optimizer.ExtractLoop",
+        FakeExtractLoop,
+    )
 
     plan = await PatchMergePolicyOptimizer(viking_fs=FakeVikingFS({}), vlm=object()).plan(
         [gradient],
@@ -865,3 +872,79 @@ async def test_patch_merge_policy_optimizer_runs_llm_for_single_patch(monkeypatc
     assert captured["constructed"] is True
     assert plan.metadata["patch_gradient_count"] == 1
     assert plan.items[0].after_content == "merged update"
+
+
+@pytest.mark.asyncio
+async def test_patch_merge_policy_optimizer_uses_session_skill_registry(monkeypatch):
+    from openviking.session.memory.dataclass import (
+        ResolvedOperation,
+        ResolvedOperations,
+    )
+
+    skill_uri = "viking://user/u/skills/code-review/SKILL.md"
+    policy_set = ExperienceSet(root_uri="viking://user/u/skills", policies=[])
+    gradient = PatchSemanticGradient(
+        before_file=None,
+        after_file=MemoryFile(
+            uri=skill_uri,
+            content="Use this skill to review code changes.",
+            memory_type=SESSION_SKILL_MEMORY_TYPE,
+            extra_fields={
+                "memory_type": SESSION_SKILL_MEMORY_TYPE,
+                "skill_name": "code-review",
+            },
+        ),
+        base_version=None,
+        rationale="test",
+        links=[],
+        confidence=0.9,
+        metadata={},
+    )
+    captured = {}
+
+    class FakeExtractLoop:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def run(self):
+            return (
+                ResolvedOperations(
+                    upsert_operations=[
+                        ResolvedOperation(
+                            old_memory_file_content=None,
+                            memory_fields={
+                                "skill_name": "code-review",
+                                "content": "Merged skill content.",
+                            },
+                            memory_type=SESSION_SKILL_MEMORY_TYPE,
+                            uris=[skill_uri],
+                        )
+                    ],
+                    delete_file_contents=[],
+                    errors=[],
+                ),
+                [],
+            )
+
+    monkeypatch.setattr(
+        "openviking.session.train.components.policy_optimizer.ExtractLoop",
+        FakeExtractLoop,
+    )
+
+    plan = await PatchMergePolicyOptimizer(
+        viking_fs=FakeVikingFS({}),
+        vlm=object(),
+        memory_type=SESSION_SKILL_MEMORY_TYPE,
+        memory_registry=load_skill_extract_registry(),
+    ).plan(
+        [gradient],
+        policy_set,
+        PatchMergePolicyOptimizerContext(request_context=fake_request_context()),
+    )
+
+    assert captured["isolation_handler"].allowed_memory_types == {SESSION_SKILL_MEMORY_TYPE}
+    assert len(plan.items) == 1
+    assert plan.items[0].memory_type == SESSION_SKILL_MEMORY_TYPE
+    assert plan.items[0].target_name == "code-review"
+    assert plan.items[0].target_uri == skill_uri
+    assert plan.items[0].after_content == "Merged skill content."


### PR DESCRIPTION
## Description

修复 session skill patch-merge 阶段错误使用 legacy `skills` schema 的问题。

session skill 训练在 patch-merge 阶段需要使用 `skill_extract/session_skills.yaml`。此前该路径仍以 `memory_type="skills"` 构造 `PatchMergePolicyOptimizer`，导致 `PatchMergeContextProvider` 从默认 memory registry 查到已禁用的 `memory/skills.yaml`，并抛出 `Memory schema not found or disabled: skills`。

本 PR 将 session skill trainer 的 patch-merge 类型改为 `session_skills`，并允许 patch-merge context provider 使用显式传入的 schema registry，从而正确读取 `skill_extract` 下启用的 session skill schema。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4368
Fixes #4186

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 `PatchMergeContextProvider` 中支持传入 `memory_registry`，用于覆盖默认 memory schema registry。
- 在 `PatchMergePolicyOptimizer` 中透传 `memory_registry` 给 patch-merge context provider。
- 将 `SessionCompressorV3` 的 session skill trainer 改为使用 `SESSION_SKILL_MEMORY_TYPE` 和 `load_skill_extract_registry()`。
- 让 `session_skills` 在 plan item 生成阶段使用 `skill_name` 作为名称字段。
- 增加聚焦测试，覆盖 session skill schema registry 解析和 optimizer 生成 `session_skills` plan item 的行为。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行命令：

```bash
OPENVIKING_CONFIG_FILE=ov.conf uv run pytest \
  tests/session/memory/test_patch_merge_context_provider.py::test_patch_merge_context_provider_uses_registry_override_for_session_skills \
  tests/session/train/test_train_components.py::test_patch_merge_policy_optimizer_uses_session_skill_registry

uv run ruff check \
  openviking/session/compressor_v3.py \
  openviking/session/memory/patch_merge_context_provider.py \
  openviking/session/train/components/policy_optimizer.py \
  tests/session/memory/test_patch_merge_context_provider.py \
  tests/session/train/test_train_components.py

git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本 PR 只修正 session skill patch-merge 的 schema registry/type 选择，不涉及 session skill 写入链路重构。
