### PR TITLE
fix(acl): remove destructive schema auto-migration

### DIFF
--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 from openviking.core.context import ContextType, ResourceContentType
 from openviking.models.embedder.base import embed_compat
 from openviking.server.identity import RequestContext, Role
-from openviking.storage.acl import ACL_CONTEXT_FIELDS, ACL_GRANT_FIELDS
+from openviking.storage.acl import ACL_GRANT_FIELDS
 from openviking.storage.errors import (
     CollectionNotFoundError,
     EmbeddingConfigurationError,
@@ -318,26 +318,6 @@ async def init_context_collection(storage) -> bool:
             "Existing collection metadata is unavailable; cannot validate embedding compatibility"
         )
 
-    existing_fields = {field.get("FieldName") for field in existing_meta.get("Fields", [])}
-    missing_acl_fields = sorted(ACL_CONTEXT_FIELDS - existing_fields)
-    existing_scalar_indexes = set(existing_meta.get("ScalarIndex", []))
-    missing_acl_indexes = sorted(ACL_CONTEXT_FIELDS - existing_scalar_indexes)
-
-    async def _migrate_acl_schema() -> None:
-        if not missing_acl_fields and not missing_acl_indexes:
-            return
-        if vectordb_cfg.backend not in {"local", "cuvs"}:
-            raise EmbeddingConfigurationError(
-                "Context collection is missing ACL schema: "
-                f"fields={missing_acl_fields}, scalar_indexes={missing_acl_indexes}. "
-                "Add them to the remote collection before starting OpenViking."
-            )
-        if not hasattr(storage, "update_collection_schema"):
-            raise EmbeddingConfigurationError(
-                "Local context collection does not support automatic schema migration"
-            )
-        await storage.update_collection_schema(schema["Fields"], schema["ScalarIndex"])
-
     base_description, existing_embedding_meta = _decode_collection_description(
         existing_meta.get("Description")
     )
@@ -356,12 +336,10 @@ async def init_context_collection(storage) -> bool:
         )
 
     if _embedding_metadata_compatible(existing_embedding_meta, embedding_meta):
-        await _migrate_acl_schema()
         return False
 
     existing_count = await storage.count() if hasattr(storage, "count") else 0
     if existing_embedding_meta is None and existing_count == 0:
