### PR TITLE
fix(vlm): resync rotated Codex credentials

### DIFF
--- a/openviking/models/vlm/backends/codex_auth.py
+++ b/openviking/models/vlm/backends/codex_auth.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
+
 from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR
 
 try:
@@ -592,47 +593,32 @@ def resolve_codex_runtime_credentials(
                 ).expanduser()
             elif _default_codex_auth_path().exists():
                 external_path = _default_codex_auth_path()
-            external_missing = False
+            external_missing = external_path is None or not external_path.exists()
+            external_unavailable = False
             external_payload = None
-            if external_path is not None:
-                external_payload = _load_tokens_from_source("codex-cli", external_path)
-                if external_payload is None:
-                    external_missing = True
-                elif (
-                    external_payload["access_token"] != access_token
-                    or external_payload["refresh_token"] != refresh_token
-                ):
-                    _write_tokens_to_ov_store(
-                        ov_auth_path,
-                        external_payload["access_token"],
-                        external_payload["refresh_token"],
-                        last_refresh=external_payload.get("last_refresh"),
-                        imported_from=str(external_path),
-                        client_id=external_payload.get("client_id"),
-                        auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
-                    )
-                    payload = external_payload
-                    access_token = payload["access_token"]
-                    refresh_token = payload["refresh_token"]
-            else:
-                external_missing = True
-            should_resync = force_refresh or (
-                refresh_if_expiring
-                and _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
-            )
-            if should_resync and external_payload is not None:
-                _write_tokens_to_ov_store(
-                    ov_auth_path,
-                    external_payload["access_token"],
-                    external_payload["refresh_token"],
-                    last_refresh=external_payload.get("last_refresh"),
-                    imported_from=str(external_path),
-                    client_id=external_payload.get("client_id"),
-                    auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
-                )
-                payload = external_payload
-                access_token = payload["access_token"]
-                refresh_token = payload["refresh_token"]
+            if external_path is not None and not external_missing:
+                if not external_path.is_file():
+                    external_unavailable = True
+                else:
+                    external_payload = _load_tokens_from_source("codex-cli", external_path)
+                    if external_payload is None:
+                        external_unavailable = True
+                    elif (
+                        external_payload["access_token"] != access_token
+                        or external_payload["refresh_token"] != refresh_token
+                    ):
+                        _write_tokens_to_ov_store(
+                            ov_auth_path,
+                            external_payload["access_token"],
+                            external_payload["refresh_token"],
+                            last_refresh=external_payload.get("last_refresh"),
+                            imported_from=str(external_path),
+                            client_id=external_payload.get("client_id"),
+                            auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
+                        )
+                        payload = external_payload
+                        access_token = payload["access_token"]
+                        refresh_token = payload["refresh_token"]
 
             should_refresh = refresh_if_expiring and _codex_access_token_is_expiring(
                 access_token, refresh_skew_seconds
@@ -664,6 +650,12 @@ def resolve_codex_runtime_credentials(
                     "path": str(ov_auth_path),
                     "auth_owner": CODEX_AUTH_OWNER_OPENVIKING,
                 }
+
+            if (force_refresh or should_refresh) and external_unavailable:
+                raise CodexAuthError(
+                    "Externally managed Codex auth exists but could not be read. "
+                    "Retry after Codex CLI finishes updating it or re-run openviking-server init."
+                )
 
             if should_refresh:
                 raise CodexAuthError(

--- a/openviking/models/vlm/backends/codex_auth.py
+++ b/openviking/models/vlm/backends/codex_auth.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
-
 from openviking_cli.utils.config.consts import DEFAULT_CONFIG_DIR
 
 try:
@@ -552,7 +551,6 @@ def has_codex_auth_available() -> bool:
     )
 
 
-
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -595,35 +593,52 @@ def resolve_codex_runtime_credentials(
             elif _default_codex_auth_path().exists():
                 external_path = _default_codex_auth_path()
             external_missing = False
+            external_payload = None
+            if external_path is not None:
+                external_payload = _load_tokens_from_source("codex-cli", external_path)
+                if external_payload is None:
+                    external_missing = True
+                elif (
+                    external_payload["access_token"] != access_token
+                    or external_payload["refresh_token"] != refresh_token
+                ):
+                    _write_tokens_to_ov_store(
+                        ov_auth_path,
+                        external_payload["access_token"],
+                        external_payload["refresh_token"],
+                        last_refresh=external_payload.get("last_refresh"),
+                        imported_from=str(external_path),
+                        client_id=external_payload.get("client_id"),
+                        auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
+                    )
+                    payload = external_payload
+                    access_token = payload["access_token"]
+                    refresh_token = payload["refresh_token"]
+            else:
+                external_missing = True
             should_resync = force_refresh or (
                 refresh_if_expiring
                 and _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
             )
-            if should_resync:
-                if external_path is not None:
-                    external_payload = _load_tokens_from_source("codex-cli", external_path)
-                    if external_payload is not None:
-                        _write_tokens_to_ov_store(
-                            ov_auth_path,
-                            external_payload["access_token"],
-                            external_payload["refresh_token"],
-                            last_refresh=external_payload.get("last_refresh"),
-                            imported_from=str(external_path),
-                            client_id=external_payload.get("client_id"),
-                            auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
-                        )
-                        payload = external_payload
-                        access_token = payload["access_token"]
-                        refresh_token = payload["refresh_token"]
-                    else:
-                        external_missing = True
-                else:
-                    external_missing = True
+            if should_resync and external_payload is not None:
+                _write_tokens_to_ov_store(
+                    ov_auth_path,
+                    external_payload["access_token"],
+                    external_payload["refresh_token"],
+                    last_refresh=external_payload.get("last_refresh"),
+                    imported_from=str(external_path),
+                    client_id=external_payload.get("client_id"),
+                    auth_owner=CODEX_AUTH_OWNER_EXTERNAL,
+                )
+                payload = external_payload
+                access_token = payload["access_token"]
+                refresh_token = payload["refresh_token"]
 
-            should_refresh = force_refresh or (
-                refresh_if_expiring
-                and _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+            should_refresh = refresh_if_expiring and _codex_access_token_is_expiring(
+                access_token, refresh_skew_seconds
             )
+            if force_refresh and external_missing:
+                should_refresh = True
             if should_refresh and external_missing:
                 refreshed = refresh_codex_oauth(
                     refresh_token,

--- a/openviking/models/vlm/backends/codex_responses_adapter.py
+++ b/openviking/models/vlm/backends/codex_responses_adapter.py
@@ -217,9 +217,15 @@ def _build_final_response_from_stream_events(
 
 
 class CodexCompletionsAdapter:
-    def __init__(self, client_factory: Callable[[], Any], model: str):
+    def __init__(
+        self,
+        client_factory: Callable[[], Any],
+        model: str,
+        auth_retry_client_factory: Optional[Callable[[], Any]] = None,
+    ):
         self._client_factory = client_factory
         self._model = model
+        self._auth_retry_client_factory = auth_retry_client_factory
 
     def _create_response(self, **kwargs) -> Any:
         client = self._client_factory()
@@ -253,7 +259,16 @@ class CodexCompletionsAdapter:
         collected_text_deltas: List[str] = []
         has_function_calls = False
         completed_response = None
-        stream = client.responses.create(**response_kwargs, stream=True)
+        try:
+            stream = client.responses.create(**response_kwargs, stream=True)
+        except Exception as exc:
+            status_code = getattr(exc, "status_code", None)
+            if status_code is None:
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            if status_code != 401 or self._auth_retry_client_factory is None:
+                raise
+            client = self._auth_retry_client_factory()
+            stream = client.responses.create(**response_kwargs, stream=True)
         try:
             for event in stream:
                 event_type = getattr(event, "type", "")

--- a/openviking/models/vlm/backends/codex_vlm.py
+++ b/openviking/models/vlm/backends/codex_vlm.py
@@ -57,12 +57,24 @@ class CodexVLM(OpenAIVLM):
         )
         return openai.OpenAI(**kwargs)
 
+    def _build_completions_adapter(self) -> CodexCompletionsAdapter:
+        auth_retry_client_factory = (
+            self._build_refreshed_responses_client
+            if not str(self.config.get("api_key", "") or "").strip()
+            else None
+        )
+        return CodexCompletionsAdapter(
+            lambda: self._build_responses_client(*self._resolve_runtime_credentials()),
+            self.model or "gpt-5.3-codex",
+            auth_retry_client_factory=auth_retry_client_factory,
+        )
+
+    def _build_refreshed_responses_client(self):
+        return self._build_responses_client(*self._resolve_runtime_credentials(force_refresh=True))
+
     def _get_or_create_sync_responses_client(self):
         if self._sync_client is None:
-            adapter = CodexCompletionsAdapter(
-                lambda: self._build_responses_client(*self._resolve_runtime_credentials()),
-                self.model or "gpt-5.3-codex",
-            )
+            adapter = self._build_completions_adapter()
             self._sync_client = SimpleNamespace(chat=CodexChatShim(adapter))
         return self._sync_client
 
@@ -70,23 +82,24 @@ class CodexVLM(OpenAIVLM):
         # The async path uses a sync Responses client behind asyncio.to_thread so
         # credential refresh and auth-store I/O do not block the event loop.
         if self._async_client is None:
-            sync_adapter = CodexCompletionsAdapter(
-                lambda: self._build_responses_client(*self._resolve_runtime_credentials()),
-                self.model or "gpt-5.3-codex",
-            )
+            sync_adapter = self._build_completions_adapter()
             self._async_client = SimpleNamespace(
                 chat=CodexAsyncChatShim(CodexAsyncCompletionsAdapter(sync_adapter))
             )
         return self._async_client
 
-    def _resolve_runtime_credentials(self) -> tuple[str, str]:
+    def _resolve_runtime_credentials(self, *, force_refresh: bool = False) -> tuple[str, str]:
         explicit_api_key = str(self.config.get("api_key", "") or "").strip()
         explicit_api_base = str(self.config.get("api_base", "") or "").strip().rstrip("/")
         if explicit_api_key:
             self.api_key = explicit_api_key
             self.api_base = explicit_api_base or DEFAULT_CODEX_BASE_URL
             return self.api_key, self.api_base
-        credentials = resolve_codex_runtime_credentials()
+        credentials = (
+            resolve_codex_runtime_credentials(force_refresh=True)
+            if force_refresh
+            else resolve_codex_runtime_credentials()
+        )
         self.api_key = credentials["api_key"]
         self.api_base = explicit_api_base or credentials["base_url"]
         return self.api_key, self.api_base

--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -4,14 +4,14 @@
 import base64
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
+from openviking_cli.utils.config.vlm_config import VLMConfig
 
 from openviking.models.vlm.backends import codex_auth
 from openviking.models.vlm.backends.codex_auth import resolve_codex_runtime_credentials
 from openviking.models.vlm.backends.codex_vlm import CodexVLM
-from openviking_cli.utils.config.vlm_config import VLMConfig
 
 
 class _MockResponsesStream:
@@ -299,6 +299,64 @@ def test_codex_auth_bootstraps_into_openviking_store(tmp_path, monkeypatch):
     assert persisted["imported_from"] == str(bootstrap_path)
 
 
+def test_codex_auth_resyncs_external_tokens_before_cached_token_expires(tmp_path, monkeypatch):
+    ov_auth_path = tmp_path / "codex_auth.json"
+    bootstrap_path = tmp_path / "codex_cli_auth.json"
+    old_access_token = _make_jwt_token({"exp": 9999999999, "version": "old"})
+    new_access_token = _make_jwt_token({"exp": 9999999999, "version": "new"})
+    ov_auth_path.write_text(
+        json.dumps(
+            {
+                "auth_owner": "external",
+                "imported_from": str(bootstrap_path),
+                "tokens": {
+                    "access_token": old_access_token,
+                    "refresh_token": "old-refresh",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    bootstrap_path.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "access_token": new_access_token,
+                    "refresh_token": "new-refresh",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_CODEX_AUTH_PATH", str(ov_auth_path))
+
+    creds = resolve_codex_runtime_credentials()
+
+    assert creds["api_key"] == new_access_token
+    persisted = json.loads(ov_auth_path.read_text(encoding="utf-8"))
+    assert persisted["tokens"]["refresh_token"] == "new-refresh"
+
+
+def test_codex_auth_force_refresh_returns_external_credentials(tmp_path, monkeypatch):
+    ov_auth_path = tmp_path / "codex_auth.json"
+    bootstrap_path = tmp_path / "codex_cli_auth.json"
+    access_token = _make_jwt_token({"exp": 9999999999})
+    payload = {"tokens": {"access_token": access_token, "refresh_token": "refresh-token"}}
+    bootstrap_path.write_text(json.dumps(payload), encoding="utf-8")
+    ov_payload = {
+        **payload,
+        "auth_owner": "external",
+        "imported_from": str(bootstrap_path),
+    }
+    ov_auth_path.write_text(json.dumps(ov_payload), encoding="utf-8")
+    monkeypatch.setenv("OPENVIKING_CODEX_AUTH_PATH", str(ov_auth_path))
+
+    creds = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert creds["api_key"] == access_token
+    assert creds["auth_owner"] == "external"
+
+
 def test_codex_auth_native_login_defaults_to_openviking_owner(tmp_path, monkeypatch):
     ov_auth_path = tmp_path / "codex_auth.json"
     monkeypatch.setenv("OPENVIKING_CODEX_AUTH_PATH", str(ov_auth_path))
@@ -520,6 +578,56 @@ def test_codex_sync_client_re_resolves_credentials_per_request(mock_resolve, moc
     assert second.choices[0].message.content == "second"
     assert mock_openai_class.call_args_list[0].kwargs["api_key"] == "oauth-token-a"
     assert mock_openai_class.call_args_list[1].kwargs["api_key"] == "oauth-token-b"
+
+
+@patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
+@patch("openviking.models.vlm.backends.codex_vlm.resolve_codex_runtime_credentials")
+def test_codex_retries_unauthorized_once_with_refreshed_credentials(
+    mock_resolve, mock_openai_class
+):
+    class _UnauthorizedError(Exception):
+        status_code = 401
+
+    mock_resolve.side_effect = [
+        {"api_key": "stale-token", "base_url": "https://example.test"},
+        {"api_key": "fresh-token", "base_url": "https://example.test"},
+    ]
+    stale_client = MagicMock()
+    stale_client.responses.create.side_effect = _UnauthorizedError()
+    fresh_client = _build_fake_openai_client("recovered")
+    mock_openai_class.side_effect = [stale_client, fresh_client]
+
+    vlm = CodexVLM({"provider": "openai-codex", "model": "gpt-5.3-codex"})
+
+    assert vlm.get_completion("hello") == "recovered"
+    assert mock_resolve.call_args_list == [call(), call(force_refresh=True)]
+    stale_client.responses.create.assert_called_once()
+    fresh_client.responses.create.assert_called_once()
+
+
+@patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
+@patch("openviking.models.vlm.backends.codex_vlm.resolve_codex_runtime_credentials")
+def test_codex_does_not_retry_a_second_unauthorized_response(mock_resolve, mock_openai_class):
+    class _UnauthorizedError(Exception):
+        status_code = 401
+
+    mock_resolve.side_effect = [
+        {"api_key": "stale-token", "base_url": "https://example.test"},
+        {"api_key": "still-invalid-token", "base_url": "https://example.test"},
+    ]
+    first_client = MagicMock()
+    second_client = MagicMock()
+    first_client.responses.create.side_effect = _UnauthorizedError()
+    second_client.responses.create.side_effect = _UnauthorizedError()
+    mock_openai_class.side_effect = [first_client, second_client]
+    vlm = CodexVLM({"provider": "openai-codex", "model": "gpt-5.3-codex"})
+
+    with pytest.raises(_UnauthorizedError):
+        vlm.get_completion("hello")
+
+    assert mock_resolve.call_args_list == [call(), call(force_refresh=True)]
+    first_client.responses.create.assert_called_once()
+    second_client.responses.create.assert_called_once()
 
 
 @patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")

--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -7,11 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from openviking_cli.utils.config.vlm_config import VLMConfig
 
 from openviking.models.vlm.backends import codex_auth
 from openviking.models.vlm.backends.codex_auth import resolve_codex_runtime_credentials
 from openviking.models.vlm.backends.codex_vlm import CodexVLM
+from openviking_cli.utils.config.vlm_config import VLMConfig
 
 
 class _MockResponsesStream:
@@ -337,24 +337,86 @@ def test_codex_auth_resyncs_external_tokens_before_cached_token_expires(tmp_path
     assert persisted["tokens"]["refresh_token"] == "new-refresh"
 
 
-def test_codex_auth_force_refresh_returns_external_credentials(tmp_path, monkeypatch):
+def test_codex_auth_force_refresh_resyncs_external_credentials_once(tmp_path, monkeypatch):
     ov_auth_path = tmp_path / "codex_auth.json"
     bootstrap_path = tmp_path / "codex_cli_auth.json"
-    access_token = _make_jwt_token({"exp": 9999999999})
-    payload = {"tokens": {"access_token": access_token, "refresh_token": "refresh-token"}}
+    old_access_token = _make_jwt_token({"exp": 9999999999, "version": "old"})
+    new_access_token = _make_jwt_token({"exp": 9999999999, "version": "new"})
+    payload = {"tokens": {"access_token": new_access_token, "refresh_token": "new-refresh"}}
     bootstrap_path.write_text(json.dumps(payload), encoding="utf-8")
+    ov_auth_path.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "access_token": old_access_token,
+                    "refresh_token": "old-refresh",
+                },
+                "auth_owner": "external",
+                "imported_from": str(bootstrap_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_CODEX_AUTH_PATH", str(ov_auth_path))
+
+    with patch.object(
+        codex_auth,
+        "_write_tokens_to_ov_store",
+        wraps=codex_auth._write_tokens_to_ov_store,
+    ) as mock_write:
+        creds = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert creds["api_key"] == new_access_token
+    assert creds["auth_owner"] == "external"
+    assert mock_write.call_count == 1
+
+
+def test_codex_auth_parse_failure_preserves_external_owner(tmp_path, monkeypatch):
+    ov_auth_path = tmp_path / "codex_auth.json"
+    bootstrap_path = tmp_path / "codex_cli_auth.json"
+    old_access_token = _make_jwt_token({"exp": 9999999999, "version": "old"})
+    new_access_token = _make_jwt_token({"exp": 9999999999, "version": "new"})
     ov_payload = {
-        **payload,
+        "tokens": {
+            "access_token": old_access_token,
+            "refresh_token": "old-refresh",
+        },
         "auth_owner": "external",
         "imported_from": str(bootstrap_path),
     }
     ov_auth_path.write_text(json.dumps(ov_payload), encoding="utf-8")
+    bootstrap_path.write_text("{invalid", encoding="utf-8")
     monkeypatch.setenv("OPENVIKING_CODEX_AUTH_PATH", str(ov_auth_path))
 
-    creds = resolve_codex_runtime_credentials(force_refresh=True)
+    with patch.object(codex_auth, "refresh_codex_oauth") as mock_refresh:
+        with pytest.raises(codex_auth.CodexAuthError, match="exists but could not be read"):
+            resolve_codex_runtime_credentials(force_refresh=True)
 
-    assert creds["api_key"] == access_token
-    assert creds["auth_owner"] == "external"
+    persisted = json.loads(ov_auth_path.read_text(encoding="utf-8"))
+    assert persisted["auth_owner"] == "external"
+    assert persisted["imported_from"] == str(bootstrap_path)
+    assert persisted["tokens"]["refresh_token"] == "old-refresh"
+    mock_refresh.assert_not_called()
+
+    bootstrap_path.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "access_token": new_access_token,
+                    "refresh_token": "new-refresh",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    recovered = resolve_codex_runtime_credentials()
+
+    assert recovered["api_key"] == new_access_token
+    assert recovered["auth_owner"] == "external"
+    recovered_persisted = json.loads(ov_auth_path.read_text(encoding="utf-8"))
+    assert recovered_persisted["auth_owner"] == "external"
+    assert recovered_persisted["imported_from"] == str(bootstrap_path)
 
 
 def test_codex_auth_native_login_defaults_to_openviking_owner(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

Externally managed Codex OAuth credentials were only resynced when the cached JWT approached its `exp` value. A token rotated or revoked earlier could therefore remain cached while every VLM request failed with HTTP 401.

This change detects token-pair changes in the external auth source on credential resolution. Managed `openai-codex` requests that still receive 401 force a resync and retry exactly once. Explicitly configured API keys retain their existing behavior.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4539

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Resync externally managed access and refresh tokens when the source token pair changes before JWT expiry.
- Make forced external resync return the refreshed external credentials instead of raising after a successful import.
- Retry a managed Codex Responses request once after HTTP 401, using freshly resolved credentials.
- Cover early rotation, forced resync, successful recovery, and repeated-401 termination.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

Commands:

```shell
python -m pytest --confcutdir=tests/unit -o addopts='' tests/unit/test_codex_vlm.py -q
# 26 passed

ruff check openviking/models/vlm/backends/codex_auth.py openviking/models/vlm/backends/codex_responses_adapter.py openviking/models/vlm/backends/codex_vlm.py tests/unit/test_codex_vlm.py
# All checks passed

python -m py_compile openviking/models/vlm/backends/codex_auth.py openviking/models/vlm/backends/codex_responses_adapter.py openviking/models/vlm/backends/codex_vlm.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- No public API, configuration, dependency, or persisted schema changes.
- Documentation was not updated because this restores the existing external-auth contract.
- Targeted mypy reports the same nine pre-existing errors on the baseline and patched trees; this patch introduces no additional mypy finding.
