### PR TITLE
fix(studio): restore jsdom storage on Node 25

### DIFF
--- a/web-studio/src/test/setup.ts
+++ b/web-studio/src/test/setup.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest/jsdom" />
+
+if (typeof jsdom !== 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    value: jsdom.window.localStorage,
+    writable: true,
+  })
+}

--- a/web-studio/vite.config.ts
+++ b/web-studio/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 import { defineConfig } from 'vite'
 import { devtools } from '@tanstack/devtools-vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
@@ -19,6 +21,9 @@ const config = defineConfig({
     }),
     viteReact(),
   ],
+  test: {
+    setupFiles: ['./src/test/setup.ts'],
+  },
 })
 
 export default config


### PR DESCRIPTION
## Description

Make jsdom tests use Vitest's own `localStorage` on Node 25, whose enabled-by-default Web Storage global otherwise prevents Vitest from exposing the complete jsdom implementation.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Part of #4471 (problem 1 of 2).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- register a shared Vitest setup file without changing the default test environment;
- replace Node's incomplete test-global `localStorage` only when Vitest exposes a `JSDOM` instance; and
- reuse `jsdom.window.localStorage` instead of maintaining a Storage mock.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Before, Node 25.8.2 failed exactly the three Playground storage tests:

```text
Test Files  1 failed | 55 passed (56)
Tests       3 failed | 211 passed (214)
TypeError: localStorage.clear is not a function
```

After:

```text
Node 25.8.2: Test Files 56 passed (56); Tests 214 passed (214)
Node 24.19.0: Test Files 56 passed (56); Tests 214 passed (214)
npm run build: passed (3955 modules transformed)
```

Focused Prettier and ESLint checks pass. Full `npm run lint` still reports the two unchanged `task-pipeline.ts` errors tracked as #4471 problem 2; that fix is intentionally a separate PR.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable. This changes only the test environment and has no rendered UI output.

## Additional Notes

The setup affects the 26 files that opt into jsdom. The remaining 30 test files stay in their existing Node environment because the setup is guarded by the presence of Vitest's `jsdom` global.