### PR TITLE
test: resolve API checker source paths portably

### DIFF
--- a/tests/api_test/tools/checkers/check_admin.py
+++ b/tests/api_test/tools/checkers/check_admin.py
@@ -1,7 +1,3 @@
-# Let's look at the admin router
-admin_path = "/usr/local/lib/python3.11/site-packages/openviking/server/routers/admin.py"
-print(f"Reading {admin_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(admin_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/routers/admin.py", "openviking.server.routers.admin"))

--- a/tests/api_test/tools/checkers/check_api_keys.py
+++ b/tests/api_test/tools/checkers/check_api_keys.py
@@ -1,6 +1,3 @@
-api_keys_path = "/usr/local/lib/python3.11/site-packages/openviking/server/api_keys.py"
-print(f"Reading {api_keys_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(api_keys_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/api_keys.py", "openviking.server.api_keys"))

--- a/tests/api_test/tools/checkers/check_app.py
+++ b/tests/api_test/tools/checkers/check_app.py
@@ -1,6 +1,3 @@
-app_path = "/usr/local/lib/python3.11/site-packages/openviking/server/app.py"
-print(f"Reading {app_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(app_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/app.py", "openviking.server.app"))

--- a/tests/api_test/tools/checkers/check_auth.py
+++ b/tests/api_test/tools/checkers/check_auth.py
@@ -1,6 +1,3 @@
-auth_path = "/usr/local/lib/python3.11/site-packages/openviking/server/auth.py"
-print(f"Reading {auth_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(auth_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/auth.py", "openviking.server.auth"))

--- a/tests/api_test/tools/checkers/check_bootstrap.py
+++ b/tests/api_test/tools/checkers/check_bootstrap.py
@@ -1,6 +1,3 @@
-bootstrap_path = "/usr/local/lib/python3.11/site-packages/openviking/server/bootstrap.py"
-print(f"Reading {bootstrap_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(bootstrap_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/bootstrap.py", "openviking.server.bootstrap"))

--- a/tests/api_test/tools/checkers/check_config.py
+++ b/tests/api_test/tools/checkers/check_config.py
@@ -1,6 +1,3 @@
-config_path = "/usr/local/lib/python3.11/site-packages/openviking/server/config.py"
-print(f"Reading {config_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(config_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/config.py", "openviking.server.config"))

--- a/tests/api_test/tools/checkers/check_logger.py
+++ b/tests/api_test/tools/checkers/check_logger.py
@@ -1,6 +1,3 @@
-logger_path = "/usr/local/lib/python3.11/site-packages/openviking_cli/utils/logger.py"
-print(f"Reading {logger_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(logger_path, "r") as f:
-    print(f.read())
+print(read_source("openviking_cli/utils/logger.py", "openviking_cli.utils.logger"))

--- a/tests/api_test/tools/checkers/check_server_config.py
+++ b/tests/api_test/tools/checkers/check_server_config.py
@@ -1,7 +1,3 @@
-# Let's look at the server config module
-server_config_path = "/usr/local/lib/python3.11/site-packages/openviking/server/config.py"
-print(f"Reading {server_config_path}...")
-print("=" * 80)
+from source_reader import read_source
 
-with open(server_config_path, "r") as f:
-    print(f.read())
+print(read_source("openviking/server/config.py", "openviking.server.config"))

--- a/tests/api_test/tools/checkers/source_reader.py
+++ b/tests/api_test/tools/checkers/source_reader.py
@@ -1,0 +1,43 @@
+"""Helpers for reading OpenViking source files from API checkers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _find_repository_root() -> Path | None:
+    """Return the source checkout root when the checker runs from a clone."""
+    checker_dir = Path(__file__).resolve().parent
+    for parent in (checker_dir, *checker_dir.parents):
+        if (parent / "pyproject.toml").is_file() and (parent / "openviking").is_dir():
+            return parent
+    return None
+
+
+def resolve_source_path(relative_path: str, module_name: str) -> Path:
+    """Resolve a source file from a checkout, then from an installed package."""
+    repository_root = _find_repository_root()
+    if repository_root is not None:
+        checkout_path = repository_root / relative_path
+        if checkout_path.is_file():
+            return checkout_path
+
+    module_spec = importlib.util.find_spec(module_name)
+    if module_spec is not None and module_spec.origin not in (None, "built-in"):
+        installed_path = Path(module_spec.origin)
+        if installed_path.is_file():
+            return installed_path
+
+    raise FileNotFoundError(
+        f"Could not locate source for {module_name!r} "
+        f"(expected {relative_path!r} in the repository or installed package)"
+    )
+
+
+def read_source(relative_path: str, module_name: str) -> str:
+    """Read a source module using the resolved checkout or package path."""
+    source_path = resolve_source_path(relative_path, module_name)
+    print(f"Reading {source_path}...")
+    print("=" * 80)
+    return source_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- resolve API checker source files from the repository checkout instead of a Python 3.11-specific absolute path
- fall back to the installed package location when the checker is run outside a source checkout
- keep the existing checker output while making it portable across Python versions and environments

## Motivation

The API checker scripts all assumed `/usr/local/lib/python3.11/site-packages`, so they failed in other Python versions and when run from a repository checkout. The shared resolver makes both supported execution modes work without changing the checks themselves.

## Testing

- `git diff --check`
- `uv run --no-project --with ruff ruff check tests/api_test/tools/checkers`
- `uv run --no-project --with ruff ruff format --check tests/api_test/tools/checkers`
- Python compileall for `tests/api_test/tools/checkers`
- executed all 8 source checker scripts successfully from the repository checkout
