### PR TITLE
fix(skills): shorten over-long skill descriptions and guard the limit in sync tests

### DIFF
--- a/examples/claude-code-memory-plugin/skills/ov-memory-doctor/SKILL.md
+++ b/examples/claude-code-memory-plugin/skills/ov-memory-doctor/SKILL.md
@@ -2,20 +2,15 @@
 name: ov-memory-doctor
 description: >
   Diagnose and fix the OpenViking memory plugin on this machine: the plugin
-  install (marketplace, enablement, hooks, MCP server), the client
-  configuration (ovcli.conf / ov.conf / OPENVIKING_* env — which one wins, what
-  the API key claims) and the connection to the OpenViking server
-  (reachability, 401/403, /mcp). Use whenever memory "isn't working": no
-  <openviking-context> block appears, recall is always empty, captures don't
-  land, MCP memory tools are missing or fail, 401/403 errors, the statusline
-  says offline, right after installing/updating the plugin or switching
-  servers/keys, or when the user asks for the plugin's status. Trigger phrases
-  include "memory not working", "check OpenViking", "plugin status", "记忆没生效",
-  "插件状态", "连不上 OpenViking", "recall 为空", "401", "0 memories
-  extracted". When the server runs on this machine (loopback url) it also
-  checks the port, plugin-only keys in ov.conf that stop the server from
-  starting, and `GET /ready`; everything else server-side stays with
-  `openviking-server doctor`.
+  install (enablement, hooks, MCP server), the client configuration
+  (ovcli.conf / ov.conf / OPENVIKING_* env) and the connection to the
+  OpenViking server (reachability, 401/403, /mcp). Use whenever memory "isn't
+  working": no <openviking-context> block, empty recall, captures not landing,
+  missing or failing MCP memory tools, 401/403, an offline statusline, right
+  after installing/updating the plugin or switching servers/keys, or when the
+  user asks for the plugin's status. Triggers: "memory not working", "check
+  OpenViking", "plugin status", "记忆没生效", "插件状态", "连不上 OpenViking",
+  "recall 为空", "401".
 allowed-tools: Bash(node ${CLAUDE_PLUGIN_ROOT}/scripts/ov-memory-doctor.mjs *)
 ---
 

--- a/examples/codex-memory-plugin/skills/ov-memory-doctor/SKILL.md
+++ b/examples/codex-memory-plugin/skills/ov-memory-doctor/SKILL.md
@@ -1,21 +1,16 @@
 ---
 name: ov-memory-doctor
 description: >
-  Diagnose and fix the OpenViking memory plugin for Codex on this machine: the
-  plugin install (marketplace, config.toml enablement, hook trust records, MCP
-  server), the client configuration (ovcli.conf / ov.conf / OPENVIKING_* env —
-  which one wins, what the API key claims) and the connection to the OpenViking
-  server (reachability, 401/403, /mcp). Use whenever memory "isn't working":
-  no <openviking-context> block appears, recall is always empty, turns are not
-  captured, MCP memory tools are missing or fail, 401/403 errors, right after
-  installing/updating the plugin or switching servers/keys, or when the user
-  asks for the plugin's status. Trigger phrases include "memory not working",
-  "check OpenViking", "plugin status", "记忆没生效", "插件状态", "连不上
-  OpenViking", "recall 为空", "401", "0 memories
-  extracted". When the server runs on this machine (loopback url) it also
-  checks the port, plugin-only keys in ov.conf that stop the server from
-  starting, and `GET /ready`; everything else server-side stays with
-  `openviking-server doctor`.
+  Diagnose and fix the OpenViking memory plugin for Codex on this machine: the plugin
+  install (enablement, hooks, MCP server), the client configuration
+  (ovcli.conf / ov.conf / OPENVIKING_* env) and the connection to the
+  OpenViking server (reachability, 401/403, /mcp). Use whenever memory "isn't
+  working": no <openviking-context> block, empty recall, captures not landing,
+  missing or failing MCP memory tools, 401/403, an offline statusline, right
+  after installing/updating the plugin or switching servers/keys, or when the
+  user asks for the plugin's status. Triggers: "memory not working", "check
+  OpenViking", "plugin status", "记忆没生效", "插件状态", "连不上 OpenViking",
+  "recall 为空", "401".
 ---
 
 # OpenViking Memory Doctor (Codex)

--- a/examples/memory-plugin-shared/sync.mjs
+++ b/examples/memory-plugin-shared/sync.mjs
@@ -59,6 +59,14 @@ const SKILL_TARGETS = [
       join(ROOT, "examples", "dsh-memory-plugin", "skills"),
     ],
   },
+  {
+    // Only the two harnesses that ship the experience workflow today.
+    skill: "ov-experience-memory",
+    dirs: [
+      join(ROOT, "examples", "codex-memory-plugin", "skills"),
+      join(ROOT, "examples", "claude-code-memory-plugin", "skills"),
+    ],
+  },
 ];
 
 async function listSharedFiles() {

--- a/examples/memory-plugin-shared/sync.test.mjs
+++ b/examples/memory-plugin-shared/sync.test.mjs
@@ -45,6 +45,14 @@ const SKILL_TARGETS = [
       join(ROOT, "examples", "codex-memory-plugin", "skills"),
       join(ROOT, "examples", "claude-code-memory-plugin", "skills"),
       join(ROOT, "examples", "cursor-memory-plugin", "skills"),
+      join(ROOT, "examples", "dsh-memory-plugin", "skills"),
+    ],
+  },
+  {
+    skill: "ov-experience-memory",
+    dirs: [
+      join(ROOT, "examples", "codex-memory-plugin", "skills"),
+      join(ROOT, "examples", "claude-code-memory-plugin", "skills"),
     ],
   },
 ];
