### PR TITLE
fix(language): ignore bare import paths during detection

### DIFF
--- a/openviking/session/memory/utils/language.py
+++ b/openviking/session/memory/utils/language.py
@@ -21,7 +21,12 @@ _JAPANESE_KANA_MIN_CHARS = 3
 _STRONG_DOMINANT_MIN_CHARS = 10
 _STRONG_DOMINANT_RATIO = 0.95
 _PRIMARY_LANGUAGES = {"zh-CN", "en"}
-_URI_LANGUAGE_NOISE_RE = re.compile(r"\b(?:viking|https?)://[^\s<>\]\)\"']+")
+# Bare import paths are machine tokens too: repeated .com domains otherwise
+# count as the Portuguese stopword "com" in code skeletons.
+_URI_LANGUAGE_NOISE_RE = re.compile(
+    r"\b(?:(?:viking|https?)://|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}/)"
+    r"[^\s<>\]\)\"'`]+"
+)
 
 _LATIN_STOPWORDS = {
     "en": set(
@@ -373,7 +378,7 @@ def resolve_output_language_from_text(
 
 
 def strip_language_detection_noise(text: str) -> str:
-    """Remove URI-like machine tokens that should not affect output language."""
+    """Remove URIs and bare domain paths that should not affect output language."""
     return _URI_LANGUAGE_NOISE_RE.sub(" ", text or "")
 
 

--- a/tests/storage/test_semantic_processor_language.py
+++ b/tests/storage/test_semantic_processor_language.py
@@ -185,6 +185,47 @@ class TestLanguageFlow:
 class TestOverviewGenerationFlow:
     """目录概述生成流程测试。"""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "description,override,expected_language",
+        [
+            ("", "", "en"),
+            ("这是用于查询任务状态和统计运行时间的客户端代码。", "", "zh-CN"),
+            (
+                "Este documento descreve as preferências do usuário e o projeto para completar.",
+                "",
+                "pt",
+            ),
+            ("", "zh-CN", "zh-CN"),
+        ],
+    )
+    async def test_import_paths_do_not_set_overview_language(
+        self, description, override, expected_language
+    ):
+        from openviking.storage.queuefs.semantic_processor import SemanticProcessor
+
+        imports = [f'"github.com/example/module{index}"' for index in range(6)]
+        skeleton = "package client\nimport (\n" + "\n".join(imports) + "\n)\nfunc NewClient()"
+        config = MagicMock()
+        config.output_language_override = override
+        config.semantic.max_overview_prompt_chars = 60_000
+        config.semantic.overview_batch_size = 50
+        config.vlm.get_completion_async = AsyncMock(return_value="# client\nClient overview.")
+
+        with patch(
+            "openviking.storage.queuefs.semantic_processor.get_openviking_config",
+            return_value=config,
+        ):
+            await SemanticProcessor()._generate_overview(
+                "viking://resources/example/client",
+                [{"name": "client.go", "summary": description + "\n" + skeleton}],
+                [],
+            )
+
+        prompt = config.vlm.get_completion_async.call_args.args[0]
+        assert f"Output Language: {expected_language}" in prompt
+        assert all(path in prompt for path in imports)
+
     @pytest.mark.parametrize(
         "lang,file_summaries",
         [
@@ -264,6 +305,7 @@ class TestOverviewGenerationFlow:
         assert "**Directory Coverage** (H2)" not in prompt
         assert "**Quick Navigation** (H2)" not in prompt
         assert "**Detailed Description** (H2)" not in prompt
+
 
 class LanguageAwareMockVLM:
     """语言感知的 MockVLM，根据 prompt 中的 Output Language 返回对应语言的响应。"""


### PR DESCRIPTION
## Description

**English**
Go directories can receive Portuguese summaries without Portuguese source prose. Code skeletons retain bare imports such as `github.com/example/module0`; the language detector counts each `com` as a Portuguese stopword. Six such imports can satisfy its strong-language threshold and produce `Output Language: pt` in the overview prompt.

Extend the existing noise filter to exclude bare domain paths from language detection only. Preserve the original paths in LLM input, content-based language selection, and explicit language overrides.

**中文**
Go 目录可能在没有葡萄牙语说明的情况下生成葡萄牙语摘要。代码骨架保留了 `github.com/example/module0` 这类裸域名 import；语言检测器把每个 `com` 当作葡萄牙语常用词计分。六条这样的 import 就可能满足强语言信号阈值，使目录摘要 Prompt 选中 `pt`。

本 PR 扩展现有去噪过滤器，仅从语言检测输入中排除裸域名路径；原始路径仍完整提供给 LLM，同时保留基于自然语言内容的判断和显式语言配置。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

A human reported the symptom, discussed the root cause and proposed fix, and authorized publication. An AI agent implemented the patch and ran validation. No manual code edits by the reporter are claimed; maintainer review is pending.

报告者观察到问题，参与根因与修复思路讨论，并授权发布；补丁实现和验证由 AI 辅助完成，不声称报告者手工修改了代码，仍需维护者审阅。

## Related Issue

Fixes #4542.

Bug report / 问题报告: https://github.com/volcengine/OpenViking/issues/4542

Related to #2288, which addresses hash-like identifier noise. This change addresses bare domain/import paths and does not depend on or include that hash-filtering change.

关联 #2288 处理的是哈希标识噪声。本次修复针对裸域名/import 路径，不依赖或包含其哈希过滤改动。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Extend the shared noise filter to bare domain paths; do not hardcode a host or force English.
  扩展共用去噪规则识别裸域名路径，不硬编码某个托管站点，也不强制英语。
- Add overview-flow regression cases for code-only input, Chinese prose, genuine Portuguese prose, and an explicit override.
  增加目录摘要链路回归，覆盖纯代码、中文说明、真实葡萄牙语说明和显式语言配置。
- Assert that original import paths remain in the generated LLM prompt.
  验证原始 import 路径仍保留在 LLM Prompt 中。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [x] Linux
  - [ ] macOS
  - [ ] Windows

Before the fix, two of the four new cases fail because the code-only and Chinese-prose cases select `pt`. After the fix, all **138 tests in the focused selection pass**, with four existing Pydantic deprecation warnings. Checks ran in an isolated Linux Docker container using Python 3.13.

修复前，四组新增用例中两组失败：纯代码及中文说明都被误判为 `pt`。修复后，**138 个选定的相关测试全部通过**，仅有四条已有的 Pydantic 弃用警告。验证在独立 Linux Docker 容器中使用 Python 3.13 执行。

Exact commands / 实际验证命令：

```sh
python -m pytest tests/storage/test_semantic_processor_language.py tests/storage/test_semantic_processor_overview_batching.py tests/storage/test_semantic_processor_code_routing.py tests/storage/test_semantic_processor_l0_l1.py tests/storage/test_semantic_parent_bubbling.py tests/session/memory/test_memory_react_system_prompt.py tests/parse/test_media_understanding_summary.py tests/misc/test_semantic_config.py -q -o addopts=''
python -m ruff check openviking/session/memory/utils/language.py tests/storage/test_semantic_processor_language.py
python -m ruff format --check openviking/session/memory/utils/language.py tests/storage/test_semantic_processor_language.py
python -m mypy --follow-imports=skip openviking/session/memory/utils/language.py tests/storage/test_semantic_processor_language.py
```

Also replayed `_generate_overview` against a configured LLM with six synthetic import paths: before the fix it selected `pt` and generated Portuguese; after the fix it selected `en` and generated English. No stored resource was overwritten.

另外使用六条合成 import 路径，通过已配置的真实 LLM 回放 `_generate_overview`：修复前选择 `pt` 并生成葡萄牙语；修复后选择 `en` 并生成英语。未覆盖任何已存储资源。

The full repository suite was not run because the change is confined to the shared language filter. The focused selection covers related semantic, memory-prompt, media, and configuration consumers. No macOS or Windows test pass is claimed.

未跑全仓测试，因为改动集中于共用语言过滤器；选定测试覆盖相关语义摘要、记忆 Prompt、媒体和配置流程。不声称完成了 macOS 或 Windows 验证。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Documentation/dependency items are not applicable: no new API, configuration, dependency, or setup step is introduced. The self-review above was performed by the implementing agent.

文档和依赖项不适用：没有新增 API、配置、依赖或安装步骤。上述代码自查由实现补丁的 agent 完成。

## Screenshots (if applicable)

Not applicable; the deterministic fixture and prompt-language assertions reproduce the issue.

不适用；通过确定性样例和 Prompt 语言断言即可复现。

## Additional Notes

This is a focused two-file change: 49 additions and 2 deletions, based on upstream `main` at `02f5c464`. Existing stored summaries are not migrated or regenerated; affected summaries must be regenerated after deployment. This PR does not address the separate issue of overly generic repository descriptions.

本次改动仅涉及两个文件，新增 49 行、删除 2 行，基于上游 `main` 的 `02f5c464`。不会自动迁移或重写已有摘要；部署后需要重新生成受影响的摘要。本 PR 不处理“仓库说明过于笼统”这一独立问题。

The patch, tests, and published reproduction use public code and synthetic examples; they do not require private repository content.

代码补丁、测试和公开复现使用公开代码与合成样例，不依赖私有仓库内容。
