### PR TITLE
test(openclaw-plugin): remove redundant provider auth assertion

### DIFF
--- a/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
+++ b/examples/openclaw-plugin/tests/ut/manifest-contracts.test.ts
@@ -12,7 +12,6 @@ const manifest = JSON.parse(
   icon?: string;
   activation?: { onStartup?: boolean; onCapabilities?: string[] };
   contracts?: { tools?: string[] };
-  setup?: { providers?: Array<{ id?: string; envVars?: string[] }> };
   configSchema?: { properties?: Record<string, unknown> };
 };
 const packageJson = JSON.parse(
@@ -99,14 +98,6 @@ describe("OpenClaw 5.2 manifest contracts", () => {
   it("opts into startup and capability-triggered hook/tool activation", () => {
     expect(manifest.activation?.onStartup).toBe(true);
     expect(manifest.activation?.onCapabilities?.toSorted()).toEqual(["hook", "tool"]);
-  });
-
-  it("declares provider auth environment variables only in current setup metadata", () => {
-    expect(manifest).not.toHaveProperty("providerAuthEnvVars");
-    expect(manifest.setup?.providers).toContainEqual(expect.objectContaining({
-      id: "openviking",
-      envVars: ["OPENVIKING_API_KEY", "OPENVIKING_BASE_URL"],
-    }));
   });
 
   it("declares recall trace configuration schema keys", () => {


### PR DESCRIPTION
## What changed

- Remove the provider-auth manifest assertion added in #4511.
- Remove the now-unused `setup` field from the test's local manifest type.
- Leave the actual manifest fix unchanged.

## Why

The assertion pins a literal copy of provider setup metadata without exercising runtime behavior. ClawHub validation is the authoritative compatibility check for this field, so keeping this test would add maintenance cost without a meaningful regression boundary.

## Validation

- `git diff --check`
- Local Vitest and TypeScript checks were attempted, but both were terminated with exit 137 under current memory pressure. CI is the remaining execution boundary for this test-only deletion.
