### PR TITLE
fix(benchmark): commit_session takes the telemetry keyword, not options

### DIFF
--- a/benchmark/locomo/openclaw/import_to_ov.py
+++ b/benchmark/locomo/openclaw/import_to_ov.py
@@ -291,7 +291,7 @@ async def viking_ingest(
             )
 
         # Commit
-        result = await client.commit_session(session_id, options={"telemetry": True})
+        result = await client.commit_session(session_id, telemetry=True)
 
         # Accept both "committed" and "accepted" as success - accepted means the session was archived
         if result.get("status") not in ("committed", "accepted"):

--- a/benchmark/locomo/vikingbot/import_to_ov.py
+++ b/benchmark/locomo/vikingbot/import_to_ov.py
@@ -612,7 +612,7 @@ async def viking_ingest(
         try:
             result = await _retry_transient_http(
                 f"commit_session session={session_id}",
-                lambda: client.commit_session(session_id, options={"telemetry": True}),
+                lambda: client.commit_session(session_id, telemetry=True),
                 attempts=2,
             )
         except _TRANSIENT_HTTP_ERRORS as exc:

--- a/benchmark/longmemeval/openviking/import_to_ov.py
+++ b/benchmark/longmemeval/openviking/import_to_ov.py
@@ -271,7 +271,7 @@ async def submit_viking_ingest(
                     options={"created_at": msg_created_at} if msg_created_at else None,
                 )
 
-            result = await client.commit_session(session_id, options={"telemetry": True})
+            result = await client.commit_session(session_id, telemetry=True)
             if result.get("status") not in ("committed", "accepted"):
                 raise RuntimeError(f"Commit failed: {result}")
 

--- a/tests/unit/test_locomo_peer_wiring.py
+++ b/tests/unit/test_locomo_peer_wiring.py
@@ -85,13 +85,15 @@ async def test_viking_ingest_uses_message_peer_id(monkeypatch):
             calls.append(("create_session", options))
             return {"session_id": "sess-1"}
 
-        async def get_session(self, session_id):
+        async def get_session(self, session_id, *, auto_create=False):
             calls.append(("get_session", session_id))
             return {"commit_count": 0}
 
         async def add_message(
-            self, session_id=None, role=None, content=None, parts=None, options=None, peer_id=None
+            self, session_id, role, content=None, parts=None, options=None, peer_id=None
         ):
+            if peer_id is not None and options and "peer_id" in options:
+                raise ValueError("options cannot override 'peer_id'")
             option_values = options or {}
             calls.append(
                 (
@@ -101,12 +103,23 @@ async def test_viking_ingest_uses_message_peer_id(monkeypatch):
                         "role": role,
                         "parts": parts,
                         "created_at": option_values.get("created_at"),
-                        "peer_id": option_values.get("peer_id", peer_id),
+                        "peer_id": peer_id if peer_id is not None else option_values.get("peer_id"),
                     },
                 )
             )
 
-        async def commit_session(self, session_id, telemetry=False, *, keep_recent_count=0):
+        async def commit_session(
+            self,
+            session_id,
+            telemetry=False,
+            *,
+            keep_recent_count=0,
+            retention_mode=None,
+            keep_recent_turn_count=None,
+            retained_message_token_budget=None,
+            min_raw_tail_steps=None,
+            event_tags=None,
+        ):
             calls.append(("commit_session", telemetry))
             return {"status": "accepted", "task_id": None, "trace_id": "trace-1"}
 

--- a/tests/unit/test_locomo_peer_wiring.py
+++ b/tests/unit/test_locomo_peer_wiring.py
@@ -81,8 +81,8 @@ async def test_viking_ingest_uses_message_peer_id(monkeypatch):
         async def initialize(self):
             return None
 
-        async def create_session(self, memory_policy=None):
-            calls.append(("create_session", memory_policy))
+        async def create_session(self, session_id=None, options=None):
+            calls.append(("create_session", options))
             return {"session_id": "sess-1"}
 
         async def get_session(self, session_id):
@@ -90,8 +90,9 @@ async def test_viking_ingest_uses_message_peer_id(monkeypatch):
             return {"commit_count": 0}
 
         async def add_message(
-            self, session_id=None, role=None, parts=None, created_at=None, peer_id=None
+            self, session_id=None, role=None, content=None, parts=None, options=None, peer_id=None
         ):
