### PR TITLE
fix(openclaw-plugin): declare OpenClaw 2026.8.1 durable-turn contract

### DIFF
--- a/examples/openclaw-plugin/context-engine.ts
+++ b/examples/openclaw-plugin/context-engine.ts
@@ -25,6 +25,11 @@ type ContextEngineInfo = {
   name: string;
   version?: string;
   ownsCompaction: true;
+  /** OpenClaw >=2026.8.1: without both declarations (and commitTurn) the engine is degraded to "legacy" every turn. */
+  transcriptSemantics: {
+    currentTurnFence: "before-current-turn-entry-v1";
+    turnAdvancementIdempotency: "atomic-idempotent-v1";
+  };
 };
 
 type AssembleResult = {
@@ -81,6 +86,14 @@ type ContextEngine = {
     tokenBudget?: number;
     runtimeContext?: Record<string, unknown>;
   }) => Promise<AssembleResult>;
+  /** OpenClaw >=2026.8.1 durable turn advancement; retried with the same advancementKey after host failure. */
+  commitTurn: (params: {
+    advancementKey: string;
+    messages: AgentMessage[];
+    sessionId: string;
+    sessionKey?: string;
+    isHeartbeat?: boolean;
+  }) => Promise<{ status: "committed" | "duplicate" }>;
   compact: (params: {
     sessionId: string;
     sessionKey?: string;
@@ -318,12 +331,18 @@ export function createMemoryOpenVikingContextEngine(params: {
     };
   }
 
+  const committedTurnKeys = new Set<string>();
+
   return {
     info: {
       id,
       name,
       version,
       ownsCompaction: true,
+      transcriptSemantics: {
+        currentTurnFence: "before-current-turn-entry-v1",
+        turnAdvancementIdempotency: "atomic-idempotent-v1",
+      },
     },
 
     commitOVSession: doCommitOVSession,
@@ -366,6 +385,22 @@ export function createMemoryOpenVikingContextEngine(params: {
         hasAutoRecallBlock,
         prependRecallToLatestUserMessage,
       });
+    },
+
+    // Capture still happens in afterTurn (host calls it per LLM call + on finalize);
+    // commitTurn only acknowledges the accepted turn so OpenClaw drains its outbox.
+    // ponytail: in-memory key set, not durable across restarts — the host outbox is.
+    async commitTurn({ advancementKey, sessionId }): Promise<{ status: "committed" | "duplicate" }> {
+      if (committedTurnKeys.has(advancementKey)) {
+        diag("commitTurn_duplicate", sessionId, { advancementKey });
+        return { status: "duplicate" };
+      }
+      committedTurnKeys.add(advancementKey);
+      if (committedTurnKeys.size > 1024) {
+        committedTurnKeys.delete(committedTurnKeys.values().next().value as string);
+      }
+      diag("commitTurn", sessionId, { advancementKey });
+      return { status: "committed" };
     },
 
     async afterTurn(afterTurnParams): Promise<void> {

--- a/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
+++ b/examples/openclaw-plugin/tests/ut/context-engine-commit-turn.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenVikingClient } from "../../client.js";
+import { memoryOpenVikingConfigSchema } from "../../config.js";
+import { createMemoryOpenVikingContextEngine } from "../../context-engine.js";
+
+function makeEngine() {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return createMemoryOpenVikingContextEngine({
+    id: "openviking",
+    name: "Context Engine (OpenViking)",
+    version: "test",
+    cfg: memoryOpenVikingConfigSchema.parse({ mode: "remote", baseUrl: "http://127.0.0.1:1933" }),
+    logger,
+    getClient: vi.fn().mockResolvedValue({} as OpenVikingClient),
+    resolveAgentId: vi.fn(() => "agent"),
+  });
+}
+
+// OpenClaw >=2026.8.1 degrades the engine to "legacy" every turn unless both
+// transcript semantics are declared and commitTurn exists.
+describe("context-engine durable turn contract (OpenClaw 2026.8.1)", () => {
+  it("declares transcript semantics", () => {
+    expect(makeEngine().info.transcriptSemantics).toEqual({
+      currentTurnFence: "before-current-turn-entry-v1",
+      turnAdvancementIdempotency: "atomic-idempotent-v1",
+    });
+  });
+
+  it("commitTurn is idempotent per advancementKey", async () => {
+    const engine = makeEngine();
+    const params = { advancementKey: "k1", sessionId: "s", messages: [] };
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+    await expect(engine.commitTurn({ ...params, advancementKey: "k2" })).resolves.toEqual({ status: "committed" });
+  });
+});


### PR DESCRIPTION
## 起因

OpenClaw 2026.8.1-beta 上装 openviking 插件后，每轮都刷：

```
[context-engine] Context engine "openviking" degraded to "legacy": current-turn transcript fencing is not declared.
```

auto-capture / auto-recall 全程不工作（#4103）。

## 为什么是这个性质

不是 assemble 的问题。对照 openclaw `2026.8.1-beta.3` dist：

- `context-engine-logical-turn.ts`（dist `context-engine-turn-attempt-*.js:63-64`）在每个 turn 开始做三项检查：`info.transcriptSemantics.currentTurnFence === "before-current-turn-entry-v1"`、`turnAdvancementIdempotency === "atomic-idempotent-v1"`、`typeof engine.commitTurn === "function"`。任一缺失就把整个 logical turn 交给 legacy 引擎，插件的 assemble / afterTurn 根本没被调到。
- `assemble` 的两种调用形态（preflight 带 `prompt/availableTools/citationsMode`，transformContext 不带）和 `afterTurn` 的调用点与 2026.7.1 相同，插件现有分支逻辑不需要改。
- 契约来自 openclaw PR #119325（crash-durable、exactly-once 的 turn 提交：host 先写 SQLite outbox，再调 `commitTurn(advancementKey, messages)`，失败下轮同 key 重试）。后续 #121461、#126593 修的是 host 侧 bug，beta.3 已含。

## 改法

`examples/openclaw-plugin/context-engine.ts`：

1. `info.transcriptSemantics` 声明两个字段。
2. 新增 `commitTurn({ advancementKey })`：内存 Set 记 key，首次返回 `committed`，重复返回 `duplicate`（上限 1024 个 key）。

## 取舍

- **commitTurn 不写 OV，只做 ack。** host 在新路径下仍然调 afterTurn（transformContext 每次 LLM call 一次 + finalize 一次），capture 留在那里；commitTurn 再写一次就是双写。
- key 集合不跨进程持久。host 自己的 outbox 是持久的，重启后重试同 key 我们回 `committed`，行被删；这和改动前的持久性一致（afterTurn 没跑完就 crash 的 turn 原本也会丢）。如果后续 OpenClaw 把 afterTurn 从 durable 路径拿掉，capture 需要搬进 commitTurn。
- `engines.openclaw` 保持 `>=2026.5.27`：旧版忽略多余 info 字段和未知方法。

## 没动什么

assemble / afterTurn / compact 逻辑、README。#4415 第 5 条（isMainAssemble duck-typing）这次核实在 8.1 仍成立，不在本 PR 处理。

## 验证

- `npm run typecheck` 通过。
- `vitest run`：750/754 通过；4 个失败在 `tests/ut/architecture-boundaries.test.ts`，main 上（stash 后）同样失败，与本改动无关。
- 新增 `tests/ut/context-engine-commit-turn.test.ts`：断言 transcriptSemantics 值、commitTurn 同 key 二次调用返回 duplicate。
- 未在真实 OpenClaw 2026.8.1 上跑（npm 尚无稳定版，只有 beta.1-3）。

Fixes #4103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TsbqPJYxEqGWrBqYeodWR
