### PR TITLE
fix(search): keep find on quick retrieval path

### DIFF
--- a/openviking/storage/viking_fs/_semantic.py
+++ b/openviking/storage/viking_fs/_semantic.py
@@ -206,7 +206,7 @@ class _SemanticMixin:
         """
         _ensure_non_empty_search_query(query, image_url)
         telemetry = get_current_telemetry()
-        from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever
+        from openviking.retrieve.hierarchical_retriever import HierarchicalRetriever, RetrieverMode
         from openviking_cli.retrieve import (
             ContextType,
             FindResult,
@@ -254,6 +254,9 @@ class _SemanticMixin:
             typed_query,
             ctx=real_ctx,
             limit=limit,
+            # ``find`` is the lightweight lookup API.  Do not let the
+            # presence of a reranker implicitly switch it to deep retrieval.
+            mode=RetrieverMode.QUICK,
             score_threshold=score_threshold,
             scope_dsl=filter,
             level=level,

--- a/tests/misc/test_vikingfs_find_without_rerank.py
+++ b/tests/misc/test_vikingfs_find_without_rerank.py
@@ -51,6 +51,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
             typed_query,
             ctx,
             limit,
+            mode,
             score_threshold,
             scope_dsl,
             level,
@@ -58,6 +59,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
             captured["typed_query"] = typed_query
             captured["ctx"] = ctx
             captured["limit"] = limit
+            captured["mode"] = mode
             captured["score_threshold"] = score_threshold
             captured["scope_dsl"] = scope_dsl
             captured["level"] = level
@@ -98,6 +100,7 @@ async def test_find_works_without_rerank_config(monkeypatch) -> None:
     assert captured["typed_query"].target_directories == ["viking://resources/docs"]
     assert captured["ctx"] == fs._ctx_or_default.return_value
     assert captured["limit"] == 3
+    assert captured["mode"].value == "quick"
     assert captured["score_threshold"] == 0.2
     assert captured["scope_dsl"] == {"category": "doc"}
     assert captured["level"] is None
@@ -118,6 +121,7 @@ async def test_find_accepts_image_url_without_text_query(monkeypatch) -> None:
             typed_query,
             ctx,
             limit,
+            mode,
             score_threshold,
             scope_dsl,
             level,


### PR DESCRIPTION
## Summary
- keep the lightweight `find` API on the quick retrieval path
- prevent configured rerankers from implicitly enabling deep THINKING retrieval
- add a regression assertion for the explicit mode

## Validation
- `python -m compileall -q openviking/storage/viking_fs/_semantic.py tests/misc/test_vikingfs_find_without_rerank.py`
- `git diff --check`
- targeted pytest attempted with uv; dependency download timed out for `firecrawl-anydoc` in this environment