### PR TITLE
fix(doctor): 修复 VLM 多凭证配置检查误报

### DIFF
--- a/openviking_cli/doctor.py
+++ b/openviking_cli/doctor.py
@@ -351,7 +351,7 @@ def check_vlm() -> tuple[bool, str, Optional[str]]:
 
     raw_vlm = data.get("vlm", {})
     normalized_vlm = VLMConfig.sync_provider_backend(dict(raw_vlm))
-    vlm = VLMConfig.model_construct(**normalized_vlm)
+    vlm = VLMConfig.model_validate(normalized_vlm)
     _, provider = vlm.get_provider_config()
     model = vlm.model or ""
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -503,6 +503,28 @@ class TestCheckVlm:
             ok, detail, fix = check_vlm()
         assert ok
 
+    def test_pass_with_credentials_config(self, tmp_path: Path):
+        config = tmp_path / "ov.conf"
+        config.write_text(
+            json.dumps(
+                {
+                    "vlm": {
+                        "provider": "openai",
+                        "model": "gpt-4o-mini",
+                        "credentials": [
+                            {"api_key": "sk-primary"},
+                            {"api_key": "sk-backup"},
+                        ],
+                    }
+                }
+            )
+        )
+        with patch("openviking_cli.doctor._find_config", return_value=config):
+            ok, detail, fix = check_vlm()
+        assert ok
+        assert "openai/gpt-4o-mini" in detail
+        assert fix is None
+
     def test_fail_no_provider(self, tmp_path: Path):
         config = tmp_path / "ov.conf"
         config.write_text(json.dumps({"vlm": {}}))


### PR DESCRIPTION
## Description

修复 `openviking-server doctor` 在 VLM 使用多 `credentials` 配置时误报 `AttributeError: dict object has no attribute api_key` 的问题。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- 将 doctor 的 VLM 配置构造从 `model_construct` 改为 `model_validate`，确保执行 Pydantic 校验和配置迁移逻辑
- 保持服务运行时配置加载行为和 doctor 检查行为一致
- 新增多 `credentials` 数组配置的回归测试

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

执行：`python -m pytest tests/cli/test_doctor.py -q`

结果：`58 passed`

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

该问题只影响 doctor 检查路径，不改变 VLM 服务运行时行为。