### PR TITLE
fix(fs): include uri in stat responses

### DIFF
--- a/openviking/server/routers/filesystem.py
+++ b/openviking/server/routers/filesystem.py
@@ -158,7 +158,7 @@ async def stat(
     uri = validate_request_viking_uri(resolve_path_variables(uri), _ctx)
     try:
         result = await service.fs.stat(uri, ctx=_ctx)
-        return Response(status="ok", result=result)
+        return Response(status="ok", result={**result, "uri": uri})
     except AGFSNotFoundError:
         raise NotFoundError(uri, "file")
     except AGFSClientError as e:

--- a/tests/api_test/filesystem/slow/test_fs_field_consistency.py
+++ b/tests/api_test/filesystem/slow/test_fs_field_consistency.py
@@ -124,15 +124,9 @@ class TestFsFieldConsistency:
             stat_resp = api_client.fs_stat(file_uri)
             assert stat_resp.status_code == 200
             result = stat_resp.json().get("result", {})
-            if "uri" in result:
-                assert result["uri"] == file_uri, (
-                    f"stat uri should match request, got {result['uri']} != {file_uri}"
-                )
-            elif "name" in result:
-                expected_name = file_uri.rstrip("/").split("/")[-1]
-                assert result["name"] == expected_name, (
-                    f"stat name should match file name, got {result['name']} != {expected_name}"
-                )
+            assert result.get("uri") == file_uri, (
+                f"stat uri should match request, got {result.get('uri')} != {file_uri}"
+            )
 
     def test_ls_simple_mode(self, api_client):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/server/test_filesystem_router.py
+++ b/tests/server/test_filesystem_router.py
@@ -4,8 +4,11 @@
 
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from fastapi import FastAPI
 
+from openviking.server.auth import get_request_context
 from openviking.server.identity import RequestContext, Role
 from openviking.server.routers import filesystem
 from openviking_cli.session.user_id import UserIdentifier
@@ -138,6 +141,48 @@ async def test_dev_root_http_mkdir_expands_home_alias_from_request_identity(
     assert seen["uri"] == "viking://user/alice/resources/notes"
     assert seen["ctx"].role == Role.ROOT
     assert seen["ctx"].account_id == "acct"
+    assert seen["ctx"].user.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_http_stat_returns_canonical_request_uri(monkeypatch):
+    seen = {}
+    request_context = RequestContext(
+        user=UserIdentifier("acct", "alice"), role=Role.USER
+    )
+
+    async def fake_stat(uri, ctx=None):
+        seen.update(uri=uri, ctx=ctx)
+        return {
+            "name": "notes.md",
+            "size": 12,
+            "mode": 0o644,
+            "modTime": "2026-08-28T00:00:00Z",
+            "isDir": False,
+            "isLocked": False,
+        }
+
+    monkeypatch.setattr(
+        filesystem,
+        "get_service",
+        lambda: SimpleNamespace(fs=SimpleNamespace(stat=fake_stat)),
+    )
+
+    app = FastAPI()
+    app.include_router(filesystem.router)
+    app.dependency_overrides[get_request_context] = lambda: request_context
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            "/api/v1/fs/stat",
+            params={"uri": "viking://~/resources/notes.md"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["result"]["uri"] == "viking://user/alice/resources/notes.md"
+    assert seen["uri"] == "viking://user/alice/resources/notes.md"
     assert seen["ctx"].user.user_id == "alice"
 
 


### PR DESCRIPTION
## Root Cause

`GET /api/v1/fs/stat` 直接透传 AGFS 的 stat 元数据。公开 API 文档从接口引入时就声明响应包含 `result.uri`，但底层 AGFS 元数据不提供该字段，因此企业版 API-key 用例和普通请求都会得到 200 响应但缺少 `uri`。

## Scope

- 在 HTTP router 层将校验、规范化后的请求 URI 写入 stat 响应。
- 新增真实 FastAPI 路由回归测试，覆盖 `viking://~` 按请求身份展开为 canonical URI。
- 收紧现有 API 一致性测试，不再用 `name` 字段兜底掩盖缺失的 `uri`。

## Verification

- PASS: focused `/api/v1/fs/stat` HTTP route regression test.
- PASS: `git diff --check`.
- PASS: Ruff checks for the three changed files.
- NOT RUN: live-server slow API test requires a running OpenViking deployment.
- ENVIRONMENT NOTE: broader server fixture setup cannot initialize locally because `ragfs_python` native binding is unavailable; an unrelated existing `attrs` mock test also fails against the current `And` filter representation.
