### PR TITLE
fix(debug): scope USER vector diagnostics to visible roots

### DIFF
--- a/openviking/server/routers/debug.py
+++ b/openviking/server/routers/debug.py
@@ -8,20 +8,37 @@ Provides debug API for system diagnostics.
 - /api/v1/debug/vector/count - Count vector records
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from openviking.core.namespace import visible_roots
 from openviking.core.path_variables import resolve_path_variables
 from openviking.core.uri_validation import validate_request_viking_uri
 from openviking.server.auth import get_request_context
 from openviking.server.dependencies import get_service
-from openviking.server.identity import RequestContext
+from openviking.server.identity import RequestContext, Role
 from openviking.server.models import Response
 from openviking.server.responses import error_response
+from openviking.storage.expr import And, FilterExpr, Or, PathScope, RawDSL
 from openviking.storage.vikingdb_manager import VikingDBManagerProxy
 
 router = APIRouter(prefix="/api/v1/debug", tags=["debug"])
+
+
+def _scope_vector_filter(
+    filter_expr: Optional[dict[str, Any] | FilterExpr], ctx: RequestContext
+) -> Optional[FilterExpr | dict[str, Any]]:
+    """Keep USER diagnostics inside the caller's visible vector roots."""
+    if ctx.role != Role.USER:
+        return filter_expr
+
+    visible_scope = Or([PathScope("uri", root, depth=-1) for root in visible_roots(ctx)])
+    if not filter_expr:
+        return visible_scope
+    if isinstance(filter_expr, dict):
+        filter_expr = RawDSL(filter_expr)
+    return And([visible_scope, filter_expr])
 
 
 @router.get("/health")
