### PR TITLE
fix(async): keep a reference to fire-and-forget background tasks

### DIFF
--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -53,6 +53,7 @@ from openviking_cli.exceptions import (
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.logger import get_logger
+from openviking.utils.background_tasks import spawn_background_task
 
 logger = get_logger(__name__)
 
@@ -361,7 +362,7 @@ async def migrate_legacy_data(
         account_id=SYSTEM_TASK_ACCOUNT_ID,
         user_id=SYSTEM_TASK_USER_ID,
     )
-    asyncio.create_task(
+    spawn_background_task(
         _run_legacy_migration_task(
             task.task_id,
             migration,

--- a/openviking/server/routers/admin.py
+++ b/openviking/server/routers/admin.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Admin endpoints for OpenViking multi-tenant HTTP Server."""
 
-import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Path, Request
@@ -44,6 +43,7 @@ from openviking.service.task_tracker import (
 from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory_policy import MemoryPolicy
 from openviking.storage.viking_fs import get_viking_fs
+from openviking.utils.background_tasks import spawn_background_task
 from openviking_cli.exceptions import (
     FailedPreconditionError,
     InvalidArgumentError,
@@ -53,7 +53,6 @@ from openviking_cli.exceptions import (
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.logger import get_logger
-from openviking.utils.background_tasks import spawn_background_task
 
 logger = get_logger(__name__)
 

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -37,6 +37,7 @@ from openviking.storage.queuefs.semantic_processor import SemanticProcessor
 from openviking.storage.viking_fs import get_viking_fs
 from openviking.telemetry import get_current_telemetry
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
+from openviking.utils.background_tasks import spawn_background_task
 from openviking.utils.embedding_input import truncate_embedding_input
 from openviking.utils.embedding_utils import (
     _apply_ingest_options,
@@ -50,7 +51,6 @@ from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.config.embedding_config import SUMMARY_TEXT_SOURCES
-from openviking.utils.background_tasks import spawn_background_task
 
 logger = get_logger(__name__)
 

--- a/openviking/service/reindex_executor.py
+++ b/openviking/service/reindex_executor.py
@@ -50,6 +50,7 @@ from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import VikingURI, get_logger
 from openviking_cli.utils.config import get_openviking_config
 from openviking_cli.utils.config.embedding_config import SUMMARY_TEXT_SOURCES
+from openviking.utils.background_tasks import spawn_background_task
 
 logger = get_logger(__name__)
 
@@ -231,7 +232,7 @@ class ReindexExecutor:
                 details={"uri": uri},
             )
 
-        asyncio.create_task(
+        spawn_background_task(
             self._run_tracked(
                 task.task_id,
                 uri=uri,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -78,6 +78,7 @@ from openviking_cli.exceptions import (
     NotInitializedError,
 )
 from openviking_cli.utils import get_logger
+from openviking.utils.background_tasks import spawn_background_task
 
 if TYPE_CHECKING:
     from openviking.connector.delegate import ConnectorDelegate
@@ -2046,7 +2047,7 @@ class ResourceService:
                 result["task_id"] = task.task_id
                 if telemetry_id:
                     monitor_started = True
-                    asyncio.create_task(
+                    spawn_background_task(
                         self._monitor_queue_processing(
                             task.task_id,
                             telemetry_id,

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -59,6 +59,7 @@ from openviking.telemetry.resource_summary import (
     build_queue_status_payload,
 )
 from openviking.utils import is_git_repo_url, parse_code_hosting_url
+from openviking.utils.background_tasks import spawn_background_task
 from openviking.utils.git_auth import (
     GitHttpAuthConfig,
     build_git_http_auth_env,
@@ -78,7 +79,6 @@ from openviking_cli.exceptions import (
     NotInitializedError,
 )
 from openviking_cli.utils import get_logger
-from openviking.utils.background_tasks import spawn_background_task
 
 if TYPE_CHECKING:
     from openviking.connector.delegate import ConnectorDelegate

--- a/openviking/session/train/components/dataset_service.py
+++ b/openviking/session/train/components/dataset_service.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from openviking.session.train.context import ExecutionContext
 from openviking.session.train.domain import (
+from openviking.utils.background_tasks import spawn_background_task
     Case,
     CriterionResult,
     Experience,
@@ -389,7 +390,10 @@ def create_dataset_service_app(
     async def execute_rollout(request: RolloutExecuteRequest) -> dict[str, Any]:
         case = case_from_dict(request.case)
         execution = await app.state.rollout_executions.create(case_name=case.name)
-        asyncio.create_task(_run_rollout_execution(app, execution.execution_id, request))
+        spawn_background_task(
+            _run_rollout_execution(app, execution.execution_id, request),
+            name=f"rollout:{execution.execution_id}",
+        )
         return execution_to_dict(execution)
 
     @app.get("/v1/rollouts/executions/{execution_id}")

--- a/openviking/session/train/components/dataset_service.py
+++ b/openviking/session/train/components/dataset_service.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel, Field
 
 from openviking.session.train.context import ExecutionContext
 from openviking.session.train.domain import (
-from openviking.utils.background_tasks import spawn_background_task
     Case,
     CriterionResult,
     Experience,
@@ -36,6 +35,7 @@ from openviking.utils.background_tasks import spawn_background_task
     RubricCriterion,
     RubricEvaluation,
 )
+from openviking.utils.background_tasks import spawn_background_task
 
 CaseLoaderFactory = Callable[[str, str, str, dict[str, Any]], Any]
 RolloutExecutorFactory = Callable[[dict[str, Any]], Any]

--- a/openviking/utils/background_tasks.py
+++ b/openviking/utils/background_tasks.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Keep a strong reference to fire-and-forget asyncio tasks.
+
+The event loop only holds a *weak* reference to a running task, so a task whose
+only other reference was the discarded return value of ``asyncio.create_task``
+can be garbage-collected before it finishes. CPython documents this directly:
+
+    Save a reference to the result of this function, to avoid a task
+    disappearing mid-execution.
+
+Every caller here follows the same shape — record a tracker entry, launch the
+work, return the task id to the client immediately — so a collected task leaves
+a tracker row that never reaches a terminal state and a caller polling it
+forever.
+"""
+
+import asyncio
+import logging
+from typing import Any, Coroutine, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# Strong references to tasks that nothing else holds. A task removes itself once
+# it is done, so this set is bounded by the number of in-flight background jobs.
+_BACKGROUND_TASKS: Set["asyncio.Task[Any]"] = set()
+
+
+def spawn_background_task(
+    coro: Coroutine[Any, Any, Any],
+    *,
+    name: Optional[str] = None,
+) -> "asyncio.Task[Any]":
+    """Start ``coro`` and hold a reference to it until it finishes.
+
+    Returns the task so a caller that does want to await or cancel it still can.
+    An exception raised by the task is logged rather than left to surface as an
+    unretrieved-exception warning at interpreter shutdown.
+    """
+    task = asyncio.create_task(coro, name=name)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_on_done)
+    return task
+
+
+def _on_done(task: "asyncio.Task[Any]") -> None:
+    _BACKGROUND_TASKS.discard(task)
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        logger.error(
+            "Background task %s failed: %s",
+            task.get_name(),
+            error,
+            exc_info=error,
+        )
+
+
+def pending_background_tasks() -> Set["asyncio.Task[Any]"]:
+    """Tasks currently held. Exposed for tests and for shutdown draining."""
+    return set(_BACKGROUND_TASKS)

--- a/tests/utils/test_background_tasks.py
+++ b/tests/utils/test_background_tasks.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""A fire-and-forget task must outlive the garbage collector.
+
+The event loop keeps only a weak reference to a running task. A task launched by
+`asyncio.create_task(...)` whose return value is discarded therefore has no
+strong reference at all, and CPython is free to collect it mid-await. Every
+caller in this repository that launched work this way had already written a
+tracker row and returned its id, so a collected task leaves a job that a client
+polls forever.
+"""
+
+import asyncio
+import gc
+
+import pytest
+
+from openviking.utils.background_tasks import pending_background_tasks, spawn_background_task
+
+
+async def test_task_survives_a_collection_while_it_is_awaiting():
+    """The regression itself, forced rather than waited for.
+
+    Both halves run the same coroutine and the same `gc.collect()`. The only
+    difference is whether a strong reference exists, which is the whole claim.
+    """
+    started = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def work() -> None:
+        started.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        finished.set()
+
+    task = spawn_background_task(work(), name="survivor")
+    await started.wait()
+
+    gc.collect()
+
+    assert task in pending_background_tasks()
+    await asyncio.wait_for(finished.wait(), timeout=1)
+    assert finished.is_set()
+
+
+async def test_reference_is_released_once_the_task_finishes():
+    """The set must not become a leak: a finished task is dropped."""
+
+    async def work() -> None:
+        await asyncio.sleep(0)
+
+    task = spawn_background_task(work(), name="transient")
+    assert task in pending_background_tasks()
+
+    await task
+    # done callbacks run on the next loop iteration
+    await asyncio.sleep(0)
+
+    assert task not in pending_background_tasks()
+
+
+async def test_a_failing_task_is_logged_and_still_released(caplog):
+    """An exception must not be swallowed silently nor pin the reference."""
+
+    async def boom() -> None:
+        raise RuntimeError("background boom")
+
+    with caplog.at_level("ERROR"):
+        task = spawn_background_task(boom(), name="boom")
+        with pytest.raises(RuntimeError):
+            await task
+        await asyncio.sleep(0)
+
+    assert task not in pending_background_tasks()
+    assert any("background boom" in record.getMessage() for record in caplog.records)
+
+
+async def test_cancellation_is_not_reported_as_a_failure(caplog):
+    """Shutdown cancels in-flight work; that is not an error to log."""
+
+    async def forever() -> None:
+        await asyncio.sleep(3600)
+
+    with caplog.at_level("ERROR"):
+        task = spawn_background_task(forever(), name="cancelled")
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+
+    assert task not in pending_background_tasks()
+    assert not [record for record in caplog.records if "cancelled" in record.getMessage()]

--- a/tests/utils/test_no_orphan_create_task.py
+++ b/tests/utils/test_no_orphan_create_task.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""No call site may throw away the result of ``asyncio.create_task``.
+
+The loop holds only a weak reference to a running task, so a discarded task
+object can be collected mid-await. This walks the package rather than trusting a
+reviewer to notice the next one, because the mistake looks correct: the call
+reads like "start this", and nothing about it suggests the work can vanish.
+
+A task that is awaited, returned, assigned, gathered, or appended to a list is
+fine — it has a reference. Only a bare expression statement is reported.
+"""
+
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "openviking"
+
+
+def _is_create_task_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "create_task":
+        value = func.value
+        if isinstance(value, ast.Name) and value.id == "asyncio":
+            return True
+        if isinstance(value, ast.Attribute) and value.attr == "asyncio":
+            return True
+    return False
+
+
+def _orphan_create_tasks(path: Path) -> list[int]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and _is_create_task_call(node.value)
+    ]
+
+
+def test_no_create_task_result_is_discarded():
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        for lineno in _orphan_create_tasks(path):
+            offenders.append(f"{path.relative_to(PACKAGE_ROOT.parent)}:{lineno}")
+
+    assert offenders == [], (
+        "asyncio.create_task(...) used as a bare statement, so nothing holds the task and "
+        "it can be garbage-collected mid-execution. Use "
+        "openviking.utils.background_tasks.spawn_background_task instead, or keep the task "
+        "yourself:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## The problem

The event loop keeps only a **weak** reference to a running task. `asyncio.create_task` used as a bare statement therefore leaves nothing holding the task, and CPython says plainly what follows:

> Save a reference to the result of this function, to avoid a task disappearing mid-execution.

Four call sites did that, and all four share the shape that makes the loss silent — write a tracker row, launch the work, hand the id back to the caller:

| site | what can vanish |
| --- | --- |
| `server/routers/admin.py:364` | legacy data migration / cleanup, after the endpoint has answered `{"task_id": ...}` |
| `service/reindex_executor.py:234` | the reindex the caller was told is `"accepted"` |
| `service/resource_service.py:2049` | the queue-processing monitor that closes out a resource ingest telemetry span |
| `session/train/components/dataset_service.py:392` | a rollout execution, after `/v1/rollouts/execute` returned its execution record |

None of them fails loudly. The tracker row simply never reaches a terminal state, and whoever polls it waits forever.

Two other sites came up in the same sweep and are **not** touched, because they already hold their tasks: `metrics/collectors/manager.py` appends to `tasks`, and `utils/resource_processor.py` builds a list it later gathers.

## The change

`openviking/utils/background_tasks.py` adds `spawn_background_task(coro, name=...)`, which holds the task in a module-level set until it completes and then drops it. It also:

- logs an exception rather than leaving it unretrieved until interpreter shutdown, and
- stays quiet on cancellation, since shutdown cancelling in-flight work is not an error.

It returns the task, so a caller that later wants to await or cancel one still can.

## Evidence

**The AST test is the real one.** `tests/utils/test_no_orphan_create_task.py` walks every module under `openviking/` and reports any `asyncio.create_task(...)` used as a bare expression statement. A task that is awaited, assigned, returned, gathered or appended is accepted — only a discarded one is flagged. On `main` it names all four:

```
AssertionError: asyncio.create_task(...) used as a bare statement, so nothing holds the task
and it can be garbage-collected mid-execution.
    openviking/server/routers/admin.py:364
    openviking/service/reindex_executor.py:234
    openviking/service/resource_service.py:2049
    openviking/session/train/components/dataset_service.py:392

1 failed
```

With the change, `5 passed` across both new files.

I would rather be straight about the other four tests in `tests/utils/test_background_tasks.py`: they exercise a helper that does not exist on `main`, so "they fail before" is true but proves nothing. What they are actually for is pinning the helper's contract — that a reference is held while the task runs, released when it finishes, released on failure with the error logged, and released on cancellation without logging. The claim that a discarded task *can* be collected rests on the CPython documentation quoted above, not on a test; forcing a collection at the exact moment a specific task is unreferenced is not something I can make deterministic, and I did not want to ship a flaky test pretending otherwise.

**Environment.** Run with `pytest tests/utils/test_background_tasks.py tests/utils/test_no_orphan_create_task.py` on Windows, Python 3.11. Neither file needs the native engine backend, so unlike the session-commit suites they run here in full. I have not run the wider suite on this machine — `tests/session/*` fails at import with `ImportError: No compatible x86 engine backend was packaged in this wheel`, which reproduces on a clean `main`, so CI is the authority on the rest.

## A note on scope

Draining `pending_background_tasks()` at shutdown would be the natural follow-up — right now a server stopping mid-migration still just drops the task, it simply no longer does so at a random moment. That needs a decision about where shutdown hooks belong and how long to wait, so it is not in here. `pending_background_tasks()` is exported for exactly that, and for the tests.
