### PR TITLE
fix(fs): mark directory matches in glob results with a trailing slash

### DIFF
--- a/openviking/storage/viking_fs/_ops.py
+++ b/openviking/storage/viking_fs/_ops.py
@@ -36,6 +36,18 @@ from openviking_cli.exceptions import (
 from openviking_cli.utils.uri import VikingURI
 
 
+def _glob_match_uri(entry_uri: str, is_dir: Optional[bool]) -> str:
+    """Mark directory matches with a trailing slash.
+
+    `glob` returns a flat list of uri strings, so the trailing slash is the only
+    way a caller can tell a directory match from a file match. Matches the
+    convention `normalize_dir_uri` and the tree renderer already use.
+    """
+    if not is_dir or entry_uri.endswith("/"):
+        return entry_uri
+    return f"{entry_uri}/"
+
+
 class _OpsMixin:
     """Core filesystem operations (read/write/mkdir/rm/mv/stat/glob/tree/ls/temp)."""
 
@@ -675,7 +687,10 @@ class _OpsMixin:
                 continuation_token=continuation_token,
             )
 
-            page_matches: List[str] = []
+            # (acl_uri, match_uri): ACL lookups keep the bare uri, while the uri we
+            # hand back marks directories with a trailing slash so callers can tell
+            # them apart -- the flat `matches` list carries no other type signal.
+            page_matches: List[tuple[str, str]] = []
             for entry in page.get("entries", []):
                 if not self._is_path_entry_visible(
                     entry["path"],
@@ -692,20 +707,23 @@ class _OpsMixin:
                     entry_path=entry["path"],
                     ctx=ctx,
                 )
+                match_uri = _glob_match_uri(entry_uri, entry.get("is_dir"))
                 if self.acl_manager is None:
-                    matches.append(entry_uri)
+                    matches.append(match_uri)
                     if node_limit is not None and node_limit > 0 and len(matches) >= node_limit:
                         return {"matches": matches, "count": len(matches)}
                     continue
 
-                page_matches.append(entry_uri)
+                page_matches.append((entry_uri, match_uri))
 
             if self.acl_manager is not None:
-                access = await self._can_access_many(page_matches, real_ctx)
-                for entry_uri in page_matches:
-                    if not access.get(entry_uri, False):
+                access = await self._can_access_many(
+                    [acl_uri for acl_uri, _ in page_matches], real_ctx
+                )
+                for acl_uri, match_uri in page_matches:
+                    if not access.get(acl_uri, False):
                         continue
-                    matches.append(entry_uri)
+                    matches.append(match_uri)
                     if node_limit is not None and node_limit > 0 and len(matches) >= node_limit:
                         return {"matches": matches, "count": len(matches)}
 

--- a/tests/storage/test_viking_fs_glob.py
+++ b/tests/storage/test_viking_fs_glob.py
@@ -254,7 +254,45 @@ async def test_glob_keeps_directory_matches(monkeypatch, fs):
 
     result = await fs.glob("**/*", uri="viking://resources", ctx=_default_ctx())
 
