### PR TITLE
revert(session): revert session skill schema patch merge

### DIFF
--- a/openviking/session/compressor_v3.py
+++ b/openviking/session/compressor_v3.py
@@ -53,10 +53,6 @@ from openviking.session.memory.streaming_memory_updater import (
 from openviking.session.memory.utils.json_parser import JsonUtils
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
 from openviking.session.memory.utils.uri import generate_uri
-from openviking.session.skill.session_skill_context_provider import (
-    SESSION_SKILL_MEMORY_TYPE,
-    load_skill_extract_registry,
-)
 from openviking.session.train import (
     Case,
     ExperienceGradientContext,
@@ -879,8 +875,7 @@ class SessionCompressorV3:
             gradient_estimator=_NoopGradientEstimator(),
             policy_optimizer=PatchMergePolicyOptimizer(
                 viking_fs=viking_fs,
-                memory_type=SESSION_SKILL_MEMORY_TYPE,
-                memory_registry=load_skill_extract_registry(),
+                memory_type="skills",
             ),
             policy_updater=SkillPolicyUpdater(
                 skill_processor=self.skill_processor,

--- a/openviking/session/memory/patch_merge_context_provider.py
+++ b/openviking/session/memory/patch_merge_context_provider.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, MemoryTypeSchema
-from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.session_extract_context_provider import (
     SessionExtractContextProvider,
 )
@@ -122,11 +121,9 @@ class PatchMergeContextProvider(SessionExtractContextProvider):
         patches: list[PatchMergePatch],
         required_file_uris: list[str] | None = None,
         output_language: str | None = None,
-        memory_registry: MemoryTypeRegistry | None = None,
     ):
         super().__init__(messages=[])
         self.memory_type = memory_type
-        self._registry = memory_registry
         self.required_file_uris = list(required_file_uris or [])
         self.patches = list(patches)
         self._output_language = output_language or _resolve_patch_output_language(self.patches)
@@ -156,8 +153,7 @@ is an existing file, put it in delete_ids; if it is only a new proposal, omit it
 
     def get_memory_schemas(self, ctx: RequestContext) -> list[MemoryTypeSchema]:
         del ctx
-        registry = self._get_registry()
-        schema = registry.get(self.memory_type)
+        schema = self._get_registry().get(self.memory_type)
         if schema is None or not schema.enabled:
             raise ValueError(f"Memory schema not found or disabled: {self.memory_type}")
         return [schema]

--- a/openviking/session/train/components/policy_optimizer.py
+++ b/openviking/session/train/components/policy_optimizer.py
@@ -13,7 +13,6 @@ from openviking.server.identity import RequestContext
 from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.extract_loop import ExtractLoop
 from openviking.session.memory.memory_isolation_handler import MemoryIsolationHandler
-from openviking.session.memory.memory_type_registry import MemoryTypeRegistry
 from openviking.session.memory.memory_updater import ExtractContext
 from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
@@ -49,7 +48,6 @@ class PatchMergePolicyOptimizer:
     viking_fs: Any = None
     vlm: Any = None
     memory_type: str = "experiences"
-    memory_registry: MemoryTypeRegistry | None = None
 
     @tracer(
         "train.policy_optimizer.patch_merge.plan",
@@ -130,7 +128,6 @@ class PatchMergePolicyOptimizer:
         extract_context = ExtractContext(list(context.messages or []))
         provider = PatchMergeContextProvider(
             memory_type=self.memory_type,
-            memory_registry=self.memory_registry,
             required_file_uris=_required_file_uris(gradients, policy_set),
             patches=[_gradient_to_merge_patch(gradient) for gradient in gradients],
         )
@@ -528,7 +525,7 @@ def _name_field_for_memory_type(memory_type: str) -> str:
     """Return the extra_fields key for the policy name in a given memory type."""
     if memory_type == "experiences":
         return "experience_name"
-    if memory_type in {"skills", "session_skills"}:
+    if memory_type == "skills":
         return "skill_name"
     if memory_type.endswith("s"):
         return f"{memory_type[:-1]}_name"

--- a/tests/session/memory/test_patch_merge_context_provider.py
+++ b/tests/session/memory/test_patch_merge_context_provider.py
@@ -14,7 +14,6 @@ from openviking.session.memory.patch_merge_context_provider import (
     PatchMergeContextProvider,
     PatchMergePatch,
 )
-from openviking.session.skill.session_skill_context_provider import load_skill_extract_registry
 
 
 def _memory_file(
@@ -353,21 +352,6 @@ def test_patch_merge_context_provider_get_memory_schema_raises_for_missing_type(
 
     with pytest.raises(ValueError, match="Memory schema not found or disabled: missing"):
         provider.get_memory_schemas(ctx=None)
-
-
-def test_patch_merge_context_provider_uses_registry_override_for_session_skills():
-    provider = PatchMergeContextProvider(
-        memory_type="session_skills",
-        memory_registry=load_skill_extract_registry(),
-        required_file_uris=[],
-        patches=[],
-    )
-
-    schemas = provider.get_memory_schemas(ctx=None)
-
-    assert len(schemas) == 1
-    assert schemas[0].memory_type == "session_skills"
-    assert schemas[0].enabled is True
 
 
 def test_patch_merge_context_provider_instruction_mentions_path_field_normalization():

--- a/tests/session/train/test_train_components.py
+++ b/tests/session/train/test_train_components.py
@@ -10,10 +10,6 @@ from test_fakes import fake_request_context
 
 from openviking.session.memory.dataclass import MemoryFile, StoredLink
 from openviking.session.memory.utils.memory_file_utils import MemoryFileUtils
-from openviking.session.skill.session_skill_context_provider import (
-    SESSION_SKILL_MEMORY_TYPE,
-    load_skill_extract_registry,
-)
 from openviking.session.train import (
     ContentHashPolicySnapshotter,
     DryRunPolicyUpdater,
@@ -722,10 +718,7 @@ async def test_patch_merge_policy_optimizer_runs_patch_merge_extract_loop(monkey
                 [],
             )
 
-    monkeypatch.setattr(
-        "openviking.session.train.components.policy_optimizer.ExtractLoop",
-        FakeExtractLoop,
-    )
+    monkeypatch.setattr("openviking.session.train.components.policy_optimizer.ExtractLoop", FakeExtractLoop)
 
     plan = await PatchMergePolicyOptimizer(viking_fs=FakeVikingFS({}), vlm=object()).plan(
         [gradient],
@@ -1081,79 +1074,3 @@ async def test_patch_merge_policy_optimizer_runs_llm_for_single_patch(monkeypatc
     assert captured["constructed"] is True
     assert plan.metadata["patch_gradient_count"] == 1
     assert plan.items[0].after_content == "merged update"
-
-
-@pytest.mark.asyncio
-async def test_patch_merge_policy_optimizer_uses_session_skill_registry(monkeypatch):
-    from openviking.session.memory.dataclass import (
-        ResolvedOperation,
-        ResolvedOperations,
-    )
-
-    skill_uri = "viking://user/u/skills/code-review/SKILL.md"
-    policy_set = ExperienceSet(root_uri="viking://user/u/skills", policies=[])
-    gradient = PatchSemanticGradient(
-        before_file=None,
-        after_file=MemoryFile(
-            uri=skill_uri,
-            content="Use this skill to review code changes.",
-            memory_type=SESSION_SKILL_MEMORY_TYPE,
-            extra_fields={
-                "memory_type": SESSION_SKILL_MEMORY_TYPE,
-                "skill_name": "code-review",
-            },
-        ),
-        base_version=None,
-        rationale="test",
-        links=[],
-        confidence=0.9,
-        metadata={},
-    )
-    captured = {}
-
-    class FakeExtractLoop:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-        async def run(self):
-            return (
-                ResolvedOperations(
-                    upsert_operations=[
-                        ResolvedOperation(
-                            old_memory_file_content=None,
-                            memory_fields={
-                                "skill_name": "code-review",
-                                "content": "Merged skill content.",
-                            },
-                            memory_type=SESSION_SKILL_MEMORY_TYPE,
-                            uris=[skill_uri],
-                        )
-                    ],
-                    delete_file_contents=[],
-                    errors=[],
-                ),
-                [],
-            )
-
-    monkeypatch.setattr(
-        "openviking.session.train.components.policy_optimizer.ExtractLoop",
-        FakeExtractLoop,
-    )
-
-    plan = await PatchMergePolicyOptimizer(
-        viking_fs=FakeVikingFS({}),
-        vlm=object(),
-        memory_type=SESSION_SKILL_MEMORY_TYPE,
-        memory_registry=load_skill_extract_registry(),
-    ).plan(
-        [gradient],
-        policy_set,
-        PatchMergePolicyOptimizerContext(request_context=fake_request_context()),
-    )
-
-    assert captured["isolation_handler"].allowed_memory_types == {SESSION_SKILL_MEMORY_TYPE}
-    assert len(plan.items) == 1
-    assert plan.items[0].memory_type == SESSION_SKILL_MEMORY_TYPE
-    assert plan.items[0].target_name == "code-review"
-    assert plan.items[0].target_uri == skill_uri
-    assert plan.items[0].after_content == "Merged skill content."


### PR DESCRIPTION
## Description

回退 #4395（`c73d7e3`）。`skills` 使用统计记忆已经下线，本次不再为 session skill patch-merge 增加独立的 `session_skills` schema/registry 适配。

### Before

配置 `memory.session_skill_extraction_enabled: true` 后，session commit 会把 skill gradient 交给专用的 `session_skills` schema，并尝试写入 `viking://user/<user_id>/skills/<skill_name>/SKILL.md`。

### After

恢复 #4395 合并前的实现：`PatchMergePolicyOptimizer` 不再接收额外 registry，session skill trainer 也不再切换到 `session_skills` schema。该 opt-in session skill 提取路径不再作为当前支持能力修复。

### Example

同样设置 `memory.session_skill_extraction_enabled: true` 并提交一段能产生 skill gradient 的 Session：修改前会进入专用 `session_skills` patch-merge；修改后恢复到 #4395 之前的行为，不再提供这层适配。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Reverts #4395

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 恢复 session skill trainer 使用 `memory_type="skills"` 的原始 wiring。
- 删除 `PatchMergePolicyOptimizer` 和 `PatchMergeContextProvider` 的 registry override。
- 删除 #4395 新增的 `session_skills` patch-merge 测试。

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

未运行单元测试；已执行 `git diff --check`，并确认回退后的完整 tree 与 #4395 合并前的 `02f5c464` 一致。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

这是对 #4395 的精确回退，不包含其他 session skill 清理或相邻重构。
