### PR TITLE
refactor(runtime): consolidate service event loop ownership

### DIFF
--- a/openviking/message/message.py
+++ b/openviking/message/message.py
@@ -6,13 +6,30 @@ Message = role + parts, supports serialization to JSONL.
 """
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
 from openviking.core.peer_id import normalize_peer_id
 from openviking.message.part import ContextPart, ImagePart, Part, TextPart, ToolPart, part_from_dict
 from openviking.utils.token_estimation import estimate_text_tokens
+
+
+def estimate_message_tokens(parts: List[Part]) -> int:
+    """Estimate the prompt tokens represented by message parts."""
+    token_text = []
+    for part in parts:
+        if isinstance(part, TextPart):
+            token_text.append(part.text)
+        elif isinstance(part, ContextPart):
+            token_text.append(part.abstract)
+        elif isinstance(part, ToolPart):
+            token_text.extend([part.tool_id, part.tool_name])
+            if part.tool_input:
+                token_text.append(json.dumps(part.tool_input, ensure_ascii=False))
+            if part.tool_output:
+                token_text.append(part.tool_output)
+    return estimate_text_tokens("".join(token_text))
 
 
 @dataclass
@@ -29,6 +46,7 @@ class Message:
         Literal["user_query", "assistant_step", "tool_transport", "checkpoint"]
     ] = None
     source_message_ids: Optional[List[str]] = None
+    _estimated_tokens: Optional[int] = field(default=None, init=False, repr=False, compare=False)
 
     @property
     def content(self) -> str:
@@ -40,36 +58,14 @@ class Message:
 
     @property
     def estimated_tokens(self) -> int:
-        """Estimate token count from all parts using a CJK-aware fallback.
+        if self._estimated_tokens is None:
+            self._estimated_tokens = estimate_message_tokens(self.parts)
+        return self._estimated_tokens
 
-        Counts fields that actually appear in the assembled prompt:
-        - TextPart.text: always emitted
-        - ContextPart.abstract: injected as text (uri is not sent to the model)
-        - ImagePart: not counted here; image captioning/model usage is tracked
-          by the VLM call that converts images into text for extraction
-        - ToolPart: tool_id (appears in toolUse.id / toolResult.toolCallId),
-          tool_name, tool_input (JSON), tool_output
-
-        Known limitation: ToolPart estimation undercounts by ~10-20 tokens per
-        tool call because tool_id/toolName appear twice in the assembled transcript
-        (toolUse + toolResult), and small literals like "(no output)" / "{}" are
-        not counted. Under 128k budgets this is negligible; for smaller budgets
-        (8k/16k) or tool-dense sessions, consider adding a conservative per-tool
-        buffer instead of mirroring the full convertToAgentMessages logic.
-        """
-        token_text = []
-        for p in self.parts:
-            if isinstance(p, TextPart):
-                token_text.append(p.text)
-            elif isinstance(p, ContextPart):
-                token_text.append(p.abstract)
-            elif isinstance(p, ToolPart):
-                token_text.extend([p.tool_id, p.tool_name])
-                if p.tool_input:
-                    token_text.append(json.dumps(p.tool_input, ensure_ascii=False))
-                if p.tool_output:
-                    token_text.append(p.tool_output)
-        return estimate_text_tokens("".join(token_text))
+    def recalculate_tokens(self) -> int:
+        """Refresh the cached count after changing message parts."""
+        self._estimated_tokens = estimate_message_tokens(self.parts)
+        return self._estimated_tokens
 
     def to_dict(self) -> dict:
         """Serialize to JSONL."""
@@ -203,3 +199,21 @@ class Message:
     def to_jsonl(self) -> str:
         """Serialize to JSONL string."""
         return json.dumps(self.to_dict(), ensure_ascii=False)
+
+
+def messages_from_jsonl(content: str) -> List[Message]:
+    """Deserialize authoritative message JSONL with stable line boundaries."""
+    messages = []
+    for line_number, line in enumerate(content.replace("\r\n", "\n").split("\n"), start=1):
+        if not line.strip():
+            continue
+        try:
+            messages.append(Message.from_dict(json.loads(line)))
+        except Exception as exc:
+            raise ValueError(f"Invalid message JSONL at line {line_number}: {exc}") from exc
+    return messages
+
+
+def messages_to_jsonl(messages: List[Message]) -> str:
+    """Serialize messages with one trailing newline per record."""
+    return "".join(f"{message.to_jsonl()}\n" for message in messages)

--- a/openviking/models/embedder/local_embedders.py
+++ b/openviking/models/embedder/local_embedders.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 import asyncio
 import importlib
 import os
-import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -91,7 +93,6 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         runtime_config.setdefault("provider", "local")
         super().__init__(model_name, runtime_config)
 
-        self._inference_lock = threading.Lock()
         self.model_spec = get_local_model_spec(model_name)
         self.model_path = model_path
         self.cache_dir = cache_dir or DEFAULT_LOCAL_MODEL_CACHE_DIR
@@ -109,6 +110,10 @@ class LocalDenseEmbedder(DenseEmbedderBase):
 
         self._resolved_model_path = self._resolve_model_path()
         self._llama = self._load_model()
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="openviking-local-embedding",
+        )
 
     def _import_llama(self):
         try:
@@ -198,34 +203,40 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         return EmbedResult(dense_vector=self._extract_embedding(payload))
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
-        with self._inference_lock:
-            formatted = self._format_text(text, is_query=is_query)
+        formatted = self._format_text(text, is_query=is_query)
 
-            try:
-                result = self._run_with_retry(
-                    lambda: self._embed_formatted_text(formatted),
-                    logger=logger,
-                    operation_name="local embedding",
-                )
-            except Exception as exc:
-                raise RuntimeError(f"Local embedding failed: {exc}") from exc
-
-            estimated_tokens = self._estimate_tokens(formatted)
-            self.update_token_usage(
-                model_name=self.model_name,
-                provider="local",
-                prompt_tokens=estimated_tokens,
-                completion_tokens=0,
+        try:
+            result = self._run_with_retry(
+                lambda: self._embed_formatted_text(formatted),
+                logger=logger,
+                operation_name="local embedding",
             )
-            return result
+        except Exception as exc:
+            raise RuntimeError(f"Local embedding failed: {exc}") from exc
+
+        estimated_tokens = self._estimate_tokens(formatted)
+        self.update_token_usage(
+            model_name=self.model_name,
+            provider="local",
+            prompt_tokens=estimated_tokens,
+            completion_tokens=0,
+        )
+        return result
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
-        return await asyncio.to_thread(self.embed, text, is_query=is_query)
+        context = copy_context()
+        call = partial(self.embed, text, is_query=is_query)
+        return await asyncio.get_running_loop().run_in_executor(
+            self._executor,
+            context.run,
+            call,
+        )
 
     def get_dimension(self) -> int:
         return self._dimension
 
     def close(self):
+        self._executor.shutdown(wait=True, cancel_futures=True)
         close_fn = getattr(self._llama, "close", None)
         if callable(close_fn):
             close_fn()

--- a/openviking/models/embedder/local_embedders.py
+++ b/openviking/models/embedder/local_embedders.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -89,6 +91,7 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         runtime_config.setdefault("provider", "local")
         super().__init__(model_name, runtime_config)
 
+        self._inference_lock = threading.Lock()
         self.model_spec = get_local_model_spec(model_name)
         self.model_path = model_path
         self.cache_dir = cache_dir or DEFAULT_LOCAL_MODEL_CACHE_DIR
@@ -195,25 +198,29 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         return EmbedResult(dense_vector=self._extract_embedding(payload))
 
     def embed(self, text: str, is_query: bool = False) -> EmbedResult:
-        formatted = self._format_text(text, is_query=is_query)
+        with self._inference_lock:
+            formatted = self._format_text(text, is_query=is_query)
 
-        try:
-            result = self._run_with_retry(
-                lambda: self._embed_formatted_text(formatted),
-                logger=logger,
-                operation_name="local embedding",
+            try:
+                result = self._run_with_retry(
+                    lambda: self._embed_formatted_text(formatted),
+                    logger=logger,
+                    operation_name="local embedding",
+                )
+            except Exception as exc:
+                raise RuntimeError(f"Local embedding failed: {exc}") from exc
+
+            estimated_tokens = self._estimate_tokens(formatted)
+            self.update_token_usage(
+                model_name=self.model_name,
+                provider="local",
+                prompt_tokens=estimated_tokens,
+                completion_tokens=0,
             )
-        except Exception as exc:
-            raise RuntimeError(f"Local embedding failed: {exc}") from exc
+            return result
 
-        estimated_tokens = self._estimate_tokens(formatted)
-        self.update_token_usage(
-            model_name=self.model_name,
-            provider="local",
-            prompt_tokens=estimated_tokens,
-            completion_tokens=0,
-        )
-        return result
+    async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
+        return await asyncio.to_thread(self.embed, text, is_query=is_query)
 
     def get_dimension(self) -> int:
         return self._dimension

--- a/openviking/models/embedder/local_embedders.py
+++ b/openviking/models/embedder/local_embedders.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import asyncio
 import importlib
 import os
-from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import dataclass
 from functools import partial
@@ -93,6 +92,7 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         runtime_config.setdefault("provider", "local")
         super().__init__(model_name, runtime_config)
 
+        self._inference_lock = asyncio.Lock()
         self.model_spec = get_local_model_spec(model_name)
         self.model_path = model_path
         self.cache_dir = cache_dir or DEFAULT_LOCAL_MODEL_CACHE_DIR
@@ -110,10 +110,6 @@ class LocalDenseEmbedder(DenseEmbedderBase):
 
         self._resolved_model_path = self._resolve_model_path()
         self._llama = self._load_model()
-        self._executor = ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="openviking-local-embedding",
-        )
 
     def _import_llama(self):
         try:
@@ -224,19 +220,19 @@ class LocalDenseEmbedder(DenseEmbedderBase):
         return result
 
     async def embed_async(self, text: str, is_query: bool = False) -> EmbedResult:
-        context = copy_context()
-        call = partial(self.embed, text, is_query=is_query)
-        return await asyncio.get_running_loop().run_in_executor(
-            self._executor,
-            context.run,
-            call,
+        await self._inference_lock.acquire()
+        inference = asyncio.get_running_loop().run_in_executor(
+            None,
+            copy_context().run,
+            partial(self.embed, text, is_query=is_query),
         )
+        inference.add_done_callback(lambda _: self._inference_lock.release())
+        return await asyncio.shield(inference)
 
     def get_dimension(self) -> int:
         return self._dimension
 
     def close(self):
-        self._executor.shutdown(wait=True, cancel_futures=True)
         close_fn = getattr(self._llama, "close", None)
         if callable(close_fn):
             close_fn()

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -17,6 +17,7 @@ from litellm import acompletion, completion
 
 from openviking.telemetry import tracer
 from openviking.utils.model_retry import retry_async, retry_sync
+from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 from ..base import ToolCall, VLMBase, VLMResponse
@@ -448,6 +449,9 @@ class LiteLLMVLMProvider(VLMBase):
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously."""
         kwargs = self._build_text_kwargs(prompt, thinking, tools, tool_choice, messages)
+        tracer.info(
+            f"request: {json.dumps(redact_image_data_urls(kwargs), ensure_ascii=False, indent=2)}"
+        )
 
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()

--- a/openviking/models/vlm/backends/litellm_vlm.py
+++ b/openviking/models/vlm/backends/litellm_vlm.py
@@ -17,7 +17,6 @@ from litellm import acompletion, completion
 
 from openviking.telemetry import tracer
 from openviking.utils.model_retry import retry_async, retry_sync
-from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 from ..base import ToolCall, VLMBase, VLMResponse
@@ -449,10 +448,6 @@ class LiteLLMVLMProvider(VLMBase):
     ) -> Union[str, VLMResponse]:
         """Get text completion asynchronously."""
         kwargs = self._build_text_kwargs(prompt, thinking, tools, tool_choice, messages)
