### PR TITLE
fix(session): honor output language for working memory

### DIFF
--- a/openviking/prompts/templates/compression/ov_wm_v2.yaml
+++ b/openviking/prompts/templates/compression/ov_wm_v2.yaml
@@ -11,6 +11,10 @@ variables:
     type: "string"
     description: "Session content to summarize into the new Working Memory"
     required: true
+  - name: "output_language"
+    type: "string"
+    description: "Language for generated Working Memory section content"
+    required: true
   - name: "latest_archive_overview"
     type: "string"
     description: "Optional prior Working Memory. When provided, still-valid info should be carried forward."
@@ -47,6 +51,7 @@ template: |
   Output a complete Working Memory using the 7-section structure below.
 
   RULES:
+  - Write all section content in {{ output_language }}. Keep the 7 canonical English section headers and italic descriptions unchanged so existing Working Memory archives remain machine-detectable.
   - All 7 section headers and italic descriptions must appear unchanged.
   - Write INFO-DENSE content: names, numbers, dates, locations, exact values.
   - For temporal facts, record the EVENT date, not the conversation date.

--- a/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
+++ b/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
@@ -15,6 +15,10 @@ variables:
     type: "string"
     description: "New conversation content since the last update."
     required: true
+  - name: "output_language"
+    type: "string"
+    description: "Language for generated Working Memory section content"
+    required: true
   - name: "wm_section_reminders"
     type: "string"
     description: "Dynamic section-size warnings generated from the current Working Memory."
@@ -50,6 +54,8 @@ template: |
   {% endif %}
 
   # RULE 0 — Produce a continuation-grade Working Memory.
+
+  Write all generated section content in {{ output_language }}. Keep the 7 canonical English section headers unchanged because the update parser relies on them.
 
   The goal is a document that lets a future assistant seamlessly continue the
   conversation. Concrete facts (names, dates, decisions, relationships, exact

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -25,6 +25,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
 from openviking.session.memory_policy import MemoryPolicy
+from openviking.session.memory.utils.language import resolve_output_language_from_conversation
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
     RetentionPlan,
@@ -4198,6 +4199,9 @@ class Session:
             return ""
 
         formatted = self._format_messages_for_wm(messages, checkpoint_requests)
+        output_language = resolve_output_language_from_conversation(
+            formatted, config=get_openviking_config()
+        )
         checkpoint_instructions = self._checkpoint_prompt_instructions(len(checkpoint_requests))
 
         vlm = get_openviking_config().vlm
@@ -4238,6 +4242,7 @@ class Session:
                         "messages": formatted,
                         "latest_archive_overview": latest_archive_overview or "",
                         "checkpoint_instructions": checkpoint_instructions,
+                        "output_language": output_language,
                     },
                 )
                 if checkpoint_requests:
@@ -4296,6 +4301,7 @@ class Session:
                     "latest_archive_overview": latest_archive_overview,
                     "wm_section_reminders": reminders,
                     "checkpoint_instructions": checkpoint_instructions,
+                    "output_language": output_language,
                 },
             )
             resp = await vlm.get_completion_async(
@@ -4314,7 +4320,7 @@ class Session:
                 raise
             logger.warning("WM update tool_call failed (%s); falling back to creation prompt", e)
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         has_tc = bool(getattr(resp, "has_tool_calls", False) and getattr(resp, "tool_calls", None))
@@ -4331,7 +4337,7 @@ class Session:
                 raise ValueError("Working Memory update returned no tool call for checkpoints")
             logger.warning("WM update: LLM returned no tool_call; falling back to creation prompt")
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         checkpoint_summaries: tuple[str, ...] = ()
@@ -4432,7 +4438,7 @@ class Session:
                 e,
             )
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         _wm_debug(
@@ -4452,6 +4458,7 @@ class Session:
         formatted_messages: str,
         messages: List[Message],
         prior_overview: str = "",
+        output_language: str = "en",
     ) -> str:
         """Re-run WM creation prompt when the update tool_call path fails.
 
@@ -4471,6 +4478,7 @@ class Session:
                     "messages": formatted_messages,
                     "latest_archive_overview": prior_overview,
                     "checkpoint_instructions": "",
+                    "output_language": output_language,
                 },
             )
             return await get_openviking_config().vlm.get_completion_async(prompt)

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -4199,8 +4199,16 @@ class Session:
             return ""
 
         formatted = self._format_messages_for_wm(messages, checkpoint_requests)
+        language_conversation = "\n".join(
+            f"[{message.role}]: {line}"
+            for message in messages
+            for part in message.parts
+            if isinstance(part, TextPart)
+            for line in part.text.splitlines()
+            if line.strip()
+        )
         output_language = resolve_output_language_from_conversation(
-            formatted, config=get_openviking_config()
+            language_conversation, config=get_openviking_config()
         )
         checkpoint_instructions = self._checkpoint_prompt_instructions(len(checkpoint_requests))
 

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -751,6 +751,34 @@ async def test_wm_creation_returns_two_products_in_one_model_call(
     assert "secret-source-id" not in calls[0]["prompt"]
 
 
+async def test_wm_creation_passes_configured_output_language_to_prompt(client, monkeypatch):
+    session = client(session_id="wm_output_language_prompt_test")
+    prompts: list[dict] = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, **kwargs):
+            prompts.append(kwargs)
+            return "# Working Memory"
+
+    vlm = FakeVLM()
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: SimpleNamespace(vlm=vlm, output_language_override="zh-CN"),
+    )
+
+    result = await session._generate_archive_summary_async(
+        [_text_message("zh-user", "user", "请总结当前部署状态")]
+    )
+
+    assert result == "# Working Memory"
+    assert len(prompts) == 1
+    assert "zh-CN" in prompts[0]["prompt"]
+
+
 async def test_wm_update_returns_two_products_in_one_model_call(
     client,
     monkeypatch,

--- a/tests/session/test_session_retention_integration.py
+++ b/tests/session/test_session_retention_integration.py
@@ -779,6 +779,42 @@ async def test_wm_creation_passes_configured_output_language_to_prompt(client, m
     assert "zh-CN" in prompts[0]["prompt"]
 
 
+async def test_wm_creation_detects_language_from_multiline_user_message(client, monkeypatch):
+    session = client(session_id="wm_multiline_output_language_detection_test")
+    prompts: list[dict] = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, **kwargs):
+            prompts.append(kwargs)
+            return "# Working Memory"
+
+    vlm = FakeVLM()
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: SimpleNamespace(vlm=vlm),
+    )
+
+    result = await session._generate_archive_summary_async(
+        [
+            _text_message(
+                "multiline-user",
+                "user",
+                "Task details:\n"
+                "当前生产环境已经完成部署。\n"
+                "请用中文总结当前状态和后续风险。",
+            )
+        ]
+    )
+
+    assert result == "# Working Memory"
+    assert len(prompts) == 1
+    assert "zh-CN" in prompts[0]["prompt"]
+
+
 async def test_wm_update_returns_two_products_in_one_model_call(
     client,
     monkeypatch,


### PR DESCRIPTION
## Summary
- resolve Working Memory output language from the conversation and configured override
- pass the resolved language to creation, update, and fallback prompts
- keep canonical English section headers for parser compatibility
- add a regression test for `output_language_override`

## Validation
- `python -m compileall -q openviking/session/session.py tests/session/test_session_retention_integration.py`
- `git diff --check`
- full pytest could not start in this environment because the locked `firecrawl-anydoc` dependency download timed out