+            option_values = options or {}
             calls.append(
                 (
                     "add_message",
@@ -99,14 +100,14 @@ async def test_viking_ingest_uses_message_peer_id(monkeypatch):
                         "session_id": session_id,
                         "role": role,
                         "parts": parts,
-                        "created_at": created_at,
-                        "peer_id": peer_id,
+                        "created_at": option_values.get("created_at"),
+                        "peer_id": option_values.get("peer_id", peer_id),
                     },
                 )
             )
 
-        async def commit_session(self, session_id, telemetry=True, memory_policy=None):
-            calls.append(("commit_session", memory_policy))
+        async def commit_session(self, session_id, telemetry=False, *, keep_recent_count=0):
+            calls.append(("commit_session", telemetry))
             return {"status": "accepted", "task_id": None, "trace_id": "trace-1"}
 
         async def close(self):


### PR DESCRIPTION
### Description

`openviking.AsyncHTTPClient` resolves to `openviking_cli.client._http_compat.AsyncHTTPClient`,
which subclasses the SDK client and overrides `commit_session`:

```python
    async def commit_session(
        self,
        session_id: str,
        telemetry: Any = False,
        *,
        keep_recent_count: int = 0,
        retention_mode: str | None = None,
        ...
    ) -> Dict[str, Any]:
```

The override builds the request payload itself and takes no `options` argument. Three benchmark
importers call it with `options=`, so they raise

```
TypeError: AsyncHTTPClient.commit_session() got an unexpected keyword argument 'options'
```

at the commit step, after every message has already been written. Nothing catches it: in the
vikingbot importer the call sits inside `_retry_transient_http`, and `_TRANSIENT_HTTP_ERRORS`
does not cover `TypeError`, so it propagates on the first attempt.

`create_session` is not overridden, so it keeps the SDK signature and `options=` is correct there
(that is issue #4493). The two methods genuinely differ, which is what makes this easy to get
backwards in either direction.

### Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

### Related Issue

Fixes #4497

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

### Changes Made

Three call sites, `options={"telemetry": True}` to `telemetry=True`:

- `benchmark/locomo/openclaw/import_to_ov.py:294`
- `benchmark/longmemeval/openviking/import_to_ov.py:274`
- `benchmark/locomo/vikingbot/import_to_ov.py:615`

`benchmark/locomo/openviking/import_to_ov.py`, `benchmark/locomo/hermes/import_to_ov.py` and
`benchmark/tau2/llm/scripts/run_memory_v2_eval.py` already used `telemetry=True` and are
untouched.

One test fake, `tests/unit/test_locomo_peer_wiring.py`. It covers the vikingbot importer and
fails on `main` today, because its `FakeClient` is stale on both sides at once: `create_session`
and `add_message` reject the `options` argument the real methods take, and `commit_session`
accepts a `memory_policy` keyword that no client has. All three now mirror the real client, so
the fake enforces the contract instead of hiding it. No new test files or functions, per
CONTRIBUTING.

### Testing

Windows 11, Python 3.11.15, dependencies from `pyproject.toml` in a uv virtualenv.

| Check | Result |
| --- | --- |
| `pytest tests/unit/test_locomo_peer_wiring.py` | 8 passed (7 passed, 1 failed on `main`) |
| `pytest tests/unit` | 1595 passed, 85 failed, 17 skipped, 1 error |
| `pytest tests/ingest` | 27 passed |
| `ruff check` (4 changed files) | All checks passed |
| `ruff format --check` (4 changed files) | 4 files already formatted |
| `mypy` (4 changed files) | 69 errors, all pre-existing and identical to `main` |

Regression proof: with the fake corrected, reverting the `commit_session` change in the vikingbot
importer fails `test_viking_ingest_uses_message_peer_id` with the exact `TypeError` above, and
restoring it passes.

The `tests/unit` failures are pre-existing. Comparing the failure set against the same commit
without the patch gives 87 lines before and 86 after, and the single line of difference is
`test_viking_ingest_uses_message_peer_id`, which this PR fixes. The rest are environmental in my
setup, mostly `ImportError: No compatible x86 engine backend was packaged in this wheel`, because
I installed the `pyproject.toml` dependencies rather than building the package (the build needs
maturin and cmake).

Not verified: the three importers were not run end to end against a live server. The defect and
the fix are both at the call signature, which the corrected fake now pins.

### Additional Notes

The compat override could accept `options` as well and merge it into its payload, which would
make both styles work and remove the trap. That is a maintainer call about the compatibility
layer's contract, so this PR only fixes the callers.
