### PR TITLE
fix(opencode): preserve project peer with shared credentials

### DIFF
--- a/examples/opencode-plugin/lib/config.mjs
+++ b/examples/opencode-plugin/lib/config.mjs
@@ -294,7 +294,7 @@ export function loadConfig(pluginRoot, projectDirectory) {
   config.apiKey = creds.apiKey
   config.account = creds.account
   config.user = creds.user
-  config.peerId = creds.peerId
+  config.peerId = creds.peerId || str(fileConfig.peerId)
   config.mcpUrl = creds.mcpUrl
   config.credentialSource = creds.credentialSource
   config.credentialPath = creds.cliPath || creds.ovPath || ""

--- a/examples/opencode-plugin/tests/config.test.mjs
+++ b/examples/opencode-plugin/tests/config.test.mjs
@@ -89,6 +89,47 @@ test("loadConfig prefers env credentials over ovcli and legacy config", async ()
   })
 })
 
+test("loadConfig uses project peer when shared credentials omit peer", async () => {
+  const snapshot = { ...process.env }
+  await withTempDir("ov-oc-config-peer-", async (dir) => {
+    try {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("OPENVIKING_")) delete process.env[key]
+      }
+      const ovcli = join(dir, "ovcli.conf")
+      const project = join(dir, "project")
+      await mkdir(join(project, ".opencode"), { recursive: true })
+      await writeFile(ovcli, JSON.stringify({
+        url: "https://cli.example.com",
+        api_key: "cli-key",
+      }))
+      await writeFile(join(project, ".opencode", "openviking-config.json"), JSON.stringify({
+        peerId: "project-peer",
+        workspacePeer: false,
+      }))
+      process.env.OPENVIKING_CLI_CONFIG_FILE = ovcli
+
+      const cfg = loadConfig(dir, project)
+      assert.equal(cfg.credentialSource, "ovcli")
+      assert.equal(cfg.peerId, "project-peer")
+      assert.deepEqual(cfg.effectivePeer, { peerId: "project-peer", source: "explicit" })
+      assert.equal(cfg.legacyCredentialsUsed, false)
+
+      process.env.OPENVIKING_CREDENTIAL_SOURCE = "env"
+      process.env.OPENVIKING_URL = "https://env.example.com"
+      process.env.OPENVIKING_API_KEY = "env-key"
+
+      const envCfg = loadConfig(dir, project)
+      assert.equal(envCfg.credentialSource, "env")
+      assert.equal(envCfg.peerId, "project-peer")
+      assert.deepEqual(envCfg.effectivePeer, { peerId: "project-peer", source: "explicit" })
+      assert.equal(envCfg.legacyCredentialsUsed, false)
+    } finally {
+      restoreOpenVikingEnv(snapshot)
+    }
+  })
+})
+
 test("loadConfig reads legacy credentials as fallback and marks deprecation", async () => {
   const snapshot = { ...process.env }
   await withTempDir("ov-oc-legacy-", async (dir) => {


### PR DESCRIPTION
## Description

Preserve the project-level `peerId` when shared ovcli or environment credentials provide connection details but omit their own peer identity. This restores the documented per-project Agent Memory isolation instead of silently falling back to shared user space.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4487

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- fall back to the project config's `peerId` when shared credentials omit a peer
- preserve an explicit shared-credential peer as the highest-priority value
- cover both ovcli and environment credential paths without enabling legacy credentials

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation:

- baseline targeted regression: failed with `actual: ''`, `expected: 'project-peer'`
- `npm test`: 28 passed
- `npm run check`: passed for all `.mjs` files
- `git diff --check`: passed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The precedence after this change is: explicit shared-credential peer > project `peerId` > workspace-derived peer. Existing tests continue to verify that an explicit environment peer is not overridden.
