### PR TITLE
fix(vlm): reject unsupported stream configuration

### DIFF
--- a/docs/en/guides/01-configuration.md
+++ b/docs/en/guides/01-configuration.md
@@ -639,14 +639,13 @@ Vision Language Model for semantic extraction (L0/L1 generation).
 | `thinking` | bool | Enable thinking mode for VolcEngine models (default: `false`) |
 | `max_concurrent` | int | Maximum concurrent semantic LLM calls (default: `32`) |
 | `max_retries` | int | Maximum retry attempts for transient VLM provider errors (default: `3`; `0` disables retry) |
-| `credentials` | array | Ordered VLM credential/model list, with index 0 having the highest priority. Each item can override `provider`, `model`, `api_key`, `api_base`, `api_version`, `extra_headers`, `extra_request_body`, `stream`, and `reasoning_effort` |
+| `credentials` | array | Ordered VLM credential/model list, with index 0 having the highest priority. Each item can override `provider`, `model`, `api_key`, `api_base`, `api_version`, `extra_headers`, `extra_request_body`, and `reasoning_effort` |
 | `failback_timeout_seconds` | float | Time threshold for attempting a step back toward a higher-priority credential after failover (default: `600`) |
 | `failback_request_count` | int | Successful requests on a lower-priority credential before attempting a step back (default: `50`) |
 | `backup` | object | Optional backup VLM configuration (same shape as `vlm`) for automatic failover when the primary fails with retryable errors such as rate limits, `5xx` responses, or connection/timeout failures. Only one level of failover is supported &mdash; the backup itself cannot define a nested `backup` |
 | `timeout` | float | Per-request HTTP timeout in seconds passed to the underlying OpenAI/LiteLLM client. Increase for slow endpoints (e.g., DashScope, local inference). Must be `> 0` (default: `600.0`) |
 | `extra_headers` | object | Custom HTTP headers for compatible HTTP providers. `kimi` also accepts header overrides, but already injects the required subscription headers by default |
 | `extra_request_body` | object | Extra JSON body fields for OpenAI-compatible completion requests, useful for provider-specific options such as Ollama `{"think": false}` |
-| `stream` | bool | Enable streaming mode (for OpenAI-compatible providers, default: `false`) |
 | `reasoning_effort` | str | Reasoning effort for OpenAI Codex Responses requests. Leave unset to use the model default |
 | `media` | object | Audio/video runtime controls. Media understanding reuses this VLM's provider, model, credentials, client, timeout, retry, headers, output-token limit, failover, and token accounting |
 | `media.enabled` | bool | Enable audio/video understanding (default: `false`) |
