### PR TITLE
fix(tasks): show persisted dev task history after restart

### DIFF
--- a/openviking/server/routers/tasks.py
+++ b/openviking/server/routers/tasks.py
@@ -37,6 +37,12 @@ async def get_task(
         if task is None:
             task = await tracker.get(
                 task_id,
+                account_id=_ctx.account_id,
+                user_id=_ctx.user.user_id,
+            )
+        if task is None:
+            task = await tracker.get(
+                task_id,
                 account_id=SYSTEM_TASK_ACCOUNT_ID,
                 user_id=SYSTEM_TASK_USER_ID,
             )
@@ -95,6 +101,14 @@ async def list_tasks(
     """List background tasks with optional filters."""
     tracker = get_task_tracker()
     if _ctx.role == Role.ROOT:
+        user_tasks = await tracker.list_tasks(
+            task_type=task_type,
+            status=status,
+            resource_id=resource_id,
+            limit=limit,
+            account_id=_ctx.account_id,
+            user_id=_ctx.user.user_id,
+        )
         system_tasks = await tracker.list_tasks(
             task_type=task_type,
             status=status,
@@ -110,6 +124,7 @@ async def list_tasks(
             limit=limit,
         )
         tasks_by_id = {task.task_id: task for task in cached_tasks}
+        tasks_by_id.update({task.task_id: task for task in user_tasks})
         tasks_by_id.update({task.task_id: task for task in system_tasks})
         tasks = sorted(tasks_by_id.values(), key=lambda task: task.created_at, reverse=True)[:limit]
     else:

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -473,6 +473,46 @@ async def test_task_endpoints_are_user_scoped():
     set_task_tracker(None)
 
 
+async def test_root_task_routes_load_default_user_history_after_tracker_restart():
+    """Dev-mode ROOT should see default/default persisted tasks after cache loss."""
+    set_task_tracker(None)
+    agfs = _FakeAgfs()
+    store = PersistentTaskStore(agfs)
+    tracker = TaskTracker(store=store)
+    set_task_tracker(tracker)
+    task = await tracker.create(
+        "session_commit",
+        resource_id="persisted-session",
+        account_id="default",
+        user_id="default",
+        task_id="persisted-default-task",
+    )
+    await tracker.complete(
+        task.task_id,
+        {"ok": True},
+        account_id="default",
+        user_id="default",
+    )
+
+    set_task_tracker(TaskTracker(store=PersistentTaskStore(agfs)))
+    app = _build_task_http_test_app(
+        ResolvedIdentity(role=Role.ROOT, account_id="default", user_id="default")
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        list_resp = await client.get("/api/v1/tasks")
+        assert list_resp.status_code == 200
+        task_ids = {item["task_id"] for item in list_resp.json()["result"]}
+        assert task.task_id in task_ids
+
+        get_resp = await client.get(f"/api/v1/tasks/{task.task_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["result"]["task_id"] == task.task_id
+
+    set_task_tracker(None)
+
+
 # ---- Role-based access tests ----
 
 


### PR DESCRIPTION
## Summary

- Load user-scoped persisted task records for ROOT task routes in dev mode.
- Merge those records with cached and system task results so restarted servers can still list completed historical tasks.
- Add a regression test covering default/default persisted task visibility after tracker cache loss.

## Root Cause

In dev authentication mode, requests run as ROOT with the default user identity. The ROOT task routes only checked in-memory/cache records plus system-scoped persisted tasks, so completed user-scoped task JSON files became invisible after a server restart rebuilt the in-memory tracker.

Fixes #4393.

## Test Plan

- [x] `.venv/bin/pytest tests/server/test_auth.py -k 'task_endpoints_are_user_scoped or root_task_routes_load_default_user_history_after_tracker_restart' -vv`

🤖 Generated with Claude Code