### PR TITLE
fix(session): retry recoverable memory extraction failures

### DIFF
--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2238,13 +2238,26 @@ class Session:
             if not _is_storage_not_found(exc):
                 raise
         else:
-            await tracker.fail(
-                msg.task_id,
-                str(failed.get("error") or "session commit failed"),
-                account_id=self.ctx.account_id,
-                user_id=self.ctx.user.user_id,
+            failed_stage = str(failed.get("stage") or "")
+            if failed_stage != "memory_extraction":
+                await tracker.fail(
+                    msg.task_id,
+                    str(failed.get("error") or "session commit failed"),
+                    account_id=self.ctx.account_id,
+                    user_id=self.ctx.user.user_id,
+                )
+                return True
+
+            # Phase 1 and messages.jsonl are still durable when only the
+            # model-backed Phase 2 failed. Keep the failure marker for
+            # observability, but remove it before phase-1 reconciliation so a
+            # later queue replay can retry the recoverable extraction.
+            logger.info(
+                "Retrying recoverable Phase 2 failure for session %s: %s",
+                self.session_id,
+                failed.get("error") or "unknown error",
             )
-            return True
+            await self._viking_fs.rm(f"{msg.archive_uri}/.failed.json", ctx=self.ctx)
 
         if not await self._ensure_phase1_ready(msg.archive_uri):
             try:

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -2334,7 +2334,7 @@ class Session:
         if user_config_error is not None:
             user_config_error = str(user_config_error)
 
-        await self._run_memory_extraction(
+        return await self._run_memory_extraction(
             task_id=msg.task_id,
             archive_uri=msg.archive_uri,
             messages=archive_messages,
@@ -2387,7 +2387,7 @@ class Session:
         user_config_error: Optional[str] = None,
         record_auto_commit_success: bool = False,
         event_search_tags: Optional[List[str]] = None,
-    ) -> None:
+    ) -> bool:
         """Phase 2: Extract memories and enqueue semantic work in the background."""
         from openviking.service.task_tracker import get_task_tracker
         from openviking.telemetry import OperationTelemetry, bind_telemetry
@@ -2845,6 +2845,7 @@ class Session:
                 user_id=self.ctx.user.user_id,
             )
             logger.info(f"Session {self.session_id} memory extraction completed")
+            return True
         except asyncio.CancelledError:
             telemetry.set_error("session.commit.phase2", "CANCELLED", "session commit cancelled")
             snapshot = telemetry.finish("cancelled")
@@ -2871,6 +2872,15 @@ class Session:
                 task_id, str(e), account_id=self.ctx.account_id, user_id=self.ctx.user.user_id
             )
             logger.exception(f"Memory extraction failed for session {self.session_id}")
