### PR TITLE
ci: include Python 3.14 in full test matrix

### DIFF
--- a/.github/workflows/_test_full.yml
+++ b/.github/workflows/_test_full.yml
@@ -12,7 +12,7 @@ on:
         description: 'JSON string of Python versions'
         required: false
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   workflow_dispatch:
     inputs:
       os_json:
@@ -22,7 +22,7 @@ on:
       python_json:
         description: 'JSON string of Python versions'
         required: false
-        default: '["3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJson(inputs.os_json || '["ubuntu-24.04", "macos-14", "windows-latest"]') }}
-        python-version: ${{ fromJson(inputs.python_json || '["3.10", "3.11", "3.12", "3.13"]') }}
+        python-version: ${{ fromJson(inputs.python_json || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Include Python 3.14 in both reusable and manual full-test defaults.
- Keep the matrix fallback aligned with the declared supported Python versions.

The project metadata and contributor guide already list Python 3.14 as supported, while this workflow still defaulted to 3.13.

## Tests

- YAML parse passed with Ruby `YAML.load_file`.
- Verified all three Python matrix defaults include 3.14.
- `git diff --check`
