### PR TITLE
fix(vlm): make OpenAI keepalive expiry configurable

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -639,11 +639,12 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
 | `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `32`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
-| `credentials` | array | Ordered VLM credential/model list, with index 0 having the highest priority. Each item can override `provider`, `model`, `api_key`, `api_base`, `api_version`, `extra_headers`, `extra_request_body`, and `reasoning_effort` |
+| `credentials` | array | Ordered VLM credential/model list, with index 0 having the highest priority. Each item can override `provider`, `model`, `api_key`, `api_base`, `api_version`, `extra_headers`, `extra_request_body`, `reasoning_effort`, and `keepalive_expiry` |
 | `failback_timeout_seconds` | float | Time threshold for attempting a step back toward a higher-priority credential after failover (default: `600`) |
 | `failback_request_count` | int | Successful requests on a lower-priority credential before attempting a step back (default: `50`) |
 | `backup` | object | Optional backup VLM configuration (same shape as `vlm`) for automatic failover when the primary fails with retryable errors such as rate limits, `5xx` responses, or connection/timeout failures. Only one level of failover is supported &mdash; the backup itself cannot define a nested `backup` |
 | `timeout` | float | Per-request HTTP timeout in seconds passed to the underlying OpenAI/LiteLLM client. Increase for slow endpoints (e.g., DashScope, local inference). Must be `> 0` (default: `600.0`) |
+| `keepalive_expiry` | float | Idle connection lifetime in seconds for OpenAI-compatible VLM clients. Set to `0` to disable idle connection reuse; unset uses the OpenAI SDK default. Must be `>= 0` |
 | `extra_headers` | object | Custom HTTP headers for compatible HTTP providers. `kimi` also accepts header overrides, but already injects the required subscription headers by default |
 | `extra_request_body` | object | Extra JSON body fields for OpenAI-compatible completion requests, useful for provider-specific options such as Ollama `{"think": false}` |
 | `reasoning_effort` | str | Reasoning effort for OpenAI Codex Responses requests. Leave unset to use the model default |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -608,11 +608,12 @@ provider，并设置 `storage.vectordb.sparse_weight > 0`。自托管模型的�
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
 | `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`32`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
-| `credentials` | array | 有序 VLM 凭据/模型列表，索引 0 优先级最高。每项可单独覆盖 `provider`、`model`、`api_key`、`api_base`、`api_version`、`extra_headers`、`extra_request_body` 和 `reasoning_effort` |
+| `credentials` | array | 有序 VLM 凭据/模型列表，索引 0 优先级最高。每项可单独覆盖 `provider`、`model`、`api_key`、`api_base`、`api_version`、`extra_headers`、`extra_request_body`、`reasoning_effort` 和 `keepalive_expiry` |
 | `failback_timeout_seconds` | float | 切换到低优先级 credential 后，尝试逐级切回的时间阈值（默认：`600`） |
 | `failback_request_count` | int | 低优先级 credential 成功处理多少次请求后尝试逐级切回（默认：`50`） |
 | `backup` | object | 可选的备用 VLM 配置（结构与 `vlm` 相同），当主 VLM 遇到限流、`5xx`、超时或连接失败等可重试错误时自动切换。仅支持 1 层备用 &mdash; 备用 VLM 本身不能再嵌套 `backup` |
 | `timeout` | float | 单次 VLM API 请求的 HTTP 超时时间（秒），传递给底层 OpenAI/LiteLLM 客户端。慢端点（如 DashScope、本地推理）可调大。必须 `> 0`（默认：`600.0`） |
+| `keepalive_expiry` | float | OpenAI 兼容 VLM 客户端的空闲连接保留秒数。设为 `0` 可禁用空闲连接复用；不设置时使用 OpenAI SDK 默认值。必须 `>= 0` |
 | `extra_headers` | object | 兼容 HTTP provider 的自定义请求头。`kimi` 默认已注入所需订阅请求头，也支持在这里覆盖或扩展 |
 | `extra_request_body` | object | 传给 OpenAI 兼容 completion 请求的额外 JSON body 字段，可用于 Ollama `{"think": false}` 等 provider 专有参数 |
 | `reasoning_effort` | str | OpenAI Codex Responses 请求的推理强度。不设置时使用模型默认值 |

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+import httpx
+
 from openviking.telemetry import tracer
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
 from openviking.utils.multimodal import redact_image_data_urls
