### PR TITLE
fix(openclaw): early-exit transformContext assemble on non-user tails

### DIFF
--- a/examples/openclaw-plugin/services/context-lifecycle-service.ts
+++ b/examples/openclaw-plugin/services/context-lifecycle-service.ts
@@ -441,10 +441,16 @@ export async function assembleOpenVikingSession({
   hasAutoRecallBlock,
   prependRecallToLatestUserMessage,
 }: AssembleOpenVikingSessionParams): Promise<AssembleOpenVikingSessionResult> {
-  const ovSessionId = openClawSessionToOvStorageId(sessionId, sessionKey);
-  const sender = extractRuntimeSenderId(runtimeContext);
   const latestMessage = messages.at(-1);
   const isTransformContextAssemble = !isMainAssemble;
+
+  // Tool-loop calls do no recall work on non-user tails; avoid scanning the full history.
+  if (isTransformContextAssemble && latestMessage?.role !== "user") {
+    return { messages, estimatedTokens: 0 };
+  }
+
+  const ovSessionId = openClawSessionToOvStorageId(sessionId, sessionKey);
+  const sender = extractRuntimeSenderId(runtimeContext);
   const originalTokens = roughEstimate(messages);
 
   rememberSessionAgentId?.({
@@ -468,16 +474,6 @@ export async function assembleOpenVikingSession({
   }
 
   if (isTransformContextAssemble) {
-    if (latestMessage?.role !== "user") {
-      return assemblePassthrough({
-        diag,
-        ovSessionId,
-        reason: "transform_context_non_user_tail",
-        liveMessages: messages,
-        originalTokens,
-        extra: { latestRole: latestMessage?.role ?? null },
-      });
-    }
     if (!cfg.autoRecall) {
       return assemblePassthrough({ diag, ovSessionId, reason: "transform_context_auto_recall_disabled", liveMessages: messages, originalTokens });
     }

--- a/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts
@@ -342,7 +342,7 @@ describe("context-engine assemble()", () => {
 
     expect(getClient).not.toHaveBeenCalled();
     expect(result.messages).toBe(sourceMessages);
-    expect(result.estimatedTokens).toBe(roughEstimate(sourceMessages));
+    expect(result.estimatedTokens).toBe(0);
   });
 
   it("passes through transformContext latest user messages when auto-recall is disabled", async () => {

--- a/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts
@@ -83,6 +83,58 @@ describe("context-engine message adapter seam", () => {
 });
 
 describe("context-engine lifecycle service seam", () => {
+  it("short-circuits transformContext non-user tails before lifecycle work", async () => {
+    const messages = [
+      { role: "user", content: "run the tool" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tool_1", name: "bash", arguments: {} }],
+      },
+    ];
+    const getClient = vi.fn();
+    const resolveAgentId = vi.fn();
+    const rememberSessionAgentId = vi.fn();
+    const isBypassedSession = vi.fn(() => false);
+    const diag = vi.fn();
+    const roughEstimate = vi.fn(() => 42);
+    const messageDigest = vi.fn(() => []);
+    const extractAgentMessageText = vi.fn(() => "");
+    const hasAutoRecallBlock = vi.fn(() => false);
+    const prependRecallToLatestUserMessage = vi.fn();
+
+    const result = await assembleOpenVikingSession({
+      sessionId: "tool-loop-session",
+      messages,
+      tokenBudget: 4096,
+      isMainAssemble: false,
+      cfg: { autoRecall: true },
+      getClient,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      resolveAgentId,
+      rememberSessionAgentId,
+      isBypassedSession,
+      diag,
+      roughEstimate,
+      messageDigest,
+      extractAgentMessageText,
+      hasAutoRecallBlock,
+      prependRecallToLatestUserMessage,
+    });
+
+    expect(result).toEqual({ messages, estimatedTokens: 0 });
+    expect(result.messages).toBe(messages);
+    expect(roughEstimate).not.toHaveBeenCalled();
+    expect(messageDigest).not.toHaveBeenCalled();
+    expect(rememberSessionAgentId).not.toHaveBeenCalled();
+    expect(isBypassedSession).not.toHaveBeenCalled();
+    expect(diag).not.toHaveBeenCalled();
+    expect(getClient).not.toHaveBeenCalled();
+    expect(resolveAgentId).not.toHaveBeenCalled();
+    expect(extractAgentMessageText).not.toHaveBeenCalled();
+    expect(hasAutoRecallBlock).not.toHaveBeenCalled();
+    expect(prependRecallToLatestUserMessage).not.toHaveBeenCalled();
+  });
+
   it("assembles through the lifecycle service seam and preserves no-data passthrough diagnostics", async () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const messages = [{ role: "user", content: "hello world" }];


### PR DESCRIPTION
## Description

**Before:** every tool-loop `assemble` call in the OpenClaw plugin scannedthe full message history twice — `roughEstimate()` plus `messageDigest()` —and performed session identity bookkeeping and diagnostics, only to discover that the tail message was not a `user` message and return theinput unchanged.

**After:** `assembleOpenVikingSession()` short-circuits at the top when the call is a `transformContext` assemble and the latest message role is not `user`. The no-op path returns the original `messages` array with `estimatedTokens: 0` and performs no token estimation, digest, diagnostic, routing, or client work. The main assemble path is unchanged.

**Root cause / execution path:** `context-engine.ts#assemble()` is invoked by OpenClaw for every model call; during tool rounds the tail message is a tool result / assistant message. `assembleOpenVikingSession()` was
unconditionally running `roughEstimate(messages)` and `messageDigest(messages)` before the existing non-user-tail passthrough branch, making each tool round O(history) work that produces no change.

**Owner module:** `examples/openclaw-plugin` — OpenClaw context-engine lifecycle (`services/context-lifecycle-service.ts`).

**Compatibility:** `estimatedTokens: 0` matches OpenClaw's pass-through contract: the tool-loop call sites on v2026.5.27 and v2026.8.1-beta.3 consume only `messages`, and the bundled LegacyContextEngine already
returns `estimatedTokens: 0` for pass-through ("Caller handles estimation"). Diagnostics for this no-op path are intentionally skipped, matching the issue's requested early-exit behavior.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Refs #4415 (item 4)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- Move the `transformContext` non-user-tail guard to the top of `assembleOpenVikingSession()` in `examples/openclaw-plugin/services/context-lifecycle-service.ts`, before token estimation, `messageDigest`, diagnostics, and session identity bookkeeping.
- Return the original `messages` with `estimatedTokens: 0` on that path, preserving the OpenClaw pass-through contract.
- Add a lifecycle-seam regression test in `examples/openclaw-plugin/tests/ut/context-engine-modules.test.ts` asserting no estimator/digest/diag/routing/client work runs, and update the existing non-user-tail test in `examples/openclaw-plugin/tests/ut/context-engine-assemble.test.ts` to expect `estimatedTokens: 0`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Validation run from `examples/openclaw-plugin`:

- `npm test -- tests/ut/context-engine-modules.test.ts tests/ut/context-engine-assemble.test.ts` — 27/27 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- Full suite: 676/676 passed outside `tests/ut/architecture-boundaries.test.ts`; its 4 failures reproduce on `upstream/main` without this change and touch files not modified here.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- Scope is intentionally limited to #4415 item 4; item 5's `isMainAssemble` duck-typing is left untouched.
- No public contract changes: `AssembleResult.messages` keeps the same reference and `estimatedTokens` remains a number, now a zero sentinel for this no-op path.
