### PR TITLE
fix(ci): wait for ClawHub prepublication checks

### DIFF
--- a/.github/workflows/clawhub-dev-release.yml
+++ b/.github/workflows/clawhub-dev-release.yml
@@ -339,7 +339,7 @@ jobs:
       - guard
       - prepare-package-source
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 40
     permissions:
       actions: read
       contents: read
@@ -496,10 +496,10 @@ jobs:
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
           set -euo pipefail
-          # ClawHub version lookup is not read-after-write consistent and the
-          # API rate-limit window can return "Version not found" seconds after
-          # a successful publish. Retry with backoff before failing the job.
-          attempts=6
+          # ClawHub keeps staged releases hidden while pre-publication security
+          # checks run. Allow the 25-minute worker job plus visibility delay
+          # before treating an exact-version 404 as a failed publication.
+          attempts=61
           delay=30
           for i in $(seq 1 "$attempts"); do
             if node "$CLAWHUB_BIN" package inspect "@openviking/openclaw-plugin" \
@@ -508,7 +508,7 @@ jobs:
               break
             fi
             if [ "$i" -eq "$attempts" ]; then
-              echo "::error title=ClawHub verify failed::Version $VERSION still not visible after $attempts attempts."
+              echo "::error title=ClawHub verify failed::Version $VERSION still not visible after 30 minutes ($attempts attempts)."
               exit 1
             fi
             echo "ClawHub version $VERSION not visible yet (attempt $i/$attempts); retrying in ${delay}s..."


### PR DESCRIPTION
## Why

- ClawHub 在发布前安全检查完成前会隐藏 pending 版本；当前约 3 分钟的轮询窗口会把已受理的发布误判为失败。
- 将轮询窗口延长到 30 分钟、job 超时延长到 40 分钟；最终 404 和非 `legacy-zip/zip` 产物仍会失败。

## Tested

- `yq eval`、`bash -n`、`shellcheck`（目标 workflow 与校验脚本通过）
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/clawhub-dev-release.yml`（仅命中与 `origin/main` 相同的 6 个既有 shellcheck 告警）
- Not run: 真实发布 workflow；会创建新的 ClawHub/npm release。
