### PR TITLE
feat(retrieval): exclude generated summaries from find results by default (issue #4518)

### DIFF
--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -253,6 +253,7 @@ async def find(
     level: Optional[List[int]] = None,
     context_type: Optional[Union[str, List[str]]] = None,
     read_content: bool = False,
+    exclude_generated_summaries: bool = True,
 ) -> str:
     """Fast semantic retrieval without session context. Returns ranked memories, resources, and skills with URI, abstract, and score."""
     service = get_service()
@@ -268,6 +269,8 @@ async def find(
         filter=_resolve_context_type_filter(context_type),
         level=level,
     )
+    if exclude_generated_summaries:
+        result = _exclude_generated_summaries(result)
     return await _format_search_result(result, service=service, ctx=ctx, read_content=read_content)
 
 
@@ -371,6 +374,23 @@ async def search(
         level=level,
     )
     return await _format_search_result(result, service=service, ctx=ctx, read_content=read_content)
+
+
+_GENERATED_SUMMARY_SUFFIXES = ("/.overview.md", "/.abstract.md")
+
+
+def _exclude_generated_summaries(result):
+    """Drop generated directory summaries (.overview.md/.abstract.md) from find results.
+
+    Aligns with upstream issue #4518: these files are directory link lists, not
+    knowledge, and since v0.4.17 they outrank the real cards they point to.
+    find() excludes them by default; callers that want them can pass
+    exclude_generated_summaries=False.
+    """
+    for attr in ("memories", "resources", "skills"):
+        bucket = getattr(result, attr)
+        setattr(result, attr, [m for m in bucket if not m.uri.endswith(_GENERATED_SUMMARY_SUFFIXES)])
+    return result
 
 
 async def _format_search_result(result, *, service, ctx, read_content: bool = False) -> str:


### PR DESCRIPTION
## Summary

Fixes #4518: since v0.4.17, generated directory summaries (`.overview.md` / `.abstract.md`) are returned by `/api/v1/search/find` and frequently **outrank the real memory cards they merely link to**.

An `.overview.md` is a directory listing, not knowledge — its link text repeats the topic, so it scores like the card it points to (sometimes higher) while carrying none of its content. For recall-budget-constrained callers (e.g. the Hermes memory plugin prefetching `recall_limit` results), this replaces knowledge with tables of contents.

## Change

- `find` now **excludes generated summaries (`.overview.md` / `.abstract.md`) by default**
- Opt-in flag `exclude_generated_summaries=False` for callers that want them
- `search` is **unaffected**: its `detail=overview/abstract` tiers intentionally surface these files, and the hierarchical retriever needs them as L0/L1 layer nodes (score propagation / directory navigation)

## Tested

- Local unit test: filter keeps real documents, drops both summary suffixes, preserves order
- Live server verification: same query before (`.overview.md` at top-2, 69%) vs after (all real documents, 0 summaries)

Happy to adjust per the second suggestion (index at a distinct level) if maintainers prefer that route.