### PR TITLE
fix(codex): 修复 MCP 代理错误绑定 actor peer

### DIFF
--- a/agent-plugins/servers/shared/mcp-proxy-config.mjs
+++ b/agent-plugins/servers/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-config.mjs
+++ b/examples/claude-code-memory-plugin/scripts/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -115,11 +115,13 @@ Hooks and the MCP proxy call the same resolver directly, so the model tools and 
 
 Auth is sent as `Authorization: Bearer <api_key>` to both the REST API (used by hooks) and the `/mcp` endpoint (used by the model); the hooks also send the same key as `X-API-Key` for compatibility with older servers.
 
-By default the plugin derives a peer from the current workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. Hooks pass the effective peer as `peer_id` for captured session messages and as `X-OpenViking-Actor-Peer` for retrieval/filesystem calls; MCP gets the same header mapping.
+By default the hooks derive a peer from the current workspace path using Claude's project-directory naming rule: every non-letter-or-digit character becomes `-`, with no path normalization. For example, `/Users/x/Dev/OpenViking` becomes `-Users-x-Dev-OpenViking`. Hooks pass the effective peer as `peer_id` for captured session messages and as `X-OpenViking-Actor-Peer` for retrieval and filesystem calls.
 
 Set `actor_peer_id` in `ovcli.conf` (or `OPENVIKING_PEER_ID` with `OPENVIKING_CREDENTIAL_SOURCE=env`) to override the workspace-derived peer. The legacy `codex.peerId` / `codex.peer_id` fields in `ov.conf` still resolve as a fallback. Set `OPENVIKING_WORKSPACE_PEER=0` or `codex.workspacePeer=false` to turn off workspace-derived peers.
 
-Recall defaults to the broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces penalized and rendered later. Set `OPENVIKING_RECALL_PEER_SCOPE=actor` or `codex.recallPeerScope="actor"` for the isolation mode, which only sees global memory plus the current workspace. In deployments where one bot serves multiple real people, such as zouk, vikingbot, or AstrBot, use the isolation mode with an explicit actor peer so one person's memories are not recalled into another person's session.
+Recall defaults to broad mode: global memory, the current workspace, and other workspace memories can all be recalled, with other workspaces ranked lower and rendered later. In this mode, the MCP proxy omits `X-OpenViking-Actor-Peer` so it can read any URI returned by broad recall for the authenticated user.
+
+Set `OPENVIKING_RECALL_PEER_SCOPE=actor` or `codex.recallPeerScope="actor"` for isolation mode, which only sees global memory plus the configured peer. The MCP proxy requires `actor_peer_id` or `OPENVIKING_PEER_ID` in this mode and exits with a configuration error if neither is set. In deployments where one bot serves multiple people, such as zouk, vikingbot, or AstrBot, use isolation mode with an explicit actor peer so sessions cannot read another person's memories.
 
 The checked-in `.mcp.json` contains only a stdio command. It never stores server URLs, bearer-token env mappings, or identity headers, so switching `ovcli.conf` changes the MCP target on the next Codex launch without cache rendering.
 

