### PR TITLE
fix(vlm): honor streaming for OpenAI completions and tool calls

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -748,6 +748,14 @@ For OpenAI-compatible providers that return SSE (Server-Sent Events) format resp
 
 > **Note**: The OpenAI SDK requires `stream=true` to properly parse SSE responses. When using providers that force SSE format, you must set this option to `true`.
 
+For backends using `OpenAIVLM` (`openai`, `azure`, `kimi`, and `glm`), this applies to
+text and vision completions, including tool calls. OpenViking consumes the stream
+internally and returns a complete result; callers still await the full completion.
+Streaming requests include `stream_options: {"include_usage": true}` for token
+accounting. If the provider omits usage, the result is still returned without usage
+counts. The separate Codex Responses and VolcEngine/LiteLLM implementations are not
+controlled by this backend's streaming support.
+
 **Audio/video understanding**
 
 Audio and video understanding is an optional capability of the configured VLM. It uses the same provider, model, credentials, client, request timeout, retries, headers, maximum output tokens, failover chain, and token accounting as other VLM calls. Enable it with the nested `vlm.media` controls; there is no separate media model configuration.

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -716,6 +716,12 @@ LiteLLM 的 Bedrock bearer-token API-key 鉴权，请设置 `forward_api_key=tru
 
 > **注意**: OpenAI SDK 需要 `stream=true` 才能正确解析 SSE 响应。使用强制返回 SSE 格式的 provider 时，必须将此选项设置为 `true`。
 
+对于使用 `OpenAIVLM` 的后端（`openai`、`azure`、`kimi`、`glm`），此设置作用于
+文本和图片补全，也包括工具调用。OpenViking 在内部合并流式分片后返回完整结果，
+调用方仍需等待整次补全结束。流式请求附带 `stream_options: {"include_usage": true}`
+以获取 token 用量；provider 不返回 usage 时，仍返回结果，但不记录该次用量。
+独立的 Codex Responses、VolcEngine 和 LiteLLM 实现不受此后端流式支持的控制。
+
 **音视频理解**
 
 音频和视频理解是当前 VLM 的可选能力，复用相同的 provider、模型、凭据、client、请求超时、重试、请求头、最大输出 token、故障切换链路和 token 统计。通过嵌套的 `vlm.media` 参数启用，不再单独配置媒体模型。

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
@@ -73,6 +74,44 @@ def _build_openai_client_kwargs(
     if extra_headers:
         kwargs["default_headers"] = extra_headers
     return kwargs
+
+
+class _StreamingResponse:
+    """Aggregate the first completion choice into the existing response shape."""
+
+    def __init__(self):
+        self.usage: Any = None
+        self.message = SimpleNamespace(content=None, reasoning_content=None, tool_calls=[])
+        self.choices = [SimpleNamespace(message=self.message, finish_reason=None)]
+        self._tool_calls: Dict[int, Any] = {}
+
+    def add_chunk(self, chunk) -> None:
+        # The final usage chunk has no choices; some providers omit usage entirely.
+        if getattr(chunk, "usage", None) is not None:
+            self.usage = chunk.usage
+        for choice in chunk.choices:
+            if choice.index != 0:
+                continue
+            if choice.finish_reason is not None:
+                self.choices[0].finish_reason = choice.finish_reason
+            delta = choice.delta
+            if delta is None:
+                continue
+            for field in ("content", "reasoning_content"):
+                value = getattr(delta, field, None)
+                if value is not None:
+                    setattr(self.message, field, (getattr(self.message, field) or "") + value)
+            for tool in delta.tool_calls or []:
+                if tool.index not in self._tool_calls:
+                    self._tool_calls[tool.index] = SimpleNamespace(
+                        id="", function=SimpleNamespace(name="", arguments="")
+                    )
+                target = self._tool_calls[tool.index]
+                target.id += tool.id or ""
+                if tool.function is not None:
+                    target.function.name += tool.function.name or ""
+                    target.function.arguments += tool.function.arguments or ""
+        self.message.tool_calls = [self._tool_calls[i] for i in sorted(self._tool_calls)]
 
 
 class OpenAIVLM(VLMBase):
@@ -210,11 +249,33 @@ class OpenAIVLM(VLMBase):
 
             return VLMResponse(
                 content=message.content,
+                reasoning_content=getattr(message, "reasoning_content", None),
                 tool_calls=self._parse_tool_calls(message),
                 finish_reason=choice.finish_reason or "stop",
                 usage=usage,
             )
         return message.content or ""
+
+    def _apply_stream_options(self, kwargs: Dict[str, Any]) -> None:
+        # Raw-body overrides must also reach the SDK, which chooses its response
+        # parser from this keyword rather than from the serialized HTTP body.
+        kwargs["stream"] = kwargs.get("extra_body", {}).pop("stream", self.stream)
+        if kwargs["stream"]:
+            kwargs["stream_options"] = {"include_usage": True}
+
+    def _collect_streaming_response(self, stream):
+        response = _StreamingResponse()
+        with stream:
+            for chunk in stream:
+                response.add_chunk(chunk)
+        return response
+
+    async def _collect_streaming_response_async(self, stream):
+        response = _StreamingResponse()
+        async with stream:
+            async for chunk in stream:
+                response.add_chunk(chunk)
+        return response
 
     def _build_text_kwargs(
         self,
@@ -242,6 +303,7 @@ class OpenAIVLM(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        self._apply_stream_options(kwargs)
         return kwargs
 
     def _build_vision_kwargs(
@@ -280,6 +342,7 @@ class OpenAIVLM(VLMBase):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+        self._apply_stream_options(kwargs)
         return kwargs
 
     def _extract_completion_content(self, response, elapsed: float) -> str:
@@ -308,6 +371,8 @@ class OpenAIVLM(VLMBase):
         def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
+            if kwargs.get("stream"):
+                response = self._collect_streaming_response(response)
             elapsed = time.perf_counter() - t0
             if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
@@ -338,6 +403,8 @@ class OpenAIVLM(VLMBase):
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
+            if kwargs.get("stream"):
+                response = await self._collect_streaming_response_async(response)
             elapsed = time.perf_counter() - t0
             if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
@@ -426,6 +493,8 @@ class OpenAIVLM(VLMBase):
         def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = client.chat.completions.create(**kwargs)
+            if kwargs.get("stream"):
+                response = self._collect_streaming_response(response)
             elapsed = time.perf_counter() - t0
             if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
@@ -458,6 +527,8 @@ class OpenAIVLM(VLMBase):
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()
             response = await client.chat.completions.create(**kwargs)
+            if kwargs.get("stream"):
+                response = await self._collect_streaming_response_async(response)
             elapsed = time.perf_counter() - t0
             if tools is not None:
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)

--- a/tests/unit/test_stream_config_vlm.py
+++ b/tests/unit/test_stream_config_vlm.py
@@ -1,293 +1,347 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for VLM stream configuration support."""
+"""Exercise streaming through the OpenAI SDK and the public VLM completion methods."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
 
+import httpx
 import pytest
+from openai import AsyncOpenAI, OpenAI
 
 from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
+from openviking.models.vlm.base import VLMResponse
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "remember",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+USAGE = {
+    "prompt_tokens": 12,
+    "completion_tokens": 8,
+    "total_tokens": 20,
+    "prompt_tokens_details": {"cached_tokens": 4},
+    "completion_tokens_details": {"reasoning_tokens": 3},
+}
+TOOL_CALLS = [
+    {
+        "id": "call_0",
+        "type": "function",
+        "function": {"name": "remember", "arguments": '{"text":"经验"}'},
+    },
+    {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "remember", "arguments": '{"count":2}'},
+    },
+]
 
 
-class MockDelta:
-    """Mock delta object for streaming chunks."""
-
-    def __init__(self, content=None):
-        self.content = content
-
-
-class MockChoice:
-    """Mock choice object for streaming chunks."""
-
-    def __init__(self, delta=None):
-        self.delta = delta
-
-
-class MockChunk:
-    """Mock chunk object for streaming response."""
-
-    def __init__(self, content=None, usage=None):
-        self.choices = [MockChoice(delta=MockDelta(content=content))] if content is not None else []
-        self.usage = usage
-
-
-class MockUsage:
-    """Mock usage object."""
-
-    def __init__(self, prompt_tokens=0, completion_tokens=0):
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class TestVLMStreamConfig:
-    """Test stream configuration is passed to OpenAI API calls."""
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_false_by_default(self, mock_openai_class):
-        """stream should default to False."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello"
-        mock_response.usage = None
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-            }
-        )
-
-        vlm.get_completion("test prompt")
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is False
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_true_passed_to_api(self, mock_openai_class):
-        """stream=True should be passed to API call."""
-        mock_client = MagicMock()
-        # Simulate streaming response
-        chunks = [
-            MockChunk(content="Hello"),
-            MockChunk(content=" world"),
-            MockChunk(content="!", usage=MockUsage(prompt_tokens=10, completion_tokens=3)),
-        ]
-        mock_client.chat.completions.create.return_value = iter(chunks)
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = vlm.get_completion("test prompt")
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Hello world!"
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_false_uses_non_streaming_path(self, mock_openai_class):
-        """stream=False should use non-streaming response handling."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Non-streaming response"
-        mock_response.usage = MockUsage(prompt_tokens=5, completion_tokens=10)
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": False,
-            }
-        )
-
-        result = vlm.get_completion("test prompt")
-
-        assert result == "Non-streaming response"
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is False
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_async_stream_true(self, mock_async_openai_class):
-        """stream=True should work with async methods."""
-        mock_client = MagicMock()
-
-        async def async_generator():
-            chunks = [
-                MockChunk(content="Async"),
-                MockChunk(content=" result"),
-                MockChunk(content="!", usage=MockUsage(prompt_tokens=8, completion_tokens=4)),
+def _payloads(has_tools, include_usage):
+    deltas = [
+        {"role": "assistant", "content": None},
+        {"content": "Hello", "reasoning_content": "Think"},
+        {"content": " world", "reasoning_content": " first"},
+    ]
+    if has_tools:
+        # Parallel tool calls interleave, and names/JSON arguments span chunks.
+        deltas.extend(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {"name": "rem", "arguments": '{"text":'},
+                        },
+                        {
+                            "index": 1,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "remember", "arguments": '{"count":'},
+                        },
+                    ]
+                },
+                {
+                    "tool_calls": [
+                        {"index": 1, "function": {"arguments": "2}"}},
+                        {"index": 0, "function": {"name": "ember", "arguments": '"经验"}'}},
+                    ]
+                },
             ]
-            for chunk in chunks:
-                yield chunk
+        )
+    finish = "tool_calls" if has_tools else "stop"
+    for delta in deltas:
+        yield {"choices": [{"index": 0, "delta": delta, "finish_reason": None}]}
+    yield {"choices": [{"index": 0, "delta": {}, "finish_reason": finish}]}
+    if include_usage:
+        yield {"choices": [], "usage": USAGE}
 
-        mock_client.chat.completions.create = AsyncMock(return_value=async_generator())
-        mock_async_openai_class.return_value = mock_client
 
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
+class ResponseBody(httpx.SyncByteStream, httpx.AsyncByteStream):
+    def __init__(self, state, has_tools, fail):
+        self.state = state
+        self.has_tools = has_tools
+        self.fail = fail
+        self.closed = 0
+
+    def __iter__(self):
+        payloads = self.state.payloads
+        if payloads is None:
+            payloads = _payloads(self.has_tools, self.state.include_usage)
+        for index, payload in enumerate(payloads):
+            payload.update(id="test", object="chat.completion.chunk", created=0, model="test-model")
+            self.state.clock += 1
+            yield ("data: " + json.dumps(payload) + "\n\n").encode()
+            if self.fail and index == 3:
+                raise httpx.ReadTimeout("stream timeout")
+        yield b"data: [DONE]\n\n"
+
+    async def __aiter__(self):
+        for data in self:
+            yield data
+            if self.state.block:
+                self.state.started.set()
+                await asyncio.Event().wait()
+
+    def close(self):
+        self.closed += 1
+
+    async def aclose(self):
+        self.close()
+
+
+@pytest.fixture
+async def backend(monkeypatch):
+    state = SimpleNamespace(
+        requests=[],
+        bodies=[],
+        include_usage=True,
+        payloads=None,
+        fail_first=False,
+        block=False,
+        started=asyncio.Event(),
+        clock=0,
+    )
+
+    def handle(request):
+        body = json.loads(request.content)
+        state.requests.append(body)
+        if body.get("stream"):
+            stream = ResponseBody(
+                state,
+                bool(body.get("tools")),
+                state.fail_first and len(state.requests) == 1,
+            )
+            state.bodies.append(stream)
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=stream,
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "tool_calls" if body.get("tools") else "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello world",
+                            "tool_calls": TOOL_CALLS if body.get("tools") else None,
+                        },
+                    }
+                ],
+                "usage": USAGE,
+            },
         )
 
-        result = await vlm.get_completion_async("test prompt")
+    transport = httpx.MockTransport(handle)
+    with OpenAI(
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        max_retries=0,
+        http_client=httpx.Client(transport=transport),
+    ) as sync_client:
+        async with AsyncOpenAI(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            max_retries=0,
+            http_client=httpx.AsyncClient(transport=transport),
+        ) as async_client:
+            vlm = OpenAIVLM({"api_key": "test-key", "model": "test-model", "max_retries": 0})
+            monkeypatch.setattr(vlm, "get_client", lambda: sync_client)
+            monkeypatch.setattr(vlm, "get_async_client", lambda: async_client)
+            monkeypatch.setattr(vlm, "update_token_usage", Mock())
+            monkeypatch.setattr(
+                "openviking.models.vlm.backends.openai_vlm.time",
+                SimpleNamespace(perf_counter=lambda: state.clock),
+            )
+            yield vlm, state
 
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Async result!"
 
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_async_stream_false(self, mock_async_openai_class):
-        """stream=False should work with async methods."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Async non-streaming"
-        mock_response.usage = MockUsage(prompt_tokens=5, completion_tokens=5)
+async def _complete(vlm, method, tools=None):
+    kwargs = {"prompt": "test", "tools": tools}
+    if "vision" in method:
+        kwargs["images"] = ["https://example.invalid/image.png"]
+    result = getattr(vlm, method)(**kwargs)
+    return await result if method.endswith("_async") else result
 
-        async def mock_create(*args, **kwargs):
-            return mock_response
 
-        mock_client.chat.completions.create = mock_create
-        mock_async_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": False,
-            }
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get_completion",
+        "get_completion_async",
+        "get_vision_completion",
+        "get_vision_completion_async",
+    ],
+)
+@pytest.mark.parametrize("tools", [None, [], TOOLS], ids=["text", "empty-tools", "tools"])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_completion_stream_contract(backend, method, tools, stream):
+    vlm, state = backend
+    vlm.stream = stream
+    result = await _complete(vlm, method, tools)
+    request = state.requests[0]
+    assert request.get("stream", False) is stream
+    assert str(result) == "Hello world"
+    assert isinstance(result, VLMResponse) is (tools is not None)
+    if tools is not None:
+        assert result.finish_reason == ("tool_calls" if tools else "stop")
+        assert [(tc.id, tc.name, tc.arguments) for tc in result.tool_calls] == (
+            [("call_0", "remember", {"text": "经验"}), ("call_1", "remember", {"count": 2})]
+            if tools
+            else []
         )
-
-        result = await vlm.get_completion_async("test prompt")
-
-        assert result == "Async non-streaming"
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_vision_completion_stream_true(self, mock_openai_class):
-        """stream=True should work with vision completion."""
-        mock_client = MagicMock()
-        chunks = [
-            MockChunk(content="Image"),
-            MockChunk(content=" description"),
-            MockChunk(content=".", usage=MockUsage(prompt_tokens=20, completion_tokens=5)),
-        ]
-        mock_client.chat.completions.create.return_value = iter(chunks)
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = vlm.get_vision_completion("describe this", ["http://example.com/image.jpg"])
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Image description."
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_vision_completion_async_stream_true(self, mock_async_openai_class):
-        """stream=True should work with async vision completion."""
-        mock_client = MagicMock()
-
-        async def async_generator():
-            chunks = [
-                MockChunk(content="Async"),
-                MockChunk(content=" image"),
-                MockChunk(
-                    content=" result", usage=MockUsage(prompt_tokens=15, completion_tokens=6)
-                ),
-            ]
-            for chunk in chunks:
-                yield chunk
-
-        mock_client.chat.completions.create = AsyncMock(return_value=async_generator())
-        mock_async_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = await vlm.get_vision_completion_async(
-            "describe this", ["http://example.com/image.jpg"]
-        )
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Async image result"
+        assert result.usage["total_tokens"] == 20
+        assert result.usage["prompt_tokens_details"].cached_tokens == 4
+    if stream:
+        assert request["stream_options"] == {"include_usage": True}
+        assert all(body.closed == 1 for body in state.bodies)
+        if tools is not None:
+            assert result.reasoning_content == "Think first"
+    else:
+        assert "stream_options" not in request
+    vlm.update_token_usage.assert_called_once_with(
+        model_name="test-model",
+        provider="openai",
+        prompt_tokens=12,
+        completion_tokens=8,
+        prompt_cached_tokens=4,
+        completion_reasoning_tokens=3,
+        duration_seconds=state.clock,
+    )
 
 
-class TestVLMBaseStreamConfig:
-    """Test VLMBase extracts stream from config."""
+@pytest.mark.parametrize("method", ["get_completion", "get_completion_async"])
+async def test_stream_without_usage(backend, method):
+    vlm, state = backend
+    vlm.stream = True
+    state.include_usage = False
+    result = await _complete(vlm, method, TOOLS)
+    assert result.tool_calls[0].arguments == {"text": "经验"}
+    assert result.usage == {}
+    vlm.update_token_usage.assert_not_called()
+    assert state.bodies[0].closed == 1
 
-    def test_stream_defaults_to_false(self):
-        """VLMBase should default stream to False."""
 
-        class StubVLM(OpenAIVLM):
-            def get_completion(self, prompt, thinking=False):
-                return ""
+@pytest.mark.parametrize("method", ["get_completion", "get_completion_async"])
+async def test_empty_stream(backend, method):
+    vlm, state = backend
+    vlm.stream = True
+    state.payloads = []
+    assert await _complete(vlm, method) == ""
+    assert state.bodies[0].closed == 1
+    vlm.update_token_usage.assert_not_called()
 
-            async def get_completion_async(self, prompt, thinking=False):
-                return ""
 
-            def get_vision_completion(self, prompt, images, thinking=False):
-                return ""
+@pytest.mark.parametrize("method", ["get_completion", "get_completion_async"])
+async def test_tool_only_stream_preserves_null_content_and_truncated_arguments(backend, method):
+    vlm, state = backend
+    vlm.stream = True
+    state.payloads = list(_payloads(True, True))
+    for payload in state.payloads:
+        for choice in payload["choices"]:
+            delta = choice["delta"]
+            delta.pop("content", None)
+            if choice["finish_reason"]:
+                choice["finish_reason"] = "length"
+            for tool in delta.get("tool_calls", []):
+                if tool["index"] == 0 and tool["function"].get("name") == "ember":
+                    tool["function"]["arguments"] = ""
+    result = await _complete(vlm, method, TOOLS)
+    assert result.content is None
+    assert result.finish_reason == "length"
+    assert result.tool_calls[0].arguments == {"raw": '{"text":'}
+    assert result.tool_calls[1].arguments == {"count": 2}
+    assert state.bodies[0].closed == 1
 
-            async def get_vision_completion_async(self, prompt, images, thinking=False):
-                return ""
 
-        vlm = StubVLM(
-            {
-                "api_key": "sk-test",
-            }
-        )
+@pytest.mark.parametrize("method", ["get_completion", "get_completion_async"])
+@pytest.mark.parametrize("override", [False, True])
+async def test_raw_stream_override_uses_matching_sdk_parser(backend, method, override):
+    vlm, state = backend
+    vlm.stream = not override
+    vlm.extra_request_body = {"stream": override}
+    result = await _complete(vlm, method, TOOLS)
+    assert state.requests[0]["stream"] is override
+    assert result.tool_calls[0].arguments == {"text": "经验"}
+    assert str(result) == "Hello world"
+    assert vlm.extra_request_body == {"stream": override}
 
-        assert vlm.stream is False
 
-    def test_stream_extracted_from_config(self):
-        """VLMBase should extract stream from config."""
+@pytest.mark.parametrize("method", ["get_completion", "get_completion_async"])
+@pytest.mark.parametrize("retries", [0, 1])
+async def test_stream_failure_closes_and_discards_partial_result(backend, method, retries):
+    vlm, state = backend
+    vlm.stream = True
+    vlm.max_retries = retries
+    state.fail_first = True
+    if retries:
+        result = await _complete(vlm, method, TOOLS)
+        assert str(result) == "Hello world"
+        assert len(result.tool_calls) == 2
+        assert len(state.requests) == 2
+        vlm.update_token_usage.assert_called_once()
+    else:
+        with pytest.raises(httpx.ReadTimeout, match="stream timeout"):
+            await _complete(vlm, method, TOOLS)
+        vlm.update_token_usage.assert_not_called()
+    assert all(body.closed == 1 for body in state.bodies)
 
-        class StubVLM(OpenAIVLM):
-            def get_completion(self, prompt, thinking=False):
-                return ""
 
-            async def get_completion_async(self, prompt, thinking=False):
-                return ""
-
-            def get_vision_completion(self, prompt, images, thinking=False):
-                return ""
-
-            async def get_vision_completion_async(self, prompt, images, thinking=False):
-                return ""
-
-        vlm = StubVLM(
-            {
-                "api_key": "sk-test",
-                "stream": True,
-            }
-        )
-
-        assert vlm.stream is True
+async def test_cancelled_stream_is_closed_without_retry(backend):
+    vlm, state = backend
+    vlm.stream = True
+    vlm.max_retries = 1
+    state.block = True
+    task = asyncio.create_task(vlm.get_completion_async("test"))
+    try:
+        await asyncio.wait_for(state.started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert len(state.requests) == 1
+        assert state.bodies[0].closed == 1
+        vlm.update_token_usage.assert_not_called()
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
 
 
 class TestVLMConfigStream:
@@ -399,77 +453,3 @@ class TestVLMConfigStream:
 
         assert config.max_retries == 3
         assert config._build_vlm_config_dict()["max_retries"] == 3
-
-
-class TestStreamingResponseProcessing:
-    """Test streaming response processing logic."""
-
-    def test_process_streaming_response_with_content(self):
-        """_process_streaming_response should extract content from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        chunks = [
-            MockChunk(content="Hello"),
-            MockChunk(content=" "),
-            MockChunk(content="world"),
-        ]
-
-        result = vlm._process_streaming_response(iter(chunks))
-        assert result == "Hello world"
-
-    def test_process_streaming_response_with_usage(self):
-        """_process_streaming_response should extract usage from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        chunks = [
-            MockChunk(content="Hello", usage=MockUsage(prompt_tokens=10, completion_tokens=5)),
-        ]
-
-        with patch.object(vlm, "update_token_usage") as mock_update:
-            vlm._process_streaming_response(iter(chunks))
-
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=10,
-                completion_tokens=5,
-            )
-
-    def test_process_streaming_response_empty_chunks(self):
-        """_process_streaming_response should handle empty chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        result = vlm._process_streaming_response(iter([]))
-        assert result == ""
-
-    @pytest.mark.asyncio
-    async def test_process_streaming_response_async(self):
-        """_process_streaming_response_async should extract content from async chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        async def async_chunks():
-            yield MockChunk(content="Async")
-            yield MockChunk(content=" result")
-            yield MockChunk(content="!", usage=MockUsage(prompt_tokens=5, completion_tokens=3))
-
-        result = await vlm._process_streaming_response_async(async_chunks())
-        assert result == "Async result!"
-
-    @pytest.mark.asyncio
-    async def test_process_streaming_response_async_with_usage(self):
-        """_process_streaming_response_async should extract usage from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        async def async_chunks():
-            yield MockChunk(content="Test")
-            yield MockChunk(content="", usage=MockUsage(prompt_tokens=15, completion_tokens=8))
-
-        with patch.object(vlm, "update_token_usage") as mock_update:
-            await vlm._process_streaming_response_async(async_chunks())
-
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=15,
-                completion_tokens=8,
-            )


### PR DESCRIPTION
## Description

Fixes #4528. Related to #3755.

`OpenAIVLM` accepts `stream: true` but omits the flag from Chat Completions requests. Memory extraction calls `get_completion_async()` with tools and uses the same path. This patch enables SSE transport for sync/async text and vision calls, including tool calls, while preserving the complete `str` / `VLMResponse` return contract.

The implementation is based on upstream `main` at `4d00feac9328b5132b808a10d5fc31a3b4b617b5`. The earlier proposals in #3406, #3756 and #3863 were closed without merging and kept tool calls non-streaming. This patch assembles tool deltas as well.

## Human Involvement

- [ ] A human participated in the implementation or review loop
- [x] This PR was generated entirely by AI agents without human participation in the loop

A human reported the deployment issue and requested this upstream fix. Codex wrote and tested the changes; there has been no independent human code review yet.

## Related Issue

Fixes #4528; related to #3755.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Forward the effective stream setting to the SDK. Normalize raw-body `stream` overrides so the HTTP body and SDK response parser agree.
- Aggregate content and reasoning deltas, indexed parallel tool calls, finish reason and final usage before using the existing response parsers. Keep `tools=[]` returning `VLMResponse`.
- Close streams with sync/async context managers. Consumption stays inside the existing retry boundary: failed attempts discard their partial result, and no tool call is handed to the caller before completion. Cancellation propagates without retry.
- Request streaming usage and measure the whole completion, including chunk consumption. Keep cached-token and reasoning-token accounting. Missing usage is allowed.
- Replace obsolete private-helper streaming tests with SDK/HTTP contract tests in the existing test file. Update the English and Chinese configuration guides.

## Testing

All provider responses in these tests are mocked. No production deployment, live model request or credential is involved.

```bash
PYTHONPATH=.:bot PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
  LITELLM_LOCAL_MODEL_COST_MAP=True python -m pytest \
  --noconftest -p pytest_asyncio.plugin -p no:cacheprovider \
  -o addopts= --tb=short -q \
  tests/unit/test_stream_config_vlm.py \
  tests/unit/test_vlm_response_formats.py \
  tests/unit/test_extra_headers_vlm.py \
  tests/unit/test_vlm_failover.py \
  tests/unit/test_vlm_reasoning_models.py \
  tests/unit/test_vikingbot_vlm_adapter_retry.py \
  tests/unit/test_codex_vlm.py \
  tests/unit/test_kimi_glm_vlm.py \
  tests/unit/test_vlm_thinking_param.py \
  tests/unit/test_model_retry.py \
  tests/unit/test_litellm_vlm_provider_detection.py \
  tests/unit/test_litellm_vlm_gemini_cache.py
