### PR TITLE
fix(embedder): bound OpenAI HTTP connection pools

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -211,7 +211,7 @@ Embedding model configuration for vector search, supporting dense, sparse, and h
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`) |
+| `max_concurrent` | int | Maximum concurrent embedding requests (`embedding.max_concurrent`, default: `10`; must be `>= 1`) |
 | `max_retries` | int | Maximum retry attempts for transient embedding provider errors (`embedding.max_retries`, default: `3`; `0` disables retry) |
 | `text_source` | str | Text used for vectorizing text files. `content_only` reads raw content, `summary_first` uses summary when available and falls back to content, `summary_only` uses only summary. Default: `content_only` |
 | `max_input_tokens` | int | Maximum estimated raw text tokens sent to the embedding model when content is used. Default: `4096` |

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -213,7 +213,7 @@ openviking-server doctor
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `max_concurrent` | int | 最大并发 Embedding 请求数（`embedding.max_concurrent`，默认：`10`） |
+| `max_concurrent` | int | 最大并发 Embedding 请求数（`embedding.max_concurrent`，默认：`10`；必须 `>= 1`） |
 | `max_retries` | int | Embedding provider 瞬时错误的最大重试次数（`embedding.max_retries`，默认：`3`；`0` 表示禁用重试） |
 | `text_source` | str | 文本文件向量化时使用的文本来源。`content_only` 读取原文内容；`summary_first` 优先使用摘要，没有摘要时回退到原文；`summary_only` 只使用摘要。默认：`content_only` |
 | `max_input_tokens` | int | 使用原文内容向量化时，发送给 embedding 模型的最大估算 token 数。默认：`4096` |

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
+import httpx
 import openai
 
 from openviking.models.embedder.base import (
@@ -147,13 +148,19 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             self._client_kwargs["api_version"] = self.api_version or DEFAULT_AZURE_API_VERSION
             if extra_headers:
                 self._client_kwargs["default_headers"] = extra_headers
-            self.client = openai.AzureOpenAI(**self._client_kwargs)
+            self.client = openai.AzureOpenAI(
+                http_client=openai.DefaultHttpxClient(limits=self._http_limits()),
+                **self._client_kwargs,
+            )
         else:
             if self.api_base:
                 self._client_kwargs["base_url"] = self.api_base
             if extra_headers:
                 self._client_kwargs["default_headers"] = extra_headers
-            self.client = openai.OpenAI(**self._client_kwargs)
+            self.client = openai.OpenAI(
+                http_client=openai.DefaultHttpxClient(limits=self._http_limits()),
+                **self._client_kwargs,
+            )
         self._async_client_cache = LoopScopedAsyncClientCache()
 
         # Auto-detect dimension
@@ -172,6 +179,13 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
         except Exception:
             # Use default value, text-embedding-3-small defaults to 1536
             return 1536
+
+    def _http_limits(self) -> httpx.Limits:
+        return httpx.Limits(
+            max_connections=self.max_concurrent,
+            max_keepalive_connections=self.max_concurrent,
+            keepalive_expiry=5.0,
+        )
 
     def _truncate_vector(self, vector: List[float]) -> List[float]:
         """Truncate vector to target dimension if needed.
@@ -297,9 +311,16 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
 
     def _get_async_client(self):
         def _build_async_client():
+            http_client = openai.DefaultAsyncHttpxClient(limits=self._http_limits())
             if self._provider == "azure":
-                return openai.AsyncAzureOpenAI(**self._client_kwargs)
-            return openai.AsyncOpenAI(**self._client_kwargs)
+                return openai.AsyncAzureOpenAI(
+                    http_client=http_client,
+                    **self._client_kwargs,
+                )
+            return openai.AsyncOpenAI(
+                http_client=http_client,
+                **self._client_kwargs,
+            )
 
         return self._async_client_cache.get(_build_async_client)
 
@@ -364,6 +385,11 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             int: Vector dimension
         """
         return self._dimension
+
+    def close(self):
+        """Close the sync client and all event-loop-scoped async clients."""
+        self.client.close()
+        self._async_client_cache.close_all_with_close()
 
 
 class OpenAISparseEmbedder(SparseEmbedderBase):

--- a/openviking/models/embedder/openai_embedders.py
+++ b/openviking/models/embedder/openai_embedders.py
@@ -181,9 +181,10 @@ class OpenAIDenseEmbedder(DenseEmbedderBase):
             return 1536
 
     def _http_limits(self) -> httpx.Limits:
+        pool_limit = max(1, self.max_concurrent)
         return httpx.Limits(
-            max_connections=self.max_concurrent,
-            max_keepalive_connections=self.max_concurrent,
+            max_connections=pool_limit,
+            max_keepalive_connections=pool_limit,
             keepalive_expiry=5.0,
         )
 

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -563,6 +563,12 @@ class OpenVikingService:
             self._agfs_client = None
             logger.info("RAGFS binding closed")
 
+        embedder = getattr(self, "_embedder", None)
+        if embedder is not None:
+            embedder.close()
+            self._embedder = None
+            await asyncio.sleep(0)
+
         self._viking_fs = None
         self._resource_processor = None
         self._skill_processor = None

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -639,7 +639,9 @@ class EmbeddingConfig(BaseModel):
     )
 
     max_concurrent: int = Field(
-        default=10, description="Maximum number of concurrent embedding requests"
+        default=10,
+        ge=1,
+        description="Maximum number of concurrent embedding requests",
     )
     max_retries: int = Field(
         default=3,

--- a/tests/unit/service/test_core_embedder_lifecycle.py
+++ b/tests/unit/service/test_core_embedder_lifecycle.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Service lifecycle coverage for embedding clients."""
+
+import pytest
+
+from openviking.service.core import OpenVikingService
+
+
+@pytest.mark.asyncio
+async def test_service_closes_embedder_after_workers_and_storage_stop(monkeypatch) -> None:
+    events = []
+
+    class _ResourceService:
+        async def close_background_tasks(self) -> None:
+            events.append("background")
+
+    class _QueueManager:
+        def stop(self) -> None:
+            events.append("queue")
+
+    class _VikingDBManager:
+        def mark_closing(self) -> None:
+            events.append("storage-mark")
+
+        async def close(self) -> None:
+            events.append("storage-close")
+
+    class _Embedder:
+        def close(self) -> None:
+            events.append("embedder")
+
+    service = OpenVikingService.__new__(OpenVikingService)
+    service._resource_service = _ResourceService()
+    service._watch_scheduler = None
+    service._session_auto_commit_scheduler = None
+    service._queue_manager = _QueueManager()
+    service._vikingdb_manager = _VikingDBManager()
+    service._agfs_client = None
+    service._embedder = _Embedder()
+    service._initialized = True
+    monkeypatch.setattr(service, "_release_data_dir_lock", lambda: None)
+
+    await service.close()
+
+    assert events == [
+        "background",
+        "queue",
+        "storage-mark",
+        "storage-close",
+        "embedder",
+    ]
+    assert service._embedder is None

--- a/tests/unit/test_openai_embedder_http_pool.py
+++ b/tests/unit/test_openai_embedder_http_pool.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Regression tests for OpenAI embedder HTTP connection ownership."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterator
+
+import openai
+import pytest
+
+from openviking.models.embedder import OpenAIDenseEmbedder
+
+
+class _EmbeddingServer(ThreadingHTTPServer):
+    daemon_threads = True
+    block_on_close = False
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _EmbeddingHandler)
+        self.connection_count = 0
+
+    def get_request(self):
+        request, address = super().get_request()
+        self.connection_count += 1
+        return request, address
+
+
+class _EmbeddingHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(content_length)
+        payload = json.dumps(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "embedding",
+                        "index": 0,
+                        "embedding": [0.1, 0.2, 0.3],
+                    }
+                ],
+                "model": "test-embedding",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@contextmanager
+def _embedding_server() -> Iterator[_EmbeddingServer]:
+    server = _EmbeddingServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _pool(client):
+    return client._client._transport._pool
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["openai", "azure"])
+async def test_openai_embedder_bounds_sync_and_async_connection_pools(provider: str) -> None:
+    provider_kwargs = {}
+    if provider == "azure":
+        provider_kwargs = {
+            "api_base": "https://test-resource.openai.azure.com",
+            "api_version": "2025-01-01-preview",
+        }
+
+    embedder = OpenAIDenseEmbedder(
+        model_name="test-embedding",
+        api_key="test-key",
+        dimension=3,
+        config={"max_concurrent": 3},
+        provider=provider,
+        **provider_kwargs,
+    )
+    async_client = embedder._get_async_client()
+
+    try:
+        for client in (embedder.client, async_client):
+            pool = _pool(client)
+            assert pool._max_connections == 3
+            assert pool._max_keepalive_connections == 3
+            assert pool._keepalive_expiry == 5.0
+            assert client._client.timeout == openai.DEFAULT_TIMEOUT
+    finally:
+        embedder.client.close()
+        await async_client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_embedder_reuses_and_closes_local_connection() -> None:
+    with _embedding_server() as server:
+        embedder = OpenAIDenseEmbedder(
+            model_name="test-embedding",
+            api_key="test-key",
+            api_base=f"http://127.0.0.1:{server.server_port}/v1",
+            dimension=3,
+            encoding_format="float",
+        )
+        async_client = embedder._get_async_client()
+
+        try:
+            first = await embedder.embed_async("first")
+            second = await embedder.embed_async("second")
+
+            assert first.dense_vector == pytest.approx([0.1, 0.2, 0.3])
+            assert second.dense_vector == pytest.approx([0.1, 0.2, 0.3])
+            assert server.connection_count == 1
+
+            embedder.close()
+            await asyncio.sleep(0)
+
+            assert embedder.client.is_closed()
+            assert async_client.is_closed()
+        finally:
+            if not embedder.client.is_closed():
+                embedder.client.close()
+            if not async_client.is_closed():
+                await async_client.close()

--- a/tests/unit/test_openai_embedder_http_pool.py
+++ b/tests/unit/test_openai_embedder_http_pool.py
@@ -13,8 +13,10 @@ from typing import Iterator
 
 import openai
 import pytest
+from pydantic import ValidationError
 
 from openviking.models.embedder import OpenAIDenseEmbedder
+from openviking_cli.utils.config.embedding_config import EmbeddingConfig
 
 
 class _EmbeddingServer(ThreadingHTTPServer):
@@ -140,3 +142,26 @@ async def test_openai_embedder_reuses_and_closes_local_connection() -> None:
                 embedder.client.close()
             if not async_client.is_closed():
                 await async_client.close()
+
+
+@pytest.mark.parametrize("max_concurrent", [0, -1])
+def test_embedding_config_rejects_non_positive_concurrency(max_concurrent: int) -> None:
+    with pytest.raises(ValidationError, match="max_concurrent"):
+        EmbeddingConfig(max_concurrent=max_concurrent)
+
+
+@pytest.mark.parametrize("max_concurrent", [0, -1])
+def test_direct_embedder_normalizes_non_positive_pool_limit(max_concurrent: int) -> None:
+    embedder = OpenAIDenseEmbedder(
+        model_name="test-embedding",
+        api_key="test-key",
+        dimension=3,
+        config={"max_concurrent": max_concurrent},
+    )
+
+    try:
+        pool = _pool(embedder.client)
+        assert pool._max_connections == 1
+        assert pool._max_keepalive_connections == 1
+    finally:
+        embedder.close()


### PR DESCRIPTION
## Description

Current main already reuses one async OpenAI client per event loop. Those clients, and the synchronous client, still let the OpenAI SDK create its default HTTP transport. In the locked SDK that means up to 1000 connections and 100 idle keepalive connections, well above OpenViking's default embedding concurrency of 10. The embedder also had no `close()` implementation for its sync client or cached async clients.

This change gives every OpenAI and Azure embedding client an SDK-default HTTP transport whose connection and keepalive limits follow the existing `max_concurrent` setting. Validated configuration now rejects values below one, while direct embedder construction preserves the existing one-request fallback instead of creating a pool that can only time out. The SDK timeout behavior and five-second keepalive expiry remain unchanged.

The service now closes and clears its embedder after queue workers and vector storage stop, so the sync client and all event-loop-scoped async clients are released during normal shutdown.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4462

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## Changes Made

- bound sync and async OpenAI/Azure HTTP pools to the configured embedding concurrency;
- reject `embedding.max_concurrent < 1` and normalize direct-constructor values to one;
- preserve the OpenAI SDK's existing timeout and keepalive-expiry defaults;
- close and clear the service-owned embedder during normal shutdown; and
- document the positive concurrency requirement and add transport, boundary, reuse, and cleanup regression coverage.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Local checks:

- 42 focused OpenAI/Azure embedder, request-configuration, pool-boundary, and lifecycle tests passed;
- 4 embedding-configuration and existing service-close tests passed;
- a controlled local HTTP/1.1 endpoint confirmed that two sequential async embeddings reuse one TCP connection and that cleanup closes both SDK clients;
- zero and negative validated concurrency values are rejected, while direct construction produces a one-connection pool instead of `PoolTimeout`; and
- Ruff lint and format checks, Python compile checks, and `git diff --check` passed on the changed files.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; this backend connection-management change has no visual output.

## Additional Notes

The issue's `keepalive_expiry=inf` description does not match the currently locked OpenAI SDK, which uses five seconds. The oversized `1000/100` connection limits are still present and are the behavior this PR bounds. Validation used a controlled local server, not a sustained production llama.cpp workload. Pool sizes and timeouts are not added as new configuration fields, and other embedding providers are unchanged.