### PR TITLE
ci: persist BuildKit mount caches across runs

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -95,7 +95,35 @@ jobs:
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
+
+      # Persist the Dockerfile's RUN --mount=type=cache dirs (cargo/ccache/uv/npm)
+      # across runs. On ephemeral runners they start empty, so the Rust CLI and
+      # C++ extension recompile from scratch every build (~13 min of a ~16 min job).
+      - name: Restore BuildKit mount caches
+        id: mount-cache
+        uses: actions/cache@v4
+        with:
+          path: buildkit-mount-cache
+          key: buildkit-mount-${{ matrix.arch }}-${{ github.sha }}
+          restore-keys: |
+            buildkit-mount-${{ matrix.arch }}-
+
+      - name: Inject mount caches into BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "buildkit-mount-cache/npm": {"target": "/root/.npm", "id": "npm-${{ matrix.platform }}"},
+              "buildkit-mount-cache/uv": {"target": "/root/.cache/uv", "id": "uv-${{ matrix.platform }}"},
+              "buildkit-mount-cache/cargo-target": {"target": "/cargo-target", "id": "cargo-target-${{ matrix.platform }}"},
+              "buildkit-mount-cache/cargo-registry": {"target": "/usr/local/cargo/registry", "id": "cargo-registry-${{ matrix.platform }}"},
+              "buildkit-mount-cache/cargo-git": {"target": "/usr/local/cargo/git", "id": "cargo-git-${{ matrix.platform }}"},
+              "buildkit-mount-cache/ccache": {"target": "/root/.ccache", "id": "ccache-${{ matrix.platform }}"}
+            }
+          skip-extraction: ${{ steps.mount-cache.outputs.cache-hit }}
 
       - name: Build and push Docker image to GHCR
         id: push-ghcr

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -98,15 +98,20 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v4
 
-      # Persist the Dockerfile's RUN --mount=type=cache dirs (cargo/ccache/uv/npm)
-      # across runs. On ephemeral runners they start empty, so the Rust CLI and
-      # C++ extension recompile from scratch every build (~13 min of a ~16 min job).
+      # Persist the Dockerfile's cargo/ccache RUN --mount=type=cache dirs across
+      # runs. On ephemeral runners they start empty, so the Rust CLI and C++
+      # extension recompile from scratch every build (~13 min of a ~16 min job).
+      # Key on the native-build inputs, not the commit sha: commits that do not
+      # touch Rust/C++ hit the exact key, which also skips the cache upload, so
+      # this stays quiet inside the repo's shared 10 GB Actions cache budget.
+      # npm/uv mounts are deliberately not persisted: they only save ~1 min and
+      # would churn the cache on every dependency change.
       - name: Restore BuildKit mount caches
         id: mount-cache
         uses: actions/cache@v4
         with:
           path: buildkit-mount-cache
