### PR TITLE
fix(retrieval): keep VikingFS.find on quick mode

### DIFF
--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -206,7 +206,10 @@ class _SemanticMixin:
         """
         _ensure_non_empty_search_query(query, image_url)
         telemetry = get_current_telemetry()
-        from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
+        from openviking.retrieve.hierarchical_retriever import (
+            HierarchicalRetriever,
+            RetrieverMode,
+        )
         from openviking_cli.retrieve import (
             ContextType,
             FindResult,
@@ -254,6 +257,7 @@ class _SemanticMixin:
             typed_query,
             ctx=real_ctx,
             limit=limit,
+            mode=RetrieverMode.QUICK,
             score_threshold=score_threshold,
             scope_dsl=filter,
             level=level,

--- a/tests/misc/test_vikingfs_find_without_rerank.py
+++ b/tests/misc/test_vikingfs_find_without_rerank.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Regression test for VikingFS.find without rerank configuration."""
+"""Regression tests for VikingFS.find retrieval behavior."""
 
 import contextvars
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from openviking.retrieve.hierarchical_retriever import RetrieverMode
 from openviking.server.identity import RequestContext, Role
 from openviking.storage.viking_fs import VikingFS
 from openviking_cli.retrieve.types import ContextType, MatchedContext, QueryResult
@@ -51,6 +52,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
             typed_query,
             ctx,
             limit,
+            mode,
             score_threshold,
             scope_dsl,
             level,
@@ -58,6 +60,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
             captured["typed_query"] = typed_query
             captured["ctx"] = ctx
             captured["limit"] = limit
+            captured["mode"] = mode
             captured["score_threshold"] = score_threshold
             captured["scope_dsl"] = scope_dsl
             captured["level"] = level
@@ -98,6 +101,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
     assert captured["typed_query"].target_directories == ["viking://resources/docs"]
     assert captured["ctx"] == fs._ctx_or_default.return_value
     assert captured["limit"] == 3
+    assert captured["mode"] == RetrieverMode.QUICK
     assert captured["score_threshold"] == 0.2
     assert captured["scope_dsl"] == {"category": "doc"}
     assert captured["level"] is None
@@ -118,11 +122,13 @@ async def test_find_accepts_image_url_without_text_query(monkeypatch) -> None:
             typed_query,
             ctx,
             limit,
+            mode,
             score_threshold,
             scope_dsl,
             level,
         ):
             captured["typed_query"] = typed_query
+            captured["mode"] = mode
             return QueryResult(
                 query=typed_query,
                 matched_contexts=[
@@ -153,3 +159,37 @@ async def test_find_accepts_image_url_without_text_query(monkeypatch) -> None:
     assert typed_query.embedding_input == [
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
     ]
+    assert captured["mode"] == RetrieverMode.QUICK
+
+
+@pytest.mark.asyncio
+async def test_find_uses_quick_mode_with_rerank_config(monkeypatch) -> None:
+    fs = _make_viking_fs()
+    fs.rerank_config = MagicMock(name="rerank_config")
+    captured = {}
+
+    class FakeRetriever:
+        def __init__(self, storage, embedder, rerank_config, retrieval_config):
+            captured["rerank_config"] = rerank_config
+
+        async def retrieve(self, typed_query, **kwargs):
+            captured["mode"] = kwargs.get("mode")
+            return QueryResult(
+                query=typed_query,
+                matched_contexts=[],
+                searched_directories=["viking://resources/docs"],
+            )
+
+    monkeypatch.setattr(
+        "openviking.retrieve.hierarchical_retriever.HierarchicalRetriever",
+        FakeRetriever,
+    )
+
+    result = await fs.find(
+        "guide",
+        target_uri="viking://resources/docs",
+    )
+
+    assert result.total == 0
+    assert captured["rerank_config"] is fs.rerank_config
+    assert captured["mode"] == RetrieverMode.QUICK


### PR DESCRIPTION
## Description

`VikingFS.find()` did not pass a retrieval mode to `HierarchicalRetriever`. When a
reranker is configured, the retriever therefore selected its recursive THINKING path,
even though `find` is the fast semantic-retrieval API.

This change makes `find` explicitly request QUICK mode. `VikingFS.search()` keeps its
existing mode selection, and the public API is unchanged.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4463

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- pass `RetrieverMode.QUICK` from `VikingFS.find()` to the hierarchical retriever;
- assert QUICK mode for text and image `find` calls; and
- cover the reranker-configured path that previously defaulted to THINKING mode.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Local checks:

- 22 relevant `find`, hierarchical-retriever, and image search-service tests passed;
- Ruff lint and format checks passed on both changed files;
- Python compile checks and `git diff --check` passed.

The full server search suite was not runnable because this environment has no
`~/.openviking/ov.conf`. Editable installation is also unavailable because Cargo and
the generated native `openviking/bin/ov` artifact are absent. The tests were therefore
run from source using an existing project test environment.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; this change has no visual output.

## Additional Notes

The regression first failed with `assert None == 'quick'`. A direct probe of the
unmodified retriever with an available reranker also entered two rerank rounds and four
child searches, confirming that the omitted mode selected the recursive path.