### PR TITLE
feat(s3fs): cache complete object reads

### DIFF
--- a/crates/ragfs/src/plugins/s3fs/cache.rs
+++ b/crates/ragfs/src/plugins/s3fs/cache.rs
@@ -14,8 +14,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
-const MAX_OBJECT_CACHE_BYTES: usize = 512 * 1024 * 1024;
-const MAX_OBJECT_CACHE_FILE_BYTES: usize = 8 * 1024 * 1024;
+/// Default total byte budget for cached S3 object bodies.
+pub const DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES: usize = 512 * 1024 * 1024;
+/// Default per-object byte budget for cached S3 object bodies.
+pub const DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES: usize = 8 * 1024 * 1024;
 
 /// Cache entry with timestamp for TTL
 #[derive(Clone)]
@@ -191,14 +193,15 @@ pub struct S3StatCache {
 }
 
 /// Full-object cache for small S3 reads.  The entry count follows the S3FS
-/// cache configuration while the fixed byte limits keep a large object set
-/// from exhausting the service process.
+/// cache configuration while configurable byte limits bound process memory.
 pub struct S3ObjectCache {
     inner: Arc<RwLock<ObjectCacheInner>>,
     generation: AtomicU64,
     ttl: Duration,
     enabled: bool,
     max_entries: usize,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
 }
 
 struct ObjectCacheInner {
@@ -208,7 +211,13 @@ struct ObjectCacheInner {
 
 impl S3ObjectCache {
     /// Create a bounded cache for complete object reads.
-    pub fn new(max_entries: usize, ttl_seconds: u64, enabled: bool) -> Self {
+    pub fn new(
+        max_entries: usize,
+        ttl_seconds: u64,
+        enabled: bool,
+        max_file_bytes: usize,
+        max_total_bytes: usize,
+    ) -> Self {
         let max_entries = if max_entries == 0 {
             10_000
         } else {
@@ -223,6 +232,8 @@ impl S3ObjectCache {
             ttl: Duration::from_secs(if ttl_seconds == 0 { 600 } else { ttl_seconds }),
             enabled,
             max_entries,
+            max_file_bytes,
+            max_total_bytes,
         }
     }
 
@@ -248,13 +259,19 @@ impl S3ObjectCache {
         Some(entry.value.clone())
     }
 
-    /// Store a complete object when it fits within the fixed safety budgets.
+    /// Store a complete object when it fits within configured safety budgets.
     pub async fn put(&self, key: String, value: Vec<u8>) {
-        if !self.enabled || value.len() > MAX_OBJECT_CACHE_FILE_BYTES {
+        if !self.enabled || value.len() > self.max_file_bytes {
             return;
         }
         let mut inner = self.inner.write().await;
-        Self::put_locked(&mut inner, self.max_entries, key, value);
+        Self::put_locked(
+            &mut inner,
+            self.max_entries,
+            self.max_total_bytes,
+            key,
+            value,
+        );
     }
 
     /// Capture the cache generation before a backend read starts.
@@ -264,28 +281,40 @@ impl S3ObjectCache {
 
     /// Store a backend read only when no write-side invalidation occurred.
     pub async fn put_if_current(&self, generation: u64, key: String, value: Vec<u8>) {
-        if !self.enabled || value.len() > MAX_OBJECT_CACHE_FILE_BYTES {
+        if !self.enabled || value.len() > self.max_file_bytes {
             return;
         }
         let mut inner = self.inner.write().await;
         if self.generation() == generation {
-            Self::put_locked(&mut inner, self.max_entries, key, value);
+            Self::put_locked(
+                &mut inner,
+                self.max_entries,
+                self.max_total_bytes,
+                key,
+                value,
+            );
         }
     }
 
-    fn put_locked(inner: &mut ObjectCacheInner, max_entries: usize, key: String, value: Vec<u8>) {
+    fn put_locked(
+        inner: &mut ObjectCacheInner,
+        max_entries: usize,
+        max_total_bytes: usize,
+        key: String,
+        value: Vec<u8>,
+    ) {
         let value_len = value.len();
         if let Some(previous) = inner.cache.pop(&key) {
             inner.bytes = inner.bytes.saturating_sub(previous.value.len());
         }
-        while (inner.bytes + value_len > MAX_OBJECT_CACHE_BYTES || inner.cache.len() >= max_entries)
+        while (inner.bytes + value_len > max_total_bytes || inner.cache.len() >= max_entries)
             && !inner.cache.is_empty()
         {
             if let Some((_key, entry)) = inner.cache.pop_lru() {
                 inner.bytes = inner.bytes.saturating_sub(entry.value.len());
             }
         }
-        if inner.bytes + value_len <= MAX_OBJECT_CACHE_BYTES {
+        if inner.bytes + value_len <= max_total_bytes {
             inner.bytes += value_len;
             inner.cache.put(
                 key,
@@ -472,7 +501,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_object_cache_returns_full_object_and_invalidates_prefix() {
-        let cache = S3ObjectCache::new(10, 60, true);
+        let cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         cache
             .put("/parent/file.txt".to_string(), b"content".to_vec())
             .await;
@@ -488,7 +523,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_object_cache_respects_capacity_and_lru_recency() {
-        let cache = S3ObjectCache::new(2, 60, true);
+        let cache = S3ObjectCache::new(
+            2,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         cache.put("/one".to_string(), b"one".to_vec()).await;
         cache.put("/two".to_string(), b"two".to_vec()).await;
 
@@ -503,25 +544,57 @@ mod tests {
 
     #[tokio::test]
     async fn test_object_cache_disabled_or_too_large_never_hits() {
-        let disabled = S3ObjectCache::new(10, 60, false);
+        let disabled = S3ObjectCache::new(
+            10,
+            60,
+            false,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         disabled
             .put("/disabled".to_string(), b"content".to_vec())
             .await;
         assert_eq!(disabled.get("/disabled").await, None);
 
-        let cache = S3ObjectCache::new(10, 60, true);
+        let cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         cache
             .put(
                 "/too-large".to_string(),
-                vec![0; MAX_OBJECT_CACHE_FILE_BYTES + 1],
+                vec![0; DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES + 1],
             )
             .await;
         assert_eq!(cache.get("/too-large").await, None);
     }
 
     #[tokio::test]
+    async fn test_object_cache_respects_configured_byte_budgets() {
+        let cache = S3ObjectCache::new(10, 60, true, 3, 5);
+
+        cache.put("/too-large".to_string(), vec![0; 4]).await;
+        assert_eq!(cache.get("/too-large").await, None);
+
+        cache.put("/first".to_string(), vec![0; 3]).await;
+        cache.put("/second".to_string(), vec![1; 3]).await;
+
+        assert_eq!(cache.get("/first").await, None);
+        assert_eq!(cache.get("/second").await, Some(vec![1; 3]));
+    }
+
+    #[tokio::test]
     async fn test_object_cache_does_not_refill_after_invalidation() {
-        let cache = S3ObjectCache::new(10, 60, true);
+        let cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         let generation = cache.generation();
 
         cache.invalidate("/file.txt").await;

--- a/crates/ragfs/src/plugins/s3fs/cache.rs
+++ b/crates/ragfs/src/plugins/s3fs/cache.rs
@@ -9,9 +9,13 @@
 use crate::core::types::FileInfo;
 use lru::LruCache;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
+
+const MAX_OBJECT_CACHE_BYTES: usize = 512 * 1024 * 1024;
+const MAX_OBJECT_CACHE_FILE_BYTES: usize = 8 * 1024 * 1024;
 
 /// Cache entry with timestamp for TTL
 #[derive(Clone)]
@@ -186,6 +190,150 @@ pub struct S3StatCache {
     cache: TtlLruCache<Option<FileInfo>>,
 }
 
+/// Full-object cache for small S3 reads.  The entry count follows the S3FS
+/// cache configuration while the fixed byte limits keep a large object set
+/// from exhausting the service process.
+pub struct S3ObjectCache {
+    inner: Arc<RwLock<ObjectCacheInner>>,
+    generation: AtomicU64,
+    ttl: Duration,
+    enabled: bool,
+    max_entries: usize,
+}
+
+struct ObjectCacheInner {
+    cache: LruCache<String, CacheEntry<Vec<u8>>>,
+    bytes: usize,
+}
+
+impl S3ObjectCache {
+    /// Create a bounded cache for complete object reads.
+    pub fn new(max_entries: usize, ttl_seconds: u64, enabled: bool) -> Self {
+        let max_entries = if max_entries == 0 {
+            10_000
+        } else {
+            max_entries
+        };
+        Self {
+            inner: Arc::new(RwLock::new(ObjectCacheInner {
+                cache: LruCache::new(NonZeroUsize::new(max_entries).unwrap()),
+                bytes: 0,
+            })),
+            generation: AtomicU64::new(0),
+            ttl: Duration::from_secs(if ttl_seconds == 0 { 600 } else { ttl_seconds }),
+            enabled,
+            max_entries,
+        }
+    }
+
+    /// Return a cached complete object when it has not expired.
+    pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
+        if !self.enabled {
+            return None;
+        }
+        let mut inner = self.inner.write().await;
+        let now = Instant::now();
+        let expired = inner
+            .cache
+            .peek(key)
+            .is_some_and(|entry| now.duration_since(entry.timestamp) > self.ttl);
+        if expired {
+            if let Some(entry) = inner.cache.pop(key) {
+                inner.bytes = inner.bytes.saturating_sub(entry.value.len());
+            }
+            return None;
+        }
+        let entry = inner.cache.get_mut(key)?;
+        entry.timestamp = now;
+        Some(entry.value.clone())
+    }
+
+    /// Store a complete object when it fits within the fixed safety budgets.
+    pub async fn put(&self, key: String, value: Vec<u8>) {
+        if !self.enabled || value.len() > MAX_OBJECT_CACHE_FILE_BYTES {
+            return;
+        }
+        let mut inner = self.inner.write().await;
+        Self::put_locked(&mut inner, self.max_entries, key, value);
+    }
+
+    /// Capture the cache generation before a backend read starts.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    /// Store a backend read only when no write-side invalidation occurred.
+    pub async fn put_if_current(&self, generation: u64, key: String, value: Vec<u8>) {
+        if !self.enabled || value.len() > MAX_OBJECT_CACHE_FILE_BYTES {
+            return;
+        }
+        let mut inner = self.inner.write().await;
+        if self.generation() == generation {
+            Self::put_locked(&mut inner, self.max_entries, key, value);
+        }
+    }
+
+    fn put_locked(inner: &mut ObjectCacheInner, max_entries: usize, key: String, value: Vec<u8>) {
+        let value_len = value.len();
+        if let Some(previous) = inner.cache.pop(&key) {
+            inner.bytes = inner.bytes.saturating_sub(previous.value.len());
+        }
+        while (inner.bytes + value_len > MAX_OBJECT_CACHE_BYTES || inner.cache.len() >= max_entries)
+            && !inner.cache.is_empty()
+        {
+            if let Some((_key, entry)) = inner.cache.pop_lru() {
+                inner.bytes = inner.bytes.saturating_sub(entry.value.len());
+            }
+        }
+        if inner.bytes + value_len <= MAX_OBJECT_CACHE_BYTES {
+            inner.bytes += value_len;
+            inner.cache.put(
+                key,
+                CacheEntry {
+                    value,
+                    timestamp: Instant::now(),
+                },
+            );
+        }
+    }
+
+    /// Invalidate one object.
+    pub async fn invalidate(&self, key: &str) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        let mut inner = self.inner.write().await;
+        if let Some(entry) = inner.cache.pop(key) {
+            inner.bytes = inner.bytes.saturating_sub(entry.value.len());
+        }
+    }
+
+    /// Invalidate an object subtree.
+    pub async fn invalidate_prefix(&self, prefix: &str) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        let normalized = if prefix == "/" {
+            "/"
+        } else {
+            prefix.trim_end_matches('/')
+        };
+        let child_prefix = if normalized == "/" {
+            "/".to_string()
+        } else {
+            format!("{normalized}/")
+        };
+        let mut inner = self.inner.write().await;
+        let keys: Vec<String> = inner
+            .cache
+            .iter()
+            .filter(|(key, _)| *key == normalized || key.starts_with(&child_prefix))
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in keys {
+            if let Some(entry) = inner.cache.pop(&key) {
+                inner.bytes = inner.bytes.saturating_sub(entry.value.len());
+            }
+        }
+    }
+}
+
 impl S3StatCache {
     /// Create a new stat cache (5x the capacity of dir cache)
     pub fn new(max_size: usize, ttl_seconds: u64, enabled: bool) -> Self {
@@ -320,6 +468,68 @@ mod tests {
         assert!(cache.get("/").await.is_none());
         assert!(cache.get("/a").await.is_none());
         assert!(cache.get("/a/b").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_object_cache_returns_full_object_and_invalidates_prefix() {
+        let cache = S3ObjectCache::new(10, 60, true);
+        cache
+            .put("/parent/file.txt".to_string(), b"content".to_vec())
+            .await;
+
+        assert_eq!(
+            cache.get("/parent/file.txt").await,
+            Some(b"content".to_vec())
+        );
+
+        cache.invalidate_prefix("/parent").await;
+        assert_eq!(cache.get("/parent/file.txt").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_object_cache_respects_capacity_and_lru_recency() {
+        let cache = S3ObjectCache::new(2, 60, true);
+        cache.put("/one".to_string(), b"one".to_vec()).await;
+        cache.put("/two".to_string(), b"two".to_vec()).await;
+
+        assert_eq!(cache.get("/one").await, Some(b"one".to_vec()));
+
+        cache.put("/three".to_string(), b"three".to_vec()).await;
+
+        assert_eq!(cache.get("/one").await, Some(b"one".to_vec()));
+        assert_eq!(cache.get("/two").await, None);
+        assert_eq!(cache.get("/three").await, Some(b"three".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_object_cache_disabled_or_too_large_never_hits() {
+        let disabled = S3ObjectCache::new(10, 60, false);
+        disabled
+            .put("/disabled".to_string(), b"content".to_vec())
+            .await;
+        assert_eq!(disabled.get("/disabled").await, None);
+
+        let cache = S3ObjectCache::new(10, 60, true);
+        cache
+            .put(
+                "/too-large".to_string(),
+                vec![0; MAX_OBJECT_CACHE_FILE_BYTES + 1],
+            )
+            .await;
+        assert_eq!(cache.get("/too-large").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_object_cache_does_not_refill_after_invalidation() {
+        let cache = S3ObjectCache::new(10, 60, true);
+        let generation = cache.generation();
+
+        cache.invalidate("/file.txt").await;
+        cache
+            .put_if_current(generation, "/file.txt".to_string(), b"stale".to_vec())
+            .await;
+
+        assert_eq!(cache.get("/file.txt").await, None);
     }
 
     #[tokio::test]

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -86,6 +86,14 @@ async fn cached_full_object_read(
     None
 }
 
+fn resolve_read_not_found(path: &str, error: Error, directory_exists: bool) -> Result<Vec<u8>> {
+    if directory_exists {
+        Err(Error::IsADirectory(path.to_string()))
+    } else {
+        Err(error)
+    }
+}
+
 async fn finalize_directory_rename_source_removal(
     object_cache: &S3ObjectCache,
     source_path: &str,
@@ -649,26 +657,35 @@ impl FileSystem for S3FileSystem {
             return Ok(content);
         }
 
-        // Check if it's a directory
-        if key.ends_with('/') || self.client.directory_exists(&normalized).await? {
-            // Try to read as file first
-            if self.client.head_object(&key).await?.is_none() {
-                return Err(Error::IsADirectory(normalized));
-            }
+        if normalized == "/" {
+            return Err(Error::IsADirectory(normalized));
         }
 
-        if offset == 0 && size == 0 {
+        let result = if offset == 0 && size == 0 {
             let cache_generation = self.object_cache.generation();
-            let content = self.client.get_object(&key).await?;
-            if !bypass_cache {
-                self.object_cache
-                    .put_if_current(cache_generation, normalized, content.clone())
-                    .await;
+            match self.client.get_object(&key).await {
+                Ok(content) => {
+                    if !bypass_cache {
+                        self.object_cache
+                            .put_if_current(cache_generation, normalized.clone(), content.clone())
+                            .await;
+                    }
+                    Ok(content)
+                }
+                Err(error) => Err(error),
             }
-            Ok(content)
         } else {
             // Range read
             self.client.get_object_range(&key, offset, size).await
+        };
+
+        match result {
+            Err(error @ Error::NotFound(_)) => resolve_read_not_found(
+                &normalized,
+                error,
+                self.client.directory_exists(&normalized).await?,
+            ),
+            result => result,
         }
     }
 
@@ -1569,6 +1586,15 @@ mod tests {
         assert_eq!(S3FileSystem::file_name("/"), "/");
         assert_eq!(S3FileSystem::file_name("/foo.txt"), "foo.txt");
         assert_eq!(S3FileSystem::file_name("/dir/file.txt"), "file.txt");
+    }
+
+    #[test]
+    fn test_read_not_found_is_translated_to_directory_only_when_directory_exists() {
+        let directory = resolve_read_not_found("/dir", Error::not_found("dir"), true);
+        assert!(matches!(directory, Err(Error::IsADirectory(path)) if path == "/dir"));
+
+        let missing = resolve_read_not_found("/missing", Error::not_found("missing"), false);
+        assert!(matches!(missing, Err(Error::NotFound(path)) if path == "missing"));
     }
 
     #[tokio::test]

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! - Full POSIX-like file system operations over S3
 //! - Directory simulation via prefix/delimiter listing + marker objects
-//! - Dual-layer caching (directory listings + stat metadata)
+//! - Local caching for directory listings, stat metadata, and small full-object reads
 //! - Range-based reads for partial file access
 //! - Configurable directory marker modes
 //! - Support for custom S3 endpoints
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use cache::{S3ListDirCache, S3StatCache};
+use cache::{S3ListDirCache, S3ObjectCache, S3StatCache};
 use client::{ListTreePage, S3Client, S3Vendor};
 use futures::stream::{self, StreamExt};
 use regex::Regex;
@@ -52,18 +52,43 @@ fn s3_is_excluded_path(path: &str, exclude_path: &str) -> bool {
 async fn finalize_remove_all(
     dir_cache: &S3ListDirCache,
     stat_cache: &S3StatCache,
+    object_cache: &S3ObjectCache,
     path: &str,
     result: Result<()>,
 ) -> Result<()> {
     if path == "/" {
         dir_cache.invalidate_prefix("/").await;
         stat_cache.invalidate_prefix("/").await;
+        object_cache.invalidate_prefix("/").await;
     } else {
         dir_cache.invalidate_parent(path).await;
         dir_cache.invalidate_prefix(path).await;
         stat_cache.invalidate_prefix(path).await;
+        object_cache.invalidate_prefix(path).await;
     }
 
+    result
+}
+
+async fn cached_full_object_read(
+    object_cache: &S3ObjectCache,
+    path: &str,
+    offset: u64,
+    size: u64,
+    bypass_cache: bool,
+) -> Option<Vec<u8>> {
+    if offset == 0 && size == 0 && !bypass_cache {
+        return object_cache.get(path).await;
+    }
+    None
+}
+
+async fn finalize_directory_rename_source_removal(
+    object_cache: &S3ObjectCache,
+    source_path: &str,
+    result: Result<()>,
+) -> Result<()> {
+    object_cache.invalidate_prefix(source_path).await;
     result
 }
 
@@ -197,6 +222,7 @@ pub struct S3FileSystem {
     client: Arc<S3Client>,
     dir_cache: S3ListDirCache,
     stat_cache: S3StatCache,
+    object_cache: S3ObjectCache,
 }
 
 impl S3FileSystem {
@@ -214,22 +240,23 @@ impl S3FileSystem {
             .params
             .get("cache_max_size")
             .and_then(|v| v.as_int())
-            .unwrap_or(1000) as usize;
+            .unwrap_or(10_000) as usize;
 
         let cache_ttl = config
             .params
             .get("cache_ttl")
             .and_then(|v| v.as_int())
-            .unwrap_or(30) as u64;
+            .unwrap_or(600) as u64;
 
         let stat_cache_ttl = config
             .params
             .get("stat_cache_ttl")
             .and_then(|v| v.as_int())
-            .unwrap_or(60) as u64;
+            .unwrap_or(600) as u64;
 
         let dir_cache = S3ListDirCache::new(cache_max_size, cache_ttl, cache_enabled);
         let stat_cache = S3StatCache::new(cache_max_size, stat_cache_ttl, cache_enabled);
+        let object_cache = S3ObjectCache::new(cache_max_size, cache_ttl, cache_enabled);
 
         tracing::info!(
             "S3FS initialized: bucket={}, cache={}",
@@ -241,6 +268,7 @@ impl S3FileSystem {
             client: Arc::new(client),
             dir_cache,
             stat_cache,
+            object_cache,
         })
     }
 
@@ -481,6 +509,7 @@ impl FileSystem for S3FileSystem {
         // Invalidate caches
         self.dir_cache.invalidate_parent(&normalized).await;
         self.stat_cache.invalidate(&normalized).await;
+        self.object_cache.invalidate(&normalized).await;
 
         Ok(())
     }
@@ -519,6 +548,7 @@ impl FileSystem for S3FileSystem {
                 self.client.delete_object(&key).await?;
                 self.dir_cache.invalidate_parent(&normalized).await;
                 self.stat_cache.invalidate(&normalized).await;
+                self.object_cache.invalidate(&normalized).await;
                 return Ok(());
             }
         }
@@ -540,6 +570,7 @@ impl FileSystem for S3FileSystem {
             self.dir_cache.invalidate_parent(&normalized).await;
             self.dir_cache.invalidate(&normalized).await;
             self.stat_cache.invalidate(&normalized).await;
+            self.object_cache.invalidate(&normalized).await;
             return Ok(());
         }
 
@@ -552,8 +583,14 @@ impl FileSystem for S3FileSystem {
         if normalized == "/" {
             // Delete everything under prefix
             let result = self.client.delete_directory("").await;
-            return finalize_remove_all(&self.dir_cache, &self.stat_cache, &normalized, result)
-                .await;
+            return finalize_remove_all(
+                &self.dir_cache,
+                &self.stat_cache,
+                &self.object_cache,
+                &normalized,
+                result,
+            )
+            .await;
         }
 
         let result = async {
@@ -569,12 +606,27 @@ impl FileSystem for S3FileSystem {
         // DeleteObjects may succeed for only part of a batch. Always evict the
         // affected cache scope before returning its error so deleted objects do
         // not remain visible until cache expiry.
-        finalize_remove_all(&self.dir_cache, &self.stat_cache, &normalized, result).await
+        finalize_remove_all(
+            &self.dir_cache,
+            &self.stat_cache,
+            &self.object_cache,
+            &normalized,
+            result,
+        )
+        .await
     }
 
     async fn read(&self, path: &str, offset: u64, size: u64) -> Result<Vec<u8>> {
         let normalized = Self::normalize_path(path);
         let key = self.client.build_key(&normalized);
+        let bypass_cache = FsContextView::current().bypass_cache();
+
+        if let Some(content) =
+            cached_full_object_read(&self.object_cache, &normalized, offset, size, bypass_cache)
+                .await
+        {
+            return Ok(content);
+        }
 
         // Check if it's a directory
         if key.ends_with('/') || self.client.directory_exists(&normalized).await? {
@@ -585,8 +637,14 @@ impl FileSystem for S3FileSystem {
         }
 
         if offset == 0 && size == 0 {
-            // Full read
-            self.client.get_object(&key).await
+            let cache_generation = self.object_cache.generation();
+            let content = self.client.get_object(&key).await?;
+            if !bypass_cache {
+                self.object_cache
+                    .put_if_current(cache_generation, normalized, content.clone())
+                    .await;
+            }
+            Ok(content)
         } else {
             // Range read
             self.client.get_object_range(&key, offset, size).await
@@ -610,6 +668,7 @@ impl FileSystem for S3FileSystem {
         // Invalidate caches
         self.dir_cache.invalidate_parent(&normalized).await;
         self.stat_cache.invalidate(&normalized).await;
+        self.object_cache.invalidate(&normalized).await;
 
         Ok(data.len() as u64)
     }
@@ -635,6 +694,7 @@ impl FileSystem for S3FileSystem {
         if changed {
             self.dir_cache.invalidate_parent(&normalized).await;
             self.stat_cache.invalidate(&normalized).await;
+            self.object_cache.invalidate(&normalized).await;
         }
         Ok(changed)
     }
@@ -652,6 +712,7 @@ impl FileSystem for S3FileSystem {
         if changed {
             self.dir_cache.invalidate_parent(&normalized).await;
             self.stat_cache.invalidate(&normalized).await;
+            self.object_cache.invalidate(&normalized).await;
         }
         Ok(changed)
     }
@@ -804,12 +865,17 @@ impl FileSystem for S3FileSystem {
                 // File rename: copy + delete
                 let new_key = self.client.build_key(&new_normalized);
                 self.client.copy_object(&old_key, &new_key).await?;
+                self.dir_cache.invalidate_parent(&new_normalized).await;
+                self.stat_cache.invalidate(&new_normalized).await;
+                self.object_cache.invalidate(&new_normalized).await;
                 self.client.delete_object(&old_key).await?;
 
                 self.dir_cache.invalidate_parent(&old_normalized).await;
                 self.dir_cache.invalidate_parent(&new_normalized).await;
                 self.stat_cache.invalidate(&old_normalized).await;
                 self.stat_cache.invalidate(&new_normalized).await;
+                self.object_cache.invalidate(&old_normalized).await;
+                self.object_cache.invalidate(&new_normalized).await;
 
                 return Ok(());
             }
@@ -827,6 +893,12 @@ impl FileSystem for S3FileSystem {
             let old_dir_key = format!("{}/", self.client.build_key(&old_normalized));
             let new_dir_key = format!("{}/", new_prefix_base);
 
+            // The destination may change even if a later copy or source deletion fails.
+            self.dir_cache.invalidate_prefix(&new_normalized).await;
+            self.dir_cache.invalidate_parent(&new_normalized).await;
+            self.stat_cache.invalidate_prefix(&new_normalized).await;
+            self.object_cache.invalidate_prefix(&new_normalized).await;
+
             if self.client.head_object(&old_dir_key).await?.is_some() {
                 self.client.copy_object(&old_dir_key, &new_dir_key).await?;
             }
@@ -836,10 +908,16 @@ impl FileSystem for S3FileSystem {
                 let relative = obj.key.strip_prefix(&old_prefix).unwrap_or(&obj.key);
                 let new_key = format!("{}/{}", new_prefix_base, relative);
                 self.client.copy_object(&obj.key, &new_key).await?;
+                self.object_cache.invalidate_prefix(&new_normalized).await;
             }
 
             // Delete old directory
-            self.client.delete_directory(&old_normalized).await?;
+            finalize_directory_rename_source_removal(
+                &self.object_cache,
+                &old_normalized,
+                self.client.delete_directory(&old_normalized).await,
+            )
+            .await?;
 
             // Also delete the old directory marker
             let _ = self.client.delete_object(&old_dir_key).await;
@@ -850,6 +928,8 @@ impl FileSystem for S3FileSystem {
             self.dir_cache.invalidate_parent(&new_normalized).await;
             self.stat_cache.invalidate_prefix(&old_normalized).await;
             self.stat_cache.invalidate_prefix(&new_normalized).await;
+            self.object_cache.invalidate_prefix(&old_normalized).await;
+            self.object_cache.invalidate_prefix(&new_normalized).await;
 
             return Ok(());
         }
@@ -880,12 +960,17 @@ impl FileSystem for S3FileSystem {
 
         let dst_key = self.client.build_key(&dst_normalized);
         self.client.copy_object(&src_key, &dst_key).await?;
+        self.dir_cache.invalidate_parent(&dst_normalized).await;
+        self.stat_cache.invalidate(&dst_normalized).await;
+        self.object_cache.invalidate(&dst_normalized).await;
         self.client.delete_object(&src_key).await?;
 
         self.dir_cache.invalidate_parent(&src_normalized).await;
         self.dir_cache.invalidate_parent(&dst_normalized).await;
         self.stat_cache.invalidate(&src_normalized).await;
         self.stat_cache.invalidate(&dst_normalized).await;
+        self.object_cache.invalidate(&src_normalized).await;
+        self.object_cache.invalidate(&dst_normalized).await;
 
         Ok(())
     }
@@ -913,6 +998,7 @@ impl FileSystem for S3FileSystem {
         self.client.put_object(&key, data).await?;
 
         self.stat_cache.invalidate(&normalized).await;
+        self.object_cache.invalidate(&normalized).await;
 
         Ok(())
     }
@@ -1215,25 +1301,25 @@ impl S3FSPlugin {
                     "cache_enabled",
                     "bool",
                     "true",
-                    "Enable caching",
+                    "Enable local directory, metadata, and full-object read caches",
                 ),
                 ConfigParameter::optional(
                     "cache_max_size",
                     "int",
-                    "1000",
-                    "Maximum cache entries",
+                    "10000",
+                    "Maximum entries in the directory and full-object read caches",
                 ),
                 ConfigParameter::optional(
                     "cache_ttl",
                     "int",
-                    "30",
-                    "Directory listing cache TTL in seconds",
+                    "600",
+                    "Sliding TTL in seconds for directory and full-object read caches",
                 ),
                 ConfigParameter::optional(
                     "stat_cache_ttl",
                     "int",
-                    "60",
-                    "Stat cache TTL in seconds",
+                    "600",
+                    "Sliding TTL in seconds for metadata cache",
                 ),
             ],
         }
@@ -1392,6 +1478,25 @@ plugins:
                 return Err(Error::config(
                     "invalid auto_detect_content_type: expected bool",
                 ));
+            }
+        }
+
+        if let Some(value) = config.params.get("cache_enabled") {
+            if value.as_bool().is_none() {
+                return Err(Error::config("invalid cache_enabled: expected bool"));
+            }
+        }
+
+        for name in ["cache_max_size", "cache_ttl", "stat_cache_ttl"] {
+            if let Some(value) = config.params.get(name) {
+                let value = value
+                    .as_int()
+                    .ok_or_else(|| Error::config(format!("invalid {name}: expected integer")))?;
+                if value <= 0 {
+                    return Err(Error::config(format!(
+                        "invalid {name}: must be greater than zero"
+                    )));
+                }
             }
         }
 
@@ -1577,9 +1682,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_plugin_validate_rejects_invalid_cache_settings() {
+        let plugin = S3FSPlugin::new();
+        for (name, value) in [
+            ("cache_max_size", crate::core::ConfigValue::Int(0)),
+            ("cache_ttl", crate::core::ConfigValue::Int(-1)),
+            ("stat_cache_ttl", crate::core::ConfigValue::Int(0)),
+        ] {
+            let mut params = std::collections::HashMap::new();
+            params.insert(
+                "bucket".to_string(),
+                crate::core::ConfigValue::String("test".to_string()),
+            );
+            params.insert(name.to_string(), value);
+            let config = PluginConfig {
+                name: "s3fs".to_string(),
+                mount_path: "/s3".to_string(),
+                params,
+                ..PluginConfig::default()
+            };
+            assert!(
+                plugin.validate(&config).await.is_err(),
+                "{name} should be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_directory_rename_invalidates_source_objects_when_delete_fails() {
+        let object_cache = S3ObjectCache::new(10, 60, true);
+        object_cache
+            .put("/old/file.txt".to_string(), b"stale".to_vec())
+            .await;
+
+        let result = finalize_directory_rename_source_removal(
+            &object_cache,
+            "/old",
+            Err(Error::internal("S3 DeleteObjects partial failure")),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(object_cache.get("/old/file.txt").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_full_read_cache_lookup_returns_before_backend_validation() {
+        let object_cache = S3ObjectCache::new(10, 60, true);
+        object_cache
+            .put("/cached.txt".to_string(), b"cached".to_vec())
+            .await;
+
+        assert_eq!(
+            cached_full_object_read(&object_cache, "/cached.txt", 0, 0, false).await,
+            Some(b"cached".to_vec())
+        );
+        assert_eq!(
+            cached_full_object_read(&object_cache, "/cached.txt", 1, 0, false).await,
+            None
+        );
+        assert_eq!(
+            cached_full_object_read(&object_cache, "/cached.txt", 0, 0, true).await,
+            None
+        );
+    }
+
+    #[tokio::test]
     async fn test_partial_remove_all_error_invalidates_deleted_prefix_caches() {
         let dir_cache = S3ListDirCache::new(10, 60, true);
         let stat_cache = S3StatCache::new(10, 60, true);
+        let object_cache = S3ObjectCache::new(10, 60, true);
 
         let info = FileInfo {
             name: "file.txt".to_string(),
@@ -1603,10 +1775,17 @@ mod tests {
         stat_cache
             .put("/unrelated/file.txt".to_string(), Some(info))
             .await;
+        object_cache
+            .put("/parent/child/file.txt".to_string(), b"deleted".to_vec())
+            .await;
+        object_cache
+            .put("/unrelated/file.txt".to_string(), b"kept".to_vec())
+            .await;
 
         let result = finalize_remove_all(
             &dir_cache,
             &stat_cache,
+            &object_cache,
             "/parent/child",
             Err(Error::internal("S3 DeleteObjects partial failure")),
         )
@@ -1616,8 +1795,13 @@ mod tests {
         assert!(dir_cache.get("/parent").await.is_none());
         assert!(dir_cache.get("/parent/child").await.is_none());
         assert!(stat_cache.get("/parent/child/file.txt").await.is_none());
+        assert!(object_cache.get("/parent/child/file.txt").await.is_none());
         assert!(dir_cache.get("/unrelated").await.is_some());
         assert!(stat_cache.get("/unrelated/file.txt").await.is_some());
+        assert_eq!(
+            object_cache.get("/unrelated/file.txt").await,
+            Some(b"kept".to_vec())
+        );
     }
 
     #[test]

--- a/crates/ragfs/src/plugins/s3fs/mod.rs
+++ b/crates/ragfs/src/plugins/s3fs/mod.rs
@@ -22,7 +22,10 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use cache::{S3ListDirCache, S3ObjectCache, S3StatCache};
+use cache::{
+    S3ListDirCache, S3ObjectCache, S3StatCache, DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+    DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+};
 use client::{ListTreePage, S3Client, S3Vendor};
 use futures::stream::{self, StreamExt};
 use regex::Regex;
@@ -254,9 +257,29 @@ impl S3FileSystem {
             .and_then(|v| v.as_int())
             .unwrap_or(600) as u64;
 
+        let object_cache_max_file_size_bytes = config
+            .params
+            .get("object_cache_max_file_size_bytes")
+            .and_then(|v| v.as_int())
+            .unwrap_or(DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES as i64)
+            as usize;
+
+        let object_cache_max_size_bytes = config
+            .params
+            .get("object_cache_max_size_bytes")
+            .and_then(|v| v.as_int())
+            .unwrap_or(DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES as i64)
+            as usize;
+
         let dir_cache = S3ListDirCache::new(cache_max_size, cache_ttl, cache_enabled);
         let stat_cache = S3StatCache::new(cache_max_size, stat_cache_ttl, cache_enabled);
-        let object_cache = S3ObjectCache::new(cache_max_size, cache_ttl, cache_enabled);
+        let object_cache = S3ObjectCache::new(
+            cache_max_size,
+            cache_ttl,
+            cache_enabled,
+            object_cache_max_file_size_bytes,
+            object_cache_max_size_bytes,
+        );
 
         tracing::info!(
             "S3FS initialized: bucket={}, cache={}",
@@ -382,8 +405,6 @@ impl S3FileSystem {
 
         Ok((matched, next_last_rel_parts))
     }
-
-
     /// Get file name from path
     fn file_name(path: &str) -> String {
         if path == "/" {
@@ -936,8 +957,6 @@ impl FileSystem for S3FileSystem {
 
         Err(Error::not_found(&old_normalized))
     }
-
-
     async fn replace(&self, src_path: &str, dst_path: &str) -> Result<()> {
         let src_normalized = Self::normalize_path(src_path);
         let dst_normalized = Self::normalize_path(dst_path);
@@ -1321,6 +1340,18 @@ impl S3FSPlugin {
                     "600",
                     "Sliding TTL in seconds for metadata cache",
                 ),
+                ConfigParameter::optional(
+                    "object_cache_max_file_size_bytes",
+                    "int",
+                    "8388608",
+                    "Maximum size in bytes of one full S3 object cached locally",
+                ),
+                ConfigParameter::optional(
+                    "object_cache_max_size_bytes",
+                    "int",
+                    "536870912",
+                    "Maximum total bytes used by the local full-object S3 cache",
+                ),
             ],
         }
     }
@@ -1487,7 +1518,13 @@ plugins:
             }
         }
 
-        for name in ["cache_max_size", "cache_ttl", "stat_cache_ttl"] {
+        for name in [
+            "cache_max_size",
+            "cache_ttl",
+            "stat_cache_ttl",
+            "object_cache_max_file_size_bytes",
+            "object_cache_max_size_bytes",
+        ] {
             if let Some(value) = config.params.get(name) {
                 let value = value
                     .as_int()
@@ -1688,6 +1725,14 @@ mod tests {
             ("cache_max_size", crate::core::ConfigValue::Int(0)),
             ("cache_ttl", crate::core::ConfigValue::Int(-1)),
             ("stat_cache_ttl", crate::core::ConfigValue::Int(0)),
+            (
+                "object_cache_max_file_size_bytes",
+                crate::core::ConfigValue::Int(0),
+            ),
+            (
+                "object_cache_max_size_bytes",
+                crate::core::ConfigValue::Int(-1),
+            ),
         ] {
             let mut params = std::collections::HashMap::new();
             params.insert(
@@ -1710,7 +1755,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_directory_rename_invalidates_source_objects_when_delete_fails() {
-        let object_cache = S3ObjectCache::new(10, 60, true);
+        let object_cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         object_cache
             .put("/old/file.txt".to_string(), b"stale".to_vec())
             .await;
@@ -1728,7 +1779,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_full_read_cache_lookup_returns_before_backend_validation() {
-        let object_cache = S3ObjectCache::new(10, 60, true);
+        let object_cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
         object_cache
             .put("/cached.txt".to_string(), b"cached".to_vec())
             .await;
@@ -1751,7 +1808,13 @@ mod tests {
     async fn test_partial_remove_all_error_invalidates_deleted_prefix_caches() {
         let dir_cache = S3ListDirCache::new(10, 60, true);
         let stat_cache = S3StatCache::new(10, 60, true);
-        let object_cache = S3ObjectCache::new(10, 60, true);
+        let object_cache = S3ObjectCache::new(
+            10,
+            60,
+            true,
+            DEFAULT_OBJECT_CACHE_MAX_FILE_SIZE_BYTES,
+            DEFAULT_OBJECT_CACHE_MAX_SIZE_BYTES,
+        );
 
         let info = FileInfo {
             name: "file.txt".to_string(),

--- a/openviking/utils/agfs_utils.py
+++ b/openviking/utils/agfs_utils.py
@@ -396,6 +396,12 @@ def _serialize_s3_plugin_params(s3_config: Any) -> Dict[str, Any]:
         "cache_max_size": _get_config_value(s3_config, "cache_max_size", 10_000),
         "cache_ttl": _get_config_value(s3_config, "cache_ttl", 600),
         "stat_cache_ttl": _get_config_value(s3_config, "stat_cache_ttl", 600),
+        "object_cache_max_file_size_bytes": _get_config_value(
+            s3_config, "object_cache_max_file_size_bytes", 8 * 1024 * 1024
+        ),
+        "object_cache_max_size_bytes": _get_config_value(
+            s3_config, "object_cache_max_size_bytes", 512 * 1024 * 1024
+        ),
     }
 
 

--- a/openviking/utils/agfs_utils.py
+++ b/openviking/utils/agfs_utils.py
@@ -392,6 +392,10 @@ def _serialize_s3_plugin_params(s3_config: Any) -> Dict[str, Any]:
             s3_config, "normalize_encoding_chars", "?#%+@"
         ),
         "auto_detect_content_type": _get_config_value(s3_config, "auto_detect_content_type", False),
+        "cache_enabled": _get_config_value(s3_config, "cache_enabled", True),
+        "cache_max_size": _get_config_value(s3_config, "cache_max_size", 10_000),
+        "cache_ttl": _get_config_value(s3_config, "cache_ttl", 600),
+        "stat_cache_ttl": _get_config_value(s3_config, "stat_cache_ttl", 600),
     }
 
 

--- a/openviking_cli/utils/config/agfs_config.py
+++ b/openviking_cli/utils/config/agfs_config.py
@@ -114,6 +114,18 @@ class S3Config(BaseModel):
         description="Sliding TTL in seconds for the local S3 metadata cache.",
     )
 
+    object_cache_max_file_size_bytes: int = Field(
+        default=8 * 1024 * 1024,
+        gt=0,
+        description="Maximum size in bytes of one full S3 object cached locally.",
+    )
+
+    object_cache_max_size_bytes: int = Field(
+        default=512 * 1024 * 1024,
+        gt=0,
+        description="Maximum total bytes used by the local full-object S3 cache.",
+    )
+
     model_config = {"extra": "forbid"}
 
     def validate_config(self):

--- a/openviking_cli/utils/config/agfs_config.py
+++ b/openviking_cli/utils/config/agfs_config.py
@@ -91,6 +91,29 @@ class S3Config(BaseModel):
         "during uploads. Disabled by default for backward compatibility.",
     )
 
+    cache_enabled: bool = Field(
+        default=True,
+        description="Enable local S3 directory, metadata, and full-object read caches.",
+    )
+
+    cache_max_size: int = Field(
+        default=10_000,
+        gt=0,
+        description="Maximum entries in the local S3 directory and object caches.",
+    )
+
+    cache_ttl: int = Field(
+        default=600,
+        gt=0,
+        description="Sliding TTL in seconds for local S3 directory and object caches.",
+    )
+
+    stat_cache_ttl: int = Field(
+        default=600,
+        gt=0,
+        description="Sliding TTL in seconds for the local S3 metadata cache.",
+    )
+
     model_config = {"extra": "forbid"}
 
     def validate_config(self):

--- a/tests/misc/test_config_validation.py
+++ b/tests/misc/test_config_validation.py
@@ -123,6 +123,8 @@ def test_agfs_s3_cache_settings_default_and_forward_to_ragfs_plugin_config():
     assert config.s3.cache_max_size == 10_000
     assert config.s3.cache_ttl == 600
     assert config.s3.stat_cache_ttl == 600
+    assert config.s3.object_cache_max_file_size_bytes == 8 * 1024 * 1024
+    assert config.s3.object_cache_max_size_bytes == 512 * 1024 * 1024
 
     plugins = _generate_plugin_config(config, Path("/tmp/ov-test"))
     assert plugins["s3fs"]["config"] == {
@@ -131,12 +133,16 @@ def test_agfs_s3_cache_settings_default_and_forward_to_ragfs_plugin_config():
         "cache_max_size": 10_000,
         "cache_ttl": 600,
         "stat_cache_ttl": 600,
+        "object_cache_max_file_size_bytes": 8 * 1024 * 1024,
+        "object_cache_max_size_bytes": 512 * 1024 * 1024,
     }
 
     config.s3.cache_enabled = False
     config.s3.cache_max_size = 123
     config.s3.cache_ttl = 456
     config.s3.stat_cache_ttl = 789
+    config.s3.object_cache_max_file_size_bytes = 12_345
+    config.s3.object_cache_max_size_bytes = 67_890
 
     plugins = _generate_plugin_config(config, Path("/tmp/ov-test"))
     assert plugins["s3fs"]["config"] == {
@@ -145,6 +151,8 @@ def test_agfs_s3_cache_settings_default_and_forward_to_ragfs_plugin_config():
         "cache_max_size": 123,
         "cache_ttl": 456,
         "stat_cache_ttl": 789,
+        "object_cache_max_file_size_bytes": 12_345,
+        "object_cache_max_size_bytes": 67_890,
     }
 
     # Test 2: invalid backend
@@ -652,6 +660,8 @@ def test_generate_plugin_config_materializes_multiwrite_backups(tmp_path):
         "cache_max_size": 10_000,
         "cache_ttl": 600,
         "stat_cache_ttl": 600,
+        "object_cache_max_file_size_bytes": 8 * 1024 * 1024,
+        "object_cache_max_size_bytes": 512 * 1024 * 1024,
     }
 
 

--- a/tests/misc/test_config_validation.py
+++ b/tests/misc/test_config_validation.py
@@ -105,6 +105,48 @@ def test_agfs_s3_auto_detect_content_type_is_forwarded_to_ragfs_plugin_config():
 
     assert plugins["s3fs"]["config"]["auto_detect_content_type"] is True
 
+
+def test_agfs_s3_cache_settings_default_and_forward_to_ragfs_plugin_config():
+    config = AGFSConfig(
+        path="/tmp/ov-test",
+        backend="s3",
+        s3=S3Config(
+            bucket="my-bucket",
+            region="us-west-1",
+            access_key="fake-access-key-for-testing",
+            secret_key="fake-secret-key-for-testing-12345",
+            endpoint="https://s3.amazonaws.com",
+        ),
+    )
+
+    assert config.s3.cache_enabled is True
+    assert config.s3.cache_max_size == 10_000
+    assert config.s3.cache_ttl == 600
+    assert config.s3.stat_cache_ttl == 600
+
+    plugins = _generate_plugin_config(config, Path("/tmp/ov-test"))
+    assert plugins["s3fs"]["config"] == {
+        **plugins["s3fs"]["config"],
+        "cache_enabled": True,
+        "cache_max_size": 10_000,
+        "cache_ttl": 600,
+        "stat_cache_ttl": 600,
+    }
+
+    config.s3.cache_enabled = False
+    config.s3.cache_max_size = 123
+    config.s3.cache_ttl = 456
+    config.s3.stat_cache_ttl = 789
+
+    plugins = _generate_plugin_config(config, Path("/tmp/ov-test"))
+    assert plugins["s3fs"]["config"] == {
+        **plugins["s3fs"]["config"],
+        "cache_enabled": False,
+        "cache_max_size": 123,
+        "cache_ttl": 456,
+        "stat_cache_ttl": 789,
+    }
+
     # Test 2: invalid backend
     print("\n2. Test invalid backend...")
     try:
@@ -606,6 +648,10 @@ def test_generate_plugin_config_materializes_multiwrite_backups(tmp_path):
         "disable_batch_delete": False,
         "normalize_encoding_chars": "#?",
         "auto_detect_content_type": False,
+        "cache_enabled": True,
+        "cache_max_size": 10_000,
+        "cache_ttl": 600,
+        "stat_cache_ttl": 600,
     }
 
 


### PR DESCRIPTION
Reuse storage.agfs.s3 cache settings for bounded local full-object reads, invalidate cached bodies across write and move paths, and guard concurrent stale refill.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Human Involvement

<!-- Select exactly one option -->

- [ ] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

<!-- Link to the related issue (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this on the following platforms:
  - [ ] Linux
  - [ ] macOS
  - [ ] Windows

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
