### PR TITLE
fix(embedding): report missing Gemini dependency

### DIFF
--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -222,6 +222,13 @@ def _probe_embedding_provider(
             else embedder.get_dimension()
         )
     except Exception as exc:
+        if "google-genai" in str(exc):
+            return (
+                False,
+                f"{label} ({exc})",
+                "Install the Gemini embedding dependency with: "
+                'pip install "openviking[gemini]" or pip install google-genai',
+            )
         return (
             False,
             f"{label} (invalid embedding config: {exc})",

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -738,6 +738,11 @@ class EmbeddingConfig(BaseModel):
 
         if provider == "litellm" and LiteLLMDenseEmbedder is None:
             raise ValueError("LiteLLM is not installed. Install it with: pip install litellm")
+        if provider == "gemini" and GeminiDenseEmbedder is None:
+            raise ValueError(
+                "Gemini embedding requires google-genai. Install it with: "
+                'pip install "openviking[gemini]" or pip install google-genai'
+            )
 
         # Factory registry: (provider, type) -> (embedder_class, param_builder)
         runtime_config = {

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -371,6 +371,24 @@ class TestCheckEmbedding:
         assert "model not found" in detail
         assert "model name" in fix
 
+    def test_embedding_probe_names_missing_gemini_dependency(self):
+        with patch("openviking.models.embedder.GeminiDenseEmbedder", None):
+            ok, detail, fix = _probe_embedding_provider(
+                {},
+                {
+                    "provider": "gemini",
+                    "model": "gemini-embedding-2-preview",
+                    "api_key": "sk-test",
+                    "dimension": 3072,
+                },
+            )
+
+        assert not ok
+        assert "google-genai" in detail
+        assert "NoneType" not in detail
+        assert "openviking[gemini]" in fix
+        assert "google-genai" in fix
+
     def test_embedding_probe_fails_on_empty_dense_vector(self):
         class FakeEmbedder:
             pass


### PR DESCRIPTION
## Summary

- Detect missing `google-genai` when Gemini embeddings are configured and raise a direct dependency error instead of falling through to a `NoneType` callable failure.
- Teach `openviking-server doctor` to surface a Gemini-specific installation hint for this case.
- Add coverage for the missing Gemini dependency path.

Fixes #4200.

## Test plan

- `NO_COLOR=1 TERM=dumb python -m pytest tests/cli/test_doctor.py`
- `NO_COLOR=1 TERM=dumb python -m ruff check openviking_cli/doctor.py openviking_cli/utils/config/embedding_config.py tests/cli/test_doctor.py`