@@ -85,6 +87,28 @@ class OpenAIVLM(VLMBase):
         self.api_version = config.get("api_version")
         self.reasoning_effort = config.get("reasoning_effort", "low")
 
+    def _http_limits(self) -> httpx.Limits:
+        defaults = openai.DEFAULT_CONNECTION_LIMITS
+        return httpx.Limits(
+            max_connections=defaults.max_connections,
+            max_keepalive_connections=defaults.max_keepalive_connections,
+            keepalive_expiry=self.keepalive_expiry,
+        )
+
+    def _configure_sync_http_client(self, kwargs: Dict[str, Any]) -> None:
+        if self.keepalive_expiry is not None:
+            kwargs["http_client"] = openai.DefaultHttpxClient(
+                limits=self._http_limits(),
+                timeout=self.timeout,
+            )
+
+    def _configure_async_http_client(self, kwargs: Dict[str, Any]) -> None:
+        if self.keepalive_expiry is not None:
+            kwargs["http_client"] = openai.DefaultAsyncHttpxClient(
+                limits=self._http_limits(),
+                timeout=self.timeout,
+            )
+
     def get_client(self):
         """Get sync client"""
         if self._sync_client is None:
@@ -98,6 +122,7 @@ class OpenAIVLM(VLMBase):
                 self.extra_headers,
                 self.timeout,
             )
+            self._configure_sync_http_client(kwargs)
             if self.provider == "azure":
                 self._sync_client = openai.AzureOpenAI(**kwargs)
             else:
@@ -116,6 +141,7 @@ class OpenAIVLM(VLMBase):
             self.extra_headers,
             self.timeout,
         )
+        self._configure_async_http_client(kwargs)
         if self.provider == "azure":
             return openai.AsyncAzureOpenAI(**kwargs)
         return openai.AsyncOpenAI(**kwargs)
@@ -123,6 +149,13 @@ class OpenAIVLM(VLMBase):
     def get_async_client(self):
         """Get an async client scoped to the current event loop."""
         return self._async_client_cache.get(self._build_async_client)
+
+    def close(self):
+        """Close clients and HTTP transports owned by this backend."""
+        close_sync_client = getattr(self._sync_client, "close", None)
+        if close_sync_client is not None:
+            close_sync_client()
+        self._async_client_cache.close_all_with_close()
 
     def _supports_enable_thinking(self) -> bool:
         """Return True for OpenAI-compatible DashScope endpoints that accept enable_thinking."""

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -332,6 +332,9 @@ class VLMBase(ABC):
         """Reset token usage"""
         self._token_tracker.reset()
 
+    def close(self) -> None:
+        """Release provider resources, if any."""
+
     def _extract_content_from_response(self, response) -> str:
         if isinstance(response, str):
             return response
@@ -759,6 +762,11 @@ class FailoverVLM(VLMBase):
         self.primary.reset_token_usage()
         self.backup.reset_token_usage()
 