-        # 用 tracer.info 打印请求
-        tracer.info(
-            f"request: {json.dumps(redact_image_data_urls(kwargs), ensure_ascii=False, indent=2)}"
-        )
 
         async def _call() -> Union[str, VLMResponse]:
             t0 = time.perf_counter()

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from openviking.telemetry import tracer
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
+from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 try:
@@ -342,6 +343,10 @@ class OpenAIVLM(VLMBase):
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return await self._extract_completion_content_async(response, elapsed)
+
+        tracer.info(
+            f"messages={json.dumps(redact_image_data_urls(kwargs), ensure_ascii=False, indent=2)}"
+        )
 
         return await retry_async(
             _call,

--- a/openviking/models/vlm/backends/openai_vlm.py
+++ b/openviking/models/vlm/backends/openai_vlm.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 
 from openviking.telemetry import tracer
 from openviking.utils.async_client_cache import LoopScopedAsyncClientCache
-from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 try:
@@ -343,11 +342,6 @@ class OpenAIVLM(VLMBase):
                 self._update_token_usage_from_response(response, duration_seconds=elapsed)
                 return self._build_vlm_response(response, has_tools=True)
             return await self._extract_completion_content_async(response, elapsed)
-
-        # 用 tracer.info 打印请求
-        tracer.info(
-            f"messages={json.dumps(redact_image_data_urls(kwargs), ensure_ascii=False, indent=2)}"
-        )
 
         return await retry_async(
             _call,

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
+from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 from ..base import ToolCall, VLMResponse
@@ -229,6 +230,15 @@ class VolcEngineVLM(OpenAIVLM):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+
+        tracer.info(
+            "request: "
+            f"{json.dumps(redact_image_data_urls(kwargs_messages), ensure_ascii=False, indent=2)}"
+        )
+        if tools:
+            tracer.info(
+                f"tools: {json.dumps([t['function']['name'] for t in tools], ensure_ascii=False)}"
+            )
 
         client = self.get_async_client()
 

--- a/openviking/models/vlm/backends/volcengine_vlm.py
+++ b/openviking/models/vlm/backends/volcengine_vlm.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from openviking.telemetry import tracer
-from openviking.utils.multimodal import redact_image_data_urls
 from openviking_cli.utils import get_logger
 
 from ..base import ToolCall, VLMResponse
@@ -230,16 +229,6 @@ class VolcEngineVLM(OpenAIVLM):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
-
-        # 用 tracer.info 打印请求
-        tracer.info(
-            "request: "
-            f"{json.dumps(redact_image_data_urls(kwargs_messages), ensure_ascii=False, indent=2)}"
-        )
-        if tools:
-            tracer.info(
-                f"tools: {json.dumps([t['function']['name'] for t in tools], ensure_ascii=False)}"
-            )
 
         client = self.get_async_client()
 

--- a/openviking/pyagfs/async_client.py
+++ b/openviking/pyagfs/async_client.py
@@ -6,11 +6,26 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from concurrent.futures import Executor
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import partial
 from typing import Any, BinaryIO, Dict, List, Union
 
 from .protocols import AGFSSyncClientProtocol
 
 _SYSTEM_ACCOUNT_ID = "_system"
+_AGFS_EXECUTOR: ContextVar[Executor | None] = ContextVar("agfs_executor", default=None)
+
+
+@contextmanager
+def bind_agfs_executor(executor: Executor) -> Iterator[None]:
+    """Route AGFS binding calls in this async context to a dedicated executor."""
+    token = _AGFS_EXECUTOR.set(executor)
+    try:
+        yield
+    finally:
+        _AGFS_EXECUTOR.reset(token)
 
 
 def fs_ctx_from_agfs_path(path: str) -> Dict[str, str]:
@@ -92,17 +107,23 @@ class AsyncAGFSClient:
 
     async def run(self, method_name: str, /, *args: Any, **kwargs: Any) -> Any:
         """Run a sync client method in a worker thread, preserving ctx when supported."""
+        async def run_call(call_kwargs: Dict[str, Any]) -> Any:
+            method = getattr(self._client, method_name)
+            executor = _AGFS_EXECUTOR.get()
+            if executor is None:
+                return await asyncio.to_thread(method, *args, **call_kwargs)
+            call = partial(method, *args, **call_kwargs)
+            return await asyncio.get_running_loop().run_in_executor(executor, call)
+
         try:
-            return await asyncio.to_thread(getattr(self._client, method_name), *args, **kwargs)
+            return await run_call(kwargs)
         except TypeError as exc:
             message = str(exc)
             if "ctx" not in kwargs or "unexpected keyword argument 'ctx'" not in message:
                 raise
             legacy_kwargs = dict(kwargs)
             legacy_kwargs.pop("ctx", None)
-            return await asyncio.to_thread(
-                getattr(self._client, method_name), *args, **legacy_kwargs
-            )
+            return await run_call(legacy_kwargs)
 
     async def ls(
         self, path: str = "/", *, fs_ctx: Dict[str, str] | None = None

--- a/openviking/server/mcp_endpoint.py
+++ b/openviking/server/mcp_endpoint.py
@@ -724,11 +724,7 @@ async def remember(messages: list[StoreMessage]) -> str:
     session = await service.sessions.get(session_id, ctx, auto_create=True)
     for msg in messages:
         if msg.content:
-            add_async = getattr(session, "add_message_async", None)
-            if callable(add_async):
-                await add_async(msg.role, [TextPart(text=msg.content)])
-            else:
-                session.add_message(msg.role, [TextPart(text=msg.content)])
+            await session.add_message_async(msg.role, [TextPart(text=msg.content)])
     await service.sessions.commit_async(session_id, ctx)
     return f"Stored {len(messages)} message(s) and committed for memory extraction."
 

--- a/openviking/server/routers/sessions.py
+++ b/openviking/server/routers/sessions.py
@@ -748,11 +748,7 @@ async def add_message(
                 "source_message_ids": request.source_message_ids,
             }
         ]
-        add_many_async = getattr(session, "add_messages_async", None)
-        if callable(add_many_async):
-            await add_many_async(specs)
-        else:
-            session.add_messages(specs)
+        await session.add_messages_async(specs)
         await service.sessions.maybe_schedule_auto_commit(
             session_id,
             _ctx,
@@ -804,11 +800,7 @@ async def batch_add_messages(
                     "source_message_ids": msg_request.source_message_ids,
                 }
             )
-        add_many_async = getattr(session, "add_messages_async", None)
-        if callable(add_many_async):
-            msgs = await add_many_async(specs)
-        else:
-            msgs = session.add_messages(specs)
+        msgs = await session.add_messages_async(specs)
         await service.sessions.maybe_schedule_auto_commit(
             session_id,
             _ctx,

--- a/openviking/service/core.py
+++ b/openviking/service/core.py
@@ -191,7 +191,7 @@ class OpenVikingService:
         # Workers are NOT started here — start() is called after VikingFS is initialized
         # in initialize(), so that recovered tasks don't race against VikingFS init.
         if self._queue_manager:
-            self._queue_manager.setup_standard_queues(self._vikingdb_manager, start=False)
+            self._queue_manager.setup_standard_queues(self._vikingdb_manager)
 
         # PathLock has been moved to Rust ragfs; Python-layer LockManager is no longer needed.
         set_task_tracker(config.build_task_tracker(self._agfs_client))
@@ -475,7 +475,6 @@ class OpenVikingService:
                     queue_name,
                     dequeue_handler=AddResourceProcessor(
                         self._resource_service,
-                        asyncio.get_running_loop(),
                         queue_name,
                         self._viking_fs,
                     ),
@@ -485,7 +484,6 @@ class OpenVikingService:
                 self._queue_manager.SESSION_COMMIT,
                 dequeue_handler=SessionCommitProcessor(
                     self._session_service,
-                    asyncio.get_running_loop(),
                 ),
                 allow_create=True,
             )
@@ -505,7 +503,7 @@ class OpenVikingService:
             logger.info("WatchScheduler disabled by config (enable_watch_scheduler=false)")
 
         if self._queue_manager:
-            self._queue_manager.start()
+            await self._queue_manager.start()
             logger.info("QueueManager workers started")
 
         # Preflight the MinerU endpoint when it will be used, so endpoint
@@ -545,7 +543,7 @@ class OpenVikingService:
             logger.info("SessionAutoCommitScheduler stopped")
 
         if self._queue_manager:
-            await asyncio.to_thread(self._queue_manager.stop)
+            await self._queue_manager.stop()
             self._queue_manager = None
             logger.info("Queue manager stopped")
 

--- a/openviking/service/resource_memory_link_service.py
+++ b/openviking/service/resource_memory_link_service.py
@@ -193,11 +193,7 @@ class ResourceMemoryLinkService:
             }
             if target_peer_id:
                 message_spec["peer_id"] = target_peer_id
-            add_many_async = getattr(session, "add_messages_async", None)
-            if callable(add_many_async):
-                await add_many_async([message_spec])
-            else:
-                session.add_messages([message_spec])
+            await session.add_messages_async([message_spec])
             commit_result = await self._session_service.commit_async(
                 session_id,
                 ctx,
@@ -263,11 +259,7 @@ class ResourceMemoryLinkService:
             }
             if target_peer_id:
                 message_spec["peer_id"] = target_peer_id
-            add_many_async = getattr(session, "add_messages_async", None)
-            if callable(add_many_async):
-                await add_many_async([message_spec])
-            else:
-                session.add_messages([message_spec])
+            await session.add_messages_async([message_spec])
             commit_result = await self._session_service.commit_async(
                 session_id,
                 ctx,

--- a/openviking/service/session_service.py
+++ b/openviking/service/session_service.py
@@ -423,7 +423,9 @@ class SessionService:
             archive_uri, archived
         """
         self._ensure_initialized()
-        session = await self.get(session_id, ctx)
+        session = self.session(ctx, session_id)
+        if not await session.exists():
+            raise NotFoundError(session_id, "session")
         commit_kwargs: Dict[str, Any] = {"keep_recent_count": keep_recent_count}
         optional_retention = {
             "retention_mode": retention_mode,

--- a/openviking/service/task_tracker.py
+++ b/openviking/service/task_tracker.py
@@ -8,7 +8,7 @@ Provides a lightweight registry for tracking background operations
 polled via the /tasks API to check completion status, results, or errors.
 
 Design decisions:
-  - Thread-safe (QueueManager workers run in separate threads).
+  - Sync and async entrypoints may reach the tracker from different loops.
   - TTL-based cleanup applies to the process-local cache.
   - Error messages are sanitized to avoid leaking sensitive data.
 """
@@ -222,7 +222,7 @@ class TaskTracker:
         )
 
     def is_cancellation_requested(self, task_id: str) -> bool:
-        """Fast thread-safe status check used by queue workers."""
+        """Fast thread-safe status check used by queue consumers."""
         with self._lock:
             task = self._tasks.get(task_id)
             return task is not None and task.status in (

--- a/openviking/service/user_deletion.py
+++ b/openviking/service/user_deletion.py
@@ -65,13 +65,11 @@ class UserDeletionService:
         *,
         service: Any,
         manager: Any,
-        service_loop: asyncio.AbstractEventLoop,
         oauth_store: Any = None,
         usage_audit_runtime: Any = None,
     ) -> None:
         self._service = service
         self._manager = manager
-        self._service_loop = service_loop
         self._oauth_store = oauth_store
         self._usage_audit_runtime = usage_audit_runtime
         self._request_lock = asyncio.Lock()
@@ -88,7 +86,7 @@ class UserDeletionService:
         }
         queue_manager.get_queue(
             queue_manager.USER_DELETION,
-            dequeue_handler=_UserDeletionProcessor(self, self._service_loop),
+            dequeue_handler=_UserDeletionProcessor(self),
         )
 
         tracker = get_task_tracker()
@@ -465,13 +463,8 @@ class UserDeletionService:
 
 
 class _UserDeletionProcessor(DequeueHandlerBase):
-    def __init__(
-        self,
-        deletion_service: UserDeletionService,
-        service_loop: asyncio.AbstractEventLoop,
-    ) -> None:
+    def __init__(self, deletion_service: UserDeletionService) -> None:
         self._deletion_service = deletion_service
-        self._service_loop = service_loop
 
     @staticmethod
     def _parse_message(data: dict[str, Any]) -> dict[str, Any]:
@@ -507,15 +500,7 @@ class _UserDeletionProcessor(DequeueHandlerBase):
             self.report_error(str(exc), data)
             return None
 
-        future = asyncio.run_coroutine_threadsafe(
-            self._deletion_service._process(message),
-            self._service_loop,
-        )
-        try:
-            error = await asyncio.wrap_future(future)
-        except asyncio.CancelledError:
-            future.cancel()
-            raise
+        error = await self._deletion_service._process(message)
         if error is None:
             self.report_success()
         else:
