### PR TITLE
fix(search): honor skill context for implicit targets

### DIFF
--- a/openviking/core/retrieval_targets.py
+++ b/openviking/core/retrieval_targets.py
@@ -27,13 +27,14 @@ class ResolvedRetrievalTargets:
 def resolve_retrieval_targets(
     target_uri: Union[str, List[str]],
     ctx: RequestContext,
+    context_type: Optional[ContextType] = None,
 ) -> ResolvedRetrievalTargets:
     """Resolve search/find target directories."""
     target_uris = _dedupe_target_uris(target_uri)
 
     if not target_uris:
         return ResolvedRetrievalTargets(
-            target_directories=default_target_directories(ctx),
+            target_directories=default_target_directories(ctx, context_type=context_type),
         )
 
     target_directories: List[str] = []

--- a/openviking/server/routers/search.py
+++ b/openviking/server/routers/search.py
@@ -44,6 +44,7 @@ from openviking.utils.search_filters import (
 )
 from openviking.utils.tags import build_search_tags_filter
 from openviking_cli.exceptions import InvalidArgumentError, NotFoundError
+from openviking_cli.retrieve import ContextType
 
 
 def _sanitize_floats(obj: Any) -> Any:
@@ -117,6 +118,17 @@ def _resolve_image_url(image_url: Optional[str], ctx: RequestContext) -> Optiona
     if is_viking_uri(resolved):
         return validate_request_viking_uri(resolved, ctx, field_name="image_url")
     return resolved
+
+
+def _resolve_target_context_type(value: Optional[SearchContextTypeInput]) -> Optional[ContextType]:
+    """Return the context type used for implicit target selection.
+
+    A multi-type filter cannot select one default target tree, so implicit
+    target expansion is only applied for the single ``skill`` value.
+    """
+    if value == ContextType.SKILL.value:
+        return ContextType.SKILL
+    return None
 
 
 class FindRequest(BaseModel):
@@ -350,6 +362,7 @@ async def find(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_resolve_target_context_type(request.context_type),
         ),
     )
     result = execution.result
@@ -464,6 +477,7 @@ async def search(
             filter=effective_filter,
             level=_resolve_levels(request.level) or None,
             image_url=resolved_image_url,
+            context_type=_resolve_target_context_type(request.context_type),
         )
 
     execution = await run_operation(

--- a/openviking/service/search_service.py
+++ b/openviking/service/search_service.py
@@ -18,6 +18,7 @@ from openviking.utils.image_search import (
 )
 from openviking_cli.exceptions import InvalidArgumentError, NotInitializedError
 from openviking_cli.utils import get_logger
+from openviking_cli.retrieve import ContextType
 
 if TYPE_CHECKING:
     from openviking.session import Session
@@ -85,6 +86,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ) -> Any:
         """Complex search with session context.
 
@@ -119,6 +121,7 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result
 
@@ -132,6 +135,7 @@ class SearchService:
         filter: Optional[Dict] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ) -> Any:
         """Semantic search without session context.
 
@@ -158,5 +162,6 @@ class SearchService:
             filter=filter,
             level=level,
             image_url=resolved_image_url,
+            context_type=context_type,
         )
         return result

--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -17,6 +17,7 @@ from openviking.storage.viking_fs._base import (
 from openviking.telemetry import get_current_telemetry
 from openviking.utils.image_search import build_multimodal_embedding_input
 from openviking_cli.exceptions import NotFoundError
+from openviking_cli.retrieve import ContextType
 
 
 class _SemanticMixin:
@@ -190,6 +191,7 @@ class _SemanticMixin:
         ctx: Optional[RequestContext] = None,
         level: Optional[List[int]] = None,
         image_url: Optional[str] = None,
+        context_type: Optional[ContextType] = None,
     ):
         """Semantic search.
 
@@ -213,7 +215,7 @@ class _SemanticMixin:
         )
 
         real_ctx = self._ctx_or_default(ctx)
-        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx)
+        retrieval_targets = resolve_retrieval_targets(target_uri, real_ctx, context_type=context_type)
 
         for target_dir in retrieval_targets.target_directories:
             self._ensure_access(target_dir, ctx)

--- a/tests/server/test_api_search.py
+++ b/tests/server/test_api_search.py
@@ -56,6 +56,21 @@ async def test_find_basic(client_with_resource):
     assert "telemetry" not in body
 
 
+@pytest.mark.parametrize("endpoint,method", [("/api/v1/search/find", "find"), ("/api/v1/search/search", "search")])
+async def test_skill_context_type_is_forwarded_for_implicit_targets(client, service, monkeypatch, endpoint, method):
+    captured = {}
+
+    async def fake_search(**kwargs):
+        captured.update(kwargs)
+        return FindResult(memories=[], resources=[], skills=[])
+
+    monkeypatch.setattr(service.search, method, fake_search)
+    response = await client.post(endpoint, json={"query": "skill", "context_type": "skill"})
+
+    assert response.status_code == 200
+    assert captured["context_type"] == ContextType.SKILL
+
+
 @pytest.mark.parametrize("endpoint", ["/api/v1/search/find", "/api/v1/search/search"])
 async def test_search_endpoints_inline_visible_content_when_requested(
     client: httpx.AsyncClient, service, monkeypatch, endpoint: str


### PR DESCRIPTION
## What does this PR do?

Fixes #3739.

When `find`/`search` receives `context_type=skill` without an explicit target URI, the API previously used the generic user/resource defaults and only applied `context_type` as a result filter. This omitted the shared `viking://agent/skills` tree.

This change threads the single `skill` context type through the router, search service, VikingFS, and target resolver so implicit target selection uses the existing skill defaults. Other context types, multi-type filters, and explicit target URIs retain their current behavior.

A server regression test verifies that both endpoints forward the skill context for implicit target resolution.

## Verification

- `python -m compileall` passes for all modified modules.
- `git diff --check` passes.
- Targeted pytest was attempted but test collection is blocked in this environment because `apscheduler` is not installed.
