### PR TITLE
fix(memory): strip copied read line numbers

### DIFF
--- a/openviking/session/memory/merge_op/factory.py
+++ b/openviking/session/memory/merge_op/factory.py
@@ -33,7 +33,7 @@ class MergeOpFactory:
         if merge_op == MergeOp.PATCH:
             return PatchOp(field_type)
         elif merge_op == MergeOp.REPLACE:
-            return ReplaceOp()
+            return ReplaceOp(field_type)
         elif merge_op == MergeOp.SUM:
             return SumOp()
         elif merge_op == MergeOp.IMMUTABLE:

--- a/openviking/session/memory/merge_op/patch.py
+++ b/openviking/session/memory/merge_op/patch.py
@@ -13,6 +13,7 @@ from openviking.session.memory.merge_op.base import (
     StrPatch,
     get_python_type_for_field,
 )
+from openviking.session.memory.utils.line_numbers import strip_line_numbers_if_present
 
 
 class PatchOp(MergeOpBase):
@@ -57,7 +58,9 @@ class PatchOp(MergeOpBase):
         # For string fields - check if current_value is None (no original)
         if current_value is None:
             # No original content - extract replace value from patch
-            return self._extract_replace_when_no_original(patch_value)
+            return strip_line_numbers_if_present(
+                self._extract_replace_when_no_original(patch_value)
+            )
 
         # For string fields with existing content
         from openviking.session.memory.merge_op.patch_handler import apply_str_patch
@@ -104,6 +107,8 @@ class PatchOp(MergeOpBase):
         # 空字符串和 None 都保持原值
         if patch_value is None or patch_value == "":
             return current_value
+        if isinstance(patch_value, str):
+            return strip_line_numbers_if_present(patch_value)
         return patch_value
 
     def _extract_replace_when_no_original(self, patch_value: Any) -> Any:

--- a/openviking/session/memory/merge_op/patch_handler.py
+++ b/openviking/session/memory/merge_op/patch_handler.py
@@ -29,6 +29,7 @@ from openviking.session.memory.utils.line_numbers import (
     every_line_has_line_numbers,
     extract_start_line_number,
     strip_line_numbers,
+    strip_line_numbers_if_present,
 )
 from openviking_cli.utils import get_logger
 
@@ -483,20 +484,20 @@ class MultiSearchReplaceDiffStrategy:
             if search_content == replace_content:
                 continue
 
-            has_line_numbers = (
-                every_line_has_line_numbers(search_content)
-                and every_line_has_line_numbers(replace_content)
-            ) or (every_line_has_line_numbers(search_content) and replace_content.strip() == "")
-
-            if has_line_numbers:
+            search_has_line_numbers = every_line_has_line_numbers(search_content)
+            if search_has_line_numbers:
                 search_content = strip_line_numbers(search_content)
-                replace_content = strip_line_numbers(replace_content)
+            replace_content = strip_line_numbers_if_present(replace_content)
 
             if not search_content:
                 all_applied = False
                 break
 
             if search_content not in result_content:
+                all_applied = False
+                break
+
+            if search_has_line_numbers and result_content.count(search_content) > 1:
                 all_applied = False
                 break
 
@@ -537,19 +538,16 @@ class MultiSearchReplaceDiffStrategy:
             replace_content = unescape_markers(replace_content)
 
             # Strip line numbers if present
-            has_all_line_numbers = (
-                every_line_has_line_numbers(search_content)
-                and every_line_has_line_numbers(replace_content)
-            ) or (every_line_has_line_numbers(search_content) and replace_content.strip() == "")
+            search_has_line_numbers = every_line_has_line_numbers(search_content)
 
-            if has_all_line_numbers and start_line == 0:
+            if search_has_line_numbers and start_line == 0:
                 inferred_start_line = extract_start_line_number(search_content)
                 if inferred_start_line is not None:
                     start_line = inferred_start_line
 
-            if has_all_line_numbers:
+            if search_has_line_numbers:
                 search_content = strip_line_numbers(search_content)