-    assert result == {"matches": ["viking://resources/folder"], "count": 1}
+    # Trailing slash is the only type signal the flat `matches` list can carry.
+    assert result == {"matches": ["viking://resources/folder/"], "count": 1}
+
+
+@pytest.mark.asyncio
+async def test_glob_marks_directories_but_not_files(monkeypatch, fs):
+    async def fake_glob_directory(path, pattern, **kwargs):
+        return {
+            "entries": [
+                {
+                    "path": "/local/test_account/resources/folder",
+                    "rel_path": "folder",
+                    "name": "folder",
+                    "is_dir": True,
+                },
+                {
+                    "path": "/local/test_account/resources/a.md",
+                    "rel_path": "a.md",
+                    "name": "a.md",
+                    "is_dir": False,
+                },
+                {
+                    "path": "/local/test_account/resources/b.md",
+                    "rel_path": "b.md",
+                    "name": "b.md",
+                },
+            ],
+            "next_token": None,
+        }
+
+    monkeypatch.setattr(fs._async_agfs, "glob_directory", fake_glob_directory)
+
+    result = await fs.glob("**/*", uri="viking://resources", ctx=_default_ctx())
+
+    assert result["matches"] == [
+        "viking://resources/folder/",
+        "viking://resources/a.md",
+        "viking://resources/b.md",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 起因

web-studio 的搜索面板加了 glob 模式后，glob 命中的**目录全部被渲染成文件图标**。查下来不是前端判断错了，而是前端根本拿不到这个信息。

## 问题性质

AGFS 的 glob entry 本身是带 `is_dir` 的（`crates/ragfs/src/core/filesystem.rs:573`），但 `_ops.py` 的 `glob()` 把结果拍平成 `matches: list[str]` 时把这个 flag 丢了。返回的目录 uri 和文件 uri 长得一模一样：

```
matches: ["viking://resources/folder", "viking://resources/a.md"]
```

调用方没有任何办法区分这两条。对比 `fs/ls` —— 它给每个 entry 一个显式的 `isDir` 字段，所以一直是对的；只有 glob 这条路把类型信息扔了。

这不是疏漏，`test_glob_keeps_directory_matches` 明确锁了「目录不带尾斜杠」这个行为，所以本 PR 一并更新该断言。

## 修改方式

`matches` 保持 `list[str]` 不变，只给目录 uri 补一个尾斜杠：

```
matches: ["viking://resources/folder/", "viking://resources/a.md"]
```

尾斜杠是 OV 里已有的目录约定 —— `normalize_dir_uri` 和 tree 渲染器（`mcp_endpoint.py` 里目录打印成 `name/`）都是这么表达的，这里只是让 glob 跟上。

实现上新增一个模块级 `_glob_match_uri(entry_uri, is_dir)`，在 append 时决定要不要补斜杠。**ACL 查询仍然用不带斜杠的原始 uri**（`page_matches` 改成 `(acl_uri, match_uri)` 二元组），所以权限判定逻辑逐字节不变。

## 待评审决策点

考虑过另一个方案：把 `matches` 改成 `[{uri, isDir}]`，语义上和 `fs/ls` 彻底对齐、最干净。但那会破坏 MCP glob 工具、CLI、web-studio `fetchGlob` 和 e2e 测试的全部调用方，代价明显不成比例。选了破坏面最小的尾斜杠方案。如果 maintainer 更倾向结构化返回，可以在这个 PR 上改。

## 未改动

- ACL / 可见性过滤逻辑，一行未动
- `matches` 的类型（仍是 `list[str]`）、`count` 字段
- 文件类 uri，完全不受影响
- 前端：web-studio 里 `uri.endsWith('/')` 的判断本来就写好了，服务端修正后自动生效，无需改动

## 验证

- `tests/storage/test_viking_fs_glob.py` 11 passed。更新了 `test_glob_keeps_directory_matches` 的断言；新增 `test_glob_marks_directories_but_not_files`，覆盖 `is_dir: True` / `is_dir: False` / `is_dir` 字段缺失三种 entry 混排。
- `tests/storage/` 全量对照：clean main 是 33 failed / 392 passed，本 PR 是 33 failed / 393 passed —— 同样的 33 个预先存在的失败（volcengine_clients、vectordb_adaptor 等，与本改动无关），多出的 1 个 pass 是新增用例。零回归。
- 内部 glob 调用方逐个查过：`image_rewrite.py`、`parsers/markdown.py`、`semantic_processor.py` 用的都是 `**/*.md`，只匹配文件，拿不到目录；`resource_memory_link_service.py` 和 `mcp_endpoint.py:1281` 消费的是 grep 的 matches 不是 glob 的。均不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C65Cb79Dvr5zLD6ib1T9Ew