+    def close(self) -> None:
+        """Close both provider instances."""
+        self.primary.close()
+        self.backup.close()
+
 
 class MultiCredentialVLM(VLMBase):
     """VLM wrapper that provides failover across multiple ordered credentials.
@@ -1123,3 +1131,8 @@ class MultiCredentialVLM(VLMBase):
         """Reset token usage for all credential instances."""
         for instance in self._vlm_instances:
             instance.reset_token_usage()
+
+    def close(self) -> None:
+        """Close all credential provider instances."""
+        for instance in self._vlm_instances:
+            instance.close()

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -73,6 +73,7 @@ class VLMBase(ABC):
         self.temperature = config.get("temperature", 0.0)
         self.max_retries = config.get("max_retries", 3)
         self.timeout = config.get("timeout", 600.0)
+        self.keepalive_expiry = config.get("keepalive_expiry")
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.extra_request_body = dict(config.get("extra_request_body") or {})

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -549,6 +549,13 @@ class OpenVikingService:
             self._queue_manager = None
             logger.info("Queue manager stopped")
 
+        config = getattr(self, "_config", None)
+        vlm_config = getattr(config, "vlm", None)
+        close_vlm = getattr(vlm_config, "close", None)
+        if close_vlm is not None:
+            close_vlm()
+            await asyncio.sleep(0)
+
         if self._vikingdb_manager:
             self._vikingdb_manager.mark_closing()
 

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -671,6 +671,13 @@ class VLMConfig(BaseModel):
 
         return self._vlm_instance
 
+    def close(self) -> None:
+        """Close and clear the cached VLM instance."""
+        instance = self._vlm_instance
+        self._vlm_instance = None
+        if instance is not None:
+            instance.close()
+
     def _build_vlm_config_dict_for_credential(self, credential: VLMCredential) -> Dict[str, Any]:
         """Build VLM instance config dict for a specific credential."""
         result = {

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -64,6 +64,11 @@ class VLMCredential(BaseModel):
         default=None,
         description="Reasoning effort for OpenAI-compatible reasoning models",
     )
+    keepalive_expiry: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description="Idle HTTP connection lifetime for OpenAI-compatible providers",
+    )
     max_tokens: Optional[int] = Field(
         default=None,
         gt=0,
@@ -135,6 +140,14 @@ class VLMConfig(BaseModel):
             "Per-request HTTP timeout in seconds for VLM API calls. Applied to "
             "the underlying OpenAI/Azure/LiteLLM clients. Increase for slow or "
             "high-latency endpoints (e.g., DashScope, local inference servers)."
+        ),
+    )
+    keepalive_expiry: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Idle HTTP connection lifetime in seconds for OpenAI-compatible VLM clients. "
+            "Set to 0 to disable connection reuse; None uses the provider SDK default."
         ),
     )
 
@@ -312,6 +325,7 @@ class VLMConfig(BaseModel):
             or self.extra_headers
             or self.extra_request_body
             or self.reasoning_effort
+            or self.keepalive_expiry is not None
             or self.forward_api_key is not None
         ):
             if self.provider not in self.providers:
@@ -334,6 +348,11 @@ class VLMConfig(BaseModel):
                 self.providers[self.provider]["extra_request_body"] = self.extra_request_body
             if self.reasoning_effort and "reasoning_effort" not in self.providers[self.provider]:
                 self.providers[self.provider]["reasoning_effort"] = self.reasoning_effort
+            if (
+                self.keepalive_expiry is not None
+                and "keepalive_expiry" not in self.providers[self.provider]
+            ):
+                self.providers[self.provider]["keepalive_expiry"] = self.keepalive_expiry
 
     def _normalize_credentials(self):
         """Normalize credentials configuration:
@@ -368,6 +387,11 @@ class VLMConfig(BaseModel):
                     primary_cfg.get("extra_request_body") or self.extra_request_body
                 ),
                 reasoning_effort=(primary_cfg.get("reasoning_effort") or self.reasoning_effort),
+                keepalive_expiry=(
+                    primary_cfg.get("keepalive_expiry")
+                    if primary_cfg.get("keepalive_expiry") is not None
+                    else self.keepalive_expiry
+                ),
                 max_tokens=self.max_tokens,
             )
             migrated_credentials.append(primary_cred)
@@ -394,6 +418,11 @@ class VLMConfig(BaseModel):
                 ),
                 reasoning_effort=(
                     backup_cfg.get("reasoning_effort") or self.backup.reasoning_effort
+                ),
+                keepalive_expiry=(
+                    backup_cfg.get("keepalive_expiry")
+                    if backup_cfg.get("keepalive_expiry") is not None
+                    else self.backup.keepalive_expiry
                 ),
                 max_tokens=self.backup.max_tokens,
             )
@@ -433,6 +462,11 @@ class VLMConfig(BaseModel):
                         reasoning_effort=(
                             provider_cfg.get("reasoning_effort") or self.reasoning_effort
                         ),