-                replace_content = strip_line_numbers(replace_content)
+            replace_content = strip_line_numbers_if_present(replace_content)
 
             # If search and replace are identical, treat as success (no changes needed)
             if search_content == replace_content:
@@ -898,6 +896,11 @@ def apply_str_patch(original_content: str, patch: StrPatch) -> str:
         if search_content == replace_content:
             continue
 
+        search_has_line_numbers = every_line_has_line_numbers(search_content)
+        if search_has_line_numbers:
+            search_content = strip_line_numbers(search_content)
+        replace_content = strip_line_numbers_if_present(replace_content)
+
         if not search_content:
             all_applied = False
             break
@@ -908,6 +911,9 @@ def apply_str_patch(original_content: str, patch: StrPatch) -> str:
 
         match_count = result_content.count(search_content)
         if match_count > 1:
+            if search_has_line_numbers:
+                all_applied = False
+                break
             raise PatchParseError(
                 f"SEARCH content matched {match_count} locations; "
                 "The re-generated SEARCH string may contain additional lines "
@@ -967,19 +973,16 @@ def apply_str_patch(original_content: str, patch: StrPatch) -> str:
         replace_content = unescape_markers(replace_content)
 
         # Strip line numbers if present
-        has_all_line_numbers = (
-            every_line_has_line_numbers(search_content)
-            and every_line_has_line_numbers(replace_content)
-        ) or (every_line_has_line_numbers(search_content) and replace_content.strip() == "")
+        search_has_line_numbers = every_line_has_line_numbers(search_content)
 
-        if has_all_line_numbers and start_line == 0:
+        if search_has_line_numbers and start_line == 0:
             inferred_start_line = extract_start_line_number(search_content)
             if inferred_start_line is not None:
                 start_line = inferred_start_line
 
-        if has_all_line_numbers:
+        if search_has_line_numbers:
             search_content = strip_line_numbers(search_content)
-            replace_content = strip_line_numbers(replace_content)
+        replace_content = strip_line_numbers_if_present(replace_content)
 
         # If search and replace are identical, treat as success (no changes needed)
         if search_content == replace_content:

--- a/openviking/session/memory/merge_op/replace.py
+++ b/openviking/session/memory/merge_op/replace.py
@@ -17,12 +17,16 @@ from openviking.session.memory.merge_op.base import (
     MergeOpBase,
     get_python_type_for_field,
 )
+from openviking.session.memory.utils.line_numbers import strip_line_numbers_if_present
 
 
 class ReplaceOp(MergeOpBase):
     """Full-replacement merge operation for string fields."""
 
     op_type = MergeOp.REPLACE
+
+    def __init__(self, field_type: FieldType | None = None):
+        self._field_type = field_type
 
     def get_output_schema_type(self, field_type: FieldType) -> Type[Any]:
         return get_python_type_for_field(field_type)
@@ -37,4 +41,6 @@ class ReplaceOp(MergeOpBase):
     async def apply(self, current_value: Any, patch_value: Any) -> Any:
         if patch_value is None or patch_value == "":
             return current_value
+        if self._field_type == FieldType.STRING and isinstance(patch_value, str):
+            return strip_line_numbers_if_present(patch_value)
         return patch_value

--- a/openviking/session/memory/utils/__init__.py
+++ b/openviking/session/memory/utils/__init__.py
@@ -26,10 +26,12 @@ from openviking.session.memory.utils.line_numbers import (
     add_line_numbers,
     every_line_has_line_numbers,
     extract_start_line_number,
+    has_sequential_line_numbers,
     line_count,
     slice_content_lines,
     split_content_lines,
     strip_line_numbers,
+    strip_line_numbers_if_present,
 )
 from openviking.session.memory.utils.messages import (
     parse_memory_file_with_fields,
@@ -53,10 +55,12 @@ __all__ = [
     "add_line_numbers",
     "every_line_has_line_numbers",
     "extract_start_line_number",
+    "has_sequential_line_numbers",
     "line_count",
     "slice_content_lines",
     "split_content_lines",
     "strip_line_numbers",
+    "strip_line_numbers_if_present",
     # Messages
     "pretty_print_messages",
     "parse_memory_file_with_fields",

--- a/openviking/session/memory/utils/line_numbers.py
+++ b/openviking/session/memory/utils/line_numbers.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 _LINE_NUMBER_PREFIX_RE = re.compile(r"^(\d+)\t")
 _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE = re.compile(r"^\s*(\d+)\t")
+_LINE_NUMBER_PREFIXES_RE = re.compile(r"^(?:\d+\t)+")
+_LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE = re.compile(r"^(?:\s*\d+\t)+")
 _LINE_SPLIT_RE = re.compile(r"\r?\n")
 
 
@@ -44,7 +46,11 @@ def extract_start_line_number(content: str) -> Optional[int]:
 
 
 def strip_line_numbers(content: str, aggressive: bool = False) -> str:
-    pattern = _LINE_NUMBER_PREFIX_WITH_LEADING_SPACE_RE if aggressive else _LINE_NUMBER_PREFIX_RE
+    pattern = (
+        _LINE_NUMBER_PREFIXES_WITH_LEADING_SPACE_RE
+        if aggressive
+        else _LINE_NUMBER_PREFIXES_RE
+    )
     return "\n".join(pattern.sub("", line) for line in split_content_lines(content))
 
 
@@ -53,3 +59,26 @@ def every_line_has_line_numbers(content: str) -> bool:
     if not lines:
         return False
     return all(_LINE_NUMBER_PREFIX_RE.match(line) for line in lines)
+
+
+def has_sequential_line_numbers(content: str) -> bool:
+    lines = split_content_lines(content)
+    if not lines:
+        return False
+
+    first_match = _LINE_NUMBER_PREFIX_RE.match(lines[0])
+    if first_match is None:
+        return False
+
+    start_line = int(first_match.group(1))
+    for index, line in enumerate(lines):
+        match = _LINE_NUMBER_PREFIX_RE.match(line)
+        if match is None or int(match.group(1)) != start_line + index:
+            return False
+    return True
+
+
+def strip_line_numbers_if_present(content: str, aggressive: bool = False) -> str:
+    if has_sequential_line_numbers(content):
+        return strip_line_numbers(content, aggressive=aggressive)
+    return content

--- a/tests/session/memory/test_merge_ops.py
+++ b/tests/session/memory/test_merge_ops.py
@@ -19,12 +19,14 @@ from openviking.session.memory.merge_op import (
     MergeOpFactory,
     PatchOp,
     PatchParseError,
+    ReplaceOp,
     SearchReplaceBlock,
     StrPatch,
     SumOp,
     apply_str_patch,
 )
 from openviking.session.memory.merge_op.base import FieldType
+from openviking.session.memory.utils.line_numbers import add_line_numbers, strip_line_numbers
 
 # ============================================================================
 # Test MergeOp Base Classes
@@ -139,6 +141,33 @@ class TestPatchOp:
 
         assert await op.apply("line 1\nline 2\nline 3\nline 4", patch) == "line 1\nline 4"
 
+    @pytest.mark.asyncio
+    async def test_apply_new_file_strips_numbered_replace_content(self):
+        op = PatchOp(FieldType.STRING)
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="",
+                    replace="1\t## Title\n2\t- fact one",
+                )
+            ]
+        )
+
+        assert await op.apply(None, patch) == "## Title\n- fact one"
+
+    @pytest.mark.asyncio
+    async def test_apply_plain_string_replacement_strips_numbered_content(self):
+        op = PatchOp(FieldType.STRING)
+
+        assert await op.apply("old", "1\t## Title\n2\t- fact one") == "## Title\n- fact one"
+
+    @pytest.mark.asyncio
+    async def test_apply_plain_string_replacement_keeps_non_sequential_tabular_content(self):
+        op = PatchOp(FieldType.STRING)
+        content = "42\tAlice\n99\tBob"
+
+        assert await op.apply("old", content) == content
+
 
 class TestSumOp:
     """Tests for SumOp."""
