### PR TITLE
fix(embedding): report missing gemini dependency

### DIFF
--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -994,6 +994,10 @@ class EmbeddingConfig(BaseModel):
             )
 
         embedder_class, param_builder = factory_registry[key]
+        if embedder_class is None and key == ("gemini", "dense"):
+            raise ValueError(
+                "google-genai is not installed. Install it with: pip install openviking[gemini]"
+            )
         params = param_builder(config)
         return embedder_class(**params)
 

--- a/tests/unit/test_embedding_config_gemini.py
+++ b/tests/unit/test_embedding_config_gemini.py
@@ -67,6 +67,19 @@ class TestGeminiContextRouting:
         assert embedder.document_param is None
 
 
+def test_factory_raises_clear_error_when_google_genai_not_installed():
+    cfg = _gcfg()
+
+    with patch("openviking.models.embedder.GeminiDenseEmbedder", None):
+        with pytest.raises(ValueError) as excinfo:
+            EmbeddingConfig(dense=cfg).get_embedder()
+
+    message = str(excinfo.value)
+    assert "google-genai" in message
+    assert "pip install openviking[gemini]" in message
+    assert "NoneType" not in message
+
+
 class TestGeminiConfigValidation:
     def test_missing_api_key_raises(self):
         with pytest.raises(ValueError, match="api_key"):


### PR DESCRIPTION
## Description

修复 Gemini embedding 可选依赖缺失时的误导性报错。

当用户配置 `provider="gemini"` 但环境中未安装 `google-genai` 时，`openviking.models.embedder` 会将 `GeminiDenseEmbedder` 导出为 `None`。此前 embedder factory 会继续调用该对象，导致报错为 `'NoneType' object is not callable`，并在 `doctor` 中被包装成 `invalid embedding config`，让用户误以为需要修改 `ov.conf`。

本 PR 在实例化 Gemini embedder 前显式检测缺失依赖，并返回包含安装方式的错误信息。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4200

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 在 `EmbeddingConfig._create_embedder()` 中，当 `GeminiDenseEmbedder` 因缺少 `google-genai` 为 `None` 时，提前抛出明确错误。
- 保留 `litellm` 原有缺依赖前置检查，避免改变既有报错顺序。
- 增加 Gemini 缺依赖测试，确认错误信息包含 `google-genai` 和 `pip install openviking[gemini]`，且不再暴露 `NoneType`。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行命令：

```bash
OPENVIKING_CONFIG_FILE=/tmp/openviking-no-config-for-tests.conf uv run pytest \
  tests/unit/test_embedding_config_gemini.py::test_factory_raises_clear_error_when_google_genai_not_installed \
  tests/unit/test_litellm_embedder.py::TestLiteLLMEmbeddingFactory::test_factory_raises_when_litellm_not_installed

uv run ruff check openviking_cli/utils/config/embedding_config.py tests/unit/test_embedding_config_gemini.py

git diff --check
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

本 PR 只改进缺少 Gemini optional dependency 时的诊断信息，不改变 Gemini embedding 的运行逻辑。用户仍需要安装 `openviking[gemini]` 或 `google-genai` 才能使用 Gemini embedding。
