### PR TITLE
fix(memory): match nested paths with recursive wildcards

### DIFF
--- a/openviking/session/memory/utils/uri.py
+++ b/openviking/session/memory/utils/uri.py
@@ -245,9 +245,12 @@ def _pattern_matches_uri(pattern: str, uri: str) -> bool:
     pattern = re.sub(r"\{\{\s*[^}]+\s*\}\}", r"[^/]+", pattern)
     # Also support legacy {variable} format
     pattern = re.sub(r"\{[^}]+\}", r"[^/]+", pattern)
-    # Convert ** to .* and * to [^/]*
-    pattern = pattern.replace("**", ".*")
+    # Convert ** to .* and * to [^/]*. Keep the recursive wildcard separate
+    # so its * is not converted as a single-segment wildcard.
+    recursive_wildcard = "\0"
+    pattern = pattern.replace("**", recursive_wildcard)
     pattern = pattern.replace("*", "[^/]*")
+    pattern = pattern.replace(recursive_wildcard, ".*")
     # Anchor the pattern
     pattern = "^" + pattern + "$"
 

--- a/tests/session/memory/test_memory_utils.py
+++ b/tests/session/memory/test_memory_utils.py
@@ -358,6 +358,29 @@ class TestUriValidation:
             is True
         )
 
+    def test_is_uri_allowed_by_recursive_pattern(self):
+        """Test URI allowed by a pattern matching nested paths."""
+        allowed_dirs = set()
+        allowed_patterns = {"viking://user/**/memories/*.md"}
+
+        assert (
+            is_uri_allowed(
+                "viking://user/alice/memories/a.md",
+                allowed_dirs,
+                allowed_patterns,
+            )
+            is True
+        )
+
+        assert (
+            is_uri_allowed(
+                "viking://user/acme/alice/memories/a.md",
+                allowed_dirs,
+                allowed_patterns,
+            )
+            is True
+        )
+
     def test_is_uri_disallowed(self):
         """Test URI not allowed."""
         allowed_dirs = {


### PR DESCRIPTION
## Description

Fix recursive `**` wildcard matching in `is_uri_allowed()` so patterns can allow URIs with multiple nested path segments.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4523

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Preserve `**` as a separate placeholder while converting single `*` wildcards.
- Translate the recursive wildcard to `.*` after single-segment conversion.
- Add regression coverage for one-level and multi-level nested paths.

The public execution path is `is_uri_allowed()` in `openviking.session.memory.utils.uri`, which delegates pattern matching to `_pattern_matches_uri()`. Before this change, converting `**` to `.*` and then converting every remaining `*` changed the recursive expression into a single-segment expression, so nested paths were incorrectly rejected. Single `*` wildcards, URI variables, directory checks, and public API signatures are unchanged.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

```text
PYTHONPATH=. /Users/jacob.z/open-source/openviking/.venv/bin/python -m pytest -q -o addopts='' tests/session/memory/test_memory_utils.py
30 passed, 5 warnings

/Users/jacob.z/open-source/openviking/.venv/bin/ruff check openviking/session/memory/utils/uri.py tests/session/memory/test_memory_utils.py
All checks passed!

/Users/jacob.z/open-source/openviking/.venv/bin/ruff format --check openviking/session/memory/utils/uri.py tests/session/memory/test_memory_utils.py
2 files already formatted
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The issue was reproduced by directly invoking the exported helper on macOS. No external service, production deployment, or in-tree production caller was used for this validation. The five test warnings are existing dependency/deprecation warnings observed during the focused test run.
