### PR TITLE
fix(studio): prevent retrieval description label overlap

### DIFF
--- a/web-studio/src/routes/retrieval/-components/retrieval-results.test.tsx
+++ b/web-studio/src/routes/retrieval/-components/retrieval-results.test.tsx
@@ -2,8 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
+import { createInstance } from 'i18next'
 import type { TFunction } from 'i18next'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resources } from '#/i18n/resources'
 
 import { RetrievalResults } from './retrieval-results'
 
@@ -12,6 +15,62 @@ const t = ((key: string) => key) as TFunction<'retrieval'>
 afterEach(cleanup)
 
 describe('RetrievalResults', () => {
+  it.each(['en', 'zh-CN'] as const)(
+    'sizes the metadata column to fit translated labels in %s',
+    async (language) => {
+      const i18n = createInstance()
+      await i18n.init({ lng: language, resources })
+      const translate = i18n.getFixedT(language, 'retrieval')
+      const queryClient = new QueryClient()
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <RetrievalResults
+            data={{
+              memories: [],
+              resources: [
+                {
+                  abstract: 'Result summary',
+                  category: '',
+                  context_type: 'resource',
+                  level: 2,
+                  match_reason: '',
+                  score: 0.8,
+                  uri: 'viking://resources/result.md',
+                },
+              ],
+              skills: [],
+              total: 1,
+            }}
+            hasRetrievableContext
+            hasSubmitted
+            isCheckingContext={false}
+            isError={false}
+            isLoading={false}
+            onUploadClick={vi.fn()}
+            resultCount={10}
+            t={translate}
+          />
+        </QueryClientProvider>,
+      )
+
+      const label = screen.getByText(translate('results.description'))
+      expect(
+        label
+          .closest('dl')
+          ?.classList.contains('grid-cols-[max-content_minmax(0,1fr)]'),
+      ).toBe(true)
+      expect(
+        screen.getByText('Result summary').classList.contains('line-clamp-2'),
+      ).toBe(true)
+      expect(
+        screen
+          .getByText('viking://resources/result.md')
+          .classList.contains('truncate'),
+      ).toBe(true)
+    },
+  )
+
   it('exposes provenance returned by semantic retrieval', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/web-studio/src/routes/retrieval/-components/retrieval-results.tsx
+++ b/web-studio/src/routes/retrieval/-components/retrieval-results.tsx
@@ -391,7 +391,7 @@ function ResultRowContent({
           </span>
         </div>
 
-        <dl className="mt-2.5 grid min-w-0 grid-cols-[3.25rem_minmax(0,1fr)] gap-x-2.5 gap-y-1.5">
+        <dl className="mt-2.5 grid min-w-0 grid-cols-[max-content_minmax(0,1fr)] gap-x-2.5 gap-y-1.5">
           <dt className="pt-px text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground/55">
             {t('results.uri')}
           </dt>


### PR DESCRIPTION
## Description

Fix the overlapping `DESCRIPTION` label in Web Studio's Retrieval results.

The metadata grid reserves 3.25rem (52px) for labels. The English label is wider than that column and extends into the description. Let the label column fit its content while keeping the value column flexible.

This is a layout-only fix. Retrieval requests, results, filters, and navigation are unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A. Reported with a screenshot of overlapping labels in the Retrieval results list.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Change one grid track from `3.25rem` to `max-content`.
- Add English and Simplified Chinese regression cases. Preserve URI truncation and the two-line description limit.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Checks from `web-studio/`:

- `npm test -- src/routes/retrieval/-components/retrieval-results.test.tsx`: 5 passed. The two new cases fail with the original grid value.
- `NODE_OPTIONS=--no-experimental-webstorage npm test`: 210 tests passed across 55 files.
- `npm run build`: passed.
- ESLint and Prettier checks on both changed files: passed.
- `git diff --check`: passed.
- Browser check using the actual component, Studio CSS, and fonts in a local fixture: English and Chinese at 375, 768, and 1200px. Covered resource, memory, and skill results, long URIs, long descriptions, and a result without a description. The original English label overlapped by about 14px; the fix leaves a 10px gap. Descriptions still use at most two lines, long URIs truncate, and the fixture has no horizontal overflow.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

No new comments, documentation changes, or dependent PRs are needed for this CSS-only change.

## Additional Notes

On this machine, Node 26's native Web Storage causes three existing Playground tests to fail without the test command's environment option. The same three failures reproduce on unmodified upstream main. No test configuration is changed in this PR.

`npx tsc --noEmit` reports the same 26 errors on upstream main and this branch, with no errors in the changed files. Both builds also emit the existing large-chunk warning. These are outside this fix.

Browser validation used local fixture data; no OpenViking backend or provider credentials were needed.
