### PR TITLE
fix(studio): defer routes until auth mode resolves

### DIFF
--- a/web-studio/src/components/app-shell.test.tsx
+++ b/web-studio/src/components/app-shell.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ConnectionScopedRouteContent } from './app-shell'
+
+afterEach(cleanup)
+
+describe('ConnectionScopedRouteContent', () => {
+  it('does not mount route content while the server mode is unresolved', () => {
+    render(
+      <ConnectionScopedRouteContent serverMode="checking">
+        <span data-testid="identity-scoped-route" />
+      </ConnectionScopedRouteContent>,
+    )
+
+    expect(screen.queryByTestId('identity-scoped-route')).toBeNull()
+  })
+
+  it.each(['api_key', 'trusted', 'dev', 'oidc', 'ldap', 'offline'] as const)(
+    'mounts route content after resolving %s mode',
+    (serverMode) => {
+      render(
+        <ConnectionScopedRouteContent serverMode={serverMode}>
+          <span data-testid="identity-scoped-route" />
+        </ConnectionScopedRouteContent>,
+      )
+
+      expect(screen.getByTestId('identity-scoped-route')).toBeTruthy()
+    },
+  )
+})

--- a/web-studio/src/components/app-shell.tsx
+++ b/web-studio/src/components/app-shell.tsx
@@ -53,6 +53,7 @@ import {
   AppConnectionProvider,
   useAppConnection,
 } from '#/hooks/use-app-connection'
+import type { ServerMode } from '#/hooks/use-server-mode'
 import { cn } from '#/lib/utils'
 import { resolveStudioManagementCapabilities } from '#/lib/studio-permissions'
 
@@ -246,8 +247,24 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 }
 
 function IdentityScopedAppShell({ children }: { children: React.ReactNode }) {
-  const { identityScopeKey } = useAppConnection()
-  return <AppShellInner key={identityScopeKey}>{children}</AppShellInner>
+  const { identityScopeKey, serverMode } = useAppConnection()
+  return (
+    <AppShellInner key={identityScopeKey}>
+      <ConnectionScopedRouteContent serverMode={serverMode}>
+        {children}
+      </ConnectionScopedRouteContent>
+    </AppShellInner>
+  )
+}
+
+export function ConnectionScopedRouteContent({
+  children,
+  serverMode,
+}: {
+  children: React.ReactNode
+  serverMode: ServerMode
+}) {
+  return serverMode === 'checking' ? null : children
 }
 
 function AppShellInner({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Description

Defer identity-scoped route content until Web Studio finishes resolving the server auth mode.

On a trusted-mode cold start, `AppConnectionProvider` initially configured the shared client with `serverMode='checking'`, which disables Account/User headers, while route children mounted immediately. Their first filesystem and session requests failed with `INVALID_ARGUMENT`; after `/health` resolved trusted mode, the same requests retried successfully with identity headers.

The shell now remains available during connection bootstrap, but route content mounts only after the mode resolves. This establishes the identity policy before tenant-scoped consumers can issue requests, without adding route-specific retries or changing server/API behavior.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

The reporter supplied the real Studio failure and approved the issue/implementation boundary. The implementation and evidence were reviewed against the resulting public contract.

## Related Issue

Fixes #4428

Related but distinct: #4111 and draft #4426 cover trusted identity selection and user switching. This PR only owns the earlier connection-bootstrap boundary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Keep `AppShellInner` mounted while auth mode is `checking`, preserving navigation and connection recovery surfaces.
- Defer route children until the mode resolves, so identity-scoped queries start with the final client policy.
- Cover unresolved bootstrap and every resolved/offline server mode with component lifecycle tests.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands and results:

```text
npx prettier --check src/components/app-shell.tsx src/components/app-shell.test.tsx
  passed

npx eslint src/components/app-shell.tsx src/components/app-shell.test.tsx
  passed with 0 warnings and 0 errors

npm test -- src/components/app-shell.test.tsx src/hooks/use-app-connection.test.ts src/lib/ov-client/client.test.ts
  3 files, 33 tests passed

NODE_OPTIONS='--localstorage-file=/tmp/openviking-vitest-localstorage' npm test
  56 files, 215 tests passed

npm run build
  passed (existing Vite large-chunk advisory remains)
```

Real current-main browser reproduction and regression check used Web Studio at `013b4a042e175ab7269e65721c2ebeb25c72b021` with a trusted-mode OpenViking 0.4.16 server:

| Cold-start tenant requests | Before | After |
| --- | ---: | ---: |
| Requests without Account/User headers | 3 | 0 |
| Failed tenant requests | 3 | 0 |
| First `fs/ls` / `sessions` status | 400 | 200 |
| Final context tree | loaded | loaded |

Repository-wide `npm run lint` is currently blocked by two errors and existing i18n warnings in unchanged task files. Repository-wide `npm run format` also reports five unchanged files. The changed files pass focused ESLint and Prettier checks, and this PR does not modify the reported baseline files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of the code
- [x] I have commented the code where needed; the lifecycle boundary is expressed directly in component structure
- [x] Documentation is unchanged because no public API, configuration, or user-facing copy changes
- [x] My changes generate no new warnings
- [x] No dependent changes are required

## Screenshots (if applicable)

No screenshot is required to understand the fix; the request sequence above records the observable failure boundary without exposing tenant identifiers.

## Additional Notes

- `offline` remains a resolved mode, so route content and connection settings stay reachable when the server cannot be contacted.
- The change does not alter dev, API-key, trusted, OIDC, or LDAP identity semantics. It only prevents consumers from running before a mode exists.
- The AppShell itself performs no initial tenant data queries, so keeping it mounted preserves recovery UX without reintroducing the race.
