### PR TITLE
fix(network-guard): refuse a remote host that cannot be resolved

### DIFF
--- a/openviking/utils/network_guard.py
+++ b/openviking/utils/network_guard.py
@@ -71,11 +71,17 @@ def _normalize_host(host: str) -> str:
     return host.rstrip(".").lower()
 
 
-def _resolve_host_addresses(host: str) -> set[str]:
+def _resolve_host_addresses(host: str) -> Optional[set[str]]:
+    """Addresses for ``host``, or ``None`` when resolution itself failed.
+
+    The distinction matters: an empty set means the host resolved to nothing this
+    guard can judge, while ``None`` means the guard never got an answer at all
+    and therefore knows nothing about where the request would go.
+    """
     try:
         infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
     except (socket.gaierror, UnicodeError, OSError):
-        return set()
+        return None
 
     addresses: set[str] = set()
     for family, _, _, _, sockaddr in infos:
@@ -126,6 +132,18 @@ def ensure_public_remote_target(source: str) -> None:
         return
 
     resolved_addresses = _resolve_host_addresses(host)
+    if resolved_addresses is None:
+        # Refuse rather than permit. A control that cannot evaluate its input
+        # must not approve it, and nothing is lost by saying so here: the fetch
+        # resolves the same name through the same resolver moments later, so a
+        # host this call cannot resolve is not a host the request could reach.
+        raise PermissionDeniedError(
+            f"HTTP server could not resolve remote resource host '{host}', so it cannot be "
+            "confirmed to be a public destination. Check the hostname, or retry if this was a "
+            "temporary DNS failure. To allow non-public destinations, add the domain to its "
+            "code.<platform>_domains list or code.code_hosting_domains "
+            "or set allow_private_networks=true in your ov.conf."
+        )
     if not resolved_addresses:
         return
 

--- a/tests/utils/test_network_guard_unresolvable.py
+++ b/tests/utils/test_network_guard_unresolvable.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+"""A guard that cannot resolve a host must not approve it.
+
+`ensure_public_remote_target` decides whether an outbound fetch is allowed by
+resolving the host and rejecting non-public addresses. When resolution failed it
+returned, which permitted the request — the one outcome a security control
+should never reach by accident.
+
+The escape hatches must keep working, so they are pinned here too: both of them
+answer before resolution is attempted, and neither needs DNS.
+"""
+
+import socket
+
+import pytest
+
+from openviking.utils import network_guard
+from openviking_cli.exceptions import PermissionDeniedError
+
+
+@pytest.fixture
+def no_dns(monkeypatch):
+    """Every lookup fails, as it would with a broken or unreachable resolver."""
+
+    def _raise(*args, **kwargs):
+        raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+    monkeypatch.setattr(network_guard.socket, "getaddrinfo", _raise)
+
+
+@pytest.fixture
+def resolves_to(monkeypatch):
+    def _install(address: str):
+        family = socket.AF_INET6 if ":" in address else socket.AF_INET
+        monkeypatch.setattr(
+            network_guard.socket,
+            "getaddrinfo",
+            lambda *a, **k: [(family, socket.SOCK_STREAM, 6, "", (address, 0))],
+        )
+
+    return _install
+
+
+@pytest.fixture(autouse=True)
+def no_global_opt_out(monkeypatch):
+    monkeypatch.setattr(network_guard, "_is_allow_private_networks", lambda: False)
+    monkeypatch.setattr(network_guard, "_get_allowed_code_hosting_domains", lambda: set())
+
+
+def test_unresolvable_host_is_refused(no_dns):
+    with pytest.raises(PermissionDeniedError) as excinfo:
+        network_guard.ensure_public_remote_target("https://internal.example/repo.git")
+
+    message = str(excinfo.value)
+    assert "internal.example" in message
+    # The message has to say what to do next, or the refusal is just a wall.
+    assert "retry" in message.lower()
+
+
+def test_public_host_still_passes(resolves_to):
+    resolves_to("93.184.216.34")
+    network_guard.ensure_public_remote_target("https://example.com/repo.git")
+
+
+def test_private_address_is_still_refused_with_its_own_message(resolves_to):
+    resolves_to("10.0.0.7")
+    with pytest.raises(PermissionDeniedError) as excinfo:
+        network_guard.ensure_public_remote_target("https://internal.example/repo.git")
+
+    assert "resolves to non-public address" in str(excinfo.value)
+
+
+def test_allow_private_networks_answers_before_dns(no_dns, monkeypatch):
+    """The opt-out must not start depending on a resolver it never needed."""
+    monkeypatch.setattr(network_guard, "_is_allow_private_networks", lambda: True)
+
+    network_guard.ensure_public_remote_target("https://internal.example/repo.git")
+
+
+def test_configured_code_hosting_domain_answers_before_dns(no_dns, monkeypatch):
+    monkeypatch.setattr(
+        network_guard,
+        "_get_allowed_code_hosting_domains",
+        lambda: {"git.internal.example"},
+    )
+
+    network_guard.ensure_public_remote_target("https://git.internal.example/repo.git")
+
+
+def test_loopback_by_name_is_still_refused_without_touching_dns(no_dns):
+    with pytest.raises(PermissionDeniedError) as excinfo:
+        network_guard.ensure_public_remote_target("http://localhost:1933/admin")
+
+    assert "loopback" in str(excinfo.value)