@@ -184,6 +213,29 @@ class TestSumOp:
         """Invalid values should keep current."""
         op = SumOp()
         assert await op.apply("not a number", 10) == "not a number"
+
+
+class TestReplaceOp:
+    """Tests for ReplaceOp."""
+
+    @pytest.mark.asyncio
+    async def test_string_replace_strips_numbered_content(self):
+        op = ReplaceOp(FieldType.STRING)
+
+        assert await op.apply("old", "1\t## Title\n2\t- fact one") == "## Title\n- fact one"
+
+    @pytest.mark.asyncio
+    async def test_string_replace_keeps_non_sequential_tabular_content(self):
+        op = ReplaceOp(FieldType.STRING)
+        content = "42\tAlice\n99\tBob"
+
+        assert await op.apply("old", content) == content
+
+    @pytest.mark.asyncio
+    async def test_non_string_replace_keeps_value(self):
+        op = ReplaceOp(FieldType.INT64)
+
+        assert await op.apply(1, 2) == 2
 
 
 class TestImmutableOp:
@@ -454,6 +506,35 @@ class TestApplyStrPatch:
         result = apply_str_patch(original, patch)
 
         assert result == "keep\nsame\nKEEP\nSAME"
+
+    def test_numbered_replace_is_stripped_when_search_is_clean(self):
+        original = "## Title\n- old fact"
+        patch = StrPatch(
+            blocks=[
+                SearchReplaceBlock(
+                    search="- old fact",
+                    replace="1\t- old fact\n2\t- new fact",
+                )
+            ]
+        )
+
+        assert apply_str_patch(original, patch) == "## Title\n- old fact\n- new fact"
+
+    def test_strip_line_numbers_removes_repeated_prefixes(self):
+        content = "## Title\n- fact one"
+        numbered_twice = add_line_numbers(add_line_numbers(content))
+
+        stripped = strip_line_numbers(numbered_twice)
+
+        assert stripped == content
+        assert strip_line_numbers(stripped) == content
+
+    def test_strip_line_numbers_if_present_keeps_non_sequential_tabular_content(self):
+        from openviking.session.memory.utils.line_numbers import strip_line_numbers_if_present
+
+        content = "42\tAlice\n99\tBob"
+
+        assert strip_line_numbers_if_present(content) == content
 
     def test_numbered_patch_uses_aggressive_strip_with_leading_spaces(self):
         """Aggressive stripping should still handle tab-prefixed line numbers."""