+                        keepalive_expiry=(
+                            provider_cfg.get("keepalive_expiry")
+                            if provider_cfg.get("keepalive_expiry") is not None
+                            else self.keepalive_expiry
+                        ),
                     )
                 )
 
@@ -463,6 +497,8 @@ class VLMConfig(BaseModel):
                 cred.extra_request_body = self.extra_request_body
             if not cred.reasoning_effort:
                 cred.reasoning_effort = self.reasoning_effort
+            if cred.keepalive_expiry is None:
+                cred.keepalive_expiry = self.keepalive_expiry
 
     def _has_legacy_provider_config(self) -> bool:
         """Check if there's legacy provider config (not credentials-based)."""
@@ -516,6 +552,8 @@ class VLMConfig(BaseModel):
             config["extra_request_body"] = self.extra_request_body
         if self.reasoning_effort and "reasoning_effort" not in config:
             config["reasoning_effort"] = self.reasoning_effort
+        if self.keepalive_expiry is not None and "keepalive_expiry" not in config:
+            config["keepalive_expiry"] = self.keepalive_expiry
         return config
 
     def _provider_has_usable_credentials(self, provider_name: str, config: Dict[str, Any]) -> bool:
@@ -545,6 +583,8 @@ class VLMConfig(BaseModel):
             config["extra_request_body"] = cred.extra_request_body
         if cred.reasoning_effort:
             config["reasoning_effort"] = cred.reasoning_effort
+        if cred.keepalive_expiry is not None:
+            config["keepalive_expiry"] = cred.keepalive_expiry
         return config
 
     def _match_provider(self, model: str | None = None) -> tuple[Dict[str, Any] | None, str | None]:
@@ -638,6 +678,7 @@ class VLMConfig(BaseModel):
             "temperature": self.temperature,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
