### PR TITLE
feat(session): add conflict-safe memory rollback

### DIFF
--- a/crates/ov_cli/src/commands/session.rs
+++ b/crates/ov_cli/src/commands/session.rs
@@ -296,6 +296,30 @@ pub async fn delete_session(
     Ok(())
 }
 
+pub async fn rollback_session(
+    client: &HttpClient,
+    session_id: &str,
+    dry_run: bool,
+    force: bool,
+    delete_session: bool,
+    output_format: OutputFormat,
+    compact: bool,
+) -> Result<()> {
+    let path = format!("/api/v1/sessions/{}/rollback", url_encode(session_id));
+    let body = rollback_session_body(dry_run, force, delete_session);
+    let response: serde_json::Value = client.post(&path, &body).await?;
+    output_success(&response, output_format, compact);
+    Ok(())
+}
+
+fn rollback_session_body(dry_run: bool, force: bool, delete_session: bool) -> serde_json::Value {
+    json!({
+        "dry_run": dry_run,
+        "force": force,
+        "delete_session": delete_session,
+    })
+}
+
 fn parse_messages(input: &str) -> Result<Vec<(String, String)>> {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(input) {
         if let Some(arr) = value.as_array() {
@@ -541,10 +565,18 @@ fn url_encode(s: &str) -> String {
 mod tests {
     use super::{
         create_session_body, event_tags_body, parse_messages, render_session_get_for_table,
-        session_config_body,
+        rollback_session_body, session_config_body,
     };
     use crate::error::Error;
     use serde_json::json;
+
+    #[test]
+    fn rollback_body_preserves_all_safety_options() {
+        assert_eq!(
+            rollback_session_body(true, true, false),
+            json!({"dry_run": true, "force": true, "delete_session": false})
+        );
+    }
 
     #[test]
     fn parse_messages_reports_invalid_array_item_as_command_error() {

--- a/crates/ov_cli/src/handlers.rs
+++ b/crates/ov_cli/src/handlers.rs
@@ -528,9 +528,49 @@ pub async fn handle_session(cmd: SessionCommands, ctx: CliContext) -> Result<()>
             )
             .await
         }
-        SessionCommands::Delete { session_id } => {
-            commands::session::delete_session(&client, &session_id, ctx.output_format, ctx.compact)
+        SessionCommands::Delete {
+            session_id,
+            rollback_memories,
+            dry_run,
+            force,
+        } => {
+            if rollback_memories {
+                commands::session::rollback_session(
+                    &client,
+                    &session_id,
+                    dry_run,
+                    force,
+                    true,
+                    ctx.output_format,
+                    ctx.compact,
+                )
                 .await
+            } else {
+                commands::session::delete_session(
+                    &client,
+                    &session_id,
+                    ctx.output_format,
+                    ctx.compact,
+                )
+                .await
+            }
+        }
+        SessionCommands::Rollback {
+            session_id,
+            dry_run,
+            force,
+            keep_session,
+        } => {
+            commands::session::rollback_session(
+                &client,
+                &session_id,
+                dry_run,
+                force,
+                !keep_session,
+                ctx.output_format,
+                ctx.compact,
+            )
+            .await
         }
         SessionCommands::AddMessage {
             session_id,

--- a/crates/ov_cli/src/main.rs
+++ b/crates/ov_cli/src/main.rs
@@ -1462,6 +1462,30 @@ enum SessionCommands {
         /// Session ID
         #[arg(value_name = "session-id")]
         session_id: String,
+        /// Reverse committed memory changes before deleting the session
+        #[arg(long = "rollback-memories")]
+        rollback_memories: bool,
+        /// Preview the rollback without changing memories or deleting the session
+        #[arg(long, requires = "rollback_memories")]
+        dry_run: bool,
+        /// Skip conflicting URIs instead of aborting the entire rollback
+        #[arg(long, requires = "rollback_memories")]
+        force: bool,
+    },
+    /// Reverse memory changes recorded by a session's commit archives
+    Rollback {
+        /// Session ID
+        #[arg(value_name = "session-id")]
+        session_id: String,
+        /// Preview changes without mutating storage
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip conflicting URIs instead of aborting the entire rollback
+        #[arg(long)]
+        force: bool,
+        /// Keep the session after a successful rollback
+        #[arg(long = "keep-session")]
+        keep_session: bool,
     },
     /// Add one message to a session
     AddMessage {
@@ -2632,6 +2656,7 @@ fn is_session_subcommand(token: &str) -> bool {
             | "get-session-context"
             | "get-session-archive"
             | "delete"
+            | "rollback"
             | "add-message"
             | "add-messages"
             | "commit"
@@ -3737,8 +3762,8 @@ async fn main() {
 mod tests {
     use super::{
         Cli, CliContext, Commands, ConfigAddTarget, ConfigCommands, LanguageGateAction,
-        ObserverCommands, PrivacyCommands, SkillCommands, SnapshotCmd, UploadCliOptions,
-        find_command_index, first_command_token, is_language_command_request,
+        ObserverCommands, PrivacyCommands, SessionCommands, SkillCommands, SnapshotCmd,
+        UploadCliOptions, find_command_index, first_command_token, is_language_command_request,
         language_command_can_run_picker, language_gate_action, language_required_message,
         legacy_upload_option_error, plain_help_misuse, pre_parse_output_options,
         pre_parse_requires_cli_config_file, preprocess_cli_args, preprocess_privacy_args,
@@ -3771,6 +3796,58 @@ mod tests {
         assert_eq!(cli.account.as_deref(), Some("acme"));
         assert_eq!(cli.user.as_deref(), Some("alice"));
         assert_eq!(cli.actor_peer_id.as_deref(), Some("peer-a"));
+    }
+
+    #[test]
+    fn cli_parses_session_rollback_safety_flags() {
+        let cli = Cli::try_parse_from([
+            "ov",
+            "session",
+            "rollback",
+            "session-1",
+            "--dry-run",
+            "--force",
+            "--keep-session",
+        ])
+        .expect("session rollback should parse");
+
+        match cli.command {
+            Commands::Session {
+                action:
+                    SessionCommands::Rollback {
+                        session_id,
+                        dry_run,
+                        force,
+                        keep_session,
+                    },
+            } => {
+                assert_eq!(session_id, "session-1");
+                assert!(dry_run);
+                assert!(force);
+                assert!(keep_session);
+            }
+            _ => panic!("expected session rollback command"),
+        }
+    }
+
+    #[test]
+    fn session_delete_safety_flags_require_rollback_memories() {
+        assert!(
+            Cli::try_parse_from(["ov", "session", "delete", "session-1", "--dry-run"]).is_err()
+        );
+        assert!(Cli::try_parse_from(["ov", "session", "delete", "session-1", "--force"]).is_err());
+        assert!(
+            Cli::try_parse_from([
+                "ov",
+                "session",
+                "delete",
+                "session-1",
+                "--rollback-memories",
+                "--dry-run",
+                "--force",
+            ])
+            .is_ok()
+        );
     }
 
     #[test]
@@ -4260,6 +4337,7 @@ mod tests {
             &["ov", "session", "get-session-context"],
             &["ov", "session", "get-session-archive"],
             &["ov", "session", "delete"],
+            &["ov", "session", "rollback"],
             &["ov", "session", "add-message"],
             &["ov", "session", "add-messages"],
             &["ov", "session", "commit"],

--- a/docs/en/api/05-sessions.md
+++ b/docs/en/api/05-sessions.md
@@ -1666,6 +1666,51 @@ When long-term memory extraction runs successfully, the commit writes a `memory_
 
 An empty `memory_diff.json` (all counts zero) is written when long-term memory extraction runs but produces no applied or intentionally skipped operations.
 
+Starting with schema version 2, each operation also records a complete raw snapshot
+(`after_raw`, `before_raw`, or `deleted_raw`) and `operation_order`. These fields retain
+the `MEMORY_FIELDS` metadata needed for an exact, conflict-safe rollback. Older audit
+files without raw snapshots remain readable, but rollback reports them as conflicts
+instead of guessing how to reconstruct metadata.
+
+## Roll Back Session Memory Changes
+
+`POST /api/v1/sessions/{session_id}/rollback` reverses all memory changes recorded by
+the Session's commit archives, newest archive and newest operation first. By default,
+the Session is deleted only after every safe inverse operation succeeds.
+
+```bash
+# Always preview first
+ov session rollback a1b2c3d4 --dry-run
+
+# Apply the rollback and delete the Session
+ov session rollback a1b2c3d4
+
+# Keep the Session after applying the rollback
+ov session rollback a1b2c3d4 --keep-session
+
+# Equivalent delete workflow
+ov session delete a1b2c3d4 --rollback-memories --dry-run
+```
+
+```bash
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/rollback \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"dry_run":true,"force":false,"delete_session":true}'
+```
+
+| Request field | Default | Description |
+|---|---:|---|
+| `dry_run` | `false` | Return the inverse plan without changing storage or deleting the Session |
+| `force` | `false` | Skip conflicting URIs and their older dependent operations; never overwrite them |
+| `delete_session` | `true` | Delete the Session after a successful non-dry-run rollback |
+
+A conflict is returned as HTTP `409` when current memory no longer matches the audited
+post-commit state. No memory changes are applied in that case. With `force=true`, the
+conflicting URI is skipped and the response status is `partial`. Filesystem writes are
+compensated if an operation fails; vector-index and overview refresh runs after the
+filesystem transaction.
+
 <a id="built-in-memory-types"></a>
 
 ## Full Example

--- a/docs/zh/api/05-sessions.md
+++ b/docs/zh/api/05-sessions.md
@@ -1636,6 +1636,47 @@ viking://user/{user_id}/sessions/{session_id}/
 
 如果长记忆抽取已运行但没有产生实际变更或策略性跳过，也会写入空结构的 `memory_diff.json`（所有计数为零）。
 
+从 schema version 2 开始，每条操作还会记录完整原始快照（`after_raw`、
+`before_raw` 或 `deleted_raw`）以及 `operation_order`。这些字段会保留精确回滚所需的
+`MEMORY_FIELDS` 元数据。缺少原始快照的旧审计文件仍可读取，但回滚会将其报告为冲突，
+不会猜测并重建可能不完整的元数据。
+
+## 回滚会话造成的记忆变更
+
+`POST /api/v1/sessions/{session_id}/rollback` 会按“最新归档、最新操作优先”的顺序，
+反向执行该会话所有 commit 审计的记忆变更。默认仅在所有安全反向操作成功后删除会话。
+
+```bash
+# 建议始终先预演
+ov session rollback a1b2c3d4 --dry-run
+
+# 执行回滚并删除会话
+ov session rollback a1b2c3d4
+
+# 执行回滚但保留会话
+ov session rollback a1b2c3d4 --keep-session
+
+# 等价的删除工作流
+ov session delete a1b2c3d4 --rollback-memories --dry-run
+```
+
+```bash
+curl -X POST http://localhost:1933/api/v1/sessions/a1b2c3d4/rollback \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-key" \
+  -d '{"dry_run":true,"force":false,"delete_session":true}'
+```
+
+| 请求字段 | 默认值 | 说明 |
+|---|---:|---|
+| `dry_run` | `false` | 只返回反向操作计划，不修改存储，也不删除会话 |
+| `force` | `false` | 跳过冲突 URI 及其依赖的更早操作；不会强制覆盖冲突文件 |
+| `delete_session` | `true` | 非预演回滚成功后删除会话 |
+
+如果当前记忆与审计记录的提交后状态不一致，默认返回 HTTP `409`，且不会应用任何记忆
+修改。使用 `force=true` 时会跳过冲突 URI，响应状态为 `partial`。单个文件系统操作失败
+时会补偿恢复事务前状态；文件系统事务完成后再刷新向量索引与 overview。
+
 <a id="内置记忆类型"></a>
 
 ## 完整示例

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -548,6 +548,39 @@ async def get_session_archive(
     return Response(status="ok", result=_to_jsonable(result))
 
 
+class RollbackSessionRequest(BaseModel):
+    """Options for reversing memory changes recorded by a Session."""
+
+    dry_run: bool = False
+    force: bool = False
+    delete_session: bool = True
+    telemetry: Optional[TelemetryRequest] = None
+
+
+@router.post("/{session_id}/rollback")
+async def rollback_session_memories(
+    session_id: str = Path(..., description="Session ID"),
+    request: RollbackSessionRequest = Body(default_factory=RollbackSessionRequest),
+    _ctx: RequestContext = Depends(get_session_request_context),
+):
+    """Reverse committed memory changes, optionally deleting the Session afterward."""
+    service = get_service()
+    execution = await run_operation(
+        operation="session.rollback",
+        telemetry=request.telemetry,
+        fn=lambda: service.sessions.rollback_memories(
+            session_id,
+            _ctx,
+            dry_run=request.dry_run,
+            force=request.force,
+            delete_session=request.delete_session,
+        ),
+    )
+    return Response(status="ok", result=execution.result, telemetry=execution.telemetry).model_dump(
+        exclude_none=True
+    )
+
+
 @router.delete("/{session_id}")
 async def delete_session(
     session_id: str = Path(..., description="Session ID"),

--- a/openviking/service/session_memory_rollback.py
+++ b/openviking/service/session_memory_rollback.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Conflict-safe reversal of memory changes recorded by Session commits."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from openviking.core.namespace import canonical_session_uri, classify_uri, is_accessible
+from openviking.server.identity import RequestContext
+from openviking.service.task_tracker import get_task_tracker
+from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
+from openviking.session.memory.memory_updater import MemoryUpdater
+from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
+from openviking.storage.viking_fs import VikingFS
+from openviking_cli.exceptions import (
+    ConflictError,
+    FailedPreconditionError,
+    InvalidArgumentError,
+    NotFoundError,
+)
+from openviking_cli.utils import get_logger
+
+logger = get_logger(__name__)
+
+_LOCK_TIMEOUT_SECONDS = 10.0
+
+
+class SessionRollbackConflictError(ConflictError):
+    """A rollback cannot safely proceed without skipping conflicting changes."""
+
+    def __init__(self, session_id: str, result: dict[str, Any]):
+        super().__init__(
+            f"Session '{session_id}' memory rollback has conflicts; rerun with force=true "
+            "to skip conflicting URIs",
+            resource=session_id,
+        )
+        self.details["rollback"] = result
+
+
+@dataclass(frozen=True)
+class _State:
+    exists: bool
+    raw: str = ""
+
+
+def _missing() -> _State:
+    return _State(False, "")
+
+
+def _present(raw: str) -> _State:
+    return _State(True, raw)
+
+
+def _state_matches(actual: _State, expected: _State) -> bool:
+    if actual.exists != expected.exists:
+        return False
+    if not actual.exists:
+        return True
+    return _canonical_memory_raw(actual.raw) == _canonical_memory_raw(expected.raw)
+
+
+def _canonical_memory_raw(raw: str) -> str:
+    """Ignore harmless serializer differences while retaining all persisted fields."""
+    try:
+        return MemoryFileUtils.write(MemoryFileUtils.read(raw), render_links=False)
+    except Exception:
+        return raw
+
+
+def _ordered_operations(diff: dict[str, Any]) -> list[dict[str, Any]]:
+    ordered = diff.get("operation_order")
+    if isinstance(ordered, list):
+        return [item for item in ordered if isinstance(item, dict)]
+
+    operations = diff.get("operations")
+    if not isinstance(operations, dict):
+        return []
+    return [
+        *[{"kind": "add", **item} for item in operations.get("adds", []) if isinstance(item, dict)],
+        *[
+            {"kind": "update", **item}
+            for item in operations.get("updates", [])
+            if isinstance(item, dict)
+        ],
+        *[
+            {"kind": "delete", **item}
+            for item in operations.get("deletes", [])
+            if isinstance(item, dict)
+        ],
+    ]
+
+
+def _validate_diff_structure(diff: dict[str, Any]) -> None:
+    operations = diff.get("operations")
+    if not isinstance(operations, dict):
+        raise ValueError("operations must be an object")
+
+    grouped: list[tuple[str, dict[str, Any]]] = []
+    for group, kind in (("adds", "add"), ("updates", "update"), ("deletes", "delete")):
+        values = operations.get(group)
+        if not isinstance(values, list) or any(not isinstance(item, dict) for item in values):
+            raise ValueError(f"operations.{group} must be an array of objects")
+        grouped.extend((kind, item) for item in values)
+
+    ordered = diff.get("operation_order")
+    if ordered is None:
+        if int(diff.get("schema_version") or 1) >= 2 and grouped:
+            raise ValueError("schema version 2 requires operation_order")
+        return
+    if not isinstance(ordered, list) or any(not isinstance(item, dict) for item in ordered):
+        raise ValueError("operation_order must be an array of objects")
+
+    grouped_keys = Counter((kind, str(item.get("uri") or "")) for kind, item in grouped)
+    ordered_keys = Counter(
+        (str(item.get("kind") or ""), str(item.get("uri") or "")) for item in ordered
+    )
+    if grouped_keys != ordered_keys:
+        raise ValueError("operation_order does not match grouped operations")
+
+
+def _inverse_states(operation: dict[str, Any]) -> tuple[_State, _State, str] | None:
+    kind = operation.get("kind")
+    if kind == "add" and isinstance(operation.get("after_raw"), str):
+        return _present(operation["after_raw"]), _missing(), "delete"
+    if (
+        kind == "update"
+        and isinstance(operation.get("after_raw"), str)
+        and isinstance(operation.get("before_raw"), str)
+    ):
+        return _present(operation["after_raw"]), _present(operation["before_raw"]), "write"
+    if kind == "delete" and isinstance(operation.get("deleted_raw"), str):
+        return _missing(), _present(operation["deleted_raw"]), "write"
+    return None
+
+
+def _is_memory_file_uri(uri: str, ctx: RequestContext) -> bool:
+    try:
+        classification = classify_uri(uri)
+    except (TypeError, ValueError):
+        return False
+    return (
+        is_accessible(uri, ctx)
+        and classification.is_memory
+        and classification.content_index is not None
+        and len(classification.parts) > classification.content_index + 1
+        and not uri.endswith("/.overview.md")
+        and not uri.endswith("/.abstract.md")
+    )
+
+
+def _operation_conflict(
+    *,
+    archive_id: str,
+    operation: dict[str, Any],
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "archive_id": archive_id,
+        "kind": str(operation.get("kind") or "unknown"),
+        "uri": str(operation.get("uri") or ""),
+        "action": "none",
+        "status": "conflict",
+        "reason": reason,
+    }
+
+
+def build_rollback_plan(
+    archive_diffs: Iterable[tuple[str, dict[str, Any]]],
+    current_states: dict[str, _State],
+    *,
+    force: bool,
+) -> dict[str, Any]:
+    """Build an inverse plan, simulating changes newest-to-oldest without mutating storage."""
+    virtual = dict(current_states)
+    items: list[dict[str, Any]] = []
+    blocked_uris: set[str] = set()
+
+    for archive_id, diff in archive_diffs:
+        for operation in reversed(_ordered_operations(diff)):
+            uri = str(operation.get("uri") or "")
+            if not uri:
+                items.append(
+                    _operation_conflict(
+                        archive_id=archive_id,
+                        operation=operation,
+                        reason="invalid_uri",
+                    )
+                )
+                continue
+            if uri in blocked_uris:
+                item = _operation_conflict(
+                    archive_id=archive_id,
+                    operation=operation,
+                    reason="blocked_by_newer_conflict",
+                )
+                item["status"] = "skipped" if force else "conflict"
+                items.append(item)
+                continue
+
+            inverse = _inverse_states(operation)
+            if inverse is None:
+                blocked_uris.add(uri)
+                item = _operation_conflict(
+                    archive_id=archive_id,
+                    operation=operation,
+                    reason="legacy_snapshot_incomplete",
+                )
+                item["status"] = "skipped" if force else "conflict"
+                items.append(item)
+                continue
+
+            expected, resulting, action = inverse
+            actual = virtual.get(uri, _missing())
+            if not _state_matches(actual, expected):
+                blocked_uris.add(uri)
+                item = _operation_conflict(
+                    archive_id=archive_id,
+                    operation=operation,
+                    reason="current_content_changed",
+                )
+                item["status"] = "skipped" if force else "conflict"
+                items.append(item)
+                continue
+
+            items.append(
+                {
+                    "archive_id": archive_id,
+                    "kind": operation["kind"],
+                    "memory_type": str(operation.get("memory_type") or "unknown"),
+                    "uri": uri,
+                    "action": action,
+                    "status": "planned",
+                    "content": resulting.raw if resulting.exists else None,
+                }
+            )
+            virtual[uri] = resulting
+
+    conflicts = sum(item["status"] == "conflict" for item in items)
+    skipped = sum(item["status"] == "skipped" for item in items)
+    planned = sum(item["status"] == "planned" for item in items)
+    return {
+        "operations": items,
+        "summary": {"planned": planned, "conflicts": conflicts, "skipped": skipped},
+    }
+
+
+class SessionMemoryRollback:
+    """Plan and execute one Session's memory rollback under storage path locks."""
+
+    def __init__(self, *, viking_fs: VikingFS, vikingdb: Any = None):
+        self._viking_fs = viking_fs
+        self._memory_updater = MemoryUpdater(
+            registry=MemoryTypeRegistry(),
+            vikingdb=vikingdb,
+        )
+
+    async def run(
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        dry_run: bool,
+        force: bool,
+        delete_session: bool,
+    ) -> dict[str, Any]:
+        session_uri = canonical_session_uri(ctx, session_id)
+        session_path = self._viking_fs._uri_to_path(session_uri, ctx=ctx)
+        session_lease = await self._viking_fs._async_agfs.pathlock_acquire_tree(
+            session_path,
+            timeout_secs=_LOCK_TIMEOUT_SECONDS,
+        )
+        try:
+            # Close the service-layer check/acquire race. A commit that starts
+            # after this check cannot finish Phase 1 while the tree lock is held.
+            if await get_task_tracker().has_running(
+                "session_commit",
+                session_id,
+                account_id=ctx.account_id,
+                user_id=ctx.user.user_id,
+            ):
+                raise FailedPreconditionError(
+                    f"Session '{session_id}' has a commit in progress",
+                    details={"session_id": session_id, "reason": "commit_in_progress"},
+                )
+            archive_diffs = await self._load_archive_diffs(session_uri, ctx)
+            uris = self._validate_and_collect_uris(archive_diffs, ctx)
+            memory_lease = None
+            if uris:
+                paths = sorted(self._viking_fs._uri_to_path(uri, ctx=ctx) for uri in uris)
+                memory_lease = await self._viking_fs._async_agfs.pathlock_acquire_exact_batch(
+                    paths,
+                    timeout_secs=_LOCK_TIMEOUT_SECONDS,
+                    owner_lease_ref=session_lease,
+                )
+            try:
+                current_states = await self._read_current_states(uris, ctx)
+                plan = build_rollback_plan(archive_diffs, current_states, force=force)
+                result = self._result(
+                    session_id=session_id,
+                    archive_count=len(archive_diffs),
+                    plan=plan,
+                    dry_run=dry_run,
+                    force=force,
+                    delete_session=delete_session,
+                )
+                if plan["summary"]["conflicts"]:
+                    raise SessionRollbackConflictError(session_id, result)
+                if dry_run:
+                    return result
+
+                original_states = dict(current_states)
+                try:
+                    await self._apply(plan["operations"], ctx, memory_lease)
+                    if delete_session:
+                        await self._viking_fs.rm(
+                            session_uri,
+                            recursive=True,
+                            ctx=ctx,
+                            lease_ref=session_lease,
+                        )
+                except BaseException:
+                    await self._restore_original_states(original_states, ctx, memory_lease)
+                    raise
+
+                for item in plan["operations"]:
+                    if item["status"] == "planned":
+                        item["status"] = "applied"
+                for public_item, planned_item in zip(
+                    result["operations"], plan["operations"], strict=True
+                ):
+                    public_item["status"] = planned_item["status"]
+                result["status"] = "partial" if plan["summary"]["skipped"] else "completed"
+                result["summary"]["applied"] = plan["summary"]["planned"]
+                result["session_deleted"] = delete_session
+            finally:
+                if memory_lease is not None:
+                    await self._viking_fs._async_agfs.pathlock_release(memory_lease)
+        finally:
+            await self._viking_fs._async_agfs.pathlock_release(session_lease)
+
+        result["refresh"] = await self._refresh(result["operations"], ctx)
+        logger.info(
+            "Rolled back session memories: session_id=%s status=%s summary=%s",
+            session_id,
+            result["status"],
+            result["summary"],
+        )
+        return result
+
+    async def _load_archive_diffs(
+        self, session_uri: str, ctx: RequestContext
+    ) -> list[tuple[str, dict[str, Any]]]:
+        history_uri = f"{session_uri}/history"
+        try:
+            entries = await self._viking_fs.ls(history_uri, ctx=ctx)
+        except NotFoundError:
+            return []
+
+        archives: list[tuple[int, str, dict[str, Any]]] = []
+        for entry in entries:
+            name = entry.get("name") if isinstance(entry, dict) else str(entry)
+            if not name or not name.startswith("archive_"):
+                continue
+            try:
+                index = int(name.removeprefix("archive_"))
+            except ValueError:
+                continue
+            diff_uri = f"{history_uri}/{name}/memory_diff.json"
+            try:
+                raw = await self._viking_fs.read_file(diff_uri, ctx=ctx)
+                diff = json.loads(raw)
+            except NotFoundError as exc:
+                raise FailedPreconditionError(
+                    f"Archive '{name}' has no memory_diff.json; rollback safety cannot be proven",
+                    details={"archive_id": name, "reason": "memory_diff_missing"},
+                ) from exc
+            except (TypeError, ValueError) as exc:
+                raise FailedPreconditionError(
+                    f"Archive '{name}' has an invalid memory_diff.json",
+                    details={"archive_id": name, "reason": "memory_diff_invalid"},
+                ) from exc
+            if not isinstance(diff, dict):
+                raise FailedPreconditionError(
+                    f"Archive '{name}' has an invalid memory_diff.json",
+                    details={"archive_id": name, "reason": "memory_diff_invalid"},
+                )
+            try:
+                _validate_diff_structure(diff)
+            except (TypeError, ValueError) as exc:
+                raise FailedPreconditionError(
+                    f"Archive '{name}' has an inconsistent memory_diff.json",
+                    details={"archive_id": name, "reason": "memory_diff_inconsistent"},
+                ) from exc
+            archives.append((index, name, diff))
+        archives.sort(key=lambda item: item[0], reverse=True)
+        return [(name, diff) for _, name, diff in archives]
+
+    @staticmethod
+    def _validate_and_collect_uris(
+        archive_diffs: Iterable[tuple[str, dict[str, Any]]], ctx: RequestContext
+    ) -> set[str]:
+        uris: set[str] = set()
+        for archive_id, diff in archive_diffs:
+            for operation in _ordered_operations(diff):
+                uri = operation.get("uri")
+                if not isinstance(uri, str) or not _is_memory_file_uri(uri, ctx):
+                    raise InvalidArgumentError(
+                        "memory_diff.json contains a URI outside the caller's memory namespace",
+                        details={"archive_id": archive_id, "uri": uri},
+                    )
+                uris.add(uri)
+        return uris
+
+    async def _read_current_states(
+        self, uris: Iterable[str], ctx: RequestContext
+    ) -> dict[str, _State]:
+        states: dict[str, _State] = {}
+        for uri in uris:
+            try:
+                states[uri] = _present(await self._viking_fs.read_file(uri, ctx=ctx))
+            except NotFoundError:
+                states[uri] = _missing()
+        return states
+
+    async def _apply(
+        self, operations: list[dict[str, Any]], ctx: RequestContext, lease_ref: Any
+    ) -> None:
+        for item in operations:
+            if item["status"] != "planned":
+                continue
+            if item["action"] == "delete":
+                await self._viking_fs.rm(item["uri"], recursive=False, ctx=ctx, lease_ref=lease_ref)
+            else:
+                await self._viking_fs.write_file(
+                    item["uri"], item["content"], ctx=ctx, lease_ref=lease_ref
+                )
+
+    async def _restore_original_states(
+        self, states: dict[str, _State], ctx: RequestContext, lease_ref: Any
+    ) -> None:
+        for uri, state in states.items():
+            try:
+                if state.exists:
+                    await self._viking_fs.write_file(uri, state.raw, ctx=ctx, lease_ref=lease_ref)
+                else:
+                    await self._viking_fs.rm(uri, recursive=False, ctx=ctx, lease_ref=lease_ref)
+            except Exception:
+                logger.exception("Failed to compensate Session memory rollback for %s", uri)
+
+    async def _refresh(
+        self, operations: list[dict[str, Any]], ctx: RequestContext
+    ) -> dict[str, Any]:
+        applied = [item for item in operations if item["status"] == "applied"]
+        restored = [item for item in applied if item["action"] == "write"]
+        deleted = [item for item in applied if item["action"] == "delete"]
+        return await self._memory_updater.refresh_after_rollback(
+            restored_uris=[item["uri"] for item in restored],
+            deleted_uris=[item["uri"] for item in deleted],
+            uri_memory_type_map={item["uri"]: item["memory_type"] for item in applied},
+            ctx=ctx,
+        )
+
+    @staticmethod
+    def _result(
+        *,
+        session_id: str,
+        archive_count: int,
+        plan: dict[str, Any],
+        dry_run: bool,
+        force: bool,
+        delete_session: bool,
+    ) -> dict[str, Any]:
+        public_operations = []
+        for item in plan["operations"]:
+            public_operations.append(
+                {key: value for key, value in item.items() if key != "content"}
+            )
+        return {
+            "session_id": session_id,
+            "status": "ready" if dry_run else "planned",
+            "dry_run": dry_run,
+            "force": force,
+            "delete_session": delete_session,
+            "session_deleted": False,
+            "archives_scanned": archive_count,
+            "operations": public_operations,
+            "summary": {**plan["summary"], "applied": 0},
+            "planned_at": datetime.now(timezone.utc).isoformat(),
+        }

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -27,6 +27,7 @@ from openviking.service.session_auto_commit import (
     has_uncommitted_content,
     is_next_check_due,
 )
+from openviking.service.session_memory_rollback import SessionMemoryRollback
 from openviking.service.task_tracker import get_task_tracker
 from openviking.session import Session
 from openviking.session.auto_commit_policy import AutoCommitPolicy
@@ -38,6 +39,7 @@ from openviking.utils.tags import normalize_search_tags
 from openviking.utils.time_utils import parse_iso_datetime
 from openviking_cli.exceptions import (
     AlreadyExistsError,
+    FailedPreconditionError,
     NotFoundError,
     NotInitializedError,
 )
@@ -361,6 +363,49 @@ class SessionService:
         logger.info(f"Deleted session: {session_id}")
         self._record_lifecycle_metric("delete", "ok")
         return True
+
+    async def rollback_memories(
+        self,
+        session_id: str,
+        ctx: RequestContext,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+        delete_session: bool = True,
+    ) -> Dict[str, Any]:
+        """Reverse memory changes recorded by a Session's commit archives."""
+        self._ensure_initialized()
+        await self.get(session_id, ctx, auto_create=False)
+        if await get_task_tracker().has_running(
+            "session_commit",
+            session_id,
+            account_id=ctx.account_id,
+            user_id=ctx.user.user_id,
+        ):
+            raise FailedPreconditionError(
+                f"Session '{session_id}' has a commit in progress",
+                details={"session_id": session_id, "reason": "commit_in_progress"},
+            )
+
+        self._record_lifecycle_metric("rollback", "attempt")
+        try:
+            result = await SessionMemoryRollback(
+                viking_fs=self._viking_fs,
+                vikingdb=self._vikingdb,
+            ).run(
+                session_id,
+                ctx,
+                dry_run=dry_run,
+                force=force,
+                delete_session=delete_session,
+            )
+            self._record_lifecycle_metric("rollback", "ok")
+            if delete_session and not dry_run:
+                self._record_lifecycle_metric("delete", "ok")
+            return result
+        except Exception:
+            self._record_lifecycle_metric("rollback", "error")
+            raise
 
     async def commit(
         self,

--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -318,11 +318,20 @@ class SessionCompressorV3:
                         "uri": uri,
                         "memory_type": memory_type,
                         "before": old_file.content,
+                        "before_raw": MemoryFileUtils.write(old_file, render_links=False),
                         "after": "",
+                        "after_raw": None,
                     }
                 )
             else:
-                adds.append({"uri": uri, "memory_type": memory_type, "after": ""})
+                adds.append(
+                    {
+                        "uri": uri,
+                        "memory_type": memory_type,
+                        "after": "",
+                        "after_raw": None,
+                    }
+                )
 
         for uri in result.edited_uris:
             op = upsert_by_uri.get(uri)
@@ -335,7 +344,11 @@ class SessionCompressorV3:
                     "uri": uri,
                     "memory_type": memory_type,
                     "before": old_file.content if old_file else "",
+                    "before_raw": (
+                        MemoryFileUtils.write(old_file, render_links=False) if old_file else None
+                    ),
                     "after": "",
+                    "after_raw": None,
                 }
             )
 
@@ -346,6 +359,9 @@ class SessionCompressorV3:
                     "uri": uri,
                     "memory_type": (deleted.memory_type if deleted else None) or "unknown",
                     "deleted_content": deleted.content if deleted else "",
+                    "deleted_raw": (
+                        MemoryFileUtils.write(deleted, render_links=False) if deleted else None
+                    ),
                 }
             )
 
@@ -359,6 +375,7 @@ class SessionCompressorV3:
             try:
                 content = await viking_fs.read_file(uri=item["uri"], ctx=ctx)
                 item["after"] = MemoryFileUtils.read(content).content
+                item["after_raw"] = content
             except Exception:
                 pass
 
@@ -371,6 +388,7 @@ class SessionCompressorV3:
                 content = await viking_fs.read_file(uri=item["uri"], ctx=ctx)
                 new_file = MemoryFileUtils.read(content, uri=item["uri"])
                 item["after"] = new_file.content
+                item["after_raw"] = content
             except Exception:
                 pass
             if old_file is not None and _same_memory_file(old_file, new_file):
@@ -1143,11 +1161,18 @@ class SessionCompressorV3:
                 if not uri or uri in seen_trajectory_uris:
                     continue
                 seen_trajectory_uris.add(uri)
+                after, after_raw = await _read_memory_content_snapshot(
+                    viking_fs,
+                    uri=uri,
+                    ctx=ctx,
+                    fallback=trajectory.content,
+                )
                 adds.append(
                     {
                         "uri": uri,
                         "memory_type": "trajectories",
-                        "after": trajectory.content,
+                        "after": after,
+                        "after_raw": after_raw,
                     }
                 )
 
@@ -1178,20 +1203,29 @@ class SessionCompressorV3:
                             "uri": uri,
                             "memory_type": "experiences",
                             "deleted_content": item.before_content or "",
+                            "deleted_raw": item.metadata.get("rollback_before_raw"),
                         }
                     )
                 continue
             if item.kind != "upsert" or uri not in applied_uris:
                 continue
-            after = await _read_plain_memory_content(
+            after, after_raw = await _read_memory_content_snapshot(
                 viking_fs,
                 uri=uri,
                 ctx=ctx,
                 fallback=item.after_content or "",
             )
             before = item.before_content
+            before_raw = item.metadata.get("rollback_before_raw")
             if before is None:
-                adds.append({"uri": uri, "memory_type": "experiences", "after": after})
+                adds.append(
+                    {
+                        "uri": uri,
+                        "memory_type": "experiences",
+                        "after": after,
+                        "after_raw": after_raw,
+                    }
+                )
             else:
                 # Filter no-op experience updates the same way as user-memory
                 # updates: a patch that re-serializes to identical content should
@@ -1209,7 +1243,9 @@ class SessionCompressorV3:
                         "uri": uri,
                         "memory_type": "experiences",
                         "before": before,
+                        "before_raw": before_raw,
                         "after": after,
+                        "after_raw": after_raw,
                     }
                 )
 
@@ -2146,7 +2182,13 @@ def _make_memory_diff(
     skipped_operations: Optional[list[dict[str, Any]]] = None,
 ) -> dict[str, Any]:
     skipped = list(skipped_operations or [])
+    operation_order = [
+        *[{"kind": "add", **item} for item in adds],
+        *[{"kind": "update", **item} for item in updates],
+        *[{"kind": "delete", **item} for item in deletes],
+    ]
     return {
+        "schema_version": 2,
         "archive_uri": archive_uri,
         "trace_id": tracer.get_trace_id() or None,
         "extracted_at": datetime.utcnow().isoformat() + "Z",
@@ -2156,6 +2198,10 @@ def _make_memory_diff(
             "deletes": list(deletes),
         },
         "skipped_operations": skipped,
+        # Preserve execution order so consumers can invert multiple changes to
+        # the same URI deterministically. The grouped operations above remain
+        # for backward compatibility with existing audit readers.
+        "operation_order": operation_order,
         "summary": {
             "total_adds": len(adds),
             "total_updates": len(updates),
@@ -2174,6 +2220,7 @@ def _merge_memory_diffs(
     updates: list[dict[str, Any]] = []
     deletes: list[dict[str, Any]] = []
     skipped_operations: list[dict[str, Any]] = []
+    operation_order: list[dict[str, Any]] = []
     trace_id = tracer.get_trace_id() or None
     for diff in diffs:
         if not isinstance(diff, dict):
@@ -2189,6 +2236,29 @@ def _merge_memory_diffs(
         adds.extend([item for item in operations.get("adds", []) if isinstance(item, dict)])
         updates.extend([item for item in operations.get("updates", []) if isinstance(item, dict)])
         deletes.extend([item for item in operations.get("deletes", []) if isinstance(item, dict)])
+        ordered = diff.get("operation_order")
+        if isinstance(ordered, list):
+            operation_order.extend(item for item in ordered if isinstance(item, dict))
+        else:
+            operation_order.extend(
+                [
+                    *[
+                        {"kind": "add", **item}
+                        for item in operations.get("adds", [])
+                        if isinstance(item, dict)
+                    ],
+                    *[
+                        {"kind": "update", **item}
+                        for item in operations.get("updates", [])
+                        if isinstance(item, dict)
+                    ],
+                    *[
+                        {"kind": "delete", **item}
+                        for item in operations.get("deletes", [])
+                        if isinstance(item, dict)
+                    ],
+                ]
+            )
     merged = _make_memory_diff(
         archive_uri=archive_uri,
         adds=adds,
@@ -2197,6 +2267,7 @@ def _merge_memory_diffs(
         skipped_operations=skipped_operations,
     )
     merged["trace_id"] = trace_id
+    merged["operation_order"] = operation_order
     return merged
 
 
@@ -2212,18 +2283,18 @@ def _memory_diff_has_changes(diff: Any) -> bool:
     )
 
 
-async def _read_plain_memory_content(
+async def _read_memory_content_snapshot(
     viking_fs: Any,
     *,
     uri: str,
     ctx: RequestContext,
     fallback: str,
-) -> str:
+) -> tuple[str, str | None]:
     try:
         raw = await viking_fs.read_file(uri, ctx=ctx)
-        return MemoryFileUtils.read(raw, uri=uri).content
+        return MemoryFileUtils.read(raw, uri=uri).content, raw
     except Exception:
-        return fallback
+        return fallback, None
 
 
 def _experience_plan_item_uri(item: PolicyPlanItem, root_uri: str) -> str:

--- a/openviking/session/memory/memory_updater.py
+++ b/openviking/session/memory/memory_updater.py
@@ -1516,6 +1516,50 @@ class MemoryUpdater:
                 tracer.error(f"Failed to vectorize memory {uri}: {e}")
         return attempted_count
 
+    async def refresh_after_rollback(
+        self,
+        *,
+        restored_uris: List[str],
+        deleted_uris: List[str],
+        uri_memory_type_map: Dict[str, str],
+        ctx: RequestContext,
+    ) -> Dict[str, Any]:
+        """Refresh vector records and directory overviews after raw snapshot restoration."""
+        result = MemoryUpdateResult()
+        for uri in dict.fromkeys(restored_uris):
+            result.add_edited(uri)
+        for uri in dict.fromkeys(deleted_uris):
+            result.add_deleted(uri)
+
+        vectorized = await self._vectorize_memories(
+            result,
+            ctx,
+            uri_memory_type_map=uri_memory_type_map,
+        )
+        overview_directories: Dict[str, str] = {}
+        for uri in dict.fromkeys(restored_uris + deleted_uris):
+            directory = uri.rsplit("/", 1)[0]
+            memory_type = (
+                uri_memory_type_map.get(uri) or self.memory_type_from_uri(uri) or "unknown"
+            )
+            overview_directories[directory] = memory_type
+
+        regenerated = 0
+        errors: List[Dict[str, str]] = []
+        for directory, memory_type in overview_directories.items():
+            try:
+                if await self.generate_overview(memory_type, directory, ctx):
+                    regenerated += 1
+            except Exception as exc:
+                errors.append({"directory": directory, "error": str(exc)})
+                logger.exception("Failed to refresh overview after rollback: %s", directory)
+
+        return {
+            "vectorization_enqueued": vectorized,
+            "overviews_regenerated": regenerated,
+            "errors": errors,
+        }
+
     @staticmethod
     def _truncate_memory_abstract(abstract: str) -> str:
         """Cap memory vector-store abstract fields below backend byte limits."""

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -18,6 +18,7 @@ from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
 )
+from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.train.domain import (
     Policy,
     PolicyPlanItem,
@@ -415,10 +416,10 @@ def _operations_to_plan_items(
         )
         target_uri = first_uri(getattr(op, "uris", []) or [])
         old_file = getattr(op, "old_memory_file_content", None)
+        existing_policy = _find_policy_by_uri(policy_set, target_uri) if target_uri else None
         before_content = old_file.plain_content() if old_file is not None else None
-        if before_content is None and target_uri:
-            policy = _find_policy_by_uri(policy_set, target_uri)
-            before_content = policy.content if policy is not None else None
+        if before_content is None and existing_policy is not None:
+            before_content = existing_policy.content
         items.append(
             PolicyPlanItem(
                 kind="upsert",
@@ -449,6 +450,10 @@ def _operations_to_plan_items(
                     "rationale": "PatchMergeContextProvider merged semantic gradients via ExtractLoop.",
                     "merge_gradient_count": len(gradients),
                     "merge_memory_fields": fields,
+                    "rollback_before_raw": _rollback_snapshot(
+                        memory_file=old_file,
+                        policy=existing_policy,
+                    ),
                     "superseded_experience_uris": [
                         policy.uri for policy in superseded_policies
                     ],
@@ -487,6 +492,7 @@ def _operations_to_plan_items(
                 metadata={
                     "rationale": "PatchMergeContextProvider merge requested memory deletion.",
                     "merge_gradient_count": len(gradients),
+                    "rollback_before_raw": _rollback_snapshot(memory_file=old_file),
                 },
             )
         )
@@ -509,6 +515,7 @@ def _operations_to_plan_items(
                 metadata={
                     "rationale": "Superseded by broader experience from semantic gradient.",
                     "merge_gradient_count": len(gradients),
+                    "rollback_before_raw": _rollback_snapshot(policy=policy),
                     "superseded_by": [
                         item.target_uri or item.target_name
                         for item in items
@@ -519,6 +526,31 @@ def _operations_to_plan_items(
         )
         delete_uris.add(policy.uri)
     return items
+
+
+def _rollback_snapshot(
+    *,
+    memory_file: MemoryFile | None = None,
+    policy: Policy | None = None,
+) -> str | None:
+    """Serialize the pre-apply policy state for a conflict-safe inverse operation."""
+    if memory_file is not None:
+        return MemoryFileUtils.write(memory_file, render_links=False)
+    if policy is None:
+        return None
+    fields = dict(policy.metadata or {})
+    memory_type = str(fields.get("memory_type") or "experiences")
+    return MemoryFileUtils.write(
+        MemoryFile(
+            uri=policy.uri,
+            content=policy.content,
+            links=list(policy.links or []),
+            backlinks=list(policy.backlinks or []),
+            memory_type=memory_type,
+            extra_fields=fields,
+        ),
+        render_links=False,
+    )
 
 
 def _name_field_for_memory_type(memory_type: str) -> str:

--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -192,6 +192,20 @@ class Session:
     async def delete(self) -> None:
         await self._client.delete_session(self.session_id)
 
+    async def rollback(
+        self,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+        delete_session: bool = True,
+    ) -> Dict[str, Any]:
+        return await self._client.rollback_session(
+            self.session_id,
+            dry_run=dry_run,
+            force=force,
+            delete_session=delete_session,
+        )
+
     async def load(self) -> Dict[str, Any]:
         return await self._client.get_session(self.session_id)
 
@@ -248,6 +262,20 @@ class SyncSession:
 
     def delete(self) -> None:
         self._client.delete_session(self.session_id)
+
+    def rollback(
+        self,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+        delete_session: bool = True,
+    ) -> Dict[str, Any]:
+        return self._client.rollback_session(
+            self.session_id,
+            dry_run=dry_run,
+            force=force,
+            delete_session=delete_session,
+        )
 
     def load(self) -> Dict[str, Any]:
         return self._client.get_session(self.session_id)
@@ -1477,6 +1505,27 @@ class AsyncHTTPClient:
         response = await self._request("DELETE", f"/api/v1/sessions/{session_path}")
         self._handle_response(response)
 
+    async def rollback_session(
+        self,
+        session_id: str,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+        delete_session: bool = True,
+    ) -> Dict[str, Any]:
+        """Reverse a Session's committed memory changes in newest-first order."""
+        session_path = self._path_segment(session_id)
+        response = await self._request(
+            "POST",
+            f"/api/v1/sessions/{session_path}/rollback",
+            json={
+                "dry_run": dry_run,
+                "force": force,
+                "delete_session": delete_session,
+            },
+        )
+        return self._handle_response(response)
+
     async def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
         response = await self._request("GET", f"/api/v1/tasks/{task_id}")
         if response.status_code == 404:
@@ -2570,6 +2619,23 @@ class SyncHTTPClient:
 
     def delete_session(self, session_id: str) -> None:
         run_async(self._async_client.delete_session(session_id))
+
+    def rollback_session(
+        self,
+        session_id: str,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+        delete_session: bool = True,
+    ) -> Dict[str, Any]:
+        return run_async(
+            self._async_client.rollback_session(
+                session_id,
+                dry_run=dry_run,
+                force=force,
+                delete_session=delete_session,
+            )
+        )
 
     def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
         return run_async(self._async_client.get_task(task_id))

--- a/sdk/python/tests/test_async_client_behaviors.py
+++ b/sdk/python/tests/test_async_client_behaviors.py
@@ -532,6 +532,7 @@ def test_sync_http_client_declares_common_sync_methods_explicitly():
         "get_session",
         "get_session_context",
         "delete_session",
+        "rollback_session",
         "search",
         "find",
         "grep",
@@ -1310,22 +1311,25 @@ async def test_session_exists_returns_false_on_not_found():
 
 
 @pytest.mark.asyncio
-async def test_session_wrapper_forwards_commit_context_and_archive_operations():
+async def test_session_wrapper_forwards_commit_context_archive_and_rollback_operations():
     client = AsyncHTTPClient(url="http://localhost:1933")
     session = Session(client, "thread-1")
     client.commit_session = AsyncMock(return_value={"status": "completed"})
     client.get_session_context = AsyncMock(return_value={"messages": []})
     client.get_session_archive = AsyncMock(return_value={"archive_id": "arc-1"})
+    client.rollback_session = AsyncMock(return_value={"status": "ready"})
     client.delete_session = AsyncMock(return_value=None)
 
     commit_result = await session.commit(keep_recent_count=2)
     context_result = await session.get_session_context(2048)
     archive_result = await session.get_archive("arc-1")
+    rollback_result = await session.rollback(dry_run=True, delete_session=False)
     await session.delete()
 
     assert commit_result == {"status": "completed"}
     assert context_result == {"messages": []}
     assert archive_result == {"archive_id": "arc-1"}
+    assert rollback_result == {"status": "ready"}
     client.commit_session.assert_awaited_once_with(
         "thread-1",
         keep_recent_count=2,
@@ -1333,7 +1337,41 @@ async def test_session_wrapper_forwards_commit_context_and_archive_operations():
     )
     client.get_session_context.assert_awaited_once_with("thread-1", 2048)
     client.get_session_archive.assert_awaited_once_with("thread-1", "arc-1")
+    client.rollback_session.assert_awaited_once_with(
+        "thread-1", dry_run=True, force=False, delete_session=False
+    )
     client.delete_session.assert_awaited_once_with("thread-1")
+
+
+def test_sync_session_wrapper_forwards_rollback_options():
+    client = Mock()
+    client.rollback_session.return_value = {"status": "partial"}
+    session = SyncSession(client, "thread-1")
+
+    result = session.rollback(force=True, delete_session=False)
+
+    assert result == {"status": "partial"}
+    client.rollback_session.assert_called_once_with(
+        "thread-1", dry_run=False, force=True, delete_session=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_http_client_rollback_session_posts_safety_options():
+    client = AsyncHTTPClient(url="http://localhost:1933")
+    client._request = AsyncMock(return_value=object())
+    client._handle_response = lambda _response: {"status": "ready"}
+
+    result = await client.rollback_session(
+        "thread/1", dry_run=True, force=True, delete_session=False
+    )
+
+    assert result == {"status": "ready"}
+    client._request.assert_awaited_once_with(
+        "POST",
+        "/api/v1/sessions/thread%2F1/rollback",
+        json={"dry_run": True, "force": True, "delete_session": False},
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_api_sessions.py
+++ b/tests/server/test_api_sessions.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -1175,6 +1175,37 @@ async def test_delete_session(client: httpx.AsyncClient):
     resp = await client.delete(f"/api/v1/sessions/{session_id}")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+async def test_rollback_session_forwards_safety_options(monkeypatch):
+    rollback = AsyncMock(
+        return_value={
+            "session_id": "session-1",
+            "status": "ready",
+            "dry_run": True,
+            "operations": [],
+            "summary": {"planned": 0, "conflicts": 0, "skipped": 0, "applied": 0},
+        }
+    )
+    service = MagicMock()
+    service.sessions.rollback_memories = rollback
+    monkeypatch.setattr(sessions_router, "get_service", lambda: service)
+    ctx = RequestContext(user=DEFAULT_USER, role=Role.ROOT)
+
+    resp = await sessions_router.rollback_session_memories(
+        session_id="session-1",
+        request=sessions_router.RollbackSessionRequest(
+            dry_run=True, force=True, delete_session=False
+        ),
+        _ctx=ctx,
+    )
+
+    assert resp["status"] == "ok"
+    assert resp["result"]["status"] == "ready"
+    rollback.assert_awaited_once()
+    call = rollback.await_args
+    assert call.args[0] == "session-1"
+    assert call.kwargs == {"dry_run": True, "force": True, "delete_session": False}
 
 
 async def test_compress_session(client: httpx.AsyncClient):

--- a/tests/service/test_session_memory_rollback.py
+++ b/tests/service/test_session_memory_rollback.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Unit tests for conflict-safe Session memory rollback."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openviking.service.session_memory_rollback import (
+    SessionMemoryRollback,
+    _missing,
+    _present,
+    _validate_diff_structure,
+    build_rollback_plan,
+)
+from openviking_cli.exceptions import FailedPreconditionError
+
+URI = "viking://user/alice/memories/preferences/editor.md"
+
+
+@pytest.fixture(autouse=True)
+def _initialized_task_tracker():
+    tracker = MagicMock()
+    tracker.has_running = AsyncMock(return_value=False)
+    with patch(
+        "openviking.service.session_memory_rollback.get_task_tracker",
+        return_value=tracker,
+    ):
+        yield tracker
+
+
+def _diff(*operations):
+    return {"schema_version": 2, "operation_order": list(operations)}
+
+
+def test_plan_reverses_archives_and_operations_newest_first():
+    archive_1 = _diff(
+        {
+            "kind": "add",
+            "uri": URI,
+            "memory_type": "preferences",
+            "after_raw": "created",
+        },
+        {
+            "kind": "update",
+            "uri": URI,
+            "memory_type": "preferences",
+            "before_raw": "created",
+            "after_raw": "first commit",
+        },
+    )
+    archive_2 = _diff(
+        {
+            "kind": "update",
+            "uri": URI,
+            "memory_type": "preferences",
+            "before_raw": "first commit",
+            "after_raw": "second commit",
+        }
+    )
+
+    plan = build_rollback_plan(
+        [("archive_2", archive_2), ("archive_1", archive_1)],
+        {URI: _present("second commit")},
+        force=False,
+    )
+
+    assert plan["summary"] == {"planned": 3, "conflicts": 0, "skipped": 0}
+    assert [item["action"] for item in plan["operations"]] == ["write", "write", "delete"]
+    assert [item["content"] for item in plan["operations"]] == [
+        "first commit",
+        "created",
+        None,
+    ]
+
+
+def test_plan_restores_deleted_file():
+    plan = build_rollback_plan(
+        [
+            (
+                "archive_1",
+                _diff(
+                    {
+                        "kind": "delete",
+                        "uri": URI,
+                        "memory_type": "preferences",
+                        "deleted_raw": "deleted snapshot",
+                    }
+                ),
+            )
+        ],
+        {URI: _missing()},
+        force=False,
+    )
+
+    assert plan["summary"]["planned"] == 1
+    assert plan["operations"][0]["action"] == "write"
+    assert plan["operations"][0]["content"] == "deleted snapshot"
+
+
+def test_plan_reports_external_change_as_conflict():
+    plan = build_rollback_plan(
+        [
+            (
+                "archive_1",
+                _diff(
+                    {
+                        "kind": "update",
+                        "uri": URI,
+                        "before_raw": "before",
+                        "after_raw": "committed",
+                    }
+                ),
+            )
+        ],
+        {URI: _present("edited externally")},
+        force=False,
+    )
+
+    assert plan["summary"] == {"planned": 0, "conflicts": 1, "skipped": 0}
+    assert plan["operations"][0]["reason"] == "current_content_changed"
+
+
+def test_force_skips_conflict_and_older_operations_for_same_uri():
+    newer = _diff({"kind": "update", "uri": URI, "before_raw": "one", "after_raw": "two"})
+    older = _diff({"kind": "add", "uri": URI, "after_raw": "one"})
+
+    plan = build_rollback_plan(
+        [("archive_2", newer), ("archive_1", older)],
+        {URI: _present("external")},
+        force=True,
+    )
+
+    assert plan["summary"] == {"planned": 0, "conflicts": 0, "skipped": 2}
+    assert [item["reason"] for item in plan["operations"]] == [
+        "current_content_changed",
+        "blocked_by_newer_conflict",
+    ]
+
+
+def test_legacy_diff_without_raw_snapshot_is_never_guessed():
+    plan = build_rollback_plan(
+        [("archive_1", {"operations": {"adds": [{"uri": URI, "after": "new"}]}})],
+        {URI: _present("new")},
+        force=False,
+    )
+
+    assert plan["summary"]["conflicts"] == 1
+    assert plan["operations"][0]["reason"] == "legacy_snapshot_incomplete"
+
+
+def test_schema_v2_rejects_truncated_operation_order():
+    with pytest.raises(ValueError, match="does not match"):
+        _validate_diff_structure(
+            {
+                "schema_version": 2,
+                "operations": {
+                    "adds": [{"uri": URI, "after_raw": "new"}],
+                    "updates": [],
+                    "deletes": [],
+                },
+                "operation_order": [],
+            }
+        )
+
+
+def test_semantically_identical_memory_serializations_do_not_conflict():
+    expected = 'body\n\n<!-- MEMORY_FIELDS\n{"memory_type":"preferences","version":1}\n-->'
+    actual = 'body\n\n<!-- MEMORY_FIELDS\n{"version": 1, "memory_type": "preferences"}\n-->'
+    plan = build_rollback_plan(
+        [("archive_1", _diff({"kind": "add", "uri": URI, "after_raw": expected}))],
+        {URI: _present(actual)},
+        force=False,
+    )
+
+    assert plan["summary"]["planned"] == 1
+    assert plan["summary"]["conflicts"] == 0
+
+
+class _FakeAgfs:
+    def __init__(self):
+        self.pathlock_acquire_tree = AsyncMock(return_value={"owner_id": "rollback"})
+        self.pathlock_acquire_exact_batch = AsyncMock(return_value={"owner_id": "rollback"})
+        self.pathlock_release = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_run_rechecks_commit_state_after_acquiring_session_tree_lock():
+    fs = MagicMock()
+    fs._async_agfs = _FakeAgfs()
+    fs._uri_to_path.side_effect = lambda uri, ctx=None: uri
+    rollback = SessionMemoryRollback.__new__(SessionMemoryRollback)
+    rollback._viking_fs = fs
+    rollback._memory_updater = MagicMock()
+    rollback._load_archive_diffs = AsyncMock()
+    tracker = MagicMock()
+    tracker.has_running = AsyncMock(return_value=True)
+    ctx = MagicMock()
+
+    with (
+        patch(
+            "openviking.service.session_memory_rollback.get_task_tracker",
+            return_value=tracker,
+        ),
+        pytest.raises(FailedPreconditionError, match="commit in progress"),
+    ):
+        await rollback.run(
+            "session-1", ctx, dry_run=False, force=False, delete_session=True
+        )
+
+    tracker.has_running.assert_awaited_once_with(
+        "session_commit",
+        "session-1",
+        account_id=ctx.account_id,
+        user_id=ctx.user.user_id,
+    )
+    rollback._load_archive_diffs.assert_not_awaited()
+    fs._async_agfs.pathlock_release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_returns_applied_statuses_and_refreshes_after_unlock():
+    fs = MagicMock()
+    fs._async_agfs = _FakeAgfs()
+    fs._uri_to_path.side_effect = lambda uri, ctx=None: uri
+    fs.rm = AsyncMock()
+    rollback = SessionMemoryRollback.__new__(SessionMemoryRollback)
+    rollback._viking_fs = fs
+    rollback._memory_updater = MagicMock()
+    rollback._load_archive_diffs = AsyncMock(
+        return_value=[("archive_1", _diff({"kind": "add", "uri": URI, "after_raw": "new"}))]
+    )
+    rollback._validate_and_collect_uris = MagicMock(return_value={URI})
+    rollback._read_current_states = AsyncMock(return_value={URI: _present("new")})
+    rollback._refresh = AsyncMock(return_value={"vectorization_enqueued": 1})
+    ctx = MagicMock()
+
+    result = await rollback.run("session-1", ctx, dry_run=False, force=False, delete_session=True)
+
+    assert result["status"] == "completed"
+    assert result["operations"][0]["status"] == "applied"
+    assert result["summary"]["applied"] == 1
+    assert result["session_deleted"] is True
+    assert fs._async_agfs.pathlock_release.await_count == 2
+    rollback._refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_never_mutates_storage_or_refreshes_indexes():
+    fs = MagicMock()
+    fs._async_agfs = _FakeAgfs()
+    fs._uri_to_path.side_effect = lambda uri, ctx=None: uri
+    fs.rm = AsyncMock()
+    fs.write_file = AsyncMock()
+    rollback = SessionMemoryRollback.__new__(SessionMemoryRollback)
+    rollback._viking_fs = fs
+    rollback._memory_updater = MagicMock()
+    rollback._load_archive_diffs = AsyncMock(
+        return_value=[("archive_1", _diff({"kind": "add", "uri": URI, "after_raw": "new"}))]
+    )
+    rollback._validate_and_collect_uris = MagicMock(return_value={URI})
+    rollback._read_current_states = AsyncMock(return_value={URI: _present("new")})
+    rollback._refresh = AsyncMock()
+
+    result = await rollback.run(
+        "session-1", MagicMock(), dry_run=True, force=False, delete_session=True
+    )
+
+    assert result["status"] == "ready"
+    assert result["delete_session"] is True
+    assert result["session_deleted"] is False
+    fs.rm.assert_not_awaited()
+    fs.write_file.assert_not_awaited()
+    rollback._refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_delete_failure_compensates_memory_changes():
+    fs = MagicMock()
+    fs._async_agfs = _FakeAgfs()
+    fs._uri_to_path.side_effect = lambda uri, ctx=None: uri
+    fs.rm = AsyncMock(side_effect=[None, RuntimeError("session delete failed")])
+    fs.write_file = AsyncMock()
+    rollback = SessionMemoryRollback.__new__(SessionMemoryRollback)
+    rollback._viking_fs = fs
+    rollback._memory_updater = MagicMock()
+    rollback._load_archive_diffs = AsyncMock(
+        return_value=[("archive_1", _diff({"kind": "add", "uri": URI, "after_raw": "new"}))]
+    )
+    rollback._validate_and_collect_uris = MagicMock(return_value={URI})
+    rollback._read_current_states = AsyncMock(return_value={URI: _present("new")})
+
+    with pytest.raises(RuntimeError, match="session delete failed"):
+        await rollback.run(
+            "session-1", MagicMock(), dry_run=False, force=False, delete_session=True
+        )
+
+    fs.write_file.assert_awaited_once()
+    assert fs.write_file.await_args.args[:2] == (URI, "new")
+
+
+@pytest.mark.asyncio
+async def test_apply_failure_compensates_every_original_state():
+    fs = MagicMock()
+    fs.rm = AsyncMock()
+    fs.write_file = AsyncMock(side_effect=[None, RuntimeError("disk failure"), None])
+    rollback = SessionMemoryRollback.__new__(SessionMemoryRollback)
+    rollback._viking_fs = fs
+    operations = [
+        {"status": "planned", "action": "write", "uri": URI, "content": "old"},
+        {
+            "status": "planned",
+            "action": "write",
+            "uri": URI + ".second",
+            "content": "old second",
+        },
+    ]
+    originals = {URI: _present("new"), URI + ".second": _missing()}
+
+    with pytest.raises(RuntimeError, match="disk failure"):
+        try:
+            await rollback._apply(operations, MagicMock(), "lease")
+        except BaseException:
+            await rollback._restore_original_states(originals, MagicMock(), "lease")
+            raise
+
+    assert fs.write_file.await_args_list[-1].args[1] == "new"
+    fs.rm.assert_awaited_once()

--- a/tests/session/memory/test_memory_diff.py
+++ b/tests/session/memory/test_memory_diff.py
@@ -7,6 +7,7 @@ Verifies that memory_diff.json is correctly written to the archive directory
 containing adds, updates, and deletes.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -79,6 +80,9 @@ class TestMemoryDiffArchive:
         assert diff["summary"]["total_adds"] == 1
         assert diff["summary"]["total_updates"] == 0
         assert diff["summary"]["total_deletes"] == 0
+        assert diff["schema_version"] == 2
+        assert diff["operations"]["adds"][0]["after_raw"] == ("# Identity\n\nTest identity content")
+        assert diff["operation_order"][0]["kind"] == "add"
 
     @pytest.mark.asyncio
     async def test_build_memory_diff_update(self, compressor, mock_viking_fs, mock_ctx):
@@ -116,6 +120,9 @@ class TestMemoryDiffArchive:
 
         assert diff["summary"]["total_adds"] == 0
         assert diff["summary"]["total_updates"] == 1
+        update = diff["operations"]["updates"][0]
+        assert "Old identity content" in update["before_raw"]
+        assert update["after_raw"] == "# Identity\n\nNew identity content"
 
     @pytest.mark.asyncio
     async def test_build_memory_diff_delete(self, compressor, mock_viking_fs, mock_ctx):
@@ -147,6 +154,76 @@ class TestMemoryDiffArchive:
         assert len(diff["operations"]["deletes"]) == 1
         assert diff["operations"]["deletes"][0]["uri"] == "memory/user/test/context/old_project.md"
         assert "This project was deleted" in diff["operations"]["deletes"][0]["deleted_content"]
+        assert "<!-- MEMORY_FIELDS" in diff["operations"]["deletes"][0]["deleted_raw"]
+        assert '"project": "test"' in diff["operations"]["deletes"][0]["deleted_raw"]
+
+    @pytest.mark.asyncio
+    async def test_training_diff_preserves_raw_update_snapshots(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        uri = "viking://user/test/memories/experiences/retry.md"
+        item = SimpleNamespace(
+            memory_type="experiences",
+            links=[],
+            target_uri=uri,
+            target_name="retry",
+            kind="upsert",
+            before_content="old body",
+            after_content="new body",
+            metadata={"rollback_before_raw": "old raw snapshot"},
+        )
+        training_result = SimpleNamespace(
+            analyses=[],
+            plan=SimpleNamespace(items=[item]),
+            apply_result=SimpleNamespace(
+                written_uris=[uri],
+                deleted_uris=[],
+                updated_policy_set=SimpleNamespace(
+                    root_uri="viking://user/test/memories/experiences"
+                ),
+            ),
+        )
+        mock_viking_fs.read_file = AsyncMock(return_value="new raw snapshot")
+
+        diff = await compressor._build_training_memory_diff(
+            training_result=training_result,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+            archive_uri="viking://user/test/sessions/s/history/archive_001",
+        )
+
+        update = diff["operations"]["updates"][0]
+        assert update["before_raw"] == "old raw snapshot"
+        assert update["after_raw"] == "new raw snapshot"
+
+    @pytest.mark.asyncio
+    async def test_training_diff_preserves_raw_trajectory_snapshot(
+        self, compressor, mock_viking_fs, mock_ctx
+    ):
+        uri = "viking://user/test/memories/trajectories/run.md"
+        training_result = SimpleNamespace(
+            analyses=[
+                SimpleNamespace(trajectories=[SimpleNamespace(uri=uri, content="trajectory")])
+            ],
+            plan=SimpleNamespace(items=[]),
+            apply_result=SimpleNamespace(
+                written_uris=[],
+                deleted_uris=[],
+                updated_policy_set=SimpleNamespace(
+                    root_uri="viking://user/test/memories/experiences"
+                ),
+            ),
+        )
+        mock_viking_fs.read_file = AsyncMock(return_value="trajectory raw snapshot")
+
+        diff = await compressor._build_training_memory_diff(
+            training_result=training_result,
+            viking_fs=mock_viking_fs,
+            ctx=mock_ctx,
+            archive_uri="viking://user/test/sessions/s/history/archive_001",
+        )
+
+        assert diff["operations"]["adds"][0]["after_raw"] == "trajectory raw snapshot"
 
     @pytest.mark.asyncio
     async def test_build_memory_diff_edited(self, compressor, mock_viking_fs, mock_ctx):
@@ -478,11 +555,13 @@ class TestMemoryDiffStructure:
         """Verify memory_diff.json structure."""
         # This test validates the expected structure
         expected_keys = [
+            "schema_version",
             "archive_uri",
             "trace_id",
             "extracted_at",
             "operations",
             "skipped_operations",
+            "operation_order",
             "summary",
         ]
 
@@ -491,10 +570,12 @@ class TestMemoryDiffStructure:
         assert set(expected_keys).issubset(
             {
                 "archive_uri",
+                "schema_version",
                 "trace_id",
                 "extracted_at",
                 "operations",
                 "skipped_operations",
+                "operation_order",
                 "summary",
             }
         )

--- a/tests/session/train/test_train_components.py
+++ b/tests/session/train/test_train_components.py
@@ -731,6 +731,8 @@ async def test_patch_merge_policy_optimizer_runs_patch_merge_extract_loop(monkey
     assert plan.items[0].target_uri == policy_set.policies[0].uri
     assert plan.items[0].before_content == "content"
     assert plan.items[0].after_content == "merged content"
+    assert "content" in plan.items[0].metadata["rollback_before_raw"]
+    assert "<!-- MEMORY_FIELDS" in plan.items[0].metadata["rollback_before_raw"]
     assert [link.to_uri for link in plan.items[0].links] == [
         "viking://user/u/memories/trajectories/traj1.md"
     ]


### PR DESCRIPTION
## Description

Session commits can mutate long-term memory, while deleting the session currently leaves those mutations behind. This PR adds a conflict-safe rollback path that replays every archived `memory_diff.json` in reverse commit and operation order before optionally deleting the session.

The owning implementation lives in `openviking/service/session_memory_rollback.py`. The server route, Python SDK, and Rust CLI transport the same `dry_run`, `force`, and `delete_session` safety options instead of reimplementing rollback rules.

The rollback service:

- reverses adds, updates, and deletes under the session tree lock and exact memory URI locks;
- compares current state with the recorded post-commit state and fails closed on conflicts;
- supports dry-run planning and force mode while blocking dependent older operations on the same URI;
- compensates already-applied memory changes if a later write or session deletion fails;
- refreshes vectors and overviews after releasing storage locks;
- rechecks running commit tasks inside the tree lock to close the check/lock race.

New audit records use schema v2 with canonical raw before/after/deleted snapshots and an explicit operation order. Legacy or incomplete snapshots are reported as conflicts rather than reconstructing metadata heuristically. Existing sessions remain readable; only rollback of records without sufficient raw snapshots is rejected safely.

The issue was not reproduced against a deployed server in this environment. The production execution paths were traced from commit audit creation through the service, REST route, SDK, and CLI, then validated with focused contract and failure-boundary tests.

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

The human selected the issue and risk standard, reviewed progress, provided the fork, and approved the release workflow. AI assistance was used for implementation and validation.

## Related Issue

Fixes #4178

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Add `POST /api/v1/sessions/{session_id}/rollback`, Python SDK methods, `ov session rollback`, and `ov session delete --rollback-memories`.
- Persist complete, ordered raw memory audit snapshots for normal and training-generated memory operations.
- Add conflict detection, dry-run, force handling, lock ordering, compensation, refresh, legacy fail-closed behavior, and English/Chinese documentation.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Validation performed on upstream `main` commit `cd8580c6f8a50ec44593618b3102799ab0b553fd`:

```text
python -m pytest -o addopts='' \
  tests/service/test_session_memory_rollback.py \
  tests/session/memory/test_memory_diff.py \
  tests/session/train/test_train_components.py \
  sdk/python/tests/test_async_client_behaviors.py \
  tests/server/test_api_sessions.py::test_rollback_session_forwards_safety_options -q
# 112 passed

python -m ruff check <changed Python paths>
# All checks passed

python -m mypy --follow-imports=skip \
  openviking/service/session_memory_rollback.py \
  openviking/session/train/components/policy_optimizer.py
# Success: no issues found in 2 source files

cargo check --locked -p ov_cli
# passed

cargo test --locked -p ov_cli -- \
  --skip base_client::tests::plain_text_http_error_preserves_status \
  --skip config_wizard::wizard::tests::display_config_home_uses_tilde_for_current_home
# 473 passed; 0 failed; 2 filtered out

rustfmt --edition 2024 --check --config skip_children=true \
  crates/ov_cli/src/commands/session.rs crates/ov_cli/src/main.rs
# passed
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

No dependent changes are required.

## Screenshots (if applicable)

Not applicable; this change exposes REST, SDK, and CLI behavior without a graphical UI.

## Additional Notes

- The default `pytest` addopts require `pytest-cov`, which was unavailable in the isolated runtime, so the exact focused command overrides addopts with `-o addopts=''`.
- Running the entire `tests/server/test_api_sessions.py` file on this Windows runtime produced 51 setup errors because the installed x86 wheel does not package the native `PersistStore` backend. The rollback route contract test itself passes and is included above.
- The two filtered Rust tests are unchanged environment/baseline tests: one requires a local HTTP behavior unavailable in this runner, and one depends on a conventional `HOME` value. All remaining 473 Rust tests pass.
- The full change is larger than the repository's preferred review-size thresholds because the issue explicitly spans persisted audit data, rollback ownership, REST, SDK, CLI, documentation, and failure-boundary tests. The PR contains no unrelated cleanup or generated files.
