### PR TITLE
fix(docker): enforce VikingBot SDK contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=py-builder /app/.venv /app/.venv
+# Fail the image build if VikingBot and the separately released SDK drift apart.
+RUN /app/.venv/bin/python -I -c "import inspect; from importlib.metadata import version; from openviking_sdk.client import AsyncHTTPClient; signature = inspect.signature(AsyncHTTPClient.get_skill); raise SystemExit(0 if 'include_integrity' in signature.parameters else f\"incompatible openviking-sdk {version('openviking-sdk')}: AsyncHTTPClient.get_skill{signature} lacks include_integrity\")"
 RUN /app/.venv/bin/python -I -c "from importlib.util import find_spec; from pathlib import Path; spec = find_spec('openviking.web_studio'); locations = list(spec.submodule_search_locations or ()) if spec else []; root = Path('/app/.venv').resolve(); p = (Path(locations[0]).resolve() / 'dist/index.html').resolve() if len(locations) == 1 else None; valid = p is not None and p.is_file() and p.is_relative_to(root); raise SystemExit(0 if valid else f'missing or misplaced Studio bundle: spec_found={spec is not None}, locations={locations!r}, resource={p}')"
 COPY docker/openviking-entrypoint.sh /usr/local/bin/openviking-entrypoint
 COPY docker/pending_health_server.py /usr/local/bin/openviking-pending-health

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "openviking-sdk>=0.1.1",
+    "openviking-sdk>=0.1.9",
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "pyyaml>=6.0",

--- a/tests/misc/test_bot_dependency_compatibility.py
+++ b/tests/misc/test_bot_dependency_compatibility.py
@@ -1,11 +1,14 @@
 """Regression checks for dependencies shared by the bot extra."""
 
+import importlib.metadata
+import inspect
 import re
 from pathlib import Path
 
 import charset_normalizer
 import requests
 import urllib3
+from openviking_sdk.client import AsyncHTTPClient
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -28,4 +31,15 @@ def test_bot_extra_locked_chardet_is_supported_by_requests() -> None:
         urllib3.__version__,
         _locked_version("chardet"),
         charset_normalizer.__version__,
+    )
+
+
+def test_locked_openviking_sdk_supports_remote_skill_integrity() -> None:
+    """The SDK installed with VikingBot must accept its remote-Skill request."""
+    assert importlib.metadata.version("openviking-sdk") == _locked_version("openviking-sdk")
+    inspect.signature(AsyncHTTPClient.get_skill).bind_partial(
+        None,
+        "example-skill",
+        target_uri="viking://agent/skills",
+        include_integrity=True,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -3829,7 +3829,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.14" },
     { name = "opentelemetry-instrumentation-asyncio", specifier = ">=0.61b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.14" },
-    { name = "openviking-sdk", specifier = ">=0.1.1" },
+    { name = "openviking-sdk", specifier = ">=0.1.9" },
     { name = "pandas", marker = "extra == 'benchmark'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0.0" },
@@ -3906,14 +3906,14 @@ dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "openviking-sdk"
-version = "0.1.4"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/85/46464494cfa4a84d8355fb43edb455f08c6517629ecf81b50d63ad9ae525/openviking_sdk-0.1.4.tar.gz", hash = "sha256:cac236b8614f3471b294aa71c1e74b297cf72c6a7f286a94c3270e7ccc386de3", size = 33174, upload-time = "2026-07-13T11:38:40.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/b0/75e49d6da4183165768a40db4876e75c4c9e4ff6ac9356d5bbabdbd51281/openviking_sdk-0.1.9.tar.gz", hash = "sha256:a4e66cd53cd7179d02332ffffb9116fc2feaa431b0bbd1eb93c6906751068e2a", size = 50752, upload-time = "2026-08-24T11:51:34.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/af/4ca139b05f39c8ed04339d7c8aa56550df80f97d39768d2df9bd72fdbbb9/openviking_sdk-0.1.4-py3-none-any.whl", hash = "sha256:1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616", size = 22316, upload-time = "2026-07-13T11:38:39.541Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d6/aa82551f9c5d06ce682b9194c784beeb16478ce103d650ed8e8b487b1aa7/openviking_sdk-0.1.9-py3-none-any.whl", hash = "sha256:6057f3ab921cee4697a7b424948347669cb7b8e04439f305503d8ab7132af3ce", size = 30889, upload-time = "2026-08-24T11:51:33.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Title

fix(docker): enforce VikingBot SDK contract

## Description

The v0.4.16 Docker image installs `openviking-sdk 0.1.4`, while the bundled
VikingBot remote-Skill path calls `AsyncHTTPClient.get_skill()` with
`include_integrity=True`. This causes remote Skill compilation to fail before
the compile workflow starts.

This change raises the SDK requirement and lock to the first compatible release,
then adds a final-image build check so future VikingBot/SDK contract drift fails
the image build instead of reaching users.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4418

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Raise the root `openviking-sdk` requirement from `>=0.1.1` to `>=0.1.9`.
- Refresh `uv.lock` so Docker installs `openviking-sdk 0.1.9`.
- Verify the installed SDK supports VikingBot's `include_integrity` call shape.
- Fail the final image build with the installed SDK version and signature when the contract is missing.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Commands run:

```text
pytest --noconftest -q -o addopts='' \
  tests/misc/test_bot_dependency_compatibility.py \
  tests/misc/test_root_docker_image_packaging.py::test_root_dockerfile_copies_bot_sources_into_build_context \
  tests/misc/test_root_docker_image_packaging.py::test_root_dockerfile_does_not_bake_zero_openviking_version_by_default
# 4 passed

ruff check tests/misc/test_bot_dependency_compatibility.py
ruff format --check tests/misc/test_bot_dependency_compatibility.py
uv lock --check
git diff --check
docker buildx build --check .
```

The final-image contract command was also exercised directly against both SDK
versions: `0.1.4` was rejected with the incompatible signature, while `0.1.9`
passed.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

A full Docker image build was not run locally because it recompiles the native
Rust and C++ components. `docker buildx build --check .` completed without
warnings, and the release build will execute the new contract gate against the
final image environment.