### PR TITLE
fix(web-studio): hydrate missing file metadata

### DIFF
--- a/web-studio/src/routes/resources/-components/file-preview.test.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.test.tsx
@@ -17,6 +17,11 @@ const previewState = vi.hoisted(() => ({
   override: null as { content: string; fileType: string } | null,
 }))
 
+const apiMocks = vi.hoisted(() => ({
+  fetchFileContent: vi.fn(),
+  fetchFsStat: vi.fn(),
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
@@ -33,30 +38,7 @@ vi.mock('#/lib/ov-client', () => ({
   ovClient: { getOptions: () => ({ baseUrl: '' }) },
 }))
 
-vi.mock('../-hooks/viking-fm', () => ({
-  useInvalidateVikingFs: () => ({
-    invalidateList: vi.fn(),
-    invalidatePreview: vi.fn(),
-    invalidateTree: vi.fn(),
-  }),
-  useVikingFilePreview: () => ({
-    canLoadContent: false,
-    isContentLoaded: true,
-    isFetching: false,
-    isLoading: false,
-    preview: {
-      content: '[Target](./target.md)',
-      fileType: 'markdown',
-      shouldAutoRead: true,
-      ...(previewState.override ?? {}),
-    },
-    refetch: vi.fn(),
-  }),
-  useVikingFsStat: () => ({
-    data: undefined,
-    isLoading: false,
-  }),
-}))
+vi.mock('../-lib/api', () => apiMocks)
 
 const file: VikingFsEntry = {
   abstract: '',
@@ -84,16 +66,42 @@ function renderPreview(
   directoryOverview?: string,
   directoryAbstract?: string,
 ) {
+  const preview = previewState.override ?? {
+    content: '[Target](./target.md)',
+    fileType: 'markdown',
+  }
+  const previewEntry =
+    preview.fileType === 'jsonl'
+      ? {
+          ...entry,
+          name: 'preview.jsonl',
+          uri: 'viking://resources/wiki/preview.jsonl',
+        }
+      : entry
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
-  if (entry.isDir) {
+  const readKey = [
+    'viking-file-read',
+    previewEntry.uri,
+    previewEntry.modTime || '',
+    { limit: -1, offset: 0, raw: true },
+  ]
+  const readResult = {
+    content: preview.content,
+    limit: -1,
+    offset: 0,
+    truncated: false,
+    uri: previewEntry.uri,
+  }
+  queryClient.setQueryData(readKey, readResult)
+  if (previewEntry.isDir) {
     queryClient.setQueryData(
-      ['viking-directory-sidecar', entry.uri, 'abstract'],
+      ['viking-directory-sidecar', previewEntry.uri, 'abstract'],
       directoryAbstract ?? '',
     )
     queryClient.setQueryData(
-      ['viking-directory-sidecar', entry.uri, 'overview'],
+      ['viking-directory-sidecar', previewEntry.uri, 'overview'],
       directoryOverview,
     )
   }
@@ -103,7 +111,7 @@ function renderPreview(
 
   return render(
     <FilePreview
-      file={entry}
+      file={previewEntry}
       onClose={vi.fn()}
       onNavigate={onNavigate}
       showCloseButton={false}
@@ -111,6 +119,35 @@ function renderPreview(
     { wrapper },
   )
 }
+
+describe('FilePreview metadata hydration', () => {
+  afterEach(() => {
+    previewState.override = null
+    vi.clearAllMocks()
+  })
+
+  it('hydrates missing Markdown metadata without reloading its content', async () => {
+    const entry: VikingFsEntry = {
+      ...file,
+      modTime: '',
+      size: '',
+      sizeBytes: null,
+    }
+    apiMocks.fetchFsStat.mockResolvedValue({
+      ...entry,
+      modTime: '2026-09-01 10:30',
+      size: '321 B',
+      sizeBytes: 321,
+    })
+    previewState.override = { content: 'Memory body', fileType: 'markdown' }
+
+    renderPreview(entry, vi.fn())
+
+    expect(await screen.findByText('321 B · 2026-09-01 10:30')).toBeDefined()
+    expect(screen.getByText('Memory body')).toBeDefined()
+    expect(apiMocks.fetchFileContent).not.toHaveBeenCalled()
+  })
+})
 
 describe('FilePreview Markdown links', () => {
   it('opens internal Markdown links in the resource preview', () => {

--- a/web-studio/src/routes/resources/-components/file-preview.tsx
+++ b/web-studio/src/routes/resources/-components/file-preview.tsx
@@ -1330,7 +1330,7 @@ export function FilePreview({
     file && !file.isDir && file.name.toLowerCase().endsWith('.json'),
   )
   const needsMetadata = Boolean(
-    isJsonPath && file && (file.sizeBytes === null || !file.modTime),
+    file && !file.isDir && (file.sizeBytes === null || !file.modTime),
   )
   const statQuery = useVikingFsStat(needsMetadata ? file?.uri : undefined)
   const resolvedFile = useMemo(() => {
@@ -1343,8 +1343,9 @@ export function FilePreview({
     }
   }, [file, statQuery.data])
   const isJsonFile = isJsonPath
+  const previewSourceFile = isJsonFile ? resolvedFile : file
   const previewQuery = useVikingFilePreview(
-    resolvedFile,
+    previewSourceFile,
     {
       maxAutoReadBytes: LARGE_FILE_PREVIEW_BYTES,
       defaultReadLimit: -1,
@@ -1355,7 +1356,7 @@ export function FilePreview({
     },
   )
   const preview = previewQuery.preview
-  const metadataLoading = needsMetadata && statQuery.isPending
+  const metadataLoading = isJsonPath && needsMetadata && statQuery.isPending
   const hasPreviewContent =
     Boolean(preview?.shouldAutoRead) || previewQuery.isContentLoaded
   const previewLoading = metadataLoading || previewQuery.isLoading


### PR DESCRIPTION
## Description

Fixes Web Studio file previews that showed `- · -` for missing size and modification time until the user clicked the file title.

The root cause was that metadata hydration via `fs/stat` was restricted to JSON files. The preview now hydrates metadata for any non-directory file while keeping non-JSON content queries independent from the hydrated `modTime`, avoiding duplicate reads or content flicker. JSON previews retain their existing known-size safety gate.

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

N/A — small Web Studio bug found during manual use.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- Hydrate missing size and modification time for all non-directory file previews.
- Keep Markdown and other non-JSON content query keys stable when stat metadata arrives.
- Preserve JSON preview size gating and add a FilePreview regression test.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on:
  - [ ] Linux
  - [ ] macOS
  - [x] Windows

Commands run:

- `npx prettier --check src/routes/resources/-components/file-preview.test.tsx src/routes/resources/-components/file-preview.tsx`
- `npx eslint src/routes/resources/-components/file-preview.test.tsx src/routes/resources/-components/file-preview.tsx`
- `npm test -- src/routes/resources/-components/file-preview.test.tsx src/routes/resources/-hooks/viking-fm.test.tsx src/routes/resources/-lib/normalize.test.ts` (37 tests passed)
- `npm run build`

Manual verification:

- Started Web Studio against a local mock API whose directory listing omitted file metadata.
- Opened Markdown files directly and confirmed size and modification time appeared without clicking the title while the file body remained visible.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no additional comments were needed)
- [x] I have made corresponding changes to the documentation (not applicable; no documentation behavior changed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (not applicable)

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![Before: metadata is missing](https://github.com/user-attachments/assets/f27867f7-c935-48f5-ba68-58dac3cada74) | ![After: metadata is displayed automatically](https://github.com/user-attachments/assets/ec291b14-6ae6-4465-b78a-c8ffdf1288c8) |

## Additional Notes

The change is limited to Web Studio. It does not modify server APIs or stored data.