@@ -88,5 +96,52 @@ test("vendored skills are byte-identical to examples/skills", async () => {
         );
       }
     }
+  }
+});
+
+// Skill loaders reject a description longer than this, and the skill then
+// silently fails to load. Guard every SKILL.md we ship, synced or not.
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+function readDescription(source) {
+  const frontmatter = /^---\n([\s\S]*?)\n---\n/.exec(source);
+  if (!frontmatter) return null;
+  const lines = frontmatter[1].split("\n");
+  const start = lines.findIndex((line) => /^description:/.test(line));
+  if (start === -1) return null;
+  const head = lines[start].slice("description:".length).trim();
+  if (head && head !== ">" && head !== "|" && head !== ">-" && head !== "|-") {
+    return head.replace(/^["']|["']$/g, "");
+  }
+  const body = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    body.push(line.trim());
+  }
+  return body.join(" ").trim();
+}
+
+async function findSkillFiles(dir) {
+  const found = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...(await findSkillFiles(full)));
+    else if (entry.name === "SKILL.md") found.push(full);
+  }
+  return found;
+}
+
+test("shipped skill descriptions stay within the loader limit", async () => {
+  const files = await findSkillFiles(join(ROOT, "examples"));
+  assert.ok(files.length > 0, "expected at least one SKILL.md");
+
+  for (const file of files) {
+    const description = readDescription(await readFile(file, "utf-8"));
+    assert.ok(description, `${relative(ROOT, file)} has no frontmatter description`);
+    assert.ok(
+      description.length <= MAX_DESCRIPTION_LENGTH,
+      `${relative(ROOT, file)} description is ${description.length} chars, over the ${MAX_DESCRIPTION_LENGTH} limit`,
+    );
   }
 });

--- a/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
+++ b/examples/openclaw-plugin/skills/install-openviking-memory/SKILL.md
@@ -2,17 +2,14 @@
 name: install-openviking-memory
 description: >
   Install and configure the OpenViking long-term memory plugin for OpenClaw via natural conversation.
-  Once installed, the plugin automatically captures important facts from chats and recalls relevant
-  context before each reply (auto-capture + auto-recall, cross-session). Covers prerequisites check,
-  plugin install through OpenClaw's plugin manager first, with ov-install only as a backup path,
-  wizard-based configuration, slot activation,
-  gateway restart, verification, plus multi-tenant root-key support, multi-instance, and uninstall.
-  Trigger when the user says any of: "install OpenViking", "set up memory", "configure memory plugin",
-  "add long-term memory", "connect to OpenViking server", "RAG", "semantic memory",
-  "帮我装 OpenViking", "配置记忆插件", "安装记忆功能", "接入 OpenViking", "我有一台 OpenViking 服务器".
-  The user does NOT need to know any CLI commands — the agent runs everything and only asks for a few values.
-  This skill assumes the OpenViking server is already running. If the server is not ready, the skill
-  tells the user to contact their admin or set it up via the OpenViking docs — it does NOT install the server.
+  Once installed, the plugin automatically captures facts from chats and recalls relevant context
+  before each reply (auto-capture + auto-recall, cross-session). Covers prerequisites, install through
+  OpenClaw's plugin manager (ov-install as backup), wizard-based configuration, slot activation,
+  gateway restart, verification, multi-tenant root keys, multi-instance and uninstall. The user needs
+  no CLI knowledge — the agent runs everything and only asks for a few values. Assumes the OpenViking
+  server is already running; it does NOT install the server. Trigger on: "install OpenViking",
+  "set up memory", "configure memory plugin", "add long-term memory", "semantic memory", "RAG",
+  "帮我装 OpenViking", "配置记忆插件", "安装记忆功能", "接入 OpenViking".
 version: 2026.6.5
 metadata:
   openclaw:


### PR DESCRIPTION
`ov-memory-doctor` (both the Claude Code and Codex plugin copies, added in #4389) and `install-openviking-memory` had `description:` fields longer than the 1024-character maximum, so the skills were rejected at load time:

```
skills/ov-memory-doctor/SKILL.md: invalid description: exceeds maximum length of 1024 characters
```

## Changes

- Trimmed the three over-long descriptions to 671 / 680 / 834 chars, keeping the what-it-does summary and the English + Chinese trigger phrases that drive skill selection.
- `examples/memory-plugin-shared/sync.test.mjs`: new test asserting every shipped `SKILL.md` under `examples/` keeps its frontmatter description within the limit, so this cannot silently reappear.
- `sync.mjs` / `sync.test.mjs`: added `ov-experience-memory` to the skill sync targets (its per-plugin copies happened to be identical but nothing enforced it), and brought the test's target list back in line with `sync.mjs` (`dsh-memory-plugin` was missing).

`ov-memory-doctor` stays per-plugin on purpose — the Codex and Claude Code copies describe different harnesses — so it is deliberately not a sync target; the new length test covers it instead.

`node --test examples/memory-plugin-shared/sync.test.mjs` passes; `node examples/memory-plugin-shared/sync.mjs` is a no-op on the tree.