### PR TITLE
fix(pathlock): recover expired empty lock tokens

### DIFF
--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -161,7 +161,8 @@ fn pathlock_err_to_py(err: PathLockError) -> PyErr {
         PathLockError::Conflict { .. }
         | PathLockError::Timeout { .. }
         | PathLockError::HandoffFailed(_)
-        | PathLockError::Busy { .. } =>
+        | PathLockError::Busy { .. }
+        | PathLockError::EmptyToken { .. } =>
         {
             #[allow(deprecated)]
             Python::with_gil(|py| {

--- a/crates/ragfs/src/core/builder.rs
+++ b/crates/ragfs/src/core/builder.rs
@@ -199,9 +199,10 @@ async fn build_stack_with_mountable_and_runtime(
 
     let provider: Arc<dyn PathLockProvider> = match config.pathlock.provider.as_str() {
         "memory" => Arc::new(MemoryPathLockProvider::new()),
-        _ => Arc::new(FilesystemPathLockProvider::new(
-            mountable.clone() as Arc<dyn FileSystem>
-        )),
+        _ => Arc::new(
+            FilesystemPathLockProvider::new(mountable.clone() as Arc<dyn FileSystem>)
+                .with_lock_expire_secs(config.pathlock.lock_expire_secs),
+        ),
     };
     let pathlock_manager = Arc::new(PathLockManager::new(
         mountable.clone() as Arc<dyn FileSystem>,

--- a/crates/ragfs/src/core/builder.rs
+++ b/crates/ragfs/src/core/builder.rs
@@ -199,10 +199,10 @@ async fn build_stack_with_mountable_and_runtime(
 
     let provider: Arc<dyn PathLockProvider> = match config.pathlock.provider.as_str() {
         "memory" => Arc::new(MemoryPathLockProvider::new()),
-        _ => Arc::new(
-            FilesystemPathLockProvider::new(mountable.clone() as Arc<dyn FileSystem>)
-                .with_lock_expire_secs(config.pathlock.lock_expire_secs),
-        ),
+        _ => Arc::new(FilesystemPathLockProvider::new(
+            mountable.clone() as Arc<dyn FileSystem>,
+            config.pathlock.lock_expire_secs,
+        )),
     };
     let pathlock_manager = Arc::new(PathLockManager::new(
         mountable.clone() as Arc<dyn FileSystem>,

--- a/crates/ragfs/src/lock/manager.rs
+++ b/crates/ragfs/src/lock/manager.rs
@@ -2404,6 +2404,7 @@ mod tests {
         fs.mkdir("/data/delete-me", 0o755).await.unwrap();
         let provider = Arc::new(crate::lock::provider::FilesystemPathLockProvider::new(
             fs.clone(),
+            PathLockConfig::default().lock_expire_secs,
         ));
         let mgr = PathLockManager::new(fs.clone(), provider, PathLockConfig::default());
         let lease = mgr

--- a/crates/ragfs/src/lock/manager.rs
+++ b/crates/ragfs/src/lock/manager.rs
@@ -681,7 +681,9 @@ impl PathLockManager {
     fn is_retryable_error(error: &PathLockError) -> bool {
         matches!(
             error,
-            PathLockError::Conflict { .. } | PathLockError::Busy { .. }
+            PathLockError::Conflict { .. }
+                | PathLockError::Busy { .. }
+                | PathLockError::EmptyToken { .. }
         )
     }
 

--- a/crates/ragfs/src/lock/provider.rs
+++ b/crates/ragfs/src/lock/provider.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
-use crate::crypto;
 use crate::core::internal_names::is_hidden_runtime_lock_name;
 use crate::core::FileSystem;
+use crate::crypto;
 
 use super::codec::LockTokenCodec;
 use super::types::{LockToken, PathLockError, PathLockResult};
@@ -168,18 +168,15 @@ pub struct FilesystemPathLockProvider {
 }
 
 impl FilesystemPathLockProvider {
-    /// Create a filesystem-backed provider.
-    pub fn new(fs: Arc<dyn FileSystem>) -> Self {
+    /// Create a filesystem-backed provider with an explicit empty-token expiry.
+    ///
+    /// `fs` stores lock files, and `lock_expire_secs` controls empty-token recovery.
+    /// Returns a configured filesystem provider.
+    pub fn new(fs: Arc<dyn FileSystem>, lock_expire_secs: f64) -> Self {
         Self {
             fs,
-            empty_token_expire_secs: 30.0,
+            empty_token_expire_secs: lock_expire_secs,
         }
-    }
-
-    /// Set the empty-token expiry and return the updated provider.
-    pub fn with_lock_expire_secs(mut self, lock_expire_secs: f64) -> Self {
-        self.empty_token_expire_secs = lock_expire_secs;
-        self
     }
 
     /// Read raw token bytes from `lock_path`, returning `None` if no token exists.
@@ -227,10 +224,15 @@ mod tests {
     async fn read_token_cleans_up_legacy_encrypted_lock() {
         let fs = Arc::new(MemFileSystem::new());
         fs.mkdir("/data", 0o755).await.unwrap();
-        fs.write("/data/.path.ovlock", b"OVE1legacy-ciphertext", 0, WriteFlag::Create)
-            .await
-            .unwrap();
-        let provider = FilesystemPathLockProvider::new(fs.clone());
+        fs.write(
+            "/data/.path.ovlock",
+            b"OVE1legacy-ciphertext",
+            0,
+            WriteFlag::Create,
+        )
+        .await
+        .unwrap();
+        let provider = FilesystemPathLockProvider::new(fs.clone(), 30.0);
 
         let token = provider.read_token("/data/.path.ovlock").await.unwrap();
 
@@ -249,7 +251,7 @@ mod tests {
         fs.write("/data/.path.ovlock", b"not-a-token", 0, WriteFlag::Create)
             .await
             .unwrap();
-        let provider = FilesystemPathLockProvider::new(fs.clone());
+        let provider = FilesystemPathLockProvider::new(fs.clone(), 30.0);
 
         let err = provider.read_token("/data/.path.ovlock").await.unwrap_err();
 
@@ -268,9 +270,13 @@ mod tests {
         fs.write("/data/.path.ovlock", b"owner:123:E", 0, WriteFlag::Create)
             .await
             .unwrap();
-        let provider = FilesystemPathLockProvider::new(fs);
+        let provider = FilesystemPathLockProvider::new(fs, 30.0);
 
-        let token = provider.read_token("/data/.path.ovlock").await.unwrap().unwrap();
+        let token = provider
+            .read_token("/data/.path.ovlock")
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(token.owner_id, "owner");
         assert_eq!(token.time_ns, 123);
@@ -331,7 +337,13 @@ impl PathLockProvider for FilesystemPathLockProvider {
                                 .fs
                                 .compare_and_remove(lock_path, &data)
                                 .await
-                                .map_err(|e| Self::map_cas_error("legacy encrypted lock cleanup", lock_path, e))?
+                                .map_err(|e| {
+                                    Self::map_cas_error(
+                                        "legacy encrypted lock cleanup",
+                                        lock_path,
+                                        e,
+                                    )
+                                })?
                             {
                                 return Ok(None);
                             }
@@ -453,11 +465,7 @@ impl FilesystemPathLockProvider {
         is_hidden_runtime_lock_name(name)
     }
 
-    async fn scan_recursive(
-        &self,
-        dir: &str,
-        result: &mut Vec<String>,
-    ) -> PathLockResult<()> {
+    async fn scan_recursive(&self, dir: &str, result: &mut Vec<String>) -> PathLockResult<()> {
         let entries = match self.fs.read_internal_dir(dir).await {
             Ok(entries) => entries,
             Err(crate::core::Error::NotFound(_) | crate::core::Error::NotADirectory(_)) => {

--- a/crates/ragfs/src/lock/provider.rs
+++ b/crates/ragfs/src/lock/provider.rs
@@ -321,17 +321,7 @@ impl PathLockProvider for FilesystemPathLockProvider {
                                 lock_path: lock_path.to_string(),
                             });
                         }
-                        if self
-                            .fs
-                            .compare_and_remove(lock_path, b"")
-                            .await
-                            .map_err(|e| Self::map_cas_error("empty lock cleanup", lock_path, e))?
-                        {
-                            tracing::warn!(lock_path = %lock_path, age_secs = age, "removed expired empty pathlock token");
-                            return Ok(None);
-                        }
-                        current = self.read_token_raw(lock_path).await?;
-                        continue;
+                        return Ok(None);
                     }
                     let raw = String::from_utf8_lossy(&data).trim().to_string();
                     match LockTokenCodec::decode(&raw) {
@@ -378,7 +368,17 @@ impl PathLockProvider for FilesystemPathLockProvider {
                         kind: t.lock_type,
                     });
                 }
-                None => last_error = Some(error),
+                None => {
+                    last_error = Some(error);
+                    if self
+                        .fs
+                        .compare_and_write(lock_path, b"", encoded.as_bytes())
+                        .await
+                        .map_err(|e| Self::map_cas_error("empty lock recovery", lock_path, e))?
+                    {
+                        return Ok(());
+                    }
+                }
             }
         }
         Err(PathLockError::Io(format!(

--- a/crates/ragfs/src/lock/provider.rs
+++ b/crates/ragfs/src/lock/provider.rs
@@ -164,12 +164,22 @@ impl PathLockProvider for MemoryPathLockProvider {
 /// Lock provider that stores tokens as files on the underlying filesystem.
 pub struct FilesystemPathLockProvider {
     fs: Arc<dyn FileSystem>,
+    empty_token_expire_secs: f64,
 }
 
 impl FilesystemPathLockProvider {
     /// Create a filesystem-backed provider.
     pub fn new(fs: Arc<dyn FileSystem>) -> Self {
-        Self { fs }
+        Self {
+            fs,
+            empty_token_expire_secs: 30.0,
+        }
+    }
+
+    /// Set the empty-token expiry and return the updated provider.
+    pub fn with_lock_expire_secs(mut self, lock_expire_secs: f64) -> Self {
+        self.empty_token_expire_secs = lock_expire_secs;
+        self
     }
 
     /// Read raw token bytes from `lock_path`, returning `None` if no token exists.
@@ -289,10 +299,41 @@ impl PathLockProvider for FilesystemPathLockProvider {
         loop {
             match current {
                 Some(data) => {
-                    let raw = String::from_utf8_lossy(&data).trim().to_string();
-                    if raw.is_empty() {
-                        return Ok(None);
+                    if data.is_empty() {
+                        let info = match self.fs.stat(lock_path).await {
+                            Ok(info) => info,
+                            Err(
+                                crate::core::Error::NotFound(_)
+                                | crate::core::Error::MountPointNotFound(_),
+                            ) => return Ok(None),
+                            Err(error) => {
+                                return Err(PathLockError::Io(format!(
+                                    "failed to stat empty lock token at '{lock_path}': {error}"
+                                )));
+                            }
+                        };
+                        let age = std::time::SystemTime::now()
+                            .duration_since(info.mod_time)
+                            .unwrap_or_default()
+                            .as_secs_f64();
+                        if age <= self.empty_token_expire_secs {
+                            return Err(PathLockError::EmptyToken {
+                                lock_path: lock_path.to_string(),
+                            });
+                        }
+                        if self
+                            .fs
+                            .compare_and_remove(lock_path, b"")
+                            .await
+                            .map_err(|e| Self::map_cas_error("empty lock cleanup", lock_path, e))?
+                        {
+                            tracing::warn!(lock_path = %lock_path, age_secs = age, "removed expired empty pathlock token");
+                            return Ok(None);
+                        }
+                        current = self.read_token_raw(lock_path).await?;
+                        continue;
                     }
+                    let raw = String::from_utf8_lossy(&data).trim().to_string();
                     match LockTokenCodec::decode(&raw) {
                         Ok(token) => return Ok(Some(token)),
                         Err(error) if crypto::is_encrypted(&data) => {
@@ -318,27 +359,32 @@ impl PathLockProvider for FilesystemPathLockProvider {
         use crate::core::WriteFlag;
 
         let encoded = LockTokenCodec::encode(token);
-        match self
-            .fs
-            .write(lock_path, encoded.as_bytes(), 0, WriteFlag::CreateNew)
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(_) => {
+        let mut last_error = None;
+        for _ in 0..2 {
+            let error = match self
+                .fs
+                .write(lock_path, encoded.as_bytes(), 0, WriteFlag::CreateNew)
+                .await
+            {
+                Ok(_) => return Ok(()),
+                Err(error) => error,
+            };
+            match self.read_token(lock_path).await? {
                 // Already exists — read and check if stale.
-                let existing = self.read_token(lock_path).await?;
-                match existing {
-                    Some(t) => Err(PathLockError::Conflict {
+                Some(t) => {
+                    return Err(PathLockError::Conflict {
                         lock_path: lock_path.to_string(),
                         owner: t.owner_id,
                         kind: t.lock_type,
-                    }),
-                    None => Err(PathLockError::Io(format!(
-                        "failed to create lock token at {lock_path}"
-                    ))),
+                    });
                 }
+                None => last_error = Some(error),
             }
         }
+        Err(PathLockError::Io(format!(
+            "failed to create lock token at {lock_path}: {}",
+            last_error.unwrap()
+        )))
     }
 
     async fn compare_and_write_token(

--- a/crates/ragfs/src/lock/types.rs
+++ b/crates/ragfs/src/lock/types.rs
@@ -196,6 +196,13 @@ pub enum PathLockError {
     #[error("invalid lock token: {0}")]
     InvalidToken(String),
 
+    /// Lock file exists but contains no token data.
+    #[error("empty lock token at '{lock_path}'")]
+    EmptyToken {
+        /// Lock path containing the empty token.
+        lock_path: String,
+    },
+
     /// Invalid lock request supplied by a caller.
     #[error("invalid lock request: {0}")]
     InvalidRequest(String),


### PR DESCRIPTION
## Description

Recover expired zero-byte PathLock files.
This prevents stale lock files from blocking writes.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

- Distinguish empty lock files from missing files
- Retry when an empty lock is still active
- Remove expired empty locks using CAS

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Empty locks use `lock_expire_secs`.
Fresh empty locks remain protected.
Expired empty locks are removed by CAS.