### PR TITLE
fix(sdk): preserve unavailable error details

### DIFF
--- a/sdk/python/openviking_sdk/client.py
+++ b/sdk/python/openviking_sdk/client.py
@@ -662,6 +662,10 @@ class AsyncHTTPClient:
             resource = details.get("resource", "") if details else ""
             resource_type = details.get("type", "resource") if details else "resource"
             raise exc_class(resource, resource_type)
+        if exc_class == UnavailableError:
+            service = details.get("service", "service") if details else "service"
+            reason = details.get("reason", "") if details else message
+            raise exc_class(service, reason)
         raise exc_class(message)
 
     def _zip_directory(self, dir_path: str) -> str:

--- a/sdk/python/tests/test_error_mapping.py
+++ b/sdk/python/tests/test_error_mapping.py
@@ -5,6 +5,7 @@ from openviking_sdk.errors import (
     ConflictError,
     OpenVikingError,
     ResourceExhaustedError,
+    UnavailableError,
     UnimplementedError,
 )
 
@@ -41,3 +42,27 @@ def test_client_preserves_unknown_error_code():
 
     assert exc_info.value.code == "PROVIDER_SPECIFIC"
     assert exc_info.value.details == {"x": 1}
+
+
+def test_client_preserves_unavailable_service_and_reason():
+    client = AsyncHTTPClient(url="http://127.0.0.1:1933")
+
+    with pytest.raises(UnavailableError) as exc_info:
+        client._raise_exception(
+            {
+                "code": "UNAVAILABLE",
+                "message": "Storage backend unavailable: lock contention",
+                "details": {
+                    "service": "storage backend",
+                    "reason": "failed to read lock token (os error 33)",
+                },
+            }
+        )
+
+    assert str(exc_info.value) == (
+        "Storage backend unavailable: failed to read lock token (os error 33)"
+    )
+    assert exc_info.value.details == {
+        "service": "storage backend",
+        "reason": "failed to read lock token (os error 33)",
+    }


### PR DESCRIPTION
## Description

Structured `service`/`reason` fields were lost when raising `UnavailableError`, causing downstream callers to miss structured failure information.

This PR preserves service and reason from the error details by mapping them into the exception, using a 4-line change in the client error path.

Baseline: `baseline regression test fails on main`; after fix `15 targeted tests and Ruff pass`.

## Human Involvement

- [x] Entirely AI agents

## Type

- [x] Bug fix
- [x] Test update

## Testing

- `pytest` on three test files
- `ruff check`
- `git diff --check`

## Related

Related to #4494 (does not claim to close the full feature).