### PR TITLE
fix(web-studio): sanitize directory markdown previews

### DIFF
--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -194,4 +194,36 @@ describe('FilePreview Markdown links', () => {
     expect(screen.queryByRole('link', { name: 'Blob' })).toBeNull()
     expect(onNavigate).not.toHaveBeenCalled()
   })
+
+  it('sanitizes raw HTML and unsafe links in a directory overview', () => {
+    const onNavigate = vi.fn()
+    const { container } = renderPreview(
+      directory,
+      onNavigate,
+      [
+        '<script>window.__pwned = true</script>',
+        '<img src="x" onerror="alert(1)">',
+        '<a href="javascript:alert(1)">Raw unsafe link</a>',
+        '[Markdown unsafe link](javascript:alert(1))',
+      ].join('\n\n'),
+    )
+
+    const directoryArticle = Array.from(
+      container.querySelectorAll('article'),
+    ).find((article) => article.className.includes('rounded-md'))
+    expect(directoryArticle).toBeTruthy()
+    expect(directoryArticle?.textContent).not.toContain('window.__pwned = true')
+    expect(directoryArticle?.querySelector('script')).toBeNull()
+    const image = directoryArticle?.querySelector('img')
+    expect(image).toBeTruthy()
+    expect(image?.getAttribute('onerror')).toBeNull()
+
+    const links = Array.from(directoryArticle?.querySelectorAll('a') ?? [])
+    expect(links).toHaveLength(2)
+    expect(
+      links.every(
+        (link) => !/^javascript:/i.test(link.getAttribute('href') ?? ''),
+      ),
+    ).toBe(true)
+  })
 })

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import hljs from 'highlight.js/lib/core'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 import { X, Pencil, Save, XCircle, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -137,6 +137,14 @@ const DIRECTORY_LEVEL_META: Array<{
     title: 'Directory overview',
   },
 ]
+
+const directoryMarkdownSanitizeSchema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), 'viking'],
+  },
+}
 
 const JSONL_MESSAGE_PREVIEW_LIMIT = 720
 const LARGE_FILE_PREVIEW_BYTES = 2 * 1024 * 1024
@@ -1580,6 +1588,10 @@ export function FilePreview({
                         <article className="prose prose-sm max-w-none break-words rounded-md border bg-muted/20 p-3 dark:prose-invert dark:prose-pre:bg-muted-foreground/20">
                           <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
+                            rehypePlugins={[
+                              rehypeRaw,
+                              [rehypeSanitize, directoryMarkdownSanitizeSchema],
+                            ]}
                             urlTransform={transformDirectoryMarkdownUrl}
                             components={{
                               ...markdownComponents,


### PR DESCRIPTION
## Summary

- Sanitize raw HTML rendered in directory L0/L1 Markdown previews.
- Preserve trusted `viking://` internal links while filtering dangerous URL schemes.
- Strip scripts and inline event-handler attributes from directory descriptions and overviews.

## Issue

Closes #4291

## Tests

- Added regression coverage for `<script>`, `onerror`, raw unsafe links, and Markdown `javascript:` links.
- `npm test -- --run`: 56 test files, 215 tests passed.
- `npm run build`: passed.
- Changed-file ESLint and Prettier checks: passed.

Note: Full lint still reports 2 pre-existing errors in `src/routes/tasks/-lib/task-pipeline.ts`.