--- a/examples/codex-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/codex-memory-plugin/scripts/marketplace.test.mjs
@@ -180,6 +180,8 @@ test("Codex MCP entrypoint forwards only native OpenViking tools", () => {
   const entrypoint = readFileSync(join(pluginDir, "servers", "mcp-proxy.mjs"), "utf-8");
   assert.doesNotMatch(entrypoint, /createExperienceToolProvider/);
   assert.doesNotMatch(entrypoint, /localToolProvider/);
+  assert.match(entrypoint, /resolveMcpActorPeerId\(cfg\)/);
+  assert.doesNotMatch(entrypoint, /resolveEffectivePeerId|process\.cwd\(\)/);
 });
 
 test("canonical MCP tool list matches server registrations", () => {

--- a/examples/codex-memory-plugin/scripts/shared/mcp-proxy-config.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/codex-memory-plugin/servers/mcp-proxy.mjs
+++ b/examples/codex-memory-plugin/servers/mcp-proxy.mjs
@@ -13,9 +13,11 @@ import { fileURLToPath } from "node:url";
 import { loadConfig } from "../scripts/config.mjs";
 import { createLogger } from "../scripts/debug-log.mjs";
 import { resolveOpenVikingCredentials } from "../scripts/ov-credentials.mjs";
-import { buildMcpProxyConfig } from "../scripts/shared/mcp-proxy-config.mjs";
+import {
+  buildMcpProxyConfig,
+  resolveMcpActorPeerId,
+} from "../scripts/shared/mcp-proxy-config.mjs";
 import { createOpenVikingMcpProxy } from "../scripts/shared/mcp-proxy-core.mjs";
-import { resolveEffectivePeerId } from "../scripts/shared/workspace-peer.mjs";
 
 export { createOpenVikingMcpProxy } from "../scripts/shared/mcp-proxy-core.mjs";
 
@@ -28,7 +30,7 @@ function readProxyConfig() {
     apiKey: creds.apiKey,
     account: creds.account,
     user: creds.user,
-    peerId: resolveEffectivePeerId({ cfg, cwd: process.cwd() }).peerId,
+    peerId: resolveMcpActorPeerId(cfg),
     userAgent: cfg.userAgent,
     timeoutMs: cfg.timeoutMs,
     debug: cfg.debug,

--- a/examples/dsh-memory-plugin/shared/mcp-proxy-config.mjs
+++ b/examples/dsh-memory-plugin/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/memory-plugin-shared/lib/mcp-proxy-config.mjs
+++ b/examples/memory-plugin-shared/lib/mcp-proxy-config.mjs
@@ -40,6 +40,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/memory-plugin-shared/mcp-proxy-config.test.mjs
+++ b/examples/memory-plugin-shared/mcp-proxy-config.test.mjs
@@ -7,6 +7,7 @@ import {
   DEFAULT_PROXY_TIMEOUT_MS,
   defaultCredentialPaths,
   normalizeConfigPath,
+  resolveMcpActorPeerId,
   trimSlash,
 } from "./lib/mcp-proxy-config.mjs";
 
@@ -64,6 +65,22 @@ test("debug stays strictly boolean-true opt-in", () => {
   assert.equal(buildMcpProxyConfig({ debug: "true" }).debug, false);
   assert.equal(buildMcpProxyConfig({ debug: 1 }).debug, false);
   assert.equal(buildMcpProxyConfig({ debug: true }).debug, true);
+});
+
+test("broad MCP recall does not send an actor peer header", () => {
+  assert.equal(resolveMcpActorPeerId({ peerId: "workspace-a", recallPeerScope: "all" }), "");
+  assert.equal(resolveMcpActorPeerId({ peerId: "workspace-a" }), "");
+});
+
+test("actor-scoped MCP recall requires and trims an explicit peer", () => {
+  assert.equal(
+    resolveMcpActorPeerId({ peerId: " workspace-a ", recallPeerScope: "actor" }),
+    "workspace-a",
+  );
+  assert.throws(
+    () => resolveMcpActorPeerId({ recallPeerScope: "actor" }),
+    /requires an explicit peer ID/,
+  );
 });
 
 test("path and URL helpers stay exported for entrypoints that need them", () => {

--- a/examples/opencode-plugin/lib/shared/mcp-proxy-config.mjs
+++ b/examples/opencode-plugin/lib/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }

--- a/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-config.mjs
+++ b/examples/zcode-memory-plugin/scripts/shared/mcp-proxy-config.mjs
@@ -41,6 +41,30 @@ export function defaultCredentialPaths(env = process.env) {
   ].filter(Boolean);
 }
 
+/**
+ * Resolve the actor peer header for a long-lived MCP proxy process.
+ *
+ * MCP servers may start in the plugin directory rather than the active
+ * workspace, so their process cwd is not a reliable peer identity. Broad
+ * recall intentionally spans the authenticated user's peer workspaces and
+ * therefore leaves the actor header unset. Actor-scoped recall requires an
+ * explicit peer so isolation never depends on the proxy launch directory.
+ */
+export function resolveMcpActorPeerId({
+  peerId = "",
+  recallPeerScope = "all",
+} = {}) {
+  if (recallPeerScope !== "actor") return "";
+
+  const explicitPeerId = String(peerId || "").trim();
+  if (explicitPeerId) return explicitPeerId;
+
+  throw new Error(
+    "OpenViking MCP actor-scoped recall requires an explicit peer ID. "
+    + "Set actor_peer_id in ovcli.conf or OPENVIKING_PEER_ID in the MCP environment.",
+  );
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }


### PR DESCRIPTION
## 说明

Codex 使用 `cwd: "."` 启动插件 MCP 服务器，这个路径实际指向插件目录。此前代理通过 `process.cwd()` 推导 actor peer，因此发送的是插件目录对应的 peer，而不是当前工作区的身份。广域召回可能返回其他工作区 peer 的 URI；随后调用 MCP 读取时，请求被错误的 peer 限定，服务端会返回 `403 Access denied`。

本次改动根据召回范围决定 MCP 请求是否携带 actor peer。默认的广域召回不再发送该请求头，因此可以读取同一认证用户在广域召回中得到的 URI。使用 `actor` 隔离范围时，必须显式配置 peer；未配置时，代理会给出明确的配置错误并退出。Hook 的捕获和召回仍保留按工作区推导 peer 的现有行为。

## 人工参与

- [x] 人工参与了实现或审查过程
- [ ] 该 PR 完全由 AI Agent 生成，过程中没有人工参与

## 关联议题

无

## 变更类型

- [x] Bug 修复（修复问题且不破坏现有功能）
- [ ] 新功能（增加功能且不破坏现有功能）
- [ ] 破坏性变更（会使现有功能无法按原方式工作）
- [x] 文档更新
- [ ] 重构（无功能变化）
- [ ] 性能改进
- [x] 测试更新

## 具体改动

- 新增 MCP actor peer 请求头解析函数，并同步到各插件的生成副本。
- Codex MCP 代理不再根据代理进程目录推导 peer。
- 补充广域召回和 `actor` 隔离范围的文档与契约测试。

## 验证

- [x] 已添加测试，验证本次修复有效
- [x] 新增及相关现有单元测试均在本地通过
- [x] 已在以下平台测试：
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

相关测试：

```text
node --test examples/memory-plugin-shared/mcp-proxy-config.test.mjs examples/codex-memory-plugin/servers/mcp-proxy.test.mjs examples/codex-memory-plugin/scripts/marketplace.test.mjs
```

结果：37 项通过，0 项失败。

其他检查：

```text
node --check <each changed .mjs file>
git diff --check
```


## 检查清单

- [x] 代码符合项目风格
- [x] 已完成自审
- [x] 已为不易理解的逻辑补充注释
- [x] 已更新相关文档
- [x] 本次改动没有引入新的警告
- [x] 不存在尚未合并或发布的依赖变更

## 截图

不适用

## 补充说明

使用 `actor` 隔离范围的 MCP 召回现在必须配置 `actor_peer_id` 或 `OPENVIKING_PEER_ID`，避免隔离边界依赖长驻代理进程的启动目录。默认广域召回无需修改配置。