### PR TITLE
fix(cli): make resource URI segments Windows-safe like memory uris

### DIFF
--- a/openviking_cli/utils/uri.py
+++ b/openviking_cli/utils/uri.py
@@ -10,6 +10,26 @@ viking://<scope>/<path>
 import re
 from typing import Dict, Optional
 
+# Win32 reserved device names. A URI segment whose stem matches one of these
+# collides with a Windows device name and causes a silent write failure, so
+# sanitize_segment defuses it with a leading underscore. Mirrors the guard PR
+# #4517 added to the memory path (openviking/session/memory/utils/uri.py).
+_WINDOWS_RESERVED_STEMS = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{index}" for index in range(1, 10)),
+        *(f"LPT{index}" for index in range(1, 10)),
+    }
+)
+
+
+def _windows_reserved_stem(segment: str) -> str:
+    """Return the Win32 device-name stem used for portability checks."""
+    return segment.split(".", 1)[0].rstrip(" .").upper()
+
 
 class VikingURI:
     """
@@ -260,6 +280,11 @@ class VikingURI:
         safe = re.sub(r"_+", "_", safe)
         # Strip leading/trailing underscores and dots, limit length
         safe = safe.strip("_.")[:50]
+        # Defuse Win32 reserved device names (CON/PRN/NUL/AUX/COM1../LPT9..)
+        # so the segment is a valid path component on Windows, mirroring PR
+        # #4517's guard on the memory path.
+        if _windows_reserved_stem(safe) in _WINDOWS_RESERVED_STEMS:
+            safe = f"_{safe}"
         return safe or "unnamed"
 
     def __str__(self) -> str:

--- a/tests/unit/test_cli_uri_windows_safe.py
+++ b/tests/unit/test_cli_uri_windows_safe.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""Tests for Windows-reserved-name safety in resource URI segments.
+
+Mirrors the Win32 device-name guard that PR #4517 added to the memory path
+(``openviking/session/memory/utils/uri.py``) onto the resource path's
+``VikingURI.sanitize_segment``. A segment whose stem is a Win32 reserved
+name (``CON``, ``PRN``, ``NUL``, ``AUX``, ``COM1``..``COM9``,
+``LPT1``..``LPT9``) is prefixed with ``_`` so it does not collide with a
+Windows device name and cause a silent write failure.
+"""
+
+import pytest
+
+from openviking_cli.utils.uri import VikingURI
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["CON", "PRN", "NUL", "AUX", "COM1", "LPT1"],
+)
+def test_sanitize_segment_rejects_windows_reserved_names(reserved: str):
+    """A bare Win32 reserved stem is prefixed so it is not a device name."""
+    result = VikingURI.sanitize_segment(reserved)
+    assert result != reserved
+    assert result.startswith("_")
+    # Exact pin: for an already-clean name the only transformation
+    # ``sanitize_segment`` applies is the reserved-stem prefix, so the result
+    # is the input preceded by a single underscore.
+    assert result == f"_{reserved}"
+
+
+def test_sanitize_segment_reserved_with_extension():
+    """A reserved stem carrying an extension is still guarded on the stem.
+
+    ``CON.txt`` -> stem ``CON`` -> ``_CON.txt`` (extension preserved). The
+    guard runs after the existing ``strip("_.")`` step, so the extension
+    survives and only the stem is defused.
+    """
+    assert VikingURI.sanitize_segment("CON.txt") == "_CON.txt"
+
+
+def test_sanitize_segment_preserves_normal_names():
+    """Non-reserved names are unaffected by the added guard."""
+    assert VikingURI.sanitize_segment("my_resource") == "my_resource"
+    # CJK characters are preserved by the existing sanitizer and must not be
+    # touched by the reserved-name guard.
+    assert VikingURI.sanitize_segment("报告") == "报告"


### PR DESCRIPTION
# fix(cli): make resource URI segments Windows-safe like memory uris

## Description

PR #4517 让 Memory 路径生成的 URI 在 Windows 上安全(Win32 保留设备名 `CON`/`PRN`/`NUL`/`AUX`/`COM1..9`/`LPT1..9` 会被消解)。但 Resource 路径使用的 `VikingURI.sanitize_segment`(`openviking_cli/utils/uri.py`)没有同样的守卫——当某一段恰好是 Win32 保留设备名时,会原样通过,在 Windows 上与设备名冲突,造成静默写入失败。

本 PR 把 #4517 的守卫镜像到 Resource 路径,补齐兄弟模块的缺口,行为与 Memory 路径保持一致。

## Human Involvement

- [x] A human participated in the implementation or review loop

## Related Issue

无对应开放 issue(跨 OS 正确性缺口,#4517 的兄弟路径遗留)。直接先例:#4517(已合入)。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- 在 `openviking_cli/utils/uri.py` 新增 `_WINDOWS_RESERVED_STEMS` frozenset 与 `_windows_reserved_stem()` helper,逐字镜像 #4517 在 `openviking/session/memory/utils/uri.py:20-37` 的实现(同样的 Win32 保留名集合与 stem 提取逻辑)。
- 在 `VikingURI.sanitize_segment` 的 `strip("_.")[:50]` 之后、`return` 之前,加一个检查:若段的保留 stem 命中集合,加 `_` 前缀消解(与 #4517 在 `_portable_uri_segment` 中的 `cleaned = f"_{cleaned}"` 行为一致)。
- 不改动 #4517 的 Memory 路径文件(避免与刚合入的 PR 产生 rebase 风险)。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [x] Linux
  - [x] macOS
  - [ ] Windows

新增 `tests/unit/test_cli_uri_windows_safe.py`:
- 保留设备名(CON/PRN/NUL/AUX/COM1/LPT1)被加 `_` 前缀,不再是设备名;
- 带扩展名的保留名(`CON.txt` → `_CON.txt`)只消解 stem;
- 正常名与中文(`my_resource`、`报告`)不受影响。

该复现测试在 `main` 上为红(7 failed),在本分支上为绿(8 passed);既有 `test_uri_validation` + `test_uri_short_format`(41 passed)无回归。

## Checklist

- [x] My code follows the project's coding style (`ruff check` / `ruff format` 通过)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation(内部 util,无需文档)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published(N/A)

## Screenshots

N/A