### PR TITLE
fix(embedding): honor explicit multimodal OpenAI config

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -219,7 +219,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 | `api_key` | str | API key |
 | `model` | str | Model name |
 | `dimension` | int | Vector dimension. For Voyage, this maps to `output_dimension` |
-| `input` | str | Input type: `"text"` or `"multimodal"` |
+| `input` | str | Input type: `"text"` or `"multimodal"`. For OpenAI-compatible providers such as `openai`/`ollama`, image parts are sent only when this is explicitly set to `"multimodal"` and the backend supports them; use `"text"` or omit it for official OpenAI text models. |
 | `batch_size` | int | Batch size for embedding requests |
 | `encoding_format` | str | (OpenAI / Azure only) Wire format for embedding values: `"float"` or `"base64"`. Leave unset to use the OpenAI Python SDK default. Set to `"float"` when the upstream gateway cannot deserialize base64 embedding payloads correctly. |
 | `extra_body` | object | (OpenAI / Azure only) Extra JSON body fields merged into every embeddings request. Useful for OpenAI-compatible gateways that accept vendor-specific fields, e.g. OpenRouter provider routing `{"provider": {"sort": "latency"}}`. Explicit `query_param`/`document_param` keys take precedence on conflict. |
@@ -255,7 +255,7 @@ When the embedding provider experiences consecutive transient failures (e.g. `42
 | `doubao-embedding-vision-251215` | 1024 | multimodal | Recommended |
 | `doubao-embedding-250615` | 1024 | text | Text only |
 
-With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), and mixed content. Image-to-image search requires this mode; text-only embedding models continue to index image summaries but cannot accept image queries.
+With `input: "multimodal"`, OpenViking can embed text, images (PNG, JPG, etc.), and mixed content. Image-to-image search requires this mode; text-only embedding models continue to index image summaries but cannot accept image queries. For OpenAI-compatible backends, verify that the selected model accepts content parts (for example, `image_url`); OpenViking does not translate image inputs for a text-only backend.
 
 **Supported providers:**
 - `openai`: OpenAI Embedding API

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -221,7 +221,7 @@ openviking-server doctor
 | `api_key` | str | API Key |
 | `model` | str | 模型名称 |
 | `dimension` | int | 向量维度 |
-| `input` | str | 输入类型：`"text"` 或 `"multimodal"` |
+| `input` | str | 输入类型：`"text"` 或 `"multimodal"`。对 `openai`/`ollama` 等 OpenAI 兼容 provider，只有显式设置为 `"multimodal"` 且后端支持内容 parts 时才会发送图片输入；官方 OpenAI 文本模型请使用 `"text"` 或省略。 |
 | `batch_size` | int | 批量请求大小 |
 | `encoding_format` | str | （仅 OpenAI / Azure）Embedding 值的传输格式：`"float"` 或 `"base64"`。留空时使用 OpenAI Python SDK 默认值；当上游网关无法正确处理 base64 embedding payload 时，可设置为 `"float"`。 |
 | `extra_body` | object | （仅 OpenAI / Azure）合并进每次 embedding 请求体的额外 JSON 字段。适用于接受厂商专有字段的 OpenAI 兼容网关，例如 OpenRouter 的 provider 路由 `{"provider": {"sort": "latency"}}`。发生冲突时，显式设置的 `query_param`/`document_param` 键优先。 |
@@ -257,7 +257,7 @@ openviking-server doctor
 | `doubao-embedding-vision-251215` | 1024 | multimodal | 推荐 |
 | `doubao-embedding-250615` | 1024 | text | 仅文本 |
 
-使用 `input: "multimodal"` 时，OpenViking 可以嵌入文本、图片（PNG、JPG 等）和混合内容。以图搜图需要该模式；纯文本 embedding 模型仍会索引图片 summary，但不能接收图片查询。
+使用 `input: "multimodal"` 时，OpenViking 可以嵌入文本、图片（PNG、JPG 等）和混合内容。以图搜图需要该模式；纯文本 embedding 模型仍会索引图片 summary，但不能接收图片查询。对于 OpenAI 兼容后端，需确认模型实际接受 `input` 内容 parts（例如 `image_url`），OpenViking 不会替后端完成图片能力转换。
 
 **支持的 provider:**
 - `openai`: OpenAI Embedding API

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -132,6 +132,10 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         self.document_param = document_param
         self.encoding_format = encoding_format
         self.extra_body = extra_body
+        # OpenAI-compatible providers may expose embedding models that accept
+        # the same content-part shape used by OpenViking's multimodal pipeline.
+        # Keep this opt-in: official OpenAI text models remain text-only.
+        self.input_type = input_type
         self._provider = provider.lower()
         self.provider = (configured_provider or provider).lower()
         self._client_kwargs: Dict[str, Any] = {"api_key": self.api_key or "no-key"}
@@ -161,6 +165,11 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         self._actual_model_dimension = None
         if self._dimension is None:
             self._dimension = self._detect_dimension()
+
+    @property
+    def supports_multimodal(self) -> bool:
+        """Whether this configured OpenAI-compatible model accepts content parts."""
+        return self.input_type == "multimodal"
 
     def _detect_dimension(self) -> int:
         """Detect dimension by making an actual API call"""

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -758,6 +758,15 @@ class EmbeddingConfig(BaseModel):
                     "dimension": cfg.dimension,
                     "provider": "openai",
                     "configured_provider": "openai",
+                    # ``input`` historically defaults to multimodal for the
+                    # Volcengine provider. Only forward it for OpenAI when the
+                    # user explicitly configured the field, so existing text
+                    # embedding configurations stay text-only.
+                    **(
+                        {"input_type": cfg.input}
+                        if "input" in cfg.model_fields_set
+                        else {}
+                    ),
                     "config": dict(runtime_config),
                     **({"query_param": cfg.query_param} if cfg.query_param else {}),
                     **({"document_param": cfg.document_param} if cfg.document_param else {}),

--- a/tests/misc/test_embedding_input_type.py
+++ b/tests/misc/test_embedding_input_type.py
@@ -138,6 +138,42 @@ class TestEmbeddingConfigContextualEmbedders:
         assert "query_param" not in call_kwargs
         assert "document_param" not in call_kwargs
 
+    @patch("openviking.models.embedder.OpenAIDenseEmbedder")
+    def test_get_embedder_openai_forwards_explicit_multimodal_input(self, mock_embedder_class):
+        """An explicit multimodal mode must reach OpenAI-compatible embedders."""
+        mock_embedder_class.return_value = MagicMock()
+        config = EmbeddingConfig(
+            dense=EmbeddingModelConfig(
+                model="custom-multimodal",
+                provider="openai",
+                api_key="sk-test",
+                api_base="http://localhost:8000/v1",
+                input="multimodal",
+            )
+        )
+
+        config.get_embedder()
+
+        call_kwargs = mock_embedder_class.call_args[1]
+        assert call_kwargs["input_type"] == "multimodal"
+
+    @patch("openviking.models.embedder.OpenAIDenseEmbedder")
+    def test_get_embedder_openai_defaults_to_text_only(self, mock_embedder_class):
+        """Omitting input keeps existing OpenAI text-model behavior."""
+        mock_embedder_class.return_value = MagicMock()
+        config = EmbeddingConfig(
+            dense=EmbeddingModelConfig(
+                model="text-embedding-3-small",
+                provider="openai",
+                api_key="sk-test",
+            )
+        )
+
+        config.get_embedder()
+
+        call_kwargs = mock_embedder_class.call_args[1]
+        assert "input_type" not in call_kwargs
+
     @patch("openviking.models.embedder.JinaDenseEmbedder")
     def test_get_embedder_jina_no_params_when_not_set(self, mock_embedder_class):
         """get_embedder should not pass query_param and document_param when not set."""
@@ -184,6 +220,25 @@ class TestOpenAIDenseEmbedderInputType:
         mock_client.embeddings.create.assert_called_once()
         call_kwargs = mock_client.embeddings.create.call_args[1]
         assert call_kwargs.get("extra_body") == {"input_type": "search_query"}
+
+    @patch("openai.OpenAI")
+    def test_explicit_multimodal_mode_preserves_content_parts(self, mock_openai_class):
+        """Multimodal mode must prevent the base guard from stripping images."""
+        from openviking.models.embedder import OpenAIDenseEmbedder
+
+        embedder = OpenAIDenseEmbedder(
+            model_name="custom-multimodal",
+            api_key="sk-test",
+            dimension=1536,
+            input_type="multimodal",
+        )
+
+        content = [
+            {"type": "text", "text": "a diagram"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+        assert embedder.supports_multimodal is True
+        assert embedder.prepare_embedding_input(content) == content
 
     @patch("openai.OpenAI")
     def test_embed_no_extra_body_when_input_type_not_set(self, mock_openai_class):


### PR DESCRIPTION
## Summary

- forward an explicitly configured `input: "multimodal"` to the OpenAI-compatible dense embedder
- preserve content parts instead of silently stripping images when the capability is enabled
- keep omitted `input` text-only for existing official OpenAI text models
- document the provider/backend requirement and add regression coverage

Closes #4416

## Validation

- `python -m compileall -q openviking openviking_cli tests/misc/test_embedding_input_type.py`
- `git diff --check`
- `uv run pytest tests/misc/test_embedding_input_type.py -q` *(blocked locally while the editable build requires Cargo edition2024; see command output)*