### PR TITLE
fix(session): extract real abstract instead of "# Working Memory" heading from WM summaries (#3136)

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -4072,6 +4072,30 @@ class Session:
         if match:
             return match.group(1).strip()
 
+        # mengxy-patch: OKF Working Memory documents always open with the
+        # "# Working Memory" heading, so first-line fallback returns a heading,
+        # not an abstract (upstream issue #3136). Prefer the "## Session Title"
+        # section value, then the first real paragraph line. Skip template
+        # prompt echoes (wholly italic lines) some VLMs re-emit verbatim.
+        def _is_heading_or_noise(line: str) -> bool:
+            s = line.strip()
+            if not s or len(s) <= 3 or s.startswith("#") or s.startswith("---"):
+                return True
+            return bool(re.fullmatch(r"_.*_", s, re.DOTALL))
+
+        title_section = re.search(
+            r"^##[ \t]*Session Title[ \t]*\n(.*?)(?=^##[ \t]|\Z)",
+            summary,
+            re.MULTILINE | re.DOTALL,
+        )
+        if title_section:
+            for line in title_section.group(1).split("\n"):
+                if not _is_heading_or_noise(line):
+                    return line.strip()
+
+        for line in summary.split("\n"):
+            if not _is_heading_or_noise(line):
+                return line.strip()
         first_line = summary.split("\n")[0].strip()
         return first_line if first_line else ""
 


### PR DESCRIPTION
## Problem

Follow-up fix for #3136. On `main`, every session archive directory gets the same L0 abstract — the literal heading `# Working Memory` (16 bytes) — because `_extract_abstract_from_summary()` falls back to the first line of the summary, and OKF Working Memory documents always open with that H1.

This makes all archive directories nearly indistinguishable at exactly the layer the hierarchical retriever uses for coarse ranking (`level 0` vector records and the rerank document list are both fed from the abstract text), degrading recursive-drill decisions for the most common query type: "what did we do in past sessions".

The design docs specify L0 extraction as *"take the Brief Description paragraph after the H1, before the first `##`"*. That rule degenerates to an empty string for WM v2 documents, because `# Working Memory` is immediately followed by `## Session Title` — there is no brief-description paragraph between them. The WM template and the extraction rule never agreed.

## Fix

Reworks `_extract_abstract_from_summary()` with a WM-aware extraction chain:

1. Legacy `**Key**: value` pattern first — unchanged behavior.
2. **New:** collect the body of the `## Session Title` section line-by-line; return the first usable line.
3. **New:** fall back to scanning the whole summary for the first real paragraph line.
4. Keep the old first-line fallback only if everything above fails.

A "usable" line skips: headings (`#`), horizontal rules (`---`), blanks, short noise (<3 chars) — and **wholly italic lines**, which some VLMs re-emit verbatim from the prompt-template instructions embedded in the section (e.g. `_Short and distinctive 5-10 word descriptive title..._`). Real-world archives do contain these echo artifacts, so a title-section-only extractor without this filter reproduces them as the abstract.

No truncation or other behavior change; legacy-format summaries are untouched.

## Verification

Unit-style cases (all pass):

| case | input | result |
|---|---|---|
| normal WM | `## Session Title` with value | the real title |
| empty title value | `## Session Title` followed directly by next `##` | first real paragraph of Current State |
| italic echo in title section | `_prompt instructions_` then real title | the real title |
| title value = separator | `---` under Session Title | falls through to paragraph scan |
| legacy format | `**Title**: ...` | unchanged |
| structure-only doc | headings + rules only | old fallback (no regression) |
| full OKF sidecar | frontmatter included | extracts correctly |

Corpus validation on a production instance (v0.4.16, `compression.ov_wm_v2`): extracted from all 74 archives — every one had the degenerate `# Working Memory` abstract before, zero italic/template echoes or empty extractions after. Rewrote them through the public write API and confirmed via search that level-0 records now return meaningful titles (e.g. querying "oMLX local deployment" now surfaces *"oMLX+OpenViking 寒月宫本地部署与 omem→OV 记忆迁移"* at score 0.69, previously indistinguishable from every other archive).

## Relation to #3137 / #3140

Same root cause; this variant additionally handles the WM-specific failure modes observed in production (empty/echo title values in degraded VLM output). Happy to consolidate into whichever implementation maintainers prefer — closing this one in favor of another is fine too.

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code)