### PR DESCRIPTION
## The problem

`ensure_public_remote_target` is the control that decides whether a server-side fetch may leave the machine. It resolves the host and refuses non-public addresses. But resolution failure was treated as "nothing to object to":

```python
resolved_addresses = _resolve_host_addresses(host)
if not resolved_addresses:
    return          # allow
```

and `_resolve_host_addresses` swallows the failure that produced it:

```python
except (socket.gaierror, UnicodeError, OSError):
    return set()
```

So an empty result meant two different things — *the host resolved to nothing I can judge* and *I never got an answer* — and both were read as approval. A resolver error, a timeout, or a transient DNS failure switched the guard off for that request. That is the one outcome a security control should never arrive at by accident.

This is also the only path with that property. Every other branch is a decision: loopback by name raises, `allow_private_networks` returns, a configured code-hosting domain returns, a non-public address raises. The fall-through was the accident.

## The change

`_resolve_host_addresses` now returns `Optional[set[str]]` and keeps the two cases apart: `None` when resolution failed, an empty set when it succeeded and produced nothing usable. The caller refuses on `None`.

**Little is lost by refusing.** The fetch resolves the same name through the same resolver moments later, so a host this call cannot resolve is not a host the request could have reached — it would have failed at connect time instead. What changes is *how* it fails: a clear refusal naming the host, rather than an approval followed by a network error further down.

The trade-off worth stating plainly: a request that hits a transient DNS blip during validation is now refused instead of being allowed and then failing anyway. The message says so and tells the caller to retry, because a refusal without a next step is just a wall.

Neither opt-out is affected. Both `allow_private_networks` and the configured code-hosting domain list answer *before* resolution is attempted, so an operator who has opted in keeps working with no DNS at all — that is pinned by two of the tests rather than left as a claim.

## Evidence

`tests/utils/test_network_guard_unresolvable.py`, six cases, run on `main` with the source change stashed:

```
1 failed, 5 passed
FAILED test_unresolvable_host_is_refused
E       Failed: DID NOT RAISE PermissionDeniedError
```

and with the change, `6 passed`.

The five that pass in both directions are the point of the file as much as the one that flips. They pin the behaviour this change must not disturb: a public host still passes, a private address still raises with its existing message, loopback by name still raises without touching DNS, and both opt-outs still short-circuit with the resolver hard-failing. If this change had quietly made the escape hatches depend on DNS, those would have caught it.

## What I did not change

While reading this I checked two things that looked like they might be adjacent holes, and neither is one — recording them so nobody re-treads it:

- **IPv4-mapped IPv6.** `::ffff:127.0.0.1`, `::ffff:169.254.169.254` and `::ffff:10.0.0.1` all return `is_global == False` on Python 3.11, so `_is_public_ip` judges them by the embedded address and they are refused correctly.
- **Alternate IPv4 spellings.** `2130706433`, `127.1`, `0177.0.0.1` and `0x7f.0.0.1` are not accepted by `ipaddress`, but they are not accepted by `socket.getaddrinfo` either — so they never became a parser differential here. Before this change they reached the fail-open branch and were allowed; after it they are refused along with everything else that does not resolve.

**Environment.** Windows, Python 3.11, `pytest tests/utils/test_network_guard_unresolvable.py`. This file monkeypatches `getaddrinfo`, so it makes no real DNS queries and needs no native engine backend. The wider `tests/session/*` suites do not run on this machine — `ImportError: No compatible x86 engine backend was packaged in this wheel`, which reproduces on a clean `main` — so CI is the authority there.