+            "keepalive_expiry": credential.keepalive_expiry,
             "provider": credential.provider,
             "thinking": self.thinking,
             "max_tokens": (
@@ -671,6 +712,11 @@ class VLMConfig(BaseModel):
             "temperature": self.temperature,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
+            "keepalive_expiry": (
+                config.get("keepalive_expiry")
+                if config and config.get("keepalive_expiry") is not None
+                else self.keepalive_expiry
+            ),
             "provider": name,
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,

--- a/tests/models/vlm/test_keepalive_config.py
+++ b/tests/models/vlm/test_keepalive_config.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for OpenAI-compatible VLM keepalive configuration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+from pydantic import ValidationError
+
+from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+class _StaleConnectionServer(ThreadingHTTPServer):
+    daemon_threads = True
+    block_on_close = False
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _StaleConnectionHandler)
+        self.connection_count = 0
+        self.connection_numbers = {}
+
+    def get_request(self):
+        request, address = super().get_request()
+        self.connection_count += 1
+        self.connection_numbers[id(request)] = self.connection_count
+        return request, address
+
+
+class _StaleConnectionHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def setup(self) -> None:
+        super().setup()
+        self.connection_number = self.server.connection_numbers.pop(id(self.request))
+        self.request_count = 0
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(content_length)
+        self.request_count += 1
+
+        if self.connection_number == 1 and self.request_count > 1:
+            time.sleep(0.5)
+            self.close_connection = True
+            return
+
+        payload = json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-vlm",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@contextmanager
+def _stale_connection_server() -> Iterator[_StaleConnectionServer]:
+    server = _StaleConnectionServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        {
+            "provider": "openai",
+            "api_key": "test-key",
+            "keepalive_expiry": 0,
+        },
+        {
+            "providers": {
+                "openai": {
+                    "api_key": "test-key",
+                    "keepalive_expiry": 0,
+                }
+            },
+        },
+        {
+            "credentials": [
+                {
+                    "provider": "openai",
+                    "api_key": "test-key",
+                    "keepalive_expiry": 0,
+                }
+            ],
+        },
+    ],
+)
+def test_vlm_config_propagates_keepalive_expiry(config_kwargs) -> None:
+    config = VLMConfig(model="test-vlm", **config_kwargs)
+
+    assert config.get_vlm_instance().keepalive_expiry == 0
+
+
+def test_vlm_config_rejects_negative_keepalive_expiry() -> None:
+    with pytest.raises(ValidationError):
+        VLMConfig(
+            model="test-vlm",
+            provider="openai",
+            api_key="test-key",
+            keepalive_expiry=-0.1,
+        )
+
+
+@patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
+def test_openai_vlm_uses_sdk_transport_when_keepalive_is_unset(mock_openai) -> None:
+    mock_openai.return_value = MagicMock()
+    vlm = OpenAIVLM(
+        {
+            "provider": "openai",
+            "model": "test-vlm",
+            "api_key": "test-key",
+        }
+    )
+
+    vlm.get_client()
+
+    assert vlm.keepalive_expiry is None
+    assert "http_client" not in mock_openai.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+async def test_openai_vlm_applies_keepalive_to_owned_clients(provider: str) -> None:
+    provider_kwargs = {}
+    if provider == "azure":
+        provider_kwargs = {
+            "api_base": "https://test-resource.openai.azure.com",
+            "api_version": "2025-01-01-preview",
+        }
+
+    vlm = OpenAIVLM(
+        {
+            "provider": provider,
+            "model": "test-vlm",
+            "api_key": "test-key",
+            "keepalive_expiry": 0,
+            "timeout": 12.0,
+            **provider_kwargs,
+        }
+    )
+    sync_client = vlm.get_client()
+    async_client = vlm.get_async_client()
+
+    sync_pool = sync_client._client._transport._pool
+    async_pool = async_client._client._transport._pool
+    assert sync_pool._max_connections == openai.DEFAULT_CONNECTION_LIMITS.max_connections
+    assert (
+        sync_pool._max_keepalive_connections
+        == openai.DEFAULT_CONNECTION_LIMITS.max_keepalive_connections
+    )
+    assert sync_pool._keepalive_expiry == 0
+    assert sync_client._client.timeout == httpx.Timeout(12.0)
+    assert async_pool._max_connections == openai.DEFAULT_CONNECTION_LIMITS.max_connections
+    assert (
+        async_pool._max_keepalive_connections
+        == openai.DEFAULT_CONNECTION_LIMITS.max_keepalive_connections
+    )
+    assert async_pool._keepalive_expiry == 0
+    assert async_client._client.timeout == httpx.Timeout(12.0)
+
+    vlm.close()
+    await asyncio.sleep(0)
+
+    assert sync_client.is_closed()
+    assert async_client.is_closed()
+
+
+@pytest.mark.asyncio
+async def test_zero_keepalive_avoids_reusing_stale_local_connection() -> None:
+    with _stale_connection_server() as server:
+        vlm = OpenAIVLM(
+            {
+                "provider": "openai",
+                "model": "test-vlm",
+                "api_key": "test-key",
+                "api_base": f"http://127.0.0.1:{server.server_port}/v1",
+                "timeout": 0.1,
+                "max_retries": 0,
+                "keepalive_expiry": 0,
+            }
+        )
+        async_client = vlm.get_async_client()
+
+        try:
+            assert await vlm.get_completion_async("first") == "ok"
+            assert await vlm.get_completion_async("second") == "ok"
+            assert server.connection_count == 2
+        finally:
+            if not async_client.is_closed():
+                await async_client.close()

--- a/tests/models/vlm/test_keepalive_config.py
+++ b/tests/models/vlm/test_keepalive_config.py
@@ -19,6 +19,7 @@ import pytest
 from pydantic import ValidationError
 
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking.models.vlm.base import FailoverVLM, MultiCredentialVLM
 from openviking_cli.utils.config.vlm_config import VLMConfig
 
 
@@ -204,6 +205,30 @@ async def test_openai_vlm_applies_keepalive_to_owned_clients(provider: str) -> N
 
     assert sync_client.is_closed()
     assert async_client.is_closed()