+            return False
+
+    async def finalize_failed_commit(self, archive_uri: str, *, error: str) -> None:
+        """Make an exhausted queued commit terminal after bounded retries."""
+        await self._write_failed_marker(
+            archive_uri,
+            stage="memory_extraction",
+            error=error,
+        )
 
     async def _write_done_file(
         self,

--- a/openviking/storage/queuefs/session_commit_msg.py
+++ b/openviking/storage/queuefs/session_commit_msg.py
@@ -21,6 +21,8 @@ class SessionCommitMsg:
     # Resolved custom scalar tags to attach to event memories extracted in this
     # commit. Already normalized by the producer; empty means "no tags".
     event_search_tags: List[str] = field(default_factory=list)
+    # Number of queue-level retries after a recoverable Phase 2 failure.
+    phase2_retry_count: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -18,9 +18,14 @@ from openviking.storage.queuefs.named_queue import DequeueHandlerBase
 from openviking.storage.queuefs.session_commit_msg import SessionCommitMsg
 from openviking.telemetry.span_models import create_root_span_attributes
 from openviking_cli.session.user_id import UserIdentifier
+from openviking_cli.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from openviking.service.session_service import SessionService
+
+
+MAX_PHASE2_RETRIES = 3
+logger = get_logger(__name__)
 
 
 class SessionCommitProcessor(DequeueHandlerBase):
@@ -86,11 +91,22 @@ class SessionCommitProcessor(DequeueHandlerBase):
             with bind_task_context(msg.task_id, ctx.account_id, ctx.user.user_id):
                 processed = await session.resume_queued_commit(msg)
             if not processed:
+                if msg.phase2_retry_count >= MAX_PHASE2_RETRIES:
+                    error = (
+                        f"session commit Phase 2 failed after {MAX_PHASE2_RETRIES} retries"
+                    )
+                    await session.finalize_failed_commit(msg.archive_uri, error=error)
+                    logger.error("%s: %s", error, msg.archive_uri)
+                    return True
                 from openviking.storage.queuefs import QueueManager, get_queue_manager
 
+                retry_payload = msg.to_dict()
+                retry_payload["phase2_retry_count"] = msg.phase2_retry_count + 1
+                retry_delay = min(2 ** msg.phase2_retry_count, 30)
+                await asyncio.sleep(retry_delay)
                 await get_queue_manager().enqueue(
                     QueueManager.SESSION_COMMIT,
-                    msg.to_dict(),
+                    retry_payload,
                 )
                 self.report_requeue()
             return processed

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -123,11 +123,15 @@ async def test_process_requeues_deferred_commit_and_resets_root_context(monkeypa
 async def test_process_retries_phase2_then_completes_without_restart(monkeypatch):
     queued = []
     outcomes = iter([False, True])
+    files: dict[str, str] = {}
 
     class _RetrySession(_FakeSession):
         async def resume_queued_commit(self, msg):
             self._processed = next(outcomes)
-            return await super().resume_queued_commit(msg)
+            processed = await super().resume_queued_commit(msg)
+            if processed:
+                files[f"{msg.archive_uri}/.done"] = "completed"
+            return processed
 
     class _RetryService(_FakeSessionService):
         def session(self, ctx, session_id, session_uri=None):
@@ -156,6 +160,7 @@ async def test_process_retries_phase2_then_completes_without_restart(monkeypatch
     second = await processor._process(retry_msg, ctx)
     assert second is True
     assert len(queued) == 1
+    assert files[f"{retry_msg.archive_uri}/.done"] == "completed"
 
 
 async def test_cancelled_queued_commit_writes_terminal_marker_before_success(monkeypatch):

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -11,7 +11,7 @@ worker binds the committing account/user (so tokens are not attributed to
 import asyncio
 import concurrent.futures
 import json
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from openviking.observability.context import get_root_observability_context
 from openviking.server.identity import RequestContext, Role
@@ -106,12 +106,56 @@ async def test_process_requeues_deferred_commit_and_resets_root_context(monkeypa
         "openviking.storage.queuefs.get_queue_manager",
         lambda: _QueueManager(),
     )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.session_commit_processor.asyncio.sleep",
+        AsyncMock(),
+    )
     ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
 
     await processor._process(_make_msg(), ctx)
 
-    assert queued == [("SessionCommit", _make_msg().to_dict())]
+    expected = _make_msg().to_dict()
+    expected["phase2_retry_count"] = 1
+    assert queued == [("SessionCommit", expected)]
     assert get_root_observability_context() is None
+
+
+async def test_process_retries_phase2_then_completes_without_restart(monkeypatch):
+    queued = []
+    outcomes = iter([False, True])
+
+    class _RetrySession(_FakeSession):
+        async def resume_queued_commit(self, msg):
+            self._processed = next(outcomes)
+            return await super().resume_queued_commit(msg)
+
+    class _RetryService(_FakeSessionService):
+        def session(self, ctx, session_id, session_uri=None):
+            return _RetrySession({}, processed=True)
+
+    class _QueueManager:
+        async def enqueue(self, queue_name, data):
+            queued.append((queue_name, data))
+
+    processor = SessionCommitProcessor(_RetryService({}), asyncio.get_running_loop())
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.get_queue_manager",
+        lambda: _QueueManager(),
+    )
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.session_commit_processor.asyncio.sleep",
+        AsyncMock(),
+    )
+    ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
+
+    first = await processor._process(_make_msg(), ctx)
+    assert first is False
+    assert queued[0][1]["phase2_retry_count"] == 1
+
+    retry_msg = SessionCommitMsg.from_dict(queued[0][1])
+    second = await processor._process(retry_msg, ctx)
+    assert second is True
+    assert len(queued) == 1
 
 
 async def test_cancelled_queued_commit_writes_terminal_marker_before_success(monkeypatch):

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -48,6 +48,10 @@ class _MemoryVikingFS:
     async def write_file(self, uri, content, ctx=None, lease_ref=None):
         self.files[uri] = content
 
+    async def rm(self, uri, recursive=False, ctx=None, lease_ref=None):
+        del recursive, ctx, lease_ref
+        self.files.pop(uri, None)
+
 
 @pytest.mark.asyncio
 async def test_resume_queued_commit_continues_phase2(monkeypatch):
@@ -87,6 +91,42 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     assert [
         item.id for item in session._run_memory_extraction.await_args.kwargs["messages"]
     ] == ["archived"]
+
+
+@pytest.mark.asyncio
+async def test_resume_queued_commit_retries_recoverable_memory_failure(monkeypatch):
+    session_uri = "viking://user/default/sessions/session-1"
+    archive_uri = f"{session_uri}/history/archive_001"
+    archived = Message(id="archived", role="user", parts=[TextPart("old")])
+    failed_uri = f"{archive_uri}/.failed.json"
+    files = {
+        f"{archive_uri}/messages.jsonl": f"{archived.to_jsonl()}\n",
+        failed_uri: json.dumps({
+            "stage": "memory_extraction",
+            "error": "temporary model backend failure",
+        }),
+    }
+    viking_fs = _MemoryVikingFS(files)
+    session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
+    tracker = TaskTracker(_TaskStore())
+    set_task_tracker(tracker)
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+    message = SessionCommitMsg(
+        task_id="task-1",
+        session_id="session-1",
+        session_uri=session_uri,
+        archive_uri=archive_uri,
+        user={"account_id": "default", "user_id": "default"},
+        memory_policy={"memory_types": []},
+    )
+
+    try:
+        await session.resume_queued_commit(message)
+    finally:
+        set_task_tracker(None)
+
+    assert failed_uri not in files
+    session._run_memory_extraction.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -70,7 +70,7 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
     tracker = TaskTracker(_TaskStore())
     set_task_tracker(tracker)
-    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock(return_value=False))
     message = SessionCommitMsg(
         task_id="task-1",
         session_id="session-1",
@@ -110,7 +110,7 @@ async def test_resume_queued_commit_retries_recoverable_memory_failure(monkeypat
     session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
     tracker = TaskTracker(_TaskStore())
     set_task_tracker(tracker)
-    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock())
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock(return_value=False))
     message = SessionCommitMsg(
         task_id="task-1",
         session_id="session-1",

--- a/tests/unit/session/test_session_commit_resume.py
+++ b/tests/unit/session/test_session_commit_resume.py
@@ -70,7 +70,7 @@ async def test_resume_queued_commit_continues_phase2(monkeypatch):
     session = Session(viking_fs=viking_fs, session_id="session-1", session_uri=session_uri)
     tracker = TaskTracker(_TaskStore())
     set_task_tracker(tracker)
-    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock(return_value=False))
+    monkeypatch.setattr(session, "_run_memory_extraction", AsyncMock(return_value=True))
     message = SessionCommitMsg(
         task_id="task-1",
         session_id="session-1",


### PR DESCRIPTION
## Summary

- allow queued session commits to retry recoverable Phase 2 memory extraction failures
- preserve terminal handling for corrupt archives, missing messages, and cancelled commits
- add regression coverage for replaying an archive after a transient extraction failure

Fixes #4419

## Validation

- `python -m py_compile openviking/session/session.py tests/unit/session/test_session_commit_resume.py`
- `git diff --check`
- targeted pytest is blocked locally by a missing `apscheduler` dependency
