### PR TITLE
fix(memory): tolerate telemetry placeholder URIs

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -140,9 +140,7 @@ def _memory_type_by_uri(operations: ResolvedOperations) -> dict[str, str]:
     for file_content in getattr(operations, "delete_file_contents", []) or []:
         uri = str(getattr(file_content, "uri", "") or "")
         if uri:
-            types_by_uri[uri] = str(
-                getattr(file_content, "memory_type", "") or "unknown"
-            )
+            types_by_uri[uri] = str(getattr(file_content, "memory_type", "") or "unknown")
     return types_by_uri
 
 
@@ -166,16 +164,25 @@ def _report_extraction_telemetry(result: Any, operations: ResolvedOperations) ->
         type_actions = actions_by_type.setdefault(normalized_type, {})
         type_actions[action] = type_actions.get(action, 0) + 1
 
+    def type_for(uri: Any) -> str:
+        mapped_type = types_by_uri.get(str(uri))
+        if mapped_type is not None:
+            return mapped_type
+        try:
+            return str(MemoryUpdater.memory_type_from_uri(str(uri)) or "unknown")
+        except ValueError:
+            return "unknown"
+
     for uri in result.written_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "created")
+        add(type_for(uri), "created")
     for uri in result.edited_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "merged")
+        add(type_for(uri), "merged")
     for uri in result.deleted_uris:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "deleted")
+        add(type_for(uri), "deleted")
     for operation in result.skipped_operations:
         add(getattr(operation, "memory_type", None), "skipped")
     for uri, _error in result.errors:
-        add(types_by_uri.get(str(uri), MemoryUpdater.memory_type_from_uri(uri)), "failed")
+        add(type_for(uri), "failed")
 
     for memory_type, actions in actions_by_type.items():
         for action, value in actions.items():

--- a/tests/session/test_compressor_v3.py
+++ b/tests/session/test_compressor_v3.py
@@ -18,6 +18,7 @@ from openviking.session.compressor_v3 import (
     _experience_root_uri,
     _experience_snapshot_provenance,
     _experience_trajectory_map,
+    _report_extraction_telemetry,
     _visible_experience_snapshot_uris,
 )
 from openviking.session.memory.dataclass import (
@@ -109,6 +110,48 @@ def test_extract_long_term_memories_preserves_legacy_positional_parameter_order(
         "event_search_tags",
         "peer_memory_enabled",
     ]
+
+
+def test_extraction_telemetry_tolerates_placeholder_uris(monkeypatch):
+    telemetry_values = {}
+    monkeypatch.setattr(
+        "openviking.session.compressor_v3.get_current_telemetry",
+        lambda: SimpleNamespace(set=telemetry_values.__setitem__),
+    )
+    mapped_placeholders = [
+        "written(page_id=1)",
+        "edited(page_id=2)",
+        "deleted(page_id=3)",
+        "failed(page_id=4)",
+    ]
+    operations = ResolvedOperations(
+        upsert_operations=[
+            ResolvedOperation(
+                old_memory_file_content=None,
+                memory_type="events",
+                uris=mapped_placeholders,
+                memory_fields={},
+            )
+        ],
+        delete_file_contents=[],
+        errors=[],
+    )
+    result = MemoryUpdateResult()
+    result.written_uris.extend([mapped_placeholders[0], "unmapped-written"])
+    result.edited_uris.extend([mapped_placeholders[1], "unmapped-edited"])
+    result.deleted_uris.extend([mapped_placeholders[2], "unmapped-deleted"])
+    result.errors.extend(
+        [
+            (mapped_placeholders[3], ValueError("mapped failure")),
+            ("unmapped-failure", ValueError("unmapped failure")),
+        ]
+    )
+
+    _report_extraction_telemetry(result, operations)
+
+    for action in ("created", "merged", "deleted", "failed"):
+        assert telemetry_values[f"memory.extract.by_type.events.{action}"] == 1
+        assert telemetry_values[f"memory.extract.by_type.unknown.{action}"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- avoid eager fallback evaluation when telemetry already has a mapped memory type
- map malformed or placeholder telemetry targets to `unknown` without weakening URI validation elsewhere
- cover mapped and unmapped placeholders across created, merged, deleted, and failed actions

Fixes #4492.

## Validation

- `pytest tests/session/test_compressor_v3.py -q -k extraction_telemetry_tolerates_placeholder_uris` — 1 passed
- `ruff check openviking/session/compressor_v3.py tests/session/test_compressor_v3.py`
- `ruff format --check openviking/session/compressor_v3.py tests/session/test_compressor_v3.py`
- `git diff --check`

The full test module still has unrelated environment/configuration failures on this checkout; the focused regression passes.