```

- macOS, Python 3.12.9 / OpenAI SDK 2.24.0: 253 passed.
- Linux amd64, Python 3.13.15: 253 passed with networking disabled and this checkout mounted read-only into a container with the runtime dependencies installed.
- Regression control: the updated `test_stream_config_vlm.py` with the unmodified `main` backend has 25 failed, 20 passed; with the fix, all 45 pass.
- The tests bypass global storage/service fixtures with `--noconftest`; this is a focused VLM suite, not a full application test.

```bash
ruff check openviking/models/vlm/backends/openai_vlm.py tests/unit/test_stream_config_vlm.py
ruff format --check openviking/models/vlm/backends/openai_vlm.py tests/unit/test_stream_config_vlm.py
git diff --check
mypy --follow-imports=silent openviking/models/vlm/backends/openai_vlm.py
```

Ruff and whitespace checks pass. Mypy reports the same 9 existing errors on both the unmodified backend and this patch, covering optional client/config types, the vision content list and the tracer decorator. No new mypy error was observed.

- [x] Tests demonstrate the fix
- [x] Focused new and existing unit tests pass
- [x] macOS tested
- [x] Linux amd64 tested
- [ ] Windows tested

## Checklist

- [x] Code follows the project's style
- [x] Self-review completed
- [x] Comments explain stream ownership and SDK/body normalization
- [x] Corresponding documentation updated
- [x] Focused test runs generate no new warnings
- [x] No dependent change is required

## Compatibility and Scope

`stream: false` remains non-streaming. Configured streaming now sends `stream_options: {"include_usage": true}`, which must be accepted by the provider; no silent fallback or provider-specific retry is added. Providers that omit usage still return their content and tools.

This changes the `OpenAIVLM` path used by OpenAI/Azure and inherited by Kimi/GLM. It does not implement streaming for the separate LiteLLM or VolcEngine completion paths, change the Codex Responses adapter, or affect embedding requests. VikingBot's explicit `chat_stream()` path keeps its existing behavior.

Calls still await the complete result. This fix does not promise lower token usage or earlier completion of memory extraction.
