### PR TITLE
fix(openclaw-plugin): remove legacy provider auth metadata

### DIFF
--- a/examples/openclaw-plugin/openclaw.plugin.json
+++ b/examples/openclaw-plugin/openclaw.plugin.json
@@ -42,12 +42,6 @@
       "cliCommand": "openviking"
     }
   ],
-  "providerAuthEnvVars": {
-    "openviking": [
-      "OPENVIKING_API_KEY",
-      "OPENVIKING_BASE_URL"
-    ]
-  },
   "skills": [
     "./skills/install-openviking-memory",
     "./skills/openviking-context-database",

--- a/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
+++ b/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
@@ -12,6 +12,7 @@ const manifest = JSON.parse(
   icon?: string;
   activation?: { onStartup?: boolean; onCapabilities?: string[] };
   contracts?: { tools?: string[] };
+  setup?: { providers?: Array<{ id?: string; envVars?: string[] }> };
   configSchema?: { properties?: Record<string, unknown> };
 };
 const packageJson = JSON.parse(
@@ -98,6 +99,14 @@ describe("OpenClaw 5.2 manifest contracts", () => {
   it("opts into startup and capability-triggered hook/tool activation", () => {
     expect(manifest.activation?.onStartup).toBe(true);
     expect(manifest.activation?.onCapabilities?.toSorted()).toEqual(["hook", "tool"]);
+  });
+
+  it("declares provider auth environment variables only in current setup metadata", () => {
+    expect(manifest).not.toHaveProperty("providerAuthEnvVars");
+    expect(manifest.setup?.providers).toContainEqual(expect.objectContaining({
+      id: "openviking",
+      envVars: ["OPENVIKING_API_KEY", "OPENVIKING_BASE_URL"],
+    }));
   });
 
   it("declares recall trace configuration schema keys", () => {


### PR DESCRIPTION
## 根因与修复

- `openclaw.plugin.json` 同时声明了旧的 `providerAuthEnvVars` 和现行的 `setup.providers[].envVars`。认证变量早已迁到后者，新版 ClawHub 因此把旧字段同时报为 legacy metadata 和 unsupported top-level metadata。
- 删除重复的顶层字段，保留 `setup.providers[openviking].envVars` 中的 `OPENVIKING_API_KEY` 与 `OPENVIKING_BASE_URL`。
- 增加 manifest 合约测试，覆盖旧字段缺失和现行认证变量完整性。

## 范围与已知现状

- 不改插件运行时认证逻辑、配置字段或发布版本。
- 该定向 manifest 测试当前未由现有 PR workflow 自动执行；本次结果来自本地验证。
- npm 上的 `clawhub@0.23.3` 内置 `plugin-inspector@0.3.20`，会在 packed OpenClaw target 上误报受支持的 `uiHints`；`plugin-inspector@0.3.21` 已修复。这里不删除有效的 UI metadata。

## 验证

- `clawhub package validate examples/openclaw-plugin --openclaw-version 2026.9.1-beta.1`（PASS；0 errors；本次三条 `providerAuthEnvVars` 相关 finding 已清零；0.3.20 仅残留已知的 `uiHints` 误报）
- `clawhub package validate examples/openclaw-plugin --openclaw-version 2026.7.1-2`（PASS；0 errors；`providerAuthEnvVars` finding 已清零）
- `./node_modules/.bin/vitest run tests/ut/manifest-contracts.test.ts --reporter=verbose --pool=threads --maxWorkers=1 --no-file-parallelism`（1 file，8 tests passed）
- `NODE_OPTIONS=--max-old-space-size=512 ./node_modules/.bin/tsc -p tsconfig.json --pretty false`（通过）
- `git diff --check`（通过）
