### PR TITLE
fix(storage): avoid blocking executor on PathLock waits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-async-runtimes"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
+dependencies = [
+ "futures",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "pyo3-build-config"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4109,7 @@ dependencies = [
  "bytes",
  "gix-hash",
  "pyo3",
+ "pyo3-async-runtimes",
  "ragfs",
  "serde",
  "serde_json",

--- a/crates/ragfs-python/Cargo.toml
+++ b/crates/ragfs-python/Cargo.toml
@@ -20,6 +20,7 @@ s3 = ["ragfs/s3"]
 [dependencies]
 ragfs = { path = "../ragfs", features = ["cache"] }
 pyo3 = { version = "0.27", features = ["abi3", "abi3-py310"] }
+pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -1106,24 +1106,6 @@ fn owned_lease_to_py_dict(py: Python<'_>, lease: &OwnedPathLockLease) -> PyResul
     Ok(dict.into())
 }
 
-/// Release a lease that completed after its Python waiter was cancelled.
-fn spawn_pathlock_release(
-    runtime: &tokio::runtime::Handle,
-    manager: Arc<PathLockManager>,
-    fs_ctx: FsContext,
-    lease: OwnedPathLockLease,
-) {
-    runtime.spawn(FS_CTX.scope(fs_ctx, async move {
-        if let Err(error) = manager.release(&lease).await {
-            tracing::error!(
-                error = %error,
-                lease_ref = %lease.lease.lease_ref,
-                "failed to release pathlock acquired for a cancelled Python waiter"
-            );
-        }
-    }));
-}
-
 /// Releases the lease unless ownership is explicitly transferred to Python.
 struct PendingPathLockLease {
     lease: Option<OwnedPathLockLease>,
@@ -1148,12 +1130,17 @@ impl PendingPathLockLease {
 impl Drop for PendingPathLockLease {
     fn drop(&mut self) {
         if let Some(lease) = self.lease.take() {
-            spawn_pathlock_release(
-                &self.runtime,
-                self.manager.clone(),
-                self.fs_ctx.clone(),
-                lease,
-            );
+            let manager = self.manager.clone();
+            self.runtime
+                .spawn(FS_CTX.scope(self.fs_ctx.clone(), async move {
+                    if let Err(error) = manager.release(&lease).await {
+                        tracing::error!(
+                            error = %error,
+                            lease_ref = %lease.lease.lease_ref,
+                            "failed to release pathlock acquired for a cancelled Python waiter"
+                        );
+                    }
+                }));
         }
     }
 }
@@ -2488,13 +2475,12 @@ impl RAGFSBindingClient {
         let task_manager = self.clone_pathlock_manager();
         let task_runtime = runtime.clone();
         let task_fs_ctx = fs_ctx.clone();
-        let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
 
-        runtime.spawn(FS_CTX.scope(fs_ctx, async move {
+        let task = runtime.spawn(FS_CTX.scope(fs_ctx, async move {
             let capability = owner_capability
                 .as_ref()
                 .map(|(lease_ref, ownership_ref)| (lease_ref.as_str(), ownership_ref.as_str()));
-            let result = task_manager
+            task_manager
                 .acquire_batch(&lock_requests, timeout, capability)
                 .await
                 .map(|lease| PendingPathLockLease {
@@ -2502,12 +2488,11 @@ impl RAGFSBindingClient {
                     manager: task_manager,
                     runtime: task_runtime,
                     fs_ctx: task_fs_ctx,
-                });
-            let _ = result_sender.send(result);
+                })
         }));
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            match result_receiver.await {
+            match task.await {
                 Ok(Ok(pending)) => Python::attach(|py| pending.into_py(py)),
                 Ok(Err(error)) => Err(pathlock_err_to_py(error)),
                 Err(error) => Err(PyRuntimeError::new_err(format!(

--- a/crates/ragfs-python/src/lib.rs
+++ b/crates/ragfs-python/src/lib.rs
@@ -1106,6 +1106,58 @@ fn owned_lease_to_py_dict(py: Python<'_>, lease: &OwnedPathLockLease) -> PyResul
     Ok(dict.into())
 }
 
+/// Release a lease that completed after its Python waiter was cancelled.
+fn spawn_pathlock_release(
+    runtime: &tokio::runtime::Handle,
+    manager: Arc<PathLockManager>,
+    fs_ctx: FsContext,
+    lease: OwnedPathLockLease,
+) {
+    runtime.spawn(FS_CTX.scope(fs_ctx, async move {
+        if let Err(error) = manager.release(&lease).await {
+            tracing::error!(
+                error = %error,
+                lease_ref = %lease.lease.lease_ref,
+                "failed to release pathlock acquired for a cancelled Python waiter"
+            );
+        }
+    }));
+}
+
+/// Releases the lease unless ownership is explicitly transferred to Python.
+struct PendingPathLockLease {
+    lease: Option<OwnedPathLockLease>,
+    manager: Arc<PathLockManager>,
+    runtime: tokio::runtime::Handle,
+    fs_ctx: FsContext,
+}
+
+impl PendingPathLockLease {
+    fn into_py(mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let value = owned_lease_to_py_dict(
+            py,
+            self.lease
+                .as_ref()
+                .expect("pending pathlock lease already consumed"),
+        )?;
+        self.lease.take();
+        Ok(value)
+    }
+}
+
+impl Drop for PendingPathLockLease {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.take() {
+            spawn_pathlock_release(
+                &self.runtime,
+                self.manager.clone(),
+                self.fs_ctx.clone(),
+                lease,
+            );
+        }
+    }
+}
+
 /// Convert a BorrowedPathLockLease to a Python dict.
 fn borrowed_lease_to_py_dict(py: Python<'_>, lease: &BorrowedPathLockLease) -> PyResult<Py<PyAny>> {
     let dict = PyDict::new(py);
@@ -2411,6 +2463,58 @@ impl RAGFSBindingClient {
             })
             .map_err(pathlock_err_to_py)?;
         Python::attach(|py| owned_lease_to_py_dict(py, &lease))
+    }
+
+    /// Acquire a batch without occupying Python's shared blocking executor.
+    ///
+    /// Cancellation does not abort the Rust acquisition mid-flight. If the
+    /// Python Future is cancelled, a lease acquired afterwards is released
+    /// before the native task finishes.
+    #[pyo3(signature = (ctx, requests, timeout_secs=0.0, owner_lease_ref=None))]
+    fn pathlock_acquire_batch_async<'py>(
+        &self,
+        py: Python<'py>,
+        ctx: Option<HashMap<String, String>>,
+        requests: Vec<HashMap<String, String>>,
+        timeout_secs: f64,
+        owner_lease_ref: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let fs_ctx = build_fs_context(ctx);
+        let timeout = validate_timeout_secs(timeout_secs)?;
+        let owner_capability = extract_optional_owned_lease_ref(py, owner_lease_ref.as_ref())?;
+        let lock_requests = parse_pathlock_request_batch(&requests)?;
+
+        let runtime = self.rt.handle().clone();
+        let task_manager = self.clone_pathlock_manager();
+        let task_runtime = runtime.clone();
+        let task_fs_ctx = fs_ctx.clone();
+        let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
+
+        runtime.spawn(FS_CTX.scope(fs_ctx, async move {
+            let capability = owner_capability
+                .as_ref()
+                .map(|(lease_ref, ownership_ref)| (lease_ref.as_str(), ownership_ref.as_str()));
+            let result = task_manager
+                .acquire_batch(&lock_requests, timeout, capability)
+                .await
+                .map(|lease| PendingPathLockLease {
+                    lease: Some(lease),
+                    manager: task_manager,
+                    runtime: task_runtime,
+                    fs_ctx: task_fs_ctx,
+                });
+            let _ = result_sender.send(result);
+        }));
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            match result_receiver.await {
+                Ok(Ok(pending)) => Python::attach(|py| pending.into_py(py)),
+                Ok(Err(error)) => Err(pathlock_err_to_py(error)),
+                Err(error) => Err(PyRuntimeError::new_err(format!(
+                    "pathlock async task stopped before returning a result: {error}"
+                ))),
+            }
+        })
     }
 
     /// Create a borrowed view of an owned lease.

--- a/openviking/pyagfs/async_client.py
+++ b/openviking/pyagfs/async_client.py
@@ -81,10 +81,9 @@ def ensure_same_encryption_account(src_path: str, dst_path: str) -> None:
 class AsyncAGFSClient:
     """Run blocking AGFS binding client operations off the event loop.
 
-    This is intentionally a thin adapter over the synchronous RAGFS binding
-    client (``RAGFSBindingClient``). If the binding later provides native async
-    methods, they can be swapped in here without changing storage and
-    transaction call sites.
+    This is a thin adapter over ``RAGFSBindingClient``. Blocking methods use a
+    worker thread; native async methods, currently PathLock acquisition, run
+    without occupying that shared executor.
     """
 
     def __init__(self, client: AGFSSyncClientProtocol):
@@ -323,6 +322,37 @@ class AsyncAGFSClient:
 
     # -- pathlock async wrappers ------------------------------------------------
 
+    async def _pathlock_acquire(
+        self,
+        requests: list[Dict[str, str]],
+        timeout_secs: float,
+        owner_lease_ref: Dict[str, Any] | None,
+        fs_ctx: Dict[str, str],
+        legacy_method: str,
+        *legacy_args: Any,
+    ) -> Dict[str, Any]:
+        native_async = getattr(self._client, "pathlock_acquire_batch_async", None)
+        if not callable(native_async):
+            return await self.run(
+                legacy_method,
+                fs_ctx,
+                *legacy_args,
+                timeout_secs,
+                owner_lease_ref,
+            )
+
+        future = asyncio.ensure_future(
+            native_async(fs_ctx, requests, timeout_secs, owner_lease_ref)
+        )
+        try:
+            return await future
+        except asyncio.CancelledError:
+            # If cancellation raced with result delivery, the native Future is
+            # already done and cannot observe cancel(). Release its lease here.
+            if future.done() and not future.cancelled() and future.exception() is None:
+                await asyncio.shield(self.pathlock_release(future.result(), fs_ctx=fs_ctx))
+            raise
+
     async def pathlock_acquire_exact(
         self,
         path: str,
@@ -332,12 +362,13 @@ class AsyncAGFSClient:
         fs_ctx: Dict[str, str] | None = None,
     ) -> Dict[str, Any]:
         """Acquire an exact lock on a single path."""
-        return await self.run(
-            "pathlock_acquire_exact",
-            _fs_ctx_or_default(path, fs_ctx),
-            path,
+        return await self._pathlock_acquire(
+            [{"path": path, "kind": "exact"}],
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(path, fs_ctx),
+            "pathlock_acquire_exact",
+            path,
         )
 
     async def pathlock_acquire_exact_batch(
@@ -349,12 +380,13 @@ class AsyncAGFSClient:
         fs_ctx: Dict[str, str] | None = None,
     ) -> Dict[str, Any]:
         """Acquire exact locks on multiple paths."""
-        return await self.run(
-            "pathlock_acquire_exact_batch",
-            _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
-            paths,
+        return await self._pathlock_acquire(
+            [{"path": path, "kind": "exact"} for path in paths],
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
+            "pathlock_acquire_exact_batch",
+            paths,
         )
 
     async def pathlock_acquire_tree(
@@ -366,12 +398,13 @@ class AsyncAGFSClient:
         fs_ctx: Dict[str, str] | None = None,
     ) -> Dict[str, Any]:
         """Acquire a tree lock on a single path."""
-        return await self.run(
-            "pathlock_acquire_tree",
-            _fs_ctx_or_default(path, fs_ctx),
-            path,
+        return await self._pathlock_acquire(
+            [{"path": path, "kind": "tree"}],
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(path, fs_ctx),
+            "pathlock_acquire_tree",
+            path,
         )
 
     async def pathlock_acquire_tree_batch(
@@ -383,12 +416,13 @@ class AsyncAGFSClient:
         fs_ctx: Dict[str, str] | None = None,
     ) -> Dict[str, Any]:
         """Acquire tree locks on multiple paths."""
-        return await self.run(
-            "pathlock_acquire_tree_batch",
-            _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
-            paths,
+        return await self._pathlock_acquire(
+            [{"path": path, "kind": "tree"} for path in paths],
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
+            "pathlock_acquire_tree_batch",
+            paths,
         )
 
     async def pathlock_acquire_exact_tree_batch(
@@ -402,13 +436,16 @@ class AsyncAGFSClient:
     ) -> Dict[str, Any]:
         """Acquire a mixed batch of exact and tree locks."""
         first = exact_paths[0] if exact_paths else (tree_paths[0] if tree_paths else "/")
-        return await self.run(
-            "pathlock_acquire_exact_tree_batch",
-            _fs_ctx_or_default(first, fs_ctx),
-            exact_paths,
-            tree_paths,
+        requests = [{"path": path, "kind": "exact"} for path in exact_paths]
+        requests.extend({"path": path, "kind": "tree"} for path in tree_paths)
+        return await self._pathlock_acquire(
+            requests,
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(first, fs_ctx),
+            "pathlock_acquire_exact_tree_batch",
+            exact_paths,
+            tree_paths,
         )
 
     async def pathlock_acquire_batch(
@@ -429,12 +466,13 @@ class AsyncAGFSClient:
             if request.get("kind") not in {"exact", "tree"}:
                 raise ValueError("pathlock request.kind must be 'exact' or 'tree'")
         first = requests[0]["path"]
-        return await self.run(
-            "pathlock_acquire_batch",
-            _fs_ctx_or_default(first, fs_ctx),
+        return await self._pathlock_acquire(
             requests,
             timeout_secs,
             owner_lease_ref,
+            _fs_ctx_or_default(first, fs_ctx),
+            "pathlock_acquire_batch",
+            requests,
         )
 
     async def pathlock_as_borrowed(

--- a/openviking/pyagfs/async_client.py
+++ b/openviking/pyagfs/async_client.py
@@ -328,21 +328,11 @@ class AsyncAGFSClient:
         timeout_secs: float,
         owner_lease_ref: Dict[str, Any] | None,
         fs_ctx: Dict[str, str],
-        legacy_method: str,
-        *legacy_args: Any,
     ) -> Dict[str, Any]:
-        native_async = getattr(self._client, "pathlock_acquire_batch_async", None)
-        if not callable(native_async):
-            return await self.run(
-                legacy_method,
-                fs_ctx,
-                *legacy_args,
-                timeout_secs,
-                owner_lease_ref,
-            )
-
         future = asyncio.ensure_future(
-            native_async(fs_ctx, requests, timeout_secs, owner_lease_ref)
+            self._client.pathlock_acquire_batch_async(
+                fs_ctx, requests, timeout_secs, owner_lease_ref
+            )
         )
         try:
             return await future
@@ -367,8 +357,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(path, fs_ctx),
-            "pathlock_acquire_exact",
-            path,
         )
 
     async def pathlock_acquire_exact_batch(
@@ -385,8 +373,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
-            "pathlock_acquire_exact_batch",
-            paths,
         )
 
     async def pathlock_acquire_tree(
@@ -403,8 +389,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(path, fs_ctx),
-            "pathlock_acquire_tree",
-            path,
         )
 
     async def pathlock_acquire_tree_batch(
@@ -421,8 +405,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(paths[0] if paths else "/", fs_ctx),
-            "pathlock_acquire_tree_batch",
-            paths,
         )
 
     async def pathlock_acquire_exact_tree_batch(
@@ -443,9 +425,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(first, fs_ctx),
-            "pathlock_acquire_exact_tree_batch",
-            exact_paths,
-            tree_paths,
         )
 
     async def pathlock_acquire_batch(
@@ -471,8 +450,6 @@ class AsyncAGFSClient:
             timeout_secs,
             owner_lease_ref,
             _fs_ctx_or_default(first, fs_ctx),
-            "pathlock_acquire_batch",
-            requests,
         )
 
     async def pathlock_as_borrowed(

--- a/openviking/pyagfs/protocols.py
+++ b/openviking/pyagfs/protocols.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Any, BinaryIO, Dict, Literal, Protocol, overload, runtime_checkable
+from typing import Any, Awaitable, BinaryIO, Dict, Literal, Protocol, overload, runtime_checkable
 
 AGFSByteStream = Iterator[bytes]
 
 
 @runtime_checkable
 class AGFSSyncClientProtocol(Protocol):
-    """Minimal synchronous AGFS client contract used by OpenViking."""
+    """AGFS binding contract used by OpenViking."""
 
     def ls(self, path: str = "/") -> list[Dict[str, Any]]:
         """List directory entries under the given AGFS path."""
@@ -109,3 +109,12 @@ class AGFSSyncClientProtocol(Protocol):
 
     def system_sync_retry(self, path: str) -> Dict[str, Any]:
         """Retry pending multi-write sync work for a file or directory path."""
+
+    def pathlock_acquire_batch_async(
+        self,
+        ctx: Dict[str, str],
+        requests: list[Dict[str, str]],
+        timeout_secs: float = 0.0,
+        owner_lease_ref: Dict[str, Any] | None = None,
+    ) -> Awaitable[Dict[str, Any]]:
+        """Acquire a PathLock batch without blocking a Python worker thread."""

--- a/tests/agfs/test_async_client.py
+++ b/tests/agfs/test_async_client.py
@@ -10,6 +10,9 @@ from openviking.pyagfs import AsyncAGFSClient
 class _SyncAGFS:
     """Minimal synchronous binding stub used by the async adapter tests."""
 
+    def __init__(self):
+        self.pathlock_acquire_calls = []
+
     def read(self, path, **kwargs):
         """Return read call arguments."""
         return ("read", path, kwargs)
@@ -25,6 +28,13 @@ class _SyncAGFS:
     def pathlock_is_locked(self, ctx, path, ignore_stale):
         """Return pathlock query arguments."""
         return ("pathlock_is_locked", ctx, path, ignore_stale)
+
+    async def pathlock_acquire_batch_async(
+        self, ctx, requests, timeout_secs, owner_lease_ref
+    ):
+        """Record a native async pathlock acquisition."""
+        self.pathlock_acquire_calls.append((ctx, requests, timeout_secs, owner_lease_ref))
+        return {"lease_ref": "lease-1", "owned": True}
 
 
 @pytest.mark.asyncio
@@ -57,6 +67,18 @@ async def test_async_agfs_client_hides_threadpool(monkeypatch):
         "/redo/id",
         {"recursive": True, "ctx": {"account_id": "_system"}},
     )
+    assert await agfs.pathlock_acquire_exact("/sessions/1", timeout_secs=30.0) == {
+        "lease_ref": "lease-1",
+        "owned": True,
+    }
+    assert sync_agfs.pathlock_acquire_calls == [
+        (
+            {"account_id": "_system"},
+            [{"path": "/sessions/1", "kind": "exact"}],
+            30.0,
+            None,
+        )
+    ]
 
     assert to_thread_calls == [
         ("write", ("/tasks/1", b"data"), {"ctx": {"account_id": "_system"}}),

--- a/tests/agfs/test_fs_binding.py
+++ b/tests/agfs/test_fs_binding.py
@@ -7,12 +7,14 @@ Tests the python binding mode of VikingFS which directly uses AGFS implementatio
 without HTTP server.
 """
 
+import asyncio
 import os
 import shutil
 import uuid
 
 import pytest
 
+from openviking.storage.errors import LockAcquisitionError
 from openviking.storage.viking_fs import init_viking_fs
 from openviking.utils.resource_processor import ResourceProcessor
 from openviking_cli.utils.config.agfs_config import AGFSConfig
@@ -128,20 +130,52 @@ class TestVikingFSBindingLocal:
                     stat_info = await vfs.stat(uri)
                     await vfs.rm(uri, recursive=bool(stat_info.get("isDir")))
 
-    async def test_borrowed_pathlock_cannot_release_via_raw_ref(self, viking_fs_binding_instance):
-        """Reject borrowed lifecycle control through typed and raw lease refs."""
+    async def test_pathlock_ownership_and_cancelled_waiter_cleanup(
+        self, viking_fs_binding_instance
+    ):
+        """Reject borrowed release and clean up a cancelled native waiter."""
         vfs = viking_fs_binding_instance
         path = f"/local/default/temp/borrowed_release_{uuid.uuid4().hex}.txt"
         owned = await vfs._async_agfs.pathlock_acquire_exact(path)
         borrowed = await vfs._async_agfs.pathlock_as_borrowed(owned)
+        waiter = None
 
         try:
             with pytest.raises(ValueError):
                 await vfs._async_agfs.pathlock_release(borrowed)
             with pytest.raises((TypeError, ValueError)):
                 await vfs._async_agfs.pathlock_release(borrowed["lease_ref"])
-        finally:
+            with pytest.raises(LockAcquisitionError):
+                await vfs._async_agfs.pathlock_acquire_exact(path)
+
+            waiter = asyncio.create_task(
+                vfs._async_agfs.pathlock_acquire_exact(path, timeout_secs=1.0)
+            )
+            for _ in range(100):
+                snapshot = await vfs._async_agfs.pathlock_observe()
+                if snapshot["waiting_locks"] == 1:
+                    break
+                await asyncio.sleep(0.01)
+            assert snapshot["waiting_locks"] == 1
+
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+
             await vfs._async_agfs.pathlock_release(owned)
+            owned = None
+            for _ in range(100):
+                snapshot = await vfs._async_agfs.pathlock_observe()
+                if snapshot["waiting_locks"] == 0 and snapshot["active_locks"] == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert snapshot["waiting_locks"] == 0
+            assert snapshot["active_locks"] == 0
+        finally:
+            if waiter is not None and not waiter.done():
+                waiter.cancel()
+            if owned is not None:
+                await vfs._async_agfs.pathlock_release(owned)
 
     async def test_pathlock_adopt_rejects_forged_tree_coverage(self, viking_fs_binding_instance):
         """Reject handoff coverage that is stronger than the live token."""


### PR DESCRIPTION
## Description

同一路径发生 PathLock 竞争时，等待锁的调用不再占用 Python 公共线程池，避免这些等待者挤占其他存储操作需要的执行线程。

### Before

`AsyncAGFSClient` 通过 `asyncio.to_thread` 调用同步的 Rust binding。同步 binding 会在工作线程中 `block_on`，直到拿到锁或 30 秒超时。

例如：`path=/local/account/sessions/1`、`contenders=40`、`timeout_secs=30`。40 个请求竞争同一把锁时，会形成 40 个阻塞调用，正在运行和排队的调用共同占用 Python 公共 executor；持锁请求后续的存储写入、释放以及无关路径的存储请求也需要这个 executor，因此可能一起变慢。

### After

相同的 `path`、`contenders` 和 `timeout_secs` 下，40 个等待者改为 Rust/Tokio 任务并通过原生 asyncio Future 等待，不再为抢锁占用 Python 公共 executor。锁类型、Session 锁范围、30 秒超时和同步 binding API 均保持不变。

流程变为：PathLock 请求 → Python 统一转换为 exact/tree request batch → native binding 在 Tokio runtime 中执行获取 → asyncio Future 返回 lease 或原有异常。若 Python 请求在等待中取消，Rust 获取流程会完成必要的回滚；如果取消后才拿到 lease，未交付的 lease 会自动释放。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

Related to #4503

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

<!-- List the main changes made in this PR -->

- 为 ragfs-python 增加标准的 PyO3/Tokio asyncio bridge，并提供 native async PathLock batch acquire。
- 让所有 Python PathLock acquire API 优先走 native async 路径，同时保留旧 binding 的同步回退。
- 为取消竞态增加未交付 lease 的自动释放，并在现有测试中覆盖线程池隔离、异常映射和取消清理。

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证通过：

- `cargo check -q -p ragfs-python`
- `.venv/bin/ruff check openviking/pyagfs/async_client.py tests/agfs/test_async_client.py tests/agfs/test_fs_binding.py`
- `.venv/bin/pytest -q --no-cov tests/agfs/test_async_client.py tests/agfs/test_fs_binding.py::TestVikingFSBindingLocal::test_pathlock_ownership_and_cancelled_waiter_cleanup`（2 passed）

完整 `tests/agfs/test_fs_binding.py` 当前为 12 passed、2 failed。两个失败均位于未修改的 handoff/adopt 契约：一个期望 `ValueError` 但当前实现返回 `LockAcquisitionError`，另一个 legacy handoff 被当前实现判定为 already adopted。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

不适用。

## Additional Notes

这次修改只处理同一进程内 PathLock 等待挤占 Python 公共线程池的问题，不改变锁范围，也不处理健康检查或 Issue 中“容器 restart 后仍复现”的外部状态现象。