-          key: buildkit-mount-${{ matrix.arch }}-${{ github.sha }}
+          key: buildkit-mount-${{ matrix.arch }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**', 'src/**', 'third_party/**', 'setup.py') }}
           restore-keys: |
             buildkit-mount-${{ matrix.arch }}-
 
@@ -116,8 +121,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-map: |
             {
-              "buildkit-mount-cache/npm": {"target": "/root/.npm", "id": "npm-${{ matrix.platform }}"},
-              "buildkit-mount-cache/uv": {"target": "/root/.cache/uv", "id": "uv-${{ matrix.platform }}"},
               "buildkit-mount-cache/cargo-target": {"target": "/cargo-target", "id": "cargo-target-${{ matrix.platform }}"},
               "buildkit-mount-cache/cargo-registry": {"target": "/usr/local/cargo/registry", "id": "cargo-registry-${{ matrix.platform }}"},
               "buildkit-mount-cache/cargo-git": {"target": "/usr/local/cargo/git", "id": "cargo-git-${{ matrix.platform }}"},


### PR DESCRIPTION
**起因**

build-docker-image 每次 run 约 16 分钟。拆最近 7 次成功 run（如 33138890865，16m16s）的 step 耗时：amd64 build job 15m46s 是关键路径，其中 uv sync 层 772.9s；buildx 日志里 `Installed 213 packages in 5.69s`，而 `Built openviking @ file:///app` 到 744s 才完成。瓶颈不是依赖下载，是项目自身 wheel 的 Rust CLI（cargo）+ C++ 扩展（cmake）冷编译，约占整条 pipeline 的 78%。

**为什么是这个性质**

Dockerfile 已经配了 cargo/ccache/uv/npm 共 6 个 BuildKit cache mount，本地重复构建有效。但 Actions 的 ephemeral runner 上 buildx builder 每次全新，cache mount 每次都是空的——这些 mount 在 CI 里从未生效过。

**本地实测（8 核，rustc 1.98，仓库 22c6b21）**

- 依赖图 607 个节点，其中 603 个是外部 crate，workspace 只有 4 个自有 crate。近 30 天 Cargo.lock 只变了 6 个 commit——外部依赖的编译产物在绝大多数 commit 之间可复用。
- 冷 `cargo build --release --workspace`：4m03s。触碰全部 workspace 源码后重建：2m18s（只重编 4 个自有 crate + fat LTO 重链，这部分是 `lto = true` 下的不可避免下限）。
- 体积（zstd 压缩后，即 actions/cache 实际占用）：cargo-target 0.44 GB + cargo registry 0.18 GB，单 arch 合计约 0.6 GB；ccache 侧 C++ 源码只有 65 个文件 + 4.8 MB vendored 三方库，估计再加 0.1-0.2 GB。双 arch 稳态占用约 1.5 GB。

推到 CI（4 核 runner）：uv sync 层预计 773s → 350-400s，整条 pipeline 16min → 9-10min。注意 COPY 会刷新源码 mtime，即使 commit 不动 Rust，workspace 4 个 crate + LTO 重链也会重跑，所以下限是 9-10min 而不是更低；想再压就要动 lto 配置，超出本 PR 范围。

**改法**

只动 `.github/workflows/build-docker-image.yml`，build-and-push-image job 加两个 step：

1. `actions/cache@v4` 持久化 `buildkit-mount-cache/`，**key 用 native 构建输入的 hashFiles（Cargo.toml/Cargo.lock/crates/src/third_party/setup.py），不用 commit sha**。没动这些路径的 commit 精确命中 key，actions/cache 直接跳过上传，不产生新条目。
2. `reproducible-containers/buildkit-cache-dance@v3.4.0` 在 build 前注入、build 后导出。cache-map 的 id 与 Dockerfile 里 `id=xxx-${TARGETPLATFORM}` 一一对应。

**取舍 / 需要 reviewer 定夺**

- 本 repo 的 Actions cache 已经在用 10.7 GB / 61 条（CLI musl 构建、setup-uv 等），10 GB 上限本来就超了。所以 key 设计特意避免了按 sha 存（main 每天 10+ 个 push，会以每天 ~26 GB 的写入量把池子刷穿）；按输入 hash 存后，新条目只在 Rust/C++ 变更时产生（近 30 天 crates/ 变更 51 个 commit，约每天 1-2 条 × 双 arch × ~0.75 GB），LRU 驱逐压力可控但非零。
- npm/uv mount 故意不缓存：实测依赖下载只占秒级，缓存它们每天都会因依赖变动产生新条目，收益/占用比太差。
- 注入/导出自身开销估 30-60s。

**没动什么**

- Dockerfile 一行没动，cache mount 定义原样复用。
- GHCR + Docker Hub 各 build 一遍的结构保留：实测第二遍 9-14s（全命中 builder 本地缓存）。
- checkout 的 fetch-depth: 0 + submodules 保留：setuptools-scm 算版本号需要完整 git 历史。

**验证**

- 本地数据如上；组合用法与 buildkit-cache-dance README 的 cache-map 示例一致（builder 名取自 setup-buildx-action 的 outputs.name）。
- CI 效果需两次 run 验证（第一次冷启动填缓存）。可在本分支用 workflow_dispatch 连发两个 dev tag 对比，我可以来跑。

数据来源：run 33138890865 / 33135341133 / 33074455948 的 jobs API step 耗时、amd64/arm64 buildx 日志、本地 8 核实测。
