### PR TITLE
fix(pi-extension): don't block session_start on the OV server chain

### DIFF
--- a/examples/pi-coding-agent-extension/index.ts
+++ b/examples/pi-coding-agent-extension/index.ts
@@ -136,7 +136,14 @@ export default async function (pi: ExtensionAPI) {
 
   // --- session_start ---
   pi.on("session_start", async (event, ctx) => {
-    await start(ctx);
+    // Fire-and-forget: the OV chain (health check, session ensure, profile
+    // build) costs ~2s against the remote server; blocking session_start on it
+    // delays every pi startup. start() is memoized via startPromise, so
+    // before_agent_start awaits the same in-flight chain before the first
+    // provider request — the first turn still gets profile + recall.
+    void start(ctx).catch((error) => {
+      debugLog(`session_start: ${error instanceof Error ? error.message : String(error)}`);
+    });
   });
 
   // --- before_agent_start ---


### PR DESCRIPTION
## Problem

`session_start` in `examples/pi-coding-agent-extension/index.ts` awaits `start(ctx)`, which runs a sequential chain against the OpenViking server:

1. `client.health()`
2. `sync.ensureSession()` + `sync.replayPending()`
3. `buildSessionProfileBlock()` — system status, `fs/ls` on `viking://user`, then profile read + two **recursive** memory `ls` calls
4. takeover restore / archive overview fetch

Against a remote server this measured **~1.9–2.5s**, and pi blocks the whole session start on it (TUI and RPC both gate their startup sequence on `session_start` handlers). On a real remote-server setup, full pi startup went from **~6.0s to ~2.4s** with this change.

## Fix

`start()` is already memoized via `startPromise`, so `session_start` can simply fire it:

```ts
void start(ctx).catch((error) => {
  debugLog(`session_start: ${error instanceof Error ? error.message : String(error)}`);
});
```

`before_agent_start` keeps `await start(ctx)` — it awaits the same in-flight chain — so the **first turn still gets profile injection and recall**. Failure behavior is unchanged: if the server is unreachable, `connected` stays `false`, `before_agent_start` skips injection exactly as before; the only difference is the failure is debug-logged at `session_start` instead of propagating to the event dispatcher.

## Validation

- `pi -p` turn completes; `OV_DEBUG_LOG` shows `turn_end: synced N entries` (chain completes in the background)
- All `.mjs` modules pass `node --check`
- Startup timing re-measured across repeated runs with a warm cache: ~2.4s vs ~6.0s baseline

Happy to add a regression test if you can point me at the preferred pattern for asserting event-handler async behavior in this repo's test suite.