### PR TITLE
fix(studio): model optional queue status entries

### DIFF
--- a/web-studio/src/routes/tasks/-lib/task-pipeline.test.ts
+++ b/web-studio/src/routes/tasks/-lib/task-pipeline.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTaskPipelineSteps } from './task-pipeline'
+
+describe('task pipeline queue status', () => {
+  it('keeps missing queue entries optional', () => {
+    const steps = getTaskPipelineSteps(
+      {
+        result: {
+          queue_status: {
+            Semantic: { processed: 3 },
+          },
+        },
+        status: 'running',
+        task_type: 'resource_import',
+      },
+      'en',
+    )
+
+    expect(steps).toEqual([
+      { name: 'Document Parsing', state: 'completed' },
+      { count: 3, name: 'Semantic Processing', state: 'completed' },
+      { count: undefined, name: 'Vector Embedding', state: 'running' },
+    ])
+  })
+})

--- a/web-studio/src/routes/tasks/-lib/task-pipeline.ts
+++ b/web-studio/src/routes/tasks/-lib/task-pipeline.ts
@@ -12,11 +12,16 @@ export type PipelineGroup =
   | { type: 'serial'; step: PipelineStep }
   | { type: 'parallel'; steps: PipelineStep[] }
 
+type QueueStatus = Record<
+  string,
+  { error_count?: number; processed?: number } | undefined
+>
+
 function inferState(
   qKey: string | null,
   fallback: StepState,
   status: string | undefined,
-  qStatus: Record<string, { error_count?: number; processed?: number }> | undefined,
+  qStatus: QueueStatus | undefined,
 ): StepState {
   if (status === 'pending') return 'pending'
   if (qKey && qStatus?.[qKey]) {
@@ -40,7 +45,7 @@ export function getTaskPipelineSteps(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as Record<string, { error_count?: number; processed?: number }> | undefined
+  const qStatus = resObj.queue_status as QueueStatus | undefined
 
   if (type === 'session_commit') {
     return [
@@ -106,7 +111,7 @@ export function getTaskPipelineGroups(
   const type = task.task_type
   const status = task.status
   const resObj = (task.result || {}) as Record<string, any>
-  const qStatus = resObj.queue_status as Record<string, { error_count?: number; processed?: number }> | undefined
+  const qStatus = resObj.queue_status as QueueStatus | undefined
 
   if (type === 'session_commit') {
     return [


### PR DESCRIPTION
## Description

Model `queue_status` keys as optional so Studio lint agrees with the API's partial runtime payloads without removing the guards on `Semantic` and `Embedding`.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Part of #4471 (problem 2 of 2).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- make arbitrary `queue_status` entries explicitly optional in the local type;
- retain the runtime guards for absent Semantic and Embedding queues; and
- cover a partial payload with only the Semantic entry present.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Before:

```text
npm run lint: 52 problems (2 errors, 50 warnings)
task-pipeline.ts:87:31  Unnecessary optional chain
task-pipeline.ts:92:32  Unnecessary optional chain
```

After:

```text
npm run lint: 50 problems (0 errors, 50 warnings)
npm test: 57 files passed; 215 tests passed
npm run build: passed (3955 modules transformed)
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable. This changes a data type and regression test without changing rendered UI output.

## Additional Notes

The backend builds some queue-status payloads from the entries actually present and uses `.get()` for named queues in its own consumers. This is why the fix changes the type rather than deleting the optional chains.