### PR TITLE
fix(webdav): align GET content length with response body

### DIFF
--- a/openviking/server/routers/webdav.py
+++ b/openviking/server/routers/webdav.py
@@ -280,9 +280,10 @@ async def get_or_head(
     if stat.get("isDir", False):
         return _error(405, "GET is only supported for files")
 
-    body = b"" if request.method == "HEAD" else await service.fs.read_file_bytes(uri, ctx=_ctx)
+    is_head = request.method == "HEAD"
+    body = b"" if is_head else await service.fs.read_file_bytes(uri, ctx=_ctx)
     headers = _webdav_headers()
-    headers["Content-Length"] = str(int(stat.get("size", 0) or 0))
+    headers["Content-Length"] = str(int(stat.get("size", 0) or 0) if is_head else len(body))
     last_modified = _http_last_modified(str(stat.get("modTime", "") or ""))
     if last_modified:
         headers["Last-Modified"] = last_modified

--- a/tests/server/test_api_webdav.py
+++ b/tests/server/test_api_webdav.py
@@ -6,7 +6,9 @@
 import xml.etree.ElementTree as ET
 
 import httpx
+from starlette.requests import Request
 
+from openviking.server.routers import webdav as webdav_router
 from openviking.server.routers.webdav import _ensure_exposed_path, _exposed_child_entries
 from openviking_cli.exceptions import NotFoundError
 
@@ -20,6 +22,40 @@ def _webdav_path_from_uri(uri: str) -> str:
     prefix = "viking://resources"
     assert uri.startswith(prefix)
     return uri[len(prefix) :].lstrip("/")
+
+
+async def test_webdav_get_content_length_uses_delivered_body_size(monkeypatch):
+    class FakeFS:
+        async def stat(self, uri: str, ctx=None):
+            assert uri == "viking://resources/scratch/notes.md"
+            return {
+                "isDir": False,
+                "name": "notes.md",
+                "size": len(b"hello") + 100,
+                "modTime": "",
+            }
+
+        async def read_file_bytes(self, uri: str, ctx=None):
+            assert uri == "viking://resources/scratch/notes.md"
+            return b"hello"
+
+    class FakeService:
+        fs = FakeFS()
+
+    monkeypatch.setattr(webdav_router, "get_service", lambda: FakeService())
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/webdav/resources/scratch/notes.md",
+            "headers": [],
+        }
+    )
+
+    resp = await webdav_router.get_or_head(request, "scratch/notes.md", None)
+
+    assert resp.body == b"hello"
+    assert resp.headers["content-length"] == "5"
 
 
 async def test_webdav_options_advertises_dav(client: httpx.AsyncClient):
@@ -112,6 +148,7 @@ async def test_webdav_put_create_get_and_replace_text_file(client: httpx.AsyncCl
     get_resp = await client.get("/webdav/resources/scratch/notes.md")
     assert get_resp.status_code == 200
     assert get_resp.text == "# Notes\n\nhello"
+    assert get_resp.headers["content-length"] == str(len(get_resp.content))
 
     replace_resp = await client.request(
         "PUT",
@@ -123,6 +160,7 @@ async def test_webdav_put_create_get_and_replace_text_file(client: httpx.AsyncCl
     get_resp = await client.get("/webdav/resources/scratch/notes.md")
     assert get_resp.status_code == 200
     assert get_resp.text == "# Notes\n\nupdated"
+    assert get_resp.headers["content-length"] == str(len(get_resp.content))
 
 
 async def test_webdav_put_replace_reuses_direct_write_path(


### PR DESCRIPTION
## Summary
- Fix WebDAV GET responses to set `Content-Length` from the delivered response body rather than `stat.size`.
- Keep HEAD responses using the stat size without reading file content.
- Add a handler-level regression test for mismatched stat size vs delivered bytes, plus integration assertions that GET headers match response content length.

Fixes #4407.

## Test plan
- [x] `python -m pytest tests/server/test_api_webdav.py::test_webdav_get_content_length_uses_delivered_body_size -q -vv`
- [x] `python -m ruff check openviking/server/routers/webdav.py tests/server/test_api_webdav.py`
- [ ] `OPENVIKING_CONFIG_FILE=/tmp/openviking-test-ov.conf python -m pytest tests/server/test_api_webdav.py -q` blocked locally by missing `ragfs_python` native library after the new focused test passes.

🤖 Generated with Claude Code