@@ -729,24 +728,6 @@ For OpenAI-compatible providers that accept provider-specific JSON body fields, 
   }
 }
 ```
-
-**Streaming Mode**
-
-For OpenAI-compatible providers that return SSE (Server-Sent Events) format responses, enable `stream` mode:
-
-```json
-{
-  "vlm": {
-    "provider": "openai",
-    "api_key": "your-api-key",
-    "model": "gpt-4o",
-    "api_base": "https://api.example.com/v1",
-    "stream": true
-  }
-}
-```
-
-> **Note**: The OpenAI SDK requires `stream=true` to properly parse SSE responses. When using providers that force SSE format, you must set this option to `true`.
 
 **Audio/video understanding**
 
@@ -1934,8 +1915,7 @@ For detailed encryption explanations, see [Data Encryption](../concepts/10-encry
     "max_concurrent": 32,
     "max_retries": 3,
     "extra_headers": {},
-    "extra_request_body": {},
-    "stream": false
+    "extra_request_body": {}
   },
   "rerank": {
     "provider": "volcengine|openai",

--- a/docs/zh/guides/01-configuration.md
+++ b/docs/zh/guides/01-configuration.md
@@ -608,14 +608,13 @@ provider，并设置 `storage.vectordb.sparse_weight > 0`。自托管模型的�
 | `thinking` | bool | 启用思考模式（仅对部分火山模型生效，默认：`false`） |
 | `max_concurrent` | int | 语义处理阶段 LLM 最大并发调用数（默认：`32`） |
 | `max_retries` | int | VLM provider 瞬时错误的最大重试次数（默认：`3`；`0` 表示禁用重试） |
-| `credentials` | array | 有序 VLM 凭据/模型列表，索引 0 优先级最高。每项可单独覆盖 `provider`、`model`、`api_key`、`api_base`、`api_version`、`extra_headers`、`extra_request_body`、`stream` 和 `reasoning_effort` |
+| `credentials` | array | 有序 VLM 凭据/模型列表，索引 0 优先级最高。每项可单独覆盖 `provider`、`model`、`api_key`、`api_base`、`api_version`、`extra_headers`、`extra_request_body` 和 `reasoning_effort` |
 | `failback_timeout_seconds` | float | 切换到低优先级 credential 后，尝试逐级切回的时间阈值（默认：`600`） |
 | `failback_request_count` | int | 低优先级 credential 成功处理多少次请求后尝试逐级切回（默认：`50`） |
 | `backup` | object | 可选的备用 VLM 配置（结构与 `vlm` 相同），当主 VLM 遇到限流、`5xx`、超时或连接失败等可重试错误时自动切换。仅支持 1 层备用 &mdash; 备用 VLM 本身不能再嵌套 `backup` |
 | `timeout` | float | 单次 VLM API 请求的 HTTP 超时时间（秒），传递给底层 OpenAI/LiteLLM 客户端。慢端点（如 DashScope、本地推理）可调大。必须 `> 0`（默认：`600.0`） |
 | `extra_headers` | object | 兼容 HTTP provider 的自定义请求头。`kimi` 默认已注入所需订阅请求头，也支持在这里覆盖或扩展 |
 | `extra_request_body` | object | 传给 OpenAI 兼容 completion 请求的额外 JSON body 字段，可用于 Ollama `{"think": false}` 等 provider 专有参数 |
-| `stream` | bool | 启用流式模式（OpenAI 兼容 provider 可用，默认：`false`） |
 | `reasoning_effort` | str | OpenAI Codex Responses 请求的推理强度。不设置时使用模型默认值 |
 | `media` | object | 音视频运行参数；音视频理解复用该 VLM 的 provider、模型、凭据、client、超时、重试、请求头、输出 token 限制、故障切换和 token 统计 |
 | `media.enabled` | bool | 启用音视频理解（默认：`false`） |
@@ -697,24 +696,6 @@ LiteLLM 的 Bedrock bearer-token API-key 鉴权，请设置 `forward_api_key=tru
   }
 }
 ```
-
-**流式模式**
-
-对于返回 SSE（Server-Sent Events）格式响应的 OpenAI 兼容 provider，启用 `stream` 模式：
-
-```json
-{
-  "vlm": {
-    "provider": "openai",
-    "api_key": "your-api-key",
-    "model": "gpt-4o",
-    "api_base": "https://api.example.com/v1",
-    "stream": true
-  }
-}
-```
-
-> **注意**: OpenAI SDK 需要 `stream=true` 才能正确解析 SSE 响应。使用强制返回 SSE 格式的 provider 时，必须将此选项设置为 `true`。
 
 **音视频理解**
 
@@ -1905,8 +1886,7 @@ Task 记录文件位于所属账号的系统目录：
     "max_concurrent": 32,
     "max_retries": 3,
     "extra_headers": {},
-    "extra_request_body": {},
-    "stream": false
+    "extra_request_body": {}
   },
   "rerank": {
     "provider": "volcengine|openai",

--- a/openviking/models/vlm/backends/codex_vlm.py
+++ b/openviking/models/vlm/backends/codex_vlm.py
@@ -91,18 +91,6 @@ class CodexVLM(OpenAIVLM):
         self.api_base = explicit_api_base or credentials["base_url"]
         return self.api_key, self.api_base
 
-    def _build_text_kwargs(self, *args, **kwargs):
-        request_kwargs = super()._build_text_kwargs(*args, **kwargs)
-        if self.stream:
-            request_kwargs["stream"] = True
-        return request_kwargs
-
-    def _build_vision_kwargs(self, *args, **kwargs):
-        request_kwargs = super()._build_vision_kwargs(*args, **kwargs)
-        if self.stream:
-            request_kwargs["stream"] = True
-        return request_kwargs
-
     def get_client(self):
         if openai is None:
             raise ImportError("Please install openai: pip install openai")

--- a/openviking/models/vlm/base.py
+++ b/openviking/models/vlm/base.py
@@ -76,7 +76,6 @@ class VLMBase(ABC):
         self.max_tokens = config.get("max_tokens")
         self.extra_headers = config.get("extra_headers")
         self.extra_request_body = dict(config.get("extra_request_body") or {})
-        self.stream = config.get("stream", False)
         self.thinking = config.get("thinking", False)
 
         # Token usage tracking

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -22,6 +22,21 @@ def _normalize_provider_name(name: Optional[str]) -> Optional[str]:
     return cleaned or None
 
 
+def _reject_stream_config(data: Any, location: str) -> None:
+    if not isinstance(data, dict):
+        return
+    if "stream" in data:
+        raise ValueError(
+            f"{location}.stream is not supported; OpenViking VLM calls return complete responses"
+        )
+    extra_request_body = data.get("extra_request_body")
+    if isinstance(extra_request_body, dict) and "stream" in extra_request_body:
+        raise ValueError(
+            f"{location}.extra_request_body.stream is not supported; "
+            "OpenViking VLM calls return complete responses"
+        )
+
+
 class VLMCredential(BaseModel):
     """Single VLM credential configuration for multi-credential failover."""
 
@@ -45,7 +60,6 @@ class VLMCredential(BaseModel):
     extra_request_body: Optional[Dict[str, Any]] = Field(
         default=None, description="Extra JSON body fields"
     )
-    stream: Optional[bool] = Field(default=None, description="Enable streaming mode")
     reasoning_effort: Optional[str] = Field(
         default=None,
         description="Reasoning effort for OpenAI-compatible reasoning models",
@@ -60,6 +74,12 @@ class VLMCredential(BaseModel):
     )
 
     model_config = {"extra": "forbid"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_stream_config(cls, data: Any) -> Any:
+        _reject_stream_config(data, "vlm.credentials[]")
+        return data
 
 
 class VLMMediaConfig(BaseModel):
@@ -163,10 +183,6 @@ class VLMConfig(BaseModel):
         ),
     )
 
-    stream: bool = Field(
-        default=False, description="Enable streaming mode for OpenAI-compatible providers"
-    )
-
     reasoning_effort: Optional[str] = Field(
         default=None,
         description="Reasoning effort for OpenAI-compatible reasoning models",
@@ -198,6 +214,7 @@ class VLMConfig(BaseModel):
     @classmethod
     def sync_provider_backend(cls, data: Any) -> Any:
         if isinstance(data, dict):
+            _reject_stream_config(data, "vlm")
             provider = data.get("provider")
             backend = data.get("backend")
 
@@ -212,6 +229,7 @@ class VLMConfig(BaseModel):
                 provider_sources: Dict[str, str] = {}
                 for name, config in providers.items():
                     normalized_name = _normalize_provider_name(name) or str(name)
+                    _reject_stream_config(config, f"vlm.providers.{normalized_name}")
                     existing_name = provider_sources.get(normalized_name)
                     if existing_name is not None and existing_name != str(name):
                         raise ValueError(
@@ -293,7 +311,6 @@ class VLMConfig(BaseModel):
             or self.api_base
             or self.extra_headers
             or self.extra_request_body
-            or self.stream
             or self.reasoning_effort
             or self.forward_api_key is not None
         ):
@@ -315,8 +332,6 @@ class VLMConfig(BaseModel):
                 and "extra_request_body" not in self.providers[self.provider]
             ):
                 self.providers[self.provider]["extra_request_body"] = self.extra_request_body
-            if self.stream and "stream" not in self.providers[self.provider]:
-                self.providers[self.provider]["stream"] = self.stream
             if self.reasoning_effort and "reasoning_effort" not in self.providers[self.provider]:
                 self.providers[self.provider]["reasoning_effort"] = self.reasoning_effort
 
@@ -352,11 +367,6 @@ class VLMConfig(BaseModel):
                 extra_request_body=(
                     primary_cfg.get("extra_request_body") or self.extra_request_body
                 ),
-                stream=(
-                    primary_cfg.get("stream")
-                    if primary_cfg.get("stream") is not None
-                    else self.stream
-                ),
                 reasoning_effort=(primary_cfg.get("reasoning_effort") or self.reasoning_effort),
                 max_tokens=self.max_tokens,
             )
@@ -381,11 +391,6 @@ class VLMConfig(BaseModel):
                 extra_headers=backup_cfg.get("extra_headers") or self.backup.extra_headers,
                 extra_request_body=(
                     backup_cfg.get("extra_request_body") or self.backup.extra_request_body
-                ),
-                stream=(
-                    backup_cfg.get("stream")
-                    if backup_cfg.get("stream") is not None
-                    else self.backup.stream
                 ),
                 reasoning_effort=(
                     backup_cfg.get("reasoning_effort") or self.backup.reasoning_effort
@@ -425,11 +430,6 @@ class VLMConfig(BaseModel):
                         extra_request_body=(
                             provider_cfg.get("extra_request_body") or self.extra_request_body
                         ),
-                        stream=(
-                            provider_cfg.get("stream")
-                            if provider_cfg.get("stream") is not None
-                            else self.stream
-                        ),
                         reasoning_effort=(
                             provider_cfg.get("reasoning_effort") or self.reasoning_effort
                         ),
@@ -461,8 +461,6 @@ class VLMConfig(BaseModel):
                 cred.extra_headers = self.extra_headers
             if not cred.extra_request_body:
                 cred.extra_request_body = self.extra_request_body
-            if cred.stream is None:
-                cred.stream = self.stream
             if not cred.reasoning_effort:
                 cred.reasoning_effort = self.reasoning_effort
 
@@ -516,8 +514,6 @@ class VLMConfig(BaseModel):
             config["extra_headers"] = self.extra_headers
         if self.extra_request_body and "extra_request_body" not in config:
             config["extra_request_body"] = self.extra_request_body
-        if self.stream and "stream" not in config:
-            config["stream"] = self.stream
         if self.reasoning_effort and "reasoning_effort" not in config:
             config["reasoning_effort"] = self.reasoning_effort
         return config
@@ -547,8 +543,6 @@ class VLMConfig(BaseModel):
             config["extra_headers"] = cred.extra_headers
         if cred.extra_request_body:
             config["extra_request_body"] = cred.extra_request_body
-        if cred.stream:
-            config["stream"] = cred.stream
         if cred.reasoning_effort:
             config["reasoning_effort"] = cred.reasoning_effort
         return config
@@ -649,7 +643,6 @@ class VLMConfig(BaseModel):
             "max_tokens": (
                 credential.max_tokens if credential.max_tokens is not None else self.max_tokens
             ),
-            "stream": credential.stream if credential.stream is not None else self.stream,
             "api_version": credential.api_version,
             "media": self.media.model_dump(),
         }
@@ -673,11 +666,6 @@ class VLMConfig(BaseModel):
         """Build VLM instance config dict."""
         config, name = self.get_provider_config()
 
-        # Get stream from provider config if available, fallback to self.stream
-        stream = (
-            config.get("stream") if config and config.get("stream") is not None else self.stream
-        )
-
         result = {
             "model": self.model,
             "temperature": self.temperature,
@@ -686,7 +674,6 @@ class VLMConfig(BaseModel):
             "provider": name,
             "thinking": self.thinking,
             "max_tokens": self.max_tokens,
-            "stream": stream,
             "api_version": self.api_version,
             "media": self.media.model_dump(),
         }

--- a/tests/unit/test_codex_vlm.py
+++ b/tests/unit/test_codex_vlm.py
@@ -464,30 +464,6 @@ def test_codex_auth_refresh_requires_persisted_client_id(tmp_path, monkeypatch):
 
 @patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
 @patch("openviking.models.vlm.backends.codex_vlm.resolve_codex_runtime_credentials")
-def test_codex_streaming_is_rejected(mock_resolve, mock_openai_class):
-    mock_resolve.return_value = {
-        "api_key": "oauth-token",
-        "base_url": "https://chatgpt.com/backend-api/codex",
-    }
-    mock_real_client = MagicMock()
-    mock_openai_class.return_value = mock_real_client
-
-    vlm = CodexVLM(
-        {
-            "provider": "openai-codex",
-            "model": "gpt-5.3-codex",
-            "stream": True,
-        }
-    )
-
-    with pytest.raises(NotImplementedError, match="Streaming is not supported"):
-        vlm.get_completion("hello")
-
-    mock_real_client.responses.create.assert_not_called()
-
-
-@patch("openviking.models.vlm.backends.codex_vlm.openai.OpenAI")
-@patch("openviking.models.vlm.backends.codex_vlm.resolve_codex_runtime_credentials")
 def test_codex_sync_client_re_resolves_credentials_per_request(mock_resolve, mock_openai_class):
     mock_resolve.side_effect = [
         {

--- a/tests/unit/test_stream_config_vlm.py
+++ b/tests/unit/test_stream_config_vlm.py
@@ -1,475 +1,54 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
-"""Tests for VLM stream configuration support."""
-
-from unittest.mock import AsyncMock, MagicMock, patch
+"""VLM streaming is not a supported configuration contract."""
 
 import pytest
-
-from openviking.models.vlm.backends.openai_vlm import OpenAIVLM
-
-
-class MockDelta:
-    """Mock delta object for streaming chunks."""
-
-    def __init__(self, content=None):
-        self.content = content
-
-
-class MockChoice:
-    """Mock choice object for streaming chunks."""
-
-    def __init__(self, delta=None):
-        self.delta = delta
-
-
-class MockChunk:
-    """Mock chunk object for streaming response."""
-
-    def __init__(self, content=None, usage=None):
-        self.choices = [MockChoice(delta=MockDelta(content=content))] if content is not None else []
-        self.usage = usage
-
-
-class MockUsage:
-    """Mock usage object."""
-
-    def __init__(self, prompt_tokens=0, completion_tokens=0):
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class TestVLMStreamConfig:
-    """Test stream configuration is passed to OpenAI API calls."""
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_false_by_default(self, mock_openai_class):
-        """stream should default to False."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello"
-        mock_response.usage = None
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-            }
-        )
-
-        vlm.get_completion("test prompt")
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is False
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_true_passed_to_api(self, mock_openai_class):
-        """stream=True should be passed to API call."""
-        mock_client = MagicMock()
-        # Simulate streaming response
-        chunks = [
-            MockChunk(content="Hello"),
-            MockChunk(content=" world"),
-            MockChunk(content="!", usage=MockUsage(prompt_tokens=10, completion_tokens=3)),
-        ]
-        mock_client.chat.completions.create.return_value = iter(chunks)
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = vlm.get_completion("test prompt")
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Hello world!"
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_stream_false_uses_non_streaming_path(self, mock_openai_class):
-        """stream=False should use non-streaming response handling."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Non-streaming response"
-        mock_response.usage = MockUsage(prompt_tokens=5, completion_tokens=10)
-        mock_client.chat.completions.create.return_value = mock_response
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": False,
-            }
-        )
-
-        result = vlm.get_completion("test prompt")
-
-        assert result == "Non-streaming response"
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is False
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_async_stream_true(self, mock_async_openai_class):
-        """stream=True should work with async methods."""
-        mock_client = MagicMock()
-
-        async def async_generator():
-            chunks = [
-                MockChunk(content="Async"),
-                MockChunk(content=" result"),
-                MockChunk(content="!", usage=MockUsage(prompt_tokens=8, completion_tokens=4)),
-            ]
-            for chunk in chunks:
-                yield chunk
-
-        mock_client.chat.completions.create = AsyncMock(return_value=async_generator())
-        mock_async_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = await vlm.get_completion_async("test prompt")
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Async result!"
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_async_stream_false(self, mock_async_openai_class):
-        """stream=False should work with async methods."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Async non-streaming"
-        mock_response.usage = MockUsage(prompt_tokens=5, completion_tokens=5)
-
-        async def mock_create(*args, **kwargs):
-            return mock_response
-
-        mock_client.chat.completions.create = mock_create
-        mock_async_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": False,
-            }
-        )
-
-        result = await vlm.get_completion_async("test prompt")
-
-        assert result == "Async non-streaming"
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.OpenAI")
-    def test_vision_completion_stream_true(self, mock_openai_class):
-        """stream=True should work with vision completion."""
-        mock_client = MagicMock()
-        chunks = [
-            MockChunk(content="Image"),
-            MockChunk(content=" description"),
-            MockChunk(content=".", usage=MockUsage(prompt_tokens=20, completion_tokens=5)),
-        ]
-        mock_client.chat.completions.create.return_value = iter(chunks)
-        mock_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = vlm.get_vision_completion("describe this", ["http://example.com/image.jpg"])
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Image description."
-
-    @patch("openviking.models.vlm.backends.openai_vlm.openai.AsyncOpenAI")
-    async def test_vision_completion_async_stream_true(self, mock_async_openai_class):
-        """stream=True should work with async vision completion."""
-        mock_client = MagicMock()
-
-        async def async_generator():
-            chunks = [
-                MockChunk(content="Async"),
-                MockChunk(content=" image"),
-                MockChunk(
-                    content=" result", usage=MockUsage(prompt_tokens=15, completion_tokens=6)
-                ),
-            ]
-            for chunk in chunks:
-                yield chunk
-
-        mock_client.chat.completions.create = AsyncMock(return_value=async_generator())
-        mock_async_openai_class.return_value = mock_client
-
-        vlm = OpenAIVLM(
-            {
-                "api_key": "sk-test",
-                "api_base": "https://api.openai.com/v1",
-                "stream": True,
-            }
-        )
-
-        result = await vlm.get_vision_completion_async(
-            "describe this", ["http://example.com/image.jpg"]
-        )
-
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs.get("stream") is True
-        assert result == "Async image result"
-
-
-class TestVLMBaseStreamConfig:
-    """Test VLMBase extracts stream from config."""
-
-    def test_stream_defaults_to_false(self):
-        """VLMBase should default stream to False."""
-
-        class StubVLM(OpenAIVLM):
-            def get_completion(self, prompt, thinking=False):
-                return ""
-
-            async def get_completion_async(self, prompt, thinking=False):
-                return ""
-
-            def get_vision_completion(self, prompt, images, thinking=False):
-                return ""
-
-            async def get_vision_completion_async(self, prompt, images, thinking=False):
-                return ""
-
-        vlm = StubVLM(
-            {
-                "api_key": "sk-test",
-            }
-        )
-
-        assert vlm.stream is False
-
-    def test_stream_extracted_from_config(self):
-        """VLMBase should extract stream from config."""
-
-        class StubVLM(OpenAIVLM):
-            def get_completion(self, prompt, thinking=False):
-                return ""
-
-            async def get_completion_async(self, prompt, thinking=False):
-                return ""
-
-            def get_vision_completion(self, prompt, images, thinking=False):
-                return ""
-
-            async def get_vision_completion_async(self, prompt, images, thinking=False):
-                return ""
-
-        vlm = StubVLM(
-            {
-                "api_key": "sk-test",
-                "stream": True,
-            }
-        )
-
-        assert vlm.stream is True
-
-
-class TestVLMConfigStream:
-    """Test VLMConfig passes stream to VLM instance."""
-
-    def test_vlm_config_accepts_stream(self):
-        """VLMConfig should accept stream field."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            stream=True,
-            providers={
+from pydantic import ValidationError
+
+from openviking_cli.utils.config.vlm_config import VLMConfig
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "provider": "openai",
+            "model": "test-model",
+            "api_key": "test-key",
+            "stream": False,
+        },
+        {
+            "model": "test-model",
+            "providers": {"openai": {"api_key": "test-key", "stream": True}},
+        },
+        {
+            "model": "test-model",
+            "credentials": [
+                {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "api_key": "test-key",
+                    "stream": True,
+                }
+            ],
+        },
+        {
+            "provider": "openai",
+            "model": "test-model",
+            "api_key": "test-key",
+            "extra_request_body": {"stream": True},
+        },
+        {
+            "model": "test-model",
+            "providers": {
                 "openai": {
-                    "api_key": "sk-test",
-                    "api_base": "https://api.openai.com/v1",
+                    "api_key": "test-key",
+                    "extra_request_body": {"stream": True},
                 }
             },
-        )
-
-        assert config.stream is True
-
-    def test_vlm_config_stream_defaults_to_false(self):
-        """VLMConfig should default stream to False."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            providers={
-                "openai": {
-                    "api_key": "sk-test",
-                }
-            },
-        )
-
-        assert config.stream is False
-
-    def test_vlm_config_stream_passed_to_vlm_dict(self):
-        """VLMConfig should pass stream to _build_vlm_config_dict."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            stream=True,
-            providers={
-                "openai": {
-                    "api_key": "sk-test",
-                }
-            },
-        )
-
-        result = config._build_vlm_config_dict()
-        assert result["stream"] is True
-
-    def test_vlm_config_stream_migrated_to_providers(self):
-        """VLMConfig should migrate stream to providers structure."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            api_key="sk-test",
-            api_base="https://api.openai.com/v1",
-            stream=True,
-        )
-
-        # Verify stream is migrated to providers structure
-        assert config.providers["openai"]["stream"] is True
-
-        # Verify _build_vlm_config_dict uses the migrated value
-        result = config._build_vlm_config_dict()
-        assert result["stream"] is True
-
-    def test_vlm_config_stream_in_providers_takes_precedence(self):
-        """stream in providers config should take precedence over flat config."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            stream=False,  # flat config is False
-            providers={
-                "openai": {
-                    "api_key": "sk-test",
-                    "stream": True,  # provider config is True, should take precedence
-                }
-            },
-        )
-
-        result = config._build_vlm_config_dict()
-        assert result["stream"] is True
-
-    def test_vlm_config_max_retries_defaults_to_three(self):
-        """VLMConfig should default max_retries to 3."""
-        from openviking_cli.utils.config.vlm_config import VLMConfig
-
-        config = VLMConfig(
-            model="gpt-4o",
-            provider="openai",
-            providers={
-                "openai": {
-                    "api_key": "sk-test",
-                }
-            },
-        )
-
-        assert config.max_retries == 3
-        assert config._build_vlm_config_dict()["max_retries"] == 3
-
-
-class TestStreamingResponseProcessing:
-    """Test streaming response processing logic."""
-
-    def test_process_streaming_response_with_content(self):
-        """_process_streaming_response should extract content from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        chunks = [
-            MockChunk(content="Hello"),
-            MockChunk(content=" "),
-            MockChunk(content="world"),
-        ]
-
-        result = vlm._process_streaming_response(iter(chunks))
-        assert result == "Hello world"
-
-    def test_process_streaming_response_with_usage(self):
-        """_process_streaming_response should extract usage from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        chunks = [
-            MockChunk(content="Hello", usage=MockUsage(prompt_tokens=10, completion_tokens=5)),
-        ]
-
-        with patch.object(vlm, "update_token_usage") as mock_update:
-            vlm._process_streaming_response(iter(chunks))
-
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=10,
-                completion_tokens=5,
-            )
-
-    def test_process_streaming_response_empty_chunks(self):
-        """_process_streaming_response should handle empty chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        result = vlm._process_streaming_response(iter([]))
-        assert result == ""
-
-    @pytest.mark.asyncio
-    async def test_process_streaming_response_async(self):
-        """_process_streaming_response_async should extract content from async chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        async def async_chunks():
-            yield MockChunk(content="Async")
-            yield MockChunk(content=" result")
-            yield MockChunk(content="!", usage=MockUsage(prompt_tokens=5, completion_tokens=3))
-
-        result = await vlm._process_streaming_response_async(async_chunks())
-        assert result == "Async result!"
-
-    @pytest.mark.asyncio
-    async def test_process_streaming_response_async_with_usage(self):
-        """_process_streaming_response_async should extract usage from chunks."""
-        vlm = OpenAIVLM({"api_key": "sk-test"})
-
-        async def async_chunks():
-            yield MockChunk(content="Test")
-            yield MockChunk(content="", usage=MockUsage(prompt_tokens=15, completion_tokens=8))
-
-        with patch.object(vlm, "update_token_usage") as mock_update:
-            await vlm._process_streaming_response_async(async_chunks())
-
-            mock_update.assert_called_once_with(
-                model_name="gpt-4o-mini",
-                provider="openai",
-                prompt_tokens=15,
-                completion_tokens=8,
-            )
+        },
+    ],
+)
+def test_vlm_config_rejects_stream(config):
+    with pytest.raises(ValidationError, match="stream.*not supported"):
+        VLMConfig(**config)

--- a/tests/unit/test_vlm_failover.py
+++ b/tests/unit/test_vlm_failover.py
@@ -222,7 +222,7 @@ class TestLegacyProvidersDictMigration:
         assert cfg.is_available() is True
 
     def test_providers_only_propagates_extra_fields(self):
-        """extra_headers / extra_request_body / api_version / stream all propagate."""
+        """extra_headers, extra_request_body, and api_version all propagate."""
         cfg = VLMConfig(
             model="gpt-4o",
             providers={
@@ -232,7 +232,6 @@ class TestLegacyProvidersDictMigration:
                     "api_version": "2024-01-01",
                     "extra_headers": {"X-Trace": "1"},
                     "extra_request_body": {"foo": "bar"},
-                    "stream": True,
                 }
             },
         )
@@ -244,7 +243,6 @@ class TestLegacyProvidersDictMigration:
         assert cred.api_version == "2024-01-01"
         assert cred.extra_headers == {"X-Trace": "1"}
         assert cred.extra_request_body == {"foo": "bar"}
-        assert cred.stream is True
 
     def test_explicit_credentials_take_precedence_over_legacy(self):
         """When ``credentials`` is set, legacy providers dict is not migrated again."""
@@ -342,14 +340,13 @@ class TestLegacyProvidersDictMigration:
         assert cfg.is_available() is True
 
     def test_legacy_backup_propagates_extra_fields_via_match_provider(self):
-        """Backup migration via providers dict propagates extra_headers / stream / etc."""
+        """Backup migration via providers dict propagates provider-specific fields."""
         cfg = VLMConfig(
             model="gpt-4o",
             providers={
                 "openai": {
                     "api_key": "sk-primary",
                     "extra_headers": {"X-Trace": "p"},
-                    "stream": True,
                 }
             },
             backup=VLMConfig(
@@ -359,7 +356,6 @@ class TestLegacyProvidersDictMigration:
                         "api_key": "sk-backup",
                         "extra_headers": {"X-Trace": "b"},
                         "extra_request_body": {"foo": "bar"},
-                        "stream": False,
                     }
                 },
             ),
@@ -368,13 +364,11 @@ class TestLegacyProvidersDictMigration:
         primary = cfg.credentials[0]
         assert primary.api_key == "sk-primary"
         assert primary.extra_headers == {"X-Trace": "p"}
-        assert primary.stream is True
 
         backup = cfg.credentials[1]
         assert backup.api_key == "sk-backup"
         assert backup.extra_headers == {"X-Trace": "b"}
         assert backup.extra_request_body == {"foo": "bar"}
-        assert backup.stream is False
 
 
 class TestFailoverVLM:


### PR DESCRIPTION
## Description

移除实际上已经失效的通用 VLM `stream` 配置契约，并在用户配置边界明确拒绝该字段，避免用户误以为语义抽取支持流式响应。

### Before

输入：

```json
{
  "vlm": {
    "provider": "openai",
    "model": "gpt-4o",
    "api_key": "test-key",
    "stream": true
  }
}
```

配置会被接受并向 VLM 实例传递，但 OpenAI VLM 请求仍返回完整响应，`stream` 实际没有生效。

### After

相同输入会在配置加载阶段直接返回 `vlm.stream is not supported`。`stream: false`、provider/credential 中的 `stream`，以及 `extra_request_body.stream` 同样会被明确拒绝；未配置 `stream` 的 VLM 仍按原流程返回完整响应。

流程变为：读取 VLM 配置 → `VLMConfig` 检查不支持的 `stream` 字段 → 存在则报配置错误，不存在则构建 VLM 并获取完整响应。

VikingBot 的实时对话流式接口和 Codex Responses 适配器内部用于拼装完整响应的流事件不属于该配置契约，本次不受影响。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4528

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 删除 VLM、provider 和 credential 中的 `stream` 字段及运行时透传逻辑
- 由 `VLMConfig` 统一拒绝各层用户配置中的 `stream`
- 删除中英文流式配置文档，并将已有流式测试收敛为“不支持”契约测试

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：177 个聚焦测试通过；Ruff、格式检查和 `git diff --check` 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

历史 changelog 保留旧版本曾支持 OpenAI VLM streaming 的发布记录；当前配置指南不再暴露该能力。