@@ -536,7 +521,6 @@ async def setup_user_deletion(
     deletion_service = UserDeletionService(
         service=service,
         manager=manager,
-        service_loop=asyncio.get_running_loop(),
         oauth_store=oauth_store,
         usage_audit_runtime=usage_audit_runtime,
     )

--- a/openviking/session/message_preparer.py
+++ b/openviking/session/message_preparer.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
+# SPDX-License-Identifier: AGPL-3.0
+"""CPU preparation for durable session messages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List
+from uuid import uuid4
+
+from openviking.core.peer_id import normalize_peer_id
+from openviking.message import Message
+from openviking.message.part import ToolPart
+from openviking.server.config import ToolOutputExternalizationConfig
+from openviking.session.retention import build_turns
+from openviking.session.tool_result_store import (
+    PreparedToolResult,
+    StoredToolResult,
+    make_preview,
+    prepare_tool_result,
+    render_preview_from_synopsis,
+    sha256_text,
+)
+from openviking_cli.exceptions import FailedPreconditionError, InvalidArgumentError
+
+
+@dataclass
+class ToolOutputWrite:
+    message: Message
+    part: ToolPart
+    prepared: PreparedToolResult
+    reason: str
+    group_id: str
+    group_original_chars: int
+    group_budget_chars: int
+
+    def apply_success(self, stored: StoredToolResult) -> None:
+        content = self.prepared.content
+        ref = stored.storage_uri
+        self.part.tool_output = render_preview_from_synopsis(
+            stored.synopsis,
+            ref=ref,
+            tool_name=self.part.tool_name,
+            sha256=self.prepared.sha256,
+            reason=self.reason,
+            original_chars=len(content),
+            preview_chars=min(len(content), max(self.prepared.preview_chars, 0)),
+        )
+        self.part.tool_output_ref = ref
+        self.part.tool_output_truncated = True
+        self.part.tool_output_original_chars = len(content)
+        self.part.tool_output_preview_chars = len(self.part.tool_output)
+        self.part.tool_output_sha256 = self.prepared.sha256
+        self.part.tool_output_storage_uri = ref
+        self.part.tool_output_mime_type = stored.metadata["mime_type"]
+        self.part.tool_output_group_id = self.group_id
+        self.part.tool_output_externalized_reason = self.reason
+        self.part.tool_output_group_original_chars = self.group_original_chars
+        self.part.tool_output_group_budget_chars = self.group_budget_chars
+
+    def apply_failure(
+        self,
+        config: ToolOutputExternalizationConfig,
+        exc: Exception,
+    ) -> None:
+        error = f"{type(exc).__name__}: {exc}"
+        self.part.tool_output_externalization_error = error
+        if config.failure_mode == "reject":
+            raise FailedPreconditionError(
+                "Failed to externalize tool output",
+                details={"tool_id": self.part.tool_id, "error": error},
+            ) from exc
+        if config.failure_mode != "preview_only":
+            return
+
+        content = self.prepared.content
+        self.part.tool_output = render_preview_from_synopsis(
+            self.prepared.synopsis,
+            tool_name=self.part.tool_name,
+            sha256=self.prepared.sha256,
+            reason=f"{self.reason}:externalization_failed",
+            original_chars=len(content),
+            preview_chars=min(len(content), max(self.prepared.preview_chars, 0)),
+        )
+        self.part.tool_output_ref = ""
+        self.part.tool_output_truncated = True
+        self.part.tool_output_original_chars = len(content)
+        self.part.tool_output_preview_chars = len(self.part.tool_output)
+        self.part.tool_output_sha256 = self.prepared.sha256
+        self.part.tool_output_externalized_reason = self.reason
+
+
+@dataclass
+class PreparedMessageBatch:
+    messages: List[Message]
+    tool_outputs: List[ToolOutputWrite]
+
+    def finalize_tokens(self) -> None:
+        for message in self.messages:
+            message.recalculate_tokens()
+
+
+class MessagePreparer:
+    """Own message normalization and expensive, pure preparation work."""
+
+    def __init__(
+        self,
+        session_uri: str,
+        config: ToolOutputExternalizationConfig,
+    ) -> None:
+        self._session_uri = session_uri
+        self._config = config
+
+    def prepare_new(self, messages_spec: List[dict]) -> PreparedMessageBatch:
+        groups = [self._build_group(spec, index) for index, spec in enumerate(messages_spec)]
+        return self.prepare_groups(groups)
+
+    def prepare_turns(self, messages: List[Message]) -> PreparedMessageBatch:
+        return self.prepare_groups(turn.messages for turn in build_turns(messages))
+
+    def prepare_groups(
+        self,
+        groups: Iterable[List[Message]],
+    ) -> PreparedMessageBatch:
+        groups = list(groups)
+        tool_outputs = []
+        if self._config.enabled:
+            for group in groups:
+                tool_outputs.extend(self._prepare_tool_output_group(group))
+        return PreparedMessageBatch(
+            messages=[message for group in groups for message in group],
+            tool_outputs=tool_outputs,
+        )
+
+    def _build_group(self, spec: dict, index: int) -> List[Message]:
+        if "role" not in spec:
+            raise ValueError(f"messages_spec[{index}]: missing required key 'role'")
+        if "parts" not in spec:
+            raise ValueError(f"messages_spec[{index}]: missing required key 'parts'")
+
+        try:
+            peer_id = normalize_peer_id(spec.get("peer_id"))
+        except ValueError as exc:
+            raise InvalidArgumentError(str(exc)) from exc
+
+        role = spec["role"]
+        parts = spec["parts"]
+        created_at = spec.get("created_at") or datetime.now(timezone.utc).isoformat()
+        common = {
+            "role": role,
+            "peer_id": peer_id,
+            "created_at": created_at,
+            "turn_id": spec.get("turn_id"),
+            "source_message_ids": (
+                list(spec["source_message_ids"])
+                if spec.get("source_message_ids") is not None
+                else None
+            ),
+        }
+        if role == "user" and len(parts) > 1 and all(isinstance(part, ToolPart) for part in parts):
+            return [
+                Message(
+                    id=f"msg_{uuid4().hex}",
+                    parts=[part],
+                    message_kind=spec.get("message_kind") or "tool_transport",
+                    **common,
+                )
+                for part in parts
+            ]
+        return [
+            Message(
+                id=f"msg_{uuid4().hex}",
+                parts=parts,
+                message_kind=spec.get("message_kind"),
+                **common,
+            )
+        ]
+
+    def _effective_preview_chars(self, externalized_count: int) -> int:
+        if externalized_count <= 0:
+            return self._config.preview_chars
+        group_share = self._config.assistant_turn_preview_budget_chars // externalized_count
+        return max(
+            0,
+            min(
+                self._config.preview_chars,
+                max(self._config.min_preview_chars, group_share),
+            ),
+        )
+
+    def _rewrite_source_read(
+        self,
+        part: ToolPart,
+        *,
+        group_id: str,
+        group_original_chars: int,
+    ) -> bool:
+        if part.tool_name != "openviking_tool_result_read":
+            return False
+        tool_input = part.tool_input if isinstance(part.tool_input, dict) else {}
+        source_ref = str(
+            tool_input.get("tool_output_ref")
+            or tool_input.get("ref")
+            or tool_input.get("uri")
+            or ""
+        )
+        if not source_ref.startswith(f"{self._session_uri}/tool-results/"):
+            return False
+
+        output = part.tool_output or ""
+        digest = sha256_text(output) if output else ""
+        preview = make_preview(
+            output,
+            preview_chars=max(self._config.min_preview_chars, self._config.preview_chars),
+            ref=source_ref,
+            tool_name=part.tool_name,
+            sha256=digest,
+            reason="source_read",
+            original_chars=len(output),
+            mime_type=part.tool_output_mime_type or "text/plain",
+        )
+        part.tool_output = preview
+        part.tool_output_ref = source_ref
+        part.tool_output_truncated = len(output) > len(preview)
+        part.tool_output_original_chars = len(output)
+        part.tool_output_preview_chars = len(preview)
+        part.tool_output_sha256 = digest
+        part.tool_output_storage_uri = source_ref
+        part.tool_output_source_ref = source_ref
+        part.tool_output_source_offset = tool_input.get("offset")
+        part.tool_output_source_limit = tool_input.get("limit")
+        part.tool_output_group_id = group_id
+        part.tool_output_externalized_reason = "source_read"
+        part.tool_output_group_original_chars = group_original_chars
+        part.tool_output_group_budget_chars = self._config.assistant_turn_inline_budget_chars
+        return True
+
+    def _prepare_tool_output_group(self, messages: List[Message]) -> List[ToolOutputWrite]:
+        tool_parts = [
+            (message, part)
+            for message in messages
+            for part in message.parts
+            if isinstance(part, ToolPart) and (part.tool_output or "")
+        ]
+        if not tool_parts:
+            return []
+
+        config = self._config
+        group_id = messages[0].id
+        group_original_chars = sum(
+            int(part.tool_output_original_chars)
+            if part.tool_output_ref
+            and part.tool_output_truncated
+            and part.tool_output_original_chars is not None
+            else len(part.tool_output or "")
+            for _, part in tool_parts
+        )
+        normal_indices: List[int] = []
+        selected: set[int] = set()
+        prepared_cache: dict[tuple[int, int], tuple[PreparedToolResult, int]] = {}
+
+        for index, (_message, part) in enumerate(tool_parts):
+            part.tool_output_group_id = group_id
+            part.tool_output_group_original_chars = group_original_chars
+            part.tool_output_group_budget_chars = config.assistant_turn_inline_budget_chars
+            if self._rewrite_source_read(
+                part,
+                group_id=group_id,
+                group_original_chars=group_original_chars,
+            ):
+                continue
+            if part.tool_output_ref and part.tool_output_truncated:
+                continue
+            normal_indices.append(index)
+            if len(part.tool_output or "") > config.threshold_chars:
+                selected.add(index)
+
+        def prepared_preview(
+            index: int,
+            part: ToolPart,
+            preview_chars: int,
+        ) -> tuple[PreparedToolResult, int]:
+            content = part.tool_output or ""
+            reason = "single_threshold" if len(content) > config.threshold_chars else "turn_budget"
+            cache_key = (index, preview_chars)
+            cached = prepared_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            prepared = prepare_tool_result(
+                content,
+                tool_id=part.tool_id,
+                tool_name=part.tool_name,
+                preview_chars=preview_chars,
+                mime_type=part.tool_output_mime_type or "text/plain",
+            )
+            ref = f"{self._session_uri}/tool-results/{prepared.tool_result_id}"
+            rendered = render_preview_from_synopsis(
+                prepared.synopsis,
+                ref=ref,
+                tool_name=part.tool_name,
+                sha256=prepared.sha256,
+                reason=reason,
+                original_chars=len(content),
+                preview_chars=min(len(content), max(preview_chars, 0)),
+            )
+            result = (prepared, len(rendered))
+            prepared_cache[cache_key] = result
+            return result
+
+        def projected_inline_chars(selected_indices: set[int]) -> int:
+            preview_chars = self._effective_preview_chars(len(selected_indices))
+            return sum(
+                prepared_preview(index, part, preview_chars)[1]
+                if index in selected_indices
+                else len(part.tool_output or "")
+                for index, (_message, part) in enumerate(tool_parts)
+            )
+
+        remaining = sorted(
+            [index for index in normal_indices if index not in selected],
+            key=lambda index: len(tool_parts[index][1].tool_output or ""),
+            reverse=True,
+        )
+        while projected_inline_chars(selected) >= config.assistant_turn_inline_budget_chars:
+            baseline = projected_inline_chars(selected)
+            chosen = next(
+                (
+                    index
+                    for index in remaining
+                    if projected_inline_chars(selected | {index}) < baseline
+                ),
+                None,
+            )
+            if chosen is None:
+                break
+            selected.add(chosen)
+            remaining.remove(chosen)
+
+        preview_chars = self._effective_preview_chars(len(selected))
+        writes = []
+        for index in sorted(selected):
+            message, part = tool_parts[index]
+            reason = (
+                "single_threshold"
+                if len(part.tool_output or "") > config.threshold_chars
+                else "turn_budget"
+            )
+            prepared, _rendered_len = prepared_preview(index, part, preview_chars)
+            writes.append(
+                ToolOutputWrite(
+                    message=message,
+                    part=part,
+                    prepared=prepared,
+                    reason=reason,
+                    group_id=group_id,
+                    group_original_chars=group_original_chars,
+                    group_budget_chars=config.assistant_turn_inline_budget_chars,
+                )
+            )
+        return writes

--- a/openviking/session/retention.py
+++ b/openviking/session/retention.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional
 
 from openviking.message import Message
+from openviking.message.message import estimate_message_tokens
 from openviking.message.part import ContextPart, TextPart, ToolPart
 from openviking.utils.token_estimation import truncate_text_to_token_budget
 
@@ -51,7 +52,7 @@ class AssistantStep:
 
     @property
     def estimated_tokens(self) -> int:
-        return sum(int(message.estimated_tokens or 0) for message in self.messages)
+        return sum(message.estimated_tokens for message in self.messages)
 
 
 @dataclass
@@ -72,7 +73,7 @@ class UserTurn:
 
     @property
     def estimated_tokens(self) -> int:
-        return sum(int(message.estimated_tokens or 0) for message in self.messages)
+        return sum(message.estimated_tokens for message in self.messages)
 
 
 @dataclass
@@ -143,7 +144,12 @@ def _flatten_turns(turns: Iterable[UserTurn]) -> List[Message]:
 
 
 def _message_tokens(messages: Iterable[Message]) -> int:
-    return sum(int(message.estimated_tokens or 0) for message in messages)
+    return sum(message.estimated_tokens for message in messages)
+
+
+def _current_message_tokens(messages: Iterable[Message]) -> int:
+    """Estimate mutable virtual messages while fitting a truncated view."""
+    return sum(estimate_message_tokens(message.parts) for message in messages)
 
 
 def _truncate_message_group(
@@ -181,25 +187,25 @@ def _truncate_message_group(
 
     # Tool inputs are structured and cannot be text-truncated safely. Preserve
     # them whenever possible, then remove oldest inputs until fixed metadata fits.
-    if _message_tokens(cloned) > token_budget:
+    if _current_message_tokens(cloned) > token_budget:
         for message in cloned:
             for part in message.parts:
                 if not isinstance(part, ToolPart) or not part.tool_input:
                     continue
                 part.tool_input = {}
                 truncated_ids.add(message.id)
-                if _message_tokens(cloned) <= token_budget:
+                if _current_message_tokens(cloned) <= token_budget:
                     break
-            if _message_tokens(cloned) <= token_budget:
+            if _current_message_tokens(cloned) <= token_budget:
                 break
 
-    if _message_tokens(cloned) > token_budget:
+    if _current_message_tokens(cloned) > token_budget:
         return [], []
 
     for _message, part, attribute, original in slots:
         if not original:
             continue
-        used = _message_tokens(cloned)
+        used = _current_message_tokens(cloned)
         remaining = max(0, token_budget - used)
         if remaining <= 0:
             break
@@ -220,10 +226,8 @@ def _truncate_message_group(
                 part.tool_output_original_chars = len(original)
             part.tool_output_preview_chars = len(fitted)
 
-    # The estimator and truncation helper share the same accounting, but keep a
-    # defensive final guard so this function is a strict budget boundary.
-    if _message_tokens(cloned) > token_budget:
-        return [], []
+    for message in cloned:
+        message.recalculate_tokens()
     return cloned, sorted(truncated_ids)
 
 
@@ -382,7 +386,7 @@ def _partial_latest_turn_plan(
     min_tail = max(1, int(min_raw_tail_steps or 0)) if steps else 0
 
     retained_steps: List[AssistantStep] = list(steps[-min_tail:]) if min_tail else []
-    retained_tokens = int(anchor.estimated_tokens or 0) if anchor is not None else 0
+    retained_tokens = anchor.estimated_tokens if anchor is not None else 0
     retained_tokens += sum(step.estimated_tokens for step in retained_steps)
 
     # Leave room for the dedicated checkpoint summary generated alongside the

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -6,6 +6,7 @@ Session as Context: Sessions integrated into L0/L1/L2 system.
 """
 
 import asyncio
+import copy
 import inspect
 import json
 import re
@@ -16,8 +17,9 @@ from uuid import uuid4
 
 from openviking.core.context import ContextLevel
 from openviking.core.namespace import canonical_session_uri
-from openviking.core.peer_id import normalize_peer_id, safe_peer_id
+from openviking.core.peer_id import safe_peer_id
 from openviking.message import Message, Part
+from openviking.message.message import messages_from_jsonl, messages_to_jsonl
 from openviking.message.part import ContextPart, TextPart, ToolPart
 from openviking.pyagfs.exceptions import AGFSClientError, AGFSHTTPError, AGFSNotFoundError
 from openviking.server.config import ToolOutputExternalizationConfig
@@ -25,6 +27,7 @@ from openviking.server.identity import RequestContext, Role
 from openviking.session.auto_commit_policy import AutoCommitPolicy
 from openviking.session.memory.constants import AGENT_EVOLUTION_MEMORY_TYPES
 from openviking.session.memory_policy import MemoryPolicy
+from openviking.session.message_preparer import MessagePreparer, PreparedMessageBatch
 from openviking.session.retention import (
     RETENTION_MODE_TURN_BUDGET,
     RetentionPlan,
@@ -33,27 +36,14 @@ from openviking.session.retention import (
     is_user_query,
     plan_retention,
 )
-from openviking.session.tool_result_store import (
-    ToolResultStore,
-    build_tool_result_id,
-    make_preview,
-    render_preview_from_synopsis,
-    sha256_text,
-)
-from openviking.session.tool_result_synopsis import (
-    ToolResultSynopsis,
-    generate_tool_result_synopsis,
-)
+from openviking.session.tool_result_store import ToolResultStore
 from openviking.storage.abstract_overview import body_for_preview, render_abstract_overview
 from openviking.telemetry import get_current_telemetry, tracer
 from openviking.telemetry.request_wait_tracker import get_request_wait_tracker
 from openviking.utils.model_retry import is_retryable_api_error, retry_async
 from openviking.utils.time_utils import get_current_timestamp
 from openviking.utils.token_estimation import estimate_text_tokens, truncate_text_to_token_budget
-from openviking_cli.exceptions import (
-    FailedPreconditionError,
-    NotFoundError,
-)
+from openviking_cli.exceptions import NotFoundError
 from openviking_cli.session.user_id import UserIdentifier
 from openviking_cli.utils import get_logger, run_async
 from openviking_cli.utils.config import get_openviking_config
@@ -110,6 +100,7 @@ def _redact_inline_images_from_tool_outputs(messages: List[Message]) -> List[Mes
         for part in message.parts:
             if isinstance(part, ToolPart):
                 part.tool_output = _redact_inline_images(part.tool_output or "")
+        message.recalculate_tokens()
     return messages
 
 
@@ -700,11 +691,7 @@ class Session:
             content = await self._viking_fs.read_file(
                 f"{self._session_uri}/messages.jsonl", ctx=self.ctx
             )
-            self._messages = [
-                Message.from_dict(json.loads(line))
-                for line in content.strip().split("\n")
-                if line.strip()
-            ]
+            self._messages = await asyncio.to_thread(messages_from_jsonl, content)
         except Exception as exc:
             if not _is_storage_not_found(exc):
                 raise
@@ -789,7 +776,7 @@ class Session:
             )
             retained_ids = {message.id for message in plan.retained_messages}
             return sum(
-                int(message.estimated_tokens or 0)
+                message.estimated_tokens
                 for message in plan.archive_messages
                 if message.id not in retained_ids
             )
@@ -797,9 +784,9 @@ class Session:
         keep = max(0, int(self._meta.keep_recent_count or 0))
         total = len(self._messages)
         if keep <= 0:
-            return sum(int(m.estimated_tokens or 0) for m in self._messages)
+            return sum(message.estimated_tokens for message in self._messages)
         if total > keep:
-            return sum(int(m.estimated_tokens or 0) for m in self._messages[: total - keep])
+            return sum(message.estimated_tokens for message in self._messages[: total - keep])
         return 0
 
     async def exists(self) -> bool:
@@ -955,10 +942,10 @@ class Session:
         messages: List[Message],
     ) -> List[Message]:
         """Return a sanitized memory-only copy with externalized tool outputs restored."""
-        hydrated = [Message.from_dict(m.to_dict()) for m in messages]
+        hydrated = await asyncio.to_thread(copy.deepcopy, messages)
         store = self._tool_result_store()
         if not store:
-            return _redact_inline_images_from_tool_outputs(hydrated)
+            return await asyncio.to_thread(_redact_inline_images_from_tool_outputs, hydrated)
 
         for msg in hydrated:
             for part in msg.parts:
@@ -999,290 +986,7 @@ class Session:
                     continue
                 part.tool_output = result.get("content", "")
 
-        return _redact_inline_images_from_tool_outputs(hydrated)
-
-    def _effective_tool_preview_chars(
-        self,
-        cfg: ToolOutputExternalizationConfig,
-        externalized_count: int,
-    ) -> int:
-        if externalized_count <= 0:
-            return cfg.preview_chars
-        group_share = cfg.assistant_turn_preview_budget_chars // externalized_count
-        return max(0, min(cfg.preview_chars, max(cfg.min_preview_chars, group_share)))
-
-    def _rewrite_source_read_tool_output(
-        self,
-        part: ToolPart,
-        cfg: ToolOutputExternalizationConfig,
-        *,
-        group_id: str,
-        group_original_chars: int,
-    ) -> bool:
-        """Rewrite read-back tool output as a source reference, not a new result."""
-        if part.tool_name != "openviking_tool_result_read":
-            return False
-        tool_input = part.tool_input if isinstance(part.tool_input, dict) else {}
-        source_ref = str(
-            tool_input.get("tool_output_ref")
-            or tool_input.get("ref")
-            or tool_input.get("uri")
-            or ""
-        )
-        if not source_ref.startswith(f"{self._session_uri}/tool-results/"):
-            return False
-
-        output = part.tool_output or ""
-        preview_chars = max(cfg.min_preview_chars, cfg.preview_chars)
-        preview = make_preview(
-            output,
-            preview_chars=preview_chars,
-            ref=source_ref,
-            tool_name=part.tool_name,
-            sha256=sha256_text(output) if output else "",
-            reason="source_read",
-            original_chars=len(output),
-            mime_type=part.tool_output_mime_type or "text/plain",
-        )
-        part.tool_output = preview
-        part.tool_output_ref = source_ref
-        part.tool_output_truncated = len(output) > len(preview)
-        part.tool_output_original_chars = len(output)
-        part.tool_output_preview_chars = len(preview)
-        part.tool_output_sha256 = sha256_text(output) if output else ""
-        part.tool_output_storage_uri = source_ref
-        part.tool_output_source_ref = source_ref
-        part.tool_output_source_offset = tool_input.get("offset")
-        part.tool_output_source_limit = tool_input.get("limit")
-        part.tool_output_group_id = group_id
-        part.tool_output_externalized_reason = "source_read"
-        part.tool_output_group_original_chars = group_original_chars
-        part.tool_output_group_budget_chars = cfg.assistant_turn_inline_budget_chars
-        return True
-
-    def _externalize_tool_part(
-        self,
-        msg: Message,
-        part: ToolPart,
-        cfg: ToolOutputExternalizationConfig,
-        *,
-        preview_chars: int,
-        reason: str,
-        group_id: str,
-        group_original_chars: int,
-        synopsis: Optional[ToolResultSynopsis] = None,
-    ) -> None:
-        store = self._tool_result_store()
-        original_output = part.tool_output or ""
-        if not store or not original_output:
-            return
-
-        digest = sha256_text(original_output)
-        try:
-            stored = run_async(
-                store.write(
-                    content=original_output,
-                    tool_id=part.tool_id,
-                    tool_name=part.tool_name,
-                    message_id=msg.id,
-                    user_id=self.ctx.user.user_id if self.ctx and self.ctx.user else None,
-                    peer_id=msg.peer_id,
-                    created_at=msg.created_at,
-                    preview_chars=preview_chars,
-                    mime_type=part.tool_output_mime_type or "text/plain",
-                    synopsis=synopsis,
-                )
-            )
-        except Exception as exc:
-            error = f"{type(exc).__name__}: {exc}"
-            part.tool_output_externalization_error = error
-            if cfg.failure_mode == "reject":
-                raise FailedPreconditionError(
-                    "Failed to externalize tool output",
-                    details={"tool_id": part.tool_id, "error": error},
-                ) from exc
-            if cfg.failure_mode == "preview_only":
-                part.tool_output = make_preview(
-                    original_output,
-                    preview_chars=preview_chars,
-                    tool_name=part.tool_name,
-                    sha256=digest,
-                    reason=f"{reason}:externalization_failed",
-                    original_chars=len(original_output),
-                    mime_type=part.tool_output_mime_type or "text/plain",
-                )
-                part.tool_output_ref = ""
-                part.tool_output_truncated = True
-                part.tool_output_original_chars = len(original_output)
-                part.tool_output_preview_chars = len(part.tool_output)
-                part.tool_output_sha256 = digest
-                part.tool_output_externalized_reason = reason
-            return
-
-        ref = stored.storage_uri
-        part.tool_output = render_preview_from_synopsis(
-            stored.synopsis,
-            ref=ref,
-            tool_name=part.tool_name,
-            sha256=digest,
-            reason=reason,
-            original_chars=len(original_output),
-            preview_chars=min(len(original_output), max(preview_chars, 0)),
-        )
-        part.tool_output_ref = ref
-        part.tool_output_truncated = True
-        part.tool_output_original_chars = len(original_output)
-        part.tool_output_preview_chars = len(part.tool_output)
-        part.tool_output_sha256 = digest
-        part.tool_output_storage_uri = ref
-        part.tool_output_mime_type = stored.metadata.get("mime_type", "text/plain")
-        part.tool_output_group_id = group_id
-        part.tool_output_externalized_reason = reason
-        part.tool_output_group_original_chars = group_original_chars
-        part.tool_output_group_budget_chars = cfg.assistant_turn_inline_budget_chars
-
-    def _externalize_large_tool_output_group(self, messages: List[Message]) -> None:
-        cfg = self._tool_output_externalization_config
-        if not cfg.enabled:
-            return
-
-        tool_parts = [
-            (msg, p)
-            for msg in messages
-            for p in msg.parts
-            if isinstance(p, ToolPart) and (p.tool_output or "")
-        ]
-        if not tool_parts:
-            return
-
-        group_id = messages[0].id
-        group_original_chars = sum(
-            (
-                int(p.tool_output_original_chars)
-                if p.tool_output_ref
-                and p.tool_output_truncated
-                and p.tool_output_original_chars is not None
-                else len(p.tool_output or "")
-            )
-            for _, p in tool_parts
-        )
-        normal_indices: List[int] = []
-        selected: set[int] = set()
-        externalized_preview_cache: Dict[tuple[int, int, str], tuple[ToolResultSynopsis, int]] = {}
-
-        for idx, (_msg, part) in enumerate(tool_parts):
-            part.tool_output_group_id = group_id
-            part.tool_output_group_original_chars = group_original_chars
-            part.tool_output_group_budget_chars = cfg.assistant_turn_inline_budget_chars
-            if self._rewrite_source_read_tool_output(
-                part,
-                cfg,
-                group_id=group_id,
-                group_original_chars=group_original_chars,
-            ):
-                continue
-            if part.tool_output_ref and part.tool_output_truncated:
-                continue
-            normal_indices.append(idx)
-            if len(part.tool_output or "") > cfg.threshold_chars:
-                selected.add(idx)
-
-        def prepared_externalized_preview(
-            idx: int, part: ToolPart, preview_chars: int
-        ) -> tuple[ToolResultSynopsis, int]:
-            content = part.tool_output or ""
-            reason = "single_threshold" if len(content) > cfg.threshold_chars else "turn_budget"
-            cache_key = (idx, preview_chars, reason)
-            cached = externalized_preview_cache.get(cache_key)
-            if cached is not None:
-                return cached
-
-            synopsis = generate_tool_result_synopsis(
-                content,
-                preview_chars=preview_chars,
-                tool_name=part.tool_name,
-                mime_type=part.tool_output_mime_type or "text/plain",
-            )
-            digest = sha256_text(content)
-            ref = f"{self._session_uri}/tool-results/{build_tool_result_id(part.tool_id, digest)}"
-            rendered = render_preview_from_synopsis(
-                synopsis,
-                ref=ref,
-                tool_name=part.tool_name,
-                sha256=digest,
-                reason=reason,
-                original_chars=len(content),
-                preview_chars=min(len(content), max(preview_chars, 0)),
-            )
-            prepared = (synopsis, len(rendered))
-            externalized_preview_cache[cache_key] = prepared
-            return prepared
-
-        def projected_inline_chars(selected_indices: set[int]) -> int:
-            preview_chars = self._effective_tool_preview_chars(cfg, len(selected_indices))
-            total = 0
-            for idx, (_, part) in enumerate(tool_parts):
-                output_len = len(part.tool_output or "")
-                if idx in selected_indices:
-                    _synopsis, rendered_len = prepared_externalized_preview(
-                        idx, part, preview_chars
-                    )
-                    total += rendered_len
-                else:
-                    total += output_len
-            return total
-
-        remaining = sorted(
-            [idx for idx in normal_indices if idx not in selected],
-            key=lambda idx: len(tool_parts[idx][1].tool_output or ""),
-            reverse=True,
-        )
-        while (
-            projected_inline_chars(selected) >= cfg.assistant_turn_inline_budget_chars and remaining
-        ):
-            baseline = projected_inline_chars(selected)
-            chosen_pos = None
-            for pos, idx in enumerate(remaining):
-                candidate = set(selected)
-                candidate.add(idx)
-                if projected_inline_chars(candidate) < baseline:
-                    chosen_pos = pos
-                    break
-            if chosen_pos is None:
-                break
-            selected.add(remaining.pop(chosen_pos))
-
-        preview_chars = self._effective_tool_preview_chars(cfg, len(selected))
-        for idx in sorted(selected):
-            msg, part = tool_parts[idx]
-            reason = (
-                "single_threshold"
-                if len(part.tool_output or "") > cfg.threshold_chars
-                else "turn_budget"
-            )
-            synopsis, _rendered_len = prepared_externalized_preview(idx, part, preview_chars)
-            self._externalize_tool_part(
-                msg,
-                part,
-                cfg,
-                preview_chars=preview_chars,
-                reason=reason,
-                group_id=group_id,
-                group_original_chars=group_original_chars,
-                synopsis=synopsis,
-            )
-
-    def _externalize_large_tool_outputs(self, msg: Message) -> None:
-        self._externalize_large_tool_output_group([msg])
-
-    def _is_tool_result_aggregate(self, role: str, parts: List[Part]) -> bool:
-        return (
-            role == "user" and len(parts) > 1 and all(isinstance(part, ToolPart) for part in parts)
-        )
-
-    def _append_messages(self, messages: List[Message]) -> None:
-        """Append messages through the same authoritative lock as commit Phase 1."""
-        run_async(self._append_messages_authoritatively(messages))
+        return await asyncio.to_thread(_redact_inline_images_from_tool_outputs, hydrated)
 
     async def _append_messages_authoritatively(self, messages: List[Message]) -> None:
         """Reload and append under the session path lock.
@@ -1323,7 +1027,7 @@ class Session:
                 self._meta = in_memory_meta
 
             await self._apply_appended_messages_to_state(messages)
-            batch_content = "".join(message.to_jsonl() + "\n" for message in messages)
+            batch_content = await asyncio.to_thread(messages_to_jsonl, messages)
             if live_messages_missing:
                 await self._viking_fs.write_file(
                     f"{self._session_uri}/messages.jsonl",
@@ -1347,7 +1051,7 @@ class Session:
 
             if is_user_query(msg):
                 self._stats.total_turns += 1
-            msg_tokens = int(msg.estimated_tokens or 0)
+            msg_tokens = msg.estimated_tokens
             self._stats.total_tokens += msg_tokens
 
             if self._meta.retention_mode != RETENTION_MODE_TURN_BUDGET:
@@ -1356,7 +1060,7 @@ class Session:
                     self._meta.pending_tokens += msg_tokens
                 elif len(self._messages) > keep:
                     pushed_out = self._messages[-(keep + 1)]
-                    self._meta.pending_tokens += int(pushed_out.estimated_tokens or 0)
+                    self._meta.pending_tokens += pushed_out.estimated_tokens
 
         if self._meta.retention_mode == RETENTION_MODE_TURN_BUDGET:
             await self._rebuild_pending_tokens()
@@ -1370,89 +1074,46 @@ class Session:
             # path lock as the counters above.
             self._meta.last_message_at = get_current_timestamp()
 
-    def _build_messages(
-        self,
-        messages_spec: List[dict],
-    ) -> List[Message]:
-        """Validate message specs and build their durable Message objects.
-
-        Args:
-            messages_spec: List of dicts, each with keys:
-                role, parts, peer_id/created_at and optional semantic fields.
-        """
-        all_messages = []
-        for i, spec in enumerate(messages_spec):
-            if "role" not in spec:
-                raise ValueError(f"messages_spec[{i}]: missing required key 'role'")
-            if "parts" not in spec:
-                raise ValueError(f"messages_spec[{i}]: missing required key 'parts'")
-            role = spec["role"]
-            parts = spec["parts"]
-            created_at = spec.get("created_at") or datetime.now(timezone.utc).isoformat()
-            turn_id = spec.get("turn_id")
-            message_kind = spec.get("message_kind")
-            source_message_ids = spec.get("source_message_ids")
-
-            try:
-                peer_id = normalize_peer_id(spec.get("peer_id"))
-            except ValueError as exc:
-                from openviking_cli.exceptions import InvalidArgumentError
-
-                raise InvalidArgumentError(str(exc)) from exc
-
-            if self._is_tool_result_aggregate(role, parts):
-                msgs = [
-                    Message(
-                        id=f"msg_{uuid4().hex}",
-                        role=role,
-                        parts=[part],
-                        peer_id=peer_id,
-                        created_at=created_at,
-                        turn_id=turn_id,
-                        message_kind=message_kind or "tool_transport",
-                        source_message_ids=(
-                            list(source_message_ids) if source_message_ids is not None else None
-                        ),
+    async def _persist_prepared_messages(self, batch: PreparedMessageBatch) -> None:
+        store = self._tool_result_store()
+        if store is not None:
+            for output in batch.tool_outputs:
+                try:
+                    stored = await store.write(
+                        prepared=output.prepared,
+                        tool_id=output.part.tool_id,
+                        tool_name=output.part.tool_name,
+                        message_id=output.message.id,
+                        user_id=self.ctx.user.user_id if self.ctx and self.ctx.user else None,
+                        peer_id=output.message.peer_id,
+                        created_at=output.message.created_at,
                     )
-                    for part in parts
-                ]
-                self._externalize_large_tool_output_group(msgs)
-                all_messages.extend(msgs)
-            else:
-                msg = Message(
-                    id=f"msg_{uuid4().hex}",
-                    role=role,
-                    parts=parts,
-                    peer_id=peer_id,
-                    created_at=created_at,
-                    turn_id=turn_id,
-                    message_kind=message_kind,
-                    source_message_ids=(
-                        list(source_message_ids) if source_message_ids is not None else None
-                    ),
-                )
-                self._externalize_large_tool_outputs(msg)
-                all_messages.append(msg)
-
-        return all_messages
+                except Exception as exc:
+                    output.apply_failure(self._tool_output_externalization_config, exc)
+                else:
+                    output.apply_success(stored)
+        await asyncio.to_thread(batch.finalize_tokens)
 
     def add_messages(
         self,
         messages_spec: List[dict],
     ) -> List[Message]:
         """Synchronously add multiple messages in one authoritative batch."""
-        messages = self._build_messages(messages_spec)
-        self._append_messages(messages)
-        return messages
+        return run_async(self.add_messages_async(messages_spec))
 
     async def add_messages_async(
         self,
         messages_spec: List[dict],
     ) -> List[Message]:
         """Asynchronously add multiple messages without blocking the caller loop."""
-        messages = self._build_messages(messages_spec)
-        await self._append_messages_authoritatively(messages)
-        return messages
+        preparer = MessagePreparer(
+            self._session_uri,
+            self._tool_output_externalization_config,
+        )
+        batch = await asyncio.to_thread(preparer.prepare_new, messages_spec)
+        await self._persist_prepared_messages(batch)
+        await self._append_messages_authoritatively(batch.messages)
+        return batch.messages
 
     def add_message(
         self,
@@ -2038,9 +1699,14 @@ class Session:
                 # The externalization budget belongs to a logical Turn, not one
                 # physical assistant message. This catches N small tool outputs
                 # whose aggregate exceeds the configured inline budget.
-                for turn in build_turns(self._messages):
-                    self._externalize_large_tool_output_group(turn.messages)
-                retention_plan = plan_retention(
+                preparer = MessagePreparer(
+                    self._session_uri,
+                    self._tool_output_externalization_config,
+                )
+                prepared = await asyncio.to_thread(preparer.prepare_turns, self._messages)
+                await self._persist_prepared_messages(prepared)
+                retention_plan = await asyncio.to_thread(
+                    plan_retention,
                     self._messages,
                     keep_recent_turn_count=effective_keep_turns,
                     token_budget=effective_token_budget,
@@ -2124,10 +1790,10 @@ class Session:
                 # Archive raw remains durable and recoverable before any live
                 # conversation history is removed from the root JSONL.
                 if self._viking_fs:
-                    lines = [m.to_jsonl() for m in messages_to_archive]
+                    content = await asyncio.to_thread(messages_to_jsonl, messages_to_archive)
                     await self._viking_fs.write_file(
                         uri=f"{archive_uri}/messages.jsonl",
-                        content="\n".join(lines) + "\n",
+                        content=content,
                         ctx=self.ctx,
                     )
                     if retention_plan is not None:
@@ -2497,7 +2163,8 @@ class Session:
                             if isinstance(generated, _ArchiveSummaryResult)
                             else _ArchiveSummaryResult(overview=str(generated or ""))
                         )
-                        checkpoint_records = self._build_checkpoint_records(
+                        checkpoint_records = await asyncio.to_thread(
+                            self._build_checkpoint_records,
                             checkpoint_requests,
                             summary_result.checkpoint_summaries,
                         )
@@ -2961,7 +2628,8 @@ class Session:
 
         context = await self._collect_session_context_components()
         merged_messages = context["messages"]
-        budgeted = fit_active_messages_to_budget(
+        budgeted = await asyncio.to_thread(
+            fit_active_messages_to_budget,
             merged_messages,
             token_budget=token_budget,
         )
@@ -3413,7 +3081,7 @@ class Session:
 
     async def _read_archive_overview_tokens(self, archive_uri: str, overview: str) -> int:
         """Read overview token estimate from archive metadata."""
-        overview_tokens = estimate_text_tokens(overview)
+        overview_tokens = await asyncio.to_thread(estimate_text_tokens, overview)
         try:
             meta_content = await self._viking_fs.read_file(
                 f"{archive_uri}/.meta.json", ctx=self.ctx
@@ -3427,17 +3095,10 @@ class Session:
     async def _read_archive_messages(self, archive_uri: str) -> List[Message]:
         """Read archived messages from one archive."""
         content = await self._viking_fs.read_file(f"{archive_uri}/messages.jsonl", ctx=self.ctx)
-
-        messages: List[Message] = []
-        for line in content.strip().split("\n"):
-            if not line.strip():
-                continue
-            try:
-                messages.append(Message.from_dict(json.loads(line)))
-            except (json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError) as exc:
-                raise _ArchiveMessagesCorruptError("invalid message record") from exc
-
-        return messages
+        try:
+            return await asyncio.to_thread(messages_from_jsonl, content)
+        except ValueError as exc:
+            raise _ArchiveMessagesCorruptError("invalid message record") from exc
 
     async def _get_latest_completed_archive_summary(
         self,
@@ -4077,23 +3738,7 @@ class Session:
             f"{self._session_uri}/messages.jsonl",
             ctx=self.ctx,
         )
-        messages: List[Message] = []
-        # Split on "\n" only, not str.splitlines(): the latter also treats
-        # U+2028 / U+2029 / NEL (\x85) / \r / \v / \f as line boundaries, which
-        # would cut a JSONL record in half when those characters appear inside a
-        # JSON string value (e.g. assistant tool_output) and break json.loads()
-        # with "Unterminated string". Normalize CRLF first so a trailing "\r"
-        # does not leak into the record. See issue #3984.
-        for line_number, line in enumerate(content.replace("\r\n", "\n").split("\n"), start=1):
-            if not line.strip():
-                continue
-            try:
-                messages.append(Message.from_dict(json.loads(line)))
-            except Exception as exc:
-                raise ValueError(
-                    f"Invalid live message JSONL at line {line_number}: {exc}"
-                ) from exc
-        return messages
+        return await asyncio.to_thread(messages_from_jsonl, content)
 
     def _extract_abstract_from_summary(self, summary: str) -> str:
         """Extract one-sentence overview from structured summary."""
@@ -4229,7 +3874,11 @@ class Session:
                 raise ValueError("Cannot generate checkpoints without archive messages")
             return ""
 
-        formatted = self._format_messages_for_wm(messages, checkpoint_requests)
+        formatted = await asyncio.to_thread(
+            self._format_messages_for_wm,
+            messages,
+            checkpoint_requests,
+        )
         checkpoint_instructions = self._checkpoint_prompt_instructions(len(checkpoint_requests))
 
         vlm = get_openviking_config().vlm
@@ -5276,8 +4925,7 @@ class Session:
         abstract = self._generate_abstract()
         overview = self._generate_overview(turn_count)
 
-        lines = [m.to_jsonl() for m in messages]
-        content = "\n".join(lines) + "\n" if lines else ""
+        content = await asyncio.to_thread(messages_to_jsonl, messages)
 
         await viking_fs.write_file(
             uri=f"{self._session_uri}/messages.jsonl",

--- a/openviking/session/session.py
+++ b/openviking/session/session.py
@@ -1304,7 +1304,7 @@ class Session:
         agent_evolution_enabled: bool = True,
         agent_memory_skip_reason: Optional[str] = None,
         lease_ref: Optional[Any] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Persist the Phase 1 intent before any destructive root rewrite."""
         payload = {
             "version": 1,
@@ -1320,32 +1320,54 @@ class Session:
             "retained_message_token_budget": retained_message_token_budget,
             "min_raw_tail_steps": min_raw_tail_steps,
         }
-        await self._merge_archive_meta(
-            archive_uri,
-            {
-                "phase1": payload,
-                "agent_evolution": {
-                    "enabled": agent_evolution_enabled,
-                    "skip_reason": agent_memory_skip_reason,
-                },
+        meta_payload = {
+            "phase1": payload,
+            "agent_evolution": {
+                "enabled": agent_evolution_enabled,
+                "skip_reason": agent_memory_skip_reason,
             },
-            lease_ref=lease_ref,
-        )
+        }
+        if self._viking_fs:
+            await self._viking_fs.write_file(
+                uri=f"{archive_uri}/.meta.json",
+                content=json.dumps(meta_payload, ensure_ascii=False),
+                ctx=self.ctx,
+                lease_ref=lease_ref,
+            )
+        return meta_payload
 
     async def _write_phase1_ready_marker(
         self,
         archive_uri: str,
         lease_ref: Optional[Any] = None,
+        *,
+        phase1: Optional[Dict[str, Any]] = None,
+        meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Persist that Phase 1 is ready using an optional held PathLock lease."""
-        phase1 = await self._read_phase1_meta(archive_uri)
+        if phase1 is None:
+            if meta is not None:
+                stored_phase1 = meta.get("phase1")
+                phase1 = dict(stored_phase1) if isinstance(stored_phase1, dict) else {}
+            else:
+                phase1 = await self._read_phase1_meta(archive_uri)
         phase1.update(
             {
                 "status": "ready",
                 "ready_at": get_current_timestamp(),
             }
         )
-        await self._merge_archive_meta(archive_uri, {"phase1": phase1}, lease_ref=lease_ref)
+        if meta is None:
+            await self._merge_archive_meta(archive_uri, {"phase1": phase1}, lease_ref=lease_ref)
+            return
+        meta["phase1"] = phase1
+        if self._viking_fs:
+            await self._viking_fs.write_file(
+                uri=f"{archive_uri}/.meta.json",
+                content=json.dumps(meta, ensure_ascii=False),
+                ctx=self.ctx,
+                lease_ref=lease_ref,
+            )
 
     async def _archive_file_exists(self, archive_uri: str, file_name: str) -> bool:
         try:
@@ -1772,7 +1794,7 @@ class Session:
             )
             phase1_stage = "phase1_persist"
             try:
-                await self._write_phase1_marker(
+                phase1_meta = await self._write_phase1_marker(
                     archive_uri,
                     queue_message=queue_msg.to_dict(),
                     original_messages=original_messages,
@@ -1826,7 +1848,6 @@ class Session:
 
                 phase1_stage = "phase1_persist"
                 self._messages = retained_messages
-                await self._write_to_agfs_async(messages=self._messages)
                 self._meta.message_count = len(self._messages)
                 self._meta.pending_tokens = 0
                 self._remember_retention_policy(
@@ -1846,8 +1867,17 @@ class Session:
                     # commit boundary, so an idle scan and a concurrent worker
                     # never see a stale state.
                     self._meta.last_auto_commit_at = get_current_timestamp()
-                await self._save_meta()
-                await self._write_phase1_ready_marker(archive_uri)
+                await asyncio.gather(
+                    self._write_to_agfs_async(messages=self._messages),
+                    self._save_meta(),
+                )
+                await self._write_phase1_ready_marker(
+                    archive_uri,
+                    meta=phase1_meta if retention_plan is None else None,
+                    phase1=(
+                        phase1_meta.get("phase1") if retention_plan is not None else None
+                    ),
+                )
             except Exception as e:
                 logger.error(f"[commit] Failed during {phase1_stage}: {e}")
                 # Whether the queue write failed or a queued Phase 1 stopped
@@ -4926,44 +4956,47 @@ class Session:
         overview = self._generate_overview(turn_count)
 
         content = await asyncio.to_thread(messages_to_jsonl, messages)
-
-        await viking_fs.write_file(
-            uri=f"{self._session_uri}/messages.jsonl",
-            content=content,
-            ctx=self.ctx,
-            lease_ref=lease_ref,
+        abstract_content = render_abstract_overview(
+            ContextLevel.ABSTRACT,
+            self._session_uri,
+            abstract,
+            {
+                "generated_by": {
+                    "component": "Session",
+                    "trigger": "session_update",
+                }
+            },
         )
-        await viking_fs.write_file(
-            uri=f"{self._session_uri}/.abstract.md",
-            content=render_abstract_overview(
-                ContextLevel.ABSTRACT,
-                self._session_uri,
-                abstract,
-                {
-                    "generated_by": {
-                        "component": "Session",
-                        "trigger": "session_update",
-                    }
-                },
-            ),
-            ctx=self.ctx,
-            lease_ref=lease_ref,
+        overview_content = render_abstract_overview(
+            ContextLevel.OVERVIEW,
+            self._session_uri,
+            overview,
+            {
+                "generated_by": {
+                    "component": "Session",
+                    "trigger": "session_update",
+                }
+            },
         )
-        await viking_fs.write_file(
-            uri=f"{self._session_uri}/.overview.md",
-            content=render_abstract_overview(
-                ContextLevel.OVERVIEW,
-                self._session_uri,
-                overview,
-                {
-                    "generated_by": {
-                        "component": "Session",
-                        "trigger": "session_update",
-                    }
-                },
+        await asyncio.gather(
+            viking_fs.write_file(
+                uri=f"{self._session_uri}/messages.jsonl",
+                content=content,
+                ctx=self.ctx,
+                lease_ref=lease_ref,
             ),
-            ctx=self.ctx,
-            lease_ref=lease_ref,
+            viking_fs.write_file(
+                uri=f"{self._session_uri}/.abstract.md",
+                content=abstract_content,
+                ctx=self.ctx,
+                lease_ref=lease_ref,
+            ),
+            viking_fs.write_file(
+                uri=f"{self._session_uri}/.overview.md",
+                content=overview_content,
+                ctx=self.ctx,
+                lease_ref=lease_ref,
+            ),
         )
 
     def _generate_abstract(self) -> str:

--- a/openviking/session/tool_result_store.py
+++ b/openviking/session/tool_result_store.py
@@ -97,6 +97,42 @@ class StoredToolResult:
     synopsis: ToolResultSynopsis
 
 
+@dataclass(frozen=True)
+class PreparedToolResult:
+    """CPU-prepared content-addressed tool result."""
+
+    content: str
+    sha256: str
+    tool_result_id: str
+    preview_chars: int
+    mime_type: str
+    synopsis: ToolResultSynopsis
+
+
+def prepare_tool_result(
+    content: str,
+    *,
+    tool_id: str,
+    tool_name: str,
+    preview_chars: int,
+    mime_type: str,
+) -> PreparedToolResult:
+    digest = sha256_text(content)
+    return PreparedToolResult(
+        content=content,
+        sha256=digest,
+        tool_result_id=build_tool_result_id(tool_id, digest),
+        preview_chars=preview_chars,
+        mime_type=mime_type,
+        synopsis=generate_tool_result_synopsis(
+            content,
+            preview_chars=preview_chars,
+            tool_name=tool_name,
+            mime_type=mime_type,
+        ),
+    )
+
+
 class ToolResultStore:
     """Persist raw tool outputs outside session messages."""
 
@@ -124,19 +160,19 @@ class ToolResultStore:
     async def write(
         self,
         *,
-        content: str,
+        prepared: PreparedToolResult,
         tool_id: str,
         tool_name: str,
         message_id: str,
         user_id: Optional[str],
         peer_id: Optional[str],
         created_at: Optional[str],
-        preview_chars: int,
-        mime_type: str = "text/plain",
-        synopsis: Optional[ToolResultSynopsis] = None,
     ) -> StoredToolResult:
-        digest = sha256_text(content)
-        tool_result_id = build_tool_result_id(tool_id, digest)
+        content = prepared.content
+        digest = prepared.sha256
+        tool_result_id = prepared.tool_result_id
+        preview_chars = prepared.preview_chars
+        mime_type = prepared.mime_type
         storage_uri = self._result_uri(tool_result_id)
         output_uri = f"{storage_uri}/output.txt"
         metadata_uri = f"{storage_uri}/metadata.json"
@@ -148,12 +184,7 @@ class ToolResultStore:
                 synopsis = (
                     ToolResultSynopsis.from_dict(synopsis_data)
                     if isinstance(synopsis_data, dict)
-                    else generate_tool_result_synopsis(
-                        content,
-                        preview_chars=preview_chars,
-                        tool_name=tool_name,
-                        mime_type=mime_type,
-                    )
+                    else prepared.synopsis
                 )
                 return StoredToolResult(
                     tool_result_id=tool_result_id,
@@ -166,12 +197,7 @@ class ToolResultStore:
         except NotFoundError:
             pass
 
-        synopsis = synopsis or generate_tool_result_synopsis(
-            content,
-            preview_chars=preview_chars,
-            tool_name=tool_name,
-            mime_type=mime_type,
-        )
+        synopsis = prepared.synopsis
         metadata = {
             "tool_result_id": tool_result_id,
             "session_id": self._session_id,

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -471,7 +471,7 @@ class TextEmbeddingHandler(DequeueHandlerBase):
 
     async def close(self) -> None:
         if self._embedder is not None:
-            await asyncio.to_thread(self._embedder.close)
+            self._embedder.close()
 
     def _log_breaker_open_reenqueue_summary(self) -> None:
         """Log a throttled warning when embeddings are re-enqueued due to an open circuit breaker."""

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -469,6 +469,10 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         """Initialize the embedder instance from config."""
         self._embedder = config.embedding.get_embedder()
 
+    async def close(self) -> None:
+        if self._embedder is not None:
+            await asyncio.to_thread(self._embedder.close)
+
     def _log_breaker_open_reenqueue_summary(self) -> None:
         """Log a throttled warning when embeddings are re-enqueued due to an open circuit breaker."""
         now = time.monotonic()

--- a/openviking/storage/collection_schemas.py
+++ b/openviking/storage/collection_schemas.py
@@ -469,10 +469,6 @@ class TextEmbeddingHandler(DequeueHandlerBase):
         """Initialize the embedder instance from config."""
         self._embedder = config.embedding.get_embedder()
 
-    async def close(self) -> None:
-        if self._embedder is not None:
-            self._embedder.close()
-
     def _log_breaker_open_reenqueue_summary(self) -> None:
         """Log a throttled warning when embeddings are re-enqueued due to an open circuit breaker."""
         now = time.monotonic()

--- a/openviking/storage/queuefs/add_resource_processor.py
+++ b/openviking/storage/queuefs/add_resource_processor.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Durable add-resource queue consumer."""
 
-import asyncio
-import concurrent.futures
 import json
 from contextlib import suppress
 from copy import deepcopy
@@ -36,12 +34,10 @@ class AddResourceProcessor(DequeueHandlerBase):
     def __init__(
         self,
         resource_service: Any,
-        service_loop: asyncio.AbstractEventLoop,
         queue_name: str,
         viking_fs: Any,
     ):
         self._resource_service = resource_service
-        self._service_loop = service_loop
         self._queue_name = queue_name
         self._viking_fs = viking_fs
 
@@ -296,20 +292,16 @@ class AddResourceProcessor(DequeueHandlerBase):
         except (json.JSONDecodeError, TypeError, ValueError) as exc:
             self.report_error(str(exc), data)
             return None
-        future = asyncio.run_coroutine_threadsafe(
-            self._release_cancelled_resources(
-                msg,
-                RequestContext(
-                    user=UserIdentifier(msg.account_id, msg.user_id),
-                    role=Role(msg.role),
-                    group_ids=tuple(msg.group_ids),
-                    actor_peer_id=msg.actor_peer_id,
-                    bypass_acl=msg.bypass_acl,
-                ),
+        await self._release_cancelled_resources(
+            msg,
+            RequestContext(
+                user=UserIdentifier(msg.account_id, msg.user_id),
+                role=Role(msg.role),
+                group_ids=tuple(msg.group_ids),
+                actor_peer_id=msg.actor_peer_id,
+                bypass_acl=msg.bypass_acl,
             ),
-            self._service_loop,
         )
-        await asyncio.wrap_future(future)
         unregister_telemetry(msg.telemetry_id or "")
         self.report_success()
         return None
@@ -328,13 +320,5 @@ class AddResourceProcessor(DequeueHandlerBase):
             self.report_error(str(exc), data)
             return None
 
-        future: concurrent.futures.Future[None] = asyncio.run_coroutine_threadsafe(
-            self._process(msg, data),
-            self._service_loop,
-        )
-        try:
-            await asyncio.wrap_future(future)
-        except asyncio.CancelledError:
-            future.cancel()
-            raise
+        await self._process(msg, data)
         return None

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -133,8 +133,9 @@ class NamedQueue:
         self._task_work_index = task_work_index
         self._initialized = False
 
-        # Status tracking
-        self._lock = threading.Lock()
+        # Consumers mutate status on the service loop; synchronous metrics may
+        # read the snapshot from their collector thread.
+        self._status_lock = threading.Lock()
         self._in_progress = 0
         self._processed = 0
         self._requeue_count = 0
@@ -156,18 +157,18 @@ class NamedQueue:
 
     def _on_dequeue_start(self) -> None:
         """Called on dequeue."""
-        with self._lock:
+        with self._status_lock:
             self._in_progress += 1
 
     def _on_process_success(self) -> None:
         """Called on processing success."""
-        with self._lock:
+        with self._status_lock:
             self._in_progress -= 1
             self._processed += 1
 
     def _on_process_requeue(self) -> None:
         """Called when a dequeued message is re-enqueued for later retry."""
-        with self._lock:
+        with self._status_lock:
             self._requeue_count += 1
 
     def _on_process_error(self, error_msg: str, data: Optional[Dict[str, Any]] = None) -> None:
@@ -176,7 +177,7 @@ class NamedQueue:
             metadata = extract_task_metadata(data)
             if metadata is not None:
                 self._task_work_index.record_failure(metadata.task_id, error_msg)
-        with self._lock:
+        with self._status_lock:
             self._in_progress -= 1
             self._error_count += 1
             self._errors.append(
@@ -192,7 +193,7 @@ class NamedQueue:
     async def get_status(self) -> QueueStatus:
         """Get queue status."""
         pending = await self.size()
-        with self._lock:
+        with self._status_lock:
             return QueueStatus(
                 pending=pending,
                 in_progress=self._in_progress,
@@ -204,12 +205,16 @@ class NamedQueue:
 
     def reset_status(self) -> None:
         """Reset status counters."""
-        with self._lock:
+        with self._status_lock:
             self._in_progress = 0
             self._processed = 0
             self._requeue_count = 0
             self._error_count = 0
             self._errors = []
+
+    def has_errors(self) -> bool:
+        with self._status_lock:
+            return self._error_count > 0
 
     def has_dequeue_handler(self) -> bool:
         """Check if dequeue handler exists."""

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -102,9 +102,6 @@ class DequeueHandlerBase(abc.ABC):
         self.report_success()
         return None
 
-    async def close(self) -> None:
-        """Release resources owned by the handler."""
-
     @abc.abstractmethod
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Called after message dequeue. Returns None to discard message."""
@@ -222,10 +219,6 @@ class NamedQueue:
     def has_dequeue_handler(self) -> bool:
         """Check if dequeue handler exists."""
         return self._dequeue_handler is not None
-
-    async def close(self) -> None:
-        if self._dequeue_handler is not None:
-            await self._dequeue_handler.close()
 
     async def _ensure_initialized(self):
         """Ensure queue directory is created in AGFS."""

--- a/openviking/storage/queuefs/named_queue.py
+++ b/openviking/storage/queuefs/named_queue.py
@@ -102,6 +102,9 @@ class DequeueHandlerBase(abc.ABC):
         self.report_success()
         return None
 
+    async def close(self) -> None:
+        """Release resources owned by the handler."""
+
     @abc.abstractmethod
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Called after message dequeue. Returns None to discard message."""
@@ -219,6 +222,10 @@ class NamedQueue:
     def has_dequeue_handler(self) -> bool:
         """Check if dequeue handler exists."""
         return self._dequeue_handler is not None
+
+    async def close(self) -> None:
+        if self._dequeue_handler is not None:
+            await self._dequeue_handler.close()
 
     async def _ensure_initialized(self):
         """Ensure queue directory is created in AGFS."""

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -6,10 +6,7 @@ All queues are managed through NamedQueue.
 """
 
 import asyncio
-import atexit
-import threading
 import time
-import traceback
 from typing import Any, Dict, Optional, Set, Union
 
 from openviking.service.task_work_index import TaskWorkIndex
@@ -108,25 +105,21 @@ class QueueManager:
         self._max_concurrent_add_resource = max_concurrent_add_resource
         self._max_concurrent_session_commit = max_concurrent_session_commit
         self._queues: Dict[str, NamedQueue] = {}
-        self._started = False
-        self._queue_threads: Dict[str, threading.Thread] = {}
-        self._queue_stop_events: Dict[str, threading.Event] = {}
+        self._workers: Dict[str, asyncio.Task[None]] = {}
+        self._stop_event: Optional[asyncio.Event] = None
         self._poll_interval = 0.2
         self._task_work_index = TaskWorkIndex()
 
-        atexit.register(self.stop)
         logger.info(
             f"[QueueManager] Initialized with agfs={type(agfs).__name__}, mount_point={mount_point}"
         )
 
-    def start(self) -> None:
+    async def start(self) -> None:
         """Start QueueManager workers."""
-        if self._started:
+        if self._stop_event is not None:
             return
 
-        self._started = True
-
-        # Start queue workers for existing queues
+        self._stop_event = asyncio.Event()
         for queue in list(self._queues.values()):
             self._start_queue_worker(queue)
 
@@ -139,17 +132,8 @@ class QueueManager:
         tracker.attach_work_index(self._task_work_index)
         await tracker.restore_work_tasks(owners)
 
-    def setup_standard_queues(self, vector_store: Any, start: bool = True) -> None:
-        """
-        Setup standard queues (Embedding and Semantic) with their handlers.
-
-        Args:
-            vector_store: Vector store instance for handlers to write results.
-            start: Whether to start worker threads immediately (default True).
-                   Pass False when the consumer depends on resources that are
-                   not yet initialized (e.g. VikingFS); call start() manually
-                   after those resources are ready.
-        """
+    def setup_standard_queues(self, vector_store: Any) -> None:
+        """Set up standard queues without starting their consumers."""
         # Import handlers here to avoid circular dependencies
         from openviking.storage.collection_schemas import TextEmbeddingHandler
         from openviking.storage.queuefs import SemanticProcessor
@@ -172,26 +156,18 @@ class QueueManager:
         )
         logger.info("Semantic queue initialized with SemanticProcessor")
 
-        if start:
-            self.start()
-
     def _start_queue_worker(self, queue: NamedQueue) -> None:
-        """Start a dedicated worker thread for a queue if not already running."""
-        if queue.name in self._queue_threads:
-            thread = self._queue_threads[queue.name]
-            if thread.is_alive():
-                return
-
-        max_concurrent = self._max_concurrent_for_queue(queue.name)
-        stop_event = threading.Event()
-        self._queue_stop_events[queue.name] = stop_event
-        thread = threading.Thread(
-            target=self._queue_worker_loop,
-            args=(queue, stop_event, max_concurrent),
-            daemon=True,
+        """Start one consumer task on the service event loop."""
+        if self._stop_event is None or queue.name in self._workers:
+            return
+        self._workers[queue.name] = asyncio.create_task(
+            self._queue_worker_loop(
+                queue,
+                self._max_concurrent_for_queue(queue.name),
+                self._stop_event,
+            ),
+            name=f"queuefs:{queue.name}",
         )
-        self._queue_threads[queue.name] = thread
-        thread.start()
 
     def _max_concurrent_for_queue(self, queue_name: str) -> int:
         """Return the worker concurrency limit for a named queue."""
@@ -207,101 +183,57 @@ class QueueManager:
             return self._max_concurrent_session_commit
         return self._max_concurrent_semantic
 
-    def _queue_worker_loop(
-        self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int = 1
+    async def _queue_worker_loop(
+        self,
+        queue: NamedQueue,
+        max_concurrent: int,
+        stop_event: asyncio.Event,
     ) -> None:
-        """Worker loop for a single queue.
-
-        When max_concurrent > 1, items are fetched and processed in parallel
-        (up to max_concurrent at a time). Otherwise items are processed one by one.
-        """
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        """Consume one durable queue with bounded in-flight work."""
         poll_interval = (
             self._SESSION_COMMIT_POLL_INTERVAL
             if queue.name == self.SESSION_COMMIT
             else self._poll_interval
         )
-        try:
-            if max_concurrent > 1:
-                loop.run_until_complete(
-                    self._worker_async_concurrent(queue, stop_event, max_concurrent)
-                )
-            else:
-                while not stop_event.is_set():
-                    try:
-                        queue_size = loop.run_until_complete(queue.size())
-                        if queue.has_dequeue_handler() and queue_size > 0:
-                            data = loop.run_until_complete(queue.dequeue())
-                            if data is not None:
-                                logger.debug("[QueueManager] Dequeued message from %s", queue.name)
-                            if queue.name == self.SESSION_COMMIT:
-                                stop_event.wait(poll_interval)
-                        else:
-                            stop_event.wait(poll_interval)
-                    except Exception as e:
-                        logger.error(f"[QueueManager] Worker error for {queue.name}: {e}")
-                        traceback.print_exc()
-                        stop_event.wait(poll_interval)
-        finally:
-            loop.close()
-
-    async def _worker_async_concurrent(
-        self, queue: NamedQueue, stop_event: threading.Event, max_concurrent: int
-    ) -> None:
-        """Concurrent worker: drains the queue and processes items in parallel.
-
-        A Semaphore caps inflight tasks at max_concurrent.
-        """
-        poll_interval = (
-            self._SESSION_COMMIT_POLL_INTERVAL
-            if queue.name == self.SESSION_COMMIT
-            else self._poll_interval
-        )
-        sem = asyncio.Semaphore(max_concurrent)
         active_tasks: Set[asyncio.Task] = set()
 
         async def process_one(data: Dict[str, Any]) -> None:
-            async with sem:
-                msg_id = data.get("id", "") if isinstance(data, dict) else ""
-                try:
-                    await queue.process_dequeued(data)
-                    # Ack after successful processing (delete from persistent storage).
-                    await queue.ack(msg_id, data)
-                except Exception as e:
-                    # Handler did not call report_error; decrement in_progress manually.
-                    # Do NOT ack — let RecoverStale re-queue on next startup.
-                    queue._on_process_error(str(e), data)
-                    logger.error(f"[QueueManager] Concurrent worker error for {queue.name}: {e}")
-
-        while not stop_event.is_set():
-            # Prune completed tasks
-            active_tasks = {t for t in active_tasks if not t.done()}
-
-            # While capacity remains, keep draining the queue
-            while len(active_tasks) < max_concurrent:
-                try:
-                    queue_size = await queue.size()
-                except Exception:
-                    break
-                if not queue.has_dequeue_handler() or queue_size == 0:
-                    break
-                data = await queue.dequeue_raw()
-                if data is None:
-                    break
-                # Increment before task creation to close the race window where
-                # size=0 and in_progress=0 between dequeue_raw() and task execution.
-                queue._on_dequeue_start()
-                task = asyncio.create_task(process_one(data))
-                active_tasks.add(task)
-                logger.debug(
-                    f"[QueueManager] Dispatched concurrent task for {queue.name} "
-                    f"(active={len(active_tasks)})"
+            msg_id = data.get("id", "")
+            try:
+                await queue.process_dequeued(data)
+                await queue.ack(msg_id, data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                queue._on_process_error(str(exc), data)
+                logger.error(
+                    "[QueueManager] Worker error for %s: %s",
+                    queue.name,
+                    exc,
                 )
 
-            await asyncio.sleep(poll_interval)
+        while not stop_event.is_set():
+            active_tasks = {task for task in active_tasks if not task.done()}
+            while queue.has_dequeue_handler() and len(active_tasks) < max_concurrent:
+                try:
+                    data = await queue.dequeue_raw()
+                except Exception as exc:
+                    logger.error("[QueueManager] Dequeue failed for %s: %s", queue.name, exc)
+                    break
+                if data is None:
+                    break
+                queue._on_dequeue_start()
+                task = asyncio.create_task(
+                    process_one(data),
+                    name=f"queuefs:{queue.name}:{data.get('id', '')}",
+                )
+                active_tasks.add(task)
 
-        # Drain remaining in-flight tasks on shutdown (with timeout)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
+            except asyncio.TimeoutError:
+                pass
+
         if active_tasks:
             try:
                 await asyncio.wait_for(
@@ -313,29 +245,23 @@ class QueueManager:
                     f"[QueueManager] Drain timeout for {queue.name}, "
                     f"cancelling {len(active_tasks)} in-flight task(s)"
                 )
-                for t in active_tasks:
-                    t.cancel()
+                for task in active_tasks:
+                    task.cancel()
                 await asyncio.gather(*active_tasks, return_exceptions=True)
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         """Stop QueueManager and release resources."""
         global _instance
-        if not self._started:
+        if self._stop_event is None:
             return
 
-        # Stop queue workers
-        for stop_event in self._queue_stop_events.values():
-            stop_event.set()
-        for name, thread in self._queue_threads.items():
-            thread.join(timeout=10.0)
-            if thread.is_alive():
-                logger.warning(f"[QueueManager] Worker thread {name} did not exit in time")
-        self._queue_threads.clear()
-        self._queue_stop_events.clear()
+        self._stop_event.set()
+        await asyncio.gather(*self._workers.values())
+        self._workers.clear()
 
         self._agfs = None
         self._queues.clear()
-        self._started = False
+        self._stop_event = None
 
         if _instance is self:
             _instance = None
@@ -344,7 +270,7 @@ class QueueManager:
 
     def is_running(self) -> bool:
         """Check if QueueManager is running."""
-        return self._started
+        return self._stop_event is not None
 
     def get_queue(
         self,
@@ -384,13 +310,12 @@ class QueueManager:
                     dequeue_handler=dequeue_handler,
                     task_work_index=self._task_work_index,
                 )
-            if self._started:
+            if self._stop_event is not None:
                 self._start_queue_worker(self._queues[name])
         else:
             if dequeue_handler is not None:
                 self._queues[name].set_dequeue_handler(dequeue_handler)
-            if self._started:
-                # Ensure existing queue has a worker running
+            if self._stop_event is not None:
                 self._start_queue_worker(self._queues[name])
         return self._queues[name]
 
@@ -431,8 +356,8 @@ class QueueManager:
         if queue_name:
             if queue_name not in self._queues:
                 return False
-            return self._queues[queue_name]._error_count > 0
-        return any(q._error_count > 0 for q in self._queues.values())
+            return self._queues[queue_name].has_errors()
+        return any(queue.has_errors() for queue in self._queues.values())
 
     async def is_all_complete(self, queue_name: Optional[str] = None) -> bool:
         """Check if all processing is complete."""

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -7,8 +7,10 @@ All queues are managed through NamedQueue.
 
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Optional, Set, Union
 
+from openviking.pyagfs.async_client import bind_agfs_executor
 from openviking.service.task_work_index import TaskWorkIndex
 from openviking_cli.utils.logger import get_logger
 
@@ -107,6 +109,7 @@ class QueueManager:
         self._queues: Dict[str, NamedQueue] = {}
         self._workers: Dict[str, asyncio.Task[None]] = {}
         self._stop_event: Optional[asyncio.Event] = None
+        self._worker_io_executor: Optional[ThreadPoolExecutor] = None
         self._poll_interval = 0.2
         self._task_work_index = TaskWorkIndex()
 
@@ -120,6 +123,7 @@ class QueueManager:
             return
 
         self._stop_event = asyncio.Event()
+        self._worker_io_executor = ThreadPoolExecutor(thread_name_prefix="queuefs-io")
         for queue in list(self._queues.values()):
             self._start_queue_worker(queue)
 
@@ -199,18 +203,22 @@ class QueueManager:
 
         async def process_one(data: Dict[str, Any]) -> None:
             msg_id = data.get("id", "")
-            try:
-                await queue.process_dequeued(data)
-                await queue.ack(msg_id, data)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                queue._on_process_error(str(exc), data)
-                logger.error(
-                    "[QueueManager] Worker error for %s: %s",
-                    queue.name,
-                    exc,
-                )
+            executor = self._worker_io_executor
+            if executor is None:
+                raise RuntimeError("QueueManager worker executor is not initialized")
+            with bind_agfs_executor(executor):
+                try:
+                    await queue.process_dequeued(data)
+                    await queue.ack(msg_id, data)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    queue._on_process_error(str(exc), data)
+                    logger.error(
+                        "[QueueManager] Worker error for %s: %s",
+                        queue.name,
+                        exc,
+                    )
 
         while not stop_event.is_set():
             active_tasks = {task for task in active_tasks if not task.done()}
@@ -262,6 +270,9 @@ class QueueManager:
         self._agfs = None
         self._queues.clear()
         self._stop_event = None
+        if self._worker_io_executor is not None:
+            self._worker_io_executor.shutdown(wait=False, cancel_futures=True)
+            self._worker_io_executor = None
 
         if _instance is self:
             _instance = None

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -259,6 +259,8 @@ class QueueManager:
         await asyncio.gather(*self._workers.values())
         self._workers.clear()
 
+        await asyncio.gather(*(queue.close() for queue in self._queues.values()))
+
         self._agfs = None
         self._queues.clear()
         self._stop_event = None

--- a/openviking/storage/queuefs/queue_manager.py
+++ b/openviking/storage/queuefs/queue_manager.py
@@ -259,8 +259,6 @@ class QueueManager:
         await asyncio.gather(*self._workers.values())
         self._workers.clear()
 
-        await asyncio.gather(*(queue.close() for queue in self._queues.values()))
-
         self._agfs = None
         self._queues.clear()
         self._stop_event = None

--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 """Queue consumer for restart-safe Session Phase 2 work."""
 
-import asyncio
-import concurrent.futures
 import json
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -27,10 +25,8 @@ class SessionCommitProcessor(DequeueHandlerBase):
     def __init__(
         self,
         session_service: "SessionService",
-        service_loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._session_service = session_service
-        self._service_loop = service_loop
 
     @staticmethod
     def _parse_message(data: Dict[str, Any]) -> tuple[SessionCommitMsg, RequestContext]:
@@ -45,11 +41,8 @@ class SessionCommitProcessor(DequeueHandlerBase):
         return msg, ctx
 
     async def _process(self, msg: SessionCommitMsg, ctx: RequestContext) -> bool:
-        # Bind a root observability context so Phase-2 extraction VLM/embedding
-        # token events are attributed to the committing account/user rather than
-        # "__unknown__" (mirrors SemanticProcessor.on_dequeue). Must bind inside
-        # this coroutine: on_dequeue hops loops via run_coroutine_threadsafe, so
-        # a context bound there would not propagate here.
+        # Bind queue work to the committing identity before Phase 2 emits model
+        # usage and trace events.
         root_attrs = create_root_span_attributes(
             http_method="QUEUE",
             http_route="/queuefs/session_commit",
@@ -116,16 +109,8 @@ class SessionCommitProcessor(DequeueHandlerBase):
             self.report_error(str(exc), data)
             return None
 
-        future = asyncio.run_coroutine_threadsafe(
-            self._finalize_cancelled(msg, ctx),
-            self._service_loop,
-        )
-        try:
-            await asyncio.wrap_future(future)
-            self.report_success()
-        except asyncio.CancelledError:
-            future.cancel()
-            raise
+        await self._finalize_cancelled(msg, ctx)
+        self.report_success()
         return None
 
     async def on_dequeue(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -137,14 +122,6 @@ class SessionCommitProcessor(DequeueHandlerBase):
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             self.report_error(str(exc), data)
             return None
-        future: concurrent.futures.Future[bool] = asyncio.run_coroutine_threadsafe(
-            self._process(msg, ctx),
-            self._service_loop,
-        )
-        try:
-            await asyncio.wrap_future(future)
-            self.report_success()
-        except asyncio.CancelledError:
-            future.cancel()
-            raise
+        await self._process(msg, ctx)
+        self.report_success()
         return None

--- a/openviking/storage/queuefs/session_commit_processor.py
+++ b/openviking/storage/queuefs/session_commit_processor.py
@@ -75,7 +75,6 @@ class SessionCommitProcessor(DequeueHandlerBase):
                     user_id=ctx.user.user_id,
                 )
                 return True
-            await session.load()
             with bind_task_context(msg.task_id, ctx.account_id, ctx.user.user_id):
                 processed = await session.resume_queued_commit(msg)
             if not processed:

--- a/openviking/telemetry/tracer.py
+++ b/openviking/telemetry/tracer.py
@@ -12,8 +12,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from loguru import logger
-
 # Try to import opentelemetry - will be None if not installed
 try:
     from opentelemetry import trace as otel_trace
@@ -66,7 +64,7 @@ except ImportError:
 # Global tracer instance
 _otel_tracer: Any = None
 _propagator: Any = None
-_trace_id_filter_added: bool = False
+logger = logging.getLogger(__name__)
 
 
 def _log_trace_internal_failure(message: str) -> None:
@@ -186,36 +184,6 @@ class TraceIdLoggingFilter(logging.Filter):
         if trace_id:
             record.msg = f"[{trace_id}] {record.msg}"
         return True
-
-
-def _setup_logging():
-    """Setup logging with trace_id injection."""
-    global _trace_id_filter_added
-
-    if _trace_id_filter_added:
-        return
-
-    try:
-        # Configure logger to patch records with trace_id
-        def _patch_trace_id(record):
-            trace_id = get_trace_id()
-            record["extra"]["trace_id"] = trace_id
-            if trace_id:
-                record["message"] = f"[{trace_id}] {record['message']}"
-
-        logger.configure(patcher=_patch_trace_id)
-        _trace_id_filter_added = True
-    except Exception:
-        _log_trace_internal_failure("[TRACER] failed to configure loguru trace_id patcher")
-
-    # Also setup standard logging filter
-    try:
-        standard_logger = logging.getLogger()
-        for handler in standard_logger.handlers:
-            if not any(isinstance(f, TraceIdLoggingFilter) for f in handler.filters):
-                handler.addFilter(TraceIdLoggingFilter())
-    except Exception:
-        _log_trace_internal_failure("[TRACER] failed to attach standard logging trace_id filter")
 
 
 def init_tracer_from_server_config(server_config: Any) -> Any:
@@ -361,9 +329,6 @@ def init_tracer(
 
         _otel_tracer = otel_trace.get_tracer(service_name)
         _propagator = TraceContextTextMapPropagator()
-
-        # Setup logging with trace_id
-        _setup_logging()
 
         # Initialize asyncio instrumentation to create child spans for create_task
         _init_asyncio_instrumentation()
@@ -646,7 +611,7 @@ class tracer:
     def info(line: str, console: bool = False) -> None:
         """Add an event to the current span."""
         if console:
-            logger.opt(depth=1).info(line)
+            logger.info(line, stacklevel=2)
         if _otel_tracer is None:
             return
 
@@ -666,7 +631,7 @@ class tracer:
     def info_span(line: str, console: bool = False) -> None:
         """Create a new span with the given name."""
         if console:
-            logger.opt(depth=1).info(line)
+            logger.info(line, stacklevel=2)
         if _otel_tracer is None:
             return
         with tracer.start_as_current_span(name=line):
@@ -677,9 +642,13 @@ class tracer:
         """Record an error on the current span."""
         if console:
             if e is not None:
-                logger.opt(depth=1).exception(f"{line}", exc_info=e)
+                logger.error(
+                    line,
+                    exc_info=(type(e), e, e.__traceback__),
+                    stacklevel=2,
+                )
             else:
-                logger.opt(depth=1).error(line)
+                logger.error(line, stacklevel=2)
         if _otel_tracer is None:
             return
 

--- a/openviking/utils/multimodal.py
+++ b/openviking/utils/multimodal.py
@@ -10,15 +10,8 @@ from typing import Any
 def redact_image_data_urls(value: Any) -> Any:
     """Return a copy with inline image payloads replaced by compact placeholders."""
     if isinstance(value, str):
-        if value.startswith("data:image/"):
-            marker = ";base64,"
-            marker_index = value.find(marker, len("data:image/"))
-            if marker_index >= 0:
-                payload_start = marker_index + len(marker)
-                return (
-                    f"{value[:payload_start]}"
-                    f"[redacted {len(value) - payload_start} base64 chars]"
-                )
+        if value.lower().startswith("data:image/") and ";base64," in value.lower():
+            return "[redacted image data]"
         return value
     if isinstance(value, list):
         return [redact_image_data_urls(item) for item in value]

--- a/openviking/utils/multimodal.py
+++ b/openviking/utils/multimodal.py
@@ -10,9 +10,15 @@ from typing import Any
 def redact_image_data_urls(value: Any) -> Any:
     """Return a copy with inline image payloads replaced by compact placeholders."""
     if isinstance(value, str):
-        if value.lower().startswith("data:image/") and ";base64," in value.lower():
-            header, payload = value.split(",", 1)
-            return f"{header},[redacted {len(payload)} base64 chars]"
+        if value.startswith("data:image/"):
+            marker = ";base64,"
+            marker_index = value.find(marker, len("data:image/"))
+            if marker_index >= 0:
+                payload_start = marker_index + len(marker)
+                return (
+                    f"{value[:payload_start]}"
+                    f"[redacted {len(value) - payload_start} base64 chars]"
+                )
         return value
     if isinstance(value, list):
         return [redact_image_data_urls(item) for item in value]

--- a/openviking_cli/utils/config/embedding_config.py
+++ b/openviking_cli/utils/config/embedding_config.py
@@ -639,7 +639,9 @@ class EmbeddingConfig(BaseModel):
     )
 
     max_concurrent: int = Field(
-        default=10, description="Maximum number of concurrent embedding requests"
+        default=10,
+        gt=0,
+        description="Maximum number of concurrent embedding requests",
     )
     max_retries: int = Field(
         default=3,

--- a/openviking_cli/utils/config/vlm_config.py
+++ b/openviking_cli/utils/config/vlm_config.py
@@ -158,7 +158,9 @@ class VLMConfig(BaseModel):
     thinking: bool = Field(default=False, description="Enable thinking mode for VolcEngine models")
 
     max_concurrent: int = Field(
-        default=32, description="Maximum number of concurrent LLM calls for semantic processing"
+        default=32,
+        gt=0,
+        description="Maximum number of concurrent LLM calls for semantic processing",
     )
 
     media: VLMMediaConfig = Field(

--- a/openviking_cli/utils/logger.py
+++ b/openviking_cli/utils/logger.py
@@ -4,16 +4,15 @@
 Logging utilities for OpenViking.
 """
 
-import atexit
 import contextvars
+import copy
 import logging
 import queue
 import sys
-import threading
 from contextlib import contextmanager
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
-from typing import Any, Iterator, Optional, Tuple
+from typing import Any, Iterator, Optional
 from uuid import uuid4
 
 from openviking.observability.context import (
@@ -67,12 +66,6 @@ _otel_log_handler: Any = None
 _MANAGED_LOGGER_ROOTS = ("openviking", "openviking_cli", "uvicorn")
 _shared_log_handler: Optional[logging.Handler] = None
 _shared_log_handler_key: Optional[tuple[Any, ...]] = None
-
-# QueueListeners for thread-safe stdout/stderr logging (avoids StreamHandler stalls
-# on application threads when process managers redirect streams).
-_std_stream_handlers: dict[str, Tuple[QueueListener, logging.Handler]] = {}
-_std_stream_handlers_lock = threading.RLock()
-_std_stream_atexit_registered = False
 
 _request_id_context: contextvars.ContextVar[str] = contextvars.ContextVar(
     "openviking_log_request_id", default=""
@@ -664,7 +657,7 @@ class LogToSpanEventFilter(logging.Filter):
         return True
 
 
-def _load_log_config() -> Tuple[str, str, str, Optional[Any]]:
+def _load_log_config() -> tuple[str, str, str, Optional[Any]]:
     config = None
     try:
         from openviking_cli.utils.config import get_openviking_config
@@ -695,48 +688,44 @@ def _managed_root_name(name: str) -> Optional[str]:
     return None
 
 
-def _stop_std_stream_listeners() -> None:
-    """Stop queue listeners created for stdout/stderr logging."""
-    with _std_stream_handlers_lock:
-        listeners = list(_std_stream_handlers.values())
-        _std_stream_handlers.clear()
+class _QueuedLogHandler(QueueHandler):
+    """Own a background sink while callers only enqueue raw records."""
 
-    for listener, real_handler in listeners:
-        try:
-            listener.stop()
-        except Exception:
-            pass
-        try:
-            real_handler.close()
-        except Exception:
-            pass
+    def __init__(self, sink: logging.Handler) -> None:
+        self._sink = sink
+        log_queue: queue.Queue = queue.Queue(-1)
+        super().__init__(log_queue)
+        self._listener = QueueListener(log_queue, sink, respect_handler_level=True)
+        self._listener.start()
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        return copy.copy(record)
+
+    def flush(self) -> None:
+        self.queue.join()
+        self._sink.flush()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._listener.stop()
+            self._sink.close()
+        super().close()
 
 
-def _create_queued_stream_handler(log_output: str) -> QueueHandler:
-    """Create a QueueHandler backed by a per-stream QueueListener."""
-    global _std_stream_atexit_registered
+def _create_log_sink(log_output: str, config: Optional[Any]) -> logging.Handler:
+    if log_output in ("stdout", "stderr"):
+        stream = sys.stdout if log_output == "stdout" else sys.stderr
+        return logging.StreamHandler(stream)
 
-    if log_output not in ("stdout", "stderr"):
-        raise ValueError(f"unsupported stream log output: {log_output}")
-
-    with _std_stream_handlers_lock:
-        entry = _std_stream_handlers.get(log_output)
-        if entry is None:
-            stream = sys.stdout if log_output == "stdout" else sys.stderr
-            real_handler = logging.StreamHandler(stream)
-            log_queue: queue.Queue = queue.Queue(-1)
-            listener = QueueListener(log_queue, real_handler, respect_handler_level=True)
-            listener.start()
-            _std_stream_handlers[log_output] = (listener, real_handler)
-            entry = (listener, real_handler)
-            if not _std_stream_atexit_registered:
-                atexit.register(_stop_std_stream_listeners)
-                _std_stream_atexit_registered = True
-
-        listener, real_handler = entry
-        handler = QueueHandler(listener.queue)
-        handler._ov_real_handler = real_handler  # type: ignore[attr-defined]
-        return handler
+    if config is not None and config.log.rotation:
+        return _RustAwareTimedRotatingFileHandler(
+            log_output,
+            when=config.log.rotation_interval,
+            interval=1,
+            backupCount=config.log.rotation_days,
+            encoding="utf-8",
+        )
+    return logging.FileHandler(log_output, encoding="utf-8")
 
 
 def _add_trace_id_filter(handler: logging.Handler) -> None:
@@ -746,41 +735,18 @@ def _add_trace_id_filter(handler: logging.Handler) -> None:
         handler.addFilter(TraceIdLoggingFilter())
 
 
-def _create_log_handler(log_output: str, config: Optional[Any]) -> logging.Handler:
+def _create_log_handler(
+    log_output: str,
+    config: Optional[Any],
+    format_string: str,
+) -> logging.Handler:
     # Prevent creating a file literally named "file"
     if log_output == "file":
         log_output = "stdout"
 
-    if log_output in ("stdout", "stderr"):
-        return _create_queued_stream_handler(log_output)
-    else:
-        if config is not None:
-            try:
-                log_rotation = config.log.rotation
-                if log_rotation:
-                    log_rotation_days = config.log.rotation_days
-                    log_rotation_interval = config.log.rotation_interval
-
-                    if log_rotation_interval == "midnight":
-                        when = "midnight"
-                        interval = 1
-                    else:
-                        when = log_rotation_interval
-                        interval = 1
-
-                    return _RustAwareTimedRotatingFileHandler(
-                        log_output,
-                        when=when,
-                        interval=interval,
-                        backupCount=log_rotation_days,
-                        encoding="utf-8",
-                    )
-                else:
-                    return logging.FileHandler(log_output, encoding="utf-8")
-            except Exception:
-                return logging.FileHandler(log_output, encoding="utf-8")
-        else:
-            return logging.FileHandler(log_output, encoding="utf-8")
+    sink = _create_log_sink(log_output, config)
+    sink.setFormatter(logging.Formatter(format_string))
+    return _QueuedLogHandler(sink)
 
 
 def _build_standard_handler(
@@ -788,17 +754,7 @@ def _build_standard_handler(
     config: Optional[Any],
     format_string: str,
 ) -> logging.Handler:
-    handler = _create_log_handler(log_output, config)
-
-    # QueueHandler must enrich and format records on the caller thread so
-    # context-local trace data and per-logger format strings are captured before
-    # the shared listener-side stream handler writes the prepared message.
-    if isinstance(handler, QueueHandler):
-        real = getattr(handler, "_ov_real_handler", None)
-        if real is not None:
-            real.setFormatter(logging.Formatter("%(message)s"))
-
-    handler.setFormatter(logging.Formatter(format_string))
+    handler = _create_log_handler(log_output, config, format_string)
     _add_trace_id_filter(handler)
     handler.addFilter(_RequestIdLoggingFilter())
     return handler
@@ -808,8 +764,6 @@ def _get_shared_handler(
     log_output: str,
     config: Optional[Any],
     format_string: str,
-    *,
-    force: bool = False,
 ) -> logging.Handler:
     global _shared_log_handler, _shared_log_handler_key
 
@@ -823,7 +777,7 @@ def _get_shared_handler(
             config.log.rotation_interval,
             config.log.rotation_days,
         )
-    if not force and _shared_log_handler is not None and _shared_log_handler_key == handler_key:
+    if _shared_log_handler is not None and _shared_log_handler_key == handler_key:
         return _shared_log_handler
 
     _shared_log_handler = _build_standard_handler(log_output, config, format_string)
@@ -923,7 +877,7 @@ def reconfigure_logging() -> None:
     """Re-apply logging configuration to already-created OpenViking loggers."""
     log_level_str, log_format, log_output, config = _load_log_config()
     level = getattr(logging, log_level_str, logging.INFO)
-    handler = _get_shared_handler(log_output, config, log_format, force=True)
+    handler = _get_shared_handler(log_output, config, log_format)
 
     logger_dict = logging.Logger.manager.loggerDict
     target_names = [

--- a/tests/parse/test_feishu_parser_api.py
+++ b/tests/parse/test_feishu_parser_api.py
@@ -1,5 +1,4 @@
 import asyncio
-import concurrent.futures
 import json
 import zipfile
 from pathlib import Path
@@ -42,7 +41,6 @@ async def test_add_resource_processor_cancelled_context_preserves_group_ids(monk
     )
     processor = AddResourceProcessor(
         service,
-        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         viking_fs,
     )
@@ -56,28 +54,6 @@ async def test_add_resource_processor_cancelled_context_preserves_group_ids(monk
         role="user",
         lock_handoff={"handle_id": "lock-1"},
         cleanup_empty_target_on_failure=True,
-    )
-
-    def run_on_current_loop(coro, _loop):
-        task = asyncio.create_task(coro)
-        future: concurrent.futures.Future[None] = concurrent.futures.Future()
-
-        def complete(completed: asyncio.Task) -> None:
-            if completed.cancelled():
-                future.cancel()
-                return
-            error = completed.exception()
-            if error is not None:
-                future.set_exception(error)
-            else:
-                future.set_result(completed.result())
-
-        task.add_done_callback(complete)
-        return future
-
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.add_resource_processor.asyncio.run_coroutine_threadsafe",
-        run_on_current_loop,
     )
 
     await processor.on_cancelled({"data": json.dumps(msg.to_dict())})
@@ -1014,7 +990,6 @@ async def test_add_resource_processor_persists_final_uri_and_cleans_staged_sourc
     )
     processor = AddResourceProcessor(
         service,
-        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         viking_fs,
     )
@@ -1152,7 +1127,6 @@ async def test_add_resource_processor_collects_stats_without_registered_telemetr
             execute_add_resource_job=AsyncMock(side_effect=execute_add_resource_job),
             _link_resource_reason_memory=AsyncMock(),
         ),
-        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         SimpleNamespace(_async_agfs=SimpleNamespace(pathlock_release=AsyncMock())),
     )
@@ -1216,7 +1190,6 @@ async def test_add_resource_processor_replay_skips_lock_adopt_when_result_exists
     )
     processor = AddResourceProcessor(
         service,
-        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         SimpleNamespace(_async_agfs=async_agfs),
     )
@@ -1269,7 +1242,6 @@ async def test_add_resource_processor_reports_zero_vectors(monkeypatch):
     )
     processor = AddResourceProcessor(
         service,
-        asyncio.get_running_loop(),
         QueueManager.ADD_RESOURCE,
         SimpleNamespace(_async_agfs=SimpleNamespace(pathlock_release=AsyncMock())),
     )

--- a/tests/service/test_resource_memory_link_service.py
+++ b/tests/service/test_resource_memory_link_service.py
@@ -143,7 +143,7 @@ class _FakeSession:
         self.messages = []
         self.meta = SimpleNamespace(memory_policy=None)
 
-    def add_messages(self, specs):
+    async def add_messages_async(self, specs):
         self.messages.extend(specs)
 
 

--- a/tests/service/test_session_service_metrics.py
+++ b/tests/service/test_session_service_metrics.py
@@ -51,13 +51,14 @@ async def test_commit_async_keeps_working_when_session_metrics_fail(
     service = SessionService(viking_fs=Mock())
     ctx = _make_ctx()
     session = Mock()
+    session.exists = AsyncMock(return_value=True)
     session.commit_async = AsyncMock(return_value={"status": "queued", "archived": False})
     debug = Mock()
 
     def _boom(*_args, **_kwargs):
         raise RuntimeError("metrics failed")
 
-    monkeypatch.setattr(service, "get", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "session", Mock(return_value=session))
     monkeypatch.setattr(SessionLifecycleDataSource, "record_lifecycle", staticmethod(_boom))
     monkeypatch.setattr(SessionLifecycleDataSource, "record_archive", staticmethod(_boom))
     monkeypatch.setattr(session_service_module.logger, "debug", debug)
@@ -65,6 +66,7 @@ async def test_commit_async_keeps_working_when_session_metrics_fail(
     result = await service.commit_async("sess-1", ctx)
 
     assert result == {"status": "queued", "archived": False}
+    session.exists.assert_awaited_once()
     session.commit_async.assert_awaited_once()
     assert debug.call_count == 2
 

--- a/tests/session/test_tool_result_externalization.py
+++ b/tests/session/test_tool_result_externalization.py
@@ -5,7 +5,6 @@ import json
 
 import pytest
 
-import openviking.session.session as session_module
 import openviking.session.tool_result_store as tool_result_store
 from openviking.message import ToolPart
 from openviking.server.config import ToolOutputExternalizationConfig
@@ -17,6 +16,16 @@ from openviking_cli.exceptions import NotFoundError
 class MemoryVikingFS:
     def __init__(self):
         self.files = {}
+        self._async_agfs = self
+
+    def _uri_to_path(self, uri, *, ctx=None):  # noqa: ANN001
+        return uri
+
+    async def pathlock_acquire_exact(self, path, timeout_secs):  # noqa: ANN001
+        return path
+
+    async def pathlock_release(self, lease):  # noqa: ANN001
+        return None
 
     async def write_file(self, uri, content, *, ctx=None, lease_ref=None):  # noqa: ANN001
         self.files[uri] = content
@@ -98,9 +107,7 @@ async def test_externalized_tool_output_generates_synopsis_once(session: Session
         return original(*args, **kwargs)
 
     monkeypatch.setattr(tool_result_store, "generate_tool_result_synopsis", wrapped)
-    monkeypatch.setattr(session_module, "generate_tool_result_synopsis", wrapped)
-
-    session.add_message(
+    await session.add_message_async(
         "user",
         [
             ToolPart(

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -8,8 +8,6 @@ worker binds the committing account/user (so tokens are not attributed to
 "__unknown__") and resets the context afterwards.
 """
 
-import asyncio
-import concurrent.futures
 import json
 from unittest.mock import Mock
 
@@ -81,7 +79,6 @@ async def test_process_binds_committing_identity_to_root_context():
     captured: dict = {}
     processor = SessionCommitProcessor(
         _FakeSessionService(captured),
-        asyncio.get_running_loop(),
     )
     ctx = RequestContext(user=UserIdentifier("acme", "alice"), role=Role.USER)
 
@@ -100,7 +97,6 @@ async def test_process_requeues_deferred_commit_and_resets_root_context(monkeypa
 
     processor = SessionCommitProcessor(
         _FakeSessionService({}, processed=False),
-        asyncio.get_running_loop(),
     )
     monkeypatch.setattr(
         "openviking.storage.queuefs.get_queue_manager",
@@ -124,33 +120,10 @@ async def test_cancelled_queued_commit_writes_terminal_marker_before_success(mon
     )
     processor = SessionCommitProcessor(
         _SingleSessionService(session),
-        asyncio.get_running_loop(),
     )
     marker_uri = f"{msg.archive_uri}/.failed.json"
     on_success = Mock(side_effect=lambda: viking_fs.files[marker_uri])
     processor.set_callbacks(on_success, Mock(), Mock())
-
-    def run_on_current_loop(coro, _loop):
-        task = asyncio.create_task(coro)
-        future: concurrent.futures.Future[None] = concurrent.futures.Future()
-
-        def complete(completed: asyncio.Task) -> None:
-            if completed.cancelled():
-                future.cancel()
-                return
-            error = completed.exception()
-            if error is not None:
-                future.set_exception(error)
-            else:
-                future.set_result(completed.result())
-
-        task.add_done_callback(complete)
-        return future
-
-    monkeypatch.setattr(
-        "openviking.storage.queuefs.session_commit_processor.asyncio.run_coroutine_threadsafe",
-        run_on_current_loop,
-    )
 
     await processor.on_cancelled({"data": json.dumps(msg.to_dict())})
 

--- a/tests/storage/test_session_commit_processor_identity.py
+++ b/tests/storage/test_session_commit_processor_identity.py
@@ -27,9 +27,6 @@ class _FakeSession:
     async def exists(self) -> bool:
         return True
 
-    async def load(self) -> None:
-        return None
-
     async def resume_queued_commit(self, msg) -> bool:
         root = get_root_observability_context()
         self._captured["account_id"] = root.account_id if root else None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -583,7 +583,6 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
         logger.propagate = True
     logger_module._shared_log_handler = None
     logger_module._shared_log_handler_key = None
-    logger_module._stop_std_stream_listeners()
 
     OpenVikingConfigSingleton.reset_instance()
     monkeypatch.setenv("OPENVIKING_CONFIG_FILE", "/tmp/codex-no-config.json")
@@ -616,8 +615,7 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
         uvicorn_access = logging.getLogger("uvicorn.access")
         assert refreshed_logger.handlers == []
         assert uvicorn_access.handlers == []
-        assert any(isinstance(h, logging.FileHandler) for h in openviking_root.handlers)
-        assert not any(type(h) is logging.StreamHandler for h in openviking_root.handlers)
+        assert any(isinstance(h, QueueHandler) for h in openviking_root.handlers)
         assert openviking_root.handlers == uvicorn_root.handlers
 
         refreshed_logger.info("child-line")
@@ -637,5 +635,4 @@ def test_early_logger_initialization_is_reconfigured_to_file_output(tmp_path, mo
             logger.propagate = True
         logger_module._shared_log_handler = None
         logger_module._shared_log_handler_key = None
-        logger_module._stop_std_stream_listeners()
         OpenVikingConfigSingleton.reset_instance()

--- a/tests/unit/service/test_core_consistency.py
+++ b/tests/unit/service/test_core_consistency.py
@@ -118,7 +118,7 @@ async def test_close_stops_queue_manager_before_ragfs_binding(monkeypatch) -> No
             events.append("resource_tasks")
 
     class QueueManager:
-        def stop(self) -> None:
+        async def stop(self) -> None:
             events.append("queue_manager")
 
     class RagfsClient:

--- a/tests/unit/test_local_embedder.py
+++ b/tests/unit/test_local_embedder.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -99,7 +101,24 @@ async def test_local_embedder_uses_explicit_model_path(monkeypatch, tmp_path):
 
     assert Path(_FakeLlama.init_kwargs[-1]["model_path"]) == model_path.resolve()
     event_loop_thread_id = threading.get_ident()
-    result = await embedder.embed_async("你好", is_query=False)
+    default_executor_blocker = threading.Event()
+    loop = asyncio.get_running_loop()
+    loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
+    occupied_default_worker = asyncio.create_task(
+        asyncio.to_thread(default_executor_blocker.wait)
+    )
+    await asyncio.sleep(0)
+
+    try:
+        result = await asyncio.wait_for(
+            embedder.embed_async("你好", is_query=False),
+            timeout=1,
+        )
+    finally:
+        default_executor_blocker.set()
+        await occupied_default_worker
+        embedder.close()
+
     assert len(result.dense_vector) == 512
     assert _FakeLlama.inputs[-1] == "你好"
     assert _FakeLlama.thread_ids[-1] != event_loop_thread_id

--- a/tests/unit/test_local_embedder.py
+++ b/tests/unit/test_local_embedder.py
@@ -40,6 +40,8 @@ class _FakeLlama:
     init_kwargs = []
     inputs = []
     thread_ids = []
+    inference_started = threading.Event()
+    inference_release = threading.Event()
 
     def __init__(self, **kwargs):
         self.__class__.init_kwargs.append(kwargs)
@@ -47,6 +49,8 @@ class _FakeLlama:
     def create_embedding(self, payload):
         self.__class__.inputs.append(payload)
         self.__class__.thread_ids.append(threading.get_ident())
+        self.__class__.inference_started.set()
+        self.__class__.inference_release.wait()
         return {"data": [{"embedding": [0.1] * 512}]}
 
 
@@ -55,6 +59,8 @@ def _reset_fake_llama():
     _FakeLlama.init_kwargs = []
     _FakeLlama.inputs = []
     _FakeLlama.thread_ids = []
+    _FakeLlama.inference_started.set()
+    _FakeLlama.inference_release.set()
 
 
 def test_embedding_config_defaults_to_local_dense():
@@ -101,27 +107,31 @@ async def test_local_embedder_uses_explicit_model_path(monkeypatch, tmp_path):
 
     assert Path(_FakeLlama.init_kwargs[-1]["model_path"]) == model_path.resolve()
     event_loop_thread_id = threading.get_ident()
-    default_executor_blocker = threading.Event()
     loop = asyncio.get_running_loop()
-    loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
-    occupied_default_worker = asyncio.create_task(
-        asyncio.to_thread(default_executor_blocker.wait)
-    )
+    loop.set_default_executor(ThreadPoolExecutor(max_workers=2))
+    _FakeLlama.inference_started.clear()
+    _FakeLlama.inference_release.clear()
+    running = asyncio.create_task(embedder.embed_async("你好", is_query=False))
+    await asyncio.to_thread(_FakeLlama.inference_started.wait)
+    running.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running
+
+    queued = asyncio.create_task(embedder.embed_async("世界", is_query=False))
     await asyncio.sleep(0)
 
     try:
-        result = await asyncio.wait_for(
-            embedder.embed_async("你好", is_query=False),
-            timeout=1,
-        )
+        worker_thread_id = await asyncio.wait_for(asyncio.to_thread(threading.get_ident), 1)
+        assert _FakeLlama.inputs == ["你好"]
     finally:
-        default_executor_blocker.set()
-        await occupied_default_worker
-        embedder.close()
+        _FakeLlama.inference_release.set()
+
+    result = await queued
 
     assert len(result.dense_vector) == 512
-    assert _FakeLlama.inputs[-1] == "你好"
-    assert _FakeLlama.thread_ids[-1] != event_loop_thread_id
+    assert _FakeLlama.inputs == ["你好", "世界"]
+    assert worker_thread_id != event_loop_thread_id
+    assert all(thread_id != event_loop_thread_id for thread_id in _FakeLlama.thread_ids)
 
 
 def test_local_embedder_downloads_default_model_and_prefixes_query(monkeypatch, tmp_path):

--- a/tests/unit/test_local_embedder.py
+++ b/tests/unit/test_local_embedder.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd.
 # SPDX-License-Identifier: AGPL-3.0
 
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -36,12 +37,14 @@ class _FakeResponse:
 class _FakeLlama:
     init_kwargs = []
     inputs = []
+    thread_ids = []
 
     def __init__(self, **kwargs):
         self.__class__.init_kwargs.append(kwargs)
 
     def create_embedding(self, payload):
         self.__class__.inputs.append(payload)
+        self.__class__.thread_ids.append(threading.get_ident())
         return {"data": [{"embedding": [0.1] * 512}]}
 
 
@@ -49,6 +52,7 @@ class _FakeLlama:
 def _reset_fake_llama():
     _FakeLlama.init_kwargs = []
     _FakeLlama.inputs = []
+    _FakeLlama.thread_ids = []
 
 
 def test_embedding_config_defaults_to_local_dense():
@@ -81,7 +85,8 @@ def test_local_embedder_requires_optional_dependency(monkeypatch, tmp_path):
         LocalDenseEmbedder(model_path=str(model_path))
 
 
-def test_local_embedder_uses_explicit_model_path(monkeypatch, tmp_path):
+@pytest.mark.asyncio
+async def test_local_embedder_uses_explicit_model_path(monkeypatch, tmp_path):
     model_path = tmp_path / "model.gguf"
     model_path.write_bytes(b"gguf")
 
@@ -93,9 +98,11 @@ def test_local_embedder_uses_explicit_model_path(monkeypatch, tmp_path):
     embedder = LocalDenseEmbedder(model_path=str(model_path))
 
     assert Path(_FakeLlama.init_kwargs[-1]["model_path"]) == model_path.resolve()
-    result = embedder.embed("你好", is_query=False)
+    event_loop_thread_id = threading.get_ident()
+    result = await embedder.embed_async("你好", is_query=False)
     assert len(result.dense_vector) == 512
     assert _FakeLlama.inputs[-1] == "你好"
+    assert _FakeLlama.thread_ids[-1] != event_loop_thread_id
 
 
 def test_local_embedder_downloads_default_model_and_prefixes_query(monkeypatch, tmp_path):

--- a/tests/unit/test_vikingbot_chat_images.py
+++ b/tests/unit/test_vikingbot_chat_images.py
@@ -229,14 +229,20 @@ def test_context_builder_keeps_trusted_local_file_support(tmp_path):
 
 def test_redact_image_data_urls_does_not_mutate_request_messages():
     inline_url = _data_url("image/png", PNG_SIGNATURE)
+    uppercase_inline_url = inline_url.replace(";base64,", ";BASE64,")
     messages = [
         {
             "role": "user",
-            "content": [{"type": "image_url", "image_url": {"url": inline_url}}],
+            "content": [
+                {"type": "image_url", "image_url": {"url": inline_url}},
+                {"type": "image_url", "image_url": {"url": uppercase_inline_url}},
+            ],
         }
     ]
 
     redacted = redact_image_data_urls(messages)
 
     assert "redacted" in redacted[0]["content"][0]["image_url"]["url"]
+    assert "redacted" in redacted[0]["content"][1]["image_url"]["url"]
     assert messages[0]["content"][0]["image_url"]["url"] == inline_url
+    assert messages[0]["content"][1]["image_url"]["url"] == uppercase_inline_url


### PR DESCRIPTION
## Description

本 PR 通过重新划分执行职责，根治 Service Event Loop 被同步 CPU、日志格式化以及跨 Event Loop 调度阻塞的问题。它不为 A/B/C 分别增加补丁，而是收敛为三个明确的执行边界：

1. **Service Event Loop**：拥有 QueueFS 生命周期、锁、取消、异步存储/模型 I/O、处理完成和 ACK。
2. **CPU Worker Thread**：只执行无 I/O 的消息规范化、工具输出摘要/哈希/选择、Token 估算、JSONL 编解码和 Prompt 构造。
3. **Logging Listener**：拥有 LogRecord 格式化和 stdout/stderr/file I/O；业务调用线程只入队原始 LogRecord。

### Before

- `QueueManager` 为每个 Queue 创建一个 daemon thread 和私有 Event Loop。Queue handler 先在 Queue Loop 中运行，再通过 `run_coroutine_threadsafe` 跳回 Service Loop；启动、停止、取消和 ACK 分散在两套生命周期中。
- HTTP/MCP/内部资源链路虽然是 async 入口，消息构造、工具输出摘要/哈希、Token 估算和 JSONL 处理仍可能直接运行在 Service Loop；工具输出持久化还会通过同步 `run_async` 再跨一次 Loop。
- `Message.estimated_tokens` 每次读取都会重新扫描全部 Parts。同一批消息在 pending-token、retention 和 context budget 阶段会重复计算。
- VLM adapter 在发请求前同步脱敏并 `json.dumps(..., indent=2)` 整个请求体；`QueueHandler.prepare()` 也在调用线程完成日志格式化，因此“大日志”仍会阻塞主循环。

旧流程：

```text
HTTP / MCP (Service Loop)
  -> 同步消息准备、Token/JSON 计算
  -> run_async (另一 Event Loop)

QueueFS daemon thread + private Event Loop
  -> dequeue
  -> run_coroutine_threadsafe(Service Loop)
  -> handler
  -> 返回 Queue Loop
  -> ACK
```

### After

- `OpenVikingService.initialize()` / `close()` 直接 await `QueueManager.start()` / `stop()`；每个 durable queue 是 Service Loop 上的一个 `asyncio.Task`，按 `dequeue -> await handler -> ACK` 单向执行。
- AddResource、SessionCommit、UserDeletion processor 直接 await 其 Service，不再保存 `service_loop`，也不再使用 `run_coroutine_threadsafe` / `wrap_future`。
- 新增 `MessagePreparer` 作为纯 CPU Owner：在 worker thread 中完成消息构造、Turn 级工具输出选择、摘要、哈希和 Token 定稿；Service Loop 只执行 `ToolResultStore` 异步 I/O 和权威消息追加。
- `Message` 的 Token 估算改为内存懒缓存，消息变更后由变更 Owner 显式刷新；本 PR 不增加 Token 持久化、历史回填或 JSONL Schema。
- Session 的 JSONL 编解码、retention/budget 计算、checkpoint 构造和 Prompt 格式化移出 Service Loop。HTTP、MCP 和资源记忆链路直接调用 async Session API，不再保留猜测式 sync fallback。
- LiteLLM、OpenAI、VolcEngine adapter 不再记录完整请求体；调用线程只入队原始 LogRecord，listener 再执行格式化和输出 I/O。

新流程：

```text
HTTP / MCP / QueueFS task (Service Loop)
  -> to_thread(纯 CPU 消息准备、Token/JSON/Prompt)
  -> await 异步存储或模型 I/O
  -> direct await handler
  -> 完成状态
  -> ACK

Log caller
  -> enqueue raw LogRecord
  -> listener format + I/O
```

### 同一场景的前后对比

输入保持一致：向 Session 写入一个包含约 100 KB `tool_output` 的消息，随后触发 commit。

| 关键字段/阶段 | Before | After |
| --- | --- | --- |
| 输入 | `role`、`parts`、`tool_output` | 完全相同 |
| 消息结果 | 生成 `message.id` 和 `tool_output_ref` | 完全相同 |
| Queue 状态 | durable message 处理完成后 ACK | 完全相同，仍为 at-least-once |
| 消息准备 | Service Loop 同步摘要、哈希、Token 计算 | CPU worker thread 生成 `PreparedMessageBatch` |
| 工具结果写入 | 同步入口跨 Loop 调用异步 Store | Service Loop 直接 await Store I/O |
| SessionCommit | Queue thread/private Loop 再跳回 Service Loop | Service Loop 上的 Queue task 直接 await processor |
| VLM 日志 | Service Loop 脱敏、格式化完整请求 JSON | 不记录完整请求体 |

对客户端返回字段、Session 消息格式、工具输出引用、Queue ACK 时机和失败恢复语义均不变。并发配置现在在配置边界要求 `embedding.max_concurrent > 0`、`vlm.max_concurrent > 0`，运行时不再静默猜测无效值。

## Human Involvement

<!-- Select exactly one option -->

- [x] A human participated in the implementation or review loop
- [ ] This PR was generated entirely by AI agents without human participation in the loop

## Related Issue

无公开 GitHub Issue；问题来自内部对 Service Event Loop 阻塞问题 A/B/C 的复盘。

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test update

## Changes Made

- 将 QueueFS 从“每 Queue 一个线程和私有 Event Loop”收敛为 Service Loop 上受并发上限控制的 async task，并保持 handler 完成后 ACK 的因果顺序。
- 将 Session 消息准备、工具输出预处理、Token/retention、JSONL 和 Prompt CPU 工作移到 worker thread；删除 Session 内旧的同步外部化路径和 async/sync fallback。
- 删除 VLM 完整请求体日志，重构标准日志队列，让 listener 负责格式化和 I/O；Tracer 统一使用 stdlib logging。

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this on the following platforms:
  - [ ] Linux
  - [x] macOS
  - [ ] Windows

验证结果：

- 272 个聚焦测试通过，覆盖 Message/Token、retention、Session commit recovery、Working Memory、工具输出外部化、QueueManager、SessionCommit processor、配置加载、AddResource processor 和资源记忆链路。
- `ruff check` 通过。
- `python -m compileall -q openviking openviking_cli` 通过。
- `git diff --check origin/main...HEAD` 通过。

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation（无公开 API/存储 Schema 文档变化）
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published（无依赖变更）

## Screenshots (if applicable)

不适用。

## Additional Notes

- 相对最新 `origin/main`：`715 insertions / 955 deletions`，净减少 240 行；`Session` 本身净减少 352 行。
- 新的 `MessagePreparer` 替代 Session 内消息构造、Turn 级工具输出选择和同步外部化职责；新旧两套机制没有并存。
- Queue 状态计数仅保留一个窄锁，因为同步 metrics collector 会从其他线程读取快照；Queue 消费、handler、取消和 ACK 均由 Service Loop 独占。
- 本 PR 不包含 Token 持久化、历史回填、兼容别名或猜测式 fallback。