@@ -55,6 +72,7 @@ async def debug_vector_scroll(
         # Resolve path variables before using URI
         uri = validate_request_viking_uri(resolve_path_variables(uri), _ctx)
         filter_expr = {"op": "must", "field": "uri", "conds": [uri]}
+    filter_expr = _scope_vector_filter(filter_expr, _ctx)
 
     records, next_cursor = await proxy.scroll(filter=filter_expr, limit=limit, cursor=cursor)
 
@@ -93,14 +111,13 @@ async def debug_vector_count(
         uri_filter = {"op": "must", "field": "uri", "conds": [uri]}
         if filter_expr:
             # For combining filters, we should use And from expr, but for simplicity, let's use RawDSL for now
-            from openviking.storage.expr import And, RawDSL
-
             if isinstance(filter_expr, dict):
                 filter_expr = RawDSL(filter_expr)
             uri_filter = RawDSL(uri_filter)
             filter_expr = And([filter_expr, uri_filter])
         else:
             filter_expr = uri_filter
+    filter_expr = _scope_vector_filter(filter_expr, _ctx)
 
     count = await proxy.count(filter=filter_expr)
     return Response(status="ok", result={"count": count})

--- a/tests/server/test_debug_vector_roles.py
+++ b/tests/server/test_debug_vector_roles.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.core.namespace import visible_roots
+from openviking.server.identity import RequestContext, Role
+from openviking.server.routers import debug
+from openviking.storage.expr import And, Or, PathScope, RawDSL
+from openviking_cli.session.user_id import UserIdentifier
+
+
+def _ctx(role: Role) -> RequestContext:
+    return RequestContext(user=UserIdentifier("acct", "alice"), role=role)
+
+
+def _visible_scope(ctx: RequestContext) -> Or:
+    return Or([PathScope("uri", root, depth=-1) for root in visible_roots(ctx)])
+
+
+def test_user_vector_filter_defaults_to_visible_roots():
+    ctx = _ctx(Role.USER)
+
+    assert debug._scope_vector_filter(None, ctx) == _visible_scope(ctx)
+
+
+def test_user_vector_filter_cannot_be_replaced_by_raw_dsl():
+    ctx = _ctx(Role.USER)
+    raw_filter = {"op": "must", "field": "context_type", "conds": ["memory"]}
+
+    assert debug._scope_vector_filter(raw_filter, ctx) == And(
+        [_visible_scope(ctx), RawDSL(raw_filter)]
+    )
+
+
+@pytest.mark.parametrize("role", [Role.ADMIN, Role.ROOT])
+def test_privileged_vector_filter_behavior_is_unchanged(role: Role):
+    ctx = _ctx(role)
+    raw_filter = {"op": "must", "field": "context_type", "conds": ["memory"]}
+
+    assert debug._scope_vector_filter(raw_filter, ctx) is raw_filter
+
+
+class _FakeProxy:
+    calls = []
+
+    def __init__(self, _manager, ctx):
+        self.ctx = ctx
+
+    async def scroll(self, **kwargs):
+        self.calls.append(("scroll", self.ctx, kwargs))
+        return [], None
+
+    async def count(self, **kwargs):
+        self.calls.append(("count", self.ctx, kwargs))
+        return 0
+
+
+@pytest.fixture
+def capture_proxy(monkeypatch):
+    _FakeProxy.calls = []
+    monkeypatch.setattr(
+        debug,
+        "get_service",
+        lambda: SimpleNamespace(vikingdb_manager=object()),
+    )
+    monkeypatch.setattr(debug, "VikingDBManagerProxy", _FakeProxy)
+    monkeypatch.setattr(debug, "resolve_path_variables", lambda uri: uri)
+    monkeypatch.setattr(
+        debug,
+        "validate_request_viking_uri",
+        lambda uri, _ctx: uri,
+    )
+    return _FakeProxy.calls
+
+
+@pytest.mark.asyncio
+async def test_user_scroll_intersects_explicit_uri_with_visible_roots(capture_proxy):
+    ctx = _ctx(Role.USER)
+    uri = "viking://user/bob/resources/private"
+
+    await debug.debug_vector_scroll(limit=10, cursor=None, uri=uri, _ctx=ctx)
+
+    assert capture_proxy == [
+        (
+            "scroll",
+            ctx,
+            {
+                "filter": And(
+                    [
+                        _visible_scope(ctx),
+                        RawDSL({"op": "must", "field": "uri", "conds": [uri]}),
+                    ]
+                ),
+                "limit": 10,
+                "cursor": None,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_count_keeps_raw_and_uri_filters_inside_visible_roots(capture_proxy):
+    ctx = _ctx(Role.USER)
+    uri = "viking://user/bob/resources/private"
+    raw_filter = {"op": "must", "field": "context_type", "conds": ["memory"]}
+
+    await debug.debug_vector_count(
+        filter='{"op":"must","field":"context_type","conds":["memory"]}',
+        uri=uri,
+        _ctx=ctx,
+    )
+
+    assert capture_proxy == [
+        (
+            "count",
+            ctx,
+            {
+                "filter": And(
+                    [
+                        _visible_scope(ctx),
+                        And(
+                            [
+                                RawDSL(raw_filter),
+                                RawDSL({"op": "must", "field": "uri", "conds": [uri]}),
+                            ]
+                        ),
+                    ]
+                )
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_admin_scroll_without_uri_remains_account_wide(capture_proxy):
+    ctx = _ctx(Role.ADMIN)
+
+    await debug.debug_vector_scroll(limit=25, cursor="50", uri=None, _ctx=ctx)
+
+    assert capture_proxy == [
+        (
+            "scroll",
+            ctx,
+            {"filter": None, "limit": 25, "cursor": "50"},
+        )
+    ]


### PR DESCRIPTION
## Summary

- intersect USER debug-vector queries with the canonical `visible_roots(ctx)` path scopes
- keep caller-provided URI and raw DSL filters inside that mandatory visibility constraint
- preserve the existing account-wide ADMIN diagnostics and ROOT behavior

`VikingDBManagerProxy` already binds non-ROOT calls to an account, but `scroll` and `count` do not apply the per-user visibility boundary used by normal retrieval. As a result, a USER without a URI filter could enumerate co-tenant vector records. The new helper reuses the repository's existing namespace model instead of introducing a separate ownership rule.

Fixes #3724.

## Testing

- focused filter and route regressions: 7 passed in the no-clone validation harness
- Ruff check on both touched files
- Ruff format check on the new test file
- Python compile check on both touched files

The patch is based on `206054cf150a117b0a4416b4f754c6f4e4e59cb4`.