-        await _migrate_acl_schema()
         if hasattr(storage, "update_collection_description"):
             await storage.update_collection_description(
                 _encode_collection_description(
@@ -372,7 +350,6 @@ async def init_context_collection(storage) -> bool:
             return False
 
     if existing_embedding_meta is None:
-        await _migrate_acl_schema()
         logger.warning(
             "Existing collection has %d vector(s) but no embedding metadata "
             "(created by an older version). Backfilling with current config and continuing.",
@@ -388,7 +365,6 @@ async def init_context_collection(storage) -> bool:
         return False
 
     if existing_count == 0 and hasattr(storage, "update_collection_description"):
-        await _migrate_acl_schema()
         await storage.update_collection_description(
             _encode_collection_description(
                 base_description or "Unified context collection",
@@ -416,7 +392,6 @@ async def init_context_collection(storage) -> bool:
         and not dimension_changed
         and hasattr(storage, "update_collection_description")
     ):
-        await _migrate_acl_schema()
         logger.warning(
             "Embedding metadata changed (provider/model) but dimension is "
             "unchanged; embedding.allow_metadata_override=true, so the existing "

--- a/openviking/storage/viking_vector_index_backend.py
+++ b/openviking/storage/viking_vector_index_backend.py
@@ -128,23 +128,6 @@ class _AsyncVectorAdapter:
             lambda: self._adapter.get_collection().update(description=description)
         )
 
-    async def update_collection_schema(
-        self, fields: List[Dict[str, Any]], scalar_index: List[str], index_name: str
-    ) -> None:
-        def _update() -> None:
-            collection = self._adapter.get_collection()
-            collection.update(fields=fields)
-            if self._adapter.mode in {"local", "cuvs"}:
-                index_meta = collection.get_index_meta_data(index_name)
-                index_meta["ScalarIndex"] = scalar_index
-                collection.drop_index(index_name)
-                collection.create_index(index_name, index_meta)
-            else:
-                collection.update_index(index_name, scalar_index=scalar_index)
-
-        await asyncio.to_thread(_update)
-
-
 class _SingleAccountBackend:
     """绑定单个 account 的后端实现（内部类）"""
 
@@ -337,12 +320,6 @@ class _SingleAccountBackend:
         await self._async_adapter.update_collection_description(description)
         await self._refresh_meta_data_async()
         return True
-
-    async def update_collection_schema(
-        self, fields: List[Dict[str, Any]], scalar_index: List[str]
-    ) -> None:
-        await self._async_adapter.update_collection_schema(fields, scalar_index, self._index_name)
-        await self._refresh_meta_data_async()
 
     # =========================================================================
     # Data Operations (with tenant enforcement)
@@ -900,15 +877,6 @@ class VikingVectorIndexBackend:
 
     async def update_collection_description(self, description: str) -> bool:
         return await self._get_default_backend().update_collection_description(description)
-
-    async def update_collection_schema(
-        self, fields: List[Dict[str, Any]], scalar_index: List[str]
-    ) -> None:
-        default_backend = self._get_default_backend()
-        await default_backend.update_collection_schema(fields, scalar_index)
-        for backend in [*self._account_backends.values(), self._root_backend]:
-            if backend is not None and backend is not default_backend:
-                await backend._refresh_meta_data_async()
 
     # =========================================================================
     # 公开数据操作 API（强制要求 ctx）

--- a/tests/storage/test_collection_schemas.py
+++ b/tests/storage/test_collection_schemas.py
@@ -13,7 +13,6 @@ import requests
 from openviking.models.embedder.base import DenseEmbedderBase, EmbedResult
 from openviking.server.identity import RequestContext, Role, UserIdentifier
 from openviking.service.resource_service import ResourceService
-from openviking.storage.acl import ACL_CONTEXT_FIELDS, ACL_GRANT_FIELDS
 from openviking.storage.collection_schemas import (
     CollectionSchemas,
     TextEmbeddingHandler,
@@ -185,9 +184,8 @@ async def test_init_context_collection_writes_embedding_metadata(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_init_context_collection_migrates_local_legacy_schema(monkeypatch):
+async def test_init_context_collection_backfills_metadata_for_empty_legacy_collection(monkeypatch):
     updates = []
-    schema_updates = []
 
     class _FakeStorage:
         async def create_collection(self, name, schema):
@@ -195,20 +193,7 @@ async def test_init_context_collection_migrates_local_legacy_schema(monkeypatch)
             return False
 
         async def get_collection_meta(self):
-            schema = CollectionSchemas.context_collection("context", 2)
-            return {
-                "Description": "Unified context collection",
-                "Fields": [
-                    field
-                    for field in schema["Fields"]
-                    if field["FieldName"] not in ACL_CONTEXT_FIELDS
-                ],
-                "ScalarIndex": [
-                    field
-                    for field in schema["ScalarIndex"]
-                    if field not in ACL_CONTEXT_FIELDS
-                ],
-            }
+            return {"Description": "Unified context collection"}
 
         async def count(self):
             return 0
@@ -217,10 +202,7 @@ async def test_init_context_collection_migrates_local_legacy_schema(monkeypatch)
             updates.append(description)
             return True
 
-        async def update_collection_schema(self, fields, scalar_index):
-            schema_updates.append((fields, scalar_index))
-
-    config = _DummyConfig(_DummyEmbedder(), backend="local")
+    config = _DummyConfig(_DummyEmbedder())
     monkeypatch.setattr(
         "openviking_cli.utils.config.get_openviking_config",
         lambda: config,
@@ -230,13 +212,7 @@ async def test_init_context_collection_migrates_local_legacy_schema(monkeypatch)
 
     assert created is False
     assert len(updates) == 1
-    assert len(schema_updates) == 1
     assert '"provider": "local"' in updates[0]
-    fields, scalar_index = schema_updates[0]
-    fields_by_name = {field["FieldName"]: field for field in fields}
-    assert fields_by_name["acl_enabled"]["FieldType"] == "bool"
-    assert all(fields_by_name[field]["FieldType"] == "list<string>" for field in ACL_GRANT_FIELDS)
-    assert ACL_CONTEXT_FIELDS <= set(scalar_index)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

移除 ACL 引入的存量 context collection 自动迁移，避免服务启动时修改 collection schema 并通过 `drop_index` / `create_index` 重建已有索引。

### Before

当服务启动并发现已有 context collection 缺少 ACL 字段或标量索引时：

1. local/cuVS backend 会先用当前完整 schema 覆盖 collection 字段；
2. 随后删除已有 index，再用新 `ScalarIndex` 创建 index；
3. 远端 backend 会因缺少 ACL schema 阻止启动。

因此迁移或索引恢复中途失败时，原本可用的存量索引可能已经被删除。

### After

已有 context collection 启动时只沿用原有 embedding metadata 兼容检查，不再自动修改 schema、删除 index 或创建替代 index，也不再由该入口校验远端 ACL schema。新建 collection 仍使用当前 schema，继续包含 ACL 字段和标量索引。

### Example

同一个场景：已有 local context collection 包含 10,000 条向量，但没有 `acl_direct_grants` 和 `acl_inherited_grants`。

- Before：启动进入 ACL 迁移，删除 `default` index 后重建；重建失败会留下不可用的索引状态。
- After：启动不修改该 collection 和 `default` index，继续执行原有 embedding metadata 检查。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 删除 `init_context_collection` 中 ACL schema 检测和自动迁移入口
- 删除 vector backend 中覆盖 schema、drop/recreate index 的迁移调用链
- 恢复原有存量 collection embedding metadata 契约测试

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证命令：

```bash
.venv/bin/pytest -o addopts='' tests/storage/test_collection_schemas.py -k 'init_context_collection' -q
.venv/bin/ruff check openviking/storage/collection_schemas.py openviking/storage/viking_vector_index_backend.py tests/storage/test_collection_schemas.py
git diff --check
```

结果：6 passed；Ruff 和 diff check 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- 现有 VikingDB collection 仍需由部署方在控制台预先配置 ACL 字段及对应标量索引。
- LocalIndex 的通用、追加式 schema 更新不在本 PR 范围内，后续单独设计和实现。
