### PR TITLE
fix(memory): strip repeated line number prefixes

### DIFF
--- a/openviking/session/memory/utils/line_numbers.py
+++ b/openviking/session/memory/utils/line_numbers.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 _LINE_NUMBER_PREFIX_RE = re.compile(r"^(\d+)\t")
 _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE = re.compile(r"^\s*(\d+)\t")
+_LINE_NUMBER_PREFIXES_RE = re.compile(r"^(?:\d+\t)+")
+_LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE = re.compile(r"^(?:\s*\d+\t)+")
 _LINE_SPLIT_RE = re.compile(r"\r?\n")
 
 
@@ -44,7 +46,11 @@ def extract_start_line_number(content: str) -> Optional[int]:
 
 
 def strip_line_numbers(content: str, aggressive: bool = False) -> str:
-    pattern = _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE if aggressive else _LINE_NUMBER_PREFIX_RE
+    pattern = (
+        _LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE
+        if aggressive
+        else _LINE_NUMBER_PREFIXES_RE
+    )
     return "\n".join(pattern.sub("", line) for line in split_content_lines(content))
 
 

--- a/tests/session/memory/test_line_numbers.py
+++ b/tests/session/memory/test_line_numbers.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+
+from openviking.session.memory.utils.line_numbers import (
+    add_line_numbers,
+    strip_line_numbers,
+)
+
+
+def test_strip_line_numbers_removes_repeated_prefixes():
+    content = "## Title\n- fact one"
+    numbered_twice = add_line_numbers(add_line_numbers(content))
+
+    assert strip_line_numbers(numbered_twice) == content
+    assert strip_line_numbers(numbered_twice) == strip_line_numbers(numbered_twice)


### PR DESCRIPTION
## What does this PR do?

Fixes #4413.

`strip_line_numbers` removed only one numeric prefix per line. When patch-merge input had already been numbered more than once, prefixes accumulated in stored memory content. The stripper now removes repeated prefixes in one pass while leaving `extract_start_line_number` unchanged.

Added a focused regression test covering content passed through `add_line_numbers` twice.

## Verification

- `git diff --check` passes.
- Targeted pytest was attempted but collection is blocked in this environment because `apscheduler` is not installed.
