### PR TITLE
fix(parser): handle angle-bracket image paths in Markdown

### DIFF
--- a/openviking/parse/parsers/markdown.py
+++ b/openviking/parse/parsers/markdown.py
@@ -949,7 +949,7 @@ class MarkdownParser(BaseParser):
             allowed root, otherwise None
         """
         try:
-            path = Path(path_str)
+            path = Path(self._unwrap_link_destination(path_str))
 
             # Reject absolute paths: they can point anywhere on the host
             if path.is_absolute():
@@ -1024,7 +1024,15 @@ class MarkdownParser(BaseParser):
         return is_valid_image(image_bytes, source_path)
 
     @staticmethod
-    def _is_remote_uri(path: str) -> bool:
+    def _unwrap_link_destination(path: str) -> str:
+        """Return the path represented by a Markdown ``<destination>``."""
+        path = path.strip()
+        if len(path) >= 2 and path.startswith("<") and path.endswith(">"):
+            return path[1:-1]
+        return path
+
+    @classmethod
+    def _is_remote_uri(cls, path: str) -> bool:
         """
         Check if a path is a remote URI.
 
@@ -1035,7 +1043,7 @@ class MarkdownParser(BaseParser):
             True if path starts with http://, https://, viking://, data:, or ftp://
         """
         remote_prefixes = ("http://", "https://", "viking://", "data:", "ftp://")
-        return path.startswith(remote_prefixes)
+        return cls._unwrap_link_destination(path).startswith(remote_prefixes)
 
     @staticmethod
     def _deduplicate_filename(filename: str, used_names: set[str]) -> str:

--- a/tests/parse/test_markdown_link_rewrite.py
+++ b/tests/parse/test_markdown_link_rewrite.py
@@ -553,6 +553,27 @@ class TestImageLinkSplit:
         assert any(u.endswith("/photo.png") for u in fake.files), fake.files
         assert any(u.endswith(".image_mappings.json") for u in fake.files), fake.files
 
+    async def test_angle_bracket_image_destination_with_spaces_is_ingested(self, tmp_path: Path):
+        kb = tmp_path / "kb"
+        image_dir = kb / "resource name" / "images"
+        image_dir.mkdir(parents=True)
+        _write_valid_png(image_dir / "photo.png")
+        src = kb / "page.md"
+        image_ref = "<resource name/images/photo.png>"
+        src.write_text(f"![p]({image_ref})", encoding="utf-8")
+
+        fake = FakeVikingFS()
+        with patch.object(BaseParser, "_get_viking_fs", return_value=fake):
+            await MarkdownParser().parse(
+                str(src), enable_link_rewrite=True, link_rewrite_root=str(kb)
+            )
+
+        md = [_decode(c) for u, c in fake.files.items() if u.endswith(".md")]
+        assert md and f"![p]({image_ref})" in md[0], fake.files
+        assert any(u.endswith("/photo.png") for u in fake.files), fake.files
+        mapping = [_decode(c) for u, c in fake.files.items() if u.endswith(".image_mappings.json")]
+        assert mapping and image_ref in mapping[0], fake.files
+
     async def test_image_outside_base_dir_depth_adjusted(self, tmp_path: Path):
         # The md lives in kb/sub; the image lives in kb/img — outside base_dir
         # (= the md's own directory) but inside the import root. #2429 cannot


### PR DESCRIPTION
## Description

修复 Markdown 图片路径使用 `<destination>` 形式时无法被正确解析的问题。该形式常见于包含空格的 AnyDoc 图片路径，之前会将尖括号视为文件名的一部分，导致图片未导入。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 解析本地图片路径和远程 URI 前，解包 Markdown 标准的 `<destination>`。
- 保留 Markdown 原始引用及普通路径行为，不修改 `doc_name`。
- 增加包含空格和尖括号的图片路径回归测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

- `tests/parse/test_markdown_link_rewrite.py`: **43 passed**
- `ruff check`、`ruff format --check` 和 `git diff --check`: passed
- 本地 AnyDoc 端到端导入：66 个图片引用全部完成重写，无失效引用

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

该修改只解释 Markdown destination 的尖括号语法，不重命名文档或修改 Markdown 原文。