### PR DESCRIPTION
## Description

修复 memory 更新时将 read tool 展示行号写入真实内容的问题。read 返回内容会带有 `line_number<TAB>` 前缀供模型定位行号，但模型偶尔会把这些前缀复制回 patch / replace 内容；此前写入链路缺少兜底清洗，导致真实 memory 文件中出现并累积 `1\t...`、`1\t1\t...` 等行号前缀。

## Human Involvement

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

Fixes #4413

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update

## Changes Made

- 让 `strip_line_numbers()` 一次移除连续多层展示行号，避免 `1\t1\t...` 只剥掉一层后继续残留。
- 在 `PatchOp` 新建内容、plain string 完整替换、`ReplaceOp` 字符串替换，以及 patch replace 插入路径上增加展示行号清洗，防止模型复制 read 行号后直接落盘。
- 将清洗条件收紧为连续递增行号，避免误伤明显合法的非连续数字 tab 内容，并补充对应回归测试。

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

测试命令：

```bash
OPENVIKING_CONFIG_FILE=/Users/bytedance/ragexp/ov-base/.tmp-nonexistent-ov.conf uv run --no-sync pytest tests/session/memory/test_merge_ops.py -q
```

结果：`63 passed`。

同时执行并通过：

```bash
git diff --check
python3 -m py_compile openviking/session/memory/utils/line_numbers.py openviking/session/memory/merge_op/patch.py openviking/session/memory/merge_op/replace.py openviking/session/memory/merge_op/patch_handler.py
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

不适用。

## Additional Notes

本次修复只在 merge op 边界处理模型复制回来的 read 展示行号，没有在最终文件写入层做全局清洗，避免对普通持久化内容做过宽处理。
