### PR TITLE
docs: clarify server log rotation

### DIFF
--- a/docs/en/getting-started/03-quickstart-server.md
+++ b/docs/en/getting-started/03-quickstart-server.md
@@ -343,8 +343,15 @@ ps aux | grep openviking-server
 
 * **Check Logs:**
 ```bash
-tail -f /data/log/openviking.log # TODO: Implement log rotation
+tail -f /data/log/openviking.log
 ```
+
+`nohup` redirects the server's stdout/stderr, so this file is not rotated automatically.
+In production, hand it to `systemd/journald` or another log manager. If you need
+OpenViking-managed rotating diagnostic logs, configure local trace output in the
+[observability guide](../guides/05-observability.md); the Usage Reporter also supports
+a dedicated JSONL file that rotates hourly in UTC, as described in the
+[configuration guide](../guides/01-configuration.md#usage-reporter).
 
 ### 5. Client Configuration and Testing (CLI)
 

--- a/docs/zh/getting-started/03-quickstart-server.md
+++ b/docs/zh/getting-started/03-quickstart-server.md
@@ -331,8 +331,13 @@ ps aux | grep openviking-server
 
 - 查看日志： 如果进程在，看看有没有报错：
 ```
-tail -f /data/log/openviking.log # TODO 支持日志滚动
+tail -f /data/log/openviking.log
 ```
+
+`nohup` 重定向的是服务进程的 stdout/stderr，默认不会自动滚动；生产环境请交给
+`systemd/journald` 或其他日志管理器处理。需要 OpenViking 自己生成可滚动的诊断日志时，
+请按[可观测性指南](../guides/05-observability.md)配置本地 trace 文件；Usage Reporter
+也支持按 UTC 小时滚动的专用 JSONL 文件，详见[配置指南](../guides/01-configuration.md#usage-reporter)。
 **配置客户端并测试 (CLI)**
 
 本地注意也要先安装 openviking 才能使用 CLI 工具, 然后在 ovcli.conf 配置好服务端地址


### PR DESCRIPTION
## Description

Clarify the server quickstart logging behavior. The file created by the `nohup` example captures stdout and stderr, but OpenViking does not rotate that file automatically. The documentation now points production deployments to an external log manager and links to the existing rotating local trace and Usage Reporter documentation.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Remove the stale log rotation TODO from both server quickstart pages.
- Clarify the ownership boundary between the `nohup` example and production log management.
- Link the existing trace rotation and Usage Reporter retention documentation.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validated with:

- `npm run test:theme` (13 tests passed)
- `npm run check:api`
- `npm run docs:build`
- `git diff --check`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This changes documentation only. It does not change runtime behavior, configuration, or public APIs.
The documentation build completed successfully; it emitted the repository's existing syntax-highlighting fallback warnings for `promql` and `caddyfile`.
