### PR TITLE
fix(rerank): validate credentials for explicitly configured providers

### DIFF
--- a/docs/en/configuration/01-server.md
+++ b/docs/en/configuration/01-server.md
@@ -147,6 +147,8 @@ Changing the model or `dimension` can make existing vector collections incompati
 
 Rerank has no separate `enabled` field. It becomes available when the required provider credentials are configured.
 
+Setting `provider` explicitly requires the credentials that provider needs: `ak` and `sk` for `vikingdb`, `api_key` for `cohere`, `api_key` and `api_base` for `openai`, `model` for `litellm`. An incomplete block is rejected when the configuration loads.
+
 ## Retrieval Settings
 
 ```json

--- a/docs/zh/configuration/01-server.md
+++ b/docs/zh/configuration/01-server.md
@@ -147,6 +147,8 @@ API 型 `embedding`、`vlm`、`query_planner` 和 `rerank` 配置会复用部分
 
 Rerank 没有单独的 `enabled` 字段；配置了对应 provider 所需的凭证后才会启用。
 
+显式指定 `provider` 时必须提供该 provider 所需的凭证：`vikingdb` 需要 `ak` 和 `sk`，`cohere` 需要 `api_key`，`openai` 需要 `api_key` 和 `api_base`，`litellm` 需要 `model`。凭证不全的配置在加载时即被拒绝。
+
 ## 检索配置
 
 ```json

--- a/openviking_cli/utils/config/rerank_config.py
+++ b/openviking_cli/utils/config/rerank_config.py
@@ -88,6 +88,12 @@ class RerankConfig(BaseModel):
         if provider == "litellm":
             if not self.model:
                 raise ValueError("LiteLLM rerank provider requires 'model'")
+        if provider == "cohere":
+            if not self.api_key:
+                raise ValueError("Cohere rerank provider requires 'api_key'")
+        if provider == "vikingdb":
+            if not self.ak or not self.sk:
+                raise ValueError("VikingDB rerank provider requires 'ak' and 'sk'")
         return self
 
     def is_available(self) -> bool:

--- a/tests/misc/test_rerank_openai.py
+++ b/tests/misc/test_rerank_openai.py
@@ -268,10 +268,13 @@ class TestRerankConfig:
         with pytest.raises(ValidationError):
             RerankConfig(provider="openai", api_base="https://example.com/rerank")
 
-    def test_default_provider_is_vikingdb(self):
-        config = RerankConfig()
-        assert config.provider == "vikingdb"
-
     def test_unknown_provider_raises_value_error(self):
-        with pytest.raises(ValueError, match="provider"):
+        with pytest.raises(ValidationError, match="provider"):
+            RerankConfig(provider="unknown", api_key="key")
+
+    def test_explicit_provider_requires_its_own_credentials(self):
+        with pytest.raises(ValidationError, match="api_key"):
             RerankConfig(provider="cohere", ak="ak", sk="sk")
+
+        with pytest.raises(ValidationError, match="ak"):
+            RerankConfig(provider="vikingdb", api_key="key")


### PR DESCRIPTION
## Description

`RerankConfig` validated required fields for `openai` and `litellm` and skipped `cohere` and
`vikingdb`. An explicit `provider: cohere` without `api_key`, or `provider: vikingdb` without
`ak`/`sk`, loaded without complaint. `is_available()` then returned False, `HierarchicalRetriever`
took its no-rerank branch, and the only trace was one info line reading "Rerank not configured".
Retrieval kept serving requests on plain vector search alone.

This PR adds the two missing checks so all four providers fail the same way.

| Config | Before | After |
|---|---|---|
| `provider: openai`, no `api_base` | ValidationError | unchanged |
| `provider: litellm`, no `model` | ValidationError | unchanged |
| `provider: cohere`, no `api_key` | accepted, rerank silently off | ValidationError |
| `provider: vikingdb`, no `ak`/`sk` | accepted, rerank silently off | ValidationError |
| no `provider` set | inferred from credentials | unchanged |

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4440

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Add required-field checks for `cohere` (`api_key`) and `vikingdb` (`ak`, `sk`) in
  `RerankConfig.validate_provider_fields()`, next to the existing `openai` and `litellm` branches.
- Rewrite `test_unknown_provider_raises_value_error`. It was named for an unknown provider but
  asserted the missing cohere check instead. Both cases now have their own test.
- Drop `test_default_provider_is_vikingdb`. It asserted a default that auto-detection replaced and
  had been failing on main. The no-credentials case is already covered by
  `test_vikingdb_not_available_without_credentials`.
- Document the credentials each rerank provider requires, in the English and Chinese configuration
  reference.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Reproduced before fixing. Revert the source change and the new test fails; put it back and the file
passes.

```
python -m pytest tests/misc/test_rerank_openai.py -q --no-cov
# fix reverted: 1 failed, 23 passed
# fix applied:  24 passed

python -m pytest tests/misc tests/client -q --no-cov
# before: 24 failed, 466 passed, 2 skipped
# after:  22 failed, 468 passed, 2 skipped

ruff check openviking_cli/utils/config/rerank_config.py tests/misc/test_rerank_openai.py  # clean
ruff format --check openviking_cli/utils/config/rerank_config.py                          # clean
mypy openviking_cli/utils/config/rerank_config.py                                         # clean
```

The two failures that disappear are the ones this PR addresses. The other 22 are pre-existing on main
and unrelated to rerank.

Environment: Linux, Python 3.11.16, main at 5e0754f3.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Scope of the break: configs that name a provider and leave out its credentials. Those already got no
rerank at runtime, so nothing that works today stops working. Only the timing of the feedback changes.
Today the operator sees worse recall and no explanation. After this, the server refuses to start and
says which field is missing.

A warning instead of an error would avoid the break, but it puts the message in the same log stream as
the info line that already fails to get noticed. The two validated providers set the precedent here,
and matching them keeps one rule instead of four.

The new checks read the effective provider rather than the raw field, same as the branches above them,
so auto-detection is out of reach: inferring cohere already requires `api_key`, inferring vikingdb
already requires `ak` and `sk`. `RerankConfig()` with no fields resolves to no provider and stays
valid.

cc @zhoujh01 @t0saki for the retrieval side.