### PR TITLE
fix(session): pass resolved output language to all WM v2 archive render paths

### DIFF
--- a/openviking/prompts/templates/compression/ov_wm_v2.yaml
+++ b/openviking/prompts/templates/compression/ov_wm_v2.yaml
@@ -21,6 +21,11 @@ variables:
     description: "Optional instructions for checkpoint summaries produced by the same call."
     required: false
     default: ""
+  - name: "output_language"
+    type: "string"
+    description: "Language for all section content, resolved from the conversation or config override."
+    required: false
+    default: "en"
 
 template: |
   You are a session note-taker. Produce a structured Working Memory document
@@ -48,6 +53,9 @@ template: |
 
   RULES:
   - All 7 section headers and italic descriptions must appear unchanged.
+  - Write all section CONTENT (including the Session Title) in {{ output_language }}.
+    The English headers and italic descriptions stay in English because the
+    server matches them to detect and merge the WM v2 format.
   - Write INFO-DENSE content: names, numbers, dates, locations, exact values.
   - For temporal facts, record the EVENT date, not the conversation date.
     Example: conversation on May 8 mentions "I went yesterday" -> record "7 May".

--- a/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
+++ b/openviking/prompts/templates/compression/ov_wm_v2_update.yaml
@@ -25,6 +25,11 @@ variables:
     description: "Optional instructions for checkpoint summaries produced by the same call."
     required: false
     default: ""
+  - name: "output_language"
+    type: "string"
+    description: "Language for all section content, resolved from the conversation or config override."
+    required: false
+    default: "en"
 
 template: |
   You are the Working Memory maintainer for a long-running session. Produce a
@@ -75,6 +80,12 @@ template: |
   Exception: raw exhaustive URL/image/search result dumps are NOT durable facts
   unless the user explicitly asked to preserve them or a specific URL was used
   as evidence. Summarize or prune bulk URL lists instead of copying them forward.
+
+  # Output language
+
+  Write all section CONTENT you produce or rewrite (including the Session
+  Title) in {{ output_language }}. The English section names in the "sections"
+  JSON keys stay in English — the server matches them when parsing and merging.
 
   # RULE 1 — Op semantics (re-read carefully).
 

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -24,6 +24,7 @@ from openviking.server.config import ToolOutputExternalizationConfig
 from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
+from openviking.session.memory.utils import resolve_output_language_from_conversation
 from openviking.session.memory_policy import MemoryPolicy
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
@@ -4200,7 +4201,8 @@ class Session:
         formatted = self._format_messages_for_wm(messages, checkpoint_requests)
         checkpoint_instructions = self._checkpoint_prompt_instructions(len(checkpoint_requests))
 
-        vlm = get_openviking_config().vlm
+        config = get_openviking_config()
+        vlm = config.vlm
         if not (vlm and vlm.is_available()):
             if checkpoint_requests:
                 raise ValueError("A configured VLM is required to generate checkpoint summaries")
@@ -4220,6 +4222,10 @@ class Session:
                 f"# Session Summary\n\n**Overview**: {turn_count} turns, {len(messages)} messages"
             )
 
+        # Resolve once, before the CREATE/UPDATE split, so every render path
+        # (create, update, update-failure fallback) shares the same language.
+        output_language = resolve_output_language_from_conversation(formatted, config)
+
         # -------- Detect WM v2 format --------
         _is_wm_v2 = latest_archive_overview and any(
             f"## {s}" in latest_archive_overview for s in WM_SEVEN_SECTIONS
@@ -4238,6 +4244,7 @@ class Session:
                         "messages": formatted,
                         "latest_archive_overview": latest_archive_overview or "",
                         "checkpoint_instructions": checkpoint_instructions,
+                        "output_language": output_language,
                     },
                 )
                 if checkpoint_requests:
@@ -4296,6 +4303,7 @@ class Session:
                     "latest_archive_overview": latest_archive_overview,
                     "wm_section_reminders": reminders,
                     "checkpoint_instructions": checkpoint_instructions,
