### PR TITLE
refactor(memory): remove unused URI allowlist

### DIFF
--- a/openviking/session/memory/__init__.py
+++ b/openviking/session/memory/__init__.py
@@ -46,7 +46,6 @@ from openviking.session.memory.tools import (
 from openviking.session.memory.utils import (
     detect_language_from_conversation,
     generate_uri,
-    is_uri_allowed,
     pretty_print_messages,
     validate_uri_template,
 )
@@ -93,5 +92,4 @@ __all__ = [
     # URI utilities
     "generate_uri",
     "validate_uri_template",
-    "is_uri_allowed",
 ]

--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -63,7 +63,6 @@ __all__ = [
     # URI
     "generate_uri",
     "validate_uri_template",
-    "is_uri_allowed",
     # JSON Parser
     "extract_json_content",
     "parse_json_with_stability",
@@ -84,16 +83,14 @@ def __getattr__(name: str):
         from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 
         return MemoryFileUtils
-    if name in {"generate_uri", "is_uri_allowed", "validate_uri_template"}:
+    if name in {"generate_uri", "validate_uri_template"}:
         from openviking.session.memory.utils.uri import (
             generate_uri,
-            is_uri_allowed,
             validate_uri_template,
         )
 
         return {
             "generate_uri": generate_uri,
-            "is_uri_allowed": is_uri_allowed,
             "validate_uri_template": validate_uri_template,
         }[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openviking/session/memory/utils/uri.py
+++ b/openviking/session/memory/utils/uri.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from openviking.session.memory.dataclass import MemoryTypeSchema
 from openviking.session.memory.utils.model import model_to_dict
@@ -216,69 +216,6 @@ def validate_uri_template(memory_type: MemoryTypeSchema) -> bool:
                 return False
 
     return True
-
-
-def _pattern_matches_uri(pattern: str, uri: str) -> bool:
-    """
-    Check if a URI matches a pattern with variables like {{ topic }}, {{ tool_name }}, etc.
-
-    The pattern matching is flexible:
-    - {{ variable }} matches any sequence of characters except '/'
-    - * matches any sequence of characters except '/' (shell-style)
-    - ** matches any sequence of characters including '/' (shell-style)
-
-    Args:
-        pattern: The pattern to match against (may contain {{ variables }} or * wildcards)
-        uri: The URI to check
-
-    Returns:
-        True if the URI matches the pattern
-    """
-    import re
-
-    # First, convert the pattern to a regex
-    # Escape regex special chars except {, }, *, /
-    pattern = re.escape(pattern)
-    # Unescape {, }, * that we need to handle specially
-    pattern = pattern.replace(r"\{", "{").replace(r"\}", "}").replace(r"\*", "*")
-    # Convert {{ variable }} to [^/]+
-    pattern = re.sub(r"\{\{\s*[^}]+\s*\}\}", r"[^/]+", pattern)
-    # Also support legacy {variable} format
-    pattern = re.sub(r"\{[^}]+\}", r"[^/]+", pattern)
-    # Convert ** to .* and * to [^/]*
-    pattern = pattern.replace("**", ".*")
-    pattern = pattern.replace("*", "[^/]*")
-    # Anchor the pattern
-    pattern = "^" + pattern + "$"
-
-    return bool(re.match(pattern, uri))
-
-
-def is_uri_allowed(
-    uri: str,
-    allowed_directories: Set[str],
-    allowed_patterns: Set[str],
-) -> bool:
-    """
-    Check if a URI is allowed based on allowed directories and patterns.
-
-    Args:
-        uri: The URI to check
-        allowed_directories: Set of allowed directory paths
-        allowed_patterns: Set of allowed path patterns
-
-    Returns:
-        True if the URI is allowed
-    """
-    # Check if URI starts with any allowed directory
-    for dir_path in allowed_directories:
-        if uri == dir_path or uri.startswith(dir_path + "/"):
-            return True
-    # Check if URI matches any allowed pattern
-    for pattern in allowed_patterns:
-        if _pattern_matches_uri(pattern, uri):
-            return True
-    return False
 
 
 def extract_uri_fields_from_flat_model(model: Any, schema: MemoryTypeSchema) -> Dict[str, Any]:

--- a/tests/session/memory/test_memory_utils.py
+++ b/tests/session/memory/test_memory_utils.py
@@ -14,7 +14,6 @@ from openviking.session.memory.dataclass import (
 from openviking.session.memory.merge_op.base import FieldType, MergeOp
 from openviking.session.memory.utils import (
     generate_uri,
-    is_uri_allowed,
     parse_memory_file_with_fields,
     validate_uri_template,
 )
@@ -302,86 +301,6 @@ class TestUriGeneration:
         )
 
         assert validate_uri_template(memory_type) is False
-
-
-class TestUriValidation:
-    """Tests for URI validation."""
-
-    def test_is_uri_allowed_by_directory(self):
-        """Test URI allowed by matching directory prefix."""
-        allowed_dirs = {
-            "viking://user/default/memories/preferences",
-            "viking://user/default/memories/tools",
-        }
-        allowed_patterns = set()
-
-        assert (
-            is_uri_allowed(
-                "viking://user/default/memories/preferences/test.md",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is True
-        )
-
-        assert (
-            is_uri_allowed(
-                "viking://user/default/memories/preferences",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is True
-        )
-
-        assert (
-            is_uri_allowed(
-                "viking://user/default/memories/preferences/subdir/test.md",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is True
-        )
-
-    def test_is_uri_allowed_by_pattern(self):
-        """Test URI allowed by matching pattern."""
-        allowed_dirs = set()
-        allowed_patterns = {
-            "viking://user/default/memories/preferences/{{ topic }}.md",
-        }
-
-        assert (
-            is_uri_allowed(
-                "viking://user/default/memories/preferences/Python code style.md",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is True
-        )
-
-    def test_is_uri_disallowed(self):
-        """Test URI not allowed."""
-        allowed_dirs = {
-            "viking://user/default/memories/preferences",
-        }
-        allowed_patterns = set()
-
-        assert (
-            is_uri_allowed(
-                "viking://user/default/memories/other/test.md",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is False
-        )
-
-        assert (
-            is_uri_allowed(
-                "viking://user/other/memories/preferences/test.md",
-                allowed_dirs,
-                allowed_patterns,
-            )
-            is False
-        )
 
 
 class TestParseMemoryFileWithFields:


### PR DESCRIPTION
## Description

Remove the obsolete URI allowlist matcher left behind after memory URI ownership moved into `MemoryIsolationHandler`.

### Before

`is_uri_allowed()` and its wildcard matcher remained importable and tested even though no Server, API, SDK, CLI, or session-memory execution path called them. The documented `**` behavior was also incorrect.

### After

The unused matcher, both internal re-exports, and the tests that existed only for that matcher are removed. Supported memory writes are unchanged: the server still selects an enabled memory schema, resolves the current user or peer target, and generates the final URI from that schema.

### Example

- Before: `from openviking.session.memory import is_uri_allowed` exposed an undocumented function that normal OpenViking requests never executed.
- After: that unsupported import is removed; committing a session still generates and writes the same memory URIs through the existing schema-based path.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Closes #4523

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Remove `is_uri_allowed()` and `_pattern_matches_uri()`.
- Remove the obsolete exports from the memory packages.
- Remove tests that covered only the unused matcher.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Validation performed:

```text
.venv/bin/python -m pytest -q -p no:cacheprovider -o addopts='' tests/session/memory/test_memory_utils.py
26 passed, 4 existing deprecation warnings

.venv/bin/ruff check openviking/session/memory/__init__.py openviking/session/memory/utils/__init__.py openviking/session/memory/utils/uri.py tests/session/memory/test_memory_utils.py
All checks passed!

.venv/bin/ruff format --check openviking/session/memory/__init__.py openviking/session/memory/utils/__init__.py openviking/session/memory/utils/uri.py tests/session/memory/test_memory_utils.py
4 files already formatted
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This intentionally removes the obsolete mechanism instead of defining new recursive-wildcard semantics. Direct imports of `is_uri_allowed` will no longer work; the symbol was undocumented and had no current in-repository runtime caller.
