### PR TITLE
fix(semantic): do not materialize missing DAG roots

### DIFF
--- a/openviking/storage/queuefs/semantic_dag.py
+++ b/openviking/storage/queuefs/semantic_dag.py
@@ -473,7 +473,7 @@ class SemanticDagExecutor:
             logger.warning(
                 f"[SemanticDagExecutor] Failed to list directory {uri}: {e} from {from_hint}"
             )
-            return [], []
+            raise
 
         children_dirs: List[str] = []
         file_paths: List[str] = []

--- a/tests/storage/test_semantic_dag_skip_files.py
+++ b/tests/storage/test_semantic_dag_skip_files.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+from types import SimpleNamespace
+
 import pytest
 
 from openviking.server.identity import RequestContext, Role
@@ -28,6 +30,23 @@ class _FakeVikingFS:
 
     def _uri_to_path(self, uri, ctx=None):
         return uri.replace("viking://", "/local/acc1/")
+
+
+class _UnlistableRootVikingFS(_FakeVikingFS):
+    def __init__(self, *, fail_sidecar_write, list_error):
+        super().__init__({})
+        self.fail_sidecar_write = fail_sidecar_write
+        self.list_error = list_error
+        self.materialized_dirs = set()
+
+    async def ls(self, uri, node_limit=None, ctx=None):
+        raise self.list_error(uri)
+
+    async def write_file(self, path, content, ctx=None, lease_ref=None):
+        self.materialized_dirs.add(path.rsplit("/", 1)[0])
+        if self.fail_sidecar_write:
+            raise OSError("sidecar write failed after creating parent")
+        await super().write_file(path, content, ctx=ctx, lease_ref=lease_ref)
 
 
 class _FakeProcessor:
@@ -131,6 +150,69 @@ async def test_messages_jsonl_excluded_in_subdirectory(monkeypatch):
     summarized_names = [p.split("/")[-1] for p in processor.summarized_files]
     assert "messages.jsonl" not in summarized_names
     assert "data.csv" in summarized_names
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_sidecar_write", [False, True])
+@pytest.mark.parametrize("list_error", [FileNotFoundError, NotADirectoryError])
+async def test_unlistable_semantic_root_is_not_materialized_as_directory(
+    monkeypatch, fail_sidecar_write, list_error
+):
+    root_uri = "viking://user/user1/memories/profile.md"
+    fake_fs = _UnlistableRootVikingFS(
+        fail_sidecar_write=fail_sidecar_write,
+        list_error=list_error,
+    )
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_openviking_config",
+        lambda: SimpleNamespace(semantic=SimpleNamespace(overview_sample_limit=32)),
+    )
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="memory",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        generation_trigger="reindex",
+        skip_vectorization=True,
+    )
+
+    await executor.run(root_uri)
+
+    assert root_uri not in fake_fs.materialized_dirs
+    assert fake_fs.writes == []
+
+
+@pytest.mark.asyncio
+async def test_empty_semantic_directory_still_receives_sidecars(monkeypatch):
+    root_uri = "viking://user/user1/memories/empty"
+    fake_fs = _FakeVikingFS({root_uri: []})
+    monkeypatch.setattr("openviking.storage.queuefs.semantic_dag.get_viking_fs", lambda: fake_fs)
+    monkeypatch.setattr(
+        "openviking.storage.queuefs.semantic_dag.get_openviking_config",
+        lambda: SimpleNamespace(semantic=SimpleNamespace(overview_sample_limit=32)),
+    )
+
+    processor = _FakeProcessor()
+    ctx = RequestContext(user=UserIdentifier("acc1", "user1"), role=Role.USER)
+    executor = SemanticDagExecutor(
+        processor=processor,
+        context_type="memory",
+        max_concurrent_llm=2,
+        ctx=ctx,
+        generation_trigger="reindex",
+        skip_vectorization=True,
+    )
+
+    await executor.run(root_uri)
+
+    assert [path for path, _content in fake_fs.writes] == [
+        f"{root_uri}/.overview.md",
+        f"{root_uri}/.abstract.md",
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`SemanticDagExecutor._list_dir()` treated every listing failure as a valid empty
directory. If a queued semantic root referred to a file removed by chunking, the DAG
therefore continued to sidecar writeback. `VikingFS.write_file()` created the missing
parent first, turning the old file URI into either an empty directory or a directory
containing only `.abstract.md` and `.overview.md`.

This change preserves the listing exception so the existing dispatch error path stops
that node before any sidecar write. A real empty directory still returns an empty list
and receives its normal generated sidecars.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4461

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- stop converting semantic DAG list failures into empty-directory results;
- cover missing and non-directory roots with both successful and failed sidecar writes; and
- verify that valid empty directories still receive generated sidecars.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Local checks:

- 16 relevant semantic DAG, parent propagation, and directory enumeration tests passed;
- Ruff lint passed on both changed files and the new test is formatter-clean;
- Python compile checks and `git diff --check` passed.

The broader DAG test selection has eight failures on the unmodified base as well: two
tests require a local OpenViking config, and six test doubles do not accept the current
`creator_acl_grant` keyword. Editable installation is also unavailable here because
Cargo and the generated native `openviking/bin/ov` artifact are absent, so tests were
run from source using an existing project test environment.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; this change has no visual output.

## Additional Notes

This prevents new phantom directories. It intentionally does not remove existing ones,
because automated cleanup cannot safely distinguish them from user-created directories.