### PR TITLE
fix(semantic): skip thematic breaks in directory abstracts

### DIFF
--- a/openviking/storage/queuefs/semantic_processor.py
+++ b/openviking/storage/queuefs/semantic_processor.py
@@ -1134,6 +1134,11 @@ class SemanticProcessor(DequeueHandlerBase):
         for line in lines:
             if in_header and line.startswith("#"):
                 continue
+            # A horizontal rule is Markdown structure, not abstract prose.
+            # In particular, keeping a leading `---` would make the generated
+            # `.abstract.md` look like an unterminated YAML frontmatter block.
+            elif in_header and re.fullmatch(r"\s{0,3}([-*_])(?:\s*\1){2,}\s*", line):
+                continue
             elif in_header and line.strip():
                 in_header = False
 

--- a/tests/storage/test_semantic_processor_l0_l1.py
+++ b/tests/storage/test_semantic_processor_l0_l1.py
@@ -65,6 +65,22 @@ def test_markdown_overview_extracts_multiline_brief_description(monkeypatch):
     assert abstract == "This is the first abstract line.\nThis is the second abstract line."
 
 
+def test_markdown_overview_skips_thematic_break_before_brief_description(monkeypatch):
+    _patch_semantic_limits(monkeypatch)
+    processor = SemanticProcessor()
+    generated = (
+        "### Directory\n"
+        "#### wiki\n\n"
+        "---\n\n"
+        "#### Brief Description:\n"
+        "This directory contains public-service and legal-aid documents.\n"
+    )
+
+    _overview, abstract = processor._normalize_overview_generation(generated)
+
+    assert abstract == "This directory contains public-service and legal-aid documents."
+
+
 def test_directory_coverage_section_is_excluded_from_abstract(monkeypatch):
     _patch_semantic_limits(monkeypatch)
     processor = SemanticProcessor()


### PR DESCRIPTION
## Summary

- skip Markdown thematic breaks while extracting a directory abstract
- prevent a bare `---` from being persisted as an unterminated YAML frontmatter sidecar
- add regression coverage for the generated overview shape in #4336

Closes #4336

## Validation

- `python -m compileall -q openviking/storage/queuefs/semantic_processor.py tests/storage/test_semantic_processor_l0_l1.py`
- `git diff --check`
- Full pytest is currently blocked in this checkout by the local missing `apscheduler` dependency.