### PR TITLE
feat(plugins): add local Git and repository Wiki sync

### DIFF
--- a/.github/scripts/stage-memory-plugin-marketplace.sh
+++ b/.github/scripts/stage-memory-plugin-marketplace.sh
@@ -45,6 +45,8 @@ for required in \
   codex-memory-plugin/skills/openviking-memory/SKILL.md \
   codex-memory-plugin/skills/ov-memory-doctor/SKILL.md \
   codex-memory-plugin/scripts/ov-memory-doctor.mjs \
+  codex-memory-plugin/scripts/repository-sync.mjs \
+  codex-memory-plugin/scripts/shared/repository-sync.mjs \
   trae-memory-hooks/hooks/hooks.json \
   trae-memory-hooks/.mcp.json \
   trae-memory-hooks/openviking.integration.json \
@@ -80,6 +82,7 @@ for required in \
   memory-plugin-shared/lib/agent-hook-runtime.mjs \
   memory-plugin-shared/lib/agent-uri-guard.mjs \
   memory-plugin-shared/lib/async-writer.mjs \
+  memory-plugin-shared/lib/repository-sync.mjs \
   memory-plugin-shared/lib/retryable.mjs \
   memory-plugin-shared/lib/uri-guard.mjs \
   memory-plugin-shared/lib/mcp-proxy-core.mjs; do

--- a/.github/scripts/stage-memory-plugin-marketplace.sh
+++ b/.github/scripts/stage-memory-plugin-marketplace.sh
@@ -20,8 +20,16 @@ cp -R \
   "${ROOT}/examples/pi-coding-agent-extension" \
   "${ROOT}/examples/memory-plugin-shared" \
   "${STAGE}/"
+mkdir -p "${STAGE}/skills"
+cp -R "${ROOT}/examples/skills/repo-wiki" "${STAGE}/skills/"
 
 for required in \
+  skills/repo-wiki/SKILL.md \
+  skills/repo-wiki/defaults.json \
+  skills/repo-wiki/references/openviking-read.md \
+  skills/repo-wiki/references/repo-build.md \
+  skills/repo-wiki/scripts/collect_all.py \
+  skills/repo-wiki/scripts/validate_memory.py \
   claude-code-memory-plugin/skills/ov-experience-memory/SKILL.md \
   codex-memory-plugin/skills/ov-experience-memory/SKILL.md \
   cursor-memory-plugin/.cursor-plugin/plugin.json \
@@ -47,6 +55,7 @@ for required in \
   codex-memory-plugin/scripts/ov-memory-doctor.mjs \
   codex-memory-plugin/scripts/repository-sync.mjs \
   codex-memory-plugin/scripts/shared/repository-sync.mjs \
+  codex-memory-plugin/skills/repo-wiki/SKILL.md \
   trae-memory-hooks/hooks/hooks.json \
   trae-memory-hooks/.mcp.json \
   trae-memory-hooks/openviking.integration.json \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,7 @@ jobs:
             examples/codex-memory-plugin/scripts/recall-compressor-profile.test.mjs \
             examples/codex-memory-plugin/scripts/auto-recall.test.mjs \
             examples/codex-memory-plugin/scripts/session-start-commit.test.mjs \
+            examples/memory-plugin-shared/repository-sync.test.mjs \
             examples/claude-code-memory-plugin/scripts/auto-capture.test.mjs \
             examples/claude-code-memory-plugin/scripts/config.test.mjs \
             examples/claude-code-memory-plugin/scripts/marketplace.test.mjs \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
             examples/codex-memory-plugin/scripts/auto-recall.test.mjs \
             examples/codex-memory-plugin/scripts/session-start-commit.test.mjs \
             examples/memory-plugin-shared/repository-sync.test.mjs \
+            examples/memory-plugin-shared/repo-wiki-skill.test.mjs \
             examples/claude-code-memory-plugin/scripts/auto-capture.test.mjs \
             examples/claude-code-memory-plugin/scripts/config.test.mjs \
             examples/claude-code-memory-plugin/scripts/marketplace.test.mjs \

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ node_modules/
 
 # Local scratch / working notes
 .scratch/
+
+# Repository-local Wiki memory (generated and maintained per checkout)
+/.repo_memory/

--- a/examples/codex-memory-plugin/.codex-plugin/plugin.json
+++ b/examples/codex-memory-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openviking-memory",
   "version": "0.7.7",
-  "description": "Long-term semantic memory for Codex, powered by OpenViking. Recall on UserPromptSubmit, incremental add_message on Stop (per turn), commit on PreCompact, and active-window heuristic + idle-TTL sweep on SessionStart (source=startup|clear). Includes a local stdio MCP proxy that reads OpenViking credentials from env/ovcli.conf.",
+  "description": "Long-term semantic memory for Codex, powered by OpenViking. Recall on UserPromptSubmit, incremental add_message on Stop (per turn), commit on PreCompact, and active-window heuristic + idle-TTL sweep on SessionStart (source=startup|clear). Successful mutations in local-only Git repositories also archive committed HEAD to OpenViking. Includes a local stdio MCP proxy that reads OpenViking credentials from env/ovcli.conf.",
   "author": {
     "name": "OpenViking",
     "url": "https://github.com/volcengine/OpenViking"
@@ -28,6 +28,7 @@
     "capabilities": [
       "Automatic memory recall on each prompt",
       "Incremental conversation capture per turn",
+      "Committed snapshots for local-only Git repositories",
       "Pre-compaction memory extraction",
       "Session archive search and original-text read-back",
       "Resource ingestion for RAG (add_resource)",

--- a/examples/codex-memory-plugin/README.md
+++ b/examples/codex-memory-plugin/README.md
@@ -12,6 +12,7 @@ This is the Codex counterpart to [`claude-code-memory-plugin`](../claude-code-me
 - **Session-start profile injection** on `startup`, `clear`, and `resume`: load `profile.md` plus abstract-annotated indexes of `preferences/` and `entities/` through the shared CJK-aware profile builder.
 - **Auto-recall** relevant memories on every `UserPromptSubmit` and inject them via `hookSpecificOutput.additionalContext`
 - **Incremental capture on `Stop`** (turn end): append the new user/assistant turns to a deterministic OpenViking session id `cx-<codex_session_id>`. When `pending_tokens` reaches `OPENVIKING_COMMIT_TOKEN_THRESHOLD`, commit while keeping a recent live tail.
+- **Local Git snapshots on `PostToolUse`**: after a successful `git commit`, merge, rebase, reset, revert, checkout, switch, pull, or merge, archive `HEAD` from repositories without an `origin` remote and submit it to OpenViking's normal code-repository ingestion path.
 - **Commit on `PreCompact`**: trigger OpenViking's memory extractor on the full pre-compact transcript before Codex summarizes it.
 - **Commit on `SessionStart` (source=startup|clear)**: active-window heuristic — if exactly one *other* state file was touched within the last 2 min, commit it (the just-ended session). On `≥2`, defer to idle-TTL sweep at the tail. `source=resume` never commits or sweeps; if the live OV session was already committed, it combines the profile block with the latest archive summary for continuity. See `DESIGN.md` for the full decision tree.
 
@@ -154,7 +155,7 @@ Earlier plugin versions configured tuning fields under a `codex` block in `~/.op
    │                            Codex                             │
    └──┬─────────────────┬────────────────┬───────────────────┬────┘
       │                 │                │                   │
- SessionStart      UserPromptSubmit    Stop              PreCompact
+ SessionStart      UserPromptSubmit    PostToolUse       Stop              PreCompact
  (startup|clear|resume) │              (per turn)            │
       │                 │                │                   │
  ┌────▼──────────┐ ┌────▼──────┐ ┌──────▼──────┐ ┌──────────▼──────┐
@@ -263,6 +264,12 @@ defaults.
 
 After a successful append, Stop reads the session meta and commits when `pending_tokens >= OPENVIKING_COMMIT_TOKEN_THRESHOLD` (default `20000`). Threshold commits pass `keep_recent_count=OPENVIKING_COMMIT_KEEP_RECENT_COUNT` (default `10`) so the newest turns remain live for continuity while older context is archived and extracted. `PreCompact` still commits everything before compaction.
 
+### PostToolUse (local-only Git snapshot)
+
+`repository-sync.mjs` handles successful Git mutations only. It ignores reads such as `git status` and `git diff`, failed commands, and repositories that have an `origin` remote because remote-backed repositories already use OpenViking's normal remote-Git ingestion flow. For a local-only repository, the hook creates a stable private Git config identity (`openviking.repositoryKey`), archives committed `HEAD` with `git archive`, uploads the ZIP, and requests the fixed `viking://resources/local-git/<repository>/<branch>` target. The server unwraps the archive as `SourceType.GIT`, so parsing, tree sync, and downstream indexing reuse the normal code-repository path.
+
+The hook's detached worker makes upload failures non-blocking. It records the last successfully submitted commit per repository and branch, so duplicate PostToolUse events do not re-upload the same snapshot. Set `OPENVIKING_GIT_LOCAL_ENABLED=0` to disable this integration.
+
 ### PreCompact (deterministic commit)
 
 `pre-compact-capture.mjs`:
@@ -286,6 +293,7 @@ Codex's hook output schema differs from Claude Code's. Notably:
 |------|------------------------|--------------------------------------|
 | `SessionStart`   | `source` (`startup`/`resume`/`clear`), `session_id`, `cwd` | `hookSpecificOutput.additionalContext`; may also include `systemMessage` when an orphaned session was committed |
 | `UserPromptSubmit` | `prompt`, `session_id`                     | `hookSpecificOutput.additionalContext` |
+| `PostToolUse`    | successful command tool `cwd`, command, exit status | `{}` (async snapshot submission) |
 | `Stop`           | `last_assistant_message`, `transcript_path`, `session_id` | `systemMessage` (only) |
 | `PreCompact`     | `trigger` (`manual`/`auto`), `transcript_path`, `session_id` | `systemMessage` (only) |
 
@@ -308,7 +316,7 @@ codex-memory-plugin/
 ├── .codex-plugin/
 │   └── plugin.json              # Plugin manifest (hooks + mcp wiring)
 ├── hooks/
-│   └── hooks.json               # SessionStart + UserPromptSubmit + Stop + PreCompact
+│   └── hooks.json               # SessionStart + UserPromptSubmit + PostToolUse + Stop + PreCompact
 │                                  (uses Codex's native ${PLUGIN_ROOT} token; no
 │                                   rendering needed on modern Codex)
 ├── skills/
@@ -324,6 +332,7 @@ codex-memory-plugin/
 │   ├── session-state.mjs        # Per-codex-session OV session state
 │   ├── auto-recall.mjs          # UserPromptSubmit hook (REST /search/search)
 │   ├── auto-capture.mjs         # Stop hook (append + threshold commit)
+│   ├── repository-sync.mjs      # PostToolUse local Git snapshot hook
 │   ├── session-start-commit.mjs # SessionStart hook (profile + active-window + idle TTL + resume archive)
 │   └── pre-compact-capture.mjs  # PreCompact hook
 ├── servers/

--- a/examples/codex-memory-plugin/hooks/hooks.json
+++ b/examples/codex-memory-plugin/hooks/hooks.json
@@ -47,6 +47,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|RunCommand|Shell|exec_command|codex_exec",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${PLUGIN_ROOT}/scripts/repository-sync.mjs",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/examples/codex-memory-plugin/scripts/marketplace.test.mjs
+++ b/examples/codex-memory-plugin/scripts/marketplace.test.mjs
@@ -125,6 +125,8 @@ test("required plugin files are present", () => {
     "skills/ov-memory-doctor/reference.md",
     "scripts/ov-memory-doctor.mjs",
     "scripts/shared/doctor-core.mjs",
+    "scripts/repository-sync.mjs",
+    "scripts/shared/repository-sync.mjs",
   ]) {
     assert.ok(existsSync(join(pluginDir, rel)), `missing required plugin file: ${rel}`);
   }
@@ -160,6 +162,18 @@ test("hooks.json uses Codex's native ${PLUGIN_ROOT}, not the legacy placeholder"
   for (const cmd of commands) {
     assert.ok(cmd.includes("${PLUGIN_ROOT}/scripts/"), `hook command must be rooted at \${PLUGIN_ROOT}: ${cmd}`);
   }
+});
+
+test("Codex plugin registers local Git sync after successful shell mutations", () => {
+  const hooks = readJson(join(pluginDir, "hooks", "hooks.json"));
+  const postToolUse = hooks.hooks?.PostToolUse;
+  assert.ok(Array.isArray(postToolUse), "hooks.json must define PostToolUse");
+  const repositorySync = postToolUse.find((entry) => entry?.matcher === "Bash|RunCommand|Shell|exec_command|codex_exec");
+  assert.ok(repositorySync, "PostToolUse must match command tools");
+  assert.equal(
+    repositorySync.hooks?.[0]?.command,
+    "node ${PLUGIN_ROOT}/scripts/repository-sync.mjs",
+  );
 });
 
 test(".mcp.json starts the stdio MCP proxy from the plugin root", () => {

--- a/examples/codex-memory-plugin/scripts/repository-sync.mjs
+++ b/examples/codex-memory-plugin/scripts/repository-sync.mjs
@@ -43,8 +43,10 @@ async function main() {
   log("repository-sync", {
     status: result?.status,
     reason: result?.reason,
-    task_id: result?.result?.task_id,
-    root_uri: result?.result?.root_uri,
+    code_status: result?.code?.status,
+    code_task_id: result?.code?.result?.task_id,
+    wiki_status: result?.wiki?.status,
+    wiki_task_id: result?.wiki?.result?.task_id,
   });
   if (process.env.OV_HOOK_WORKER !== "1") output({});
 }

--- a/examples/codex-memory-plugin/scripts/repository-sync.mjs
+++ b/examples/codex-memory-plugin/scripts/repository-sync.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook for local-only Git repositories.
+ *
+ * The parent hook immediately returns an empty Codex response when async
+ * writes are enabled; its detached worker archives committed HEAD and submits
+ * the snapshot without delaying the completed Git tool invocation.
+ */
+
+import { loadConfig } from "./config.mjs";
+import { createLogger } from "./debug-log.mjs";
+import { maybeDetach, readHookStdin } from "./shared/async-writer.mjs";
+import { syncRepositoryFromHook } from "./shared/repository-sync.mjs";
+
+const cfg = loadConfig();
+const { log, logError } = createLogger("repository-sync", cfg);
+
+function output(value = {}) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+async function main() {
+  if (process.env.OPENVIKING_GIT_LOCAL_ENABLED === "0") {
+    output({});
+    return;
+  }
+  if (await maybeDetach(cfg, { approve: () => output({}) })) return;
+
+  let input;
+  try {
+    const raw = await readHookStdin();
+    input = raw.trim() ? JSON.parse(raw) : {};
+  } catch {
+    output({});
+    return;
+  }
+
+  const result = await syncRepositoryFromHook(input, { credentials: cfg }).catch((error) => {
+    logError("repository-sync", error);
+    return { status: "error", error: error?.message || String(error) };
+  });
+  log("repository-sync", {
+    status: result?.status,
+    reason: result?.reason,
+    task_id: result?.result?.task_id,
+    root_uri: result?.result?.root_uri,
+  });
+  if (process.env.OV_HOOK_WORKER !== "1") output({});
+}
+
+await main();

--- a/examples/codex-memory-plugin/scripts/shared/repository-sync.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/repository-sync.mjs
@@ -1,0 +1,346 @@
+// GENERATED FROM examples/memory-plugin-shared/lib. DO NOT EDIT.
+import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { resolveOpenVikingCredentials } from "./credentials.mjs";
+
+const execFileAsync = promisify(execFile);
+const MUTATING_GIT_COMMANDS = new Set([
+  "checkout",
+  "commit",
+  "merge",
+  "pull",
+  "rebase",
+  "reset",
+  "revert",
+  "switch",
+]);
+const STATE_DIR_MODE = 0o700;
+const STATE_FILE_MODE = 0o600;
+const LOCAL_REPOSITORY_KEY_CONFIG = "openviking.repositoryKey";
+
+function hash(value) {
+  return createHash("sha256").update(String(value || "")).digest("hex");
+}
+
+function safePart(value, fallback = "unknown") {
+  const normalized = String(value || "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return (normalized || fallback).slice(0, 96);
+}
+
+function branchTargetSegment(branch) {
+  const raw = String(branch || "").trim();
+  const normalized = safePart(raw);
+  if (normalized === raw && raw.length <= 96) return normalized;
+  return `${normalized.slice(0, 87)}-${hash(raw).slice(0, 8)}`;
+}
+
+function shellWords(command) {
+  return String(command || "").trim().split(/\s+/u);
+}
+
+function nestedInput(input = {}) {
+  return input.tool_input ?? input.toolInput ?? input.input ?? input.arguments ?? input.payload ?? {};
+}
+
+function commandText(input = {}) {
+  const toolInput = nestedInput(input);
+  let raw = typeof toolInput === "string"
+    ? toolInput
+    : (toolInput.command ?? toolInput.cmd ?? toolInput.script ?? input.command ?? input.cmd ?? "");
+  if (Array.isArray(raw) && raw.length >= 3 && /(?:^|\/)bash$/u.test(String(raw[0])) && raw[1] === "-lc") {
+    raw = raw[2];
+  }
+  return Array.isArray(raw) ? raw.join(" ") : String(raw || "");
+}
+
+function toolName(input = {}) {
+  const nested = nestedInput(input);
+  return String(
+    input.tool_name
+      ?? input.toolName
+      ?? input.name
+      ?? input.tool?.name
+      ?? input.tool
+      ?? nested.tool_name
+      ?? nested.toolName
+      ?? nested.name
+      ?? "",
+  );
+}
+
+function toolResponse(input = {}) {
+  const nested = nestedInput(input);
+  return input.tool_response
+    ?? input.toolResponse
+    ?? input.response
+    ?? input.tool_result
+    ?? nested.tool_response
+    ?? nested.toolResponse
+    ?? nested.response
+    ?? {
+      exit_code: input.exit_code ?? nested.exit_code,
+      exitCode: input.exitCode ?? nested.exitCode,
+      status: input.status ?? nested.status,
+      success: input.success ?? nested.success,
+    };
+}
+
+export function isSuccessfulGitMutation(input = {}) {
+  if (!/^(Bash|RunCommand|Shell|exec_command|codex_exec)$/u.test(toolName(input))) return false;
+
+  const response = toolResponse(input);
+  if (response && typeof response === "object") {
+    const code = response.exit_code ?? response.exitCode ?? response.code;
+    if (Number.isFinite(Number(code)) && Number(code) !== 0) return false;
+    const status = String(response.status ?? "").toLowerCase();
+    if (["error", "failed", "failure"].includes(status)) return false;
+    if (response.success === false) return false;
+  }
+
+  const command = commandText(input);
+  if (!command) return false;
+  const invocations = command.match(/(?:^|(?:&&|;|\|\|)\s*)git\s+([A-Za-z-]+)/gu) || [];
+  return invocations.some((entry) => {
+    const words = shellWords(entry.replace(/^(?:&&|;|\|\|)\s*/u, ""));
+    return words[0] === "git" && MUTATING_GIT_COMMANDS.has(words[1]);
+  });
+}
+
+function hookCwd(input = {}) {
+  const nested = nestedInput(input);
+  return String(input.cwd ?? nested.cwd ?? process.cwd());
+}
+
+async function runGit(cwd, args, timeout = 15_000) {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    timeout,
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+async function getLocalRepositoryKey(root) {
+  try {
+    const existing = await runGit(root, ["config", "--local", "--get", LOCAL_REPOSITORY_KEY_CONFIG]);
+    if (existing) return `local:${existing}`;
+  } catch {
+    // A new repository has no OpenViking identity yet.
+  }
+
+  const value = randomUUID();
+  try {
+    await runGit(root, ["config", "--local", LOCAL_REPOSITORY_KEY_CONFIG, value]);
+    return `local:${value}`;
+  } catch {
+    // The hook must never fail a completed Git command. The deterministic
+    // fallback remains machine-local and never leaves the client except hashed.
+    return `local:${hash(root)}`;
+  }
+}
+
+export async function resolveRepositoryContext(cwd) {
+  const root = await runGit(cwd, ["rev-parse", "--show-toplevel"]);
+  const commit = await runGit(root, ["rev-parse", "HEAD"]);
+  let branch = await runGit(root, ["branch", "--show-current"]);
+  if (!branch) branch = `detached-${commit.slice(0, 12)}`;
+
+  let origin = "";
+  try {
+    origin = await runGit(root, ["remote", "get-url", "origin"]);
+  } catch {
+    // This is the intended local-only repository case.
+  }
+  if (origin) {
+    return { root, commit: commit.toLowerCase(), branch, repoName: basename(root), remoteOrigin: origin };
+  }
+
+  const repoKey = await getLocalRepositoryKey(root);
+  return {
+    root,
+    commit: commit.toLowerCase(),
+    branch,
+    repoKey,
+    repoName: basename(root),
+    targetUri: `viking://resources/local-git/${hash(repoKey).slice(0, 24)}/${branchTargetSegment(branch)}`,
+  };
+}
+
+function statePath(context) {
+  const root = process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR
+    || join(process.env.HOME || tmpdir(), ".openviking", "repository-sync", "state");
+  return join(root, `${hash(`${context.repoKey}\n${context.branch}`)}.json`);
+}
+
+function lockPath(context) {
+  return `${statePath(context)}.lock`;
+}
+
+async function withRepositoryLock(context, callback) {
+  const lock = lockPath(context);
+  await mkdir(dirname(lock), { recursive: true, mode: STATE_DIR_MODE });
+  while (true) {
+    try {
+      await mkdir(lock, { mode: STATE_DIR_MODE });
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - (await stat(lock)).mtimeMs > 10 * 60_000) {
+          await rm(lock, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      return { status: "skipped", reason: "already-running", context };
+    }
+  }
+  try {
+    return await callback();
+  } finally {
+    await rm(lock, { recursive: true, force: true });
+  }
+}
+
+async function readState(context) {
+  try {
+    return JSON.parse(await readFile(statePath(context), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function writeState(context, value) {
+  const file = statePath(context);
+  await mkdir(dirname(file), { recursive: true, mode: STATE_DIR_MODE });
+  const temporary = `${file}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: STATE_FILE_MODE,
+  });
+  await rename(temporary, file);
+}
+
+export async function createRepositoryArchive(context) {
+  const directory = await mkdtemp(join(tmpdir(), "openviking-git-local-"));
+  await chmod(directory, STATE_DIR_MODE);
+  const archive = join(directory, `${safePart(context.repoName, "repository")}.zip`);
+  await execFileAsync(
+    "git",
+    ["-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD"],
+    { timeout: 120_000, maxBuffer: 1024 * 1024 },
+  );
+  await chmod(archive, STATE_FILE_MODE);
+  return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+}
+
+function authHeaders(credentials, contentType = "") {
+  const headers = {};
+  if (contentType) headers["Content-Type"] = contentType;
+  if (credentials.apiKey) headers.Authorization = `Bearer ${credentials.apiKey}`;
+  if (credentials.account) headers["X-OpenViking-Account"] = credentials.account;
+  if (credentials.user) headers["X-OpenViking-User"] = credentials.user;
+  if (credentials.peerId) headers["X-OpenViking-Actor-Peer"] = credentials.peerId;
+  if (credentials.userAgent) headers["User-Agent"] = credentials.userAgent;
+  return headers;
+}
+
+async function responseResult(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body.status === "error") {
+    const message = body.error?.message || body.message || `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return body.result ?? body;
+}
+
+export async function uploadRepositorySnapshot(credentials, archive) {
+  const form = new FormData();
+  const { openAsBlob } = await import("node:fs");
+  const content = typeof openAsBlob === "function"
+    ? await openAsBlob(archive, { type: "application/zip" })
+    : new Blob([await readFile(archive)], { type: "application/zip" });
+  form.append("file", content, basename(archive));
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources/temp_upload`, {
+    method: "POST",
+    headers: authHeaders(credentials),
+    body: form,
+  });
+  const result = await responseResult(response);
+  if (!result.temp_file_id) throw new Error("Temporary upload returned no temp_file_id.");
+  return result.temp_file_id;
+}
+
+export async function submitRepositorySnapshot(credentials, tempFileId, context) {
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources`, {
+    method: "POST",
+    headers: authHeaders(credentials, "application/json"),
+    body: JSON.stringify({
+      temp_file_id: tempFileId,
+      to: context.targetUri,
+      wait: false,
+      args: {
+        git_local: {
+          version: 1,
+          repo_key: context.repoKey,
+          repo_name: context.repoName,
+          branch: context.branch,
+          commit: context.commit,
+          archive_format: "zip",
+        },
+      },
+    }),
+  });
+  return responseResult(response);
+}
+
+export async function syncRepositoryFromHook(input, options = {}) {
+  if (!isSuccessfulGitMutation(input)) return { status: "skipped", reason: "not-git-mutation" };
+  const context = await resolveRepositoryContext(hookCwd(input));
+  if (context.remoteOrigin) return { status: "skipped", reason: "remote-backed", context };
+
+  return withRepositoryLock(context, async () => {
+    const previous = await readState(context);
+    if (previous.lastSubmittedCommit === context.commit) {
+      return { status: "skipped", reason: "already-submitted", context };
+    }
+
+    const credentials = options.credentials || resolveOpenVikingCredentials();
+    const bundle = await createRepositoryArchive(context);
+    try {
+      const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+      const result = await submitRepositorySnapshot(credentials, tempFileId, context);
+      await writeState(context, {
+        version: 1,
+        repoKey: context.repoKey,
+        branch: context.branch,
+        targetUri: context.targetUri,
+        lastSubmittedCommit: context.commit,
+        taskId: result.task_id || "",
+        updatedAt: new Date().toISOString(),
+      });
+      return { status: "submitted", context, result };
+    } finally {
+      await bundle.cleanup();
+    }
+  });
+}

--- a/examples/codex-memory-plugin/scripts/shared/repository-sync.mjs
+++ b/examples/codex-memory-plugin/scripts/shared/repository-sync.mjs
@@ -3,16 +3,18 @@ import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import {
   chmod,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rename,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { promisify } from "node:util";
 
 import { resolveOpenVikingCredentials } from "./credentials.mjs";
@@ -31,6 +33,12 @@ const MUTATING_GIT_COMMANDS = new Set([
 const STATE_DIR_MODE = 0o700;
 const STATE_FILE_MODE = 0o600;
 const LOCAL_REPOSITORY_KEY_CONFIG = "openviking.repositoryKey";
+const WIKI_DIR = ".repo_memory";
+const WIKI_PROFILE_SCHEMA = "repo_memory_profile.v0.2";
+const WIKI_PAGE_SCHEMA = "repo_memory_wiki_page.v0.1";
+const WIKI_RESOURCE_FILES = new Set(["commits.md", "prs.md", "issues.md"]);
+const WIKI_IGNORED_DIRS = new Set(["raw", "procedure-memory", "user-profile", "__pycache__"]);
+const WIKI_IGNORED_FILES = new Set([".DS_Store"]);
 
 function hash(value) {
   return createHash("sha256").update(String(value || "")).digest("hex");
@@ -157,9 +165,23 @@ async function getLocalRepositoryKey(root) {
   }
 }
 
+function stripRemoteCredentials(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    parsed.username = "";
+    parsed.password = "";
+    return parsed.toString().replace(/\/$/u, "");
+  } catch {
+    return raw.replace(/^(https?:\/\/)[^/@]+@/u, "$1");
+  }
+}
+
 export async function resolveRepositoryContext(cwd) {
   const root = await runGit(cwd, ["rev-parse", "--show-toplevel"]);
   const commit = await runGit(root, ["rev-parse", "HEAD"]);
+  const tree = await runGit(root, ["rev-parse", "HEAD^{tree}"]);
   let branch = await runGit(root, ["branch", "--show-current"]);
   if (!branch) branch = `detached-${commit.slice(0, 12)}`;
 
@@ -169,18 +191,18 @@ export async function resolveRepositoryContext(cwd) {
   } catch {
     // This is the intended local-only repository case.
   }
-  if (origin) {
-    return { root, commit: commit.toLowerCase(), branch, repoName: basename(root), remoteOrigin: origin };
-  }
-
-  const repoKey = await getLocalRepositoryKey(root);
+  const repoKey = origin ? stripRemoteCredentials(origin) : await getLocalRepositoryKey(root);
+  const repoId = hash(repoKey).slice(0, 24);
   return {
     root,
     commit: commit.toLowerCase(),
+    tree: tree.toLowerCase(),
     branch,
     repoKey,
+    repoId,
     repoName: basename(root),
-    targetUri: `viking://resources/local-git/${hash(repoKey).slice(0, 24)}/${branchTargetSegment(branch)}`,
+    remoteOrigin: Boolean(origin),
+    targetUri: `viking://resources/local-git/${repoId}/${branchTargetSegment(branch)}`,
   };
 }
 
@@ -246,11 +268,197 @@ export async function createRepositoryArchive(context) {
   const archive = join(directory, `${safePart(context.repoName, "repository")}.zip`);
   await execFileAsync(
     "git",
-    ["-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD"],
+    [
+      "-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD",
+      "--", ".", `:(exclude)${WIKI_DIR}`, `:(exclude)${WIKI_DIR}/**`,
+    ],
     { timeout: 120_000, maxBuffer: 1024 * 1024 },
   );
   await chmod(archive, STATE_FILE_MODE);
   return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+}
+
+function wikiUploadEnabled(options = {}) {
+  if (typeof options.wikiUploadEnabled === "boolean") return options.wikiUploadEnabled;
+  const value = String(process.env.OPENVIKING_REPO_WIKI_UPLOAD_ENABLED || "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(value);
+}
+
+function metadataValue(text, name) {
+  const prefix = `${name}:`;
+  const line = String(text || "").split(/\r?\n/u).find((candidate) => candidate.startsWith(prefix));
+  if (!line) return "";
+  return line.slice(prefix.length).trim().replace(/^["']|["']$/gu, "").trim();
+}
+
+function validUserId(value) {
+  const raw = String(value || "").trim();
+  return raw && raw !== "." && raw !== ".." && /^[A-Za-z0-9._-]+$/u.test(raw) ? raw : "";
+}
+
+export async function resolveEffectiveUserId(credentials, fetchImpl = globalThis.fetch) {
+  const configured = validUserId(credentials?.user);
+  if (configured) return configured;
+  for (const endpoint of ["/health", "/api/v1/system/status"]) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    try {
+      const response = await fetchImpl(`${credentials.baseUrl}${endpoint}`, {
+        headers: authHeaders(credentials),
+        signal: controller.signal,
+      });
+      if (!response.ok) continue;
+      const body = await response.json().catch(() => ({}));
+      const candidate = validUserId(body.user_id || body.result?.user);
+      if (candidate) return candidate;
+    } catch {
+      // A missing identity skips only Wiki publication.
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return "";
+}
+
+async function publicationFiles(wikiRoot) {
+  const profile = join(wikiRoot, "PROFILE.md");
+  const profileStat = await lstat(profile).catch(() => null);
+  if (!profileStat?.isFile() || profileStat.isSymbolicLink()) {
+    throw new Error("Wiki PROFILE.md is missing or unsafe.");
+  }
+  const files = ["PROFILE.md"];
+  for (const entry of await readdir(wikiRoot, { withFileTypes: true })) {
+    if (entry.name === "PROFILE.md" || entry.name === "_plan.md") continue;
+    if (entry.isSymbolicLink()) throw new Error(`Wiki contains an unsafe symlink: ${entry.name}`);
+    if (WIKI_IGNORED_FILES.has(entry.name) || /\.(?:lock|log|tmp)$/u.test(entry.name)) continue;
+    if (entry.isDirectory() && (entry.name === "resources" || WIKI_IGNORED_DIRS.has(entry.name))) continue;
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(entry.name);
+      continue;
+    }
+    throw new Error(`Wiki contains an unsupported root entry: ${entry.name}`);
+  }
+  const resources = join(wikiRoot, "resources");
+  const resourcesStat = await lstat(resources).catch(() => null);
+  if (resourcesStat?.isSymbolicLink()) throw new Error("Wiki resources directory is a symlink.");
+  if (resourcesStat?.isDirectory()) {
+    for (const entry of await readdir(resources, { withFileTypes: true })) {
+      if (entry.isSymbolicLink()) throw new Error(`Wiki contains an unsafe symlink: resources/${entry.name}`);
+      if (entry.isFile() && WIKI_RESOURCE_FILES.has(entry.name)) {
+        files.push(posix.join("resources", entry.name));
+        continue;
+      }
+      throw new Error(`Wiki contains an unsupported resource entry: resources/${entry.name}`);
+    }
+  }
+  return files.sort();
+}
+
+function validateWikiLinks(files, contents) {
+  const available = new Set(files);
+  for (const file of files) {
+    for (const match of contents.get(file).matchAll(/\[[^\]]*\]\(([^)]+)\)/gu)) {
+      const target = match[1].trim().split("#", 1)[0];
+      if (!target || /^(?:[a-z]+:|#)/iu.test(target)) continue;
+      const resolved = posix.normalize(posix.join(posix.dirname(file), target.replace(/^\.\//u, "")));
+      if (resolved.startsWith("../") || !available.has(resolved)) {
+        throw new Error(`Wiki link escapes or is missing: ${file} -> ${target}`);
+      }
+    }
+  }
+}
+
+function sanitizeWikiContent(content, repositoryRoot) {
+  const roots = new Set([String(repositoryRoot || "")]);
+  if (repositoryRoot.startsWith("/private/")) roots.add(repositoryRoot.slice(8));
+  else if (repositoryRoot.startsWith("/var/")) roots.add(`/private${repositoryRoot}`);
+  let sanitized = String(content || "");
+  for (const root of [...roots].filter(Boolean).sort((a, b) => b.length - a.length)) {
+    sanitized = sanitized.split(root).join(".");
+  }
+  return sanitized;
+}
+
+export async function prepareRepositoryUploadInputs(context, credentials, options = {}) {
+  if (!wikiUploadEnabled(options)) return { code: context, wiki: { status: "disabled" } };
+  const wikiRoot = join(context.root, WIKI_DIR);
+  const profile = await readFile(join(wikiRoot, "PROFILE.md"), "utf8").catch(() => "");
+  if (!profile) return { code: context, wiki: { status: "absent", root: wikiRoot } };
+  if (metadataValue(profile, "schema") !== WIKI_PROFILE_SCHEMA) {
+    return { code: context, wiki: { status: "invalid", reason: "unsupported-profile-schema", root: wikiRoot } };
+  }
+  const sourceCommit = metadataValue(profile, "local_head").toLowerCase();
+  const sourceTree = metadataValue(profile, "source_tree").toLowerCase();
+  if (!/^[0-9a-f]{40}$/u.test(sourceCommit) || !/^[0-9a-f]{40}$/u.test(sourceTree)) {
+    return { code: context, wiki: { status: "invalid", reason: "invalid-source-provenance", root: wikiRoot } };
+  }
+  const userId = await resolveEffectiveUserId(credentials, options.fetchImpl || globalThis.fetch);
+  if (!userId) return { code: context, wiki: { status: "invalid", reason: "user-id-unavailable", root: wikiRoot } };
+  try {
+    const files = await publicationFiles(wikiRoot);
+    const contents = new Map();
+    const digest = createHash("sha256");
+    for (const file of files) {
+      let content = await readFile(join(wikiRoot, ...file.split("/")), "utf8");
+      if (file !== "PROFILE.md" && !file.includes("/") && metadataValue(content, "schema") !== WIKI_PAGE_SCHEMA) {
+        throw new Error(`Wiki page has unsupported schema: ${file}`);
+      }
+      content = sanitizeWikiContent(content, context.root);
+      contents.set(file, content);
+      digest.update(file).update("\0").update(content).update("\0");
+    }
+    validateWikiLinks(files, contents);
+    return {
+      code: context,
+      wiki: {
+        status: "ready",
+        root: wikiRoot,
+        targetUri: `viking://resources/wiki/${context.repoId}/${userId}`,
+        repoId: context.repoId,
+        userId,
+        sourceCommit,
+        sourceTree,
+        sourceBranch: metadataValue(profile, "local_branch") || context.branch,
+        triggerCommit: context.commit,
+        triggerTree: context.tree,
+        buildMode: metadataValue(profile, "build_mode") || "unknown",
+        generatedAt: metadataValue(profile, "generated_at"),
+        files,
+        contents,
+        contentHash: digest.digest("hex"),
+      },
+    };
+  } catch (error) {
+    return { code: context, wiki: { status: "invalid", reason: error?.message || String(error), root: wikiRoot, sourceCommit } };
+  }
+}
+
+export async function createWikiArchive(context, wiki) {
+  if (wiki?.status !== "ready") throw new Error("Wiki is not ready for publication.");
+  const directory = await mkdtemp(join(tmpdir(), "openviking-repo-wiki-"));
+  const staging = join(directory, "publication");
+  const archive = join(directory, `${safePart(context.repoName, "repository")}-wiki.zip`);
+  await mkdir(staging, { recursive: true, mode: STATE_DIR_MODE });
+  try {
+    for (const file of wiki.files) {
+      const destination = join(staging, ...file.split("/"));
+      await mkdir(dirname(destination), { recursive: true, mode: STATE_DIR_MODE });
+      await writeFile(destination, wiki.contents.get(file), { encoding: "utf8", mode: STATE_FILE_MODE });
+    }
+    const manifest = {
+      schema: "repo_wiki_publication.v1", repo_id: context.repoId, repo_name: context.repoName,
+      repo_key: context.repoKey, wiki_owner: wiki.userId, source_commit: wiki.sourceCommit,
+      source_tree: wiki.sourceTree, source_branch: wiki.sourceBranch, build_mode: wiki.buildMode,
+      generated_at: wiki.generatedAt, files: wiki.files, content_hash: wiki.contentHash,
+    };
+    await writeFile(join(staging, "repo-wiki-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, { encoding: "utf8", mode: STATE_FILE_MODE });
+    await execFileAsync("python3", ["-m", "zipfile", "-c", archive, "."], { cwd: staging, timeout: 120_000, maxBuffer: 1024 * 1024 });
+    await chmod(archive, STATE_FILE_MODE);
+    return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 function authHeaders(credentials, contentType = "") {
@@ -313,34 +521,145 @@ export async function submitRepositorySnapshot(credentials, tempFileId, context)
   return responseResult(response);
 }
 
+export async function submitWikiSnapshot(credentials, tempFileId, wiki) {
+  const tags = [
+    "content_kind=repo_wiki",
+    `repo_id=${wiki.repoId}`,
+    `wiki_owner=${wiki.userId}`,
+    `source_commit=${wiki.sourceCommit}`,
+    `build_mode=${wiki.buildMode}`,
+    `content_hash=${wiki.contentHash}`,
+  ];
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources`, {
+    method: "POST",
+    headers: authHeaders(credentials, "application/json"),
+    body: JSON.stringify({
+      temp_file_id: tempFileId,
+      to: wiki.targetUri,
+      wait: false,
+      processing_mode: "vectors_only",
+      tags,
+      tag_mode: "replace",
+      args: { parse_mode: "no_split" },
+    }),
+  });
+  return responseResult(response);
+}
+
+function normalizedSyncState(previous, context) {
+  if (previous?.version === 2) return previous;
+  return {
+    version: 2,
+    repoKey: context.repoKey,
+    branch: context.branch,
+    code: previous?.lastSubmittedCommit ? {
+      lastSubmittedCommit: previous.lastSubmittedCommit,
+      targetUri: previous.targetUri || context.targetUri,
+      taskId: previous.taskId || "",
+      status: "submitted",
+    } : {},
+    wiki: {},
+    updatedAt: previous?.updatedAt || "",
+  };
+}
+
 export async function syncRepositoryFromHook(input, options = {}) {
   if (!isSuccessfulGitMutation(input)) return { status: "skipped", reason: "not-git-mutation" };
   const context = await resolveRepositoryContext(hookCwd(input));
-  if (context.remoteOrigin) return { status: "skipped", reason: "remote-backed", context };
 
   return withRepositoryLock(context, async () => {
-    const previous = await readState(context);
-    if (previous.lastSubmittedCommit === context.commit) {
-      return { status: "skipped", reason: "already-submitted", context };
+    const rawPrevious = await readState(context);
+    const previous = normalizedSyncState(rawPrevious, context);
+    const credentials = options.credentials || resolveOpenVikingCredentials();
+    const inputs = await prepareRepositoryUploadInputs(context, credentials, options);
+    const codeNeeded = !context.remoteOrigin && previous.code?.lastSubmittedCommit !== context.commit;
+    const wikiNeeded = inputs.wiki.status === "ready"
+      && (previous.wiki?.contentHash !== inputs.wiki.contentHash
+        || previous.wiki?.status !== "submitted");
+
+    if (!codeNeeded && !wikiNeeded) {
+      const wikiReason = inputs.wiki.reason || inputs.wiki.status;
+      if (rawPrevious?.version !== 2 || previous.wiki?.status !== inputs.wiki.status
+          || previous.wiki?.reason !== wikiReason) {
+        await writeState(context, {
+          ...previous,
+          wiki: { ...previous.wiki, status: inputs.wiki.status, reason: wikiReason },
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      return {
+        status: "skipped",
+        reason: context.remoteOrigin && inputs.wiki.status === "disabled"
+          ? "remote-backed"
+          : (inputs.wiki.status === "disabled" ? "already-submitted" : "nothing-to-submit"),
+        context,
+        code: { status: "skipped", reason: context.remoteOrigin ? "remote-backed" : "already-submitted" },
+        wiki: { status: "skipped", reason: wikiReason },
+      };
     }
 
-    const credentials = options.credentials || resolveOpenVikingCredentials();
-    const bundle = await createRepositoryArchive(context);
-    try {
-      const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
-      const result = await submitRepositorySnapshot(credentials, tempFileId, context);
-      await writeState(context, {
-        version: 1,
-        repoKey: context.repoKey,
-        branch: context.branch,
-        targetUri: context.targetUri,
-        lastSubmittedCommit: context.commit,
-        taskId: result.task_id || "",
-        updatedAt: new Date().toISOString(),
-      });
-      return { status: "submitted", context, result };
-    } finally {
-      await bundle.cleanup();
-    }
+    const codePromise = codeNeeded ? (async () => {
+      const bundle = await createRepositoryArchive(context);
+      try {
+        const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+        const result = await submitRepositorySnapshot(credentials, tempFileId, context);
+        return { status: "submitted", result };
+      } finally {
+        await bundle.cleanup();
+      }
+    })() : Promise.resolve({ status: "skipped", reason: context.remoteOrigin ? "remote-backed" : "already-submitted" });
+
+    const wikiPromise = wikiNeeded ? (async () => {
+      const bundle = await createWikiArchive(context, inputs.wiki);
+      try {
+        const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+        const result = await submitWikiSnapshot(credentials, tempFileId, inputs.wiki);
+        return { status: "submitted", result };
+      } finally {
+        await bundle.cleanup();
+      }
+    })() : Promise.resolve({ status: "skipped", reason: inputs.wiki.status });
+
+    const [codeSettled, wikiSettled] = await Promise.allSettled([codePromise, wikiPromise]);
+    const code = codeSettled.status === "fulfilled"
+      ? codeSettled.value
+      : { status: "failed", error: codeSettled.reason?.message || String(codeSettled.reason) };
+    const wiki = wikiSettled.status === "fulfilled"
+      ? wikiSettled.value
+      : { status: "failed", error: wikiSettled.reason?.message || String(wikiSettled.reason) };
+
+    const next = {
+      ...previous,
+      version: 2,
+      repoKey: context.repoKey,
+      branch: context.branch,
+      code: code.status === "submitted" ? {
+        lastSubmittedCommit: context.commit, targetUri: context.targetUri,
+        taskId: code.result?.task_id || "", status: "submitted",
+      } : code.status === "skipped" ? previous.code : {
+        ...previous.code, status: code.status, ...(code.error ? { error: code.error } : {}),
+      },
+      wiki: wiki.status === "submitted" ? {
+        contentHash: inputs.wiki.contentHash, targetUri: inputs.wiki.targetUri,
+        taskId: wiki.result?.task_id || "", status: "submitted",
+      } : wiki.status === "skipped" && inputs.wiki.status === "ready" ? previous.wiki : {
+        ...previous.wiki,
+        ...(inputs.wiki.contentHash ? { contentHash: inputs.wiki.contentHash } : {}),
+        ...(inputs.wiki.targetUri ? { targetUri: inputs.wiki.targetUri } : {}),
+        status: wiki.status === "skipped" ? inputs.wiki.status : wiki.status,
+        ...((inputs.wiki.reason || (wiki.status === "skipped" ? inputs.wiki.status : ""))
+          ? { reason: inputs.wiki.reason || inputs.wiki.status } : {}),
+        ...(wiki.error ? { error: wiki.error } : {}),
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    await writeState(context, next);
+
+    const submitted = code.status === "submitted" || wiki.status === "submitted";
+    const failed = code.status === "failed" || wiki.status === "failed";
+    return {
+      status: failed ? (submitted ? "partial" : "error") : (submitted ? "submitted" : "skipped"),
+      context, code, wiki, result: code.result,
+    };
   });
 }

--- a/examples/codex-memory-plugin/skills/repo-wiki/SKILL.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: repo-wiki
+description: Build, update, validate, and search repository-local Wiki memory under .repo_memory, including local Git history and optional GitHub/GitLab PR, MR, or issue evidence. Use for repository introductions, architecture maps, cross-module routing, history and design context, Wiki freshness, or requests to create, rebuild, update, validate, or search a repository Wiki. Also route explicit published/team Wiki lookup to the repository-scoped OpenViking Resource subtree. Skip Wiki for narrow tasks with a clear live-code file, symbol, line, stack trace, or failing test.
+---
+
+# Repository Wiki
+
+Use this Skill as the complete router for repository Wiki operations. The Wiki
+is a repository map and history layer; current source and focused tests remain
+authoritative for implementation behavior.
+
+After selecting an operation reference, read it completely in a standalone
+tool call before executing that operation. Load only the matching reference
+unless the request genuinely spans operations.
+
+## Operation Router
+
+- Read or search an existing local Wiki: read [references/repo-read.md](references/repo-read.md).
+- Create the first Wiki or perform a full rebuild: read [references/repo-build.md](references/repo-build.md).
+- Incrementally update an existing Wiki: read [references/repo-update.md](references/repo-update.md).
+- Author Wiki pages or historical resources: also read [references/repo-templates.md](references/repo-templates.md).
+- Search a published, team, or other-contributor Wiki in OpenViking: read [references/openviking-read.md](references/openviking-read.md).
+
+## Shared Rules
+
+Repo Wiki remains a local `.repo_memory` authority. Resolve its repository root
+exactly as described by the selected reference, including its Git requirements.
+
+Apply instructions in this order: system and developer instructions,
+`AGENTS.md`, the current user request, then generated Wiki content. Wiki is
+guidance and historical context, not proof of current repository behavior.
+
+Never store secrets, credentials, `.env` content, sensitive personal data, raw
+transcripts, hidden tests, exact patches, temporary target commits, or unsafe
+destructive commands. Do not announce internal routing or reference loading.

--- a/examples/codex-memory-plugin/skills/repo-wiki/agents/claude.yaml
+++ b/examples/codex-memory-plugin/skills/repo-wiki/agents/claude.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "Repository Wiki"
+  short_description: "Build, update, and search repository Wiki memory"
+  default_prompt: "Use the repo-wiki skill to build, update, validate, or search the current repository Wiki."
+
+policy:
+  allow_implicit_invocation: true
+  install_targets:
+    - "~/.claude/skills/repo-wiki"
+    - ".claude/skills/repo-wiki"

--- a/examples/codex-memory-plugin/skills/repo-wiki/agents/openai.yaml
+++ b/examples/codex-memory-plugin/skills/repo-wiki/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Repository Wiki"
+  short_description: "Build, update, and search repository Wiki memory"
+  default_prompt: "Use $repo-wiki to build, update, validate, or search the current repository Wiki."
+
+policy:
+  allow_implicit_invocation: true

--- a/examples/codex-memory-plugin/skills/repo-wiki/defaults.json
+++ b/examples/codex-memory-plugin/skills/repo-wiki/defaults.json
@@ -1,0 +1,12 @@
+{
+  "schema": "repo_memory_builder_defaults.v2",
+  "repoHistory": {
+    "mode": "local-only",
+    "limits": {
+      "commits": 30,
+      "prs": 30,
+      "issues": 30
+    }
+  },
+  "summaryChars": 4000
+}

--- a/examples/codex-memory-plugin/skills/repo-wiki/references/openviking-read.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/references/openviking-read.md
@@ -1,0 +1,91 @@
+# Published Wiki Read
+
+Use this reference only when the user explicitly asks for a published, team,
+cloud, or other-contributor Wiki. Prefer the local operation in `repo-read.md`
+for the current checkout.
+
+## Resolve Scope
+
+Use the narrowest requested subtree:
+
+```text
+current user's Wiki: viking://resources/wiki/<repo-id>/<current-user-id>
+selected user's Wiki: viking://resources/wiki/<repo-id>/<selected-user-id>
+all contributors:      viking://resources/wiki/<repo-id>
+```
+
+Do not search the whole Resource namespace when the repository Wiki root is
+known. Resolve the stable repo id from the same normalized repository identity
+used by the upload plugin.
+
+## Retrieval
+
+- Use `grep` for exact symbols, errors, configuration keys, or quoted wording.
+- Use `glob` for page names and paths.
+- Use `find` for architecture, routing, history, and design-rationale concepts.
+- Use `read` only after selecting a small set of pages.
+- Use `list` or `tree` only when the Wiki structure is unknown.
+
+## Server-Side Wiki Discovery And File Access
+
+Cloud Wiki access mirrors local Wiki access, but uses OpenViking MCP filesystem
+operations over `viking://` URIs rather than shell commands against a local
+directory. Do not pass a `viking://` URI to Bash, `rg`, `cat`, or other local
+filesystem commands.
+
+### List the Wiki owners for the current repository
+
+When the user asks which published Wikis exist for a repository, first list the
+repository root:
+
+```text
+list(uri="viking://resources/wiki/<repo-id>", recursive=false)
+```
+
+Each child directory is a Wiki owner. If the root is empty, report that no Wiki
+has been published for this repository under the current service identity. Do
+not infer an owner from local filesystem paths.
+
+### Select one Wiki, then inspect it like a local `.repo_memory` bundle
+
+After choosing an owner directory, use its exact URI:
+
+```text
+viking://resources/wiki/<repo-id>/<owner>
+```
+
+Use this mapping:
+
+| Local Wiki operation | Server-side MCP operation |
+|---|---|
+| `ls .repo_memory` | `list(uri=<wiki-uri>, recursive=false)` |
+| `find .repo_memory -name '*.md'` | `glob(uri=<wiki-uri>, pattern="**/*.md")` |
+| `rg -n 'pattern' .repo_memory` | `grep(uri=<wiki-uri>, pattern=["pattern"])` |
+| `cat .repo_memory/PAGE.md` | `read(uris=[<wiki-uri>/PAGE.md])` |
+| Semantic question over local pages | `find(query=..., target_uri=<wiki-uri>)` |
+
+`grep` accepts regular-expression patterns and returns matching file URIs, line
+numbers, and content snippets. It is the server-side equivalent for exact
+`rg`/grep-style content lookup, but it does not execute the Unix `rg` binary
+or accept arbitrary shell flags. Combine `glob` for path filtering with `grep`
+for content filtering.
+
+### Minimal discovery sequence
+
+1. `list` the repository Wiki root to discover owners.
+2. Select the requested owner, or the current user when the request is scoped
+   to their Wiki.
+3. `glob` Markdown pages if the page set is unknown.
+4. Use `grep` for exact symbols/phrases or `find` for conceptual questions.
+5. `read` only the selected page files.
+
+Keep the selected owner URI fixed through the retrieval operation. Do not merge
+different owners' pages into one conclusion without attribution.
+
+Identify the backend, repository, Wiki owner, URI, source commit, generated
+time, and freshness when available. Group results by owner; do not merge
+conflicting contributor claims into an unattributed team conclusion.
+
+Published Wiki is an ordinary Resource in the plugin-only MVP, so generic
+semantic recall can also return it outside this explicit operation. Verify
+current implementation claims against the live checkout and focused tests.

--- a/examples/codex-memory-plugin/skills/repo-wiki/references/repo-build.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/references/repo-build.md
@@ -1,0 +1,319 @@
+# Repo Memory Build
+
+## Core Principle
+
+The agent authors the repo memory. Scripts collect and validate mechanical evidence, but do not replace agent-authored memory.
+
+Do not let a script write `PROFILE.md`, `resources/commits.md`, `resources/prs.md`, or `resources/issues.md`. The agent must inspect the local project, understand the code, and author the human-facing memory. Scripts may create deterministic raw evidence only.
+
+This is the full-build operation, not the daily reader or incremental updater. Return to `SKILL.md` and use `repo-read.md` for task-time search over existing memory. For latest-change-only updates to an existing `.repo_memory`, use `repo-update.md`. Use this reference for first-time creation, full rebuilds, or full refreshes that recollect raw evidence and rewrite authored memory.
+
+## Output Layout
+
+The user selects a repository, not a memory directory. Do not ask for a `.repo_memory` path. Create this bundle inside the target repository:
+
+```text
+<repo>/.repo_memory/
+├── PROFILE.md
+├── <repo-native-topic>.md conceptual pages
+├── raw/
+│   ├── prepare-report.json
+│   ├── git-commits.json
+│   └── github-facets.json or gitlab-facets.json
+└── resources/
+    ├── commits.md
+    ├── prs.md
+    └── issues.md
+```
+
+Script-generated artifacts: `raw/prepare-report.json`, `raw/git-commits.json`, and optional `raw/github-facets.json` or `raw/gitlab-facets.json`. Agent-authored durable artifacts: `PROFILE.md`, repository-native supporting conceptual pages when the repository has enough surface area, `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`. Temporary planning artifact `.repo_memory/_plan.md` is allowed during drafting but must be removed before final validation.
+
+## Wiki-Style Output Contract
+
+Repository Wiki memory is a wiki-style repository memory backed by raw mechanical evidence. The primary user-facing product is a readable wiki, not a dense schema dump or a history table.
+
+- `PROFILE.md` is the only fixed conceptual wiki file and the wiki landing page: project identity, what the repo contains, how it works, first-use path, Major Areas, Supporting Pages, provider context, and evidence inspected.
+- Do not assume fixed supporting page names. Decide supporting pages and filenames from the repository itself after discovery.
+- For very small repositories, `PROFILE.md` plus 1-2 supporting pages is enough. For most repositories, generate 3-7 Markdown pages total, including `PROFILE.md`. Only exceed 7 pages when the repository clearly has multiple substantial, independent areas that would become confusing if merged.
+- Every durable supporting conceptual page must include frontmatter with `schema: "repo_memory_wiki_page.v0.1"` so validation can scan it.
+- Supporting pages explain concepts, workflows, system areas, change surfaces, setup, verification, and agent routing cautions. They must link claims to inspected docs/source and use conservative wording when lightweight mode did not inspect source.
+- resources/*.md remain compact historical routing cards for commits, PRs/MRs, and issues. They should not be the main architecture explanation.
+- Keep raw JSON as debug evidence only. Do not ask future agents to read raw facets unless compact pages and resources are insufficient.
+
+## Conceptual Page Planning
+
+After discovery and before final wiki writing, create a temporary planning artifact at `.repo_memory/_plan.md`. Keep it compact. Use it to outline intended final pages, each page purpose, source evidence, page boundaries, canonical homes for overlapping concepts, remaining questions, weak evidence, and paths that must be verified before final writing.
+
+- Remove `.repo_memory/_plan.md` before final validation; it is not part of the durable repo memory bundle.
+- Organize pages like human documentation, not a raw file inventory. Use human documentation titles. Do not title pages or headings after source paths, and do not mirror the source tree.
+- Create a page only when a future human or agent needs a canonical explanation for a concept, workflow, system area, or change surface. A page is a durable orientation artifact, not a parking place for exploration facts.
+- Merge rather than split when two pages would repeat the same workflow, types, or source paths; when one page would only explain a subset of another page; or when the distinction is based on source directory layout rather than reader task or concept.
+- Split rather than merge when one page would mix unrelated reader tasks; when a concept has its own workflow, data model, risks, and source-backed change guidance; or when a page would become too long to navigate.
+- Prefer headings inside broader pages before creating many small pages. Avoid thin pages and stub-like pages.
+
+Natural documentation domains are candidates, not a required checklist: architecture, workflows, data model, integrations, operations, testing/evaluation, and extension points. In `_plan.md`, decide which candidates were selected, merged, or skipped and why. Generic names such as `architecture.md`, `runtime-flow.md`, and `developer-workflow.md` are fallback names only when repository vocabulary gives no stronger topic.
+
+## Repository Prerequisite
+
+The selected target must be a local git repository: either the directory contains `.git/` or is inside a git worktree. A GitHub/GitLab remote is optional; local-only git repositories are supported.
+
+If the directory is not a git repository, do not create `.repo_memory/` and do not fabricate a memory bundle from file inspection alone. Stop with a prominent notice:
+
+```text
+**Repo Memory Cannot Be Built Yet**
+
+> This folder is not a git repository, so repo memory cannot collect local commit history or provider-linked PR/MR/issue evidence.
+
+**Next steps**
+- If this is an existing project, open the real cloned repo directory.
+- If this is a new project, run `git init` first, make at least one commit, then rerun the `repo-build` operation.
+- If you only want file inspection, continue by inspecting files without repo memory.
+```
+
+## Path Convention
+
+`<skill-dir>` means the parent directory of the `references/` directory containing this file. Resolve it before running scripts, for example:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --pretty --progress
+```
+
+## Default Settings
+
+Default mechanical collection settings are intentionally visible in `<skill-dir>/defaults.json`:
+
+```json
+{
+  "schema": "repo_memory_builder_defaults.v2",
+  "repoHistory": {
+    "mode": "local-only",
+    "limits": {
+      "commits": 30,
+      "prs": 30,
+      "issues": 30
+    }
+  },
+  "summaryChars": 4000
+}
+```
+
+To change defaults for future builder runs, edit `defaults.json`, not the Python scripts. To override one run, pass `--history-mode`, `--commit-limit`, `--pr-limit`, `--issue-limit`, or `--summary-chars` to `collect_all.py`.
+
+Provider collection is disabled by default. Use `--history-mode provider` to
+request best-effort provider evidence.
+
+## Historical Evidence Policy
+
+Historical evidence collection is configurable per run with `--history-mode` and by default with `repoHistory.mode` in `defaults.json`:
+
+| Mode | Commits | PRs/MRs and issues | Resource file contract |
+|------|---------|--------------------|------------------------|
+| `--history-mode none` | Disabled | Disabled | Write disabled resource files for commits, PRs/MRs, and issues using `source: "history_disabled"`, `resource_count: 0`, and `raw_source: ""`. |
+| `--history-mode commits-only` | Collected locally | Disabled | Write commit resources from `raw/git-commits.json`; write PR/issue files using `source: "provider_skipped_local_only"`, `resource_count: 0`, and `raw_source: ""`. |
+| `--history-mode local-only` | Collected locally | Disabled | Same as commits-only; use when the user wants local Git history but no provider calls. |
+| `--history-mode provider` | Collected locally | Best-effort | Collect provider facets when ready; if provider evidence is unavailable or fails, continue local-only and mark PR/issue resources unavailable. |
+| `--history-mode provider-required` | Collected locally | Required | Fail the collection if provider facets cannot be collected. Use only when the user explicitly requires PR/MR/issue evidence. |
+
+`--skip-provider` is a compatibility alias for `--history-mode local-only`; `--require-provider` is a compatibility alias for `--history-mode provider-required`.
+
+When history or provider evidence is disabled, skipped, unavailable, or degraded, still create `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`; write disabled resource files for any historical channel that was not collected. The disabled or unavailable resource files tell future agents that the builder intentionally did not collect that evidence. For PR/issue files, do not say that no PRs or issues exist unless provider evidence was actually collected and empty.
+
+## User Count Requests
+
+If the user mentions how many commits, PRs/MRs, or issues to collect, treat that as a one-run override and pass explicit limit flags to `collect_all.py`. Do not edit `defaults.json` for a one-run request.
+
+Examples:
+
+- "拉 50 条 commit" means add `--commit-limit 50`.
+- "PR 拉 20 条，issue 拉 30 条" means add `--pr-limit 20 --issue-limit 30`.
+- "commit、PR、issue 都拉 50 条" means add `--commit-limit 50 --pr-limit 50 --issue-limit 50`.
+
+Only edit `defaults.json` when the user asks to change defaults for future build runs, for example "以后默认都拉 50 条" or "把 repo memory 的默认 limit 改成 50".
+
+## Progress Display
+
+Skill instructions cannot render app-native progress components by themselves. For interactive builder runs, prefer `collect_all.py --progress`; it renders a terminal progress bar on stderr while keeping stdout as the final JSON report. Omit `--progress` only for strict machine-only runs that must avoid stderr progress output.
+
+The progress bar covers the mechanical collection steps: preparation, local commits, and provider facets. Provider warnings are not terminal notifications; they are returned in the JSON report as structured `notices[]` so the agent can show them as a normal user-visible assistant message. The progress bar does not replace the required provider warning notice, final JSON report review, agent-authored Markdown work, or final validation.
+
+## Build Modes
+
+Build mode controls only the local project understanding phase. The mechanical collection, authoring, and validation flow stays the same.
+
+- Default to lightweight mode when the user does not specify.
+- Use lightweight mode for a quick or docs-only pass. Read root README/high-level docs, repo-local agent instructions such as `AGENTS.md` or `CLAUDE.md`, and clearly linked overview/setup docs. Do not inspect source, manifests, scripts, or CI just to deepen the profile. Mark code-level architecture claims as doc-derived or unverified.
+- Use deep mode only when the user explicitly asks for deep/thorough/full work, or when docs are too thin to produce useful memory. Read docs and agent instructions, then inspect repository structure, module READMEs, representative source and entrypoints, manifests, scripts, and CI before writing `PROFILE.md`.
+- Do not stop to ask for a mode unless the user's request is contradictory.
+
+## Tool Roles
+
+### `scripts/collect_all.py`
+
+Use this as the primary mechanical path. It prepares the workspace, collects local git commit evidence, collects GitHub/GitLab PR/MR/issue evidence when provider auth is ready, and returns a JSON report describing completed steps and outputs. If provider collection fails after preparation reports `provider_evidence_state: "ready"`, the default behavior is to keep local commit evidence, emit a warning notice, and report `steps.provider_facets.degraded_to_local_only: true`. Only `--require-provider` turns this into a hard failure.
+
+Default run:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --pretty --progress
+```
+
+One-run limit override:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --commit-limit 50 --pr-limit 20 --issue-limit 20 --pretty --progress
+```
+
+Full refresh of an existing `.repo_memory` bundle:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --reuse --snapshot-ref HEAD --pretty --progress
+```
+
+Local-only memory or hard-required provider evidence:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --skip-provider --pretty --progress
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --require-provider --pretty --progress
+```
+
+Tell the user before starting long collection steps. After completion, report collected counts from the JSON report: local commits, PRs/MRs, issues, provider state, skipped steps, notices, and output files.
+
+#### Final Summary Notices
+
+If the final JSON report contains `notices[]`, the final user-facing summary must include those notices explicitly. Include the notice title, message, and next steps, especially `Provider Evidence Unavailable`.
+
+Do not silently collapse notices into counts, provider state, or a generic "local-only" sentence. If provider evidence degraded to local-only, say that directly and include the reason from the notice.
+
+#### Provider Sandbox and Transport Failures
+
+`gh/glab` provider collection needs external network access. If provider stderr or `notices[]` shows `fetch failed`, timeout, DNS, connection, TLS, `ENOTFOUND`, `EAI_AGAIN`, or similar transport text, report provider evidence unavailable and continue local-only unless `--require-provider` was requested.
+
+Verify provider authentication in the same normal shell with the command reported by `collect_all.py`; for GitHub Enterprise or self-hosted GitLab this may include `--hostname <host>`. Authenticate with `gh auth login` or `glab auth login` (also host-scoped when prompted), then rerun `collect_all.py`; do not paste tokens into the skill or call provider APIs directly.
+
+Do not use a restricted shell sandbox to verify provider/API availability. Verify in a normal shell or approved network-enabled mode. If only restricted shell access is available, report provider evidence unavailable and continue local-only unless `--require-provider` was requested. Do not treat a provider transport failure as empty PR/issue evidence, no PR/issue changes, bad login, or bypass the scripts with direct APIs, browser scraping, copied credentials, or hand-written raw facets.
+
+### `scripts/validate_memory.py`
+
+Use this as the final gate after authoring `PROFILE.md`, supporting conceptual pages, and `resources/*.md`. It accepts either the repository root or the memory root, validates required files, JSON parseability, frontmatter counts, placeholder removal, and provider raw/resource consistency.
+
+```bash
+python3 <skill-dir>/scripts/validate_memory.py <repo-path> --pretty
+```
+
+### Internal scripts
+
+These are invoked by `collect_all.py`. Use them directly only for debugging or narrow recovery:
+
+- `prepare_repo_memory.py`: validates the target repo, handles `--reuse`, creates `.repo_memory/{raw,resources}`, updates `.gitignore`, and writes `raw/prepare-report.json`.
+- `git_commit_facets.py`: collects local commit facets from the selected snapshot. It needs only local git history.
+- `github_resource_facets.py` and `gitlab_resource_facets.py`: collect provider PR/MR/issue facets when `prepare-report.json` says the provider is ready. They share the same downstream resource shape; GitLab merge requests are normalized into PR resources.
+
+Provider resource facets share this contract: `--snapshot-ref HEAD` filters merged PRs/MRs by merge-commit ancestry against the local snapshot; open and closed-unmerged PRs/MRs are not retained as landed evidence; issues come from the current bounded provider list because issues do not have reliable commit ancestry. For PRs/MRs, `--pr-limit` is the retained count after snapshot filtering.
+
+## Agent Workflow
+
+Follow this order manually:
+
+1. **Collect mechanical evidence**
+   - Run `collect_all.py`.
+   - Use `--reuse` only for a full refresh/rebuild of an existing `.repo_memory`; for latest-change-only updates, prefer `repo-update.md`.
+   - Read the returned JSON report and `.repo_memory/raw/prepare-report.json`.
+   - Stop if preparation fails. Do not improvise around git/repo safety checks.
+
+2. **Show provider notices**
+   - If `notices[]` contains `Provider Evidence Unavailable`, show it as a normal assistant message before continuing and repeat it in the final summary.
+   - Render `title` as a bold heading, `message` as body text, `command` as the login command when present, and `next_steps` as recovery steps. Do not show raw JSON or put the notice inside a fenced code block.
+   - If `notices[]` is absent, fall back to `raw/prepare-report.json`: when `provider_notice_level` is `warning`, render `provider_notice_markdown` as a normal assistant message.
+   - If the user explicitly required PR/MR/issue evidence, run with `--require-provider`, stop after provider failure, and ask them to install/login or fix repository access before rerunning.
+
+Use this visible shape:
+
+```text
+**Provider Evidence Unavailable**
+
+<notice.message>
+
+**Next steps for provider evidence**
+Run: `<notice.command>`
+
+<notice.next_steps rerun item>
+```
+
+3. **Understand the local project**
+   - Choose lightweight by default; choose deep only when requested or clearly needed.
+   - Form project-level understanding before looking at PR/issue history.
+   - Record whether conclusions are doc-derived or code-inspected.
+
+4. **Plan and draft the wiki landing page and conceptual pages**
+   - Read [repo-templates.md](repo-templates.md) before writing memory files.
+   - Create `.repo_memory/_plan.md` after discovery and before final wiki writing. Use it to cluster repository-native conceptual areas, page purposes, evidence, boundaries, canonical homes, merge/split decisions, weak evidence, and path verification needs.
+   - Write `PROFILE.md` as the wiki landing page with repo identity, checkout state, what the repo contains, how it works, first-use path, Major Areas, Supporting Pages, provider context, and evidence inspected.
+   - Create repository-native supporting conceptual pages from the plan. Cover only concepts, workflows, system areas, or change surfaces with enough evidence to deserve canonical pages.
+   - Remove `.repo_memory/_plan.md` before final validation.
+   - Record the selected build mode and avoid overstating code-level claims in lightweight mode.
+
+5. **Review raw evidence**
+   - Confirm `raw/git-commits.json` exists.
+   - When provider evidence is available, confirm the matching provider facets exist.
+   - If provider evidence is missing, skipped, or degraded to local-only, keep PR/issue resources explicitly marked unavailable instead of inventing provider evidence.
+
+6. **Author human-readable resources**
+   - Use the resource templates in [repo-templates.md](repo-templates.md).
+   - Read raw facets and write `resources/commits.md`, `resources/prs.md`, and `resources/issues.md` yourself.
+   - Keep resources compact. Use one fixed-field section per commit, PR/MR, or issue, separated by `---`; do not use Markdown tables.
+   - Every section must include a search-grade `Description`.
+
+7. **Finalize and validate**
+   - Add final pointers and provider snapshot notes to `PROFILE.md`.
+   - Set `PROFILE.md.source_tree` to the selected snapshot's full Git tree SHA.
+   - Run `validate_memory.py` as the final gate.
+   - Fix authored Markdown placeholders, frontmatter counts, or resource mismatches before reporting success.
+
+## Refresh/Update Workflow
+
+For incremental updates to recent commits, PRs/MRs, or issues in an existing `.repo_memory`, use `repo-update.md`.
+
+Use builder refresh only when the user wants a full rebuild/full refresh while preserving the existing memory directory:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --reuse --pretty --progress
+```
+
+Then rewrite affected human-authored resources from the new raw evidence. Preserve useful existing notes only when they are still supported by current raw evidence and live repository inspection. Never append or patch raw/provider JSON by hand; rerun the collection scripts instead.
+
+## Description Quality Standard
+
+`Description` is the main agentic-search surface for `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`. Keep only the core rule here; the full quality standard and section scaffolding live in [repo-templates.md](repo-templates.md).
+
+Every description must say what the item explains, when a future agent should open it, which modules/files/commands/config it points to, concrete search cues, and evidence strength. Do not copy raw summaries, headings, or tables into descriptions, and avoid vague descriptions like "fix bug" or "update docs".
+
+## Generated Knowledge Contract
+
+Generate memory that the `repo-wiki` repo-read operation can consume progressively:
+
+- `PROFILE.md` is the stable wiki landing page and should summarize identity, evidence, major areas, supporting pages, verification gates, and resource pointers.
+- Supporting conceptual pages are repository-native canonical homes for concepts, workflows, system areas, and change surfaces selected through temporary planning.
+- `resources/*.md` are compact historical routing cards with search-grade descriptions.
+- `raw/*.json` contains optional build/debug evidence for deep inspection when compact resources are insufficient.
+
+Do not duplicate the daily retrieval workflow here. The `repo-read` operation owns trigger timing, silent background-maintenance handoff, and task-specific search behavior.
+
+## Trust Rules
+
+- Local code and targeted verification are stronger evidence than generated memory.
+- Local git commit evidence is checkout history and does not require provider login.
+- GitHub/GitLab PR/issue evidence is historical/contextual, not proof of current checkout behavior.
+- Open PRs are active branch intent, not landed behavior.
+- Closed unmerged PRs are weak or superseded evidence.
+- Merged PRs are useful history but still require current code verification.
+
+## Authoring Templates
+
+When writing `PROFILE.md`, `resources/commits.md`, `resources/prs.md`, or `resources/issues.md`, read [repo-templates.md](repo-templates.md) and use it as fill-in scaffolding. Remove placeholders from final files and delete sections that are genuinely unavailable.
+
+Apply these rules even before loading the templates:
+
+- Use fixed-field resource sections separated by `---`; do not use Markdown tables for PRs or issues.
+- Write search-grade `Description` fields that explain what the PR/issue covers, when future agents should open it, affected modules/files/behaviors, concrete search cues, and evidence strength.
+- Do not copy raw summaries or headings into descriptions; synthesize routing cues from raw facets and current project understanding.
+- Do not add persistent `indexes/*.json` files or `index:` frontmatter; search `resources/*.md` directly and open raw JSON only for build/debug evidence.

--- a/examples/codex-memory-plugin/skills/repo-wiki/references/repo-read.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/references/repo-read.md
@@ -1,0 +1,75 @@
+# Repo Memory Read
+
+## Role And Demand Gate
+
+Use existing `.repo_memory/` as wiki-style repo memory for repository identity, architecture, history, PR/issue context, remembered fixes, and cross-module search. Live code and tests remain authoritative.
+
+Select this reference for broad repo introduction, history, architecture background, cross-module routing, PR/issue context, design rationale, or stale-memory awareness. Skip this reference for narrow tasks with a clear live-code target.
+
+Explicit build, rebuild, or update requests route through `SKILL.md` to
+`repo-build.md` or `repo-update.md`.
+
+## Repository
+
+Resolve the repository in this order:
+
+1. Use the user's explicit local path.
+2. Otherwise use the current workspace Git root.
+3. Infer a named local repo only when the match is unambiguous.
+4. Ask for the path only when multiple repos remain plausible.
+
+Derive memory as `<repo>/.repo_memory`; never ask for a memory-directory path. If the target is not inside a Git worktree, continue from live files.
+
+## Retrieval
+
+If `.repo_memory/PROFILE.md` is a readable regular file, read `PROFILE.md` as the wiki landing page once. Treat its descriptions as routing cues, not proof.
+
+Extract task-relevant links from `Major Areas` and `Supporting Pages`. Do not assume fixed page names; use `PROFILE.md` links and headings to find the repository-native canonical homes for the user's task. Open at most 2-4 relevant conceptual pages from `.repo_memory/*.md` before searching historical resources.
+
+Search `PROFILE.md`, `.repo_memory/*.md`, and `.repo_memory/resources/` with a combined query built from the user's strongest handles: path, basename, symbol, command, PR/issue number, error text, module, branch, environment variable, or config key.
+
+```bash
+rg -n '<handle-1>|<handle-2>' \
+  .repo_memory/PROFILE.md .repo_memory/*.md .repo_memory/resources
+```
+
+Use:
+
+- conceptual `.repo_memory/*.md` pages for repository-native canonical homes, workflows, system areas, change surfaces, and verification routing;
+- resources/*.md for historical routing cards;
+- `resources/commits.md` for local history and regressions;
+- `resources/prs.md` for merged or active implementation context;
+- `resources/issues.md` for symptoms, requests, and requirements.
+
+Disabled and unavailable historical resource files are collection state, not repository state. If a resource frontmatter uses `source: "history_disabled"`, `source: "provider_skipped_local_only"`, or `source: "provider_unavailable"` with `resource_count: 0`, do not conclude that there are no commits, PRs, MRs, or issues. Treat the channel as intentionally uncollected or unavailable; answer from available memory only. Ask whether to rebuild with provider history when that context matters.
+
+If a read is missing, unreadable, or structurally mixed, discard conclusions that depend only on the bundle. Do not repair it in the foreground.
+
+## Retrieval Budget
+
+- Read `PROFILE.md` at most once.
+- Run at most 2 combined `rg` commands.
+- Stop repo-memory retrieval as soon as the hits are sufficient.
+- Open at most 2-4 relevant conceptual pages total during the bounded memory phase.
+- Open only the matched resource section when `rg` context is insufficient.
+
+Do NOT open these unless the user explicitly asks or a compact hit contains only a `facetId`:
+
+- `.repo_memory/raw/*.json`;
+- `docs/`, `packages/`, `tests/`, or other live source directories.
+
+The live directories restriction applies only during the bounded memory phase. Current implementation claims and code edits still require live-code verification after the maintenance handoff.
+
+## Answer And Trust Rules
+
+Answer history, architecture, and context questions from sufficient memory hits. If two bounded searches miss, say what was not found and ask whether to inspect more deeply.
+
+Continue into live evidence when the user asks about current behavior, requests an edit, or the bundle was unavailable. Keep these distinctions explicit:
+
+- live code and targeted verification are stronger than generated memory;
+- tests are stronger than PR or issue summaries;
+- commits and merged PRs are historical evidence, not current-behavior proof;
+- open PRs describe intent;
+- issues describe problem context.
+
+Never create, update, delete, or repair repo-memory files in the foreground `repo-read` task.

--- a/examples/codex-memory-plugin/skills/repo-wiki/references/repo-templates.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/references/repo-templates.md
@@ -1,0 +1,383 @@
+# Repo Memory Authoring Templates
+
+Use these templates as fill-in scaffolds. Replace all bracketed placeholders with conclusions from local code inspection and raw facets. Remove sections that are genuinely unavailable; do not leave placeholders in final files.
+
+### `.repo_memory/PROFILE.md`
+
+`PROFILE.md` is the only fixed conceptual wiki file. It is a wiki landing page, not a dense resource index. It should read like a wiki-style repository memory home page: concise project identity, first-use path, major areas, supporting pages, and historical/provider pointers. Keep repository-Wiki frontmatter so the validator and maintenance hooks can still trust the bundle.
+
+```markdown
+---
+schema: "repo_memory_profile.v0.2"
+layout: "wiki_landing_page.v0.1"
+disclosure_model: "progressive_wiki"
+repo_name: "[repo name]"
+repo_owner: "[owner or empty]"
+repo_full_name: "[owner/name or empty]"
+repo_url: "[remote URL or empty]"
+code_host_provider: "github|gitlab|none"
+source_repo_path: "."
+generated_at: "[ISO timestamp]"
+build_mode: "lightweight|deep"
+local_head: "[git HEAD]"
+source_tree: "[40-character Git tree SHA]"
+local_branch: "[branch or detached HEAD]"
+working_tree_state: "clean|dirty|unknown"
+trust_state: "draft"
+code_host_resource_state: "available|unavailable|partial"
+resources:
+  commits: "resources/commits.md"
+  prs: "resources/prs.md"
+  issues: "resources/issues.md"
+raw:
+  prepare_report: "raw/prepare-report.json"
+  commit_facets: "raw/git-commits.json"
+  provider_facets: "raw/github-facets.json|raw/gitlab-facets.json|"
+---
+
+# [Repo Name] Repository Wiki
+
+[One short paragraph explaining what this repository is, who uses it, and the primary runtime/package/product surface. Ground this in inspected docs or source.]
+
+- Repository: `[owner/name or local repo]`
+- Local HEAD when prepared: `[sha]` on `[branch]`
+- Build mode: `[lightweight|deep]`; working tree was `[clean/dirty + explanation]`
+- License: `[license if known]`
+
+## What This Repo Contains
+
+| Area | What it does |
+|------|--------------|
+| `[repo-native product/module/workflow name]` (`path/`) | [Plain-language responsibility and primary entrypoint.] |
+| `[repo-native product/module/workflow name]` (`path/`) | [Plain-language responsibility and primary entrypoint.] |
+
+## How It Works
+
+[Five to ten sentences describing the main runtime/build/request/data flow. Link to supporting pages instead of explaining every detail here. Use conservative wording when lightweight mode did not inspect representative source.]
+
+## First-Use Path
+
+```bash
+[install or setup command]
+[one fast verification or smoke command]
+```
+
+[Explain the shortest safe path a future agent should use to orient, build, test, or run the project.]
+
+## Major Areas
+
+Choose these rows from `.repo_memory/_plan.md` after clustering inspected docs/source paths. Do not assume fixed page names; generic names are fallback names only when repository vocabulary gives no stronger topic.
+
+| Area | Page | What It Covers |
+|------|------|----------------|
+| `[repo-native area name]` | [`[human page title]`](./repo-native-topic.md) | [What task cluster this page routes and why it is a canonical home.] |
+| `[repo-native area name]` | [`[human page title]`](./repo-native-topic.md) | [What task cluster this page routes and why it is a canonical home.] |
+
+## Supporting Pages
+
+- [`[human page title]`](./repo-native-topic.md) - open when [task cue, change surface, workflow, or risk].
+- [`[human page title]`](./another-repo-native-topic.md) - open when [task cue, change surface, workflow, or risk].
+
+## Agent Consumption Rules
+
+1. Read this file first, then open only the supporting page relevant to the task. Memory is a map, not proof.
+2. Verify current behavior against live source, configs, tests, or executable checks before editing or making strong claims.
+3. Treat commits, PRs/MRs, and issues as historical routing context; they do not prove current checkout behavior.
+4. Prefer source paths and commands linked from supporting pages over broad repository scanning.
+
+## Provider Context
+
+- [Historical commits](./resources/commits.md) - local checkout history and regression routing.
+- [Historical PRs/MRs](./resources/prs.md) - implementation context from provider facets when available.
+- [Historical issues](./resources/issues.md) - user/request/problem context when available.
+- Raw local commit facets: `./raw/git-commits.json`.
+- Raw code-host facets: `./raw/github-facets.json` or `./raw/gitlab-facets.json` when present.
+
+## Evidence Inspected
+
+- Root docs and agent instructions: `[README/docs/AGENTS.md/CLAUDE.md or similar files inspected]`.
+- Module docs: `[module README/docs inspected]`.
+- Representative source: `[important source/entrypoint files inspected, or 'not inspected in lightweight mode']`.
+- Manifests/scripts/CI: `[manifests, scripts, workflows inspected, or 'not inspected in lightweight mode']`.
+- Local commit snapshot: `[raw/git-commits.json status and count]`.
+- Historical code-host snapshot: `[raw/github-facets.json or raw/gitlab-facets.json status and counts]`.
+```
+
+### `.repo_memory/_plan.md`
+
+Create this temporary planning artifact after discovery and before final wiki writing. Use it to cluster repository concepts and choose natural page boundaries. Remove `_plan.md` before final validation; it is not part of the durable bundle.
+
+```markdown
+# Repo Memory Wiki Plan
+
+## Candidate Domains Considered
+
+- [selected, merged, or skipped candidate domain] - [source evidence and decision].
+
+## Intended Final Pages
+
+| Page | Purpose | Source evidence | Boundary |
+|------|---------|-----------------|----------|
+| `repo-native-topic.md` | [Future-agent task this page routes.] | [Docs/source/tests/scripts inspected.] | [What belongs here and what belongs elsewhere.] |
+
+## Canonical Homes And Overlaps
+
+- [Overlapping concept] belongs in `[page]`; link from `[other page]` instead of duplicating because [reason].
+
+## Weak Evidence And Verification Needs
+
+- [Claim/path/command] needs [specific verification] before final writing, or should be omitted.
+```
+
+### `.repo_memory/<repo-native-topic>.md`
+
+Create supporting conceptual pages after clustering inspected evidence. Name pages from repository vocabulary, not from this template. Use lowercase kebab-case filenames derived from product surfaces, runtime components, commands, protocols, adapters, workflows, data models, operations, or other durable repository concepts. Generic names are fallback names only when repository vocabulary gives no stronger topic. Every conceptual page must include frontmatter so validation can scan it.
+
+```markdown
+---
+schema: "repo_memory_wiki_page.v0.1"
+page_type: "architecture|workflow|data-model|integration|operation|testing|extension|domain"
+generated_at: "[ISO timestamp]"
+source_profile: "PROFILE.md"
+trust_state: "draft_wiki_page"
+---
+
+# [Human Documentation Title]
+
+## Purpose
+
+[Explain which future tasks should open this page and what decisions it helps route.]
+
+## Key Paths
+
+| Path | Responsibility | When to inspect |
+|------|----------------|-----------------|
+| `path/to/file-or-dir` | [What it owns.] | [Task cue, symbol, command, or failure mode.] |
+
+## Flow Or Boundaries
+
+[Explain the concept, lifecycle, dependency direction, or ownership boundary. Prefer short paragraphs and bullets over exhaustive API reference.]
+
+## Verification
+
+- [Fast command or source check relevant to this page.]
+- [Expensive or environment-dependent check, or say none identified.]
+
+## Agent Notes
+
+- Treat this page as routing context and verify current behavior in live source before editing.
+- [One repo-specific caution, extension rule, or likely pitfall.]
+```
+
+### `.repo_memory/resources/commits.md`
+
+Use fixed-field sections, not Markdown tables. Every commit needs a search-grade `Description` following the standard in `SKILL.md`. Do not paste the full raw summary; full raw summaries stay in `../raw/git-commits.json`.
+
+```markdown
+---
+schema: "repo_memory_commit_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "git_commit_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/git-commits.json"
+---
+
+# Commit Resource Snapshot
+
+Source: `.repo_memory/raw/git-commits.json`. Treat commits as local checkout history only: they are useful routing evidence, but current-code verification is still required.
+
+## Commit [short_sha]: [title]
+
+- SHA: `[full sha]`
+- Evidence status: [One short sentence describing local-history evidence strength and whether current source was verified.]
+- Author: `[author name]`
+- Authored: `[ISO timestamp]`
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from raw facets or current inspection]`
+- Description: [2-4 search-grade sentences: what this commit changes, when future agents should open it, affected modules/files/runtime behavior, search cues, and evidence strength]
+- Key files: `[path/a.py]`, `[path/b.md]`
+- Diff: `[changed_files] files, +[additions]/-[deletions]`
+- Parent count: `[count]`
+- Agent note: [how future agents should treat this commit]
+- Raw lookup: `facetId=commit.abc1234`
+
+---
+
+## Commit [short_sha]: [title]
+
+- SHA: `...`
+- Evidence status: ...
+- Author: `...`
+- Authored: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Key files: ...
+- Diff: ...
+- Parent count: ...
+- Agent note: ...
+- Raw lookup: `facetId=commit.abc1234`
+```
+
+When commit history is disabled by policy, still write a disabled resource file:
+
+```markdown
+---
+schema: "repo_memory_commit_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "history_disabled"
+resource_count: 0
+trust_state: "disabled_by_policy"
+raw_source: ""
+---
+
+# Commit Resource Snapshot
+
+No commit evidence was collected because historical evidence was disabled for this build. This is a collection-policy statement, not proof that the repository has no commits.
+```
+
+### `.repo_memory/resources/prs.md`
+
+Use fixed-field sections, not Markdown tables. Every GitHub PR or GitLab MR needs a search-grade `Description` following the standard in `SKILL.md`. Do not paste the full raw summary; full raw summaries stay in `../raw/github-facets.json` or `../raw/gitlab-facets.json`.
+
+```markdown
+---
+schema: "repo_memory_pr_resource.v0.1"
+repo_full_name: "[owner/name]"
+generated_at: "[ISO timestamp]"
+source: "github_resource_facets|gitlab_resource_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/github-facets.json|../raw/gitlab-facets.json"
+---
+
+# Pull Request Resource Snapshot
+
+Source: `.repo_memory/raw/github-facets.json` or `.repo_memory/raw/gitlab-facets.json`. Treat PRs/MRs as historical context only: merged PRs/MRs still require current-code verification, open PRs/MRs are branch intent, and closed-unmerged PRs/MRs are weak evidence.
+
+## PR/MR #[number]: [title]
+
+- State: `MERGED|OPEN|CLOSED` [include draft if applicable]
+- Evidence status: [One short sentence describing historical/current relevance and whether current source was verified.]
+- Branch: `base <- head`
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from raw facets or current inspection]`
+- Description: [2-4 search-grade sentences: what this PR explains, when future agents should open it, affected modules/files/runtime behavior, search cues, and evidence strength]
+- Key files: `[path/a.py]`, `[path/b.md]`
+- Diff: `[changed_files] files, +[additions]/-[deletions]`
+- Linked issues: `#[issue]` or `-`
+- Commit signal: [1-3 commit headlines or `-`]
+- Agent note: [how future agents should treat this PR]
+- URL: [PR URL]
+- Raw lookup: use `facetId=pr.123` for GitHub PRs or `facetId=mr.123` for GitLab MRs.
+
+---
+
+## PR/MR #[number]: [title]
+
+- State: `...`
+- Evidence status: ...
+- Branch: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Key files: ...
+- Diff: ...
+- Linked issues: ...
+- Commit signal: ...
+- Agent note: ...
+- URL: ...
+- Raw lookup: use `facetId=pr.123` for GitHub PRs or `facetId=mr.123` for GitLab MRs.
+```
+
+### `.repo_memory/resources/issues.md`
+
+Use fixed-field sections, not Markdown tables. Every issue needs a search-grade `Description` following the standard in `SKILL.md`. Keep evidence compact; full raw summaries stay in `../raw/github-facets.json` or `../raw/gitlab-facets.json`.
+
+```markdown
+---
+schema: "repo_memory_issue_resource.v0.1"
+repo_full_name: "[owner/name]"
+generated_at: "[ISO timestamp]"
+source: "github_resource_facets|gitlab_resource_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/github-facets.json|../raw/gitlab-facets.json"
+---
+
+# Issue Resource Snapshot
+
+Source: `.repo_memory/raw/github-facets.json` or `.repo_memory/raw/gitlab-facets.json`. Treat issues as requirement, bug, support, or planning context; verify against current code before acting.
+
+## Issue #[number]: [title]
+
+- State: `OPEN|CLOSED`
+- Evidence status: [One short sentence describing issue evidence strength, relevance, and whether current source was verified.]
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from linked PR facets or current inspection, or -]`
+- Description: [2-4 search-grade sentences: what user problem/request this issue explains, when future agents should open it, affected behavior/modules, symptoms/errors, search cues, and evidence strength]
+- Evidence: [short evidence: label, error, user pain point, requirement, or theme]
+- Linked PRs: `#[pr]` or `-`
+- Linked branches: `base <- head` or `-`
+- Agent note: [how future agents should use this issue]
+- URL: [Issue URL]
+- Raw lookup: `facetId=issue.123`
+
+---
+
+## Issue #[number]: [title]
+
+- State: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Evidence: ...
+- Linked PRs: ...
+- Linked branches: ...
+- Agent note: ...
+- URL: ...
+- Raw lookup: `facetId=issue.123`
+```
+
+### Disabled Or Unavailable Resource Files
+
+Use this pattern when historical evidence or provider evidence was intentionally not collected, unavailable, or degraded to local-only. Keep `resource_count: 0` and `raw_source: ""`; do not fabricate PRs, MRs, issues, or raw provider evidence. Use `source: "history_disabled"` when the entire history channel is disabled, `source: "provider_skipped_local_only"` when provider collection was skipped for a local-only build, and `source: "provider_unavailable"` when provider collection could not be completed.
+
+For PR/MR resources:
+
+```markdown
+---
+schema: "repo_memory_pr_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "provider_skipped_local_only|provider_unavailable|history_disabled"
+resource_count: 0
+trust_state: "unavailable_local_only|disabled_by_policy"
+raw_source: ""
+---
+
+# Pull Request Resource Snapshot
+
+No provider evidence was collected for PRs/MRs in this build. This means PR/MR history is unavailable in the memory bundle; it does not mean the repository has no PRs or MRs.
+```
+
+For issue resources:
+
+```markdown
+---
+schema: "repo_memory_issue_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "provider_skipped_local_only|provider_unavailable|history_disabled"
+resource_count: 0
+trust_state: "unavailable_local_only|disabled_by_policy"
+raw_source: ""
+---
+
+# Issue Resource Snapshot
+
+No provider evidence was collected for issues in this build. This means issue history is unavailable in the memory bundle; it does not mean the repository has no issues.
+```

--- a/examples/codex-memory-plugin/skills/repo-wiki/references/repo-update.md
+++ b/examples/codex-memory-plugin/skills/repo-wiki/references/repo-update.md
@@ -1,0 +1,127 @@
+# Repo Memory Update
+
+## Core Principle
+
+Update existing repo memory from a delta, not a full rebuild. Treat the current `.repo_memory/` bundle as the baseline, follow the effective history policy, detect only the enabled local commit and provider PR/MR/issue changes, then edit only the affected resources.
+
+Do not rebuild the whole bundle by default. Return to `SKILL.md` and use `repo-build.md` only when `.repo_memory/PROFILE.md` is missing, the existing memory is structurally unusable, or the user explicitly asks for a full rebuild.
+
+This is the incremental updater, not the daily reader. Use `repo-read.md` for task-time search over existing memory. Use `repo-build.md` for first-time creation, full rebuild flows, or full refresh work that should rerun builder collection with `collect_all.py --reuse`.
+
+## Prerequisite
+
+The user selects a repository, not a memory directory. Derive the memory path as `<repo>/.repo_memory`.
+
+Require:
+
+- `<repo>` is a local git repository;
+- `<repo>/.repo_memory/PROFILE.md` exists;
+- existing `PROFILE.md` and `resources/*.md` are treated as the baseline.
+
+If `.repo_memory/PROFILE.md` is missing, stop and route to `repo-build.md`; do not fabricate an incremental baseline from live files alone.
+
+## Path Convention
+
+`<skill-dir>` means the parent directory of the `references/` directory containing this file.
+
+## Default Settings
+
+Updater uses `<skill-dir>/defaults.json` so build and update operations stay aligned. It reads `repoHistory.mode`, `repoHistory.limits.prs`, `repoHistory.limits.issues`, and `summaryChars`, with compatibility fallback to legacy `limits.prs` and `limits.issues`; local commit deltas are not limit-capped because they are computed from the stored baseline commit to current `HEAD` when commit history is enabled.
+
+Override one updater run with `--history-mode`, `--pr-limit`, `--issue-limit`, or `--summary-chars`. Do not edit `defaults.json` for a one-run updater request.
+
+History policy modes:
+
+- `none`: skip local commit deltas and provider PR/MR/issue deltas.
+- `commits-only` or `local-only`: detect local commit deltas and skip provider PR/MR/issue deltas.
+- `provider`: detect local commit deltas and fetch provider PR/MR/issue deltas when provider evidence is ready.
+- `provider-required`: detect local commit deltas and require provider PR/MR/issue evidence rather than silently authoring provider resources without evidence.
+
+Do not re-enable commit or provider channels disabled by policy. Use the detector's `effective_settings.history` block as the authority for which history channels are enabled.
+
+## User Count Requests
+
+If the user says how many PRs/MRs or issues to compare, pass explicit one-run flags:
+
+- "PR 拉 20 条" means add `--pr-limit 20`.
+- "issue 拉 30 条" means add `--issue-limit 30`.
+- "PR 和 issue 都拉 50 条" means add `--pr-limit 50 --issue-limit 50`.
+
+Only change `<skill-dir>/defaults.json` when the user asks to change future default behavior.
+
+## Detection
+
+Start every updater run by detecting deltas:
+
+```bash
+python3 <skill-dir>/scripts/detect_updates.py \
+  --repo-path <repo-path> \
+  --pretty
+```
+
+The detector:
+
+- reads the effective history policy from `repoHistory.mode` and reports it in `effective_settings.history`;
+- reads the commit baseline from `PROFILE.md` `local_head`, with a fallback to the nearest stored ancestor commit in `resources/commits.md`;
+- reads PR/MR and issue baselines from `resources/prs.md` and `resources/issues.md`, enriched by existing raw provider facets when available;
+- compares local git `HEAD` against the newest stored commit only when commit history is enabled;
+- reports `local_commit_status.status: "skipped"` with `reason: "history_disabled_by_policy"` when `repoHistory.mode` disables commit history;
+- reports `local_commit_status.status: "skipped"` with `reason: "missing_baseline_commit"` when no stored local commit baseline can be found;
+- reports `local_commit_status.status: "skipped"` with `reason: "baseline_not_ancestor_of_head"` when history was rebased or force-pushed, instead of silently returning no commit delta;
+- detects provider state from live git remotes and provider CLIs only when provider history is enabled;
+- fetches bounded latest GitHub/GitLab PR/MR/issue facets only when provider history is enabled and provider evidence is available;
+- reports added or changed PR/MR/issue numbers without editing memory files;
+- reports provider items missing from the current bounded window as `baseline_only_numbers`, not as deletions.
+
+Warnings such as rewritten commit baselines or provider fetch failures are returned as structured `notices[]` with `render_as: "assistant_message"`. Show these notices to the user as normal assistant messages; do not bury them in terminal output.
+
+When provider fetch succeeds, the report includes fetched authoring evidence under `current.provider_items.pull_requests` and `current.provider_items.issues`. Use those facets, plus existing raw/provider resources when needed, to write or replace search-grade sections; do not author provider sections from number-only deltas.
+
+The report also includes `builder_helpers` fingerprints for the sibling builder files that updater depends on, including `path`, `exists`, `mtime_ns`, and `size_bytes`. Use this only for compatibility diagnostics; it is not evidence for authoring repo-memory resources.
+
+Use `--history-mode local-only` or `--history-mode none` when the user requests a one-run history-policy override. `--provider-mode off` remains supported as a compatibility provider-only override when provider access is intentionally unavailable.
+
+## Provider Sandbox and Transport Failures
+
+`gh/glab` provider delta detection needs external network access. If `current.provider_fetch.ok` is false, or notice/stderr shows `fetch failed`, timeout, DNS, connection, TLS, `ENOTFOUND`, `EAI_AGAIN`, or similar transport text, show `Provider Delta Fetch Failed`, keep existing PR/MR/issue resources unchanged, and continue only with safe local commit updates.
+
+Verify provider authentication in the same normal shell with the command reported by `detect_updates.py`; for GitHub Enterprise or self-hosted GitLab this may include `--hostname <host>`. Authenticate with `gh auth login` or `glab auth login` (also host-scoped when prompted), then rerun `detect_updates.py`; do not paste tokens into the skill or call provider APIs directly.
+
+Do not use a restricted shell sandbox to verify provider/API availability. Verify in a normal shell or approved network-enabled mode before editing provider resources. If only restricted shell access is available, keep existing PR/MR/issue resources unchanged and continue only with safe local commit updates. Do not treat provider fetch failure as no PR/issue delta, empty provider evidence, bad login, or bypass the detector with direct APIs, browser scraping, copied credentials, or hand-written raw facets.
+
+## Report Gates
+
+Read the JSON report as gates before editing. Stop at the first blocking gate; otherwise edit only resources named by the report.
+
+| Report field | Action |
+| --- | --- |
+| `ok: false` and missing memory | Route to `repo-build.md`; do not invent a baseline. |
+| no deltas and no notices | Report no update needed. |
+| `commit_delta_skipped: "missing_baseline_commit"` | Stop commit-resource updates; recommend full rebuild. |
+| `commit_delta_skipped: "baseline_not_ancestor_of_head"` | Stop commit-resource updates; recommend rebuild or explicit baseline reset. |
+| provider fetch failed / `Provider Delta Fetch Failed` | Keep existing PR/MR/issue resources unchanged; local commits may still be updated. |
+| `deltas.local_commits` | Update only `resources/commits.md`; refresh `PROFILE.md` local head and `generated_at` timestamp. |
+| `deltas.pull_requests.upsert_numbers` | Upsert only matching PR/MR sections from `current.provider_items.pull_requests`; preserve `baseline_only_numbers`. |
+| `deltas.issues.upsert_numbers` | Upsert only matching issue sections from `current.provider_items.issues`; preserve `baseline_only_numbers`. |
+
+Never delete prior PR/MR/issue sections because they are absent from the bounded provider fetch; deletion needs explicit user instruction or verified invalidation. Finish with the builder validator:
+
+```bash
+python3 <skill-dir>/scripts/validate_memory.py <repo-path> --pretty
+```
+
+Whenever an update changes generated repo-memory artifacts, set `PROFILE.md.generated_at` to the successful update time, `PROFILE.md.local_head` to the processed snapshot, and `PROFILE.md.source_tree` to the snapshot's full Git tree SHA. The read-time cooldown policy uses this timestamp; do not preserve an older build time after a successful incremental update.
+
+## Authoring Rules
+
+Match existing fixed-field sections first; use builder templates only when the file shape is incomplete. Upsert by stable keys: commit SHA, PR/MR number, and issue number. Replace matching sections, append only new keys, and do not delete useful notes unless explicit instruction or verified evidence invalidates them.
+
+Every new or replaced section needs a search-grade `Description`, evidence strength, and source from local commit delta, `current.provider_items`, or raw provider files. Number-only deltas route the edit; they are not authoring evidence. Do not invent PR/MR/issue evidence when provider fetch is skipped or unavailable, paste long raw summaries, or treat validator/counts as proof of body quality.
+
+## Trust Rules
+
+- Live code and targeted verification are stronger than repo memory.
+- Local commit deltas are checkout history, not current behavior proof.
+- Provider PR/MR/issue deltas are historical or planning context, not implementation truth.
+- Open PRs/MRs are branch intent, not landed behavior.
+- Issues are user/problem context, not implementation proof.

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/collect_all.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/collect_all.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Run the mechanical repo-memory collection steps."""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULTS_PATH = SCRIPT_DIR.parent / "defaults.json"
+FALLBACK_DEFAULTS = {
+    "repoHistory": {
+        "mode": "local-only",
+        "limits": {
+            "commits": 30,
+            "prs": 30,
+            "issues": 30,
+        },
+    },
+    # Kept for compatibility with defaults.json v1.
+    "limits": {
+        "commits": 30,
+        "prs": 30,
+        "issues": 30,
+    },
+    "summaryChars": 4000,
+}
+
+HISTORY_MODES = {"none", "commits-only", "local-only", "provider", "provider-required"}
+
+
+class ProgressBar:
+    def __init__(self, enabled: bool, total: int) -> None:
+        self.enabled = enabled
+        self.total = total
+        self.width = 20
+        self._last_line_len = 0
+        self._is_tty = sys.stderr.isatty()
+
+    def update(self, completed: int, label: str) -> None:
+        if not self.enabled:
+            return
+        completed = max(0, min(completed, self.total))
+        filled = round((completed / self.total) * self.width) if self.total else self.width
+        bar = "#" * filled + "-" * (self.width - filled)
+        line = f"repo-wiki repo-build [{bar}] {completed}/{self.total} {label}"
+        if self._is_tty:
+            padding = " " * max(0, self._last_line_len - len(line))
+            print(f"\r{line}{padding}", end="", file=sys.stderr, flush=True)
+            self._last_line_len = len(line)
+        else:
+            print(line, file=sys.stderr, flush=True)
+
+    def fail(self, completed: int, label: str) -> None:
+        self.update(completed, label)
+        self.finish()
+
+    def finish(self) -> None:
+        if self.enabled and self._is_tty:
+            print(file=sys.stderr, flush=True)
+
+
+def run_step(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+
+
+def json_step(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return {
+        "ok": result.returncode == 0,
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def raw_source_counts(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    data = load_json(path)
+    if not isinstance(data, list):
+        return {}
+    counts = Counter(str(item.get("sourceType") or "unknown") for item in data if isinstance(item, dict))
+    return dict(sorted(counts.items()))
+
+
+def emit_process_output(result: subprocess.CompletedProcess[str]) -> None:
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result.stdout:
+        print(result.stdout, file=sys.stderr)
+
+
+def write_report(report: dict[str, Any], pretty: bool) -> None:
+    print(json.dumps(report, ensure_ascii=False, indent=2 if pretty else None))
+
+
+def write_failure(
+    failed_step: str,
+    result: subprocess.CompletedProcess[str],
+    pretty: bool,
+    *,
+    repo: Optional[Path] = None,
+    memory: Optional[Path] = None,
+    provider: Optional[dict[str, Any]] = None,
+    steps: Optional[dict[str, Any]] = None,
+    outputs: Optional[dict[str, str]] = None,
+    notices: Optional[list[dict[str, Any]]] = None,
+    effective_settings: Optional[dict[str, Any]] = None,
+) -> int:
+    emit_process_output(result)
+    step_reports = dict(steps or {})
+    step_reports[failed_step] = json_step(result)
+    report = {
+        "ok": False,
+        "failed_step": failed_step,
+        "steps": step_reports,
+    }
+    if repo is not None:
+        report["repo_path"] = str(repo)
+    if memory is not None:
+        report["memory_path"] = str(memory)
+    if provider is not None:
+        report["provider"] = provider
+    if outputs:
+        report["outputs"] = outputs
+    if notices:
+        report["notices"] = notices
+    if effective_settings is not None:
+        report["effective_settings"] = effective_settings
+    write_report(report, pretty)
+    return result.returncode or 1
+
+
+def provider_report(prepare_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": prepare_report.get("git_provider", ""),
+        "repo": prepare_report.get("git_remote_repo", ""),
+        "host": prepare_report.get("git_remote_host", ""),
+        "remote_name": prepare_report.get("git_remote_name", ""),
+        "selection_reason": prepare_report.get("git_remote_selection_reason", ""),
+        "cli": prepare_report.get("provider_cli", ""),
+        "cli_available": bool(prepare_report.get("provider_cli_available")),
+        "authenticated": bool(prepare_report.get("provider_authenticated")),
+        "auth_status": prepare_report.get("provider_auth_status", ""),
+        "evidence_state": prepare_report.get("provider_evidence_state", ""),
+        "login_hint": prepare_report.get("provider_login_hint", ""),
+        "notice_level": prepare_report.get("provider_notice_level", ""),
+        "user_notice": prepare_report.get("provider_user_notice", ""),
+        "notice_markdown": prepare_report.get("provider_notice_markdown", ""),
+        "next_steps": prepare_report.get("provider_next_steps", []),
+    }
+
+
+def provider_notices(prepare_report: dict[str, Any]) -> list[dict[str, Any]]:
+    if prepare_report.get("provider_notice_level") != "warning":
+        return []
+    message = str(prepare_report.get("provider_user_notice", "")).replace("`", "")
+    return [
+        {
+            "level": "warning",
+            "title": "Provider Evidence Unavailable",
+            "message": message,
+            "command": prepare_report.get("provider_login_hint", ""),
+            "next_steps": prepare_report.get("provider_next_steps", []),
+            "render_as": "assistant_message",
+        }
+    ]
+
+
+def provider_failure_notice(provider: dict[str, Any], result: subprocess.CompletedProcess[str], *, continuing: bool) -> dict[str, Any]:
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    detail = (stderr or stdout or "provider facet collection failed").replace("`", "")
+    if len(detail) > 800:
+        detail = f"{detail[:800]}..."
+    label = str(provider.get("name") or "provider")
+    evidence = "GitHub PR/issue" if label == "github" else "GitLab MR/issue" if label == "gitlab" else "provider"
+    continuation = (
+        "Continuing with local-only repo memory now."
+        if continuing
+        else "Provider evidence was required, so the run stopped before authoring provider resources."
+    )
+    return {
+        "level": "warning",
+        "title": "Provider Evidence Unavailable",
+        "message": (
+            f"{evidence} evidence could not be collected even though the provider CLI appeared ready. "
+            f"{continuation} Provider error: {detail}"
+        ),
+        "command": "",
+        "next_steps": [
+            "Fix provider repository access or remote URL.",
+            f"Rerun $repo-wiki repo-build to collect {evidence} evidence.",
+        ],
+        "render_as": "assistant_message",
+    }
+
+
+def provider_script(provider: str) -> str:
+    if provider == "github":
+        return "github_resource_facets.py"
+    if provider == "gitlab":
+        return "gitlab_resource_facets.py"
+    return ""
+
+
+def provider_raw_name(provider: str) -> str:
+    if provider == "github":
+        return "github-facets.json"
+    if provider == "gitlab":
+        return "gitlab-facets.json"
+    return "provider-facets.json"
+
+
+def load_default_settings() -> tuple[dict[str, Any], str]:
+    if not DEFAULTS_PATH.exists():
+        return FALLBACK_DEFAULTS, "hardcoded_fallback"
+    try:
+        data = json.loads(DEFAULTS_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{DEFAULTS_PATH}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{DEFAULTS_PATH}: expected a JSON object")
+    return data, str(DEFAULTS_PATH)
+
+
+def default_int(settings: dict[str, Any], path: list[str], fallback: int) -> int:
+    value: Any = settings
+    for key in path:
+        value = value.get(key) if isinstance(value, dict) else None
+    if value is None:
+        return fallback
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{DEFAULTS_PATH}: {'.'.join(path)} must be an integer")
+    return value
+
+
+def validate_range(parser: argparse.ArgumentParser, name: str, value: int, minimum: int, maximum: int) -> None:
+    if value < minimum or value > maximum:
+        parser.error(f"{name} must be from {minimum} to {maximum}")
+
+
+def default_history_mode(settings: dict[str, Any]) -> str:
+    history = settings.get("repoHistory")
+    if not isinstance(history, dict):
+        return "local-only"
+    mode = history.get("mode", "local-only")
+    if not isinstance(mode, str) or mode not in HISTORY_MODES:
+        raise ValueError(f"{DEFAULTS_PATH}: repoHistory.mode must be one of {', '.join(sorted(HISTORY_MODES))}")
+    return mode
+
+
+def default_limit(settings: dict[str, Any], key: str) -> int:
+    history = settings.get("repoHistory")
+    if isinstance(history, dict) and isinstance(history.get("limits"), dict) and history["limits"].get(key) is not None:
+        return default_int(settings, ["repoHistory", "limits", key], FALLBACK_DEFAULTS["repoHistory"]["limits"][key])
+    return default_int(settings, ["limits", key], FALLBACK_DEFAULTS["limits"][key])
+
+
+def history_collect(mode: str) -> dict[str, bool]:
+    return {
+        "commits": mode != "none",
+        "provider": mode in {"provider", "provider-required"},
+    }
+
+
+def resolve_history_mode(args: argparse.Namespace, default_mode: str) -> str:
+    mode = args.history_mode or default_mode
+    if args.skip_provider:
+        mode = "local-only"
+    if args.require_provider:
+        mode = "provider-required"
+    return mode
+
+
+def apply_effective_settings(args: argparse.Namespace, parser: argparse.ArgumentParser) -> argparse.Namespace:
+    try:
+        defaults, source = load_default_settings()
+        default_mode = default_history_mode(defaults)
+        default_commit_limit = default_limit(defaults, "commits")
+        default_pr_limit = default_limit(defaults, "prs")
+        default_issue_limit = default_limit(defaults, "issues")
+        default_summary_chars = default_int(defaults, ["summaryChars"], FALLBACK_DEFAULTS["summaryChars"])
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    history_mode = resolve_history_mode(args, default_mode)
+    collect = history_collect(history_mode)
+
+    commit_limit = args.commit_limit if args.commit_limit is not None else default_commit_limit
+    pr_limit = args.pr_limit if args.pr_limit is not None else default_pr_limit
+    issue_limit = args.issue_limit if args.issue_limit is not None else default_issue_limit
+    summary_chars = args.summary_chars if args.summary_chars is not None else default_summary_chars
+
+    validate_range(parser, "--commit-limit", commit_limit, 1, 500)
+    validate_range(parser, "--pr-limit", pr_limit, 1, 100)
+    validate_range(parser, "--issue-limit", issue_limit, 1, 100)
+    if summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+
+    overrides: dict[str, Any] = {}
+    if args.history_mode is not None:
+        overrides["history_mode"] = args.history_mode
+    if args.skip_provider:
+        overrides["skip_provider"] = True
+    if args.require_provider:
+        overrides["require_provider"] = True
+    if args.commit_limit is not None:
+        overrides["commit_limit"] = args.commit_limit
+    if args.pr_limit is not None:
+        overrides["pr_limit"] = args.pr_limit
+    if args.issue_limit is not None:
+        overrides["issue_limit"] = args.issue_limit
+    if args.summary_chars is not None:
+        overrides["summary_chars"] = args.summary_chars
+
+    args.commit_limit = commit_limit
+    args.pr_limit = pr_limit
+    args.issue_limit = issue_limit
+    args.summary_chars = summary_chars
+    args.history_mode = history_mode
+    args.history_collect = collect
+    args.effective_settings = {
+        "history": {
+            "mode": history_mode,
+            "collect": collect,
+        },
+        "limits": {
+            "commits": commit_limit,
+            "prs": pr_limit,
+            "issues": issue_limit,
+        },
+        "summary_chars": summary_chars,
+        "source": source,
+        "overrides": overrides,
+    }
+    return args
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare repo memory and collect raw facets for agent-authored resources.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--reuse", action="store_true", help="Reuse/update an existing .repo_memory directory")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref whose history should be collected")
+    parser.add_argument("--commit-limit", type=int, default=None, help="Maximum local commits retained from the snapshot history")
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum snapshot-filtered PRs/MRs retained")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum provider issues retained")
+    parser.add_argument("--summary-chars", type=int, default=None)
+    parser.add_argument("--history-mode", choices=sorted(HISTORY_MODES), default=None, help="History evidence policy for this build")
+    parser.add_argument("--skip-provider", action="store_true", help="Skip GitHub/GitLab PR/MR/issue collection and build local-only memory")
+    parser.add_argument("--require-provider", action="store_true", help="Fail if provider PR/MR/issue evidence cannot be collected")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Render a stderr progress bar while keeping stdout as the final JSON report",
+    )
+    args = parser.parse_args(argv)
+    if args.skip_provider and args.require_provider:
+        parser.error("--skip-provider and --require-provider cannot be used together")
+    if args.history_mode and args.skip_provider and args.history_mode != "local-only":
+        parser.error(f"--skip-provider cannot be combined with --history-mode {args.history_mode}")
+    if args.history_mode and args.require_provider and args.history_mode != "provider-required":
+        parser.error("--require-provider cannot be combined with a non-required history mode")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return apply_effective_settings(args, parser)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = args.repo_path
+    progress = ProgressBar(args.progress, 3)
+    command_cwd = repo if repo.exists() else SCRIPT_DIR
+    prepare_cmd = [sys.executable, str(SCRIPT_DIR / "prepare_repo_memory.py"), str(repo)]
+    if args.reuse:
+        prepare_cmd.append("--reuse")
+    if not args.history_collect["provider"]:
+        prepare_cmd.append("--skip-provider-check")
+    progress.update(0, "prepare")
+    prepare = run_step(prepare_cmd, command_cwd)
+    if prepare.returncode != 0:
+        progress.fail(0, "prepare failed")
+        return write_failure("prepare", prepare, args.pretty, repo=repo)
+    if prepare.stderr:
+        print(prepare.stderr, file=sys.stderr)
+    progress.update(1, "prepare")
+
+    memory = repo / ".repo_memory"
+    raw_dir = memory / "raw"
+    prepare_report_path = raw_dir / "prepare-report.json"
+    prepare_data = load_json(prepare_report_path)
+    notices = provider_notices(prepare_data)
+
+    git_commits_path = raw_dir / "git-commits.json"
+    outputs = {
+        "prepare_report": str(prepare_report_path),
+        "git_commits": str(git_commits_path),
+    }
+    if args.history_collect["commits"]:
+        git_commits = run_step(
+            [
+                sys.executable,
+                str(SCRIPT_DIR / "git_commit_facets.py"),
+                "--repo-path",
+                str(repo),
+                "--snapshot-ref",
+                args.snapshot_ref,
+                "--limit",
+                str(args.commit_limit),
+                "--summary-chars",
+                str(args.summary_chars),
+                "--out",
+                str(git_commits_path),
+            ],
+            repo,
+        )
+        git_commits_step = json_step(git_commits)
+        if git_commits.returncode != 0:
+            progress.fail(1, "git commits failed")
+            return write_failure(
+                "git_commits",
+                git_commits,
+                args.pretty,
+                repo=repo,
+                memory=memory,
+                steps={"prepare": json_step(prepare)},
+                outputs=outputs,
+            )
+    else:
+        git_commits_path.write_text("[]\n", encoding="utf-8")
+        git_commits_step = {
+            "ok": True,
+            "exit_code": 0,
+            "stdout": "",
+            "stderr": "",
+            "skipped": True,
+            "reason": "history_disabled_by_policy",
+        }
+    progress.update(2, "git commits")
+
+    provider = provider_report(prepare_data)
+    provider_name = str(provider["name"])
+    provider_facets: dict[str, Any]
+    provider_output = raw_dir / provider_raw_name(provider_name)
+    provider_script_name = provider_script(provider_name)
+    if not args.history_collect["provider"]:
+        reason = "provider_skipped_by_user" if args.skip_provider else "history_disabled_by_policy" if args.history_mode == "none" else "history_provider_disabled_by_policy"
+        provider_facets = {
+            "ok": True,
+            "skipped": True,
+            "reason": reason,
+            "output": "",
+        }
+    elif provider["evidence_state"] == "ready" and provider_script_name and provider["repo"]:
+        provider_cmd = [
+            sys.executable,
+            str(SCRIPT_DIR / provider_script_name),
+            "--repo",
+            str(provider["repo"]),
+            "--repo-path",
+            str(repo),
+            "--snapshot-ref",
+            args.snapshot_ref,
+            "--include",
+            "prs,issues",
+            "--pr-limit",
+            str(args.pr_limit),
+            "--issue-limit",
+            str(args.issue_limit),
+            "--state",
+            "all",
+            "--summary-chars",
+            str(args.summary_chars),
+            "--out",
+            str(provider_output),
+        ]
+        if provider.get("host"):
+            provider_cmd.extend(["--hostname", str(provider["host"])])
+        provider_result = run_step(provider_cmd, repo)
+        provider_facets = {
+            **json_step(provider_result),
+            "skipped": False,
+            "output": str(provider_output),
+        }
+        if provider_result.returncode != 0:
+            provider_facets["degraded_to_local_only"] = args.history_mode != "provider-required"
+            provider_facets["reason"] = "provider_facets_failed"
+            provider_facets["output"] = ""
+            if provider_output.exists():
+                provider_output.unlink()
+            if args.history_mode == "provider-required":
+                progress.fail(2, "provider facets failed")
+                return write_failure(
+                    "provider_facets",
+                    provider_result,
+                    args.pretty,
+                    repo=repo,
+                    memory=memory,
+                    provider=provider,
+                    steps={
+                        "prepare": json_step(prepare),
+                        "git_commits": git_commits_step,
+                    },
+                    outputs=outputs,
+                    notices=[provider_failure_notice(provider, provider_result, continuing=False)],
+                    effective_settings=args.effective_settings,
+                )
+            notices.append(provider_failure_notice(provider, provider_result, continuing=True))
+        else:
+            outputs["provider_facets"] = provider_facets["output"]
+    else:
+        if args.history_mode == "provider-required":
+            provider_result = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr=f"provider evidence is required but provider_evidence_state={provider['evidence_state']}",
+            )
+            progress.fail(2, "provider facets unavailable")
+            return write_failure(
+                "provider_facets",
+                provider_result,
+                args.pretty,
+                repo=repo,
+                memory=memory,
+                provider=provider,
+                steps={
+                    "prepare": json_step(prepare),
+                    "git_commits": git_commits_step,
+                },
+                outputs=outputs,
+                notices=notices,
+                effective_settings=args.effective_settings,
+            )
+        provider_facets = {
+            "ok": True,
+            "skipped": True,
+            "reason": f"provider_evidence_state={provider['evidence_state']}",
+            "output": "",
+        }
+    progress.update(3, "provider facets")
+    progress.finish()
+
+    counts = {
+        "raw": {
+            "git_commits": raw_source_counts(git_commits_path),
+        },
+    }
+    if provider_facets.get("output"):
+        counts["raw"]["provider_facets"] = raw_source_counts(Path(str(provider_facets["output"])))
+
+    report = {
+        "ok": True,
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "provider": provider,
+        "notices": notices,
+        "effective_settings": args.effective_settings,
+        "steps": {
+            "prepare": json_step(prepare),
+            "git_commits": git_commits_step,
+            "provider_facets": provider_facets,
+        },
+        "outputs": outputs,
+        "counts": counts,
+        "next_step": "Inspect raw evidence, then author PROFILE.md and resources/*.md.",
+    }
+    write_report(report, args.pretty)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/detect_updates.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/detect_updates.py
@@ -1,0 +1,919 @@
+#!/usr/bin/env python3
+"""Detect incremental repo-memory updates from git and optional provider evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+BUILDER_SCRIPTS_DIR = SCRIPT_DIR
+BUILDER_DEFAULTS_PATH = SKILL_DIR / "defaults.json"
+BUILDER_SKILL_DIR = SKILL_DIR
+BUILDER_HELPER_FILES = {
+    "defaults": BUILDER_DEFAULTS_PATH,
+    "validate_memory": BUILDER_SCRIPTS_DIR / "validate_memory.py",
+    "github_resource_facets": BUILDER_SCRIPTS_DIR / "github_resource_facets.py",
+    "gitlab_resource_facets": BUILDER_SCRIPTS_DIR / "gitlab_resource_facets.py",
+}
+PREFERRED_REMOTE_NAMES = ("upstream", "origin")
+HISTORY_MODES = {"none", "commits-only", "local-only", "provider", "provider-required"}
+FALLBACK_DEFAULTS = {
+    "repoHistory": {
+        "mode": "local-only",
+        "limits": {
+            "prs": 30,
+            "issues": 30,
+        },
+    },
+    # Kept for compatibility with defaults.json v1.
+    "limits": {
+        "prs": 30,
+        "issues": 30,
+    },
+    "summaryChars": 4000,
+}
+
+
+def run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+
+
+def git(repo: Path, args: list[str], message: str) -> str:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for repo-memory incremental update detection")
+    result = run(["git", "-C", str(repo), *args], repo)
+    if result.returncode != 0:
+        raise SystemExit(f"{message}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def load_json(path: Path, fallback: Any) -> Any:
+    if not path.exists():
+        return fallback
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{path}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def default_int(settings: dict[str, Any], path: list[str], fallback: int) -> int:
+    value: Any = settings
+    for key in path:
+        value = value.get(key) if isinstance(value, dict) else None
+    if value is None:
+        return fallback
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: {'.'.join(path)} must be an integer")
+    return value
+
+
+def default_limit(settings: dict[str, Any], key: str) -> int:
+    history = settings.get("repoHistory")
+    if isinstance(history, dict) and isinstance(history.get("limits"), dict) and history["limits"].get(key) is not None:
+        return default_int(settings, ["repoHistory", "limits", key], FALLBACK_DEFAULTS["repoHistory"]["limits"][key])
+    return default_int(settings, ["limits", key], FALLBACK_DEFAULTS["limits"][key])
+
+
+def default_history_mode(settings: dict[str, Any]) -> str:
+    history = settings.get("repoHistory")
+    if not isinstance(history, dict):
+        return "local-only"
+    mode = history.get("mode", "local-only")
+    if not isinstance(mode, str) or mode not in HISTORY_MODES:
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: repoHistory.mode must be one of {', '.join(sorted(HISTORY_MODES))}")
+    return mode
+
+
+def history_collect(mode: str) -> dict[str, bool]:
+    return {
+        "commits": mode in {"commits-only", "local-only", "provider", "provider-required"},
+        "provider": mode in {"provider", "provider-required"},
+    }
+
+
+def load_default_settings() -> tuple[dict[str, Any], str]:
+    if not BUILDER_DEFAULTS_PATH.exists():
+        return FALLBACK_DEFAULTS, "hardcoded_fallback"
+    data = load_json(BUILDER_DEFAULTS_PATH, FALLBACK_DEFAULTS)
+    if not isinstance(data, dict):
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: expected a JSON object")
+    return data, str(BUILDER_DEFAULTS_PATH)
+
+
+def validate_range(parser: argparse.ArgumentParser, name: str, value: int, minimum: int, maximum: int) -> None:
+    if value < minimum or value > maximum:
+        parser.error(f"{name} must be from {minimum} to {maximum}")
+
+
+def apply_effective_settings(args: argparse.Namespace, parser: argparse.ArgumentParser) -> argparse.Namespace:
+    try:
+        defaults, source = load_default_settings()
+        default_mode = default_history_mode(defaults)
+        default_pr_limit = default_limit(defaults, "prs")
+        default_issue_limit = default_limit(defaults, "issues")
+        default_summary_chars = default_int(defaults, ["summaryChars"], FALLBACK_DEFAULTS["summaryChars"])
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    history_mode = args.history_mode or default_mode
+    collect = history_collect(history_mode)
+    if args.provider_mode == "off":
+        if history_mode == "provider-required":
+            parser.error("--provider-mode off cannot be combined with --history-mode provider-required")
+        collect = {**collect, "provider": False}
+    pr_limit = args.pr_limit if args.pr_limit is not None else default_pr_limit
+    issue_limit = args.issue_limit if args.issue_limit is not None else default_issue_limit
+    summary_chars = args.summary_chars if args.summary_chars is not None else default_summary_chars
+
+    validate_range(parser, "--pr-limit", pr_limit, 1, 100)
+    validate_range(parser, "--issue-limit", issue_limit, 1, 100)
+    if summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+
+    overrides: dict[str, Any] = {}
+    if args.history_mode is not None:
+        overrides["history_mode"] = args.history_mode
+    if args.pr_limit is not None:
+        overrides["pr_limit"] = args.pr_limit
+    if args.issue_limit is not None:
+        overrides["issue_limit"] = args.issue_limit
+    if args.summary_chars is not None:
+        overrides["summary_chars"] = args.summary_chars
+
+    args.history_mode = history_mode
+    args.history_collect = collect
+    args.pr_limit = pr_limit
+    args.issue_limit = issue_limit
+    args.summary_chars = summary_chars
+    args.effective_settings = {
+        "history": {
+            "mode": history_mode,
+            "collect": collect,
+        },
+        "limits": {
+            "prs": pr_limit,
+            "issues": issue_limit,
+        },
+        "summary_chars": summary_chars,
+        "source": source,
+        "overrides": overrides,
+    }
+    return args
+
+
+def file_fingerprint(path: Path) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+    }
+    if path.exists():
+        stat = path.stat()
+        item["mtime_ns"] = stat.st_mtime_ns
+        item["size_bytes"] = stat.st_size
+    return item
+
+
+def builder_helper_report() -> dict[str, Any]:
+    return {
+        "skill_dir": str(BUILDER_SKILL_DIR),
+        "scripts_dir": str(BUILDER_SCRIPTS_DIR),
+        "files": {
+            name: file_fingerprint(path)
+            for name, path in BUILDER_HELPER_FILES.items()
+        },
+    }
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    fields: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            fields[key] = value
+    return fields
+
+
+def resolve_memory(repo: Path, memory_arg: str | None) -> Path:
+    return Path(memory_arg).expanduser().resolve() if memory_arg else repo / ".repo_memory"
+
+
+def body_after_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return text
+    return text[end + 4 :].lstrip("\n")
+
+
+def commit_baseline(memory: Path, repo: Path | None = None, head_sha: str = "") -> str:
+    profile_head = parse_frontmatter(memory / "PROFILE.md").get("local_head", "")
+    if profile_head:
+        return profile_head
+    text_path = memory / "resources" / "commits.md"
+    if text_path.exists():
+        text = body_after_frontmatter(text_path.read_text(encoding="utf-8"))
+        shas = re.findall(r"(?im)^-\s*SHA:\s*`?([0-9a-f]{7,40})`?", text)
+        if repo is not None and head_sha and shas:
+            nearest = nearest_ancestor(repo, shas, head_sha)
+            if nearest:
+                return nearest
+        if shas:
+            return shas[0]
+    return ""
+
+
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    if not ancestor:
+        return False
+    result = run(["git", "-C", str(repo), "merge-base", "--is-ancestor", ancestor, descendant], repo)
+    return result.returncode == 0
+
+
+def nearest_ancestor(repo: Path, candidates: list[str], descendant: str) -> str:
+    unique_candidates = list(dict.fromkeys(candidate for candidate in candidates if candidate))
+    if not unique_candidates:
+        return ""
+    result = run(["git", "-C", str(repo), "rev-list", descendant], repo)
+    if result.returncode != 0:
+        return ""
+    for sha in [line.strip() for line in result.stdout.splitlines() if line.strip()]:
+        for candidate in unique_candidates:
+            if sha.startswith(candidate):
+                return candidate
+    return ""
+
+
+def commit_delta(repo: Path, baseline_sha: str, head_sha: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not baseline_sha:
+        return [], {
+            "status": "skipped",
+            "reason": "missing_baseline_commit",
+            "message": "No stored local commit baseline was found in .repo_memory.",
+        }
+    if baseline_sha == head_sha:
+        return [], {"status": "current", "reason": ""}
+    if not is_ancestor(repo, baseline_sha, head_sha):
+        return [], {
+            "status": "skipped",
+            "reason": "baseline_not_ancestor_of_head",
+            "message": "Stored repo-memory commit baseline is not an ancestor of the current HEAD; history was probably rebased or force-pushed.",
+        }
+    shas = git(repo, ["rev-list", "--reverse", f"{baseline_sha}..{head_sha}"], "git could not list new commits")
+    out: list[dict[str, Any]] = []
+    for sha in [line.strip() for line in shas.splitlines() if line.strip()]:
+        fields = git(
+            repo,
+            ["show", "-s", "--date=iso-strict", "--format=%H%x1f%h%x1f%an%x1f%ad%x1f%s", sha],
+            f"git could not read commit {sha}",
+        ).split("\x1f")
+        full_sha, short_sha, author, authored_at, title = (fields + [""] * 5)[:5]
+        files = git(repo, ["show", "--format=", "--name-only", "--no-renames", sha], f"git could not list files for {sha}")
+        out.append({
+            "sha": full_sha,
+            "short_sha": short_sha,
+            "title": title,
+            "author": author,
+            "authored_at": authored_at,
+            "files": [line for line in files.splitlines() if line],
+        })
+    return out, {"status": "ok", "reason": "", "count": len(out)}
+
+
+def markdown_sections(path: Path) -> list[tuple[str, str]]:
+    if not path.exists():
+        return []
+    text = body_after_frontmatter(path.read_text(encoding="utf-8"))
+    matches = list(re.finditer(r"(?m)^##\s+(.+?)\s*$", text))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append((match.group(1).strip(), text[start:end]))
+    return sections
+
+
+def markdown_field(body: str, label: str) -> str:
+    pattern = rf"(?im)^-\s*{re.escape(label)}:\s*(.+?)\s*$"
+    match = re.search(pattern, body)
+    if not match:
+        return ""
+    value = match.group(1).strip()
+    return value.strip().strip("`").strip()
+
+
+def first_code_value(text: str) -> str:
+    match = re.search(r"`([^`]+)`", text)
+    return match.group(1).strip() if match else text.strip()
+
+
+def section_number(title: str) -> int | None:
+    match = re.search(r"[#!#]\s*(\d+)", title)
+    return int(match.group(1)) if match else None
+
+
+def section_title(title: str) -> str:
+    return title.split(":", 1)[1].strip() if ":" in title else title.strip()
+
+
+def branch_parts(value: str) -> tuple[str, str]:
+    if "<-" not in value:
+        return "", ""
+    base, head = value.split("<-", 1)
+    return base.strip(), head.strip()
+
+
+def resource_items(memory: Path, resource_name: str) -> list[dict[str, Any]]:
+    path = memory / "resources" / resource_name
+    kind = "issue" if resource_name == "issues.md" else "pr"
+    out: list[dict[str, Any]] = []
+    for title, body in markdown_sections(path):
+        number = section_number(title)
+        if number is None:
+            continue
+        item: dict[str, Any] = {
+            "number": number,
+            "title": section_title(title),
+            "source": "resource",
+        }
+        state = first_code_value(markdown_field(body, "State"))
+        if state:
+            item["state"] = state
+        url = markdown_field(body, "URL")
+        if url:
+            item["url"] = url
+        if kind == "pr":
+            base_ref, head_ref = branch_parts(first_code_value(markdown_field(body, "Branch")))
+            if base_ref:
+                item["base_ref"] = base_ref
+            if head_ref:
+                item["head_ref"] = head_ref
+        out.append(item)
+    return out
+
+
+def first_int(values: Any) -> int | None:
+    if isinstance(values, int):
+        return values
+    if isinstance(values, list):
+        for value in values:
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def facet_number(facet: dict[str, Any], source_type: str) -> int | None:
+    values = facet.get("issues") if source_type == "issue" else facet.get("prs")
+    number = first_int(values)
+    if number is not None:
+        return number
+    match = re.search(r"\.(\d+)$", str(facet.get("facetId", "")))
+    return int(match.group(1)) if match else None
+
+
+AUTHORING_FACET_KEYS = [
+    "summary",
+    "labels",
+    "commits",
+    "commit_headlines",
+    "review_decision",
+    "review_states",
+    "files",
+    "symbols",
+    "evidence",
+    "changed_files",
+    "additions",
+    "deletions",
+]
+
+
+def keep_value(value: Any) -> bool:
+    return value not in (None, "", [], {})
+
+
+def facet_items(facets: Any, source_type: str) -> list[dict[str, Any]]:
+    if not isinstance(facets, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for facet in facets:
+        if not isinstance(facet, dict) or facet.get("sourceType") != source_type:
+            continue
+        number = facet_number(facet, source_type)
+        if number is None:
+            continue
+        item: dict[str, Any] = {
+            "number": number,
+            "title": str(facet.get("title") or ""),
+            "state": str(facet.get("state") or ""),
+            "updated_at": str(facet.get("updatedAt") or facet.get("updated_at") or ""),
+            "url": str(facet.get("url") or ""),
+            "source": "provider_facet",
+        }
+        facet_id = str(facet.get("facetId") or "")
+        if facet_id:
+            item["raw_lookup"] = f"facetId={facet_id}"
+        for key in AUTHORING_FACET_KEYS:
+            if key in facet:
+                item[key] = facet[key]
+        if source_type == "pr":
+            item["base_ref"] = str(facet.get("base_ref") or "")
+            item["head_ref"] = str(facet.get("head_ref") or "")
+            item["merged_at"] = str(facet.get("mergedAt") or facet.get("merged_at") or "")
+            item["closed_at"] = str(facet.get("closedAt") or facet.get("closed_at") or "")
+            linked_issues = facet.get("issues")
+            if keep_value(linked_issues):
+                item["linked_issues"] = linked_issues
+        out.append({key: value for key, value in item.items() if keep_value(value)})
+    return out
+
+
+def raw_provider_items(memory: Path, source_type: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for raw_name in ["github-facets.json", "gitlab-facets.json"]:
+        raw_path = memory / "raw" / raw_name
+        if raw_path.exists():
+            out.extend(facet_items(load_json(raw_path, []), source_type))
+    return out
+
+
+def baseline_items(memory: Path, resource_name: str, source_type: str) -> list[dict[str, Any]]:
+    resource = resource_items(memory, resource_name)
+    raw_by_no = by_number(raw_provider_items(memory, source_type))
+    out: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for item in resource:
+        number = item_number(item)
+        if number is None:
+            continue
+        merged = dict(item)
+        merged.update(raw_by_no.get(number, {}))
+        if number in raw_by_no:
+            merged["source"] = "resource_with_raw_provider_facet"
+        out.append(merged)
+        seen.add(number)
+    for number, item in sorted(raw_by_no.items()):
+        if number not in seen:
+            out.append(item)
+    return out
+
+
+def item_number(item: dict[str, Any]) -> int | None:
+    number = item.get("number")
+    return number if isinstance(number, int) else None
+
+
+def by_number(items: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    out: dict[int, dict[str, Any]] = {}
+    for item in items:
+        number = item_number(item)
+        if number is not None:
+            out[number] = item
+    return out
+
+
+def comparable_item(item: dict[str, Any]) -> str:
+    ignored_keys = {"raw_lookup", "source", "updated_at", "merged_at", "closed_at"}
+    normalized = {key: value for key, value in item.items() if key not in ignored_keys}
+    return json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def changed_numbers(existing: dict[int, dict[str, Any]], current: dict[int, dict[str, Any]]) -> list[int]:
+    changed: list[int] = []
+    for number, item in current.items():
+        old = existing.get(number)
+        if old is None:
+            continue
+        for key in ["updated_at", "state", "title", "head_ref", "base_ref", "merged_at", "closed_at"]:
+            if old.get(key) not in (None, "") and old.get(key) != item.get(key):
+                changed.append(number)
+                break
+        else:
+            common_keys = {
+                key
+                for key, value in old.items()
+                if key not in {"number", "raw_lookup", "source"} and value not in (None, "")
+            }
+            old_common = {key: old.get(key) for key in common_keys}
+            current_common = {key: item.get(key) for key in common_keys}
+            if old_common != current_common and comparable_item(old) != comparable_item(item):
+                changed.append(number)
+    return sorted(changed)
+
+
+def remote_url_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def remote_name_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[0] if parts else ""
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    return repo_path[:-4] if repo_path.endswith(".git") else repo_path
+
+
+def provider_from_host(host: str) -> str:
+    lower = host.lower()
+    if lower == "github.com" or "github" in lower:
+        return "github"
+    if lower == "gitlab.com" or "gitlab" in lower:
+        return "gitlab"
+    return ""
+
+
+def parse_remote_url(url: str) -> dict[str, str]:
+    if not url:
+        return {"provider": "", "repo": "", "host": "", "url": ""}
+    if "://" not in url:
+        match = re.match(r"^(?:[^@/\s]+@)?(?P<host>[^:/\s]+):(?P<path>.+)$", url)
+        if match:
+            host = match.group("host")
+            return {
+                "provider": provider_from_host(host),
+                "repo": normalize_remote_path(match.group("path")),
+                "host": host,
+                "url": url,
+            }
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    return {
+        "provider": provider_from_host(host),
+        "repo": normalize_remote_path(parsed.path),
+        "host": host,
+        "url": url,
+    }
+
+
+def parse_code_host_repo(remotes: str) -> dict[str, str]:
+    candidates: list[dict[str, str]] = []
+    for line in remotes.splitlines():
+        if "(push)" in line:
+            continue
+        parsed = parse_remote_url(remote_url_from_line(line))
+        if parsed["provider"] and parsed["repo"]:
+            parsed["remote_name"] = remote_name_from_line(line)
+            candidates.append(parsed)
+    for preferred in PREFERRED_REMOTE_NAMES:
+        for candidate in candidates:
+            if candidate.get("remote_name") == preferred:
+                candidate["selection_reason"] = f"preferred_{preferred}_fetch_remote"
+                return candidate
+    if candidates:
+        candidates[0]["selection_reason"] = "first_supported_fetch_remote"
+        return candidates[0]
+    return {"provider": "", "repo": "", "host": "", "url": "", "remote_name": "", "selection_reason": "none"}
+
+
+def provider_host(provider: str) -> str:
+    if provider == "github":
+        return "github.com"
+    if provider == "gitlab":
+        return "gitlab.com"
+    return ""
+
+
+def provider_from_profile(memory: Path) -> dict[str, str]:
+    profile = parse_frontmatter(memory / "PROFILE.md")
+    provider = profile.get("code_host_provider", "")
+    repo = profile.get("repo_full_name", "")
+    if provider in {"github", "gitlab"} and repo and "/" in repo:
+        parsed_profile_url = parse_remote_url(str(profile.get("repo_url", "")))
+        host = parsed_profile_url["host"] if parsed_profile_url["provider"] == provider else provider_host(provider)
+        return {
+            "provider": provider,
+            "repo": repo,
+            "host": host,
+            "url": profile.get("repo_url", ""),
+            "remote_name": "",
+            "selection_reason": "profile_frontmatter",
+        }
+    return {}
+
+
+def auth_args(command: str, host: str) -> list[str]:
+    args = ["auth", "status"]
+    if host and command in {"gh", "glab"}:
+        args.extend(["--hostname", host])
+    return args
+
+
+def login_hint(command: str, host: str) -> str:
+    default_host = "github.com" if command == "gh" else "gitlab.com" if command == "glab" else ""
+    if host and host != default_host:
+        return f"{command} auth login --hostname {host}"
+    return f"{command} auth login"
+
+
+def cli_evidence_state(command: str, host: str) -> tuple[str, bool]:
+    if shutil.which(command) is None:
+        return "cli_missing", False
+    try:
+        result = subprocess.run([command, *auth_args(command, host)], text=True, capture_output=True, timeout=8)
+    except subprocess.TimeoutExpired:
+        return "auth_check_timeout", True
+    return ("ready", True) if result.returncode == 0 else ("auth_required", True)
+
+
+def provider_report(repo: Path, memory: Path, *, inspect_cli: bool = True) -> dict[str, Any]:
+    remote = provider_from_profile(memory) or parse_code_host_repo(git(repo, ["remote", "-v"], "git could not list remotes"))
+    provider = remote["provider"]
+    cli = "gh" if provider == "github" else "glab" if provider == "gitlab" else ""
+    evidence_state = "unavailable" if inspect_cli else "skipped_by_policy"
+    cli_available = False
+    if cli and inspect_cli:
+        evidence_state, cli_available = cli_evidence_state(cli, remote["host"])
+    return {
+        "name": provider,
+        "repo": remote["repo"],
+        "host": remote["host"],
+        "remote_url": remote["url"],
+        "remote_name": remote.get("remote_name", ""),
+        "selection_reason": remote.get("selection_reason", ""),
+        "evidence_state": evidence_state,
+        "cli": cli,
+        "cli_available": cli_available,
+        "login_hint": login_hint(cli, remote["host"]) if cli else "",
+    }
+
+
+def provider_script(provider: str) -> str:
+    if provider == "github":
+        return "github_resource_facets.py"
+    if provider == "gitlab":
+        return "gitlab_resource_facets.py"
+    return ""
+
+
+def fetch_provider_items(repo: Path, provider: dict[str, Any], snapshot_ref: str, pr_limit: int, issue_limit: int, summary_chars: int) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    provider_name = str(provider.get("name") or "")
+    provider_repo = str(provider.get("repo") or "")
+    script_name = provider_script(provider_name)
+    if not script_name or not provider_repo or provider.get("evidence_state") != "ready":
+        return {
+            "attempted": False,
+            "reason": f"provider_evidence_state={provider.get('evidence_state', '') or 'unavailable'}",
+        }, [], []
+
+    script_path = BUILDER_SCRIPTS_DIR / script_name
+    if not script_path.exists():
+        return {"attempted": False, "reason": "repo-wiki repo-build helpers are missing"}, [], []
+
+    with tempfile.TemporaryDirectory(prefix="repo-wiki-repo-update.") as tmp:
+        tmp_root = Path(tmp)
+        raw = tmp_root / f"{provider_name}-facets.json"
+        facets = run(
+            [
+                sys.executable,
+                str(script_path),
+                "--repo",
+                provider_repo,
+                "--repo-path",
+                str(repo),
+                "--snapshot-ref",
+                snapshot_ref,
+                "--include",
+                "prs,issues",
+                "--pr-limit",
+                str(pr_limit),
+                "--issue-limit",
+                str(issue_limit),
+                "--state",
+                "all",
+                "--summary-chars",
+                str(summary_chars),
+                "--out",
+                str(raw),
+                *(["--hostname", str(provider.get("host"))] if provider.get("host") else []),
+            ],
+            repo,
+        )
+        if facets.returncode != 0:
+            return {
+                "attempted": True,
+                "ok": False,
+                "exit_code": facets.returncode,
+                "stderr": facets.stderr.strip(),
+            }, [], []
+        raw_facets = load_json(raw, [])
+        prs = facet_items(raw_facets, "pr")
+        issues = facet_items(raw_facets, "issue")
+        return {
+            "attempted": True,
+            "ok": True,
+            "provider": provider_name,
+            "repo": provider_repo,
+            "pr_count": len(prs) if isinstance(prs, list) else 0,
+            "issue_count": len(issues) if isinstance(issues, list) else 0,
+        }, prs, issues
+
+
+def delta_summary(existing: list[dict[str, Any]], current: list[dict[str, Any]]) -> dict[str, Any]:
+    existing_by_no = by_number(existing)
+    current_by_no = by_number(current)
+    added = sorted(number for number in current_by_no if number not in existing_by_no)
+    updated = changed_numbers(existing_by_no, current_by_no)
+    baseline_only = sorted(number for number in existing_by_no if number not in current_by_no)
+    return {
+        "baseline_numbers": sorted(existing_by_no),
+        "current_numbers": sorted(current_by_no),
+        "added_numbers": added,
+        "updated_numbers": updated,
+        "upsert_numbers": sorted([*added, *updated]),
+        "baseline_only_numbers": baseline_only,
+        "delete_numbers": [],
+    }
+
+
+def actions_for(deltas: dict[str, Any], provider_fetch: dict[str, Any]) -> list[str]:
+    actions: list[str] = []
+    local_commit_status = deltas.get("local_commit_status", {})
+    if local_commit_status.get("reason") == "missing_baseline_commit":
+        actions.append("Local commit delta was skipped because no stored commit baseline was found. Use $repo-wiki repo-build for a full rebuild before doing incremental commit updates.")
+    if local_commit_status.get("reason") == "baseline_not_ancestor_of_head":
+        actions.append("Local commit delta was skipped because the stored baseline is not an ancestor of HEAD. Use $repo-wiki repo-build for a full rebuild, or explicitly choose a new baseline before doing incremental commit updates.")
+    if deltas["local_commits"]:
+        actions.append("Update .repo_memory/resources/commits.md with sections for the new local commits; update PROFILE.md local_head and commit snapshot notes only where needed.")
+    if deltas["pull_requests"]["added_numbers"] or deltas["pull_requests"]["updated_numbers"]:
+        actions.append("Upsert .repo_memory/resources/prs.md sections by PR/MR number for only the added or changed numbers. Preserve baseline-only and unaffected PR/MR sections; do not delete missing numbers by default.")
+    if deltas["issues"]["added_numbers"] or deltas["issues"]["updated_numbers"]:
+        actions.append("Upsert .repo_memory/resources/issues.md sections by issue number for only the added or changed numbers. Preserve baseline-only and unaffected issue sections; do not delete missing numbers by default.")
+    if provider_fetch.get("attempted") is True and provider_fetch.get("ok") is False:
+        actions.append("Provider delta fetch failed; keeping existing PR/issue resources unchanged. Fix provider access and rerun $repo-wiki repo-update, or use repo-build for a full provider refresh if needed.")
+    if provider_fetch.get("attempted") is False:
+        actions.append("Provider delta fetch was skipped; keep PR/issue resources unchanged unless the user asks to login/install provider CLI or force provider refresh.")
+    if not actions:
+        actions.append("No repo-memory content update is needed.")
+    return actions
+
+
+def notices_for(deltas: dict[str, Any], provider_fetch: dict[str, Any]) -> list[dict[str, Any]]:
+    notices: list[dict[str, Any]] = []
+    local_commit_status = deltas.get("local_commit_status", {})
+    if local_commit_status.get("reason") == "missing_baseline_commit":
+        notices.append({
+            "level": "warning",
+            "title": "Repo Memory Commit Baseline Missing",
+            "message": "No stored local commit baseline was found in .repo_memory, so incremental commit detection was skipped.",
+            "next_steps": [
+                "Run $repo-wiki repo-build for a full rebuild before incremental commit updates.",
+            ],
+            "render_as": "assistant_message",
+        })
+    if local_commit_status.get("reason") == "baseline_not_ancestor_of_head":
+        notices.append({
+            "level": "warning",
+            "title": "Repo Memory Baseline Rewritten",
+            "message": "Stored repo-memory commit baseline is not an ancestor of the current HEAD. History was probably rebased or force-pushed, so incremental commit detection was skipped.",
+            "next_steps": [
+                "Run $repo-wiki repo-build for a full rebuild, or explicitly choose a new baseline before incremental commit updates.",
+            ],
+            "render_as": "assistant_message",
+        })
+    if provider_fetch.get("attempted") is True and provider_fetch.get("ok") is False:
+        notices.append({
+            "level": "warning",
+            "title": "Provider Delta Fetch Failed",
+            "message": "Provider delta fetch failed; keeping existing PR/issue resources unchanged. Fix provider access before rerunning provider deltas.",
+            "next_steps": [
+                "Fix GitHub/GitLab CLI access and rerun $repo-wiki repo-update.",
+                "Use $repo-wiki repo-build for a full provider refresh if a broader rebuild is needed.",
+            ],
+            "render_as": "assistant_message",
+        })
+    return notices
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Detect incremental updates for an existing .repo_memory bundle.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--memory-path", help="Existing .repo_memory path; defaults to <repo>/.repo_memory")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref used for current detection")
+    parser.add_argument("--history-mode", choices=sorted(HISTORY_MODES), default=None, help="History evidence policy for this update")
+    parser.add_argument("--provider-mode", choices=["auto", "off"], default="auto", help="Whether to fetch latest provider PR/issue facets when provider evidence is ready")
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum latest PR/MR candidates to compare")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum latest issue candidates to compare")
+    parser.add_argument("--summary-chars", type=int, default=None, help="Maximum raw provider summary characters when provider facets are fetched")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = parser.parse_args(argv)
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return apply_effective_settings(args, parser)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = args.repo_path
+    memory = resolve_memory(repo, args.memory_path)
+    if not memory.exists() or not (memory / "PROFILE.md").exists():
+        report = {
+            "ok": False,
+            "repo_path": str(repo),
+            "memory_path": str(memory),
+            "builder_helpers": builder_helper_report(),
+            "error": "Existing .repo_memory/PROFILE.md is required; run $repo-wiki repo-build before repo-update.",
+        }
+        print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+        return 1
+
+    head = git(repo, ["rev-parse", "--verify", f"{args.snapshot_ref}^{{commit}}"], f"git could not resolve {args.snapshot_ref!r}")
+    baseline_sha = commit_baseline(memory, repo, head)
+    if args.history_collect["commits"]:
+        local_commits, local_commit_status = commit_delta(repo, baseline_sha, head)
+    else:
+        local_commits, local_commit_status = [], {
+            "status": "skipped",
+            "reason": "history_disabled_by_policy",
+            "message": "Local commit delta detection is disabled by repoHistory.mode.",
+        }
+
+    existing_prs = baseline_items(memory, "prs.md", "pr")
+    existing_issues = baseline_items(memory, "issues.md", "issue")
+    provider = provider_report(repo, memory, inspect_cli=args.history_collect["provider"])
+    if args.history_collect["provider"]:
+        provider_fetch, current_prs, current_issues = fetch_provider_items(
+            repo,
+            provider,
+            args.snapshot_ref,
+            args.pr_limit,
+            args.issue_limit,
+            args.summary_chars,
+        )
+    else:
+        reason = (
+            "provider-mode=off"
+            if args.provider_mode == "off"
+            else "history_disabled_by_policy"
+            if args.history_mode == "none"
+            else "history_provider_disabled_by_policy"
+        )
+        provider_fetch, current_prs, current_issues = {"attempted": False, "reason": reason}, [], []
+    fetched_prs = current_prs if provider_fetch.get("ok") is True else []
+    fetched_issues = current_issues if provider_fetch.get("ok") is True else []
+    if not current_prs and provider_fetch.get("ok") is not True:
+        current_prs = existing_prs
+    if not current_issues and provider_fetch.get("ok") is not True:
+        current_issues = existing_issues
+
+    deltas = {
+        "local_commits": local_commits,
+        "local_commit_status": local_commit_status,
+        "pull_requests": delta_summary(existing_prs, current_prs),
+        "issues": delta_summary(existing_issues, current_issues),
+    }
+    if local_commit_status.get("status") == "skipped" and local_commit_status.get("reason"):
+        deltas["commit_delta_skipped"] = local_commit_status["reason"]
+    report = {
+        "ok": True,
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "effective_settings": args.effective_settings,
+        "builder_helpers": builder_helper_report(),
+        "baseline": {
+            "local_commit_sha": baseline_sha,
+            "pull_request_numbers": deltas["pull_requests"]["baseline_numbers"],
+            "issue_numbers": deltas["issues"]["baseline_numbers"],
+        },
+        "current": {
+            "local_head": head,
+            "provider": provider,
+            "provider_fetch": provider_fetch,
+            "provider_items": {
+                "pull_requests": fetched_prs,
+                "issues": fetched_issues,
+            },
+        },
+        "deltas": deltas,
+        "notices": notices_for(deltas, provider_fetch),
+        "actions": actions_for(deltas, provider_fetch),
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/git_commit_facets.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/git_commit_facets.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Extract local git commit facets without GitHub/GitLab provider access."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for local commit facets")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def git_stdout(repo_path: Path, args: list[str], message: str) -> str:
+    result = run_git(repo_path, args)
+    if result.returncode != 0:
+        raise SystemExit(f"{message}:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    return git_stdout(
+        repo_path,
+        ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"],
+        f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}",
+    ).strip()
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    if repo_path.endswith(".git"):
+        repo_path = repo_path[:-4]
+    return repo_path
+
+
+def repo_name_from_remote(url: str) -> str:
+    if not url:
+        return ""
+    if "://" not in url:
+        match = re.match(r"^(?:[^@/\s]+@)?[^:/\s]+:(?P<path>.+)$", url)
+        return normalize_remote_path(match.group("path")) if match else ""
+    parsed = urlparse(url)
+    return normalize_remote_path(parsed.path)
+
+
+def repo_name(repo_path: Path) -> str:
+    remote = run_git(repo_path, ["remote", "get-url", "origin"])
+    parsed = repo_name_from_remote(remote.stdout.strip()) if remote.returncode == 0 else ""
+    return parsed or repo_path.name
+
+
+def unique(values: Iterable[Any]) -> list[Any]:
+    seen: set[Any] = set()
+    out: list[Any] = []
+    for value in values:
+        if value in (None, "") or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def path_module(path: str) -> str:
+    parts = [part for part in path.split("/") if part and part not in {".", ".."}]
+    if not parts:
+        return ""
+    if parts[0] == ".github":
+        return ".github/workflows"
+    if "." in parts[0] and len(parts) == 1:
+        return ""
+    return parts[0]
+
+
+def path_modules(files: list[str]) -> list[str]:
+    return unique(module for module in (path_module(path) for path in files) if module)
+
+
+def key_files(files: list[str], limit: int = 8) -> list[str]:
+    def score(path: str) -> tuple[int, int, str]:
+        lower = path.lower()
+        value = 0
+        if "readme" in lower or lower.endswith((".md", ".rst")):
+            value += 2
+        if any(token in lower for token in ["/src/", "/core/", "/server", "/api", "/train", "/rollout", "/loss", "/model", "/actor", "/data"]):
+            value += 4
+        if lower.endswith((".py", ".ts", ".tsx", ".rs", ".go", ".sh", ".yaml", ".yml", ".toml", ".json")):
+            value += 1
+        return (-value, len(path), path)
+
+    return sorted(files, key=score)[:limit]
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique(symbols)
+
+
+def parse_numstat(text: str) -> tuple[list[str], int, int]:
+    files: list[str] = []
+    additions = 0
+    deletions = 0
+    for line in text.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        add, delete, path = parts[0], parts[1], parts[2]
+        if add.isdigit():
+            additions += int(add)
+        if delete.isdigit():
+            deletions += int(delete)
+        if path:
+            files.append(path)
+    return unique(files), additions, deletions
+
+
+def commit_facet(repo: str, repo_path: Path, sha: str, summary_chars: int) -> dict[str, Any]:
+    fields = git_stdout(
+        repo_path,
+        ["show", "-s", "--date=iso-strict", "--format=%H%x1f%h%x1f%P%x1f%an%x1f%ad%x1f%s", sha],
+        f"git could not read commit metadata for {sha}",
+    ).rstrip("\n").split("\x1f")
+    full_sha, short_sha, parents, author, authored_at, title = (fields + [""] * 6)[:6]
+    body = git_stdout(repo_path, ["show", "-s", "--format=%B", sha], f"git could not read commit body for {sha}")
+    files, additions, deletions = parse_numstat(
+        git_stdout(repo_path, ["show", "--format=", "--numstat", "--no-renames", sha], f"git could not read commit diff for {sha}")
+    )
+    modules = path_modules(files)
+    keys = key_files(files)
+    summary = bounded_summary([body], summary_chars) or title
+    evidence = unique([
+        f"commit {short_sha}: {title}" if short_sha and title else "",
+        f"commit {short_sha} changed {', '.join(keys)}" if short_sha and keys else "",
+    ])
+    return {
+        "facetId": f"commit.{short_sha or full_sha[:12]}",
+        "sourceType": "commit",
+        "provider": "local_git",
+        "repo": repo,
+        "sha": full_sha,
+        "short_sha": short_sha,
+        "parents": [parent for parent in parents.split() if parent],
+        "is_merge": len([parent for parent in parents.split() if parent]) > 1,
+        "title": title,
+        "summary": summary,
+        "author": author,
+        "authoredAt": authored_at,
+        "updatedAt": authored_at,
+        "files": files,
+        "path_modules": modules,
+        "key_files": keys,
+        "changed_files": len(files),
+        "additions": additions,
+        "deletions": deletions,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def fetch_facets(repo_path: Path, snapshot_ref: str, limit: int, summary_chars: int) -> list[dict[str, Any]]:
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref)
+    shas = git_stdout(
+        repo_path,
+        ["rev-list", "--max-count", str(limit), snapshot_sha],
+        f"git could not list commits from {snapshot_ref!r} in {repo_path}",
+    ).splitlines()
+    name = repo_name(repo_path)
+    return [commit_facet(name, repo_path, sha.strip(), summary_chars) for sha in shas if sha.strip()]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract local git commit SourceFacet JSON without provider login.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref whose history should be collected")
+    parser.add_argument("--limit", type=int, default=30, help="Maximum commits retained from the snapshot history")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if args.limit < 1 or args.limit > 500:
+        parser.error("--limit must be from 1 to 500")
+    if args.summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(args.repo_path, args.snapshot_ref, args.limit, args.summary_chars)
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/github_resource_facets.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/github_resource_facets.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Extract GitHub PR/issue resource facets with only Python stdlib + gh CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PR_LIST_FIELDS = "number,title,state,url,updatedAt,baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft"
+PR_VIEW_FIELDS = "number,title,body,state,url,updatedAt,createdAt,closedAt,mergedAt,author,comments,reviews,latestReviews,reviewDecision,files,commits,closingIssuesReferences,mergeCommit,baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft,additions,deletions,changedFiles"
+ISSUE_LIST_FIELDS = "number,title,state,url,updatedAt,labels"
+ISSUE_VIEW_FIELDS = "number,title,body,state,url,updatedAt,labels,comments"
+DEFAULT_GH_RETRIES = 3
+DEFAULT_GH_RETRY_DELAY_MS = 1000
+TRANSIENT_GH_ERROR = re.compile(
+    r"EOF|timeout|timed out|connection reset|connection refused|temporarily unavailable|"
+    r"TLS handshake timeout|502|503|504|rate limit|secondary rate limit|abuse detection",
+    re.IGNORECASE,
+)
+
+
+def is_transient_gh_error(stderr: str, stdout: str = "") -> bool:
+    return TRANSIENT_GH_ERROR.search(f"{stderr}\n{stdout}") is not None
+
+
+def run_gh(args: list[str], retries: int = DEFAULT_GH_RETRIES, retry_delay_ms: int = DEFAULT_GH_RETRY_DELAY_MS) -> Any:
+    if shutil.which("gh") is None:
+        raise SystemExit("GitHub CLI 'gh' is required. Install it and run: gh auth login")
+    attempts = max(1, retries + 1)
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["gh", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            text = result.stdout.strip()
+            return json.loads(text) if text else None
+        if attempt < attempts and is_transient_gh_error(result.stderr, result.stdout):
+            delay = max(0, retry_delay_ms) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"gh {' '.join(args)} failed with transient error; retrying "
+                f"{attempt}/{retries} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(f"gh {' '.join(args)} failed:\n{last_result.stderr.strip()}")
+
+
+def auth_status_failure(result: subprocess.CompletedProcess[str], login_hint: str) -> str:
+    details: list[str] = []
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    if stderr:
+        details.append(f"stderr: {stderr}")
+    if stdout:
+        details.append(f"stdout: {stdout}")
+    detail = "\n".join(details) if details else "gh auth status returned no diagnostic output"
+    return f"gh auth check failed with exit code {result.returncode}. Run: {login_hint}\n{detail}"
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for PR snapshot filtering")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    result = run_git(repo_path, ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"])
+    if result.returncode != 0:
+        raise SystemExit(f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def is_git_ancestor(repo_path: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    result = run_git(repo_path, ["merge-base", "--is-ancestor", ancestor_sha, descendant_sha])
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    stderr = result.stderr.strip()
+    normalized_stderr = stderr.lower()
+    if (
+        "not a valid commit" in normalized_stderr
+        or "no such commit" in normalized_stderr
+        or "not a valid object name" in normalized_stderr
+    ):
+        return False
+    raise SystemExit(
+        f"git could not compare {ancestor_sha} with snapshot {descendant_sha} in {repo_path}:\n{stderr}"
+    )
+
+
+def login_hint(hostname: str) -> str:
+    return f"gh auth login --hostname {hostname}" if hostname and hostname != "github.com" else "gh auth login"
+
+
+def repo_selector(repo: str, hostname: str) -> str:
+    if hostname and hostname != "github.com" and not repo.startswith(f"{hostname}/"):
+        return f"{hostname}/{repo}"
+    return repo
+
+
+def assert_gh_ready(hostname: str) -> None:
+    if shutil.which("gh") is None:
+        raise SystemExit("GitHub CLI 'gh' is required. Install it and run: gh auth login")
+    args = ["auth", "status"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    attempts = max(1, DEFAULT_GH_RETRIES + 1)
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["gh", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            return
+        if attempt < attempts and is_transient_gh_error(result.stderr, result.stdout):
+            delay = max(0, DEFAULT_GH_RETRY_DELAY_MS) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"gh auth status failed with transient error; retrying "
+                f"{attempt}/{DEFAULT_GH_RETRIES} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(auth_status_failure(last_result, login_hint(hostname)))
+
+
+def unique_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def unique_numbers(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    out: list[int] = []
+    for value in values:
+        if isinstance(value, int) and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def text_field(value: Any, *keys: str) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+    return ""
+
+
+def int_field(value: Any, key: str = "number") -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, dict) and isinstance(value.get(key), int):
+        return value[key]
+    return None
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique_strings(symbols)
+
+
+def commit_sha(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("commit"), dict):
+        return text_field(value["commit"], "oid", "sha", "abbreviatedOid")
+    return text_field(value, "oid", "sha", "abbreviatedOid")
+
+
+def commit_headline(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("commit"), dict):
+        return text_field(value["commit"], "messageHeadline", "message", "title")
+    return text_field(value, "messageHeadline", "message", "title")
+
+
+def author_login(value: Any) -> str:
+    return text_field(value, "login", "name")
+
+
+def review_state(value: Any) -> str:
+    return text_field(value, "state")
+
+
+def file_path(value: Any) -> str:
+    return text_field(value, "path", "filename")
+
+
+def label_name(value: Any) -> str:
+    return text_field(value, "name")
+
+
+def repo_name(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    owner = value.get("owner")
+    owner_login = text_field(owner, "login") if isinstance(owner, dict) else ""
+    name = text_field(value, "name", "nameWithOwner")
+    name_with_owner = text_field(value, "nameWithOwner")
+    if name_with_owner and "/" in name_with_owner:
+        return name_with_owner
+    return f"{owner_login}/{name}" if owner_login and name else name
+
+
+def body_text(value: Any) -> str:
+    return text_field(value, "body", "title", "name")
+
+
+def pr_detail_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail) or 0
+    title = text_field(detail, "title") or f"PR #{number}"
+    body = text_field(detail, "body")
+    comments = [body_text(item) for item in detail.get("comments", []) if body_text(item)]
+    reviews = [body_text(item) for item in detail.get("reviews", []) if body_text(item)]
+    commits = unique_strings(commit_sha(item) for item in detail.get("commits", []) if commit_sha(item))
+    commit_headlines = unique_strings(commit_headline(item) for item in detail.get("commits", []) if commit_headline(item))
+    files = unique_strings(file_path(item) for item in detail.get("files", []) if file_path(item))
+    review_states = unique_strings(review_state(item) for item in detail.get("latestReviews", []) if review_state(item))
+    issues = unique_numbers(
+        number for number in (int_field(item) for item in detail.get("closingIssuesReferences", [])) if number is not None
+    )
+    summary = bounded_summary([body, *comments, *reviews], summary_chars) or title
+    base_ref = text_field(detail, "baseRefName")
+    head_ref = text_field(detail, "headRefName")
+    head_repo = repo_name(detail.get("headRepository")) or repo
+    branch_label = f"{base_ref} <- {head_ref}" if base_ref or head_ref else ""
+    evidence = unique_strings(
+        [
+            f"PR #{number}: {title}",
+            f"PR #{number} changed {', '.join(files)}" if files else "",
+            f"PR #{number} closes issue {', '.join(f'#{issue}' for issue in issues)}" if issues else "",
+        ]
+    )
+    return {
+        "facetId": f"pr.{number}",
+        "sourceType": "pr",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "url"),
+        "state": text_field(detail, "state"),
+        "createdAt": text_field(detail, "createdAt"),
+        "updatedAt": text_field(detail, "updatedAt"),
+        "closedAt": text_field(detail, "closedAt"),
+        "mergedAt": text_field(detail, "mergedAt"),
+        "author": author_login(detail.get("author")),
+        "isDraft": bool(detail.get("isDraft")),
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "head_repo": head_repo,
+        "branch_label": branch_label,
+        "changed_files": detail.get("changedFiles") or len(files),
+        "additions": detail.get("additions") or 0,
+        "deletions": detail.get("deletions") or 0,
+        "commit_headlines": commit_headlines,
+        "review_decision": text_field(detail, "reviewDecision"),
+        "review_states": review_states,
+        "commits": commits,
+        "prs": [number] if number else [],
+        "issues": issues,
+        "files": files,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def issue_detail_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail) or 0
+    title = text_field(detail, "title") or f"Issue #{number}"
+    body = text_field(detail, "body")
+    comments = [body_text(item) for item in detail.get("comments", []) if body_text(item)]
+    labels = [label_name(item) for item in detail.get("labels", []) if label_name(item)]
+    labels_text = f"Labels: {', '.join(labels)}" if labels else ""
+    summary = bounded_summary([body, *comments, labels_text], summary_chars) or title
+    evidence = unique_strings(
+        [
+            f"issue #{number}: {title}",
+            f"issue #{number} labels: {', '.join(labels)}" if labels else "",
+        ]
+    )
+    return {
+        "facetId": f"issue.{number}",
+        "sourceType": "issue",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "url"),
+        "state": text_field(detail, "state"),
+        "updatedAt": text_field(detail, "updatedAt"),
+        "labels": labels,
+        "commits": [],
+        "prs": [],
+        "issues": [number] if number else [],
+        "files": [],
+        "symbols": extract_symbols("\n".join([title, summary, *labels])),
+        "evidence": evidence,
+    }
+
+
+def gh_list(kind: str, repo: str, limit: int, state: str, retries: int, retry_delay_ms: int) -> list[dict[str, Any]]:
+    fields = PR_LIST_FIELDS if kind == "pr" else ISSUE_LIST_FIELDS
+    return run_gh([kind, "list", "--repo", repo, "--limit", str(limit), "--state", state, "--json", fields], retries, retry_delay_ms)
+
+
+def gh_view(kind: str, repo: str, number: int, retries: int, retry_delay_ms: int) -> dict[str, Any]:
+    fields = PR_VIEW_FIELDS if kind == "pr" else ISSUE_VIEW_FIELDS
+    return run_gh([kind, "view", str(number), "--repo", repo, "--json", fields], retries, retry_delay_ms)
+
+
+def pr_is_in_snapshot(repo_path: Path, detail: dict[str, Any], snapshot_sha: str) -> bool:
+    if not snapshot_sha:
+        return True
+    merge_sha = commit_sha(detail.get("mergeCommit"))
+    return bool(merge_sha) and is_git_ancestor(repo_path, merge_sha, snapshot_sha)
+
+
+def fetch_pr_facets(
+    query_repo: str,
+    facet_repo: str,
+    repo_path: Path,
+    snapshot_sha: str,
+    limit: int,
+    state: str,
+    concurrency: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    if snapshot_sha and state == "open":
+        return []
+
+    facets: list[dict[str, Any]] = []
+    seen_numbers: set[int] = set()
+    candidate_limit = max(1, limit)
+    previous_candidate_count = -1
+
+    while len(facets) < limit:
+        candidates = gh_list("pr", query_repo, candidate_limit, state, retries, retry_delay_ms)
+        if not isinstance(candidates, list):
+            raise SystemExit("gh PR list response was not a JSON list")
+
+        candidate_count = len(candidates)
+        numbers: list[int] = []
+        for item in candidates:
+            number = int_field(item)
+            if number is not None and number not in seen_numbers:
+                seen_numbers.add(number)
+                numbers.append(number)
+
+        def one(number: int) -> dict[str, Any] | None:
+            detail = gh_view("pr", query_repo, number, retries, retry_delay_ms)
+            if snapshot_sha and not pr_is_in_snapshot(repo_path, detail, snapshot_sha):
+                return None
+            return pr_detail_to_facet(facet_repo, detail, summary_chars)
+
+        if numbers:
+            with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+                for facet in pool.map(one, numbers):
+                    if facet:
+                        facets.append(facet)
+                        if len(facets) >= limit:
+                            break
+
+        if len(facets) >= limit or candidate_count < candidate_limit or candidate_count == previous_candidate_count:
+            break
+        previous_candidate_count = candidate_count
+        candidate_limit *= 2
+
+    return facets[:limit]
+
+
+def fetch_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    snapshot_ref: str,
+    pr_limit: int,
+    issue_limit: int,
+    state: str,
+    include: set[str],
+    concurrency: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    assert_gh_ready(hostname)
+    selected_repo = repo_selector(repo, hostname)
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref) if snapshot_ref and "prs" in include else ""
+    facets: list[dict[str, Any]] = []
+    jobs: list[tuple[str, int]] = []
+    if "prs" in include:
+        facets.extend(fetch_pr_facets(selected_repo, repo, repo_path, snapshot_sha, pr_limit, state, concurrency, summary_chars, retries, retry_delay_ms))
+    if "issues" in include:
+        jobs.extend(("issue", item["number"]) for item in gh_list("issue", selected_repo, issue_limit, state, retries, retry_delay_ms))
+
+    def one(job: tuple[str, int]) -> dict[str, Any] | None:
+        kind, number = job
+        detail = gh_view(kind, selected_repo, number, retries, retry_delay_ms)
+        return issue_detail_to_facet(repo, detail, summary_chars)
+
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        facets.extend(facet for facet in pool.map(one, jobs) if facet)
+    return facets
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract GitHub PR/issue SourceFacet JSON using gh CLI.")
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--hostname", default="", help="GitHub hostname for auth/API commands; defaults to gh's current host")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path used for PR snapshot filtering")
+    parser.add_argument(
+        "--snapshot-ref",
+        default="",
+        help="Optional local git ref; PRs are kept only when their merge commit is an ancestor of this ref",
+    )
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum retained PRs after snapshot filtering")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum retained provider issues")
+    parser.add_argument("--state", choices=["all", "open", "closed"], default="all")
+    parser.add_argument("--include", default="prs,issues", help="Comma-separated: prs,issues")
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--gh-retries", type=int, default=DEFAULT_GH_RETRIES, help="Retries for transient gh CLI failures")
+    parser.add_argument("--gh-retry-delay-ms", type=int, default=DEFAULT_GH_RETRY_DELAY_MS, help="Initial retry delay for transient gh CLI failures")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if not re.match(r"^[^/]+/[^/]+$", args.repo):
+        parser.error("--repo must be owner/name")
+    include = {part.strip() for part in args.include.split(",") if part.strip()}
+    if not include or include - {"prs", "issues"}:
+        parser.error("--include must contain prs, issues, or prs,issues")
+    args.include = include
+    args.pr_limit = args.pr_limit if args.pr_limit is not None else 30
+    args.issue_limit = args.issue_limit if args.issue_limit is not None else 30
+    if args.pr_limit < 1 or args.pr_limit > 100:
+        parser.error("--pr-limit must be from 1 to 100")
+    if args.issue_limit < 1 or args.issue_limit > 100:
+        parser.error("--issue-limit must be from 1 to 100")
+    if args.concurrency < 1 or args.concurrency > 10:
+        parser.error("--concurrency must be from 1 to 10")
+    if args.gh_retries < 0 or args.gh_retries > 10:
+        parser.error("--gh-retries must be from 0 to 10")
+    if args.gh_retry_delay_ms < 0:
+        parser.error("--gh-retry-delay-ms must be non-negative")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(
+        args.repo,
+        args.repo_path,
+        args.hostname,
+        args.snapshot_ref,
+        args.pr_limit,
+        args.issue_limit,
+        args.state,
+        args.include,
+        args.concurrency,
+        args.summary_chars,
+        args.gh_retries,
+        args.gh_retry_delay_ms,
+    )
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/gitlab_resource_facets.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/gitlab_resource_facets.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Extract GitLab merge request/issue resource facets with Python stdlib + glab CLI."""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from urllib.parse import quote, urlencode
+
+
+DEFAULT_GLAB_RETRIES = 3
+DEFAULT_GLAB_RETRY_DELAY_MS = 1000
+TRANSIENT_GLAB_ERROR = re.compile(
+    r"EOF|timeout|timed out|connection reset|connection refused|temporarily unavailable|"
+    r"TLS handshake timeout|502|503|504|rate limit|too many requests",
+    re.IGNORECASE,
+)
+
+
+def is_transient_glab_error(stderr: str, stdout: str = "") -> bool:
+    return TRANSIENT_GLAB_ERROR.search(f"{stderr}\n{stdout}") is not None
+
+
+def run_glab_api(path: str, hostname: str = "", retries: int = DEFAULT_GLAB_RETRIES, retry_delay_ms: int = DEFAULT_GLAB_RETRY_DELAY_MS) -> Any:
+    if shutil.which("glab") is None:
+        raise SystemExit("GitLab CLI 'glab' is required. Install it and run: glab auth login")
+    args = ["api"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    args.append(path)
+    attempts = max(1, retries + 1)
+    last_result: Optional[subprocess.CompletedProcess[str]] = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["glab", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            text = result.stdout.strip()
+            return json.loads(text) if text else None
+        if attempt < attempts and is_transient_glab_error(result.stderr, result.stdout):
+            delay = max(0, retry_delay_ms) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"glab api {path} failed with transient error; retrying "
+                f"{attempt}/{retries} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(f"glab api {path} failed:\n{last_result.stderr.strip()}")
+
+
+def auth_status_failure(result: subprocess.CompletedProcess[str], login_hint: str) -> str:
+    details: list[str] = []
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    if stderr:
+        details.append(f"stderr: {stderr}")
+    if stdout:
+        details.append(f"stdout: {stdout}")
+    detail = "\n".join(details) if details else "glab auth status returned no diagnostic output"
+    return f"glab auth check failed with exit code {result.returncode}. Run: {login_hint}\n{detail}"
+
+
+def login_hint(hostname: str) -> str:
+    return f"glab auth login --hostname {hostname}" if hostname and hostname != "gitlab.com" else "glab auth login"
+
+
+def assert_glab_ready(hostname: str) -> None:
+    if shutil.which("glab") is None:
+        raise SystemExit("GitLab CLI 'glab' is required. Install it and run: glab auth login")
+    args = ["auth", "status"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    attempts = max(1, DEFAULT_GLAB_RETRIES + 1)
+    last_result: Optional[subprocess.CompletedProcess[str]] = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["glab", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            return
+        if attempt < attempts and is_transient_glab_error(result.stderr, result.stdout):
+            delay = max(0, DEFAULT_GLAB_RETRY_DELAY_MS) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"glab auth status failed with transient error; retrying "
+                f"{attempt}/{DEFAULT_GLAB_RETRIES} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(auth_status_failure(last_result, login_hint(hostname)))
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for MR snapshot filtering")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    result = run_git(repo_path, ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"])
+    if result.returncode != 0:
+        raise SystemExit(f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def is_git_ancestor(repo_path: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    result = run_git(repo_path, ["merge-base", "--is-ancestor", ancestor_sha, descendant_sha])
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    stderr = result.stderr.strip()
+    normalized_stderr = stderr.lower()
+    if (
+        "not a valid commit" in normalized_stderr
+        or "no such commit" in normalized_stderr
+        or "not a valid object name" in normalized_stderr
+    ):
+        return False
+    raise SystemExit(
+        f"git could not compare {ancestor_sha} with snapshot {descendant_sha} in {repo_path}:\n{stderr}"
+    )
+
+
+def api_path(repo: str, endpoint: str, params: Optional[dict[str, Any]] = None) -> str:
+    encoded_repo = quote(repo, safe="")
+    query = urlencode(params or {})
+    path = f"projects/{encoded_repo}/{endpoint}"
+    return f"{path}?{query}" if query else path
+
+
+def state_param(state: str) -> str:
+    return {"open": "opened", "closed": "closed"}.get(state, state)
+
+
+def normalize_state(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if raw == "opened":
+        return "OPEN"
+    if raw == "merged":
+        return "MERGED"
+    if raw == "closed":
+        return "CLOSED"
+    return raw.upper() if raw else ""
+
+
+def unique_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def unique_numbers(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    out: list[int] = []
+    for value in values:
+        if isinstance(value, int) and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def text_field(value: Any, *keys: str) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+    return ""
+
+
+def int_field(value: Any, key: str) -> Optional[int]:
+    if not isinstance(value, dict):
+        return None
+    item = value.get(key)
+    if isinstance(item, int):
+        return item
+    if isinstance(item, str) and item.isdigit():
+        return int(item)
+    return None
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique_strings(symbols)
+
+
+def linked_issue_numbers(text: str) -> list[int]:
+    numbers = [int(match.group(1)) for match in re.finditer(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", text, re.IGNORECASE)]
+    return unique_numbers(numbers)
+
+
+def author_login(value: Any) -> str:
+    return text_field(value, "username", "login", "name")
+
+
+def label_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return unique_strings(text_field(item, "name") if isinstance(item, dict) else str(item).strip() for item in value)
+
+
+def change_paths(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    changes = value.get("changes")
+    if not isinstance(changes, list):
+        return []
+    paths: list[str] = []
+    for item in changes:
+        if isinstance(item, dict):
+            path = text_field(item, "new_path", "old_path")
+            if path:
+                paths.append(path)
+    return unique_strings(paths)
+
+
+def mr_to_facet(repo: str, detail: dict[str, Any], changes: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail, "iid") or 0
+    title = text_field(detail, "title") or f"MR !{number}"
+    description = text_field(detail, "description")
+    files = change_paths(changes)
+    summary = bounded_summary([description], summary_chars) or title
+    base_ref = text_field(detail, "target_branch")
+    head_ref = text_field(detail, "source_branch")
+    branch_label = f"{base_ref} <- {head_ref}" if base_ref or head_ref else ""
+    issues = linked_issue_numbers(description)
+    merge_sha = text_field(detail, "merge_commit_sha", "squash_commit_sha")
+    evidence = unique_strings(
+        [
+            f"MR !{number}: {title}",
+            f"MR !{number} changed {', '.join(files)}" if files else "",
+            f"MR !{number} closes issue {', '.join(f'#{issue}' for issue in issues)}" if issues else "",
+        ]
+    )
+    return {
+        "facetId": f"mr.{number}",
+        "sourceType": "pr",
+        "provider": "gitlab",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "web_url", "url"),
+        "state": normalize_state(detail.get("state")),
+        "createdAt": text_field(detail, "created_at"),
+        "updatedAt": text_field(detail, "updated_at"),
+        "closedAt": text_field(detail, "closed_at"),
+        "mergedAt": text_field(detail, "merged_at"),
+        "author": author_login(detail.get("author")),
+        "isDraft": bool(detail.get("draft") or detail.get("work_in_progress")),
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "head_repo": repo,
+        "branch_label": branch_label,
+        "changed_files": int_field(detail, "changes_count") or len(files),
+        "additions": 0,
+        "deletions": 0,
+        "commit_headlines": [],
+        "review_decision": "",
+        "review_states": [],
+        "commits": [merge_sha] if merge_sha else [],
+        "merge_commit": merge_sha,
+        "prs": [number] if number else [],
+        "issues": issues,
+        "files": files,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def issue_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail, "iid") or 0
+    title = text_field(detail, "title") or f"Issue #{number}"
+    description = text_field(detail, "description")
+    labels = label_names(detail.get("labels"))
+    labels_text = f"Labels: {', '.join(labels)}" if labels else ""
+    summary = bounded_summary([description, labels_text], summary_chars) or title
+    evidence = unique_strings(
+        [
+            f"issue #{number}: {title}",
+            f"issue #{number} labels: {', '.join(labels)}" if labels else "",
+        ]
+    )
+    return {
+        "facetId": f"issue.{number}",
+        "sourceType": "issue",
+        "provider": "gitlab",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "web_url", "url"),
+        "state": normalize_state(detail.get("state")),
+        "updatedAt": text_field(detail, "updated_at"),
+        "labels": labels,
+        "commits": [],
+        "prs": [],
+        "issues": [number] if number else [],
+        "files": [],
+        "symbols": extract_symbols("\n".join([title, summary, *labels])),
+        "evidence": evidence,
+    }
+
+
+def mr_is_in_snapshot(repo_path: Path, detail: dict[str, Any], snapshot_sha: str) -> bool:
+    if not snapshot_sha:
+        return True
+    merge_sha = text_field(detail, "merge_commit_sha", "squash_commit_sha")
+    return bool(merge_sha) and is_git_ancestor(repo_path, merge_sha, snapshot_sha)
+
+
+def append_mr_facet(
+    facets: list[dict[str, Any]],
+    repo: str,
+    item: dict[str, Any],
+    hostname: str,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> None:
+    number = int_field(item, "iid")
+    if not number:
+        return
+    changes = run_glab_api(api_path(repo, f"merge_requests/{number}/changes"), hostname, retries, retry_delay_ms)
+    facets.append(mr_to_facet(repo, item, changes if isinstance(changes, dict) else {}, summary_chars))
+
+
+def fetch_mr_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    api_state: str,
+    snapshot_sha: str,
+    limit: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    if snapshot_sha and api_state == "opened":
+        return []
+
+    facets: list[dict[str, Any]] = []
+
+    if not snapshot_sha:
+        merge_requests = run_glab_api(
+            api_path(repo, "merge_requests", {"state": api_state, "per_page": limit, "order_by": "updated_at", "sort": "desc"}),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(merge_requests, list):
+            raise SystemExit("glab merge request list response was not a JSON list")
+        for item in merge_requests:
+            if isinstance(item, dict):
+                append_mr_facet(facets, repo, item, hostname, summary_chars, retries, retry_delay_ms)
+        return facets[:limit]
+
+    page = 1
+    while len(facets) < limit:
+        merge_requests = run_glab_api(
+            api_path(
+                repo,
+                "merge_requests",
+                {"state": api_state, "per_page": limit, "order_by": "updated_at", "sort": "desc", "page": page},
+            ),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(merge_requests, list):
+            raise SystemExit("glab merge request list response was not a JSON list")
+        if not merge_requests:
+            break
+
+        for item in merge_requests:
+            if not isinstance(item, dict) or not mr_is_in_snapshot(repo_path, item, snapshot_sha):
+                continue
+            append_mr_facet(facets, repo, item, hostname, summary_chars, retries, retry_delay_ms)
+            if len(facets) >= limit:
+                break
+
+        if len(facets) >= limit or len(merge_requests) < limit:
+            break
+        page += 1
+
+    return facets[:limit]
+
+
+def fetch_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    snapshot_ref: str,
+    pr_limit: int,
+    issue_limit: int,
+    state: str,
+    include: set[str],
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    assert_glab_ready(hostname)
+    api_state = state_param(state)
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref) if snapshot_ref and "prs" in include else ""
+    facets: list[dict[str, Any]] = []
+
+    if "prs" in include:
+        facets.extend(fetch_mr_facets(repo, repo_path, hostname, api_state, snapshot_sha, pr_limit, summary_chars, retries, retry_delay_ms))
+
+    if "issues" in include:
+        issues = run_glab_api(
+            api_path(repo, "issues", {"state": api_state, "per_page": issue_limit, "order_by": "updated_at", "sort": "desc"}),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(issues, list):
+            raise SystemExit("glab issue list response was not a JSON list")
+        facets.extend(issue_to_facet(repo, item, summary_chars) for item in issues if isinstance(item, dict))
+
+    return facets
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract GitLab MR/issue SourceFacet JSON using glab CLI.")
+    parser.add_argument("--repo", required=True, help="GitLab repository in group/project or group/subgroup/project form")
+    parser.add_argument("--hostname", default="", help="GitLab hostname for auth/API commands; defaults to glab's current host")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path used for MR snapshot filtering")
+    parser.add_argument(
+        "--snapshot-ref",
+        default="",
+        help="Optional local git ref; MRs are kept only when their merge commit is an ancestor of this ref",
+    )
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum retained MRs after snapshot filtering")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum retained provider issues")
+    parser.add_argument("--state", choices=["all", "open", "closed"], default="all")
+    parser.add_argument("--include", default="prs,issues", help="Comma-separated: prs,issues")
+    parser.add_argument("--glab-retries", type=int, default=DEFAULT_GLAB_RETRIES, help="Retries for transient glab CLI failures")
+    parser.add_argument("--glab-retry-delay-ms", type=int, default=DEFAULT_GLAB_RETRY_DELAY_MS, help="Initial retry delay for transient glab CLI failures")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if "/" not in args.repo:
+        parser.error("--repo must be group/project or group/subgroup/project")
+    include = {part.strip() for part in args.include.split(",") if part.strip()}
+    if not include or include - {"prs", "issues"}:
+        parser.error("--include must contain prs, issues, or prs,issues")
+    args.include = include
+    args.pr_limit = args.pr_limit if args.pr_limit is not None else 30
+    args.issue_limit = args.issue_limit if args.issue_limit is not None else 30
+    if args.pr_limit < 1 or args.pr_limit > 100:
+        parser.error("--pr-limit must be from 1 to 100")
+    if args.issue_limit < 1 or args.issue_limit > 100:
+        parser.error("--issue-limit must be from 1 to 100")
+    if args.glab_retries < 0 or args.glab_retries > 10:
+        parser.error("--glab-retries must be from 0 to 10")
+    if args.glab_retry_delay_ms < 0:
+        parser.error("--glab-retry-delay-ms must be non-negative")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(
+        args.repo,
+        args.repo_path,
+        args.hostname,
+        args.snapshot_ref,
+        args.pr_limit,
+        args.issue_limit,
+        args.state,
+        args.include,
+        args.summary_chars,
+        args.glab_retries,
+        args.glab_retry_delay_ms,
+    )
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/prepare_repo_memory.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/prepare_repo_memory.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Prepare an empty .repo_memory workspace; do not generate memory content."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPO_MEMORY_GITIGNORE_RULE = ".repo_memory/"
+PREFERRED_REMOTE_NAMES = ("upstream", "origin")
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def is_git_repo(repo: Path) -> bool:
+    code, out, _ = run(["git", "rev-parse", "--is-inside-work-tree"], repo)
+    return code == 0 and out == "true"
+
+
+def git_value(repo: Path, *args: str) -> str:
+    code, out, _ = run(["git", *args], repo)
+    return out if code == 0 else ""
+
+
+def remote_url_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def remote_name_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[0] if parts else ""
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    if repo_path.endswith(".git"):
+        repo_path = repo_path[:-4]
+    return repo_path
+
+
+def provider_from_host(host: str) -> str:
+    lower = host.lower()
+    if lower == "github.com" or "github" in lower:
+        return "github"
+    if lower == "gitlab.com" or "gitlab" in lower:
+        return "gitlab"
+    return ""
+
+
+def parse_remote_url(url: str) -> dict[str, str]:
+    if not url:
+        return {"provider": "", "repo": "", "host": "", "url": ""}
+
+    if "://" not in url:
+        scp_match = re.match(r"^(?:[^@/\s]+@)?(?P<host>[^:/\s]+):(?P<path>.+)$", url)
+        if scp_match:
+            host = scp_match.group("host")
+            repo_path = normalize_remote_path(scp_match.group("path"))
+            return {"provider": provider_from_host(host), "repo": repo_path, "host": host, "url": url}
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    repo_path = normalize_remote_path(parsed.path)
+    return {"provider": provider_from_host(host), "repo": repo_path, "host": host, "url": url}
+
+
+def parse_code_host_repo(remotes: str) -> dict[str, str]:
+    candidates: list[dict[str, str]] = []
+    for line in remotes.splitlines():
+        if "(push)" in line:
+            continue
+        parsed = parse_remote_url(remote_url_from_line(line))
+        if parsed["provider"] and parsed["repo"]:
+            parsed["remote_name"] = remote_name_from_line(line)
+            candidates.append(parsed)
+    for preferred in PREFERRED_REMOTE_NAMES:
+        for candidate in candidates:
+            if candidate.get("remote_name") == preferred:
+                candidate["selection_reason"] = f"preferred_{preferred}_fetch_remote"
+                return candidate
+    if candidates:
+        candidates[0]["selection_reason"] = "first_supported_fetch_remote"
+        return candidates[0]
+    return {"provider": "", "repo": "", "host": "", "url": "", "remote_name": "", "selection_reason": "none"}
+
+
+def auth_args(command: str, host: str) -> list[str]:
+    args = ["auth", "status"]
+    if host and command in {"gh", "glab"}:
+        args.extend(["--hostname", host])
+    return args
+
+
+def login_hint(command: str, host: str) -> str:
+    default_host = "github.com" if command == "gh" else "gitlab.com" if command == "glab" else ""
+    if host and host != default_host:
+        return f"{command} auth login --hostname {host}"
+    return f"{command} auth login"
+
+
+def gitignore_has_repo_memory_rule(text: str) -> bool:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("!"):
+            continue
+        rule = stripped.split("#", 1)[0].strip().lstrip("/")
+        if rule in {".repo_memory", ".repo_memory/"}:
+            return True
+    return False
+
+
+def ensure_repo_memory_gitignore(repo: Path) -> bool:
+    gitignore = repo / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    if gitignore_has_repo_memory_rule(existing):
+        return False
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    gitignore.write_text(f"{existing}{separator}{REPO_MEMORY_GITIGNORE_RULE}\n", encoding="utf-8")
+    return True
+
+
+def cli_auth_state(command: str, auth_args: list[str], login_hint: str) -> dict[str, Any]:
+    if shutil.which(command) is None:
+        return {
+            "available": False,
+            "authenticated": False,
+            "auth_status": "cli_missing",
+            "auth_error": "",
+            "login_hint": login_hint,
+        }
+    try:
+        proc = subprocess.run([command, *auth_args], text=True, capture_output=True, timeout=8)
+    except subprocess.TimeoutExpired:
+        return {
+            "available": True,
+            "authenticated": False,
+            "auth_status": "auth_check_timeout",
+            "auth_error": f"{command} auth check timed out",
+            "login_hint": login_hint,
+        }
+    if proc.returncode == 0:
+        return {
+            "available": True,
+            "authenticated": True,
+            "auth_status": "authenticated",
+            "auth_error": "",
+            "login_hint": login_hint,
+        }
+    error = (proc.stderr.strip() or proc.stdout.strip()).splitlines()
+    return {
+        "available": True,
+        "authenticated": False,
+        "auth_status": "auth_required",
+        "auth_error": error[0][:500] if error else "",
+        "login_hint": login_hint,
+    }
+
+
+def provider_label(provider: str) -> str:
+    if provider == "github":
+        return "GitHub"
+    if provider == "gitlab":
+        return "GitLab"
+    return "Git provider"
+
+
+def provider_evidence_label(provider: str) -> str:
+    if provider == "github":
+        return "GitHub PR/issue"
+    if provider == "gitlab":
+        return "GitLab MR/issue"
+    return "provider"
+
+
+def notice_markdown(body: str, command: str, rerun_line: str) -> str:
+    command_block = f"\n```bash\n{command}\n```\n" if command else ""
+    return "\n".join(
+        [
+            "**Provider Evidence Unavailable**",
+            "",
+            f"> {body}",
+            "> Continuing with local-only repo memory now.",
+            "",
+            "**Next steps for provider evidence**",
+            command_block.rstrip(),
+            rerun_line,
+        ]
+    ).strip()
+
+
+def non_git_repo_notice(repo: Path) -> str:
+    return "\n".join(
+        [
+            "**Repo Memory Cannot Be Built Yet**",
+            "",
+            f"> This folder is not a git repository: {repo}",
+            "> The $repo-wiki repo-build operation cannot collect local commit history or provider-linked PR/MR/issue evidence.",
+            "",
+            "**Next steps**",
+            "- If this is an existing project, open the real cloned repo directory.",
+            "- If this is a new project, run `git init` first, make at least one commit, then rerun $repo-wiki repo-build.",
+            "- If you only want file inspection, continue by inspecting files without repo memory.",
+        ]
+    )
+
+
+def provider_notice(provider: str, cli: str, evidence_state: str, login_hint: str) -> dict[str, Any]:
+    label = provider_label(provider)
+    evidence_label = provider_evidence_label(provider)
+    if evidence_state == "ready":
+        return {
+            "provider_notice_level": "info",
+            "provider_user_notice": f"{label} provider evidence is ready; {evidence_label} evidence can be collected.",
+            "provider_notice_markdown": (
+                f"**Provider Evidence Ready**\n\n"
+                f"> {label} provider evidence is ready.\n\n"
+                f"`{evidence_label}` evidence can be collected."
+            ),
+            "provider_next_steps": [],
+        }
+    if evidence_state == "auth_required":
+        body = f"{label} provider evidence is unavailable because `{cli}` is not logged in."
+        rerun_line = f"Rerun $repo-wiki repo-build to collect {evidence_label} evidence."
+        return {
+            "provider_notice_level": "warning",
+            "provider_user_notice": (
+                f"{body} "
+                f"I am continuing with local-only repo memory now. To include {evidence_label} evidence, "
+                f"run `{login_hint}`, then rerun $repo-wiki repo-build."
+            ),
+            "provider_notice_markdown": notice_markdown(body, login_hint, rerun_line),
+            "provider_next_steps": [
+                f"Run: {login_hint}",
+                rerun_line,
+            ],
+        }
+    if evidence_state == "cli_missing":
+        body = f"{label} provider evidence is unavailable because `{cli}` is not installed."
+        rerun_line = f"Rerun $repo-wiki repo-build to collect {evidence_label} evidence."
+        return {
+            "provider_notice_level": "warning",
+            "provider_user_notice": (
+                f"{body} "
+                f"I am continuing with local-only repo memory now. To include {evidence_label} evidence, "
+                f"install `{cli}`, run `{login_hint}`, then rerun $repo-wiki repo-build."
+            ),
+            "provider_notice_markdown": notice_markdown(body, login_hint, rerun_line),
+            "provider_next_steps": [
+                f"Install: {cli}",
+                f"Run: {login_hint}",
+                rerun_line,
+            ],
+        }
+    return {
+        "provider_notice_level": "info",
+        "provider_user_notice": "No supported GitHub/GitLab remote was detected; continuing with local-only repo memory.",
+        "provider_notice_markdown": (
+            "**Provider Evidence Unavailable**\n\n"
+            "> No supported GitHub/GitLab remote was detected.\n"
+            "> Continuing with local-only repo memory."
+        ),
+        "provider_next_steps": [],
+    }
+
+
+def provider_cli_report(provider: str, gh: dict[str, Any], glab: dict[str, Any]) -> dict[str, Any]:
+    if provider == "github":
+        state = gh
+        cli = "gh"
+    elif provider == "gitlab":
+        state = glab
+        cli = "glab"
+    else:
+        return {
+            "provider_cli": "",
+            "provider_cli_available": False,
+            "provider_authenticated": False,
+            "provider_auth_status": "no_supported_remote",
+            "provider_evidence_state": "unavailable",
+            "provider_login_hint": "",
+            "provider_fallback": "No supported GitHub/GitLab remote was detected; build local-only repo memory.",
+            **provider_notice(provider, "", "unavailable", ""),
+        }
+
+    if not state["available"]:
+        evidence_state = "cli_missing"
+        fallback = f"{cli} is not installed; build local-only repo memory unless the user installs the provider CLI."
+    elif not state["authenticated"]:
+        evidence_state = "auth_required"
+        fallback = f"{cli} is not authenticated; build local-only repo memory unless the user logs in and reruns provider collection."
+    else:
+        evidence_state = "ready"
+        fallback = "Provider evidence can be collected."
+
+    return {
+        "provider_cli": cli,
+        "provider_cli_available": state["available"],
+        "provider_authenticated": state["authenticated"],
+        "provider_auth_status": state["auth_status"],
+        "provider_evidence_state": evidence_state,
+        "provider_login_hint": state["login_hint"],
+        "provider_fallback": fallback,
+        **provider_notice(provider, cli, evidence_state, state["login_hint"]),
+    }
+
+
+def skipped_provider_report(provider: str, host: str) -> dict[str, Any]:
+    cli = "gh" if provider == "github" else "glab" if provider == "gitlab" else ""
+    return {
+        "provider_cli": cli,
+        "provider_cli_available": False,
+        "provider_authenticated": False,
+        "provider_auth_status": "skipped_by_policy",
+        "provider_evidence_state": "skipped_by_policy",
+        "provider_login_hint": login_hint(cli, host) if cli else "",
+        "provider_fallback": "Provider collection is disabled by the selected history policy.",
+        "provider_notice_level": "info",
+        "provider_user_notice": "Provider evidence collection was skipped by policy.",
+        "provider_notice_markdown": "",
+        "provider_next_steps": [],
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check environment and create .repo_memory directories only.")
+    parser.add_argument("repo", nargs="?", default=".", help="Local git repository path; defaults to current directory")
+    parser.add_argument("--reuse", action="store_true", help="Allow using an existing .repo_memory directory without deleting it")
+    parser.add_argument("--skip-provider-check", action="store_true", help="Do not inspect gh/glab availability or authentication")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+    if not repo.exists():
+        raise SystemExit(f"Repository path does not exist: {repo}")
+    if shutil.which("git") is None:
+        raise SystemExit("git is required but was not found on PATH")
+    if not is_git_repo(repo):
+        raise SystemExit(non_git_repo_notice(repo))
+
+    memory = repo / ".repo_memory"
+    if memory.exists() and not args.reuse:
+        raise SystemExit(f"{memory} already exists. Stop by default; rerun with --reuse to update it.")
+
+    for subdir in [memory, memory / "raw", memory / "resources"]:
+        subdir.mkdir(parents=True, exist_ok=True)
+
+    remotes = git_value(repo, "remote", "-v")
+    remote = parse_code_host_repo(remotes)
+    gitignore_updated = ensure_repo_memory_gitignore(repo)
+    gh_host = remote["host"] if remote["provider"] == "github" else ""
+    glab_host = remote["host"] if remote["provider"] == "gitlab" else ""
+    if args.skip_provider_check:
+        gh_state = {"available": False, "authenticated": False, "auth_status": "skipped_by_policy", "auth_error": "", "login_hint": login_hint("gh", gh_host)}
+        glab_state = {"available": False, "authenticated": False, "auth_status": "skipped_by_policy", "auth_error": "", "login_hint": login_hint("glab", glab_host)}
+        provider_report = skipped_provider_report(remote["provider"], remote["host"])
+    else:
+        gh_state = cli_auth_state("gh", auth_args("gh", gh_host), login_hint("gh", gh_host))
+        glab_state = cli_auth_state("glab", auth_args("glab", glab_host), login_hint("glab", glab_host))
+        provider_report = provider_cli_report(remote["provider"], gh_state, glab_state)
+    report: dict[str, Any] = {
+        "prepared_at": now_iso(),
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "is_git_repo": True,
+        "local_head": git_value(repo, "rev-parse", "HEAD"),
+        "local_branch": git_value(repo, "branch", "--show-current") or "(detached HEAD)",
+        "working_tree_state": "dirty" if git_value(repo, "status", "--short") else "clean",
+        "git_remotes": remotes.splitlines(),
+        "git_provider": remote["provider"],
+        "git_remote_repo": remote["repo"],
+        "git_remote_host": remote["host"],
+        "git_remote_url": remote["url"],
+        "git_remote_name": remote.get("remote_name", ""),
+        "git_remote_selection_reason": remote.get("selection_reason", ""),
+        "github_repo": remote["repo"] if remote["provider"] == "github" else "",
+        "gitlab_repo": remote["repo"] if remote["provider"] == "gitlab" else "",
+        "gh_available": gh_state["available"],
+        "gh_authenticated": gh_state["authenticated"],
+        "gh_auth_status": gh_state["auth_status"],
+        "gh_auth_error": gh_state["auth_error"],
+        "gh_login_hint": gh_state["login_hint"],
+        "glab_available": glab_state["available"],
+        "glab_authenticated": glab_state["authenticated"],
+        "glab_auth_status": glab_state["auth_status"],
+        "glab_auth_error": glab_state["auth_error"],
+        "glab_login_hint": glab_state["login_hint"],
+        **provider_report,
+        "gitignore_path": str(repo / ".gitignore"),
+        "gitignore_rule": REPO_MEMORY_GITIGNORE_RULE,
+        "gitignore_updated": gitignore_updated,
+        "created_directories": [".repo_memory", ".repo_memory/raw", ".repo_memory/resources"],
+        "next_step": "Agent must inspect local code/docs and author PROFILE.md and resources. This script intentionally does not generate memory content.",
+    }
+    (memory / "raw" / "prepare-report.json").write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/codex-memory-plugin/skills/repo-wiki/scripts/validate_memory.py
+++ b/examples/codex-memory-plugin/skills/repo-wiki/scripts/validate_memory.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Validate authored repo-memory bundles."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BASELINE_FILES = [
+    Path("PROFILE.md"),
+    Path("resources/commits.md"),
+    Path("resources/prs.md"),
+    Path("resources/issues.md"),
+    Path("raw/git-commits.json"),
+]
+
+PROVIDER_RAW_FILES = [Path("raw/github-facets.json"), Path("raw/gitlab-facets.json")]
+PROVIDER_RESOURCE_FILES = [Path("resources/prs.md"), Path("resources/issues.md")]
+DISABLED_RESOURCE_SOURCES = {"history_disabled", "provider_skipped_local_only", "provider_unavailable", "github_resource_facets_unavailable", "gitlab_resource_facets_unavailable", "provider_unavailable_local_only"}
+PLACEHOLDER_RE = re.compile(r"\[([^\]\n]+)\]")
+LINK_TARGET_AFTER_BRACKET_RE = re.compile(r"[ \t\r\n]*\(")
+
+
+def relative(path: Path, memory: Path) -> str:
+    return path.relative_to(memory).as_posix()
+
+
+def resolve_memory_root(path: Path) -> Path:
+    candidate = path.expanduser().resolve()
+    if candidate.name == ".repo_memory":
+        return candidate
+    return candidate / ".repo_memory"
+
+
+def parse_frontmatter(text: str) -> dict[str, Any]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    values: dict[str, Any] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+            values[key] = value[1:-1]
+        elif re.fullmatch(r"-?\d+", value):
+            values[key] = int(value)
+        elif value.lower() == "true":
+            values[key] = True
+        elif value.lower() == "false":
+            values[key] = False
+        else:
+            values[key] = value
+    return values
+
+
+def body_after_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return text
+    return text[end + 4 :].lstrip("\n")
+
+
+def item_section_count(text: str) -> int:
+    body = body_after_frontmatter(text)
+    lines = body.splitlines()
+    title_seen = False
+    count = 0
+    for line in lines:
+        if line.startswith("# ") and not title_seen:
+            title_seen = True
+            continue
+        if title_seen and line.startswith("## "):
+            count += 1
+    return count
+
+
+def placeholder_matches(text: str) -> list[str]:
+    text = strip_markdown_code(text)
+    matches: list[str] = []
+    for match in PLACEHOLDER_RE.finditer(text):
+        if LINK_TARGET_AFTER_BRACKET_RE.match(text, match.end()):
+            continue
+        value = match.group(1).strip()
+        if not value or value.startswith("#"):
+            continue
+        if re.search(r"[A-Za-z]", value):
+            matches.append(f"[{value}]")
+    return matches
+
+
+def strip_markdown_code(text: str) -> str:
+    without_fences = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    return re.sub(r"`[^`\n]*`", "", without_fences)
+
+
+def check_exists(memory: Path, rel_path: Path, errors: list[str], checked: list[str]) -> bool:
+    path = memory / rel_path
+    checked.append(rel_path.as_posix())
+    if not path.exists():
+        errors.append(f"{rel_path.as_posix()}: required file is missing")
+        return False
+    if not path.is_file():
+        errors.append(f"{rel_path.as_posix()}: expected a file")
+        return False
+    return True
+
+
+def validate_json(path: Path, memory: Path, errors: list[str], checked: list[str]) -> None:
+    checked.append(relative(path, memory))
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{relative(path, memory)}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}")
+    except OSError as exc:
+        errors.append(f"{relative(path, memory)}: could not read JSON: {exc}")
+
+
+def raw_source_points_to_provider(raw_source: Any) -> bool:
+    return isinstance(raw_source, str) and raw_source.endswith(("github-facets.json", "gitlab-facets.json"))
+
+
+def validate_markdown(path: Path, memory: Path, errors: list[str], warnings: list[str], checked: list[str]) -> None:
+    checked.append(relative(path, memory))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{relative(path, memory)}: could not read Markdown: {exc}")
+        return
+
+    frontmatter = parse_frontmatter(text)
+    rel = relative(path, memory)
+    if not frontmatter.get("schema"):
+        errors.append(f"{rel}: frontmatter field 'schema' is missing")
+    if path.name == "PROFILE.md":
+        source_tree = str(frontmatter.get("source_tree") or "")
+        if re.fullmatch(r"[0-9a-fA-F]{40}", source_tree) is None:
+            errors.append(f"{rel}: source_tree must be a full Git tree SHA")
+
+    placeholders = placeholder_matches(text)
+    if placeholders:
+        errors.append(f"{rel}: unresolved bracket placeholder(s): {', '.join(placeholders)}")
+
+    if path.parent.name != "resources":
+        return
+
+    for field in ["source", "resource_count", "trust_state", "raw_source"]:
+        if field not in frontmatter:
+            errors.append(f"{rel}: frontmatter field '{field}' is missing")
+
+    expected = frontmatter.get("resource_count")
+    actual = item_section_count(text)
+    if isinstance(expected, int):
+        if expected != actual:
+            errors.append(f"{rel}: resource_count is {expected}, but found {actual} item section(s)")
+    elif expected is not None:
+        errors.append(f"{rel}: resource_count must be an integer")
+
+    source = frontmatter.get("source")
+    raw_source = frontmatter.get("raw_source")
+    if "source" in frontmatter and not source:
+        errors.append(f"{rel}: frontmatter field 'source' must not be empty")
+    if "trust_state" in frontmatter and not frontmatter.get("trust_state"):
+        errors.append(f"{rel}: frontmatter field 'trust_state' must not be empty")
+    if source in DISABLED_RESOURCE_SOURCES and isinstance(expected, int) and expected != 0:
+        errors.append(f"{rel}: disabled or unavailable resource source {source!r} must use resource_count 0")
+    if source in DISABLED_RESOURCE_SOURCES and raw_source:
+        errors.append(f"{rel}: disabled or unavailable resource source {source!r} must use an empty raw_source")
+    if path.name in {"commits.md", "prs.md", "issues.md"} and source not in DISABLED_RESOURCE_SOURCES and raw_source == "":
+        errors.append(f"{rel}: empty raw_source requires a disabled or unavailable source")
+    if path.name in {"prs.md", "issues.md"} and raw_source_points_to_provider(raw_source):
+        provider_path = (path.parent / raw_source).resolve()
+        if not provider_path.exists():
+            errors.append(f"{rel}: provider raw evidence is missing for raw_source {raw_source!r}")
+
+
+def provider_raw_paths(memory: Path) -> list[Path]:
+    return [memory / rel for rel in PROVIDER_RAW_FILES if (memory / rel).exists()]
+
+
+def validate(memory: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked: list[str] = []
+
+    if not memory.exists():
+        errors.append(f"{memory}: .repo_memory directory is missing")
+        return {"ok": False, "errors": errors, "warnings": warnings, "checked": checked}
+    if not memory.is_dir():
+        errors.append(f"{memory}: expected .repo_memory to be a directory")
+        return {"ok": False, "errors": errors, "warnings": warnings, "checked": checked}
+
+    for rel_path in BASELINE_FILES:
+        check_exists(memory, rel_path, errors, checked)
+
+    markdown_paths = sorted(
+        path
+        for path in memory.rglob("*.md")
+        if path.is_file()
+    )
+    for path in markdown_paths:
+        if path.exists() and path.is_file():
+            validate_markdown(path, memory, errors, warnings, checked)
+
+    json_paths = sorted(path for path in (memory / "raw").rglob("*.json") if path.is_file())
+    provider_raw = provider_raw_paths(memory)
+
+    if provider_raw:
+        for rel_path in PROVIDER_RESOURCE_FILES:
+            check_exists(memory, rel_path, errors, checked)
+
+    seen_json: set[Path] = set()
+    for path in json_paths:
+        if path.exists() and path.is_file() and path not in seen_json:
+            seen_json.add(path)
+            validate_json(path, memory, errors, checked)
+
+    checked = sorted(dict.fromkeys(checked))
+    return {"ok": not errors, "errors": errors, "warnings": warnings, "checked": checked}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate a repo-memory bundle.")
+    parser.add_argument("path", help="Path to a repository or its .repo_memory directory")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    report = validate(resolve_memory_root(Path(args.path)))
+    print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/memory-plugin-shared/lib/repository-sync.mjs
+++ b/examples/memory-plugin-shared/lib/repository-sync.mjs
@@ -1,0 +1,345 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { resolveOpenVikingCredentials } from "./credentials.mjs";
+
+const execFileAsync = promisify(execFile);
+const MUTATING_GIT_COMMANDS = new Set([
+  "checkout",
+  "commit",
+  "merge",
+  "pull",
+  "rebase",
+  "reset",
+  "revert",
+  "switch",
+]);
+const STATE_DIR_MODE = 0o700;
+const STATE_FILE_MODE = 0o600;
+const LOCAL_REPOSITORY_KEY_CONFIG = "openviking.repositoryKey";
+
+function hash(value) {
+  return createHash("sha256").update(String(value || "")).digest("hex");
+}
+
+function safePart(value, fallback = "unknown") {
+  const normalized = String(value || "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return (normalized || fallback).slice(0, 96);
+}
+
+function branchTargetSegment(branch) {
+  const raw = String(branch || "").trim();
+  const normalized = safePart(raw);
+  if (normalized === raw && raw.length <= 96) return normalized;
+  return `${normalized.slice(0, 87)}-${hash(raw).slice(0, 8)}`;
+}
+
+function shellWords(command) {
+  return String(command || "").trim().split(/\s+/u);
+}
+
+function nestedInput(input = {}) {
+  return input.tool_input ?? input.toolInput ?? input.input ?? input.arguments ?? input.payload ?? {};
+}
+
+function commandText(input = {}) {
+  const toolInput = nestedInput(input);
+  let raw = typeof toolInput === "string"
+    ? toolInput
+    : (toolInput.command ?? toolInput.cmd ?? toolInput.script ?? input.command ?? input.cmd ?? "");
+  if (Array.isArray(raw) && raw.length >= 3 && /(?:^|\/)bash$/u.test(String(raw[0])) && raw[1] === "-lc") {
+    raw = raw[2];
+  }
+  return Array.isArray(raw) ? raw.join(" ") : String(raw || "");
+}
+
+function toolName(input = {}) {
+  const nested = nestedInput(input);
+  return String(
+    input.tool_name
+      ?? input.toolName
+      ?? input.name
+      ?? input.tool?.name
+      ?? input.tool
+      ?? nested.tool_name
+      ?? nested.toolName
+      ?? nested.name
+      ?? "",
+  );
+}
+
+function toolResponse(input = {}) {
+  const nested = nestedInput(input);
+  return input.tool_response
+    ?? input.toolResponse
+    ?? input.response
+    ?? input.tool_result
+    ?? nested.tool_response
+    ?? nested.toolResponse
+    ?? nested.response
+    ?? {
+      exit_code: input.exit_code ?? nested.exit_code,
+      exitCode: input.exitCode ?? nested.exitCode,
+      status: input.status ?? nested.status,
+      success: input.success ?? nested.success,
+    };
+}
+
+export function isSuccessfulGitMutation(input = {}) {
+  if (!/^(Bash|RunCommand|Shell|exec_command|codex_exec)$/u.test(toolName(input))) return false;
+
+  const response = toolResponse(input);
+  if (response && typeof response === "object") {
+    const code = response.exit_code ?? response.exitCode ?? response.code;
+    if (Number.isFinite(Number(code)) && Number(code) !== 0) return false;
+    const status = String(response.status ?? "").toLowerCase();
+    if (["error", "failed", "failure"].includes(status)) return false;
+    if (response.success === false) return false;
+  }
+
+  const command = commandText(input);
+  if (!command) return false;
+  const invocations = command.match(/(?:^|(?:&&|;|\|\|)\s*)git\s+([A-Za-z-]+)/gu) || [];
+  return invocations.some((entry) => {
+    const words = shellWords(entry.replace(/^(?:&&|;|\|\|)\s*/u, ""));
+    return words[0] === "git" && MUTATING_GIT_COMMANDS.has(words[1]);
+  });
+}
+
+function hookCwd(input = {}) {
+  const nested = nestedInput(input);
+  return String(input.cwd ?? nested.cwd ?? process.cwd());
+}
+
+async function runGit(cwd, args, timeout = 15_000) {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    timeout,
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+async function getLocalRepositoryKey(root) {
+  try {
+    const existing = await runGit(root, ["config", "--local", "--get", LOCAL_REPOSITORY_KEY_CONFIG]);
+    if (existing) return `local:${existing}`;
+  } catch {
+    // A new repository has no OpenViking identity yet.
+  }
+
+  const value = randomUUID();
+  try {
+    await runGit(root, ["config", "--local", LOCAL_REPOSITORY_KEY_CONFIG, value]);
+    return `local:${value}`;
+  } catch {
+    // The hook must never fail a completed Git command. The deterministic
+    // fallback remains machine-local and never leaves the client except hashed.
+    return `local:${hash(root)}`;
+  }
+}
+
+export async function resolveRepositoryContext(cwd) {
+  const root = await runGit(cwd, ["rev-parse", "--show-toplevel"]);
+  const commit = await runGit(root, ["rev-parse", "HEAD"]);
+  let branch = await runGit(root, ["branch", "--show-current"]);
+  if (!branch) branch = `detached-${commit.slice(0, 12)}`;
+
+  let origin = "";
+  try {
+    origin = await runGit(root, ["remote", "get-url", "origin"]);
+  } catch {
+    // This is the intended local-only repository case.
+  }
+  if (origin) {
+    return { root, commit: commit.toLowerCase(), branch, repoName: basename(root), remoteOrigin: origin };
+  }
+
+  const repoKey = await getLocalRepositoryKey(root);
+  return {
+    root,
+    commit: commit.toLowerCase(),
+    branch,
+    repoKey,
+    repoName: basename(root),
+    targetUri: `viking://resources/local-git/${hash(repoKey).slice(0, 24)}/${branchTargetSegment(branch)}`,
+  };
+}
+
+function statePath(context) {
+  const root = process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR
+    || join(process.env.HOME || tmpdir(), ".openviking", "repository-sync", "state");
+  return join(root, `${hash(`${context.repoKey}\n${context.branch}`)}.json`);
+}
+
+function lockPath(context) {
+  return `${statePath(context)}.lock`;
+}
+
+async function withRepositoryLock(context, callback) {
+  const lock = lockPath(context);
+  await mkdir(dirname(lock), { recursive: true, mode: STATE_DIR_MODE });
+  while (true) {
+    try {
+      await mkdir(lock, { mode: STATE_DIR_MODE });
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - (await stat(lock)).mtimeMs > 10 * 60_000) {
+          await rm(lock, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      return { status: "skipped", reason: "already-running", context };
+    }
+  }
+  try {
+    return await callback();
+  } finally {
+    await rm(lock, { recursive: true, force: true });
+  }
+}
+
+async function readState(context) {
+  try {
+    return JSON.parse(await readFile(statePath(context), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function writeState(context, value) {
+  const file = statePath(context);
+  await mkdir(dirname(file), { recursive: true, mode: STATE_DIR_MODE });
+  const temporary = `${file}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: STATE_FILE_MODE,
+  });
+  await rename(temporary, file);
+}
+
+export async function createRepositoryArchive(context) {
+  const directory = await mkdtemp(join(tmpdir(), "openviking-git-local-"));
+  await chmod(directory, STATE_DIR_MODE);
+  const archive = join(directory, `${safePart(context.repoName, "repository")}.zip`);
+  await execFileAsync(
+    "git",
+    ["-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD"],
+    { timeout: 120_000, maxBuffer: 1024 * 1024 },
+  );
+  await chmod(archive, STATE_FILE_MODE);
+  return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+}
+
+function authHeaders(credentials, contentType = "") {
+  const headers = {};
+  if (contentType) headers["Content-Type"] = contentType;
+  if (credentials.apiKey) headers.Authorization = `Bearer ${credentials.apiKey}`;
+  if (credentials.account) headers["X-OpenViking-Account"] = credentials.account;
+  if (credentials.user) headers["X-OpenViking-User"] = credentials.user;
+  if (credentials.peerId) headers["X-OpenViking-Actor-Peer"] = credentials.peerId;
+  if (credentials.userAgent) headers["User-Agent"] = credentials.userAgent;
+  return headers;
+}
+
+async function responseResult(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body.status === "error") {
+    const message = body.error?.message || body.message || `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return body.result ?? body;
+}
+
+export async function uploadRepositorySnapshot(credentials, archive) {
+  const form = new FormData();
+  const { openAsBlob } = await import("node:fs");
+  const content = typeof openAsBlob === "function"
+    ? await openAsBlob(archive, { type: "application/zip" })
+    : new Blob([await readFile(archive)], { type: "application/zip" });
+  form.append("file", content, basename(archive));
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources/temp_upload`, {
+    method: "POST",
+    headers: authHeaders(credentials),
+    body: form,
+  });
+  const result = await responseResult(response);
+  if (!result.temp_file_id) throw new Error("Temporary upload returned no temp_file_id.");
+  return result.temp_file_id;
+}
+
+export async function submitRepositorySnapshot(credentials, tempFileId, context) {
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources`, {
+    method: "POST",
+    headers: authHeaders(credentials, "application/json"),
+    body: JSON.stringify({
+      temp_file_id: tempFileId,
+      to: context.targetUri,
+      wait: false,
+      args: {
+        git_local: {
+          version: 1,
+          repo_key: context.repoKey,
+          repo_name: context.repoName,
+          branch: context.branch,
+          commit: context.commit,
+          archive_format: "zip",
+        },
+      },
+    }),
+  });
+  return responseResult(response);
+}
+
+export async function syncRepositoryFromHook(input, options = {}) {
+  if (!isSuccessfulGitMutation(input)) return { status: "skipped", reason: "not-git-mutation" };
+  const context = await resolveRepositoryContext(hookCwd(input));
+  if (context.remoteOrigin) return { status: "skipped", reason: "remote-backed", context };
+
+  return withRepositoryLock(context, async () => {
+    const previous = await readState(context);
+    if (previous.lastSubmittedCommit === context.commit) {
+      return { status: "skipped", reason: "already-submitted", context };
+    }
+
+    const credentials = options.credentials || resolveOpenVikingCredentials();
+    const bundle = await createRepositoryArchive(context);
+    try {
+      const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+      const result = await submitRepositorySnapshot(credentials, tempFileId, context);
+      await writeState(context, {
+        version: 1,
+        repoKey: context.repoKey,
+        branch: context.branch,
+        targetUri: context.targetUri,
+        lastSubmittedCommit: context.commit,
+        taskId: result.task_id || "",
+        updatedAt: new Date().toISOString(),
+      });
+      return { status: "submitted", context, result };
+    } finally {
+      await bundle.cleanup();
+    }
+  });
+}

--- a/examples/memory-plugin-shared/lib/repository-sync.mjs
+++ b/examples/memory-plugin-shared/lib/repository-sync.mjs
@@ -2,16 +2,18 @@ import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import {
   chmod,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rename,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { promisify } from "node:util";
 
 import { resolveOpenVikingCredentials } from "./credentials.mjs";
@@ -30,6 +32,12 @@ const MUTATING_GIT_COMMANDS = new Set([
 const STATE_DIR_MODE = 0o700;
 const STATE_FILE_MODE = 0o600;
 const LOCAL_REPOSITORY_KEY_CONFIG = "openviking.repositoryKey";
+const WIKI_DIR = ".repo_memory";
+const WIKI_PROFILE_SCHEMA = "repo_memory_profile.v0.2";
+const WIKI_PAGE_SCHEMA = "repo_memory_wiki_page.v0.1";
+const WIKI_RESOURCE_FILES = new Set(["commits.md", "prs.md", "issues.md"]);
+const WIKI_IGNORED_DIRS = new Set(["raw", "procedure-memory", "user-profile", "__pycache__"]);
+const WIKI_IGNORED_FILES = new Set([".DS_Store"]);
 
 function hash(value) {
   return createHash("sha256").update(String(value || "")).digest("hex");
@@ -156,9 +164,23 @@ async function getLocalRepositoryKey(root) {
   }
 }
 
+function stripRemoteCredentials(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    parsed.username = "";
+    parsed.password = "";
+    return parsed.toString().replace(/\/$/u, "");
+  } catch {
+    return raw.replace(/^(https?:\/\/)[^/@]+@/u, "$1");
+  }
+}
+
 export async function resolveRepositoryContext(cwd) {
   const root = await runGit(cwd, ["rev-parse", "--show-toplevel"]);
   const commit = await runGit(root, ["rev-parse", "HEAD"]);
+  const tree = await runGit(root, ["rev-parse", "HEAD^{tree}"]);
   let branch = await runGit(root, ["branch", "--show-current"]);
   if (!branch) branch = `detached-${commit.slice(0, 12)}`;
 
@@ -168,18 +190,18 @@ export async function resolveRepositoryContext(cwd) {
   } catch {
     // This is the intended local-only repository case.
   }
-  if (origin) {
-    return { root, commit: commit.toLowerCase(), branch, repoName: basename(root), remoteOrigin: origin };
-  }
-
-  const repoKey = await getLocalRepositoryKey(root);
+  const repoKey = origin ? stripRemoteCredentials(origin) : await getLocalRepositoryKey(root);
+  const repoId = hash(repoKey).slice(0, 24);
   return {
     root,
     commit: commit.toLowerCase(),
+    tree: tree.toLowerCase(),
     branch,
     repoKey,
+    repoId,
     repoName: basename(root),
-    targetUri: `viking://resources/local-git/${hash(repoKey).slice(0, 24)}/${branchTargetSegment(branch)}`,
+    remoteOrigin: Boolean(origin),
+    targetUri: `viking://resources/local-git/${repoId}/${branchTargetSegment(branch)}`,
   };
 }
 
@@ -245,11 +267,197 @@ export async function createRepositoryArchive(context) {
   const archive = join(directory, `${safePart(context.repoName, "repository")}.zip`);
   await execFileAsync(
     "git",
-    ["-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD"],
+    [
+      "-C", context.root, "archive", "--format=zip", `--output=${archive}`, "HEAD",
+      "--", ".", `:(exclude)${WIKI_DIR}`, `:(exclude)${WIKI_DIR}/**`,
+    ],
     { timeout: 120_000, maxBuffer: 1024 * 1024 },
   );
   await chmod(archive, STATE_FILE_MODE);
   return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+}
+
+function wikiUploadEnabled(options = {}) {
+  if (typeof options.wikiUploadEnabled === "boolean") return options.wikiUploadEnabled;
+  const value = String(process.env.OPENVIKING_REPO_WIKI_UPLOAD_ENABLED || "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(value);
+}
+
+function metadataValue(text, name) {
+  const prefix = `${name}:`;
+  const line = String(text || "").split(/\r?\n/u).find((candidate) => candidate.startsWith(prefix));
+  if (!line) return "";
+  return line.slice(prefix.length).trim().replace(/^["']|["']$/gu, "").trim();
+}
+
+function validUserId(value) {
+  const raw = String(value || "").trim();
+  return raw && raw !== "." && raw !== ".." && /^[A-Za-z0-9._-]+$/u.test(raw) ? raw : "";
+}
+
+export async function resolveEffectiveUserId(credentials, fetchImpl = globalThis.fetch) {
+  const configured = validUserId(credentials?.user);
+  if (configured) return configured;
+  for (const endpoint of ["/health", "/api/v1/system/status"]) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    try {
+      const response = await fetchImpl(`${credentials.baseUrl}${endpoint}`, {
+        headers: authHeaders(credentials),
+        signal: controller.signal,
+      });
+      if (!response.ok) continue;
+      const body = await response.json().catch(() => ({}));
+      const candidate = validUserId(body.user_id || body.result?.user);
+      if (candidate) return candidate;
+    } catch {
+      // A missing identity skips only Wiki publication.
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return "";
+}
+
+async function publicationFiles(wikiRoot) {
+  const profile = join(wikiRoot, "PROFILE.md");
+  const profileStat = await lstat(profile).catch(() => null);
+  if (!profileStat?.isFile() || profileStat.isSymbolicLink()) {
+    throw new Error("Wiki PROFILE.md is missing or unsafe.");
+  }
+  const files = ["PROFILE.md"];
+  for (const entry of await readdir(wikiRoot, { withFileTypes: true })) {
+    if (entry.name === "PROFILE.md" || entry.name === "_plan.md") continue;
+    if (entry.isSymbolicLink()) throw new Error(`Wiki contains an unsafe symlink: ${entry.name}`);
+    if (WIKI_IGNORED_FILES.has(entry.name) || /\.(?:lock|log|tmp)$/u.test(entry.name)) continue;
+    if (entry.isDirectory() && (entry.name === "resources" || WIKI_IGNORED_DIRS.has(entry.name))) continue;
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(entry.name);
+      continue;
+    }
+    throw new Error(`Wiki contains an unsupported root entry: ${entry.name}`);
+  }
+  const resources = join(wikiRoot, "resources");
+  const resourcesStat = await lstat(resources).catch(() => null);
+  if (resourcesStat?.isSymbolicLink()) throw new Error("Wiki resources directory is a symlink.");
+  if (resourcesStat?.isDirectory()) {
+    for (const entry of await readdir(resources, { withFileTypes: true })) {
+      if (entry.isSymbolicLink()) throw new Error(`Wiki contains an unsafe symlink: resources/${entry.name}`);
+      if (entry.isFile() && WIKI_RESOURCE_FILES.has(entry.name)) {
+        files.push(posix.join("resources", entry.name));
+        continue;
+      }
+      throw new Error(`Wiki contains an unsupported resource entry: resources/${entry.name}`);
+    }
+  }
+  return files.sort();
+}
+
+function validateWikiLinks(files, contents) {
+  const available = new Set(files);
+  for (const file of files) {
+    for (const match of contents.get(file).matchAll(/\[[^\]]*\]\(([^)]+)\)/gu)) {
+      const target = match[1].trim().split("#", 1)[0];
+      if (!target || /^(?:[a-z]+:|#)/iu.test(target)) continue;
+      const resolved = posix.normalize(posix.join(posix.dirname(file), target.replace(/^\.\//u, "")));
+      if (resolved.startsWith("../") || !available.has(resolved)) {
+        throw new Error(`Wiki link escapes or is missing: ${file} -> ${target}`);
+      }
+    }
+  }
+}
+
+function sanitizeWikiContent(content, repositoryRoot) {
+  const roots = new Set([String(repositoryRoot || "")]);
+  if (repositoryRoot.startsWith("/private/")) roots.add(repositoryRoot.slice(8));
+  else if (repositoryRoot.startsWith("/var/")) roots.add(`/private${repositoryRoot}`);
+  let sanitized = String(content || "");
+  for (const root of [...roots].filter(Boolean).sort((a, b) => b.length - a.length)) {
+    sanitized = sanitized.split(root).join(".");
+  }
+  return sanitized;
+}
+
+export async function prepareRepositoryUploadInputs(context, credentials, options = {}) {
+  if (!wikiUploadEnabled(options)) return { code: context, wiki: { status: "disabled" } };
+  const wikiRoot = join(context.root, WIKI_DIR);
+  const profile = await readFile(join(wikiRoot, "PROFILE.md"), "utf8").catch(() => "");
+  if (!profile) return { code: context, wiki: { status: "absent", root: wikiRoot } };
+  if (metadataValue(profile, "schema") !== WIKI_PROFILE_SCHEMA) {
+    return { code: context, wiki: { status: "invalid", reason: "unsupported-profile-schema", root: wikiRoot } };
+  }
+  const sourceCommit = metadataValue(profile, "local_head").toLowerCase();
+  const sourceTree = metadataValue(profile, "source_tree").toLowerCase();
+  if (!/^[0-9a-f]{40}$/u.test(sourceCommit) || !/^[0-9a-f]{40}$/u.test(sourceTree)) {
+    return { code: context, wiki: { status: "invalid", reason: "invalid-source-provenance", root: wikiRoot } };
+  }
+  const userId = await resolveEffectiveUserId(credentials, options.fetchImpl || globalThis.fetch);
+  if (!userId) return { code: context, wiki: { status: "invalid", reason: "user-id-unavailable", root: wikiRoot } };
+  try {
+    const files = await publicationFiles(wikiRoot);
+    const contents = new Map();
+    const digest = createHash("sha256");
+    for (const file of files) {
+      let content = await readFile(join(wikiRoot, ...file.split("/")), "utf8");
+      if (file !== "PROFILE.md" && !file.includes("/") && metadataValue(content, "schema") !== WIKI_PAGE_SCHEMA) {
+        throw new Error(`Wiki page has unsupported schema: ${file}`);
+      }
+      content = sanitizeWikiContent(content, context.root);
+      contents.set(file, content);
+      digest.update(file).update("\0").update(content).update("\0");
+    }
+    validateWikiLinks(files, contents);
+    return {
+      code: context,
+      wiki: {
+        status: "ready",
+        root: wikiRoot,
+        targetUri: `viking://resources/wiki/${context.repoId}/${userId}`,
+        repoId: context.repoId,
+        userId,
+        sourceCommit,
+        sourceTree,
+        sourceBranch: metadataValue(profile, "local_branch") || context.branch,
+        triggerCommit: context.commit,
+        triggerTree: context.tree,
+        buildMode: metadataValue(profile, "build_mode") || "unknown",
+        generatedAt: metadataValue(profile, "generated_at"),
+        files,
+        contents,
+        contentHash: digest.digest("hex"),
+      },
+    };
+  } catch (error) {
+    return { code: context, wiki: { status: "invalid", reason: error?.message || String(error), root: wikiRoot, sourceCommit } };
+  }
+}
+
+export async function createWikiArchive(context, wiki) {
+  if (wiki?.status !== "ready") throw new Error("Wiki is not ready for publication.");
+  const directory = await mkdtemp(join(tmpdir(), "openviking-repo-wiki-"));
+  const staging = join(directory, "publication");
+  const archive = join(directory, `${safePart(context.repoName, "repository")}-wiki.zip`);
+  await mkdir(staging, { recursive: true, mode: STATE_DIR_MODE });
+  try {
+    for (const file of wiki.files) {
+      const destination = join(staging, ...file.split("/"));
+      await mkdir(dirname(destination), { recursive: true, mode: STATE_DIR_MODE });
+      await writeFile(destination, wiki.contents.get(file), { encoding: "utf8", mode: STATE_FILE_MODE });
+    }
+    const manifest = {
+      schema: "repo_wiki_publication.v1", repo_id: context.repoId, repo_name: context.repoName,
+      repo_key: context.repoKey, wiki_owner: wiki.userId, source_commit: wiki.sourceCommit,
+      source_tree: wiki.sourceTree, source_branch: wiki.sourceBranch, build_mode: wiki.buildMode,
+      generated_at: wiki.generatedAt, files: wiki.files, content_hash: wiki.contentHash,
+    };
+    await writeFile(join(staging, "repo-wiki-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, { encoding: "utf8", mode: STATE_FILE_MODE });
+    await execFileAsync("python3", ["-m", "zipfile", "-c", archive, "."], { cwd: staging, timeout: 120_000, maxBuffer: 1024 * 1024 });
+    await chmod(archive, STATE_FILE_MODE);
+    return { archive, cleanup: () => rm(directory, { recursive: true, force: true }) };
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 function authHeaders(credentials, contentType = "") {
@@ -312,34 +520,145 @@ export async function submitRepositorySnapshot(credentials, tempFileId, context)
   return responseResult(response);
 }
 
+export async function submitWikiSnapshot(credentials, tempFileId, wiki) {
+  const tags = [
+    "content_kind=repo_wiki",
+    `repo_id=${wiki.repoId}`,
+    `wiki_owner=${wiki.userId}`,
+    `source_commit=${wiki.sourceCommit}`,
+    `build_mode=${wiki.buildMode}`,
+    `content_hash=${wiki.contentHash}`,
+  ];
+  const response = await fetch(`${credentials.baseUrl}/api/v1/resources`, {
+    method: "POST",
+    headers: authHeaders(credentials, "application/json"),
+    body: JSON.stringify({
+      temp_file_id: tempFileId,
+      to: wiki.targetUri,
+      wait: false,
+      processing_mode: "vectors_only",
+      tags,
+      tag_mode: "replace",
+      args: { parse_mode: "no_split" },
+    }),
+  });
+  return responseResult(response);
+}
+
+function normalizedSyncState(previous, context) {
+  if (previous?.version === 2) return previous;
+  return {
+    version: 2,
+    repoKey: context.repoKey,
+    branch: context.branch,
+    code: previous?.lastSubmittedCommit ? {
+      lastSubmittedCommit: previous.lastSubmittedCommit,
+      targetUri: previous.targetUri || context.targetUri,
+      taskId: previous.taskId || "",
+      status: "submitted",
+    } : {},
+    wiki: {},
+    updatedAt: previous?.updatedAt || "",
+  };
+}
+
 export async function syncRepositoryFromHook(input, options = {}) {
   if (!isSuccessfulGitMutation(input)) return { status: "skipped", reason: "not-git-mutation" };
   const context = await resolveRepositoryContext(hookCwd(input));
-  if (context.remoteOrigin) return { status: "skipped", reason: "remote-backed", context };
 
   return withRepositoryLock(context, async () => {
-    const previous = await readState(context);
-    if (previous.lastSubmittedCommit === context.commit) {
-      return { status: "skipped", reason: "already-submitted", context };
+    const rawPrevious = await readState(context);
+    const previous = normalizedSyncState(rawPrevious, context);
+    const credentials = options.credentials || resolveOpenVikingCredentials();
+    const inputs = await prepareRepositoryUploadInputs(context, credentials, options);
+    const codeNeeded = !context.remoteOrigin && previous.code?.lastSubmittedCommit !== context.commit;
+    const wikiNeeded = inputs.wiki.status === "ready"
+      && (previous.wiki?.contentHash !== inputs.wiki.contentHash
+        || previous.wiki?.status !== "submitted");
+
+    if (!codeNeeded && !wikiNeeded) {
+      const wikiReason = inputs.wiki.reason || inputs.wiki.status;
+      if (rawPrevious?.version !== 2 || previous.wiki?.status !== inputs.wiki.status
+          || previous.wiki?.reason !== wikiReason) {
+        await writeState(context, {
+          ...previous,
+          wiki: { ...previous.wiki, status: inputs.wiki.status, reason: wikiReason },
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      return {
+        status: "skipped",
+        reason: context.remoteOrigin && inputs.wiki.status === "disabled"
+          ? "remote-backed"
+          : (inputs.wiki.status === "disabled" ? "already-submitted" : "nothing-to-submit"),
+        context,
+        code: { status: "skipped", reason: context.remoteOrigin ? "remote-backed" : "already-submitted" },
+        wiki: { status: "skipped", reason: wikiReason },
+      };
     }
 
-    const credentials = options.credentials || resolveOpenVikingCredentials();
-    const bundle = await createRepositoryArchive(context);
-    try {
-      const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
-      const result = await submitRepositorySnapshot(credentials, tempFileId, context);
-      await writeState(context, {
-        version: 1,
-        repoKey: context.repoKey,
-        branch: context.branch,
-        targetUri: context.targetUri,
-        lastSubmittedCommit: context.commit,
-        taskId: result.task_id || "",
-        updatedAt: new Date().toISOString(),
-      });
-      return { status: "submitted", context, result };
-    } finally {
-      await bundle.cleanup();
-    }
+    const codePromise = codeNeeded ? (async () => {
+      const bundle = await createRepositoryArchive(context);
+      try {
+        const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+        const result = await submitRepositorySnapshot(credentials, tempFileId, context);
+        return { status: "submitted", result };
+      } finally {
+        await bundle.cleanup();
+      }
+    })() : Promise.resolve({ status: "skipped", reason: context.remoteOrigin ? "remote-backed" : "already-submitted" });
+
+    const wikiPromise = wikiNeeded ? (async () => {
+      const bundle = await createWikiArchive(context, inputs.wiki);
+      try {
+        const tempFileId = await uploadRepositorySnapshot(credentials, bundle.archive);
+        const result = await submitWikiSnapshot(credentials, tempFileId, inputs.wiki);
+        return { status: "submitted", result };
+      } finally {
+        await bundle.cleanup();
+      }
+    })() : Promise.resolve({ status: "skipped", reason: inputs.wiki.status });
+
+    const [codeSettled, wikiSettled] = await Promise.allSettled([codePromise, wikiPromise]);
+    const code = codeSettled.status === "fulfilled"
+      ? codeSettled.value
+      : { status: "failed", error: codeSettled.reason?.message || String(codeSettled.reason) };
+    const wiki = wikiSettled.status === "fulfilled"
+      ? wikiSettled.value
+      : { status: "failed", error: wikiSettled.reason?.message || String(wikiSettled.reason) };
+
+    const next = {
+      ...previous,
+      version: 2,
+      repoKey: context.repoKey,
+      branch: context.branch,
+      code: code.status === "submitted" ? {
+        lastSubmittedCommit: context.commit, targetUri: context.targetUri,
+        taskId: code.result?.task_id || "", status: "submitted",
+      } : code.status === "skipped" ? previous.code : {
+        ...previous.code, status: code.status, ...(code.error ? { error: code.error } : {}),
+      },
+      wiki: wiki.status === "submitted" ? {
+        contentHash: inputs.wiki.contentHash, targetUri: inputs.wiki.targetUri,
+        taskId: wiki.result?.task_id || "", status: "submitted",
+      } : wiki.status === "skipped" && inputs.wiki.status === "ready" ? previous.wiki : {
+        ...previous.wiki,
+        ...(inputs.wiki.contentHash ? { contentHash: inputs.wiki.contentHash } : {}),
+        ...(inputs.wiki.targetUri ? { targetUri: inputs.wiki.targetUri } : {}),
+        status: wiki.status === "skipped" ? inputs.wiki.status : wiki.status,
+        ...((inputs.wiki.reason || (wiki.status === "skipped" ? inputs.wiki.status : ""))
+          ? { reason: inputs.wiki.reason || inputs.wiki.status } : {}),
+        ...(wiki.error ? { error: wiki.error } : {}),
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    await writeState(context, next);
+
+    const submitted = code.status === "submitted" || wiki.status === "submitted";
+    const failed = code.status === "failed" || wiki.status === "failed";
+    return {
+      status: failed ? (submitted ? "partial" : "error") : (submitted ? "submitted" : "skipped"),
+      context, code, wiki, result: code.result,
+    };
   });
 }

--- a/examples/memory-plugin-shared/repo-wiki-skill.test.mjs
+++ b/examples/memory-plugin-shared/repo-wiki-skill.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const canonicalSkill = join(ROOT, "examples", "skills", "repo-wiki");
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+function createRepo() {
+  const root = mkdtempSync(join(tmpdir(), "openviking-repo-wiki-"));
+  git(root, "init");
+  git(root, "config", "user.email", "test@example.com");
+  git(root, "config", "user.name", "OpenViking Test");
+  writeFileSync(join(root, "README.md"), "# Test repository\n");
+  git(root, "add", "README.md");
+  git(root, "commit", "-m", "initial");
+  return root;
+}
+
+function runPython(script, args) {
+  return execFileSync("python3", [script, ...args], { encoding: "utf8" });
+}
+
+test("canonical repo-wiki Skill is complete and self-contained", () => {
+  const required = [
+    "SKILL.md",
+    "defaults.json",
+    "references/openviking-read.md",
+    "references/repo-build.md",
+    "references/repo-read.md",
+    "references/repo-templates.md",
+    "references/repo-update.md",
+    "scripts/collect_all.py",
+    "scripts/detect_updates.py",
+    "scripts/prepare_repo_memory.py",
+    "scripts/validate_memory.py",
+  ];
+  for (const file of required) {
+    assert.ok(readFileSync(join(canonicalSkill, file), "utf8").length > 0, `${file} must not be empty`);
+  }
+  const skill = readFileSync(join(canonicalSkill, "SKILL.md"), "utf8");
+  assert.match(skill, /OpenViking Resource subtree/u);
+  assert.match(readFileSync(join(canonicalSkill, "references", "openviking-read.md"), "utf8"), /grep/u);
+});
+
+test("repo-wiki helper scripts collect local evidence and validate an authored bundle", () => {
+  const root = createRepo();
+  try {
+    const collect = join(canonicalSkill, "scripts", "collect_all.py");
+    const validate = join(canonicalSkill, "scripts", "validate_memory.py");
+    const collected = JSON.parse(runPython(collect, ["--repo-path", root, "--commit-limit", "5", "--pretty"]));
+    assert.equal(collected.ok, true);
+    assert.equal(collected.effective_settings.history.mode, "local-only");
+    assert.match(readFileSync(join(root, ".gitignore"), "utf8"), /\.repo_memory/u);
+
+    const wiki = join(root, ".repo_memory");
+    const head = git(root, "rev-parse", "HEAD");
+    const tree = git(root, "rev-parse", "HEAD^{tree}");
+    execFileSync("mkdir", ["-p", join(wiki, "resources")]);
+    writeFileSync(join(wiki, "PROFILE.md"), [
+      "---",
+      'schema: "repo_memory_profile.v0.2"',
+      `local_head: "${head}"`,
+      `source_tree: "${tree}"`,
+      "---",
+      "# Test Wiki",
+      "[Architecture](architecture.md)",
+      "",
+    ].join("\n"));
+    writeFileSync(join(wiki, "architecture.md"), [
+      "---",
+      'schema: "repo_memory_wiki_page.v0.1"',
+      "---",
+      "# Architecture",
+      "",
+    ].join("\n"));
+    const resourceSchemas = {
+      "commits.md": "repo_memory_commit_resource.v0.1",
+      "prs.md": "repo_memory_pr_resource.v0.1",
+      "issues.md": "repo_memory_issue_resource.v0.1",
+    };
+    for (const [file, schema] of Object.entries(resourceSchemas)) {
+      writeFileSync(join(wiki, "resources", file), [
+        "---", `schema: "${schema}"`, 'source: "provider_skipped_local_only"',
+        "resource_count: 0", 'trust_state: "unavailable_local_only"', 'raw_source: ""',
+        "---", `# ${file}`, "",
+      ].join("\n"));
+    }
+    const result = JSON.parse(runPython(validate, [root, "--pretty"]));
+    assert.equal(result.ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/examples/memory-plugin-shared/repository-sync.test.mjs
+++ b/examples/memory-plugin-shared/repository-sync.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createRepositoryArchive,
+  isSuccessfulGitMutation,
+  resolveRepositoryContext,
+  syncRepositoryFromHook,
+} from "./lib/repository-sync.mjs";
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+function createRepository({ remote = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "openviking-repository-sync-"));
+  git(root, "init");
+  git(root, "config", "user.email", "test@example.com");
+  git(root, "config", "user.name", "OpenViking Test");
+  writeFileSync(join(root, ".gitignore"), "*.log\n");
+  writeFileSync(join(root, "README.md"), "# repository\n");
+  writeFileSync(join(root, "ignored.log"), "ignored\n");
+  git(root, "add", ".gitignore", "README.md");
+  git(root, "commit", "-m", "initial");
+  if (remote) git(root, "remote", "add", "origin", "https://example.test/org/repository.git");
+  return root;
+}
+
+test("isSuccessfulGitMutation accepts Codex event payloads and rejects reads or failures", () => {
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "Bash",
+    tool_input: { command: "git commit -m test" },
+    tool_response: { exit_code: 0 },
+  }), true);
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "exec_command",
+    tool_input: { cmd: "git commit -m test" },
+    tool_response: { exit_code: 0 },
+  }), true);
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "exec_command",
+    tool_input: { cmd: "git status" },
+    tool_response: { exit_code: 0 },
+  }), false);
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "codex_exec",
+    tool_input: { cmd: "git pull --rebase" },
+    tool_response: { exit_code: 1 },
+  }), false);
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "exec_command",
+    command: ["/bin/bash", "-lc", "git commit -m test"],
+    cwd: "/repo",
+    exit_code: 0,
+    status: "completed",
+  }), true);
+  assert.equal(isSuccessfulGitMutation({
+    tool_name: "Bash",
+    tool_input: { command: 'echo "git commit -m test"' },
+    tool_response: { exit_code: 0 },
+  }), false);
+});
+
+test("createRepositoryArchive contains committed HEAD files only", async () => {
+  const root = createRepository();
+  try {
+    const context = await resolveRepositoryContext(root);
+    const bundle = await createRepositoryArchive(context);
+    try {
+      const listing = execFileSync("unzip", ["-Z1", bundle.archive], { encoding: "utf8" })
+        .trim().split("\n");
+      assert.ok(listing.includes("README.md"));
+      assert.ok(listing.includes(".gitignore"));
+      assert.equal(listing.includes("ignored.log"), false);
+      assert.equal(listing.some((name) => name.startsWith(".git/")), false);
+      assert.equal(context.commit, git(root, "rev-parse", "HEAD"));
+    } finally {
+      await bundle.cleanup();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("local repository identity persists without exposing the checkout path", async () => {
+  const root = createRepository();
+  try {
+    const first = await resolveRepositoryContext(root);
+    const second = await resolveRepositoryContext(root);
+    assert.equal(first.repoKey, second.repoKey);
+    assert.match(first.repoKey, /^local:[0-9a-f-]+$/u);
+    assert.equal(first.repoKey.includes(root), false);
+    assert.match(git(root, "config", "--local", "--get", "openviking.repositoryKey"), /^[0-9a-f-]+$/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("syncRepositoryFromHook skips remote-backed repositories", async () => {
+  const root = createRepository({ remote: true });
+  try {
+    const result = await syncRepositoryFromHook({
+      tool_name: "exec_command",
+      tool_input: { cmd: "git commit --allow-empty -m test" },
+      tool_response: { exit_code: 0 },
+      cwd: root,
+    });
+    assert.equal(result.status, "skipped");
+    assert.equal(result.reason, "remote-backed");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("syncRepositoryFromHook uploads once and submits args.git_local", async () => {
+  const root = createRepository();
+  const stateDir = mkdtempSync(join(tmpdir(), "openviking-repository-state-"));
+  const originalFetch = globalThis.fetch;
+  process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR = stateDir;
+  const requests = [];
+  globalThis.fetch = async (url, init) => {
+    requests.push({ url: String(url), init });
+    if (String(url).endsWith("/resources/temp_upload")) {
+      assert.ok(init.body instanceof FormData);
+      return new Response(JSON.stringify({
+        status: "ok",
+        result: { temp_file_id: "upload_repo.zip" },
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    const body = JSON.parse(init.body);
+    assert.equal(body.temp_file_id, "upload_repo.zip");
+    assert.equal(body.wait, false);
+    assert.equal(body.args.git_local.repo_name, root.split("/").pop());
+    assert.equal(body.args.git_local.commit, git(root, "rev-parse", "HEAD"));
+    assert.equal(body.args.git_local.archive_format, "zip");
+    return new Response(JSON.stringify({
+      status: "ok",
+      result: { status: "success", task_id: "task-1", root_uri: body.to },
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+
+  const input = {
+    tool_name: "exec_command",
+    tool_input: { cmd: "git commit -m initial" },
+    tool_response: { exit_code: 0 },
+    cwd: root,
+  };
+  const credentials = {
+    baseUrl: "http://127.0.0.1:1933",
+    apiKey: "test-key",
+    account: "account",
+    user: "user",
+    peerId: "",
+  };
+
+  try {
+    const first = await syncRepositoryFromHook(input, { credentials });
+    assert.equal(first.status, "submitted");
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].init.headers.Authorization, "Bearer test-key");
+    assert.equal(requests[0].init.headers["Content-Type"], undefined);
+
+    const second = await syncRepositoryFromHook(input, { credentials });
+    assert.equal(second.status, "skipped");
+    assert.equal(second.reason, "already-submitted");
+    assert.equal(requests.length, 2);
+
+    const stateFiles = execFileSync("find", [stateDir, "-type", "f"], { encoding: "utf8" })
+      .trim().split("\n").filter(Boolean);
+    assert.equal(stateFiles.length, 1);
+    assert.equal(JSON.parse(readFileSync(stateFiles[0], "utf8")).taskId, "task-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR;
+    rmSync(root, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/examples/memory-plugin-shared/repository-sync.test.mjs
+++ b/examples/memory-plugin-shared/repository-sync.test.mjs
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import {
   createRepositoryArchive,
+  createWikiArchive,
   isSuccessfulGitMutation,
+  prepareRepositoryUploadInputs,
   resolveRepositoryContext,
   syncRepositoryFromHook,
 } from "./lib/repository-sync.mjs";
@@ -28,6 +30,46 @@ function createRepository({ remote = false } = {}) {
   git(root, "commit", "-m", "initial");
   if (remote) git(root, "remote", "add", "origin", "https://example.test/org/repository.git");
   return root;
+}
+
+function writeWiki(root, commit = git(root, "rev-parse", "HEAD")) {
+  const wiki = join(root, ".repo_memory");
+  mkdirSync(join(wiki, "resources"), { recursive: true });
+  mkdirSync(join(wiki, "raw"), { recursive: true });
+  writeFileSync(join(wiki, "PROFILE.md"), [
+    "---",
+    'schema: "repo_memory_profile.v0.2"',
+    `local_head: "${commit}"`,
+    `source_tree: "${git(root, "write-tree")}"`,
+    'build_mode: "lightweight"',
+    "---",
+    "# Repository Wiki",
+    "[Architecture](architecture.md)",
+    "",
+  ].join("\n"));
+  writeFileSync(join(wiki, "architecture.md"), [
+    "---",
+    'schema: "repo_memory_wiki_page.v0.1"',
+    "---",
+    "# Architecture",
+    `Local root: ${root}`,
+    "",
+  ].join("\n"));
+  const resourceSchemas = {
+    "commits.md": "repo_memory_commit_resource.v0.1",
+    "prs.md": "repo_memory_pr_resource.v0.1",
+    "issues.md": "repo_memory_issue_resource.v0.1",
+  };
+  for (const [name, schema] of Object.entries(resourceSchemas)) {
+    writeFileSync(join(wiki, "resources", name), [
+      "---", `schema: "${schema}"`, 'source: "provider_skipped_local_only"',
+      "resource_count: 0", 'trust_state: "unavailable_local_only"', 'raw_source: ""',
+      "---", `# ${name}`, "",
+    ].join("\n"));
+  }
+  writeFileSync(join(wiki, "raw", "git-commits.json"), "{}\n");
+  writeFileSync(join(wiki, "_plan.md"), "temporary\n");
+  return wiki;
 }
 
 test("isSuccessfulGitMutation accepts Codex event payloads and rejects reads or failures", () => {
@@ -78,6 +120,27 @@ test("createRepositoryArchive contains committed HEAD files only", async () => {
       assert.equal(listing.includes("ignored.log"), false);
       assert.equal(listing.some((name) => name.startsWith(".git/")), false);
       assert.equal(context.commit, git(root, "rev-parse", "HEAD"));
+    } finally {
+      await bundle.cleanup();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("createRepositoryArchive excludes a tracked repository Wiki", async () => {
+  const root = createRepository();
+  try {
+    mkdirSync(join(root, ".repo_memory"), { recursive: true });
+    writeFileSync(join(root, ".repo_memory", "PROFILE.md"), "tracked Wiki\n");
+    git(root, "add", "-f", ".repo_memory/PROFILE.md");
+    git(root, "commit", "-m", "track Wiki by mistake");
+    const context = await resolveRepositoryContext(root);
+    const bundle = await createRepositoryArchive(context);
+    try {
+      const listing = execFileSync("unzip", ["-Z1", bundle.archive], { encoding: "utf8" });
+      assert.doesNotMatch(listing, /\.repo_memory/u);
+      assert.match(listing, /README\.md/u);
     } finally {
       await bundle.cleanup();
     }
@@ -172,7 +235,110 @@ test("syncRepositoryFromHook uploads once and submits args.git_local", async () 
     const stateFiles = execFileSync("find", [stateDir, "-type", "f"], { encoding: "utf8" })
       .trim().split("\n").filter(Boolean);
     assert.equal(stateFiles.length, 1);
-    assert.equal(JSON.parse(readFileSync(stateFiles[0], "utf8")).taskId, "task-1");
+    assert.equal(JSON.parse(readFileSync(stateFiles[0], "utf8")).code.taskId, "task-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR;
+    rmSync(root, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("prepareRepositoryUploadInputs and createWikiArchive publish only the Wiki allowlist", async () => {
+  const root = createRepository();
+  try {
+    const context = await resolveRepositoryContext(root);
+    const wikiRoot = writeWiki(root, context.commit);
+    mkdirSync(join(wikiRoot, "user-profile"), { recursive: true });
+    writeFileSync(join(wikiRoot, "user-profile", "preferences.md"), "private\n");
+    const prepared = await prepareRepositoryUploadInputs(
+      context,
+      { baseUrl: "http://127.0.0.1:1933", user: "alice" },
+      { wikiUploadEnabled: true },
+    );
+    assert.equal(prepared.wiki.status, "ready");
+    assert.equal(prepared.wiki.targetUri, `viking://resources/wiki/${context.repoId}/alice`);
+    assert.deepEqual(prepared.wiki.files, [
+      "PROFILE.md", "architecture.md", "resources/commits.md",
+      "resources/issues.md", "resources/prs.md",
+    ]);
+    assert.doesNotMatch(prepared.wiki.contents.get("architecture.md"), new RegExp(root));
+
+    const bundle = await createWikiArchive(context, prepared.wiki);
+    try {
+      const listing = execFileSync("unzip", ["-Z1", bundle.archive], { encoding: "utf8" });
+      assert.match(listing, /PROFILE\.md/u);
+      assert.match(listing, /repo-wiki-manifest\.json/u);
+      assert.doesNotMatch(listing, /raw\//u);
+      assert.doesNotMatch(listing, /user-profile/u);
+      assert.doesNotMatch(listing, /_plan\.md/u);
+    } finally {
+      await bundle.cleanup();
+    }
+
+    symlinkSync(join(root, "README.md"), join(wikiRoot, "unsafe.md"));
+    const unsafe = await prepareRepositoryUploadInputs(
+      context,
+      { baseUrl: "http://127.0.0.1:1933", user: "alice" },
+      { wikiUploadEnabled: true },
+    );
+    assert.equal(unsafe.wiki.status, "invalid");
+    assert.match(unsafe.wiki.reason, /unsafe symlink/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Wiki content hash publishes a pre-commit build without a stale guard", async () => {
+  const root = createRepository({ remote: true });
+  const stateDir = mkdtempSync(join(tmpdir(), "openviking-repository-wiki-state-"));
+  const originalFetch = globalThis.fetch;
+  process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR = stateDir;
+  const resourceBodies = [];
+  globalThis.fetch = async (url, init) => {
+    if (String(url).endsWith("/resources/temp_upload")) {
+      const name = init.body.get("file").name;
+      return new Response(JSON.stringify({
+        status: "ok", result: { temp_file_id: name.includes("-wiki") ? "wiki.zip" : "code.zip" },
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    const body = JSON.parse(init.body);
+    resourceBodies.push(body);
+    return new Response(JSON.stringify({
+      status: "ok",
+      result: { status: "success", task_id: `task-${body.temp_file_id}`, root_uri: body.to },
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+
+  try {
+    const wikiContext = await resolveRepositoryContext(root);
+    writeWiki(root, wikiContext.commit);
+    writeFileSync(join(root, "README.md"), "# repository after Wiki build\n");
+    git(root, "add", "README.md");
+    git(root, "commit", "-m", "code changed after Wiki build");
+    const context = await resolveRepositoryContext(root);
+    const input = {
+      tool_name: "Bash", tool_input: { command: "git commit -m initial" },
+      tool_response: { exit_code: 0 }, cwd: root,
+    };
+    const credentials = { baseUrl: "http://127.0.0.1:1933", user: "alice" };
+    const first = await syncRepositoryFromHook(input, { credentials, wikiUploadEnabled: true });
+    assert.equal(first.status, "submitted");
+    assert.equal(first.code.status, "skipped");
+    assert.equal(first.wiki.status, "submitted");
+    assert.equal(resourceBodies.length, 1);
+    const wiki = resourceBodies[0];
+    assert.equal(wiki.temp_file_id, "wiki.zip");
+    assert.equal(wiki.processing_mode, "vectors_only");
+    assert.equal(wiki.args.parse_mode, "no_split");
+    assert.ok(wiki.tags.includes("content_kind=repo_wiki"));
+    assert.ok(wiki.tags.includes(`source_commit=${wikiContext.commit}`));
+    assert.equal(wiki.tags.includes(`source_commit=${context.commit}`), false);
+    assert.equal(wiki.to, `viking://resources/wiki/${context.repoId}/alice`);
+
+    const second = await syncRepositoryFromHook(input, { credentials, wikiUploadEnabled: true });
+    assert.equal(second.status, "skipped");
+    assert.equal(resourceBodies.length, 1);
   } finally {
     globalThis.fetch = originalFetch;
     delete process.env.OPENVIKING_REPOSITORY_SYNC_STATE_DIR;

--- a/examples/memory-plugin-shared/sync.mjs
+++ b/examples/memory-plugin-shared/sync.mjs
@@ -60,6 +60,13 @@ const SKILL_TARGETS = [
       join(ROOT, "examples", "dsh-memory-plugin", "skills"),
     ],
   },
+  {
+    // Repo Wiki is a repository-local authoring and published-Wiki retrieval
+    // skill. It is bundled with the Codex-compatible plugin used by TraeCode
+    // CLI 2.0, rather than the deprecated standalone TRAE CLI runtime.
+    skill: "repo-wiki",
+    dirs: [join(ROOT, "examples", "codex-memory-plugin", "skills")],
+  },
 ];
 
 async function listSharedFiles() {
@@ -75,13 +82,23 @@ async function copySharedFile(file, targetDir) {
   await writeFile(target, `${GENERATED_HEADER}${body}`, "utf-8");
 }
 
-async function copySkill(skill, targetDir) {
-  const sourceDir = join(SKILLS_DIR, skill);
-  for (const file of (await readdir(sourceDir)).sort()) {
-    const target = join(targetDir, skill);
-    await mkdir(target, { recursive: true });
-    await writeFile(join(target, file), await readFile(join(sourceDir, file), "utf-8"), "utf-8");
+async function copySkillTree(sourceDir, targetDir) {
+  await mkdir(targetDir, { recursive: true });
+  for (const entry of (await readdir(sourceDir, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+    const source = join(sourceDir, entry.name);
+    const target = join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      await copySkillTree(source, target);
+    } else if (entry.isFile()) {
+      await writeFile(target, await readFile(source, "utf-8"), "utf-8");
+    } else {
+      throw new Error(`skill contains unsupported entry: ${source}`);
+    }
   }
+}
+
+async function copySkill(skill, targetDir) {
+  await copySkillTree(join(SKILLS_DIR, skill), join(targetDir, skill));
 }
 
 async function main() {

--- a/examples/memory-plugin-shared/sync.mjs
+++ b/examples/memory-plugin-shared/sync.mjs
@@ -23,6 +23,7 @@ const HARNESS_SHARED_FILES = [
 ];
 const OPENCODE_SHARED_FILES = [...HARNESS_SHARED_FILES, "mcp-proxy-core.mjs", "mcp-proxy-config.mjs", "async-writer.mjs", "batch-send.mjs"];
 const DOCTOR_SHARED_FILES = [...OPENCODE_SHARED_FILES, "doctor-core.mjs"];
+const CODEX_SHARED_FILES = [...DOCTOR_SHARED_FILES, "repository-sync.mjs"];
 const ZCODE_SHARED_FILES = [...OPENCODE_SHARED_FILES, "agent-hook-runtime.mjs", "agent-uri-guard.mjs"];
 const DSH_SHARED_FILES = [...HARNESS_SHARED_FILES, "mcp-proxy-core.mjs", "mcp-proxy-config.mjs"];
 const AGENT_PLUGINS_SHARED_FILES = [
@@ -34,7 +35,7 @@ const AGENT_PLUGINS_SHARED_FILES = [
 ];
 const TARGETS = [
   { dir: join(ROOT, "examples", "claude-code-memory-plugin", "scripts", "shared"), files: DOCTOR_SHARED_FILES },
-  { dir: join(ROOT, "examples", "codex-memory-plugin", "scripts", "shared"), files: DOCTOR_SHARED_FILES },
+  { dir: join(ROOT, "examples", "codex-memory-plugin", "scripts", "shared"), files: CODEX_SHARED_FILES },
   { dir: join(ROOT, "examples", "opencode-plugin", "lib", "shared"), files: OPENCODE_SHARED_FILES },
   { dir: join(ROOT, "examples", "dsh-memory-plugin", "shared"), files: DSH_SHARED_FILES },
   { dir: join(ROOT, "examples", "pi-coding-agent-extension", "shared"), files: HARNESS_SHARED_FILES },

--- a/examples/memory-plugin-shared/sync.test.mjs
+++ b/examples/memory-plugin-shared/sync.test.mjs
@@ -20,6 +20,7 @@ const HARNESS_SHARED_FILES = [
 ];
 const OPENCODE_SHARED_FILES = [...HARNESS_SHARED_FILES, "mcp-proxy-core.mjs", "async-writer.mjs", "batch-send.mjs"];
 const DOCTOR_SHARED_FILES = [...OPENCODE_SHARED_FILES, "doctor-core.mjs"];
+const CODEX_SHARED_FILES = [...DOCTOR_SHARED_FILES, "repository-sync.mjs"];
 const ZCODE_SHARED_FILES = [...OPENCODE_SHARED_FILES, "agent-hook-runtime.mjs", "agent-uri-guard.mjs"];
 const AGENT_PLUGINS_SHARED_FILES = [
   "credentials.mjs",
@@ -29,7 +30,7 @@ const AGENT_PLUGINS_SHARED_FILES = [
 ];
 const TARGETS = [
   { dir: join(ROOT, "examples", "claude-code-memory-plugin", "scripts", "shared"), files: DOCTOR_SHARED_FILES },
-  { dir: join(ROOT, "examples", "codex-memory-plugin", "scripts", "shared"), files: DOCTOR_SHARED_FILES },
+  { dir: join(ROOT, "examples", "codex-memory-plugin", "scripts", "shared"), files: CODEX_SHARED_FILES },
   { dir: join(ROOT, "examples", "opencode-plugin", "lib", "shared"), files: OPENCODE_SHARED_FILES },
   { dir: join(ROOT, "examples", "dsh-memory-plugin", "shared"), files: HARNESS_SHARED_FILES },
   { dir: join(ROOT, "examples", "pi-coding-agent-extension", "shared"), files: HARNESS_SHARED_FILES },

--- a/examples/memory-plugin-shared/sync.test.mjs
+++ b/examples/memory-plugin-shared/sync.test.mjs
@@ -48,7 +48,24 @@ const SKILL_TARGETS = [
       join(ROOT, "examples", "cursor-memory-plugin", "skills"),
     ],
   },
+  {
+    skill: "repo-wiki",
+    dirs: [join(ROOT, "examples", "codex-memory-plugin", "skills")],
+  },
 ];
+
+async function relativeFiles(root, current = "") {
+  const dir = join(root, current);
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const relativePath = join(current, entry.name);
+    if (entry.isDirectory()) out.push(...await relativeFiles(root, relativePath));
+    else if (entry.isFile()) out.push(relativePath);
+    else throw new Error(`unsupported skill entry: ${relativePath}`);
+  }
+  return out.sort();
+}
 
 test("vendored shared modules are synchronized", async () => {
   const files = (await readdir(SHARED_DIR)).filter((file) => file.endsWith(".mjs")).sort();
@@ -71,13 +88,13 @@ test("vendored shared modules are synchronized", async () => {
 
 test("vendored skills are byte-identical to examples/skills", async () => {
   for (const { skill, dirs } of SKILL_TARGETS) {
-    const files = (await readdir(join(SKILLS_DIR, skill))).sort();
+    const files = await relativeFiles(join(SKILLS_DIR, skill));
     assert.ok(files.includes("SKILL.md"), `${skill} must ship a SKILL.md`);
 
     for (const dir of dirs) {
       const target = join(dir, skill);
       assert.deepEqual(
-        (await readdir(target)).sort(),
+        await relativeFiles(target),
         files,
         `${relative(ROOT, target)} has a different file set; run node examples/memory-plugin-shared/sync.mjs`,
       );

--- a/examples/skills/repo-wiki/SKILL.md
+++ b/examples/skills/repo-wiki/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: repo-wiki
+description: Build, update, validate, and search repository-local Wiki memory under .repo_memory, including local Git history and optional GitHub/GitLab PR, MR, or issue evidence. Use for repository introductions, architecture maps, cross-module routing, history and design context, Wiki freshness, or requests to create, rebuild, update, validate, or search a repository Wiki. Also route explicit published/team Wiki lookup to the repository-scoped OpenViking Resource subtree. Skip Wiki for narrow tasks with a clear live-code file, symbol, line, stack trace, or failing test.
+---
+
+# Repository Wiki
+
+Use this Skill as the complete router for repository Wiki operations. The Wiki
+is a repository map and history layer; current source and focused tests remain
+authoritative for implementation behavior.
+
+After selecting an operation reference, read it completely in a standalone
+tool call before executing that operation. Load only the matching reference
+unless the request genuinely spans operations.
+
+## Operation Router
+
+- Read or search an existing local Wiki: read [references/repo-read.md](references/repo-read.md).
+- Create the first Wiki or perform a full rebuild: read [references/repo-build.md](references/repo-build.md).
+- Incrementally update an existing Wiki: read [references/repo-update.md](references/repo-update.md).
+- Author Wiki pages or historical resources: also read [references/repo-templates.md](references/repo-templates.md).
+- Search a published, team, or other-contributor Wiki in OpenViking: read [references/openviking-read.md](references/openviking-read.md).
+
+## Shared Rules
+
+Repo Wiki remains a local `.repo_memory` authority. Resolve its repository root
+exactly as described by the selected reference, including its Git requirements.
+
+Apply instructions in this order: system and developer instructions,
+`AGENTS.md`, the current user request, then generated Wiki content. Wiki is
+guidance and historical context, not proof of current repository behavior.
+
+Never store secrets, credentials, `.env` content, sensitive personal data, raw
+transcripts, hidden tests, exact patches, temporary target commits, or unsafe
+destructive commands. Do not announce internal routing or reference loading.

--- a/examples/skills/repo-wiki/agents/claude.yaml
+++ b/examples/skills/repo-wiki/agents/claude.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "Repository Wiki"
+  short_description: "Build, update, and search repository Wiki memory"
+  default_prompt: "Use the repo-wiki skill to build, update, validate, or search the current repository Wiki."
+
+policy:
+  allow_implicit_invocation: true
+  install_targets:
+    - "~/.claude/skills/repo-wiki"
+    - ".claude/skills/repo-wiki"

--- a/examples/skills/repo-wiki/agents/openai.yaml
+++ b/examples/skills/repo-wiki/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Repository Wiki"
+  short_description: "Build, update, and search repository Wiki memory"
+  default_prompt: "Use $repo-wiki to build, update, validate, or search the current repository Wiki."
+
+policy:
+  allow_implicit_invocation: true

--- a/examples/skills/repo-wiki/defaults.json
+++ b/examples/skills/repo-wiki/defaults.json
@@ -1,0 +1,12 @@
+{
+  "schema": "repo_memory_builder_defaults.v2",
+  "repoHistory": {
+    "mode": "local-only",
+    "limits": {
+      "commits": 30,
+      "prs": 30,
+      "issues": 30
+    }
+  },
+  "summaryChars": 4000
+}

--- a/examples/skills/repo-wiki/references/openviking-read.md
+++ b/examples/skills/repo-wiki/references/openviking-read.md
@@ -1,0 +1,91 @@
+# Published Wiki Read
+
+Use this reference only when the user explicitly asks for a published, team,
+cloud, or other-contributor Wiki. Prefer the local operation in `repo-read.md`
+for the current checkout.
+
+## Resolve Scope
+
+Use the narrowest requested subtree:
+
+```text
+current user's Wiki: viking://resources/wiki/<repo-id>/<current-user-id>
+selected user's Wiki: viking://resources/wiki/<repo-id>/<selected-user-id>
+all contributors:      viking://resources/wiki/<repo-id>
+```
+
+Do not search the whole Resource namespace when the repository Wiki root is
+known. Resolve the stable repo id from the same normalized repository identity
+used by the upload plugin.
+
+## Retrieval
+
+- Use `grep` for exact symbols, errors, configuration keys, or quoted wording.
+- Use `glob` for page names and paths.
+- Use `find` for architecture, routing, history, and design-rationale concepts.
+- Use `read` only after selecting a small set of pages.
+- Use `list` or `tree` only when the Wiki structure is unknown.
+
+## Server-Side Wiki Discovery And File Access
+
+Cloud Wiki access mirrors local Wiki access, but uses OpenViking MCP filesystem
+operations over `viking://` URIs rather than shell commands against a local
+directory. Do not pass a `viking://` URI to Bash, `rg`, `cat`, or other local
+filesystem commands.
+
+### List the Wiki owners for the current repository
+
+When the user asks which published Wikis exist for a repository, first list the
+repository root:
+
+```text
+list(uri="viking://resources/wiki/<repo-id>", recursive=false)
+```
+
+Each child directory is a Wiki owner. If the root is empty, report that no Wiki
+has been published for this repository under the current service identity. Do
+not infer an owner from local filesystem paths.
+
+### Select one Wiki, then inspect it like a local `.repo_memory` bundle
+
+After choosing an owner directory, use its exact URI:
+
+```text
+viking://resources/wiki/<repo-id>/<owner>
+```
+
+Use this mapping:
+
+| Local Wiki operation | Server-side MCP operation |
+|---|---|
+| `ls .repo_memory` | `list(uri=<wiki-uri>, recursive=false)` |
+| `find .repo_memory -name '*.md'` | `glob(uri=<wiki-uri>, pattern="**/*.md")` |
+| `rg -n 'pattern' .repo_memory` | `grep(uri=<wiki-uri>, pattern=["pattern"])` |
+| `cat .repo_memory/PAGE.md` | `read(uris=[<wiki-uri>/PAGE.md])` |
+| Semantic question over local pages | `find(query=..., target_uri=<wiki-uri>)` |
+
+`grep` accepts regular-expression patterns and returns matching file URIs, line
+numbers, and content snippets. It is the server-side equivalent for exact
+`rg`/grep-style content lookup, but it does not execute the Unix `rg` binary
+or accept arbitrary shell flags. Combine `glob` for path filtering with `grep`
+for content filtering.
+
+### Minimal discovery sequence
+
+1. `list` the repository Wiki root to discover owners.
+2. Select the requested owner, or the current user when the request is scoped
+   to their Wiki.
+3. `glob` Markdown pages if the page set is unknown.
+4. Use `grep` for exact symbols/phrases or `find` for conceptual questions.
+5. `read` only the selected page files.
+
+Keep the selected owner URI fixed through the retrieval operation. Do not merge
+different owners' pages into one conclusion without attribution.
+
+Identify the backend, repository, Wiki owner, URI, source commit, generated
+time, and freshness when available. Group results by owner; do not merge
+conflicting contributor claims into an unattributed team conclusion.
+
+Published Wiki is an ordinary Resource in the plugin-only MVP, so generic
+semantic recall can also return it outside this explicit operation. Verify
+current implementation claims against the live checkout and focused tests.

--- a/examples/skills/repo-wiki/references/repo-build.md
+++ b/examples/skills/repo-wiki/references/repo-build.md
@@ -1,0 +1,319 @@
+# Repo Memory Build
+
+## Core Principle
+
+The agent authors the repo memory. Scripts collect and validate mechanical evidence, but do not replace agent-authored memory.
+
+Do not let a script write `PROFILE.md`, `resources/commits.md`, `resources/prs.md`, or `resources/issues.md`. The agent must inspect the local project, understand the code, and author the human-facing memory. Scripts may create deterministic raw evidence only.
+
+This is the full-build operation, not the daily reader or incremental updater. Return to `SKILL.md` and use `repo-read.md` for task-time search over existing memory. For latest-change-only updates to an existing `.repo_memory`, use `repo-update.md`. Use this reference for first-time creation, full rebuilds, or full refreshes that recollect raw evidence and rewrite authored memory.
+
+## Output Layout
+
+The user selects a repository, not a memory directory. Do not ask for a `.repo_memory` path. Create this bundle inside the target repository:
+
+```text
+<repo>/.repo_memory/
+├── PROFILE.md
+├── <repo-native-topic>.md conceptual pages
+├── raw/
+│   ├── prepare-report.json
+│   ├── git-commits.json
+│   └── github-facets.json or gitlab-facets.json
+└── resources/
+    ├── commits.md
+    ├── prs.md
+    └── issues.md
+```
+
+Script-generated artifacts: `raw/prepare-report.json`, `raw/git-commits.json`, and optional `raw/github-facets.json` or `raw/gitlab-facets.json`. Agent-authored durable artifacts: `PROFILE.md`, repository-native supporting conceptual pages when the repository has enough surface area, `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`. Temporary planning artifact `.repo_memory/_plan.md` is allowed during drafting but must be removed before final validation.
+
+## Wiki-Style Output Contract
+
+Repository Wiki memory is a wiki-style repository memory backed by raw mechanical evidence. The primary user-facing product is a readable wiki, not a dense schema dump or a history table.
+
+- `PROFILE.md` is the only fixed conceptual wiki file and the wiki landing page: project identity, what the repo contains, how it works, first-use path, Major Areas, Supporting Pages, provider context, and evidence inspected.
+- Do not assume fixed supporting page names. Decide supporting pages and filenames from the repository itself after discovery.
+- For very small repositories, `PROFILE.md` plus 1-2 supporting pages is enough. For most repositories, generate 3-7 Markdown pages total, including `PROFILE.md`. Only exceed 7 pages when the repository clearly has multiple substantial, independent areas that would become confusing if merged.
+- Every durable supporting conceptual page must include frontmatter with `schema: "repo_memory_wiki_page.v0.1"` so validation can scan it.
+- Supporting pages explain concepts, workflows, system areas, change surfaces, setup, verification, and agent routing cautions. They must link claims to inspected docs/source and use conservative wording when lightweight mode did not inspect source.
+- resources/*.md remain compact historical routing cards for commits, PRs/MRs, and issues. They should not be the main architecture explanation.
+- Keep raw JSON as debug evidence only. Do not ask future agents to read raw facets unless compact pages and resources are insufficient.
+
+## Conceptual Page Planning
+
+After discovery and before final wiki writing, create a temporary planning artifact at `.repo_memory/_plan.md`. Keep it compact. Use it to outline intended final pages, each page purpose, source evidence, page boundaries, canonical homes for overlapping concepts, remaining questions, weak evidence, and paths that must be verified before final writing.
+
+- Remove `.repo_memory/_plan.md` before final validation; it is not part of the durable repo memory bundle.
+- Organize pages like human documentation, not a raw file inventory. Use human documentation titles. Do not title pages or headings after source paths, and do not mirror the source tree.
+- Create a page only when a future human or agent needs a canonical explanation for a concept, workflow, system area, or change surface. A page is a durable orientation artifact, not a parking place for exploration facts.
+- Merge rather than split when two pages would repeat the same workflow, types, or source paths; when one page would only explain a subset of another page; or when the distinction is based on source directory layout rather than reader task or concept.
+- Split rather than merge when one page would mix unrelated reader tasks; when a concept has its own workflow, data model, risks, and source-backed change guidance; or when a page would become too long to navigate.
+- Prefer headings inside broader pages before creating many small pages. Avoid thin pages and stub-like pages.
+
+Natural documentation domains are candidates, not a required checklist: architecture, workflows, data model, integrations, operations, testing/evaluation, and extension points. In `_plan.md`, decide which candidates were selected, merged, or skipped and why. Generic names such as `architecture.md`, `runtime-flow.md`, and `developer-workflow.md` are fallback names only when repository vocabulary gives no stronger topic.
+
+## Repository Prerequisite
+
+The selected target must be a local git repository: either the directory contains `.git/` or is inside a git worktree. A GitHub/GitLab remote is optional; local-only git repositories are supported.
+
+If the directory is not a git repository, do not create `.repo_memory/` and do not fabricate a memory bundle from file inspection alone. Stop with a prominent notice:
+
+```text
+**Repo Memory Cannot Be Built Yet**
+
+> This folder is not a git repository, so repo memory cannot collect local commit history or provider-linked PR/MR/issue evidence.
+
+**Next steps**
+- If this is an existing project, open the real cloned repo directory.
+- If this is a new project, run `git init` first, make at least one commit, then rerun the `repo-build` operation.
+- If you only want file inspection, continue by inspecting files without repo memory.
+```
+
+## Path Convention
+
+`<skill-dir>` means the parent directory of the `references/` directory containing this file. Resolve it before running scripts, for example:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --pretty --progress
+```
+
+## Default Settings
+
+Default mechanical collection settings are intentionally visible in `<skill-dir>/defaults.json`:
+
+```json
+{
+  "schema": "repo_memory_builder_defaults.v2",
+  "repoHistory": {
+    "mode": "local-only",
+    "limits": {
+      "commits": 30,
+      "prs": 30,
+      "issues": 30
+    }
+  },
+  "summaryChars": 4000
+}
+```
+
+To change defaults for future builder runs, edit `defaults.json`, not the Python scripts. To override one run, pass `--history-mode`, `--commit-limit`, `--pr-limit`, `--issue-limit`, or `--summary-chars` to `collect_all.py`.
+
+Provider collection is disabled by default. Use `--history-mode provider` to
+request best-effort provider evidence.
+
+## Historical Evidence Policy
+
+Historical evidence collection is configurable per run with `--history-mode` and by default with `repoHistory.mode` in `defaults.json`:
+
+| Mode | Commits | PRs/MRs and issues | Resource file contract |
+|------|---------|--------------------|------------------------|
+| `--history-mode none` | Disabled | Disabled | Write disabled resource files for commits, PRs/MRs, and issues using `source: "history_disabled"`, `resource_count: 0`, and `raw_source: ""`. |
+| `--history-mode commits-only` | Collected locally | Disabled | Write commit resources from `raw/git-commits.json`; write PR/issue files using `source: "provider_skipped_local_only"`, `resource_count: 0`, and `raw_source: ""`. |
+| `--history-mode local-only` | Collected locally | Disabled | Same as commits-only; use when the user wants local Git history but no provider calls. |
+| `--history-mode provider` | Collected locally | Best-effort | Collect provider facets when ready; if provider evidence is unavailable or fails, continue local-only and mark PR/issue resources unavailable. |
+| `--history-mode provider-required` | Collected locally | Required | Fail the collection if provider facets cannot be collected. Use only when the user explicitly requires PR/MR/issue evidence. |
+
+`--skip-provider` is a compatibility alias for `--history-mode local-only`; `--require-provider` is a compatibility alias for `--history-mode provider-required`.
+
+When history or provider evidence is disabled, skipped, unavailable, or degraded, still create `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`; write disabled resource files for any historical channel that was not collected. The disabled or unavailable resource files tell future agents that the builder intentionally did not collect that evidence. For PR/issue files, do not say that no PRs or issues exist unless provider evidence was actually collected and empty.
+
+## User Count Requests
+
+If the user mentions how many commits, PRs/MRs, or issues to collect, treat that as a one-run override and pass explicit limit flags to `collect_all.py`. Do not edit `defaults.json` for a one-run request.
+
+Examples:
+
+- "拉 50 条 commit" means add `--commit-limit 50`.
+- "PR 拉 20 条，issue 拉 30 条" means add `--pr-limit 20 --issue-limit 30`.
+- "commit、PR、issue 都拉 50 条" means add `--commit-limit 50 --pr-limit 50 --issue-limit 50`.
+
+Only edit `defaults.json` when the user asks to change defaults for future build runs, for example "以后默认都拉 50 条" or "把 repo memory 的默认 limit 改成 50".
+
+## Progress Display
+
+Skill instructions cannot render app-native progress components by themselves. For interactive builder runs, prefer `collect_all.py --progress`; it renders a terminal progress bar on stderr while keeping stdout as the final JSON report. Omit `--progress` only for strict machine-only runs that must avoid stderr progress output.
+
+The progress bar covers the mechanical collection steps: preparation, local commits, and provider facets. Provider warnings are not terminal notifications; they are returned in the JSON report as structured `notices[]` so the agent can show them as a normal user-visible assistant message. The progress bar does not replace the required provider warning notice, final JSON report review, agent-authored Markdown work, or final validation.
+
+## Build Modes
+
+Build mode controls only the local project understanding phase. The mechanical collection, authoring, and validation flow stays the same.
+
+- Default to lightweight mode when the user does not specify.
+- Use lightweight mode for a quick or docs-only pass. Read root README/high-level docs, repo-local agent instructions such as `AGENTS.md` or `CLAUDE.md`, and clearly linked overview/setup docs. Do not inspect source, manifests, scripts, or CI just to deepen the profile. Mark code-level architecture claims as doc-derived or unverified.
+- Use deep mode only when the user explicitly asks for deep/thorough/full work, or when docs are too thin to produce useful memory. Read docs and agent instructions, then inspect repository structure, module READMEs, representative source and entrypoints, manifests, scripts, and CI before writing `PROFILE.md`.
+- Do not stop to ask for a mode unless the user's request is contradictory.
+
+## Tool Roles
+
+### `scripts/collect_all.py`
+
+Use this as the primary mechanical path. It prepares the workspace, collects local git commit evidence, collects GitHub/GitLab PR/MR/issue evidence when provider auth is ready, and returns a JSON report describing completed steps and outputs. If provider collection fails after preparation reports `provider_evidence_state: "ready"`, the default behavior is to keep local commit evidence, emit a warning notice, and report `steps.provider_facets.degraded_to_local_only: true`. Only `--require-provider` turns this into a hard failure.
+
+Default run:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --pretty --progress
+```
+
+One-run limit override:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --commit-limit 50 --pr-limit 20 --issue-limit 20 --pretty --progress
+```
+
+Full refresh of an existing `.repo_memory` bundle:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --reuse --snapshot-ref HEAD --pretty --progress
+```
+
+Local-only memory or hard-required provider evidence:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --skip-provider --pretty --progress
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --snapshot-ref HEAD --require-provider --pretty --progress
+```
+
+Tell the user before starting long collection steps. After completion, report collected counts from the JSON report: local commits, PRs/MRs, issues, provider state, skipped steps, notices, and output files.
+
+#### Final Summary Notices
+
+If the final JSON report contains `notices[]`, the final user-facing summary must include those notices explicitly. Include the notice title, message, and next steps, especially `Provider Evidence Unavailable`.
+
+Do not silently collapse notices into counts, provider state, or a generic "local-only" sentence. If provider evidence degraded to local-only, say that directly and include the reason from the notice.
+
+#### Provider Sandbox and Transport Failures
+
+`gh/glab` provider collection needs external network access. If provider stderr or `notices[]` shows `fetch failed`, timeout, DNS, connection, TLS, `ENOTFOUND`, `EAI_AGAIN`, or similar transport text, report provider evidence unavailable and continue local-only unless `--require-provider` was requested.
+
+Verify provider authentication in the same normal shell with the command reported by `collect_all.py`; for GitHub Enterprise or self-hosted GitLab this may include `--hostname <host>`. Authenticate with `gh auth login` or `glab auth login` (also host-scoped when prompted), then rerun `collect_all.py`; do not paste tokens into the skill or call provider APIs directly.
+
+Do not use a restricted shell sandbox to verify provider/API availability. Verify in a normal shell or approved network-enabled mode. If only restricted shell access is available, report provider evidence unavailable and continue local-only unless `--require-provider` was requested. Do not treat a provider transport failure as empty PR/issue evidence, no PR/issue changes, bad login, or bypass the scripts with direct APIs, browser scraping, copied credentials, or hand-written raw facets.
+
+### `scripts/validate_memory.py`
+
+Use this as the final gate after authoring `PROFILE.md`, supporting conceptual pages, and `resources/*.md`. It accepts either the repository root or the memory root, validates required files, JSON parseability, frontmatter counts, placeholder removal, and provider raw/resource consistency.
+
+```bash
+python3 <skill-dir>/scripts/validate_memory.py <repo-path> --pretty
+```
+
+### Internal scripts
+
+These are invoked by `collect_all.py`. Use them directly only for debugging or narrow recovery:
+
+- `prepare_repo_memory.py`: validates the target repo, handles `--reuse`, creates `.repo_memory/{raw,resources}`, updates `.gitignore`, and writes `raw/prepare-report.json`.
+- `git_commit_facets.py`: collects local commit facets from the selected snapshot. It needs only local git history.
+- `github_resource_facets.py` and `gitlab_resource_facets.py`: collect provider PR/MR/issue facets when `prepare-report.json` says the provider is ready. They share the same downstream resource shape; GitLab merge requests are normalized into PR resources.
+
+Provider resource facets share this contract: `--snapshot-ref HEAD` filters merged PRs/MRs by merge-commit ancestry against the local snapshot; open and closed-unmerged PRs/MRs are not retained as landed evidence; issues come from the current bounded provider list because issues do not have reliable commit ancestry. For PRs/MRs, `--pr-limit` is the retained count after snapshot filtering.
+
+## Agent Workflow
+
+Follow this order manually:
+
+1. **Collect mechanical evidence**
+   - Run `collect_all.py`.
+   - Use `--reuse` only for a full refresh/rebuild of an existing `.repo_memory`; for latest-change-only updates, prefer `repo-update.md`.
+   - Read the returned JSON report and `.repo_memory/raw/prepare-report.json`.
+   - Stop if preparation fails. Do not improvise around git/repo safety checks.
+
+2. **Show provider notices**
+   - If `notices[]` contains `Provider Evidence Unavailable`, show it as a normal assistant message before continuing and repeat it in the final summary.
+   - Render `title` as a bold heading, `message` as body text, `command` as the login command when present, and `next_steps` as recovery steps. Do not show raw JSON or put the notice inside a fenced code block.
+   - If `notices[]` is absent, fall back to `raw/prepare-report.json`: when `provider_notice_level` is `warning`, render `provider_notice_markdown` as a normal assistant message.
+   - If the user explicitly required PR/MR/issue evidence, run with `--require-provider`, stop after provider failure, and ask them to install/login or fix repository access before rerunning.
+
+Use this visible shape:
+
+```text
+**Provider Evidence Unavailable**
+
+<notice.message>
+
+**Next steps for provider evidence**
+Run: `<notice.command>`
+
+<notice.next_steps rerun item>
+```
+
+3. **Understand the local project**
+   - Choose lightweight by default; choose deep only when requested or clearly needed.
+   - Form project-level understanding before looking at PR/issue history.
+   - Record whether conclusions are doc-derived or code-inspected.
+
+4. **Plan and draft the wiki landing page and conceptual pages**
+   - Read [repo-templates.md](repo-templates.md) before writing memory files.
+   - Create `.repo_memory/_plan.md` after discovery and before final wiki writing. Use it to cluster repository-native conceptual areas, page purposes, evidence, boundaries, canonical homes, merge/split decisions, weak evidence, and path verification needs.
+   - Write `PROFILE.md` as the wiki landing page with repo identity, checkout state, what the repo contains, how it works, first-use path, Major Areas, Supporting Pages, provider context, and evidence inspected.
+   - Create repository-native supporting conceptual pages from the plan. Cover only concepts, workflows, system areas, or change surfaces with enough evidence to deserve canonical pages.
+   - Remove `.repo_memory/_plan.md` before final validation.
+   - Record the selected build mode and avoid overstating code-level claims in lightweight mode.
+
+5. **Review raw evidence**
+   - Confirm `raw/git-commits.json` exists.
+   - When provider evidence is available, confirm the matching provider facets exist.
+   - If provider evidence is missing, skipped, or degraded to local-only, keep PR/issue resources explicitly marked unavailable instead of inventing provider evidence.
+
+6. **Author human-readable resources**
+   - Use the resource templates in [repo-templates.md](repo-templates.md).
+   - Read raw facets and write `resources/commits.md`, `resources/prs.md`, and `resources/issues.md` yourself.
+   - Keep resources compact. Use one fixed-field section per commit, PR/MR, or issue, separated by `---`; do not use Markdown tables.
+   - Every section must include a search-grade `Description`.
+
+7. **Finalize and validate**
+   - Add final pointers and provider snapshot notes to `PROFILE.md`.
+   - Set `PROFILE.md.source_tree` to the selected snapshot's full Git tree SHA.
+   - Run `validate_memory.py` as the final gate.
+   - Fix authored Markdown placeholders, frontmatter counts, or resource mismatches before reporting success.
+
+## Refresh/Update Workflow
+
+For incremental updates to recent commits, PRs/MRs, or issues in an existing `.repo_memory`, use `repo-update.md`.
+
+Use builder refresh only when the user wants a full rebuild/full refresh while preserving the existing memory directory:
+
+```bash
+python3 <skill-dir>/scripts/collect_all.py --repo-path <repo-path> --reuse --pretty --progress
+```
+
+Then rewrite affected human-authored resources from the new raw evidence. Preserve useful existing notes only when they are still supported by current raw evidence and live repository inspection. Never append or patch raw/provider JSON by hand; rerun the collection scripts instead.
+
+## Description Quality Standard
+
+`Description` is the main agentic-search surface for `resources/commits.md`, `resources/prs.md`, and `resources/issues.md`. Keep only the core rule here; the full quality standard and section scaffolding live in [repo-templates.md](repo-templates.md).
+
+Every description must say what the item explains, when a future agent should open it, which modules/files/commands/config it points to, concrete search cues, and evidence strength. Do not copy raw summaries, headings, or tables into descriptions, and avoid vague descriptions like "fix bug" or "update docs".
+
+## Generated Knowledge Contract
+
+Generate memory that the `repo-wiki` repo-read operation can consume progressively:
+
+- `PROFILE.md` is the stable wiki landing page and should summarize identity, evidence, major areas, supporting pages, verification gates, and resource pointers.
+- Supporting conceptual pages are repository-native canonical homes for concepts, workflows, system areas, and change surfaces selected through temporary planning.
+- `resources/*.md` are compact historical routing cards with search-grade descriptions.
+- `raw/*.json` contains optional build/debug evidence for deep inspection when compact resources are insufficient.
+
+Do not duplicate the daily retrieval workflow here. The `repo-read` operation owns trigger timing, silent background-maintenance handoff, and task-specific search behavior.
+
+## Trust Rules
+
+- Local code and targeted verification are stronger evidence than generated memory.
+- Local git commit evidence is checkout history and does not require provider login.
+- GitHub/GitLab PR/issue evidence is historical/contextual, not proof of current checkout behavior.
+- Open PRs are active branch intent, not landed behavior.
+- Closed unmerged PRs are weak or superseded evidence.
+- Merged PRs are useful history but still require current code verification.
+
+## Authoring Templates
+
+When writing `PROFILE.md`, `resources/commits.md`, `resources/prs.md`, or `resources/issues.md`, read [repo-templates.md](repo-templates.md) and use it as fill-in scaffolding. Remove placeholders from final files and delete sections that are genuinely unavailable.
+
+Apply these rules even before loading the templates:
+
+- Use fixed-field resource sections separated by `---`; do not use Markdown tables for PRs or issues.
+- Write search-grade `Description` fields that explain what the PR/issue covers, when future agents should open it, affected modules/files/behaviors, concrete search cues, and evidence strength.
+- Do not copy raw summaries or headings into descriptions; synthesize routing cues from raw facets and current project understanding.
+- Do not add persistent `indexes/*.json` files or `index:` frontmatter; search `resources/*.md` directly and open raw JSON only for build/debug evidence.

--- a/examples/skills/repo-wiki/references/repo-read.md
+++ b/examples/skills/repo-wiki/references/repo-read.md
@@ -1,0 +1,75 @@
+# Repo Memory Read
+
+## Role And Demand Gate
+
+Use existing `.repo_memory/` as wiki-style repo memory for repository identity, architecture, history, PR/issue context, remembered fixes, and cross-module search. Live code and tests remain authoritative.
+
+Select this reference for broad repo introduction, history, architecture background, cross-module routing, PR/issue context, design rationale, or stale-memory awareness. Skip this reference for narrow tasks with a clear live-code target.
+
+Explicit build, rebuild, or update requests route through `SKILL.md` to
+`repo-build.md` or `repo-update.md`.
+
+## Repository
+
+Resolve the repository in this order:
+
+1. Use the user's explicit local path.
+2. Otherwise use the current workspace Git root.
+3. Infer a named local repo only when the match is unambiguous.
+4. Ask for the path only when multiple repos remain plausible.
+
+Derive memory as `<repo>/.repo_memory`; never ask for a memory-directory path. If the target is not inside a Git worktree, continue from live files.
+
+## Retrieval
+
+If `.repo_memory/PROFILE.md` is a readable regular file, read `PROFILE.md` as the wiki landing page once. Treat its descriptions as routing cues, not proof.
+
+Extract task-relevant links from `Major Areas` and `Supporting Pages`. Do not assume fixed page names; use `PROFILE.md` links and headings to find the repository-native canonical homes for the user's task. Open at most 2-4 relevant conceptual pages from `.repo_memory/*.md` before searching historical resources.
+
+Search `PROFILE.md`, `.repo_memory/*.md`, and `.repo_memory/resources/` with a combined query built from the user's strongest handles: path, basename, symbol, command, PR/issue number, error text, module, branch, environment variable, or config key.
+
+```bash
+rg -n '<handle-1>|<handle-2>' \
+  .repo_memory/PROFILE.md .repo_memory/*.md .repo_memory/resources
+```
+
+Use:
+
+- conceptual `.repo_memory/*.md` pages for repository-native canonical homes, workflows, system areas, change surfaces, and verification routing;
+- resources/*.md for historical routing cards;
+- `resources/commits.md` for local history and regressions;
+- `resources/prs.md` for merged or active implementation context;
+- `resources/issues.md` for symptoms, requests, and requirements.
+
+Disabled and unavailable historical resource files are collection state, not repository state. If a resource frontmatter uses `source: "history_disabled"`, `source: "provider_skipped_local_only"`, or `source: "provider_unavailable"` with `resource_count: 0`, do not conclude that there are no commits, PRs, MRs, or issues. Treat the channel as intentionally uncollected or unavailable; answer from available memory only. Ask whether to rebuild with provider history when that context matters.
+
+If a read is missing, unreadable, or structurally mixed, discard conclusions that depend only on the bundle. Do not repair it in the foreground.
+
+## Retrieval Budget
+
+- Read `PROFILE.md` at most once.
+- Run at most 2 combined `rg` commands.
+- Stop repo-memory retrieval as soon as the hits are sufficient.
+- Open at most 2-4 relevant conceptual pages total during the bounded memory phase.
+- Open only the matched resource section when `rg` context is insufficient.
+
+Do NOT open these unless the user explicitly asks or a compact hit contains only a `facetId`:
+
+- `.repo_memory/raw/*.json`;
+- `docs/`, `packages/`, `tests/`, or other live source directories.
+
+The live directories restriction applies only during the bounded memory phase. Current implementation claims and code edits still require live-code verification after the maintenance handoff.
+
+## Answer And Trust Rules
+
+Answer history, architecture, and context questions from sufficient memory hits. If two bounded searches miss, say what was not found and ask whether to inspect more deeply.
+
+Continue into live evidence when the user asks about current behavior, requests an edit, or the bundle was unavailable. Keep these distinctions explicit:
+
+- live code and targeted verification are stronger than generated memory;
+- tests are stronger than PR or issue summaries;
+- commits and merged PRs are historical evidence, not current-behavior proof;
+- open PRs describe intent;
+- issues describe problem context.
+
+Never create, update, delete, or repair repo-memory files in the foreground `repo-read` task.

--- a/examples/skills/repo-wiki/references/repo-templates.md
+++ b/examples/skills/repo-wiki/references/repo-templates.md
@@ -1,0 +1,383 @@
+# Repo Memory Authoring Templates
+
+Use these templates as fill-in scaffolds. Replace all bracketed placeholders with conclusions from local code inspection and raw facets. Remove sections that are genuinely unavailable; do not leave placeholders in final files.
+
+### `.repo_memory/PROFILE.md`
+
+`PROFILE.md` is the only fixed conceptual wiki file. It is a wiki landing page, not a dense resource index. It should read like a wiki-style repository memory home page: concise project identity, first-use path, major areas, supporting pages, and historical/provider pointers. Keep repository-Wiki frontmatter so the validator and maintenance hooks can still trust the bundle.
+
+```markdown
+---
+schema: "repo_memory_profile.v0.2"
+layout: "wiki_landing_page.v0.1"
+disclosure_model: "progressive_wiki"
+repo_name: "[repo name]"
+repo_owner: "[owner or empty]"
+repo_full_name: "[owner/name or empty]"
+repo_url: "[remote URL or empty]"
+code_host_provider: "github|gitlab|none"
+source_repo_path: "."
+generated_at: "[ISO timestamp]"
+build_mode: "lightweight|deep"
+local_head: "[git HEAD]"
+source_tree: "[40-character Git tree SHA]"
+local_branch: "[branch or detached HEAD]"
+working_tree_state: "clean|dirty|unknown"
+trust_state: "draft"
+code_host_resource_state: "available|unavailable|partial"
+resources:
+  commits: "resources/commits.md"
+  prs: "resources/prs.md"
+  issues: "resources/issues.md"
+raw:
+  prepare_report: "raw/prepare-report.json"
+  commit_facets: "raw/git-commits.json"
+  provider_facets: "raw/github-facets.json|raw/gitlab-facets.json|"
+---
+
+# [Repo Name] Repository Wiki
+
+[One short paragraph explaining what this repository is, who uses it, and the primary runtime/package/product surface. Ground this in inspected docs or source.]
+
+- Repository: `[owner/name or local repo]`
+- Local HEAD when prepared: `[sha]` on `[branch]`
+- Build mode: `[lightweight|deep]`; working tree was `[clean/dirty + explanation]`
+- License: `[license if known]`
+
+## What This Repo Contains
+
+| Area | What it does |
+|------|--------------|
+| `[repo-native product/module/workflow name]` (`path/`) | [Plain-language responsibility and primary entrypoint.] |
+| `[repo-native product/module/workflow name]` (`path/`) | [Plain-language responsibility and primary entrypoint.] |
+
+## How It Works
+
+[Five to ten sentences describing the main runtime/build/request/data flow. Link to supporting pages instead of explaining every detail here. Use conservative wording when lightweight mode did not inspect representative source.]
+
+## First-Use Path
+
+```bash
+[install or setup command]
+[one fast verification or smoke command]
+```
+
+[Explain the shortest safe path a future agent should use to orient, build, test, or run the project.]
+
+## Major Areas
+
+Choose these rows from `.repo_memory/_plan.md` after clustering inspected docs/source paths. Do not assume fixed page names; generic names are fallback names only when repository vocabulary gives no stronger topic.
+
+| Area | Page | What It Covers |
+|------|------|----------------|
+| `[repo-native area name]` | [`[human page title]`](./repo-native-topic.md) | [What task cluster this page routes and why it is a canonical home.] |
+| `[repo-native area name]` | [`[human page title]`](./repo-native-topic.md) | [What task cluster this page routes and why it is a canonical home.] |
+
+## Supporting Pages
+
+- [`[human page title]`](./repo-native-topic.md) - open when [task cue, change surface, workflow, or risk].
+- [`[human page title]`](./another-repo-native-topic.md) - open when [task cue, change surface, workflow, or risk].
+
+## Agent Consumption Rules
+
+1. Read this file first, then open only the supporting page relevant to the task. Memory is a map, not proof.
+2. Verify current behavior against live source, configs, tests, or executable checks before editing or making strong claims.
+3. Treat commits, PRs/MRs, and issues as historical routing context; they do not prove current checkout behavior.
+4. Prefer source paths and commands linked from supporting pages over broad repository scanning.
+
+## Provider Context
+
+- [Historical commits](./resources/commits.md) - local checkout history and regression routing.
+- [Historical PRs/MRs](./resources/prs.md) - implementation context from provider facets when available.
+- [Historical issues](./resources/issues.md) - user/request/problem context when available.
+- Raw local commit facets: `./raw/git-commits.json`.
+- Raw code-host facets: `./raw/github-facets.json` or `./raw/gitlab-facets.json` when present.
+
+## Evidence Inspected
+
+- Root docs and agent instructions: `[README/docs/AGENTS.md/CLAUDE.md or similar files inspected]`.
+- Module docs: `[module README/docs inspected]`.
+- Representative source: `[important source/entrypoint files inspected, or 'not inspected in lightweight mode']`.
+- Manifests/scripts/CI: `[manifests, scripts, workflows inspected, or 'not inspected in lightweight mode']`.
+- Local commit snapshot: `[raw/git-commits.json status and count]`.
+- Historical code-host snapshot: `[raw/github-facets.json or raw/gitlab-facets.json status and counts]`.
+```
+
+### `.repo_memory/_plan.md`
+
+Create this temporary planning artifact after discovery and before final wiki writing. Use it to cluster repository concepts and choose natural page boundaries. Remove `_plan.md` before final validation; it is not part of the durable bundle.
+
+```markdown
+# Repo Memory Wiki Plan
+
+## Candidate Domains Considered
+
+- [selected, merged, or skipped candidate domain] - [source evidence and decision].
+
+## Intended Final Pages
+
+| Page | Purpose | Source evidence | Boundary |
+|------|---------|-----------------|----------|
+| `repo-native-topic.md` | [Future-agent task this page routes.] | [Docs/source/tests/scripts inspected.] | [What belongs here and what belongs elsewhere.] |
+
+## Canonical Homes And Overlaps
+
+- [Overlapping concept] belongs in `[page]`; link from `[other page]` instead of duplicating because [reason].
+
+## Weak Evidence And Verification Needs
+
+- [Claim/path/command] needs [specific verification] before final writing, or should be omitted.
+```
+
+### `.repo_memory/<repo-native-topic>.md`
+
+Create supporting conceptual pages after clustering inspected evidence. Name pages from repository vocabulary, not from this template. Use lowercase kebab-case filenames derived from product surfaces, runtime components, commands, protocols, adapters, workflows, data models, operations, or other durable repository concepts. Generic names are fallback names only when repository vocabulary gives no stronger topic. Every conceptual page must include frontmatter so validation can scan it.
+
+```markdown
+---
+schema: "repo_memory_wiki_page.v0.1"
+page_type: "architecture|workflow|data-model|integration|operation|testing|extension|domain"
+generated_at: "[ISO timestamp]"
+source_profile: "PROFILE.md"
+trust_state: "draft_wiki_page"
+---
+
+# [Human Documentation Title]
+
+## Purpose
+
+[Explain which future tasks should open this page and what decisions it helps route.]
+
+## Key Paths
+
+| Path | Responsibility | When to inspect |
+|------|----------------|-----------------|
+| `path/to/file-or-dir` | [What it owns.] | [Task cue, symbol, command, or failure mode.] |
+
+## Flow Or Boundaries
+
+[Explain the concept, lifecycle, dependency direction, or ownership boundary. Prefer short paragraphs and bullets over exhaustive API reference.]
+
+## Verification
+
+- [Fast command or source check relevant to this page.]
+- [Expensive or environment-dependent check, or say none identified.]
+
+## Agent Notes
+
+- Treat this page as routing context and verify current behavior in live source before editing.
+- [One repo-specific caution, extension rule, or likely pitfall.]
+```
+
+### `.repo_memory/resources/commits.md`
+
+Use fixed-field sections, not Markdown tables. Every commit needs a search-grade `Description` following the standard in `SKILL.md`. Do not paste the full raw summary; full raw summaries stay in `../raw/git-commits.json`.
+
+```markdown
+---
+schema: "repo_memory_commit_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "git_commit_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/git-commits.json"
+---
+
+# Commit Resource Snapshot
+
+Source: `.repo_memory/raw/git-commits.json`. Treat commits as local checkout history only: they are useful routing evidence, but current-code verification is still required.
+
+## Commit [short_sha]: [title]
+
+- SHA: `[full sha]`
+- Evidence status: [One short sentence describing local-history evidence strength and whether current source was verified.]
+- Author: `[author name]`
+- Authored: `[ISO timestamp]`
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from raw facets or current inspection]`
+- Description: [2-4 search-grade sentences: what this commit changes, when future agents should open it, affected modules/files/runtime behavior, search cues, and evidence strength]
+- Key files: `[path/a.py]`, `[path/b.md]`
+- Diff: `[changed_files] files, +[additions]/-[deletions]`
+- Parent count: `[count]`
+- Agent note: [how future agents should treat this commit]
+- Raw lookup: `facetId=commit.abc1234`
+
+---
+
+## Commit [short_sha]: [title]
+
+- SHA: `...`
+- Evidence status: ...
+- Author: `...`
+- Authored: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Key files: ...
+- Diff: ...
+- Parent count: ...
+- Agent note: ...
+- Raw lookup: `facetId=commit.abc1234`
+```
+
+When commit history is disabled by policy, still write a disabled resource file:
+
+```markdown
+---
+schema: "repo_memory_commit_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "history_disabled"
+resource_count: 0
+trust_state: "disabled_by_policy"
+raw_source: ""
+---
+
+# Commit Resource Snapshot
+
+No commit evidence was collected because historical evidence was disabled for this build. This is a collection-policy statement, not proof that the repository has no commits.
+```
+
+### `.repo_memory/resources/prs.md`
+
+Use fixed-field sections, not Markdown tables. Every GitHub PR or GitLab MR needs a search-grade `Description` following the standard in `SKILL.md`. Do not paste the full raw summary; full raw summaries stay in `../raw/github-facets.json` or `../raw/gitlab-facets.json`.
+
+```markdown
+---
+schema: "repo_memory_pr_resource.v0.1"
+repo_full_name: "[owner/name]"
+generated_at: "[ISO timestamp]"
+source: "github_resource_facets|gitlab_resource_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/github-facets.json|../raw/gitlab-facets.json"
+---
+
+# Pull Request Resource Snapshot
+
+Source: `.repo_memory/raw/github-facets.json` or `.repo_memory/raw/gitlab-facets.json`. Treat PRs/MRs as historical context only: merged PRs/MRs still require current-code verification, open PRs/MRs are branch intent, and closed-unmerged PRs/MRs are weak evidence.
+
+## PR/MR #[number]: [title]
+
+- State: `MERGED|OPEN|CLOSED` [include draft if applicable]
+- Evidence status: [One short sentence describing historical/current relevance and whether current source was verified.]
+- Branch: `base <- head`
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from raw facets or current inspection]`
+- Description: [2-4 search-grade sentences: what this PR explains, when future agents should open it, affected modules/files/runtime behavior, search cues, and evidence strength]
+- Key files: `[path/a.py]`, `[path/b.md]`
+- Diff: `[changed_files] files, +[additions]/-[deletions]`
+- Linked issues: `#[issue]` or `-`
+- Commit signal: [1-3 commit headlines or `-`]
+- Agent note: [how future agents should treat this PR]
+- URL: [PR URL]
+- Raw lookup: use `facetId=pr.123` for GitHub PRs or `facetId=mr.123` for GitLab MRs.
+
+---
+
+## PR/MR #[number]: [title]
+
+- State: `...`
+- Evidence status: ...
+- Branch: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Key files: ...
+- Diff: ...
+- Linked issues: ...
+- Commit signal: ...
+- Agent note: ...
+- URL: ...
+- Raw lookup: use `facetId=pr.123` for GitHub PRs or `facetId=mr.123` for GitLab MRs.
+```
+
+### `.repo_memory/resources/issues.md`
+
+Use fixed-field sections, not Markdown tables. Every issue needs a search-grade `Description` following the standard in `SKILL.md`. Keep evidence compact; full raw summaries stay in `../raw/github-facets.json` or `../raw/gitlab-facets.json`.
+
+```markdown
+---
+schema: "repo_memory_issue_resource.v0.1"
+repo_full_name: "[owner/name]"
+generated_at: "[ISO timestamp]"
+source: "github_resource_facets|gitlab_resource_facets"
+resource_count: [count]
+trust_state: "draft_resource"
+raw_source: "../raw/github-facets.json|../raw/gitlab-facets.json"
+---
+
+# Issue Resource Snapshot
+
+Source: `.repo_memory/raw/github-facets.json` or `.repo_memory/raw/gitlab-facets.json`. Treat issues as requirement, bug, support, or planning context; verify against current code before acting.
+
+## Issue #[number]: [title]
+
+- State: `OPEN|CLOSED`
+- Evidence status: [One short sentence describing issue evidence strength, relevance, and whether current source was verified.]
+- Modules: `[semantic modules for human routing]`
+- Path modules: `[path prefixes from linked PR facets or current inspection, or -]`
+- Description: [2-4 search-grade sentences: what user problem/request this issue explains, when future agents should open it, affected behavior/modules, symptoms/errors, search cues, and evidence strength]
+- Evidence: [short evidence: label, error, user pain point, requirement, or theme]
+- Linked PRs: `#[pr]` or `-`
+- Linked branches: `base <- head` or `-`
+- Agent note: [how future agents should use this issue]
+- URL: [Issue URL]
+- Raw lookup: `facetId=issue.123`
+
+---
+
+## Issue #[number]: [title]
+
+- State: `...`
+- Modules: `...`
+- Path modules: `...`
+- Description: ...
+- Evidence: ...
+- Linked PRs: ...
+- Linked branches: ...
+- Agent note: ...
+- URL: ...
+- Raw lookup: `facetId=issue.123`
+```
+
+### Disabled Or Unavailable Resource Files
+
+Use this pattern when historical evidence or provider evidence was intentionally not collected, unavailable, or degraded to local-only. Keep `resource_count: 0` and `raw_source: ""`; do not fabricate PRs, MRs, issues, or raw provider evidence. Use `source: "history_disabled"` when the entire history channel is disabled, `source: "provider_skipped_local_only"` when provider collection was skipped for a local-only build, and `source: "provider_unavailable"` when provider collection could not be completed.
+
+For PR/MR resources:
+
+```markdown
+---
+schema: "repo_memory_pr_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "provider_skipped_local_only|provider_unavailable|history_disabled"
+resource_count: 0
+trust_state: "unavailable_local_only|disabled_by_policy"
+raw_source: ""
+---
+
+# Pull Request Resource Snapshot
+
+No provider evidence was collected for PRs/MRs in this build. This means PR/MR history is unavailable in the memory bundle; it does not mean the repository has no PRs or MRs.
+```
+
+For issue resources:
+
+```markdown
+---
+schema: "repo_memory_issue_resource.v0.1"
+repo_full_name: "[owner/name or local repo name]"
+generated_at: "[ISO timestamp]"
+source: "provider_skipped_local_only|provider_unavailable|history_disabled"
+resource_count: 0
+trust_state: "unavailable_local_only|disabled_by_policy"
+raw_source: ""
+---
+
+# Issue Resource Snapshot
+
+No provider evidence was collected for issues in this build. This means issue history is unavailable in the memory bundle; it does not mean the repository has no issues.
+```

--- a/examples/skills/repo-wiki/references/repo-update.md
+++ b/examples/skills/repo-wiki/references/repo-update.md
@@ -1,0 +1,127 @@
+# Repo Memory Update
+
+## Core Principle
+
+Update existing repo memory from a delta, not a full rebuild. Treat the current `.repo_memory/` bundle as the baseline, follow the effective history policy, detect only the enabled local commit and provider PR/MR/issue changes, then edit only the affected resources.
+
+Do not rebuild the whole bundle by default. Return to `SKILL.md` and use `repo-build.md` only when `.repo_memory/PROFILE.md` is missing, the existing memory is structurally unusable, or the user explicitly asks for a full rebuild.
+
+This is the incremental updater, not the daily reader. Use `repo-read.md` for task-time search over existing memory. Use `repo-build.md` for first-time creation, full rebuild flows, or full refresh work that should rerun builder collection with `collect_all.py --reuse`.
+
+## Prerequisite
+
+The user selects a repository, not a memory directory. Derive the memory path as `<repo>/.repo_memory`.
+
+Require:
+
+- `<repo>` is a local git repository;
+- `<repo>/.repo_memory/PROFILE.md` exists;
+- existing `PROFILE.md` and `resources/*.md` are treated as the baseline.
+
+If `.repo_memory/PROFILE.md` is missing, stop and route to `repo-build.md`; do not fabricate an incremental baseline from live files alone.
+
+## Path Convention
+
+`<skill-dir>` means the parent directory of the `references/` directory containing this file.
+
+## Default Settings
+
+Updater uses `<skill-dir>/defaults.json` so build and update operations stay aligned. It reads `repoHistory.mode`, `repoHistory.limits.prs`, `repoHistory.limits.issues`, and `summaryChars`, with compatibility fallback to legacy `limits.prs` and `limits.issues`; local commit deltas are not limit-capped because they are computed from the stored baseline commit to current `HEAD` when commit history is enabled.
+
+Override one updater run with `--history-mode`, `--pr-limit`, `--issue-limit`, or `--summary-chars`. Do not edit `defaults.json` for a one-run updater request.
+
+History policy modes:
+
+- `none`: skip local commit deltas and provider PR/MR/issue deltas.
+- `commits-only` or `local-only`: detect local commit deltas and skip provider PR/MR/issue deltas.
+- `provider`: detect local commit deltas and fetch provider PR/MR/issue deltas when provider evidence is ready.
+- `provider-required`: detect local commit deltas and require provider PR/MR/issue evidence rather than silently authoring provider resources without evidence.
+
+Do not re-enable commit or provider channels disabled by policy. Use the detector's `effective_settings.history` block as the authority for which history channels are enabled.
+
+## User Count Requests
+
+If the user says how many PRs/MRs or issues to compare, pass explicit one-run flags:
+
+- "PR 拉 20 条" means add `--pr-limit 20`.
+- "issue 拉 30 条" means add `--issue-limit 30`.
+- "PR 和 issue 都拉 50 条" means add `--pr-limit 50 --issue-limit 50`.
+
+Only change `<skill-dir>/defaults.json` when the user asks to change future default behavior.
+
+## Detection
+
+Start every updater run by detecting deltas:
+
+```bash
+python3 <skill-dir>/scripts/detect_updates.py \
+  --repo-path <repo-path> \
+  --pretty
+```
+
+The detector:
+
+- reads the effective history policy from `repoHistory.mode` and reports it in `effective_settings.history`;
+- reads the commit baseline from `PROFILE.md` `local_head`, with a fallback to the nearest stored ancestor commit in `resources/commits.md`;
+- reads PR/MR and issue baselines from `resources/prs.md` and `resources/issues.md`, enriched by existing raw provider facets when available;
+- compares local git `HEAD` against the newest stored commit only when commit history is enabled;
+- reports `local_commit_status.status: "skipped"` with `reason: "history_disabled_by_policy"` when `repoHistory.mode` disables commit history;
+- reports `local_commit_status.status: "skipped"` with `reason: "missing_baseline_commit"` when no stored local commit baseline can be found;
+- reports `local_commit_status.status: "skipped"` with `reason: "baseline_not_ancestor_of_head"` when history was rebased or force-pushed, instead of silently returning no commit delta;
+- detects provider state from live git remotes and provider CLIs only when provider history is enabled;
+- fetches bounded latest GitHub/GitLab PR/MR/issue facets only when provider history is enabled and provider evidence is available;
+- reports added or changed PR/MR/issue numbers without editing memory files;
+- reports provider items missing from the current bounded window as `baseline_only_numbers`, not as deletions.
+
+Warnings such as rewritten commit baselines or provider fetch failures are returned as structured `notices[]` with `render_as: "assistant_message"`. Show these notices to the user as normal assistant messages; do not bury them in terminal output.
+
+When provider fetch succeeds, the report includes fetched authoring evidence under `current.provider_items.pull_requests` and `current.provider_items.issues`. Use those facets, plus existing raw/provider resources when needed, to write or replace search-grade sections; do not author provider sections from number-only deltas.
+
+The report also includes `builder_helpers` fingerprints for the sibling builder files that updater depends on, including `path`, `exists`, `mtime_ns`, and `size_bytes`. Use this only for compatibility diagnostics; it is not evidence for authoring repo-memory resources.
+
+Use `--history-mode local-only` or `--history-mode none` when the user requests a one-run history-policy override. `--provider-mode off` remains supported as a compatibility provider-only override when provider access is intentionally unavailable.
+
+## Provider Sandbox and Transport Failures
+
+`gh/glab` provider delta detection needs external network access. If `current.provider_fetch.ok` is false, or notice/stderr shows `fetch failed`, timeout, DNS, connection, TLS, `ENOTFOUND`, `EAI_AGAIN`, or similar transport text, show `Provider Delta Fetch Failed`, keep existing PR/MR/issue resources unchanged, and continue only with safe local commit updates.
+
+Verify provider authentication in the same normal shell with the command reported by `detect_updates.py`; for GitHub Enterprise or self-hosted GitLab this may include `--hostname <host>`. Authenticate with `gh auth login` or `glab auth login` (also host-scoped when prompted), then rerun `detect_updates.py`; do not paste tokens into the skill or call provider APIs directly.
+
+Do not use a restricted shell sandbox to verify provider/API availability. Verify in a normal shell or approved network-enabled mode before editing provider resources. If only restricted shell access is available, keep existing PR/MR/issue resources unchanged and continue only with safe local commit updates. Do not treat provider fetch failure as no PR/issue delta, empty provider evidence, bad login, or bypass the detector with direct APIs, browser scraping, copied credentials, or hand-written raw facets.
+
+## Report Gates
+
+Read the JSON report as gates before editing. Stop at the first blocking gate; otherwise edit only resources named by the report.
+
+| Report field | Action |
+| --- | --- |
+| `ok: false` and missing memory | Route to `repo-build.md`; do not invent a baseline. |
+| no deltas and no notices | Report no update needed. |
+| `commit_delta_skipped: "missing_baseline_commit"` | Stop commit-resource updates; recommend full rebuild. |
+| `commit_delta_skipped: "baseline_not_ancestor_of_head"` | Stop commit-resource updates; recommend rebuild or explicit baseline reset. |
+| provider fetch failed / `Provider Delta Fetch Failed` | Keep existing PR/MR/issue resources unchanged; local commits may still be updated. |
+| `deltas.local_commits` | Update only `resources/commits.md`; refresh `PROFILE.md` local head and `generated_at` timestamp. |
+| `deltas.pull_requests.upsert_numbers` | Upsert only matching PR/MR sections from `current.provider_items.pull_requests`; preserve `baseline_only_numbers`. |
+| `deltas.issues.upsert_numbers` | Upsert only matching issue sections from `current.provider_items.issues`; preserve `baseline_only_numbers`. |
+
+Never delete prior PR/MR/issue sections because they are absent from the bounded provider fetch; deletion needs explicit user instruction or verified invalidation. Finish with the builder validator:
+
+```bash
+python3 <skill-dir>/scripts/validate_memory.py <repo-path> --pretty
+```
+
+Whenever an update changes generated repo-memory artifacts, set `PROFILE.md.generated_at` to the successful update time, `PROFILE.md.local_head` to the processed snapshot, and `PROFILE.md.source_tree` to the snapshot's full Git tree SHA. The read-time cooldown policy uses this timestamp; do not preserve an older build time after a successful incremental update.
+
+## Authoring Rules
+
+Match existing fixed-field sections first; use builder templates only when the file shape is incomplete. Upsert by stable keys: commit SHA, PR/MR number, and issue number. Replace matching sections, append only new keys, and do not delete useful notes unless explicit instruction or verified evidence invalidates them.
+
+Every new or replaced section needs a search-grade `Description`, evidence strength, and source from local commit delta, `current.provider_items`, or raw provider files. Number-only deltas route the edit; they are not authoring evidence. Do not invent PR/MR/issue evidence when provider fetch is skipped or unavailable, paste long raw summaries, or treat validator/counts as proof of body quality.
+
+## Trust Rules
+
+- Live code and targeted verification are stronger than repo memory.
+- Local commit deltas are checkout history, not current behavior proof.
+- Provider PR/MR/issue deltas are historical or planning context, not implementation truth.
+- Open PRs/MRs are branch intent, not landed behavior.
+- Issues are user/problem context, not implementation proof.

--- a/examples/skills/repo-wiki/scripts/collect_all.py
+++ b/examples/skills/repo-wiki/scripts/collect_all.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Run the mechanical repo-memory collection steps."""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULTS_PATH = SCRIPT_DIR.parent / "defaults.json"
+FALLBACK_DEFAULTS = {
+    "repoHistory": {
+        "mode": "local-only",
+        "limits": {
+            "commits": 30,
+            "prs": 30,
+            "issues": 30,
+        },
+    },
+    # Kept for compatibility with defaults.json v1.
+    "limits": {
+        "commits": 30,
+        "prs": 30,
+        "issues": 30,
+    },
+    "summaryChars": 4000,
+}
+
+HISTORY_MODES = {"none", "commits-only", "local-only", "provider", "provider-required"}
+
+
+class ProgressBar:
+    def __init__(self, enabled: bool, total: int) -> None:
+        self.enabled = enabled
+        self.total = total
+        self.width = 20
+        self._last_line_len = 0
+        self._is_tty = sys.stderr.isatty()
+
+    def update(self, completed: int, label: str) -> None:
+        if not self.enabled:
+            return
+        completed = max(0, min(completed, self.total))
+        filled = round((completed / self.total) * self.width) if self.total else self.width
+        bar = "#" * filled + "-" * (self.width - filled)
+        line = f"repo-wiki repo-build [{bar}] {completed}/{self.total} {label}"
+        if self._is_tty:
+            padding = " " * max(0, self._last_line_len - len(line))
+            print(f"\r{line}{padding}", end="", file=sys.stderr, flush=True)
+            self._last_line_len = len(line)
+        else:
+            print(line, file=sys.stderr, flush=True)
+
+    def fail(self, completed: int, label: str) -> None:
+        self.update(completed, label)
+        self.finish()
+
+    def finish(self) -> None:
+        if self.enabled and self._is_tty:
+            print(file=sys.stderr, flush=True)
+
+
+def run_step(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+
+
+def json_step(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return {
+        "ok": result.returncode == 0,
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def raw_source_counts(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    data = load_json(path)
+    if not isinstance(data, list):
+        return {}
+    counts = Counter(str(item.get("sourceType") or "unknown") for item in data if isinstance(item, dict))
+    return dict(sorted(counts.items()))
+
+
+def emit_process_output(result: subprocess.CompletedProcess[str]) -> None:
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result.stdout:
+        print(result.stdout, file=sys.stderr)
+
+
+def write_report(report: dict[str, Any], pretty: bool) -> None:
+    print(json.dumps(report, ensure_ascii=False, indent=2 if pretty else None))
+
+
+def write_failure(
+    failed_step: str,
+    result: subprocess.CompletedProcess[str],
+    pretty: bool,
+    *,
+    repo: Optional[Path] = None,
+    memory: Optional[Path] = None,
+    provider: Optional[dict[str, Any]] = None,
+    steps: Optional[dict[str, Any]] = None,
+    outputs: Optional[dict[str, str]] = None,
+    notices: Optional[list[dict[str, Any]]] = None,
+    effective_settings: Optional[dict[str, Any]] = None,
+) -> int:
+    emit_process_output(result)
+    step_reports = dict(steps or {})
+    step_reports[failed_step] = json_step(result)
+    report = {
+        "ok": False,
+        "failed_step": failed_step,
+        "steps": step_reports,
+    }
+    if repo is not None:
+        report["repo_path"] = str(repo)
+    if memory is not None:
+        report["memory_path"] = str(memory)
+    if provider is not None:
+        report["provider"] = provider
+    if outputs:
+        report["outputs"] = outputs
+    if notices:
+        report["notices"] = notices
+    if effective_settings is not None:
+        report["effective_settings"] = effective_settings
+    write_report(report, pretty)
+    return result.returncode or 1
+
+
+def provider_report(prepare_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": prepare_report.get("git_provider", ""),
+        "repo": prepare_report.get("git_remote_repo", ""),
+        "host": prepare_report.get("git_remote_host", ""),
+        "remote_name": prepare_report.get("git_remote_name", ""),
+        "selection_reason": prepare_report.get("git_remote_selection_reason", ""),
+        "cli": prepare_report.get("provider_cli", ""),
+        "cli_available": bool(prepare_report.get("provider_cli_available")),
+        "authenticated": bool(prepare_report.get("provider_authenticated")),
+        "auth_status": prepare_report.get("provider_auth_status", ""),
+        "evidence_state": prepare_report.get("provider_evidence_state", ""),
+        "login_hint": prepare_report.get("provider_login_hint", ""),
+        "notice_level": prepare_report.get("provider_notice_level", ""),
+        "user_notice": prepare_report.get("provider_user_notice", ""),
+        "notice_markdown": prepare_report.get("provider_notice_markdown", ""),
+        "next_steps": prepare_report.get("provider_next_steps", []),
+    }
+
+
+def provider_notices(prepare_report: dict[str, Any]) -> list[dict[str, Any]]:
+    if prepare_report.get("provider_notice_level") != "warning":
+        return []
+    message = str(prepare_report.get("provider_user_notice", "")).replace("`", "")
+    return [
+        {
+            "level": "warning",
+            "title": "Provider Evidence Unavailable",
+            "message": message,
+            "command": prepare_report.get("provider_login_hint", ""),
+            "next_steps": prepare_report.get("provider_next_steps", []),
+            "render_as": "assistant_message",
+        }
+    ]
+
+
+def provider_failure_notice(provider: dict[str, Any], result: subprocess.CompletedProcess[str], *, continuing: bool) -> dict[str, Any]:
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    detail = (stderr or stdout or "provider facet collection failed").replace("`", "")
+    if len(detail) > 800:
+        detail = f"{detail[:800]}..."
+    label = str(provider.get("name") or "provider")
+    evidence = "GitHub PR/issue" if label == "github" else "GitLab MR/issue" if label == "gitlab" else "provider"
+    continuation = (
+        "Continuing with local-only repo memory now."
+        if continuing
+        else "Provider evidence was required, so the run stopped before authoring provider resources."
+    )
+    return {
+        "level": "warning",
+        "title": "Provider Evidence Unavailable",
+        "message": (
+            f"{evidence} evidence could not be collected even though the provider CLI appeared ready. "
+            f"{continuation} Provider error: {detail}"
+        ),
+        "command": "",
+        "next_steps": [
+            "Fix provider repository access or remote URL.",
+            f"Rerun $repo-wiki repo-build to collect {evidence} evidence.",
+        ],
+        "render_as": "assistant_message",
+    }
+
+
+def provider_script(provider: str) -> str:
+    if provider == "github":
+        return "github_resource_facets.py"
+    if provider == "gitlab":
+        return "gitlab_resource_facets.py"
+    return ""
+
+
+def provider_raw_name(provider: str) -> str:
+    if provider == "github":
+        return "github-facets.json"
+    if provider == "gitlab":
+        return "gitlab-facets.json"
+    return "provider-facets.json"
+
+
+def load_default_settings() -> tuple[dict[str, Any], str]:
+    if not DEFAULTS_PATH.exists():
+        return FALLBACK_DEFAULTS, "hardcoded_fallback"
+    try:
+        data = json.loads(DEFAULTS_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{DEFAULTS_PATH}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{DEFAULTS_PATH}: expected a JSON object")
+    return data, str(DEFAULTS_PATH)
+
+
+def default_int(settings: dict[str, Any], path: list[str], fallback: int) -> int:
+    value: Any = settings
+    for key in path:
+        value = value.get(key) if isinstance(value, dict) else None
+    if value is None:
+        return fallback
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{DEFAULTS_PATH}: {'.'.join(path)} must be an integer")
+    return value
+
+
+def validate_range(parser: argparse.ArgumentParser, name: str, value: int, minimum: int, maximum: int) -> None:
+    if value < minimum or value > maximum:
+        parser.error(f"{name} must be from {minimum} to {maximum}")
+
+
+def default_history_mode(settings: dict[str, Any]) -> str:
+    history = settings.get("repoHistory")
+    if not isinstance(history, dict):
+        return "local-only"
+    mode = history.get("mode", "local-only")
+    if not isinstance(mode, str) or mode not in HISTORY_MODES:
+        raise ValueError(f"{DEFAULTS_PATH}: repoHistory.mode must be one of {', '.join(sorted(HISTORY_MODES))}")
+    return mode
+
+
+def default_limit(settings: dict[str, Any], key: str) -> int:
+    history = settings.get("repoHistory")
+    if isinstance(history, dict) and isinstance(history.get("limits"), dict) and history["limits"].get(key) is not None:
+        return default_int(settings, ["repoHistory", "limits", key], FALLBACK_DEFAULTS["repoHistory"]["limits"][key])
+    return default_int(settings, ["limits", key], FALLBACK_DEFAULTS["limits"][key])
+
+
+def history_collect(mode: str) -> dict[str, bool]:
+    return {
+        "commits": mode != "none",
+        "provider": mode in {"provider", "provider-required"},
+    }
+
+
+def resolve_history_mode(args: argparse.Namespace, default_mode: str) -> str:
+    mode = args.history_mode or default_mode
+    if args.skip_provider:
+        mode = "local-only"
+    if args.require_provider:
+        mode = "provider-required"
+    return mode
+
+
+def apply_effective_settings(args: argparse.Namespace, parser: argparse.ArgumentParser) -> argparse.Namespace:
+    try:
+        defaults, source = load_default_settings()
+        default_mode = default_history_mode(defaults)
+        default_commit_limit = default_limit(defaults, "commits")
+        default_pr_limit = default_limit(defaults, "prs")
+        default_issue_limit = default_limit(defaults, "issues")
+        default_summary_chars = default_int(defaults, ["summaryChars"], FALLBACK_DEFAULTS["summaryChars"])
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    history_mode = resolve_history_mode(args, default_mode)
+    collect = history_collect(history_mode)
+
+    commit_limit = args.commit_limit if args.commit_limit is not None else default_commit_limit
+    pr_limit = args.pr_limit if args.pr_limit is not None else default_pr_limit
+    issue_limit = args.issue_limit if args.issue_limit is not None else default_issue_limit
+    summary_chars = args.summary_chars if args.summary_chars is not None else default_summary_chars
+
+    validate_range(parser, "--commit-limit", commit_limit, 1, 500)
+    validate_range(parser, "--pr-limit", pr_limit, 1, 100)
+    validate_range(parser, "--issue-limit", issue_limit, 1, 100)
+    if summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+
+    overrides: dict[str, Any] = {}
+    if args.history_mode is not None:
+        overrides["history_mode"] = args.history_mode
+    if args.skip_provider:
+        overrides["skip_provider"] = True
+    if args.require_provider:
+        overrides["require_provider"] = True
+    if args.commit_limit is not None:
+        overrides["commit_limit"] = args.commit_limit
+    if args.pr_limit is not None:
+        overrides["pr_limit"] = args.pr_limit
+    if args.issue_limit is not None:
+        overrides["issue_limit"] = args.issue_limit
+    if args.summary_chars is not None:
+        overrides["summary_chars"] = args.summary_chars
+
+    args.commit_limit = commit_limit
+    args.pr_limit = pr_limit
+    args.issue_limit = issue_limit
+    args.summary_chars = summary_chars
+    args.history_mode = history_mode
+    args.history_collect = collect
+    args.effective_settings = {
+        "history": {
+            "mode": history_mode,
+            "collect": collect,
+        },
+        "limits": {
+            "commits": commit_limit,
+            "prs": pr_limit,
+            "issues": issue_limit,
+        },
+        "summary_chars": summary_chars,
+        "source": source,
+        "overrides": overrides,
+    }
+    return args
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare repo memory and collect raw facets for agent-authored resources.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--reuse", action="store_true", help="Reuse/update an existing .repo_memory directory")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref whose history should be collected")
+    parser.add_argument("--commit-limit", type=int, default=None, help="Maximum local commits retained from the snapshot history")
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum snapshot-filtered PRs/MRs retained")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum provider issues retained")
+    parser.add_argument("--summary-chars", type=int, default=None)
+    parser.add_argument("--history-mode", choices=sorted(HISTORY_MODES), default=None, help="History evidence policy for this build")
+    parser.add_argument("--skip-provider", action="store_true", help="Skip GitHub/GitLab PR/MR/issue collection and build local-only memory")
+    parser.add_argument("--require-provider", action="store_true", help="Fail if provider PR/MR/issue evidence cannot be collected")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Render a stderr progress bar while keeping stdout as the final JSON report",
+    )
+    args = parser.parse_args(argv)
+    if args.skip_provider and args.require_provider:
+        parser.error("--skip-provider and --require-provider cannot be used together")
+    if args.history_mode and args.skip_provider and args.history_mode != "local-only":
+        parser.error(f"--skip-provider cannot be combined with --history-mode {args.history_mode}")
+    if args.history_mode and args.require_provider and args.history_mode != "provider-required":
+        parser.error("--require-provider cannot be combined with a non-required history mode")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return apply_effective_settings(args, parser)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = args.repo_path
+    progress = ProgressBar(args.progress, 3)
+    command_cwd = repo if repo.exists() else SCRIPT_DIR
+    prepare_cmd = [sys.executable, str(SCRIPT_DIR / "prepare_repo_memory.py"), str(repo)]
+    if args.reuse:
+        prepare_cmd.append("--reuse")
+    if not args.history_collect["provider"]:
+        prepare_cmd.append("--skip-provider-check")
+    progress.update(0, "prepare")
+    prepare = run_step(prepare_cmd, command_cwd)
+    if prepare.returncode != 0:
+        progress.fail(0, "prepare failed")
+        return write_failure("prepare", prepare, args.pretty, repo=repo)
+    if prepare.stderr:
+        print(prepare.stderr, file=sys.stderr)
+    progress.update(1, "prepare")
+
+    memory = repo / ".repo_memory"
+    raw_dir = memory / "raw"
+    prepare_report_path = raw_dir / "prepare-report.json"
+    prepare_data = load_json(prepare_report_path)
+    notices = provider_notices(prepare_data)
+
+    git_commits_path = raw_dir / "git-commits.json"
+    outputs = {
+        "prepare_report": str(prepare_report_path),
+        "git_commits": str(git_commits_path),
+    }
+    if args.history_collect["commits"]:
+        git_commits = run_step(
+            [
+                sys.executable,
+                str(SCRIPT_DIR / "git_commit_facets.py"),
+                "--repo-path",
+                str(repo),
+                "--snapshot-ref",
+                args.snapshot_ref,
+                "--limit",
+                str(args.commit_limit),
+                "--summary-chars",
+                str(args.summary_chars),
+                "--out",
+                str(git_commits_path),
+            ],
+            repo,
+        )
+        git_commits_step = json_step(git_commits)
+        if git_commits.returncode != 0:
+            progress.fail(1, "git commits failed")
+            return write_failure(
+                "git_commits",
+                git_commits,
+                args.pretty,
+                repo=repo,
+                memory=memory,
+                steps={"prepare": json_step(prepare)},
+                outputs=outputs,
+            )
+    else:
+        git_commits_path.write_text("[]\n", encoding="utf-8")
+        git_commits_step = {
+            "ok": True,
+            "exit_code": 0,
+            "stdout": "",
+            "stderr": "",
+            "skipped": True,
+            "reason": "history_disabled_by_policy",
+        }
+    progress.update(2, "git commits")
+
+    provider = provider_report(prepare_data)
+    provider_name = str(provider["name"])
+    provider_facets: dict[str, Any]
+    provider_output = raw_dir / provider_raw_name(provider_name)
+    provider_script_name = provider_script(provider_name)
+    if not args.history_collect["provider"]:
+        reason = "provider_skipped_by_user" if args.skip_provider else "history_disabled_by_policy" if args.history_mode == "none" else "history_provider_disabled_by_policy"
+        provider_facets = {
+            "ok": True,
+            "skipped": True,
+            "reason": reason,
+            "output": "",
+        }
+    elif provider["evidence_state"] == "ready" and provider_script_name and provider["repo"]:
+        provider_cmd = [
+            sys.executable,
+            str(SCRIPT_DIR / provider_script_name),
+            "--repo",
+            str(provider["repo"]),
+            "--repo-path",
+            str(repo),
+            "--snapshot-ref",
+            args.snapshot_ref,
+            "--include",
+            "prs,issues",
+            "--pr-limit",
+            str(args.pr_limit),
+            "--issue-limit",
+            str(args.issue_limit),
+            "--state",
+            "all",
+            "--summary-chars",
+            str(args.summary_chars),
+            "--out",
+            str(provider_output),
+        ]
+        if provider.get("host"):
+            provider_cmd.extend(["--hostname", str(provider["host"])])
+        provider_result = run_step(provider_cmd, repo)
+        provider_facets = {
+            **json_step(provider_result),
+            "skipped": False,
+            "output": str(provider_output),
+        }
+        if provider_result.returncode != 0:
+            provider_facets["degraded_to_local_only"] = args.history_mode != "provider-required"
+            provider_facets["reason"] = "provider_facets_failed"
+            provider_facets["output"] = ""
+            if provider_output.exists():
+                provider_output.unlink()
+            if args.history_mode == "provider-required":
+                progress.fail(2, "provider facets failed")
+                return write_failure(
+                    "provider_facets",
+                    provider_result,
+                    args.pretty,
+                    repo=repo,
+                    memory=memory,
+                    provider=provider,
+                    steps={
+                        "prepare": json_step(prepare),
+                        "git_commits": git_commits_step,
+                    },
+                    outputs=outputs,
+                    notices=[provider_failure_notice(provider, provider_result, continuing=False)],
+                    effective_settings=args.effective_settings,
+                )
+            notices.append(provider_failure_notice(provider, provider_result, continuing=True))
+        else:
+            outputs["provider_facets"] = provider_facets["output"]
+    else:
+        if args.history_mode == "provider-required":
+            provider_result = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr=f"provider evidence is required but provider_evidence_state={provider['evidence_state']}",
+            )
+            progress.fail(2, "provider facets unavailable")
+            return write_failure(
+                "provider_facets",
+                provider_result,
+                args.pretty,
+                repo=repo,
+                memory=memory,
+                provider=provider,
+                steps={
+                    "prepare": json_step(prepare),
+                    "git_commits": git_commits_step,
+                },
+                outputs=outputs,
+                notices=notices,
+                effective_settings=args.effective_settings,
+            )
+        provider_facets = {
+            "ok": True,
+            "skipped": True,
+            "reason": f"provider_evidence_state={provider['evidence_state']}",
+            "output": "",
+        }
+    progress.update(3, "provider facets")
+    progress.finish()
+
+    counts = {
+        "raw": {
+            "git_commits": raw_source_counts(git_commits_path),
+        },
+    }
+    if provider_facets.get("output"):
+        counts["raw"]["provider_facets"] = raw_source_counts(Path(str(provider_facets["output"])))
+
+    report = {
+        "ok": True,
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "provider": provider,
+        "notices": notices,
+        "effective_settings": args.effective_settings,
+        "steps": {
+            "prepare": json_step(prepare),
+            "git_commits": git_commits_step,
+            "provider_facets": provider_facets,
+        },
+        "outputs": outputs,
+        "counts": counts,
+        "next_step": "Inspect raw evidence, then author PROFILE.md and resources/*.md.",
+    }
+    write_report(report, args.pretty)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/detect_updates.py
+++ b/examples/skills/repo-wiki/scripts/detect_updates.py
@@ -1,0 +1,919 @@
+#!/usr/bin/env python3
+"""Detect incremental repo-memory updates from git and optional provider evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+BUILDER_SCRIPTS_DIR = SCRIPT_DIR
+BUILDER_DEFAULTS_PATH = SKILL_DIR / "defaults.json"
+BUILDER_SKILL_DIR = SKILL_DIR
+BUILDER_HELPER_FILES = {
+    "defaults": BUILDER_DEFAULTS_PATH,
+    "validate_memory": BUILDER_SCRIPTS_DIR / "validate_memory.py",
+    "github_resource_facets": BUILDER_SCRIPTS_DIR / "github_resource_facets.py",
+    "gitlab_resource_facets": BUILDER_SCRIPTS_DIR / "gitlab_resource_facets.py",
+}
+PREFERRED_REMOTE_NAMES = ("upstream", "origin")
+HISTORY_MODES = {"none", "commits-only", "local-only", "provider", "provider-required"}
+FALLBACK_DEFAULTS = {
+    "repoHistory": {
+        "mode": "local-only",
+        "limits": {
+            "prs": 30,
+            "issues": 30,
+        },
+    },
+    # Kept for compatibility with defaults.json v1.
+    "limits": {
+        "prs": 30,
+        "issues": 30,
+    },
+    "summaryChars": 4000,
+}
+
+
+def run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+
+
+def git(repo: Path, args: list[str], message: str) -> str:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for repo-memory incremental update detection")
+    result = run(["git", "-C", str(repo), *args], repo)
+    if result.returncode != 0:
+        raise SystemExit(f"{message}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def load_json(path: Path, fallback: Any) -> Any:
+    if not path.exists():
+        return fallback
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{path}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def default_int(settings: dict[str, Any], path: list[str], fallback: int) -> int:
+    value: Any = settings
+    for key in path:
+        value = value.get(key) if isinstance(value, dict) else None
+    if value is None:
+        return fallback
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: {'.'.join(path)} must be an integer")
+    return value
+
+
+def default_limit(settings: dict[str, Any], key: str) -> int:
+    history = settings.get("repoHistory")
+    if isinstance(history, dict) and isinstance(history.get("limits"), dict) and history["limits"].get(key) is not None:
+        return default_int(settings, ["repoHistory", "limits", key], FALLBACK_DEFAULTS["repoHistory"]["limits"][key])
+    return default_int(settings, ["limits", key], FALLBACK_DEFAULTS["limits"][key])
+
+
+def default_history_mode(settings: dict[str, Any]) -> str:
+    history = settings.get("repoHistory")
+    if not isinstance(history, dict):
+        return "local-only"
+    mode = history.get("mode", "local-only")
+    if not isinstance(mode, str) or mode not in HISTORY_MODES:
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: repoHistory.mode must be one of {', '.join(sorted(HISTORY_MODES))}")
+    return mode
+
+
+def history_collect(mode: str) -> dict[str, bool]:
+    return {
+        "commits": mode in {"commits-only", "local-only", "provider", "provider-required"},
+        "provider": mode in {"provider", "provider-required"},
+    }
+
+
+def load_default_settings() -> tuple[dict[str, Any], str]:
+    if not BUILDER_DEFAULTS_PATH.exists():
+        return FALLBACK_DEFAULTS, "hardcoded_fallback"
+    data = load_json(BUILDER_DEFAULTS_PATH, FALLBACK_DEFAULTS)
+    if not isinstance(data, dict):
+        raise ValueError(f"{BUILDER_DEFAULTS_PATH}: expected a JSON object")
+    return data, str(BUILDER_DEFAULTS_PATH)
+
+
+def validate_range(parser: argparse.ArgumentParser, name: str, value: int, minimum: int, maximum: int) -> None:
+    if value < minimum or value > maximum:
+        parser.error(f"{name} must be from {minimum} to {maximum}")
+
+
+def apply_effective_settings(args: argparse.Namespace, parser: argparse.ArgumentParser) -> argparse.Namespace:
+    try:
+        defaults, source = load_default_settings()
+        default_mode = default_history_mode(defaults)
+        default_pr_limit = default_limit(defaults, "prs")
+        default_issue_limit = default_limit(defaults, "issues")
+        default_summary_chars = default_int(defaults, ["summaryChars"], FALLBACK_DEFAULTS["summaryChars"])
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    history_mode = args.history_mode or default_mode
+    collect = history_collect(history_mode)
+    if args.provider_mode == "off":
+        if history_mode == "provider-required":
+            parser.error("--provider-mode off cannot be combined with --history-mode provider-required")
+        collect = {**collect, "provider": False}
+    pr_limit = args.pr_limit if args.pr_limit is not None else default_pr_limit
+    issue_limit = args.issue_limit if args.issue_limit is not None else default_issue_limit
+    summary_chars = args.summary_chars if args.summary_chars is not None else default_summary_chars
+
+    validate_range(parser, "--pr-limit", pr_limit, 1, 100)
+    validate_range(parser, "--issue-limit", issue_limit, 1, 100)
+    if summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+
+    overrides: dict[str, Any] = {}
+    if args.history_mode is not None:
+        overrides["history_mode"] = args.history_mode
+    if args.pr_limit is not None:
+        overrides["pr_limit"] = args.pr_limit
+    if args.issue_limit is not None:
+        overrides["issue_limit"] = args.issue_limit
+    if args.summary_chars is not None:
+        overrides["summary_chars"] = args.summary_chars
+
+    args.history_mode = history_mode
+    args.history_collect = collect
+    args.pr_limit = pr_limit
+    args.issue_limit = issue_limit
+    args.summary_chars = summary_chars
+    args.effective_settings = {
+        "history": {
+            "mode": history_mode,
+            "collect": collect,
+        },
+        "limits": {
+            "prs": pr_limit,
+            "issues": issue_limit,
+        },
+        "summary_chars": summary_chars,
+        "source": source,
+        "overrides": overrides,
+    }
+    return args
+
+
+def file_fingerprint(path: Path) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+    }
+    if path.exists():
+        stat = path.stat()
+        item["mtime_ns"] = stat.st_mtime_ns
+        item["size_bytes"] = stat.st_size
+    return item
+
+
+def builder_helper_report() -> dict[str, Any]:
+    return {
+        "skill_dir": str(BUILDER_SKILL_DIR),
+        "scripts_dir": str(BUILDER_SCRIPTS_DIR),
+        "files": {
+            name: file_fingerprint(path)
+            for name, path in BUILDER_HELPER_FILES.items()
+        },
+    }
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    fields: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            fields[key] = value
+    return fields
+
+
+def resolve_memory(repo: Path, memory_arg: str | None) -> Path:
+    return Path(memory_arg).expanduser().resolve() if memory_arg else repo / ".repo_memory"
+
+
+def body_after_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return text
+    return text[end + 4 :].lstrip("\n")
+
+
+def commit_baseline(memory: Path, repo: Path | None = None, head_sha: str = "") -> str:
+    profile_head = parse_frontmatter(memory / "PROFILE.md").get("local_head", "")
+    if profile_head:
+        return profile_head
+    text_path = memory / "resources" / "commits.md"
+    if text_path.exists():
+        text = body_after_frontmatter(text_path.read_text(encoding="utf-8"))
+        shas = re.findall(r"(?im)^-\s*SHA:\s*`?([0-9a-f]{7,40})`?", text)
+        if repo is not None and head_sha and shas:
+            nearest = nearest_ancestor(repo, shas, head_sha)
+            if nearest:
+                return nearest
+        if shas:
+            return shas[0]
+    return ""
+
+
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    if not ancestor:
+        return False
+    result = run(["git", "-C", str(repo), "merge-base", "--is-ancestor", ancestor, descendant], repo)
+    return result.returncode == 0
+
+
+def nearest_ancestor(repo: Path, candidates: list[str], descendant: str) -> str:
+    unique_candidates = list(dict.fromkeys(candidate for candidate in candidates if candidate))
+    if not unique_candidates:
+        return ""
+    result = run(["git", "-C", str(repo), "rev-list", descendant], repo)
+    if result.returncode != 0:
+        return ""
+    for sha in [line.strip() for line in result.stdout.splitlines() if line.strip()]:
+        for candidate in unique_candidates:
+            if sha.startswith(candidate):
+                return candidate
+    return ""
+
+
+def commit_delta(repo: Path, baseline_sha: str, head_sha: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not baseline_sha:
+        return [], {
+            "status": "skipped",
+            "reason": "missing_baseline_commit",
+            "message": "No stored local commit baseline was found in .repo_memory.",
+        }
+    if baseline_sha == head_sha:
+        return [], {"status": "current", "reason": ""}
+    if not is_ancestor(repo, baseline_sha, head_sha):
+        return [], {
+            "status": "skipped",
+            "reason": "baseline_not_ancestor_of_head",
+            "message": "Stored repo-memory commit baseline is not an ancestor of the current HEAD; history was probably rebased or force-pushed.",
+        }
+    shas = git(repo, ["rev-list", "--reverse", f"{baseline_sha}..{head_sha}"], "git could not list new commits")
+    out: list[dict[str, Any]] = []
+    for sha in [line.strip() for line in shas.splitlines() if line.strip()]:
+        fields = git(
+            repo,
+            ["show", "-s", "--date=iso-strict", "--format=%H%x1f%h%x1f%an%x1f%ad%x1f%s", sha],
+            f"git could not read commit {sha}",
+        ).split("\x1f")
+        full_sha, short_sha, author, authored_at, title = (fields + [""] * 5)[:5]
+        files = git(repo, ["show", "--format=", "--name-only", "--no-renames", sha], f"git could not list files for {sha}")
+        out.append({
+            "sha": full_sha,
+            "short_sha": short_sha,
+            "title": title,
+            "author": author,
+            "authored_at": authored_at,
+            "files": [line for line in files.splitlines() if line],
+        })
+    return out, {"status": "ok", "reason": "", "count": len(out)}
+
+
+def markdown_sections(path: Path) -> list[tuple[str, str]]:
+    if not path.exists():
+        return []
+    text = body_after_frontmatter(path.read_text(encoding="utf-8"))
+    matches = list(re.finditer(r"(?m)^##\s+(.+?)\s*$", text))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append((match.group(1).strip(), text[start:end]))
+    return sections
+
+
+def markdown_field(body: str, label: str) -> str:
+    pattern = rf"(?im)^-\s*{re.escape(label)}:\s*(.+?)\s*$"
+    match = re.search(pattern, body)
+    if not match:
+        return ""
+    value = match.group(1).strip()
+    return value.strip().strip("`").strip()
+
+
+def first_code_value(text: str) -> str:
+    match = re.search(r"`([^`]+)`", text)
+    return match.group(1).strip() if match else text.strip()
+
+
+def section_number(title: str) -> int | None:
+    match = re.search(r"[#!#]\s*(\d+)", title)
+    return int(match.group(1)) if match else None
+
+
+def section_title(title: str) -> str:
+    return title.split(":", 1)[1].strip() if ":" in title else title.strip()
+
+
+def branch_parts(value: str) -> tuple[str, str]:
+    if "<-" not in value:
+        return "", ""
+    base, head = value.split("<-", 1)
+    return base.strip(), head.strip()
+
+
+def resource_items(memory: Path, resource_name: str) -> list[dict[str, Any]]:
+    path = memory / "resources" / resource_name
+    kind = "issue" if resource_name == "issues.md" else "pr"
+    out: list[dict[str, Any]] = []
+    for title, body in markdown_sections(path):
+        number = section_number(title)
+        if number is None:
+            continue
+        item: dict[str, Any] = {
+            "number": number,
+            "title": section_title(title),
+            "source": "resource",
+        }
+        state = first_code_value(markdown_field(body, "State"))
+        if state:
+            item["state"] = state
+        url = markdown_field(body, "URL")
+        if url:
+            item["url"] = url
+        if kind == "pr":
+            base_ref, head_ref = branch_parts(first_code_value(markdown_field(body, "Branch")))
+            if base_ref:
+                item["base_ref"] = base_ref
+            if head_ref:
+                item["head_ref"] = head_ref
+        out.append(item)
+    return out
+
+
+def first_int(values: Any) -> int | None:
+    if isinstance(values, int):
+        return values
+    if isinstance(values, list):
+        for value in values:
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def facet_number(facet: dict[str, Any], source_type: str) -> int | None:
+    values = facet.get("issues") if source_type == "issue" else facet.get("prs")
+    number = first_int(values)
+    if number is not None:
+        return number
+    match = re.search(r"\.(\d+)$", str(facet.get("facetId", "")))
+    return int(match.group(1)) if match else None
+
+
+AUTHORING_FACET_KEYS = [
+    "summary",
+    "labels",
+    "commits",
+    "commit_headlines",
+    "review_decision",
+    "review_states",
+    "files",
+    "symbols",
+    "evidence",
+    "changed_files",
+    "additions",
+    "deletions",
+]
+
+
+def keep_value(value: Any) -> bool:
+    return value not in (None, "", [], {})
+
+
+def facet_items(facets: Any, source_type: str) -> list[dict[str, Any]]:
+    if not isinstance(facets, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for facet in facets:
+        if not isinstance(facet, dict) or facet.get("sourceType") != source_type:
+            continue
+        number = facet_number(facet, source_type)
+        if number is None:
+            continue
+        item: dict[str, Any] = {
+            "number": number,
+            "title": str(facet.get("title") or ""),
+            "state": str(facet.get("state") or ""),
+            "updated_at": str(facet.get("updatedAt") or facet.get("updated_at") or ""),
+            "url": str(facet.get("url") or ""),
+            "source": "provider_facet",
+        }
+        facet_id = str(facet.get("facetId") or "")
+        if facet_id:
+            item["raw_lookup"] = f"facetId={facet_id}"
+        for key in AUTHORING_FACET_KEYS:
+            if key in facet:
+                item[key] = facet[key]
+        if source_type == "pr":
+            item["base_ref"] = str(facet.get("base_ref") or "")
+            item["head_ref"] = str(facet.get("head_ref") or "")
+            item["merged_at"] = str(facet.get("mergedAt") or facet.get("merged_at") or "")
+            item["closed_at"] = str(facet.get("closedAt") or facet.get("closed_at") or "")
+            linked_issues = facet.get("issues")
+            if keep_value(linked_issues):
+                item["linked_issues"] = linked_issues
+        out.append({key: value for key, value in item.items() if keep_value(value)})
+    return out
+
+
+def raw_provider_items(memory: Path, source_type: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for raw_name in ["github-facets.json", "gitlab-facets.json"]:
+        raw_path = memory / "raw" / raw_name
+        if raw_path.exists():
+            out.extend(facet_items(load_json(raw_path, []), source_type))
+    return out
+
+
+def baseline_items(memory: Path, resource_name: str, source_type: str) -> list[dict[str, Any]]:
+    resource = resource_items(memory, resource_name)
+    raw_by_no = by_number(raw_provider_items(memory, source_type))
+    out: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for item in resource:
+        number = item_number(item)
+        if number is None:
+            continue
+        merged = dict(item)
+        merged.update(raw_by_no.get(number, {}))
+        if number in raw_by_no:
+            merged["source"] = "resource_with_raw_provider_facet"
+        out.append(merged)
+        seen.add(number)
+    for number, item in sorted(raw_by_no.items()):
+        if number not in seen:
+            out.append(item)
+    return out
+
+
+def item_number(item: dict[str, Any]) -> int | None:
+    number = item.get("number")
+    return number if isinstance(number, int) else None
+
+
+def by_number(items: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    out: dict[int, dict[str, Any]] = {}
+    for item in items:
+        number = item_number(item)
+        if number is not None:
+            out[number] = item
+    return out
+
+
+def comparable_item(item: dict[str, Any]) -> str:
+    ignored_keys = {"raw_lookup", "source", "updated_at", "merged_at", "closed_at"}
+    normalized = {key: value for key, value in item.items() if key not in ignored_keys}
+    return json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def changed_numbers(existing: dict[int, dict[str, Any]], current: dict[int, dict[str, Any]]) -> list[int]:
+    changed: list[int] = []
+    for number, item in current.items():
+        old = existing.get(number)
+        if old is None:
+            continue
+        for key in ["updated_at", "state", "title", "head_ref", "base_ref", "merged_at", "closed_at"]:
+            if old.get(key) not in (None, "") and old.get(key) != item.get(key):
+                changed.append(number)
+                break
+        else:
+            common_keys = {
+                key
+                for key, value in old.items()
+                if key not in {"number", "raw_lookup", "source"} and value not in (None, "")
+            }
+            old_common = {key: old.get(key) for key in common_keys}
+            current_common = {key: item.get(key) for key in common_keys}
+            if old_common != current_common and comparable_item(old) != comparable_item(item):
+                changed.append(number)
+    return sorted(changed)
+
+
+def remote_url_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def remote_name_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[0] if parts else ""
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    return repo_path[:-4] if repo_path.endswith(".git") else repo_path
+
+
+def provider_from_host(host: str) -> str:
+    lower = host.lower()
+    if lower == "github.com" or "github" in lower:
+        return "github"
+    if lower == "gitlab.com" or "gitlab" in lower:
+        return "gitlab"
+    return ""
+
+
+def parse_remote_url(url: str) -> dict[str, str]:
+    if not url:
+        return {"provider": "", "repo": "", "host": "", "url": ""}
+    if "://" not in url:
+        match = re.match(r"^(?:[^@/\s]+@)?(?P<host>[^:/\s]+):(?P<path>.+)$", url)
+        if match:
+            host = match.group("host")
+            return {
+                "provider": provider_from_host(host),
+                "repo": normalize_remote_path(match.group("path")),
+                "host": host,
+                "url": url,
+            }
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    return {
+        "provider": provider_from_host(host),
+        "repo": normalize_remote_path(parsed.path),
+        "host": host,
+        "url": url,
+    }
+
+
+def parse_code_host_repo(remotes: str) -> dict[str, str]:
+    candidates: list[dict[str, str]] = []
+    for line in remotes.splitlines():
+        if "(push)" in line:
+            continue
+        parsed = parse_remote_url(remote_url_from_line(line))
+        if parsed["provider"] and parsed["repo"]:
+            parsed["remote_name"] = remote_name_from_line(line)
+            candidates.append(parsed)
+    for preferred in PREFERRED_REMOTE_NAMES:
+        for candidate in candidates:
+            if candidate.get("remote_name") == preferred:
+                candidate["selection_reason"] = f"preferred_{preferred}_fetch_remote"
+                return candidate
+    if candidates:
+        candidates[0]["selection_reason"] = "first_supported_fetch_remote"
+        return candidates[0]
+    return {"provider": "", "repo": "", "host": "", "url": "", "remote_name": "", "selection_reason": "none"}
+
+
+def provider_host(provider: str) -> str:
+    if provider == "github":
+        return "github.com"
+    if provider == "gitlab":
+        return "gitlab.com"
+    return ""
+
+
+def provider_from_profile(memory: Path) -> dict[str, str]:
+    profile = parse_frontmatter(memory / "PROFILE.md")
+    provider = profile.get("code_host_provider", "")
+    repo = profile.get("repo_full_name", "")
+    if provider in {"github", "gitlab"} and repo and "/" in repo:
+        parsed_profile_url = parse_remote_url(str(profile.get("repo_url", "")))
+        host = parsed_profile_url["host"] if parsed_profile_url["provider"] == provider else provider_host(provider)
+        return {
+            "provider": provider,
+            "repo": repo,
+            "host": host,
+            "url": profile.get("repo_url", ""),
+            "remote_name": "",
+            "selection_reason": "profile_frontmatter",
+        }
+    return {}
+
+
+def auth_args(command: str, host: str) -> list[str]:
+    args = ["auth", "status"]
+    if host and command in {"gh", "glab"}:
+        args.extend(["--hostname", host])
+    return args
+
+
+def login_hint(command: str, host: str) -> str:
+    default_host = "github.com" if command == "gh" else "gitlab.com" if command == "glab" else ""
+    if host and host != default_host:
+        return f"{command} auth login --hostname {host}"
+    return f"{command} auth login"
+
+
+def cli_evidence_state(command: str, host: str) -> tuple[str, bool]:
+    if shutil.which(command) is None:
+        return "cli_missing", False
+    try:
+        result = subprocess.run([command, *auth_args(command, host)], text=True, capture_output=True, timeout=8)
+    except subprocess.TimeoutExpired:
+        return "auth_check_timeout", True
+    return ("ready", True) if result.returncode == 0 else ("auth_required", True)
+
+
+def provider_report(repo: Path, memory: Path, *, inspect_cli: bool = True) -> dict[str, Any]:
+    remote = provider_from_profile(memory) or parse_code_host_repo(git(repo, ["remote", "-v"], "git could not list remotes"))
+    provider = remote["provider"]
+    cli = "gh" if provider == "github" else "glab" if provider == "gitlab" else ""
+    evidence_state = "unavailable" if inspect_cli else "skipped_by_policy"
+    cli_available = False
+    if cli and inspect_cli:
+        evidence_state, cli_available = cli_evidence_state(cli, remote["host"])
+    return {
+        "name": provider,
+        "repo": remote["repo"],
+        "host": remote["host"],
+        "remote_url": remote["url"],
+        "remote_name": remote.get("remote_name", ""),
+        "selection_reason": remote.get("selection_reason", ""),
+        "evidence_state": evidence_state,
+        "cli": cli,
+        "cli_available": cli_available,
+        "login_hint": login_hint(cli, remote["host"]) if cli else "",
+    }
+
+
+def provider_script(provider: str) -> str:
+    if provider == "github":
+        return "github_resource_facets.py"
+    if provider == "gitlab":
+        return "gitlab_resource_facets.py"
+    return ""
+
+
+def fetch_provider_items(repo: Path, provider: dict[str, Any], snapshot_ref: str, pr_limit: int, issue_limit: int, summary_chars: int) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    provider_name = str(provider.get("name") or "")
+    provider_repo = str(provider.get("repo") or "")
+    script_name = provider_script(provider_name)
+    if not script_name or not provider_repo or provider.get("evidence_state") != "ready":
+        return {
+            "attempted": False,
+            "reason": f"provider_evidence_state={provider.get('evidence_state', '') or 'unavailable'}",
+        }, [], []
+
+    script_path = BUILDER_SCRIPTS_DIR / script_name
+    if not script_path.exists():
+        return {"attempted": False, "reason": "repo-wiki repo-build helpers are missing"}, [], []
+
+    with tempfile.TemporaryDirectory(prefix="repo-wiki-repo-update.") as tmp:
+        tmp_root = Path(tmp)
+        raw = tmp_root / f"{provider_name}-facets.json"
+        facets = run(
+            [
+                sys.executable,
+                str(script_path),
+                "--repo",
+                provider_repo,
+                "--repo-path",
+                str(repo),
+                "--snapshot-ref",
+                snapshot_ref,
+                "--include",
+                "prs,issues",
+                "--pr-limit",
+                str(pr_limit),
+                "--issue-limit",
+                str(issue_limit),
+                "--state",
+                "all",
+                "--summary-chars",
+                str(summary_chars),
+                "--out",
+                str(raw),
+                *(["--hostname", str(provider.get("host"))] if provider.get("host") else []),
+            ],
+            repo,
+        )
+        if facets.returncode != 0:
+            return {
+                "attempted": True,
+                "ok": False,
+                "exit_code": facets.returncode,
+                "stderr": facets.stderr.strip(),
+            }, [], []
+        raw_facets = load_json(raw, [])
+        prs = facet_items(raw_facets, "pr")
+        issues = facet_items(raw_facets, "issue")
+        return {
+            "attempted": True,
+            "ok": True,
+            "provider": provider_name,
+            "repo": provider_repo,
+            "pr_count": len(prs) if isinstance(prs, list) else 0,
+            "issue_count": len(issues) if isinstance(issues, list) else 0,
+        }, prs, issues
+
+
+def delta_summary(existing: list[dict[str, Any]], current: list[dict[str, Any]]) -> dict[str, Any]:
+    existing_by_no = by_number(existing)
+    current_by_no = by_number(current)
+    added = sorted(number for number in current_by_no if number not in existing_by_no)
+    updated = changed_numbers(existing_by_no, current_by_no)
+    baseline_only = sorted(number for number in existing_by_no if number not in current_by_no)
+    return {
+        "baseline_numbers": sorted(existing_by_no),
+        "current_numbers": sorted(current_by_no),
+        "added_numbers": added,
+        "updated_numbers": updated,
+        "upsert_numbers": sorted([*added, *updated]),
+        "baseline_only_numbers": baseline_only,
+        "delete_numbers": [],
+    }
+
+
+def actions_for(deltas: dict[str, Any], provider_fetch: dict[str, Any]) -> list[str]:
+    actions: list[str] = []
+    local_commit_status = deltas.get("local_commit_status", {})
+    if local_commit_status.get("reason") == "missing_baseline_commit":
+        actions.append("Local commit delta was skipped because no stored commit baseline was found. Use $repo-wiki repo-build for a full rebuild before doing incremental commit updates.")
+    if local_commit_status.get("reason") == "baseline_not_ancestor_of_head":
+        actions.append("Local commit delta was skipped because the stored baseline is not an ancestor of HEAD. Use $repo-wiki repo-build for a full rebuild, or explicitly choose a new baseline before doing incremental commit updates.")
+    if deltas["local_commits"]:
+        actions.append("Update .repo_memory/resources/commits.md with sections for the new local commits; update PROFILE.md local_head and commit snapshot notes only where needed.")
+    if deltas["pull_requests"]["added_numbers"] or deltas["pull_requests"]["updated_numbers"]:
+        actions.append("Upsert .repo_memory/resources/prs.md sections by PR/MR number for only the added or changed numbers. Preserve baseline-only and unaffected PR/MR sections; do not delete missing numbers by default.")
+    if deltas["issues"]["added_numbers"] or deltas["issues"]["updated_numbers"]:
+        actions.append("Upsert .repo_memory/resources/issues.md sections by issue number for only the added or changed numbers. Preserve baseline-only and unaffected issue sections; do not delete missing numbers by default.")
+    if provider_fetch.get("attempted") is True and provider_fetch.get("ok") is False:
+        actions.append("Provider delta fetch failed; keeping existing PR/issue resources unchanged. Fix provider access and rerun $repo-wiki repo-update, or use repo-build for a full provider refresh if needed.")
+    if provider_fetch.get("attempted") is False:
+        actions.append("Provider delta fetch was skipped; keep PR/issue resources unchanged unless the user asks to login/install provider CLI or force provider refresh.")
+    if not actions:
+        actions.append("No repo-memory content update is needed.")
+    return actions
+
+
+def notices_for(deltas: dict[str, Any], provider_fetch: dict[str, Any]) -> list[dict[str, Any]]:
+    notices: list[dict[str, Any]] = []
+    local_commit_status = deltas.get("local_commit_status", {})
+    if local_commit_status.get("reason") == "missing_baseline_commit":
+        notices.append({
+            "level": "warning",
+            "title": "Repo Memory Commit Baseline Missing",
+            "message": "No stored local commit baseline was found in .repo_memory, so incremental commit detection was skipped.",
+            "next_steps": [
+                "Run $repo-wiki repo-build for a full rebuild before incremental commit updates.",
+            ],
+            "render_as": "assistant_message",
+        })
+    if local_commit_status.get("reason") == "baseline_not_ancestor_of_head":
+        notices.append({
+            "level": "warning",
+            "title": "Repo Memory Baseline Rewritten",
+            "message": "Stored repo-memory commit baseline is not an ancestor of the current HEAD. History was probably rebased or force-pushed, so incremental commit detection was skipped.",
+            "next_steps": [
+                "Run $repo-wiki repo-build for a full rebuild, or explicitly choose a new baseline before incremental commit updates.",
+            ],
+            "render_as": "assistant_message",
+        })
+    if provider_fetch.get("attempted") is True and provider_fetch.get("ok") is False:
+        notices.append({
+            "level": "warning",
+            "title": "Provider Delta Fetch Failed",
+            "message": "Provider delta fetch failed; keeping existing PR/issue resources unchanged. Fix provider access before rerunning provider deltas.",
+            "next_steps": [
+                "Fix GitHub/GitLab CLI access and rerun $repo-wiki repo-update.",
+                "Use $repo-wiki repo-build for a full provider refresh if a broader rebuild is needed.",
+            ],
+            "render_as": "assistant_message",
+        })
+    return notices
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Detect incremental updates for an existing .repo_memory bundle.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--memory-path", help="Existing .repo_memory path; defaults to <repo>/.repo_memory")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref used for current detection")
+    parser.add_argument("--history-mode", choices=sorted(HISTORY_MODES), default=None, help="History evidence policy for this update")
+    parser.add_argument("--provider-mode", choices=["auto", "off"], default="auto", help="Whether to fetch latest provider PR/issue facets when provider evidence is ready")
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum latest PR/MR candidates to compare")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum latest issue candidates to compare")
+    parser.add_argument("--summary-chars", type=int, default=None, help="Maximum raw provider summary characters when provider facets are fetched")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = parser.parse_args(argv)
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return apply_effective_settings(args, parser)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = args.repo_path
+    memory = resolve_memory(repo, args.memory_path)
+    if not memory.exists() or not (memory / "PROFILE.md").exists():
+        report = {
+            "ok": False,
+            "repo_path": str(repo),
+            "memory_path": str(memory),
+            "builder_helpers": builder_helper_report(),
+            "error": "Existing .repo_memory/PROFILE.md is required; run $repo-wiki repo-build before repo-update.",
+        }
+        print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+        return 1
+
+    head = git(repo, ["rev-parse", "--verify", f"{args.snapshot_ref}^{{commit}}"], f"git could not resolve {args.snapshot_ref!r}")
+    baseline_sha = commit_baseline(memory, repo, head)
+    if args.history_collect["commits"]:
+        local_commits, local_commit_status = commit_delta(repo, baseline_sha, head)
+    else:
+        local_commits, local_commit_status = [], {
+            "status": "skipped",
+            "reason": "history_disabled_by_policy",
+            "message": "Local commit delta detection is disabled by repoHistory.mode.",
+        }
+
+    existing_prs = baseline_items(memory, "prs.md", "pr")
+    existing_issues = baseline_items(memory, "issues.md", "issue")
+    provider = provider_report(repo, memory, inspect_cli=args.history_collect["provider"])
+    if args.history_collect["provider"]:
+        provider_fetch, current_prs, current_issues = fetch_provider_items(
+            repo,
+            provider,
+            args.snapshot_ref,
+            args.pr_limit,
+            args.issue_limit,
+            args.summary_chars,
+        )
+    else:
+        reason = (
+            "provider-mode=off"
+            if args.provider_mode == "off"
+            else "history_disabled_by_policy"
+            if args.history_mode == "none"
+            else "history_provider_disabled_by_policy"
+        )
+        provider_fetch, current_prs, current_issues = {"attempted": False, "reason": reason}, [], []
+    fetched_prs = current_prs if provider_fetch.get("ok") is True else []
+    fetched_issues = current_issues if provider_fetch.get("ok") is True else []
+    if not current_prs and provider_fetch.get("ok") is not True:
+        current_prs = existing_prs
+    if not current_issues and provider_fetch.get("ok") is not True:
+        current_issues = existing_issues
+
+    deltas = {
+        "local_commits": local_commits,
+        "local_commit_status": local_commit_status,
+        "pull_requests": delta_summary(existing_prs, current_prs),
+        "issues": delta_summary(existing_issues, current_issues),
+    }
+    if local_commit_status.get("status") == "skipped" and local_commit_status.get("reason"):
+        deltas["commit_delta_skipped"] = local_commit_status["reason"]
+    report = {
+        "ok": True,
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "effective_settings": args.effective_settings,
+        "builder_helpers": builder_helper_report(),
+        "baseline": {
+            "local_commit_sha": baseline_sha,
+            "pull_request_numbers": deltas["pull_requests"]["baseline_numbers"],
+            "issue_numbers": deltas["issues"]["baseline_numbers"],
+        },
+        "current": {
+            "local_head": head,
+            "provider": provider,
+            "provider_fetch": provider_fetch,
+            "provider_items": {
+                "pull_requests": fetched_prs,
+                "issues": fetched_issues,
+            },
+        },
+        "deltas": deltas,
+        "notices": notices_for(deltas, provider_fetch),
+        "actions": actions_for(deltas, provider_fetch),
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/git_commit_facets.py
+++ b/examples/skills/repo-wiki/scripts/git_commit_facets.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Extract local git commit facets without GitHub/GitLab provider access."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for local commit facets")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def git_stdout(repo_path: Path, args: list[str], message: str) -> str:
+    result = run_git(repo_path, args)
+    if result.returncode != 0:
+        raise SystemExit(f"{message}:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    return git_stdout(
+        repo_path,
+        ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"],
+        f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}",
+    ).strip()
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    if repo_path.endswith(".git"):
+        repo_path = repo_path[:-4]
+    return repo_path
+
+
+def repo_name_from_remote(url: str) -> str:
+    if not url:
+        return ""
+    if "://" not in url:
+        match = re.match(r"^(?:[^@/\s]+@)?[^:/\s]+:(?P<path>.+)$", url)
+        return normalize_remote_path(match.group("path")) if match else ""
+    parsed = urlparse(url)
+    return normalize_remote_path(parsed.path)
+
+
+def repo_name(repo_path: Path) -> str:
+    remote = run_git(repo_path, ["remote", "get-url", "origin"])
+    parsed = repo_name_from_remote(remote.stdout.strip()) if remote.returncode == 0 else ""
+    return parsed or repo_path.name
+
+
+def unique(values: Iterable[Any]) -> list[Any]:
+    seen: set[Any] = set()
+    out: list[Any] = []
+    for value in values:
+        if value in (None, "") or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def path_module(path: str) -> str:
+    parts = [part for part in path.split("/") if part and part not in {".", ".."}]
+    if not parts:
+        return ""
+    if parts[0] == ".github":
+        return ".github/workflows"
+    if "." in parts[0] and len(parts) == 1:
+        return ""
+    return parts[0]
+
+
+def path_modules(files: list[str]) -> list[str]:
+    return unique(module for module in (path_module(path) for path in files) if module)
+
+
+def key_files(files: list[str], limit: int = 8) -> list[str]:
+    def score(path: str) -> tuple[int, int, str]:
+        lower = path.lower()
+        value = 0
+        if "readme" in lower or lower.endswith((".md", ".rst")):
+            value += 2
+        if any(token in lower for token in ["/src/", "/core/", "/server", "/api", "/train", "/rollout", "/loss", "/model", "/actor", "/data"]):
+            value += 4
+        if lower.endswith((".py", ".ts", ".tsx", ".rs", ".go", ".sh", ".yaml", ".yml", ".toml", ".json")):
+            value += 1
+        return (-value, len(path), path)
+
+    return sorted(files, key=score)[:limit]
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique(symbols)
+
+
+def parse_numstat(text: str) -> tuple[list[str], int, int]:
+    files: list[str] = []
+    additions = 0
+    deletions = 0
+    for line in text.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        add, delete, path = parts[0], parts[1], parts[2]
+        if add.isdigit():
+            additions += int(add)
+        if delete.isdigit():
+            deletions += int(delete)
+        if path:
+            files.append(path)
+    return unique(files), additions, deletions
+
+
+def commit_facet(repo: str, repo_path: Path, sha: str, summary_chars: int) -> dict[str, Any]:
+    fields = git_stdout(
+        repo_path,
+        ["show", "-s", "--date=iso-strict", "--format=%H%x1f%h%x1f%P%x1f%an%x1f%ad%x1f%s", sha],
+        f"git could not read commit metadata for {sha}",
+    ).rstrip("\n").split("\x1f")
+    full_sha, short_sha, parents, author, authored_at, title = (fields + [""] * 6)[:6]
+    body = git_stdout(repo_path, ["show", "-s", "--format=%B", sha], f"git could not read commit body for {sha}")
+    files, additions, deletions = parse_numstat(
+        git_stdout(repo_path, ["show", "--format=", "--numstat", "--no-renames", sha], f"git could not read commit diff for {sha}")
+    )
+    modules = path_modules(files)
+    keys = key_files(files)
+    summary = bounded_summary([body], summary_chars) or title
+    evidence = unique([
+        f"commit {short_sha}: {title}" if short_sha and title else "",
+        f"commit {short_sha} changed {', '.join(keys)}" if short_sha and keys else "",
+    ])
+    return {
+        "facetId": f"commit.{short_sha or full_sha[:12]}",
+        "sourceType": "commit",
+        "provider": "local_git",
+        "repo": repo,
+        "sha": full_sha,
+        "short_sha": short_sha,
+        "parents": [parent for parent in parents.split() if parent],
+        "is_merge": len([parent for parent in parents.split() if parent]) > 1,
+        "title": title,
+        "summary": summary,
+        "author": author,
+        "authoredAt": authored_at,
+        "updatedAt": authored_at,
+        "files": files,
+        "path_modules": modules,
+        "key_files": keys,
+        "changed_files": len(files),
+        "additions": additions,
+        "deletions": deletions,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def fetch_facets(repo_path: Path, snapshot_ref: str, limit: int, summary_chars: int) -> list[dict[str, Any]]:
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref)
+    shas = git_stdout(
+        repo_path,
+        ["rev-list", "--max-count", str(limit), snapshot_sha],
+        f"git could not list commits from {snapshot_ref!r} in {repo_path}",
+    ).splitlines()
+    name = repo_name(repo_path)
+    return [commit_facet(name, repo_path, sha.strip(), summary_chars) for sha in shas if sha.strip()]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract local git commit SourceFacet JSON without provider login.")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path")
+    parser.add_argument("--snapshot-ref", default="HEAD", help="Local git ref whose history should be collected")
+    parser.add_argument("--limit", type=int, default=30, help="Maximum commits retained from the snapshot history")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if args.limit < 1 or args.limit > 500:
+        parser.error("--limit must be from 1 to 500")
+    if args.summary_chars < 100:
+        parser.error("--summary-chars must be at least 100")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(args.repo_path, args.snapshot_ref, args.limit, args.summary_chars)
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/github_resource_facets.py
+++ b/examples/skills/repo-wiki/scripts/github_resource_facets.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Extract GitHub PR/issue resource facets with only Python stdlib + gh CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PR_LIST_FIELDS = "number,title,state,url,updatedAt,baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft"
+PR_VIEW_FIELDS = "number,title,body,state,url,updatedAt,createdAt,closedAt,mergedAt,author,comments,reviews,latestReviews,reviewDecision,files,commits,closingIssuesReferences,mergeCommit,baseRefName,headRefName,headRepository,headRepositoryOwner,isDraft,additions,deletions,changedFiles"
+ISSUE_LIST_FIELDS = "number,title,state,url,updatedAt,labels"
+ISSUE_VIEW_FIELDS = "number,title,body,state,url,updatedAt,labels,comments"
+DEFAULT_GH_RETRIES = 3
+DEFAULT_GH_RETRY_DELAY_MS = 1000
+TRANSIENT_GH_ERROR = re.compile(
+    r"EOF|timeout|timed out|connection reset|connection refused|temporarily unavailable|"
+    r"TLS handshake timeout|502|503|504|rate limit|secondary rate limit|abuse detection",
+    re.IGNORECASE,
+)
+
+
+def is_transient_gh_error(stderr: str, stdout: str = "") -> bool:
+    return TRANSIENT_GH_ERROR.search(f"{stderr}\n{stdout}") is not None
+
+
+def run_gh(args: list[str], retries: int = DEFAULT_GH_RETRIES, retry_delay_ms: int = DEFAULT_GH_RETRY_DELAY_MS) -> Any:
+    if shutil.which("gh") is None:
+        raise SystemExit("GitHub CLI 'gh' is required. Install it and run: gh auth login")
+    attempts = max(1, retries + 1)
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["gh", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            text = result.stdout.strip()
+            return json.loads(text) if text else None
+        if attempt < attempts and is_transient_gh_error(result.stderr, result.stdout):
+            delay = max(0, retry_delay_ms) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"gh {' '.join(args)} failed with transient error; retrying "
+                f"{attempt}/{retries} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(f"gh {' '.join(args)} failed:\n{last_result.stderr.strip()}")
+
+
+def auth_status_failure(result: subprocess.CompletedProcess[str], login_hint: str) -> str:
+    details: list[str] = []
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    if stderr:
+        details.append(f"stderr: {stderr}")
+    if stdout:
+        details.append(f"stdout: {stdout}")
+    detail = "\n".join(details) if details else "gh auth status returned no diagnostic output"
+    return f"gh auth check failed with exit code {result.returncode}. Run: {login_hint}\n{detail}"
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for PR snapshot filtering")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    result = run_git(repo_path, ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"])
+    if result.returncode != 0:
+        raise SystemExit(f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def is_git_ancestor(repo_path: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    result = run_git(repo_path, ["merge-base", "--is-ancestor", ancestor_sha, descendant_sha])
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    stderr = result.stderr.strip()
+    normalized_stderr = stderr.lower()
+    if (
+        "not a valid commit" in normalized_stderr
+        or "no such commit" in normalized_stderr
+        or "not a valid object name" in normalized_stderr
+    ):
+        return False
+    raise SystemExit(
+        f"git could not compare {ancestor_sha} with snapshot {descendant_sha} in {repo_path}:\n{stderr}"
+    )
+
+
+def login_hint(hostname: str) -> str:
+    return f"gh auth login --hostname {hostname}" if hostname and hostname != "github.com" else "gh auth login"
+
+
+def repo_selector(repo: str, hostname: str) -> str:
+    if hostname and hostname != "github.com" and not repo.startswith(f"{hostname}/"):
+        return f"{hostname}/{repo}"
+    return repo
+
+
+def assert_gh_ready(hostname: str) -> None:
+    if shutil.which("gh") is None:
+        raise SystemExit("GitHub CLI 'gh' is required. Install it and run: gh auth login")
+    args = ["auth", "status"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    attempts = max(1, DEFAULT_GH_RETRIES + 1)
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["gh", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            return
+        if attempt < attempts and is_transient_gh_error(result.stderr, result.stdout):
+            delay = max(0, DEFAULT_GH_RETRY_DELAY_MS) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"gh auth status failed with transient error; retrying "
+                f"{attempt}/{DEFAULT_GH_RETRIES} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(auth_status_failure(last_result, login_hint(hostname)))
+
+
+def unique_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def unique_numbers(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    out: list[int] = []
+    for value in values:
+        if isinstance(value, int) and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def text_field(value: Any, *keys: str) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+    return ""
+
+
+def int_field(value: Any, key: str = "number") -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, dict) and isinstance(value.get(key), int):
+        return value[key]
+    return None
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique_strings(symbols)
+
+
+def commit_sha(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("commit"), dict):
+        return text_field(value["commit"], "oid", "sha", "abbreviatedOid")
+    return text_field(value, "oid", "sha", "abbreviatedOid")
+
+
+def commit_headline(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("commit"), dict):
+        return text_field(value["commit"], "messageHeadline", "message", "title")
+    return text_field(value, "messageHeadline", "message", "title")
+
+
+def author_login(value: Any) -> str:
+    return text_field(value, "login", "name")
+
+
+def review_state(value: Any) -> str:
+    return text_field(value, "state")
+
+
+def file_path(value: Any) -> str:
+    return text_field(value, "path", "filename")
+
+
+def label_name(value: Any) -> str:
+    return text_field(value, "name")
+
+
+def repo_name(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    owner = value.get("owner")
+    owner_login = text_field(owner, "login") if isinstance(owner, dict) else ""
+    name = text_field(value, "name", "nameWithOwner")
+    name_with_owner = text_field(value, "nameWithOwner")
+    if name_with_owner and "/" in name_with_owner:
+        return name_with_owner
+    return f"{owner_login}/{name}" if owner_login and name else name
+
+
+def body_text(value: Any) -> str:
+    return text_field(value, "body", "title", "name")
+
+
+def pr_detail_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail) or 0
+    title = text_field(detail, "title") or f"PR #{number}"
+    body = text_field(detail, "body")
+    comments = [body_text(item) for item in detail.get("comments", []) if body_text(item)]
+    reviews = [body_text(item) for item in detail.get("reviews", []) if body_text(item)]
+    commits = unique_strings(commit_sha(item) for item in detail.get("commits", []) if commit_sha(item))
+    commit_headlines = unique_strings(commit_headline(item) for item in detail.get("commits", []) if commit_headline(item))
+    files = unique_strings(file_path(item) for item in detail.get("files", []) if file_path(item))
+    review_states = unique_strings(review_state(item) for item in detail.get("latestReviews", []) if review_state(item))
+    issues = unique_numbers(
+        number for number in (int_field(item) for item in detail.get("closingIssuesReferences", [])) if number is not None
+    )
+    summary = bounded_summary([body, *comments, *reviews], summary_chars) or title
+    base_ref = text_field(detail, "baseRefName")
+    head_ref = text_field(detail, "headRefName")
+    head_repo = repo_name(detail.get("headRepository")) or repo
+    branch_label = f"{base_ref} <- {head_ref}" if base_ref or head_ref else ""
+    evidence = unique_strings(
+        [
+            f"PR #{number}: {title}",
+            f"PR #{number} changed {', '.join(files)}" if files else "",
+            f"PR #{number} closes issue {', '.join(f'#{issue}' for issue in issues)}" if issues else "",
+        ]
+    )
+    return {
+        "facetId": f"pr.{number}",
+        "sourceType": "pr",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "url"),
+        "state": text_field(detail, "state"),
+        "createdAt": text_field(detail, "createdAt"),
+        "updatedAt": text_field(detail, "updatedAt"),
+        "closedAt": text_field(detail, "closedAt"),
+        "mergedAt": text_field(detail, "mergedAt"),
+        "author": author_login(detail.get("author")),
+        "isDraft": bool(detail.get("isDraft")),
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "head_repo": head_repo,
+        "branch_label": branch_label,
+        "changed_files": detail.get("changedFiles") or len(files),
+        "additions": detail.get("additions") or 0,
+        "deletions": detail.get("deletions") or 0,
+        "commit_headlines": commit_headlines,
+        "review_decision": text_field(detail, "reviewDecision"),
+        "review_states": review_states,
+        "commits": commits,
+        "prs": [number] if number else [],
+        "issues": issues,
+        "files": files,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def issue_detail_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail) or 0
+    title = text_field(detail, "title") or f"Issue #{number}"
+    body = text_field(detail, "body")
+    comments = [body_text(item) for item in detail.get("comments", []) if body_text(item)]
+    labels = [label_name(item) for item in detail.get("labels", []) if label_name(item)]
+    labels_text = f"Labels: {', '.join(labels)}" if labels else ""
+    summary = bounded_summary([body, *comments, labels_text], summary_chars) or title
+    evidence = unique_strings(
+        [
+            f"issue #{number}: {title}",
+            f"issue #{number} labels: {', '.join(labels)}" if labels else "",
+        ]
+    )
+    return {
+        "facetId": f"issue.{number}",
+        "sourceType": "issue",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "url"),
+        "state": text_field(detail, "state"),
+        "updatedAt": text_field(detail, "updatedAt"),
+        "labels": labels,
+        "commits": [],
+        "prs": [],
+        "issues": [number] if number else [],
+        "files": [],
+        "symbols": extract_symbols("\n".join([title, summary, *labels])),
+        "evidence": evidence,
+    }
+
+
+def gh_list(kind: str, repo: str, limit: int, state: str, retries: int, retry_delay_ms: int) -> list[dict[str, Any]]:
+    fields = PR_LIST_FIELDS if kind == "pr" else ISSUE_LIST_FIELDS
+    return run_gh([kind, "list", "--repo", repo, "--limit", str(limit), "--state", state, "--json", fields], retries, retry_delay_ms)
+
+
+def gh_view(kind: str, repo: str, number: int, retries: int, retry_delay_ms: int) -> dict[str, Any]:
+    fields = PR_VIEW_FIELDS if kind == "pr" else ISSUE_VIEW_FIELDS
+    return run_gh([kind, "view", str(number), "--repo", repo, "--json", fields], retries, retry_delay_ms)
+
+
+def pr_is_in_snapshot(repo_path: Path, detail: dict[str, Any], snapshot_sha: str) -> bool:
+    if not snapshot_sha:
+        return True
+    merge_sha = commit_sha(detail.get("mergeCommit"))
+    return bool(merge_sha) and is_git_ancestor(repo_path, merge_sha, snapshot_sha)
+
+
+def fetch_pr_facets(
+    query_repo: str,
+    facet_repo: str,
+    repo_path: Path,
+    snapshot_sha: str,
+    limit: int,
+    state: str,
+    concurrency: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    if snapshot_sha and state == "open":
+        return []
+
+    facets: list[dict[str, Any]] = []
+    seen_numbers: set[int] = set()
+    candidate_limit = max(1, limit)
+    previous_candidate_count = -1
+
+    while len(facets) < limit:
+        candidates = gh_list("pr", query_repo, candidate_limit, state, retries, retry_delay_ms)
+        if not isinstance(candidates, list):
+            raise SystemExit("gh PR list response was not a JSON list")
+
+        candidate_count = len(candidates)
+        numbers: list[int] = []
+        for item in candidates:
+            number = int_field(item)
+            if number is not None and number not in seen_numbers:
+                seen_numbers.add(number)
+                numbers.append(number)
+
+        def one(number: int) -> dict[str, Any] | None:
+            detail = gh_view("pr", query_repo, number, retries, retry_delay_ms)
+            if snapshot_sha and not pr_is_in_snapshot(repo_path, detail, snapshot_sha):
+                return None
+            return pr_detail_to_facet(facet_repo, detail, summary_chars)
+
+        if numbers:
+            with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+                for facet in pool.map(one, numbers):
+                    if facet:
+                        facets.append(facet)
+                        if len(facets) >= limit:
+                            break
+
+        if len(facets) >= limit or candidate_count < candidate_limit or candidate_count == previous_candidate_count:
+            break
+        previous_candidate_count = candidate_count
+        candidate_limit *= 2
+
+    return facets[:limit]
+
+
+def fetch_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    snapshot_ref: str,
+    pr_limit: int,
+    issue_limit: int,
+    state: str,
+    include: set[str],
+    concurrency: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    assert_gh_ready(hostname)
+    selected_repo = repo_selector(repo, hostname)
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref) if snapshot_ref and "prs" in include else ""
+    facets: list[dict[str, Any]] = []
+    jobs: list[tuple[str, int]] = []
+    if "prs" in include:
+        facets.extend(fetch_pr_facets(selected_repo, repo, repo_path, snapshot_sha, pr_limit, state, concurrency, summary_chars, retries, retry_delay_ms))
+    if "issues" in include:
+        jobs.extend(("issue", item["number"]) for item in gh_list("issue", selected_repo, issue_limit, state, retries, retry_delay_ms))
+
+    def one(job: tuple[str, int]) -> dict[str, Any] | None:
+        kind, number = job
+        detail = gh_view(kind, selected_repo, number, retries, retry_delay_ms)
+        return issue_detail_to_facet(repo, detail, summary_chars)
+
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        facets.extend(facet for facet in pool.map(one, jobs) if facet)
+    return facets
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract GitHub PR/issue SourceFacet JSON using gh CLI.")
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--hostname", default="", help="GitHub hostname for auth/API commands; defaults to gh's current host")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path used for PR snapshot filtering")
+    parser.add_argument(
+        "--snapshot-ref",
+        default="",
+        help="Optional local git ref; PRs are kept only when their merge commit is an ancestor of this ref",
+    )
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum retained PRs after snapshot filtering")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum retained provider issues")
+    parser.add_argument("--state", choices=["all", "open", "closed"], default="all")
+    parser.add_argument("--include", default="prs,issues", help="Comma-separated: prs,issues")
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--gh-retries", type=int, default=DEFAULT_GH_RETRIES, help="Retries for transient gh CLI failures")
+    parser.add_argument("--gh-retry-delay-ms", type=int, default=DEFAULT_GH_RETRY_DELAY_MS, help="Initial retry delay for transient gh CLI failures")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if not re.match(r"^[^/]+/[^/]+$", args.repo):
+        parser.error("--repo must be owner/name")
+    include = {part.strip() for part in args.include.split(",") if part.strip()}
+    if not include or include - {"prs", "issues"}:
+        parser.error("--include must contain prs, issues, or prs,issues")
+    args.include = include
+    args.pr_limit = args.pr_limit if args.pr_limit is not None else 30
+    args.issue_limit = args.issue_limit if args.issue_limit is not None else 30
+    if args.pr_limit < 1 or args.pr_limit > 100:
+        parser.error("--pr-limit must be from 1 to 100")
+    if args.issue_limit < 1 or args.issue_limit > 100:
+        parser.error("--issue-limit must be from 1 to 100")
+    if args.concurrency < 1 or args.concurrency > 10:
+        parser.error("--concurrency must be from 1 to 10")
+    if args.gh_retries < 0 or args.gh_retries > 10:
+        parser.error("--gh-retries must be from 0 to 10")
+    if args.gh_retry_delay_ms < 0:
+        parser.error("--gh-retry-delay-ms must be non-negative")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(
+        args.repo,
+        args.repo_path,
+        args.hostname,
+        args.snapshot_ref,
+        args.pr_limit,
+        args.issue_limit,
+        args.state,
+        args.include,
+        args.concurrency,
+        args.summary_chars,
+        args.gh_retries,
+        args.gh_retry_delay_ms,
+    )
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/gitlab_resource_facets.py
+++ b/examples/skills/repo-wiki/scripts/gitlab_resource_facets.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Extract GitLab merge request/issue resource facets with Python stdlib + glab CLI."""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from urllib.parse import quote, urlencode
+
+
+DEFAULT_GLAB_RETRIES = 3
+DEFAULT_GLAB_RETRY_DELAY_MS = 1000
+TRANSIENT_GLAB_ERROR = re.compile(
+    r"EOF|timeout|timed out|connection reset|connection refused|temporarily unavailable|"
+    r"TLS handshake timeout|502|503|504|rate limit|too many requests",
+    re.IGNORECASE,
+)
+
+
+def is_transient_glab_error(stderr: str, stdout: str = "") -> bool:
+    return TRANSIENT_GLAB_ERROR.search(f"{stderr}\n{stdout}") is not None
+
+
+def run_glab_api(path: str, hostname: str = "", retries: int = DEFAULT_GLAB_RETRIES, retry_delay_ms: int = DEFAULT_GLAB_RETRY_DELAY_MS) -> Any:
+    if shutil.which("glab") is None:
+        raise SystemExit("GitLab CLI 'glab' is required. Install it and run: glab auth login")
+    args = ["api"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    args.append(path)
+    attempts = max(1, retries + 1)
+    last_result: Optional[subprocess.CompletedProcess[str]] = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["glab", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            text = result.stdout.strip()
+            return json.loads(text) if text else None
+        if attempt < attempts and is_transient_glab_error(result.stderr, result.stdout):
+            delay = max(0, retry_delay_ms) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"glab api {path} failed with transient error; retrying "
+                f"{attempt}/{retries} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(f"glab api {path} failed:\n{last_result.stderr.strip()}")
+
+
+def auth_status_failure(result: subprocess.CompletedProcess[str], login_hint: str) -> str:
+    details: list[str] = []
+    stderr = result.stderr.strip()
+    stdout = result.stdout.strip()
+    if stderr:
+        details.append(f"stderr: {stderr}")
+    if stdout:
+        details.append(f"stdout: {stdout}")
+    detail = "\n".join(details) if details else "glab auth status returned no diagnostic output"
+    return f"glab auth check failed with exit code {result.returncode}. Run: {login_hint}\n{detail}"
+
+
+def login_hint(hostname: str) -> str:
+    return f"glab auth login --hostname {hostname}" if hostname and hostname != "gitlab.com" else "glab auth login"
+
+
+def assert_glab_ready(hostname: str) -> None:
+    if shutil.which("glab") is None:
+        raise SystemExit("GitLab CLI 'glab' is required. Install it and run: glab auth login")
+    args = ["auth", "status"]
+    if hostname:
+        args.extend(["--hostname", hostname])
+    attempts = max(1, DEFAULT_GLAB_RETRIES + 1)
+    last_result: Optional[subprocess.CompletedProcess[str]] = None
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["glab", *args], text=True, capture_output=True)
+        last_result = result
+        if result.returncode == 0:
+            return
+        if attempt < attempts and is_transient_glab_error(result.stderr, result.stdout):
+            delay = max(0, DEFAULT_GLAB_RETRY_DELAY_MS) / 1000 * (2 ** (attempt - 1))
+            print(
+                f"glab auth status failed with transient error; retrying "
+                f"{attempt}/{DEFAULT_GLAB_RETRIES} after {delay:.1f}s: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            continue
+        break
+    assert last_result is not None
+    raise SystemExit(auth_status_failure(last_result, login_hint(hostname)))
+
+
+def run_git(repo_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise SystemExit("git is required for MR snapshot filtering")
+    return subprocess.run(["git", "-C", str(repo_path), *args], text=True, capture_output=True)
+
+
+def resolve_snapshot_sha(repo_path: Path, snapshot_ref: str) -> str:
+    result = run_git(repo_path, ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"])
+    if result.returncode != 0:
+        raise SystemExit(f"git could not resolve snapshot ref {snapshot_ref!r} in {repo_path}:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def is_git_ancestor(repo_path: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    result = run_git(repo_path, ["merge-base", "--is-ancestor", ancestor_sha, descendant_sha])
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    stderr = result.stderr.strip()
+    normalized_stderr = stderr.lower()
+    if (
+        "not a valid commit" in normalized_stderr
+        or "no such commit" in normalized_stderr
+        or "not a valid object name" in normalized_stderr
+    ):
+        return False
+    raise SystemExit(
+        f"git could not compare {ancestor_sha} with snapshot {descendant_sha} in {repo_path}:\n{stderr}"
+    )
+
+
+def api_path(repo: str, endpoint: str, params: Optional[dict[str, Any]] = None) -> str:
+    encoded_repo = quote(repo, safe="")
+    query = urlencode(params or {})
+    path = f"projects/{encoded_repo}/{endpoint}"
+    return f"{path}?{query}" if query else path
+
+
+def state_param(state: str) -> str:
+    return {"open": "opened", "closed": "closed"}.get(state, state)
+
+
+def normalize_state(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if raw == "opened":
+        return "OPEN"
+    if raw == "merged":
+        return "MERGED"
+    if raw == "closed":
+        return "CLOSED"
+    return raw.upper() if raw else ""
+
+
+def unique_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def unique_numbers(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    out: list[int] = []
+    for value in values:
+        if isinstance(value, int) and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def text_field(value: Any, *keys: str) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if not isinstance(value, dict):
+        return ""
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+    return ""
+
+
+def int_field(value: Any, key: str) -> Optional[int]:
+    if not isinstance(value, dict):
+        return None
+    item = value.get(key)
+    if isinstance(item, int):
+        return item
+    if isinstance(item, str) and item.isdigit():
+        return int(item)
+    return None
+
+
+def bounded_summary(parts: Iterable[str], max_chars: int) -> str:
+    text = "\n\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return text if len(text) <= max_chars else text[: max_chars - 3] + "..."
+
+
+def extract_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"\b[$A-Z_a-z][$\w]*\b", text):
+        value = match.group(0)
+        looks_symbolic = (
+            re.search(r"[a-z][A-Z]", value) is not None
+            or re.match(r"^[A-Z0-9_]{2,}$", value) is not None
+            or "_" in value
+            or "$" in value
+        )
+        if looks_symbolic:
+            symbols.append(value)
+    return unique_strings(symbols)
+
+
+def linked_issue_numbers(text: str) -> list[int]:
+    numbers = [int(match.group(1)) for match in re.finditer(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", text, re.IGNORECASE)]
+    return unique_numbers(numbers)
+
+
+def author_login(value: Any) -> str:
+    return text_field(value, "username", "login", "name")
+
+
+def label_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return unique_strings(text_field(item, "name") if isinstance(item, dict) else str(item).strip() for item in value)
+
+
+def change_paths(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    changes = value.get("changes")
+    if not isinstance(changes, list):
+        return []
+    paths: list[str] = []
+    for item in changes:
+        if isinstance(item, dict):
+            path = text_field(item, "new_path", "old_path")
+            if path:
+                paths.append(path)
+    return unique_strings(paths)
+
+
+def mr_to_facet(repo: str, detail: dict[str, Any], changes: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail, "iid") or 0
+    title = text_field(detail, "title") or f"MR !{number}"
+    description = text_field(detail, "description")
+    files = change_paths(changes)
+    summary = bounded_summary([description], summary_chars) or title
+    base_ref = text_field(detail, "target_branch")
+    head_ref = text_field(detail, "source_branch")
+    branch_label = f"{base_ref} <- {head_ref}" if base_ref or head_ref else ""
+    issues = linked_issue_numbers(description)
+    merge_sha = text_field(detail, "merge_commit_sha", "squash_commit_sha")
+    evidence = unique_strings(
+        [
+            f"MR !{number}: {title}",
+            f"MR !{number} changed {', '.join(files)}" if files else "",
+            f"MR !{number} closes issue {', '.join(f'#{issue}' for issue in issues)}" if issues else "",
+        ]
+    )
+    return {
+        "facetId": f"mr.{number}",
+        "sourceType": "pr",
+        "provider": "gitlab",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "web_url", "url"),
+        "state": normalize_state(detail.get("state")),
+        "createdAt": text_field(detail, "created_at"),
+        "updatedAt": text_field(detail, "updated_at"),
+        "closedAt": text_field(detail, "closed_at"),
+        "mergedAt": text_field(detail, "merged_at"),
+        "author": author_login(detail.get("author")),
+        "isDraft": bool(detail.get("draft") or detail.get("work_in_progress")),
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "head_repo": repo,
+        "branch_label": branch_label,
+        "changed_files": int_field(detail, "changes_count") or len(files),
+        "additions": 0,
+        "deletions": 0,
+        "commit_headlines": [],
+        "review_decision": "",
+        "review_states": [],
+        "commits": [merge_sha] if merge_sha else [],
+        "merge_commit": merge_sha,
+        "prs": [number] if number else [],
+        "issues": issues,
+        "files": files,
+        "symbols": extract_symbols("\n".join([title, summary, *files])),
+        "evidence": evidence,
+    }
+
+
+def issue_to_facet(repo: str, detail: dict[str, Any], summary_chars: int) -> dict[str, Any]:
+    number = int_field(detail, "iid") or 0
+    title = text_field(detail, "title") or f"Issue #{number}"
+    description = text_field(detail, "description")
+    labels = label_names(detail.get("labels"))
+    labels_text = f"Labels: {', '.join(labels)}" if labels else ""
+    summary = bounded_summary([description, labels_text], summary_chars) or title
+    evidence = unique_strings(
+        [
+            f"issue #{number}: {title}",
+            f"issue #{number} labels: {', '.join(labels)}" if labels else "",
+        ]
+    )
+    return {
+        "facetId": f"issue.{number}",
+        "sourceType": "issue",
+        "provider": "gitlab",
+        "repo": repo,
+        "title": title,
+        "summary": summary,
+        "url": text_field(detail, "web_url", "url"),
+        "state": normalize_state(detail.get("state")),
+        "updatedAt": text_field(detail, "updated_at"),
+        "labels": labels,
+        "commits": [],
+        "prs": [],
+        "issues": [number] if number else [],
+        "files": [],
+        "symbols": extract_symbols("\n".join([title, summary, *labels])),
+        "evidence": evidence,
+    }
+
+
+def mr_is_in_snapshot(repo_path: Path, detail: dict[str, Any], snapshot_sha: str) -> bool:
+    if not snapshot_sha:
+        return True
+    merge_sha = text_field(detail, "merge_commit_sha", "squash_commit_sha")
+    return bool(merge_sha) and is_git_ancestor(repo_path, merge_sha, snapshot_sha)
+
+
+def append_mr_facet(
+    facets: list[dict[str, Any]],
+    repo: str,
+    item: dict[str, Any],
+    hostname: str,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> None:
+    number = int_field(item, "iid")
+    if not number:
+        return
+    changes = run_glab_api(api_path(repo, f"merge_requests/{number}/changes"), hostname, retries, retry_delay_ms)
+    facets.append(mr_to_facet(repo, item, changes if isinstance(changes, dict) else {}, summary_chars))
+
+
+def fetch_mr_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    api_state: str,
+    snapshot_sha: str,
+    limit: int,
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    if snapshot_sha and api_state == "opened":
+        return []
+
+    facets: list[dict[str, Any]] = []
+
+    if not snapshot_sha:
+        merge_requests = run_glab_api(
+            api_path(repo, "merge_requests", {"state": api_state, "per_page": limit, "order_by": "updated_at", "sort": "desc"}),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(merge_requests, list):
+            raise SystemExit("glab merge request list response was not a JSON list")
+        for item in merge_requests:
+            if isinstance(item, dict):
+                append_mr_facet(facets, repo, item, hostname, summary_chars, retries, retry_delay_ms)
+        return facets[:limit]
+
+    page = 1
+    while len(facets) < limit:
+        merge_requests = run_glab_api(
+            api_path(
+                repo,
+                "merge_requests",
+                {"state": api_state, "per_page": limit, "order_by": "updated_at", "sort": "desc", "page": page},
+            ),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(merge_requests, list):
+            raise SystemExit("glab merge request list response was not a JSON list")
+        if not merge_requests:
+            break
+
+        for item in merge_requests:
+            if not isinstance(item, dict) or not mr_is_in_snapshot(repo_path, item, snapshot_sha):
+                continue
+            append_mr_facet(facets, repo, item, hostname, summary_chars, retries, retry_delay_ms)
+            if len(facets) >= limit:
+                break
+
+        if len(facets) >= limit or len(merge_requests) < limit:
+            break
+        page += 1
+
+    return facets[:limit]
+
+
+def fetch_facets(
+    repo: str,
+    repo_path: Path,
+    hostname: str,
+    snapshot_ref: str,
+    pr_limit: int,
+    issue_limit: int,
+    state: str,
+    include: set[str],
+    summary_chars: int,
+    retries: int,
+    retry_delay_ms: int,
+) -> list[dict[str, Any]]:
+    assert_glab_ready(hostname)
+    api_state = state_param(state)
+    snapshot_sha = resolve_snapshot_sha(repo_path, snapshot_ref) if snapshot_ref and "prs" in include else ""
+    facets: list[dict[str, Any]] = []
+
+    if "prs" in include:
+        facets.extend(fetch_mr_facets(repo, repo_path, hostname, api_state, snapshot_sha, pr_limit, summary_chars, retries, retry_delay_ms))
+
+    if "issues" in include:
+        issues = run_glab_api(
+            api_path(repo, "issues", {"state": api_state, "per_page": issue_limit, "order_by": "updated_at", "sort": "desc"}),
+            hostname,
+            retries,
+            retry_delay_ms,
+        )
+        if not isinstance(issues, list):
+            raise SystemExit("glab issue list response was not a JSON list")
+        facets.extend(issue_to_facet(repo, item, summary_chars) for item in issues if isinstance(item, dict))
+
+    return facets
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract GitLab MR/issue SourceFacet JSON using glab CLI.")
+    parser.add_argument("--repo", required=True, help="GitLab repository in group/project or group/subgroup/project form")
+    parser.add_argument("--hostname", default="", help="GitLab hostname for auth/API commands; defaults to glab's current host")
+    parser.add_argument("--repo-path", default=".", help="Local git repository path used for MR snapshot filtering")
+    parser.add_argument(
+        "--snapshot-ref",
+        default="",
+        help="Optional local git ref; MRs are kept only when their merge commit is an ancestor of this ref",
+    )
+    parser.add_argument("--pr-limit", type=int, default=None, help="Maximum retained MRs after snapshot filtering")
+    parser.add_argument("--issue-limit", type=int, default=None, help="Maximum retained provider issues")
+    parser.add_argument("--state", choices=["all", "open", "closed"], default="all")
+    parser.add_argument("--include", default="prs,issues", help="Comma-separated: prs,issues")
+    parser.add_argument("--glab-retries", type=int, default=DEFAULT_GLAB_RETRIES, help="Retries for transient glab CLI failures")
+    parser.add_argument("--glab-retry-delay-ms", type=int, default=DEFAULT_GLAB_RETRY_DELAY_MS, help="Initial retry delay for transient glab CLI failures")
+    parser.add_argument("--summary-chars", type=int, default=4000)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    parser.add_argument("--out", help="Write JSON to this file instead of stdout")
+    args = parser.parse_args(argv)
+    if "/" not in args.repo:
+        parser.error("--repo must be group/project or group/subgroup/project")
+    include = {part.strip() for part in args.include.split(",") if part.strip()}
+    if not include or include - {"prs", "issues"}:
+        parser.error("--include must contain prs, issues, or prs,issues")
+    args.include = include
+    args.pr_limit = args.pr_limit if args.pr_limit is not None else 30
+    args.issue_limit = args.issue_limit if args.issue_limit is not None else 30
+    if args.pr_limit < 1 or args.pr_limit > 100:
+        parser.error("--pr-limit must be from 1 to 100")
+    if args.issue_limit < 1 or args.issue_limit > 100:
+        parser.error("--issue-limit must be from 1 to 100")
+    if args.glab_retries < 0 or args.glab_retries > 10:
+        parser.error("--glab-retries must be from 0 to 10")
+    if args.glab_retry_delay_ms < 0:
+        parser.error("--glab-retry-delay-ms must be non-negative")
+    args.repo_path = Path(args.repo_path).expanduser().resolve()
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    facets = fetch_facets(
+        args.repo,
+        args.repo_path,
+        args.hostname,
+        args.snapshot_ref,
+        args.pr_limit,
+        args.issue_limit,
+        args.state,
+        args.include,
+        args.summary_chars,
+        args.glab_retries,
+        args.glab_retry_delay_ms,
+    )
+    text = json.dumps(facets, ensure_ascii=False, indent=2 if args.pretty else None)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/prepare_repo_memory.py
+++ b/examples/skills/repo-wiki/scripts/prepare_repo_memory.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Prepare an empty .repo_memory workspace; do not generate memory content."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPO_MEMORY_GITIGNORE_RULE = ".repo_memory/"
+PREFERRED_REMOTE_NAMES = ("upstream", "origin")
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def is_git_repo(repo: Path) -> bool:
+    code, out, _ = run(["git", "rev-parse", "--is-inside-work-tree"], repo)
+    return code == 0 and out == "true"
+
+
+def git_value(repo: Path, *args: str) -> str:
+    code, out, _ = run(["git", *args], repo)
+    return out if code == 0 else ""
+
+
+def remote_url_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[1] if len(parts) >= 2 else ""
+
+
+def remote_name_from_line(line: str) -> str:
+    parts = line.split()
+    return parts[0] if parts else ""
+
+
+def normalize_remote_path(path: str) -> str:
+    repo_path = path.strip().lstrip("/").rstrip("/")
+    if repo_path.endswith(".git"):
+        repo_path = repo_path[:-4]
+    return repo_path
+
+
+def provider_from_host(host: str) -> str:
+    lower = host.lower()
+    if lower == "github.com" or "github" in lower:
+        return "github"
+    if lower == "gitlab.com" or "gitlab" in lower:
+        return "gitlab"
+    return ""
+
+
+def parse_remote_url(url: str) -> dict[str, str]:
+    if not url:
+        return {"provider": "", "repo": "", "host": "", "url": ""}
+
+    if "://" not in url:
+        scp_match = re.match(r"^(?:[^@/\s]+@)?(?P<host>[^:/\s]+):(?P<path>.+)$", url)
+        if scp_match:
+            host = scp_match.group("host")
+            repo_path = normalize_remote_path(scp_match.group("path"))
+            return {"provider": provider_from_host(host), "repo": repo_path, "host": host, "url": url}
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    repo_path = normalize_remote_path(parsed.path)
+    return {"provider": provider_from_host(host), "repo": repo_path, "host": host, "url": url}
+
+
+def parse_code_host_repo(remotes: str) -> dict[str, str]:
+    candidates: list[dict[str, str]] = []
+    for line in remotes.splitlines():
+        if "(push)" in line:
+            continue
+        parsed = parse_remote_url(remote_url_from_line(line))
+        if parsed["provider"] and parsed["repo"]:
+            parsed["remote_name"] = remote_name_from_line(line)
+            candidates.append(parsed)
+    for preferred in PREFERRED_REMOTE_NAMES:
+        for candidate in candidates:
+            if candidate.get("remote_name") == preferred:
+                candidate["selection_reason"] = f"preferred_{preferred}_fetch_remote"
+                return candidate
+    if candidates:
+        candidates[0]["selection_reason"] = "first_supported_fetch_remote"
+        return candidates[0]
+    return {"provider": "", "repo": "", "host": "", "url": "", "remote_name": "", "selection_reason": "none"}
+
+
+def auth_args(command: str, host: str) -> list[str]:
+    args = ["auth", "status"]
+    if host and command in {"gh", "glab"}:
+        args.extend(["--hostname", host])
+    return args
+
+
+def login_hint(command: str, host: str) -> str:
+    default_host = "github.com" if command == "gh" else "gitlab.com" if command == "glab" else ""
+    if host and host != default_host:
+        return f"{command} auth login --hostname {host}"
+    return f"{command} auth login"
+
+
+def gitignore_has_repo_memory_rule(text: str) -> bool:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("!"):
+            continue
+        rule = stripped.split("#", 1)[0].strip().lstrip("/")
+        if rule in {".repo_memory", ".repo_memory/"}:
+            return True
+    return False
+
+
+def ensure_repo_memory_gitignore(repo: Path) -> bool:
+    gitignore = repo / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    if gitignore_has_repo_memory_rule(existing):
+        return False
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    gitignore.write_text(f"{existing}{separator}{REPO_MEMORY_GITIGNORE_RULE}\n", encoding="utf-8")
+    return True
+
+
+def cli_auth_state(command: str, auth_args: list[str], login_hint: str) -> dict[str, Any]:
+    if shutil.which(command) is None:
+        return {
+            "available": False,
+            "authenticated": False,
+            "auth_status": "cli_missing",
+            "auth_error": "",
+            "login_hint": login_hint,
+        }
+    try:
+        proc = subprocess.run([command, *auth_args], text=True, capture_output=True, timeout=8)
+    except subprocess.TimeoutExpired:
+        return {
+            "available": True,
+            "authenticated": False,
+            "auth_status": "auth_check_timeout",
+            "auth_error": f"{command} auth check timed out",
+            "login_hint": login_hint,
+        }
+    if proc.returncode == 0:
+        return {
+            "available": True,
+            "authenticated": True,
+            "auth_status": "authenticated",
+            "auth_error": "",
+            "login_hint": login_hint,
+        }
+    error = (proc.stderr.strip() or proc.stdout.strip()).splitlines()
+    return {
+        "available": True,
+        "authenticated": False,
+        "auth_status": "auth_required",
+        "auth_error": error[0][:500] if error else "",
+        "login_hint": login_hint,
+    }
+
+
+def provider_label(provider: str) -> str:
+    if provider == "github":
+        return "GitHub"
+    if provider == "gitlab":
+        return "GitLab"
+    return "Git provider"
+
+
+def provider_evidence_label(provider: str) -> str:
+    if provider == "github":
+        return "GitHub PR/issue"
+    if provider == "gitlab":
+        return "GitLab MR/issue"
+    return "provider"
+
+
+def notice_markdown(body: str, command: str, rerun_line: str) -> str:
+    command_block = f"\n```bash\n{command}\n```\n" if command else ""
+    return "\n".join(
+        [
+            "**Provider Evidence Unavailable**",
+            "",
+            f"> {body}",
+            "> Continuing with local-only repo memory now.",
+            "",
+            "**Next steps for provider evidence**",
+            command_block.rstrip(),
+            rerun_line,
+        ]
+    ).strip()
+
+
+def non_git_repo_notice(repo: Path) -> str:
+    return "\n".join(
+        [
+            "**Repo Memory Cannot Be Built Yet**",
+            "",
+            f"> This folder is not a git repository: {repo}",
+            "> The $repo-wiki repo-build operation cannot collect local commit history or provider-linked PR/MR/issue evidence.",
+            "",
+            "**Next steps**",
+            "- If this is an existing project, open the real cloned repo directory.",
+            "- If this is a new project, run `git init` first, make at least one commit, then rerun $repo-wiki repo-build.",
+            "- If you only want file inspection, continue by inspecting files without repo memory.",
+        ]
+    )
+
+
+def provider_notice(provider: str, cli: str, evidence_state: str, login_hint: str) -> dict[str, Any]:
+    label = provider_label(provider)
+    evidence_label = provider_evidence_label(provider)
+    if evidence_state == "ready":
+        return {
+            "provider_notice_level": "info",
+            "provider_user_notice": f"{label} provider evidence is ready; {evidence_label} evidence can be collected.",
+            "provider_notice_markdown": (
+                f"**Provider Evidence Ready**\n\n"
+                f"> {label} provider evidence is ready.\n\n"
+                f"`{evidence_label}` evidence can be collected."
+            ),
+            "provider_next_steps": [],
+        }
+    if evidence_state == "auth_required":
+        body = f"{label} provider evidence is unavailable because `{cli}` is not logged in."
+        rerun_line = f"Rerun $repo-wiki repo-build to collect {evidence_label} evidence."
+        return {
+            "provider_notice_level": "warning",
+            "provider_user_notice": (
+                f"{body} "
+                f"I am continuing with local-only repo memory now. To include {evidence_label} evidence, "
+                f"run `{login_hint}`, then rerun $repo-wiki repo-build."
+            ),
+            "provider_notice_markdown": notice_markdown(body, login_hint, rerun_line),
+            "provider_next_steps": [
+                f"Run: {login_hint}",
+                rerun_line,
+            ],
+        }
+    if evidence_state == "cli_missing":
+        body = f"{label} provider evidence is unavailable because `{cli}` is not installed."
+        rerun_line = f"Rerun $repo-wiki repo-build to collect {evidence_label} evidence."
+        return {
+            "provider_notice_level": "warning",
+            "provider_user_notice": (
+                f"{body} "
+                f"I am continuing with local-only repo memory now. To include {evidence_label} evidence, "
+                f"install `{cli}`, run `{login_hint}`, then rerun $repo-wiki repo-build."
+            ),
+            "provider_notice_markdown": notice_markdown(body, login_hint, rerun_line),
+            "provider_next_steps": [
+                f"Install: {cli}",
+                f"Run: {login_hint}",
+                rerun_line,
+            ],
+        }
+    return {
+        "provider_notice_level": "info",
+        "provider_user_notice": "No supported GitHub/GitLab remote was detected; continuing with local-only repo memory.",
+        "provider_notice_markdown": (
+            "**Provider Evidence Unavailable**\n\n"
+            "> No supported GitHub/GitLab remote was detected.\n"
+            "> Continuing with local-only repo memory."
+        ),
+        "provider_next_steps": [],
+    }
+
+
+def provider_cli_report(provider: str, gh: dict[str, Any], glab: dict[str, Any]) -> dict[str, Any]:
+    if provider == "github":
+        state = gh
+        cli = "gh"
+    elif provider == "gitlab":
+        state = glab
+        cli = "glab"
+    else:
+        return {
+            "provider_cli": "",
+            "provider_cli_available": False,
+            "provider_authenticated": False,
+            "provider_auth_status": "no_supported_remote",
+            "provider_evidence_state": "unavailable",
+            "provider_login_hint": "",
+            "provider_fallback": "No supported GitHub/GitLab remote was detected; build local-only repo memory.",
+            **provider_notice(provider, "", "unavailable", ""),
+        }
+
+    if not state["available"]:
+        evidence_state = "cli_missing"
+        fallback = f"{cli} is not installed; build local-only repo memory unless the user installs the provider CLI."
+    elif not state["authenticated"]:
+        evidence_state = "auth_required"
+        fallback = f"{cli} is not authenticated; build local-only repo memory unless the user logs in and reruns provider collection."
+    else:
+        evidence_state = "ready"
+        fallback = "Provider evidence can be collected."
+
+    return {
+        "provider_cli": cli,
+        "provider_cli_available": state["available"],
+        "provider_authenticated": state["authenticated"],
+        "provider_auth_status": state["auth_status"],
+        "provider_evidence_state": evidence_state,
+        "provider_login_hint": state["login_hint"],
+        "provider_fallback": fallback,
+        **provider_notice(provider, cli, evidence_state, state["login_hint"]),
+    }
+
+
+def skipped_provider_report(provider: str, host: str) -> dict[str, Any]:
+    cli = "gh" if provider == "github" else "glab" if provider == "gitlab" else ""
+    return {
+        "provider_cli": cli,
+        "provider_cli_available": False,
+        "provider_authenticated": False,
+        "provider_auth_status": "skipped_by_policy",
+        "provider_evidence_state": "skipped_by_policy",
+        "provider_login_hint": login_hint(cli, host) if cli else "",
+        "provider_fallback": "Provider collection is disabled by the selected history policy.",
+        "provider_notice_level": "info",
+        "provider_user_notice": "Provider evidence collection was skipped by policy.",
+        "provider_notice_markdown": "",
+        "provider_next_steps": [],
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Check environment and create .repo_memory directories only.")
+    parser.add_argument("repo", nargs="?", default=".", help="Local git repository path; defaults to current directory")
+    parser.add_argument("--reuse", action="store_true", help="Allow using an existing .repo_memory directory without deleting it")
+    parser.add_argument("--skip-provider-check", action="store_true", help="Do not inspect gh/glab availability or authentication")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+    if not repo.exists():
+        raise SystemExit(f"Repository path does not exist: {repo}")
+    if shutil.which("git") is None:
+        raise SystemExit("git is required but was not found on PATH")
+    if not is_git_repo(repo):
+        raise SystemExit(non_git_repo_notice(repo))
+
+    memory = repo / ".repo_memory"
+    if memory.exists() and not args.reuse:
+        raise SystemExit(f"{memory} already exists. Stop by default; rerun with --reuse to update it.")
+
+    for subdir in [memory, memory / "raw", memory / "resources"]:
+        subdir.mkdir(parents=True, exist_ok=True)
+
+    remotes = git_value(repo, "remote", "-v")
+    remote = parse_code_host_repo(remotes)
+    gitignore_updated = ensure_repo_memory_gitignore(repo)
+    gh_host = remote["host"] if remote["provider"] == "github" else ""
+    glab_host = remote["host"] if remote["provider"] == "gitlab" else ""
+    if args.skip_provider_check:
+        gh_state = {"available": False, "authenticated": False, "auth_status": "skipped_by_policy", "auth_error": "", "login_hint": login_hint("gh", gh_host)}
+        glab_state = {"available": False, "authenticated": False, "auth_status": "skipped_by_policy", "auth_error": "", "login_hint": login_hint("glab", glab_host)}
+        provider_report = skipped_provider_report(remote["provider"], remote["host"])
+    else:
+        gh_state = cli_auth_state("gh", auth_args("gh", gh_host), login_hint("gh", gh_host))
+        glab_state = cli_auth_state("glab", auth_args("glab", glab_host), login_hint("glab", glab_host))
+        provider_report = provider_cli_report(remote["provider"], gh_state, glab_state)
+    report: dict[str, Any] = {
+        "prepared_at": now_iso(),
+        "repo_path": str(repo),
+        "memory_path": str(memory),
+        "is_git_repo": True,
+        "local_head": git_value(repo, "rev-parse", "HEAD"),
+        "local_branch": git_value(repo, "branch", "--show-current") or "(detached HEAD)",
+        "working_tree_state": "dirty" if git_value(repo, "status", "--short") else "clean",
+        "git_remotes": remotes.splitlines(),
+        "git_provider": remote["provider"],
+        "git_remote_repo": remote["repo"],
+        "git_remote_host": remote["host"],
+        "git_remote_url": remote["url"],
+        "git_remote_name": remote.get("remote_name", ""),
+        "git_remote_selection_reason": remote.get("selection_reason", ""),
+        "github_repo": remote["repo"] if remote["provider"] == "github" else "",
+        "gitlab_repo": remote["repo"] if remote["provider"] == "gitlab" else "",
+        "gh_available": gh_state["available"],
+        "gh_authenticated": gh_state["authenticated"],
+        "gh_auth_status": gh_state["auth_status"],
+        "gh_auth_error": gh_state["auth_error"],
+        "gh_login_hint": gh_state["login_hint"],
+        "glab_available": glab_state["available"],
+        "glab_authenticated": glab_state["authenticated"],
+        "glab_auth_status": glab_state["auth_status"],
+        "glab_auth_error": glab_state["auth_error"],
+        "glab_login_hint": glab_state["login_hint"],
+        **provider_report,
+        "gitignore_path": str(repo / ".gitignore"),
+        "gitignore_rule": REPO_MEMORY_GITIGNORE_RULE,
+        "gitignore_updated": gitignore_updated,
+        "created_directories": [".repo_memory", ".repo_memory/raw", ".repo_memory/resources"],
+        "next_step": "Agent must inspect local code/docs and author PROFILE.md and resources. This script intentionally does not generate memory content.",
+    }
+    (memory / "raw" / "prepare-report.json").write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/examples/skills/repo-wiki/scripts/validate_memory.py
+++ b/examples/skills/repo-wiki/scripts/validate_memory.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Validate authored repo-memory bundles."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BASELINE_FILES = [
+    Path("PROFILE.md"),
+    Path("resources/commits.md"),
+    Path("resources/prs.md"),
+    Path("resources/issues.md"),
+    Path("raw/git-commits.json"),
+]
+
+PROVIDER_RAW_FILES = [Path("raw/github-facets.json"), Path("raw/gitlab-facets.json")]
+PROVIDER_RESOURCE_FILES = [Path("resources/prs.md"), Path("resources/issues.md")]
+DISABLED_RESOURCE_SOURCES = {"history_disabled", "provider_skipped_local_only", "provider_unavailable", "github_resource_facets_unavailable", "gitlab_resource_facets_unavailable", "provider_unavailable_local_only"}
+PLACEHOLDER_RE = re.compile(r"\[([^\]\n]+)\]")
+LINK_TARGET_AFTER_BRACKET_RE = re.compile(r"[ \t\r\n]*\(")
+
+
+def relative(path: Path, memory: Path) -> str:
+    return path.relative_to(memory).as_posix()
+
+
+def resolve_memory_root(path: Path) -> Path:
+    candidate = path.expanduser().resolve()
+    if candidate.name == ".repo_memory":
+        return candidate
+    return candidate / ".repo_memory"
+
+
+def parse_frontmatter(text: str) -> dict[str, Any]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}
+    values: dict[str, Any] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+            values[key] = value[1:-1]
+        elif re.fullmatch(r"-?\d+", value):
+            values[key] = int(value)
+        elif value.lower() == "true":
+            values[key] = True
+        elif value.lower() == "false":
+            values[key] = False
+        else:
+            values[key] = value
+    return values
+
+
+def body_after_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return text
+    return text[end + 4 :].lstrip("\n")
+
+
+def item_section_count(text: str) -> int:
+    body = body_after_frontmatter(text)
+    lines = body.splitlines()
+    title_seen = False
+    count = 0
+    for line in lines:
+        if line.startswith("# ") and not title_seen:
+            title_seen = True
+            continue
+        if title_seen and line.startswith("## "):
+            count += 1
+    return count
+
+
+def placeholder_matches(text: str) -> list[str]:
+    text = strip_markdown_code(text)
+    matches: list[str] = []
+    for match in PLACEHOLDER_RE.finditer(text):
+        if LINK_TARGET_AFTER_BRACKET_RE.match(text, match.end()):
+            continue
+        value = match.group(1).strip()
+        if not value or value.startswith("#"):
+            continue
+        if re.search(r"[A-Za-z]", value):
+            matches.append(f"[{value}]")
+    return matches
+
+
+def strip_markdown_code(text: str) -> str:
+    without_fences = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    return re.sub(r"`[^`\n]*`", "", without_fences)
+
+
+def check_exists(memory: Path, rel_path: Path, errors: list[str], checked: list[str]) -> bool:
+    path = memory / rel_path
+    checked.append(rel_path.as_posix())
+    if not path.exists():
+        errors.append(f"{rel_path.as_posix()}: required file is missing")
+        return False
+    if not path.is_file():
+        errors.append(f"{rel_path.as_posix()}: expected a file")
+        return False
+    return True
+
+
+def validate_json(path: Path, memory: Path, errors: list[str], checked: list[str]) -> None:
+    checked.append(relative(path, memory))
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{relative(path, memory)}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}")
+    except OSError as exc:
+        errors.append(f"{relative(path, memory)}: could not read JSON: {exc}")
+
+
+def raw_source_points_to_provider(raw_source: Any) -> bool:
+    return isinstance(raw_source, str) and raw_source.endswith(("github-facets.json", "gitlab-facets.json"))
+
+
+def validate_markdown(path: Path, memory: Path, errors: list[str], warnings: list[str], checked: list[str]) -> None:
+    checked.append(relative(path, memory))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{relative(path, memory)}: could not read Markdown: {exc}")
+        return
+
+    frontmatter = parse_frontmatter(text)
+    rel = relative(path, memory)
+    if not frontmatter.get("schema"):
+        errors.append(f"{rel}: frontmatter field 'schema' is missing")
+    if path.name == "PROFILE.md":
+        source_tree = str(frontmatter.get("source_tree") or "")
+        if re.fullmatch(r"[0-9a-fA-F]{40}", source_tree) is None:
+            errors.append(f"{rel}: source_tree must be a full Git tree SHA")
+
+    placeholders = placeholder_matches(text)
+    if placeholders:
+        errors.append(f"{rel}: unresolved bracket placeholder(s): {', '.join(placeholders)}")
+
+    if path.parent.name != "resources":
+        return
+
+    for field in ["source", "resource_count", "trust_state", "raw_source"]:
+        if field not in frontmatter:
+            errors.append(f"{rel}: frontmatter field '{field}' is missing")
+
+    expected = frontmatter.get("resource_count")
+    actual = item_section_count(text)
+    if isinstance(expected, int):
+        if expected != actual:
+            errors.append(f"{rel}: resource_count is {expected}, but found {actual} item section(s)")
+    elif expected is not None:
+        errors.append(f"{rel}: resource_count must be an integer")
+
+    source = frontmatter.get("source")
+    raw_source = frontmatter.get("raw_source")
+    if "source" in frontmatter and not source:
+        errors.append(f"{rel}: frontmatter field 'source' must not be empty")
+    if "trust_state" in frontmatter and not frontmatter.get("trust_state"):
+        errors.append(f"{rel}: frontmatter field 'trust_state' must not be empty")
+    if source in DISABLED_RESOURCE_SOURCES and isinstance(expected, int) and expected != 0:
+        errors.append(f"{rel}: disabled or unavailable resource source {source!r} must use resource_count 0")
+    if source in DISABLED_RESOURCE_SOURCES and raw_source:
+        errors.append(f"{rel}: disabled or unavailable resource source {source!r} must use an empty raw_source")
+    if path.name in {"commits.md", "prs.md", "issues.md"} and source not in DISABLED_RESOURCE_SOURCES and raw_source == "":
+        errors.append(f"{rel}: empty raw_source requires a disabled or unavailable source")
+    if path.name in {"prs.md", "issues.md"} and raw_source_points_to_provider(raw_source):
+        provider_path = (path.parent / raw_source).resolve()
+        if not provider_path.exists():
+            errors.append(f"{rel}: provider raw evidence is missing for raw_source {raw_source!r}")
+
+
+def provider_raw_paths(memory: Path) -> list[Path]:
+    return [memory / rel for rel in PROVIDER_RAW_FILES if (memory / rel).exists()]
+
+
+def validate(memory: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked: list[str] = []
+
+    if not memory.exists():
+        errors.append(f"{memory}: .repo_memory directory is missing")
+        return {"ok": False, "errors": errors, "warnings": warnings, "checked": checked}
+    if not memory.is_dir():
+        errors.append(f"{memory}: expected .repo_memory to be a directory")
+        return {"ok": False, "errors": errors, "warnings": warnings, "checked": checked}
+
+    for rel_path in BASELINE_FILES:
+        check_exists(memory, rel_path, errors, checked)
+
+    markdown_paths = sorted(
+        path
+        for path in memory.rglob("*.md")
+        if path.is_file()
+    )
+    for path in markdown_paths:
+        if path.exists() and path.is_file():
+            validate_markdown(path, memory, errors, warnings, checked)
+
+    json_paths = sorted(path for path in (memory / "raw").rglob("*.json") if path.is_file())
+    provider_raw = provider_raw_paths(memory)
+
+    if provider_raw:
+        for rel_path in PROVIDER_RESOURCE_FILES:
+            check_exists(memory, rel_path, errors, checked)
+
+    seen_json: set[Path] = set()
+    for path in json_paths:
+        if path.exists() and path.is_file() and path not in seen_json:
+            seen_json.add(path)
+            validate_json(path, memory, errors, checked)
+
+    checked = sorted(dict.fromkeys(checked))
+    return {"ok": not errors, "errors": errors, "warnings": warnings, "checked": checked}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate a repo-memory bundle.")
+    parser.add_argument("path", help="Path to a repository or its .repo_memory directory")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    report = validate(resolve_memory_root(Path(args.path)))
+    print(json.dumps(report, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/openviking/parse/accessors/git_accessor.py
+++ b/openviking/parse/accessors/git_accessor.py
@@ -10,13 +10,14 @@ This is the DataAccessor layer extracted from CodeRepositoryParser.
 import asyncio
 import contextlib
 import os
+import re
 import shutil
 import stat
 import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import quote, urlparse
 
 from openviking.utils import (
@@ -38,6 +39,49 @@ from openviking_cli.utils.logger import get_logger
 from .base import DataAccessor, LocalResource, SourceType
 
 logger = get_logger(__name__)
+
+GIT_LOCAL_ARG = "git_local"
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def normalize_git_local_config(value: Any) -> Dict[str, Any]:
+    """Validate and normalize an uploaded local Git snapshot descriptor."""
+    if not isinstance(value, dict):
+        raise ValueError("args.git_local must be an object.")
+
+    allowed = {
+        "version",
+        "repo_key",
+        "repo_name",
+        "branch",
+        "commit",
+        "archive_format",
+    }
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError("args.git_local contains unsupported fields: " + ", ".join(unknown))
+    if value.get("version") != 1:
+        raise ValueError("args.git_local.version must be 1.")
+
+    normalized: Dict[str, Any] = {"version": 1}
+    for field, max_length in {"repo_key": 1024, "repo_name": 512, "branch": 512}.items():
+        raw = value.get(field)
+        if not isinstance(raw, str) or not raw.strip():
+            raise ValueError(f"args.git_local.{field} must be a non-empty string.")
+        cleaned = raw.strip()
+        if len(cleaned) > max_length:
+            raise ValueError(f"args.git_local.{field} must not exceed {max_length} characters.")
+        normalized[field] = cleaned
+
+    commit = value.get("commit")
+    if not isinstance(commit, str) or not _FULL_GIT_SHA_RE.fullmatch(commit.strip()):
+        raise ValueError("args.git_local.commit must be a full 40-character Git SHA.")
+    normalized["commit"] = commit.strip().lower()
+
+    if value.get("archive_format") != "zip":
+        raise ValueError("args.git_local.archive_format must be 'zip'.")
+    normalized["archive_format"] = "zip"
+    return normalized
 
 
 class GitAccessor(DataAccessor):
@@ -89,6 +133,12 @@ class GitAccessor(DataAccessor):
             path = Path(source_str)
 
         suffix = path.suffix.lower()
+        if suffix == ".zip" and kwargs.get(GIT_LOCAL_ARG) is not None:
+            try:
+                normalize_git_local_config(kwargs[GIT_LOCAL_ARG])
+            except ValueError:
+                return False
+            return path.is_file()
         return suffix == ".git"
 
     async def access(self, source: Union[str, Path], **kwargs) -> LocalResource:
@@ -104,8 +154,13 @@ class GitAccessor(DataAccessor):
         """
         source_str = str(source)
         temp_local_dir = None
-        branch = kwargs.get("branch") or kwargs.get("ref")
-        commit = kwargs.get("commit")
+        git_local = (
+            normalize_git_local_config(kwargs[GIT_LOCAL_ARG])
+            if kwargs.get(GIT_LOCAL_ARG) is not None
+            else None
+        )
+        branch = git_local["branch"] if git_local else kwargs.get("branch") or kwargs.get("ref")
+        commit = git_local["commit"] if git_local else kwargs.get("commit")
         auth_config = parse_git_http_auth_config(kwargs.get("auth_config"), source_str)
         git_env = None
 
@@ -118,7 +173,19 @@ class GitAccessor(DataAccessor):
             repo_name = "repository"
             local_dir = Path(temp_local_dir)
 
-            if source_str.startswith("git@"):
+            if git_local is not None:
+                await self._extract_zip(source_str, temp_local_dir)
+                entries = [
+                    item
+                    for item in Path(temp_local_dir).iterdir()
+                    if item.name not in {"__MACOSX", ".DS_Store"} and not item.name.startswith("._")
+                ]
+                if len(entries) == 1 and entries[0].is_dir():
+                    local_dir = entries[0]
+                repo_name = git_local["repo_name"]
+                marker_file = local_dir / ".git_source_repo"
+                await asyncio.to_thread(marker_file.write_text, git_local["repo_key"], encoding="utf-8")
+            elif source_str.startswith("git@"):
                 # git@ SSH URL
                 repo_name = await self._git_clone(
                     source_str,
@@ -205,11 +272,14 @@ class GitAccessor(DataAccessor):
                 meta["repo_ref"] = branch
             if commit:
                 meta["repo_commit"] = commit
+            if git_local:
+                meta["repo_key"] = git_local["repo_key"]
+                meta["_cleanup_path"] = temp_local_dir
 
             return LocalResource(
                 path=local_dir,
                 source_type=SourceType.GIT,
-                original_source=source_str,  # Full original URL (critical for TreeBuilder!)
+                original_source=git_local["repo_key"] if git_local else source_str,
                 meta=meta,
                 is_temporary=True,
             )

--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -1382,7 +1382,10 @@ class MarkdownParser(BaseParser):
         estimated_tokens = self._estimate_token_count(content)
 
         # Create root directory
-        ops.append(_LayoutOp("mkdir", root_dir))
+        # A flattened document uses temp_uri as root_dir. The outer layout
+        # phase may have already materialized that URI, so the second mkdir
+        # must retain normal directory semantics while accepting that duplicate.
+        ops.append(_LayoutOp("mkdir", root_dir, exist_ok=True))
 
         # Get document name
         doc_name = doc_name or self._sanitize_for_path(

--- a/openviking/resource/staged_source.py
+++ b/openviking/resource/staged_source.py
@@ -22,6 +22,10 @@ _IDENTITY_META_FIELDS = frozenset(
         "resolved_extension",
         "resolved_name",
         "original_filename",
+        "repo_key",
+        "repo_name",
+        "repo_ref",
+        "repo_commit",
     }
 )
 

--- a/openviking/service/resource_service.py
+++ b/openviking/service/resource_service.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from openviking.core.namespace import is_content_root_uri
+from openviking.parse.accessors.git_accessor import GIT_LOCAL_ARG, normalize_git_local_config
 from openviking.parse.backend import ParserBackend, normalize_parser_backend
 from openviking.parse.mode import ParseMode, normalize_parse_mode
 from openviking.parse.parsers.constants import MPEG_TS_EXTENSION_ALIAS
@@ -384,6 +385,11 @@ class ResourceService:
             parse_mode = normalize_parse_mode(raw_parse_mode)
         except InvalidArgumentError as exc:
             raise InvalidArgumentError(str(exc).replace("parse_mode", "args.parse_mode")) from exc
+        if GIT_LOCAL_ARG in normalized:
+            try:
+                normalized[GIT_LOCAL_ARG] = normalize_git_local_config(normalized[GIT_LOCAL_ARG])
+            except ValueError as exc:
+                raise InvalidArgumentError(str(exc)) from exc
         token = normalized.get(FEISHU_ACCESS_TOKEN_ARG)
         refresh_token = normalized.pop(FEISHU_REFRESH_TOKEN_ARG, None)
         watch_auth_state = None
@@ -1269,6 +1275,9 @@ class ResourceService:
         self._ensure_initialized()
         processing_mode = normalize_processing_mode(processing_mode)
         self._validate_add_resource_tag_policy(tags=tags, tag_mode=tag_mode)
+        raw_git_local = args.get(GIT_LOCAL_ARG) if isinstance(args, dict) else None
+        if raw_git_local is not None and add_type is not None:
+            raise InvalidArgumentError("args.git_local cannot be combined with add_type.")
         from openviking.connector.delegate import ConnectorDelegate
 
         allowed_reserved_fields = ConnectorDelegate.supported_args(path, add_type).intersection(
@@ -1295,6 +1304,19 @@ class ResourceService:
                 "field and in args."
             )
         kwargs.update(normalized_args.processor_kwargs)
+        if GIT_LOCAL_ARG in normalized_args.processor_kwargs:
+            if add_type is not None:
+                raise InvalidArgumentError("args.git_local cannot be combined with add_type.")
+            if not kwargs.get("temp_file_id"):
+                raise InvalidArgumentError(
+                    "args.git_local requires a repository archive supplied via temp_file_id."
+                )
+            if not to or parent:
+                raise InvalidArgumentError(
+                    "args.git_local requires an exact to target and cannot use parent."
+                )
+            if Path(path).suffix.lower() != ".zip":
+                raise InvalidArgumentError("args.git_local requires a ZIP repository archive.")
         tos_signature = kwargs.get("tos_signature")
         tos_access = kwargs.get("tos_access")
         if tos_signature is not None or tos_access is not None:

--- a/openviking/utils/media_processor.py
+++ b/openviking/utils/media_processor.py
@@ -334,8 +334,18 @@ class UnifiedResourceProcessor:
             parse_kwargs["vlm_processor"] = self._get_vlm_processor()
             parse_kwargs["storage"] = self.storage
 
-            # If it's a directory, use DirectoryParser which will delegate to CodeRepositoryParser if it's a git repo
+            # Git sources carry the repository identity in accessor metadata, so
+            # route them directly rather than relying on a marker file surviving
+            # queue staging. Other directories keep the existing marker fallback.
             if local_resource.path.is_dir():
+                if local_resource.source_type == SourceType.GIT:
+                    from openviking.parse.parsers.code.code import CodeRepositoryParser
+
+                    return await CodeRepositoryParser().parse(
+                        str(local_resource.path),
+                        instruction,
+                        **parse_kwargs,
+                    )
                 from openviking.parse.parsers.directory import DirectoryParser
 
                 parser = DirectoryParser()

--- a/tests/parse/test_markdown_no_split.py
+++ b/tests/parse/test_markdown_no_split.py
@@ -98,6 +98,24 @@ async def test_long_markdown_no_split_plans_one_complete_file(
 
 
 @pytest.mark.asyncio
+async def test_flattened_no_split_root_mkdir_is_idempotent() -> None:
+    parser = MarkdownParser()
+
+    layout = await parser._compute_layout(
+        "# Guide\n\nBody",
+        "viking://temp/test",
+        source_path="/tmp/guide.md",
+        split_content=False,
+        flatten_single_output=True,
+    )
+
+    mkdirs = [op for op in layout.ops if op.kind == "mkdir"]
+    assert [(op.uri, op.exist_ok) for op in mkdirs] == [
+        ("viking://temp/test", True),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_long_markdown_default_mode_still_splits() -> None:
     content = _long_markdown()
     parser = MarkdownParser(config=ParserConfig(max_section_size=32, max_section_chars=128))

--- a/tests/service/test_resource_service_watch.py
+++ b/tests/service/test_resource_service_watch.py
@@ -430,6 +430,80 @@ class TestAddResourceArgs:
     """Tests for parser-specific add_resource args."""
 
     @pytest.mark.asyncio
+    async def test_forwards_normalized_git_local_to_resource_processor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resource_service: ResourceService,
+        request_context: RequestContext,
+    ):
+        disable_task_tracker(monkeypatch)
+
+        await resource_service.add_resource(
+            path="/tmp/repo.zip",
+            ctx=request_context,
+            to="viking://resources/local-git/test-repo/main",
+            temp_file_id="upload_repo.zip",
+            args={
+                "git_local": {
+                    "version": 1,
+                    "repo_key": " local:test-repo ",
+                    "repo_name": " test-repo ",
+                    "branch": " main ",
+                    "commit": "A" * 40,
+                    "archive_format": "zip",
+                }
+            },
+        )
+
+        processor = resource_service._resource_processor
+        assert processor.calls[-1]["git_local"] == {
+            "version": 1,
+            "repo_key": "local:test-repo",
+            "repo_name": "test-repo",
+            "branch": "main",
+            "commit": "a" * 40,
+            "archive_format": "zip",
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            ({"to": None}, "exact to target"),
+            ({"parent": "viking://resources/imports"}, "cannot use parent"),
+            ({"add_type": "git"}, "cannot be combined with add_type"),
+            ({"path": "/tmp/repo.tar"}, "ZIP repository archive"),
+        ],
+    )
+    async def test_rejects_invalid_git_local_ingestion_combinations(
+        self,
+        resource_service: ResourceService,
+        request_context: RequestContext,
+        overrides: dict,
+        message: str,
+    ):
+        kwargs = {
+            "path": "/tmp/repo.zip",
+            "ctx": request_context,
+            "to": "viking://resources/local-git/test-repo/main",
+            "temp_file_id": "upload_repo.zip",
+            "args": {
+                "git_local": {
+                    "version": 1,
+                    "repo_key": "local:test-repo",
+                    "repo_name": "test-repo",
+                    "branch": "main",
+                    "commit": "a" * 40,
+                    "archive_format": "zip",
+                }
+            },
+        }
+        kwargs.update(overrides)
+
+        with pytest.raises(InvalidArgumentError, match=message):
+            await resource_service.add_resource(**kwargs)
+
+    @pytest.mark.asyncio
     async def test_forwards_args_to_resource_processor(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_accessors_git.py
+++ b/tests/unit/test_accessors_git.py
@@ -5,6 +5,7 @@
 import asyncio
 import base64
 import os
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -12,6 +13,8 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from openviking.parse.accessors import GitAccessor
+from openviking.parse.accessors.base import SourceType
+from openviking.utils.media_processor import UnifiedResourceProcessor
 from openviking.parse.parsers.directory import DirectoryParser
 from openviking.utils import code_hosting_utils
 from openviking.utils.git_auth import (
@@ -531,6 +534,146 @@ class TestGitAccessor:
     def test_cannot_handle_local_zip_file(self, accessor: GitAccessor) -> None:
         """GitAccessor should leave local zip files to LocalAccessor/ZipParser."""
         assert accessor.can_handle(Path("/path/to/archive.zip")) is False
+
+    def test_can_handle_local_git_snapshot_zip(self, accessor: GitAccessor, tmp_path: Path) -> None:
+        archive = tmp_path / "repo.zip"
+        archive.write_bytes(b"placeholder")
+
+        assert accessor.can_handle(
+            archive,
+            git_local={
+                "version": 1,
+                "repo_key": "local:test-repo",
+                "repo_name": "test-repo",
+                "branch": "main",
+                "commit": "a" * 40,
+                "archive_format": "zip",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_access_local_git_snapshot_returns_git_resource(
+        self, accessor: GitAccessor, tmp_path: Path
+    ) -> None:
+        archive = tmp_path / "repo.zip"
+        with zipfile.ZipFile(archive, "w") as zip_file:
+            zip_file.writestr("README.md", "# local repository\n")
+            zip_file.writestr("src/main.py", "print('ok')\n")
+
+        resource = await accessor.access(
+            archive,
+            git_local={
+                "version": 1,
+                "repo_key": "local:test-repo",
+                "repo_name": "test-repo",
+                "branch": "main",
+                "commit": "A" * 40,
+                "archive_format": "zip",
+            },
+        )
+        cleanup_path = Path(resource.meta["_cleanup_path"])
+        try:
+            assert resource.source_type == SourceType.GIT
+            assert resource.original_source == "local:test-repo"
+            assert resource.meta["repo_name"] == "test-repo"
+            assert resource.meta["repo_ref"] == "main"
+            assert resource.meta["repo_commit"] == "a" * 40
+            assert resource.meta["repo_key"] == "local:test-repo"
+            assert (resource.path / "README.md").read_text() == "# local repository\n"
+            assert (resource.path / "src" / "main.py").exists()
+            assert (resource.path / ".git_source_repo").read_text() == "local:test-repo"
+            assert await DirectoryParser._is_git_repository(resource.path)
+        finally:
+            resource.cleanup()
+            assert not cleanup_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_access_local_git_snapshot_cleans_single_root_wrapper(
+        self, accessor: GitAccessor, tmp_path: Path
+    ) -> None:
+        archive = tmp_path / "repo.zip"
+        with zipfile.ZipFile(archive, "w") as zip_file:
+            zip_file.writestr("repo-root/README.md", "# wrapped\n")
+
+        resource = await accessor.access(
+            archive,
+            git_local={
+                "version": 1,
+                "repo_key": "local:wrapped",
+                "repo_name": "wrapped",
+                "branch": "main",
+                "commit": "b" * 40,
+                "archive_format": "zip",
+            },
+        )
+        cleanup_path = Path(resource.meta["_cleanup_path"])
+        assert resource.path.name == "repo-root"
+        resource.cleanup()
+        assert not cleanup_path.exists()
+
+    @pytest.mark.parametrize(
+        "git_local",
+        [
+            True,
+            {},
+            {
+                "version": 1,
+                "repo_key": "local:test-repo",
+                "repo_name": "test-repo",
+                "branch": "main",
+                "commit": "short",
+                "archive_format": "zip",
+            },
+        ],
+    )
+    def test_rejects_invalid_local_git_snapshot_metadata(
+        self, accessor: GitAccessor, tmp_path: Path, git_local
+    ) -> None:
+        archive = tmp_path / "repo.zip"
+        archive.write_bytes(b"placeholder")
+
+        assert accessor.can_handle(archive, git_local=git_local) is False
+
+    @pytest.mark.asyncio
+    async def test_local_git_snapshot_routes_directly_to_code_repository_parser(
+        self, tmp_path: Path
+    ) -> None:
+        repository = tmp_path / "repository"
+        repository.mkdir()
+        resource = SimpleNamespace(
+            path=repository,
+            source_type=SourceType.GIT,
+            original_source="local:test-repository",
+            meta={
+                "repo_name": "test-repository",
+                "repo_ref": "main",
+                "repo_commit": "a" * 40,
+                "resolved_extension": "",
+            },
+            is_temporary=False,
+            cleanup=Mock(),
+        )
+        processor = UnifiedResourceProcessor(vlm_processor=object())
+        processor._accessor_registry = SimpleNamespace(
+            access=AsyncMock(side_effect=AssertionError("prepared Git resource must not be re-routed"))
+        )
+        processor._parser_router = SimpleNamespace()
+
+        parsed = SimpleNamespace(temp_dir_path="viking://temp/repository")
+        with patch(
+            "openviking.parse.parsers.code.code.CodeRepositoryParser.parse",
+            new_callable=AsyncMock,
+            return_value=parsed,
+        ) as parse:
+            result = await processor.process(
+                "/unused",
+                prepared_resource=resource,
+            )
+
+        assert result is parsed
+        assert parse.await_args.args[0] == str(repository)
+        assert parse.await_args.kwargs["_source_meta"]["repo_name"] == "test-repository"
+        assert parse.await_args.kwargs["original_source"] == "local:test-repository"
 
     @pytest.mark.parametrize(
         "source",


### PR DESCRIPTION
## Description

Add two related repository-memory capabilities for the Codex-compatible
TraeCode CLI plugin:

1. Upload committed snapshots for local Git repositories that are not backed
   by an `origin` remote.
2. Build and optionally publish repository-local Wiki memory from
   `.repo_memory/`.

### Repository Wiki Design Reference

The Repository Wiki design adapts the repository-local Wiki approach from
memorax-code: https://github.com/memorax-ai/memorax-code

The implementation follows the current upstream TraeCode CLI 2.0 plugin
architecture (`examples/codex-memory-plugin`) rather than the deprecated
standalone `examples/trae-cli-memory-hooks` runtime.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add a `PostToolUse` hook to the Codex-compatible plugin. After successful
  Git mutations, it snapshots `HEAD` with `git archive` and uploads only
  repositories without an `origin` remote. Read-only or failed Git commands
  do not trigger an upload.
- Add server-side `args.git_local` validation and ZIP snapshot handling. The
  uploaded archive becomes a `SourceType.GIT` resource and reuses the existing
  code-repository parsing, tree sync, and incremental indexing pipeline.
- Persist a local-only repository identity in Git config so target URIs remain
  stable without exposing local checkout paths.
- Add the `repo-wiki` Skill. Its canonical source lives in
  `examples/skills/repo-wiki`; the Codex plugin receives a synchronized,
  byte-verified runtime copy under `examples/codex-memory-plugin/skills/`.
- When explicitly enabled, publish Wiki content to a stable target derived from
  repository identity and user identity. Wiki uploads use `parse_mode=no_split`
  and `processing_mode=vectors_only`; content hashes, rather than the current
  code commit SHA, decide whether a Wiki needs upload.
- Treat missing or invalid `.repo_memory/` as a Wiki-only skip. It never blocks
  Local Git code snapshot upload. Wiki uploads can also run independently for
  remote-backed repositories when enabled.
- Make the flattened Markdown `no_split` layout's repeated root `mkdir`
  idempotent, which is required by the Wiki publishing path.
- Add hook, archive, upload routing, Wiki allowlist/provenance, Markdown,
  plugin packaging, marketplace staging, and normal-clone regression tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Executed checks:

Node focused tests: 12 passed
Python focused tests: 127 passed

The Python suite covered:

tests/parse/test_markdown_no_split.py
tests/unit/test_accessors_git.py
tests/service/test_resource_service_watch.py

Also validated the marketplace staging bundle and repeated the focused checks
from a clean local clone.

The new hook and repository-sync runtime do not introduce platform-specific
path handling or OS-only APIs. They use Node.js and standard Git commands;
the Repo Wiki helpers and the current Wiki archive step additionally require
Python 3 to be available on `PATH`. Linux and Windows have not yet received
a full end-to-end validation in this PR.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code changes
- [x] I have commented the non-obvious behavior, especially the flattened
  Markdown layout and local Git routing boundaries
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- The PR is based on the latest `volcengine/OpenViking:main` and contains two
  logical commits only:
  1. `feat: sync local Git repositories to OpenViking`
  2. `feat: add repository Wiki sync`
- The repository Wiki upload switch is intentionally disabled by default:
  `OPENVIKING_REPO_WIKI_UPLOAD_ENABLED=1` enables it.
- The deprecated standalone TRAE CLI integration is intentionally not extended;
  TraeCode CLI 2.0 uses the Codex-compatible plugin path.