### PR TITLE
fix(knowledge-graph): style recommended module entities

### DIFF
--- a/examples/compile/graph-show/knowledge-graph/knowledge_graph.py
+++ b/examples/compile/graph-show/knowledge-graph/knowledge_graph.py
@@ -72,6 +72,7 @@ _TYPE_STYLE = {
     "project": {"label": "项目", "color": "#ff8f3d", "symbol": "square"},
     "system": {"label": "系统", "color": "#2dc8ff", "symbol": "hexagon"},
     "service": {"label": "服务", "color": "#2dc8ff", "symbol": "hexagon"},
+    "module": {"label": "模块", "color": "#67d5b5", "symbol": "square"},
     "dataset": {"label": "数据集", "color": "#82aaff", "symbol": "square"},
     "standard": {"label": "标准", "color": "#c792ea", "symbol": "diamond"},
     "other": {"label": "其他", "color": "#9aa8c7", "symbol": "circle"},

--- a/examples/compile/ov-compile-skills/knowledge-graph/SKILL.md
+++ b/examples/compile/ov-compile-skills/knowledge-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-graph
-description: Compile documents, notes, web content, transcripts, research materials, or code repositories into an evidence-grounded, visualization-ready knowledge graph with semantically typed entity nodes, statement-level provenance, and typed relationship edges. Use with ov compile to create or incrementally refresh `entities/*.md` node artifacts and a root `relations.jsonl` edge file for people, organizations, groups, animals, places, products, projects, systems, services, documents, events, and other identifiable things.
+description: Compile documents, notes, web content, transcripts, research materials, or code repositories into an evidence-grounded, visualization-ready knowledge graph with semantically typed entity nodes, statement-level provenance, and typed relationship edges. Use with ov compile to create or incrementally refresh `entities/*.md` node artifacts and a root `relations.jsonl` edge file for people, organizations, groups, animals, places, products, projects, systems, services, modules, datasets, standards, documents, events, and other identifiable things.
 ---
 
 # Knowledge Graph


### PR DESCRIPTION
## Summary

- add a dedicated visualization style for the `module` entity type
- align the knowledge-graph skill description with the complete supported vocabulary
- prevent recommended `module` entities from silently falling back to `other`

Closes #4427

## Validation

- direct normalization check for `module`, `dataset`, `standard`, and an unknown type
- `git diff --check`