+
+
+def test_vlm_config_close_clears_cached_instance() -> None:
+    config = VLMConfig(model="test-vlm", provider="openai", api_key="test-key")
+    instance = MagicMock()
+    config._vlm_instance = instance
+
+    config.close()
+
+    instance.close.assert_called_once_with()
+    assert config._vlm_instance is None
+
+
+def test_vlm_wrappers_close_all_provider_instances() -> None:
+    primary = MagicMock(model="primary", provider="openai", thinking=False)
+    backup = MagicMock(model="backup", provider="openai", thinking=False)
+    failover = FailoverVLM(primary, backup)
+    multi = MultiCredentialVLM([primary, backup], ["primary", "backup"])
+
+    failover.close()
+    multi.close()
+
+    assert primary.close.call_count == 2
+    assert backup.close.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/service/test_core_vlm_lifecycle.py
+++ b/tests/unit/service/test_core_vlm_lifecycle.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Service lifecycle coverage for configured VLM clients."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openviking.service.core import OpenVikingService
+
+
+@pytest.mark.asyncio
+async def test_service_closes_vlm_after_queue_workers_stop(monkeypatch) -> None:
+    events = []
+
+    class _ResourceService:
+        async def close_background_tasks(self) -> None:
+            events.append("background")
+
+    class _QueueManager:
+        def stop(self) -> None:
+            events.append("queue")
+
+    class _VLMConfig:
+        def close(self) -> None:
+            events.append("vlm")
+
+    service = OpenVikingService.__new__(OpenVikingService)
+    service._resource_service = _ResourceService()
+    service._watch_scheduler = None
+    service._session_auto_commit_scheduler = None
+    service._queue_manager = _QueueManager()
+    service._vikingdb_manager = None
+    service._agfs_client = None
+    service._config = SimpleNamespace(vlm=_VLMConfig())
+    service._initialized = True
+    monkeypatch.setattr(service, "_release_data_dir_lock", lambda: None)
+
+    await service.close()
+
+    assert events == ["background", "queue", "vlm"]


### PR DESCRIPTION
## Description

Some OpenAI-compatible VLM endpoints leave an idle HTTP connection reusable from the client's perspective but stop answering on it. A later burst request can then block on that stale connection until its read timeout. OpenViking always used the OpenAI SDK's five-second keepalive expiry and offered no transport override through `VLMConfig`.

This change adds an optional non-negative `keepalive_expiry` setting to flat, provider, and credential VLM configurations. When set, sync and event-loop-scoped async OpenAI or Azure clients receive an SDK-default HTTP transport with only that expiry overridden. The SDK's connection limits and OpenViking's existing request timeout are preserved. Leaving the setting unset keeps the current SDK-managed transport unchanged; setting it to `0` disables idle connection reuse for endpoints affected by stale keepalives.

Configured VLM clients now also participate in service shutdown: cleanup propagates through failover and multi-credential wrappers, clears the cached `VLMConfig` instance, and runs after queue workers stop.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4464

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- validate and propagate `keepalive_expiry` through flat, provider, credential, and legacy failover VLM config paths;
- preserve zero as an explicit value instead of treating it as a missing setting;
- apply configured expiry to owned sync and async OpenAI/Azure HTTP clients while retaining SDK connection limits and request timeout;
- propagate client cleanup through VLM wrappers and normal service shutdown; and
- document the setting in the English and Chinese configuration guides.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Local checks:

- 148 focused VLM keepalive, timeout, request configuration, failover, reasoning, response, and lifecycle tests passed;
- the 3 existing service-close tests passed with the new cleanup hook;
- a controlled local HTTP/1.1 endpoint made a reused first connection stall on its second request: current main timed out, while `keepalive_expiry: 0` opened a second connection and completed;
- OpenAI and Azure sync/async transport tests confirmed that SDK connection limits and the configured request timeout are preserved; and
- Ruff lint and format checks, Python compile checks, and `git diff --check` passed on the changed files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; this backend transport and lifecycle change has no visual output.

## Additional Notes

Disabling keepalive adds TCP/TLS setup cost, so this remains opt-in rather than changing the default for healthy cloud endpoints. The stale-connection counterfactual used a controlled local server; a sustained production Sensenova workload was not available. Retry policy, request bodies, response parsing, and non-OpenAI-compatible transports are unchanged.