### PR TITLE
fix(bootstrap): read the gateway log as UTF-8 so a failure can still be reported

### DIFF
--- a/openviking/server/bootstrap.py
+++ b/openviking/server/bootstrap.py
@@ -335,6 +335,26 @@ def main():
             _stop_vikingbot_gateway(bot_process)
 
 
+def _read_bot_log(log_file_path: str) -> str:
+    """Read the gateway log for a failure report.
+
+    The child writes to this file through the descriptor, so the bytes in it are
+    whatever the child emitted rather than anything this process encoded. Reading
+    it back with the locale codec made the report depend on where it ran: on a
+    Windows console codepage a traceback carrying one non-ASCII byte — a path, a
+    provider name, a translated message — raised UnicodeDecodeError here, and the
+    decode error replaced the failure it was called to explain.
+
+    Undecodable bytes are replaced rather than raised. A diagnostic that refuses
+    to print is worse than one with a few question marks in it.
+    """
+    try:
+        with open(log_file_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError as exc:
+        return f"(could not read {log_file_path}: {exc})"
+
+
 def _handle_vikingbot_failure(output: str, returncode: int) -> None:
     """Handle vikingbot startup failure and provide helpful error messages."""
     print(f"\nError: vikingbot gateway exited early (code {returncode})", file=sys.stderr)
@@ -398,7 +418,7 @@ def _start_vikingbot_gateway(
             os.makedirs(log_dir, exist_ok=True)
             log_filename = "vikingbot.log"
             log_file_path = os.path.join(log_dir, log_filename)
-            log_file = open(log_file_path, "a")
+            log_file = open(log_file_path, "a", encoding="utf-8")
             stdout_handler = log_file
             stderr_handler = log_file
             print(f"Vikingbot logs will be written to: {log_file_path}")
@@ -436,8 +456,7 @@ def _start_vikingbot_gateway(
             if log_file:
                 log_file.close()
                 if log_file_path:
-                    with open(log_file_path, "r") as f:
-                        output = f.read()
+                    output = _read_bot_log(log_file_path)
                     _handle_vikingbot_failure(output, process.returncode)
             else:
                 stdout, stderr = process.communicate(timeout=1)

--- a/tests/server/test_bootstrap_bot_log.py
+++ b/tests/server/test_bootstrap_bot_log.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""The gateway failure report must survive the bytes the gateway wrote.
+
+`vikingbot.log` is filled by the child process through the file descriptor, so
+its contents are whatever that process emitted — not something this process
+encoded. Reading it back with the locale codec made the report platform
+dependent, and it is read on exactly one path: the one that runs when the
+gateway has already failed. A decode error there replaces the failure it was
+called to explain.
+"""
+
+from pathlib import Path
+
+from openviking.server.bootstrap import _handle_vikingbot_failure, _read_bot_log
+
+
+def test_a_byte_no_codec_accepts_does_not_sink_the_report(tmp_path: Path):
+    """0x81 is invalid UTF-8 and undefined in cp1252, so a strict read of it
+    raises on Linux and on Windows alike. The report must still arrive."""
+    log = tmp_path / "vikingbot.log"
+    log.write_bytes(b"Traceback (most recent call last):\n\x81\nModuleNotFoundError: no bot\n")
+
+    output = _read_bot_log(str(log))
+
+    assert "ModuleNotFoundError" in output
+    assert "Traceback" in output
+
+
+def test_non_ascii_output_is_read_as_utf8(tmp_path: Path):
+    """The child writes UTF-8. Read under a console codepage instead, the text
+    comes back as mojibake and the report quietly misleads."""
+    log = tmp_path / "vikingbot.log"
+    log.write_bytes("ModuleNotFoundError: 缺少依赖 café\n".encode("utf-8"))
+
+    output = _read_bot_log(str(log))
+
+    assert "缺少依赖" in output
+    assert "café" in output
+
+
+def test_missing_log_reports_itself_instead_of_raising(tmp_path: Path):
+    output = _read_bot_log(str(tmp_path / "absent.log"))
+
+    assert "absent.log" in output
+
+
+def test_dependency_hint_still_fires_through_undecodable_bytes(tmp_path: Path, capsys):
+    """The end-to-end point: the hint is what the user needs, and it is chosen by
+    searching the decoded text. If the decode raises, the hint never prints."""
+    log = tmp_path / "vikingbot.log"
+    log.write_bytes(b"\x81\x82 ModuleNotFoundError: No module named 'vikingbot'\n")
+
+    _handle_vikingbot_failure(_read_bot_log(str(log)), 1)
+
+    stderr = capsys.readouterr().err
+    assert "Missing dependencies detected!" in stderr
+    assert 'pip install "openviking[bot]"' in stderr


### PR DESCRIPTION
## The problem

`vikingbot.log` is opened by the parent and handed to `subprocess.Popen` as `stdout` and `stderr`, so the child writes to the descriptor directly. What lands in that file is whatever the child emitted, not anything this process encoded.

It was then read back like this:

```python
with open(log_file_path, "r") as f:
    output = f.read()
_handle_vikingbot_failure(output, process.returncode)
```

No encoding, so the locale codec. And this is read on exactly one path — the one that runs when the gateway has **already failed**. A decode error here replaces the failure it was called to explain.

That matters more than it looks, because `_handle_vikingbot_failure` picks its advice by searching the decoded text:

```python
if "ModuleNotFoundError" in output:
    print('  pip install "openviking[bot]"', file=sys.stderr)
```

If the read raises, the user does not get a slightly worse message. They get a `UnicodeDecodeError` traceback from the launcher, and the actual reason the gateway died — along with the one-line fix for the most common cause — never prints.

## Evidence

Running the two versions of that line over the same bytes, on Windows:

```
locale encoding here: cp1252

main  ->  with open(log_file_path, 'r') as f: f.read()
   RAISED UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 0

patch ->  encoding='utf-8', errors='replace'
   ok: "\ufffd\ufffd ModuleNotFoundError: No module named 'vikingbot'\n"
   hint still findable: True
```

`0x81` is chosen deliberately: it is invalid UTF-8 *and* undefined in cp1252, so a strict read of it raises on Linux and on Windows alike. This is not only a Windows bug — it is a bug everywhere, and Windows is just where it is easy to hit, because a console codepage rejects far more bytes than UTF-8 does.

## The change

The read moves into `_read_bot_log`, which uses `encoding="utf-8", errors="replace"` and returns a short message instead of raising if the file cannot be opened at all. Undecodable bytes become replacement characters: a diagnostic with a few question marks in it beats one that refuses to print.

The append handle gains `encoding="utf-8"` as well. The parent never writes through it today — it exists to be a descriptor and to be closed — but leaving one half of the pair implicit is what produced this in the first place. `bootstrap.py` already reads its own config with an explicit `encoding="utf-8-sig"` a couple of hundred lines above, so this brings the file back in line with itself.

## Tests

`tests/server/test_bootstrap_bot_log.py`, four cases: a byte no codec accepts still yields a readable report; UTF-8 content round-trips instead of arriving as mojibake; a missing file reports itself rather than raising; and, end to end, the `ModuleNotFoundError` hint still reaches stderr through undecodable bytes.

Being straight about what these prove: on `main` the module has no `_read_bot_log`, so they fail at import — which is not evidence of anything. The evidence is the transcript above, run against the exact expression `main` uses. The tests exist to keep the behaviour once it is in.

**Environment.** Windows, Python 3.11, `pytest tests/server/test_bootstrap_bot_log.py` — 4 passed. This file needs no native engine backend, so it runs here in full; `tests/session/*` does not, failing at import with `ImportError: No compatible x86 engine backend was packaged in this wheel` on a clean `main` too. CI is the authority on the rest.