+                    "output_language": output_language,
                 },
             )
             resp = await vlm.get_completion_async(
@@ -4314,7 +4322,7 @@ class Session:
                 raise
             logger.warning("WM update tool_call failed (%s); falling back to creation prompt", e)
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         has_tc = bool(getattr(resp, "has_tool_calls", False) and getattr(resp, "tool_calls", None))
@@ -4331,7 +4339,7 @@ class Session:
                 raise ValueError("Working Memory update returned no tool call for checkpoints")
             logger.warning("WM update: LLM returned no tool_call; falling back to creation prompt")
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         checkpoint_summaries: tuple[str, ...] = ()
@@ -4432,7 +4440,7 @@ class Session:
                 e,
             )
             return await self._fallback_generate_wm_creation(
-                formatted, messages, latest_archive_overview
+                formatted, messages, latest_archive_overview, output_language
             )
 
         _wm_debug(
@@ -4452,6 +4460,7 @@ class Session:
         formatted_messages: str,
         messages: List[Message],
         prior_overview: str = "",
+        output_language: str = "en",
     ) -> str:
         """Re-run WM creation prompt when the update tool_call path fails.
 
@@ -4471,6 +4480,7 @@ class Session:
                     "messages": formatted_messages,
                     "latest_archive_overview": prior_overview,
                     "checkpoint_instructions": "",
+                    "output_language": output_language,
                 },
             )
             return await get_openviking_config().vlm.get_completion_async(prompt)

--- a/tests/session/test_wm_output_language.py
+++ b/tests/session/test_wm_output_language.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""WM v2 archive prompts must carry the resolved output language.
+
+Prompt-capture tests for the three render paths of the archive pipeline
+(create / incremental update / update-failure fallback) plus the
+output_language_override precedence.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import openviking.prompts.manager as prompt_manager_module
+from openviking.message import Message
+from openviking.message.part import TextPart
+from openviking.models.vlm.base import VLMResponse
+from openviking.session.session import Session, WM_SEVEN_SECTIONS
+
+
+@pytest.fixture(autouse=True)
+def _use_bundled_templates(monkeypatch):
+    """Force the repo's bundled templates so a user templates_dir override
+    in the local config does not shadow the templates under test."""
+    bundled = Path(__file__).parents[2] / "openviking" / "prompts" / "templates"
+    monkeypatch.setenv("OPENVIKING_PROMPT_TEMPLATES_DIR", str(bundled))
+    monkeypatch.setattr(prompt_manager_module, "_default_manager", None)
+
+_PRIOR_WM = """# Working Memory
+
+## Session Title
+Outage investigation
+
+## Current State
+Investigation continues.
+
+## Task & Goals
+Find the outage cause.
+
+## Key Facts & Decisions
+None.
+
+## Files & Context
+None.
+
+## Errors & Corrections
+None.
+
+## Open Issues
+Confirm the database state.
+"""
+
+
+def _zh_message() -> Message:
+    return Message(
+        id="zh-user-1",
+        role="user",
+        parts=[TextPart("排查退款接口的积分回滚问题，先查事务日志")],
+    )
+
+
+def _session_with_vlm(vlm, monkeypatch, override=None):
+    monkeypatch.setattr(
+        "openviking.session.session.get_openviking_config",
+        lambda: SimpleNamespace(vlm=vlm, output_language_override=override),
+    )
+    return Session.__new__(Session)
+
+
+def _assert_language_and_headers(prompt: str, language: str) -> None:
+    assert f"in {language}" in prompt
+    for header in WM_SEVEN_SECTIONS:
+        assert f"## {header}" in prompt
+
+
+async def test_wm_creation_prompt_includes_detected_language(monkeypatch):
+    calls = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, prompt=None, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            return "WM document"
+
+    session = _session_with_vlm(FakeVLM(), monkeypatch)
+    await session._generate_archive_summary_async([_zh_message()])
+
+    assert len(calls) == 1
+    _assert_language_and_headers(calls[0]["prompt"], "zh-CN")
+
+
+async def test_wm_update_prompt_includes_detected_language(monkeypatch):
+    from openviking.models.vlm.base import ToolCall
+
+    calls = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, prompt=None, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            return VLMResponse(
+                tool_calls=[
+                    ToolCall(
+                        id="tool-call-1",
+                        name="update_working_memory",
+                        arguments={
+                            "sections": {
+                                name: {"op": "KEEP"} for name in WM_SEVEN_SECTIONS
+                            }
+                        },
+                    )
+                ],
+                finish_reason="tool_calls",
+            )
+
+    session = _session_with_vlm(FakeVLM(), monkeypatch)
+    result = await session._generate_archive_summary_async(
+        [_zh_message()], latest_archive_overview=_PRIOR_WM
+    )
+
+    assert len(calls) == 1
+    assert "Investigation continues." in result
+    _assert_language_and_headers(calls[0]["prompt"], "zh-CN")
+
+
+async def test_wm_update_fallback_prompt_includes_detected_language(monkeypatch):
+    calls = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, prompt=None, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            if "tools" in kwargs:
+                # Update tool_call path: no tool call -> falls back to creation.
+                return VLMResponse(finish_reason="stop")
+            return "WM document"
+
+    session = _session_with_vlm(FakeVLM(), monkeypatch)
+    await session._generate_archive_summary_async(
+        [_zh_message()], latest_archive_overview=_PRIOR_WM
+    )
+
+    assert len(calls) == 2
+    assert "tools" in calls[0]
+    assert "tools" not in calls[1]
+    _assert_language_and_headers(calls[1]["prompt"], "zh-CN")
+
+
+async def test_wm_creation_language_override_wins(monkeypatch):
+    calls = []
+
+    class FakeVLM:
+        @staticmethod
+        def is_available() -> bool:
+            return True
+
+        async def get_completion_async(self, prompt=None, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            return "WM document"
+
+    session = _session_with_vlm(FakeVLM(), monkeypatch, override="de")
+    await session._generate_archive_summary_async([_zh_message()])
+
+    assert len(calls) == 1
+    _assert_language_and_headers(calls[0]["prompt"], "de")


### PR DESCRIPTION
## Summary

Fixes #4481. The Working Memory archive pipeline (`compression.ov_wm_v2` / `compression.ov_wm_v2_update`) produced English archives regardless of conversation language, because:

1. both templates had no output-language instruction in the prompt body, and
2. the WM render paths in `session.py` never called the language negotiation that 0.4.17 already ships (`resolve_output_language_from_conversation`, honoring `output_language_override` first).

## Changes

- `session.py` `_generate_archive_summary_async`: resolve the language **once from the formatted conversation, before the CREATE/UPDATE split**, and pass `output_language` to
  - the creation render,
  - the update render, and
  - `_fallback_generate_wm_creation()` for **every** fallback call (tool_call exception / no tool_call / args-parse failure), as called out in the issue discussion.
- `_fallback_generate_wm_creation()`: new `output_language: str = "en"` parameter (keyword-safe for existing callers).
- Both templates: new `output_language` variable (default `"en"`) and one rule instructing the model to write all section CONTENT (including the Session Title) in that language while keeping the seven English section headers — and, for the update template, the English `sections` JSON keys — canonical, so `_is_wm_v2` / `_parse_wm_sections()` / `_merge_wm_sections()` keep working and existing v2 archives keep being recognized.

This matches the memory-extraction pipelines, which already resolve the output language per conversation: Chinese session → Chinese WM, English session → English WM, `output_language_override` always wins when set.

## Tests

New `tests/session/test_wm_output_language.py` — prompt-capture coverage for the three render paths from the issue discussion:

- first archive creation → rendered prompt contains the detected-language instruction (`zh-CN` for a Chinese session) and all seven English headers
- incremental update → same assertions on the update prompt
- update failure → creation fallback → same assertions on the fallback prompt (and update path still receives the same language)
- `output_language_override` precedence (config override `de` wins over a Chinese conversation)

The file uses an autouse fixture pinning `OPENVIKING_PROMPT_TEMPLATES_DIR` to the bundled templates so a local `prompts.templates_dir` override cannot shadow the templates under test. Full existing WM suites (`test_working_memory_v2.py`, `test_wm_v2_guards.py`, `test_working_memory_growth.py`) pass: 115 passed.